### PR TITLE
WebRTC: And webrtc canvas recorder to record the webgl into video

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -324,6 +324,9 @@ var files = {
 		"webaudio_timing",
 		"webaudio_visualizer"
 	],
+	"webrtc": [
+		"webrtc_recorder"
+	],
 	"webvr": [
 		"webvr_ballshooter",
 		"webvr_cubes",

--- a/examples/js/rtc/WebRTCRecorder.js
+++ b/examples/js/rtc/WebRTCRecorder.js
@@ -24,7 +24,6 @@ THREE.WebRTCRecorder = function ( canvas, options ) {
 
 	}
 
-	// this.video = document.createElement( "video" );
 	this.canvas = canvas;
 	this.state = "stopped";
 	this.init( options );
@@ -137,13 +136,6 @@ THREE.WebRTCRecorder.prototype = Object.assign( THREE.WebRTCRecorder.prototype, 
 			return;
 
 		}
-
-		this.mediaRecorder.onstop = function () {
-
-			var superBuffer = new Blob( this.recordedBlobs, { type: "video/" + this.format } );
-			// this.video.src = window.URL.createObjectURL( superBuffer );
-
-		}.bind( this );
 
 		this.mediaRecorder.ondataavailable = function ( event ) {
 

--- a/examples/js/rtc/WebRTCRecorder.js
+++ b/examples/js/rtc/WebRTCRecorder.js
@@ -1,0 +1,219 @@
+/**
+ * @author hypnosnova / https://github.com/HypnosNova
+ * @param canvas: in most time, it is renderer.domElement.
+ * @param options: {
+ *     fps: default is 60,
+ *     format: default is 'webm',
+ *     codecs: default is 'vp8'
+ * }
+ */
+
+THREE.WebRTCRecorder = function ( canvas, options ) {
+
+	if ( ! MediaSource ) {
+
+		console.error( "Your browser doesn't support WebRTC MediaSource. Try to use chrome or firefox browser." );
+		return;
+
+	}
+
+	if ( ! canvas.captureStream ) {
+
+		console.error( "Your browser doesn't support canvas captureStream. Try to use chrome or firefox browser." );
+		return;
+
+	}
+
+	this.video = document.createElement( "video" );
+	this.canvas = canvas;
+	this.state = "stopped";
+	this.init( options );
+
+};
+
+THREE.WebRTCRecorder.prototype = Object.assign( THREE.WebRTCRecorder.prototype, {
+
+	constructor: THREE.WebRTCRecorder,
+
+	isWebRTCRecorder: true,
+
+	init: function ( options ) {
+
+		this.dispose();
+		if ( ! options ) {
+
+			options = {
+				fps: 60,
+				format: "webm",
+				codecs: "vp9"
+			};
+
+		}
+		this.fps = options.fps || 60;
+		this.format = options.format || "webm";
+		this.codecs = options.codecs || "vp9";
+
+		this.mediaSource = new MediaSource();
+		this.stream = this.canvas.captureStream( this.fps );
+
+	},
+
+	playVideo: function () {
+
+		this.video.play();
+
+	},
+
+	stopVideo: function () {
+
+		this.video.stop();
+
+	},
+
+	pauseVideo: function () {
+
+		this.video.pause();
+
+	},
+
+	dispose: function () {
+
+		if ( this.mediaSource ) {
+
+			let arr = this.mediaSource.sourceBuffers;
+			for ( var i = 0; i < arr.length; i ++ ) {
+
+				this.mediaSource.removeSourceBuffer( arr[ i ] );
+
+			}
+
+		}
+		if ( this.stream ) {
+
+			let arr = this.stream.getTracks();
+			for ( var i = 0; i < arr.length; i ++ ) {
+
+				arr[ i ].enabled = false;
+				arr[ i ].stop();
+				this.stream.removeTrack( arr[ i ] );
+
+			}
+
+		}
+		this.recordedBlobs = [];
+
+	},
+
+	download: function ( fileName ) {
+
+		const blob = new Blob( this.recordedBlobs, { type: "video/" + this.format } );
+		const url = window.URL.createObjectURL( blob );
+		const a = document.createElement( 'a' );
+		a.style.display = 'none';
+		a.href = url;
+		a.download = ( fileName || "canvas_capture" ) + "." + this.format;
+		document.body.appendChild( a );
+		a.click();
+		setTimeout( () => {
+
+			document.body.removeChild( a );
+			window.URL.revokeObjectURL( url );
+
+		}, 100 );
+
+	},
+
+	startRecording: function ( ms ) {
+
+		var options1 = { mimeType: "video/" + this.format + ";codecs=" + this.codecs };
+		var options2 = { mimeType: "video/" + this.format };
+		this.recordedBlobs = [];
+		if ( MediaRecorder.isTypeSupported( options1.mimeType ) ) {
+
+			this.mediaRecorder = new MediaRecorder( this.stream, options1 );
+
+		} else if ( MediaRecorder.isTypeSupported( options2.mimeType ) ) {
+
+			this.mediaRecorder = new MediaRecorder( this.stream, options2 );
+
+		} else {
+
+			console.error( "Your browser doesn't support format in MediaRecorder: " + this.format );
+			this.state = "stopped";
+			return;
+
+		}
+
+		this.mediaRecorder.onstop = function () {
+
+			var superBuffer = new Blob( this.recordedBlobs, { type: "video/" + this.format } );
+			this.video.src = window.URL.createObjectURL( superBuffer );
+
+		}.bind( this );
+
+		this.mediaRecorder.ondataavailable = function ( event ) {
+
+			if ( event.data && event.data.size > 0 ) {
+
+				this.recordedBlobs.push( event.data );
+
+			}
+
+		}.bind( this );
+
+		this.mediaRecorder.start( ms || 100 );
+		this.state = "started";
+
+	},
+
+	pauseRecording: function () {
+
+		if ( this.state === "started" ) {
+
+			this.mediaRecorder.pause();
+			this.state = "paused";
+
+		} else {
+
+			console.warning( "The record is not \"started\". Current state is: " + this.state );
+
+		}
+
+	},
+
+	resumeRecording: function () {
+
+		if ( this.state === "paused" ) {
+
+			this.mediaRecorder.resume();
+			this.state = "started";
+
+		} else {
+
+			console.warning( "The record is not \"paused\". Current state is: " + this.state );
+
+		}
+
+	},
+
+	stopRecording: function () {
+
+		this.state = "stop";
+		this.mediaRecorder.stop();
+
+	},
+
+	toggleRecording: function () {
+
+		if ( this.state === "stopped" ) {
+
+			this.startRecording();
+
+		} else {
+
+			this.stopRecording();
+
+		}
+
+	}
+} );

--- a/examples/js/rtc/WebRTCRecorder.js
+++ b/examples/js/rtc/WebRTCRecorder.js
@@ -24,7 +24,7 @@ THREE.WebRTCRecorder = function ( canvas, options ) {
 
 	}
 
-	this.video = document.createElement( "video" );
+	// this.video = document.createElement( "video" );
 	this.canvas = canvas;
 	this.state = "stopped";
 	this.init( options );
@@ -55,24 +55,6 @@ THREE.WebRTCRecorder.prototype = Object.assign( THREE.WebRTCRecorder.prototype, 
 
 		this.mediaSource = new MediaSource();
 		this.stream = this.canvas.captureStream( this.fps );
-
-	},
-
-	playVideo: function () {
-
-		this.video.play();
-
-	},
-
-	stopVideo: function () {
-
-		this.video.stop();
-
-	},
-
-	pauseVideo: function () {
-
-		this.video.pause();
 
 	},
 
@@ -123,6 +105,18 @@ THREE.WebRTCRecorder.prototype = Object.assign( THREE.WebRTCRecorder.prototype, 
 
 	},
 
+	getBlob: function () {
+
+		return new Blob( this.recordedBlobs, { type: "video/" + this.format } );
+
+	},
+
+	getUrl: function () {
+
+		return window.URL.createObjectURL( this.getBlob() );
+
+	},
+
 	startRecording: function ( ms ) {
 
 		var options1 = { mimeType: "video/" + this.format + ";codecs=" + this.codecs };
@@ -147,7 +141,7 @@ THREE.WebRTCRecorder.prototype = Object.assign( THREE.WebRTCRecorder.prototype, 
 		this.mediaRecorder.onstop = function () {
 
 			var superBuffer = new Blob( this.recordedBlobs, { type: "video/" + this.format } );
-			this.video.src = window.URL.createObjectURL( superBuffer );
+			// this.video.src = window.URL.createObjectURL( superBuffer );
 
 		}.bind( this );
 

--- a/examples/js/rtc/WebRTCRecorder.js
+++ b/examples/js/rtc/WebRTCRecorder.js
@@ -10,7 +10,7 @@
 
 THREE.WebRTCRecorder = function ( canvas, options ) {
 
-	if ( ! MediaSource ) {
+	if ( ! window.MediaSource ) {
 
 		console.error( "Your browser doesn't support WebRTC MediaSource. Try to use chrome or firefox browser." );
 		return;

--- a/examples/webrtc_recorder.html
+++ b/examples/webrtc_recorder.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - WebRTC - WebGL canvas recording into video</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #fff;
+				color: #000;
+				margin: 0px;
+				overflow: hidden;
+			}
+			#info {
+				color: #000;
+				position: absolute;
+				top: 10px;
+				width: 100%;
+				text-align: center;
+				display:block;
+			}
+			video{
+				position: fixed;
+				bottom: 0;
+				width: 320px;
+				height: 180px;
+			}
+			.disabled-btn{
+				pointer-events: none;
+			}
+			.disabled-btn .property-name{
+				color: #888;
+				text-decoration: line-through;
+			}
+			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+		</style>
+	</head>
+
+	<body>
+		<div id="info">
+		<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - WebRTC canvas recording into video<br />
+		<a href="https://github.com/mrdoob/three.js/tree/master/examples/models/mmd#readme" target="_blank" rel="noopener">MMD Assets license</a><br />
+		Copyright
+		<a href="http://www.geocities.jp/higuchuu4/index_e.htm" target="_blank" rel="noopener">Model Data</a>
+		<a href="http://www.nicovideo.jp/watch/sm13147122" target="_blank" rel="noopener">Dance Data</a>
+		</div>
+
+		<script src="../build/three.js"></script>
+
+		<script src="js/libs/mmdparser.min.js"></script>
+		<script src="js/libs/ammo.js"></script>
+
+		<script src="js/loaders/TGALoader.js"></script>
+		<script src="js/loaders/MMDLoader.js"></script>
+		<script src="js/animation/CCDIKSolver.js"></script>
+		<script src="js/animation/MMDPhysics.js"></script>
+		<script src="js/animation/MMDAnimationHelper.js"></script>
+
+		<script src="js/controls/OrbitControls.js"></script>
+
+		<script src="js/libs/dat.gui.min.js"></script>
+
+		<script src="js/rtc/WebRTCRecorder.js"></script>
+
+		<script>
+
+			var container, stats, recorder;
+
+			var mesh, camera, scene, renderer, effect;
+			var helper, ikHelper, physicsHelper;
+
+			var clock = new THREE.Clock();
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
+				camera.position.z = 30;
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0xffffff );
+
+				var gridHelper = new THREE.PolarGridHelper( 30, 10 );
+				gridHelper.position.y = - 10;
+				scene.add( gridHelper );
+
+				var ambient = new THREE.AmbientLight( 0x666666 );
+				scene.add( ambient );
+
+				var directionalLight = new THREE.DirectionalLight( 0x887766 );
+				directionalLight.position.set( - 1, 1, 1 ).normalize();
+				scene.add( directionalLight );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
+				// model
+
+				function onProgress( xhr ) {
+
+					if ( xhr.lengthComputable ) {
+
+						var percentComplete = xhr.loaded / xhr.total * 100;
+						console.log( Math.round( percentComplete, 2 ) + '% downloaded' );
+
+					}
+
+				}
+
+				var modelFile = 'models/mmd/miku/miku_v2.pmd';
+				var vmdFiles = [ 'models/mmd/vmds/wavefile_v2.vmd' ];
+
+				helper = new THREE.MMDAnimationHelper( {
+					afterglow: 2.0
+				} );
+
+				var loader = new THREE.MMDLoader();
+
+				loader.loadWithAnimation( modelFile, vmdFiles, function ( mmd ) {
+
+					mesh = mmd.mesh;
+					mesh.position.y = - 10;
+					scene.add( mesh );
+
+					helper.add( mesh, {
+						animation: mmd.animation,
+						physics: true
+					} );
+
+					ikHelper = helper.objects.get( mesh ).ikSolver.createHelper();
+					ikHelper.visible = false;
+					scene.add( ikHelper );
+
+					physicsHelper = helper.objects.get( mesh ).physics.createHelper();
+					physicsHelper.visible = false;
+					scene.add( physicsHelper );
+
+					initRecorder();
+					initGui();
+
+				}, onProgress, null );
+
+				var controls = new THREE.OrbitControls( camera, renderer.domElement );
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+				var phongMaterials;
+				var originalMaterials;
+
+				function makePhongMaterials( materials ) {
+
+					var array = [];
+
+					for ( var i = 0, il = materials.length; i < il; i ++ ) {
+
+						var m = new THREE.MeshPhongMaterial();
+						m.copy( materials[ i ] );
+						m.needsUpdate = true;
+
+						array.push( m );
+
+					}
+
+					phongMaterials = array;
+
+				}
+
+				// Create WebRTC canvas recorder
+
+				function initRecorder(){
+
+					recorder = new THREE.WebRTCRecorder( renderer.domElement );
+					recorder.video.controls = "controls";
+					document.body.appendChild( recorder.video );
+
+				}
+
+				function initGui() {
+
+					var api = {
+						"fps": recorder.fps,
+						"codecs": "vp9",
+						"show dom": true,
+						"start": recorder.startRecording.bind( recorder ),
+						"stop": recorder.stopRecording.bind( recorder ),
+						"pause": recorder.pauseRecording.bind( recorder ),
+						"resume": recorder.resumeRecording.bind( recorder ),
+						"download": recorder.download.bind( recorder )
+					};
+
+					var gui = new dat.GUI();
+					gui.add( api, "fps", 1, 60 ).step( 1 ).onChange( updateRecorder );
+					gui.add( api, "codecs", ["vp9", "vp8", "h264"] ).onChange( updateRecorder );
+					gui.add( api, "start" ).onChange( function() {
+
+						startBtn.classList.add( "disabled-btn" );
+						stopBtn.classList.remove( "disabled-btn" );
+						pauseBtn.classList.remove( "disabled-btn" );
+						resumeBtn.classList.add( "disabled-btn" );
+
+					});
+					gui.add( api, "resume" ).onChange( function() {
+
+						startBtn.classList.add( "disabled-btn" );
+						stopBtn.classList.remove( "disabled-btn" );
+						pauseBtn.classList.remove( "disabled-btn" );
+						resumeBtn.classList.add( "disabled-btn" );
+
+					});
+					gui.add( api, "pause" ).onChange( function() {
+
+						startBtn.classList.add( "disabled-btn" );
+						stopBtn.classList.remove( "disabled-btn" );
+						pauseBtn.classList.add( "disabled-btn" );
+						resumeBtn.classList.remove( "disabled-btn" );
+
+					});
+					gui.add( api, "stop" ).onChange( function() {
+
+						startBtn.classList.remove( "disabled-btn" );
+						stopBtn.classList.add( "disabled-btn" );
+						pauseBtn.classList.add( "disabled-btn" );
+						resumeBtn.classList.add( "disabled-btn" );
+
+					});
+					gui.add( api, "show dom" ).onChange( function( val ) {
+
+						recorder.video.style.display = val ? "block" : "none";
+
+					} );
+					gui.add( api, "download" );
+
+					var buttons = document.querySelectorAll( ".function" );
+					var startBtn = buttons[ 0 ];
+					var stopBtn = buttons[ 3 ];
+					var pauseBtn = buttons[ 2 ];
+					var resumeBtn = buttons[ 1 ];
+					stopBtn.classList.add( "disabled-btn" );
+					pauseBtn.classList.add( "disabled-btn" );
+					resumeBtn.classList.add( "disabled-btn" );
+
+					function updateRecorder() {
+						recorder.init( {
+							fps: api.fps,
+							codecs: api.codecs
+						} );
+					}
+
+				}
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
+
+				helper.update( clock.getDelta() );
+				renderer.render( scene, camera );
+
+			}
+		</script>
+
+	</body>
+</html>

--- a/examples/webrtc_recorder.html
+++ b/examples/webrtc_recorder.html
@@ -45,7 +45,7 @@
 		<a href="http://www.geocities.jp/higuchuu4/index_e.htm" target="_blank" rel="noopener">Model Data</a>
 		<a href="http://www.nicovideo.jp/watch/sm13147122" target="_blank" rel="noopener">Dance Data</a>
 		</div>
-
+		<video id="recorderVideo"></video>
 		<script src="../build/three.js"></script>
 
 		<script src="js/libs/mmdparser.min.js"></script>
@@ -69,15 +69,17 @@
 
 			var mesh, camera, scene, renderer, effect;
 			var helper, ikHelper, physicsHelper;
-
 			var clock = new THREE.Clock();
+
+			var video = document.getElementById( "recorderVideo" )
+			video.controls = "controls";
 
 			init();
 			animate();
 
 			function init() {
 
-				container = document.createElement( 'div' );
+				container = document.createElement( "div" );
 				document.body.appendChild( container );
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
@@ -109,14 +111,14 @@
 					if ( xhr.lengthComputable ) {
 
 						var percentComplete = xhr.loaded / xhr.total * 100;
-						console.log( Math.round( percentComplete, 2 ) + '% downloaded' );
+						console.log( Math.round( percentComplete, 2 ) + "% downloaded" );
 
 					}
 
 				}
 
-				var modelFile = 'models/mmd/miku/miku_v2.pmd';
-				var vmdFiles = [ 'models/mmd/vmds/wavefile_v2.vmd' ];
+				var modelFile = "models/mmd/miku/miku_v2.pmd";
+				var vmdFiles = [ "models/mmd/vmds/wavefile_v2.vmd" ];
 
 				helper = new THREE.MMDAnimationHelper( {
 					afterglow: 2.0
@@ -150,7 +152,7 @@
 
 				var controls = new THREE.OrbitControls( camera, renderer.domElement );
 
-				window.addEventListener( 'resize', onWindowResize, false );
+				window.addEventListener( "resize", onWindowResize, false );
 
 				var phongMaterials;
 				var originalMaterials;
@@ -178,8 +180,7 @@
 				function initRecorder(){
 
 					recorder = new THREE.WebRTCRecorder( renderer.domElement );
-					recorder.video.controls = "controls";
-					document.body.appendChild( recorder.video );
+					
 
 				}
 
@@ -190,7 +191,9 @@
 						"codecs": "vp9",
 						"show dom": true,
 						"start": recorder.startRecording.bind( recorder ),
-						"stop": recorder.stopRecording.bind( recorder ),
+						"stop": function () {
+							video.src = recorder.getUrl();
+						},
 						"pause": recorder.pauseRecording.bind( recorder ),
 						"resume": recorder.resumeRecording.bind( recorder ),
 						"download": recorder.download.bind( recorder )
@@ -233,7 +236,7 @@
 					});
 					gui.add( api, "show dom" ).onChange( function( val ) {
 
-						recorder.video.style.display = val ? "block" : "none";
+						video.style.display = val ? "block" : "none";
 
 					} );
 					gui.add( api, "download" );


### PR DESCRIPTION
Sometime we need a tool to capture canvas and record the 3D demo into a video to share on the internet. So I create  WebRTCRecorder to do it.

It has 5 important apis:

1.startRecording: Start recording canvas into video stream 
2.stopRecording: Stop recording and put the video stream into blob so the video dom element can play the video
3.pauseRecording: Pause recording
4.resumeRecording: Resume recording
5.dispose: Clear the stream and blobs, stop webrtc tracks.

I think webrtc could be a new collection and I may create a few other demos using webrtc later.
So in file.js, I change into json like this:
var files = {
    .....// many demos
    "webrtc": [ // this is the new collection and i think all demos using webrtc api could put here
        "webrtc_recorder"
    ],
    .....// many demos
}