### PR TITLE
Update Built UMD File Readability

### DIFF
--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -17,6 +17,20 @@ function createOutput( file ) {
 		treeshake: false,
 		external: p => p !== inputPath,
 
+		plugins: [{
+
+			generateBundle: function(options, bundle) {
+
+				for ( var key in bundle ) {
+
+					bundle[ key ].code = bundle[ key ].code.replace( /three_module_js/g, 'THREE' );
+
+				}
+
+			}
+
+		}],
+
 		output: {
 
 			format: 'umd',
@@ -30,7 +44,8 @@ function createOutput( file ) {
 			banner:
 				'/**\n' +
 				` * Generated from '${ path.relative( '.', inputPath.replace( /\\/, '/' ) ) }'\n` +
-				' */\n'
+				' */\n',
+			esModule: false
 
 		}
 

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -43,7 +43,7 @@ function createOutput( file ) {
 
 			banner:
 				'/**\n' +
-				` * Generated from '${ path.relative( '.', inputPath.replace( /\\/, '/' ) ) }'\n` +
+				` * Generated from '${ path.relative( '.', inputPath ).replace( /\\/g, '/' ) }'\n` +
 				' */\n',
 			esModule: false
 


### PR DESCRIPTION
Per the discussion in #15526:

Replace the `three_module_js` local UMD variable name with `THREE` to retain the source readability. Also remove the addition of the `__esModule` variable onto THREE.

This uses the `generateBundle` Rollup plugin hook to replace the `three_module_js` variable name with `THREE`. Unfortunately I didn't see a better way to control that variable name in Rollup so this is a pretty non discriminating find and replace in the file but given the code style expectations in the repo I don't think it should be a problem.

You can see the new built GLTFLoader code here: https://github.com/gkjohnson/three.js/blob/rollup-jsm-examples-output/examples/js/loaders/GLTFLoader.js