### PR TITLE
ShaderMaterial: Added Matrix3 to .toJSON()

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -2,6 +2,7 @@ import { Color } from '../math/Color.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
+import { Matrix3 } from '../math/Matrix3.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { FileLoader } from './FileLoader.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
@@ -128,6 +129,9 @@ Object.assign( MaterialLoader.prototype, {
 					case 'v4':
 						material.uniforms[ name ].value = new Vector4().fromArray( uniform.value );
 						break;
+
+					case 'm3':
+						material.uniforms[ name ].value = new Matrix3().fromArray( uniform.value );
 
 					case 'm4':
 						material.uniforms[ name ].value = new Matrix4().fromArray( uniform.value );

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -158,6 +158,13 @@ ShaderMaterial.prototype.toJSON = function ( meta ) {
 				value: value.toArray()
 			};
 
+		} else if ( value && value.isMatrix3 ) {
+
+			data.uniforms[ name ] = {
+				type: 'm3',
+				value: value.toArray()
+			};
+
 		} else if ( value && value.isMatrix4 ) {
 
 			data.uniforms[ name ] = {


### PR DESCRIPTION
Missed `Matrix3` in the initial commit that added support for serialization/deserialization.