### PR TITLE
Improved Lambert shadowmaps + Hemisphere light

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
@@ -13,8 +13,15 @@ backGeometry.viewDir = geometry.viewDir;
 
 vLightFront = vec3( 0.0 );
 
+#if defined (USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+	vAmbientLightFront = vec3( 0.0 );
+#endif
+
 #ifdef DOUBLE_SIDED
 	vLightBack = vec3( 0.0 );
+	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+		vAmbientLightBack = vec3( 0.0 );
+	#endif
 #endif
 
 IncidentLight directLight;
@@ -103,11 +110,19 @@ vec3 directLightColor_Diffuse;
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-		vLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+		#ifdef USE_SHADOWMAP
+			vAmbientLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+		#else
+			vLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+		#endif
 
 		#ifdef DOUBLE_SIDED
 
-			vLightBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
+			#ifdef USE_SHADOWMAP
+				vAmbientLightBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
+			#else
+				vLightBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
+			#endif
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
@@ -12,16 +12,11 @@ backGeometry.normal = -geometry.normal;
 backGeometry.viewDir = geometry.viewDir;
 
 vLightFront = vec3( 0.0 );
-
-#if defined (USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-	vAmbientLightFront = vec3( 0.0 );
-#endif
+vIndirectFront = vec3( 0.0 );
 
 #ifdef DOUBLE_SIDED
 	vLightBack = vec3( 0.0 );
-	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-		vAmbientLightBack = vec3( 0.0 );
-	#endif
+	vIndirectBack = vec3( 0.0 );
 #endif
 
 IncidentLight directLight;
@@ -110,19 +105,11 @@ vec3 directLightColor_Diffuse;
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-		#ifdef USE_SHADOWMAP
-			vAmbientLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
-		#else
-			vLightFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
-		#endif
+		vIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
 
 		#ifdef DOUBLE_SIDED
 
-			#ifdef USE_SHADOWMAP
-				vAmbientLightBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
-			#else
-				vLightBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
-			#endif
+			vIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );
 
 		#endif
 

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -4,12 +4,17 @@ uniform vec3 emissive;
 uniform float opacity;
 
 varying vec3 vLightFront;
+#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+	varying vec3 vAmbientLightFront;
+#endif
 
 #ifdef DOUBLE_SIDED
-
 	varying vec3 vLightBack;
-
+	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+		varying vec3 vAmbientLightBack;
+	#endif
 #endif
+
 
 #include <common>
 #include <packing>
@@ -51,6 +56,18 @@ void main() {
 	// accumulation
 	reflectedLight.indirectDiffuse = getAmbientLightIrradiance( ambientLightColor );
 
+	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+		#ifdef DOUBLE_SIDED
+
+			reflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vAmbientLightFront : vAmbientLightBack;
+
+		#else
+
+			reflectedLight.indirectDiffuse += vAmbientLightFront;
+
+		#endif
+	#endif
+
 	#include <lightmap_fragment>
 
 	reflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );
@@ -81,6 +98,5 @@ void main() {
 	#include <fog_fragment>
 	#include <premultiplied_alpha_fragment>
 	#include <dithering_fragment>
-
 }
 `;

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -4,15 +4,11 @@ uniform vec3 emissive;
 uniform float opacity;
 
 varying vec3 vLightFront;
-#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-	varying vec3 vAmbientLightFront;
-#endif
+varying vec3 vIndirectFront;
 
 #ifdef DOUBLE_SIDED
 	varying vec3 vLightBack;
-	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-		varying vec3 vAmbientLightBack;
-	#endif
+	varying vec3 vIndirectBack;
 #endif
 
 
@@ -56,16 +52,14 @@ void main() {
 	// accumulation
 	reflectedLight.indirectDiffuse = getAmbientLightIrradiance( ambientLightColor );
 
-	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-		#ifdef DOUBLE_SIDED
+	#ifdef DOUBLE_SIDED
 
-			reflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vAmbientLightFront : vAmbientLightBack;
+		reflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;
 
-		#else
+	#else
 
-			reflectedLight.indirectDiffuse += vAmbientLightFront;
+		reflectedLight.indirectDiffuse += vIndirectFront;
 
-		#endif
 	#endif
 
 	#include <lightmap_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
@@ -2,11 +2,15 @@ export default /* glsl */`
 #define LAMBERT
 
 varying vec3 vLightFront;
+#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+	varying vec3 vAmbientLightFront;
+#endif
 
 #ifdef DOUBLE_SIDED
-
 	varying vec3 vLightBack;
-
+	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
+		varying vec3 vAmbientLightBack;
+	#endif
 #endif
 
 #include <common>

--- a/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_vert.glsl.js
@@ -2,15 +2,11 @@ export default /* glsl */`
 #define LAMBERT
 
 varying vec3 vLightFront;
-#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-	varying vec3 vAmbientLightFront;
-#endif
+varying vec3 vIndirectFront;
 
 #ifdef DOUBLE_SIDED
 	varying vec3 vLightBack;
-	#if defined(USE_SHADOWMAP) && NUM_HEMI_LIGHTS > 0
-		varying vec3 vAmbientLightBack;
-	#endif
+	varying vec3 vIndirectBack;
 #endif
 
 #include <common>
@@ -51,6 +47,5 @@ void main() {
 	#include <lights_lambert_vertex>
 	#include <shadowmap_vertex>
 	#include <fog_vertex>
-
 }
 `;


### PR DESCRIPTION
I changed the indirect lighting on the Lambert material so that shadows aren't pitch black when using hemispherical light. I accomplished this with an extra varying for ambient light, but only if using shadows and a hemisphere light. Supports double-sided materials.
![new-lambert](https://user-images.githubusercontent.com/453513/50998211-a0391680-14db-11e9-9020-e45ceb25ad50.png)

Fixes #15530.

