### PR TITLE
Reflector: Fix rendering issue with WebGLBackground

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -63,7 +63,6 @@ THREE.Reflector = function ( geometry, options ) {
 	material.uniforms[ "textureMatrix" ].value = textureMatrix;
 
 	this.material = material;
-	this.renderOrder = - Infinity; // render first
 
 	this.onBeforeRender = function ( renderer, scene, camera ) {
 


### PR DESCRIPTION
Fixes #14006

The background needs to be rendered first, not the reflector. Otherwise you can see visual glitches like in the WebVR sandbox demo:

https://threejs.org/examples/webvr_sandbox.html