### PR TITLE
GLTFLoader: Reset spotlight default position.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -365,6 +365,10 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
+		// Some lights (e.g. spot) default to a position other than the origin. Reset the position
+		// here, because node-level parsing will only override position if explicitly specified.
+		lightNode.position.set( 0, 0, 0 );
+
 		lightNode.decay = 2;
 
 		if ( lightDef.intensity !== undefined ) lightNode.intensity = lightDef.intensity;


### PR DESCRIPTION
Fixes an inconsistency shown in https://github.com/KhronosGroup/glTF-Sample-Models/pull/210.