### PR TITLE
Update docs for BufferGeometryUtils

### DIFF
--- a/docs/examples/utils/BufferGeometryUtils.html
+++ b/docs/examples/utils/BufferGeometryUtils.html
@@ -45,6 +45,34 @@
 
     </p>
 
+    <h3>[method:InterleavedBufferAttribute interleaveAttributes]( [param:Array attributes] )</h3>
+    <p>
+    attributes -- Array of [page:BufferAttribute BufferAttribute] instances.<br /><br />
+
+    Interleaves a set of attributes and returns a new array of corresponding attributes that share
+    a single InterleavedBuffer instance. All attributes must have compatible types. If merge does not
+    succeed, the method returns null.
+
+    </p>
+
+    <h3>[method:Number estimateBytesUsed]( [param:BufferGeometry geometry] )</h3>
+    <p>
+    geometry -- Instance of [page:BufferGeometry BufferGeometry] to estimate the memory use of.<br /><br />
+
+    Returns the amount of bytes used by all attributes to represent the geometry.
+
+    </p>
+
+    <h3>[method:BufferGeometry mergeVertices]( [param:BufferGeometry geometry], [param:Number tolerance] )</h3>
+    <p>
+    geometry -- Instance of [page:BufferGeometry BufferGeometry] to merge the vertices of.<br />
+    tolerance -- The maximum allowable difference between vertex attributes to merge. Defaults to 1e-4.<br /><br />
+
+    Returns a new [page:BufferGeometry BufferGeometry] with vertices closer than the provided tolerance merged.
+    All vertex attributes are accounted for.
+
+    </p>
+
     <h2>Source</h2>
 
     [link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/BufferGeometryUtils.js examples/js/utils/BufferGeometryUtils.js]

--- a/docs/examples/utils/BufferGeometryUtils.html
+++ b/docs/examples/utils/BufferGeometryUtils.html
@@ -68,8 +68,8 @@
     geometry -- Instance of [page:BufferGeometry BufferGeometry] to merge the vertices of.<br />
     tolerance -- The maximum allowable difference between vertex attributes to merge. Defaults to 1e-4.<br /><br />
 
-    Returns a new [page:BufferGeometry BufferGeometry] with vertices closer than the provided tolerance merged.
-    All vertex attributes are accounted for.
+    Returns a new [page:BufferGeometry BufferGeometry] with vertices for which all similar vertex attributes
+    (within tolerance) are merged.
 
     </p>
 


### PR DESCRIPTION
Add docs for functions add in PR #14116.

- `interleaveAttributes`
- `estimateBytesUsed`
- `mergeVertices`

http://raw.githack.com/gkjohnson/three.js/buffer-geometry-utils-docs/docs/#examples/utils/BufferGeometryUtils