### PR TITLE
Fix Code Style and Bugs in Module Examples

### DIFF
--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -1163,4 +1163,4 @@ Object.defineProperties( MapControls.prototype, {
 
 } );
 
-export { MapControls }
+export { MapControls };

--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -1036,7 +1036,7 @@ var MapControls = function ( object, domElement ) {
 };
 
 MapControls.prototype = Object.create( EventDispatcher.prototype );
-MapControls.prototype.constructor = THREE.MapControls;
+MapControls.prototype.constructor = MapControls;
 
 Object.defineProperties( MapControls.prototype, {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1059,4 +1059,4 @@ Object.defineProperties( OrbitControls.prototype, {
 
 } );
 
-export { OrbitControls }
+export { OrbitControls };

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -932,7 +932,7 @@ var OrbitControls = function ( object, domElement ) {
 };
 
 OrbitControls.prototype = Object.create( EventDispatcher.prototype );
-OrbitControls.prototype.constructor = THREE.OrbitControls;
+OrbitControls.prototype.constructor = OrbitControls;
 
 Object.defineProperties( OrbitControls.prototype, {
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -499,7 +499,7 @@ var TrackballControls = function ( object, domElement ) {
 	function touchstart( event ) {
 
 		if ( _this.enabled === false ) return;
-		
+
 		event.preventDefault();
 
 		switch ( event.touches.length ) {
@@ -625,4 +625,4 @@ var TrackballControls = function ( object, domElement ) {
 TrackballControls.prototype = Object.create( EventDispatcher.prototype );
 TrackballControls.prototype.constructor = THREE.TrackballControls;
 
-export { TrackballControls }
+export { TrackballControls };

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -623,6 +623,6 @@ var TrackballControls = function ( object, domElement ) {
 };
 
 TrackballControls.prototype = Object.create( EventDispatcher.prototype );
-TrackballControls.prototype.constructor = THREE.TrackballControls;
+TrackballControls.prototype.constructor = TrackballControls;
 
 export { TrackballControls };

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -432,7 +432,7 @@ var GLTFLoader = ( function () {
 
 			case 'directional':
 				lightNode = new DirectionalLight( color );
-				lightNode.target.position.set( 0, 0, -1 );
+				lightNode.target.position.set( 0, 0, - 1 );
 				lightNode.add( lightNode.target );
 				break;
 
@@ -450,7 +450,7 @@ var GLTFLoader = ( function () {
 				lightDef.spot.outerConeAngle = lightDef.spot.outerConeAngle !== undefined ? lightDef.spot.outerConeAngle : Math.PI / 4.0;
 				lightNode.angle = lightDef.spot.outerConeAngle;
 				lightNode.penumbra = 1.0 - lightDef.spot.innerConeAngle / lightDef.spot.outerConeAngle;
-				lightNode.target.position.set( 0, 0, -1 );
+				lightNode.target.position.set( 0, 0, - 1 );
 				lightNode.add( lightNode.target );
 				break;
 
@@ -1058,6 +1058,7 @@ var GLTFLoader = ( function () {
 					uniforms.refractionRatio.value = material.refractionRatio;
 
 					uniforms.maxMipLevel.value = renderer.properties.get( material.envMap ).__maxMipLevel;
+
 				}
 
 				uniforms.specular.value.copy( material.specular );
@@ -1450,8 +1451,10 @@ var GLTFLoader = ( function () {
 				var accessor = target.POSITION !== undefined
 					? parser.getDependency( 'accessor', target.POSITION )
 						.then( function ( accessor ) {
+
 							// Cloning not to pollute original accessor below
 							return cloneBufferAttribute( accessor );
+
 						} )
 					: geometry.attributes.position;
 
@@ -1465,7 +1468,9 @@ var GLTFLoader = ( function () {
 				var accessor = target.NORMAL !== undefined
 					? parser.getDependency( 'accessor', target.NORMAL )
 						.then( function ( accessor ) {
+
 							return cloneBufferAttribute( accessor );
+
 						} )
 					: geometry.attributes.normal;
 
@@ -1942,7 +1947,7 @@ var GLTFLoader = ( function () {
 
 				case 'light':
 					dependency = this.extensions[ EXTENSIONS.KHR_LIGHTS_PUNCTUAL ].loadLight( index );
-					break
+					break;
 
 				default:
 					throw new Error( 'Unknown type: ' + type );
@@ -3223,7 +3228,7 @@ var GLTFLoader = ( function () {
 
 		var nodeDef = json.nodes[ nodeIndex ];
 
-		return ( function() {
+		return ( function () {
 
 			// .isBone isn't in glTF spec. See .markDefs
 			if ( nodeDef.isBone === true ) {
@@ -3416,7 +3421,7 @@ var GLTFLoader = ( function () {
 
 						mesh.bind( new Skeleton( bones, boneInverses ), mesh.matrixWorld );
 
-					};
+					}
 
 					return node;
 
@@ -3487,4 +3492,4 @@ var GLTFLoader = ( function () {
 
 } )();
 
-export { GLTFLoader }
+export { GLTFLoader };

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -813,4 +813,4 @@ var OBJLoader = ( function () {
 
 } )();
 
-export { OBJLoader }
+export { OBJLoader };


### PR DESCRIPTION
- Adds missing semicolons and some other code style issues
- Fixes lingering references to `THREE.` in `MapControls`, `OrbitControls`, and `TrackballControls`, making them unusable.