### PR TITLE
JSM: Update Modularize Script to Produce Usable Modules

### DIFF
--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -83,7 +83,7 @@ function convert( path, ignoreList ) {
 
 	var keys = Object.keys( dependencies ).sort().map( value => '\n\t' + value ).toString();
 	var imports = `import {${keys}\n} from "../../../build/three.module.js";`;
-	var exports = `export { ${className} };`;
+	var exports = `export { ${className} };\n`;
 
 	var output = contents.replace( '_IMPORTS_', imports ) + '\n' + exports;
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -44,9 +44,9 @@ function convert( path, ignoreList ) {
 
 	} );
 
-	contents = contents.replace( /THREE\.([a-zA-Z0-9]+)\./g, function ( match, p1 ) {
+	contents = contents.replace( /THREE\.([a-zA-Z0-9]+)(\.{0,1})/g, function ( match, p1, p2 ) {
 
-		if ( p1 === className ) return `${p1}.`;
+		if ( p1 === className ) return `${p1}${p2}`;
 
 		return match;
 
@@ -83,7 +83,7 @@ function convert( path, ignoreList ) {
 
 	var keys = Object.keys( dependencies ).sort().map( value => '\n\t' + value ).toString();
 	var imports = `import {${keys}\n} from "../../../build/three.module.js";`;
-	var exports = `export { ${className} }`;
+	var exports = `export { ${className} };`;
 
 	var output = contents.replace( '_IMPORTS_', imports ) + '\n' + exports;
 


### PR DESCRIPTION
Updates the `modularize.js` script to automatically perform some of the fixes made in https://github.com/mrdoob/three.js/pull/15572.

Some of the notable changes that this results in:

### Update 1
```js
MapControls.prototype.constructor = THREE.MapControls;
```
to
```js
MapControls.prototype.constructor = MapControls;
```

### Update 2
```js
export { MapControls }
```
to
```js
export { MapControls };
```

### Update 3

This one may be undesirable but it's a side effect of the first fix without getting more sophisticated in excluding strings from the regex replacement.

```js
console.warn( 'THREE.MapControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
```
to
```js
console.warn( 'MapControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
```