### PR TITLE
New GLTFExporter exporter options "maxTextureWidth" and "maxTextureHeight"

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -96,6 +96,8 @@
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
+			<li>maxTextureWidth - int. Restricts the image maximum width to the given value. This option works only if embedImages is true. Default is 4096.</li>
+			<li>maxTextureHeight - int. Restricts the image maximum height to the given value. This option works only if embedImages is true. Default is 4096.</li>
 		</ul>
 		</p>
 		<p>

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -96,8 +96,7 @@
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
-			<li>maxTextureWidth - int. Restricts the image maximum width to the given value. This option works only if embedImages is true. Default is 4096.</li>
-			<li>maxTextureHeight - int. Restricts the image maximum height to the given value. This option works only if embedImages is true. Default is 4096.</li>
+			<li>maxTextureSize - int. Restricts the image maximum size (both width and height) to the given value. This option works only if embedImages is true. Default is Infinity.</li>
 		</ul>
 		</p>
 		<p>

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -711,14 +711,13 @@ THREE.GLTFExporter.prototype = {
 				canvas.width = Math.min( image.width, options.maxTextureSize );
 				canvas.height = Math.min( image.height, options.maxTextureSize );
 
-				if ( options.forcePowerOfTwoTextures ) {
+				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( canvas ) ) {
 
-					if(! isPowerOfTwo( image )) {
-						console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
-					}
+					console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
 
 					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
 					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
+
 				}
 
 				var ctx = canvas.getContext( '2d' );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -81,8 +81,7 @@ THREE.GLTFExporter.prototype = {
 			animations: [],
 			forceIndices: false,
 			forcePowerOfTwoTextures: false,
-			maxTextureHeight: 4096,
-			maxTextureWidth: 4096
+			maxTextureSize: Infinity
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -709,21 +708,27 @@ THREE.GLTFExporter.prototype = {
 
 				var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
 
-				if ( image.width > options.maxTextureWidth || image.height > options.maxTextureHeight ) {
+				canvas.width = Math.min( image.width, options.maxTextureSize );
+				canvas.height = Math.min( image.height, options.maxTextureSize );
 
-					console.warn( 'GLTFExporter: Resized too big image.', image );
-				}
+				if ( options.forcePowerOfTwoTextures) {
 
-				canvas.width = Math.min( image.width, options.maxTextureWidth );
-				canvas.height = Math.min( image.height, options.maxTextureHeight );
+					if(! isPowerOfTwo( image )) {
+						console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
+					}
 
-				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( image ) ) {
+					if(! THREE.Math.isPowerOfTwo( canvas.width )) {
+						console.warn( 'GLTFExporter: power-of-two textures requested, but the given maxTextureSize is not power-of-two.')
+					}
 
-					console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
-
-					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
-					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
-
+					// REMARK: These 'if' checks are performed just to avoid the unnecessary POW+LOG calls behind floorPowerOfTwo
+					if(! THREE.Math.isPowerOfTwo( canvas.width )) {
+						canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
+					}
+					
+					if(! THREE.Math.isPowerOfTwo( canvas.height )) {
+						canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
+					}
 				}
 
 				var ctx = canvas.getContext( '2d' );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -711,24 +711,14 @@ THREE.GLTFExporter.prototype = {
 				canvas.width = Math.min( image.width, options.maxTextureSize );
 				canvas.height = Math.min( image.height, options.maxTextureSize );
 
-				if ( options.forcePowerOfTwoTextures) {
+				if ( options.forcePowerOfTwoTextures ) {
 
 					if(! isPowerOfTwo( image )) {
 						console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
 					}
 
-					if(! THREE.Math.isPowerOfTwo( canvas.width )) {
-						console.warn( 'GLTFExporter: power-of-two textures requested, but the given maxTextureSize is not power-of-two.')
-					}
-
-					// REMARK: These 'if' checks are performed just to avoid the unnecessary POW+LOG calls behind floorPowerOfTwo
-					if(! THREE.Math.isPowerOfTwo( canvas.width )) {
-						canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
-					}
-					
-					if(! THREE.Math.isPowerOfTwo( canvas.height )) {
-						canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
-					}
+					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
+					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
 				}
 
 				var ctx = canvas.getContext( '2d' );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -80,7 +80,9 @@ THREE.GLTFExporter.prototype = {
 			embedImages: true,
 			animations: [],
 			forceIndices: false,
-			forcePowerOfTwoTextures: false
+			forcePowerOfTwoTextures: false,
+			maxTextureHeight: 4096,
+			maxTextureWidth: 4096
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -707,8 +709,13 @@ THREE.GLTFExporter.prototype = {
 
 				var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
 
-				canvas.width = image.width;
-				canvas.height = image.height;
+				if ( image.width > options.maxTextureWidth || image.height > options.maxTextureHeight ) {
+
+					console.warn( 'GLTFExporter: Resized too big image.', image );
+				}
+
+				canvas.width = Math.min( image.width, options.maxTextureWidth );
+				canvas.height = Math.min( image.height, options.maxTextureHeight );
 
 				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( image ) ) {
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -36,6 +36,8 @@
 			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
 			<label><input id="option_forceindices" name="visible" type="checkbox">Force indices</label>
 			<label><input id="option_forcepot" name="visible" type="checkbox">Force POT textures</label>
+			<label><input id="option_maxwidth" name="maxWidth" type="number" value="4096" min="2" max="4096"> Max texture width</label>
+			<label><input id="option_maxheight" name="maxHeight" type="number" value="4096" min="2" max="4096"> Max texture height</label>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -56,7 +58,10 @@
 					truncateDrawRange: document.getElementById( 'option_drawrange' ).checked,
 					binary: document.getElementById( 'option_binary' ).checked,
 					forceIndices: document.getElementById( 'option_forceindices' ).checked,
-					forcePowerOfTwoTextures: document.getElementById( 'option_forcepot' ).checked
+					forcePowerOfTwoTextures: document.getElementById( 'option_forcepot' ).checked,
+					maxTextureHeight: parseInt(document.getElementById('option_maxheight').nodeValue, 10) || 4096, // To prevent NaN value
+					maxTextureWidth: parseInt(document.getElementById('option_maxheight').nodeValue, 10) || 4096 // To prevent NaN value
+
 				};
 				gltfExporter.parse( input, function ( result ) {
 
@@ -112,6 +117,22 @@
 
 			} );
 
+			// ---------------------------------------------------------------------
+			// Force never empty inputs for texture max width/height
+			// ---------------------------------------------------------------------
+
+			document.getElementById('option_maxwidth').addEventListener('change', function (e) {
+    			if (e.target.value == '') {
+      				e.target.value = parseInt(document.getElementById('option_maxwidth').getAttribute('max'), 10)
+    			}
+			  } );
+			  
+			document.getElementById('option_maxheight').addEventListener('change', function (e) {
+				if (e.target.value == '') {
+					e.target.value = parseInt(document.getElementById('option_maxheight').getAttribute('max'), 10)
+				}
+			} );
+			  
 
 			var link = document.createElement( 'a' );
 			link.style.display = 'none';

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -36,8 +36,7 @@
 			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
 			<label><input id="option_forceindices" name="visible" type="checkbox">Force indices</label>
 			<label><input id="option_forcepot" name="visible" type="checkbox">Force POT textures</label>
-			<label><input id="option_maxwidth" name="maxWidth" type="number" value="4096" min="2" max="4096"> Max texture width</label>
-			<label><input id="option_maxheight" name="maxHeight" type="number" value="4096" min="2" max="4096"> Max texture height</label>
+			<label><input id="option_maxsize" name="maxSize" type="number" value="4096" min="2" max="8192" step="1"> Max texture size</label>
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -59,8 +58,7 @@
 					binary: document.getElementById( 'option_binary' ).checked,
 					forceIndices: document.getElementById( 'option_forceindices' ).checked,
 					forcePowerOfTwoTextures: document.getElementById( 'option_forcepot' ).checked,
-					maxTextureHeight: parseInt(document.getElementById('option_maxheight').nodeValue, 10) || 4096, // To prevent NaN value
-					maxTextureWidth: parseInt(document.getElementById('option_maxheight').nodeValue, 10) || 4096 // To prevent NaN value
+					maxTextureSize: Number(document.getElementById('option_maxsize').value) || Infinity // To prevent NaN value
 
 				};
 				gltfExporter.parse( input, function ( result ) {
@@ -116,23 +114,6 @@
 				exportGLTF( [ scene1, gridHelper ] );
 
 			} );
-
-			// ---------------------------------------------------------------------
-			// Force never empty inputs for texture max width/height
-			// ---------------------------------------------------------------------
-
-			document.getElementById('option_maxwidth').addEventListener('change', function (e) {
-    			if (e.target.value == '') {
-      				e.target.value = parseInt(document.getElementById('option_maxwidth').getAttribute('max'), 10)
-    			}
-			  } );
-			  
-			document.getElementById('option_maxheight').addEventListener('change', function (e) {
-				if (e.target.value == '') {
-					e.target.value = parseInt(document.getElementById('option_maxheight').getAttribute('max'), 10)
-				}
-			} );
-			  
 
 			var link = document.createElement( 'a' );
 			link.style.display = 'none';


### PR DESCRIPTION
New export options added to the GLTFExporter allowing to resize the embedded textures restricting them to a maximum of 'maxTextureWidth' x 'maxTextureHeight'. Example and documentation updated according to it.