### PR TITLE
Mesh: Improve handling of material index.

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -264,6 +264,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 								if ( intersection ) {
 
 									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in indexed buffer semantics
+									intersection.face.materialIndex = group.materialIndex;
 									intersects.push( intersection );
 
 								}
@@ -321,6 +322,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 								if ( intersection ) {
 
 									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in non-indexed buffer semantics
+									intersection.face.materialIndex = group.materialIndex;
 									intersects.push( intersection );
 
 								}


### PR DESCRIPTION
When raycasting against a mesh with a `BufferGeoemtry` and multiple materials, `Mesh.raycast()` now returns the material index so it's easier for the user to determine the material of the intersected face. This was already possible with `Geometry`.