### PR TITLE
GLTFExporter: aoMap's texCoord should be 1

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -981,7 +981,10 @@ THREE.GLTFExporter.prototype = {
 			// occlusionTexture
 			if ( material.aoMap ) {
 
-				var occlusionMapDef = { index: processTexture( material.aoMap ) };
+				var occlusionMapDef = { 
+					index: processTexture( material.aoMap ),
+					texCoord: 1
+				};
 
 				if ( material.aoMapIntensity !== 1.0 ) {
 


### PR DESCRIPTION
In ```Three.js```, aoMap always use the second uv.