### PR TITLE
GLTFExporter: Omit .range=0.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -385,7 +385,7 @@ THREE.GLTFExporter.prototype = {
 			if ( texture.repeat.x !== 1 || texture.repeat.y !== 1 ) {
 
 				transformDef.scale = texture.repeat.toArray();
-				didTransform = true;				
+				didTransform = true;
 
 			}
 
@@ -1608,12 +1608,12 @@ THREE.GLTFExporter.prototype = {
 			} else if ( light.isPointLight ) {
 
 				lightDef.type = 'point';
-				lightDef.range = light.distance;
+				if ( light.distance > 0 ) lightDef.range = light.distance;
 
 			} else if ( light.isSpotLight ) {
 
 				lightDef.type = 'spot';
-				lightDef.range = light.distance;
+				if ( light.distance > 0 ) lightDef.range = light.distance;
 				lightDef.spot = {};
 				lightDef.spot.innerConeAngle = ( light.penumbra - 1.0 ) * light.angle * -1.0;
 				lightDef.spot.outerConeAngle = light.angle;


### PR DESCRIPTION
In three.js with `render.physicallyCorrectLights=true`, a range of zero means:

> ...light will attenuate according to inverse-square law to infinite distance.

In glTF, range must be > 0 when specified, and should be left undefined for the behavior above.