### PR TITLE
Audio: Fix usage of detune

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -95,16 +95,17 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		var source = this.context.createBufferSource();
 
 		source.buffer = this.buffer;
-		this.setDetune( this.detune );
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
-		source.playbackRate.setValueAtTime( this.playbackRate, this.startTime );
 		this.startTime = this.context.currentTime;
 		source.start( this.startTime, this.offset );
 
 		this.isPlaying = true;
 
 		this.source = source;
+
+		this.setDetune( this.detune );
+		this.setPlaybackRate( this.playbackRate );
 
 		return this.connect();
 
@@ -228,12 +229,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		this.detune = value;
 
-		if ( this.source.detune === undefined ) {
-
-			console.warn( 'THREE.Audio: AudioBufferSourceNode.detune not supported by the browser.' );
-			return;
-
-		}
+		if ( this.source.detune === undefined ) return; // only set detune when available
 
 		if ( this.isPlaying === true ) {
 


### PR DESCRIPTION
Right now, `Audio.play()` in `dev` is broken since `Audio.detune()` tries to access `Audio.source` before it is set in `Audio.play()`. Besides, the actual detune value is never set to the `AudioBufferSourceNode` since `Audio.playing` is still `false`.

The PR fixes both bugs and ensures a consistent setting of a `AudioBufferSourceNode` properties which have a `AudioParam` value (`detune` and `playbackRate`).