### PR TITLE
Update TypeScript definition typings to match @types/three

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -44,6 +44,7 @@ export class BufferGeometry extends EventDispatcher {
   boundingBox: Box3;
   boundingSphere: Sphere;
   drawRange: { start: number; count: number };
+  userData: {[key: string]: any};
 
   getIndex(): BufferAttribute;
   setIndex(index: BufferAttribute | number[]): void;

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -308,6 +308,8 @@ export class Object3D extends EventDispatcher {
    */
   updateMatrixWorld(force: boolean): void;
 
+  updateWorldMatrix(updateParents: boolean, updateChildren: boolean): void;
+
   toJSON(meta?: {
     geometries: any;
     materials: any;

--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -125,4 +125,5 @@ export class Color {
   equals(color: Color): boolean;
   fromArray(rgb: number[], offset?: number): this;
   toArray(array?: number[], offset?: number): number[];
+  toArray(xyz: ArrayLike<number>, offset?: number): ArrayLike<number>;
 }

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -401,8 +401,17 @@ export class Vector2 implements Vector {
    * Returns an array [x, y], or copies x and y into the provided array.
    * @param array (optional) array to store the vector to. If this is not provided, a new array will be created.
    * @param offset (optional) optional offset into the array.
+   * @return The created or provided array.
    */
   toArray(array?: number[], offset?: number): number[];
+
+  /**
+   * Copies x and y into the provided array-like.
+   * @param array array-like to store the vector to.
+   * @param offset (optional) optional offset into the array.
+   * @return The provided array-like.
+   */
+  toArray(array: ArrayLike<number>, offset?: number): ArrayLike<number>;
 
   /**
    * Sets this vector's x and y values from the attribute.

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -112,7 +112,7 @@ export class Vector3 implements Vector {
 
   applyQuaternion(q: Quaternion): this;
 
-  project(camrea: Camera): this;
+  project(camera: Camera): this;
 
   unproject(camera: Camera): this;
 
@@ -246,7 +246,23 @@ export class Vector3 implements Vector {
   equals(v: Vector3): boolean;
 
   fromArray(xyz: number[], offset?: number): Vector3;
+
+  /**
+   * Returns an array [x, y, z], or copies x, y and z into the provided array.
+   * @param array (optional) array to store the vector to. If this is not provided, a new array will be created.
+   * @param offset (optional) optional offset into the array.
+   * @return The created or provided array.
+   */
   toArray(xyz?: number[], offset?: number): number[];
+
+  /**
+   * Copies x, y and z into the provided array-like.
+   * @param array array-like to store the vector to.
+   * @param offset (optional) optional offset into the array.
+   * @return The provided array-like.
+   */
+  toArray(xyz: ArrayLike<number>, offset?: number): ArrayLike<number>;
+
   fromBufferAttribute(
     attribute: BufferAttribute,
     index: number,


### PR DESCRIPTION
This a port of [all the changes](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/master/types/three) that have been made to @types/three since the [typings were generated from @types/three](https://github.com/mrdoob/three.js/pull/15597). We should make sure to [delete the typing on the DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped#removing-a-package) once r101 is released to avoid having to do this in the future.