### PR TITLE
Cache and reuse attribute buffer bindings

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -648,6 +648,12 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	var boundBufferCache = []
+	for(var i = 0; i < 64; i++) {
+		boundBufferCache[i] = null
+	}
+	var boundIndexBuffer = null;
+
 	this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
 
 		var frontFaceCW = ( object.isMesh && object.normalMatrix.determinant() < 0 );
@@ -706,9 +712,10 @@ function WebGLRenderer( parameters ) {
 
 			setupVertexAttributes( material, program, geometry );
 
-			if ( index !== null ) {
+			if ( index !== null && boundIndexBuffer !== attribute.buffer) {
 
 				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
+				boundIndexBuffer = attribute.buffer;
 
 			}
 
@@ -885,8 +892,11 @@ function WebGLRenderer( parameters ) {
 
 						}
 
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+						if(boundBufferCache[programAttribute] !== buffer) {
+							_gl.bindBuffer( 34962, buffer );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+							boundBufferCache[programAttribute] = buffer;
+						}
 
 					} else {
 
@@ -906,8 +916,11 @@ function WebGLRenderer( parameters ) {
 
 						}
 
-						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+						if(boundBufferCache[programAttribute] !== buffer) {
+							_gl.bindBuffer( 34962, buffer );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+							boundBufferCache[programAttribute] = buffer;
+						}
 
 					}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -648,9 +648,11 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	var boundBufferCache = []
-	for(var i = 0; i < 64; i++) {
-		boundBufferCache[i] = null
+	var boundBufferCache = [];
+	for ( var i = 0; i < 64; i ++ ) {
+
+		boundBufferCache[ i ] = null;
+
 	}
 	var boundIndexBuffer = null;
 
@@ -712,7 +714,7 @@ function WebGLRenderer( parameters ) {
 
 			setupVertexAttributes( material, program, geometry );
 
-			if ( index !== null && boundIndexBuffer !== attribute.buffer) {
+			if ( index !== null && boundIndexBuffer !== attribute.buffer ) {
 
 				_gl.bindBuffer( _gl.ELEMENT_ARRAY_BUFFER, attribute.buffer );
 				boundIndexBuffer = attribute.buffer;
@@ -892,10 +894,12 @@ function WebGLRenderer( parameters ) {
 
 						}
 
-						if(boundBufferCache[programAttribute] !== buffer) {
+						if ( boundBufferCache[ programAttribute ] !== buffer ) {
+
 							_gl.bindBuffer( 34962, buffer );
 							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
-							boundBufferCache[programAttribute] = buffer;
+							boundBufferCache[ programAttribute ] = buffer;
+
 						}
 
 					} else {
@@ -916,10 +920,12 @@ function WebGLRenderer( parameters ) {
 
 						}
 
-						if(boundBufferCache[programAttribute] !== buffer) {
+						if ( boundBufferCache[ programAttribute ] !== buffer ) {
+
 							_gl.bindBuffer( 34962, buffer );
 							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
-							boundBufferCache[programAttribute] = buffer;
+							boundBufferCache[ programAttribute ] = buffer;
+
 						}
 
 					}


### PR DESCRIPTION
Improved rendering speed by preventing rebinding of identical attribute buffers, if for instance you reuse some buffers across objects, like duplicated meshes whose only difference are the UV buffer.

Note: this only improves performance if you have geometries that share attributes whose render order is back to back.