### PR TITLE
WebGLBackground: CubeTexture shouldn't test depth

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -60,7 +60,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 						vertexShader: ShaderLib.cube.vertexShader,
 						fragmentShader: ShaderLib.cube.fragmentShader,
 						side: BackSide,
-						depthTest: true,
+						depthTest: false,
 						depthWrite: false,
 						fog: false
 					} )


### PR DESCRIPTION
Follow up fix from #15329, the render list is ordered such that the background is first on the list, but the WebGLBackground box mesh still checks the depth buffer (the non cube texture does not)