### PR TITLE
Indirect specular dark fresnel fix

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -128,7 +128,11 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 
 		BRDF_Specular_Multiscattering_Environment( geometry, material.specularColor, material.specularRoughness, singleScattering, multiScattering );
 
-		vec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );
+		// The multiscattering paper uses the below formula for calculating diffuse 
+		// for dielectrics, but this is already handled when initially computing the 
+		// specular and diffuse color, so we can just use the diffuseColor directly.
+		//vec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );
+		vec3 diffuse = material.diffuseColor;
 
 		reflectedLight.indirectSpecular += clearCoatInv * radiance * singleScattering;
 		reflectedLight.indirectDiffuse += multiScattering * cosineWeightedIrradiance;


### PR DESCRIPTION
Diffuse color has already been calculated relative to the specular, so use that directly to fix dark fresnel for indirect specular lighting. I *believe* this is already handled here, but could use a second set of eyes:

https://github.com/mrdoob/three.js/blob/5283af5e535c0b0f0602edc9f5ef413c6acd1185/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js#L3

This still passes the furnace test and looks similar to the previous implementation, except slightly brighter fresnel; here's a gif flipping between the two, not terribly exciting for dielectrics, but better than the dark fresnel border! (Look at the upper left edge, and the edges inside the knot)

![output_7d0qm6](https://user-images.githubusercontent.com/641267/52018342-f11aaa00-249e-11e9-8c63-5034bb429419.gif)
