### PR TITLE
NodeMaterial - fix name conflict + label + gets and sets

### DIFF
--- a/examples/js/nodes/accessors/CameraNode.js
+++ b/examples/js/nodes/accessors/CameraNode.js
@@ -101,7 +101,7 @@ CameraNode.prototype.getType = function ( builder ) {
 
 };
 
-CameraNode.prototype.isUnique = function ( builder ) {
+CameraNode.prototype.getUnique = function ( builder ) {
 
 	switch ( this.scope ) {
 
@@ -116,7 +116,7 @@ CameraNode.prototype.isUnique = function ( builder ) {
 
 };
 
-CameraNode.prototype.isShared = function ( builder ) {
+CameraNode.prototype.getShared = function ( builder ) {
 
 	switch ( this.scope ) {
 

--- a/examples/js/nodes/accessors/NormalNode.js
+++ b/examples/js/nodes/accessors/NormalNode.js
@@ -21,7 +21,7 @@ NormalNode.prototype = Object.create( TempNode.prototype );
 NormalNode.prototype.constructor = NormalNode;
 NormalNode.prototype.nodeType = "Normal";
 
-NormalNode.prototype.isShared = function ( builder ) {
+NormalNode.prototype.getShared = function ( builder ) {
 
 	switch ( this.scope ) {
 

--- a/examples/js/nodes/accessors/PositionNode.js
+++ b/examples/js/nodes/accessors/PositionNode.js
@@ -36,7 +36,7 @@ PositionNode.prototype.getType = function ( ) {
 
 };
 
-PositionNode.prototype.isShared = function ( builder ) {
+PositionNode.prototype.getShared = function ( builder ) {
 
 	switch ( this.scope ) {
 

--- a/examples/js/nodes/core/FunctionNode.js
+++ b/examples/js/nodes/core/FunctionNode.js
@@ -25,7 +25,7 @@ FunctionNode.prototype.nodeType = "Function";
 
 FunctionNode.prototype.useKeywords = true;
 
-FunctionNode.prototype.isShared = function ( builder, output ) {
+FunctionNode.prototype.getShared = function ( builder, output ) {
 
 	return ! this.isMethod;
 

--- a/examples/js/nodes/core/InputNode.js
+++ b/examples/js/nodes/core/InputNode.js
@@ -18,7 +18,15 @@ function InputNode( type, params ) {
 InputNode.prototype = Object.create( TempNode.prototype );
 InputNode.prototype.constructor = InputNode;
 
-InputNode.prototype.isReadonly = function ( builder ) {
+InputNode.prototype.setReadonly = function ( value ) {
+
+	this.readonly = value;
+
+	return this;
+
+};
+
+InputNode.prototype.getReadonly = function ( builder ) {
 
 	return this.readonly;
 
@@ -48,7 +56,7 @@ InputNode.prototype.generate = function ( builder, output, uuid, type, ns, needs
 	type = type || this.getType( builder );
 
 	var data = builder.getNodeData( uuid ),
-		readonly = this.isReadonly( builder ) && this.generateReadonly !== undefined;
+		readonly = this.getReadonly( builder ) && this.generateReadonly !== undefined;
 
 	if ( readonly ) {
 
@@ -60,7 +68,7 @@ InputNode.prototype.generate = function ( builder, output, uuid, type, ns, needs
 
 			if ( ! data.vertex ) {
 
-				data.vertex = builder.createVertexUniform( type, this, ns, needsUpdate );
+				data.vertex = builder.createVertexUniform( type, this, ns, needsUpdate, this.getLabel() );
 
 			}
 
@@ -70,7 +78,7 @@ InputNode.prototype.generate = function ( builder, output, uuid, type, ns, needs
 
 			if ( ! data.fragment ) {
 
-				data.fragment = builder.createFragmentUniform( type, this, ns, needsUpdate );
+				data.fragment = builder.createFragmentUniform( type, this, ns, needsUpdate, this.getLabel() );
 
 			}
 

--- a/examples/js/nodes/core/NodeBuilder.js
+++ b/examples/js/nodes/core/NodeBuilder.js
@@ -443,9 +443,7 @@ NodeBuilder.prototype = {
 
 	},
 
-	getVar: function ( uuid, type, ns, shader ) {
-
-		shader = shader || 'varying';
+	getVar: function ( uuid, type, ns, shader = 'varying', prefix = 'V', label = '' ) {
 
 		var vars = this.getVars( shader ),
 			data = vars[ uuid ];
@@ -453,7 +451,7 @@ NodeBuilder.prototype = {
 		if ( ! data ) {
 
 			var index = vars.length,
-				name = ns ? ns : 'nVv' + index;
+				name = ns ? ns : 'node' + prefix + index + ( label ? '_' + label : '' );
 
 			data = { name: name, type: type };
 
@@ -466,9 +464,9 @@ NodeBuilder.prototype = {
 
 	},
 
-	getTempVar: function ( uuid, type, ns ) {
+	getTempVar: function ( uuid, type, ns, label ) {
 
-		return this.getVar( uuid, type, ns, this.shader );
+		return this.getVar( uuid, type, ns, this.shader, 'T', label );
 
 	},
 
@@ -551,14 +549,14 @@ NodeBuilder.prototype = {
 
 	},
 
-	createUniform: function ( shader, type, node, ns, needsUpdate ) {
+	createUniform: function ( shader, type, node, ns, needsUpdate, label ) {
 
 		var uniforms = this.inputs.uniforms,
 			index = uniforms.list.length;
 
 		var uniform = new NodeUniform( {
 			type: type,
-			name: ns ? ns : 'nVu' + index,
+			name: ns ? ns : 'nodeU' + index + ( label ? '_' + label : '' ),
 			node: node,
 			needsUpdate: needsUpdate
 		} );
@@ -574,15 +572,15 @@ NodeBuilder.prototype = {
 
 	},
 
-	createVertexUniform: function ( type, node, ns, needsUpdate ) {
+	createVertexUniform: function ( type, node, ns, needsUpdate, label ) {
 
-		return this.createUniform( 'vertex', type, node, ns, needsUpdate );
+		return this.createUniform( 'vertex', type, node, ns, needsUpdate, label );
 
 	},
 
-	createFragmentUniform: function ( type, node, ns, needsUpdate ) {
+	createFragmentUniform: function ( type, node, ns, needsUpdate, label ) {
 
-		return this.createUniform( 'fragment', type, node, ns, needsUpdate );
+		return this.createUniform( 'fragment', type, node, ns, needsUpdate, label );
 
 	},
 

--- a/examples/js/nodes/core/TempNode.js
+++ b/examples/js/nodes/core/TempNode.js
@@ -23,24 +23,24 @@ TempNode.prototype.build = function ( builder, output, uuid, ns ) {
 
 	output = output || this.getType( builder );
 
-	if ( this.isShared( builder, output ) ) {
+	if ( this.getShared( builder, output ) ) {
 
-		var isUnique = this.isUnique( builder, output );
+		var getUnique = this.getUnique( builder, output );
 
-		if ( isUnique && this.constructor.uuid === undefined ) {
+		if ( getUnique && this.constructor.uuid === undefined ) {
 
 			this.constructor.uuid = THREE.Math.generateUUID();
 
 		}
 
-		uuid = builder.getUuid( uuid || this.getUuid(), ! isUnique );
+		uuid = builder.getUuid( uuid || this.getUuid(), ! getUnique );
 
 		var data = builder.getNodeData( uuid ),
 			type = data.output || this.getType( builder );
 
 		if ( builder.parsing ) {
 
-			if ( ( data.deps || 0 ) > 0 ) {
+			if ( ( data.deps || 0 ) > 0 || this.getLabel() ) {
 
 				this.appendDepsNode( builder, data, output );
 
@@ -50,13 +50,13 @@ TempNode.prototype.build = function ( builder, output, uuid, ns ) {
 
 			return Node.prototype.build.call( this, builder, output, uuid );
 
-		} else if ( isUnique ) {
+		} else if ( getUnique ) {
 
 			data.name = data.name || Node.prototype.build.call( this, builder, output, uuid );
 
 			return data.name;
 
-		} else if ( ! this.isShared( builder, type ) || ( ! builder.optimize || data.deps == 1 ) ) {
+		} else if ( ! this.getLabel() && ( ! this.getShared( builder, type ) || ( ! builder.optimize || data.deps === 1 ) ) ) {
 
 			return Node.prototype.build.call( this, builder, output, uuid );
 
@@ -88,15 +88,29 @@ TempNode.prototype.build = function ( builder, output, uuid, ns ) {
 
 };
 
-TempNode.prototype.isShared = function ( builder, output ) {
+TempNode.prototype.getShared = function ( builder, output ) {
 
 	return output !== 'sampler2D' && output !== 'samplerCube' && this.shared;
 
 };
 
-TempNode.prototype.isUnique = function ( builder, output ) {
+TempNode.prototype.getUnique = function ( builder, output ) {
 
 	return this.unique;
+
+};
+
+TempNode.prototype.setLabel = function ( name ) {
+
+	this.label = name;
+
+	return this;
+
+};
+
+TempNode.prototype.getLabel = function ( builder ) {
+
+	return this.label;
 
 };
 
@@ -104,7 +118,7 @@ TempNode.prototype.getUuid = function ( unique ) {
 
 	var uuid = unique || unique == undefined ? this.constructor.uuid || this.uuid : this.uuid;
 
-	if ( typeof this.scope == "string" ) uuid = this.scope + '-' + uuid;
+	if ( typeof this.scope === "string" ) uuid = this.scope + '-' + uuid;
 
 	return uuid;
 
@@ -122,11 +136,11 @@ TempNode.prototype.getTemp = function ( builder, uuid ) {
 
 TempNode.prototype.generate = function ( builder, output, uuid, type, ns ) {
 
-	if ( ! this.isShared( builder, output ) ) console.error( "THREE.TempNode is not shared!" );
+	if ( ! this.getShared( builder, output ) ) console.error( "THREE.TempNode is not shared!" );
 
 	uuid = uuid || this.uuid;
 
-	return builder.getTempVar( uuid, type || this.getType( builder ), ns ).name;
+	return builder.getTempVar( uuid, type || this.getType( builder ), ns, this.getLabel() ).name;
 
 };
 

--- a/examples/js/nodes/core/TempNode.js
+++ b/examples/js/nodes/core/TempNode.js
@@ -25,15 +25,15 @@ TempNode.prototype.build = function ( builder, output, uuid, ns ) {
 
 	if ( this.getShared( builder, output ) ) {
 
-		var getUnique = this.getUnique( builder, output );
+		var isUnique = this.getUnique( builder, output );
 
-		if ( getUnique && this.constructor.uuid === undefined ) {
+		if ( isUnique && this.constructor.uuid === undefined ) {
 
 			this.constructor.uuid = THREE.Math.generateUUID();
 
 		}
 
-		uuid = builder.getUuid( uuid || this.getUuid(), ! getUnique );
+		uuid = builder.getUuid( uuid || this.getUuid(), ! isUnique );
 
 		var data = builder.getNodeData( uuid ),
 			type = data.output || this.getType( builder );
@@ -50,7 +50,7 @@ TempNode.prototype.build = function ( builder, output, uuid, ns ) {
 
 			return Node.prototype.build.call( this, builder, output, uuid );
 
-		} else if ( getUnique ) {
+		} else if ( isUnique ) {
 
 			data.name = data.name || Node.prototype.build.call( this, builder, output, uuid );
 

--- a/examples/js/nodes/inputs/ScreenNode.js
+++ b/examples/js/nodes/inputs/ScreenNode.js
@@ -15,7 +15,7 @@ ScreenNode.prototype = Object.create( TextureNode.prototype );
 ScreenNode.prototype.constructor = ScreenNode;
 ScreenNode.prototype.nodeType = "Screen";
 
-ScreenNode.prototype.isUnique = function () {
+ScreenNode.prototype.getUnique = function () {
 
 	return true;
 

--- a/examples/js/nodes/utils/TimerNode.js
+++ b/examples/js/nodes/utils/TimerNode.js
@@ -24,7 +24,7 @@ TimerNode.prototype = Object.create( FloatNode.prototype );
 TimerNode.prototype.constructor = TimerNode;
 TimerNode.prototype.nodeType = "Timer";
 
-TimerNode.prototype.isReadonly = function () {
+TimerNode.prototype.getReadonly = function () {
 
 	// never use TimerNode as readonly but aways as "uniform"
 
@@ -32,7 +32,7 @@ TimerNode.prototype.isReadonly = function () {
 
 };
 
-TimerNode.prototype.isUnique = function () {
+TimerNode.prototype.getUnique = function () {
 
 	// share TimerNode "uniform" input if is used on more time with others TimerNode
 

--- a/examples/js/nodes/utils/VelocityNode.js
+++ b/examples/js/nodes/utils/VelocityNode.js
@@ -21,7 +21,7 @@ VelocityNode.prototype = Object.create( Vector3Node.prototype );
 VelocityNode.prototype.constructor = VelocityNode;
 VelocityNode.prototype.nodeType = "Velocity";
 
-VelocityNode.prototype.isReadonly = function ( builder ) {
+VelocityNode.prototype.getReadonly = function ( builder ) {
 
 	return false;
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -203,6 +203,7 @@
 					'misc / varying': 'varying',
 					'misc / void-function': 'void-function',
 					'misc / readonly': 'readonly',
+					'misc / label': 'label',
 					'misc / custom-attribute': 'custom-attribute'
 				} ).onFinishChange( function () {
 
@@ -2243,6 +2244,7 @@
 						//THREE.NodeLib.add( new THREE.ConstNode("float MY_CONST .05") )
 
 						// reserved keywords
+
 						console.log( THREE.NodeLib.keywords );
 
 						// keywords conflit? use this to disable:
@@ -2521,15 +2523,55 @@
 
 						mtl = new THREE.PhongNodeMaterial();
 
-						mtl.color = new THREE.ColorNode( 0xFFFFFF );
-						mtl.specular = new THREE.FloatNode( .5 );
-						mtl.shininess = new THREE.FloatNode( 15 );
-
 						// not use "uniform" input ( for optimization )
 						// instead use explicit declaration, for example:
 						// vec3( 1.0, 1.0, 1.0 ) instead "uniform vec3"
 						// if readonly is true not allow change the value after build the shader material
-						mtl.color.readonly = mtl.specular.readonly = mtl.shininess.readonly = true;
+
+						mtl.color = new THREE.ColorNode( 0xFFFFFF ).setReadonly( true );
+						mtl.specular = new THREE.FloatNode( .5 ).setReadonly( true );
+						mtl.shininess = new THREE.FloatNode( 15 ).setReadonly( true );
+
+						break;
+
+					case 'label':
+
+						// MATERIAL
+
+						mtl = new THREE.PhongNodeMaterial();
+
+						// label can be useful for finding the nodes as variables in debug level
+						// but this always force the creation of a variable
+						// same as the code can be writed in the same line (inline)
+						// for optimization this is not recommended
+
+						var colorInput = new THREE.ColorNode( 0xFFFFFF ).setLabel( "colorInput" );
+						var specularInput = new THREE.FloatNode( .5 ).setLabel( "specularInput" );
+
+						var colorMix = new THREE.OperatorNode(
+							colorInput,
+							new THREE.ColorNode( 0x6495ED ).setReadonly( true ),
+							THREE.OperatorNode.MUL
+						).setLabel("colorMix");
+
+						mtl.color = colorMix;
+						mtl.specular = specularInput;
+
+						// default: without use label
+						// this is optimized writed the code in a single line (inline)
+						// for the reason that this node is used only once in this shader program
+						mtl.shininess = new THREE.OperatorNode(
+							new THREE.FloatNode( 10 ).setReadonly( true ),
+							new THREE.FloatNode( 5 ).setReadonly( true ),
+							THREE.OperatorNode.ADD
+						);
+
+						mtl.build();
+
+						// show names glsl fragment shader
+						// open console e find using CTRL+F "colorMix" for example
+
+						console.log( mtl.fragmentShader );
 
 						break;
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -275,8 +275,9 @@
 
 				}
 
-				var name = param.example;
-				var mtl;
+				var name = param.example,
+					defaultSide = THREE.DoubleSide,
+					mtl;
 
 				clearGui();
 
@@ -1576,6 +1577,8 @@
 
 						mtl.environment = new THREE.ColorNode( 0xFFFFFF );
 						mtl.alpha = clouds;
+
+						defaultSide = THREE.FrontSide;
 
 						// GUI
 
@@ -2890,7 +2893,7 @@
 
 				// set material
 
-				mtl.side = THREE.DoubleSide;
+				mtl.side = defaultSide;
 
 				mesh.material = mtl;
 


### PR DESCRIPTION
### Issue
https://github.com/mrdoob/three.js/issues/15666

### New examples

**label** 
https://rawgit.com/sunag/three.js/dev-fix-nameconflict/examples/webgl_materials_nodes.html?e=label

### Description
- fix `Conflicting names for varying and temp var` issue https://github.com/mrdoob/three.js/issues/15666
- new `setLabel` and `getLabel` in `TempNode`
- new internal var names:
  * `nodeU0` = node uniform id
  * `nodeV0` = node varying id
  * `nodeT0` = node temp id
- `isShared`, `isUnique`, `isReadonly` renamed to `getShared`, `getUnique`, `getReadonly`

### Usages

**label**
```javascript
var colorInput = new THREE.ColorNode( 0xFFFFFF ).setLabel( "colorInput" );
var specularInput = new THREE.FloatNode( .5 ).setLabel( "specularInput" );

var colorMix = new THREE.OperatorNode(
	colorInput,
	new THREE.ColorNode( 0x6495ED ).setReadonly( true ),
	THREE.OperatorNode.MUL
).setLabel("colorMix");

mtl.color = colorMix;
mtl.specular = specularInput;
```

**optimization alerts**
https://github.com/sunag/three.js/blob/40651f3fa6e6b12a2ae145cf3de14efde04065d3/examples/webgl_materials_nodes.html#L2543

https://github.com/sunag/three.js/blob/40651f3fa6e6b12a2ae145cf3de14efde04065d3/examples/webgl_materials_nodes.html#L2560


**readonly**
```javascript
material.color = new THREE.ColorNode( 0xFFFFFF ).setReadonly( true );
```