### PR TITLE
Clean up rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -196,7 +196,6 @@ export default {
 		glconstants(),
 		glsl()
 	],
-	// sourceMap: true,
 	output: [
 		{
 			format: 'umd',


### PR DESCRIPTION
Adding the `sourceMap` parameter at the current place leads to a warning:

> You have passed an unrecognized option

The correct approach would look like so (at least with rollup version `1.0.0`):

```js
{
   format: 'umd',
   name: 'THREE',
   file: 'build/three.js',
   indent: '\t',
   sourcemap: true
}
```