### PR TITLE
CubemapGenerator: Ensure options is never undefined

### DIFF
--- a/examples/js/loaders/EquirectangularToCubeGenerator.js
+++ b/examples/js/loaders/EquirectangularToCubeGenerator.js
@@ -86,15 +86,17 @@ THREE.CubemapGenerator.prototype.fromEquirectangular = function ( texture, optio
 
 	scene.add( mesh );
 
+	options = options || {};
+
 	var resolution = options.resolution || 512;
 
 	var params = {
 		type: texture.type,
 		format: texture.format,
 		encoding: texture.encoding,
-		generateMipmaps: ( options.generateMipmaps !== undefined ) ?  options.generateMipmaps : texture.generateMipmaps,
-		minFilter: ( options.minFilter !== undefined ) ?  options.minFilter : texture.minFilter,
-		magFilter: ( options.magFilter !== undefined ) ?  options.magFilter : texture.magFilter
+		generateMipmaps: ( options.generateMipmaps !== undefined ) ? options.generateMipmaps : texture.generateMipmaps,
+		minFilter: ( options.minFilter !== undefined ) ? options.minFilter : texture.minFilter,
+		magFilter: ( options.magFilter !== undefined ) ? options.magFilter : texture.magFilter
 	};
 
 	var camera = new THREE.CubeCamera( 1, 10, resolution, params );
@@ -119,6 +121,8 @@ THREE.EquirectangularToCubeGenerator = ( function () {
 	scene.add( boxMesh );
 
 	var EquirectangularToCubeGenerator = function ( sourceTexture, options ) {
+
+		options = options || {};
 
 		this.sourceTexture = sourceTexture;
 		this.resolution = options.resolution || 512;


### PR DESCRIPTION
This PR ensures that `options` is never `undefined` even if no options parameter is applied. In this way, the behavior is similar to `WebGLRenderTarget`. Added the same fix for `EquirectangularToCubeGenerator`.