### PR TITLE
EffectComposer2

### DIFF
--- a/examples/js/postprocessing2/AfterimagePass2.js
+++ b/examples/js/postprocessing2/AfterimagePass2.js
@@ -1,0 +1,89 @@
+/**
+ * @author HypnosNova / https://www.threejs.org.cn/gallery/
+ * @author Oletus / http://oletus.fi/ - ported to EffectComposer2
+ */
+
+THREE.AfterimagePass2 = function ( damp ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorWriteBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorWriteBufferConfig.clear = true;
+
+	this.colorReadBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorReadBufferConfig.isOutput = false;
+	this.colorReadBufferConfig.isInput = true;
+
+	this.bufferConfigs = [ this.colorWriteBufferConfig, this.colorReadBufferConfig ];
+
+	if ( THREE.AfterimageShader === undefined )
+		console.error( "THREE.AfterimagePass relies on THREE.AfterimageShader" );
+
+	this.shader = THREE.AfterimageShader;
+
+	this.uniforms = THREE.UniformsUtils.clone( this.shader.uniforms );
+
+	this.uniforms[ "damp" ].value = damp !== undefined ? damp : 0.96;
+
+	this.textureComp = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, {
+
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.NearestFilter,
+		format: THREE.RGBAFormat
+
+	} );
+
+	this.textureOld = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, {
+
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.NearestFilter,
+		format: THREE.RGBAFormat
+
+	} );
+
+	this.shaderMaterial = new THREE.ShaderMaterial( {
+
+		uniforms: this.uniforms,
+		vertexShader: this.shader.vertexShader,
+		fragmentShader: this.shader.fragmentShader
+
+	} );
+
+	this.compQuad = THREE.Pass2.createFillQuadScene( this.shaderMaterial );
+
+	var material = new THREE.MeshBasicMaterial( { 
+		map: this.textureComp.texture
+	} );
+	this.copyQuad = THREE.Pass2.createFillQuadScene( material );
+
+};
+
+THREE.AfterimagePass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.AfterimagePass2,
+
+	render: function ( renderer, buffers ) {
+
+		var writeBuffer = buffers[0];
+		var readBuffer = buffers[1];
+
+		this.uniforms[ "tOld" ].value = this.textureOld.texture;
+		this.uniforms[ "tNew" ].value = readBuffer.texture;
+
+		this.compQuad.quad.material = this.shaderMaterial;
+
+		renderer.render( this.compQuad.scene, this.compQuad.camera, this.textureComp );
+		renderer.render( this.copyQuad.scene, this.copyQuad.camera, this.textureOld );
+
+		THREE.Pass2.renderWithClear( renderer, this.copyQuad.scene, this.copyQuad.camera, writeBuffer, this.colorWriteBufferConfig.clear );
+
+	},
+
+	setSize: function ( width, height ) {
+
+		this.textureComp.setSize( width, height );
+		this.textureOld.setSize( width, height );
+
+	}
+
+} );

--- a/examples/js/postprocessing2/ClearColorPass2.js
+++ b/examples/js/postprocessing2/ClearColorPass2.js
@@ -1,0 +1,50 @@
+/**
+ * @author mrdoob / http://mrdoob.com/
+ * @author Oletus / http://oletus.fi/
+ */
+
+THREE.ClearColorPass2 = function ( clearColor, clearAlpha ) {
+
+	THREE.Pass2.call( this );
+
+	var colorBufferConfig = new THREE.IntermediateBufferConfig();
+	colorBufferConfig.clear = true;
+
+	this.bufferConfigs = [ colorBufferConfig ];
+
+	this.clearColor = ( clearColor !== undefined ) ? clearColor : 0x000000;
+	this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
+
+};
+
+THREE.ClearColorPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.ClearColorPass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var colorBuffer = buffers[0];
+
+		var oldClearColor, oldClearAlpha;
+
+		if ( this.clearColor ) {
+
+			oldClearColor = renderer.getClearColor().getHex();
+			oldClearAlpha = renderer.getClearAlpha();
+
+			renderer.setClearColor( this.clearColor, this.clearAlpha );
+
+		}
+
+		renderer.setRenderTarget( colorBuffer );
+		renderer.clear();
+
+		if ( this.clearColor ) {
+
+			renderer.setClearColor( oldClearColor, oldClearAlpha );
+
+		}
+
+	}
+
+} );

--- a/examples/js/postprocessing2/CubeTexturePass2.js
+++ b/examples/js/postprocessing2/CubeTexturePass2.js
@@ -1,0 +1,59 @@
+/**
+ * @author bhouston / http://clara.io/
+ * @author Oletus / http://oletus.fi/
+ */
+
+THREE.CubeTexturePass2 = function ( camera, envMap, opacity ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.clear = true;
+	this.colorBufferConfig.isInput = true;
+
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	this.camera = camera;
+
+	this.cubeShader = THREE.ShaderLib[ 'cube' ];
+	this.cubeMesh = new THREE.Mesh(
+		new THREE.BoxBufferGeometry( 10, 10, 10 ),
+		new THREE.ShaderMaterial( {
+			uniforms: this.cubeShader.uniforms,
+			vertexShader: this.cubeShader.vertexShader,
+			fragmentShader: this.cubeShader.fragmentShader,
+			depthTest: false,
+			depthWrite: false,
+			side: THREE.BackSide
+		} )
+	);
+
+	this.envMap = envMap;
+	this.opacity = ( opacity !== undefined ) ? opacity : 1.0;
+
+	this.cubeScene = new THREE.Scene();
+	this.cubeCamera = new THREE.PerspectiveCamera();
+	this.cubeScene.add( this.cubeMesh );
+
+};
+
+THREE.CubeTexturePass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.CubeTexturePass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var colorBuffer = buffers[0];
+
+		this.cubeCamera.projectionMatrix.copy( this.camera.projectionMatrix );
+		this.cubeCamera.quaternion.setFromRotationMatrix( this.camera.matrixWorld );
+
+		this.cubeMesh.material.uniforms[ "tCube" ].value = this.envMap;
+		this.cubeMesh.material.uniforms[ "opacity" ].value = this.opacity;
+		this.cubeMesh.material.transparent = ( this.opacity < 1.0 );
+
+		THREE.Pass2.renderWithClear( renderer, this.cubeScene, this.cubeCamera, colorBuffer, this.colorBufferConfig.clear );
+
+	}
+
+} );

--- a/examples/js/postprocessing2/EffectComposer2.js
+++ b/examples/js/postprocessing2/EffectComposer2.js
@@ -106,7 +106,7 @@ Object.assign( THREE.EffectComposer2.prototype, {
 					var buffer;
 					if ( writeToFinalColorTarget ) {
 						buffer = finalColorRenderTarget;
-						if ( bufferConfig.isInput )
+						if ( bufferConfig.isInput && !bufferConfig.clear )
 						{
 							// The output buffer is also used as a color input in the pass.
 							// Copy the color buffer from the previous pass to the final target before executing the pass.
@@ -236,6 +236,8 @@ THREE.IntermediateBufferConfig = function() {
 	this.isOutput = true;
 
 	// Set to true if the pass clears this buffer before writing to it. Should only be set if isOutput is also true.
+	// If this is set then isInput is essentially ignored and the contents of the buffer are undefined when it is
+	// given to the pass.
 	this.clear = false;
 
 };

--- a/examples/js/postprocessing2/EffectComposer2.js
+++ b/examples/js/postprocessing2/EffectComposer2.js
@@ -312,14 +312,14 @@ Object.assign( THREE.Pass2.prototype, {
 } );
 
 // Helper for passes that need a scene that simply has the whole viewport filled with a single quad.
-THREE.Pass2.createFillQuadScene = function() {
+THREE.Pass2.createFillQuadScene = function( material ) {
 
 	var fillQuad = {};
 
 	fillQuad.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
 	fillQuad.scene = new THREE.Scene();
 
-	fillQuad.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+	fillQuad.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), material );
 	fillQuad.quad.frustumCulled = false; // Avoid getting clipped
 	fillQuad.scene.add( fillQuad.quad );
 

--- a/examples/js/postprocessing2/EffectComposer2.js
+++ b/examples/js/postprocessing2/EffectComposer2.js
@@ -92,6 +92,29 @@ Object.assign( THREE.EffectComposer2.prototype, {
 
 	},
 
+	getColorOutputBuffer: function ( bufferConfig, writeToFinalColorTarget, finalColorRenderTarget ) {
+
+		// finalColorRenderTarget null or undefined means rendering to the default framebuffer.
+		// If the buffer must be a texture then we can't render directly to that but will do an extra copy
+		// step afterwards.
+		var canUseFinalColorTarget = finalColorRenderTarget || !bufferConfig.mustBeTexture;
+		if ( writeToFinalColorTarget && canUseFinalColorTarget ) {
+
+			return finalColorRenderTarget;
+
+		} else if ( bufferConfig.isInput ) {
+
+			// The output buffer is also used as a color input in the pass.
+			return this.colorReadBuffer;
+
+		} else {
+
+			return this.colorWriteBuffer;
+
+		}
+
+	},
+
 	gatherBuffersForPass: function ( pass, writeToFinalColorTarget, finalColorRenderTarget, buffers ) {
 
 		var writesToColorWriteBuffer = false;
@@ -103,20 +126,14 @@ Object.assign( THREE.EffectComposer2.prototype, {
 
 				if ( bufferConfig.isOutput ) {
 
-					var buffer;
-					if ( writeToFinalColorTarget ) {
-						buffer = finalColorRenderTarget;
-						if ( bufferConfig.isInput && !bufferConfig.clear )
-						{
-							// The output buffer is also used as a color input in the pass.
-							// Copy the color buffer from the previous pass to the final target before executing the pass.
-							this.copyPass.render( this.renderer, [ buffer, this.colorReadBuffer ], 0 );
-						}
-					} else if ( bufferConfig.isInput ) {
+					var buffer = this.getColorOutputBuffer( bufferConfig, writeToFinalColorTarget, finalColorRenderTarget );
+					if ( buffer == finalColorRenderTarget && bufferConfig.isInput && !bufferConfig.clear )
+					{
 						// The output buffer is also used as a color input in the pass.
-						buffer = this.colorReadBuffer;
-					} else {
-						buffer = this.colorWriteBuffer;
+						// Copy the color buffer from the previous pass to the final target before executing the pass.
+						this.copyPass.render( this.renderer, [ buffer, this.colorReadBuffer ], 0 );
+					}
+					if ( buffer == this.colorWriteBuffer ) {
 						writesToColorWriteBuffer = true;
 					}
 					buffers.push( buffer );
@@ -133,6 +150,24 @@ Object.assign( THREE.EffectComposer2.prototype, {
 		}
 
 		return writesToColorWriteBuffer;
+
+	},
+
+	passWroteToBuffer: function( pass, writeToFinalColorTarget, finalColorRenderTarget ) {
+
+		for ( i = 0; i < pass.bufferConfigs.length; ++i ) {
+
+			var bufferConfig = pass.bufferConfigs[i];
+			if ( bufferConfig.content == THREE.EffectComposer2.BufferContent.Color ) {
+
+				if ( bufferConfig.isOutput ) {
+					return this.getColorOutputBuffer( bufferConfig, writeToFinalColorTarget, finalColorRenderTarget );
+				}
+
+			}
+
+		}
+		return null;
 
 	},
 
@@ -162,14 +197,23 @@ Object.assign( THREE.EffectComposer2.prototype, {
 
 			if ( pass.enabled === false ) continue;
 
-			var writeToFinalRenderTarget = this.isLastEnabledPass( i );
+			var writeToFinalColorTarget = this.isLastEnabledPass( i );
 
 			var buffers = [];
-			var writesToColorWriteBuffer = this.gatherBuffersForPass( pass, writeToFinalRenderTarget, finalColorRenderTarget, buffers );
+			var writesToColorWriteBuffer = this.gatherBuffersForPass( pass, writeToFinalColorTarget, finalColorRenderTarget, buffers );
 
 			pass.render( this.renderer, buffers, deltaTime );
 
-			if ( writesToColorWriteBuffer ) {
+			// Check if we need to copy the final output from a texture to the default framebuffer.
+			if ( writeToFinalColorTarget && !finalColorRenderTarget ) {
+
+				var wroteToBuffer = this.passWroteToBuffer( pass, writeToFinalColorTarget, finalColorRenderTarget );
+				if ( wroteToBuffer ) {
+					// In case the pass is only able to use a texture as its write buffer, copy the result to screen here.
+					this.copyPass.render( this.renderer, [ null, wroteToBuffer ], 0 );
+				}
+
+			} else if ( writesToColorWriteBuffer ) {
 
 				this.swapBuffers();
 
@@ -229,15 +273,18 @@ THREE.IntermediateBufferConfig = function() {
 	// color format.
 	this.content = THREE.EffectComposer2.BufferContent.Color;
 
-	// Set to true if this buffer is read by the pass.
+	// Set to true if the pass intends to either blend new things on top of this buffer or reads it as a texture.
 	this.isInput = false;
 
-	// Set to true if this buffer is written by the pass.
+	// Set to true if this buffer is written to by the pass.
 	this.isOutput = true;
 
-	// Set to true if the pass clears this buffer before writing to it. Should only be set if isOutput is also true.
-	// If this is set then isInput is essentially ignored and the contents of the buffer are undefined when it is
-	// given to the pass.
+	// Set to true if this buffer needs to be stored in a texture. Should only be set if isInput is also true.
+	this.mustBeTexture = false;
+
+	// Set to true if the pass clears this buffer before reading from or writing to it. Should only be set if isOutput
+	// is also true. If this is set then isInput is essentially ignored and the contents of the buffer are undefined
+	// when it is given to the pass.
 	this.clear = false;
 
 };

--- a/examples/js/postprocessing2/EffectComposer2.js
+++ b/examples/js/postprocessing2/EffectComposer2.js
@@ -1,0 +1,291 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus http://oletus.fi/
+ */
+
+THREE.EffectComposer2 = function ( renderer, colorRenderTarget ) {
+
+	this.renderer = renderer;
+
+	if ( colorRenderTarget === undefined ) {
+
+		var parameters = {
+			minFilter: THREE.LinearFilter,
+			magFilter: THREE.LinearFilter,
+			format: THREE.RGBAFormat,
+			stencilBuffer: false
+		};
+
+		var size = renderer.getDrawingBufferSize();
+		colorRenderTarget = new THREE.WebGLRenderTarget( size.width, size.height, parameters );
+		colorRenderTarget.texture.name = 'EffectComposer2.rt1';
+
+	}
+
+	this.colorRenderTarget1 = colorRenderTarget;
+	this.colorRenderTarget2 = colorRenderTarget.clone();
+	this.colorRenderTarget2.texture.name = 'EffectComposer2.rt2';
+
+	this.colorWriteBuffer = this.colorRenderTarget1;
+	this.colorReadBuffer = this.colorRenderTarget2;
+
+	this.passes = [];
+
+	// dependencies
+
+	if ( THREE.CopyShader === undefined ) {
+
+		console.error( 'THREE.EffectComposer2 relies on THREE.CopyShader' );
+
+	}
+
+	if ( THREE.ShaderPass2 === undefined ) {
+
+		console.error( 'THREE.EffectComposer2 relies on THREE.ShaderPass2' );
+
+	}
+
+	this.copyPass = new THREE.ShaderPass2( THREE.CopyShader );
+
+	this._previousFrameTime = Date.now();
+
+};
+
+Object.assign( THREE.EffectComposer2.prototype, {
+
+	swapBuffers: function () {
+
+		var tmp = this.colorReadBuffer;
+		this.colorReadBuffer = this.colorWriteBuffer;
+		this.colorWriteBuffer = tmp;
+
+	},
+
+	addPass: function ( pass ) {
+
+		this.passes.push( pass );
+
+		var size = this.renderer.getDrawingBufferSize();
+		pass.setSize( size.width, size.height );
+
+	},
+
+	insertPass: function ( pass, index ) {
+
+		this.passes.splice( index, 0, pass );
+
+	},
+
+	isLastEnabledPass: function ( passIndex ) {
+
+		for ( i = passIndex + 1; i < this.passes.length; ++i ) {
+
+			if ( this.passes[i].enabled ) {
+
+				return false;
+
+			}
+
+		}
+
+		return true;
+
+	},
+
+	gatherBuffersForPass: function ( pass, writeToFinalColorTarget, finalColorRenderTarget, buffers ) {
+
+		var writesToColorWriteBuffer = false;
+
+		for ( i = 0; i < pass.bufferConfigs.length; ++i ) {
+
+			var bufferConfig = pass.bufferConfigs[i];
+			if ( bufferConfig.content == THREE.EffectComposer2.BufferContent.Color ) {
+
+				if ( bufferConfig.isOutput ) {
+
+					var buffer;
+					if ( writeToFinalColorTarget ) {
+						buffer = finalColorRenderTarget;
+						if ( bufferConfig.isInput )
+						{
+							// The output buffer is also used as a color input in the pass.
+							// Copy the color buffer from the previous pass to the final target before executing the pass.
+							this.copyPass.render( this.renderer, [ buffer, this.colorReadBuffer ], 0 );
+						}
+					} else if ( bufferConfig.isInput ) {
+						// The output buffer is also used as a color input in the pass.
+						buffer = this.colorReadBuffer;
+					} else {
+						buffer = this.colorWriteBuffer;
+						writesToColorWriteBuffer = true;
+					}
+					buffers.push( buffer );
+
+				} else {
+
+					buffers.push( this.colorReadBuffer );
+
+				}
+
+			}
+			// TODO: Support passing other buffers than color buffers between passes.
+
+		}
+
+		return writesToColorWriteBuffer;
+
+	},
+
+	render: function ( finalColorRenderTarget, deltaTime ) {
+		
+		if ( finalColorRenderTarget == undefined ) {
+
+			// Write to the default framebuffer.
+			finalColorRenderTarget = null;
+
+		}
+
+		// deltaTime value is in seconds
+
+		if ( deltaTime === undefined ) {
+
+			deltaTime = ( Date.now() - this._previousFrameTime ) * 0.001;
+
+		}
+		this._previousFrameTime = Date.now();
+
+		var pass, i, il = this.passes.length;
+
+		for ( i = 0; i < il; i ++ ) {
+
+			pass = this.passes[ i ];
+
+			if ( pass.enabled === false ) continue;
+
+			var writeToFinalRenderTarget = this.isLastEnabledPass( i );
+
+			var buffers = [];
+			var writesToColorWriteBuffer = this.gatherBuffersForPass( pass, writeToFinalRenderTarget, finalColorRenderTarget, buffers );
+
+			pass.render( this.renderer, buffers, deltaTime );
+
+			if ( writesToColorWriteBuffer ) {
+
+				this.swapBuffers();
+
+			}
+
+		}
+
+	},
+
+	reset: function ( colorRenderTarget ) {
+
+		if ( colorRenderTarget === undefined ) {
+
+			var size = this.renderer.getDrawingBufferSize();
+
+			colorRenderTarget = this.colorRenderTarget1.clone();
+			colorRenderTarget.setSize( size.width, size.height );
+
+		}
+
+		this.colorRenderTarget1.dispose();
+		this.colorRenderTarget2.dispose();
+		this.colorRenderTarget1 = colorRenderTarget;
+		this.colorRenderTarget2 = colorRenderTarget.clone();
+
+		this.colorWriteBuffer = this.colorRenderTarget1;
+		this.colorReadBuffer = this.colorRenderTarget2;
+
+	},
+
+	setSize: function ( width, height ) {
+
+		this.colorRenderTarget1.setSize( width, height );
+		this.colorRenderTarget2.setSize( width, height );
+
+		for ( var i = 0; i < this.passes.length; i ++ ) {
+
+			this.passes[ i ].setSize( width, height );
+
+		}
+
+	}
+
+} );
+
+THREE.EffectComposer2.BufferContent = {
+
+	Color: 0,
+	Depth: 1,
+	Normal: 2
+
+};
+
+THREE.IntermediateBufferConfig = function() {
+
+	// This is the content of the buffer. Note that even if the buffer's content is Depth, it may still be packed into a
+	// color format.
+	this.content = THREE.EffectComposer2.BufferContent.Color;
+
+	// Set to true if this buffer is read by the pass.
+	this.isInput = false;
+
+	// Set to true if this buffer is written by the pass.
+	this.isOutput = true;
+
+	// Set to true if the pass clears this buffer before writing to it. Should only be set if isOutput is also true.
+	this.clear = false;
+
+};
+
+THREE.Pass2 = function () {
+
+	// If set to true, the pass is processed by the composer.
+	this.enabled = true;
+
+	// Configuration of input and output buffers used by this pass.
+	this.bufferConfigs = [ new THREE.IntermediateBufferConfig() ];
+
+};
+
+Object.assign( THREE.Pass2.prototype, {
+
+	setSize: function ( width, height ) {},
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		console.error( 'THREE.Pass2: .render() must be implemented in derived pass.' );
+
+	},
+	
+} );
+
+// Helper for passes that need a scene that simply has the whole viewport filled with a single quad.
+THREE.Pass2.createFillQuadScene = function() {
+
+	var fillQuad = {};
+
+	fillQuad.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+	fillQuad.scene = new THREE.Scene();
+
+	fillQuad.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+	fillQuad.quad.frustumCulled = false; // Avoid getting clipped
+	fillQuad.scene.add( fillQuad.quad );
+
+	return fillQuad;
+
+};
+
+// Helper for passes that need a specific clear setting, autoClear temporarily disabled.
+THREE.Pass2.renderWithClear = function( renderer, scene, camera, writeBuffer, clear ) {
+
+	var oldAutoClear = renderer.autoClear;
+	renderer.autoClear = false;
+
+	renderer.render( scene, camera, writeBuffer, clear );
+
+	renderer.autoClear = oldAutoClear;
+
+};

--- a/examples/js/postprocessing2/GlitchPass2.js
+++ b/examples/js/postprocessing2/GlitchPass2.js
@@ -1,0 +1,116 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus / http://oletus.fi/ - Ported to EffectComposer2
+ */
+
+THREE.GlitchPass2 = function ( dt_size ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorWriteBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorWriteBufferConfig.clear = true;
+
+	this.colorReadBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorReadBufferConfig.isOutput = false;
+	this.colorReadBufferConfig.isInput = true;
+
+	this.bufferConfigs = [ this.colorWriteBufferConfig, this.colorReadBufferConfig ];
+
+	if ( THREE.DigitalGlitch === undefined ) console.error( "THREE.GlitchPass2 relies on THREE.DigitalGlitch" );
+
+	var shader = THREE.DigitalGlitch;
+	this.uniforms = THREE.UniformsUtils.clone( shader.uniforms );
+
+	if ( dt_size == undefined ) dt_size = 64;
+
+
+	this.uniforms[ "tDisp" ].value = this.generateHeightmap( dt_size );
+
+
+	this.material = new THREE.ShaderMaterial( {
+		uniforms: this.uniforms,
+		vertexShader: shader.vertexShader,
+		fragmentShader: shader.fragmentShader
+	} );
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene( this.material );
+
+	this.goWild = false;
+	this.curF = 0;
+	this.generateTrigger();
+
+};
+
+THREE.GlitchPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.GlitchPass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var writeBuffer = buffers[0];
+		var readBuffer = buffers[1];
+
+		this.uniforms[ "tDiffuse" ].value = readBuffer.texture;
+		this.uniforms[ 'seed' ].value = Math.random();//default seeding
+		this.uniforms[ 'byp' ].value = 0;
+
+		if ( this.curF % this.randX == 0 || this.goWild == true ) {
+
+			this.uniforms[ 'amount' ].value = Math.random() / 30;
+			this.uniforms[ 'angle' ].value = THREE.Math.randFloat( - Math.PI, Math.PI );
+			this.uniforms[ 'seed_x' ].value = THREE.Math.randFloat( - 1, 1 );
+			this.uniforms[ 'seed_y' ].value = THREE.Math.randFloat( - 1, 1 );
+			this.uniforms[ 'distortion_x' ].value = THREE.Math.randFloat( 0, 1 );
+			this.uniforms[ 'distortion_y' ].value = THREE.Math.randFloat( 0, 1 );
+			this.curF = 0;
+			this.generateTrigger();
+
+		} else if ( this.curF % this.randX < this.randX / 5 ) {
+
+			this.uniforms[ 'amount' ].value = Math.random() / 90;
+			this.uniforms[ 'angle' ].value = THREE.Math.randFloat( - Math.PI, Math.PI );
+			this.uniforms[ 'distortion_x' ].value = THREE.Math.randFloat( 0, 1 );
+			this.uniforms[ 'distortion_y' ].value = THREE.Math.randFloat( 0, 1 );
+			this.uniforms[ 'seed_x' ].value = THREE.Math.randFloat( - 0.3, 0.3 );
+			this.uniforms[ 'seed_y' ].value = THREE.Math.randFloat( - 0.3, 0.3 );
+
+		} else if ( this.goWild == false ) {
+
+			this.uniforms[ 'byp' ].value = 1;
+
+		}
+
+		this.curF ++;
+		this.fillQuad.quad.material = this.material;
+
+		THREE.Pass2.renderWithClear( renderer, this.fillQuad.scene, this.fillQuad.camera, writeBuffer, this.colorWriteBufferConfig.clear );
+
+	},
+
+	generateTrigger: function() {
+
+		this.randX = THREE.Math.randInt( 120, 240 );
+
+	},
+
+	generateHeightmap: function( dt_size ) {
+
+		var data_arr = new Float32Array( dt_size * dt_size * 3 );
+		var length = dt_size * dt_size;
+
+		for ( var i = 0; i < length; i ++ ) {
+
+			var val = THREE.Math.randFloat( 0, 1 );
+			data_arr[ i * 3 + 0 ] = val;
+			data_arr[ i * 3 + 1 ] = val;
+			data_arr[ i * 3 + 2 ] = val;
+
+		}
+
+		var texture = new THREE.DataTexture( data_arr, dt_size, dt_size, THREE.RGBFormat, THREE.FloatType );
+		texture.needsUpdate = true;
+		return texture;
+
+	}
+
+} );

--- a/examples/js/postprocessing2/MaskPass2.js
+++ b/examples/js/postprocessing2/MaskPass2.js
@@ -1,0 +1,97 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus / http://oletus.fi/ - Ported to EffectComposer2
+ */
+
+THREE.MaskPass2 = function ( scene, camera ) {
+
+	THREE.Pass2.call( this );
+
+	this.scene = scene;
+	this.camera = camera;
+
+	this.clearStencil = true;
+
+	this.inverse = false;
+
+};
+
+THREE.MaskPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.MaskPass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var context = renderer.context;
+		var state = renderer.state;
+
+		// don't update color or depth
+
+		state.buffers.color.setMask( false );
+		state.buffers.depth.setMask( false );
+
+		// lock buffers
+
+		state.buffers.color.setLocked( true );
+		state.buffers.depth.setLocked( true );
+
+		// set up stencil
+
+		var writeValue, clearValue;
+
+		if ( this.inverse ) {
+
+			writeValue = 0;
+			clearValue = 1;
+
+		} else {
+
+			writeValue = 1;
+			clearValue = 0;
+
+		}
+
+		state.buffers.stencil.setTest( true );
+		state.buffers.stencil.setOp( context.REPLACE, context.REPLACE, context.REPLACE );
+		state.buffers.stencil.setFunc( context.ALWAYS, writeValue, 0xffffffff );
+		state.buffers.stencil.setClear( clearValue );
+
+		// draw into the stencil buffer
+
+		renderer.autoClearStencil = true;
+		renderer.render( this.scene, this.camera, buffers[0], this.clearStencil );
+		renderer.render( this.scene, this.camera, buffers[1], this.clearStencil );
+		renderer.autoClearStencil = false;
+
+		// unlock color and depth buffer for subsequent rendering
+
+		state.buffers.color.setLocked( false );
+		state.buffers.depth.setLocked( false );
+
+		// only render where stencil is set to 1
+
+		state.buffers.stencil.setFunc( context.EQUAL, 1, 0xffffffff );  // draw if == 1
+		state.buffers.stencil.setOp( context.KEEP, context.KEEP, context.KEEP );
+
+	}
+
+} );
+
+
+THREE.ClearMaskPass2 = function () {
+
+	THREE.Pass2.call( this );
+
+};
+
+THREE.ClearMaskPass2.prototype = Object.create( THREE.Pass2.prototype );
+
+Object.assign( THREE.ClearMaskPass2.prototype, {
+
+	render: function ( renderer, writeBuffer, readBuffer, deltaTime, maskActive ) {
+
+		renderer.state.buffers.stencil.setTest( false );
+
+	}
+
+} );

--- a/examples/js/postprocessing2/RenderPass2.js
+++ b/examples/js/postprocessing2/RenderPass2.js
@@ -1,0 +1,65 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus / http://oletus.fi/
+ */
+
+THREE.RenderPass2 = function ( scene, camera, overrideMaterial, clearColor, clearAlpha ) {
+
+	THREE.Pass2.call( this );
+
+	this.scene = scene;
+	this.camera = camera;
+
+	this.overrideMaterial = overrideMaterial;
+
+	this.clearColor = clearColor;
+	this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.clear = true;
+
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	this.clearDepth = false;
+
+};
+
+THREE.RenderPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.RenderPass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		colorBuffer = buffers[0];
+
+		this.scene.overrideMaterial = this.overrideMaterial;
+
+		var oldClearColor, oldClearAlpha;
+
+		if ( this.clearColor ) {
+
+			oldClearColor = renderer.getClearColor().getHex();
+			oldClearAlpha = renderer.getClearAlpha();
+
+			renderer.setClearColor( this.clearColor, this.clearAlpha );
+
+		}
+
+		if ( this.clearDepth ) {
+
+			renderer.clearDepth();
+
+		}
+
+		THREE.Pass2.renderWithClear( renderer, this.scene, this.camera, colorBuffer, this.colorBufferConfig.clear );
+
+		if ( this.clearColor ) {
+
+			renderer.setClearColor( oldClearColor, oldClearAlpha );
+
+		}
+
+		this.scene.overrideMaterial = null;
+	}
+
+} );

--- a/examples/js/postprocessing2/RenderPass2.js
+++ b/examples/js/postprocessing2/RenderPass2.js
@@ -17,6 +17,7 @@ THREE.RenderPass2 = function ( scene, camera, overrideMaterial, clearColor, clea
 
 	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
 	this.colorBufferConfig.clear = true;
+	this.colorBufferConfig.isInput = true;
 
 	this.bufferConfigs = [ this.colorBufferConfig ];
 

--- a/examples/js/postprocessing2/SAOPass2.js
+++ b/examples/js/postprocessing2/SAOPass2.js
@@ -1,0 +1,379 @@
+/**
+ * @author ludobaka / ludobaka.github.io
+ * SAO implementation inspired from bhouston previous SAO work
+ * @author Oletus / http://oletus.fi/ - ported to EffectComposer2
+ */
+
+THREE.SAOPass2 = function ( scene, camera, depthTexture, useNormals, resolution ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.isInput = true;
+
+	// TODO: Get depth and normal buffers as inputs instead of rendering them here.
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	this.scene = scene;
+	this.camera = camera;
+
+	this.supportsDepthTextureExtension = ( depthTexture !== undefined ) ? depthTexture : false;
+	this.supportsNormalTexture = ( useNormals !== undefined ) ? useNormals : false;
+
+	this.originalClearColor = new THREE.Color();
+	this.oldClearColor = new THREE.Color();
+	this.oldClearAlpha = 1;
+
+	this.params = {
+		output: 0,
+		saoBias: 0.5,
+		saoIntensity: 0.18,
+		saoScale: 1,
+		saoKernelRadius: 100,
+		saoMinResolution: 0,
+		saoBlur: true,
+		saoBlurRadius: 8,
+		saoBlurStdDev: 4,
+		saoBlurDepthCutoff: 0.01
+	};
+
+	this.resolution = ( resolution !== undefined ) ? new THREE.Vector2( resolution.x, resolution.y ) : new THREE.Vector2( 256, 256 );
+
+	this.saoRenderTarget = new THREE.WebGLRenderTarget( this.resolution.x, this.resolution.y, {
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.LinearFilter,
+		format: THREE.RGBAFormat
+	} );
+	this.blurIntermediateRenderTarget = this.saoRenderTarget.clone();
+	this.beautyRenderTarget = this.saoRenderTarget.clone();
+
+	this.normalRenderTarget = new THREE.WebGLRenderTarget( this.resolution.x, this.resolution.y, {
+		minFilter: THREE.NearestFilter,
+		magFilter: THREE.NearestFilter,
+		format: THREE.RGBAFormat
+	} );
+	this.depthRenderTarget = this.normalRenderTarget.clone();
+
+	if ( this.supportsDepthTextureExtension ) {
+
+		var depthTexture = new THREE.DepthTexture();
+		depthTexture.type = THREE.UnsignedShortType;
+		depthTexture.minFilter = THREE.NearestFilter;
+		depthTexture.maxFilter = THREE.NearestFilter;
+
+		this.beautyRenderTarget.depthTexture = depthTexture;
+		this.beautyRenderTarget.depthBuffer = true;
+
+	}
+
+	this.depthMaterial = new THREE.MeshDepthMaterial();
+	this.depthMaterial.depthPacking = THREE.RGBADepthPacking;
+	this.depthMaterial.blending = THREE.NoBlending;
+
+	this.normalMaterial = new THREE.MeshNormalMaterial();
+	this.normalMaterial.blending = THREE.NoBlending;
+
+	if ( THREE.SAOShader === undefined ) {
+
+		console.error( 'THREE.SAOPass2 relies on THREE.SAOShader' );
+
+	}
+
+	this.saoMaterial = new THREE.ShaderMaterial( {
+		defines: Object.assign( {}, THREE.SAOShader.defines ),
+		fragmentShader: THREE.SAOShader.fragmentShader,
+		vertexShader: THREE.SAOShader.vertexShader,
+		uniforms: THREE.UniformsUtils.clone( THREE.SAOShader.uniforms )
+	} );
+	this.saoMaterial.extensions.derivatives = true;
+	this.saoMaterial.defines[ 'DEPTH_PACKING' ] = this.supportsDepthTextureExtension ? 0 : 1;
+	this.saoMaterial.defines[ 'NORMAL_TEXTURE' ] = this.supportsNormalTexture ? 1 : 0;
+	this.saoMaterial.defines[ 'PERSPECTIVE_CAMERA' ] = this.camera.isPerspectiveCamera ? 1 : 0;
+	this.saoMaterial.uniforms[ 'tDepth' ].value = ( this.supportsDepthTextureExtension ) ? depthTexture : this.depthRenderTarget.texture;
+	this.saoMaterial.uniforms[ 'tNormal' ].value = this.normalRenderTarget.texture;
+	this.saoMaterial.uniforms[ 'size' ].value.set( this.resolution.x, this.resolution.y );
+	this.saoMaterial.uniforms[ 'cameraInverseProjectionMatrix' ].value.getInverse( this.camera.projectionMatrix );
+	this.saoMaterial.uniforms[ 'cameraProjectionMatrix' ].value = this.camera.projectionMatrix;
+	this.saoMaterial.blending = THREE.NoBlending;
+
+	if ( THREE.DepthLimitedBlurShader === undefined ) {
+
+		console.error( 'THREE.SAOPass relies on THREE.DepthLimitedBlurShader' );
+
+	}
+
+	this.vBlurMaterial = new THREE.ShaderMaterial( {
+		uniforms: THREE.UniformsUtils.clone( THREE.DepthLimitedBlurShader.uniforms ),
+		defines: Object.assign( {}, THREE.DepthLimitedBlurShader.defines ),
+		vertexShader: THREE.DepthLimitedBlurShader.vertexShader,
+		fragmentShader: THREE.DepthLimitedBlurShader.fragmentShader
+	} );
+	this.vBlurMaterial.defines[ 'DEPTH_PACKING' ] = this.supportsDepthTextureExtension ? 0 : 1;
+	this.vBlurMaterial.defines[ 'PERSPECTIVE_CAMERA' ] = this.camera.isPerspectiveCamera ? 1 : 0;
+	this.vBlurMaterial.uniforms[ 'tDiffuse' ].value = this.saoRenderTarget.texture;
+	this.vBlurMaterial.uniforms[ 'tDepth' ].value = ( this.supportsDepthTextureExtension ) ? depthTexture : this.depthRenderTarget.texture;
+	this.vBlurMaterial.uniforms[ 'size' ].value.set( this.resolution.x, this.resolution.y );
+	this.vBlurMaterial.blending = THREE.NoBlending;
+
+	this.hBlurMaterial = new THREE.ShaderMaterial( {
+		uniforms: THREE.UniformsUtils.clone( THREE.DepthLimitedBlurShader.uniforms ),
+		defines: Object.assign( {}, THREE.DepthLimitedBlurShader.defines ),
+		vertexShader: THREE.DepthLimitedBlurShader.vertexShader,
+		fragmentShader: THREE.DepthLimitedBlurShader.fragmentShader
+	} );
+	this.hBlurMaterial.defines[ 'DEPTH_PACKING' ] = this.supportsDepthTextureExtension ? 0 : 1;
+	this.hBlurMaterial.defines[ 'PERSPECTIVE_CAMERA' ] = this.camera.isPerspectiveCamera ? 1 : 0;
+	this.hBlurMaterial.uniforms[ 'tDiffuse' ].value = this.blurIntermediateRenderTarget.texture;
+	this.hBlurMaterial.uniforms[ 'tDepth' ].value = ( this.supportsDepthTextureExtension ) ? depthTexture : this.depthRenderTarget.texture;
+	this.hBlurMaterial.uniforms[ 'size' ].value.set( this.resolution.x, this.resolution.y );
+	this.hBlurMaterial.blending = THREE.NoBlending;
+
+	if ( THREE.CopyShader === undefined ) {
+
+		console.error( 'THREE.SAOPass relies on THREE.CopyShader' );
+
+	}
+
+	this.materialCopy = new THREE.ShaderMaterial( {
+		uniforms: THREE.UniformsUtils.clone( THREE.CopyShader.uniforms ),
+		vertexShader: THREE.CopyShader.vertexShader,
+		fragmentShader: THREE.CopyShader.fragmentShader,
+		blending: THREE.NoBlending
+	} );
+	this.materialCopy.transparent = true;
+	this.materialCopy.depthTest = false;
+	this.materialCopy.depthWrite = false;
+	this.materialCopy.blending = THREE.CustomBlending;
+	this.materialCopy.blendSrc = THREE.DstColorFactor;
+	this.materialCopy.blendDst = THREE.ZeroFactor;
+	this.materialCopy.blendEquation = THREE.AddEquation;
+	this.materialCopy.blendSrcAlpha = THREE.DstAlphaFactor;
+	this.materialCopy.blendDstAlpha = THREE.ZeroFactor;
+	this.materialCopy.blendEquationAlpha = THREE.AddEquation;
+
+	if ( THREE.CopyShader === undefined ) {
+
+		console.error( 'THREE.SAOPass relies on THREE.UnpackDepthRGBAShader' );
+
+	}
+
+	this.depthCopy = new THREE.ShaderMaterial( {
+		uniforms: THREE.UniformsUtils.clone( THREE.UnpackDepthRGBAShader.uniforms ),
+		vertexShader: THREE.UnpackDepthRGBAShader.vertexShader,
+		fragmentShader: THREE.UnpackDepthRGBAShader.fragmentShader,
+		blending: THREE.NoBlending
+	} );
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene();
+
+};
+
+THREE.SAOPass2.OUTPUT = {
+	'Beauty': 1,
+	'Default': 0,
+	'SAO': 2,
+	'Depth': 3,
+	'Normal': 4
+};
+
+THREE.SAOPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+	constructor: THREE.SAOPass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var colorBuffer = buffers[0];
+
+		if ( this.params.output === 1 ) {
+
+			return;
+
+		}
+
+		this.oldClearColor.copy( renderer.getClearColor() );
+		this.oldClearAlpha = renderer.getClearAlpha();
+		var oldAutoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		renderer.setRenderTarget( this.depthRenderTarget );
+		renderer.clear();
+
+		this.saoMaterial.uniforms[ 'bias' ].value = this.params.saoBias;
+		this.saoMaterial.uniforms[ 'intensity' ].value = this.params.saoIntensity;
+		this.saoMaterial.uniforms[ 'scale' ].value = this.params.saoScale;
+		this.saoMaterial.uniforms[ 'kernelRadius' ].value = this.params.saoKernelRadius;
+		this.saoMaterial.uniforms[ 'minResolution' ].value = this.params.saoMinResolution;
+		this.saoMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
+		this.saoMaterial.uniforms[ 'cameraFar' ].value = this.camera.far;
+		// this.saoMaterial.uniforms['randomSeed'].value = Math.random();
+
+		var depthCutoff = this.params.saoBlurDepthCutoff * ( this.camera.far - this.camera.near );
+		this.vBlurMaterial.uniforms[ 'depthCutoff' ].value = depthCutoff;
+		this.hBlurMaterial.uniforms[ 'depthCutoff' ].value = depthCutoff;
+
+		this.vBlurMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
+		this.vBlurMaterial.uniforms[ 'cameraFar' ].value = this.camera.far;
+		this.hBlurMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
+		this.hBlurMaterial.uniforms[ 'cameraFar' ].value = this.camera.far;
+
+		this.params.saoBlurRadius = Math.floor( this.params.saoBlurRadius );
+		if ( ( this.prevStdDev !== this.params.saoBlurStdDev ) || ( this.prevNumSamples !== this.params.saoBlurRadius ) ) {
+
+			THREE.BlurShaderUtils.configure( this.vBlurMaterial, this.params.saoBlurRadius, this.params.saoBlurStdDev, new THREE.Vector2( 0, 1 ) );
+			THREE.BlurShaderUtils.configure( this.hBlurMaterial, this.params.saoBlurRadius, this.params.saoBlurStdDev, new THREE.Vector2( 1, 0 ) );
+			this.prevStdDev = this.params.saoBlurStdDev;
+			this.prevNumSamples = this.params.saoBlurRadius;
+
+		}
+
+		// Rendering scene to depth texture
+		renderer.setClearColor( 0x000000 );
+		renderer.render( this.scene, this.camera, this.beautyRenderTarget, true );
+
+		// Re-render scene if depth texture extension is not supported
+		if ( ! this.supportsDepthTextureExtension ) {
+
+			// Clear rule : far clipping plane in both RGBA and Basic encoding
+			this.renderOverride( renderer, this.depthMaterial, this.depthRenderTarget, 0x000000, 1.0 );
+
+		}
+
+		if ( this.supportsNormalTexture ) {
+
+			// Clear rule : default normal is facing the camera
+			this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0x7777ff, 1.0 );
+
+		}
+
+		// Rendering SAO texture
+		this.renderPass( renderer, this.saoMaterial, this.saoRenderTarget, 0xffffff, 1.0 );
+
+		// Blurring SAO texture
+		if ( this.params.saoBlur ) {
+
+			this.renderPass( renderer, this.vBlurMaterial, this.blurIntermediateRenderTarget, 0xffffff, 1.0 );
+			this.renderPass( renderer, this.hBlurMaterial, this.saoRenderTarget, 0xffffff, 1.0 );
+
+		}
+
+		var outputMaterial = this.materialCopy;
+		// Setting up SAO rendering
+		if ( this.params.output === 3 ) {
+
+			if ( this.supportsDepthTextureExtension ) {
+
+				this.materialCopy.uniforms[ 'tDiffuse' ].value = this.beautyRenderTarget.depthTexture;
+				this.materialCopy.needsUpdate = true;
+
+			} else {
+
+				this.depthCopy.uniforms[ 'tDiffuse' ].value = this.depthRenderTarget.texture;
+				this.depthCopy.needsUpdate = true;
+				outputMaterial = this.depthCopy;
+
+			}
+
+		} else if ( this.params.output === 4 ) {
+
+			this.materialCopy.uniforms[ 'tDiffuse' ].value = this.normalRenderTarget.texture;
+			this.materialCopy.needsUpdate = true;
+
+		} else {
+
+			this.materialCopy.uniforms[ 'tDiffuse' ].value = this.saoRenderTarget.texture;
+			this.materialCopy.needsUpdate = true;
+
+		}
+
+		// Blending depends on output, only want a CustomBlending when showing SAO
+		if ( this.params.output === 0 ) {
+
+			outputMaterial.blending = THREE.CustomBlending;
+
+		} else {
+
+			outputMaterial.blending = THREE.NoBlending;
+
+		}
+
+		// Rendering SAOPass result on top of previous pass
+		this.renderPass( renderer, outputMaterial, colorBuffer );
+
+		renderer.setClearColor( this.oldClearColor, this.oldClearAlpha );
+		renderer.autoClear = oldAutoClear;
+
+	},
+
+	renderPass: function ( renderer, passMaterial, renderTarget, clearColor, clearAlpha ) {
+
+		// save original state
+		this.originalClearColor.copy( renderer.getClearColor() );
+		var originalClearAlpha = renderer.getClearAlpha();
+		var originalAutoClear = renderer.autoClear;
+
+		// setup pass state
+		var clearNeeded = ( clearColor !== undefined ) && ( clearColor !== null );
+		if ( clearNeeded ) {
+
+			renderer.setClearColor( clearColor );
+			renderer.setClearAlpha( clearAlpha || 0.0 );
+
+		}
+
+		this.fillQuad.quad.material = passMaterial;
+		THREE.Pass2.renderWithClear( renderer, this.fillQuad.scene, this.fillQuad.camera, renderTarget, clearNeeded );
+
+		// restore original state
+		renderer.setClearColor( this.originalClearColor );
+		renderer.setClearAlpha( originalClearAlpha );
+
+	},
+
+	renderOverride: function ( renderer, overrideMaterial, renderTarget, clearColor, clearAlpha ) {
+
+		this.originalClearColor.copy( renderer.getClearColor() );
+		var originalClearAlpha = renderer.getClearAlpha();
+		var originalAutoClear = renderer.autoClear;
+
+		clearColor = overrideMaterial.clearColor || clearColor;
+		clearAlpha = overrideMaterial.clearAlpha || clearAlpha;
+		var clearNeeded = ( clearColor !== undefined ) && ( clearColor !== null );
+		if ( clearNeeded ) {
+
+			renderer.setClearColor( clearColor );
+			renderer.setClearAlpha( clearAlpha || 0.0 );
+
+		}
+
+		this.scene.overrideMaterial = overrideMaterial;
+		
+		renderer.render( this.scene, this.camera, renderTarget, clearNeeded );
+		this.scene.overrideMaterial = null;
+
+		// restore original state
+		renderer.setClearColor( this.originalClearColor );
+		renderer.setClearAlpha( originalClearAlpha );
+
+	},
+
+	setSize: function ( width, height ) {
+
+		this.beautyRenderTarget.setSize( width, height );
+		this.saoRenderTarget.setSize( width, height );
+		this.blurIntermediateRenderTarget.setSize( width, height );
+		this.normalRenderTarget.setSize( width, height );
+		this.depthRenderTarget.setSize( width, height );
+
+		this.saoMaterial.uniforms[ 'size' ].value.set( width, height );
+		this.saoMaterial.uniforms[ 'cameraInverseProjectionMatrix' ].value.getInverse( this.camera.projectionMatrix );
+		this.saoMaterial.uniforms[ 'cameraProjectionMatrix' ].value = this.camera.projectionMatrix;
+		this.saoMaterial.needsUpdate = true;
+
+		this.vBlurMaterial.uniforms[ 'size' ].value.set( width, height );
+		this.vBlurMaterial.needsUpdate = true;
+
+		this.hBlurMaterial.uniforms[ 'size' ].value.set( width, height );
+		this.hBlurMaterial.needsUpdate = true;
+
+	}
+
+} );

--- a/examples/js/postprocessing2/SSAARenderPass2.js
+++ b/examples/js/postprocessing2/SSAARenderPass2.js
@@ -1,0 +1,184 @@
+/**
+*
+* Supersample Anti-Aliasing Render Pass
+*
+* @author bhouston / http://clara.io/
+*
+* This manual approach to SSAA re-renders the scene ones for each sample with camera jitter and accumulates the results.
+*
+* References: https://en.wikipedia.org/wiki/Supersampling
+*
+* @author Oletus / http://oletus.fi/ - ported to EffectComposer2
+*/
+
+THREE.SSAARenderPass2 = function ( scene, camera, clearColor, clearAlpha ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.clear = true;
+
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	this.scene = scene;
+	this.camera = camera;
+
+	this.sampleLevel = 4; // specified as n, where the number of samples is 2^n, so sampleLevel = 4, is 2^4 samples, 16.
+	this.unbiased = true;
+
+	// as we need to clear the buffer in this pass, clearColor must be set to something, defaults to black.
+	this.clearColor = ( clearColor !== undefined ) ? clearColor : 0x000000;
+	this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
+
+	if ( THREE.CopyShader === undefined ) console.error( "THREE.SSAARenderPass2 relies on THREE.CopyShader" );
+
+	var copyShader = THREE.CopyShader;
+	this.copyUniforms = THREE.UniformsUtils.clone( copyShader.uniforms );
+
+	this.copyMaterial = new THREE.ShaderMaterial(	{
+		uniforms: this.copyUniforms,
+		vertexShader: copyShader.vertexShader,
+		fragmentShader: copyShader.fragmentShader,
+		premultipliedAlpha: true,
+		transparent: true,
+		blending: THREE.AdditiveBlending,
+		depthTest: false,
+		depthWrite: false
+	} );
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene( this.copyMaterial );
+};
+
+THREE.SSAARenderPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.SSAARenderPass2,
+
+	dispose: function () {
+
+		if ( this.sampleRenderTarget ) {
+
+			this.sampleRenderTarget.dispose();
+			this.sampleRenderTarget = null;
+
+		}
+
+	},
+
+	setSize: function ( width, height ) {
+
+		if ( ! this.sampleRenderTarget ) {
+
+			this.sampleRenderTarget = new THREE.WebGLRenderTarget( width, height, { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat } );
+			this.sampleRenderTarget.texture.name = "SSAARenderPass2.sample";
+
+		}
+		this.sampleRenderTarget.setSize( width, height );
+
+	},
+	
+	setAccumulateToTexture ( accumulateToTexture ) {
+
+		this.colorBufferConfig.mustBeTexture = accumulateToTexture;
+
+	},
+
+	render: function ( renderer, buffers ) {
+
+		var writeBuffer = buffers[0];
+
+		var jitterOffsets = THREE.SSAARenderPass2.JitterVectors[ Math.max( 0, Math.min( this.sampleLevel, 5 ) ) ];
+
+		var oldClearColor = renderer.getClearColor().getHex();
+		var oldClearAlpha = renderer.getClearAlpha();
+
+		var baseSampleWeight = 1.0 / jitterOffsets.length;
+		var roundingRange = 1 / 32;
+		this.copyUniforms[ "tDiffuse" ].value = this.sampleRenderTarget.texture;
+
+		var width = this.sampleRenderTarget.width, height = this.sampleRenderTarget.height;
+
+		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
+		for ( var i = 0; i < jitterOffsets.length; i ++ ) {
+
+			var jitterOffset = jitterOffsets[ i ];
+
+			if ( this.camera.setViewOffset ) {
+
+				this.camera.setViewOffset( width, height,
+					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625,   // 0.0625 = 1 / 16
+					width, height );
+
+			}
+
+			var sampleWeight = baseSampleWeight;
+
+			if ( this.unbiased ) {
+
+				// the theory is that equal weights for each sample lead to an accumulation of rounding errors.
+				// The following equation varies the sampleWeight per sample so that it is uniformly distributed
+				// across a range of values whose rounding errors cancel each other out.
+
+				var uniformCenteredDistribution = ( - 0.5 + ( i + 0.5 ) / jitterOffsets.length );
+				sampleWeight += roundingRange * uniformCenteredDistribution;
+
+			}
+
+			renderer.setClearColor( this.clearColor, this.clearAlpha );
+			renderer.render( this.scene, this.camera, this.sampleRenderTarget, true );
+
+			if ( i === 0 ) {
+
+				renderer.setClearColor( 0x000000, 0.0 );
+
+			}
+
+			this.copyUniforms[ "opacity" ].value = sampleWeight;
+			THREE.Pass2.renderWithClear(renderer, this.fillQuad.scene, this.fillQuad.camera, writeBuffer, ( i === 0 ) );
+
+		}
+
+		if ( this.camera.clearViewOffset ) this.camera.clearViewOffset();
+
+		renderer.setClearColor( oldClearColor, oldClearAlpha );
+
+	}
+
+} );
+
+
+// These jitter vectors are specified in integers because it is easier.
+// I am assuming a [-8,8) integer grid, but it needs to be mapped onto [-0.5,0.5)
+// before being used, thus these integers need to be scaled by 1/16.
+//
+// Sample patterns reference: https://msdn.microsoft.com/en-us/library/windows/desktop/ff476218%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
+THREE.SSAARenderPass2.JitterVectors = [
+	[
+		[ 0, 0 ]
+	],
+	[
+		[ 4, 4 ], [ - 4, - 4 ]
+	],
+	[
+		[ - 2, - 6 ], [ 6, - 2 ], [ - 6, 2 ], [ 2, 6 ]
+	],
+	[
+		[ 1, - 3 ], [ - 1, 3 ], [ 5, 1 ], [ - 3, - 5 ],
+		[ - 5, 5 ], [ - 7, - 1 ], [ 3, 7 ], [ 7, - 7 ]
+	],
+	[
+		[ 1, 1 ], [ - 1, - 3 ], [ - 3, 2 ], [ 4, - 1 ],
+		[ - 5, - 2 ], [ 2, 5 ], [ 5, 3 ], [ 3, - 5 ],
+		[ - 2, 6 ], [ 0, - 7 ], [ - 4, - 6 ], [ - 6, 4 ],
+		[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ]
+	],
+	[
+		[ - 4, - 7 ], [ - 7, - 5 ], [ - 3, - 5 ], [ - 5, - 4 ],
+		[ - 1, - 4 ], [ - 2, - 2 ], [ - 6, - 1 ], [ - 4, 0 ],
+		[ - 7, 1 ], [ - 1, 2 ], [ - 6, 3 ], [ - 3, 3 ],
+		[ - 7, 6 ], [ - 3, 6 ], [ - 5, 7 ], [ - 1, 7 ],
+		[ 5, - 7 ], [ 1, - 6 ], [ 6, - 5 ], [ 4, - 4 ],
+		[ 2, - 3 ], [ 7, - 2 ], [ 1, - 1 ], [ 4, - 1 ],
+		[ 2, 1 ], [ 6, 2 ], [ 0, 4 ], [ 4, 4 ],
+		[ 2, 5 ], [ 7, 5 ], [ 5, 6 ], [ 3, 7 ]
+	]
+];

--- a/examples/js/postprocessing2/ShaderPass2.js
+++ b/examples/js/postprocessing2/ShaderPass2.js
@@ -1,0 +1,67 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus / http://oletus.fi/
+ */
+
+THREE.ShaderPass2 = function ( shader, textureID ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorWriteBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorWriteBufferConfig.clear = true;
+
+	this.colorReadBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorReadBufferConfig.isOutput = false;
+	this.colorReadBufferConfig.isInput = true;
+
+	this.bufferConfigs = [ this.colorWriteBufferConfig, this.colorReadBufferConfig ];
+
+	this.textureID = ( textureID !== undefined ) ? textureID : "tDiffuse";
+
+	if ( shader instanceof THREE.ShaderMaterial ) {
+
+		this.uniforms = shader.uniforms;
+
+		this.material = shader;
+
+	} else if ( shader ) {
+
+		this.uniforms = THREE.UniformsUtils.clone( shader.uniforms );
+
+		this.material = new THREE.ShaderMaterial( {
+
+			defines: Object.assign( {}, shader.defines ),
+			uniforms: this.uniforms,
+			vertexShader: shader.vertexShader,
+			fragmentShader: shader.fragmentShader
+
+		} );
+
+	}
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene();
+
+};
+
+THREE.ShaderPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.ShaderPass2,
+
+	render: function( renderer, buffers, deltaTime, maskActive ) {
+
+		var writeBuffer = buffers[0];
+		var readBuffer = buffers[1];
+
+		if ( this.uniforms[ this.textureID ] ) {
+
+			this.uniforms[ this.textureID ].value = readBuffer.texture;
+
+		}
+
+		this.fillQuad.quad.material = this.material;
+
+		THREE.Pass2.renderWithClear( renderer, this.fillQuad.scene, this.fillQuad.camera, writeBuffer, this.colorWriteBufferConfig.clear );
+
+	}
+
+} );

--- a/examples/js/postprocessing2/ShaderPass2.js
+++ b/examples/js/postprocessing2/ShaderPass2.js
@@ -39,7 +39,7 @@ THREE.ShaderPass2 = function ( shader, textureID ) {
 
 	}
 
-	this.fillQuad = THREE.Pass2.createFillQuadScene();
+	this.fillQuad = THREE.Pass2.createFillQuadScene( this.material );
 
 };
 

--- a/examples/js/postprocessing2/TexturePass2.js
+++ b/examples/js/postprocessing2/TexturePass2.js
@@ -1,0 +1,57 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author Oletus / http://oletus.fi/
+ */
+
+THREE.TexturePass2 = function ( map, opacity ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.clear = true;
+	this.colorBufferConfig.isInput = true;
+
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	if ( THREE.CopyShader === undefined )
+		console.error( "THREE.TexturePass2 relies on THREE.CopyShader" );
+
+	var shader = THREE.CopyShader;
+
+	this.map = map;
+	this.opacity = ( opacity !== undefined ) ? opacity : 1.0;
+
+	this.uniforms = THREE.UniformsUtils.clone( shader.uniforms );
+
+	this.material = new THREE.ShaderMaterial( {
+
+		uniforms: this.uniforms,
+		vertexShader: shader.vertexShader,
+		fragmentShader: shader.fragmentShader,
+		depthTest: false,
+		depthWrite: false
+
+	} );
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene();
+
+};
+
+THREE.TexturePass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.TexturePass2,
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var writeBuffer = buffers[0];
+
+		this.fillQuad.quad.material = this.material;
+
+		this.uniforms[ "opacity" ].value = this.opacity;
+		this.uniforms[ "tDiffuse" ].value = this.map;
+		this.material.transparent = ( this.opacity < 1.0 );
+
+		THREE.Pass2.renderWithClear( renderer, this.fillQuad.scene, this.fillQuad.camera, writeBuffer, this.colorBufferConfig.clear );
+	}
+
+} );

--- a/examples/js/postprocessing2/TexturePass2.js
+++ b/examples/js/postprocessing2/TexturePass2.js
@@ -33,7 +33,7 @@ THREE.TexturePass2 = function ( map, opacity ) {
 
 	} );
 
-	this.fillQuad = THREE.Pass2.createFillQuadScene();
+	this.fillQuad = THREE.Pass2.createFillQuadScene( this.material );
 
 };
 
@@ -44,8 +44,6 @@ THREE.TexturePass2.prototype = Object.assign( Object.create( THREE.Pass2.prototy
 	render: function ( renderer, buffers, deltaTime, maskActive ) {
 
 		var writeBuffer = buffers[0];
-
-		this.fillQuad.quad.material = this.material;
 
 		this.uniforms[ "opacity" ].value = this.opacity;
 		this.uniforms[ "tDiffuse" ].value = this.map;

--- a/examples/js/postprocessing2/UnrealBloomPass2.js
+++ b/examples/js/postprocessing2/UnrealBloomPass2.js
@@ -1,0 +1,363 @@
+/**
+ * @author spidersharma / http://eduperiment.com/
+ *
+ * Inspired from Unreal Engine
+ * https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/
+ * @author Oletus / http://oletus.fi/ - ported to EffectComposer2
+ */
+THREE.UnrealBloomPass2 = function ( resolution, strength, radius, threshold ) {
+
+	THREE.Pass2.call( this );
+
+	this.colorBufferConfig = new THREE.IntermediateBufferConfig();
+	this.colorBufferConfig.isInput = true;
+	this.colorBufferConfig.mustBeTexture = true;
+
+	this.bufferConfigs = [ this.colorBufferConfig ];
+
+	this.strength = ( strength !== undefined ) ? strength : 1;
+	this.radius = radius;
+	this.threshold = threshold;
+	this.resolution = ( resolution !== undefined ) ? new THREE.Vector2( resolution.x, resolution.y ) : new THREE.Vector2( 256, 256 );
+
+	// create color only once here, reuse it later inside the render function
+	this.clearColor = new THREE.Color( 0, 0, 0 );
+
+	// render targets
+	var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
+	this.renderTargetsHorizontal = [];
+	this.renderTargetsVertical = [];
+	this.nMips = 5;
+	var resx = Math.round( this.resolution.x / 2 );
+	var resy = Math.round( this.resolution.y / 2 );
+
+	this.renderTargetBright = new THREE.WebGLRenderTarget( resx, resy, pars );
+	this.renderTargetBright.texture.name = "UnrealBloomPass2.bright";
+	this.renderTargetBright.texture.generateMipmaps = false;
+
+	for ( var i = 0; i < this.nMips; i ++ ) {
+
+		var renderTargetHorizonal = new THREE.WebGLRenderTarget( resx, resy, pars );
+
+		renderTargetHorizonal.texture.name = "UnrealBloomPass2.h" + i;
+		renderTargetHorizonal.texture.generateMipmaps = false;
+
+		this.renderTargetsHorizontal.push( renderTargetHorizonal );
+
+		var renderTargetVertical = new THREE.WebGLRenderTarget( resx, resy, pars );
+
+		renderTargetVertical.texture.name = "UnrealBloomPass2.v" + i;
+		renderTargetVertical.texture.generateMipmaps = false;
+
+		this.renderTargetsVertical.push( renderTargetVertical );
+
+		resx = Math.round( resx / 2 );
+
+		resy = Math.round( resy / 2 );
+
+	}
+
+	// luminosity high pass material
+
+	if ( THREE.LuminosityHighPassShader === undefined )
+		console.error( "THREE.UnrealBloomPass2 relies on THREE.LuminosityHighPassShader" );
+
+	var highPassShader = THREE.LuminosityHighPassShader;
+	this.highPassUniforms = THREE.UniformsUtils.clone( highPassShader.uniforms );
+
+	this.highPassUniforms[ "luminosityThreshold" ].value = threshold;
+	this.highPassUniforms[ "smoothWidth" ].value = 0.01;
+
+	this.materialHighPassFilter = new THREE.ShaderMaterial( {
+		uniforms: this.highPassUniforms,
+		vertexShader: highPassShader.vertexShader,
+		fragmentShader: highPassShader.fragmentShader,
+		defines: {}
+	} );
+
+	// Gaussian Blur Materials
+	this.separableBlurMaterials = [];
+	var kernelSizeArray = [ 3, 5, 7, 9, 11 ];
+	var resx = Math.round( this.resolution.x / 2 );
+	var resy = Math.round( this.resolution.y / 2 );
+
+	for ( var i = 0; i < this.nMips; i ++ ) {
+
+		this.separableBlurMaterials.push( this.getSeperableBlurMaterial( kernelSizeArray[ i ] ) );
+
+		this.separableBlurMaterials[ i ].uniforms[ "texSize" ].value = new THREE.Vector2( resx, resy );
+
+		resx = Math.round( resx / 2 );
+
+		resy = Math.round( resy / 2 );
+
+	}
+
+	// Composite material
+	this.compositeMaterial = this.getCompositeMaterial( this.nMips );
+	this.compositeMaterial.uniforms[ "blurTexture1" ].value = this.renderTargetsVertical[ 0 ].texture;
+	this.compositeMaterial.uniforms[ "blurTexture2" ].value = this.renderTargetsVertical[ 1 ].texture;
+	this.compositeMaterial.uniforms[ "blurTexture3" ].value = this.renderTargetsVertical[ 2 ].texture;
+	this.compositeMaterial.uniforms[ "blurTexture4" ].value = this.renderTargetsVertical[ 3 ].texture;
+	this.compositeMaterial.uniforms[ "blurTexture5" ].value = this.renderTargetsVertical[ 4 ].texture;
+	this.compositeMaterial.uniforms[ "bloomStrength" ].value = strength;
+	this.compositeMaterial.uniforms[ "bloomRadius" ].value = 0.1;
+	this.compositeMaterial.needsUpdate = true;
+
+	var bloomFactors = [ 1.0, 0.8, 0.6, 0.4, 0.2 ];
+	this.compositeMaterial.uniforms[ "bloomFactors" ].value = bloomFactors;
+	this.bloomTintColors = [ new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ),
+							 new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ) ];
+	this.compositeMaterial.uniforms[ "bloomTintColors" ].value = this.bloomTintColors;
+
+	// copy material
+	if ( THREE.CopyShader === undefined ) {
+
+		console.error( "THREE.UnrealBloomPass2 relies on THREE.CopyShader" );
+
+	}
+
+	var copyShader = THREE.CopyShader;
+
+	this.copyUniforms = THREE.UniformsUtils.clone( copyShader.uniforms );
+	this.copyUniforms[ "opacity" ].value = 1.0;
+
+	this.materialCopy = new THREE.ShaderMaterial( {
+		uniforms: this.copyUniforms,
+		vertexShader: copyShader.vertexShader,
+		fragmentShader: copyShader.fragmentShader,
+		blending: THREE.AdditiveBlending,
+		depthTest: false,
+		depthWrite: false,
+		transparent: true
+	} );
+
+	this.oldClearColor = new THREE.Color();
+	this.oldClearAlpha = 1;
+
+	this.fillQuad = THREE.Pass2.createFillQuadScene();
+
+};
+
+THREE.UnrealBloomPass2.prototype = Object.assign( Object.create( THREE.Pass2.prototype ), {
+
+	constructor: THREE.UnrealBloomPass2,
+
+	dispose: function () {
+
+		for ( var i = 0; i < this.renderTargetsHorizontal.length; i ++ ) {
+
+			this.renderTargetsHorizontal[ i ].dispose();
+
+		}
+
+		for ( var i = 0; i < this.renderTargetsVertical.length; i ++ ) {
+
+			this.renderTargetsVertical[ i ].dispose();
+
+		}
+
+		this.renderTargetBright.dispose();
+
+	},
+
+	setSize: function ( width, height ) {
+
+		var resx = Math.round( width / 2 );
+		var resy = Math.round( height / 2 );
+
+		this.renderTargetBright.setSize( resx, resy );
+
+		for ( var i = 0; i < this.nMips; i ++ ) {
+
+			this.renderTargetsHorizontal[ i ].setSize( resx, resy );
+			this.renderTargetsVertical[ i ].setSize( resx, resy );
+
+			this.separableBlurMaterials[ i ].uniforms[ "texSize" ].value = new THREE.Vector2( resx, resy );
+
+			resx = Math.round( resx / 2 );
+			resy = Math.round( resy / 2 );
+
+		}
+
+	},
+
+	render: function ( renderer, buffers, deltaTime, maskActive ) {
+
+		var colorBuffer = buffers[0];
+
+		this.oldClearColor.copy( renderer.getClearColor() );
+		this.oldClearAlpha = renderer.getClearAlpha();
+		var oldAutoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		renderer.setClearColor( this.clearColor, 0 );
+
+		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
+
+		// 1. Extract Bright Areas
+
+		this.highPassUniforms[ "tDiffuse" ].value = colorBuffer.texture;
+		this.highPassUniforms[ "luminosityThreshold" ].value = this.threshold;
+		this.fillQuad.quad.material = this.materialHighPassFilter;
+
+		renderer.render( this.fillQuad.scene, this.fillQuad.camera, this.renderTargetBright, true );
+
+		// 2. Blur All the mips progressively
+
+		var inputRenderTarget = this.renderTargetBright;
+
+		for ( var i = 0; i < this.nMips; i ++ ) {
+
+			this.fillQuad.quad.material = this.separableBlurMaterials[ i ];
+
+			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = inputRenderTarget.texture;
+			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass2.BlurDirectionX;
+			renderer.render( this.fillQuad.scene, this.fillQuad.camera, this.renderTargetsHorizontal[ i ], true );
+
+			this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = this.renderTargetsHorizontal[ i ].texture;
+			this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass2.BlurDirectionY;
+			renderer.render( this.fillQuad.scene, this.fillQuad.camera, this.renderTargetsVertical[ i ], true );
+
+			inputRenderTarget = this.renderTargetsVertical[ i ];
+
+		}
+
+		// Composite All the mips
+
+		this.fillQuad.quad.material = this.compositeMaterial;
+		this.compositeMaterial.uniforms[ "bloomStrength" ].value = this.strength;
+		this.compositeMaterial.uniforms[ "bloomRadius" ].value = this.radius;
+		this.compositeMaterial.uniforms[ "bloomTintColors" ].value = this.bloomTintColors;
+
+		renderer.render( this.fillQuad.scene, this.fillQuad.camera, this.renderTargetsHorizontal[ 0 ], true );
+
+		// Blend it additively over the input texture
+
+		this.fillQuad.quad.material = this.materialCopy;
+		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetsHorizontal[ 0 ].texture;
+
+		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
+
+		renderer.render( this.fillQuad.scene, this.fillQuad.camera, colorBuffer, false );
+
+		// Restore renderer settings
+
+		renderer.setClearColor( this.oldClearColor, this.oldClearAlpha );
+		renderer.autoClear = oldAutoClear;
+
+	},
+
+	getSeperableBlurMaterial: function ( kernelRadius ) {
+
+		return new THREE.ShaderMaterial( {
+
+			defines: {
+				"KERNEL_RADIUS": kernelRadius,
+				"SIGMA": kernelRadius
+			},
+
+			uniforms: {
+				"colorTexture": { value: null },
+				"texSize": { value: new THREE.Vector2( 0.5, 0.5 ) },
+				"direction": { value: new THREE.Vector2( 0.5, 0.5 ) }
+			},
+
+			vertexShader:
+				"varying vec2 vUv;\n\
+				void main() {\n\
+					vUv = uv;\n\
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
+				}",
+
+			fragmentShader:
+				"#include <common>\
+				varying vec2 vUv;\n\
+				uniform sampler2D colorTexture;\n\
+				uniform vec2 texSize;\
+				uniform vec2 direction;\
+				\
+				float gaussianPdf(in float x, in float sigma) {\
+					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;\
+				}\
+				void main() {\n\
+					vec2 invSize = 1.0 / texSize;\
+					float fSigma = float(SIGMA);\
+					float weightSum = gaussianPdf(0.0, fSigma);\
+					vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;\
+					for( int i = 1; i < KERNEL_RADIUS; i ++ ) {\
+						float x = float(i);\
+						float w = gaussianPdf(x, fSigma);\
+						vec2 uvOffset = direction * invSize * x;\
+						vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;\
+						vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;\
+						diffuseSum += (sample1 + sample2) * w;\
+						weightSum += 2.0 * w;\
+					}\
+					gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n\
+				}"
+		} );
+
+	},
+
+	getCompositeMaterial: function ( nMips ) {
+
+		return new THREE.ShaderMaterial( {
+
+			defines: {
+				"NUM_MIPS": nMips
+			},
+
+			uniforms: {
+				"blurTexture1": { value: null },
+				"blurTexture2": { value: null },
+				"blurTexture3": { value: null },
+				"blurTexture4": { value: null },
+				"blurTexture5": { value: null },
+				"dirtTexture": { value: null },
+				"bloomStrength": { value: 1.0 },
+				"bloomFactors": { value: null },
+				"bloomTintColors": { value: null },
+				"bloomRadius": { value: 0.0 }
+			},
+
+			vertexShader:
+				"varying vec2 vUv;\n\
+				void main() {\n\
+					vUv = uv;\n\
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
+				}",
+
+			fragmentShader:
+				"varying vec2 vUv;\
+				uniform sampler2D blurTexture1;\
+				uniform sampler2D blurTexture2;\
+				uniform sampler2D blurTexture3;\
+				uniform sampler2D blurTexture4;\
+				uniform sampler2D blurTexture5;\
+				uniform sampler2D dirtTexture;\
+				uniform float bloomStrength;\
+				uniform float bloomRadius;\
+				uniform float bloomFactors[NUM_MIPS];\
+				uniform vec3 bloomTintColors[NUM_MIPS];\
+				\
+				float lerpBloomFactor(const in float factor) { \
+					float mirrorFactor = 1.2 - factor;\
+					return mix(factor, mirrorFactor, bloomRadius);\
+				}\
+				\
+				void main() {\
+					gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + \
+													 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + \
+													 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + \
+													 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + \
+													 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );\
+				}"
+		} );
+
+	}
+
+} );
+
+THREE.UnrealBloomPass2.BlurDirectionX = new THREE.Vector2( 1.0, 0.0 );
+THREE.UnrealBloomPass2.BlurDirectionY = new THREE.Vector2( 0.0, 1.0 );

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -51,9 +51,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 		<script>
 
@@ -133,19 +133,18 @@
 				var size = renderer.getDrawingBufferSize();
 				var renderTarget = new THREE.WebGLMultisampleRenderTarget( size.width, size.height, parameters );
 
-				var renderPass = new THREE.RenderPass( scene, camera );
-				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
+				var renderPass = new THREE.RenderPass2( scene, camera );
+				var copyPass = new THREE.ShaderPass2( THREE.CopyShader );
 
 				//
 
-				composer1 = new THREE.EffectComposer( renderer, renderTarget );
+				composer1 = new THREE.EffectComposer2( renderer, renderTarget );
 				composer1.addPass( renderPass );
 				composer1.addPass( copyPass );
 
 				//
 
-				composer2 = new THREE.EffectComposer( renderer );
+				composer2 = new THREE.EffectComposer2( renderer );
 				composer2.addPass( renderPass );
 				composer2.addPass( copyPass );
 
@@ -174,13 +173,20 @@
 
 				group.rotation.y += clock.getDelta() * 0.1;
 
+				// Scissor test is needed so that the clear performed when rendering composer2 doesn't clear composer1 results.
+				renderer.setScissorTest( true );
+
 				renderer.setViewport( 0, 0, halfWidth, window.innerHeight );
+				renderer.setScissor( 0, 0, halfWidth, window.innerHeight );
 
 				composer1.render();
 
 				renderer.setViewport( halfWidth, 0, halfWidth, window.innerHeight );
+				renderer.setScissor( halfWidth, 0, halfWidth, window.innerHeight );
 
 				composer2.render();
+
+				renderer.setScissorTest( false );
 
 			}
 

--- a/examples/webgl_materials_bumpmap_skin.html
+++ b/examples/webgl_materials_bumpmap_skin.html
@@ -46,10 +46,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 		<script src="js/loaders/GLTFLoader.js"></script>
 
@@ -131,15 +130,14 @@
 
 				// BECKMANN
 
-				var effectBeckmann = new THREE.ShaderPass( THREE.ShaderSkin[ "beckmann" ] );
-				var effectCopy = new THREE.ShaderPass( THREE.CopyShader );
-
-				effectCopy.renderToScreen = true;
+				var effectBeckmann = new THREE.ShaderPass2( THREE.ShaderSkin[ "beckmann" ] );
+				var effectCopy = new THREE.ShaderPass2( THREE.CopyShader );
 
 				var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBFormat, stencilBuffer: false };
 				var rtwidth = 512, rtheight = 512;
 
-				composerBeckmann = new THREE.EffectComposer( renderer, new THREE.WebGLRenderTarget( rtwidth, rtheight, pars ) );
+				composerBeckmann = new THREE.EffectComposer2( renderer, { alpha: false } );
+				composerBeckmann.setSize( rtwidth, rtheight );
 				composerBeckmann.addPass( effectBeckmann );
 				composerBeckmann.addPass( effectCopy );
 
@@ -182,7 +180,7 @@
 				uniforms[ "enableBump" ].value = true;
 				uniforms[ "enableSpecular" ].value = true;
 
-				uniforms[ "tBeckmann" ].value = composerBeckmann.renderTarget1.texture;
+				uniforms[ "tBeckmann" ].value = composerBeckmann.colorReadTarget().texture;
 				uniforms[ "tDiffuse" ].value = mapColor;
 
 				uniforms[ "bumpMap" ].value = mapHeight;

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -60,10 +60,9 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 		<script>
 
@@ -158,11 +157,11 @@
 
 				renderer.autoClear = false;
 
-				var renderModel = new THREE.RenderPass( scene, camera );
+				var renderModel = new THREE.RenderPass2( scene, camera );
 
-				var effectBleach = new THREE.ShaderPass( THREE.BleachBypassShader );
-				var effectColor = new THREE.ShaderPass( THREE.ColorCorrectionShader );
-				effectFXAA = new THREE.ShaderPass( THREE.FXAAShader );
+				var effectBleach = new THREE.ShaderPass2( THREE.BleachBypassShader );
+				var effectColor = new THREE.ShaderPass2( THREE.ColorCorrectionShader );
+				effectFXAA = new THREE.ShaderPass2( THREE.FXAAShader );
 
 				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / window.innerWidth, 1 / window.innerHeight );
 
@@ -171,9 +170,7 @@
 				effectColor.uniforms[ 'powRGB' ].value.set( 1.4, 1.45, 1.45 );
 				effectColor.uniforms[ 'mulRGB' ].value.set( 1.1, 1.1, 1.1 );
 
-				effectColor.renderToScreen = true;
-
-				composer = new THREE.EffectComposer( renderer );
+				composer = new THREE.EffectComposer2( renderer );
 
 				composer.addPass( renderModel );
 				composer.addPass( effectFXAA );

--- a/examples/webgl_postprocessing.html
+++ b/examples/webgl_postprocessing.html
@@ -20,9 +20,9 @@
 		<script src="js/shaders/DotScreenShader.js"></script>
 		<script src="js/shaders/RGBShiftShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 
 		<script>
@@ -73,16 +73,15 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
-				composer.addPass( new THREE.RenderPass( scene, camera ) );
+				composer = new THREE.EffectComposer2( renderer );
+				composer.addPass( new THREE.RenderPass2( scene, camera ) );
 
-				var effect = new THREE.ShaderPass( THREE.DotScreenShader );
+				var effect = new THREE.ShaderPass2( THREE.DotScreenShader );
 				effect.uniforms[ 'scale' ].value = 4;
 				composer.addPass( effect );
 
-				var effect = new THREE.ShaderPass( THREE.RGBShiftShader );
+				var effect = new THREE.ShaderPass2( THREE.RGBShiftShader );
 				effect.uniforms[ 'amount' ].value = 0.0015;
-				effect.renderToScreen = true;
 				composer.addPass( effect );
 
 				//

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -19,11 +19,10 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/AfterimageShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/AfterimagePass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
+		<script src="js/postprocessing2/AfterimagePass2.js"></script>
 
 		<script src="js/libs/dat.gui.min.js" type="text/javascript" charset="utf-8"></script>
 
@@ -64,11 +63,10 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
-				composer.addPass( new THREE.RenderPass( scene, camera ) );
+				composer = new THREE.EffectComposer2( renderer );
+				composer.addPass( new THREE.RenderPass2( scene, camera ) );
 
-				afterimagePass = new THREE.AfterimagePass();
-				afterimagePass.renderToScreen = true;
+				afterimagePass = new THREE.AfterimagePass2();
 				composer.addPass( afterimagePass );
 
 				window.addEventListener( 'resize', onWindowResize, false );

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -41,12 +41,12 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/ClearPass.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/TexturePass.js"></script>
-		<script src="js/postprocessing/CubeTexturePass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/ClearColorPass2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/TexturePass2.js"></script>
+		<script src="js/postprocessing2/CubeTexturePass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
 
@@ -184,12 +184,12 @@
 
 				};
 
-				composer = new THREE.EffectComposer( renderer );
+				composer = new THREE.EffectComposer2( renderer );
 
-				clearPass = new THREE.ClearPass( params.clearColor, params.clearAlpha );
+				clearPass = new THREE.ClearColorPass2( params.clearColor, params.clearAlpha );
 				composer.addPass( clearPass );
 
-				texturePass = new THREE.TexturePass();
+				texturePass = new THREE.TexturePass2();
 				composer.addPass( texturePass );
 
 				var textureLoader = new THREE.TextureLoader();
@@ -199,7 +199,7 @@
 
 				} );
 
-				cubeTexturePassP = new THREE.CubeTexturePass( cameraP );
+				cubeTexturePassP = new THREE.CubeTexturePass2( cameraP );
 				composer.addPass( cubeTexturePassP );
 
 				var ldrUrls = genCubeUrls( "textures/cube/pisa/", ".png" );
@@ -210,12 +210,11 @@
 
 				} );
 
-				renderPass = new THREE.RenderPass( scene, cameraP );
-				renderPass.clear = false;
+				renderPass = new THREE.RenderPass2( scene, cameraP );
+				renderPass.colorBufferConfig.clear = false;
 				composer.addPass( renderPass );
 
-				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
+				var copyPass = new THREE.ShaderPass2( THREE.CopyShader );
 				composer.addPass( copyPass );
 
 				var controls = new THREE.OrbitControls( cameraP, renderer.domElement );

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -51,9 +51,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 		<script src="js/shaders/FXAAShader.js"></script>
 
 		<script>
@@ -131,30 +131,25 @@
 
 				//
 
-				var renderPass = new THREE.RenderPass( scene, camera );
+				var renderPass = new THREE.RenderPass2( scene, camera );
 
 				//
 
-				fxaaPass = new THREE.ShaderPass( THREE.FXAAShader );
-				fxaaPass.renderToScreen = true;
+				fxaaPass = new THREE.ShaderPass2( THREE.FXAAShader );
 
 				var pixelRatio = renderer.getPixelRatio();
 
 				fxaaPass.material.uniforms[ 'resolution' ].value.x = 1 / ( window.innerWidth * pixelRatio );
 				fxaaPass.material.uniforms[ 'resolution' ].value.y = 1 / ( window.innerHeight * pixelRatio );
 
-				composer1 = new THREE.EffectComposer( renderer );
+				composer1 = new THREE.EffectComposer2( renderer );
 				composer1.addPass( renderPass );
 				composer1.addPass( fxaaPass );
 
 				//
 
-				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
-
-				composer2 = new THREE.EffectComposer( renderer );
+				composer2 = new THREE.EffectComposer2( renderer );
 				composer2.addPass( renderPass );
-				composer2.addPass( copyPass );
 
 				//
 
@@ -186,14 +181,20 @@
 
 				group.rotation.y += clock.getDelta() * 0.1;
 
+				// Scissor test is needed so that the clear performed when rendering composer2 doesn't clear composer1 results.
+				renderer.setScissorTest( true );
+
 				renderer.setViewport( 0, 0, halfWidth, window.innerHeight );
+				renderer.setScissor( 0, 0, halfWidth, window.innerHeight );
 
 				composer1.render();
 
 				renderer.setViewport( halfWidth, 0, halfWidth, window.innerHeight );
+				renderer.setScissor( halfWidth, 0, halfWidth, window.innerHeight );
 
 				composer2.render();
 
+				renderer.setScissorTest( false );
 			}
 
 		</script>

--- a/examples/webgl_postprocessing_glitch.html
+++ b/examples/webgl_postprocessing_glitch.html
@@ -31,11 +31,10 @@
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/DigitalGlitch.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/GlitchPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
+		<script src="js/postprocessing2/GlitchPass2.js"></script>
 
 		<div>
 			<label for="dotScreen">Glitch me wild:</label><input id="wildGlitch" type="checkbox" onchange="updateOptions()"/><br />
@@ -99,11 +98,10 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
-				composer.addPass( new THREE.RenderPass( scene, camera ) );
+				composer = new THREE.EffectComposer2( renderer );
+				composer.addPass( new THREE.RenderPass2( scene, camera ) );
 
-				glitchPass = new THREE.GlitchPass();
-				glitchPass.renderToScreen = true;
+				glitchPass = new THREE.GlitchPass2();
 				composer.addPass( glitchPass );
 
 

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -82,16 +82,7 @@
 
 				var outputPass = new THREE.ShaderPass2( THREE.CopyShader );
 
-				var parameters = {
-					minFilter: THREE.LinearFilter,
-					magFilter: THREE.LinearFilter,
-					format: THREE.RGBFormat,
-					stencilBuffer: true
-				};
-
-				var renderTarget = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, parameters );
-
-				composer = new THREE.EffectComposer2( renderer, renderTarget );
+				composer = new THREE.EffectComposer2( renderer, { alpha: false } );
 				composer.addPass( clearPass );
 				composer.addPass( maskPass1 );
 				composer.addPass( texturePass1 );

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -20,11 +20,11 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/ClearPass.js"></script>
-		<script src="js/postprocessing/TexturePass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/ClearColorPass2.js"></script>
+		<script src="js/postprocessing2/TexturePass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
+		<script src="js/postprocessing2/MaskPass2.js"></script>
 
 		<script src="js/WebGL.js"></script>
 		<script src="js/libs/stats.min.js"></script>
@@ -66,22 +66,21 @@
 
 				//
 
-				var clearPass = new THREE.ClearPass();
+				var clearPass = new THREE.ClearColorPass2();
 
-				var clearMaskPass = new THREE.ClearMaskPass();
+				var clearMaskPass = new THREE.ClearMaskPass2();
 
-				var maskPass1 = new THREE.MaskPass( scene1, camera );
-				var maskPass2 = new THREE.MaskPass( scene2, camera );
+				var maskPass1 = new THREE.MaskPass2( scene1, camera );
+				var maskPass2 = new THREE.MaskPass2( scene2, camera );
 
 				var texture1 = new THREE.TextureLoader().load( 'textures/758px-Canestra_di_frutta_(Caravaggio).jpg' );
 				texture1.minFilter = THREE.LinearFilter;
 				var texture2 = new THREE.TextureLoader().load( 'textures/2294472375_24a3b8ef46_o.jpg' );
 
-				var texturePass1 = new THREE.TexturePass( texture1 );
-				var texturePass2 = new THREE.TexturePass( texture2 );
+				var texturePass1 = new THREE.TexturePass2( texture1 );
+				var texturePass2 = new THREE.TexturePass2( texture2 );
 
-				var outputPass = new THREE.ShaderPass( THREE.CopyShader );
-				outputPass.renderToScreen = true;
+				var outputPass = new THREE.ShaderPass2( THREE.CopyShader );
 
 				var parameters = {
 					minFilter: THREE.LinearFilter,
@@ -92,7 +91,7 @@
 
 				var renderTarget = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, parameters );
 
-				composer = new THREE.EffectComposer( renderer, renderTarget );
+				composer = new THREE.EffectComposer2( renderer, renderTarget );
 				composer.addPass( clearPass );
 				composer.addPass( maskPass1 );
 				composer.addPass( texturePass1 );
@@ -121,7 +120,7 @@
 				torus.rotation.y = time / 2;
 
 				renderer.clear();
-				composer.render( time );
+				composer.render( );
 
 			}
 

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -42,9 +42,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/PixelShader.js"></script>
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 		<script src="js/controls/TrackballControls.js"></script>
 		<script src='js/libs/dat.gui.min.js'></script>
 
@@ -141,13 +141,12 @@
 
 				scene.add( group );
 
-				composer = new THREE.EffectComposer( renderer );
-				composer.addPass( new THREE.RenderPass( scene, camera ) );
+				composer = new THREE.EffectComposer2( renderer );
+				composer.addPass( new THREE.RenderPass2( scene, camera ) );
 
-				pixelPass = new THREE.ShaderPass( THREE.PixelShader );
+				pixelPass = new THREE.ShaderPass2( THREE.PixelShader );
 				pixelPass.uniforms[ "resolution" ].value = new THREE.Vector2( window.innerWidth, window.innerHeight );
 				pixelPass.uniforms[ "resolution" ].value.multiplyScalar( window.devicePixelRatio );
-				pixelPass.renderToScreen = true;
 				composer.addPass( pixelPass );
 
 				window.addEventListener( 'resize', resize );

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -32,10 +32,10 @@
 	<body>
 		<script src="../build/three.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
-		<script src="js/postprocessing/SAOPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
+		<script src="js/postprocessing2/SAOPass2.js"></script>
 
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/SAOShader.js"></script>
@@ -135,21 +135,20 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				composer = new THREE.EffectComposer( renderer );
-				renderPass = new THREE.RenderPass( scene, camera );
+				composer = new THREE.EffectComposer2( renderer );
+				renderPass = new THREE.RenderPass2( scene, camera );
 				composer.addPass( renderPass );
-				saoPass = new THREE.SAOPass( scene, camera, false, true );
-				saoPass.renderToScreen = true;
+				saoPass = new THREE.SAOPass2( scene, camera, false, true );
 				composer.addPass( saoPass );
 
 				// Init gui
 				var gui = new dat.GUI();
 				gui.add( saoPass.params, 'output', {
-					'Beauty': THREE.SAOPass.OUTPUT.Beauty,
-					'Beauty+SAO': THREE.SAOPass.OUTPUT.Default,
-					'SAO': THREE.SAOPass.OUTPUT.SAO,
-					'Depth': THREE.SAOPass.OUTPUT.Depth,
-					'Normal': THREE.SAOPass.OUTPUT.Normal
+					'Beauty': THREE.SAOPass2.OUTPUT.Beauty,
+					'Beauty+SAO': THREE.SAOPass2.OUTPUT.Default,
+					'SAO': THREE.SAOPass2.OUTPUT.SAO,
+					'Depth': THREE.SAOPass2.OUTPUT.Depth,
+					'Normal': THREE.SAOPass2.OUTPUT.Normal
 				} ).onChange( function ( value ) {
 
 					saoPass.params.output = parseInt( value );

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -40,9 +40,9 @@
 		<script src="js/shaders/LuminosityShader.js"></script>
 		<script src="js/shaders/SobelOperatorShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - webgl - postprocessing - sobel (edge detection)
@@ -103,13 +103,13 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
-				var renderPass = new THREE.RenderPass( scene, camera );
+				composer = new THREE.EffectComposer2( renderer );
+				var renderPass = new THREE.RenderPass2( scene, camera );
 				composer.addPass( renderPass );
 
 				// color to grayscale conversion
 
-				var effectGrayScale = new THREE.ShaderPass( THREE.LuminosityShader );
+				var effectGrayScale = new THREE.ShaderPass2( THREE.LuminosityShader );
 				composer.addPass( effectGrayScale );
 
 				// you might want to use a gaussian blur filter before
@@ -117,8 +117,7 @@
 
 				// Sobel operator
 
-				effectSobel = new THREE.ShaderPass( THREE.SobelOperatorShader );
-				effectSobel.renderToScreen = true;
+				effectSobel = new THREE.ShaderPass2( THREE.SobelOperatorShader );
 				effectSobel.uniforms[ "resolution" ].value.x = window.innerWidth;
 				effectSobel.uniforms[ "resolution" ].value.y = window.innerHeight;
 				composer.addPass( effectSobel );

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -43,11 +43,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/SSAARenderPass.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/SSAARenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 
 		<script>
@@ -121,15 +119,11 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
+				composer = new THREE.EffectComposer2( renderer );
 
-				ssaaRenderPass = new THREE.SSAARenderPass( scene, camera );
+				ssaaRenderPass = new THREE.SSAARenderPass2( scene, camera );
 				ssaaRenderPass.unbiased = false;
 				composer.addPass( ssaaRenderPass );
-
-				copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
-				composer.addPass( copyPass );
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_postprocessing_ssaa_unbiased.html
+++ b/examples/webgl_postprocessing_ssaa_unbiased.html
@@ -43,11 +43,9 @@
 
 		<script src="js/shaders/CopyShader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/SSAARenderPass.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/SSAARenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 
 
 		<script>
@@ -59,7 +57,7 @@
 
 			var params = {
 				sampleLevel: 4,
-				renderToScreen: false,
+				renderToScreen: true,
 				unbiased: true,
 				camera: 'perspective',
 				clearColor: 'black',
@@ -176,14 +174,11 @@
 
 				// postprocessing
 
-				composer = new THREE.EffectComposer( renderer );
-				ssaaRenderPassP = new THREE.SSAARenderPass( scene, cameraP );
+				composer = new THREE.EffectComposer2( renderer );
+				ssaaRenderPassP = new THREE.SSAARenderPass2( scene, cameraP );
 				composer.addPass( ssaaRenderPassP );
-				ssaaRenderPassO = new THREE.SSAARenderPass( scene, cameraO );
+				ssaaRenderPassO = new THREE.SSAARenderPass2( scene, cameraO );
 				composer.addPass( ssaaRenderPassO );
-				copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
-				composer.addPass( copyPass );
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -251,8 +246,8 @@
 				ssaaRenderPassP.enabled = ( params.camera === 'perspective' );
 				ssaaRenderPassO.enabled = ( params.camera === 'orthographic' );
 
-				ssaaRenderPassP.renderToScreen = ssaaRenderPassO.renderToScreen = params.renderToScreen;
-				copyPass.enabled = ! params.renderToScreen;
+				ssaaRenderPassP.setAccumulateToTexture( !params.renderToScreen );
+				ssaaRenderPassO.setAccumulateToTexture( !params.renderToScreen );
 
 				composer.render();
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -54,12 +54,12 @@
 		<script src="js/controls/OrbitControls.js"></script>
 		<script src="js/loaders/GLTFLoader.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 		<script src="js/shaders/LuminosityHighPassShader.js"></script>
-		<script src="js/postprocessing/UnrealBloomPass.js"></script>
+		<script src="js/postprocessing2/UnrealBloomPass2.js"></script>
 
 		<script>
 
@@ -101,15 +101,14 @@
 			pointLight = new THREE.PointLight( 0xffffff, 1 );
 			camera.add( pointLight );
 
-			var renderScene = new THREE.RenderPass( scene, camera );
+			var renderScene = new THREE.RenderPass2( scene, camera );
 
-			var bloomPass = new THREE.UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
-			bloomPass.renderToScreen = true;
+			var bloomPass = new THREE.UnrealBloomPass2( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
 			bloomPass.threshold = params.bloomThreshold;
 			bloomPass.strength = params.bloomStrength;
 			bloomPass.radius = params.bloomRadius;
 
-			composer = new THREE.EffectComposer( renderer );
+			composer = new THREE.EffectComposer2( renderer );
 			composer.setSize( window.innerWidth, window.innerHeight );
 			composer.addPass( renderScene );
 			composer.addPass( bloomPass );

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -43,10 +43,9 @@
 		<script src="js/pmrem/PMREMGenerator.js"></script>
 		<script src="js/pmrem/PMREMCubeUVPacker.js"></script>
 
-		<script src="js/postprocessing/EffectComposer.js"></script>
-		<script src="js/postprocessing/RenderPass.js"></script>
-		<script src="js/postprocessing/MaskPass.js"></script>
-		<script src="js/postprocessing/ShaderPass.js"></script>
+		<script src="js/postprocessing2/EffectComposer2.js"></script>
+		<script src="js/postprocessing2/RenderPass2.js"></script>
+		<script src="js/postprocessing2/ShaderPass2.js"></script>
 		<script src="js/shaders/CopyShader.js"></script>
 
 		<script>
@@ -208,14 +207,13 @@
 
 				renderer.gammaOutput = true;
 
-				composer = new THREE.EffectComposer( renderer );
+				composer = new THREE.EffectComposer2( renderer );
 				composer.setSize( window.innerWidth, window.innerHeight );
 
-				var renderScene = new THREE.RenderPass( scene, camera );
+				var renderScene = new THREE.RenderPass2( scene, camera );
 				composer.addPass( renderScene );
 
-				var copyPass = new THREE.ShaderPass( THREE.CopyShader );
-				copyPass.renderToScreen = true;
+				var copyPass = new THREE.ShaderPass2( THREE.CopyShader );
 				composer.addPass( copyPass );
 
 				stats = new Stats();


### PR DESCRIPTION
EffectComposer2 is a successor to the post-processing stack EffectComposer. Its advantages are:

1. A simpler but more flexible Pass API. Passes specify a list of input and output buffers that they need instead of having "readBuffer" and "writeBuffer" passed in. It's intended that in the future buffers handled by EffectComposer2 can contain depth, normal etc. information in addition to color information. There's no more "renderToScreen" flag for each pass - instead the final color render target for EffectComposer2 gets passed to the render() function.

2. Common functionality is shared between render passes.

The API for the passes has changed so that passes written against EffectComposer are not compatible with EffectComposer2, so this is added alongside the old EffectComposer instead of replacing it. However, the outward-facing API is mostly the same with the exception of removal of the "renderToScreen" flag.