### PR TITLE
npm: publish examples/jsm folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build/three.module.js",
     "src",
     "examples/js",
+    "examples/jsm",
     "examples/fonts"
   ],
   "directories": {


### PR DESCRIPTION
`node_modules` doesn't have `examples/jsm` after `npm install three` .

![image](https://user-images.githubusercontent.com/23699926/52172459-6b527380-27aa-11e9-862f-894e65d3f02d.png)
