### PR TITLE
Add types property to indicate the main declaration file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 examples/*
 !examples/js/
-src/
 test/
 utils/
 docs/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "mrdoob/three.js",
   "jsnext:main": "build/three.module.js",
   "module": "build/three.module.js",
+  "types": "src/Three.d.ts",
   "files": [
     "package.json",
     "LICENSE",


### PR DESCRIPTION
Add `types` property to indicate the main declaration file.
[docs](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)