### PR TITLE
[WIP] Add position/quaternion/scale cache into Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -81,6 +81,10 @@ function Object3D() {
 		}
 	} );
 
+	this._positionCache = new Vector3();
+	this._quaternionCache = new Quaternion();
+	this._scaleCache = new Vector3().copy( scale );
+
 	this.matrix = new Matrix4();
 	this.matrixWorld = new Matrix4();
 
@@ -592,9 +596,19 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	updateMatrix: function () {
 
-		this.matrix.compose( this.position, this.quaternion, this.scale );
+		if ( ! this._positionCache.equals( this.position ) ||
+			! this._quaternionCache.equals( this.quaternion ) ||
+			! this._scaleCache.equals( this.scale ) ) {
 
-		this.matrixWorldNeedsUpdate = true;
+			this.matrix.compose( this.position, this.quaternion, this.scale );
+
+			this.matrixWorldNeedsUpdate = true;
+
+			this._positionCache.copy( this.position );
+			this._quaternionCache.copy( this.quaternion );
+			this._scaleCache.copy( this.scale );
+
+		}
 
 	},
 


### PR DESCRIPTION
This PR adds `position/quaternion/scale` cache into `Object3D`. This is one of the ideas, discussed in #14138, to skip unnecessary matrix update in `.updateMatrixWorld()`. 

This PR is still WIP because it could have performance penalty in some cases. But you can see how small the change is from this PR.