### PR TITLE
GLTFExporter: Warn when exporting Geometry

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1078,6 +1078,8 @@ THREE.GLTFExporter.prototype = {
 			} else {
 
 				if ( ! geometry.isBufferGeometry ) {
+					
+					console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use THREE.BufferGeometry instead.' );
 
 					var geometryTemp = new THREE.BufferGeometry();
 					geometryTemp.fromGeometry( geometry );


### PR DESCRIPTION
Per https://github.com/mrdoob/three.js/issues/15649.