### PR TITLE
Add setResolveUrl to GLTFLoader

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -204,6 +204,14 @@
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
 		</p>
 
+		<h3>[method:null setResolveUrl]( [param:Function resolveUrl] )</h3>
+		<p>
+		[page:Function resolveUrl] — A function to be called when resolving the url for an asset (image or binary file) referenced in the glTF.<br />
+		The arguments are:<br />
+		[page:String url] — The url of the asset stored in the gltf file. Ex. "textures/grid.png"<br />
+		[page:String path] — The base path to the gltf file. Does not include the gltf file name. Ex. "https://example.com/assets/models/"<br />
+		</p>
+
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -12,6 +12,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 		this.dracoLoader = null;
+		this.resolveUrl = defaultResolveURL;
 
 	}
 
@@ -118,6 +119,13 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
+		setResolveUrl: function ( resolveUrl ) {
+
+			this.resolveUrl = resolveUrl;
+			return this;
+
+		},
+
 		parse: function ( data, path, onLoad, onError ) {
 
 			var content;
@@ -214,7 +222,8 @@ THREE.GLTFLoader = ( function () {
 
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
-				manager: this.manager
+				manager: this.manager,
+				resolveUrl: this.resolveUrl
 
 			} );
 
@@ -1247,7 +1256,7 @@ THREE.GLTFLoader = ( function () {
 
 	/* UTILITY FUNCTIONS */
 
-	function resolveURL( url, path ) {
+	function defaultResolveURL( url, path ) {
 
 		// Invalid URL
 		if ( typeof url !== 'string' || url === '' ) return '';
@@ -1691,6 +1700,8 @@ THREE.GLTFLoader = ( function () {
 		this.multiplePrimitivesCache = [];
 		this.multiPassGeometryCache = [];
 
+		this.resolveUrl = this.options.resolveUrl || defaultResolveURL;
+
 		this.textureLoader = new THREE.TextureLoader( this.options.manager );
 		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 
@@ -1957,7 +1968,7 @@ THREE.GLTFLoader = ( function () {
 
 		return new Promise( function ( resolve, reject ) {
 
-			loader.load( resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
+			loader.load( this.resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
 
 				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
@@ -2180,7 +2191,7 @@ THREE.GLTFLoader = ( function () {
 
 			return new Promise( function ( resolve, reject ) {
 
-				loader.load( resolveURL( sourceURI, options.path ), resolve, undefined, reject );
+				loader.load( this.resolveURL( sourceURI, options.path ), resolve, undefined, reject );
 
 			} );
 


### PR DESCRIPTION
In Mozilla Hubs we rewrite urls contained within glTF files so that they are requested from our CORS proxy ([see here](https://github.com/mozilla/hubs/blob/71975e49d8f67764add2596585c7da500f920a6c/src/utils/media-utils.js#L80)). This PR adds a function `setResolveUrl` to the GLTFLoader class so that you can provide your own url resolution function.