### PR TITLE
Fix GLTFExporter camera yfov value handling.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1408,7 +1408,7 @@ THREE.GLTFExporter.prototype = {
 				gltfCamera.perspective = {
 
 					aspectRatio: camera.aspect,
-					yfov: THREE.Math.degToRad( camera.fov ) / camera.aspect,
+					yfov: THREE.Math.degToRad( camera.fov ),
 					zfar: camera.far <= 0 ? 0.001 : camera.far,
 					znear: camera.near < 0 ? 0 : camera.near
 


### PR DESCRIPTION
The GLTF `yfov` value is the vertical field of view. The `camera.fov` attribute in THREE.js is also a vertical field of view, so it should not be divided by the aspect ratio when exporting.