### PR TITLE
FBXLoader: fix .setPath()

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -44,6 +44,7 @@ THREE.FBXLoader = ( function () {
 			var path = ( self.path === undefined ) ? THREE.LoaderUtils.extractUrlBase( url ) : self.path;
 
 			var loader = new THREE.FileLoader( this.manager );
+			loader.setPath( self.path );
 			loader.setResponseType( 'arraybuffer' );
 
 			loader.load( url, function ( buffer ) {


### PR DESCRIPTION
fix #15717

Consistent with other loaders, such as:
https://github.com/mrdoob/three.js/blob/76e6d92085e5a8a6217de4e3271d4c173d87b080/examples/js/loaders/ColladaLoader.js#L25
https://github.com/mrdoob/three.js/blob/76e6d92085e5a8a6217de4e3271d4c173d87b080/examples/js/loaders/GLTFLoader.js#L68