### PR TITLE
CubeTexture: Use RGBFormat by default.

### DIFF
--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -152,6 +152,7 @@
 					.load( rgbmUrls, function () {
 
 						rgbmCubeMap.encoding = THREE.RGBM16Encoding;
+						rgbmCubeMap.format = THREE.RGBAFormat;
 
 						var pmremGenerator = new THREE.PMREMGenerator( rgbmCubeMap );
 						pmremGenerator.update( renderer );
@@ -160,6 +161,9 @@
 						pmremCubeUVPacker.update( renderer );
 
 						rgbmCubeRenderTarget = pmremCubeUVPacker.CubeUVRenderTarget;
+
+						rgbmCubeMap.magFilter = THREE.LinearFilter;
+						rgbmCubeMap.needsUpdate = true;
 
 						pmremGenerator.dispose();
 						pmremCubeUVPacker.dispose();

--- a/src/textures/CubeTexture.js
+++ b/src/textures/CubeTexture.js
@@ -3,12 +3,13 @@
  */
 
 import { Texture } from './Texture.js';
-import { CubeReflectionMapping } from '../constants.js';
+import { CubeReflectionMapping, RGBFormat } from '../constants.js';
 
 function CubeTexture( images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding ) {
 
 	images = images !== undefined ? images : [];
 	mapping = mapping !== undefined ? mapping : CubeReflectionMapping;
+	format = format !== undefined ? format : RGBFormat;
 
 	Texture.call( this, images, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 


### PR DESCRIPTION
I noticed we were setting RGBA to the 6 textures we upload when using `scene.background`. I would think `RGBFormat` should be a better default for `CubeTexture`.