### PR TITLE
GLTFLoader: Use RGBFormat for aoMap, emissiveMap, metalnessMap, normalMap and roughnessMap.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2232,6 +2232,16 @@ THREE.GLTFLoader = ( function () {
 
 		return this.getDependency( 'texture', mapDef.index ).then( function ( texture ) {
 
+			switch ( mapName ) {
+
+				case 'aoMap':
+				case 'roughnessMap':
+				case 'metalnessMap':
+					texture.format = THREE.RGBFormat;
+					break;
+
+			}
+
 			if ( parser.extensions[ EXTENSIONS.KHR_TEXTURE_TRANSFORM ] ) {
 
 				var transform = mapDef.extensions !== undefined ? mapDef.extensions[ EXTENSIONS.KHR_TEXTURE_TRANSFORM ] : undefined;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2237,6 +2237,7 @@ THREE.GLTFLoader = ( function () {
 				case 'aoMap':
 				case 'emissiveMap':
 				case 'metalnessMap':
+				case 'normalMap':
 				case 'roughnessMap':
 					texture.format = THREE.RGBFormat;
 					break;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2235,6 +2235,7 @@ THREE.GLTFLoader = ( function () {
 			switch ( mapName ) {
 
 				case 'aoMap':
+				case 'emissiveMap':
 				case 'roughnessMap':
 				case 'metalnessMap':
 					texture.format = THREE.RGBFormat;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2236,8 +2236,8 @@ THREE.GLTFLoader = ( function () {
 
 				case 'aoMap':
 				case 'emissiveMap':
-				case 'roughnessMap':
 				case 'metalnessMap':
+				case 'roughnessMap':
 					texture.format = THREE.RGBFormat;
 					break;
 


### PR DESCRIPTION
I suspect we can assume these textures are supposed to be `RGBFormat`.
@donmccurdy is this the right implementation?