### PR TITLE
Documentation: Fixed wrong source and adds missing attribute for ShapePath

### DIFF
--- a/docs/api/en/extras/core/ShapePath.html
+++ b/docs/api/en/extras/core/ShapePath.html
@@ -44,6 +44,9 @@
 		The current [page:Path] that is being generated.
 		</p>
 
+		<h3>[property:Color color]</h3>
+		<p>[page:Color] of the shape, by default set to white (0xffffff).</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:null moveTo]( [param:Float x], [param:Float y] )</h3>
@@ -86,6 +89,6 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/extras/core/Path.js src/extras/core/Path.js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/extras/core/ShapePath.js src/extras/core/ShapePath.js]
 	</body>
 </html>


### PR DESCRIPTION
Fixed the linked source from `Path.js` to `ShapePath.js` and added the missing property `color`.