### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -93,7 +93,7 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 
 		renderer.setRenderTarget( _renderTargetR );
 		renderer.clear();
-		renderer.render( scene, _stereo.cameraR, _renderTargetR, true );
+		renderer.render( scene, _stereo.cameraR );
 
 		renderer.setRenderTarget( null );
 		renderer.render( _scene, _camera );

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -164,7 +164,7 @@ THREE.AdaptiveToneMappingPass.prototype = Object.assign( Object.create( THREE.Pa
 			this.quad.material = this.materialCopy;
 			this.copyUniforms.tDiffuse.value = this.luminanceRT.texture;
 			renderer.setRenderTarget( this.previousLuminanceRT );
-			renderer.render( this.scene, this.camera, this.previousLuminanceRT );
+			renderer.render( this.scene, this.camera );
 
 		}
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -361,7 +361,7 @@
 					postprocessing.godraysFakeSunUniforms[ "fAspect" ].value = window.innerWidth / window.innerHeight;
 
 					postprocessing.scene.overrideMaterial = postprocessing.materialGodraysFakeSun;
-					renderer.render( postprocessing.rtTextureColors );
+					renderer.setRenderTarget( postprocessing.rtTextureColors );
 					renderer.render( postprocessing.scene, postprocessing.camera );
 
 					renderer.setScissorTest( false );


### PR DESCRIPTION
Some more fixes related to the new signature of `WebGLRenderer.render()`.

/cc @maccesch