### PR TITLE
Fix Object3D.updateMatrixWorld definition

### DIFF
--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -306,7 +306,7 @@ export class Object3D extends EventDispatcher {
   /**
    * Updates global transform of the object and its children.
    */
-  updateMatrixWorld(force: boolean): void;
+  updateMatrixWorld(force?: boolean): void;
 
   updateWorldMatrix(updateParents: boolean, updateChildren: boolean): void;
 


### PR DESCRIPTION
Judging by the implementation, the `force` parameter should be optional.