### PR TITLE
WebGLRenderer: add getViewport() method

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -372,6 +372,13 @@
 		Returns the width and height of the renderer's output canvas, in pixels.
 		</p>
 
+		<h3>[method:Vector4 getViewport]( [param:Vector4 target] )</h3>
+		<p>
+		[page:Vector4 target] — the result will be copied into this Vector4.<br /><br />
+
+		Returns the viewport.
+		</p>
+
 		<h3>[method:null resetGLState]( )</h3>
 		<p>Reset the GL state to default. Called internally if the WebGL context is lost.</p>
 

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -215,6 +215,12 @@ export class WebGLRenderer implements Renderer {
   setSize(width: number, height: number, updateStyle?: boolean): void;
 
   getCurrentViewport(target: Vector4): Vector4;
+
+  /**
+   * Copies the viewport into target.
+   */
+  getViewport(target: Vector4): Vector4;
+
   /**
    * Sets the viewport to render from (x, y) to (x + width, y + height).
    */

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -443,6 +443,12 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.getViewport = function ( target ) {
+
+		return target.copy( _viewport );
+
+	};
+
 	this.setViewport = function ( x, y, width, height ) {
 
 		_viewport.set( x, y, width, height );


### PR DESCRIPTION
This new method enables the user to save the viewport so it can be restored later.

