### PR TITLE
WebGLRenderer: Remove getCurrentViewport() method

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -348,13 +348,6 @@
 		<h3>[method:RenderTarget getRenderTarget]()</h3>
 		<p>Returns the current RenderTarget, if any.</p>
 
-		<h3>[method:Vector4 getCurrentViewport]( [param:Vector4 target] )</h3>
-		<p>
-		[page:Vector4 target] — the result will be copied into this Vector4.<br /><br />
-
-		Returns the current viewport.
-		</p>
-
 		<h3>[method:Vector2 getDrawingBufferSize]( [param:Vector2 target] )</h3>
 		<p>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />

--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -162,7 +162,7 @@ THREE.Lensflare = function () {
 
 	this.onBeforeRender = function ( renderer, scene, camera ) {
 
-		renderer.getCurrentViewport( viewport );
+		renderer.getViewport( viewport ).multiplyScalar( renderer.getPixelRatio() );
 
 		var invAspect = viewport.w / viewport.z;
 		var halfViewportWidth = viewport.z / 2.0;

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1363,6 +1363,12 @@ Object.defineProperties( ShaderMaterial.prototype, {
 
 Object.assign( WebGLRenderer.prototype, {
 
+	getCurrentViewport: function () {
+
+		console.warn( 'THREE.WebGLRenderer: .getCurrentViewport() has been removed.' );
+
+	},
+
 	clearTarget: function ( renderTarget, color, depth, stencil ) {
 
 		console.warn( 'THREE.WebGLRenderer: .clearTarget() has been deprecated. Use .setRenderTarget() and .clear() instead.' );

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -214,8 +214,6 @@ export class WebGLRenderer implements Renderer {
    */
   setSize(width: number, height: number, updateStyle?: boolean): void;
 
-  getCurrentViewport(target: Vector4): Vector4;
-
   /**
    * Copies the viewport into target.
    */

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -429,20 +429,6 @@ function WebGLRenderer( parameters ) {
 
 	};
 
-	this.getCurrentViewport = function ( target ) {
-
-		if ( target === undefined ) {
-
-			console.warn( 'WebGLRenderer: .getCurrentViewport() now requires a Vector4 as an argument' );
-
-			target = new Vector4();
-
-		}
-
-		return target.copy( _currentViewport );
-
-	};
-
 	this.getViewport = function ( target ) {
 
 		return target.copy( _viewport );


### PR DESCRIPTION
Users need to be able to set the viewport, and then get the viewport, and get back what they set.

The methods `getViewport()` and `setViewport()` handle that now.

`getCurrentViewport()` was only used by `lensflare.js`.

Plus the method name was confusing, IMO.
