### PR TITLE
WebGLRenderer: support Vector4 arg in setViewport()

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -468,8 +468,16 @@
 		The slot number can be found as a value of the uniform of the sampler.
 		</p>
 
-		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
-		<p>Sets the viewport to render from (x, y) to (x + width, y + height).</p>
+		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
+		[method:null setViewport]( [param:Vector4 vector] )</h3>
+
+		<p>
+		The x, y, width, and height parameters of the viewport.<br />
+		Optionally, a 4-component vector specifying the parameters of a viewport.<br /><br />
+
+		Sets the viewport to render from (x, y) to (x + width, y + height).<br />
+		(x, y) is the lower-left corner of the region.
+		</p>
 
 		<h2>Source</h2>
 

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -223,8 +223,9 @@ export class WebGLRenderer implements Renderer {
 
   /**
    * Sets the viewport to render from (x, y) to (x + width, y + height).
+   * (x, y) is the lower-left corner of the region.
    */
-  setViewport(x?: number, y?: number, width?: number, height?: number): void;
+  setViewport(x: Vector4 | number, y?: number, width?: number, height?: number): void;
 
   /**
    * Sets the scissor area from (x, y) to (x + width, y + height).

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -451,7 +451,16 @@ function WebGLRenderer( parameters ) {
 
 	this.setViewport = function ( x, y, width, height ) {
 
-		_viewport.set( x, y, width, height );
+		if ( x.isVector4 ) {
+
+			_viewport.set( x.x, x.y, x.z, x.w );
+
+		} else {
+
+			_viewport.set( x, y, width, height );
+
+		}
+
 		state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ) );
 
 	};


### PR DESCRIPTION
This is the current API:

```js
var vp = new THREE.Vector4();

renderer.getViewport( vp ); // save viewport
. . .
setViewport( vp.x, vp.y, vp.z, vp.w ); // restore viewport
```

With this PR, this is also supported:

```js
renderer.setViewport( vp );
```
