### PR TITLE
ImageBitmapLoader: Fix usage of loading manager

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -90,6 +90,8 @@ ImageBitmapLoader.prototype = {
 
 		} );
 
+		scope.manager.itemStart( url );
+
 	},
 
 	setCrossOrigin: function ( /* value */ ) {


### PR DESCRIPTION
The usage of `LoadingManager` with `ImageBitmapLoader` is currently broken since `itemStart()` is not correctly called, see https://jsfiddle.net/r47sjkt3/