### PR TITLE
add attribute resize tracking

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -24,6 +24,7 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
+	this.resized = false;
 
 	this.version = 0;
 
@@ -53,6 +54,7 @@ Object.assign( BufferAttribute.prototype, {
 
 		}
 
+		this.resized = ( array.length !== this.array.length );
 		this.count = array !== undefined ? array.length / this.itemSize : 0;
 		this.array = array;
 
@@ -71,6 +73,7 @@ Object.assign( BufferAttribute.prototype, {
 	copy: function ( source ) {
 
 		this.name = source.name;
+		this.resized = ( source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.itemSize = source.itemSize;
 		this.count = source.count;

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -24,7 +24,7 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
-	this.resized = false;
+	this._resized = false;
 
 	this.version = 0;
 
@@ -54,7 +54,7 @@ Object.assign( BufferAttribute.prototype, {
 
 		}
 
-		this.resized = ( array.length !== this.array.length );
+		this._resized = ( array.length !== this.array.length );
 		this.count = array !== undefined ? array.length / this.itemSize : 0;
 		this.array = array;
 
@@ -73,7 +73,7 @@ Object.assign( BufferAttribute.prototype, {
 	copy: function ( source ) {
 
 		this.name = source.name;
-		this.resized = ( this.array === undefined || source.array.length !== this.array.length );
+		this._resized = ( this.array === undefined || source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.itemSize = source.itemSize;
 		this.count = source.count;

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -73,7 +73,7 @@ Object.assign( BufferAttribute.prototype, {
 	copy: function ( source ) {
 
 		this.name = source.name;
-		this.resized = ( source.array.length !== this.array.length );
+		this.resized = ( this.array === undefined || source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.itemSize = source.itemSize;
 		this.count = source.count;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -11,7 +11,7 @@ function InterleavedBuffer( array, stride ) {
 
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
-	this.resized = false;
+	this._resized = false;
 
 	this.version = 0;
 
@@ -41,7 +41,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		}
 
-		this.resized = ( array.length !== this.array.length );
+		this._resized = ( array.length !== this.array.length );
 		this.count = array !== undefined ? array.length / this.stride : 0;
 		this.array = array;
 
@@ -59,7 +59,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	copy: function ( source ) {
 
-		this.resized = ( this.array === undefined || source.array.length !== this.array.length );
+		this._resized = ( this.array === undefined || source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.count = source.count;
 		this.stride = source.stride;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -59,7 +59,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	copy: function ( source ) {
 
-		this.resized = ( source.array.length !== this.array.length );
+		this.resized = ( this.array === undefined || source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.count = source.count;
 		this.stride = source.stride;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -11,6 +11,7 @@ function InterleavedBuffer( array, stride ) {
 
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
+	this.resized = false;
 
 	this.version = 0;
 
@@ -40,6 +41,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		}
 
+		this.resized = ( array.length !== this.array.length );
 		this.count = array !== undefined ? array.length / this.stride : 0;
 		this.array = array;
 
@@ -57,6 +59,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	copy: function ( source ) {
 
+		this.resized = ( source.array.length !== this.array.length );
 		this.array = new source.array.constructor( source.array );
 		this.count = source.count;
 		this.stride = source.stride;

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -70,9 +70,13 @@ function WebGLAttributes( gl ) {
 
 		gl.bindBuffer( bufferType, buffer );
 
-		if ( attribute.dynamic === false ) {
+		if ( attribute.resized === true ) {
 
-			gl.bufferData( bufferType, array, gl.STATIC_DRAW );
+			var usage = attribute.dynamic ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW;
+
+			gl.bufferData( bufferType, array, usage );
+
+			attribute.resized = false;
 
 		} else if ( updateRange.count === - 1 ) {
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -70,7 +70,7 @@ function WebGLAttributes( gl ) {
 
 		gl.bindBuffer( bufferType, buffer );
 
-		if ( attribute.resized === true ) {
+		if ( attribute._resized === true ) {
 
 			var usage = attribute.dynamic ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW;
 


### PR DESCRIPTION
Untangle overloading of BufferAttribute.dynamic property, re #14730 

.dynamic sets buffer usage expectations as documented.

.updateRange works as documented if dynamic = false. (currently updates entire buffer)

.setArray() and .copy() are safe to use if dynamic = true. (currently produces error)


By default gl.bufferSubData is used for updates except in resize operations.

(a flag to select update mechanism could be added if required )