### PR TITLE
WebGLRenderer: throw error when unable to create GL context.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -233,6 +233,7 @@ function WebGLRenderer( parameters ) {
 
 		console.error( 'THREE.WebGLRenderer: ' + error.message );
 		throw error;
+
 	}
 
 	var extensions, capabilities, state, info;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -232,7 +232,7 @@ function WebGLRenderer( parameters ) {
 	} catch ( error ) {
 
 		console.error( 'THREE.WebGLRenderer: ' + error.message );
-
+		throw error;
 	}
 
 	var extensions, capabilities, state, info;


### PR DESCRIPTION
When unable to create GL context, throw meaningful error rather proceeding with null _gl object and later failing in extensions.get()