### PR TITLE
Fixed TGALoader failing with web workers because of undefined document

### DIFF
--- a/examples/js/loaders/TGALoader.js
+++ b/examples/js/loaders/TGALoader.js
@@ -522,7 +522,9 @@ THREE.TGALoader.prototype = {
 
 		//
 
-		var canvas = document.createElement( 'canvas' );
+		var useOffscreen = typeof OffscreenCanvas !== 'undefined';
+
+		var canvas = useOffscreen ? new OffscreenCanvas(header.width, header.height) : document.createElement( 'canvas' );
 		canvas.width = header.width;
 		canvas.height = header.height;
 
@@ -534,7 +536,7 @@ THREE.TGALoader.prototype = {
 
 		context.putImageData( imageData, 0, 0 );
 
-		return canvas;
+		return useOffscreen ? canvas.transferToImageBitmap() : canvas;
 
 	},
 


### PR DESCRIPTION
The TGA loader did not work with web workers because it used a reference to `document` to create a canvas.

This patch uses an `OffscreenCanvas` by default, which works in both  the usual browser context and in web workers. If not available, we fallback to `document.createElement()`, which corresponds to the previous behavior.