### PR TITLE
Fix texture resizing failing with web workers

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -30,25 +30,40 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			// only perform resize for certain image types
 
-			if ( image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof ImageBitmap ) {
+			if ( image instanceof ImageBitmap || image instanceof HTMLImageElement || image instanceof HTMLCanvasElement ) {
 
-				if ( _canvas === undefined ) _canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
+				// Use an offscreen canvas to resize the image if available, otherwise a canvas element will be created but this won't work in web workers
 
-				// cube textures can't reuse the same canvas
+				var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
 
-				var canvas = needsNewCanvas ? document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' ) : _canvas;
+				function createCanvas( width, height ) {
+
+					return useOffscreenCanvas ?
+						new OffscreenCanvas( width, height ) :
+						document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
+
+				}
 
 				var floor = needsPowerOfTwo ? _Math.floorPowerOfTwo : Math.floor;
 
-				canvas.width = floor( scale * image.width );
-				canvas.height = floor( scale * image.height );
+				var width = floor( scale * image.width );
+				var height = floor( scale * image.height );
+
+				if ( _canvas === undefined ) _canvas = createCanvas( width, height );
+
+				// cube textures can't reuse the same canvas
+
+				var canvas = needsNewCanvas ? createCanvas( width, height ) : _canvas;
+
+				canvas.width = width;
+				canvas.height = height;
 
 				var context = canvas.getContext( '2d' );
-				context.drawImage( image, 0, 0, canvas.width, canvas.height );
+				context.drawImage( image, 0, 0, width, height );
 
-				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + canvas.width + 'x' + canvas.height + ').' );
+				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );
 
-				return canvas;
+				return useOffscreenCanvas ? canvas.transferToImageBitmap() : canvas;
 
 			} else {
 


### PR DESCRIPTION
Fixes #15768.

**The main issue that made resizing fail with web workers was the usage of `document.createElement( 'canvas' )`, which is undefined in web workers.**

This patch uses an `OffscreenCanvas` instead, which works in both the usual browser context and in web workers. If not available, we fallback to `document.createElement()`, which corresponds to the previous behavior.

Because two canvas are needed when dealing with cube textures, the canvas creation is done in a local function to avoid repetitions.

I also swapped the order of the `ImageBitmap`, `HTMLImageElement ` and `HTMLCanvasElement` in the first condition so that `ImageBitmap` is evaluated first and web workers do not complain about the two other undefined types.