### PR TITLE
WebGLRenderer: Add .getScissor(), .getScissorTest() methods

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -365,6 +365,16 @@
 		<h3>[method:number getPixelRatio]()</h3>
 		<p>Returns current device pixel ratio used.</p>
 
+		<h3>[method:Vector4 getScissor]( [param:Vector4 target] )</h3>
+		<p>
+		[page:Vector4 target] — the result will be copied into this Vector4.<br /><br />
+
+		Returns the scissor region.
+		</p>
+
+		<h3>[method:Boolean getScissorTest]()</h3>
+		<p>Returns *true* if scissor test is enabled; returns *false* otherwise.</p>
+
 		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
 		<p>
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -228,9 +228,19 @@ export class WebGLRenderer implements Renderer {
   setViewport(x: Vector4 | number, y?: number, width?: number, height?: number): void;
 
   /**
+   * Copies the scissor area into target.
+   */
+  getScissor(target: Vector4): Vector4;
+
+  /**
    * Sets the scissor area from (x, y) to (x + width, y + height).
    */
   setScissor(x: number, y: number, width: number, height: number): void;
+
+  /**
+   * Returns true if scissor test is enabled; returns false otherwise.
+   */
+  getScissorTest(): boolean;
 
   /**
    * Enable the scissor test. When this is enabled, only the pixels within the defined scissor area will be affected by further renderer actions.

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -466,10 +466,22 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.getScissor = function ( target ) {
+
+		return target.copy( _scissor );
+
+	};
+
 	this.setScissor = function ( x, y, width, height ) {
 
 		_scissor.set( x, y, width, height );
 		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ) );
+
+	};
+
+	this.getScissorTest = function () {
+
+		return _scissorTest;
 
 	};
 


### PR DESCRIPTION
These new methods enable the user to save the scissor region so it can be restored later.