### PR TITLE
WebGLRenderer: support Vector4 arg in setScissor()

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -440,9 +440,15 @@
 		This method sets the active rendertarget. If the parameter is omitted the canvas is set as the active rendertarget.
 		</p>
 
-		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
+		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
+		[method:null setScissor]( [param:Vector4 vector] )</h3>
+
 		<p>
-		Sets the scissor area from (x, y) to (x + width, y + height)
+		The x, y, width, and height parameters of the scissor region.<br />
+		Optionally, a 4-component vector specifying the parameters of the region.<br /><br />
+
+		Sets the scissor region from (x, y) to (x + width, y + height).<br />
+		(x, y) is the lower-left corner of the scissor region.
 		</p>
 
 		<h3>[method:null setScissorTest]( [param:Boolean boolean] )</h3>

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -235,7 +235,7 @@ export class WebGLRenderer implements Renderer {
   /**
    * Sets the scissor area from (x, y) to (x + width, y + height).
    */
-  setScissor(x: number, y: number, width: number, height: number): void;
+  setScissor(x: Vector4 | number, y?: number, width?: number, height?: number): void;
 
   /**
    * Returns true if scissor test is enabled; returns false otherwise.

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -474,7 +474,16 @@ function WebGLRenderer( parameters ) {
 
 	this.setScissor = function ( x, y, width, height ) {
 
-		_scissor.set( x, y, width, height );
+		if ( x.isVector4 ) {
+
+			_scissor.set( x.x, x.y, x.z, x.w );
+
+		} else {
+
+			_scissor.set( x, y, width, height );
+
+		}
+
 		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ) );
 
 	};


### PR DESCRIPTION
Currently, we have to do this:

```js
var sc = new THREE.Vector4();

renderer.getScissor( sc ); // save scissor

. . .

setScissor( sc.x, sc.y, sc.z, sc.w ); // restore scissor
```

With this PR, this is also supported:

```js
renderer.setScissor( sc );
```
