### PR TITLE
Fix and clean up BufferGeometry/Attribute serialization

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -986,11 +986,9 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		if ( index !== null ) {
 
-			var array = Array.prototype.slice.call( index.array );
-
 			data.data.index = {
 				type: index.array.constructor.name,
-				array: array
+				array: Array.prototype.slice.call( index.array )
 			};
 
 		}
@@ -1001,12 +999,10 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			var attribute = attributes[ key ];
 
-			var array = Array.prototype.slice.call( attribute.array );
-
 			var attributeData = {
 				itemSize: attribute.itemSize,
 				type: attribute.array.constructor.name,
-				array: array,
+				array: Array.prototype.slice.call( attribute.array ),
 				normalized: attribute.normalized
 			};
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1025,13 +1025,16 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				var attribute = attributeArray[ i ];
 
-				array.push( {
-					name: attribute.name,
+				var attributeData = {
 					itemSize: attribute.itemSize,
 					type: attribute.array.constructor.name,
 					array: Array.prototype.slice.call( attribute.array ),
 					normalized: attribute.normalized
-				} );
+				};
+
+				if ( attribute.name !== '' ) attributeData.name = attribute.name;
+
+				array.push( attributeData );
 
 			}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -980,7 +980,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		data.data = { attributes: {}, morphAttributes: {} };
+		data.data = { attributes: {} };
 
 		var index = this.index;
 
@@ -1012,9 +1012,10 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
-		var morphAttributes = this.morphAttributes;
+		var morphAttributes = {};
+		var hasMorphAttributes = false;
 
-		for ( var key in morphAttributes ) {
+		for ( var key in this.morphAttributes ) {
 
 			var attributeArray = this.morphAttributes[ key ];
 
@@ -1034,9 +1035,17 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			}
 
-			data.data.morphAttributes[ key ] = array;
+			if ( array.length > 0 ) {
+
+				morphAttributes[ key ] = array;
+
+				hasMorphAttributes = true;
+
+			}
 
 		}
+
+		if ( hasMorphAttributes ) data.data.morphAttributes = morphAttributes;
 
 		var groups = this.groups;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1003,12 +1003,16 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			var array = Array.prototype.slice.call( attribute.array );
 
-			data.data.attributes[ key ] = {
+			var attributeData = {
 				itemSize: attribute.itemSize,
 				type: attribute.array.constructor.name,
 				array: array,
 				normalized: attribute.normalized
 			};
+
+			if ( attribute.name !== '' ) attributeData.name = attribute.name;
+
+			data.data.attributes[ key ] = attributeData;
 
 		}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -57,24 +57,28 @@ Object.assign( BufferGeometryLoader.prototype, {
 
 		var morphAttributes = json.data.morphAttributes;
 
-		for ( var key in morphAttributes ) {
+		if ( morphAttributes ) {
 
-			var attributeArray = morphAttributes[ key ];
+			for ( var key in morphAttributes ) {
 
-			var array = [];
+				var attributeArray = morphAttributes[ key ];
 
-			for ( var i = 0, il = attributeArray.length; i < il; i ++ ) {
+				var array = [];
 
-				var attribute = attributeArray[ i ];
-				var typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+				for ( var i = 0, il = attributeArray.length; i < il; i ++ ) {
 
-				var bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
-				if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
-				array.push( bufferAttribute );
+					var attribute = attributeArray[ i ];
+					var typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+
+					var bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
+					if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
+					array.push( bufferAttribute );
+
+				}
+
+				geometry.morphAttributes[ key ] = array;
 
 			}
-
-			geometry.morphAttributes[ key ] = array;
 
 		}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -51,7 +51,9 @@ Object.assign( BufferGeometryLoader.prototype, {
 			var attribute = attributes[ key ];
 			var typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
 
-			geometry.addAttribute( key, new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized ) );
+			var bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
+			if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
+			geometry.addAttribute( key, bufferAttribute );
 
 		}
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -809,6 +809,7 @@ export default QUnit.module( 'Core', () => {
 
 			var index = new BufferAttribute( new Uint16Array( [ 0, 1, 2, 3 ] ), 1 );
 			var attribute1 = new BufferAttribute( new Uint16Array( [ 1, 3, 5, 7 ] ), 1 );
+			attribute1.name = "attribute1";
 			var a = new BufferGeometry();
 			a.name = "JSONQUnit.test";
 			// a.parameters = { "placeholder": 0 };
@@ -817,7 +818,6 @@ export default QUnit.module( 'Core', () => {
 			a.addGroup( 0, 1, 2 );
 			a.boundingSphere = new Sphere( new Vector3( x, y, z ), 0.5 );
 			var j = a.toJSON();
-
 			var gold = {
 				"metadata": {
 					"version": 4.5,
@@ -833,7 +833,8 @@ export default QUnit.module( 'Core', () => {
 							"itemSize": 1,
 							"type": "Uint16Array",
 							"array": [ 1, 3, 5, 7 ],
-							"normalized": false
+							"normalized": false,
+							"name": "attribute1"
 						}
 					},
 					"index": {
@@ -855,6 +856,22 @@ export default QUnit.module( 'Core', () => {
 			};
 
 			assert.deepEqual( j, gold, "Generated JSON is as expected" );
+
+			// add morphAttributes
+			a.morphAttributes.attribute1 = [];
+			a.morphAttributes.attribute1.push( attribute1.clone() );
+			j = a.toJSON();
+			gold.data.morphAttributes = {
+				"attribute1": [ {
+					"itemSize": 1,
+					"type": "Uint16Array",
+					"array": [ 1, 3, 5, 7 ],
+					"normalized": false,
+					"name": "attribute1"
+				} ]
+			};
+
+			assert.deepEqual( j, gold, "Generated JSON with morphAttributes is as expected" );
 
 		} );
 


### PR DESCRIPTION
Changes
- Add morphAttribute to serialized buffer geometry data only when `geometry.morphAttribute` isn't empty. Fix travis error. See https://github.com/mrdoob/three.js/pull/11596#issuecomment-465397632
- Serialize non-morph attribute name
- Add name to serialized buffer attribute data only when `attribute.name` isn't empty
- Minor clean up
- Update BufferGeometry.toJSON() test