### PR TITLE
WebVR examples: Add support for 'additive' XR devices

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -7,7 +7,7 @@
 
 var WEBVR = {
 
-	createButton: function ( renderer, options ) {
+	createButton: function ( renderer, options, onXRSessionStarted, onXRSessionEnded ) {
 
 		if ( options && options.frameOfReferenceType ) {
 
@@ -49,6 +49,8 @@ var WEBVR = {
 				renderer.vr.setSession( session );
 				button.textContent = 'EXIT VR';
 
+				if ( onXRSessionStarted ) onXRSessionStarted( session );
+
 				currentSession = session;
 
 			}
@@ -59,6 +61,8 @@ var WEBVR = {
 
 				renderer.vr.setSession( null );
 				button.textContent = 'ENTER VR';
+
+				if ( onXRSessionEnded ) onXRSessionEnded( currentSession );
 
 				currentSession = null;
 

--- a/examples/webvr_ballshooter.html
+++ b/examples/webvr_ballshooter.html
@@ -59,8 +59,9 @@
 				info.innerHTML = '<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - ball shooter';
 				container.appendChild( info );
 
+				var sceneBackgroundColor = new THREE.Color( 0x505050 );
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x505050 );
+				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
 
@@ -104,7 +105,27 @@
 
 				//
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				function onXRSessionStarted( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					if ( session && session.environmentBlendMode === 'additive' ) {
+
+						scene.background = null;
+
+					}
+
+				}
+
+				function onXRSessionEnded( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					scene.background = sceneBackgroundColor;
+
+				}
+
+				document.body.appendChild( WEBVR.createButton( renderer, {}, onXRSessionStarted, onXRSessionEnded ) );
 
 				// controllers
 

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -57,8 +57,9 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - interactive cubes';
 				container.appendChild( info );
 
+				var sceneBackgroundColor = new THREE.Color( 0x505050 );
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x505050 );
+				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
 				scene.add( camera );
@@ -134,7 +135,27 @@
 				window.addEventListener( 'vrdisplaypointerrestricted', onPointerRestricted, false );
 				window.addEventListener( 'vrdisplaypointerunrestricted', onPointerUnrestricted, false );
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				function onXRSessionStarted( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					if ( session && session.environmentBlendMode === 'additive' ) {
+
+						scene.background = null;
+
+					}
+
+				}
+
+				function onXRSessionEnded( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					scene.background = sceneBackgroundColor;
+
+				}
+
+				document.body.appendChild( WEBVR.createButton( renderer, {}, onXRSessionStarted, onXRSessionEnded ) );
 
 			}
 

--- a/examples/webvr_dragging.html
+++ b/examples/webvr_dragging.html
@@ -53,7 +53,7 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - dragging';
 				container.appendChild( info );
 
-				var sceneBackgroundColor = new THREE.Color( 0x505050 );
+				var sceneBackgroundColor = new THREE.Color( 0x808080 );
 				scene = new THREE.Scene();
 				scene.background = sceneBackgroundColor;
 

--- a/examples/webvr_dragging.html
+++ b/examples/webvr_dragging.html
@@ -53,8 +53,9 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - dragging';
 				container.appendChild( info );
 
+				var sceneBackgroundColor = new THREE.Color( 0x505050 );
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x808080 );
+				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
 
@@ -131,7 +132,29 @@
 				renderer.vr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				function onXRSessionStarted( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					if ( session && session.environmentBlendMode === 'additive' ) {
+
+						scene.background = null;
+						floor.visible = false;
+
+					}
+
+				}
+
+				function onXRSessionEnded( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					scene.background = sceneBackgroundColor;
+					floor.visible = true;
+
+				}
+
+				document.body.appendChild( WEBVR.createButton( renderer, {}, onXRSessionStarted, onXRSessionEnded ) );
 
 				// controllers
 

--- a/examples/webvr_dragging.html
+++ b/examples/webvr_dragging.html
@@ -53,8 +53,8 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - dragging';
 				container.appendChild( info );
 
-				var sceneBackgroundColor = new THREE.Color( 0x808080 );
 				scene = new THREE.Scene();
+				var sceneBackgroundColor = new THREE.Color( 0x808080 );
 				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );

--- a/examples/webvr_paint.html
+++ b/examples/webvr_paint.html
@@ -61,8 +61,9 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - paint';
 				container.appendChild( info );
 
+				var sceneBackgroundColor = new THREE.Color( 0x505050 );
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x222222 );
+				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
 
@@ -99,7 +100,8 @@
 				floor.receiveShadow = true;
 				scene.add( floor );
 
-				scene.add( new THREE.GridHelper( 20, 40, 0x111111, 0x111111 ) );
+				var grid = new THREE.GridHelper( 20, 40, 0x111111, 0x111111 );
+				scene.add( grid );
 
 				scene.add( new THREE.HemisphereLight( 0x888877, 0x777788 ) );
 
@@ -127,7 +129,31 @@
 				renderer.vr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				function onXRSessionStarted( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					if ( session && session.environmentBlendMode === 'additive' ) {
+
+						scene.background = null;
+						floor.visible = false;
+						grid.visible = false;
+
+					}
+
+				}
+
+				function onXRSessionEnded( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					scene.background = sceneBackgroundColor;
+					floor.visible = true;
+					grid.visible = true;
+
+				}
+
+				document.body.appendChild( WEBVR.createButton( renderer, {}, onXRSessionStarted, onXRSessionEnded ) );
 
 				// controllers
 

--- a/examples/webvr_paint.html
+++ b/examples/webvr_paint.html
@@ -61,7 +61,7 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - paint';
 				container.appendChild( info );
 
-				var sceneBackgroundColor = new THREE.Color( 0x505050 );
+				var sceneBackgroundColor = new THREE.Color( 0x222222 );
 				scene = new THREE.Scene();
 				scene.background = sceneBackgroundColor;
 

--- a/examples/webvr_sculpt.html
+++ b/examples/webvr_sculpt.html
@@ -56,8 +56,9 @@
 				info.innerHTML = '<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - sculpt';
 				container.appendChild( info );
 
+				var sceneBackgroundColor = new THREE.Color( 0x222222 );
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x222222 );
+				scene.background = sceneBackgroundColor;
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
 
@@ -114,7 +115,31 @@
 				renderer.vr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				function onXRSessionStarted( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					if ( session && session.environmentBlendMode !== undefined ) {
+
+						if ( session.environmentBlendMode === 'additive' ) {
+
+							scene.background = null;
+
+						}
+
+					}
+
+				}
+
+				function onXRSessionEnded( session ) {
+
+					if ( scene.background === undefined ) return;
+
+					scene.background = sceneBackgroundColor;
+
+				}
+
+				document.body.appendChild( WEBVR.createButton( renderer, {}, onXRSessionStarted, onXRSessionEnded ) );
 
 				// controllers
 


### PR DESCRIPTION
Hide / Show background elements not required on see-through devices like the MagicLeap One based on the `XRSession` [environmentBlendMode](https://github.com/immersive-web/webxr-reference/blob/master/webxr-device-api/xrsession.md).