### PR TITLE
GLTFLoader minor clean up

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -189,7 +189,7 @@ THREE.GLTFLoader = ( function () {
 							break;
 
 						case EXTENSIONS.MSFT_TEXTURE_DDS:
-							extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension( json );
+							extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension();
 							break;
 
 						case EXTENSIONS.KHR_TEXTURE_TRANSFORM:


### PR DESCRIPTION
`GLTFLoader` minor clean up. `GLTFTextureDDSExtension` constructor doesn't take any arguments.