### PR TITLE
[SSAOPass] Fix an incorrect variable name.

### DIFF
--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -392,7 +392,7 @@ THREE.SSAOPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 
 		}
 
-		this.noiseTexture = new THREE.DataTexture( data, width, height, THREE.RGBA, THREE.FloatType );
+		this.noiseTexture = new THREE.DataTexture( data, width, height, THREE.RGBAFormat, THREE.FloatType );
 		this.noiseTexture.wrapS = THREE.RepeatWrapping;
 		this.noiseTexture.wrapT = THREE.RepeatWrapping;
 		this.noiseTexture.needsUpdate = true;


### PR DESCRIPTION
 Replace THREE.RGBA with THREE.RGBAFormat.