### PR TITLE
Fix dat.gui slider in animation_skinning_morph example

### DIFF
--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -223,7 +223,7 @@
 
 				for ( var i = 0; i < expressions.length; i++ ) {
 
-					expressionFolder.add( face.morphTargetInfluences, i, 0, 1 ).name( expressions[ i ] );
+					expressionFolder.add( face.morphTargetInfluences, i, 0, 1, 0.01 ).name( expressions[ i ] );
 
 				}
 


### PR DESCRIPTION
Before(left) and After(right).

![image](https://user-images.githubusercontent.com/7637832/53201352-244bf580-3667-11e9-8271-7ce6310f1522.png)
