### PR TITLE
Add function for querying whether OrbitControls have updated

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -82,6 +82,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.position0 = this.object.position.clone();
 	this.zoom0 = this.object.zoom;
 
+    // for querying if update calls have made changes
+	this.updated = false;
+
 	//
 	// public methods
 	//
@@ -120,6 +123,13 @@ THREE.OrbitControls = function ( object, domElement ) {
 		state = STATE.NONE;
 
 	};
+
+    // Allows querying for whether the controls have been updated since last query.
+    this.wasUpdated = function () {
+        var temp = this.updated;
+        this.updated = false;
+        return temp;
+    };
 
 	// this method is exposed, but perhaps it would be better if we can make it private...
 	this.update = function () {
@@ -210,6 +220,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 				lastPosition.copy( scope.object.position );
 				lastQuaternion.copy( scope.object.quaternion );
 				zoomChanged = false;
+
+				this.updated = true;
 
 				return true;
 


### PR DESCRIPTION
This PR adds a function to OrbitControls that allows for querying whether orbit controls have updated. I have added and used this on a local fork in my render loop as follows:

```typescript
  private startRenderingLoop() {
  // ...
  (function render() {
      requestAnimationFrame(render);
      if (component.needsRender()) {
        component.animateMeshes(); // animateMeshes is a function I want to call when "intensive" assets are enabled
        component.renderer.render(component.scene, component.camera);
      }
    }());
  }

  private needsRender(): boolean {
    const controlUpdate = this.controls.wasUpdated();
    const result = controlUpdate || this.sceneChanged || this.intensiveAssetsEnabled;
    this.sceneChanged = false;
    return result;

    // return true; // this is the "strawman" case, usually renderer.render() is always called.
  }
```

In my particular use case, I have a game that only needs to be redrawn if there has been some user interaction, like fiddling with the camera or manipulating the scene. In making this rendering change I have no side effects, and the application when idling uses 0% of my GPU according to Task Manager (previously, it would hover around 15% usage).