### PR TITLE
Fix: wrong face cull for shadows of freshly inserted mirrored objects.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -706,7 +706,7 @@ function WebGLRenderer( parameters ) {
 
 	this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
 
-		var frontFaceCW = ( object.isMesh && object.normalMatrix.determinant() < 0 );
+		var frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
 		state.setMaterial( material, frontFaceCW );
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -383,6 +383,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 			if ( object.castShadow && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
+				object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
 				var geometry = _objects.update( object );
 				var material = object.material;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -383,7 +383,6 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 			if ( object.castShadow && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
-				object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
 				var geometry = _objects.update( object );
 				var material = object.material;


### PR DESCRIPTION
PR for #15821

As the function `renderBufferDirect` uses a `object.normalMatrix` value to determine the face cull direction, it needs to be set in `WebGLShadowMap.renderObject` as well, not only in the `WebGLRenderer.renderObject`.

Note: `normalMatrix` is computed as `this.setFromMatrix4( matrix4 ).getInverse( this ).transpose()`. I hope the performance impact caused by this is acceptable. If not, I suggest adding parameter `mirrored` to the `renderBufferDirect` function and to compute matrix determinant directly without inverting the matrix (matrix inversion does not change determinant sign).