### PR TITLE
Add a ColladaExporter link to the docs

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -382,7 +382,8 @@ var list = {
 
 			"Exporters": {
 				"GLTFExporter": "examples/exporters/GLTFExporter",
-				"PLYExporter": "examples/exporters/PLYExporter"
+				"PLYExporter": "examples/exporters/PLYExporter",
+				"ColladaExporter": "examples/exporters/ColladaExporter"
 			},
 
 			"Plugins": {


### PR DESCRIPTION
Updates the list.js file to include a link to the ColladaExporter docs.

https://raw.githack.com/gkjohnson/three.js/add-collada-exporter-link/docs/#examples/exporters/ColladaExporter