### PR TITLE
Fix WebVR examples with WebXR API

### DIFF
--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -93,6 +93,7 @@ function WebXRManager( renderer ) {
 	function onSessionEnd() {
 
 		renderer.setFramebuffer( null );
+		renderer.setRenderTarget( renderer.getRenderTarget() );
 		animation.stop();
 
 	}


### PR DESCRIPTION
`webvr` examples with WebXR API have been broken in dev branch.

Renderer viewport is resized in `WebGLRenderer.render()` when rendering object with `ArrayCamera` in VR mode.

https://github.com/mrdoob/three.js/blob/r101/src/renderers/WebGLRenderer.js#L1306-L1321

But viewport size isn't reset when user leaves VR mode.

In r101 `.setRenderTarget()` resetting viewport inside was called in each `.render()` call then viewport was automatically reset.

https://github.com/mrdoob/three.js/blob/r101/src/renderers/WebGLRenderer.js#L1106

But with #15571 `.setRenderTarget()` is no longer called in `.render()` (unless you give deprecated third argument `renderTarget`). So we need to reset viewport size when session ends in `WebXRManager` like `WebVRManager` does.

Probably adding `renderer.setRenderTarget( renderer.getRenderTarget() );` in `onSessionEnd()` is the easiest solution. Let me know if there is any better ideas.

Update: Plus, I think we need to re-bind framebuffer from `session.baseLayer.framebuffer` to regular one on session end so calling `.setRenderTarget()` seems a good solution.