### PR TITLE
VertexTangents: Only create varyings if necessary

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -163,7 +163,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 			combine: material.combine,
 
-			vertexTangents: material.vertexTangents,
+			vertexTangents: ( material.normalMap && material.vertexTangents ),
 			vertexColors: material.vertexColors,
 
 			fog: !! fog,


### PR DESCRIPTION
This PR ensures that varyings related to vertex tangents are only created if a normal map is present. Without this fix, a warning appears in the browser console like in this example:

https://raw.githack.com/mrdoob/three.js/dev/examples/webgl_animation_keyframes.html

see https://github.com/mrdoob/three.js/pull/15749#issuecomment-464206817 