### PR TITLE
RenderPass: Fix usage in context of WebGLDeferredRenderer

### DIFF
--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -49,7 +49,9 @@ THREE.RenderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 		}
 
 		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );
-		if ( this.clear ) renderer.clear();
+
+		// TODO: Avoid using autoClear properties, see https://github.com/mrdoob/three.js/pull/15571#issuecomment-465669600
+		if ( this.clear ) renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 		renderer.render( this.scene, this.camera );
 
 		if ( this.clearColor ) {


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/15571#issuecomment-465952857

[webgldeferred_animation](https://raw.githack.com/Mugen87/three.js/dev26/examples/webgldeferred_animation.html) does now work again.