### PR TITLE
Update TypeScript definition typings to match @types/three

### DIFF
--- a/src/loaders/LoadingManager.d.ts
+++ b/src/loaders/LoadingManager.d.ts
@@ -32,7 +32,7 @@ export class LoadingManager {
   constructor(
     onLoad?: () => void,
     onProgress?: (url: string, loaded: number, total: number) => void,
-    onError?: () => void
+    onError?: (url: string) => void
   );
 
   onStart?: (url: string, loaded: number, total: number) => void;

--- a/src/objects/Line.d.ts
+++ b/src/objects/Line.d.ts
@@ -15,7 +15,7 @@ export class Line extends Object3D {
   geometry: Geometry | BufferGeometry;
   material: Material | Material[];
 
-  type: 'Line';
+  type: "Line" | "LineLoop" | "LineSegments";
   isLine: true;
 
   computeLineDistances(): this;

--- a/src/objects/Line.d.ts
+++ b/src/objects/Line.d.ts
@@ -15,7 +15,7 @@ export class Line extends Object3D {
   geometry: Geometry | BufferGeometry;
   material: Material | Material[];
 
-  type: "Line" | "LineLoop" | "LineSegments";
+  type: 'Line' | 'LineLoop' | 'LineSegments';
   isLine: true;
 
   computeLineDistances(): this;

--- a/src/objects/LineLoop.d.ts
+++ b/src/objects/LineLoop.d.ts
@@ -9,6 +9,6 @@ export class LineLoop extends Line {
     material?: Material | Material[]
   );
 
-  type: "LineLoop";
+  type: 'LineLoop';
   isLineLoop: true;
 }

--- a/src/objects/LineLoop.d.ts
+++ b/src/objects/LineLoop.d.ts
@@ -8,4 +8,7 @@ export class LineLoop extends Line {
     geometry?: Geometry | BufferGeometry,
     material?: Material | Material[]
   );
+
+  type: "LineLoop";
+  isLineLoop: true;
 }

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -19,6 +19,6 @@ export class LineSegments extends Line {
     mode?: number
   );
 
-  type: "LineSegments";
+  type: 'LineSegments';
   isLineSegments: true;
 }

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -18,4 +18,7 @@ export class LineSegments extends Line {
     material?: Material | Material[],
     mode?: number
   );
+
+  type: "LineSegments";
+  isLineSegments: true;
 }

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -70,16 +70,14 @@ export interface WebGLRendererParameters {
   preserveDrawingBuffer?: boolean;
 
   /**
-   * default is 0x000000.
+   *  Can be "high-performance", "low-power" or "default"
    */
-  clearColor?: number;
+  powerPreference?: string;
 
   /**
-   * default is 0.
+   * default is true.
    */
-  clearAlpha?: number;
-
-  devicePixelRatio?: number;
+  depth?: boolean;
 
   /**
    * default is false.


### PR DESCRIPTION
This a port of [all the changes](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/master/types/three) that have been made to @types/three since the last release of three.js.