### PR TITLE
Skip unnecessary matrices update in performance_static example

### DIFF
--- a/examples/webgl_performance_static.html
+++ b/examples/webgl_performance_static.html
@@ -46,6 +46,7 @@
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xffffff );
+				scene.matrixAutoUpdate = false;
 
 				var material = new THREE.MeshNormalMaterial();
 


### PR DESCRIPTION
I think `scene.matrixAutoUpdate` should be `false` in `performance_static.html` example. Otherwise, root `scene` local and world matrices are updated and then the world matrices of all the objects under the `scene` are unnecessarily updated every frame.

https://github.com/mrdoob/three.js/blob/r101/src/core/Object3D.js#L593-L634

Another option is `scene.autoUpdate  = false`.