### PR TITLE
Examples: Fix onWindowResize() in webgl_postprocessing_dof2

### DIFF
--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -332,6 +332,15 @@
 				camera.aspect = window.innerWidth / window.innerHeight;
 				camera.updateProjectionMatrix();
 
+				windowHalfX = window.innerWidth / 2;
+				windowHalfY = window.innerHeight / 2;
+
+				postprocessing.rtTextureDepth.setSize( window.innerWidth, window.innerHeight );
+				postprocessing.rtTextureColor.setSize( window.innerWidth, window.innerHeight );
+
+				postprocessing.bokeh_uniforms[ 'textureWidth' ].value = window.innerWidth;
+				postprocessing.bokeh_uniforms[ 'textureHeight' ].value = window.innerHeight;
+
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 			}


### PR DESCRIPTION
see https://discourse.threejs.org/t/resize-issue-depth-of-field-bokeh/6361