### PR TITLE
ShaderPass: Fix transparency bug in  WebGLDeferredRenderer

### DIFF
--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -60,7 +60,8 @@ THREE.ShaderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype 
 		} else {
 
 			renderer.setRenderTarget( writeBuffer );
-			if ( this.clear ) renderer.clear();
+			// TODO: Avoid using autoClear properties, see https://github.com/mrdoob/three.js/pull/15571#issuecomment-465669600
+			if ( this.clear ) renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 			renderer.render( this.scene, this.camera );
 
 		}


### PR DESCRIPTION
Without this PR, `WebGLDeferredRenderer` does not handle transparency in classic mode correctly. 