### PR TITLE
Fix export of TypeScript Math namespace

### DIFF
--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -105,7 +105,7 @@ export * from './math/interpolants/DiscreteInterpolant';
 export * from './math/interpolants/CubicInterpolant';
 export * from './math/Interpolant';
 export * from './math/Triangle';
-export * from './math/Math';
+export { _Math as Math } from './math/Math';
 export * from './math/Spherical';
 export * from './math/Cylindrical';
 export * from './math/Plane';


### PR DESCRIPTION
Context: https://github.com/mrdoob/three.js/pull/15823#issuecomment-468764424