### PR TITLE
[WIP] VR Multiview support with opaque framebuffer approach (for Oculus headset)

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -328,6 +328,7 @@ var files = {
 	],
 	"webvr": [
 		"webvr_ballshooter",
+		//"webvr_ballshooter_multiview",
 		"webvr_cubes",
 		"webvr_dragging",
 		"webvr_lorenzattractor",

--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -30,7 +30,8 @@ var WEBVR = {
 
 			button.onclick = function () {
 
-				device.isPresenting ? device.exitPresent() : device.requestPresent( [ { source: renderer.domElement } ] );
+				var attributes = { multiview: renderer.vr.multiview };
+				device.isPresenting ? device.exitPresent() : device.requestPresent( [ { source: renderer.domElement, attributes: attributes } ] );
 
 			};
 

--- a/examples/webvr_ballshooter_multiview.html
+++ b/examples/webvr_ballshooter_multiview.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webvr - ball shooter multiview</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+		<!-- Origin Trial Token, feature = WebXR Device API (For Chrome M69+), origin = https://threejs.org, expires = 2019-03-06 -->
+		<meta http-equiv="origin-trial" data-feature="WebXR Device API (For Chrome M69+)" data-expires="2019-03-06" content="AvDjbxYpoTgOL1PS0JEra7KFCehfTlKnXpU/ORSwNdCQ35cX70cTUkXOnQ26A5XJi3eXHSKpBPchdt5lbcxDuAIAAABTeyJvcmlnaW4iOiJodHRwczovL3RocmVlanMub3JnOjQ0MyIsImZlYXR1cmUiOiJXZWJYUkRldmljZU02OSIsImV4cGlyeSI6MTU1MTgzMDM5OX0=">
+		<style>
+			body {
+				font-family: Monospace;
+				background-color: #101010;
+				color: #fff;
+				margin: 0px;
+				overflow: hidden;
+			}
+			a {
+				color: #48f;
+			}
+		</style>
+	</head>
+	<body>
+
+		<script src="../build/three.js"></script>
+		<script src="js/vr/WebVR.js"></script>
+
+		<script src="js/geometries/BoxLineGeometry.js"></script>
+
+		<script>
+
+			var container;
+			var camera, scene, renderer;
+			var controller1, controller2;
+
+			var room;
+
+			var count = 0;
+			var radius = 0.08;
+			var normal = new THREE.Vector3();
+			var relativeVelocity = new THREE.Vector3();
+
+			var clock = new THREE.Clock();
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				var info = document.createElement( 'div' );
+				info.style.position = 'absolute';
+				info.style.top = '10px';
+				info.style.width = '100%';
+				info.style.textAlign = 'center';
+				info.innerHTML = '<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webvr - ball shooter';
+				container.appendChild( info );
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0x505050 );
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+
+				room = new THREE.LineSegments(
+					new THREE.BoxLineGeometry( 6, 6, 6, 10, 10, 10 ),
+					new THREE.LineBasicMaterial( { color: 0x808080 } )
+				);
+				room.geometry.translate( 0, 3, 0 );
+				scene.add( room );
+
+				var light = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+				light.position.set( 1, 1, 1 );
+				scene.add( light );
+
+				var geometry = new THREE.IcosahedronBufferGeometry( radius, 2 );
+
+				for ( var i = 0; i < 200; i ++ ) {
+
+					var object = new THREE.Mesh( geometry, new THREE.MeshLambertMaterial( { color: Math.random() * 0xffffff } ) );
+
+					object.position.x = Math.random() * 4 - 2;
+					object.position.y = Math.random() * 4;
+					object.position.z = Math.random() * 4 - 2;
+
+					object.userData.velocity = new THREE.Vector3();
+					object.userData.velocity.x = Math.random() * 0.01 - 0.005;
+					object.userData.velocity.y = Math.random() * 0.01 - 0.005;
+					object.userData.velocity.z = Math.random() * 0.01 - 0.005;
+
+					room.add( object );
+
+				}
+
+				//
+
+				var rendererParameters = { antialias: true };
+
+				var useMultiview = false
+				var canvas = document.createElement( 'canvas' );
+				var context = canvas.getContext( 'webgl2' );
+				useMultiview = !! context &&  !! context.getExtension( 'WEBGL_multiview' ) || !! context.getExtension( 'OVR_multiview' );
+
+				if ( useMultiview ) {
+
+					rendererParameters.canvas = canvas;
+					rendererParameters.context = context;
+
+					console.log( 'Using VR Multiview' );
+
+				}
+
+				renderer = new THREE.WebGLRenderer( rendererParameters );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.vr.enabled = true;
+				renderer.vr.multiview = useMultiview;
+				container.appendChild( renderer.domElement );
+
+				//
+
+				document.body.appendChild( WEBVR.createButton( renderer ) );
+
+				// controllers
+
+				function onSelectStart() {
+
+					this.userData.isSelecting = true;
+
+				}
+
+				function onSelectEnd() {
+
+					this.userData.isSelecting = false;
+
+				}
+
+				controller1 = renderer.vr.getController( 0 );
+				controller1.addEventListener( 'selectstart', onSelectStart );
+				controller1.addEventListener( 'selectend', onSelectEnd );
+				scene.add( controller1 );
+
+				controller2 = renderer.vr.getController( 1 );
+				controller2.addEventListener( 'selectstart', onSelectStart );
+				controller2.addEventListener( 'selectend', onSelectEnd );
+				scene.add( controller2 );
+
+				// helpers
+
+				var geometry = new THREE.BufferGeometry();
+				geometry.addAttribute( 'position', new THREE.Float32BufferAttribute( [ 0, 0, 0, 0, 0, - 1 ], 3 ) );
+				geometry.addAttribute( 'color', new THREE.Float32BufferAttribute( [ 0.5, 0.5, 0.5, 0, 0, 0 ], 3 ) );
+
+				var material = new THREE.LineBasicMaterial( { vertexColors: true, blending: THREE.AdditiveBlending } );
+
+				controller1.add( new THREE.Line( geometry, material ) );
+				controller2.add( new THREE.Line( geometry, material ) );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function handleController( controller ) {
+
+				if ( controller.userData.isSelecting ) {
+
+					var object = room.children[ count ++ ];
+
+					object.position.copy( controller.position );
+					object.userData.velocity.x = ( Math.random() - 0.5 ) * 3;
+					object.userData.velocity.y = ( Math.random() - 0.5 ) * 3;
+					object.userData.velocity.z = ( Math.random() - 9 );
+					object.userData.velocity.applyQuaternion( controller.quaternion );
+
+					if ( count === room.children.length ) count = 0;
+
+				}
+
+			}
+
+			//
+
+			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
+
+				handleController( controller1 );
+				handleController( controller2 );
+
+				//
+
+				var delta = clock.getDelta() * 0.8; // slow down simulation
+
+				var range = 3 - radius;
+
+				for ( var i = 0; i < room.children.length; i ++ ) {
+
+					var object = room.children[ i ];
+
+					object.position.x += object.userData.velocity.x * delta;
+					object.position.y += object.userData.velocity.y * delta;
+					object.position.z += object.userData.velocity.z * delta;
+
+					// keep objects inside room
+
+					if ( object.position.x < - range || object.position.x > range ) {
+
+						object.position.x = THREE.Math.clamp( object.position.x, - range, range );
+						object.userData.velocity.x = - object.userData.velocity.x;
+
+					}
+
+					if ( object.position.y < radius || object.position.y > 6 ) {
+
+						object.position.y = Math.max( object.position.y, radius );
+
+						object.userData.velocity.x *= 0.98;
+						object.userData.velocity.y = - object.userData.velocity.y * 0.8;
+						object.userData.velocity.z *= 0.98;
+
+					}
+
+					if ( object.position.z < - range || object.position.z > range ) {
+
+						object.position.z = THREE.Math.clamp( object.position.z, - range, range );
+						object.userData.velocity.z = - object.userData.velocity.z;
+
+					}
+
+					for ( var j = i + 1; j < room.children.length; j ++ ) {
+
+						var object2 = room.children[ j ];
+
+						normal.copy( object.position ).sub( object2.position );
+
+						var distance = normal.length();
+
+						if ( distance < 2 * radius ) {
+
+							normal.multiplyScalar( 0.5 * distance - radius );
+
+							object.position.sub( normal );
+							object2.position.add( normal );
+
+							normal.normalize();
+
+							relativeVelocity.copy( object.userData.velocity ).sub( object2.userData.velocity );
+
+							normal = normal.multiplyScalar( relativeVelocity.dot( normal ) );
+
+							object.userData.velocity.sub( normal );
+							object2.userData.velocity.add( normal );
+
+						}
+
+					}
+
+					object.userData.velocity.y -= 9.8 * delta;
+
+				}
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+	</body>
+</html>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1408,7 +1408,7 @@ function WebGLRenderer( parameters ) {
 					renderObject( object, scene, cameras[ 0 ], geometry, material, group );
 
 					multiview.inProgress = false;
-					multiview.camera = null
+					multiview.camera = null;
 
 					continue;
 

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -86,6 +86,8 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	var maxSamples = isWebGL2 ? gl.getParameter( gl.MAX_SAMPLES ) : 0;
 
+	var multiview = isWebGL2 && ( !! extensions.get( 'WEBGL_multiview' ) || !! extensions.get( 'OVR_multiview' ) );
+
 	return {
 
 		isWebGL2: isWebGL2,
@@ -110,7 +112,9 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 		floatFragmentTextures: floatFragmentTextures,
 		floatVertexTextures: floatVertexTextures,
 
-		maxSamples: maxSamples
+		maxSamples: maxSamples,
+
+		multiview: multiview
 
 	};
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -388,6 +388,22 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			'uniform mat3 normalMatrix;',
 			'uniform vec3 cameraPosition;',
 
+			renderer.vr.multiview ? [ // For VR multiview
+
+				'uniform mat4 modelViewMatrix2;',
+				'uniform mat4 projectionMatrix2;',
+				'uniform mat4 viewMatrix2;',
+				'uniform mat3 normalMatrix2;',
+				'uniform vec3 cameraPosition2;',
+
+				'#define modelViewMatrix (gl_ViewID_OVR==0u?modelViewMatrix:modelViewMatrix2)',
+				'#define projectionMatrix (gl_ViewID_OVR==0u?projectionMatrix:projectionMatrix2)',
+				'#define viewMatrix (gl_ViewID_OVR==0u?viewMatrix:viewMatrix2)',
+				'#define normalMatrix (gl_ViewID_OVR==0u?normalMatrix:normalMatrix2)',
+				'#define cameraPosition (gl_ViewID_OVR==0u?cameraPosition:cameraPosition2)'
+
+			].join( '\n' ) : '',
+
 			'attribute vec3 position;',
 			'attribute vec3 normal;',
 			'attribute vec2 uv;',
@@ -500,6 +516,14 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',
 
+			renderer.vr.multiview ? [ // For VR multiview
+
+				'uniform vec3 cameraPosition2;',
+
+				'#define cameraPosition (gl_ViewID_OVR==0u?cameraPosition:cameraPosition2)'
+
+			].join( '\n' ) : '',
+
 			( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
 			( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
@@ -553,6 +577,14 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 		// GLSL 3.0 conversion
 		prefixVertex = [
 			'#version 300 es\n',
+
+			renderer.vr.multiview ? [ // For VR multiview
+
+				'#extension GL_OVR_multiview : require',
+				'layout(num_views = 2) in;'
+
+			].join( '\n' ) : '',
+
 			'#define attribute in',
 			'#define varying out',
 			'#define texture2D texture'

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -53,6 +53,21 @@ function WebVRManager( renderer ) {
 	cameraVR.layers.enable( 1 );
 	cameraVR.layers.enable( 2 );
 
+	// Multiview with opaque framebuffer approach
+
+	this.multiview = false;
+
+	var multiviewAvailability = null;
+
+	function checkMultiviewAvailability() {
+
+		if ( ! device.getViews ) return false;
+
+		var views = device.getViews();
+		return !! views && views.length === 1 && !! views[ 0 ].getAttributes().multiview;
+
+	}
+
 	//
 
 	function isPresenting() {
@@ -76,6 +91,15 @@ function WebVRManager( renderer ) {
 
 			renderer.setDrawingBufferSize( renderWidth * 2, renderHeight, 1 );
 
+			multiviewAvailability = checkMultiviewAvailability();
+
+			if ( multiviewAvailability ) {
+
+				renderer.setFramebuffer( device.getViews()[ 0 ].framebuffer );
+				renderer.setRenderTarget( renderer.getRenderTarget() );
+
+			}
+
 			animation.start();
 
 		} else {
@@ -83,6 +107,13 @@ function WebVRManager( renderer ) {
 			if ( scope.enabled ) {
 
 				renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
+
+				if ( multiviewAvailability ) {
+
+					renderer.setFramebuffer( null );
+					renderer.setRenderTarget( renderer.getRenderTarget() );
+
+				}
 
 			}
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -46,6 +46,10 @@ function WebXRManager( renderer ) {
 	cameraVR.layers.enable( 1 );
 	cameraVR.layers.enable( 2 );
 
+	// Multiview with opaque framebuffer approach
+
+	this.multiview = false;
+
 	//
 
 	this.enabled = false;
@@ -121,12 +125,13 @@ function WebXRManager( renderer ) {
 			session.addEventListener( 'selectend', onSessionEvent );
 			session.addEventListener( 'end', onSessionEnd );
 
-			session.baseLayer = new XRWebGLLayer( session, gl, { framebufferScaleFactor: framebufferScaleFactor } );
+			session.baseLayer = new XRWebGLLayer( session, gl, { framebufferScaleFactor: framebufferScaleFactor, multiview: this.multiview } );
 			session.requestFrameOfReference( frameOfReferenceType ).then( function ( value ) {
 
 				frameOfReference = value;
 
 				renderer.setFramebuffer( session.baseLayer.framebuffer );
+				renderer.setRenderTarget( renderer.getRenderTarget() );
 
 				animation.setContext( session );
 				animation.start();


### PR DESCRIPTION
This PR is WIP because I'm not really sure if we should merge this feature now although the code is ready (unless there's any bugs). I think we need discussion.

This PR adds `WEBGL/OVR_multiview` support with (Oculus) opaque multiview framebuffer approach which doesn't require a lot of JS code change but may be old style in WebXR/VR.

I first started to work on for local performance test purpose but realized that many developers are interested in significant performance gain and seem to want to try. I'm wondering if you folks are interested in merging.

Note that `WEBGL_multiview` extension is still draft and `WebXR/VR` specification relating multiview seems not fixed yet. I don't think we should implement with non-stable API but it may be ok to add as an experimental feature for performance test purpose.

The change isn't so big, additional lines are about 150 lines in core. And I guess most of the code can be usable for finalized API. So it may not be too bad for us to get it merged now.

**API**

Use WebGL 2.0 and set `renderer.vr.multiview = true`.

```javascript
var canvas = document.createElement( 'canvas' );
var context = canvas.getContext( 'webgl2' );
renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
renderer.setPixelRatio( window.devicePixelRatio );
renderer.setSize( window.innerWidth, window.innerHeight );
renderer.vr.enabled = true;
renderer.vr.multiview = true;
```

Setting `renderer.vr.multiview = true` may be problematic for platform which doesn't support opaque multiview framebuffer. Detecting the compatibility and setting `true` is under user responsibility.

**Compatibility**

Oculus Headset + OculusBrowser. I'm not sure if it works on other platforms.

**Demo**

Access the following link with Oculus headset + OculusBrowser.

https://raw.githack.com/takahirox/three.js/MultiviewOculusTest/examples/webvr_ballshooter_multiview.html

You don't need to turn on any special flags because `OVR_multiview` seems being enabled as default on Oculus headset.

- https://twitter.com/abolgar/status/1101209017282490368

To confirm whether multiview is used, see the console with USB remote debug and find "using VR Multiview" without any errors.

**Specifications**

`WEBGL_multiview` extension is still draft.

- https://www.khronos.org/registry/webgl/extensions/WEBGL_multiview/

Oculus opaque multiview framebuffer approach with WebVR

- https://developer.oculus.com/documentation/oculus-browser/latest/concepts/browser-multiview/

WebXR API. They already removed multiview attribute and seem to go with texture arrays approach instead of opaque framebuffer approach, 

- https://github.com/immersive-web/webxr/pull/361 Removed multiview attribute from XRWebGLLayer
- https://github.com/immersive-web/webxr/issues/414 Determine the shape of Multiview support

Oculus plan.

> Oculus Browser will continue support opaque multiview approach (and it should work for both - WebVR and WebXR), at least until WebXR and WebGL define a way to use texture arrays with multisampling

- https://twitter.com/abolgar/status/1101208589325152256

So probably we need to update the code from opaque framebuffer approach to texture array approach when the specification is finalized. But I guess most of the code can be reusable for example shaders, updating uniforms, and so on..

Even if we start with texture array approach, I think this PR can be a good start.

**As an experimental feature**

The specifications aren't stable yet so I'd like to suggest we add multiview as experimental feature if we merge. Experimental feature here for example means and/or

- No document
- Can be buggy
- We don't guarantee it always works 100% fine
- It may not work on some platforms/version
- We don't add complex code for multiview
- API can change
- etc.

Feedback is very welcome.