### PR TITLE
Remove reference to deprecated '.activeCubeFace'. Pass cube face inde…

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -97,8 +97,7 @@ function CubeCamera( near, far, cubeResolution, options ) {
 
 		for ( var i = 0; i < 6; i ++ ) {
 
-			renderTarget.activeCubeFace = i;
-			renderer.setRenderTarget( renderTarget );
+			renderer.setRenderTarget( renderTarget, i );
 
 			renderer.clear( color, depth, stencil );
 


### PR DESCRIPTION
Remove reference to deprecated '.activeCubeFace'. Pass cube face index directly into setRenderTarget(). Fixes #15865