### PR TITLE
GLTFLoader: Fix runtime error when accessing the cache.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2569,7 +2569,7 @@ THREE.GLTFLoader = ( function () {
 				var cacheKey = createMultiPassGeometryKey( baseGeometry, originalPrimitives );
 				var cached = cache[ cacheKey ];
 
-				if ( cached !== null ) return [ cached.geometry ];
+				if ( cached ) return [ cached.geometry ];
 
 				// Cloning geometry because of index override.
 				// Attributes can be reused so cloning by myself here.


### PR DESCRIPTION
I've noticed this problem when loading a file with the latest version of `GLTFLoader`. If you access an object with an unknown key, `undefined` is returned and not `null`. 