### PR TITLE
BufferGeometryUtil: Replace for-of loop by a for loop

### DIFF
--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -498,9 +498,8 @@ THREE.BufferGeometryUtils = {
 		var getters = [ 'getX', 'getY', 'getZ', 'getW' ];
 
 		// initialize the arrays
-		var name = undefined;
-		for ( var attributeNameIndex = 0, numberOfAttributeNames = attributeNames.length ; attributeNameIndex < numberOfAttributeNames ; attributeNameIndex++  ) {
-			name = attributeNames[ attributeNameIndex ];
+		for ( var i = 0, l = attributeNames.length; i < l; i ++ ) {
+			var name = attributeNames[ i ];
 
 			attrArrays[ name ] = [];
 

--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -498,7 +498,9 @@ THREE.BufferGeometryUtils = {
 		var getters = [ 'getX', 'getY', 'getZ', 'getW' ];
 
 		// initialize the arrays
-		for ( var name of attributeNames ) {
+		var name = undefined;
+		for ( var attributeNameIndex = 0, numberOfAttributeNames = attributeNames.length ; attributeNameIndex < numberOfAttributeNames ; attributeNameIndex++  ) {
+			name = attributeNames[ attributeNameIndex ];
 
 			attrArrays[ name ] = [];
 


### PR DESCRIPTION
The PR replace the only "for of" loop in the all library by a classic for loop to keep consistency.

The es6 "for of" loop should not be support in the current javascript "version" used in the library (Es5).

Furthermore this break any build using rollup-plugin-buble base on Es5 stuff.

In case this type of loop is now accepted as usable stuff in the library maybe some other Es6 feature like class, arrow, scoping should be used too ?