### PR TITLE
Examples: Use linear workflow for examples with ROME models.

### DIFF
--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -78,6 +78,10 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				renderer.gammaOutput = true;
+				renderer.gammaFactor = 2.2;
+
 				container.appendChild(renderer.domElement);
 
 				//

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -134,6 +134,8 @@
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				container.appendChild( renderer.domElement );
 
+				renderer.gammaOutput = true;
+				renderer.gammaFactor = 2.2;
 				renderer.autoClear = false;
 
 				//
@@ -195,7 +197,7 @@
 				// GROUND
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
-				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffdd99 } );
+				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffb851 } );
 
 				var ground = new THREE.Mesh( geometry, planeMaterial );
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/15876 corrected the vertex colors in the ROME models, this PR adjusts settings in affected examples.

After:

![screen shot 2019-03-02 at 11 57 08 am](https://user-images.githubusercontent.com/1848368/53686928-a6c95a80-3ce2-11e9-898b-fc06d81deff7.png)
![screen shot 2019-03-02 at 11 57 42 am](https://user-images.githubusercontent.com/1848368/53686929-a7fa8780-3ce2-11e9-880c-706dfc1a21e0.png)
