### PR TITLE
JSM: Adding GLTFExporter as a module in examples/jsm/exporters

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -37,16 +37,16 @@ var WEBGL_CONSTANTS = {
 
 var THREE_TO_WEBGL = {};
 
-THREE_TO_WEBGL[ THREE.NearestFilter ] = WEBGL_CONSTANTS.NEAREST;
-THREE_TO_WEBGL[ THREE.NearestMipMapNearestFilter ] = WEBGL_CONSTANTS.NEAREST_MIPMAP_NEAREST;
-THREE_TO_WEBGL[ THREE.NearestMipMapLinearFilter ] = WEBGL_CONSTANTS.NEAREST_MIPMAP_LINEAR;
-THREE_TO_WEBGL[ THREE.LinearFilter ] = WEBGL_CONSTANTS.LINEAR;
-THREE_TO_WEBGL[ THREE.LinearMipMapNearestFilter ] = WEBGL_CONSTANTS.LINEAR_MIPMAP_NEAREST;
-THREE_TO_WEBGL[ THREE.LinearMipMapLinearFilter ] = WEBGL_CONSTANTS.LINEAR_MIPMAP_LINEAR;
+THREE_TO_WEBGL[ NearestFilter ] = WEBGL_CONSTANTS.NEAREST;
+THREE_TO_WEBGL[ NearestMipMapNearestFilter ] = WEBGL_CONSTANTS.NEAREST_MIPMAP_NEAREST;
+THREE_TO_WEBGL[ NearestMipMapLinearFilter ] = WEBGL_CONSTANTS.NEAREST_MIPMAP_LINEAR;
+THREE_TO_WEBGL[ LinearFilter ] = WEBGL_CONSTANTS.LINEAR;
+THREE_TO_WEBGL[ LinearMipMapNearestFilter ] = WEBGL_CONSTANTS.LINEAR_MIPMAP_NEAREST;
+THREE_TO_WEBGL[ LinearMipMapLinearFilter ] = WEBGL_CONSTANTS.LINEAR_MIPMAP_LINEAR;
 
-THREE_TO_WEBGL[ THREE.ClampToEdgeWrapping ] = WEBGL_CONSTANTS.CLAMP_TO_EDGE;
-THREE_TO_WEBGL[ THREE.RepeatWrapping ] = WEBGL_CONSTANTS.REPEAT;
-THREE_TO_WEBGL[ THREE.MirroredRepeatWrapping ] = WEBGL_CONSTANTS.MIRRORED_REPEAT;
+THREE_TO_WEBGL[ ClampToEdgeWrapping ] = WEBGL_CONSTANTS.CLAMP_TO_EDGE;
+THREE_TO_WEBGL[ RepeatWrapping ] = WEBGL_CONSTANTS.REPEAT;
+THREE_TO_WEBGL[ MirroredRepeatWrapping ] = WEBGL_CONSTANTS.MIRRORED_REPEAT;
 
 var PATH_PROPERTIES = {
 	scale: 'scale',
@@ -58,15 +58,47 @@ var PATH_PROPERTIES = {
 //------------------------------------------------------------------------------
 // GLTF Exporter
 //------------------------------------------------------------------------------
-THREE.GLTFExporter = function () {};
+import {
+	AnimationClip,
+	BufferAttribute,
+	BufferGeometry,
+	Camera,
+	ClampToEdgeWrapping,
+	DoubleSide,
+	Geometry,
+	InterpolateDiscrete,
+	LinearFilter,
+	LinearMipMapLinearFilter,
+	LinearMipMapNearestFilter,
+	Material,
+	Mesh,
+	MirroredRepeatWrapping,
+	NearestFilter,
+	NearestMipMapLinearFilter,
+	NearestMipMapNearestFilter,
+	Object3D,
+	PropertyBinding,
+	RGBAFormat,
+	RGBFormat,
+	RepeatWrapping,
+	Scene,
+	Scenes,
+	ShaderMaterial,
+	TriangleFanDrawMode,
+	TriangleStripDrawMode,
+	Vector3,
+	VertexColors
+} from "../../../build/three.module.js";
 
-THREE.GLTFExporter.prototype = {
+var GLTFExporter = function () {};
 
-	constructor: THREE.GLTFExporter,
+GLTFExporter.prototype = {
+
+	constructor: GLTFExporter,
 
 	/**
 	 * Parse scenes and generate GLTF output
-	 * @param  {THREE.Scene or [THREE.Scenes]} input   THREE.Scene or Array of THREE.Scenes
+	 * @param  {Scene or [Scenes]} input   Scene or Array of Scenes
 	 * @param  {Function} onDone  Callback on completed
 	 * @param  {Object} options options
 	 */
@@ -171,7 +203,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Get the min and max vectors from the given attribute
-		 * @param  {THREE.BufferAttribute} attribute Attribute to find the min/max in range from start to start + count
+		 * @param  {BufferAttribute} attribute Attribute to find the min/max in range from start to start + count
 		 * @param  {Integer} start
 		 * @param  {Integer} count
 		 * @return {Object} Object containing the `min` and `max` values (As an array of attribute.itemSize components)
@@ -210,14 +242,14 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function isPowerOfTwo( image ) {
 
-			return THREE.Math.isPowerOfTwo( image.width ) && THREE.Math.isPowerOfTwo( image.height );
+			return Math.isPowerOfTwo( image.width ) && Math.isPowerOfTwo( image.height );
 
 		}
 
 		/**
 		 * Checks if normal attribute values are normalized.
 		 *
-		 * @param {THREE.BufferAttribute} normal
+		 * @param {BufferAttribute} normal
 		 * @returns {Boolean}
 		 *
 		 */
@@ -229,7 +261,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var v = new THREE.Vector3();
+			var v = new Vector3();
 
 			for ( var i = 0, il = normal.count; i < il; i ++ ) {
 
@@ -245,8 +277,8 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Creates normalized normal buffer attribute.
 		 *
-		 * @param {THREE.BufferAttribute} normal
-		 * @returns {THREE.BufferAttribute}
+		 * @param {BufferAttribute} normal
+		 * @returns {BufferAttribute}
 		 *
 		 */
 		function createNormalizedNormalAttribute( normal ) {
@@ -259,7 +291,7 @@ THREE.GLTFExporter.prototype = {
 
 			var attribute = normal.clone();
 
-			var v = new THREE.Vector3();
+			var v = new Vector3();
 
 			for ( var i = 0, il = attribute.count; i < il; i ++ ) {
 
@@ -339,7 +371,7 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Serializes a userData.
 		 *
-		 * @param {THREE.Object3D|THREE.Material} object
+		 * @param {Object3D|Material} object
 		 * @returns {Object}
 		 */
 		function serializeUserData( object ) {
@@ -421,7 +453,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process and generate a BufferView
-		 * @param  {THREE.BufferAttribute} attribute
+		 * @param  {BufferAttribute} attribute
 		 * @param  {number} componentType
 		 * @param  {number} start
 		 * @param  {number} count
@@ -564,8 +596,8 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process attribute to generate an accessor
-		 * @param  {THREE.BufferAttribute} attribute Attribute to process
-		 * @param  {THREE.BufferGeometry} geometry (Optional) Geometry used for truncated draw range
+		 * @param  {BufferAttribute} attribute Attribute to process
+		 * @param  {BufferGeometry} geometry (Optional) Geometry used for truncated draw range
 		 * @param  {Integer} start (Optional)
 		 * @param  {Integer} count (Optional)
 		 * @return {Integer}           Index of the processed accessor on the "accessors" array
@@ -673,7 +705,7 @@ THREE.GLTFExporter.prototype = {
 		/**
 		 * Process image
 		 * @param  {Image} image to process
-		 * @param  {Integer} format of the image (e.g. THREE.RGBFormat, THREE.RGBAFormat etc)
+		 * @param  {Integer} format of the image (e.g. RGBFormat, RGBAFormat etc)
 		 * @param  {Boolean} flipY before writing out the image
 		 * @return {Integer}     Index of the processed texture in the "images" array
 		 */
@@ -686,7 +718,7 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			var cachedImages = cachedData.images.get( image );
-			var mimeType = format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
+			var mimeType = format === RGBAFormat ? 'image/png' : 'image/jpeg';
 			var key = mimeType + ":flipY/" + flipY.toString();
 
 			if ( cachedImages[ key ] !== undefined ) {
@@ -714,8 +746,8 @@ THREE.GLTFExporter.prototype = {
 
 					console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
 
-					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
-					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
+					canvas.width = Math.floorPowerOfTwo( canvas.width );
+					canvas.height = Math.floorPowerOfTwo( canvas.height );
 
 				}
 
@@ -834,7 +866,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process material
-		 * @param  {THREE.Material} material Material to process
+		 * @param  {Material} material Material to process
 		 * @return {Integer}      Index of the processed material in the "materials" array
 		 */
 		function processMaterial( material ) {
@@ -853,7 +885,7 @@ THREE.GLTFExporter.prototype = {
 
 			if ( material.isShaderMaterial ) {
 
-				console.warn( 'GLTFExporter: THREE.ShaderMaterial not supported.' );
+				console.warn( 'GLTFExporter: ShaderMaterial not supported.' );
 				return null;
 
 			}
@@ -1013,7 +1045,7 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			// doubleSided
-			if ( material.side === THREE.DoubleSide ) {
+			if ( material.side === DoubleSide ) {
 
 				gltfMaterial.doubleSided = true;
 
@@ -1042,7 +1074,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process mesh
-		 * @param  {THREE.Mesh} mesh Mesh to process
+		 * @param  {Mesh} mesh Mesh to process
 		 * @return {Integer}      Index of the processed mesh in the "meshes" array
 		 */
 		function processMesh( mesh ) {
@@ -1079,20 +1111,20 @@ THREE.GLTFExporter.prototype = {
 
 				if ( ! geometry.isBufferGeometry ) {
 
-					console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use THREE.BufferGeometry instead.' );
+					console.warn( 'GLTFExporter: Exporting Geometry will increase file size. Use BufferGeometry instead.' );
 
-					var geometryTemp = new THREE.BufferGeometry();
+					var geometryTemp = new BufferGeometry();
 					geometryTemp.fromGeometry( geometry );
 					geometry = geometryTemp;
 
 				}
 
-				if ( mesh.drawMode === THREE.TriangleFanDrawMode ) {
+				if ( mesh.drawMode === TriangleFanDrawMode ) {
 
 					console.warn( 'GLTFExporter: TriangleFanDrawMode and wireframe incompatible.' );
 					mode = WEBGL_CONSTANTS.TRIANGLE_FAN;
 
-				} else if ( mesh.drawMode === THREE.TriangleStripDrawMode ) {
+				} else if ( mesh.drawMode === TriangleStripDrawMode ) {
 
 					mode = mesh.material.wireframe ? WEBGL_CONSTANTS.LINE_STRIP : WEBGL_CONSTANTS.TRIANGLE_STRIP;
 
@@ -1131,7 +1163,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			// @QUESTION Detect if .vertexColors = THREE.VertexColors?
+			// @QUESTION Detect if .vertexColors = VertexColors?
 			// For every attribute create an accessor
 			var modifiedAttribute = null;
 			for ( var attributeName in geometry.attributes ) {
@@ -1154,7 +1186,7 @@ THREE.GLTFExporter.prototype = {
 					! ( array instanceof Uint8Array ) ) {
 
 					console.warn( 'GLTFExporter: Attribute "skinIndex" converted to type UNSIGNED_SHORT.' );
-					modifiedAttribute = new THREE.BufferAttribute( new Uint16Array( array ), attribute.itemSize, attribute.normalized );
+					modifiedAttribute = new BufferAttribute( new Uint16Array( array ), attribute.itemSize, attribute.normalized );
 
 				}
 
@@ -1375,7 +1407,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process camera
-		 * @param  {THREE.Camera} camera Camera to process
+		 * @param  {Camera} camera Camera to process
 		 * @return {Integer}      Index of the processed mesh in the "camera" array
 		 */
 		function processCamera( camera ) {
@@ -1410,7 +1442,7 @@ THREE.GLTFExporter.prototype = {
 				gltfCamera.perspective = {
 
 					aspectRatio: camera.aspect,
-					yfov: THREE.Math.degToRad( camera.fov ),
+					yfov: Math.degToRad( camera.fov ),
 					zfar: camera.far <= 0 ? 0.001 : camera.far,
 					znear: camera.near < 0 ? 0 : camera.near
 
@@ -1436,8 +1468,8 @@ THREE.GLTFExporter.prototype = {
 		 * Status:
 		 * - Only properties listed in PATH_PROPERTIES may be animated.
 		 *
-		 * @param {THREE.AnimationClip} clip
-		 * @param {THREE.Object3D} root
+		 * @param {AnimationClip} clip
+		 * @param {Object3D} root
 		 * @return {number}
 		 */
 		function processAnimation( clip, root ) {
@@ -1448,7 +1480,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			clip = THREE.GLTFExporter.Utils.mergeMorphTargetTracks( clip.clone(), root );
+			clip = GLTFExporter.Utils.mergeMorphTargetTracks( clip.clone(), root );
 
 			var tracks = clip.tracks;
 			var channels = [];
@@ -1457,8 +1489,8 @@ THREE.GLTFExporter.prototype = {
 			for ( var i = 0; i < tracks.length; ++ i ) {
 
 				var track = tracks[ i ];
-				var trackBinding = THREE.PropertyBinding.parseTrackName( track.name );
-				var trackNode = THREE.PropertyBinding.findNode( root, trackBinding.nodeName );
+				var trackBinding = PropertyBinding.parseTrackName( track.name );
+				var trackNode = PropertyBinding.findNode( root, trackBinding.nodeName );
 				var trackProperty = PATH_PROPERTIES[ trackBinding.propertyName ];
 
 				if ( trackBinding.objectName === 'bones' ) {
@@ -1507,7 +1539,7 @@ THREE.GLTFExporter.prototype = {
 					// but needs to be stored as VEC3 so dividing by 3 here.
 					outputItemSize /= 3;
 
-				} else if ( track.getInterpolation() === THREE.InterpolateDiscrete ) {
+				} else if ( track.getInterpolation() === InterpolateDiscrete ) {
 
 					interpolation = 'STEP';
 
@@ -1519,8 +1551,8 @@ THREE.GLTFExporter.prototype = {
 
 				samplers.push( {
 
-					input: processAccessor( new THREE.BufferAttribute( track.times, inputItemSize ) ),
-					output: processAccessor( new THREE.BufferAttribute( track.values, outputItemSize ) ),
+					input: processAccessor( new BufferAttribute( track.times, inputItemSize ) ),
+					output: processAccessor( new BufferAttribute( track.values, outputItemSize ) ),
 					interpolation: interpolation
 
 				} );
@@ -1577,7 +1609,7 @@ THREE.GLTFExporter.prototype = {
 
 			outputJSON.skins.push( {
 
-				inverseBindMatrices: processAccessor( new THREE.BufferAttribute( inverseBindMatrices, 16 ) ),
+				inverseBindMatrices: processAccessor( new BufferAttribute( inverseBindMatrices, 16 ) ),
 				joints: joints,
 				skeleton: nodeMap.get( rootJoint )
 
@@ -1644,7 +1676,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process Object3D node
-		 * @param  {THREE.Object3D} node Object3D to processNode
+		 * @param  {Object3D} node Object3D to processNode
 		 * @return {Integer}      Index of the node in the nodes list
 		 */
 		function processNode( object ) {
@@ -1787,7 +1819,7 @@ THREE.GLTFExporter.prototype = {
 
 		/**
 		 * Process Scene
-		 * @param  {THREE.Scene} node Scene to process
+		 * @param  {Scene} node Scene to process
 		 */
 		function processScene( scene ) {
 
@@ -1847,12 +1879,12 @@ THREE.GLTFExporter.prototype = {
 		}
 
 		/**
-		 * Creates a THREE.Scene to hold a list of objects and parse it
+		 * Creates a Scene to hold a list of objects and parse it
 		 * @param  {Array} objects List of objects to process
 		 */
 		function processObjects( objects ) {
 
-			var scene = new THREE.Scene();
+			var scene = new Scene();
 			scene.name = 'AuxScene';
 
 			for ( var i = 0; i < objects.length; i ++ ) {
@@ -1875,7 +1907,7 @@ THREE.GLTFExporter.prototype = {
 
 			for ( var i = 0; i < input.length; i ++ ) {
 
-				if ( input[ i ] instanceof THREE.Scene ) {
+				if ( input[ i ] instanceof Scene ) {
 
 					processScene( input[ i ] );
 
@@ -2005,7 +2037,7 @@ THREE.GLTFExporter.prototype = {
 
 };
 
-THREE.GLTFExporter.Utils = {
+GLTFExporter.Utils = {
 
 	insertKeyframe: function ( track, time ) {
 
@@ -2100,8 +2132,8 @@ THREE.GLTFExporter.Utils = {
 		for ( var i = 0; i < sourceTracks.length; ++ i ) {
 
 			var sourceTrack = sourceTracks[ i ];
-			var sourceTrackBinding = THREE.PropertyBinding.parseTrackName( sourceTrack.name );
-			var sourceTrackNode = THREE.PropertyBinding.findNode( root, sourceTrackBinding.nodeName );
+			var sourceTrackBinding = PropertyBinding.parseTrackName( sourceTrack.name );
+			var sourceTrackNode = PropertyBinding.findNode( root, sourceTrackBinding.nodeName );
 
 			if ( sourceTrackBinding.propertyName !== 'morphTargetInfluences' || sourceTrackBinding.propertyIndex === undefined ) {
 
@@ -2197,3 +2229,5 @@ THREE.GLTFExporter.Utils = {
 	}
 
 };
+
+export { GLTFExporter }


### PR DESCRIPTION
I ran `modularize.js` on `examples/js/exporters/GLTFExporter.js` and made a few minor changes to get it to export correctly in my ES6 environment.

Also made one minor code change - GLTFExporter didn't like running into vanilla `Geometry` objects.