### PR TITLE
Fix non power-of-2 textures being flipped when resized

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -59,16 +59,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				canvas.height = height;
 
 				var context = canvas.getContext( '2d' );
-
-				// ImageBitmap is flipped vertically
-
-				if ( useOffscreenCanvas ) {
-
-					context.translate( 0, height );
-					context.scale( 1, - 1 );
-
-				}
-
 				context.drawImage( image, 0, 0, width, height );
 
 				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -62,11 +62,10 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				// ImageBitmap is flipped vertically
 
-				if ( useOffscreenCanvas )
-				{
+				if ( useOffscreenCanvas ) {
 
 					context.translate( 0, height );
-					context.scale( 1, -1 );
+					context.scale( 1, - 1 );
 
 				}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -12,13 +12,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	//
 
-	var useOffscreenCanvas = typeof document === 'undefined';
+	var isWorker = typeof document === 'undefined';
 
 	function createCanvas( width, height ) {
 
 		// Use OffscreenCanvas when available. Specially needed in web workers
 
-		return useOffscreenCanvas ?
+		return isWorker ?
 			new OffscreenCanvas( width, height ) :
 			document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 
@@ -62,7 +62,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				// ImageBitmap is flipped vertically
 
-				if ( useOffscreenCanvas ) {
+				if ( isWorker ) {
 
 					context.translate( 0, height );
 					context.scale( 1, - 1 );
@@ -73,7 +73,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );
 
-				return useOffscreenCanvas ? canvas.transferToImageBitmap() : canvas;
+				return isWorker ? canvas.transferToImageBitmap() : canvas;
 
 			} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -12,7 +12,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	//
 
-	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
+	var useOffscreenCanvas = typeof document === 'undefined';
 
 	function createCanvas( width, height ) {
 
@@ -59,6 +59,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				canvas.height = height;
 
 				var context = canvas.getContext( '2d' );
+
+				// ImageBitmap is flipped vertically
+
+				if ( useOffscreenCanvas )
+				{
+
+					context.translate( 0, height );
+					context.scale( 1, -1 );
+
+				}
+
 				context.drawImage( image, 0, 0, width, height );
 
 				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -12,7 +12,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	//
 
-	var useOffscreenCanvas  = typeof OffscreenCanvas  !== 'undefined';
+	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
 
 	function createCanvas( width, height ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -12,13 +12,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	//
 
-	var isWorker = typeof document === 'undefined';
+	var useOffscreenCanvas  = typeof OffscreenCanvas  === 'undefined';
 
 	function createCanvas( width, height ) {
 
 		// Use OffscreenCanvas when available. Specially needed in web workers
 
-		return isWorker ?
+		return useOffscreenCanvas ?
 			new OffscreenCanvas( width, height ) :
 			document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
 
@@ -62,7 +62,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				// ImageBitmap is flipped vertically
 
-				if ( isWorker ) {
+				if ( useOffscreenCanvas ) {
 
 					context.translate( 0, height );
 					context.scale( 1, - 1 );
@@ -73,7 +73,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );
 
-				return isWorker ? canvas.transferToImageBitmap() : canvas;
+				return useOffscreenCanvas ? canvas.transferToImageBitmap() : canvas;
 
 			} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -12,7 +12,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	//
 
-	var useOffscreenCanvas  = typeof OffscreenCanvas  === 'undefined';
+	var useOffscreenCanvas  = typeof OffscreenCanvas  !== 'undefined';
 
 	function createCanvas( width, height ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -73,7 +73,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				console.warn( 'THREE.WebGLRenderer: Texture has been resized from (' + image.width + 'x' + image.height + ') to (' + width + 'x' + height + ').' );
 
-				return useOffscreenCanvas ? canvas.transferToImageBitmap() : canvas;
+				return canvas;
 
 			} else {
 


### PR DESCRIPTION
Fix for https://github.com/mrdoob/three.js/issues/15896

* Uses an OffscreenCanvas *only* when document is not available (was the default choice before)
* Flips the texture vertically in this case