### PR TITLE
Typescript: Added angleTo and rotateTowards definitions for quaternions

### DIFF
--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -57,6 +57,9 @@ export class Quaternion {
    */
   setFromRotationMatrix(m: Matrix4): Quaternion;
   setFromUnitVectors(vFrom: Vector3, vTo: Vector3): Quaternion;
+  angleTo(q: Quaternion): number;
+  rotateTowards(q: Quaternion, step: number): Quaternion;
+
   /**
    * Inverts this quaternion.
    */


### PR DESCRIPTION
TypeScript file Quaternion.d.ts was missing two methods from the js source.