### PR TITLE
WebGLRenderer: Fix sprite rendering when Material.visible is false.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1276,7 +1276,11 @@ function WebGLRenderer( parameters ) {
 					var geometry = objects.update( object );
 					var material = object.material;
 
-					currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+					if ( material.visible ) {
+
+						currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+
+					}
 
 				}
 


### PR DESCRIPTION
Ensure `Material.visible` is also honored for sprites, see

https://discourse.threejs.org/t/visible-property-of-transparent-material-is-not-work/6418