### PR TITLE
Add workaround for FireFox in ImageBitmapLoader

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -71,7 +71,16 @@ ImageBitmapLoader.prototype = {
 
 		} ).then( function ( blob ) {
 
-			return createImageBitmap( blob, scope.options );
+			if ( scope.options === undefined ) {
+
+				// Workaround for FireFox. It causes an error if you pass options.
+				return createImageBitmap( blob );
+
+			} else {
+
+				return createImageBitmap( blob, scope.options );
+
+			}
 
 		} ).then( function ( imageBitmap ) {
 


### PR DESCRIPTION
FireFox has an unrecognized `ImageBitmap` options issue in `createImageBitmap()`.

If you pass an second argument for options, it causes an error.

```javascript
createImageBitmap(new ImageData(1,1), {});
TypeError: 2 is not a valid argument count for any overload of Window.createImageBitmap.
```

Even if you pass `undefined`, it still causes.

```javascript
createImageBitmap(new ImageData(1,1), undefined);
TypeError: 2 is not a valid argument count for any overload of Window.createImageBitmap.
```

So the following line in `ImageBitmapLoader` always causes an error on FireFox.

```javascript
return createImageBitmap( blob, scope.options );
```

I heard that it may still take time to fix this issue.

So what do you think of adding the following workaround to `ImageBitmapLoader` for FireFox? In case users don't need options for `ImageBitmap` they can use `ImageBitmapLoader` even on FireFox.

```javascript
if ( scope.options === undefined ) {

	// Workaround for FireFox. It causes an error if you pass options.
	return createImageBitmap( blob );

} else {

	return createImageBitmap( blob, scope.options );

}
```
