### PR TITLE
Export types as namespace

### DIFF
--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -172,3 +172,5 @@ export * from './renderers/webgl/WebGLUniforms';
 export * from './renderers/webvr/WebVRManager';
 export * from './constants';
 export * from './Three.Legacy';
+
+export as namespace THREE;


### PR DESCRIPTION
The types should be exported as a namespace since three.js is a UMD library. This is in line with how they are currently [exported from @types/three](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/three/index.d.ts) and fixes its usages in other @types libraries. This is required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33477 to get merged.