### PR TITLE
[WIP] Suggestion: Add a way to enable ImageBitmapLoader to GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -12,6 +12,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 		this.dracoLoader = null;
+		this._useImageBitmapLoader = false;
 
 	}
 
@@ -118,6 +119,13 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
+		enableImageBitmapLoader: function () {
+
+			this._useImageBitmapLoader = true;
+			return this;
+
+		},
+
 		parse: function ( data, path, onLoad, onError ) {
 
 			var content;
@@ -214,7 +222,8 @@ THREE.GLTFLoader = ( function () {
 
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
-				manager: this.manager
+				manager: this.manager,
+				enableImageBitmapLoader: this._useImageBitmapLoader
 
 			} );
 
@@ -1604,6 +1613,8 @@ THREE.GLTFLoader = ( function () {
 
 		this.textureLoader = new THREE.TextureLoader( this.options.manager );
 		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
+
+		if ( options.enableImageBitmapLoader ) this.textureLoader.enableImageBitmapLoader();
 
 		this.fileLoader = new THREE.FileLoader( this.options.manager );
 		this.fileLoader.setResponseType( 'arraybuffer' );

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -4,6 +4,7 @@
 
 import { RGBAFormat, RGBFormat } from '../constants.js';
 import { ImageLoader } from './ImageLoader.js';
+import { ImageBitmapLoader } from './ImageBitmapLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
 
@@ -11,6 +12,7 @@ import { DefaultLoadingManager } from './LoadingManager.js';
 function TextureLoader( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+	this._useImageBitmapLoader = false;
 
 }
 
@@ -22,7 +24,8 @@ Object.assign( TextureLoader.prototype, {
 
 		var texture = new Texture();
 
-		var loader = new ImageLoader( this.manager );
+		var loader = this._useImageBitmapLoader
+			? new ImageBitmapLoader( this.manager ) : new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 
@@ -45,6 +48,13 @@ Object.assign( TextureLoader.prototype, {
 		}, onProgress, onError );
 
 		return texture;
+
+	},
+
+	enableImageBitmapLoader: function () {
+
+		this._useImageBitmapLoader = true;
+		return this;
 
 	},
 


### PR DESCRIPTION
**Background**

`ImageBitmap` has a very good advantage to regular images, the main thread blocking time caused by uploading to texture is shorter. For example, VR app will have better presence with `ImageBitmap`.

But `ImageBitmap` has two problems in Three.js. First, compatibility. IE, Edge, and Safari don't seem to support yet.

https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap

And FireFox doesn't handle `ImageBitmap` options now #15910. We tried to fix in FireFox side https://github.com/mrdoob/three.js/issues/11746#issuecomment-414845303 but I heard it may still take time to fix.

Second, `ImageBitmap` doesn't fit to some current Three.js `Texture` API. `flipY` and `premultiplyAlpha` should be specified on `ImageBitmap` creation. Changing `texture.flipY/premultiplyAlpha` later has no effect.

```javascript
texture.flipY = ! texture.flipY;
texture.premultiplyAlpha = ! texture.premultiplyAlpha;
texture.needsUpdate = true; // no effect if texture.image is ImageBitmap
```

So it's too early to switch from `ImageLoader` to `ImageBitmapLoader` as default now. But I think there are users who want to use `ImageBitmap` where it works fine. Especially they may want to use in case they don't need the `ImageBitmap` options because it works even on FireFox. Loading glTF assets may be a good use case. glTF core spec doesn't require `flipY` and `premultiplyAlpha`.

But `TextureLoader` uses `ImageLoader` inside. And there is no way to switch to `ImageBitmapLoader`.

**Suggestion**

I'd like to suggest providing users a way to switch from `ImageLoader` to `ImageBitmapLoader` in `TextureLoader` and `GLTFLoader` under their responsibility.

As I mentioned above, using `ImageBitmap` in Three.js may be problematic for some use cases. So I think it's better that users, who understand the limitation/restriction, explicitly enable `ImageBitmapLoader` rather than we automatically detect `ImageBitmap` availability and switch.

Suggested API.

```javascript
var loader = new THREE.TextureLoader();
if ( 'createImageBitmap' in window ) loader.enableImageBitmapLoader();
loader.load( ... ); // using ImageBitmapLoader instead of ImageLoader inside

var gltfLoader = new THREE.GLTFLoader().enableImageBitmapLoader();
if ( 'createImageBitmap' in window ) gltfLoader.enableImageBitmapLoader();
gltfLoader.load( ... );  // using ImageBitmapLoader instead of ImageLoader inside
```

What do you think? Sounds hacky? Any better solutions?

I haven't updated the document yet in this PR. I'll update and remove "[WIP]" from the title if this suggestion looks ok.