### PR TITLE
CSS2DRenderer: properly clip objects outside frustum

### DIFF
--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -36,7 +36,6 @@ THREE.CSS2DRenderer = function () {
 	var vector = new THREE.Vector3();
 	var viewMatrix = new THREE.Matrix4();
 	var viewProjectionMatrix = new THREE.Matrix4();
-	var frustum = new THREE.Frustum();
 
 	var cache = {
 		objects: new WeakMap()
@@ -83,7 +82,7 @@ THREE.CSS2DRenderer = function () {
 			element.style.MozTransform = style;
 			element.style.oTransform = style;
 			element.style.transform = style;
-			element.style.display = frustum.containsPoint( object.position ) ? '' : 'none';
+			element.style.display = ( vector.z < - 1 || vector.z > 1 ) ? 'none' : '';
 
 			var objectData = {
 				distanceToCameraSquared: getDistanceToSquared( camera, object )
@@ -166,7 +165,6 @@ THREE.CSS2DRenderer = function () {
 
 		viewMatrix.copy( camera.matrixWorldInverse );
 		viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, viewMatrix );
-		frustum.setFromMatrix( viewProjectionMatrix );
 
 		renderObject( scene, camera );
 		zOrder( scene );

--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -36,6 +36,7 @@ THREE.CSS2DRenderer = function () {
 	var vector = new THREE.Vector3();
 	var viewMatrix = new THREE.Matrix4();
 	var viewProjectionMatrix = new THREE.Matrix4();
+	var frustum = new THREE.Frustum();
 
 	var cache = {
 		objects: new WeakMap()
@@ -82,6 +83,7 @@ THREE.CSS2DRenderer = function () {
 			element.style.MozTransform = style;
 			element.style.oTransform = style;
 			element.style.transform = style;
+			element.style.display = frustum.containsPoint( object.position ) ? '' : 'none';
 
 			var objectData = {
 				distanceToCameraSquared: getDistanceToSquared( camera, object )
@@ -164,6 +166,7 @@ THREE.CSS2DRenderer = function () {
 
 		viewMatrix.copy( camera.matrixWorldInverse );
 		viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, viewMatrix );
+		frustum.setFromMatrix( viewProjectionMatrix );
 
 		renderObject( scene, camera );
 		zOrder( scene );


### PR DESCRIPTION
So I discovered a bug while working on a project of mine. Basically, it seems like when using the `CSS2DRenderer` there is no check to see if an object is out of the camera's frustum. It results on some weird effects like this (notice the "Z" reappearing):

<img src="https://user-images.githubusercontent.com/23218579/53927856-1c705600-4056-11e9-82a7-054e283d0640.gif" width=400/>

So I added the check and now it looks like this :

<img src="https://user-images.githubusercontent.com/23218579/53927880-2eea8f80-4056-11e9-8930-8d2a34de04dc.gif" width=400/>

If there is a better way to do it please let me know!
