### PR TITLE
SVGLoader: Added fill-opacity style support.

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -701,7 +701,7 @@ THREE.SVGLoader.prototype = {
 			if ( node.style.fill !== '' ) style.fill = node.style.fill;
 
 			if ( node.hasAttribute( 'fill-opacity' ) ) style.fillOpacity = node.getAttribute( 'fill-opacity' );
-      if ( node.style.fillOpacity !== '' ) style.fillOpacity = node.style.fillOpacity;
+			if ( node.style.fillOpacity !== '' ) style.fillOpacity = node.style.fillOpacity;
 
 			return style;
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -8,8 +8,6 @@ THREE.SVGLoader = function ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 
-	this.rootNode = null;
-
 };
 
 THREE.SVGLoader.prototype = {
@@ -1018,14 +1016,16 @@ THREE.SVGLoader.prototype = {
 		console.time( 'THREE.SVGLoader: Parse' );
 
 		parseNode( xml.documentElement, { fill: '#000' } );
-		this.rootNode = xml.documentElement;
+		
+		var data = { paths: paths, xml: xml.documentElement };
 
 		// console.log( paths );
 
 
 		console.timeEnd( 'THREE.SVGLoader: Parse' );
 
-		return paths;
+
+		return data;
 
 	}
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -7,6 +7,9 @@
 THREE.SVGLoader = function ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+	
+	this.nodeMap = new Map();
+	this.rootNode = null;
 
 };
 
@@ -1016,6 +1019,7 @@ THREE.SVGLoader.prototype = {
 		console.time( 'THREE.SVGLoader: Parse' );
 
 		parseNode( xml.documentElement, { fill: '#000' } );
+		this.rootNode = xml.documentElement;
 
 		// console.log( paths );
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -122,6 +122,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 
 			var point = new THREE.Vector2();
 			var control = new THREE.Vector2();
@@ -545,6 +546,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 			path.moveTo( x + 2 * rx, y );
 			path.lineTo( x + w - 2 * rx, y );
 			if ( rx !== 0 || ry !== 0 ) path.bezierCurveTo( x + w, y, x + w, y, x + w, y + 2 * ry );
@@ -591,6 +593,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 
 			var index = 0;
 
@@ -623,6 +626,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 
 			var index = 0;
 
@@ -645,6 +649,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 			path.subPaths.push( subpath );
 
 			return path;
@@ -663,6 +668,7 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
+			path.fillOpacity = style.fillOpacity;
 			path.subPaths.push( subpath );
 
 			return path;
@@ -693,6 +699,9 @@ THREE.SVGLoader.prototype = {
 
 			if ( node.hasAttribute( 'fill' ) ) style.fill = node.getAttribute( 'fill' );
 			if ( node.style.fill !== '' ) style.fill = node.style.fill;
+
+			if ( node.hasAttribute( 'fill-opacity' ) ) style.fillOpacity = node.getAttribute( 'fill-opacity' );
+      if ( node.style.fillOpacity !== '' ) style.fillOpacity = node.style.fillOpacity;
 
 			return style;
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -7,8 +7,7 @@
 THREE.SVGLoader = function ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
-	
-	this.nodeMap = new Map();
+
 	this.rootNode = null;
 
 };

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -1016,7 +1016,6 @@ THREE.SVGLoader.prototype = {
 		console.time( 'THREE.SVGLoader: Parse' );
 
 		parseNode( xml.documentElement, { fill: '#000' } );
-		this.rootNode = xml.documentElement;
 
 		// console.log( paths );
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -99,6 +99,7 @@ THREE.SVGLoader.prototype = {
 				transformPath( path, currentTransform );
 
 				paths.push( path );
+				path.userData = { node: node, style: style };
 
 			}
 
@@ -122,7 +123,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 
 			var point = new THREE.Vector2();
 			var control = new THREE.Vector2();
@@ -546,7 +546,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 			path.moveTo( x + 2 * rx, y );
 			path.lineTo( x + w - 2 * rx, y );
 			if ( rx !== 0 || ry !== 0 ) path.bezierCurveTo( x + w, y, x + w, y, x + w, y + 2 * ry );
@@ -593,7 +592,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 
 			var index = 0;
 
@@ -626,7 +624,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 
 			var index = 0;
 
@@ -649,7 +646,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 			path.subPaths.push( subpath );
 
 			return path;
@@ -668,7 +664,6 @@ THREE.SVGLoader.prototype = {
 
 			var path = new THREE.ShapePath();
 			path.color.setStyle( style.fill );
-			path.fillOpacity = style.fillOpacity;
 			path.subPaths.push( subpath );
 
 			return path;
@@ -1021,6 +1016,7 @@ THREE.SVGLoader.prototype = {
 		console.time( 'THREE.SVGLoader: Parse' );
 
 		parseNode( xml.documentElement, { fill: '#000' } );
+		this.rootNode = xml.documentElement;
 
 		// console.log( paths );
 

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -161,9 +161,9 @@
 					group.position.y = 70;
 					group.scale.y *= - 1;
 
-					for ( var i = 0; i < paths.length; i ++ ) {
+					for ( key in paths['paths'] ) {
 
-						var path = paths[ i ];
+						var path = paths['paths'][ key ];
 
 						var material = new THREE.MeshBasicMaterial( {
 							color: path.color,

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -153,7 +153,9 @@
 				//
 
 				var loader = new THREE.SVGLoader();
-				loader.load( url, function ( paths ) {
+				loader.load( url, function ( data ) {
+
+					var paths = data.paths;
 
 					var group = new THREE.Group();
 					group.scale.multiplyScalar( 0.25 );
@@ -161,9 +163,9 @@
 					group.position.y = 70;
 					group.scale.y *= - 1;
 
-					for ( key in paths['paths'] ) {
+					for ( var i = 0; i < paths.length; i ++ ) {
 
-						var path = paths['paths'][ key ];
+						var path = paths[ i ];
 
 						var material = new THREE.MeshBasicMaterial( {
 							color: path.color,


### PR DESCRIPTION
Working example here: https://btevc.cf/repos/three.js/examples/webgl_loader_svg_update_1.html