### PR TITLE
Remove Loader inheritance from CTMLoader

### DIFF
--- a/examples/js/loaders/ctm/CTMLoader.js
+++ b/examples/js/loaders/ctm/CTMLoader.js
@@ -10,11 +10,8 @@
 
 THREE.CTMLoader = function () {
 
-	THREE.Loader.call( this );
-
 };
 
-THREE.CTMLoader.prototype = Object.create( THREE.Loader.prototype );
 THREE.CTMLoader.prototype.constructor = THREE.CTMLoader;
 
 // Load multiple CTM parts defined in JSON
@@ -58,7 +55,7 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 				for ( var i = 0; i < jsonObject.materials.length; i ++ ) {
 
-					materials[ i ] = scope.createMaterial( jsonObject.materials[ i ], basePath );
+					materials[ i ] = THREE.Loader.prototype.createMaterial( jsonObject.materials[ i ], basePath );
 
 				}
 


### PR DESCRIPTION
`CTMLoader` is the only loader inheriting `Loader` but it doesn't look it really needs to inherit. `CTMLoader` calls `scope(this).createMaterial()` but it can be replaced with `THREE.Loader.prototype.createMaterial()` without inheriting `Loader` as similarly `LegacyJSONLoader` does.

With this change, no loader will inherit `Loader`. We may remove `Loader` if we move `initMaterials()`, `createMaterial()` and `Handlers` to somewhere(`LoaderUtils`?).