### PR TITLE
WebGLRenderer: Remove .setTexture3D() and .setTexture2DArray().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -277,7 +277,7 @@ function WebGLRenderer( parameters ) {
 		geometries = new WebGLGeometries( _gl, attributes, info );
 		objects = new WebGLObjects( geometries, info );
 		morphtargets = new WebGLMorphtargets( _gl );
-		programCache = new WebGLPrograms( _this, extensions, capabilities );
+		programCache = new WebGLPrograms( _this, extensions, capabilities, textures );
 		renderLists = new WebGLRenderLists();
 		renderStates = new WebGLRenderStates();
 
@@ -1950,13 +1950,13 @@ function WebGLRenderer( parameters ) {
 			if ( m_uniforms.ltc_1 !== undefined ) m_uniforms.ltc_1.value = UniformsLib.LTC_1;
 			if ( m_uniforms.ltc_2 !== undefined ) m_uniforms.ltc_2.value = UniformsLib.LTC_2;
 
-			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, _this );
+			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, _this, textures );
 
 		}
 
 		if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
 
-			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, _this );
+			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, _this, textures );
 			material.uniformsNeedUpdate = false;
 
 		}
@@ -2465,18 +2465,6 @@ function WebGLRenderer( parameters ) {
 		};
 
 	}() );
-
-	this.setTexture2DArray = function ( texture, slot ) {
-
-		textures.setTexture2DArray( texture, slot );
-
-	};
-
-	this.setTexture3D = function ( texture, slot ) {
-
-		textures.setTexture3D( texture, slot );
-
-	};
 
 	this.setTexture = ( function () {
 

--- a/src/renderers/webgl/WebGLProgram.d.ts
+++ b/src/renderers/webgl/WebGLProgram.d.ts
@@ -1,14 +1,22 @@
 import { WebGLRenderer, WebGLRendererParameters } from './../WebGLRenderer';
 import { ShaderMaterial } from './../../materials/ShaderMaterial';
 import { WebGLShader } from './WebGLShader';
+import { WebGLCapabilities } from './WebGLCapabilities';
+import { WebGLExtensions } from './WebGLExtensions';
+import { WebGLShader } from './WebGLShader';
+import { WebGLTextures } from './WebGLTextures';
 import { WebGLUniforms } from './WebGLUniforms';
 
 export class WebGLProgram {
   constructor(
     renderer: WebGLRenderer,
+		extensions: WebGLExtensions,
     code: string,
     material: ShaderMaterial,
-    parameters: WebGLRendererParameters
+		shader: WebGLShader,
+    parameters: WebGLRendererParameters,
+		capabilities: WebGLCapabilities,
+		textures: WebGLTextures
   );
 
   id: number;

--- a/src/renderers/webgl/WebGLProgram.d.ts
+++ b/src/renderers/webgl/WebGLProgram.d.ts
@@ -10,13 +10,13 @@ import { WebGLUniforms } from './WebGLUniforms';
 export class WebGLProgram {
   constructor(
     renderer: WebGLRenderer,
-		extensions: WebGLExtensions,
+    extensions: WebGLExtensions,
     code: string,
     material: ShaderMaterial,
-		shader: WebGLShader,
+    shader: WebGLShader,
     parameters: WebGLRendererParameters,
-		capabilities: WebGLCapabilities,
-		textures: WebGLTextures
+    capabilities: WebGLCapabilities,
+    textures: WebGLTextures
   );
 
   id: number;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -206,7 +206,7 @@ function unrollLoops( string ) {
 
 }
 
-function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities ) {
+function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities, textures ) {
 
 	var gl = renderer.context;
 
@@ -670,7 +670,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 		if ( cachedUniforms === undefined ) {
 
-			cachedUniforms = new WebGLUniforms( gl, program, renderer );
+			cachedUniforms = new WebGLUniforms( gl, program, renderer, textures );
 
 		}
 

--- a/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/src/renderers/webgl/WebGLPrograms.d.ts
@@ -1,9 +1,12 @@
 import { WebGLRenderer } from './../WebGLRenderer';
 import { WebGLProgram } from './WebGLProgram';
+import { WebGLCapabilities } from './WebGLCapabilities';
+import { WebGLExtensions } from './WebGLExtensions';
+import { WebGLTextures } from './WebGLTextures';
 import { ShaderMaterial } from './../../materials/ShaderMaterial';
 
 export class WebGLPrograms {
-  constructor(renderer: WebGLRenderer, capabilities: any);
+  constructor(renderer: WebGLRenderer, extensions: WebGLExtensions, capabilities: WebGLCapabilities, textures: WebGLTextures);
 
   programs: WebGLProgram[];
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -5,7 +5,7 @@
 import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap } from '../../constants.js';
 import { WebGLProgram } from './WebGLProgram.js';
 
-function WebGLPrograms( renderer, extensions, capabilities ) {
+function WebGLPrograms( renderer, extensions, capabilities, textures ) {
 
 	var programs = [];
 
@@ -279,7 +279,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 		if ( program === undefined ) {
 
-			program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities );
+			program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities, textures );
 			programs.push( program );
 
 		}

--- a/src/renderers/webgl/WebGLUniforms.d.ts
+++ b/src/renderers/webgl/WebGLUniforms.d.ts
@@ -1,8 +1,9 @@
 import { WebGLProgram } from './WebGLProgram';
 import { WebGLRenderer } from './../WebGLRenderer';
+import { WebGLTextures } from './WebGLTextures';
 
 export class WebGLUniforms {
-  constructor(gl: any, program: WebGLProgram, renderer: WebGLRenderer);
+  constructor(gl: any, program: WebGLProgram, renderer: WebGLRenderer, textures: WebGLTextures);
 
   renderer: WebGLRenderer;
 

--- a/src/renderers/webgl/WebGLUniforms.d.ts
+++ b/src/renderers/webgl/WebGLUniforms.d.ts
@@ -7,11 +7,11 @@ export class WebGLUniforms {
 
   renderer: WebGLRenderer;
 
-  setValue(gl: any, value: any, renderer?: any): void;
+  setValue(gl: any, name: string, value: any): void;
   set(gl: any, object: any, name: string): void;
   setOptional(gl: any, object: any, name: string): void;
 
-  static upload(gl: any, seq: any, values: any[], renderer: any): void;
+  static upload(gl: any, seq: any, values: any[], renderer: WebGLRenderer, textures: WebGLTextures): void;
   static seqWithValue(seq: any, values: any[]): any[];
   static splitDynamic(seq: any, values: any[]): any[];
   static evalDynamic(seq: any, values: any[], object: any, camera: any): any[];

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -392,7 +392,7 @@ function setValueT1( gl, v, renderer ) {
 
 }
 
-function setValueT2DArray1( gl, v, renderer ) {
+function setValueT2DArray1( gl, v, renderer, textures ) {
 
 	var cache = this.cache;
 	var unit = renderer.allocTextureUnit();
@@ -404,11 +404,11 @@ function setValueT2DArray1( gl, v, renderer ) {
 
 	}
 
-	renderer.setTexture2DArray( v || emptyTexture2dArray, unit );
+	textures.setTexture2DArray( v || emptyTexture2dArray, unit );
 
 }
 
-function setValueT3D1( gl, v, renderer ) {
+function setValueT3D1( gl, v, renderer, textures ) {
 
 	var cache = this.cache;
 	var unit = renderer.allocTextureUnit();
@@ -420,7 +420,7 @@ function setValueT3D1( gl, v, renderer ) {
 
 	}
 
-	renderer.setTexture3D( v || emptyTexture3d, unit );
+	textures.setTexture3D( v || emptyTexture3d, unit );
 
 }
 
@@ -821,11 +821,12 @@ function parseUniform( activeInfo, addr, container ) {
 
 // Root Container
 
-function WebGLUniforms( gl, program, renderer ) {
+function WebGLUniforms( gl, program, renderer, textures ) {
 
 	UniformContainer.call( this );
 
 	this.renderer = renderer;
+	this.textures = textures;
 
 	var n = gl.getProgramParameter( program, gl.ACTIVE_UNIFORMS );
 
@@ -844,7 +845,7 @@ WebGLUniforms.prototype.setValue = function ( gl, name, value ) {
 
 	var u = this.map[ name ];
 
-	if ( u !== undefined ) u.setValue( gl, value, this.renderer );
+	if ( u !== undefined ) u.setValue( gl, value, this.renderer, this.textures );
 
 };
 
@@ -859,7 +860,7 @@ WebGLUniforms.prototype.setOptional = function ( gl, object, name ) {
 
 // Static interface
 
-WebGLUniforms.upload = function ( gl, seq, values, renderer ) {
+WebGLUniforms.upload = function ( gl, seq, values, renderer, textures ) {
 
 	for ( var i = 0, n = seq.length; i !== n; ++ i ) {
 
@@ -869,7 +870,7 @@ WebGLUniforms.upload = function ( gl, seq, values, renderer ) {
 		if ( v.needsUpdate !== false ) {
 
 			// note: always updating when .needsUpdate is undefined
-			u.setValue( gl, v.value, renderer );
+			u.setValue( gl, v.value, renderer, textures );
 
 		}
 


### PR DESCRIPTION
As requested in https://github.com/mrdoob/three.js/pull/15901/files#r262705188

`WebGLUniforms` directly uses now `WebGLTextures` for `DataTexture2DArray` and `DataTexture3D`.

This PR also provides basic changes which are necessary to deprecate `.allocTextureUnit()`, `.setTexture2D()` and `setTextureCube()` from `WebGLRenderer` at a later point.

Also see #15924