### PR TITLE
GLTFLoader: Remove dependency on 'THREE.DRACOLoader' global

### DIFF
--- a/docs/examples/loaders/GLTFLoader.html
+++ b/docs/examples/loaders/GLTFLoader.html
@@ -58,6 +58,9 @@
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
 		THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
 		loader.setDRACOLoader( new THREE.DRACOLoader() );
+			
+		// Optional: Pre-fetch Draco WASM/JS module, to save time while parsing.
+		THREE.DRACOLoader.getDecoderModule();
 
 		// Load a glTF resource
 		loader.load(

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -496,7 +496,6 @@ THREE.GLTFLoader = ( function () {
 		this.name = EXTENSIONS.KHR_DRACO_MESH_COMPRESSION;
 		this.json = json;
 		this.dracoLoader = dracoLoader;
-		THREE.DRACOLoader.getDecoderModule();
 
 	}
 


### PR DESCRIPTION
Rolls back https://github.com/mrdoob/three.js/pull/15177.

I think it's better to avoid a dependency on the global `THREE.DRACOLoader` namespace. It will be an issue for our ES module refactoring (GLTFLoader can accept a DRACOLoader instance as a parameter, but doesn't depend on it directly) and it prevents users from providing a custom DRACOLoader instance, per https://github.com/mrdoob/three.js/pull/15249 and https://github.com/GoogleWebComponents/model-viewer/issues/72.

Fortunately, an easy workaround for users is to call `THREE.DRACOLoader.getDecoderModule()` in their own code when they know Draco is needed, which actually performs even better (it doesn't have to wait for the JSON header). I've documented this accordingly.

/cc @TyLindberg

