### PR TITLE
Add note about ignored texture properties for ImageBitmap to ImageBitmapLoader document

### DIFF
--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -17,10 +17,10 @@
 		</p>
 
 		<p>
-			Note that [page:Texture.flipY .flipY] and [page:Texture.premultiplyAlpha .premultiplyAlpha] properties of [page:Texture]
-			with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored. 
-			You need to set the equivalent options on [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] creation via [page:ImageBitmapLoader.setOptions] instead.
-			Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
+			Note that [page:Texture.flipY] and [page:Texture.premultiplyAlpha] with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored.
+			[link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] needs these configuration on bitmap creation
+			unlike regular images need them on uploading to GPU. You need to set the equivalent options via [page:ImageBitmapLoader.setOptions]
+			instead. Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
 		</p>
 
 		<h2>Example</h2>

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -16,6 +16,13 @@
 			Unlike [page:FileLoader], [name] does not avoid multiple concurrent requests to the same URL.
 		</p>
 
+		<p>
+			Note that [page:Texture.flipY .flipY] and [page:Texture.premultiplyAlpha .premultiplyAlpha] properties of [page:Texture]
+			with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored. 
+			You need to set the equivalent options on [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] creation via [page:ImageBitmapLoader.setOptions] instead.
+			Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
+		</p>
+
 		<h2>Example</h2>
 
 		<p>
@@ -25,6 +32,9 @@
 		<code>
 		// instantiate a loader
 		var loader = new THREE.ImageBitmapLoader();
+
+		// set options if needed
+		loader.setOptions( { imageOrientation: 'flipY' } );
 
 		// load a image resource
 		loader.load(

--- a/docs/api/zh/loaders/ImageBitmapLoader.html
+++ b/docs/api/zh/loaders/ImageBitmapLoader.html
@@ -16,6 +16,13 @@
 			不像[page:FileLoader], [name]无需避免对同一的URL进行多次请求。
 		</p>
 
+		<p>
+			Note that [page:Texture.flipY .flipY] and [page:Texture.premultiplyAlpha .premultiplyAlpha] properties of [page:Texture]
+			with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored. 
+			You need to set the equivalent options on [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] creation via [page:ImageBitmapLoader.setOptions] instead.
+			Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
+		</p>
+
 		<h2>例子</h2>
 
 		<p>
@@ -25,6 +32,9 @@
 		<code>
 		// 初始化一个加载器
 		var loader = new THREE.ImageBitmapLoader();
+
+		// set options if needed
+		loader.setOptions( { imageOrientation: 'flipY' } );
 
 		// 加载一个图片资源
 		loader.load(

--- a/docs/api/zh/loaders/ImageBitmapLoader.html
+++ b/docs/api/zh/loaders/ImageBitmapLoader.html
@@ -17,10 +17,10 @@
 		</p>
 
 		<p>
-			Note that [page:Texture.flipY .flipY] and [page:Texture.premultiplyAlpha .premultiplyAlpha] properties of [page:Texture]
-			with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored. 
-			You need to set the equivalent options on [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] creation via [page:ImageBitmapLoader.setOptions] instead.
-			Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
+			Note that [page:Texture.flipY] and [page:Texture.premultiplyAlpha] with [link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] are ignored.
+			[link:https://developer.mozilla.org/de/docs/Web/API/ImageBitmap ImageBitmap] needs these configuration on bitmap creation
+			unlike regular images need them on uploading to GPU. You need to set the equivalent options via [page:ImageBitmapLoader.setOptions]
+			instead. Refer to [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10 WebGL specification] for the detail.
 		</p>
 
 		<h2>例子</h2>


### PR DESCRIPTION
`.flipY` and `.premultiplyAlpha` of `Texture` properties with `ImageBitmap` are ignored because `UNPACK_FLIP_Y_WEBGL`, `UNPACK_PREMULTIPLY_ALPHA_WEBGL` (, and `UNPACK_COLORSPACE_CONVERSION_WEBGL`) for `gl.pixelStorei` are ignored if the image source is `ImageBitmap`.

https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.10

I'd like to add the note about it to `ImageBitmapLoader` document. Please feel free to correct the sentences if looking weird because English isn't my first language.