### PR TITLE
MTLLoader : fix restricted to MeshPhongMaterial

### DIFF
--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -76,6 +76,7 @@
 		<p>
 			[page:Object options] — required
 			<ul>
+				<li>baseMaterial: Which mesh [page:Material] class will be instantiated per loaded material. THREE.MeshPhongMaterial (default)</li>
 				<li>side: Which side to apply the material. THREE.FrontSide (default), THREE.BackSide, THREE.DoubleSide</li>
 				<li>wrap: What type of wrapping to apply for textures. THREE.RepeatWrapping (default), THREE.ClampToEdgeWrapping, THREE.MirroredRepeatWrapping</li>
 				<li>normalizeRGB: RGBs need to be normalized to 0-1 from 0-255. Default: false, assumed to be already normalized</li>

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -178,6 +178,8 @@ THREE.MTLLoader.prototype = {
  * Create a new THREE-MTLLoader.MaterialCreator
  * @param baseUrl - Url relative to which textures are loaded
  * @param options - Set of options on how to construct the materials
+ *                  baseMaterial: Which mesh Material class will be instantiated
+ *                                per loaded material. THREE.MeshPhongMaterial (default)
  *                  side: Which side to apply the material
  *                        THREE.FrontSide (default), THREE.BackSide, THREE.DoubleSide
  *                  wrap: What type of wrapping to apply for textures
@@ -201,6 +203,7 @@ THREE.MTLLoader.MaterialCreator = function ( baseUrl, options ) {
 	this.materialsArray = [];
 	this.nameLookup = {};
 
+	this.baseMaterial = ( this.options && this.options.baseMaterial ) ? this.options.baseMaterial : THREE.MeshPhongMaterial;
 	this.side = ( this.options && this.options.side ) ? this.options.side : THREE.FrontSide;
 	this.wrap = ( this.options && this.options.wrap ) ? this.options.wrap : THREE.RepeatWrapping;
 
@@ -513,8 +516,20 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 		}
 
-		this.materials[ materialName ] = new THREE.MeshPhongMaterial( params );
-		return this.materials[ materialName ];
+		// instantiate material (without passing params yet)
+		var materialInstance = this.materials[ materialName ] = new this.baseMaterial();
+
+		// remove params not supported by this material (we do it here to prevent console warnings)
+		var keptParams = {};
+		for ( var i in params ) {
+			if ( typeof materialInstance[ i ] !== 'undefined' ) {
+				keptParams[ i ] = params[ i ];
+			}
+		}
+
+		materialInstance.setValues( keptParams );
+
+		return materialInstance;
 
 	},
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -186,6 +186,9 @@ THREE.MTLLoader.prototype = {
  *                                Default: false, assumed to be already normalized
  *                  ignoreZeroRGBs: Ignore values of RGBs (Ka,Kd,Ks) that are all 0's
  *                                  Default: false
+ *                  invertTrProperty: Use values 1 of Tr field for fully opaque.
+ *                                    This option is useful for obj exported from 3ds MAX,
+ *                                    vcglib or meshlab. Default: false
  * @constructor
  */
 
@@ -413,6 +416,15 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					break;
 
+				case 'ns':
+
+					// The specular exponent (defines the focus of the specular highlight)
+					// A high exponent results in a tight, concentrated highlight. Ns values normally range from 0 to 1000.
+
+					params.shininess = parseFloat( value );
+
+					break;
+
 				case 'ke':
 
 					// Emissive using RGB values
@@ -465,15 +477,6 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 
 					setMapForType( "alphaMap", value );
 					params.transparent = true;
-
-					break;
-
-				case 'ns':
-
-					// The specular exponent (defines the focus of the specular highlight)
-					// A high exponent results in a tight, concentrated highlight. Ns values normally range from 0 to 1000.
-
-					params.shininess = parseFloat( value );
 
 					break;
 

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -22,6 +22,9 @@
 				display:block;
 			}
 			#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+			.dg.ac {
+				z-index: 200 !important;
+			}
 		</style>
 	</head>
 
@@ -37,6 +40,7 @@
 		<script src="js/loaders/OBJLoader.js"></script>
 
 		<script src="js/libs/stats.min.js"></script>
+		<script src="js/libs/dat.gui.min.js"></script>
 
 		<script>
 
@@ -49,9 +53,33 @@
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
+			var params = {
+				baseMaterial: 'MeshPhongMaterial',
+			};
+			var baseMaterials = {
+				MeshBasicMaterial: THREE.MeshBasicMaterial,
+				MeshDepthMaterial: THREE.MeshDepthMaterial,
+				MeshLambertMaterial: THREE.MeshLambertMaterial,
+				MeshNormalMaterial: THREE.MeshNormalMaterial,
+				MeshPhongMaterial: THREE.MeshPhongMaterial,
+				MeshPhysicalMaterial: THREE.MeshPhysicalMaterial,
+				MeshStandardMaterial: THREE.MeshStandardMaterial,
+				MeshToonMaterial: THREE.MeshToonMaterial,
+			};
 
+			initGUI();
 			init();
 			animate();
+
+
+			function initGUI() {
+				var gui = new dat.GUI( { width: 300 } );
+				var folderMaterialOptions = gui.addFolder( 'Material options' );
+				folderMaterialOptions.add( params, 'baseMaterial', Object.keys( baseMaterials ) ).onChange( function ( value ) {
+					loadModel( value );
+				} );
+				folderMaterialOptions.open();
+			}
 
 
 			function init() {
@@ -75,6 +103,31 @@
 
 				// model
 
+				THREE.Loader.Handlers.add( /\.dds$/i, new THREE.DDSLoader() );
+				loadModel( params.baseMaterial );
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
+				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			var lastModelLoaded = null;
+			function loadModel( baseMaterial ) {
+
+				console.log( '--- Loading model with ' + baseMaterial );
+
+				if ( lastModelLoaded ) {
+					scene.remove( lastModelLoaded );
+				}
+
 				var onProgress = function ( xhr ) {
 
 					if ( xhr.lengthComputable ) {
@@ -88,10 +141,11 @@
 
 				var onError = function () { };
 
-				THREE.Loader.Handlers.add( /\.dds$/i, new THREE.DDSLoader() );
-
 				new THREE.MTLLoader()
 					.setPath( 'models/obj/male02/' )
+					.setMaterialOptions( {
+						baseMaterial: baseMaterials[baseMaterial],
+					} )
 					.load( 'male02_dds.mtl', function ( materials ) {
 
 						materials.preload();
@@ -104,23 +158,11 @@
 								object.position.y = - 95;
 								scene.add( object );
 
+								lastModelLoaded = object;
+
 							}, onProgress, onError );
 
 					} );
-
-				//
-
-				renderer = new THREE.WebGLRenderer();
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				container.appendChild( renderer.domElement );
-
-				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
-
-				//
-
-				window.addEventListener( 'resize', onWindowResize, false );
-
 			}
 
 			function onWindowResize() {


### PR DESCRIPTION
Hi, first PR in the lands of threejs :raising_hand_man: Yay !

I noticed that the MTLLoader could only output `TREE.MeshPhongMaterial` (and for my project I want some `TREE.MeshLambertMaterial` so... :man_shrugging: )

- I added the possibility to choose which material type get created using the existing `MTLLoader.setMaterialOptions(...)` interface in which I added the `baseMaterial` option.
- the default value is still `TREE.MeshPhongMaterial`
- I also updated the `webgl_loader_obj_mtl.html` example
- and the doc

**NOTE :** (as far as I know) the .mtl format does not support physically based materials, so if someone choose `TREE.MeshPhysicalMaterial` as the baseMaterial, it will not try to convert values, it'll just return the material with defaults. But at least values can be tweaked manually afterwards !

Thank you :slightly_smiling_face: 