### PR TITLE
Add a .editorconfig file to enforce coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+# http://editorconfig.org
+
 root = true
 
 [*]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,ts,html}]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+
+[*.{js,ts}]
+trim_trailing_whitespace = true


### PR DESCRIPTION
In case you didn't know :man_shrugging:  , this will automatically set almost any text editor to the proper config :
**utf-8, 2 tabs, LF newlines and no trailing white spaces** ([from Mr.doob's Code Style](https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2#general-provisions))

It makes things much more easier ! And different config can be applied to different files types, etc.

You just need the plugin for your text editor : https://editorconfig.org/ (there is one for Atom :atom:  )

**If this gets merged**, I guess it could be mentioned in the [wiki page](https://github.com/mrdoob/three.js/wiki/How-to-contribute-to-three.js) before last point.