### PR TITLE
Added Z axis to normalScale of some materials

### DIFF
--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -185,10 +185,10 @@
 			Options are [page:constant THREE.TangentSpaceNormalMap] (default), and [page:constant THREE.ObjectSpaceNormalMap].
 		</p>
 
-		<h3>[property:Vector2 normalScale]</h3>
+		<h3>[property:Vector3 normalScale]</h3>
 		<p>
 			How much the normal map affects the material. Typical ranges are 0-1.
-			Default is a [page:Vector2] set to (1,1).
+			Default is a [page:Vector3] set to (1,1,1).
 		</p>
 
 

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -233,10 +233,10 @@
 			Options are [page:constant THREE.TangentSpaceNormalMap] (default), and [page:constant THREE.ObjectSpaceNormalMap].
 		</p>
 
-		<h3>[property:Vector2 normalScale]</h3>
+		<h3>[property:Vector3 normalScale]</h3>
 		<p>
 			How much the normal map affects the material. Typical ranges are 0-1.
-			Default is a [page:Vector2] set to (1,1).
+			Default is a [page:Vector3] set to (1,1,1).
 		</p>
 
 		<h3>[property:Float refractionRatio]</h3>

--- a/docs/api/zh/materials/MeshPhongMaterial.html
+++ b/docs/api/zh/materials/MeshPhongMaterial.html
@@ -141,8 +141,8 @@
 			选项为[page:constant THREE.TangentSpaceNormalMap]（默认）和[page:constant THREE.ObjectSpaceNormalMap]。
 		</p>
 
-		<h3>[property:Vector2 normalScale]</h3>
-		<p> 法线贴图对材质的影响程度。典型范围是0-1。默认值是[page:Vector2]设置为（1,1）。
+		<h3>[property:Vector3 normalScale]</h3>
+		<p> 法线贴图对材质的影响程度。典型范围是0-1。默认值是[page:Vector3]设置为（1,1,1）。
 		</p>
 
 

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -182,8 +182,8 @@
 			选项为[page:constant THREE.TangentSpaceNormalMap]（默认）和[page:constant THREE.ObjectSpaceNormalMap]。
 		</p>
 
-		<h3>[property:Vector2 normalScale]</h3>
-		<p> 法线贴图对材质的影响程度。典型范围是0-1。默认值是[page:Vector2]设置为（1,1）。
+		<h3>[property:Vector3 normalScale]</h3>
+		<p> 法线贴图对材质的影响程度。典型范围是0-1。默认值是[page:Vector2]设置为（1,1,1）。
 		</p>
 
 		<h3>[property:Float refractionRatio]</h3>

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -2389,8 +2389,8 @@
           "!doc": "The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change\n\t\t\tthe way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting."
         },
         "normalScale": {
-          "!type": "+THREE.Vector2",
-          "!doc": "How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1)."
+          "!type": "+THREE.Vector3",
+          "!doc": "How much the normal map affects the material. Typical ranges are 0-1. Default is (1,1,1)."
         },
         "specularMap": {
           "!type": "+THREE.Texture",

--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -84,7 +84,7 @@
 					map: textureLoader.load( 'textures/planets/earth_atmos_2048.jpg' ),
 					specularMap: textureLoader.load( 'textures/planets/earth_specular_2048.jpg' ),
 					normalMap: textureLoader.load( 'textures/planets/earth_normal_2048.jpg' ),
-					normalScale: new THREE.Vector2( 0.85, 0.85 )
+					normalScale: new THREE.Vector3( 0.85, 0.85, 1 )
 				} );
 				earth = new THREE.Mesh( earthGeometry, earthMaterial );
 				scene.add( earth );

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2361,11 +2361,11 @@ THREE.GLTFLoader = ( function () {
 
 			pending.push( parser.assignTexture( materialParams, 'normalMap', materialDef.normalTexture ) );
 
-			materialParams.normalScale = new THREE.Vector2( 1, 1 );
+			materialParams.normalScale = new THREE.Vector3( 1, 1, 1 );
 
 			if ( materialDef.normalTexture.scale !== undefined ) {
 
-				materialParams.normalScale.set( materialDef.normalTexture.scale, materialDef.normalTexture.scale );
+				materialParams.normalScale.set( materialDef.normalTexture.scale, materialDef.normalTexture.scale, materialDef.normalTexture.scale );
 
 			}
 

--- a/examples/js/loaders/XLoader.js
+++ b/examples/js/loaders/XLoader.js
@@ -1228,7 +1228,7 @@
 								break;
 							case "NormalMapFilename":
 								_nowMat.normalMap = this.texloader.load( fileName );
-								_nowMat.normalScale = new THREE.Vector2( 2, 2 );
+								_nowMat.normalScale = new THREE.Vector3( 2, 2, 1 );
 								break;
 							case "EmissiveMapFilename":
 								_nowMat.emissiveMap = this.texloader.load( fileName );

--- a/examples/js/nodes/materials/nodes/MeshStandardNode.js
+++ b/examples/js/nodes/materials/nodes/MeshStandardNode.js
@@ -16,14 +16,14 @@ function MeshStandardNode() {
 		color: new THREE.Color( 0xffffff ),
 		roughness: 0.5,
 		metalness: 0.5,
-		normalScale: new THREE.Vector2( 1, 1 )
+		normalScale: new THREE.Vector3( 1, 1, 1 )
 	};
 
 	this.inputs = {
 		color: new PropertyNode( this.properties, 'color', 'c' ),
 		roughness: new PropertyNode( this.properties, 'roughness', 'f' ),
 		metalness: new PropertyNode( this.properties, 'metalness', 'f' ),
-		normalScale: new PropertyNode( this.properties, 'normalScale', 'v2' )
+		normalScale: new PropertyNode( this.properties, 'normalScale', 'v3' )
 	};
 
 }

--- a/examples/js/nodes/misc/NormalMapNode.js
+++ b/examples/js/nodes/misc/NormalMapNode.js
@@ -25,7 +25,7 @@ NormalMapNode.Nodes = ( function () {
 		// Per-Pixel Tangent Space Normal Mapping
 		// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
 
-		"vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 mUv, vec2 normalScale ) {",
+		"vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 mUv, vec3 normalScale ) {",
 
 		// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
@@ -43,7 +43,7 @@ NormalMapNode.Nodes = ( function () {
 
 		"	vec3 mapN = map * 2.0 - 1.0;",
 
-		"	mapN.xy *= normalScale;",
+		"	mapN *= normalScale;",
 		"	mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );",
 
 		"	return normalize( tsn * mapN );",

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2441,11 +2441,11 @@ var GLTFLoader = ( function () {
 
 			pending.push( parser.assignTexture( materialParams, 'normalMap', materialDef.normalTexture ) );
 
-			materialParams.normalScale = new Vector2( 1, 1 );
+			materialParams.normalScale = new Vector3( 1, 1, 1 );
 
 			if ( materialDef.normalTexture.scale !== undefined ) {
 
-				materialParams.normalScale.set( materialDef.normalTexture.scale, materialDef.normalTexture.scale );
+				materialParams.normalScale.set( materialDef.normalTexture.scale, materialDef.normalTexture.scale, materialDef.normalTexture.scale );
 
 			}
 

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -113,7 +113,7 @@
 					map: textureLoader.load( "textures/planets/earth_atmos_2048.jpg" ),
 					specularMap: textureLoader.load( "textures/planets/earth_specular_2048.jpg" ),
 					normalMap: textureLoader.load( "textures/planets/earth_normal_2048.jpg" ),
-					normalScale: new THREE.Vector2( 0.85, 0.85 )
+					normalScale: new THREE.Vector3( 0.85, 0.85, 1 )
 
 				} );
 

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -65,7 +65,7 @@
 			specular: 0x444444,
 			map: decalDiffuse,
 			normalMap: decalNormal,
-			normalScale: new THREE.Vector2( 1, 1 ),
+			normalScale: new THREE.Vector3( 1, 1, 1 ),
 			shininess: 30,
 			transparent: true,
 			depthTest: true,

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -182,7 +182,7 @@
 						map: textureLoader.load( "models/gltf/LeePerrySmith/Map-COL.jpg" ),
 						specularMap: textureLoader.load( "models/gltf/LeePerrySmith/Map-SPEC.jpg" ),
 						normalMap: textureLoader.load( "models/gltf/LeePerrySmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
-						normalScale: new THREE.Vector2( 0.8, 0.8 )
+						normalScale: new THREE.Vector3( 0.8, 0.8, 1 )
 
 					} );
 

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -173,7 +173,7 @@
 					aoMap: aoMap,
 
 					normalMap: normalMap,
-					normalScale: new THREE.Vector2( 1, - 1 ),
+					normalScale: new THREE.Vector3( 1, - 1, 1 ),
 
 					//flatShading: true,
 
@@ -206,7 +206,7 @@
 					displacementBias: BIAS,
 
 					normalMap: normalMap,
-					normalScale: new THREE.Vector2( 1, - 1 ),
+					normalScale: new THREE.Vector3( 1, - 1, 1 ),
 
 					//flatShading: true,
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -125,7 +125,7 @@
 
 				gui.add( settings, "normalScale" ).min( - 1 ).max( 1 ).onChange( function ( value ) {
 
-					material.normalScale.set( 1, - 1 ).multiplyScalar( value );
+					material.normalScale.set( 1, - 1, 1 ).multiplyScalar( value ).setZ( 1 );
 
 				} );
 
@@ -202,7 +202,7 @@
 					metalness: settings.metalness,
 
 					normalMap: normalMap,
-					normalScale: new THREE.Vector2( 1, - 1 ), // why does the normal map require negation in this case?
+					normalScale: new THREE.Vector3( 1, - 1, 1 ), // why does the normal map require negation in this case?
 
 					aoMap: aoMap,
 					aoMapIntensity: 1,

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -434,7 +434,7 @@
 							mtl.map = useMap ? getTexture( "brick" ) : undefined;
 
 							mtl.normalMap = useNormals ? getTexture( "decalNormal" ) : undefined;
-							mtl.normalScale = oldMaterial ? oldMaterial.normalScale : new THREE.Vector2( .5, .5 );
+							mtl.normalScale = oldMaterial ? oldMaterial.normalScale : new THREE.Vector3( .5, .5, 1 );
 
 							mtl.envMap = cubemap;
 

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -129,7 +129,7 @@
 					map: textureLoader.load( "models/gltf/LeePerrySmith/Map-COL.jpg" ),
 					specularMap: textureLoader.load( "models/gltf/LeePerrySmith/Map-SPEC.jpg" ),
 					normalMap: textureLoader.load( "models/gltf/LeePerrySmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
-					normalScale: new THREE.Vector2( 0.8, 0.8 )
+					normalScale: new THREE.Vector3( 0.8, 0.8, 1 )
 				} );
 
 				loader = new THREE.GLTFLoader();

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -338,7 +338,7 @@
 					shininess: 20,
 					map: new THREE.TextureLoader().load( "models/gltf/LeePerrySmith/Map-COL.jpg" ),
 					normalMap: new THREE.TextureLoader().load( "models/gltf/LeePerrySmith/Infinite-Level_02_Tangent_SmoothUV.jpg" ),
-					normalScale: new THREE.Vector2( 0.75, 0.75 )
+					normalScale: new THREE.Vector3( 0.75, 0.75, 1 )
 
 				} );
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -193,11 +193,11 @@ Object.assign( MaterialLoader.prototype, {
 
 				// Blender exporter used to export a scalar. See #7459
 
-				normalScale = [ normalScale, normalScale ];
+				normalScale = [ normalScale, normalScale, normalScale ];
 
 			}
 
-			material.normalScale = new Vector2().fromArray( normalScale );
+			material.normalScale = new Vector3().fromArray( normalScale );
 
 		}
 

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -1,6 +1,6 @@
 import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Color } from '../math/Color.js';
 
 /**
@@ -19,7 +19,7 @@ import { Color } from '../math/Color.js';
  *
  *  normalMap: new THREE.Texture( <Image> ),
  *  normalMapType: THREE.TangentSpaceNormalMap,
- *  normalScale: <Vector2>,
+ *  normalScale: <Vector3>,
  *
  *  displacementMap: new THREE.Texture( <Image> ),
  *  displacementScale: <float>,
@@ -52,7 +52,7 @@ function MeshMatcapMaterial( parameters ) {
 
 	this.normalMap = null;
 	this.normalMapType = TangentSpaceNormalMap;
-	this.normalScale = new Vector2( 1, 1 );
+	this.normalScale = new Vector3( 1, 1, 1 );
 
 	this.displacementMap = null;
 	this.displacementScale = 1;

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -1,6 +1,6 @@
 import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -14,7 +14,7 @@ import { Vector2 } from '../math/Vector2.js';
  *
  *  normalMap: new THREE.Texture( <Image> ),
  *  normalMapType: THREE.TangentSpaceNormalMap,
- *  normalScale: <Vector2>,
+ *  normalScale: <Vector3>,
  *
  *  displacementMap: new THREE.Texture( <Image> ),
  *  displacementScale: <float>,
@@ -40,7 +40,7 @@ function MeshNormalMaterial( parameters ) {
 
 	this.normalMap = null;
 	this.normalMapType = TangentSpaceNormalMap;
-	this.normalScale = new Vector2( 1, 1 );
+	this.normalScale = new Vector3( 1, 1, 1 );
 
 	this.displacementMap = null;
 	this.displacementScale = 1;

--- a/src/materials/MeshPhongMaterial.d.ts
+++ b/src/materials/MeshPhongMaterial.d.ts
@@ -21,7 +21,7 @@ export interface MeshPhongMaterialParameters extends MaterialParameters {
   bumpMap?: Texture;
   bumpScale?: number;
   normalMap?: Texture;
-  normalScale?: Vector2;
+  normalScale?: Vector3;
   displacementMap?: Texture;
   displacementScale?: number;
   displacementBias?: number;
@@ -57,7 +57,7 @@ export class MeshPhongMaterial extends Material {
   bumpMap: Texture | null;
   bumpScale: number;
   normalMap: Texture | null;
-  normalScale: Vector2;
+  normalScale: Vector3;
   displacementMap: Texture | null;
   displacementScale: number;
   displacementBias: number;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -1,6 +1,6 @@
 import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Color } from '../math/Color.js';
 
 /**
@@ -30,7 +30,7 @@ import { Color } from '../math/Color.js';
  *
  *  normalMap: new THREE.Texture( <Image> ),
  *  normalMapType: THREE.TangentSpaceNormalMap,
- *  normalScale: <Vector2>,
+ *  normalScale: <Vector3>,
  *
  *  displacementMap: new THREE.Texture( <Image> ),
  *  displacementScale: <float>,
@@ -81,7 +81,7 @@ function MeshPhongMaterial( parameters ) {
 
 	this.normalMap = null;
 	this.normalMapType = TangentSpaceNormalMap;
-	this.normalScale = new Vector2( 1, 1 );
+	this.normalScale = new Vector3( 1, 1, 1 );
 
 	this.displacementMap = null;
 	this.displacementScale = 1;

--- a/src/materials/MeshStandardMaterial.d.ts
+++ b/src/materials/MeshStandardMaterial.d.ts
@@ -1,6 +1,6 @@
 import { Color } from './../math/Color';
 import { Texture } from './../textures/Texture';
-import { Vector2 } from './../math/Vector2';
+import { Vector3 } from './../math/Vector3';
 import { MaterialParameters, Material } from './Material';
 
 export interface MeshStandardMaterialParameters extends MaterialParameters {
@@ -18,7 +18,7 @@ export interface MeshStandardMaterialParameters extends MaterialParameters {
   bumpMap?: Texture;
   bumpScale?: number;
   normalMap?: Texture;
-  normalScale?: Vector2;
+  normalScale?: Vector3;
   displacementMap?: Texture;
   displacementScale?: number;
   displacementBias?: number;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -1,6 +1,6 @@
 import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Color } from '../math/Color.js';
 
 /**
@@ -29,7 +29,7 @@ import { Color } from '../math/Color.js';
  *
  *  normalMap: new THREE.Texture( <Image> ),
  *  normalMapType: THREE.TangentSpaceNormalMap,
- *  normalScale: <Vector2>,
+ *  normalScale: <Vector3>,
  *
  *  displacementMap: new THREE.Texture( <Image> ),
  *  displacementScale: <float>,
@@ -84,7 +84,7 @@ function MeshStandardMaterial( parameters ) {
 
 	this.normalMap = null;
 	this.normalMapType = TangentSpaceNormalMap;
-	this.normalScale = new Vector2( 1, 1 );
+	this.normalScale = new Vector3( 1, 1, 1 );
 
 	this.displacementMap = null;
 	this.displacementScale = 1;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2222,7 +2222,12 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
+			if ( material.side === BackSide ) {
+
+				uniforms.normalScale.value.x = - uniforms.normalScale.value.x;
+				uniforms.normalScale.value.y = - uniforms.normalScale.value.y;
+
+			}
 
 		}
 
@@ -2283,7 +2288,12 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
+			if ( material.side === BackSide ) {
+
+				uniforms.normalScale.value.x = - uniforms.normalScale.value.x;
+				uniforms.normalScale.value.y = - uniforms.normalScale.value.y;
+
+			}
 
 		}
 
@@ -2335,7 +2345,12 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
+			if ( material.side === BackSide ) {
+
+				uniforms.normalScale.value.x = - uniforms.normalScale.value.x;
+				uniforms.normalScale.value.y = - uniforms.normalScale.value.y;
+
+			}
 
 		}
 
@@ -2391,7 +2406,12 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
+			if ( material.side === BackSide ) {
+
+				uniforms.normalScale.value.x = - uniforms.normalScale.value.x;
+				uniforms.normalScale.value.y = - uniforms.normalScale.value.y;
+
+			}
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -25,7 +25,7 @@ export default /* glsl */`
 
 			mat3 vTBN = mat3( tangent, bitangent, normal );
 			vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
-			mapN.xy = normalScale * mapN.xy;
+			mapN = normalScale * mapN;
 			normal = normalize( vTBN * mapN );
 
 		#else

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -2,7 +2,7 @@ export default /* glsl */`
 #ifdef USE_NORMALMAP
 
 	uniform sampler2D normalMap;
-	uniform vec2 normalScale;
+	uniform vec3 normalScale;
 
 	#ifdef OBJECTSPACE_NORMALMAP
 
@@ -31,7 +31,7 @@ export default /* glsl */`
 
 			vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
 
-			mapN.xy *= normalScale;
+			mapN *= normalScale;
 			mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
 
 			return normalize( tsn * mapN );

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -1,5 +1,6 @@
 import { Color } from '../../math/Color.js';
 import { Vector2 } from '../../math/Vector2.js';
+import { Vector3 } from '../../math/Vector3.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 
 /**
@@ -66,7 +67,7 @@ var UniformsLib = {
 	normalmap: {
 
 		normalMap: { value: null },
-		normalScale: { value: new Vector2( 1, 1 ) }
+		normalScale: { value: new Vector3( 1, 1, 1 ) }
 
 	},
 


### PR DESCRIPTION
I've added access to the `z`-axis of the `normalScale` of a `MeshStandardMaterial` and `MeshPhongMaterial`.

This is a prerequisite to fix our issue #15850 by flipping the blue channel (z-axis) of the normal map.

In this PR, I've converted `normalScale` from a `THREE.Vector2` to a `THREE.Vector3`.
