### PR TITLE
JSM: Move imports beneath JSDoc header.

### DIFF
--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -7,14 +7,6 @@
  * @author moroine / https://github.com/moroine
  */
 
-// This set of controls performs orbiting, dollying (zooming), and panning.
-// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
-// This is very similar to OrbitControls, another set of touch behavior
-//
-//    Orbit - right mouse, or left mouse + ctrl/meta/shiftKey / touch: two-finger rotate
-//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
-//    Pan - left mouse, or arrow keys / touch: one-finger move
-
 import {
 	EventDispatcher,
 	MOUSE,
@@ -23,6 +15,14 @@ import {
 	Vector2,
 	Vector3
 } from "../../../build/three.module.js";
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+// This is very similar to OrbitControls, another set of touch behavior
+//
+//    Orbit - right mouse, or left mouse + ctrl/meta/shiftKey / touch: two-finger rotate
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - left mouse, or arrow keys / touch: one-finger move
 
 var MapControls = function ( object, domElement ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -6,13 +6,6 @@
  * @author erich666 / http://erichaines.com
  */
 
-// This set of controls performs orbiting, dollying (zooming), and panning.
-// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
-//
-//    Orbit - left mouse / touch: one-finger move
-//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
-//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
-
 import {
 	EventDispatcher,
 	MOUSE,
@@ -21,6 +14,13 @@ import {
 	Vector2,
 	Vector3
 } from "../../../build/three.module.js";
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one-finger move
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
 var OrbitControls = function ( object, domElement ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -4,6 +4,29 @@
  * @author Takahiro / https://github.com/takahirox
  */
 
+import {
+	BufferAttribute,
+	BufferGeometry,
+	ClampToEdgeWrapping,
+	DoubleSide,
+	InterpolateDiscrete,
+	LinearFilter,
+	LinearMipMapLinearFilter,
+	LinearMipMapNearestFilter,
+	Math as _Math,
+	MirroredRepeatWrapping,
+	NearestFilter,
+	NearestMipMapLinearFilter,
+	NearestMipMapNearestFilter,
+	PropertyBinding,
+	RGBAFormat,
+	RepeatWrapping,
+	Scene,
+	TriangleFanDrawMode,
+	TriangleStripDrawMode,
+	Vector3
+} from "../../../build/three.module.js";
+
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
@@ -58,29 +81,6 @@ var PATH_PROPERTIES = {
 //------------------------------------------------------------------------------
 // GLTF Exporter
 //------------------------------------------------------------------------------
-import {
-	BufferAttribute,
-	BufferGeometry,
-	ClampToEdgeWrapping,
-	DoubleSide,
-	InterpolateDiscrete,
-	LinearFilter,
-	LinearMipMapLinearFilter,
-	LinearMipMapNearestFilter,
-	Math as _Math,
-	MirroredRepeatWrapping,
-	NearestFilter,
-	NearestMipMapLinearFilter,
-	NearestMipMapNearestFilter,
-	PropertyBinding,
-	RGBAFormat,
-	RepeatWrapping,
-	Scene,
-	TriangleFanDrawMode,
-	TriangleStripDrawMode,
-	Vector3
-} from "../../../build/three.module.js";
-
 var GLTFExporter = function () {};
 
 GLTFExporter.prototype = {

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -12,7 +12,7 @@ var files = [
 	{ path: 'controls/MapControls.js', ignoreList: [] },
 	{ path: 'controls/TrackballControls.js', ignoreList: [] },
 	// { path: 'controls/TransformControls.js', ignoreList: [] },
-	{ path: 'exporters/GLTFExporter.js', ignoreList: ['AnimationClip', 'Camera', 'Geometry', 'Material', 'Mesh', 'Object3D', 'RGBFormat', 'Scenes', 'ShaderMaterial', 'VertexColors' ] },
+	{ path: 'exporters/GLTFExporter.js', ignoreList: [ 'AnimationClip', 'Camera', 'Geometry', 'Material', 'Mesh', 'Object3D', 'RGBFormat', 'Scenes', 'ShaderMaterial', 'VertexColors' ] },
 	{ path: 'exporters/MMDExporter.js', ignoreList: [] },
 	{ path: 'exporters/OBJExporter.js', ignoreList: [] },
 	{ path: 'exporters/PLYExporter.js', ignoreList: [] },
@@ -39,6 +39,14 @@ function convert( path, ignoreList ) {
 	var className = '';
 	var dependencies = {};
 
+	// imports
+
+	contents = contents.replace( /^\/\*+[^*]*\*+(?:[^/*][^*]*\*+)*\//, function ( match, p1 ) {
+
+		return `${match}\n\n_IMPORTS_`;
+
+	} );
+
 	// class name
 
 	contents = contents.replace( /THREE\.([a-zA-Z0-9]+) = /g, function ( match, p1 ) {
@@ -47,7 +55,7 @@ function convert( path, ignoreList ) {
 
 		console.log( className );
 
-		return `_IMPORTS_\n\nvar ${p1} = `;
+		return `var ${p1} = `;
 
 	} );
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -41,7 +41,7 @@ function convert( path, ignoreList ) {
 
 	// imports
 
-	contents = contents.replace( /^\/\*+[^*]*\*+(?:[^/*][^*]*\*+)*\//, function ( match, p1 ) {
+	contents = contents.replace( /^\/\*+[^*]*\*+(?:[^/*][^*]*\*+)*\//, function ( match ) {
 
 		return `${match}\n\n_IMPORTS_`;
 


### PR DESCRIPTION
Small fix to the modularize script to ensure imports go beneath the file header, not just above the constructor.