### PR TITLE
GLTFExporter: Avoid exporting null indices.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -81,7 +81,8 @@ THREE.GLTFExporter.prototype = {
 			animations: [],
 			forceIndices: false,
 			forcePowerOfTwoTextures: false,
-			includeCustomExtensions: false
+			includeCustomExtensions: false,
+			stripGeomAttributes: [],
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -90,6 +91,13 @@ THREE.GLTFExporter.prototype = {
 
 			// Only TRS properties, and not matrices, may be targeted by animation.
 			options.trs = true;
+
+		}
+
+		for ( var i = 0; i < options.stripGeomAttributes.length; i++ ) {
+
+			// geom attributes are compared as upper case
+			options.stripGeomAttributes = options.stripGeomAttributes.toUpperCase();
 
 		}
 
@@ -1165,6 +1173,8 @@ THREE.GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
+				if (options.stripGeomAttributes.includes( attributeName )) continue;
+
 				if ( cachedData.attributes.has( attribute ) ) {
 
 					attributes[ attributeName ] = cachedData.attributes.get( attribute );
@@ -1352,14 +1362,13 @@ THREE.GLTFExporter.prototype = {
 					if ( cachedData.attributes.has( geometry.index ) ) {
 
 						primitive.indices = cachedData.attributes.get( geometry.index );
-
 					} else {
 
 						primitive.indices = processAccessor( geometry.index, geometry, groups[ i ].start, groups[ i ].count );
 						cachedData.attributes.set( geometry.index, primitive.indices );
-
 					}
-
+					if (primitive.indices === null)
+						delete primitive.indices
 				}
 
 				var material = processMaterial( materials[ groups[ i ].materialIndex ] );
@@ -1754,7 +1763,7 @@ THREE.GLTFExporter.prototype = {
 
 			} else if ( object.isLight ) {
 
-				console.warn( 'THREE.GLTFExporter: Only directional, point, and spot lights are supported.' );
+				console.warn( `THREE.GLTFExporter: light ${object.name} of type ${object.constructor.name}: Only directional, point, and spot lights are supported.` );
 				return null;
 
 			}

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -104,7 +104,8 @@ GLTFExporter.prototype = {
 			animations: [],
 			forceIndices: false,
 			forcePowerOfTwoTextures: false,
-			includeCustomExtensions: false
+			includeCustomExtensions: false,
+			stripGeomAttributes: [],
 		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
@@ -113,6 +114,13 @@ GLTFExporter.prototype = {
 
 			// Only TRS properties, and not matrices, may be targeted by animation.
 			options.trs = true;
+
+		}
+
+		for ( var i = 0; i < options.stripGeomAttributes.length; i++ ) {
+
+			// geom attributes are compared as upper case
+			options.stripGeomAttributes = options.stripGeomAttributes.toUpperCase();
 
 		}
 
@@ -1188,6 +1196,8 @@ GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
+				if (options.stripGeomAttributes.includes( attributeName )) continue;
+
 				if ( cachedData.attributes.has( attribute ) ) {
 
 					attributes[ attributeName ] = cachedData.attributes.get( attribute );
@@ -1375,14 +1385,13 @@ GLTFExporter.prototype = {
 					if ( cachedData.attributes.has( geometry.index ) ) {
 
 						primitive.indices = cachedData.attributes.get( geometry.index );
-
 					} else {
 
 						primitive.indices = processAccessor( geometry.index, geometry, groups[ i ].start, groups[ i ].count );
 						cachedData.attributes.set( geometry.index, primitive.indices );
-
 					}
-
+					if (primitive.indices === null)
+						delete primitive.indices
 				}
 
 				var material = processMaterial( materials[ groups[ i ].materialIndex ] );
@@ -1777,7 +1786,7 @@ GLTFExporter.prototype = {
 
 			} else if ( object.isLight ) {
 
-				console.warn( 'THREE.GLTFExporter: Only directional, point, and spot lights are supported.' );
+				console.warn( `GLTFExporter: light ${object.name} of type ${object.constructor.name}: Only directional, point, and spot lights are supported.` );
 				return null;
 
 			}


### PR DESCRIPTION
I'm using Houdini's glTF reader and it has a problem with null primitive indices (it was actually coming out in the gltf file as the string "null"), as well as with `PRIMITIVEID` as a geom attribute. This PR removes null primitive indices, and adds an option so the user can specify any geom attributes to be stripped from the output. (Default is not to strip anything, preserving current behavior.)
Also improved the error message about light types to have more info about the errant light.
I regenerated the JSM version to match.