### PR TITLE
Start WebVRManager animation when setting the animation callback

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -379,6 +379,8 @@ function WebVRManager( renderer ) {
 
 		animation.setAnimationLoop( callback );
 
+		if ( isPresenting() ) { animation.start(); }
+
 	};
 
 	this.submitFrame = function () {


### PR DESCRIPTION
VR render loop never kicks off If the event `vrdisplaypresentchange` fires before `setAnimationLoop` is invoked.

Add `animation.start` call in VRManager `setAnimationLoop`. Consistent with [WebGLRenderer `setAnimationLoop` method](https://github.com/mrdoob/three.js/blob/dev/src/renderers/WebGLRenderer.js#L1077)
