### PR TITLE
GLTFExporter: omit null indices

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1360,8 +1360,8 @@ THREE.GLTFExporter.prototype = {
 
 					}
 
-					if (primitive.indices === null)
-						delete primitive.indices
+					if ( primitive.indices === null ) delete primitive.indices;
+
 				}
 
 				var material = processMaterial( materials[ groups[ i ].materialIndex ] );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1360,6 +1360,8 @@ THREE.GLTFExporter.prototype = {
 
 					}
 
+					if (primitive.indices === null)
+						delete primitive.indices
 				}
 
 				var material = processMaterial( materials[ groups[ i ].materialIndex ] );


### PR DESCRIPTION
In some cases you can end up with a null set of primitive indices. This comes out in the glTF file as the string "null". This PR removes those null index sets.