### PR TITLE
GLTFExporter: prefix all geom attributes except official ones

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1162,6 +1162,9 @@ THREE.GLTFExporter.prototype = {
 			var modifiedAttribute = null;
 			for ( var attributeName in geometry.attributes ) {
 
+				// Ignore morph target attributes, which are exported later.
+				if ( attributeName.substr( 0, 5 ) === 'morph' ) continue;
+
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
@@ -1194,15 +1197,11 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
-				if ( attributeName.substr( 0, 5 ) !== 'MORPH' ) {
+				var accessor = processAccessor( modifiedAttribute || attribute, geometry );
+				if ( accessor !== null ) {
 
-					var accessor = processAccessor( modifiedAttribute || attribute, geometry );
-					if ( accessor !== null ) {
-
-						attributes[ attributeName ] = accessor;
-						cachedData.attributes.set( attribute, accessor );
-
-					}
+					attributes[ attributeName ] = accessor;
+					cachedData.attributes.set( attribute, accessor );
 
 				}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1165,6 +1165,30 @@ THREE.GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
+				// Prefix all geometry attributes except the ones specifically
+				// listed in the spec; non-spec attributes are considered custom.
+				var validVertexAttributes = [
+					/^POSITION$/,
+					/^NORMAL$/,
+					/^TANGENT$/,
+					/^TEXCOORD_\d+$/,
+					/^COLOR_\d+$/,
+					/^JOINTS_\d+$/,
+					/^WEIGHTS_\d+$/,
+				];
+
+				var isValidAttribute = false;
+				for (var i = 0; i < validVertexAttributes.length; i++) {
+					if (validVertexAttributes[i].test(attributeName)) {
+						isValidAttribute = true;
+						break;
+					}
+				}
+				if (!isValidAttribute) {
+					console.log(`Prefixing ${attributeName}`)
+					attributeName = '_' + attributeName
+				}
+
 				if ( cachedData.attributes.has( attribute ) ) {
 
 					attributes[ attributeName ] = cachedData.attributes.get( attribute );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1167,26 +1167,12 @@ THREE.GLTFExporter.prototype = {
 
 				// Prefix all geometry attributes except the ones specifically
 				// listed in the spec; non-spec attributes are considered custom.
-				var validVertexAttributes = [
-					/^POSITION$/,
-					/^NORMAL$/,
-					/^TANGENT$/,
-					/^TEXCOORD_\d+$/,
-					/^COLOR_\d+$/,
-					/^JOINTS_\d+$/,
-					/^WEIGHTS_\d+$/,
-				];
+				var validVertexAttributes =
+						/^(POSITION|NORMAL|TANGENT|TEXCOORD_\d+|COLOR_\d+|JOINTS_\d+|WEIGHTS_\d+)$/;
+				if ( ! validVertexAttributes.test( attributeName ) ) {
 
-				var isValidAttribute = false;
-				for (var i = 0; i < validVertexAttributes.length; i++) {
-					if (validVertexAttributes[i].test(attributeName)) {
-						isValidAttribute = true;
-						break;
-					}
-				}
-				if (!isValidAttribute) {
-					console.log(`Prefixing ${attributeName}`)
-					attributeName = '_' + attributeName
+					attributeName = '_' + attributeName;
+
 				}
 
 				if ( cachedData.attributes.has( attribute ) ) {

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1188,6 +1188,16 @@ GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
+				// Prefix all geometry attributes except the ones specifically
+				// listed in the spec; non-spec attributes are considered custom.
+				var validVertexAttributes =
+						/^(POSITION|NORMAL|TANGENT|TEXCOORD_\d+|COLOR_\d+|JOINTS_\d+|WEIGHTS_\d+)$/;
+				if ( ! validVertexAttributes.test( attributeName ) ) {
+
+					attributeName = '_' + attributeName;
+
+				}
+
 				if ( cachedData.attributes.has( attribute ) ) {
 
 					attributes[ attributeName ] = cachedData.attributes.get( attribute );

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1188,16 +1188,6 @@ GLTFExporter.prototype = {
 				var attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();
 
-				// Prefix all geometry attributes except the ones specifically
-				// listed in the spec; non-spec attributes are considered custom.
-				var validVertexAttributes =
-						/^(POSITION|NORMAL|TANGENT|TEXCOORD_\d+|COLOR_\d+|JOINTS_\d+|WEIGHTS_\d+)$/;
-				if ( ! validVertexAttributes.test( attributeName ) ) {
-
-					attributeName = '_' + attributeName;
-
-				}
-
 				if ( cachedData.attributes.has( attribute ) ) {
 
 					attributes[ attributeName ] = cachedData.attributes.get( attribute );


### PR DESCRIPTION
Per recent discussions in PR #15988, this PR prefixes any non-spec (custom) geometry attributes with `_`. I tested this and it works with Houdini.