### PR TITLE
Editor: Avoid runtime error when fog is removed.

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -478,16 +478,20 @@ var Viewport = function ( editor ) {
 
 		}
 
-		if ( scene.fog.isFog ) {
+		if ( scene.fog ) {
 
-			scene.fog.color.setHex( fogColor );
-			scene.fog.near = fogNear;
-			scene.fog.far = fogFar;
+			if ( scene.fog.isFog ) {
 
-		} else if ( scene.fog.isFogExp2 ) {
+				scene.fog.color.setHex( fogColor );
+				scene.fog.near = fogNear;
+				scene.fog.far = fogFar;
 
-			scene.fog.color.setHex( fogColor );
-			scene.fog.density = fogDensity;
+			} else if ( scene.fog.isFogExp2 ) {
+
+				scene.fog.color.setHex( fogColor );
+				scene.fog.density = fogDensity;
+
+			}
 
 		}
 


### PR DESCRIPTION
I Change Fog's value to `NONE`, `scene.fog` is `null` after Fog's value is `Linear` or `Exponential`.
```
Uncaught TypeError: Cannot read property 'isFog' of null
    at Viewport.js:481
    at g.execute (signals.min.js:8)
    at e.Signal.dispatch (signals.min.js:12)
    at onFogChanged (Sidebar.Scene.js:132)
    at UI.Select.<anonymous> (Sidebar.Scene.js:152)
```