### PR TITLE
Vector3.unproject(): Avoid computing inverse

### DIFF
--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -158,10 +158,10 @@ CameraHelper.prototype.update = function () {
 
 		var w = 1, h = 1;
 
-		// we need just camera projection matrix
+		// we need just camera projection matrix inverse
 		// world matrix must be identity
 
-		camera.projectionMatrix.copy( this.camera.projectionMatrix );
+		camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
 
 		// center / target
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -1,5 +1,4 @@
 import { _Math } from './Math.js';
-import { Matrix4 } from './Matrix4.js';
 import { Quaternion } from './Quaternion.js';
 
 /**
@@ -318,17 +317,11 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	unproject: function () {
+	unproject: function ( camera ) {
 
-		var matrix = new Matrix4();
+		return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
 
-		return function unproject( camera ) {
-
-			return this.applyMatrix4( matrix.getInverse( camera.projectionMatrix ) ).applyMatrix4( camera.matrixWorld );
-
-		};
-
-	}(),
+	},
 
 	transformDirection: function ( m ) {
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/14685#issuecomment-414067093.

...plus it removes another annoying cyclic reference in the build. :-)

In some examples, `Vector3.unproject()` is recomputing  the matrix inverse every frame.

I think we are safe making this change now, but we need to be careful when using `projectionMatrix.copy()`.

@Mugen87 What do you think?