### PR TITLE
Update vr drawing buffer size when the WebVRManager device is set.

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -65,26 +65,13 @@ function WebVRManager( renderer ) {
 
 	function onVRDisplayPresentChange() {
 
+		updateDrawingBufferSize();
+
 		if ( isPresenting() ) {
-
-			var eyeParameters = device.getEyeParameters( 'left' );
-			var renderWidth = eyeParameters.renderWidth * framebufferScaleFactor;
-			var renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
-
-			currentPixelRatio = renderer.getPixelRatio();
-			renderer.getSize( currentSize );
-
-			renderer.setDrawingBufferSize( renderWidth * 2, renderHeight, 1 );
 
 			animation.start();
 
 		} else {
-
-			if ( scope.enabled ) {
-
-				renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
-
-			}
 
 			animation.stop();
 
@@ -112,6 +99,31 @@ function WebVRManager( renderer ) {
 				if ( j === id ) return gamepad;
 
 				j ++;
+
+			}
+
+		}
+
+	}
+
+	function updateDrawingBufferSize() {
+
+		if ( isPresenting() ) {
+
+			var eyeParameters = device.getEyeParameters( 'left' );
+			var renderWidth = eyeParameters.renderWidth * framebufferScaleFactor;
+			var renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
+
+			renderer.setDrawingBufferSize( renderWidth * 2, renderHeight, 1 );
+
+		} else {
+
+			if ( scope.enabled ) {
+
+				currentPixelRatio = renderer.getPixelRatio();
+				renderer.getSize( currentSize );
+
+				renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
 
 			}
 
@@ -209,6 +221,10 @@ function WebVRManager( renderer ) {
 		if ( value !== undefined ) device = value;
 
 		animation.setContext( value );
+
+		updateDrawingBufferSize();
+
+		if ( isPresenting() ) animation.start();
 
 	};
 


### PR DESCRIPTION
It fixes scenarios where buffer size is set to the screen resolution instead of headset. See below

Buffer will end up with the wrong size if `vrdisplaypresentchange`  event fires before user code has called `renderer.vr.setDevice`.

This PR factors out the buffer resizing logic to be also invoked when the device is set.

**Before**

![Before](https://cl.ly/510a334cefd7/Image%202019-03-16%20at%208.41.12%20PM.png)

**After**

![After](https://cl.ly/a7ecb9f04a82/Image%202019-03-16%20at%208.41.38%20PM.png)