### PR TITLE
WebGLRenderer: Ensure buffers are not overwritten by Scene.onAfterRender().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1205,6 +1205,10 @@ function WebGLRenderer( parameters ) {
 
 		//
 
+		scene.onAfterRender( _this, scene, camera );
+
+		//
+
 		if ( _currentRenderTarget !== null ) {
 
 			// Generate mipmap if we're using any kind of mipmap filtering
@@ -1224,8 +1228,6 @@ function WebGLRenderer( parameters ) {
 		state.buffers.color.setMask( true );
 
 		state.setPolygonOffset( false );
-
-		scene.onAfterRender( _this, scene, camera );
 
 		if ( vr.enabled ) {
 


### PR DESCRIPTION
Fixes #13448 (The code of the related fiddle now renders correctly).

`Scene.onAfterRender()` is now called right after rendering the related render lists.