### PR TITLE
Box3: Avoid cyclic dependency on Sphere

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -1,5 +1,4 @@
 import { Vector3 } from './Vector3.js';
-import { Sphere } from './Sphere.js';
 
 /**
  * @author bhouston / http://clara.io
@@ -523,8 +522,8 @@ Object.assign( Box3.prototype, {
 
 			if ( target === undefined ) {
 
-				console.warn( 'THREE.Box3: .getBoundingSphere() target is now required' );
-				target = new Sphere();
+				console.error( 'THREE.Box3: .getBoundingSphere() target is now required' );
+				//target = new Sphere(); // removed to avoid cyclic dependency
 
 			}
 


### PR DESCRIPTION
A one-year-old warning is modified to remove a cyclic dependency. For now, I retained the old code as a comment.

The down-side is the warning is no longer self-healing.

It is a judgement call if the trade-off is worth it.
