### PR TITLE
Quaternion: Avoid cyclic dependency on Vector3

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -6,7 +6,6 @@
  */
 
 import { _Math } from './Math.js';
-import { Vector3 } from './Vector3.js';
 
 function Quaternion( x, y, z, w ) {
 
@@ -354,14 +353,11 @@ Object.assign( Quaternion.prototype, {
 
 		// assumes direction vectors vFrom and vTo are normalized
 
-		var v1 = new Vector3();
 		var r;
 
 		var EPS = 0.000001;
 
 		return function setFromUnitVectors( vFrom, vTo ) {
-
-			if ( v1 === undefined ) v1 = new Vector3();
 
 			r = vFrom.dot( vTo ) + 1;
 
@@ -371,24 +367,30 @@ Object.assign( Quaternion.prototype, {
 
 				if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
 
-					v1.set( - vFrom.y, vFrom.x, 0 );
+					this._x = - vFrom.y;
+					this._y = vFrom.x;
+					this._z = 0;
+					this._w = r;
 
 				} else {
 
-					v1.set( 0, - vFrom.z, vFrom.y );
+					this._x = 0;
+					this._y = - vFrom.z;
+					this._z = vFrom.y;
+					this._w = r;
 
 				}
 
 			} else {
 
-				v1.crossVectors( vFrom, vTo );
+				// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
+
+				this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
+				this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
+				this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
+				this._w = r;
 
 			}
-
-			this._x = v1.x;
-			this._y = v1.y;
-			this._z = v1.z;
-			this._w = r;
 
 			return this.normalize();
 


### PR DESCRIPTION
The inline comments should make it clear how, and why, this was done.

If for some reason, cyclic dependencies are preferred, this can easily be reverted.