### PR TITLE
Clarify documentation for Object3D copy method

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -229,6 +229,8 @@
 		recursive -- if true, descendants of the object are also copied. Default is true.<br /><br />
 
 		Copy the given object into this object.
+
+		Note, the callbacks [page:.onAfterRender] and [page:.onBeforeRender] are not copied across.
 		</p>
 
 		<h3>[method:Object3D getObjectById]( [param:Integer id] )</h3>


### PR DESCRIPTION
Related to: #14009

After cloning an object, it took me a lot of effort to track down the reason that the clone was rendering differently. We use the on(After|Before)Render functions to set the stencil state and this wasn't clear to me until we used RenderDoc to see that the stencil state was different.
This should at least save some people some hassle.