### PR TITLE
Spelling mistake in doc

### DIFF
--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -25,7 +25,7 @@
 
 
 		<code>
-var axesHelper = new THREE.AxesHelper( 5 );
+var axesHelper = new THREE.AxisHelper( 5 );
 scene.add( axesHelper );
     </code>
 


### PR DESCRIPTION
Its THREE.AxisHelper right? not Axes.  AxesHelper throws an error.