### PR TITLE
Prevent UV shearing near the poles in sphere geometries

### DIFF
--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -89,6 +89,10 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 
 		var v = iy / heightSegments;
 
+		// special case for the poles
+
+		var uOffset = ( iy == 0 ) ? 0.5 / widthSegments : ( ( iy == heightSegments ) ? - 0.5 / widthSegments : 0 );
+
 		for ( ix = 0; ix <= widthSegments; ix ++ ) {
 
 			var u = ix / widthSegments;
@@ -103,12 +107,12 @@ function SphereBufferGeometry( radius, widthSegments, heightSegments, phiStart, 
 
 			// normal
 
-			normal.set( vertex.x, vertex.y, vertex.z ).normalize();
+			normal.copy( vertex ).normalize();
 			normals.push( normal.x, normal.y, normal.z );
 
 			// uv
 
-			uvs.push( u, 1 - v );
+			uvs.push( u + uOffset, 1 - v );
 
 			verticesRow.push( index ++ );
 


### PR DESCRIPTION
Shearing is particularly evident in low-poly geometries.

UV map before:

![Screen Shot 2019-03-22 at 2 57 52 PM](https://user-images.githubusercontent.com/1000017/54847584-19f83800-4cb5-11e9-8ac0-572f8c37181e.png)

UV map with this PR:

![Screen Shot 2019-03-22 at 2 58 13 PM](https://user-images.githubusercontent.com/1000017/54847591-2086af80-4cb5-11e9-975b-dc52dc9d2eb3.png)


