### PR TITLE
WebGLRenderLists.d.ts: add groupOrder to RenderItem interface

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -15,6 +15,7 @@ export interface RenderItem {
   geometry: Geometry | BufferGeometry;
   material: Material;
   program: WebGLProgram;
+	groupOrder: number;
   renderOrder: number;
   z: number;
   group: Group;

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -15,7 +15,7 @@ export interface RenderItem {
   geometry: Geometry | BufferGeometry;
   material: Material;
   program: WebGLProgram;
-	groupOrder: number;
+  groupOrder: number;
   renderOrder: number;
   z: number;
   group: Group;


### PR DESCRIPTION
micro PR

minor relevance to #16060 , additional change to https://github.com/mrdoob/three.js/pull/15484

`RenderItem` interface in `WebGLRenderLists.d.ts` lacks groupOrder so I added the it