### PR TITLE
Add renderOrder for Materials

### DIFF
--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -47,8 +47,8 @@ export interface MaterialParameters {
   transparent?: boolean;
   vertexColors?: Colors;
   vertexTangents?: boolean;
-	visible?: boolean;
-	renderOrder?: number;
+  visible?: boolean;
+  renderOrder?: number;
 }
 
 /**

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -47,7 +47,8 @@ export interface MaterialParameters {
   transparent?: boolean;
   vertexColors?: Colors;
   vertexTangents?: boolean;
-  visible?: boolean;
+	visible?: boolean;
+	renderOrder?: number;
 }
 
 /**
@@ -248,6 +249,11 @@ export class Material extends EventDispatcher {
   visible: boolean;
 
   /**
+   * Overrides the default rendering order of scene graph objects, from lowest to highest renderOrder. Opaque and transparent objects remain sorted independently though. renderOrder of Objects and Groups takes priority than this property.
+   */
+  renderOrder: number;
+
+  /**
    * An object that can be used to store custom data about the Material. It should not hold references to functions as these will not be cloned.
    */
   userData: any;
@@ -269,7 +275,7 @@ export class Material extends EventDispatcher {
   dispose(): void;
 
   /**
-   * An optional callback that is executed immediately before the shader program is compiled. This function is called with the shader source code as a parameter. Useful for the modification of built-in materials. 
+   * An optional callback that is executed immediately before the shader program is compiled. This function is called with the shader source code as a parameter. Useful for the modification of built-in materials.
    * @param shader Source code of the shader
    * @param renderer WebGLRenderer Context that is initializing the material
    */

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -62,6 +62,8 @@ function Material() {
 
 	this.visible = true;
 
+	this.renderOrder = 0;
+
 	this.userData = {};
 
 	this.needsUpdate = true;
@@ -264,6 +266,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.skinning === true ) data.skinning = true;
 
 		if ( this.visible === false ) data.visible = false;
+		if ( this.renderOrder !== 0 ) data.renderOrder = this.renderOrder;
 		if ( JSON.stringify( this.userData ) !== '{}' ) data.userData = this.userData;
 
 		// TODO: Copied from Object3D.toJSON
@@ -344,6 +347,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.premultipliedAlpha = source.premultipliedAlpha;
 
 		this.visible = source.visible;
+		this.renderOrder = source.renderOrder;
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
 		this.clipShadows = source.clipShadows;

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -16,6 +16,7 @@ export interface RenderItem {
   material: Material;
   program: WebGLProgram;
   renderOrder: number;
+  materialOrder: number;
   z: number;
   group: Group;
 }

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -12,6 +12,10 @@ function painterSortStable( a, b ) {
 
 		return a.renderOrder - b.renderOrder;
 
+	} else if ( a.materialOrder !== b.materialOrder ) {
+
+		return a.materialOrder - b.materialOrder;
+
 	} else if ( a.program !== b.program ) {
 
 		return a.program.id - b.program.id;
@@ -41,6 +45,10 @@ function reversePainterSortStable( a, b ) {
 	} else if ( a.renderOrder !== b.renderOrder ) {
 
 		return a.renderOrder - b.renderOrder;
+
+	} else if ( a.materialOrder !== b.materialOrder ) {
+
+		return a.materialOrder - b.materialOrder;
 
 	} else if ( a.z !== b.z ) {
 
@@ -88,6 +96,7 @@ function WebGLRenderList() {
 				program: material.program || defaultProgram,
 				groupOrder: groupOrder,
 				renderOrder: object.renderOrder,
+				materialOrder: material.renderOrder,
 				z: z,
 				group: group
 			};
@@ -103,6 +112,7 @@ function WebGLRenderList() {
 			renderItem.program = material.program || defaultProgram;
 			renderItem.groupOrder = groupOrder;
 			renderItem.renderOrder = object.renderOrder;
+			renderItem.materialOrder = material.renderOrder;
 			renderItem.z = z;
 			renderItem.group = group;
 


### PR DESCRIPTION
will resolve #16060 

New property for `Material` : `renderOrder` .
Behaves like `Object3D` 's [`renderOrder`](https://threejs.org/docs/#api/en/core/Object3D.renderOrder) .

`WebGLRenderLists` sees the property, then sorts the rendering order.