### PR TITLE
GridHelper: Fix clone()

### DIFF
--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -11,6 +11,13 @@ import { Color } from '../math/Color.js';
 
 function GridHelper( size, divisions, color1, color2 ) {
 
+	this.parameters = {
+		size: size,
+		divisions: divisions,
+		color1: color1,
+		color2: color2
+	};
+
 	size = size || 10;
 	divisions = divisions || 10;
 	color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
@@ -46,7 +53,28 @@ function GridHelper( size, divisions, color1, color2 ) {
 
 }
 
-GridHelper.prototype = Object.create( LineSegments.prototype );
-GridHelper.prototype.constructor = GridHelper;
+GridHelper.prototype = Object.assign( Object.create( LineSegments.prototype ), {
+
+	constructor: GridHelper,
+
+	copy( source ) {
+
+		LineSegments.prototype.copy.call( this, source );
+
+		Object.assign( this.parameters, source.parameters );
+
+		return this;
+
+	},
+
+	clone() {
+
+		var paramters = this.parameters;
+
+		return new this.constructor( paramters.size, paramters.divisions, paramters.color1, paramters.color2 );
+
+	}
+
+} );
 
 export { GridHelper };


### PR DESCRIPTION
Fixes #8451, #8452 

The idea is to store the given parameters similar to the geometry generators and then use them when cloning the helper.