### PR TITLE
GridHelper: Fixed .copy()

### DIFF
--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -63,6 +63,9 @@ GridHelper.prototype = Object.assign( Object.create( LineSegments.prototype ), {
 
 		Object.assign( this.parameters, source.parameters );
 
+		this.geometry.copy( source.geometry );
+		this.material.copy( source.material );
+
 		return this;
 
 	},


### PR DESCRIPTION
I've missed this commit in the last PR. It ensures to copy the geometry and material which is not done in `LineSegments`.