### PR TITLE
Improve WebGLRenderLists.d.ts

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -28,7 +28,8 @@ export class WebGLRenderList {
   push(
     object: Object3D,
     geometry: Geometry | BufferGeometry,
-    material: Material,
+		material: Material,
+		groupOrder: number,
     z: number,
     group: Group
   ): void;

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -23,7 +23,7 @@ export interface RenderItem {
 
 export class WebGLRenderList {
   opaque: Array<RenderItem>;
-  transparent: Array<any>;
+  transparent: Array<RenderItem>;
   init(): void;
   push(
     object: Object3D,

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -1,5 +1,4 @@
 import { Object3D } from './../../core/Object3D';
-import { Geometry } from './../../core/Geometry';
 import { Material } from './../../materials/Material';
 import { WebGLProgram } from './WebGLProgram';
 import { Group } from './../../objects/Group';
@@ -12,7 +11,7 @@ export interface RenderTarget {} // not defined in the code, used in LightShadow
 export interface RenderItem {
   id: number;
   object: Object3D;
-  geometry: Geometry | BufferGeometry;
+  geometry: BufferGeometry;
   material: Material;
   program: WebGLProgram;
   groupOrder: number;
@@ -27,7 +26,7 @@ export class WebGLRenderList {
   init(): void;
   push(
     object: Object3D,
-    geometry: Geometry | BufferGeometry,
+    geometry: BufferGeometry,
     material: Material,
     groupOrder: number,
     z: number,
@@ -35,7 +34,7 @@ export class WebGLRenderList {
   ): void;
   unshift(
     object: Object3D,
-    geometry: Geometry | BufferGeometry,
+    geometry: BufferGeometry,
     material: Material,
     groupOrder: number,
     z: number,

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -11,13 +11,13 @@ export interface RenderTarget {} // not defined in the code, used in LightShadow
 export interface RenderItem {
   id: number;
   object: Object3D;
-  geometry: BufferGeometry;
+  geometry: BufferGeometry | null;
   material: Material;
   program: WebGLProgram;
   groupOrder: number;
   renderOrder: number;
   z: number;
-  group: Group;
+  group: Group | null;
 }
 
 export class WebGLRenderList {
@@ -26,19 +26,19 @@ export class WebGLRenderList {
   init(): void;
   push(
     object: Object3D,
-    geometry: BufferGeometry,
+    geometry: BufferGeometry | null,
     material: Material,
     groupOrder: number,
     z: number,
-    group: Group
+    group: Group | null
   ): void;
   unshift(
     object: Object3D,
-    geometry: BufferGeometry,
+    geometry: BufferGeometry | null,
     material: Material,
     groupOrder: number,
     z: number,
-    group: Group
+    group: Group | null
   ): void;
   sort(): void;
 }

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -45,9 +45,5 @@ export class WebGLRenderList {
 
 export class WebGLRenderLists {
   dispose(): void;
-  /**
-   *
-   * returns {<String> : <WebGLRenderList>}
-   */
   get(scene: Scene, camera: Camera): WebGLRenderList;
 }

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -28,8 +28,8 @@ export class WebGLRenderList {
   push(
     object: Object3D,
     geometry: Geometry | BufferGeometry,
-		material: Material,
-		groupOrder: number,
+    material: Material,
+    groupOrder: number,
     z: number,
     group: Group
   ): void;

--- a/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -33,7 +33,14 @@ export class WebGLRenderList {
     z: number,
     group: Group
   ): void;
-
+  unshift(
+    object: Object3D,
+    geometry: Geometry | BufferGeometry,
+    material: Material,
+    groupOrder: number,
+    z: number,
+    group: Group
+  ): void;
   sort(): void;
 }
 


### PR DESCRIPTION
related to #16062 

- Add definition of `groupOrder` parameter of `WebGLRenderLists.push`
- Fix type definition of `WebGLRenderLists.transparent`
- Add definition of `WebGLRenderLists.unshift`
- `geometry` now only accepts `BufferGeometry`
- Mark `geometry` and `group` as nullable