### PR TITLE
WebGLRenderer.d.ts: getDrawingBufferSize now receives Vector2 and returns Vector2

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -201,7 +201,7 @@ export class WebGLRenderer implements Renderer {
   getPixelRatio(): number;
   setPixelRatio(value: number): void;
 
-  getDrawingBufferSize(): { width: number; height: number };
+  getDrawingBufferSize(target: Vector2): Vector2;
   setDrawingBufferSize(width: number, height: number, pixelRatio: number): void;
 
   getSize(target: Vector2): Vector2;


### PR DESCRIPTION
micro PR

See: https://threejs.org/docs/#api/en/renderers/WebGLRenderer.getDrawingBufferSize