### PR TITLE
WebGLRenderer: Update docs and type definitions related to RenderTarget

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -339,7 +339,7 @@
 		<p>Returns an object that describes the attributes set on the WebGL context when it was created.</p>
 
 		<h3>[method:RenderTarget getRenderTarget]()</h3>
-		<p>Returns the current RenderTarget, if any.</p>
+		<p>Returns the current [page:RenderTarget RenderTarget] if there are; returns *null* otherwise.</p>
 
 		<h3>[method:Vector4 getCurrentViewport]( [param:Vector4 target] )</h3>
 		<p>
@@ -429,10 +429,10 @@
 
 		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipMapLevel] )</h3>
 		<p>
-		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated (optional).<br />
+		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated. When *null* is given, the canvas is set as the active render target instead.<br />
 		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLRenderTargetCube] (optional).<br />
 		activeMipMapLevel -- Specifies the active mipmap level (optional).<br /><br />
-		This method sets the active rendertarget. If the parameter is omitted the canvas is set as the active rendertarget.
+		This method sets the active rendertarget.
 		</p>
 
 		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -333,14 +333,17 @@ export class WebGLRenderer implements Renderer {
   ): void;
 
   /**
-   * @deprecated
+   * Returns the current RenderTarget if there are; returns null otherwise.
    */
   getRenderTarget(): RenderTarget | null;
+
   /**
    * @deprecated Use {@link WebGLRenderer#getRenderTarget .getRenderTarget()} instead.
    */
   getCurrentRenderTarget(): RenderTarget | null;
+
   setRenderTarget(renderTarget: RenderTarget | null, activeCubeFace?: number, activeMipMapLevel?: number): void;
+
   readRenderTargetPixels(
     renderTarget: RenderTarget,
     x: number,

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -333,7 +333,7 @@ export class WebGLRenderer implements Renderer {
   ): void;
 
   /**
-   * Returns the current RenderTarget if there are; returns null otherwise.
+   * Returns the current render target. If no render target is set, null is returned.
    */
   getRenderTarget(): RenderTarget | null;
 

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -335,12 +335,12 @@ export class WebGLRenderer implements Renderer {
   /**
    * @deprecated
    */
-  getRenderTarget(): RenderTarget;
+  getRenderTarget(): RenderTarget | null;
   /**
    * @deprecated Use {@link WebGLRenderer#getRenderTarget .getRenderTarget()} instead.
    */
-  getCurrentRenderTarget(): RenderTarget;
-  setRenderTarget(renderTarget?: RenderTarget, activeCubeFace?: number, activeMipMapLevel?: number): void;
+  getCurrentRenderTarget(): RenderTarget | null;
+  setRenderTarget(renderTarget: RenderTarget | null, activeCubeFace?: number, activeMipMapLevel?: number): void;
   readRenderTargetPixels(
     renderTarget: RenderTarget,
     x: number,

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -342,6 +342,13 @@ export class WebGLRenderer implements Renderer {
    */
   getCurrentRenderTarget(): RenderTarget | null;
 
+  /**
+   * Sets the active render target.
+   *
+   * @param renderTarget The {@link WebGLRenderTarget renderTarget} that needs to be activated. When `null` is given, the canvas is set as the active render target instead.
+	 * @param activeCubeFace Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of {@link WebGLRenderTargetCube}.
+	 * @param activeMipMapLevel Specifies the active mipmap level.
+   */
   setRenderTarget(renderTarget: RenderTarget | null, activeCubeFace?: number, activeMipMapLevel?: number): void;
 
   readRenderTargetPixels(


### PR DESCRIPTION
will close #16084 

This commit bans giving `undefined` for `renderer.setRenderTarget` .
No code changes, just docs and type definitions.