### PR TITLE
Fixed a bug with loading KTX cube textures

### DIFF
--- a/examples/js/loaders/KTXLoader.js
+++ b/examples/js/loaders/KTXLoader.js
@@ -137,13 +137,14 @@ var KhronosTextureContainer = ( function () {
 		for ( var level = 0; level < mipmapCount; level ++ ) {
 
 			var imageSize = new Int32Array( this.arrayBuffer, dataOffset, 1 )[ 0 ]; // size per face, since not supporting array cubemaps
+			dataOffset += imageSize + 4; // size of the image + 4 for the imageSize field
+			
 			for ( var face = 0; face < this.numberOfFaces; face ++ ) {
 
 				var byteArray = new Uint8Array( this.arrayBuffer, dataOffset + 4, imageSize );
 
 				mipmaps.push( { "data": byteArray, "width": width, "height": height } );
 
-				dataOffset += imageSize + 4; // size of the image + 4 for the imageSize field
 				dataOffset += 3 - ( ( imageSize + 3 ) % 4 ); // add padding for odd sized image
 
 			}

--- a/examples/js/loaders/KTXLoader.js
+++ b/examples/js/loaders/KTXLoader.js
@@ -137,14 +137,15 @@ var KhronosTextureContainer = ( function () {
 		for ( var level = 0; level < mipmapCount; level ++ ) {
 
 			var imageSize = new Int32Array( this.arrayBuffer, dataOffset, 1 )[ 0 ]; // size per face, since not supporting array cubemaps
-			dataOffset += imageSize + 4; // size of the image + 4 for the imageSize field
+			dataOffset += 4; // size of the image + 4 for the imageSize field
 			
 			for ( var face = 0; face < this.numberOfFaces; face ++ ) {
 
-				var byteArray = new Uint8Array( this.arrayBuffer, dataOffset + 4, imageSize );
+				var byteArray = new Uint8Array( this.arrayBuffer, dataOffset, imageSize );
 
 				mipmaps.push( { "data": byteArray, "width": width, "height": height } );
-
+				
+				dataOffset += imageSize;
 				dataOffset += 3 - ( ( imageSize + 3 ) % 4 ); // add padding for odd sized image
 
 			}


### PR DESCRIPTION
Fixed #16089. Moved code accounting for moving past the data field for the size of the texture outside of the loop loading them.

For reference, see the loader this was ported from in Babylon for the correct implementation:

https://github.com/BabylonJS/Babylon.js/blob/master/src/Misc/khronosTextureContainer.ts#L169