### PR TITLE
SVGLoader: Fix bug with transforms of brother nodes

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -122,8 +122,16 @@ THREE.SVGLoader.prototype = {
 
 				transformStack.pop();
 
-				if ( transformStack.length > 0 ) currentTransform.copy( transformStack[ transformStack.length - 1 ] );
-				else currentTransform.identity();
+				if ( transformStack.length > 0 ) {
+
+					currentTransform.copy( transformStack[ transformStack.length - 1 ] );
+
+				}
+				else {
+
+					currentTransform.identity();
+
+				}
 
 			}
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -120,7 +120,10 @@ THREE.SVGLoader.prototype = {
 
 			if ( transform ) {
 
-				currentTransform.copy( transformStack.pop() );
+				transformStack.pop();
+
+				if ( transformStack.length > 0 ) currentTransform.copy( transformStack[ transformStack.length - 1 ] );
+				else currentTransform.identity();
 
 			}
 


### PR DESCRIPTION
This solves a bug with SVGLoader transforms.

I misunderstood the SVG spec when doing this, thinking that a node transform affects its subsequent brothers. But it doesn't, a node transform only affects its children.