### PR TITLE
TransformControls PointerLock support

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -519,7 +519,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 			return {
 				x: 0,
 				y: 0,
-				button: event.button,
+				button: event.button
 			};
 
 		} else {

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -514,15 +514,27 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 	function getPointer( event ) {
 
-		var pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
+		if ( document.pointerLockElement ) {
 
-		var rect = domElement.getBoundingClientRect();
+			return {
+				x: 0,
+				y: 0,
+				button: event.button,
+			};
 
-		return {
-			x: ( pointer.clientX - rect.left ) / rect.width * 2 - 1,
-			y: - ( pointer.clientY - rect.top ) / rect.height * 2 + 1,
-			button: event.button
-		};
+		} else {
+
+			var pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
+
+			var rect = domElement.getBoundingClientRect();
+
+			return {
+				x: ( pointer.clientX - rect.left ) / rect.width * 2 - 1,
+				y: - ( pointer.clientY - rect.top ) / rect.height * 2 + 1,
+				button: event.button
+			};
+
+		}
 
 	}
 


### PR DESCRIPTION
This pull request extends TransformControl's ```getPointer``` method to allow it to be used when pointer lock is enabled.  Without this patch, the TransformControl will react to the mouse at the position it was when the pointer was locked, which leads to confusing behavior.  The patch fixes this behavior by returning the center of the screen as the pointer location whenever the pointer is locked.