### PR TITLE
WebGLRenderer: Add 'failIfMajorPerformanceCaveat' preference

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -55,7 +55,10 @@
 
 		[page:String powerPreference] - Provides a hint to the user agent indicating what configuration
 		of GPU is suitable for this WebGL context. Can be *"high-performance"*, *"low-power"* or *"default"*. Default is *"default"*.
-		See the [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2 WebGL spec] for more information.<br />
+		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.<br />
+
+		[page:Boolean failIfMajorPerformanceCaveat] - whether the renderer creation will fail upon low perfomance is detected. Default is *false*.
+		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.<br />
 
 		[page:Boolean depth] - whether the drawing buffer has a
 		[link:https://en.wikipedia.org/wiki/Z-buffering depth buffer] of at least 16 bits.

--- a/src/renderers/WebGL2Renderer.js
+++ b/src/renderers/WebGL2Renderer.js
@@ -23,7 +23,8 @@ function WebGL2Renderer( parameters ) {
 		_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 		_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
-		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default';
+		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default',
+		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false;
 
 	// initialize
 
@@ -38,7 +39,8 @@ function WebGL2Renderer( parameters ) {
 			antialias: _antialias,
 			premultipliedAlpha: _premultipliedAlpha,
 			preserveDrawingBuffer: _preserveDrawingBuffer,
-			powerPreference: _powerPreference
+			powerPreference: _powerPreference,
+			failIfMajorPerformanceCaveat: _failIfMajorPerformanceCaveat
 		};
 
 		// event listeners must be registered before WebGL context is created, see #12753

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -67,7 +67,8 @@ function WebGLRenderer( parameters ) {
 		_antialias = parameters.antialias !== undefined ? parameters.antialias : false,
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 		_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
-		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default';
+		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default',
+		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false;
 
 	var currentRenderList = null;
 	var currentRenderState = null;
@@ -189,7 +190,8 @@ function WebGLRenderer( parameters ) {
 			antialias: _antialias,
 			premultipliedAlpha: _premultipliedAlpha,
 			preserveDrawingBuffer: _preserveDrawingBuffer,
-			powerPreference: _powerPreference
+			powerPreference: _powerPreference,
+			failIfMajorPerformanceCaveat: _failIfMajorPerformanceCaveat
 		};
 
 		// event listeners must be registered before WebGL context is created, see #12753


### PR DESCRIPTION
WebGL specification informs of a `failIfMajorPerformanceCaveat` option when requesting a webgl context: [WebGL spec](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2.1)

Apparently there is good browsers support for this feature.
Both chromium ([codebase](https://cs.chromium.org/search/?q=failifmajorperformancecaveat&sq=package:chromium&type=cs)) and webkit ([codebase](https://github.com/WebKit/webkit/search?q=failifmajorperformancecaveat&unscoped_q=failifmajorperformancecaveat)) have the option listed as valid context attributes.
Performed soft tests on Gecko engine and it functioned properly under systems with no GPU. 

This also seems to be the current best way of determining if chromium **hardware acceleration** ( or different browser equivalents) is enabled. 

Recommended usage example:
```js
try {
    _renderer = new THREE.WebGLRenderer( { failIfMajorPerformanceCaveat: true } );
}
catch(e) {
    // halt initialization
    // custom fallback options:
    // - swap to different rendering option
    // - inform user about possibility of disabled GPU acceleration
  }
```

Error message appears in-line with expected output upon poor performance detection. 
```ruby
# THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.
```
