### PR TITLE
Matcap example: specify encoding in drag-n-drop

### DIFF
--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -192,6 +192,9 @@
 				mesh.material.matcap = new THREE.Texture( event.target );
 				mesh.material.matcap.needsUpdate = true;
 
+				mesh.material.matcap.encoding = THREE.sRGBEncoding; // assume it is sRGB
+				mesh.material.needsUpdate = true;
+
 				image.src = mesh.material.matcap.image.src; // corner div
 
 				render();


### PR DESCRIPTION
Follow-up to #15313.

When a new `Texture` is instantiated, the encoding is set to linear, the default, so we reset it to `sRGB`.

Since encoding is handled via code injection, the shader must be also recompiled.