### PR TITLE
ArrowHelper.setColor(): support all color formats

### DIFF
--- a/src/helpers/ArrowHelper.js
+++ b/src/helpers/ArrowHelper.js
@@ -114,8 +114,8 @@ ArrowHelper.prototype.setLength = function ( length, headLength, headWidth ) {
 
 ArrowHelper.prototype.setColor = function ( color ) {
 
-	this.line.material.color.copy( color );
-	this.cone.material.color.copy( color );
+	this.line.material.color.set( color );
+	this.cone.material.color.set( color );
 
 };
 


### PR DESCRIPTION
fix `setColor` function in ArrowHelper, support all color format.

[Documentation](https://threejs.org/docs/index.html#api/en/helpers/ArrowHelper) says use number but actually can't.

> .setColor (hex : Number) : null
> hex -- The hexadecimal value of the color.
> 
> Sets the color of the arrowHelper.
