### PR TITLE
Add check for Object3D.add and Object3D.remove

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -358,11 +358,11 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	}(),
 
 	add: function ( object ) {
-		
+
 		if ( object.parent === this ) {
-			
+
 		  return this;
-			
+
 		}
 
 		if ( arguments.length > 1 ) {
@@ -408,11 +408,11 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	},
 
 	remove: function ( object ) {
-		
+
 		if ( object.parent === null ) {
-			
+
 		  return this;
-			
+
 		}
 
 		if ( arguments.length > 1 ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -359,12 +359,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	add: function ( object ) {
 
-		if ( object.parent === this ) {
-
-		  return this;
-
-		}
-
 		if ( arguments.length > 1 ) {
 
 			for ( var i = 0; i < arguments.length; i ++ ) {
@@ -374,6 +368,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			}
 
 			return this;
+
+		}
+
+		if ( object.parent === this ) {
+
+		  return this;
 
 		}
 
@@ -409,12 +409,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	remove: function ( object ) {
 
-		if ( object.parent === null ) {
-
-		  return this;
-
-		}
-
 		if ( arguments.length > 1 ) {
 
 			for ( var i = 0; i < arguments.length; i ++ ) {
@@ -424,6 +418,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			}
 
 			return this;
+
+		}
+
+		if ( object.parent === null ) {
+
+		  return this;
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -358,6 +358,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	}(),
 
 	add: function ( object ) {
+		
+		if ( object.parent === this ) {
+			
+		  return this;
+			
+		}
 
 		if ( arguments.length > 1 ) {
 
@@ -402,6 +408,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	},
 
 	remove: function ( object ) {
+		
+		if ( object.parent === null ) {
+			
+		  return this;
+			
+		}
 
 		if ( arguments.length > 1 ) {
 


### PR DESCRIPTION
Adds a fast path when the result of `Object3D.add` or `Object3D.remove` should be a no-op.

Sometimes it is convenient to use `add` and `remove` methods in a context where they will be called each frame, potentially on the same parent/child objects:
```js
function animate() {
  // ...
  const intersection = raycaster.intersectObject(scene, true)[0]
  if (intersection) intersection.object.add(cursor) // <-- may be added to the same object every frame
}
```

This change prevents unnecessary work in the `add` and `remove` methods when sequentially adding/removing the same object to to/from the same parent, including preventing the "added" and "removed" events from being dispatched repeatedly. 