### PR TITLE
Remove unused uniform from custom_attributes_points examples

### DIFF
--- a/examples/webgl_custom_attributes_points.html
+++ b/examples/webgl_custom_attributes_points.html
@@ -38,7 +38,6 @@
 
 		<script type="x-shader/x-vertex" id="vertexshader">
 
-			uniform float amplitude;
 			attribute float size;
 			attribute vec3 customColor;
 
@@ -143,7 +142,6 @@
 			var material = new THREE.ShaderMaterial( {
 
 				uniforms: {
-					amplitude: { value: 1.0 },
 					color: { value: new THREE.Color( 0xffffff ) },
 					texture: { value: new THREE.TextureLoader().load( "textures/sprites/spark1.png" ) }
 				},

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -149,7 +149,6 @@
 			var material = new THREE.ShaderMaterial( {
 
 				uniforms: {
-					amplitude: { value: 1.0 },
 					color: { value: new THREE.Color( 0xffffff ) },
 					texture: { value: texture }
 				},


### PR DESCRIPTION
Removed an unused uniform `amplitude` from **webgl_custom_attributes_points** and **webgl_custom_attributes_points2**.