### PR TITLE
Example physics_convex_break: Improvements and cleanup

### DIFF
--- a/examples/webgl_physics_convex_break.html
+++ b/examples/webgl_physics_convex_break.html
@@ -37,6 +37,7 @@
 	<script src="js/controls/OrbitControls.js"></script>
 	<script src="js/WebGL.js"></script>
 	<script src="js/libs/stats.min.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
 	<script src="js/ConvexObjectBreaker.js"></script>
 	<script src="js/QuickHull.js"></script>
 	<script src="js/geometries/ConvexGeometry.js"></script>
@@ -59,6 +60,7 @@
 		var camera, controls, scene, renderer;
 		var textureLoader;
 		var clock = new THREE.Clock();
+		var gui, guiData;
 
 		var mouseCoords = new THREE.Vector2();
 		var raycaster = new THREE.Raycaster();
@@ -76,23 +78,27 @@
 		var convexBreaker = new THREE.ConvexObjectBreaker();
 
 		// Rigid bodies include all movable objects
-		var rigidBodies = [];
+		var rigidBodies;
 
 		var pos = new THREE.Vector3();
 		var quat = new THREE.Quaternion();
 		var transformAux1;
 		var tempBtVec3_1;
-
-		var time = 0;
+		var tempBtQuat_1;
 
 		var objectsToRemove = [];
-		for ( var i = 0; i < 500; i++ ) {
+		for ( var i = 0; i < 500; i ++ ) {
+
 			objectsToRemove[ i ] = null;
+
 		}
 		var numObjectsToRemove = 0;
 
 		var impactPoint = new THREE.Vector3();
 		var impactNormal = new THREE.Vector3();
+
+		var tempVel = new THREE.Vector3();
+		var tempAngVel = new THREE.Vector3();
 
 		// - Main code -
 
@@ -112,11 +118,9 @@
 
 			initGraphics();
 
-			initPhysics();
+			initUI();
 
-			createObjects();
-
-			initInput();
+			createScene();
 
 		}
 
@@ -126,42 +130,18 @@
 
 			camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.2, 2000 );
 
-			scene = new THREE.Scene();
-			scene.background = new THREE.Color( 0xbfd1e5 );
-
-			camera.position.set( -14, 8, 16 );
-
-			controls = new THREE.OrbitControls( camera );
-			controls.target.set( 0, 2, 0 );
-			controls.update();
+			camera.position.set( - 14, 8, 16 );
 
 			renderer = new THREE.WebGLRenderer();
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.shadowMap.enabled = true;
 
+			controls = new THREE.OrbitControls( camera, renderer.domElement );
+			controls.target.set( 0, 2, 0 );
+			controls.update();
+
 			textureLoader = new THREE.TextureLoader();
-
-			var ambientLight = new THREE.AmbientLight( 0x707070 );
-			scene.add( ambientLight );
-
-			var light = new THREE.DirectionalLight( 0xffffff, 1 );
-			light.position.set( -10, 18, 5 );
-			light.castShadow = true;
-			var d = 14;
-			light.shadow.camera.left = -d;
-			light.shadow.camera.right = d;
-			light.shadow.camera.top = d;
-			light.shadow.camera.bottom = -d;
-
-			light.shadow.camera.near = 2;
-			light.shadow.camera.far = 50;
-
-			light.shadow.mapSize.x = 1024;
-			light.shadow.mapSize.y = 1024;
-
-			scene.add( light );
-
 
 			container.innerHTML = "";
 
@@ -180,6 +160,16 @@
 
 		function initPhysics() {
 
+			if ( physicsWorld ) {
+
+				destroyPhysicsWorld();
+
+			}
+
+			transformAux1 = new Ammo.btTransform();
+			tempBtVec3_1 = new Ammo.btVector3( 0, 0, 0 )
+			tempBtQuat_1 = new Ammo.btQuaternion( 0, 0, 0, 1 )
+
 			// Physics configuration
 
 			collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
@@ -187,92 +177,79 @@
 			broadphase = new Ammo.btDbvtBroadphase();
 			solver = new Ammo.btSequentialImpulseConstraintSolver();
 			physicsWorld = new Ammo.btDiscreteDynamicsWorld( dispatcher, broadphase, solver, collisionConfiguration );
-			physicsWorld.setGravity( new Ammo.btVector3( 0, - gravityConstant, 0 ) );
+			tempBtVec3_1.setValue( 0, - gravityConstant, 0 );
+			physicsWorld.setGravity( tempBtVec3_1 );
 
-			transformAux1 = new Ammo.btTransform();
-			tempBtVec3_1 = new Ammo.btVector3( 0, 0, 0 );
+			rigidBodies = [];
+
 		}
 
-		function createObject( mass, halfExtents, pos, quat, material ) {
+		function destroyPhysicsWorld() {
+
+			for ( var o = 0; o < rigidBodies.length; o ++ ) {
+
+				removeRigidBody( rigidBodies[ o ].userData.physicsBody );
+
+			}
+
+			Ammo.destroy( physicsWorld );
+			Ammo.destroy( solver );
+			Ammo.destroy( broadphase );
+			Ammo.destroy( dispatcher );
+			Ammo.destroy( collisionConfiguration );
+			Ammo.destroy( transformAux1 );
+			Ammo.destroy( tempBtVec3_1 );
+			Ammo.destroy( tempBtQuat_1 );
+
+		}
+
+		function removeRigidBody( body ) {
+
+			var threeObject = body.threeObject;
+
+			var i = rigidBodies.indexOf( threeObject );
+			if ( i >= 0 ) {
+
+				rigidBodies.splice( i, 1 );
+
+			}
+
+			var physShape = body.getCollisionShape();
+
+			var motionState = Ammo.castObject( body.getMotionState(), Ammo.btDefaultMotionState );
+
+			physicsWorld.removeRigidBody( body );
+
+			Ammo.destroy( motionState );
+			Ammo.destroy( physShape );
+			Ammo.destroy( body );
+
+		}
+
+		function removeObject( object ) {
+
+			scene.remove( object );
+
+			removeRigidBody( object.userData.physicsBody );
+
+		}
+
+		function createBox( mass, halfExtents, pos, quat, material ) {
 
 			var object = new THREE.Mesh( new THREE.BoxBufferGeometry( halfExtents.x * 2, halfExtents.y * 2, halfExtents.z * 2 ), material );
 			object.position.copy( pos );
 			object.quaternion.copy( quat );
 			convexBreaker.prepareBreakableObject( object, mass, new THREE.Vector3(), new THREE.Vector3(), true );
-			createDebrisFromBreakableObject( object );
+			createPhysicsObjectFromConvex( object );
 
 		}
 
-		function createObjects() {
-
-			// Ground
-			pos.set( 0, - 0.5, 0 );
-			quat.set( 0, 0, 0, 1 );
-			var ground = createParalellepipedWithPhysics( 40, 1, 40, 0, pos, quat, new THREE.MeshPhongMaterial( { color: 0xFFFFFF } ) );
-			ground.receiveShadow = true;
-			textureLoader.load( "textures/grid.png", function( texture ) {
-				texture.wrapS = THREE.RepeatWrapping;
-				texture.wrapT = THREE.RepeatWrapping;
-				texture.repeat.set( 40, 40 );
-				ground.material.map = texture;
-				ground.material.needsUpdate = true;
-			} );
-
-			// Tower 1
-			var towerMass = 1000;
-			var towerHalfExtents = new THREE.Vector3( 2, 5, 2 );
-			pos.set( -8, 5, 0 );
-			quat.set( 0, 0, 0, 1 );
-			createObject( towerMass, towerHalfExtents, pos, quat, createMaterial( 0xB03014 ) );
-
-			// Tower 2
-			pos.set( 8, 5, 0 );
-			quat.set( 0, 0, 0, 1 );
-			createObject( towerMass, towerHalfExtents, pos, quat, createMaterial( 0xB03214 ) );
-
-			//Bridge
-			var bridgeMass = 100;
-			var bridgeHalfExtents = new THREE.Vector3( 7, 0.2, 1.5 );
-			pos.set( 0, 10.2, 0 );
-			quat.set( 0, 0, 0, 1 );
-			createObject( bridgeMass, bridgeHalfExtents, pos, quat, createMaterial( 0xB3B865 ) );
-
-			// Stones
-			var stoneMass = 120;
-			var stoneHalfExtents = new THREE.Vector3( 1, 2, 0.15 );
-			var numStones = 8;
-			quat.set( 0, 0, 0, 1 );
-			for ( var i = 0; i < numStones; i++ ) {
-
-				pos.set( 0, 2, 15 * ( 0.5 - i / ( numStones + 1 ) ) );
-
-				createObject( stoneMass, stoneHalfExtents, pos, quat, createMaterial( 0xB0B0B0 ) );
-
-			}
-
-			// Mountain
-			var mountainMass = 860;
-			var mountainHalfExtents = new THREE.Vector3( 4, 5, 4 );
-			pos.set( 5, mountainHalfExtents.y * 0.5, - 7 );
-			quat.set( 0, 0, 0, 1 );
-			var mountainPoints = [];
-			mountainPoints.push( new THREE.Vector3( mountainHalfExtents.x, - mountainHalfExtents.y, mountainHalfExtents.z ) );
-			mountainPoints.push( new THREE.Vector3( - mountainHalfExtents.x, - mountainHalfExtents.y, mountainHalfExtents.z ) );
-			mountainPoints.push( new THREE.Vector3( mountainHalfExtents.x, - mountainHalfExtents.y, - mountainHalfExtents.z ) );
-			mountainPoints.push( new THREE.Vector3( - mountainHalfExtents.x, - mountainHalfExtents.y, - mountainHalfExtents.z ) );
-			mountainPoints.push( new THREE.Vector3( 0, mountainHalfExtents.y, 0 ) );
-			var mountain = new THREE.Mesh( new THREE.ConvexBufferGeometry( mountainPoints ), createMaterial( 0xB03814 ) );
-			mountain.position.copy( pos );
-			mountain.quaternion.copy( quat );
-			convexBreaker.prepareBreakableObject( mountain, mountainMass, new THREE.Vector3(), new THREE.Vector3(), true );
-			createDebrisFromBreakableObject( mountain );
-
-		}
-
-		function createParalellepipedWithPhysics( sx, sy, sz, mass, pos, quat, material ) {
+		function createBoxNotBreakable( sx, sy, sz, mass, pos, quat, material ) {
 
 			var object = new THREE.Mesh( new THREE.BoxBufferGeometry( sx, sy, sz, 1, 1, 1 ), material );
-			var shape = new Ammo.btBoxShape( new Ammo.btVector3( sx * 0.5, sy * 0.5, sz * 0.5 ) );
+
+			tempBtVec3_1.setValue( sx * 0.5, sy * 0.5, sz * 0.5 );
+			var shape = new Ammo.btBoxShape( tempBtVec3_1 );
 			shape.setMargin( margin );
 
 			createRigidBody( object, shape, mass, pos, quat );
@@ -281,7 +258,7 @@
 
 		}
 
-		function createDebrisFromBreakableObject( object ) {
+		function createPhysicsObjectFromConvex( object, vel, angVel ) {
 
 			object.castShadow = true;
 			object.receiveShadow = true;
@@ -289,20 +266,7 @@
 			var shape = createConvexHullPhysicsShape( object.geometry.attributes.position.array );
 			shape.setMargin( margin );
 
-			var body = createRigidBody( object, shape, object.userData.mass, null, null, object.userData.velocity, object.userData.angularVelocity );
-
-			// Set pointer back to the three object only in the debris objects
-			var btVecUserData = new Ammo.btVector3( 0, 0, 0 );
-			btVecUserData.threeObject = object;
-			body.setUserPointer( btVecUserData );
-
-		}
-
-		function removeDebris( object ) {
-
-			scene.remove( object );
-
-			physicsWorld.removeRigidBody( object.userData.physicsBody );
+			var body = createRigidBody( object, shape, object.userData.mass, null, null, vel, angVel );
 
 		}
 
@@ -310,7 +274,7 @@
 
 			var shape = new Ammo.btConvexHullShape();
 
-			for ( var i = 0, il = coords.length; i < il; i+= 3 ) {
+			for ( var i = 0, il = coords.length; i < il; i += 3 ) {
 				tempBtVec3_1.setValue( coords[ i ], coords[ i + 1 ], coords[ i + 2 ] );
 				var lastOne = ( i >= ( il - 3 ) );
 				shape.addPoint( tempBtVec3_1, lastOne );
@@ -323,37 +287,48 @@
 		function createRigidBody( object, physicsShape, mass, pos, quat, vel, angVel ) {
 
 			if ( pos ) {
+
 				object.position.copy( pos );
+
 			}
 			else {
+
 				pos = object.position;
+
 			}
 			if ( quat ) {
+
 				object.quaternion.copy( quat );
+
 			}
 			else {
+
 				quat = object.quaternion;
+
 			}
 
-			var transform = new Ammo.btTransform();
-			transform.setIdentity();
-			transform.setOrigin( new Ammo.btVector3( pos.x, pos.y, pos.z ) );
-			transform.setRotation( new Ammo.btQuaternion( quat.x, quat.y, quat.z, quat.w ) );
-			var motionState = new Ammo.btDefaultMotionState( transform );
+			transformAux1.setIdentity();
+			tempBtVec3_1.setValue( pos.x, pos.y, pos.z );
+			transformAux1.setOrigin( tempBtVec3_1 );
+			tempBtQuat_1.setValue( quat.x, quat.y, quat.z, quat.w );
+			transformAux1.setRotation( tempBtQuat_1 );
+			var motionState = new Ammo.btDefaultMotionState( transformAux1 );
 
-			var localInertia = new Ammo.btVector3( 0, 0, 0 );
-			physicsShape.calculateLocalInertia( mass, localInertia );
+			tempBtVec3_1.setValue( 0, 0, 0 );
+			physicsShape.calculateLocalInertia( mass, tempBtVec3_1 );
 
-			var rbInfo = new Ammo.btRigidBodyConstructionInfo( mass, motionState, physicsShape, localInertia );
+			var rbInfo = new Ammo.btRigidBodyConstructionInfo( mass, motionState, physicsShape, tempBtVec3_1 );
 			var body = new Ammo.btRigidBody( rbInfo );
 
 			body.setFriction( 0.5 );
 
 			if ( vel ) {
-				body.setLinearVelocity( new Ammo.btVector3( vel.x, vel.y, vel.z ) );
+				tempBtVec3_1.setValue( vel.x, vel.y, vel.z );
+				body.setLinearVelocity( tempBtVec3_1 );
 			}
 			if ( angVel ) {
-				body.setAngularVelocity( new Ammo.btVector3( angVel.x, angVel.y, angVel.z ) );
+				tempBtVec3_1.setValue( angVel.x, angVel.y, angVel.z );
+				body.setAngularVelocity( tempBtVec3_1 );
 			}
 
 			object.userData.physicsBody = body;
@@ -362,29 +337,133 @@
 			scene.add( object );
 
 			if ( mass > 0 ) {
+
 				rigidBodies.push( object );
 
-				// Disable deactivation
-				body.setActivationState( 4 );
 			}
 
 			physicsWorld.addRigidBody( body );
 
-			return body;
-		}
+			// Set reference back to the three object
+			body.threeObject = object;
 
-		function createRandomColor() {
-			return Math.floor( Math.random() * ( 1 << 24 ) );
+			return body;
+
 		}
 
 		function createMaterial( color ) {
-			color = color || createRandomColor();
+
 			return new THREE.MeshPhongMaterial( { color: color } );
+
 		}
 
-		function initInput() {
+		function createScene() {
 
-			window.addEventListener( 'mousedown', function( event ) {
+			initPhysics();
+
+			scene = new THREE.Scene();
+			scene.background = new THREE.Color( 0xbfd1e5 );
+
+			var ambientLight = new THREE.AmbientLight( 0x707070 );
+			scene.add( ambientLight );
+
+			var light = new THREE.DirectionalLight( 0xffffff, 1 );
+			light.position.set( - 10, 18, 5 );
+			light.castShadow = true;
+			var d = 26;
+			light.shadow.camera.left = - d;
+			light.shadow.camera.right = d;
+			light.shadow.camera.top = d;
+			light.shadow.camera.bottom = - d;
+
+			light.shadow.camera.near = 2;
+			light.shadow.camera.far = 50;
+
+			light.shadow.mapSize.x = 1024;
+			light.shadow.mapSize.y = 1024;
+
+			scene.add( light );
+
+			quat.set( 0, 0, 0, 1 );
+
+			// Ground
+			pos.set( 0, - 0.5, 0 );
+			var ground = createBoxNotBreakable( 40, 1, 40, 0, pos, quat, new THREE.MeshPhongMaterial( { color: 0xFFFFFF } ) );
+			ground.receiveShadow = true;
+			textureLoader.load( "textures/grid.png", function ( texture ) {
+
+				texture.wrapS = THREE.RepeatWrapping;
+				texture.wrapT = THREE.RepeatWrapping;
+				texture.repeat.set( 40, 40 );
+				ground.material.map = texture;
+				ground.material.needsUpdate = true;
+
+			} );
+
+			// Tower 1
+			var towerMass = 1000;
+			var towerHalfExtents = new THREE.Vector3( 2, 5, 2 );
+			pos.set( - 8, 5, 0 );
+			createBox( towerMass, towerHalfExtents, pos, quat, createMaterial( 0xB03014 ) );
+
+			// Tower 2
+			pos.set( 8, 5, 0 );
+			createBox( towerMass, towerHalfExtents, pos, quat, createMaterial( 0xB03214 ) );
+
+			//Bridge
+			var bridgeMass = 100;
+			var bridgeHalfExtents = new THREE.Vector3( 7, 0.2, 1.5 );
+			pos.set( 0, 10.2, 0 );
+			createBox( bridgeMass, bridgeHalfExtents, pos, quat, createMaterial( 0xB3B865 ) );
+
+			// Stones
+			var stoneMass = 120;
+			var stoneHalfExtents = new THREE.Vector3( 1, 2, 0.15 );
+			var numStones = 8;
+
+			var stoneMat = createMaterial( 0xB0B0B0 );
+			for ( var i = 0; i < numStones; i ++ ) {
+
+				pos.set( 0, 2, 15 * ( 0.5 - i / ( numStones + 1 ) ) );
+				createBox( stoneMass, stoneHalfExtents, pos, quat, stoneMat );
+
+			}
+
+			// Mountain
+			var mountainMass = 860;
+			var mountainHalfExtents = new THREE.Vector3( 4, 5, 4 );
+			pos.set( 5, mountainHalfExtents.y, - 7 );
+
+			var mountainPoints = [];
+			mountainPoints.push( new THREE.Vector3( mountainHalfExtents.x, - mountainHalfExtents.y, mountainHalfExtents.z ) );
+			mountainPoints.push( new THREE.Vector3( - mountainHalfExtents.x, - mountainHalfExtents.y, mountainHalfExtents.z ) );
+			mountainPoints.push( new THREE.Vector3( mountainHalfExtents.x, - mountainHalfExtents.y, - mountainHalfExtents.z ) );
+			mountainPoints.push( new THREE.Vector3( - mountainHalfExtents.x, - mountainHalfExtents.y, - mountainHalfExtents.z ) );
+			mountainPoints.push( new THREE.Vector3( 0, mountainHalfExtents.y, 0 ) );
+			var mountain = new THREE.Mesh( new THREE.ConvexBufferGeometry( mountainPoints ), createMaterial( 0xB03814 ) );
+			mountain.position.copy( pos );
+			mountain.quaternion.copy( quat );
+			convexBreaker.prepareBreakableObject( mountain, mountainMass, new THREE.Vector3(), new THREE.Vector3(), true );
+			createPhysicsObjectFromConvex( mountain );
+
+		}
+
+		function initUI() {
+
+			guiData = {
+
+				restart: createScene
+
+			};
+
+			gui = new dat.GUI( { width: 400 } );
+
+			gui.add( guiData, 'restart' ).name( 'Restart scene' );
+
+			// Creates a ball and throws it on mouse press
+			window.addEventListener( 'mousedown', function ( event ) {
+
+				if ( event.target !== renderer.domElement ) return;
 
 				mouseCoords.set(
 					( event.clientX / window.innerWidth ) * 2 - 1,
@@ -393,7 +472,6 @@
 
 				raycaster.setFromCamera( mouseCoords, camera );
 
-				// Creates a ball and throws it
 				var ballMass = 35;
 				var ballRadius = 0.4;
 
@@ -404,12 +482,13 @@
 				ballShape.setMargin( margin );
 				pos.copy( raycaster.ray.direction );
 				pos.add( raycaster.ray.origin );
-				quat.set( 0, 0, 0, 1 );
+
 				var ballBody = createRigidBody( ball, ballShape, ballMass, pos, quat );
 
 				pos.copy( raycaster.ray.direction );
 				pos.multiplyScalar( 24 );
-				ballBody.setLinearVelocity( new Ammo.btVector3( pos.x, pos.y, pos.z ) );
+				tempBtVec3_1.setValue( pos.x, pos.y, pos.z );
+				ballBody.setLinearVelocity( tempBtVec3_1 );
 
 			}, false );
 
@@ -441,8 +520,6 @@
 
 			renderer.render( scene, camera );
 
-			time += deltaTime;
-
 		}
 
 		function updatePhysics( deltaTime ) {
@@ -451,7 +528,7 @@
 			physicsWorld.stepSimulation( deltaTime, 10 );
 
 			// Update rigid bodies
-			for ( var i = 0, il = rigidBodies.length; i < il; i++ ) {
+			for ( var i = 0, il = rigidBodies.length; i < il; i ++ ) {
 				var objThree = rigidBodies[ i ];
 				var objPhys = objThree.userData.physicsBody;
 				var ms = objPhys.getMotionState();
@@ -466,20 +543,19 @@
 					objThree.userData.collided = false;
 
 				}
+
 			}
 
 			for ( var i = 0, il = dispatcher.getNumManifolds(); i < il; i ++ ) {
 
 				var contactManifold = dispatcher.getManifoldByIndexInternal( i );
-				var rb0 = contactManifold.getBody0();
-				var rb1 = contactManifold.getBody1();
+				var rb0 = Ammo.castObject( contactManifold.getBody0(), Ammo.btRigidBody );
+				var rb1 = Ammo.castObject( contactManifold.getBody1(), Ammo.btRigidBody );
 
-				var threeObject0 = Ammo.castObject( rb0.getUserPointer(), Ammo.btVector3 ).threeObject;
-				var threeObject1 = Ammo.castObject( rb1.getUserPointer(), Ammo.btVector3 ).threeObject;
+				var threeObject0 = rb0.threeObject;
+				var threeObject1 = rb1.threeObject;
 
-				if ( ! threeObject0 && ! threeObject1 ) {
-					continue;
-				}
+				if ( ! threeObject0 && ! threeObject1 ) continue;
 
 				var userData0 = threeObject0 ? threeObject0.userData : null;
 				var userData1 = threeObject1 ? threeObject1.userData : null;
@@ -490,61 +566,69 @@
 				var collided0 = userData0 ? userData0.collided : false;
 				var collided1 = userData1 ? userData1.collided : false;
 
-				if ( ( ! breakable0 && ! breakable1 ) || ( collided0 && collided1 ) ) {
-					continue;
-				}
-
 				var contact = false;
-				var maxImpulse = 0;
+				var impulse = 0;
 				for ( var j = 0, jl = contactManifold.getNumContacts(); j < jl; j ++ ) {
+
 					var contactPoint = contactManifold.getContactPoint( j );
 					if ( contactPoint.getDistance() < 0 ) {
+
 						contact = true;
-						var impulse = contactPoint.getAppliedImpulse();
-						if ( impulse > maxImpulse ) {
-							maxImpulse = impulse;
+						var imp = contactPoint.getAppliedImpulse();
+						if ( imp > impulse ) {
+
+							impulse = imp;
 							var pos = contactPoint.get_m_positionWorldOnB();
 							var normal = contactPoint.get_m_normalWorldOnB();
 							impactPoint.set( pos.x(), pos.y(), pos.z() );
 							impactNormal.set( normal.x(), normal.y(), normal.z() );
+
 						}
+
 						break;
 					}
+
 				}
 
 				// If no point has contact, abort
-				if ( ! contact ) {
-					continue;
-				}
+				if ( ! contact ) continue;
 
 				// Subdivision
 
-				var fractureImpulse = 250;
+				var fractureImpulse = 230;
 
-				if ( breakable0 && !collided0 && maxImpulse > fractureImpulse ) {
+				if ( breakable0 && ! collided0 && impulse > fractureImpulse ) {
 
-					var debris = convexBreaker.subdivideByImpact( threeObject0, impactPoint, impactNormal , 1, 2, 1.5 );
+					var debris = convexBreaker.subdivideByImpact( threeObject0, impactPoint, impactNormal, 1, 2, 1.5 );
 
 					var numObjects = debris.length;
-					for ( var j = 0; j < numObjects; j++ ) {
+					for ( var j = 0; j < numObjects; j ++ ) {
 
-						createDebrisFromBreakableObject( debris[ j ] );
+						var vel = rb0.getLinearVelocity();
+						var angVel = rb0.getAngularVelocity();
+						tempVel.set( vel.x(), vel.y(), vel.z() );
+						tempAngVel.set( angVel.x(), angVel.y(), angVel.z() );
+						createPhysicsObjectFromConvex( debris[ j ], tempVel, tempAngVel );
 
 					}
 
-					objectsToRemove[ numObjectsToRemove++ ] = threeObject0;
+					objectsToRemove[ numObjectsToRemove ++ ] = threeObject0;
 					userData0.collided = true;
 
 				}
 
-				if ( breakable1 && !collided1 && maxImpulse > fractureImpulse ) {
+				if ( breakable1 && ! collided1 && impulse > fractureImpulse ) {
 
-					var debris = convexBreaker.subdivideByImpact( threeObject1, impactPoint, impactNormal , 1, 2, 1.5 );
+					var debris = convexBreaker.subdivideByImpact( threeObject1, impactPoint, impactNormal, 1, 2, 1.5 );
 
 					var numObjects = debris.length;
-					for ( var j = 0; j < numObjects; j++ ) {
+					for ( var j = 0; j < numObjects; j ++ ) {
 
-						createDebrisFromBreakableObject( debris[ j ] );
+						var vel = rb1.getLinearVelocity();
+						var angVel = rb1.getAngularVelocity();
+						tempVel.set( vel.x(), vel.y(), vel.z() );
+						tempAngVel.set( angVel.x(), angVel.y(), angVel.z() );
+						createPhysicsObjectFromConvex( debris[ j ], tempVel, tempAngVel );
 
 					}
 
@@ -555,9 +639,12 @@
 
 			}
 
-			for ( var i = 0; i < numObjectsToRemove; i++ ) {
 
-				removeDebris( objectsToRemove[ i ] );
+			// Remove broken objects
+
+			for ( var i = 0; i < numObjectsToRemove; i ++ ) {
+
+				removeObject( objectsToRemove[ i ] );
 
 			}
 			numObjectsToRemove = 0;


### PR DESCRIPTION
- Added linear and angular velocity to debris when they start after parent object breaks (better simulation)
- Added gui with reset scene button. Hence, destruction code for the physics world is added, which is useful for production code.
- Less temporary Ammo vectors are used.
- Added more comments.
- Renamed some utility functions and variables to more descriptive names.
- Removed unused `createRandomColor()`

Live link: https://raw.githack.com/yomboprime/three.js/break_update/examples/webgl_physics_convex_break.html
