### PR TITLE
Camera: Introduce .dispose()

### DIFF
--- a/docs/api/en/cameras/Camera.html
+++ b/docs/api/en/cameras/Camera.html
@@ -74,7 +74,8 @@
 
 		<h3>[method:null dispose]()</h3>
 		<p>
-		Clears camera related data internally cached by [page:WebGLRenderer].
+			Clears camera-related data structures cached by [page:WebGLRenderer].
+			You should call this method if you don't need the camera for rendering anymore.
 		</p>
 
 		<h3>[method:Vector3 getWorldDirection]( [param:Vector3 target] )</h3>

--- a/docs/api/en/cameras/Camera.html
+++ b/docs/api/en/cameras/Camera.html
@@ -72,6 +72,11 @@
 		Copy the properties from the source camera into this one.
 		</p>
 
+		<h3>[method:null dispose]()</h3>
+		<p>
+		Clears camera related data internally cached by [page:WebGLRenderer].
+		</p>
+
 		<h3>[method:Vector3 getWorldDirection]( [param:Vector3 target] )</h3>
 		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3. <br /><br />

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -53,8 +53,10 @@
 
 		<h3>[method:null dispose]()</h3>
 		<p>
-		Clears scene related data internally cached by [page:WebGLRenderer].
+			Clears scene-related data structures cached by [page:WebGLRenderer].
+			You should call this method if you don't need the scene for rendering anymore.
 		</p>
+
 
 		<h2>Source</h2>
 

--- a/docs/api/zh/cameras/Camera.html
+++ b/docs/api/zh/cameras/Camera.html
@@ -79,6 +79,11 @@
 
 		</p>
 
+		<h3>[method:null dispose]()</h3>
+		<p>
+		TODO
+		</p>
+
 		<h3>[method:Vector3 getWorldDirection]( [param:Vector3 target] )</h3>
 		<p>
 

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -54,11 +54,11 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
-	<h2>Scenes</h2>
+	<h2>Scenes and Cameras</h2>
 
 	<p>
-		The renderer maintains for scenes special data structures for sorting and rendering. If for some reasons a scene object becomes obsolete in an application,
-		call [page:Scene.dispose]() in order to free these resources.
+		The renderer maintains for scenes and cameras special data structures for sorting and rendering. If for some reasons a camera or a scene becomes obsolete in an
+		application, call [page:Camera.dispose]() or [page:Scene.dispose]() in order to free these resources.
 	</p>
 
 	<h2>Miscellaneous</h2>

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -57,8 +57,8 @@
 	<h2>Scenes and Cameras</h2>
 
 	<p>
-		The renderer maintains for scenes and cameras special data structures for sorting and rendering. If for some reasons a camera or a scene becomes obsolete in an
-		application, call [page:Camera.dispose]() or [page:Scene.dispose]() in order to free these resources.
+		If you delete a scene, or no longer need the scene for rendering, call [page:Scene.dispose]() to clear scene-related data structures cached by [page:WebGLRenderer].
+		This is also true for cameras.
 	</p>
 
 	<h2>Miscellaneous</h2>

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -69,6 +69,12 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		return new this.constructor().copy( this );
 
+	},
+
+	dispose: function () {
+
+		this.dispatchEvent( { type: 'dispose' } );
+
 	}
 
 } );

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -164,10 +164,27 @@ function WebGLRenderLists() {
 
 	}
 
+	function onCameraDispose( event ) {
+
+		var camera = event.target;
+
+		camera.removeEventListener( 'dispose', onCameraDispose );
+
+		for ( var sceneId in lists ) {
+
+			var list = lists[ sceneId ];
+
+			if ( list[ camera.id ] !== undefined ) delete list[ camera.id ];
+
+		}
+
+	}
+
 	function get( scene, camera ) {
 
 		var cameras = lists[ scene.id ];
 		var list;
+
 		if ( cameras === undefined ) {
 
 			list = new WebGLRenderList();
@@ -175,14 +192,18 @@ function WebGLRenderLists() {
 			lists[ scene.id ][ camera.id ] = list;
 
 			scene.addEventListener( 'dispose', onSceneDispose );
+			camera.addEventListener( 'dispose', onCameraDispose );
 
 		} else {
 
 			list = cameras[ camera.id ];
+
 			if ( list === undefined ) {
 
 				list = new WebGLRenderList();
 				cameras[ camera.id ] = list;
+
+				camera.addEventListener( 'dispose', onCameraDispose );
 
 			}
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -68,6 +68,22 @@ function WebGLRenderStates() {
 
 	}
 
+	function onCameraDispose( event ) {
+
+		var camera = event.target;
+
+		camera.removeEventListener( 'dispose', onCameraDispose );
+
+		for ( var sceneId in renderStates ) {
+
+			var renderState = renderStates[ sceneId ];
+
+			if ( renderState[ camera.id ] !== undefined ) delete renderState[ camera.id ];
+
+		}
+
+	}
+
 	function get( scene, camera ) {
 
 		var renderState;
@@ -79,6 +95,7 @@ function WebGLRenderStates() {
 			renderStates[ scene.id ][ camera.id ] = renderState;
 
 			scene.addEventListener( 'dispose', onSceneDispose );
+			camera.addEventListener( 'dispose', onCameraDispose );
 
 		} else {
 
@@ -86,6 +103,8 @@ function WebGLRenderStates() {
 
 				renderState = new WebGLRenderState();
 				renderStates[ scene.id ][ camera.id ] = renderState;
+
+				camera.addEventListener( 'dispose', onCameraDispose );
 
 			} else {
 


### PR DESCRIPTION
Solves https://github.com/mrdoob/three.js/pull/12464#issuecomment-465563120

Analogous to `Scene.dispose()`. Allows more control about the disposal of internal cached objects.