### PR TITLE
GPUParticleSystem: Remove unnecessary lines

### DIFF
--- a/examples/js/GPUParticleSystem.js
+++ b/examples/js/GPUParticleSystem.js
@@ -83,18 +83,7 @@ THREE.GPUParticleSystem = function ( options ) {
 			'	vec3 noiseVel = ( noise.rgb - 0.5 ) * 30.0;',
 
 			'	newPosition = mix( newPosition, newPosition + vec3( noiseVel * ( turbulence * 5.0 ) ), ( timeElapsed / lifeTime ) );',
-
-			'	if( v.y > 0. && v.y < .05 ) {',
-
-			'		lifeLeft = 0.0;',
-
-			'	}',
-
-			'	if( v.x < - 1.45 ) {',
-
-			'		lifeLeft = 0.0;',
-
-			'	}',
+			
 
 			'	if( timeElapsed > 0.0 ) {',
 


### PR DESCRIPTION
The script in its current form isn't working as intended, which can be seen by immobilising the origin of the particles, setting the position randomness to 0, and the turbulence to zero. The lines are removed seem to be the cause of the unintended behaviour, and I see no justification for their presence. Removing them fixes the issue.