### PR TITLE
GPU cubemap to spherical harmonics

### DIFF
--- a/examples/js/loaders/SHGenerator.js
+++ b/examples/js/loaders/SHGenerator.js
@@ -1,0 +1,132 @@
+/**
+* @author Richard M. / https://github.com/richardmonette
+*/
+
+THREE.SHGenerator = function( sourceTexture ) {
+
+	this.sourceTexture = sourceTexture;
+
+	this.camera = new THREE.Camera();
+
+	this.shader = this.getShader();
+
+	this.planeMesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), this.shader );
+	this.scene = new THREE.Scene();
+	this.scene.add( this.planeMesh );
+
+	var params = {
+		format: THREE.RGBFormat,
+		magFilter: THREE.NearestFilter,
+		minFilter: THREE.NearestFilter,
+		type: THREE.HalfFloatType,
+	};
+
+	this.renderTarget = new THREE.WebGLRenderTarget( 9, 1, params );
+	this.renderTarget.texture.name = "SHTexture";
+	this.renderTarget.texture.mapping = THREE.SphericalHarmonicReflectionMapping;
+
+};
+
+THREE.SHGenerator.prototype = {
+
+	constructor : THREE.SHGenerator,
+
+	update: function( renderer ) {
+
+		var currentRenderTarget = renderer.getRenderTarget();
+
+		renderer.setRenderTarget(this.renderTarget);
+		renderer.clear();
+		renderer.render( this.scene, this.camera );
+
+		renderer.setRenderTarget( currentRenderTarget );
+
+	},
+
+	dispose: function () {
+
+		this.shader.dispose();
+
+	},
+
+	getShader: function() {
+
+		return new THREE.ShaderMaterial( {
+
+			uniforms: {
+				"cubeMap": { value: this.sourceTexture },
+			},
+
+			vertexShader:
+				`
+				void main() {
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+				`,
+
+			fragmentShader:
+				`
+				#include <common>
+				uniform samplerCube cubeMap;
+
+				vec3 calcSH(int id, vec3 dir, vec3 color) {
+					float p_0_0 = 0.282094791773878140;
+					float p_1_0 = 0.488602511902919920 * dir.z;
+					float p_1_1 = -0.488602511902919920;
+					float p_2_0 = 0.946174695757560080 * dir.z * dir.z - 0.315391565252520050;
+					float p_2_1 = -1.092548430592079200 * dir.z;
+					float p_2_2 = 0.546274215296039590;
+
+					if (id == 0) {
+						return color * p_0_0;
+					} else if (id == 1) {
+						return color * p_1_1 * dir.y;
+					} else if (id == 2) {
+						return color * p_1_0;
+					} else if (id == 3) {
+						return color * p_1_1 * dir.x;
+					} else if (id == 4) {
+						return color * p_2_2 * (dir.x * dir.y + dir.y * dir.x);
+					} else if (id == 5) {
+						return color * p_2_1 * dir.y;
+					} else if (id == 6) {
+						return color * p_2_0;
+					} else if (id == 7) {
+						return color * p_2_1 * dir.x;
+					} else if (id == 8) {
+						return color * p_2_2 * (dir.x * dir.x - dir.y * dir.y);
+					}
+				}
+
+				#define SAMPLES 32
+
+				void main() {
+					vec3 samples;
+
+					for (int t = 0; t < SAMPLES; t++) {
+						for (int p = 0; p < SAMPLES; p++) {
+							float theta = 2.0 * PI * float(t)/float(SAMPLES);
+			        float phi = acos(1.0 - 2.0 * float(p)/float(SAMPLES));
+
+			        float x = sin(phi) * cos(theta);
+			        float y = sin(phi) * sin(theta);
+			        float z = cos(phi);
+
+							vec3 sampleDirection = normalize(vec3(x, y, z));
+
+							vec3 envSample = textureCube(cubeMap, sampleDirection).rgb;
+
+							samples += calcSH(int(gl_FragCoord.x), sampleDirection, envSample);
+						}
+					}
+
+					gl_FragColor = vec4(samples / float(SAMPLES*SAMPLES), 1.0);
+				}
+				`,
+
+		} );
+
+	}
+
+};
+

--- a/examples/webgl_materials_envmaps_sh.html
+++ b/examples/webgl_materials_envmaps_sh.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>threejs webgl - materials - sh environment mapping</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				color: #fff;
+				font-family:Monospace;
+				font-size:13px;
+				text-align:center;
+
+				background-color: #000;
+
+				margin: 0px;
+				overflow: hidden;
+			}
+			a { color: #00f }
+
+			#info {
+				position: absolute;
+				top: 0px; width: 100%;
+				padding: 5px;
+			}
+		</style>
+	</head>
+	<body>
+
+		<div id="container"></div>
+		<div id="info"><a href="http://threejs.org" target="_blank" rel="noopener">threejs</a> - Spherical Harmonics lighting using run-time generated coefficients.<br>
+			Created by <a href="https://github.com/richardmonette" target="_blank" rel="noopener">Richard Monette</a></div>
+
+		<script src="../build/three.js"></script>
+		<script src="js/controls/OrbitControls.js"></script>
+
+		<script src="js/loaders/RGBELoader.js"></script>
+		<script src="js/loaders/HDRCubeTextureLoader.js"></script>
+		<script src="js/loaders/SHGenerator.js"></script>
+
+		<script src="js/WebGL.js"></script>
+		<script src="js/libs/stats.min.js"></script>
+
+		<script src="js/libs/dat.gui.min.js"></script>
+
+		<script>
+
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
+
+			var container, stats;
+			var params = {
+				roughness: 0.0,
+				metalness: 0.0,
+				exposure: 1.0,
+				envMapIntensity: 5.0
+			};
+			var camera, scene, renderer, controls, objects = [];
+			var standardMaterial;
+			var shRenderTarget, hdrCubeMap;
+
+			init();
+			animate();
+
+			function init() {
+
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
+
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0.0, 0, 120 );
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0x000000 );
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.toneMapping = THREE.LinearToneMapping;
+				renderer.setClearColor(new THREE.Color( 0x00FF00 ), 1.0);
+
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				standardMaterial = new THREE.MeshStandardMaterial( {
+					map: null,
+					color: 0xffffff,
+					metalness: params.metalness,
+					roughness: params.roughness,
+					envMapIntensity: params.envMapIntensity
+				} );
+
+				var geometry = new THREE.TorusKnotBufferGeometry( 18, 8, 150, 20 );
+
+				var torusMesh = new THREE.Mesh( geometry, standardMaterial );
+
+				scene.add( torusMesh );
+				objects.push( torusMesh );
+
+				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
+				hdrCubeMap = new THREE.HDRCubeTextureLoader()
+					.setPath( './textures/cube/pisaHDR/' )
+					.load( THREE.HalfFloatType, hdrUrls, function () {
+
+					scene.background = hdrCubeMap;
+
+					var shGenerator = new THREE.SHGenerator( hdrCubeMap );
+					shGenerator.update( renderer );
+
+					shRenderTarget = shGenerator.renderTarget;
+
+					standardMaterial.envMap = shRenderTarget.texture;
+					standardMaterial.needsUpdate = true;
+
+					shGenerator.dispose();
+
+				} );
+
+				container.appendChild( renderer.domElement );
+
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
+				controls = new THREE.OrbitControls( camera, renderer.domElement );
+				controls.minDistance = 50;
+				controls.maxDistance = 300;
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+				var gui = new dat.GUI();
+				gui.add( params, 'roughness', 0, 1 );
+				gui.add( params, 'metalness', 0, 1 );
+				gui.add( params, 'exposure', 0, 2 );
+				gui.add( params, 'envMapIntensity', 0, 10 );
+				gui.open();
+
+			}
+
+			function onWindowResize() {
+
+				var width = window.innerWidth;
+				var height = window.innerHeight;
+
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				stats.begin();
+				render();
+				stats.end();
+
+			}
+
+			function render() {
+
+				standardMaterial.roughness = params.roughness;
+				standardMaterial.metalness = params.metalness;
+				standardMaterial.envMapIntensity = params.envMapIntensity;
+
+				renderer.toneMappingExposure = params.exposure;
+
+				for ( var i = 0, l = objects.length; i < l; i ++ ) {
+
+					var object = objects[ i ];
+					object.rotation.y += 0.005;
+
+				}
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/constants.js
+++ b/src/constants.js
@@ -65,6 +65,7 @@ export var EquirectangularRefractionMapping = 304;
 export var SphericalReflectionMapping = 305;
 export var CubeUVReflectionMapping = 306;
 export var CubeUVRefractionMapping = 307;
+export var SphericalHarmonicReflectionMapping = 308;
 export var RepeatWrapping = 1000;
 export var ClampToEdgeWrapping = 1001;
 export var MirroredRepeatWrapping = 1002;

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -1,6 +1,64 @@
 export default /* glsl */`
 #if defined( USE_ENVMAP ) && defined( PHYSICAL )
 
+	#if defined( ENVMAP_TYPE_SH )
+
+		vec3 sampleSHMap(int id) {
+			return texture2D(envMap, vec2(float(id) / 8.0, 0)).rgb;
+		}
+
+		vec3 shGetRadianceAt( vec3 shCoefficients[9], vec3 normal )
+		{
+			normal.y *= -1.0;
+
+	    // band 0
+	    vec3 result = sampleSHMap(0);
+
+	    // band 1
+	    result += sampleSHMap(1) * normal.y;
+	    result += sampleSHMap(2) * normal.z;
+	    result += sampleSHMap(3) * normal.x;
+
+	    // band 2
+	    result += sampleSHMap(4) * ( normal.x*normal.y );
+	    result += sampleSHMap(5) * ( normal.y*normal.z );
+	    result += sampleSHMap(6) * ( 3.0 * normal.z*normal.z - 1.0 );
+	    result += sampleSHMap(7) * ( normal.x*normal.z );
+	    result += sampleSHMap(8) * ( normal.x*normal.x - normal.y*normal.y );
+
+	    return result;
+		}
+
+		#define C1 0.429043
+		#define C2 0.511664
+		#define C3 0.743125
+		#define C4 0.886227
+		#define C5 0.247708
+
+		vec3 shGetIrradianceAt( vec3 normal ) {
+			// This does fix the orientation, but would be good to determine why this is "needed"
+			normal.y *= -1.0;
+
+		  // band 0
+		  vec3 result = sampleSHMap(0) * C4;
+
+		  // band 1
+		  result += sampleSHMap(1) * ( 2.0 * C2 * normal.y );
+		  result += sampleSHMap(2) * ( 2.0 * C2 * normal.z );
+		  result += sampleSHMap(3) * ( 2.0 * C2 * normal.x );
+
+		  // band 2
+		  result += sampleSHMap(4) * ( 2.0 * C1 * normal.x*normal.y );
+		  result += sampleSHMap(5) * ( 2.0 * C1 * normal.y*normal.z );
+		  result += sampleSHMap(6) * ( C3 * normal.z*normal.z - C5 );
+		  result += sampleSHMap(7) * ( 2.0 * C1 * normal.x*normal.z );
+		  result += sampleSHMap(8) * ( C1 * ( normal.x*normal.x - normal.y*normal.y ) );
+
+		  return result;
+		}
+
+	#endif
+
 	vec3 getLightProbeIndirectIrradiance( /*const in SpecularLightProbe specularLightProbe,*/ const in GeometricContext geometry, const in int maxMIPLevel ) {
 
 		vec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );
@@ -29,6 +87,11 @@ export default /* glsl */`
 
 			vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
 			vec4 envMapColor = textureCubeUV( envMap, queryVec, 1.0 );
+
+		#elif defined( ENVMAP_TYPE_SH )
+
+			vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
+			vec3 envMapColor = shGetIrradianceAt( queryVec );
 
 		#else
 
@@ -124,6 +187,11 @@ export default /* glsl */`
 			#endif
 
 			envMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;
+
+		#elif defined( ENVMAP_TYPE_SH )
+
+			vec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
+			vec3 envMapColor = shGetIrradianceAt(queryReflectVec);
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -15,9 +15,13 @@ export default /* glsl */`
 
 	#endif
 
-	#if defined( USE_ENVMAP ) && defined( PHYSICAL ) && defined( ENVMAP_TYPE_CUBE_UV )
+	#if defined( USE_ENVMAP ) && defined( PHYSICAL )
 
-		irradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, maxMipLevel );
+		#if defined( ENVMAP_TYPE_CUBE_UV ) || defined( ENVMAP_TYPE_SH )
+
+			irradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, maxMipLevel );
+
+		#endif
 
 	#endif
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -5,7 +5,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, EquirectangularRefractionMapping, CubeRefractionMapping, SphericalReflectionMapping, EquirectangularReflectionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, ACESFilmicToneMapping, CineonToneMapping, Uncharted2ToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding } from '../../constants.js';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, SphericalHarmonicReflectionMapping, EquirectangularRefractionMapping, CubeRefractionMapping, SphericalReflectionMapping, EquirectangularReflectionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, ACESFilmicToneMapping, CineonToneMapping, Uncharted2ToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding } from '../../constants.js';
 
 var programIdCount = 0;
 
@@ -252,6 +252,10 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			case SphericalReflectionMapping:
 				envMapTypeDefine = 'ENVMAP_TYPE_SPHERE';
+				break;
+
+			case SphericalHarmonicReflectionMapping:
+				envMapTypeDefine = 'ENVMAP_TYPE_SH';
 				break;
 
 		}

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap } from '../../constants.js';
+import { BackSide, DoubleSide, SphericalHarmonicReflectionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap } from '../../constants.js';
 import { WebGLProgram } from './WebGLProgram.js';
 
 function WebGLPrograms( renderer, extensions, capabilities, textures ) {


### PR DESCRIPTION
Related https://github.com/mrdoob/three.js/issues/6251

<img width="1055" alt="Screen Shot 2019-04-04 at 4 20 02 PM" src="https://user-images.githubusercontent.com/1041278/55586056-0eb1fd00-56f6-11e9-8c95-9cead4f99ad7.png">

Spherical harmonics (GPU based) generator and example. Pulled in some of the code from https://github.com/mrdoob/three.js/pull/6405

Similar pipeline where we load an HDR cubemap, but instead of converting to PMREM, we convert to SH.

SH has the advantage of being represented, at 2nd order, by only 27 float values (9 * 3 channel RGB values). This impressively compact representation comes at the expense of only being able to capture low-mid frequency lighting information. 

I noticed that `envMap` actually supports several different `USE_ENVMAP_TYPE_XXX`s, so it was quite natural adding in one more representation of environment map lighting data.

![SH_v_PMREM](https://user-images.githubusercontent.com/1041278/55586412-e1198380-56f6-11e9-9643-ec8b7f777b3a.png)

SH on the left, PMREM on the right. Note how SH is plausibly consistent, but also that this only holds for rough surfaces. It's possible to approximate smooth reflections, but as significant data is omitted in the low-mid frequency representation mirror reflections are not possible. Still, this compact size makes this an attractive mapping type for multiple light probes. 

Also, a few performance notes:

SHGenerator uses one step: ~18.63ms
PMREMGenerator+PMREMCubeUVPacker: ~22.09ms + ~49.59ms

_Note: not really a fair performance comparison because PMREM is able to capture high frequency reflections, which SH does not capture. Still, interesting to see they are both in the same ballpark._

Per https://github.com/mrdoob/three.js/issues/6251, we still need to introduce a LightProbe meta system, where we pick the closest LightProbe and set it onto the material. This PR moves towards that goal by adding support for SH env map representation. 