### PR TITLE
Docs: Add link to .customDistanceMaterial

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -46,7 +46,7 @@
 
 		<h3>[property:Material customDistanceMaterial]</h3>
 		<p>
-		Same as customDepthMaterial, but used with [page:PointLight]. Default is *undefined*.
+		Same as [page:.customDepthMaterial customDepthMaterial], but used with [page:PointLight]. Default is *undefined*.
 		</p>
 
 		<h3>[property:Boolean frustumCulled]</h3>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -44,7 +44,7 @@
 	</p>
 
 	<h3>[property:Material customDistanceMaterial]</h3>
-	<p>与customDepthMaterial相同，但与[page:PointLight]一起使用。默认值为*undefined*。
+	<p>与[page:.customDepthMaterial customDepthMaterial]相同，但与[page:PointLight]一起使用。默认值为*undefined*。
 	</p>
 
 	<h3>[property:Boolean frustumCulled]</h3>


### PR DESCRIPTION
Linking to `customDepthMaterial` ensures users don't overlook the documentation.