### PR TITLE
TypeScript: Add normalMapType to materials.

### DIFF
--- a/src/constants.d.ts
+++ b/src/constants.d.ts
@@ -233,3 +233,8 @@ export const RGBDEncoding: TextureEncoding;
 export enum DepthPackingStrategies {}
 export const BasicDepthPacking: DepthPackingStrategies;
 export const RGBADepthPacking: DepthPackingStrategies;
+
+// Normal Map types
+export enum NormalMapTypes {}
+export const TangentSpaceNormalMap: NormalMapTypes;
+export const ObjectSpaceNormalMap: NormalMapTypes;

--- a/src/materials/MeshMatcapMaterial.d.ts
+++ b/src/materials/MeshMatcapMaterial.d.ts
@@ -2,6 +2,7 @@ import { Color } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
+import { NormalMapTypes } from '../constants';
 
 export interface MeshMatcapMaterialParameters extends MaterialParameters {
 
@@ -11,6 +12,7 @@ export interface MeshMatcapMaterialParameters extends MaterialParameters {
 	bumpMap?: Texture;
 	bumpScale?: number;
 	normalMap?: Texture;
+	normalMapType?: NormalMapTypes;
 	normalScale?: Vector2;
 	displacementMap?: Texture;
 	displacementScale?: number;
@@ -30,6 +32,7 @@ export class MeshMatcapMaterial extends Material {
 	bumpMap: Texture | null;
 	bumpScale: number;
 	normalMap: Texture | null;
+	normalMapType: NormalMapTypes;
 	normalScale: Vector2;
 	displacementMap: Texture | null;
 	displacementScale: number;

--- a/src/materials/MeshNormalMaterial.d.ts
+++ b/src/materials/MeshNormalMaterial.d.ts
@@ -1,19 +1,41 @@
 import { MaterialParameters, Material } from './Material';
+import { Texture } from './../textures/Texture';
+import { Vector2 } from './../math/Vector2';
+import { NormalMapTypes } from '../constants';
 
 export interface MeshNormalMaterialParameters extends MaterialParameters {
-  /** Render geometry as wireframe. Default is false (i.e. render as smooth shaded). */
-  wireframe?: boolean;
-  /** Controls wireframe thickness. Default is 1. */
-  wireframeLinewidth?: number;
-  morphTargets?: boolean;
+
+	bumpMap?: Texture;
+	bumpScale?: number;
+	normalMap?: Texture;
+	normalMapType?: NormalMapTypes;
+	normalScale?: Vector2;
+	displacementMap?: Texture;
+	displacementScale?: number;
+	displacementBias?: number;
+	wireframe?: boolean;
+	wireframeLinewidth?: number;
+	skinning?: boolean;
+	morphTargets?: boolean;
+	morphNormals?: boolean;
 }
 
 export class MeshNormalMaterial extends Material {
-  constructor(parameters?: MeshNormalMaterialParameters);
+	constructor(parameters?: MeshNormalMaterialParameters);
 
-  wireframe: boolean;
-  wireframeLinewidth: number;
-  morphTargets: boolean;
+	bumpMap: Texture | null;
+	bumpScale: number;
+	normalMap: Texture | null;
+	normalMapType: NormalMapTypes;
+	normalScale: Vector2;
+	displacementMap: Texture | null;
+	displacementScale: number;
+	displacementBias: number;
+	wireframe: boolean;
+	wireframeLinewidth: number;
+	skinning: boolean;
+	morphTargets: boolean;
+	morphNormals: boolean;
 
-  setValues(parameters: MeshNormalMaterialParameters): void;
+	setValues(parameters: MeshNormalMaterialParameters): void;
 }

--- a/src/materials/MeshPhongMaterial.d.ts
+++ b/src/materials/MeshPhongMaterial.d.ts
@@ -2,7 +2,7 @@ import { Color } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
-import { Combine } from '../constants';
+import { Combine, NormalMapTypes } from '../constants';
 
 export interface MeshPhongMaterialParameters extends MaterialParameters {
   /** geometry color in hexadecimal. Default is 0xffffff. */
@@ -21,6 +21,7 @@ export interface MeshPhongMaterialParameters extends MaterialParameters {
   bumpMap?: Texture;
   bumpScale?: number;
   normalMap?: Texture;
+  normalMapType?: NormalMapTypes;
   normalScale?: Vector2;
   displacementMap?: Texture;
   displacementScale?: number;
@@ -57,6 +58,7 @@ export class MeshPhongMaterial extends Material {
   bumpMap: Texture | null;
   bumpScale: number;
   normalMap: Texture | null;
+  normalMapType: NormalMapTypes;
   normalScale: Vector2;
   displacementMap: Texture | null;
   displacementScale: number;

--- a/src/materials/MeshStandardMaterial.d.ts
+++ b/src/materials/MeshStandardMaterial.d.ts
@@ -2,6 +2,7 @@ import { Color } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
+import { NormalMapTypes } from '../constants';
 
 export interface MeshStandardMaterialParameters extends MaterialParameters {
   color?: Color | string | number;
@@ -18,6 +19,7 @@ export interface MeshStandardMaterialParameters extends MaterialParameters {
   bumpMap?: Texture;
   bumpScale?: number;
   normalMap?: Texture;
+  normalMapType?: NormalMapTypes;
   normalScale?: Vector2;
   displacementMap?: Texture;
   displacementScale?: number;
@@ -53,6 +55,7 @@ export class MeshStandardMaterial extends Material {
   bumpMap: Texture | null;
   bumpScale: number;
   normalMap: Texture | null;
+  normalMapType: NormalMapTypes;
   normalScale: number;
   displacementMap: Texture | null;
   displacementScale: number;


### PR DESCRIPTION
Also added many missing properties to `MeshNormalMaterial.d.ts`.

Friendly review request: @Methuselah96 😊 