### PR TITLE
Fix MMDPhysics _updateBonePosition()

### DIFF
--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -994,14 +994,8 @@ THREE.MMDPhysics = ( function () {
 		_getWorldTransformForBone: function () {
 
 			var manager = this.manager;
-
-			var tr = manager.allocTransform();
-			this.body.getMotionState().getWorldTransform( tr );
-			var tr2 = manager.multiplyTransforms( tr, this.boneOffsetFormInverse );
-
-			manager.freeTransform( tr );
-
-			return tr2;
+			var tr = this.body.getCenterOfMassTransform();
+			return manager.multiplyTransforms( tr, this.boneOffsetFormInverse );
 
 		},
 
@@ -1072,19 +1066,24 @@ THREE.MMDPhysics = ( function () {
 
 			var manager = this.manager;
 
-			var tr = this.body.getCenterOfMassTransform();
-			var origin = tr.getOrigin();
-			
-			var matrixInv = manager.allocThreeMatrix4();
-			matrixInv.copy( this.bone.parent.matrixWorld ).getInverse( matrixInv );
-			
-			var pos = manager.allocThreeVector3();
-			pos.set( origin.x(), origin.y(), origin.z() ).applyMatrix4( matrixInv );
+			var tr = this._getWorldTransformForBone();
 
-			this.bone.position.copy( pos );
+			var thV = manager.allocThreeVector3();
 
-			manager.freeThreeVector3( pos );
-			manager.freeThreeMatrix4( matrixInv );
+			var o = manager.getOrigin( tr );
+			thV.set( o.x(), o.y(), o.z() );
+
+			if ( this.bone.parent ) {
+
+				this.bone.parent.worldToLocal( thV );
+
+			}
+
+			this.bone.position.copy( thV );
+
+			manager.freeThreeVector3( thV );
+
+			manager.freeTransform( tr );
 
 		}
 


### PR DESCRIPTION
#15368 has lost `.boneOffsetFormInverse` to update bone position from rigid body. This PR fixes it.