### PR TITLE
MMDLoader: NearestFilter magFilter and minFilter for gradientMap

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1359,6 +1359,9 @@ THREE.MMDLoader = ( function () {
 
 					t.image = scope._getRotatedImage( t.image );
 
+					t.magFilter = THREE.NearestFilter;
+					t.minFilter = THREE.NearestFilter;
+
 				}
 
 				t.flipY = false;


### PR DESCRIPTION
I think `gradientMap.mag/minFilter` for MMD should be `NearestFilter` not to pick up intermediate color.