### PR TITLE
Add Back Face Culling Extension Support to LDrawLoader

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -475,7 +475,15 @@ THREE.LDrawLoader = ( function () {
 					subobject.url = subobjectURL;
 
 					// Load the subobject
-					subobjectLoad( subobjectURL, onSubobjectLoaded, undefined, onSubobjectError, subobject );
+					// Use another file loader here so we can keep track of the subobject information
+					// and use it when processing the next model.
+					var fileLoader = new THREE.FileLoader( scope.manager );
+					fileLoader.setPath( scope.path );
+					fileLoader.load( subobjectURL, function ( text ) {
+
+						processObject( text, onSubobjectLoaded, subobject );
+
+					}, undefined, onSubobjectError );
 
 				}
 
@@ -1162,6 +1170,7 @@ THREE.LDrawLoader = ( function () {
 
 								case 'BFC':
 
+									// Changes to the backface culling state
 									while ( ! lp.isAtTheEnd() ) {
 
 										var token = lp.getToken();
@@ -1265,6 +1274,8 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
+						// If the scale of the object is negated then the triangle winding order
+						// needs to be flipped.
 						if ( scope.separateObjects === false && matrix.determinant() < 0 ) {
 
 							bfcInverted = ! bfcInverted;

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1164,13 +1164,14 @@ THREE.LDrawLoader = ( function () {
 									while ( ! lp.isAtTheEnd() ) {
 
 										var token = lp.getToken();
-										bfcCCW = true;
+
 										switch ( token ) {
 
 											case 'CERTIFY':
 											case 'NOCERTIFY':
 
 												bfcEnabled = token === 'CERTIFY';
+												bfcCCW = true;
 
 												break;
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1265,7 +1265,7 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
-						if ( matrix.determinant() < 0 ) {
+						if ( scope.separateObjects === false && matrix.determinant() < 0 ) {
 
 							bfcInverted = ! bfcInverted;
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1305,7 +1305,7 @@ THREE.LDrawLoader = ( function () {
 						var material = parseColourCode( lp );
 
 						var inverted = currentParseScope.inverted;
-						var ccw = ! bfcEnabled || bfcEnabled && bfcCCW && ! inverted;
+						var ccw = ! bfcEnabled || ( bfcCCW !== inverted );
 						var v0, v1, v2;
 
 						if ( ccw === true ) {
@@ -1338,7 +1338,7 @@ THREE.LDrawLoader = ( function () {
 						var material = parseColourCode( lp );
 
 						var inverted = currentParseScope.inverted;
-						var ccw = ! bfcEnabled || bfcEnabled && bfcCCW && ! inverted;
+						var ccw = ! bfcEnabled || ( bfcCCW !== inverted );
 						var v0, v1, v2, v3;
 
 						if ( ccw === true ) {

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1046,9 +1046,10 @@ THREE.LDrawLoader = ( function () {
 
 			}
 
-			var bfcEnabled = false;
+			var bfcCertified = false;
 			var bfcCCW = true;
 			var bfcInverted = false;
+			var bfcCull = true;
 
 			// Parse all line commands
 			for ( lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
@@ -1152,7 +1153,7 @@ THREE.LDrawLoader = ( function () {
 										currentEmbeddedFileName = lp.getRemainingString();
 										currentEmbeddedText = '';
 
-										bfcEnabled = false;
+										bfcCertified = false;
 										bfcCCW = true;
 
 									}
@@ -1170,7 +1171,7 @@ THREE.LDrawLoader = ( function () {
 											case 'CERTIFY':
 											case 'NOCERTIFY':
 
-												bfcEnabled = token === 'CERTIFY';
+												bfcCertified = token === 'CERTIFY';
 												bfcCCW = true;
 
 												break;
@@ -1191,7 +1192,7 @@ THREE.LDrawLoader = ( function () {
 											case 'CLIP':
 											case 'NOCLIP':
 
-												console.warn( 'THREE.LDrawLoader: BFC CLIP and NOCLIP directives ignored.' );
+											  bfcCull = token === 'CLIP';
 
 												break;
 
@@ -1305,7 +1306,8 @@ THREE.LDrawLoader = ( function () {
 						var material = parseColourCode( lp );
 
 						var inverted = currentParseScope.inverted;
-						var ccw = ! bfcEnabled || ( bfcCCW !== inverted );
+						var ccw = bfcCCW !== inverted;
+						var doubleSided = ! bfcCertified || ! bfcCull;
 						var v0, v1, v2;
 
 						if ( ccw === true ) {
@@ -1330,6 +1332,18 @@ THREE.LDrawLoader = ( function () {
 							v2: v2
 						} );
 
+						if ( doubleSided === true ) {
+
+							triangles.push( {
+								material: material,
+								colourCode: material.userData.code,
+								v0: v0,
+								v1: v2,
+								v2: v1
+							} );
+
+						}
+
 						break;
 
 					// Line type 4: Quadrilateral
@@ -1338,7 +1352,8 @@ THREE.LDrawLoader = ( function () {
 						var material = parseColourCode( lp );
 
 						var inverted = currentParseScope.inverted;
-						var ccw = ! bfcEnabled || ( bfcCCW !== inverted );
+						var ccw = bfcCCW !== inverted;
+						var doubleSided = ! bfcCertified || ! bfcCull;
 						var v0, v1, v2, v3;
 
 						if ( ccw === true ) {
@@ -1372,6 +1387,26 @@ THREE.LDrawLoader = ( function () {
 							v1: v2,
 							v2: v3
 						} );
+
+						if ( doubleSided === true ) {
+
+							triangles.push( {
+								material: material,
+								colourCode: material.userData.code,
+								v0: v0,
+								v1: v2,
+								v2: v1
+							} );
+
+							triangles.push( {
+								material: material,
+								colourCode: material.userData.code,
+								v0: v0,
+								v1: v3,
+								v2: v2
+							} );
+
+						}
 
 						break;
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1263,6 +1263,12 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
+						if ( matrix.determinant() < 0 ) {
+
+							bfcInverted = ! bfcInverted;
+
+						}
+
 						subobjects.push( {
 							material: material,
 							matrix: matrix,

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -97,7 +97,7 @@
 
 				//
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -108,7 +108,8 @@
 
 				guiData = {
 					modelFileName: modelFileList[ 'Car' ],
-					envMapActivated: false
+					envMapActivated: false,
+					separateObjects: false
 				};
 
 				gui = new dat.GUI();
@@ -122,6 +123,12 @@
 				gui.add( guiData, 'envMapActivated' ).name( 'Env. map' ).onChange( function ( value ) {
 
 					envMapActivated = value;
+
+					reloadObject( false );
+
+				} );
+
+				gui.add( guiData, 'separateObjects' ).name( 'Separate Objects' ).onChange( function ( value ) {
 
 					reloadObject( false );
 
@@ -160,6 +167,7 @@
 				showProgressBar();
 
 				var lDrawLoader = new THREE.LDrawLoader();
+				lDrawLoader.separateObjects = guiData.separateObjects;
 				lDrawLoader
 					.setPath( ldrawPath )
 					.load( guiData.modelFileName, function ( group2 ) {


### PR DESCRIPTION
This PR adds back face culling directive support to the `LDrawLoader`. The behavior of the extension is described in detail here: https://www.ldraw.org/article/415.

To handle double-sided polygons the triangles are now added to the model twice (facing two directions) but it doesn't look like any of the models in the examples folder require that and I'm not sure how common this is in general.

I'm going to be looking into adding geometry smoothing and vertex merging in a subsequent PR.

PS I love that there's a Lego loader in the library. Awesome work!

@yomboprime @mrdoob 