### PR TITLE
Editor: Prevent error when double clicking Editor's camera

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -482,7 +482,11 @@ Editor.prototype = {
 
 	focus: function ( object ) {
 
-		this.signals.objectFocused.dispatch( object );
+		if ( object !== undefined ) {
+
+			this.signals.objectFocused.dispatch( object );
+
+		}
 
 	},
 


### PR DESCRIPTION
When an object in the `Outliner` is double clicked, the object's `uuid` is used to look for that object in the scene. Since the editor's camera is not part of the scene, `undefined` is returned. So, this check is necessary to prevent an error.