### PR TITLE
Add Azure Pipelines for CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,44 @@
+trigger:
+- master
+- dev
+
+jobs:
+  - job: Tests
+    displayName: Run tests
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-16.04'
+        mac:
+          imageName: 'macos-10.13'
+        windows:
+          imageName: 'vs2017-win2016'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 10
+        displayName: Use Node
+
+      - script: npm install
+        displayName: Install Dependencies
+
+      - script: npm test
+        displayName: Run Tests
+
+  - job: Lint_Linux
+    displayName: Run Linter on Linux
+    pool:
+      vmImage: "Ubuntu 16.04"
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 10
+        displayName: Use Node
+
+      - script: npm install
+        displayName: Install Dependencies
+
+      - script: npm run lint
+        displayName: Run Linter


### PR DESCRIPTION
**The Change**

This PR adds Azure Pipelines to perform CI builds and PR builds. Pipelines offers several key advantages:

1) Single definition for all platforms (Linux/Windows/Mac) reduces the amount of time spent maintaining CI. In addition, while this project is currently only building on Linux, adding Mac/Windows builds can help avoid OS-specific bugs (e.g. #15383)
2) Free parallelism - Pipelines offers 10 free concurrent jobs and unlimited build minutes for all OSS projects. This means low queue time and fast time to completion even as we add additional jobs.

**Disclaimer**

Full disclosure, I'm an engineer on the Pipelines team, but I also think Pipelines provides some pretty significant advantages here.

**Additional Info**

You can see that this works in [my pipeline](https://dev.azure.com/threejs/threejs/_build?definitionId=3).

![image](https://user-images.githubusercontent.com/42773683/55825465-0da51500-5ad4-11e9-9607-443433fe5099.png)