### PR TITLE
Geometry/BufferGeometry: allow return of offset value

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -220,7 +220,7 @@
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>
-		<p>Center the geometry based on the bounding box.</p>
+		<p>Center the geometry based on the bounding box. Returns the offset vector.</p>
 
 		<h3>[method:BufferGeometry clone]()</h3>
 		<p>Creates a clone of this BufferGeometry.</p>

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -220,7 +220,7 @@
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>
-		<p>Center the geometry based on the bounding box. Returns the offset vector.</p>
+		<p>Center the geometry based on the bounding box. An optional [page:Vector3] argument returns the offset vector.</p>
 
 		<h3>[method:BufferGeometry clone]()</h3>
 		<p>Creates a clone of this BufferGeometry.</p>

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -214,7 +214,7 @@
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:Geometry center] ()</h3>
-		<p>Center the geometry based on the bounding box. Returns the offset vector.</p>
+		<p>Center the geometry based on the bounding box. An optional [page:Vector3] argument returns the offset vector.</p>
 
 		<h3>[method:Geometry clone]()</h3>
 		<p>

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -214,7 +214,7 @@
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:Geometry center] ()</h3>
-		<p>Center the geometry based on the bounding box.</p>
+		<p>Center the geometry based on the bounding box. Returns the offset vector.</p>
 
 		<h3>[method:Geometry clone]()</h3>
 		<p>

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -300,7 +300,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			this.translate( offset.x, offset.y, offset.z );
 
-			return this;
+			return offset;
 
 		};
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -288,7 +288,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	}(),
 
-	center: function () {
+	center: function ( target ) {
 
 		var offset = new Vector3();
 
@@ -299,8 +299,10 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 			this.boundingBox.getCenter( offset ).negate();
 
 			this.translate( offset.x, offset.y, offset.z );
+			
+			if ( target !== undefined ) target.copy( offset );
 
-			return offset;
+			return this;
 
 		};
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -299,7 +299,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 			this.boundingBox.getCenter( offset ).negate();
 
 			this.translate( offset.x, offset.y, offset.z );
-			
+
 			if ( target !== undefined ) target.copy( offset );
 
 			return this;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -346,7 +346,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	center: function () {
+	center: function ( target ) {
 
 		var offset = new Vector3();
 
@@ -357,6 +357,8 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			this.boundingBox.getCenter( offset ).negate();
 
 			this.translate( offset.x, offset.y, offset.z );
+			
+			if ( target !== undefined ) target.copy( offset );
 
 			return offset;
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -358,7 +358,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			this.translate( offset.x, offset.y, offset.z );
 
-			return this;
+			return offset;
 
 		};
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -360,7 +360,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			
 			if ( target !== undefined ) target.copy( offset );
 
-			return offset;
+			return this;
 
 		};
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -357,7 +357,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			this.boundingBox.getCenter( offset ).negate();
 
 			this.translate( offset.x, offset.y, offset.z );
-			
+
 			if ( target !== undefined ) target.copy( offset );
 
 			return this;


### PR DESCRIPTION
Here's a use case for returning the offset vector: mathematical software like SageMath creates sets of vertices for an object at their location in world space. If this data is used to create a geometry and added to a mesh, everything is fine for opaque objects. Allowing transparency creates immediate problems with multiple objects because all of the meshes are located at the origin. The solution is to center the geometry in its own frame and move the mesh to the negative of the offset vector. Having that return value available in one step is extremely useful.

Yes I know I can duplicate the code in the `center()` function and achieve the same result, but that is inefficient. Since one already has a reference to the geometry in order to center it, what is the harm in returning the offset vector rather than `this`? Why throw away information that is useful?