### PR TITLE
Method chainable LOD.addLevel

### DIFF
--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -72,7 +72,7 @@ scene.add( lod );
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null addLevel]( [param:Object3D object], [param:Float distance] )</h3>
+		<h3>[method:LOD addLevel]( [param:Object3D object], [param:Float distance] )</h3>
 		<p>
 		[page:Object3D object] - The [page:Object3D] to display at this level.<br />
 		[page:Float distance] - The distance at which to display this level of detail.<br /><br />

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -72,7 +72,7 @@ scene.add( lod );
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:LOD addLevel]( [param:Object3D object], [param:Float distance] )</h3>
+		<h3>[method:this addLevel]( [param:Object3D object], [param:Float distance] )</h3>
 		<p>
 		[page:Object3D object] - The [page:Object3D] to display at this level.<br />
 		[page:Float distance] - The distance at which to display this level of detail.<br /><br />

--- a/docs/api/zh/objects/LOD.html
+++ b/docs/api/zh/objects/LOD.html
@@ -69,7 +69,7 @@ scene.add( lod );
 		<h2>方法</h2>
 		<p>请参阅其基类[page:Object3D]来查看共有方法。</p>
 
-		<h3>[method:LOD addLevel]( [param:Object3D object], [param:Float distance] )</h3>
+		<h3>[method:this addLevel]( [param:Object3D object], [param:Float distance] )</h3>
 		<p>
 		[page:Object3D object] —— 在这个层次中将要显示的[page:Object3D]。<br />
 		[page:Float distance] —— 将显示这一细节层次的距离。<br /><br />

--- a/docs/api/zh/objects/LOD.html
+++ b/docs/api/zh/objects/LOD.html
@@ -69,7 +69,7 @@ scene.add( lod );
 		<h2>方法</h2>
 		<p>请参阅其基类[page:Object3D]来查看共有方法。</p>
 
-		<h3>[method:null addLevel]( [param:Object3D object], [param:Float distance] )</h3>
+		<h3>[method:LOD addLevel]( [param:Object3D object], [param:Float distance] )</h3>
 		<p>
 		[page:Object3D object] —— 在这个层次中将要显示的[page:Object3D]。<br />
 		[page:Float distance] —— 将显示这一细节层次的距离。<br /><br />

--- a/src/objects/LOD.d.ts
+++ b/src/objects/LOD.d.ts
@@ -10,7 +10,7 @@ export class LOD extends Object3D {
 
   levels: { distance: number; object: Object3D }[];
 
-  addLevel(object: Object3D, distance?: number): void;
+  addLevel(object: Object3D, distance?: number): LOD;
   getObjectForDistance(distance: number): Object3D;
   raycast(raycaster: Raycaster, intersects: Intersection[]): void;
   update(camera: Camera): void;

--- a/src/objects/LOD.d.ts
+++ b/src/objects/LOD.d.ts
@@ -10,7 +10,7 @@ export class LOD extends Object3D {
 
   levels: { distance: number; object: Object3D }[];
 
-  addLevel(object: Object3D, distance?: number): LOD;
+  addLevel(object: Object3D, distance?: number): this;
   getObjectForDistance(distance: number): Object3D;
   raycast(raycaster: Raycaster, intersects: Intersection[]): void;
   update(camera: Camera): void;

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -66,7 +66,7 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		levels.splice( l, 0, { distance: distance, object: object } );
 
-		this.add( object );
+		return this.add( object );
 
 	},
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -66,7 +66,9 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		levels.splice( l, 0, { distance: distance, object: object } );
 
-		return this.add( object );
+		this.add( object );
+
+		return this;
 
 	},
 


### PR DESCRIPTION
This PR enables `LOD.addLevel()` method chaining by returning `this` from the method.

```javascript
lod.addLevel( mesh0, 0 ).addLevel( mesh1, 0.4 );
```
