### PR TITLE
Make Box3.expandByObject use geometry.boundingBox

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -220,9 +220,9 @@ Object.assign( Box3.prototype, {
 		// Computes the world-axis-aligned bounding box of an object (including its children),
 		// accounting for both the object's, and children's, world transforms
 
-		var scope, i, l;
+		var scope;
 
-		var v1 = new Vector3();
+		var bounds = new Box3();
 
 		function traverse( node ) {
 
@@ -230,36 +230,13 @@ Object.assign( Box3.prototype, {
 
 			if ( geometry !== undefined ) {
 
-				if ( geometry.isGeometry ) {
+				if ( geometry.boundingBox == null ) {
 
-					var vertices = geometry.vertices;
-
-					for ( i = 0, l = vertices.length; i < l; i ++ ) {
-
-						v1.copy( vertices[ i ] );
-						v1.applyMatrix4( node.matrixWorld );
-
-						scope.expandByPoint( v1 );
-
-					}
-
-				} else if ( geometry.isBufferGeometry ) {
-
-					var attribute = geometry.attributes.position;
-
-					if ( attribute !== undefined ) {
-
-						for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-							v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-
-							scope.expandByPoint( v1 );
-
-						}
-
-					}
+					geometry.computeBoundingBox();
 
 				}
+
+				scope.union( bounds.copy( geometry.boundingBox ).applyMatrix4( node.matrixWorld ) );
 
 			}
 


### PR DESCRIPTION
This seems preferable to the existing implementation for three reasons:

1. It reuses the geometry's vertex iteration code, so it's more concise and doesn't need to distinguish between varieties of geometry representations.
2. It is polite to re-use (or populate if not present) the geometry's cached bounding box, rather than recomputing it every time.
3. It should be much more efficient to compute each child bounding box in local space and only thereafter apply the object's transform to the maximum and minimum of the child box and expand the root's bounds, rather than to apply the object's transform to each vertex on the child geometry and expand the root's bounds one vertex at a time.