### PR TITLE
Examples: parallax envmaps fix 

### DIFF
--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -79,8 +79,8 @@
 					vec3 parallaxCorrectNormal( vec3 v, vec3 cubeSize, vec3 cubePos ) {
 
 						vec3 nDir = normalize( v );
-						vec3 rbmax = (   .5 * ( cubeSize - cubePos ) - vWorldPosition ) / nDir;
-						vec3 rbmin = ( - .5 * ( cubeSize - cubePos ) - vWorldPosition ) / nDir;
+						vec3 rbmax = ( .5 * cubeSize + cubePos - vWorldPosition ) / nDir;
+						vec3 rbmin = ( -.5 * cubeSize + cubePos - vWorldPosition ) / nDir;
 
 						vec3 rbminmax;
 						rbminmax.x = ( nDir.x > 0. ) ? rbmax.x : rbmin.x;
@@ -356,7 +356,8 @@
 
 				boxProjectedMat.onBeforeCompile = function ( shader ) {
 
-					shader.uniforms.cubeMapSize = { value: new THREE.Vector3( 200, 100, 100 ) };
+					//these parameters are wrt the cubeCamera texture
+					shader.uniforms.cubeMapSize = { value: new THREE.Vector3( 200, 200, 100 ) };
 					shader.uniforms.cubeMapPos = { value: new THREE.Vector3( 0, - 50, 0 ) };
 					shader.uniforms.flipEnvMap.value = true;
 

--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -356,7 +356,7 @@
 
 				boxProjectedMat.onBeforeCompile = function ( shader ) {
 
-					//these parameters are with respect to the cubeCamera texture
+					//these parameters are for the cubeCamera texture
 					shader.uniforms.cubeMapSize = { value: new THREE.Vector3( 200, 200, 100 ) };
 					shader.uniforms.cubeMapPos = { value: new THREE.Vector3( 0, - 50, 0 ) };
 					shader.uniforms.flipEnvMap.value = true;

--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -356,7 +356,7 @@
 
 				boxProjectedMat.onBeforeCompile = function ( shader ) {
 
-					//these parameters are wrt the cubeCamera texture
+					//these parameters are with respect to the cubeCamera texture
 					shader.uniforms.cubeMapSize = { value: new THREE.Vector3( 200, 200, 100 ) };
 					shader.uniforms.cubeMapPos = { value: new THREE.Vector3( 0, - 50, 0 ) };
 					shader.uniforms.flipEnvMap.value = true;


### PR DESCRIPTION
I had made a PR for the [BPCEM example](https://threejs.org/examples/?q=paralla#webgl_materials_envmaps_parallax) a few months ago, and recently found a bug. Turns out the shader code I had referenced from [this page](https://www.clicktorelease.com/blog/making-of-cruciform/) only works when the cube map is centered at the origin. 

I have fixed this issue by correctly calculating the min/max of the cube map in this PR, and it now works with any arbitrary cube map position. 


