### PR TITLE
Deprecate BufferGeometry.index/attributes direct access.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -539,9 +539,13 @@ THREE.GLTFLoader = ( function () {
 
 				dracoLoader.decodeDracoFile( bufferView, function ( geometry ) {
 
-					for ( var attributeName in geometry.attributes ) {
+					var attributeNames = geometry.getAttributeNames();
 
-						var attribute = geometry.attributes[ attributeName ];
+					for ( var i = 0, il = attributeNames.length; i < il; i ++ ) {
+
+						var attributeName = attributeNames[ i ];
+
+						var attribute = geometry.getAttribute( attributeName );
 						var normalized = attributeNormalizedMap[ attributeName ];
 
 						if ( normalized !== undefined ) attribute.normalized = normalized;
@@ -1348,7 +1352,7 @@ THREE.GLTFLoader = ( function () {
 
 				var pendingAccessor = target.POSITION !== undefined
 					? parser.getDependency( 'accessor', target.POSITION )
-					: geometry.attributes.position;
+					: geometry.getAttribute( 'position' );
 
 				pendingPositionAccessors.push( pendingAccessor );
 
@@ -1358,7 +1362,7 @@ THREE.GLTFLoader = ( function () {
 
 				var pendingAccessor = target.NORMAL !== undefined
 					? parser.getDependency( 'accessor', target.NORMAL )
-					: geometry.attributes.normal;
+					: geometry.getAttribute( 'normal' );
 
 				pendingNormalAccessors.push( pendingAccessor );
 
@@ -1378,7 +1382,7 @@ THREE.GLTFLoader = ( function () {
 
 			for ( var i = 0, il = morphPositions.length; i < il; i ++ ) {
 
-				if ( geometry.attributes.position === morphPositions[ i ] ) continue;
+				if ( geometry.getAttribute( 'position' ) === morphPositions[ i ] ) continue;
 
 				morphPositions[ i ] = cloneBufferAttribute( morphPositions[ i ] );
 
@@ -1386,7 +1390,7 @@ THREE.GLTFLoader = ( function () {
 
 			for ( var i = 0, il = morphNormals.length; i < il; i ++ ) {
 
-				if ( geometry.attributes.normal === morphNormals[ i ] ) continue;
+				if ( geometry.getAttribute( 'normal' ) === morphNormals[ i ] ) continue;
 
 				morphNormals[ i ] = cloneBufferAttribute( morphNormals[ i ] );
 
@@ -1416,7 +1420,7 @@ THREE.GLTFLoader = ( function () {
 						var positionAttribute = morphPositions[ i ];
 						positionAttribute.name = attributeName;
 
-						var position = geometry.attributes.position;
+						var position = geometry.getAttribute( 'position' );
 
 						for ( var j = 0, jl = positionAttribute.count; j < jl; j ++ ) {
 
@@ -1442,7 +1446,7 @@ THREE.GLTFLoader = ( function () {
 						var normalAttribute = morphNormals[ i ];
 						normalAttribute.name = attributeName;
 
-						var normal = geometry.attributes.normal;
+						var normal = geometry.getAttribute( 'normal' );
 
 						for ( var j = 0, jl = normalAttribute.count; j < jl; j ++ ) {
 
@@ -2165,9 +2169,9 @@ THREE.GLTFLoader = ( function () {
 		var material = mesh.material;
 		var extensions = this.extensions;
 
-		var useVertexTangents = geometry.attributes.tangent !== undefined;
-		var useVertexColors = geometry.attributes.color !== undefined;
-		var useFlatShading = geometry.attributes.normal === undefined;
+		var useVertexTangents = geometry.getAttribute( 'tangent' ) !== undefined;
+		var useVertexColors = geometry.getAttribute( 'color' ) !== undefined;
+		var useFlatShading = geometry.getAttribute( 'normal' ) === undefined;
 		var useSkinning = mesh.isSkinnedMesh === true;
 		var useMorphTargets = Object.keys( geometry.morphAttributes ).length > 0;
 		var useMorphNormals = useMorphTargets && geometry.morphAttributes.normal !== undefined;
@@ -2251,10 +2255,10 @@ THREE.GLTFLoader = ( function () {
 
 		// workarounds for mesh and geometry
 
-		if ( material.aoMap && geometry.attributes.uv2 === undefined && geometry.attributes.uv !== undefined ) {
+		if ( material.aoMap && geometry.getAttribute( 'uv2' ) === undefined && geometry.getAttribute( 'uv' ) !== undefined ) {
 
 			console.log( 'THREE.GLTFLoader: Duplicating UVs to support aoMap.' );
-			geometry.addAttribute( 'uv2', new THREE.BufferAttribute( geometry.attributes.uv.array, 2 ) );
+			geometry.addAttribute( 'uv2', new THREE.BufferAttribute( geometry.getAttribute( 'uv' ).array, 2 ) );
 
 		}
 
@@ -2454,18 +2458,20 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
+		var geometryAttributeNames = geometry.getAttributeNames();
+
 		for ( var gltfAttributeName in attributes ) {
 
 			var threeAttributeName = ATTRIBUTES[ gltfAttributeName ] || gltfAttributeName.toLowerCase();
 
 			// Skip attributes already provided by e.g. Draco extension.
-			if ( threeAttributeName in geometry.attributes ) continue;
+			if ( geometryAttributeNames.indexOf( threeAttributeName ) >= 0 ) continue;
 
 			pending.push( assignAttributeAccessor( attributes[ gltfAttributeName ], threeAttributeName ) );
 
 		}
 
-		if ( primitiveDef.indices !== undefined && ! geometry.index ) {
+		if ( primitiveDef.indices !== undefined && ! geometry.getIndex() ) {
 
 			var accessor = parser.getDependency( 'accessor', primitiveDef.indices ).then( function ( accessor ) {
 

--- a/examples/webgl_buffergeometry_instancing_billboards.html
+++ b/examples/webgl_buffergeometry_instancing_billboards.html
@@ -143,8 +143,17 @@
 			var circleGeometry = new THREE.CircleBufferGeometry( 1, 6 );
 
 			geometry = new THREE.InstancedBufferGeometry();
-			geometry.index = circleGeometry.index;
-			geometry.attributes = circleGeometry.attributes;
+			geometry.setIndex( circleGeometry.getIndex() );
+
+			var attributeNames = circleGeometry.getAttributeNames();
+
+			for ( var i = 0, il = attributeNames.length; i < il; i ++ ) {
+
+				var attributeName = attributeNames[ i ];
+
+				geometry.addAttribute( attributeName, circleGeometry.getAttribute( attributeName ) );
+
+			}
 
 			var particleCount = 75000;
 

--- a/examples/webgl_buffergeometry_instancing_dynamic.html
+++ b/examples/webgl_buffergeometry_instancing_dynamic.html
@@ -138,9 +138,9 @@
 			// copying data from a simple box geometry, but you can specify a custom geometry if you want
 
 			var geometry = new THREE.InstancedBufferGeometry();
-			geometry.index = bufferGeometry.index;
-			geometry.attributes.position = bufferGeometry.attributes.position;
-			geometry.attributes.uv = bufferGeometry.attributes.uv;
+			geometry.setIndex( bufferGeometry.getIndex() );
+			geometry.addAttribute( 'position', bufferGeometry.getAttribute( 'position' ) );
+			geometry.addAttribute( 'uv', bufferGeometry.getAttribute( 'uv' ) );
 
 			// per instance data
 

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -251,7 +251,7 @@
 
 			}
 
-			geometry.index.needsUpdate = true;
+			geometry.getIndex().needsUpdate = true;
 
 		}
 
@@ -272,19 +272,19 @@
 			sphere.rotation.z = 0.02 * time;
 
 			var geometry = sphere.geometry;
-			var attributes = geometry.attributes;
+			var sizeAttribute = geometry.getAttribute( 'size' );
 
-			for ( var i = 0; i < attributes.size.array.length; i ++ ) {
+			for ( var i = 0, il = sizeAttribute.array.length; i < il; i ++ ) {
 
 				if ( i < length1 ) {
 
-					attributes.size.array[ i ] = 16 + 12 * Math.sin( 0.1 * i + time );
+					sizeAttribute.array[ i ] = 16 + 12 * Math.sin( 0.1 * i + time );
 
 				}
 
 			}
 
-			attributes.size.needsUpdate = true;
+			sizeAttribute.needsUpdate = true;
 
 			sortPoints();
 

--- a/examples/webgl_interactive_points.html
+++ b/examples/webgl_interactive_points.html
@@ -211,7 +211,7 @@
 				particles.rotation.y += 0.001;
 
 				var geometry = particles.geometry;
-				var attributes = geometry.attributes;
+				var sizeAttribute = geometry.getAttribute( 'size' );
 
 				raycaster.setFromCamera( mouse, camera );
 
@@ -221,19 +221,19 @@
 
 					if ( INTERSECTED != intersects[ 0 ].index ) {
 
-						attributes.size.array[ INTERSECTED ] = PARTICLE_SIZE;
+						sizeAttribute.array[ INTERSECTED ] = PARTICLE_SIZE;
 
 						INTERSECTED = intersects[ 0 ].index;
 
-						attributes.size.array[ INTERSECTED ] = PARTICLE_SIZE * 1.25;
-						attributes.size.needsUpdate = true;
+						sizeAttribute.array[ INTERSECTED ] = PARTICLE_SIZE * 1.25;
+						sizeAttribute.needsUpdate = true;
 
 					}
 
 				} else if ( INTERSECTED !== null ) {
 
-					attributes.size.array[ INTERSECTED ] = PARTICLE_SIZE;
-					attributes.size.needsUpdate = true;
+					sizeAttribute.array[ INTERSECTED ] = PARTICLE_SIZE;
+					sizeAttribute.needsUpdate = true;
 					INTERSECTED = null;
 
 				}

--- a/examples/webgl_loader_prwm.html
+++ b/examples/webgl_loader_prwm.html
@@ -164,9 +164,9 @@
 						mesh.scale.set( 50, 50, 50 );
 						scene.add( mesh );
 
-						console.log( geometry.index ? 'indexed geometry' : 'non-indexed geometry' );
-						console.log( '# of vertices: ' + geometry.attributes.position.count );
-						console.log( '# of polygons: ' + ( geometry.index ? geometry.index.count / 3 : geometry.attributes.position.count / 3 ) );
+						console.log( geometry.getIndex() ? 'indexed geometry' : 'non-indexed geometry' );
+						console.log( '# of vertices: ' + geometry.getAttribute( 'position' ).count );
+						console.log( '# of polygons: ' + ( geometry.getIndex() ? geometry.getIndex().count / 3 : geometry.getAttribute( 'position' ).count / 3 ) );
 						busy = false;
 
 					}, onProgress, onError );

--- a/examples/webgl_physics_volume.html
+++ b/examples/webgl_physics_volume.html
@@ -226,9 +226,9 @@
 
 				// Creates ammoVertices, ammoIndices and ammoIndexAssociation in bufGeometry
 
-				var vertices = bufGeometry.attributes.position.array;
-				var idxVertices = indexedBufferGeom.attributes.position.array;
-				var indices = indexedBufferGeom.index.array;
+				var vertices = bufGeometry.getAttribute( 'position' ).array;
+				var idxVertices = indexedBufferGeom.getAttribute( 'position' ).array;
+				var indices = indexedBufferGeom.getIndex().array;
 
 				var numIdxVertices = idxVertices.length / 3;
 				var numVertices = vertices.length / 3;
@@ -453,8 +453,8 @@
 					var volume = softBodies[ i ];
 					var geometry = volume.geometry;
 					var softBody = volume.userData.physicsBody;
-					var volumePositions = geometry.attributes.position.array;
-					var volumeNormals = geometry.attributes.normal.array;
+					var volumePositions = geometry.getAttribute( 'position' ).array;
+					var volumeNormals = geometry.getAttribute( 'normal' ).array;
 					var association = geometry.ammoIndexAssociation;
 					var numVerts = association.length;
 					var nodes = softBody.get_m_nodes();
@@ -488,8 +488,8 @@
 
 					}
 
-					geometry.attributes.position.needsUpdate = true;
-					geometry.attributes.normal.needsUpdate = true;
+					geometry.getAttribute( 'position' ).needsUpdate = true;
+					geometry.getAttribute( 'normal' ).needsUpdate = true;
 
 				}
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -217,8 +217,8 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		var scope = this;
 
-		var indices = geometry.index !== null ? geometry.index.array : undefined;
-		var attributes = geometry.attributes;
+		var indices = geometry._index !== null ? geometry._index.array : undefined;
+		var attributes = geometry._attributes;
 
 		var positions = attributes.position.array;
 		var normals = attributes.normal !== undefined ? attributes.normal.array : undefined;

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -140,7 +140,7 @@ function LatheBufferGeometry( points, segments, phiStart, phiLength ) {
 
 	if ( phiLength === Math.PI * 2 ) {
 
-		var normals = this.attributes.normal.array;
+		var normals = this._attributes.normal.array;
 		var n1 = new Vector3();
 		var n2 = new Vector3();
 		var n = new Vector3();

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -77,12 +77,12 @@ function WireframeGeometry( geometry ) {
 
 		vertex = new Vector3();
 
-		if ( geometry.index !== null ) {
+		if ( geometry._index !== null ) {
 
 			// indexed BufferGeometry
 
-			position = geometry.attributes.position;
-			indices = geometry.index;
+			position = geometry._attributes.position;
+			indices = geometry._index;
 			groups = geometry.groups;
 
 			if ( groups.length === 0 ) {
@@ -141,7 +141,7 @@ function WireframeGeometry( geometry ) {
 
 			// non-indexed BufferGeometry
 
-			position = geometry.attributes.position;
+			position = geometry._attributes.position;
 
 			for ( i = 0, l = ( position.count / 3 ); i < l; i ++ ) {
 

--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -72,7 +72,7 @@ BoxHelper.prototype.update = ( function () {
 		7: max.x, min.y, min.z
 		*/
 
-		var position = this.geometry.attributes.position;
+		var position = this.geometry._attributes.position;
 		var array = position.array;
 
 		array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;

--- a/src/helpers/FaceNormalsHelper.js
+++ b/src/helpers/FaceNormalsHelper.js
@@ -72,7 +72,7 @@ FaceNormalsHelper.prototype.update = ( function () {
 
 		var matrixWorld = this.object.matrixWorld;
 
-		var position = this.geometry.attributes.position;
+		var position = this.geometry._attributes.position;
 
 		//
 

--- a/src/helpers/PositionalAudioHelper.js
+++ b/src/helpers/PositionalAudioHelper.js
@@ -50,7 +50,7 @@ PositionalAudioHelper.prototype.update = function () {
 	var i, stride;
 
 	var geometry = this.geometry;
-	var positionAttribute = geometry.attributes.position;
+	var positionAttribute = geometry._attributes.position;
 
 	geometry.clearGroups();
 

--- a/src/helpers/VertexNormalsHelper.js
+++ b/src/helpers/VertexNormalsHelper.js
@@ -32,7 +32,7 @@ function VertexNormalsHelper( object, size, hex, linewidth ) {
 
 	} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 
-		nNormals = objGeometry.attributes.normal.count;
+		nNormals = objGeometry._attributes.normal.count;
 
 	}
 
@@ -73,7 +73,7 @@ VertexNormalsHelper.prototype.update = ( function () {
 
 		var matrixWorld = this.object.matrixWorld;
 
-		var position = this.geometry.attributes.position;
+		var position = this.geometry._attributes.position;
 
 		//
 
@@ -115,9 +115,9 @@ VertexNormalsHelper.prototype.update = ( function () {
 
 		} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 
-			var objPos = objGeometry.attributes.position;
+			var objPos = objGeometry._attributes.position;
 
-			var objNorm = objGeometry.attributes.normal;
+			var objNorm = objGeometry._attributes.normal;
 
 			var idx = 0;
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -245,7 +245,7 @@ Object.assign( Box3.prototype, {
 
 				} else if ( geometry.isBufferGeometry ) {
 
-					var attribute = geometry.attributes.position;
+					var attribute = geometry._attributes.position;
 
 					if ( attribute !== undefined ) {
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -47,9 +47,9 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 				// we assume non-indexed geometry
 
-				if ( geometry.index === null ) {
+				if ( geometry._index === null ) {
 
-					var positionAttribute = geometry.attributes.position;
+					var positionAttribute = geometry._attributes.position;
 					var lineDistances = [ 0 ];
 
 					for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
@@ -131,8 +131,8 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( geometry.isBufferGeometry ) {
 
-				var index = geometry.index;
-				var attributes = geometry.attributes;
+				var index = geometry._index;
+				var attributes = geometry._attributes;
 				var positions = attributes.position.array;
 
 				if ( index !== null ) {

--- a/src/objects/LineSegments.js
+++ b/src/objects/LineSegments.js
@@ -33,9 +33,9 @@ LineSegments.prototype = Object.assign( Object.create( Line.prototype ), {
 
 				// we assume non-indexed geometry
 
-				if ( geometry.index === null ) {
+				if ( geometry._index === null ) {
 
-					var positionAttribute = geometry.attributes.position;
+					var positionAttribute = geometry._attributes.position;
 					var lineDistances = [];
 
 					for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -265,10 +265,10 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			if ( geometry.isBufferGeometry ) {
 
 				var a, b, c;
-				var index = geometry.index;
-				var position = geometry.attributes.position;
+				var index = geometry._index;
+				var position = geometry._attributes.position;
 				var morphPosition = geometry.morphAttributes.position;
-				var uv = geometry.attributes.uv;
+				var uv = geometry._attributes.uv;
 				var groups = geometry.groups;
 				var drawRange = geometry.drawRange;
 				var i, j, il, jl;

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -90,8 +90,8 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( geometry.isBufferGeometry ) {
 
-				var index = geometry.index;
-				var attributes = geometry.attributes;
+				var index = geometry._index;
+				var attributes = geometry._attributes;
 				var positions = attributes.position.array;
 
 				if ( index !== null ) {

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -61,7 +61,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		var vector = new Vector4();
 
-		var skinWeight = this.geometry.attributes.skinWeight;
+		var skinWeight = this.geometry._attributes.skinWeight;
 
 		for ( var i = 0, l = skinWeight.count; i < l; i ++ ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -725,8 +725,8 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		var index = geometry.index;
-		var position = geometry.attributes.position;
+		var index = geometry._index;
+		var position = geometry._attributes.position;
 		var rangeFactor = 1;
 
 		if ( material.wireframe === true ) {
@@ -880,7 +880,7 @@ function WebGLRenderer( parameters ) {
 
 		state.initAttributes();
 
-		var geometryAttributes = geometry.attributes;
+		var geometryAttributes = geometry._attributes;
 
 		var programAttributes = program.getAttributes();
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -16,15 +16,15 @@ function WebGLGeometries( gl, attributes, info ) {
 		var geometry = event.target;
 		var buffergeometry = geometries[ geometry.id ];
 
-		if ( buffergeometry.index !== null ) {
+		if ( buffergeometry._index !== null ) {
 
-			attributes.remove( buffergeometry.index );
+			attributes.remove( buffergeometry._index );
 
 		}
 
-		for ( var name in buffergeometry.attributes ) {
+		for ( var name in buffergeometry._attributes ) {
 
-			attributes.remove( buffergeometry.attributes[ name ] );
+			attributes.remove( buffergeometry._attributes[ name ] );
 
 		}
 
@@ -81,8 +81,8 @@ function WebGLGeometries( gl, attributes, info ) {
 
 	function update( geometry ) {
 
-		var index = geometry.index;
-		var geometryAttributes = geometry.attributes;
+		var index = geometry._index;
+		var geometryAttributes = geometry._attributes;
 
 		if ( index !== null ) {
 
@@ -122,8 +122,8 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		var indices = [];
 
-		var geometryIndex = geometry.index;
-		var geometryAttributes = geometry.attributes;
+		var geometryIndex = geometry._index;
+		var geometryAttributes = geometry._attributes;
 
 		// console.time( 'wireframe' );
 

--- a/test/unit/example/loaders/GLTFLoader.tests.js
+++ b/test/unit/example/loaders/GLTFLoader.tests.js
@@ -39,13 +39,13 @@ export default QUnit.module( 'Loaders', () => {
 				loader.parse( binary, './', function ( gltf ) {
 
 					var meshOut = gltf.scene.children[ 0 ];
-					var attrsIn = meshIn.geometry.attributes;
-					var attrsOut = meshOut.geometry.attributes;
+					var geometryIn = meshIn.geometry;
+					var geometryOut = meshOut.geometry;
 
 					assert.equal( meshIn.name, meshOut.name, 'loads names' );
 					assert.equal( meshIn.material.color.getHex(), meshOut.material.color.getHex(), 'loads color' );
-					assert.smartEqual( attrsIn.position.array, attrsOut.position.array, 'loads positions' );
-					assert.equal( undefined, attrsOut.normal, 'ignores missing attributes' );
+					assert.smartEqual( geometryIn.getAttribute( 'position' ).array, geometryOut.getAttribute( 'position' ).array, 'loads positions' );
+					assert.equal( undefined, geometryOut.getAttribute( 'normal' ), 'ignores missing attributes' );
 
 					done();
 

--- a/test/unit/example/utils/BufferGeometryUtils.tests.js
+++ b/test/unit/example/utils/BufferGeometryUtils.tests.js
@@ -55,8 +55,8 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
     var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
 
     assert.ok( mergedGeometry, 'merge succeeds' );
-    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
-    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
+    assert.smartEqual( Array.from( mergedGeometry.getAttribute( 'position' ).array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.equal( mergedGeometry.getAttribute( 'position' ).itemSize, 1, 'retains .itemSize' );
 
   } );
 
@@ -73,9 +73,9 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
     var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
 
     assert.ok( mergedGeometry, 'merge succeeds' );
-    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
-    assert.smartEqual( Array.from( mergedGeometry.index.array ), [ 0, 1, 2, 2, 1, 0, 3, 4, 5 ], 'merges indices' );
-    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
+    assert.smartEqual( Array.from( mergedGeometry.getAttribute( 'position' ).array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.smartEqual( Array.from( mergedGeometry.getIndex().array ), [ 0, 1, 2, 2, 1, 0, 3, 4, 5 ], 'merges indices' );
+    assert.equal( mergedGeometry.getAttribute( 'position' ).itemSize, 1, 'retains .itemSize' );
 
   } );
 
@@ -98,10 +98,10 @@ export default QUnit.module( 'BufferGeometryUtils', () => {
     var mergedGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries( [ geometry1, geometry2 ] );
 
     assert.ok( mergedGeometry, 'merge succeeds' );
-    assert.smartEqual( Array.from( mergedGeometry.attributes.position.array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
+    assert.smartEqual( Array.from( mergedGeometry.getAttribute( 'position' ).array ), [ 1, 2, 3, 4, 5, 6 ], 'merges elements' );
     assert.smartEqual( Array.from( mergedGeometry.morphAttributes.position[ 0 ].array ), [ 10, 20, 30, 40, 50, 60 ], 'merges morph targets' );
     assert.smartEqual( Array.from( mergedGeometry.morphAttributes.position[ 1 ].array ), [ 100, 200, 300, 400, 500, 600 ], 'merges morph targets' );
-    assert.equal( mergedGeometry.attributes.position.itemSize, 1, 'retains .itemSize' );
+    assert.equal( mergedGeometry.getAttribute( 'position' ).itemSize, 1, 'retains .itemSize' );
 
   } );
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -83,9 +83,9 @@ function getNormalsForVertices( vertices, assert ) {
 
 	geometry.computeVertexNormals();
 
-	assert.ok( geometry.attributes.normal !== undefined, "normal attribute was created" );
+	assert.ok( geometry.getAttribute( 'normal' ) !== undefined, "normal attribute was created" );
 
-	return geometry.attributes.normal.array;
+	return geometry.getAttribute( 'normal' ).array;
 
 }
 
@@ -175,15 +175,15 @@ export default QUnit.module( 'Core', () => {
 			var geometry = new BufferGeometry();
 			var attributeName = "position";
 
-			assert.ok( geometry.attributes[ attributeName ] === undefined, 'no attribute defined' );
+			assert.ok( geometry.getAttribute( attributeName ) === undefined, 'no attribute defined' );
 
 			geometry.addAttribute( attributeName, new BufferAttribute( new Float32Array( [ 1, 2, 3 ], 1 ) ) );
 
-			assert.ok( geometry.attributes[ attributeName ] !== undefined, 'attribute is defined' );
+			assert.ok( geometry.getAttribute( attributeName ) !== undefined, 'attribute is defined' );
 
 			geometry.removeAttribute( attributeName );
 
-			assert.ok( geometry.attributes[ attributeName ] === undefined, 'no attribute defined' );
+			assert.ok( geometry.getAttribute( attributeName ) === undefined, 'no attribute defined' );
 
 		} );
 
@@ -244,11 +244,11 @@ export default QUnit.module( 'Core', () => {
 			);
 			geometry.applyMatrix( matrix );
 
-			var position = geometry.attributes.position.array;
+			var position = geometry.getAttribute( 'position' ).array;
 			var m = matrix.elements;
 			assert.ok( position[ 0 ] === m[ 12 ] && position[ 1 ] === m[ 13 ] && position[ 2 ] === m[ 14 ], "position was extracted from matrix" );
 			assert.ok( position[ 3 ] === m[ 12 ] && position[ 4 ] === m[ 13 ] && position[ 5 ] === m[ 14 ], "position was extracted from matrix twice" );
-			assert.ok( geometry.attributes.position.version === 1, "version was increased during update" );
+			assert.ok( geometry.getAttribute( 'position' ).version === 1, "version was increased during update" );
 
 		} );
 
@@ -257,7 +257,7 @@ export default QUnit.module( 'Core', () => {
 			var geometry = new BufferGeometry();
 			geometry.addAttribute( "position", new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 ) );
 
-			var pos = geometry.attributes.position.array;
+			var pos = geometry.getAttribute( 'position' ).array;
 
 			geometry.rotateX( 180 * DegToRad );
 
@@ -284,7 +284,7 @@ export default QUnit.module( 'Core', () => {
 			var geometry = new BufferGeometry();
 			geometry.addAttribute( "position", new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 ) );
 
-			var pos = geometry.attributes.position.array;
+			var pos = geometry.getAttribute( 'position' ).array;
 
 			geometry.translate( 10, 20, 30 );
 
@@ -298,7 +298,7 @@ export default QUnit.module( 'Core', () => {
 			var geometry = new BufferGeometry();
 			geometry.addAttribute( "position", new BufferAttribute( new Float32Array( [ - 1, - 1, - 1, 2, 2, 2 ] ), 3 ) );
 
-			var pos = geometry.attributes.position.array;
+			var pos = geometry.getAttribute( 'position' ).array;
 
 			geometry.scale( 1, 2, 3 );
 
@@ -334,7 +334,7 @@ export default QUnit.module( 'Core', () => {
 
 			a.lookAt( new Vector3( 0, 1, - 1 ) );
 
-			assert.ok( bufferAttributeEquals( a.attributes.position.array, expected ), "Rotation is correct" );
+			assert.ok( bufferAttributeEquals( a.getAttribute( 'position' ).array, expected ), "Rotation is correct" );
 
 		} );
 
@@ -349,7 +349,7 @@ export default QUnit.module( 'Core', () => {
 
 			geometry.center();
 
-			var pos = geometry.attributes.position.array;
+			var pos = geometry.getAttribute( 'position' ).array;
 
 			// the boundingBox should go from (-1, -1, -1) to (4, 4, 4) so it has a size of (5, 5, 5)
 			// after centering it the vertices should be placed between (-2.5, -2.5, -2.5) and (2.5, 2.5, 2.5)
@@ -377,8 +377,8 @@ export default QUnit.module( 'Core', () => {
 			var line = new Line( lineGeo, null );
 			var geometry = new BufferGeometry().setFromObject( line );
 
-			var pos = geometry.attributes.position.array;
-			var col = geometry.attributes.color.array;
+			var pos = geometry.getAttribute( 'position' ).array;
+			var col = geometry.getAttribute( 'color' ).array;
 			var v = lineGeo.vertices;
 			var c = lineGeo.colors;
 
@@ -390,7 +390,7 @@ export default QUnit.module( 'Core', () => {
 				v.length * 3 === pos.length &&
 
 				// there are three complete vertices (each vertex contains three values)
-				geometry.attributes.position.count === 3 &&
+				geometry.getAttribute( 'position' ).count === 3 &&
 
 				// check if both arrays contains the same data
 				pos[ 0 ] === v[ 0 ].x && pos[ 1 ] === v[ 0 ].y && pos[ 2 ] === v[ 0 ].z &&
@@ -406,7 +406,7 @@ export default QUnit.module( 'Core', () => {
 				c.length * 3 === col.length &&
 
 				// there are three complete colors (each color contains three values)
-				geometry.attributes.color.count === 3 &&
+				geometry.getAttribute( 'color' ).count === 3 &&
 
 				// check if both arrays contains the same data
 				col[ 0 ] === c[ 0 ].r && col[ 1 ] === c[ 0 ].g && col[ 2 ] === c[ 0 ].b &&
@@ -439,20 +439,20 @@ export default QUnit.module( 'Core', () => {
 			assert.ok( geometry.boundingBox.equals( lineGeo.boundingBox ), "BoundingBox was set correctly" );
 			assert.ok( geometry.boundingSphere.equals( lineGeo.boundingSphere ), "BoundingSphere was set correctly" );
 
-			var pos = geometry.attributes.position.array;
-			var col = geometry.attributes.color.array;
+			var pos = geometry.getAttribute( 'position' ).array;
+			var col = geometry.getAttribute( 'color' ).array;
 			var v = lineGeo.vertices;
 			var c = lineGeo.colors;
 
 			// adapted from setFromObject QUnit.test (way up)
 			assert.notStrictEqual( pos, undefined, "Position attribute exists" );
 			assert.strictEqual( v.length * 3, pos.length, "Vertex arrays have the same size" );
-			assert.strictEqual( geometry.attributes.position.count, 3, "Correct number of vertices" );
+			assert.strictEqual( geometry.getAttribute( 'position' ).count, 3, "Correct number of vertices" );
 			assert.ok( comparePositions( pos, v ), "Positions are identical" );
 
 			assert.notStrictEqual( col, undefined, "Color attribute exists" );
 			assert.strictEqual( c.length * 3, col.length, "Color arrays have the same size" );
-			assert.strictEqual( geometry.attributes.color.count, 3, "Correct number of colors" );
+			assert.strictEqual( geometry.getAttribute( 'color' ).count, 3, "Correct number of colors" );
 			assert.ok( compareColors( col, c ), "Colors are identical" );
 
 			// setFromObject with a Mesh as object
@@ -461,12 +461,12 @@ export default QUnit.module( 'Core', () => {
 			var geometry = new BufferGeometry().setFromObject( lineMesh );
 
 			// no colors
-			var pos = geometry.attributes.position.array;
+			var pos = geometry.getAttribute( 'position' ).array;
 			var v = lineGeo.vertices;
 
 			assert.notStrictEqual( pos, undefined, "Mesh: position attribute exists" );
 			assert.strictEqual( v.length * 3, pos.length, "Mesh: vertex arrays have the same size" );
-			assert.strictEqual( geometry.attributes.position.count, 3, "Mesh: correct number of vertices" );
+			assert.strictEqual( geometry.getAttribute( 'position' ).count, 3, "Mesh: correct number of vertices" );
 			assert.ok( comparePositions( pos, v ), "Mesh: positions are identical" );
 
 		} );
@@ -512,10 +512,10 @@ export default QUnit.module( 'Core', () => {
 			geometry.updateFromObject( mesh ); // first call to create the underlying structure (DirectGeometry)
 			geometry.updateFromObject( mesh ); // second time to actually go thru the motions and update
 
-			var pos = geometry.attributes.position.array;
-			var col = geometry.attributes.color.array;
-			var norm = geometry.attributes.normal.array;
-			var uvs = geometry.attributes.uv.array;
+			var pos = geometry.getAttribute( 'position' ).array;
+			var col = geometry.getAttribute( 'color' ).array;
+			var norm = geometry.getAttribute( 'normal' ).array;
+			var uvs = geometry.getAttribute( 'uv' ).array;
 			var v = geo.vertices;
 			var c = geo.faces[ 0 ].vertexColors;
 			var n = geo.faces[ 0 ].vertexNormals;
@@ -523,22 +523,22 @@ export default QUnit.module( 'Core', () => {
 
 			assert.notStrictEqual( pos, undefined, "Position attribute exists" );
 			assert.strictEqual( v.length * 3, pos.length, "Both arrays have the same size" );
-			assert.strictEqual( geometry.attributes.position.count, v.length, "Correct number of vertices" );
+			assert.strictEqual( geometry.getAttribute( 'position' ).count, v.length, "Correct number of vertices" );
 			assert.ok( comparePositions( pos, v ), "Positions are identical" );
 
 			assert.notStrictEqual( col, undefined, "Color attribute exists" );
 			assert.strictEqual( c.length * 3, col.length, "Both arrays have the same size" );
-			assert.strictEqual( geometry.attributes.color.count, c.length, "Correct number of colors" );
+			assert.strictEqual( geometry.getAttribute( 'color' ).count, c.length, "Correct number of colors" );
 			assert.ok( compareColors( col, c ), "Colors are identical" );
 
 			assert.notStrictEqual( norm, undefined, "Normal attribute exists" );
 			assert.strictEqual( n.length * 3, norm.length, "Both arrays have the same size" );
-			assert.strictEqual( geometry.attributes.normal.count, n.length, "Correct number of normals" );
+			assert.strictEqual( geometry.getAttribute( 'normal' ).count, n.length, "Correct number of normals" );
 			assert.ok( comparePositions( norm, n ), "Normals are identical" );
 
 			assert.notStrictEqual( uvs, undefined, "UV attribute exists" );
 			assert.strictEqual( u.length * 2, uvs.length, "Both arrays have the same size" );
-			assert.strictEqual( geometry.attributes.uv.count, u.length, "Correct number of UV coordinates" );
+			assert.strictEqual( geometry.getAttribute( 'uv' ).count, u.length, "Correct number of UV coordinates" );
 			assert.ok( compareUvs( uvs, u ), "UVs are identical" );
 
 		} );
@@ -620,14 +620,12 @@ export default QUnit.module( 'Core', () => {
 				0.8, 0.1, 0.1, 0, 1, 0, 0, 0, 0.8, 0.2, 0, 0
 			] );
 
-			var attributes = bufferGeometry.attributes;
-
-			assert.deepEqual( attributes.position.array, vertices, "Vertices are as expected" );
-			assert.deepEqual( attributes.normal.array, normals, "Normals are as expected" );
-			assert.deepEqual( attributes.color.array, colors, "Colors are as expected" );
-			assert.deepEqual( attributes.uv.array, uvs, "Texture coordinates are as expected" );
-			assert.deepEqual( attributes.skinIndex.array, skinIndices, "Skin indices are as expected" );
-			assert.deepEqual( attributes.skinWeight.array, skindWeights, "Skin weights are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'position' ).array, vertices, "Vertices are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'normal' ).array, normals, "Normals are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'color' ).array, colors, "Colors are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'uv' ).array, uvs, "Texture coordinates are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'skinIndex' ).array, skinIndices, "Skin indices are as expected" );
+			assert.deepEqual( bufferGeometry.getAttribute( 'skinWeight' ).array, skindWeights, "Skin weights are as expected" );
 
 		} );
 
@@ -762,7 +760,7 @@ export default QUnit.module( 'Core', () => {
 			var geometry2 = new BufferGeometry();
 			geometry2.addAttribute( "attrName", new BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 3 ) );
 
-			var attr = geometry1.attributes.attrName.array;
+			var attr = geometry1.getAttribute( 'attrName' ).array;
 
 			geometry1.merge( geometry2, 1 );
 
@@ -890,7 +888,7 @@ export default QUnit.module( 'Core', () => {
 			assert.notEqual( a.id, b.id, "New object has a different GUID" );
 
 			assert.strictEqual(
-				Object.keys( a.attributes ).count, Object.keys( b.attributes ).count,
+				a.getAttributeNames().length, b.getAttributeNames().length,
 				"Both objects have the same amount of attributes"
 			);
 			assert.ok(
@@ -922,18 +920,22 @@ export default QUnit.module( 'Core', () => {
 
 			assert.ok( copy !== geometry && geometry.id !== copy.id, "new object was created" );
 
-			Object.keys( geometry.attributes ).forEach( function ( key ) {
+			var attributeNames = geometry.getAttributeNames();
 
-				var attribute = geometry.attributes[ key ];
+			for ( var i = 0, il = attributeNames.length; i < il; i ++ ) {
+
+				var key = attributeNames[ i ];
+
+				var attribute = geometry.getAttribute( key );
 				assert.ok( attribute !== undefined, "all attributes where copied" );
 
-				for ( var i = 0; i < attribute.array.length; i ++ ) {
+				for ( var j = 0; j < attribute.array.length; j ++ ) {
 
-					assert.ok( attribute.array[ i ] === copy.attributes[ key ].array[ i ], "values of the attribute are equal" );
+					assert.ok( attribute.array[ j ] === copy.getAttribute( key ).array[ j ], "values of the attribute are equal" );
 
 				}
 
-			} );
+			}
 
 		} );
 

--- a/test/unit/src/core/InstancedBufferGeometry.tests.js
+++ b/test/unit/src/core/InstancedBufferGeometry.tests.js
@@ -59,12 +59,12 @@ export default QUnit.module( 'Core', () => {
 
 			assert.ok( copiedInstance instanceof InstancedBufferGeometry, "the clone has the correct type" );
 
-			assert.equal( copiedInstance.index, indexMock, "index was copied" );
-			assert.equal( copiedInstance.index.callCount, 1, "index.clone was called once" );
+			assert.equal( copiedInstance.getIndex(), indexMock, "index was copied" );
+			assert.equal( copiedInstance.getIndex().callCount, 1, "index.clone was called once" );
 
-			assert.ok( copiedInstance.attributes[ 'defaultAttribute1' ] instanceof BufferAttribute, "attribute was created" );
-			assert.deepEqual( copiedInstance.attributes[ 'defaultAttribute1' ].array, defaultAttribute1.array, "attribute was copied" );
-			assert.deepEqual( copiedInstance.attributes[ 'defaultAttribute2' ].array, defaultAttribute2.array, "attribute was copied" );
+			assert.ok( copiedInstance.getAttribute( 'defaultAttribute1' ) instanceof BufferAttribute, "attribute was created" );
+			assert.deepEqual( copiedInstance.getAttribute( 'defaultAttribute1' ).array, defaultAttribute1.array, "attribute was copied" );
+			assert.deepEqual( copiedInstance.getAttribute( 'defaultAttribute2' ).array, defaultAttribute2.array, "attribute was copied" );
 
 			assert.equal( copiedInstance.groups[ 0 ].start, 0, "group was copied" );
 			assert.equal( copiedInstance.groups[ 0 ].count, 10, "group was copied" );

--- a/test/unit/src/geometries/EdgesGeometry.tests.js
+++ b/test/unit/src/geometries/EdgesGeometry.tests.js
@@ -100,7 +100,7 @@ function createIndexedBufferGeometry( vertList, idxList ) {
 
 function addDrawCalls( geometry ) {
 
-	var numTris = geometry.index.count / 3;
+	var numTris = geometry.getIndex().count / 3;
 
 	for ( var i = 0; i < numTris; i ++ ) {
 
@@ -129,7 +129,7 @@ function countEdges( geom ) {
 
 	}
 
-	var indices = geom.index;
+	var indices = geom.getIndex();
 	if ( indices ) {
 
 		return indices.count;


### PR DESCRIPTION
From #16132. To show how the change will look like and how big the change will be.

This PR includes `core`, `tests`, `examples/*.html`, `examples/js/loaders/GLTFLoader.js`. I'd like to make another PR for `examples/js/*.js` if we go with this change.

I added private (more precisely friend in C++) properties `._attributes` and `._index` to `BufferGeometry`. Core codes still can directly access them, not via getter for performance and less change.