### PR TITLE
LDrawLoader: Fix stack overflow exceptions

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -271,18 +271,6 @@ THREE.LDrawLoader = ( function () {
 
 			}, onProgress, onError );
 
-			function subobjectLoad( url, onLoad, onProgress, onError, subobject ) {
-
-				var fileLoader = new THREE.FileLoader( scope.manager );
-				fileLoader.setPath( scope.path );
-				fileLoader.load( url, function ( text ) {
-
-					processObject( text, onLoad, subobject );
-
-				}, onProgress, onError );
-
-			}
-
 			function processObject( text, onProcessed, subobject ) {
 
 				var parseScope = scope.newParseScopeLevel();

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -279,7 +279,13 @@ THREE.LDrawLoader = ( function () {
 				var parentParseScope = scope.getParentParseScope();
 
 				// Add to cache
-				var currentFileName = parentParseScope.currentFileName && parentParseScope.currentFileName.toLowerCase();
+				var currentFileName = parentParseScope.currentFileName;
+				if ( currentFileName !== null ) {
+
+					currentFileName = parentParseScope.currentFileName.toLowerCase();
+
+				}
+
 				if ( scope.subobjectCache[ currentFileName ] === undefined ) {
 
 					scope.subobjectCache[ currentFileName ] = text;

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -317,6 +317,12 @@ THREE.LDrawLoader = ( function () {
 
 					} else {
 
+						// Once the previous subobject has finished we can start processing the next one in the list.
+						// The subobject processing shares scope in processing so it's important that they be loaded serially
+						// to avoid race conditions.
+						// Promise.resolve is used as an approach to asynchronously schedule a task _before_ this frame ends to
+						// avoid stack overflow exceptions when loading many subobjects from the cache. RequestAnimationFrame
+						// will work but causes the load to happen after the next frame which causes the load to take significantly longer.
 						var subobject = parseScope.subobjects[ parseScope.subobjectIndex ];
 						Promise.resolve().then( function () {
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -291,7 +291,7 @@ THREE.LDrawLoader = ( function () {
 				var parentParseScope = scope.getParentParseScope();
 
 				// Add to cache
-				var currentFileName = parentParseScope.currentFileName;
+				var currentFileName = parentParseScope.currentFileName && parentParseScope.currentFileName.toLowerCase();
 				if ( scope.subobjectCache[ currentFileName ] === undefined ) {
 
 					scope.subobjectCache[ currentFileName ] = text;
@@ -1043,10 +1043,10 @@ THREE.LDrawLoader = ( function () {
 					if ( line.startsWith( '0 FILE ' ) ) {
 
 						// Save previous embedded file in the cache
-						this.subobjectCache[ currentEmbeddedFileName ] = currentEmbeddedText;
+						this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
 
 						// New embedded text file
-						currentEmbeddedFileName = line.substring( 7 ).toLowerCase();
+						currentEmbeddedFileName = line.substring( 7 );
 						currentEmbeddedText = '';
 
 					} else {
@@ -1408,7 +1408,7 @@ THREE.LDrawLoader = ( function () {
 
 			if ( parsingEmbeddedFiles ) {
 
-				this.subobjectCache[ currentEmbeddedFileName ] = currentEmbeddedText;
+				this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
 
 			}
 


### PR DESCRIPTION
@yomboprime 

Follow up to #16183.

We discussed this in the other PR but this updates the LDrawLoader to use asynchronous part processing to avoid stack overflow exceptions and to use lowercased keys in the cache so parts are not missed in the cache when referenced by different names.

This enables the loading of models that couldn't be previously loaded including:

_10182-1 - Cafe Corner.mpd_
![image](https://user-images.githubusercontent.com/734200/56087846-3c025780-5e28-11e9-8f09-ebf14aab62e3.png)

_10030-1 - Imperial Star Destroyer - UCS.mpd_
![image](https://user-images.githubusercontent.com/734200/56087849-576d6280-5e28-11e9-815c-c9e05d828198.png)

<!--
https://raw.githack.com/gkjohnson/three.js/ldraw-fixes/examples/webgl_loader_ldraw.html
-->