### PR TITLE
Object3D: make applyMatrix() more robust

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -114,7 +114,9 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	applyMatrix: function ( matrix ) {
 
-		this.matrix.multiplyMatrices( matrix, this.matrix );
+		if ( this.matrixAutoUpdate ) this.updateMatrix();
+
+		this.matrix.premultiply( matrix );
 
 		this.matrix.decompose( this.position, this.quaternion, this.scale );
 


### PR DESCRIPTION
Ensure `.matrix` is updated before using it in a calculation.