### PR TITLE
Readonly Attribute properties for VAO.

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -17,10 +17,10 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 	this.name = '';
 
-	this.array = array;
-	this.itemSize = itemSize;
+	this._array = array;
+	this._itemSize = itemSize;
 	this.count = array !== undefined ? array.length / itemSize : 0;
-	this.normalized = normalized === true;
+	this._normalized = normalized === true;
 
 	this.dynamic = false;
 	this.updateRange = { offset: 0, count: - 1 };
@@ -29,11 +29,63 @@ function BufferAttribute( array, itemSize, normalized ) {
 
 }
 
-Object.defineProperty( BufferAttribute.prototype, 'needsUpdate', {
+Object.defineProperties( BufferAttribute.prototype, {
 
-	set: function ( value ) {
+	needsUpdate: {
 
-		if ( value === true ) this.version ++;
+		set: function ( value ) {
+
+			if ( value === true ) this.version ++;
+
+		}
+
+	},
+
+	array: {
+
+		get: function () {
+
+			return this._array;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.BufferAttribute: .array is readonly.' );
+
+		}
+
+	},
+
+	itemSize: {
+
+		get: function () {
+
+			return this._itemSize;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.BufferAttribute: .itemSize is readonly.' );
+
+		}
+
+	},
+
+	normalized: {
+
+		get: function () {
+
+			return this._normalized;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.BufferAttribute: .normalized is readonly.' );
+
+		}
 
 	}
 
@@ -45,21 +97,6 @@ Object.assign( BufferAttribute.prototype, {
 
 	onUploadCallback: function () {},
 
-	setArray: function ( array ) {
-
-		if ( Array.isArray( array ) ) {
-
-			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-		}
-
-		this.count = array !== undefined ? array.length / this.itemSize : 0;
-		this.array = array;
-
-		return this;
-
-	},
-
 	setDynamic: function ( value ) {
 
 		this.dynamic = value;
@@ -68,13 +105,13 @@ Object.assign( BufferAttribute.prototype, {
 
 	},
 
-	copy: function ( source ) {
+	_copy: function ( source ) {
 
 		this.name = source.name;
-		this.array = new source.array.constructor( source.array );
-		this.itemSize = source.itemSize;
+		this._array = new source.array.constructor( source.array );
+		this._itemSize = source.itemSize;
 		this.count = source.count;
-		this.normalized = source.normalized;
+		this._normalized = source.normalized;
 
 		this.dynamic = source.dynamic;
 
@@ -317,7 +354,7 @@ Object.assign( BufferAttribute.prototype, {
 
 	clone: function () {
 
-		return new this.constructor( this.array, this.itemSize ).copy( this );
+		return new this.constructor( this.array, this.itemSize )._copy( this );
 
 	}
 

--- a/src/core/InstancedBufferAttribute.js
+++ b/src/core/InstancedBufferAttribute.js
@@ -18,7 +18,7 @@ function InstancedBufferAttribute( array, itemSize, normalized, meshPerAttribute
 
 	BufferAttribute.call( this, array, itemSize, normalized );
 
-	this.meshPerAttribute = meshPerAttribute || 1;
+	this._meshPerAttribute = meshPerAttribute || 1;
 
 }
 
@@ -28,11 +28,11 @@ InstancedBufferAttribute.prototype = Object.assign( Object.create( BufferAttribu
 
 	isInstancedBufferAttribute: true,
 
-	copy: function ( source ) {
+	_copy: function ( source ) {
 
-		BufferAttribute.prototype.copy.call( this, source );
+		BufferAttribute.prototype._copy.call( this, source );
 
-		this.meshPerAttribute = source.meshPerAttribute;
+		this._meshPerAttribute = source.meshPerAttribute;
 
 		return this;
 
@@ -40,6 +40,24 @@ InstancedBufferAttribute.prototype = Object.assign( Object.create( BufferAttribu
 
 } );
 
+Object.defineProperties( InstancedBufferAttribute.prototype, {
 
+	meshPerAttribute: {
+
+		get: function () {
+
+			return this._meshPerAttribute;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InstancedBufferAttribute: .meshPerAttribute is readonly.' );
+
+		}
+
+	}
+
+} );
 
 export { InstancedBufferAttribute };

--- a/src/core/InstancedInterleavedBuffer.js
+++ b/src/core/InstancedInterleavedBuffer.js
@@ -8,7 +8,7 @@ function InstancedInterleavedBuffer( array, stride, meshPerAttribute ) {
 
 	InterleavedBuffer.call( this, array, stride );
 
-	this.meshPerAttribute = meshPerAttribute || 1;
+	this._meshPerAttribute = meshPerAttribute || 1;
 
 }
 
@@ -18,13 +18,33 @@ InstancedInterleavedBuffer.prototype = Object.assign( Object.create( Interleaved
 
 	isInstancedInterleavedBuffer: true,
 
-	copy: function ( source ) {
+	_copy: function ( source ) {
 
 		InterleavedBuffer.prototype.copy.call( this, source );
 
-		this.meshPerAttribute = source.meshPerAttribute;
+		this._meshPerAttribute = source.meshPerAttribute;
 
 		return this;
+
+	}
+
+} );
+
+Object.defineProperties( InstancedInterleavedBuffer.prototype, {
+
+	meshPerAttribute: {
+
+		get: function () {
+
+			return this._meshPerAttribute;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InstancedInterleavedBuffer: .meshPerAttribute is readonly.' );
+
+		}
 
 	}
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -5,8 +5,8 @@
 
 function InterleavedBuffer( array, stride ) {
 
-	this.array = array;
-	this.stride = stride;
+	this._array = array;
+	this._stride = stride;
 	this.count = array !== undefined ? array.length / stride : 0;
 
 	this.dynamic = false;
@@ -16,11 +16,47 @@ function InterleavedBuffer( array, stride ) {
 
 }
 
-Object.defineProperty( InterleavedBuffer.prototype, 'needsUpdate', {
+Object.defineProperties( InterleavedBuffer.prototype, {
 
-	set: function ( value ) {
+	needsUpdate: {
 
-		if ( value === true ) this.version ++;
+		set: function ( value ) {
+
+			if ( value === true ) this.version ++;
+
+		}
+
+	},
+
+	array: {
+
+		get: function () {
+
+			return this._array;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBuffer: .array is readonly.' );
+
+		}
+
+	},
+
+	stride: {
+
+		get: function () {
+
+			return this._stride;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBuffer: .stride is readonly.' );
+
+		}
 
 	}
 
@@ -32,21 +68,6 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	onUploadCallback: function () {},
 
-	setArray: function ( array ) {
-
-		if ( Array.isArray( array ) ) {
-
-			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-		}
-
-		this.count = array !== undefined ? array.length / this.stride : 0;
-		this.array = array;
-
-		return this;
-
-	},
-
 	setDynamic: function ( value ) {
 
 		this.dynamic = value;
@@ -55,11 +76,11 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	},
 
-	copy: function ( source ) {
+	_copy: function ( source ) {
 
-		this.array = new source.array.constructor( source.array );
+		this._array = new source.array.constructor( source.array );
 		this.count = source.count;
-		this.stride = source.stride;
+		this._stride = source.stride;
 		this.dynamic = source.dynamic;
 
 		return this;
@@ -93,7 +114,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	clone: function () {
 
-		return new this.constructor().copy( this );
+		return new this.constructor()._copy( this );
 
 	},
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -5,11 +5,11 @@
 
 function InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, normalized ) {
 
-	this.data = interleavedBuffer;
-	this.itemSize = itemSize;
-	this.offset = offset;
+	this._data = interleavedBuffer;
+	this._itemSize = itemSize;
+	this._offset = offset;
 
-	this.normalized = normalized === true;
+	this._normalized = normalized === true;
 
 }
 
@@ -30,6 +30,70 @@ Object.defineProperties( InterleavedBufferAttribute.prototype, {
 		get: function () {
 
 			return this.data.array;
+
+		}
+
+	},
+
+	data: {
+
+		get: function () {
+
+			return this._data;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBufferAttribute: .data is readonly.' );
+
+		}
+
+	},
+
+	itemSize: {
+
+		get: function () {
+
+			return this._itemSize;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBufferAttribute: .itemSize is readonly.' );
+
+		}
+
+	},
+
+	offset: {
+
+		get: function () {
+
+			return this._offset;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBufferAttribute: .offset is readonly.' );
+
+		}
+
+	},
+
+	normalized: {
+
+		get: function () {
+
+			return this._normalized;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBufferAttribute: .normalized is readonly.' );
 
 		}
 

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -42,47 +42,9 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "setArray", ( assert ) => {
-
-			var f32a = new Float32Array( [ 1, 2, 3, 4 ] );
-			var a = new BufferAttribute( f32a, 2, false );
-
-			a.setArray( f32a, 2 );
-
-			assert.strictEqual( a.count, 2, "Check item count" );
-			assert.strictEqual( a.array, f32a, "Check array" );
-
-			assert.throws(
-				function () {
-
-					a.setArray( [ 1, 2, 3, 4 ] );
-
-				},
-				/array should be a Typed Array/,
-				"Calling setArray with a simple array throws Error"
-			);
-
-		} );
-
 		QUnit.todo( "setDynamic", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		QUnit.test( "copy", ( assert ) => {
-
-			var attr = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
-			attr.setDynamic( true );
-			attr.needsUpdate = true;
-
-			var attrCopy = new BufferAttribute().copy( attr );
-
-			assert.ok( attr.count === attrCopy.count, 'count is equal' );
-			assert.ok( attr.itemSize === attrCopy.itemSize, 'itemSize is equal' );
-			assert.ok( attr.dynamic === attrCopy.dynamic, 'dynamic is equal' );
-			assert.ok( attr.array.length === attrCopy.array.length, 'array length is equal' );
-			assert.ok( attr.version === 1 && attrCopy.version === 0, 'version is not copied which is good' );
 
 		} );
 

--- a/test/unit/src/core/InstancedBufferAttribute.tests.js
+++ b/test/unit/src/core/InstancedBufferAttribute.tests.js
@@ -27,25 +27,6 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		// PUBLIC STUFF
-		QUnit.test( "copy", ( assert ) => {
-
-			var array = new Float32Array( [ 1, 2, 3, 7, 8, 9 ] );
-			var instance = new InstancedBufferAttribute( array, 2, 123 );
-			var copiedInstance = instance.copy( instance );
-
-			assert.ok( copiedInstance instanceof InstancedBufferAttribute, "the clone has the correct type" );
-			assert.ok( copiedInstance.itemSize === 2, "itemSize was copied" );
-			assert.ok( copiedInstance.meshPerAttribute === 123, "meshPerAttribute was copied" );
-
-			for ( var i = 0; i < array.length; i ++ ) {
-
-				assert.ok( copiedInstance.array[ i ] === array[ i ], "array was copied" );
-
-			}
-
-		} );
-
 	} );
 
 } );

--- a/test/unit/src/core/InstancedInterleavedBuffer.tests.js
+++ b/test/unit/src/core/InstancedInterleavedBuffer.tests.js
@@ -33,16 +33,6 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "copy", ( assert ) => {
-
-			var array = new Float32Array( [ 1, 2, 3, 7, 8, 9 ] );
-			var instance = new InstancedInterleavedBuffer( array, 3 );
-			var copiedInstance = instance.copy( instance );
-
-			assert.ok( copiedInstance.meshPerAttribute === 1, "additional attribute was copied" );
-
-		} );
-
 	} );
 
 } );

--- a/test/unit/src/core/InterleavedBuffer.tests.js
+++ b/test/unit/src/core/InterleavedBuffer.tests.js
@@ -49,47 +49,9 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "setArray", ( assert ) => {
-
-			var f32a = new Float32Array( [ 1, 2, 3, 4 ] );
-			var f32b = new Float32Array( [] );
-			var a = new InterleavedBuffer( f32a, 2, false );
-
-			a.setArray( f32a );
-
-			assert.strictEqual( a.count, 2, "Check item count for non-empty array" );
-			assert.strictEqual( a.array, f32a, "Check array itself" );
-
-			a.setArray( f32b );
-
-			assert.strictEqual( a.count, 0, "Check item count for empty array" );
-			assert.strictEqual( a.array, f32b, "Check array itself" );
-
-			assert.throws(
-				function () {
-
-					a.setArray( [ 1, 2, 3, 4 ] );
-
-				},
-				/array should be a Typed Array/,
-				"Calling setArray with a non-typed array throws Error"
-			);
-
-		} );
-
 		QUnit.todo( "setDynamic", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		QUnit.test( "copy", ( assert ) => {
-
-			var array = new Float32Array( [ 1, 2, 3, 7, 8, 9 ] );
-			var instance = new InterleavedBuffer( array, 3 );
-			instance.setDynamic( true );
-
-			checkInstanceAgainstCopy( instance, instance.copy( instance ), assert );
 
 		} );
 


### PR DESCRIPTION
Draft PR to show how the change looks like for https://github.com/mrdoob/three.js/pull/14600#issuecomment-478768913

Readonly
- BufferAttribute: .normalized, .itemSize, .array
- InterleavedBufferAttribute: .normalized, .itemSize, .offset, .data(InterleavedBuffer)
- InterleavedBuffer: .stride, .array
- InstancedBufferAttribute/InstancedInterleavedBuffer: .meshPerAttribute

Remove
- BufferAttribute: .setArray()
- InterleavedBuffer: .setArray()

Private
- BufferAttribute: .copy()
- InterleavedBuffer: .copy()
- InstancedBufferAttribute: .copy()
- InstancedInterleavedBuffer: .copy()
