### PR TITLE
scene graph based light probe

### DIFF
--- a/examples/webgl_lights_lightprobe.html
+++ b/examples/webgl_lights_lightprobe.html
@@ -104,7 +104,7 @@
 				scene.add( ambientLight );
 
 				// probe
-				lightProbe = new THREE.LightProbe( 0xffffff, API.lightProbeIntensity );
+				lightProbe = new THREE.DiffuseLightProbe( 0xffffff, API.lightProbeIntensity );
 				scene.add( lightProbe );
 
 				// light
@@ -137,7 +137,7 @@
 					//var geometry = new THREE.TorusKnotBufferGeometry( 4, 1.5, 256, 32, 2, 3 );
 
 					var material = new THREE.MeshStandardMaterial( {
-						color: 0xffffff, 
+						color: 0xffffff,
 						metalness: 0,
 						roughness: 0,
 						envMap: cubeTexture,

--- a/src/Three.js
+++ b/src/Three.js
@@ -60,6 +60,7 @@ export { DirectionalLight } from './lights/DirectionalLight.js';
 export { AmbientLight } from './lights/AmbientLight.js';
 export { LightShadow } from './lights/LightShadow.js';
 export { Light } from './lights/Light.js';
+export { DiffuseLightProbe } from './lights/DiffuseLightProbe.js';
 export { LightProbe } from './lights/LightProbe.js';
 export { StereoCamera } from './cameras/StereoCamera.js';
 export { PerspectiveCamera } from './cameras/PerspectiveCamera.js';

--- a/src/lights/DiffuseLightProbe.js
+++ b/src/lights/DiffuseLightProbe.js
@@ -1,0 +1,165 @@
+import { _Math } from '../math/Math.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Color } from '../math/Color.js';
+import { SphericalHarmonics3 } from '../math/SphericalHarmonics3.js';
+import { LightProbe } from './LightProbe.js';
+
+/**
+ * @author WestLangley / http://github.com/WestLangley
+ */
+
+// A DiffuseLightProbe is a source of indirect-diffuse light
+
+function DiffuseLightProbe( color, intensity ) {
+
+	LightProbe.call( this );
+
+	this.color = new Color( color );
+	this.intensity = intensity;
+
+	this.sh = new SphericalHarmonics3();
+
+	this.sh.coefficients[ 0 ].set( this.color.r, this.color.g, this.color.b );
+
+	this.type = 'LightProbe';
+
+}
+
+DiffuseLightProbe.prototype = Object.assign( Object.create( LightProbe.prototype ), {
+
+	constructor: DiffuseLightProbe,
+
+	// https://www.ppsloan.org/publications/StupidSH36.pdf
+	setFromCubeTexture: function ( cubeTexture ) {
+
+		var norm, lengthSq, weight, totalWeight = 0;
+
+		var coord = new Vector3();
+
+		var dir = new Vector3();
+
+		var color = new Color();
+
+		var shBasis = [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+
+		var shCoefficients = this.sh.coefficients;
+
+		for ( var faceIndex = 0; faceIndex < 6; faceIndex ++ ) {
+
+			var image = cubeTexture.image[ faceIndex ];
+
+			var width = image.width;
+			var height = image.height;
+
+			var canvas = document.createElement( 'canvas' );
+
+			canvas.width = width;
+			canvas.height = height;
+
+			var context = canvas.getContext( '2d' );
+
+			context.drawImage( image, 0, 0, width, height );
+
+			var imageData = context.getImageData( 0, 0, width, height );
+
+			var data = imageData.data;
+
+			var imageWidth = imageData.width; // assumed to be square
+
+			var pixelSize = 2 / imageWidth;
+
+			for ( var i = 0, il = data.length; i < il; i += 4 ) { // RGBA assumed
+
+				// pixel color
+				color.setRGB( data[ i ] / 255, data[ i + 1 ] / 255, data[ i + 2 ] / 255 );
+
+				// convert to linear color space
+				color.copySRGBToLinear( color );
+
+				// pixel coordinate on unit cube
+
+				var pixelIndex = i / 4;
+
+				var col = - 1 + ( pixelIndex % imageWidth + 0.5 ) * pixelSize;
+
+				var row = 1 - ( Math.floor( pixelIndex / imageWidth ) + 0.5 ) * pixelSize;
+
+				switch ( faceIndex ) {
+
+					case 0: coord.set( - 1, row, - col ); break;
+
+					case 1: coord.set( 1, row, col ); break;
+
+					case 2: coord.set( - col, 1, - row ); break;
+
+					case 3: coord.set( - col, - 1, row ); break;
+
+					case 4: coord.set( - col, row, 1 ); break;
+
+					case 5: coord.set( col, row, - 1 ); break;
+
+				}
+
+				// weight assigned to this pixel
+
+				lengthSq = coord.lengthSq();
+
+				weight = 4 / ( Math.sqrt( lengthSq ) * lengthSq );
+
+				totalWeight += weight;
+
+				// direction vector to this pixel
+				dir.copy( coord ).normalize();
+
+				// evaluate SH basis functions in direction dir
+				SphericalHarmonics3.getBasisAt( dir, shBasis );
+
+				// accummuulate
+				for ( var j = 0; j < 9; j ++ ) {
+
+					shCoefficients[ j ].x += shBasis[ j ] * color.r * weight;
+					shCoefficients[ j ].y += shBasis[ j ] * color.g * weight;
+					shCoefficients[ j ].z += shBasis[ j ] * color.b * weight;
+
+				}
+
+			}
+
+		}
+
+		// normalize
+		norm = ( 4 * Math.PI ) / totalWeight;
+
+		for ( var j = 0; j < 9; j ++ ) {
+
+			shCoefficients[ j ].x *= norm;
+			shCoefficients[ j ].y *= norm;
+			shCoefficients[ j ].z *= norm;
+
+		}
+
+	},
+
+	copy: function ( source ) {
+
+		Light.prototype.copy.call( this, source );
+
+		this.sh.copy( source.sh );
+
+		return this;
+
+	},
+
+	toJSON: function ( meta ) {
+
+		var data = Light.prototype.toJSON.call( this, meta );
+
+		//data.sh = this.sh.toArray(); // todo
+
+		return data;
+
+	}
+
+} );
+
+export { DiffuseLightProbe };

--- a/src/lights/LightProbe.js
+++ b/src/lights/LightProbe.js
@@ -1,164 +1,32 @@
-import { _Math } from '../math/Math.js';
-import { Vector3 } from '../math/Vector3.js';
-import { Color } from '../math/Color.js';
-import { SphericalHarmonics3 } from '../math/SphericalHarmonics3.js';
-import { Light } from './Light.js';
+import { Object3D } from '../core/Object3D.js';
 
 /**
  * @author WestLangley / http://github.com/WestLangley
  */
 
-// A LightProbe is a source of indirect-diffuse light
+function LightProbe( ) {
 
-function LightProbe( color, intensity ) {
-
-	Light.call( this, color, intensity );
-
-	this.sh = new SphericalHarmonics3();
-
-	this.sh.coefficients[ 0 ].set( this.color.r, this.color.g, this.color.b );
+	Object3D.call( this );
 
 	this.type = 'LightProbe';
 
 }
 
-LightProbe.prototype = Object.assign( Object.create( Light.prototype ), {
+LightProbe.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	constructor: LightProbe,
 
 	isLightProbe: true,
 
-	// https://www.ppsloan.org/publications/StupidSH36.pdf
-	setFromCubeTexture: function ( cubeTexture ) {
-
-		var norm, lengthSq, weight, totalWeight = 0;
-
-		var coord = new Vector3();
-
-		var dir = new Vector3();
-
-		var color = new Color();
-
-		var shBasis = [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
-
-		var shCoefficients = this.sh.coefficients;
-
-		for ( var faceIndex = 0; faceIndex < 6; faceIndex ++ ) {
-
-			var image = cubeTexture.image[ faceIndex ];
-
-			var width = image.width;
-			var height = image.height;
-
-			var canvas = document.createElement( 'canvas' );
-
-			canvas.width = width;
-			canvas.height = height;
-
-			var context = canvas.getContext( '2d' );
-
-			context.drawImage( image, 0, 0, width, height );
-
-			var imageData = context.getImageData( 0, 0, width, height );
-
-			var data = imageData.data;
-
-			var imageWidth = imageData.width; // assumed to be square
-
-			var pixelSize = 2 / imageWidth;
-
-			for ( var i = 0, il = data.length; i < il; i += 4 ) { // RGBA assumed
-
-				// pixel color
-				color.setRGB( data[ i ] / 255, data[ i + 1 ] / 255, data[ i + 2 ] / 255 );
-
-				// convert to linear color space
-				color.copySRGBToLinear( color );
-
-				// pixel coordinate on unit cube
-
-				var pixelIndex = i / 4;
-
-				var col = - 1 + ( pixelIndex % imageWidth + 0.5 ) * pixelSize;
-
-				var row = 1 - ( Math.floor( pixelIndex / imageWidth ) + 0.5 ) * pixelSize;
-
-				switch ( faceIndex ) {
-
-					case 0: coord.set( - 1, row, - col ); break;
-
-					case 1: coord.set( 1, row, col ); break;
-
-					case 2: coord.set( - col, 1, - row ); break;
-
-					case 3: coord.set( - col, - 1, row ); break;
-
-					case 4: coord.set( - col, row, 1 ); break;
-
-					case 5: coord.set( col, row, - 1 ); break;
-
-				}
-
-				// weight assigned to this pixel
-
-				lengthSq = coord.lengthSq();
-
-				weight = 4 / ( Math.sqrt( lengthSq ) * lengthSq );
-
-				totalWeight += weight;
-
-				// direction vector to this pixel
-				dir.copy( coord ).normalize();
-
-				// evaluate SH basis functions in direction dir
-				SphericalHarmonics3.getBasisAt( dir, shBasis );
-
-				// accummuulate
-				for ( var j = 0; j < 9; j ++ ) {
-
-					shCoefficients[ j ].x += shBasis[ j ] * color.r * weight;
-					shCoefficients[ j ].y += shBasis[ j ] * color.g * weight;
-					shCoefficients[ j ].z += shBasis[ j ] * color.b * weight;
-
-				}
-
-			}
-
-		}
-
-		// normalize
-		norm = ( 4 * Math.PI ) / totalWeight;
-
-		for ( var j = 0; j < 9; j ++ ) {
-
-			shCoefficients[ j ].x *= norm;
-			shCoefficients[ j ].y *= norm;
-			shCoefficients[ j ].z *= norm;
-
-		}
-
-	},
-
 	copy: function ( source ) {
 
-		Light.prototype.copy.call( this, source );
-
-		this.sh.copy( source.sh );
+		Object3D.prototype.copy.call( this, source );
 
 		return this;
 
 	},
 
-	toJSON: function ( meta ) {
-
-		var data = Light.prototype.toJSON.call( this, meta );
-
-		//data.sh = this.sh.toArray(); // todo
-
-		return data;
-
-	}
-
 } );
+
 
 export { LightProbe };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1406,6 +1406,31 @@ function WebGLRenderer( parameters ) {
 
 	}
 
+	function computeInterpolatedLightProbe( object, scene ) {
+
+		// This is where we need to implemented a smart(er) system for interpolating the various light probes
+		// in the scene (right now it's just nearest neighbor with a hard cutover, but illustrates the point of
+		// needing to compute this per object)
+
+		var closestProbe = null;
+		var closestDist = Number.MAX_SAFE_INTEGER;
+
+		var children = scene.children;
+
+		for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+			if ( children[i].isLightProbe && children[i].position.distanceTo(object.position) < closestDist ) {
+
+				closestProbe = children[i];
+
+			}
+
+		}
+
+		return closestProbe;
+
+	}
+
 	function renderObject( object, scene, camera, geometry, material, group ) {
 
 		object.onBeforeRender( _this, scene, camera, geometry, material, group );
@@ -1413,6 +1438,8 @@ function WebGLRenderer( parameters ) {
 
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+
+		object.interpolatedDiffuseLightProbe = computeInterpolatedLightProbe( object, scene );
 
 		if ( object.isImmediateRenderObject ) {
 
@@ -1599,7 +1626,7 @@ function WebGLRenderer( parameters ) {
 			// wire up the material to this renderer's lighting state
 
 			uniforms.ambientLightColor.value = lights.state.ambient;
-			uniforms.lightProbe.value = lights.state.probe;
+			uniforms.lightProbe.value = object.interpolatedDiffuseLightProbe.sh.coefficients;
 			uniforms.directionalLights.value = lights.state.directional;
 			uniforms.spotLights.value = lights.state.spot;
 			uniforms.rectAreaLights.value = lights.state.rectArea;

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -121,7 +121,6 @@ function WebGLLights() {
 		},
 
 		ambient: [ 0, 0, 0 ],
-		probe: [],
 		directional: [],
 		directionalShadowMap: [],
 		directionalShadowMatrix: [],
@@ -136,8 +135,6 @@ function WebGLLights() {
 
 	};
 
-	for ( var i = 0; i < 9; i ++ ) state.probe.push( new Vector3() );
-
 	var vector3 = new Vector3();
 	var matrix4 = new Matrix4();
 	var matrix42 = new Matrix4();
@@ -145,8 +142,6 @@ function WebGLLights() {
 	function setup( lights, shadows, camera ) {
 
 		var r = 0, g = 0, b = 0;
-
-		for ( var i = 0; i < 9; i ++ ) state.probe[ i ].set( 0, 0, 0 );
 
 		var directionalLength = 0;
 		var pointLength = 0;
@@ -171,14 +166,6 @@ function WebGLLights() {
 				r += color.r * intensity;
 				g += color.g * intensity;
 				b += color.b * intensity;
-
-			} else if ( light.isLightProbe ) {
-
-				for ( var j = 0; j < 9; j ++ ) {
-
-					state.probe[ j ].addScaledVector( light.sh.coefficients[ j ], intensity );
-
-				}
 
 			} else if ( light.isDirectionalLight ) {
 


### PR DESCRIPTION
related: https://github.com/mrdoob/three.js/pull/16223

Per https://github.com/mrdoob/three.js/pull/16223#issuecomment-483229620

> I really like @mrdoob's recommendation is that LightProbe is derived from Object3D. 

I've changed LightProbe to be Object3D based.

Per https://github.com/mrdoob/three.js/pull/16199#issuecomment-481295833

> > Thus I do want baby steps that may not be the perfect solution. This is one of them.

> > Just change the interpolation to per mesh rather than per vertex for now.

> I do agree with that. Per-mesh interpolation, even with a naive interpolation method, should be a great basis to build from.

I've changed from using the lighting system directly to a baby step towards making the interpolated light probe per object.

We will still need to do:

- [ ] A better interpolation scheme
- [ ] A proper dirty state tracking system which determine when an object needs it's interpolated SH information updated (e.g. either the object or one or more light probes has moved in the previous frame)

This gets us a tiny bit closer to our goal however, as it will at least in some basic way take into account the relative position of the light probe(s) and objects.

@WestLangley @donmccurdy @bhouston 