### PR TITLE
Object3D: use updateWorldMatrix() instead updateMatrixWorld()

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -475,7 +475,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
-		this.updateMatrixWorld( true );
+		this.updateWorldMatrix( true, false );
 
 		return target.setFromMatrixPosition( this.matrixWorld );
 
@@ -495,7 +495,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			}
 
-			this.updateMatrixWorld( true );
+			this.updateWorldMatrix( true, false );
 
 			this.matrixWorld.decompose( position, target, scale );
 
@@ -519,7 +519,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			}
 
-			this.updateMatrixWorld( true );
+			this.updateWorldMatrix( true, false );
 
 			this.matrixWorld.decompose( position, quaternion, target );
 
@@ -538,7 +538,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
-		this.updateMatrixWorld( true );
+		this.updateWorldMatrix( true, false );
 
 		var e = this.matrixWorld.elements;
 


### PR DESCRIPTION
`updateMatrixWorld()` does not do what its name says it does. Certainly not correctly.

Maybe we can someday replace its use with `updateWorldMatrix()`.

For now, this is a step in that direction.