### PR TITLE
fix IE11 breakage with LightProbeHelper

### DIFF
--- a/src/helpers/LightProbeHelper.js
+++ b/src/helpers/LightProbeHelper.js
@@ -2,6 +2,9 @@ import { Mesh } from '../objects/Mesh.js';
 import { ShaderMaterial } from '../materials/ShaderMaterial.js';
 import { SphereBufferGeometry } from '../geometries/SphereGeometry.js';
 
+import LightProbeHelper_vert from './LightProbeHelper_vert.glsl.js';
+import LightProbeHelper_frag from './LightProbeHelper_frag.glsl.js';
+
 /**
  * @author WestLangley / http://github.com/WestLangley
  */
@@ -28,92 +31,9 @@ function LightProbeHelper( lightProbe, size ) {
 
 		},
 
-		vertexShader: `
+		vertexShader: LightProbeHelper_vert,
 
-			varying vec3 vNormal;
-
-			void main() {
-
-				vNormal = normalize( normalMatrix * normal );
-
-				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-			}`,
-
-		fragmentShader: `
-
-			#define RECIPROCAL_PI 0.318309886
-
-			vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {
-
-				// matrix is assumed to be orthogonal
-
-				return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
-
-			}
-
-			vec3 linearToOutput( in vec3 a ) {
-
-				#ifdef GAMMA_OUTPUT
-
-					return pow( a, vec3( 1.0 / float( GAMMA_FACTOR ) ) );
-
-				#else
-
-					return a;
-
-				#endif
-
-			}
-
-			// get the irradiance (radiance convolved with cosine lobe) at the point 'normal' on the unit sphere
-			// source: https://graphics.stanford.edu/papers/envmap/envmap.pdf
-			vec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {
-
-				// normal is assumed to have unit length
-
-				float x = normal.x, y = normal.y, z = normal.z;
-
-				// band 0
-				vec3 result = shCoefficients[ 0 ] * 0.886227;
-
-				// band 1
-				result += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;
-				result += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;
-				result += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;
-
-				// band 2
-				result += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;
-				result += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;
-				result += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );
-				result += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;
-				result += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );
-
-				return result;
-
-			}
-
-			uniform vec3 sh[ 9 ]; // sh coefficients
-
-			uniform float intensity; // light probe intensity
-
-			varying vec3 vNormal;
-
-			void main() {
-
-				vec3 normal = normalize( vNormal );
-
-				vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
-
-				vec3 irradiance = shGetIrradianceAt( worldNormal, sh );
-
-				vec3 outgoingLight = RECIPROCAL_PI * irradiance * intensity;
-
-				outgoingLight = linearToOutput( outgoingLight );
-
-				gl_FragColor = vec4( outgoingLight, 1.0 );
-
-			}`
+		fragmentShader: LightProbeHelper_frag
 
 	} );
 

--- a/src/helpers/LightProbeHelper_frag.glsl.js
+++ b/src/helpers/LightProbeHelper_frag.glsl.js
@@ -1,0 +1,80 @@
+/**
+ * @author WestLangley / http://github.com/WestLangley
+ */
+
+export default /* glsl */`
+
+#define RECIPROCAL_PI 0.318309886
+
+vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {
+
+	// matrix is assumed to be orthogonal
+
+	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );
+
+}
+
+vec3 linearToOutput( in vec3 a ) {
+
+	#ifdef GAMMA_OUTPUT
+
+		return pow( a, vec3( 1.0 / float( GAMMA_FACTOR ) ) );
+
+	#else
+
+		return a;
+
+	#endif
+
+}
+
+// get the irradiance (radiance convolved with cosine lobe) at the point 'normal' on the unit sphere
+// source: https://graphics.stanford.edu/papers/envmap/envmap.pdf
+
+vec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {
+
+	// normal is assumed to have unit length
+
+	float x = normal.x, y = normal.y, z = normal.z;
+
+	// band 0
+	vec3 result = shCoefficients[ 0 ] * 0.886227;
+
+	// band 1
+	result += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;
+	result += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;
+	result += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;
+
+	// band 2
+	result += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;
+	result += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;
+	result += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );
+	result += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;
+	result += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );
+
+	return result;
+
+}
+
+uniform vec3 sh[ 9 ]; // sh coefficients
+
+uniform float intensity; // light probe intensity
+
+varying vec3 vNormal;
+
+void main() {
+
+	vec3 normal = normalize( vNormal );
+
+	vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
+
+	vec3 irradiance = shGetIrradianceAt( worldNormal, sh );
+
+	vec3 outgoingLight = RECIPROCAL_PI * irradiance * intensity;
+
+	outgoingLight = linearToOutput( outgoingLight );
+
+	gl_FragColor = vec4( outgoingLight, 1.0 );
+
+}
+`;

--- a/src/helpers/LightProbeHelper_vert.glsl.js
+++ b/src/helpers/LightProbeHelper_vert.glsl.js
@@ -1,0 +1,16 @@
+/**
+ * @author WestLangley / http://github.com/WestLangley
+ */
+
+export default /* glsl */`
+
+varying vec3 vNormal;
+
+	void main() {
+
+	vNormal = normalize( normalMatrix * normal );
+
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+}
+`;


### PR DESCRIPTION
Fix shader inclusion for compatibility with IE11.

@WestLangley - I've followed the shader inclusion method used for the built in shaders, unless you have objections.