### PR TITLE
Enable tree-shaking both for the main and examples files

### DIFF
--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -14,7 +14,7 @@ import {
 	Spherical,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -13,7 +13,7 @@ import {
 	Spherical,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -10,7 +10,7 @@ import {
 	Quaternion,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var TrackballControls = function ( object, domElement ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -26,7 +26,7 @@ import {
 	TriangleFanDrawMode,
 	TriangleStripDrawMode,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 //------------------------------------------------------------------------------
 // Constants
@@ -147,9 +147,23 @@ GLTFExporter.prototype = {
 
 		var cachedCanvas;
 
+		var uids = new Map();
+		var uid = 0;
+
 		/**
-		 * Compare two arrays
+		 * Assign and return a temporal unique id for an object
+		 * especially which doesn't have .uuid
+		 * @param  {Object} object
+		 * @return {Integer}
 		 */
+		function getUID( object ) {
+
+			if ( ! uids.has( object ) ) uids.set( object, uid ++ );
+
+			return uids.get( object );
+
+		}
+
 		/**
 		 * Compare two arrays
 		 * @param  {Array} array1 Array 1 to compare
@@ -1202,9 +1216,9 @@ GLTFExporter.prototype = {
 
 				}
 
-				if ( cachedData.attributes.has( attribute ) ) {
+				if ( cachedData.attributes.has( getUID( attribute ) ) ) {
 
-					attributes[ attributeName ] = cachedData.attributes.get( attribute );
+					attributes[ attributeName ] = cachedData.attributes.get( getUID( attribute ) );
 					continue;
 
 				}
@@ -1225,7 +1239,7 @@ GLTFExporter.prototype = {
 				if ( accessor !== null ) {
 
 					attributes[ attributeName ] = accessor;
-					cachedData.attributes.set( attribute, accessor );
+					cachedData.attributes.set( getUID( attribute ), accessor );
 
 				}
 
@@ -1291,9 +1305,9 @@ GLTFExporter.prototype = {
 
 						var baseAttribute = geometry.attributes[ attributeName ];
 
-						if ( cachedData.attributes.has( attribute ) ) {
+						if ( cachedData.attributes.has( getUID( attribute ) ) ) {
 
-							target[ gltfAttributeName ] = cachedData.attributes.get( attribute );
+							target[ gltfAttributeName ] = cachedData.attributes.get( getUID( attribute ) );
 							continue;
 
 						}
@@ -1313,7 +1327,7 @@ GLTFExporter.prototype = {
 						}
 
 						target[ gltfAttributeName ] = processAccessor( relativeAttribute, geometry );
-						cachedData.attributes.set( baseAttribute, target[ gltfAttributeName ] );
+						cachedData.attributes.set( getUID( baseAttribute ), target[ gltfAttributeName ] );
 
 					}
 
@@ -1382,14 +1396,22 @@ GLTFExporter.prototype = {
 
 				if ( geometry.index !== null ) {
 
-					if ( cachedData.attributes.has( geometry.index ) ) {
+					var cacheKey = getUID( geometry.index );
 
-						primitive.indices = cachedData.attributes.get( geometry.index );
+					if ( groups[ i ].start !== undefined || groups[ i ].count !== undefined ) {
+
+						cacheKey += ':' + groups[ i ].start + ':' + groups[ i ].count;
+
+					}
+
+					if ( cachedData.attributes.has( cacheKey ) ) {
+
+						primitive.indices = cachedData.attributes.get( cacheKey );
 
 					} else {
 
 						primitive.indices = processAccessor( geometry.index, geometry, groups[ i ].start, groups[ i ].count );
-						cachedData.attributes.set( geometry.index, primitive.indices );
+						cachedData.attributes.set( cacheKey, primitive.indices );
 
 					}
 

--- a/examples/jsm/exporters/MMDExporter.js
+++ b/examples/jsm/exporters/MMDExporter.js
@@ -9,7 +9,7 @@ import {
 	Matrix4,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var MMDExporter = function () {
 

--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -10,7 +10,7 @@ import {
 	Mesh,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var OBJExporter = function () {};
 

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -16,7 +16,7 @@ import {
 	BufferGeometry,
 	Matrix3,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var PLYExporter = function () {};
 

--- a/examples/jsm/exporters/STLExporter.js
+++ b/examples/jsm/exporters/STLExporter.js
@@ -16,7 +16,7 @@ import {
 	Geometry,
 	Matrix3,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var STLExporter = function () {};
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -96,7 +96,7 @@ import {
 	VertexColors,
 	ZeroFactor,
 	sRGBEncoding
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var GLTFLoader = ( function () {
 
@@ -460,26 +460,26 @@ var GLTFLoader = ( function () {
 	 *
 	 * PR: https://github.com/KhronosGroup/glTF/pull/1163
 	 */
-	function GLTFMaterialsUnlitExtension( json ) {
+	function GLTFMaterialsUnlitExtension() {
 
 		this.name = EXTENSIONS.KHR_MATERIALS_UNLIT;
 
 	}
 
-	GLTFMaterialsUnlitExtension.prototype.getMaterialType = function ( material ) {
+	GLTFMaterialsUnlitExtension.prototype.getMaterialType = function () {
 
 		return MeshBasicMaterial;
 
 	};
 
-	GLTFMaterialsUnlitExtension.prototype.extendParams = function ( materialParams, material, parser ) {
+	GLTFMaterialsUnlitExtension.prototype.extendParams = function ( materialParams, materialDef, parser ) {
 
 		var pending = [];
 
 		materialParams.color = new Color( 1.0, 1.0, 1.0 );
 		materialParams.opacity = 1.0;
 
-		var metallicRoughness = material.pbrMetallicRoughness;
+		var metallicRoughness = materialDef.pbrMetallicRoughness;
 
 		if ( metallicRoughness ) {
 
@@ -655,7 +655,7 @@ var GLTFLoader = ( function () {
 	 *
 	 * Specification:
 	 */
-	function GLTFTextureTransformExtension( json ) {
+	function GLTFTextureTransformExtension() {
 
 		this.name = EXTENSIONS.KHR_TEXTURE_TRANSFORM;
 
@@ -738,9 +738,9 @@ var GLTFLoader = ( function () {
 
 			},
 
-			extendParams: function ( params, material, parser ) {
+			extendParams: function ( materialParams, materialDef, parser ) {
 
-				var pbrSpecularGlossiness = material.extensions[ this.name ];
+				var pbrSpecularGlossiness = materialDef.extensions[ this.name ];
 
 				var shader = ShaderLib[ 'standard' ];
 
@@ -803,13 +803,13 @@ var GLTFLoader = ( function () {
 				uniforms.specularMap = { value: null };
 				uniforms.glossinessMap = { value: null };
 
-				params.vertexShader = shader.vertexShader;
-				params.fragmentShader = fragmentShader;
-				params.uniforms = uniforms;
-				params.defines = { 'STANDARD': '' };
+				materialParams.vertexShader = shader.vertexShader;
+				materialParams.fragmentShader = fragmentShader;
+				materialParams.uniforms = uniforms;
+				materialParams.defines = { 'STANDARD': '' };
 
-				params.color = new Color( 1.0, 1.0, 1.0 );
-				params.opacity = 1.0;
+				materialParams.color = new Color( 1.0, 1.0, 1.0 );
+				materialParams.opacity = 1.0;
 
 				var pending = [];
 
@@ -817,32 +817,32 @@ var GLTFLoader = ( function () {
 
 					var array = pbrSpecularGlossiness.diffuseFactor;
 
-					params.color.fromArray( array );
-					params.opacity = array[ 3 ];
+					materialParams.color.fromArray( array );
+					materialParams.opacity = array[ 3 ];
 
 				}
 
 				if ( pbrSpecularGlossiness.diffuseTexture !== undefined ) {
 
-					pending.push( parser.assignTexture( params, 'map', pbrSpecularGlossiness.diffuseTexture ) );
+					pending.push( parser.assignTexture( materialParams, 'map', pbrSpecularGlossiness.diffuseTexture ) );
 
 				}
 
-				params.emissive = new Color( 0.0, 0.0, 0.0 );
-				params.glossiness = pbrSpecularGlossiness.glossinessFactor !== undefined ? pbrSpecularGlossiness.glossinessFactor : 1.0;
-				params.specular = new Color( 1.0, 1.0, 1.0 );
+				materialParams.emissive = new Color( 0.0, 0.0, 0.0 );
+				materialParams.glossiness = pbrSpecularGlossiness.glossinessFactor !== undefined ? pbrSpecularGlossiness.glossinessFactor : 1.0;
+				materialParams.specular = new Color( 1.0, 1.0, 1.0 );
 
 				if ( Array.isArray( pbrSpecularGlossiness.specularFactor ) ) {
 
-					params.specular.fromArray( pbrSpecularGlossiness.specularFactor );
+					materialParams.specular.fromArray( pbrSpecularGlossiness.specularFactor );
 
 				}
 
 				if ( pbrSpecularGlossiness.specularGlossinessTexture !== undefined ) {
 
 					var specGlossMapDef = pbrSpecularGlossiness.specularGlossinessTexture;
-					pending.push( parser.assignTexture( params, 'glossinessMap', specGlossMapDef ) );
-					pending.push( parser.assignTexture( params, 'specularMap', specGlossMapDef ) );
+					pending.push( parser.assignTexture( materialParams, 'glossinessMap', specGlossMapDef ) );
+					pending.push( parser.assignTexture( materialParams, 'specularMap', specGlossMapDef ) );
 
 				}
 
@@ -885,6 +885,7 @@ var GLTFLoader = ( function () {
 				material.bumpScale = 1;
 
 				material.normalMap = params.normalMap === undefined ? null : params.normalMap;
+
 				if ( params.normalScale ) material.normalScale = params.normalScale;
 
 				material.displacementMap = null;
@@ -2208,15 +2209,19 @@ var GLTFLoader = ( function () {
 
 		return this.getDependency( 'texture', mapDef.index ).then( function ( texture ) {
 
-			switch ( mapName ) {
+			if ( ! texture.isCompressedTexture ) {
 
-				case 'aoMap':
-				case 'emissiveMap':
-				case 'metalnessMap':
-				case 'normalMap':
-				case 'roughnessMap':
-					texture.format = RGBFormat;
-					break;
+				switch ( mapName ) {
+
+					case 'aoMap':
+					case 'emissiveMap':
+					case 'metalnessMap':
+					case 'normalMap':
+					case 'roughnessMap':
+						texture.format = RGBFormat;
+						break;
+
+				}
 
 			}
 
@@ -2377,13 +2382,13 @@ var GLTFLoader = ( function () {
 		if ( materialExtensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ] ) {
 
 			var sgExtension = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ];
-			materialType = sgExtension.getMaterialType( materialDef );
+			materialType = sgExtension.getMaterialType();
 			pending.push( sgExtension.extendParams( materialParams, materialDef, parser ) );
 
 		} else if ( materialExtensions[ EXTENSIONS.KHR_MATERIALS_UNLIT ] ) {
 
 			var kmuExtension = extensions[ EXTENSIONS.KHR_MATERIALS_UNLIT ];
-			materialType = kmuExtension.getMaterialType( materialDef );
+			materialType = kmuExtension.getMaterialType();
 			pending.push( kmuExtension.extendParams( materialParams, materialDef, parser ) );
 
 		} else {

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -19,7 +19,7 @@ import {
 	RepeatWrapping,
 	TextureLoader,
 	Vector2
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var MTLLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -17,7 +17,7 @@ import {
 	Points,
 	PointsMaterial,
 	VertexColors
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var OBJLoader = ( function () {
 

--- a/examples/jsm/pmrem/PMREMCubeUVPacker.js
+++ b/examples/jsm/pmrem/PMREMCubeUVPacker.js
@@ -29,7 +29,7 @@ import {
 	Vector2,
 	Vector3,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var PMREMCubeUVPacker = ( function () {
 

--- a/examples/jsm/pmrem/PMREMGenerator.js
+++ b/examples/jsm/pmrem/PMREMGenerator.js
@@ -26,7 +26,7 @@ import {
 	ShaderMaterial,
 	WebGLRenderTargetCube,
 	sRGBEncoding
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var PMREMGenerator = ( function () {
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -9,7 +9,7 @@ import {
 	InterleavedBufferAttribute,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var BufferGeometryUtils = {
 

--- a/examples/jsm/utils/GeometryUtils.js
+++ b/examples/jsm/utils/GeometryUtils.js
@@ -6,7 +6,7 @@
 import {
 	Mesh,
 	Vector3
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var GeometryUtils = {
 

--- a/examples/jsm/utils/MathUtils.js
+++ b/examples/jsm/utils/MathUtils.js
@@ -7,69 +7,61 @@
 
 var MathUtils = {
 
+    setQuaternionFromProperEuler: function ( q, a, b, c, order ) {
 
-	/**
-	 * @param {Quaternion} q
-	 * @param {number} a
-	 * @param {number} b
-	 * @param {number} c
-	 * @param {string} order
-	 */
-	setQuaternionFromProperEuler: function (q, a, b, c, order) {
+        // Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
 
-		// Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
+        // rotations are applied to the axes in the order specified by 'order'
+        // rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
+        // angles are in radians
 
-		// rotations are applied to the axes in the order specified by 'order'
-		// rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
-		// angles are in radians
+        var cos = Math.cos;
+        var sin = Math.sin;
 
-		var cos = Math.cos;
-		var sin = Math.sin;
+        var c2 = cos( b / 2 );
+        var s2 = sin( b / 2 );
 
-		var c2 = cos(b / 2);
-		var s2 = sin(b / 2);
+        var c13 = cos( ( a + c ) / 2 );
+        var s13 = sin( ( a + c ) / 2 );
 
-		var c13 = cos((a + c) / 2);
-		var s13 = sin((a + c) / 2);
+        var c1_3 = cos( ( a - c ) / 2 );
+        var s1_3 = sin( ( a - c ) / 2 );
 
-		var c1_3 = cos((a - c) / 2);
-		var s1_3 = sin((a - c) / 2);
+        var c3_1 = cos( ( c - a ) / 2 );
+        var s3_1 = sin( ( c - a ) / 2 );
 
-		var c3_1 = cos((c - a) / 2);
-		var s3_1 = sin((c - a) / 2);
+        if ( order === 'XYX' ) {
 
-		if (order === 'XYX') {
+            q.set( c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13 );
 
-			q.set(c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13);
+        } else if ( order === 'YZY' ) {
 
-		} else if (order === 'YZY') {
+            q.set( s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13 );
 
-			q.set(s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13);
+        } else if ( order === 'ZXZ' ) {
 
-		} else if (order === 'ZXZ') {
+            q.set( s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13 );
 
-			q.set(s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13);
+        } else if ( order === 'XZX' ) {
 
-		} else if (order === 'XZX') {
+            q.set( c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13 );
 
-			q.set(c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13);
+        } else if ( order === 'YXY' ) {
 
-		} else if (order === 'YXY') {
+            q.set( s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13 );
 
-			q.set(s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13);
+        } else if ( order === 'ZYZ' ) {
 
-		} else if (order === 'ZYZ') {
+            q.set( s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13 );
 
-			q.set(s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13);
+        } else {
 
-		} else {
+            console.warn( 'THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order.' );
 
-			console.warn('THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order.');
+        }
 
-		}
-
-	}
+    }
 
 };
 
-export {MathUtils};
+export { MathUtils };

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -6,7 +6,7 @@ import {
 	Group,
 	Matrix4,
 	Mesh
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var SceneUtils = {
 

--- a/examples/jsm/utils/ShadowMapViewer.js
+++ b/examples/jsm/utils/ShadowMapViewer.js
@@ -39,7 +39,7 @@ import {
 	Texture,
 	UniformsUtils,
 	UnpackDepthRGBAShader
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var ShadowMapViewer = function ( light ) {
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -13,7 +13,7 @@ import {
 	Vector2,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 'use strict';
 

--- a/examples/jsm/utils/UVsDebug.js
+++ b/examples/jsm/utils/UVsDebug.js
@@ -12,7 +12,7 @@
 
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from "../../../src/Three.js";
 
 var UVsDebug = function ( geometry, size ) {
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "start": "npm run dev",
     "lint": "eslint src",
     "test": "npm run build-test && qunit test/unit/three.source.unit.js",
-    "travis": "npm run lint && npm test"
+    "travis": "npm run lint && npm test",
+    "prepublishOnly": "node utils/modularize.js"
   },
   "keywords": [
     "three",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "jsnext:main": "build/three.module.js",
   "module": "build/three.module.js",
   "types": "src/Three.d.ts",
+  "sideEffects": false,
   "files": [
     "build/three.js",
     "build/three.min.js",

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -134,7 +134,7 @@ function convert( path, ignoreList ) {
 		.map( value => '\n\t' + value )
 		.sort()
 		.toString();
-	var imports = `import {${keys}\n} from "../../../build/three.module.js";`;
+	var imports = `import {${keys}\n} from "../../../src/Three.js";`;
 	var exports = `export { ${className} };\n`;
 
 	var output = contents.replace( '_IMPORTS_', keys ? imports : '' ) + '\n' + exports;


### PR DESCRIPTION
Happy easter everyone! 

The aim of this PR is to optimize the repo in order to enable tree-shaking for the webpack users so all of the non-necessary three.js code isn't included in the final bundle.

All the heavy work is done by the property `"sideEffects": false` in the package.json, which is saying there isn't any shared "state" in three.js which is affected by other non-required files. This is true since three.js' core uses only import/exports and isn't using any non-imported module (correct me if I'm wrong).

[More info here](https://webpack.js.org/guides/tree-shaking/)

With this, importing any component from the main `Three.js` file won't include all of the non-executed components in the bundle anymore, for example

```js
import { Vector3 } from 'three/src/Three'
console.log(Vector3)
```

Before:
```
  Asset     Size  
main.js  569 KiB 
```

After:
```
  Asset    Size  
main.js  15 KiB
```

Even better importing three.js `* as THREE` will still be tree-shaked and include in the bundle only the properties which you use in the code:

```js
import * as THREE from 'three/src/Three'
console.log(THREE.Vector3)
```

Becomes:
```
  Asset    Size  
main.js  15 KiB
```

### Here is a test-repo if you want to test this out: [three-test.zip](https://github.com/mrdoob/three.js/files/3101854/three-test.zip)

-----------

For the `examples/jsm` files instead, I updated the imports from `"../../../build/three.module.js"` to `"../../../src/Three.js"`, the tree-shaking takes care of the rest. This is because the file **`three.module.js` cannot be tree-shaken** since all the code is in the same file. (If anyone has more insight on this please share)

Here is a test:

```js
import { UVsDebug } from 'three/examples/jsm/utils/UVsDebug'
console.log(UVsDebug)
```

Before:
```
  Asset     Size  
main.js  543 KiB
```

After: 
```
  Asset      Size 
main.js  6.54 KiB
```

-------------

Finally I added `"prepublishOnly": "node utils/modularize.js"` to the package.json just to make sure the jsmodules are always up-to-date.