### PR TITLE
Docs: Added note about importable examples.

### DIFF
--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -62,11 +62,64 @@
 		...
 		</code>
 
-		<h2>Caveats</h2>
-
+		<h2>Importable Examples</h2>
 		<p>
-			Currently it's not possible to import the files within the "examples/js" directory in this way.
-			This is due to some of the files relying on global namespace pollution of THREE. For more information see <a href="https://github.com/mrdoob/three.js/issues/9562" target="_blank">Transform `examples/js` to support modules #9562</a>.
+			The core of three.js is focused on the most important components of a 3D engine. Many other components like loaders or controls are part of the
+			examples directory. three.js ensures to keep these files in sync with the core but users have to import them separately if they are required
+			for their project. However, most of these files are no modules which makes their usage in certain cases inconvenient. In order to address this issue,
+			three.js is going to provide more and more files as modules in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory.
+			If you install three.js via npm, you can import them like so:
+		</p>
+		<code>
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+		</code>
+		<p>
+			The following examples files are already available as modules:
+			<ul>
+				<li>controls
+					<ul>
+						<li>MapControls</li>
+						<li>OrbitControls</li>
+						<li>TrackballControls</li>
+					</ul>
+				</li>
+				<li>exporters
+					<ul>
+						<li>ColladaExporter</li>
+						<li>GLTFExporter</li>
+						<li>MMDExporter</li>
+						<li>OBJExporter</li>
+						<li>PLYExporter</li>
+						<li>STLExporter</li>
+						<li>TypedGeometryExporter</li>
+					</ul>
+				</li>
+				<li>loaders
+					<ul>
+						<li>GLTFLoader</li>
+						<li>MTLLoader</li>
+						<li>OBJLoader</li>
+					</ul>
+				</li>
+				<li>pmrem
+					<ul>
+						<li>PMREMCubeUVPacker</li>
+						<li>PMREMGenerator</li>
+					</ul>
+				</li>
+				<li>utils
+					<ul>
+						<li>BufferGeometryUtils</li>
+						<li>GeometryUtils</li>
+						<li>MathUtils</li>
+						<li>SceneUtils</li>
+						<li>ShadowMapViewer</li>
+						<li>SkeletonUtils</li>
+						<li>TypedArrayUtils</li>
+						<li>UVsDebug</li>
+					</ul>
+				</li>
+			</ul>
 		</p>
 	</body>
 </html>

--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -99,6 +99,7 @@
 						<li>GLTFLoader</li>
 						<li>MTLLoader</li>
 						<li>OBJLoader</li>
+						<li>STLLoader</li>
 					</ul>
 				</li>
 				<li>pmrem

--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -66,7 +66,7 @@
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other components like loaders or controls are part of the
 			examples directory. three.js ensures to keep these files in sync with the core but users have to import them separately if they are required
-			for their project. However, most of these files are no modules which makes their usage in certain cases inconvenient. In order to address this issue,
+			for their project. However, most of these files are not modules which makes their usage in certain cases inconvenient. In order to address this issue,
 			three.js is going to provide more and more files as modules in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory.
 			If you install three.js via npm, you can import them like so:
 		</p>

--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -65,9 +65,9 @@
 		<h2>Importable Examples</h2>
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other components like loaders or controls are part of the
-			examples directory. three.js ensures to keep these files in sync with the core but users have to import them separately if they are required
+			examples directory. three.js ensures that these files are kept in sync with the core but users have to import them separately if they are required
 			for their project. However, most of these files are not modules which makes their usage in certain cases inconvenient. In order to address this issue,
-			three.js is going to provide more and more files as modules in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory.
+			we are working to provide all the examples as modules in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory.
 			If you install three.js via npm, you can import them like so:
 		</p>
 		<code>
@@ -120,6 +120,13 @@
 					</ul>
 				</li>
 			</ul>
+		</p>
+		<p>
+			Note: When using code from the examples directory, it's important that all files match the version of
+			your three.js main file. For example it's no good approach to use *GLTFLoader* and *OrbitControls* from R96 together
+			with three.js R103. You can easily keep your files in sync by using the modules from the JSM directory. If the file
+			is not available as a module, you can still use third-party npm packages or convert the file to a module by yourself.
+			In both cases, ensure the code is compatible with your three.js main file.
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
Fixed #16220

The PR updates `Import-via-modules.html` by adding useful notes about JSM. It also lists all examples files which are currently available as modules.