### PR TITLE
Examples: Replace "DRACOExporter" with "DracoExporter"

### DIFF
--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -39,7 +39,7 @@
 		<script src="js/libs/draco/draco_encoder.js"></script>
 
 		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/exporters/DRACOExporter.js"></script>
+		<script src="js/exporters/DracoExporter.js"></script>
 
 		<script src="js/WebGL.js"></script>
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/blob/0828c0b4671443dc55dce05c4b1cc7d0ed4a8a3f/examples/misc_exporter_draco.html#L42

Error 404 for `js/exporters/DRACOExporter.js`: The file is named `DracoExporter.js`, only the class is `DRACOExporter`.