### PR TITLE
Allow tree-shaking by adding "sideEffects": false flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "jsnext:main": "build/three.module.js",
   "module": "build/three.module.js",
   "types": "src/Three.d.ts",
+  "sideEffects": false,
   "files": [
     "build/three.js",
     "build/three.min.js",


### PR DESCRIPTION
This PR adds the flag `"sideEffects": false` in the package.json, with the objective to allow tree-shaking for webpack users. More precisely this will allow people to do

```js
import * as THREE from 'three/src/Three'
```

while including only the components which are actually used in the code in the bundle.

#### Example

```
import * as THREE from 'three/src/Three'
console.log(THREE.Vector3)
```

```
  Asset    Size  
main.js  15 KiB
```

Setting `sideEffects` to false means there isn't any shared "state" in three.js which is affected by other non-required files (side effects). This is true since three.js' core uses only import/exports and isn't using any non-imported module (correct me if I'm wrong, don't know 100% of three.js' core).

[More info here](https://webpack.js.org/guides/tree-shaking/)