### PR TITLE
Update SVGLoader.js

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -804,13 +804,15 @@ THREE.SVGLoader.prototype = {
 
 			var transform = new THREE.Matrix3();
 			var currentTransform = tempTransform0;
-			var transformsTexts = node.getAttribute( 'transform' ).split( ' ' );
+			var transformsTexts = node.getAttribute( 'transform' ).split( ')' );
 
 			for ( var tIndex = transformsTexts.length - 1; tIndex >= 0; tIndex -- ) {
 
-				var transformText = transformsTexts[ tIndex ];
+				var transformText = transformsTexts[ tIndex ].trim();
+				if (transformText == "")
+					continue;				
 				var openParPos = transformText.indexOf( "(" );
-				var closeParPos = transformText.indexOf( ")" );
+				var closeParPos = transformText.length;
 
 				if ( openParPos > 0 && openParPos < closeParPos ) {
 


### PR DESCRIPTION
These changes parse SVG transforms without basing them on spaces.  For instance translate(200, 200) would split improperly because it has a space between the comma and the 2.

The following example appears differently in Windows Edge than in other browsers without the changes.  Edge inserts white spaces after commas in transforms for some reason.
https://threejs.org/examples/webgl_loader_svg.html