### PR TITLE
Examples: Ensure controls using the wheel event don't use document.

### DIFF
--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -56,8 +56,7 @@ function animate() {
 		<p>
 			[page:Camera object]: (required) The camera to be controlled.<br><br>
 
-			[page:HTMLDOMElement domElement]: The HTML element used for event listeners. In most cases, you want to pass in
-			the renderer's canvas element via *renderer.domElement*.
+			[page:HTMLDOMElement domElement]: The HTML element used for event listeners.
 		</p>
 
 

--- a/docs/examples/controls/OrbitControls.html
+++ b/docs/examples/controls/OrbitControls.html
@@ -56,8 +56,8 @@ function animate() {
 		<p>
 			[page:Camera object]: (required) The camera to be controlled.<br><br>
 
-			[page:HTMLDOMElement domElement]: (optional) The HTML element used for event listeners. By default this is the whole document,
-			however if you only want the controls to work over a specific element (e.g. the canvas) you can specify that here.
+			[page:HTMLDOMElement domElement]: The HTML element used for event listeners. In most cases, you want to pass in
+			the renderer's canvas element via *renderer.domElement*.
 		</p>
 
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -7,7 +7,7 @@
 
 THREE.EditorControls = function ( object, domElement ) {
 
-	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.warn( 'THREE.EditorControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	// API

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -8,7 +8,7 @@
 THREE.EditorControls = function ( object, domElement ) {
 
 	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.warn( 'THREE.EditorControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === document ) console.error( 'THREE.EditorControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	// API
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -7,8 +7,8 @@
 
 THREE.EditorControls = function ( object, domElement ) {
 
-	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
-	if ( domElement === document ) console.warn( 'THREE.EditorControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.EditorControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	// API
 

--- a/examples/js/controls/EditorControls.js
+++ b/examples/js/controls/EditorControls.js
@@ -7,7 +7,8 @@
 
 THREE.EditorControls = function ( object, domElement ) {
 
-	domElement = ( domElement !== undefined ) ? domElement : document;
+	if ( domElement === undefined ) console.error( 'THREE.EditorControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.EditorControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
 
 	// API
 

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -20,7 +20,7 @@ THREE.MapControls = function ( object, domElement ) {
 	this.object = object;
 
 	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.warn( 'THREE.MapControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === document ) console.error( 'THREE.MapControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 
@@ -366,7 +366,7 @@ THREE.MapControls = function ( object, domElement ) {
 
 		return function pan( deltaX, deltaY ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -478,7 +478,7 @@ THREE.MapControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -643,7 +643,7 @@ THREE.MapControls = function ( object, domElement ) {
 
 		if ( isRotateUp() ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			// rotating up and down along whole screen attempts to go 360, but limited to 180
 			rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -19,8 +19,8 @@ THREE.MapControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
-	if ( domElement === document ) console.warn( 'THREE.MapControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.MapControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -19,7 +19,10 @@ THREE.MapControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.MapControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+
+	this.domElement = domElement;
 
 	// Set to false to disable this control
 	this.enabled = true;

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -19,7 +19,7 @@ THREE.MapControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.warn( 'THREE.MapControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -18,7 +18,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.object = object;
 
 	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.warn( 'THREE.OrbitControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 
@@ -350,7 +350,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		return function pan( deltaX, deltaY ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -462,7 +462,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -622,7 +622,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -17,8 +17,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
-	if ( domElement === document ) console.warn( 'THREE.OrbitControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.OrbitControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -17,7 +17,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.warn( 'THREE.OrbitControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -17,7 +17,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.OrbitControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+
+	this.domElement = domElement;
 
 	// Set to false to disable this control
 	this.enabled = true;

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -11,7 +11,11 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	var STATE = { NONE: - 1, ROTATE: 0, ZOOM: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_ZOOM_PAN: 4 };
 
 	this.object = object;
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.OrthographicTrackballControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+
+	this.domElement = domElement;
 
 	// API
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -13,7 +13,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 	this.object = object;
 
 	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.warn( 'THREE.OrthographicTrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === document ) console.error( 'THREE.OrthographicTrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -12,8 +12,8 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
-	if ( domElement === document ) console.warn( 'THREE.OrthographicTrackballControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.OrthographicTrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -12,7 +12,7 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === undefined ) console.error( 'THREE.OrthographicTrackballControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.warn( 'THREE.OrthographicTrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 	this.domElement = domElement;

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -11,7 +11,12 @@ THREE.TrackballControls = function ( object, domElement ) {
 	var STATE = { NONE: - 1, ROTATE: 0, ZOOM: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_ZOOM_PAN: 4 };
 
 	this.object = object;
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.TrackballControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+
+
+	this.domElement = domElement;
 
 	// API
 
@@ -492,7 +497,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 	function touchstart( event ) {
 
 		if ( _this.enabled === false ) return;
-		
+
 		event.preventDefault();
 
 		switch ( event.touches.length ) {

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -12,8 +12,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second paramter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
-	if ( domElement === document ) console.warn( 'THREE.TrackballControls: "document" is no valid value for "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === document ) console.warn( 'THREE.TrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 
 	this.domElement = domElement;

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -13,7 +13,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.object = object;
 
 	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.warn( 'THREE.TrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+	if ( domElement === document ) console.error( 'THREE.TrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 
 	this.domElement = domElement;
@@ -85,24 +85,14 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.handleResize = function () {
 
-		if ( this.domElement === document ) {
+		var box = this.domElement.getBoundingClientRect();
+		// adjustments come from similar code in the jquery offset() function
+		var d = this.domElement.ownerDocument.documentElement;
+		this.screen.left = box.left + window.pageXOffset - d.clientLeft;
+		this.screen.top = box.top + window.pageYOffset - d.clientTop;
+		this.screen.width = box.width;
+		this.screen.height = box.height;
 
-			this.screen.left = 0;
-			this.screen.top = 0;
-			this.screen.width = window.innerWidth;
-			this.screen.height = window.innerHeight;
-
-		} else {
-
-			var box = this.domElement.getBoundingClientRect();
-			// adjustments come from similar code in the jquery offset() function
-			var d = this.domElement.ownerDocument.documentElement;
-			this.screen.left = box.left + window.pageXOffset - d.clientLeft;
-			this.screen.top = box.top + window.pageYOffset - d.clientTop;
-			this.screen.width = box.width;
-			this.screen.height = box.height;
-
-		}
 
 	};
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -12,7 +12,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second parameter "domElement" is now mandatory. In most cases, "renderer.domElement" is best.' );
+	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.warn( 'THREE.TrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 

--- a/examples/jsm/controls/MapControls.d.ts
+++ b/examples/jsm/controls/MapControls.d.ts
@@ -7,10 +7,10 @@ import {
 } from '../../../src/Three';
 
 export class MapControls extends EventDispatcher {
-  constructor(object: Camera, domElement?: HTMLElement);
+  constructor(object: Camera, domElement: HTMLElement);
 
   object: Camera;
-  domElement: HTMLElement | HTMLDocument;
+  domElement: HTMLElement;
 
   // API
   enabled: boolean;

--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -28,7 +28,10 @@ var MapControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+	if ( domElement === undefined ) console.error( 'THREE.MapControls: The second parameter "domElement" is now mandatory.' );
+	if ( domElement === document ) console.error( 'THREE.MapControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+	this.domElement = domElement;
 
 	// Set to false to disable this control
 	this.enabled = true;
@@ -372,7 +375,7 @@ var MapControls = function ( object, domElement ) {
 
 		return function pan( deltaX, deltaY ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -484,7 +487,7 @@ var MapControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -649,7 +652,7 @@ var MapControls = function ( object, domElement ) {
 
 		if ( isRotateUp() ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			// rotating up and down along whole screen attempts to go 360, but limited to 180
 			rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );

--- a/examples/jsm/controls/OrbitControls.d.ts
+++ b/examples/jsm/controls/OrbitControls.d.ts
@@ -1,10 +1,10 @@
 import { Camera, MOUSE, Object3D, Vector3 } from '../../../src/Three';
 
 export class OrbitControls {
-	constructor(object: Camera, domElement?: HTMLElement);
+	constructor(object: Camera, domElement: HTMLElement);
 
 	object: Camera;
-	domElement: HTMLElement | HTMLDocument;
+	domElement: HTMLElement;
 
 	// API
 	enabled: boolean;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -26,7 +26,10 @@ var OrbitControls = function ( object, domElement ) {
 
 	this.object = object;
 
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+	if ( domElement === undefined ) console.error( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
+	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+	this.domElement = domElement;
 
 	// Set to false to disable this control
 	this.enabled = true;
@@ -356,7 +359,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		return function pan( deltaX, deltaY ) {
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -468,7 +471,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -628,7 +631,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+		var element = scope.domElement;
 
 		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 

--- a/examples/jsm/controls/TrackballControls.d.ts
+++ b/examples/jsm/controls/TrackballControls.d.ts
@@ -1,7 +1,7 @@
 import { Camera, EventDispatcher, Vector3 } from '../../../src/Three';
 
 export class TrackballControls extends EventDispatcher {
-  constructor(object: Camera, domElement?: HTMLElement);
+  constructor(object: Camera, domElement: HTMLElement);
 
   object: Camera;
   domElement: HTMLElement;

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -18,7 +18,12 @@ var TrackballControls = function ( object, domElement ) {
 	var STATE = { NONE: - 1, ROTATE: 0, ZOOM: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_ZOOM_PAN: 4 };
 
 	this.object = object;
-	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	if ( domElement === undefined ) console.error( 'THREE.TrackballControls: The second parameter "domElement" is now mandatory.' );
+	if ( domElement === document ) console.error( 'THREE.TrackballControls: "document" cannot be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+
+	this.domElement = domElement;
 
 	// API
 
@@ -87,24 +92,14 @@ var TrackballControls = function ( object, domElement ) {
 
 	this.handleResize = function () {
 
-		if ( this.domElement === document ) {
+		var box = this.domElement.getBoundingClientRect();
+		// adjustments come from similar code in the jquery offset() function
+		var d = this.domElement.ownerDocument.documentElement;
+		this.screen.left = box.left + window.pageXOffset - d.clientLeft;
+		this.screen.top = box.top + window.pageYOffset - d.clientTop;
+		this.screen.width = box.width;
+		this.screen.height = box.height;
 
-			this.screen.left = 0;
-			this.screen.top = 0;
-			this.screen.width = window.innerWidth;
-			this.screen.height = window.innerHeight;
-
-		} else {
-
-			var box = this.domElement.getBoundingClientRect();
-			// adjustments come from similar code in the jquery offset() function
-			var d = this.domElement.ownerDocument.documentElement;
-			this.screen.left = box.left + window.pageXOffset - d.clientLeft;
-			this.screen.top = box.top + window.pageYOffset - d.clientTop;
-			this.screen.width = box.width;
-			this.screen.height = box.height;
-
-		}
 
 	};
 
@@ -499,7 +494,7 @@ var TrackballControls = function ( object, domElement ) {
 	function touchstart( event ) {
 
 		if ( _this.enabled === false ) return;
-		
+
 		event.preventDefault();
 
 		switch ( event.touches.length ) {


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/16329#issuecomment-486802432

All controls utilizing the `wheel` event now log a warning if `document` is passed in as the second ctor parameter. Besides, this parameter (`domElement`) is now mandatory. Otherwise, the controls would use `document` as default value.

Should we make `domElement` to a mandatory parameter for all controls? It is already required for `DragControls` but not for `FlyControls`, `FirstPersonControls`, `TransformControls` and `PointerLockControls`.