### PR TITLE
OBJLoader2 V2.5.1

### DIFF
--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -356,9 +356,9 @@ THREE.LoaderSupport.MeshBuilder = function() {
 	};
 
 	this.callbacks = new THREE.LoaderSupport.Callbacks();
-	this.materials = [];
+	this.materials = {};
 };
-THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION = '1.3.0';
+THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION = '1.3.1';
 
 THREE.LoaderSupport.MeshBuilder.prototype = {
 

--- a/examples/js/loaders/LoaderSupport.js
+++ b/examples/js/loaders/LoaderSupport.js
@@ -347,7 +347,6 @@ THREE.LoaderSupport.PrepData.prototype = {
  * @class
  */
 THREE.LoaderSupport.MeshBuilder = function() {
-	console.info( 'Using THREE.LoaderSupport.MeshBuilder version: ' + THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION );
 	this.validator = THREE.LoaderSupport.Validator;
 
 	this.logging = {
@@ -359,6 +358,8 @@ THREE.LoaderSupport.MeshBuilder = function() {
 	this.materials = {};
 };
 THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION = '1.3.1';
+console.info( 'Using THREE.LoaderSupport.MeshBuilder version: ' + THREE.LoaderSupport.MeshBuilder.LOADER_MESH_BUILDER_VERSION );
+
 
 THREE.LoaderSupport.MeshBuilder.prototype = {
 
@@ -715,7 +716,6 @@ THREE.LoaderSupport.MeshBuilder.prototype = {
  * @class
  */
 THREE.LoaderSupport.WorkerSupport = function () {
-	console.info( 'Using THREE.LoaderSupport.WorkerSupport version: ' + THREE.LoaderSupport.WorkerSupport.WORKER_SUPPORT_VERSION );
 	this.logging = {
 		enabled: true,
 		debug: false
@@ -726,6 +726,8 @@ THREE.LoaderSupport.WorkerSupport = function () {
 };
 
 THREE.LoaderSupport.WorkerSupport.WORKER_SUPPORT_VERSION = '2.3.0';
+console.info( 'Using THREE.LoaderSupport.WorkerSupport version: ' + THREE.LoaderSupport.WorkerSupport.WORKER_SUPPORT_VERSION );
+
 
 THREE.LoaderSupport.WorkerSupport.prototype = {
 
@@ -1285,10 +1287,10 @@ THREE.LoaderSupport.WorkerRunnerRefImpl.prototype = {
 
 			var self = this.getParentScope();
 			var callbacks = {
-				callbackMeshBuilder: function ( payload ) {
+				callbackOnAssetAvailable: function ( payload ) {
 					self.postMessage( payload );
 				},
-				callbackProgress: function ( text ) {
+				callbackOnProgress: function ( text ) {
 					if ( payload.logging.enabled && payload.logging.debug ) console.debug( 'WorkerRunner: progress: ' + text );
 				}
 			};
@@ -1304,7 +1306,7 @@ THREE.LoaderSupport.WorkerRunnerRefImpl.prototype = {
 
 			if ( payload.logging.enabled ) console.log( 'WorkerRunner: Run complete!' );
 
-			callbacks.callbackMeshBuilder( {
+			callbacks.callbackOnAssetAvailable( {
 				cmd: 'complete',
 				msg: 'WorkerRunner completed run.'
 			} );
@@ -1414,7 +1416,6 @@ THREE.LoaderSupport.WorkerSupport.NodeLoaderWorker.prototype.initWorker = functi
  * @param {string} classDef Class definition to be used for construction
  */
 THREE.LoaderSupport.WorkerDirector = function ( classDef ) {
-	console.info( 'Using THREE.LoaderSupport.WorkerDirector version: ' + THREE.LoaderSupport.WorkerDirector.LOADER_WORKER_DIRECTOR_VERSION );
 	this.logging = {
 		enabled: true,
 		debug: false
@@ -1443,6 +1444,8 @@ THREE.LoaderSupport.WorkerDirector = function ( classDef ) {
 THREE.LoaderSupport.WorkerDirector.LOADER_WORKER_DIRECTOR_VERSION = '2.3.0';
 THREE.LoaderSupport.WorkerDirector.MAX_WEB_WORKER = 16;
 THREE.LoaderSupport.WorkerDirector.MAX_QUEUE_SIZE = 2048;
+console.info( 'Using THREE.LoaderSupport.WorkerDirector version: ' + THREE.LoaderSupport.WorkerDirector.LOADER_WORKER_DIRECTOR_VERSION );
+
 
 THREE.LoaderSupport.WorkerDirector.prototype = {
 

--- a/examples/js/loaders/OBJLoader2.js
+++ b/examples/js/loaders/OBJLoader2.js
@@ -41,7 +41,7 @@ THREE.OBJLoader2 = function ( manager ) {
 	this.terminateWorkerOnLoad = true;
 };
 
-THREE.OBJLoader2.OBJLOADER2_VERSION = '2.5.0';
+THREE.OBJLoader2.OBJLOADER2_VERSION = '2.5.1';
 
 THREE.OBJLoader2.prototype = {
 
@@ -339,10 +339,9 @@ THREE.OBJLoader2.prototype = {
 	 */
 	parse: function ( content ) {
 		// fast-fail in case of illegal data
-		if ( ! THREE.LoaderSupport.Validator.isValid( content ) ) {
+		if ( content === null || content === undefined ) {
 
-			console.warn( 'Provided content is not a valid ArrayBuffer or String.' );
-			return this.loaderRootNode;
+			throw 'Provided content is not a valid ArrayBuffer or String. Unable to continue parsing';
 
 		}
 		if ( this.logging.enabled ) console.time( 'OBJLoader2 parse: ' + this.modelName );
@@ -414,10 +413,9 @@ THREE.OBJLoader2.prototype = {
 			if ( measureTime && scope.logging.enabled ) console.timeEnd( 'OBJLoader2 parseAsync: ' + scope.modelName );
 		};
 		// fast-fail in case of illegal data
-		if ( ! THREE.LoaderSupport.Validator.isValid( content ) ) {
+		if ( content === null || content === undefined ) {
 
-			console.warn( 'Provided content is not a valid ArrayBuffer.' );
-			scopedOnLoad()
+			throw 'Provided content is not a valid ArrayBuffer or String. Unable to continue parsing';
 
 		} else {
 
@@ -503,7 +501,7 @@ THREE.OBJLoader2.prototype = {
 		if ( THREE.MTLLoader === undefined ) console.error( '"THREE.MTLLoader" is not available. "THREE.OBJLoader2" requires it for loading MTL files.' );
 		if ( THREE.LoaderSupport.Validator.isValid( resource ) && this.logging.enabled ) console.time( 'Loading MTL: ' + resource.name );
 
-		var materials = [];
+		var materials = {};
 		var scope = this;
 		var processMaterials = function ( materialCreator ) {
 			var materialCreatorMaterials = [];
@@ -1287,9 +1285,13 @@ THREE.OBJLoader2.Parser.prototype = {
 
 				var defaultMaterialName = haveVertexColors ? 'defaultVertexColorMaterial' : 'defaultMaterial';
 				materialOrg = this.materials[ defaultMaterialName ];
-				if ( this.logging.enabled ) console.warn( 'object_group "' + meshOutputGroup.objectName + '_' +
-					meshOutputGroup.groupName + '" was defined with unresolvable material "' +
-					materialNameOrg + '"! Assigning "' + defaultMaterialName + '".' );
+				if ( this.logging.enabled ) {
+
+					console.info( 'object_group "' + meshOutputGroup.objectName + '_' +
+						meshOutputGroup.groupName + '" was defined with unresolvable material "' +
+						materialNameOrg + '"! Assigning "' + defaultMaterialName + '".' );
+
+				}
 				materialNameOrg = defaultMaterialName;
 
 				// if names are identical then there is no need for later manipulation

--- a/examples/webgl_loader_obj2_meshspray.html
+++ b/examples/webgl_loader_obj2_meshspray.html
@@ -226,8 +226,9 @@
 				this.debug = false;
 				this.dimension = 200;
 				this.quantity = 1;
-				this.callbackMeshBuilder = null;
-				this.callbackProgress = null;
+				this.callbacks = {
+					onAssetAvailable: null
+				};
 				this.serializedMaterials = null;
 				this.logging = {
 					enabled: true,
@@ -238,6 +239,14 @@
 			MeshSpray.Parser.prototype = {
 
 				constructor: MeshSpray.Parser,
+
+				setCallbackOnAssetAvailable: function ( onAssetAvailable ) {
+					if ( onAssetAvailable !== null && onAssetAvailable !== undefined ) {
+
+						this.callbacks.onAssetAvailable = onAssetAvailable;
+
+					}
+				},
 
 				setLogging: function ( enabled, debug ) {
 					this.logging.enabled = enabled === true;
@@ -330,10 +339,10 @@
 							serializedMaterials: newSerializedMaterials
 						}
 					};
-					this.callbackMeshBuilder( payload );
+					this.callbacks.onAssetAvailable( payload );
 
 					this.globalObjectCount++;
-					this.callbackMeshBuilder(
+					this.callbacks.onAssetAvailable(
 						{
 							cmd: 'meshData',
 							progress: {


### PR DESCRIPTION
This fixes the following issues:
#15219: Materials are initialised as objects.
#15468. OBJLoader2: Reduced log level from warn to info when defaultMaterial is used when material name was not resolvable.
#16307: Backported onError function usage from OBJLoader2/Parser V3. Unified callback naming

From now on versions are only printed once in the logs.