### PR TITLE
Prevent unexpected renderTarget override in OutlineEffect

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -439,7 +439,7 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	this.render = function ( scene, camera ) {
 
-		var renderTarget = null;
+		var renderTarget;
 		var forceClear = false;
 
 		if ( arguments[ 2 ] !== undefined ) {
@@ -456,7 +456,7 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 		}
 
-		renderer.setRenderTarget( renderTarget );
+		if ( renderTarget !== undefined ) renderer.setRenderTarget( renderTarget );
 
 		if ( forceClear ) renderer.clear();
 


### PR DESCRIPTION
I realized I shouldn't call `setRenderTarget()` with `null` in `OutlineEffect` unless deprecated `renderTarget` argument is passed. Otherwise it unexpectedly overrides `renderTarget` set to `renderer` beforehand.