### PR TITLE
Fix documentation related to MTLLoader materials

### DIFF
--- a/docs/examples/loaders/MTLLoader.html
+++ b/docs/examples/loaders/MTLLoader.html
@@ -94,7 +94,7 @@
 			[page:String path] — The path to the MTL file.
 		</p>
 		<p>
-			Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator] instance.<br />
+			Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
 		</p>
 
 

--- a/docs/examples/loaders/OBJLoader.html
+++ b/docs/examples/loaders/OBJLoader.html
@@ -89,12 +89,12 @@
 		If an <em>obj</em> object or group uses multiple materials while declaring faces, geometry groups and an array of materials are used.
 		</p>
 
-		<h3>[method:OBJLoader setMaterials]( [param:Array materials] )</h3>
+		<h3>[method:OBJLoader setMaterials]( [param:MTLLoader.MaterialCreator materials] )</h3>
 		<p>
-		[page:Array materials] - Array of [page:Material Materials].
+		[page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator materials] - A MaterialCreator instance.
 		</p>
 		<p>
-		Sets materials loaded by MTLLoader or any other supplier of an Array of [page:Material Materials].
+		Sets materials loaded by MTLLoader or any other supplier of a [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator].
 		</p>
 
 		<h3>[method:OBJLoader setPath]( [param:String path] )</h3>


### PR DESCRIPTION
MTLLoader returns materials as MTLLoader.MaterialCreator, not as an array, and this is the type that OBJLoader.setMaterials takes as a parameter.