### PR TITLE
PCDLoader: Fix data parsing for Edge.

### DIFF
--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -169,7 +169,7 @@ THREE.PCDLoader.prototype = {
 
 		}
 
-		var textData = THREE.LoaderUtils.decodeText( data );
+		var textData = THREE.LoaderUtils.decodeText( new Uint8Array( data ) );
 
 		// parse header (always ascii format)
 

--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -24,8 +24,17 @@ var LoaderUtils = {
 
 		}
 
-		// Merges multi-byte utf-8 characters.
-		return decodeURIComponent( escape( s ) );
+		try {
+
+			// merges multi-byte utf-8 characters.
+
+			return decodeURIComponent( escape( s ) );
+
+		} catch ( e ) { // see #16358
+
+			return s;
+
+		}
 
 	},
 

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -18,6 +18,9 @@ export default QUnit.module( 'Loaders', () => {
 			var multibyteArray = new Uint8Array( [ 230, 151, 165, 230, 156, 172, 229, 155, 189 ] );
 			assert.equal( '日本国', LoaderUtils.decodeText( multibyteArray ) );
 
+			var uriError = new Uint8Array( [ 219 ] );
+			assert.equal( 'Û', LoaderUtils.decodeText( uriError ) );
+
 		} );
 
 		QUnit.test( 'extractUrlBase', ( assert ) => {

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -18,9 +18,6 @@ export default QUnit.module( 'Loaders', () => {
 			var multibyteArray = new Uint8Array( [ 230, 151, 165, 230, 156, 172, 229, 155, 189 ] );
 			assert.equal( '日本国', LoaderUtils.decodeText( multibyteArray ) );
 
-			var uriError = new Uint8Array( [ 219 ] );
-			assert.equal( 'Û', LoaderUtils.decodeText( uriError ) );
-
 		} );
 
 		QUnit.test( 'extractUrlBase', ( assert ) => {


### PR DESCRIPTION
Fixed #16358

`PCDLoader` is passing right now an instance of `ArrayBuffer` to `LoaderUtils.decodeText()`. If `TextDecoder` is not supported (like in Edge), the fallback is only able to handle typed arrays.