### PR TITLE
Consistently Document Full Object Inheritance

### DIFF
--- a/docs/api/en/cameras/ArrayCamera.html
+++ b/docs/api/en/cameras/ArrayCamera.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:PerspectiveCamera] &rarr;
+		[page:Object3D] &rarr; [page:Camera] &rarr; [page:PerspectiveCamera] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/extras/core/Path.html
+++ b/docs/api/en/extras/core/Path.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:CurvePath] &rarr;
+		[page:Curve] &rarr; [page:CurvePath] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/extras/core/Shape.html
+++ b/docs/api/en/extras/core/Shape.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Path] &rarr;
+		[page:Curve] &rarr; [page:CurvePath] &rarr; [page:Path] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/extras/core/ShapePath.html
+++ b/docs/api/en/extras/core/ShapePath.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:CurvePath] &rarr;
+		[page:Curve] &rarr; [page:CurvePath] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/extras/curves/ArcCurve.html
+++ b/docs/api/en/extras/curves/ArcCurve.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:EllipseCurve] &rarr;
+		[page:Curve] &rarr; [page:EllipseCurve] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/ConeBufferGeometry.html
+++ b/docs/api/en/geometries/ConeBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:CylinderBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:CylinderBufferGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/ConeGeometry.html
+++ b/docs/api/en/geometries/ConeGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:CylinderGeometry] &rarr;
+		[page:Geometry] &rarr; [page:CylinderGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/en/geometries/DodecahedronBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:PolyhedronBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:PolyhedronBufferGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/en/geometries/IcosahedronBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:PolyhedronBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:PolyhedronBufferGeometry] &rarr;
 		<h1>[name]</h1>
 
 		<p class="desc">A class for generating an icosahedron geometry.</p>

--- a/docs/api/en/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/en/geometries/OctahedronBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:PolyhedronBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:PolyhedronBufferGeometry] &rarr;
 		<h1>[name]</h1>
 
 		<p class="desc">A class for generating an octahedron geometry.</p>

--- a/docs/api/en/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/en/geometries/TetrahedronBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:PolyhedronBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:PolyhedronBufferGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/TextBufferGeometry.html
+++ b/docs/api/en/geometries/TextBufferGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:ExtrudeBufferGeometry] &rarr;
+		[page:BufferGeometry] &rarr; [page:ExtrudeBufferGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/geometries/TextGeometry.html
+++ b/docs/api/en/geometries/TextGeometry.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:ExtrudeGeometry] &rarr;
+		[page:Geometry] &rarr; [page:ExtrudeGeometry] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/Box3Helper.html
+++ b/docs/api/en/helpers/Box3Helper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/BoxHelper.html
+++ b/docs/api/en/helpers/BoxHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/FaceNormalsHelper.html
+++ b/docs/api/en/helpers/FaceNormalsHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -8,8 +8,8 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Line] &rarr;
-
+		[page:Object3D] &rarr; [page:Line] &rarr;
+		
 		<h1>[name]</h1>
 
 		<p class="desc">The GridHelper is an object to define grids. Grids are two-dimensional arrays of lines.</p>

--- a/docs/api/en/helpers/PlaneHelper.html
+++ b/docs/api/en/helpers/PlaneHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:LineSegments] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/PointLightHelper.html
+++ b/docs/api/en/helpers/PointLightHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Mesh] &rarr;
+		[page:Object3D] &rarr; [page:Mesh] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/PolarGridHelper.html
+++ b/docs/api/en/helpers/PolarGridHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Line] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/helpers/VertexNormalsHelper.html
+++ b/docs/api/en/helpers/VertexNormalsHelper.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Line] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr;
 
 		<h1>[name]</h1>
 

--- a/docs/api/en/materials/RawShaderMaterial.html
+++ b/docs/api/en/materials/RawShaderMaterial.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:ShaderMaterial] &rarr;
+		[page:Material] &rarr; [page:ShaderMaterial] &rarr;
 
 		<h1>[name]</h1>
 


### PR DESCRIPTION
Fix some docs pages that didn't document an objects full inheritance chain.

Fix #16345 