### PR TITLE
Resize cameras viewports correctly on the webgl_camera_array example

### DIFF
--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -20,6 +20,7 @@
 
 			var camera, scene, renderer;
 			var mesh;
+			var AMOUNT = 6;
 
 			init();
 			animate();
@@ -28,7 +29,6 @@
 
 				var ASPECT_RATIO = window.innerWidth / window.innerHeight;
 
-				var AMOUNT = 6;
 				var WIDTH = ( window.innerWidth / AMOUNT ) * window.devicePixelRatio;
 				var HEIGHT = ( window.innerHeight / AMOUNT ) * window.devicePixelRatio;
 
@@ -95,8 +95,30 @@
 
 			function onWindowResize() {
 
-				camera.aspect = window.innerWidth / window.innerHeight;
+				var ASPECT_RATIO = window.innerWidth / window.innerHeight;
+				var WIDTH = ( window.innerWidth / AMOUNT ) * window.devicePixelRatio;
+				var HEIGHT = ( window.innerHeight / AMOUNT ) * window.devicePixelRatio;
+
+				camera.aspect = ASPECT_RATIO;
 				camera.updateProjectionMatrix();
+
+				for ( var y = 0; y < AMOUNT; y ++ ) {
+
+					for ( var x = 0; x < AMOUNT; x ++ ) {
+
+						var subcamera = camera.cameras[ AMOUNT * y + x ];
+
+						subcamera.viewport.set(
+							Math.floor( x * WIDTH ),
+							Math.floor( y * HEIGHT ),
+							Math.ceil( WIDTH ),
+							Math.ceil( HEIGHT ) );
+
+						subcamera.aspect = ASPECT_RATIO;
+						subcamera.updateProjectionMatrix();
+
+					}
+				}
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 


### PR DESCRIPTION
Currently they have a fixed size and resizing the canvas is not affecting the viewports.
As it seems we are moving definitely from `bounds` to `viewports` per https://github.com/mrdoob/three.js/issues/16361