### PR TITLE
WebGLUniforms: Remove cache on uniform arrays

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -523,40 +523,25 @@ function setValue1iv( gl, v ) {
 
 function setValueV2a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 2 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniform2fv( this.addr, data );
-
-	this.updateCache( data );
 
 }
 
 function setValueV3a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 3 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniform3fv( this.addr, data );
-
-	this.updateCache( data );
 
 }
 
 function setValueV4a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 4 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniform4fv( this.addr, data );
-
-	this.updateCache( data );
 
 }
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -590,17 +590,11 @@ function setValueM4a( gl, v ) {
 
 function setValueT1a( gl, v, textures ) {
 
-	var cache = this.cache;
 	var n = v.length;
 
 	var units = allocTexUnits( textures, n );
 
-	if ( arraysEqual( cache, units ) === false ) {
-
-		gl.uniform1iv( this.addr, units );
-		copyArray( cache, units );
-
-	}
+	gl.uniform1iv( this.addr, units );
 
 	for ( var i = 0; i !== n; ++ i ) {
 
@@ -612,17 +606,11 @@ function setValueT1a( gl, v, textures ) {
 
 function setValueT6a( gl, v, textures ) {
 
-	var cache = this.cache;
 	var n = v.length;
 
 	var units = allocTexUnits( textures, n );
 
-	if ( arraysEqual( cache, units ) === false ) {
-
-		gl.uniform1iv( this.addr, units );
-		copyArray( cache, units );
-
-	}
+	gl.uniform1iv( this.addr, units );
 
 	for ( var i = 0; i !== n; ++ i ) {
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -564,40 +564,25 @@ function setValueV4a( gl, v ) {
 
 function setValueM2a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 4 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniformMatrix2fv( this.addr, false, data );
-
-	this.updateCache( data );
 
 }
 
 function setValueM3a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 9 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniformMatrix3fv( this.addr, false, data );
-
-	this.updateCache( data );
 
 }
 
 function setValueM4a( gl, v ) {
 
-	var cache = this.cache;
 	var data = flatten( v, this.size, 16 );
 
-	if ( arraysEqual( cache, data ) ) return;
-
 	gl.uniformMatrix4fv( this.addr, false, data );
-
-	this.updateCache( data );
 
 }
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -156,7 +156,7 @@ function allocTexUnits( textures, n ) {
 
 // Single scalar
 
-function setValue1f( gl, v ) {
+function setValueV1f( gl, v ) {
 
 	var cache = this.cache;
 
@@ -168,21 +168,9 @@ function setValue1f( gl, v ) {
 
 }
 
-function setValue1i( gl, v ) {
-
-	var cache = this.cache;
-
-	if ( cache[ 0 ] === v ) return;
-
-	gl.uniform1i( this.addr, v );
-
-	cache[ 0 ] = v;
-
-}
-
 // Single float vector (from flat array or THREE.VectorN)
 
-function setValue2fv( gl, v ) {
+function setValueV2f( gl, v ) {
 
 	var cache = this.cache;
 
@@ -209,7 +197,7 @@ function setValue2fv( gl, v ) {
 
 }
 
-function setValue3fv( gl, v ) {
+function setValueV3f( gl, v ) {
 
 	var cache = this.cache;
 
@@ -249,7 +237,7 @@ function setValue3fv( gl, v ) {
 
 }
 
-function setValue4fv( gl, v ) {
+function setValueV4f( gl, v ) {
 
 	var cache = this.cache;
 
@@ -280,7 +268,7 @@ function setValue4fv( gl, v ) {
 
 // Single matrix (from flat array or MatrixN)
 
-function setValue2fm( gl, v ) {
+function setValueM2( gl, v ) {
 
 	var cache = this.cache;
 	var elements = v.elements;
@@ -307,7 +295,7 @@ function setValue2fm( gl, v ) {
 
 }
 
-function setValue3fm( gl, v ) {
+function setValueM3( gl, v ) {
 
 	var cache = this.cache;
 	var elements = v.elements;
@@ -334,7 +322,7 @@ function setValue3fm( gl, v ) {
 
 }
 
-function setValue4fm( gl, v ) {
+function setValueM4( gl, v ) {
 
 	var cache = this.cache;
 	var elements = v.elements;
@@ -429,7 +417,19 @@ function setValueT6( gl, v, textures ) {
 
 // Integer / Boolean vectors or arrays thereof (always flat arrays)
 
-function setValue2iv( gl, v ) {
+function setValueV1i( gl, v ) {
+
+	var cache = this.cache;
+
+	if ( arraysEqual( cache, v ) ) return;
+
+	gl.uniform1iv( this.addr, v );
+
+	copyArray( cache, v );
+
+}
+
+function setValueV2i( gl, v ) {
 
 	var cache = this.cache;
 
@@ -441,7 +441,7 @@ function setValue2iv( gl, v ) {
 
 }
 
-function setValue3iv( gl, v ) {
+function setValueV3i( gl, v ) {
 
 	var cache = this.cache;
 
@@ -453,7 +453,7 @@ function setValue3iv( gl, v ) {
 
 }
 
-function setValue4iv( gl, v ) {
+function setValueV4i( gl, v ) {
 
 	var cache = this.cache;
 
@@ -471,57 +471,65 @@ function getSingularSetter( type ) {
 
 	switch ( type ) {
 
-		case 0x1406: return setValue1f; // FLOAT
-		case 0x8b50: return setValue2fv; // _VEC2
-		case 0x8b51: return setValue3fv; // _VEC3
-		case 0x8b52: return setValue4fv; // _VEC4
+		case 0x1406: return setValueV1f; // FLOAT
+		case 0x8b50: return setValueV2f; // _VEC2
+		case 0x8b51: return setValueV3f; // _VEC3
+		case 0x8b52: return setValueV4f; // _VEC4
 
-		case 0x8b5a: return setValue2fm; // _MAT2
-		case 0x8b5b: return setValue3fm; // _MAT3
-		case 0x8b5c: return setValue4fm; // _MAT4
+		case 0x8b5a: return setValueM2; // _MAT2
+		case 0x8b5b: return setValueM3; // _MAT3
+		case 0x8b5c: return setValueM4; // _MAT4
 
 		case 0x8b5e: case 0x8d66: return setValueT1; // SAMPLER_2D, SAMPLER_EXTERNAL_OES
 		case 0x8b5f: return setValueT3D1; // SAMPLER_3D
 		case 0x8b60: return setValueT6; // SAMPLER_CUBE
 		case 0x8DC1: return setValueT2DArray1; // SAMPLER_2D_ARRAY
 
-		case 0x1404: case 0x8b56: return setValue1i; // INT, BOOL
-		case 0x8b53: case 0x8b57: return setValue2iv; // _VEC2
-		case 0x8b54: case 0x8b58: return setValue3iv; // _VEC3
-		case 0x8b55: case 0x8b59: return setValue4iv; // _VEC4
+		case 0x1404: case 0x8b56: return setValueV1i; // INT, BOOL
+		case 0x8b53: case 0x8b57: return setValueV2i; // _VEC2
+		case 0x8b54: case 0x8b58: return setValueV3i; // _VEC3
+		case 0x8b55: case 0x8b59: return setValueV4i; // _VEC4
 
 	}
 
 }
 
 // Array of scalars
-
-function setValue1fv( gl, v ) {
-
-	var cache = this.cache;
-
-	if ( arraysEqual( cache, v ) ) return;
+function setValueV1fa( gl, v ) {
 
 	gl.uniform1fv( this.addr, v );
 
-	copyArray( cache, v );
-
 }
-function setValue1iv( gl, v ) {
 
-	var cache = this.cache;
-
-	if ( arraysEqual( cache, v ) ) return;
+// Integer / Boolean vectors or arrays thereof (always flat arrays)
+function setValueV1ia( gl, v ) {
 
 	gl.uniform1iv( this.addr, v );
 
-	copyArray( cache, v );
+}
+
+function setValueV2ia( gl, v ) {
+
+	gl.uniform2iv( this.addr, v );
 
 }
 
+function setValueV3ia( gl, v ) {
+
+	gl.uniform3iv( this.addr, v );
+
+}
+
+function setValueV4ia( gl, v ) {
+
+	gl.uniform4iv( this.addr, v );
+
+}
+
+
 // Array of vectors (flat or from THREE classes)
 
-function setValueV2a( gl, v ) {
+function setValueV2fa( gl, v ) {
 
 	var data = flatten( v, this.size, 2 );
 
@@ -529,7 +537,7 @@ function setValueV2a( gl, v ) {
 
 }
 
-function setValueV3a( gl, v ) {
+function setValueV3fa( gl, v ) {
 
 	var data = flatten( v, this.size, 3 );
 
@@ -537,7 +545,7 @@ function setValueV3a( gl, v ) {
 
 }
 
-function setValueV4a( gl, v ) {
+function setValueV4fa( gl, v ) {
 
 	var data = flatten( v, this.size, 4 );
 
@@ -611,10 +619,10 @@ function getPureArraySetter( type ) {
 
 	switch ( type ) {
 
-		case 0x1406: return setValue1fv; // FLOAT
-		case 0x8b50: return setValueV2a; // _VEC2
-		case 0x8b51: return setValueV3a; // _VEC3
-		case 0x8b52: return setValueV4a; // _VEC4
+		case 0x1406: return setValueV1fa; // FLOAT
+		case 0x8b50: return setValueV2fa; // _VEC2
+		case 0x8b51: return setValueV3fa; // _VEC3
+		case 0x8b52: return setValueV4fa; // _VEC4
 
 		case 0x8b5a: return setValueM2a; // _MAT2
 		case 0x8b5b: return setValueM3a; // _MAT3
@@ -623,10 +631,10 @@ function getPureArraySetter( type ) {
 		case 0x8b5e: return setValueT1a; // SAMPLER_2D
 		case 0x8b60: return setValueT6a; // SAMPLER_CUBE
 
-		case 0x1404: case 0x8b56: return setValue1iv; // INT, BOOL
-		case 0x8b53: case 0x8b57: return setValue2iv; // _VEC2
-		case 0x8b54: case 0x8b58: return setValue3iv; // _VEC3
-		case 0x8b55: case 0x8b59: return setValue4iv; // _VEC4
+		case 0x1404: case 0x8b56: return setValueV1ia; // INT, BOOL
+		case 0x8b53: case 0x8b57: return setValueV2ia; // _VEC2
+		case 0x8b54: case 0x8b58: return setValueV3ia; // _VEC3
+		case 0x8b55: case 0x8b59: return setValueV4ia; // _VEC4
 
 	}
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -495,32 +495,32 @@ function getSingularSetter( type ) {
 }
 
 // Array of scalars
-function setValueV1fa( gl, v ) {
+function setValueV1fArray( gl, v ) {
 
 	gl.uniform1fv( this.addr, v );
 
 }
 
 // Integer / Boolean vectors or arrays thereof (always flat arrays)
-function setValueV1ia( gl, v ) {
+function setValueV1iArray( gl, v ) {
 
 	gl.uniform1iv( this.addr, v );
 
 }
 
-function setValueV2ia( gl, v ) {
+function setValueV2iArray( gl, v ) {
 
 	gl.uniform2iv( this.addr, v );
 
 }
 
-function setValueV3ia( gl, v ) {
+function setValueV3iArray( gl, v ) {
 
 	gl.uniform3iv( this.addr, v );
 
 }
 
-function setValueV4ia( gl, v ) {
+function setValueV4iArray( gl, v ) {
 
 	gl.uniform4iv( this.addr, v );
 
@@ -529,7 +529,7 @@ function setValueV4ia( gl, v ) {
 
 // Array of vectors (flat or from THREE classes)
 
-function setValueV2fa( gl, v ) {
+function setValueV2fArray( gl, v ) {
 
 	var data = flatten( v, this.size, 2 );
 
@@ -537,7 +537,7 @@ function setValueV2fa( gl, v ) {
 
 }
 
-function setValueV3fa( gl, v ) {
+function setValueV3fArray( gl, v ) {
 
 	var data = flatten( v, this.size, 3 );
 
@@ -545,7 +545,7 @@ function setValueV3fa( gl, v ) {
 
 }
 
-function setValueV4fa( gl, v ) {
+function setValueV4fArray( gl, v ) {
 
 	var data = flatten( v, this.size, 4 );
 
@@ -555,7 +555,7 @@ function setValueV4fa( gl, v ) {
 
 // Array of matrices (flat or from THREE clases)
 
-function setValueM2a( gl, v ) {
+function setValueM2Array( gl, v ) {
 
 	var data = flatten( v, this.size, 4 );
 
@@ -563,7 +563,7 @@ function setValueM2a( gl, v ) {
 
 }
 
-function setValueM3a( gl, v ) {
+function setValueM3Array( gl, v ) {
 
 	var data = flatten( v, this.size, 9 );
 
@@ -571,7 +571,7 @@ function setValueM3a( gl, v ) {
 
 }
 
-function setValueM4a( gl, v ) {
+function setValueM4Array( gl, v ) {
 
 	var data = flatten( v, this.size, 16 );
 
@@ -581,7 +581,7 @@ function setValueM4a( gl, v ) {
 
 // Array of textures (2D / Cube)
 
-function setValueT1a( gl, v, textures ) {
+function setValueT1Array( gl, v, textures ) {
 
 	var n = v.length;
 
@@ -597,7 +597,7 @@ function setValueT1a( gl, v, textures ) {
 
 }
 
-function setValueT6a( gl, v, textures ) {
+function setValueT6Array( gl, v, textures ) {
 
 	var n = v.length;
 
@@ -619,22 +619,22 @@ function getPureArraySetter( type ) {
 
 	switch ( type ) {
 
-		case 0x1406: return setValueV1fa; // FLOAT
-		case 0x8b50: return setValueV2fa; // _VEC2
-		case 0x8b51: return setValueV3fa; // _VEC3
-		case 0x8b52: return setValueV4fa; // _VEC4
+		case 0x1406: return setValueV1fArray; // FLOAT
+		case 0x8b50: return setValueV2fArray; // _VEC2
+		case 0x8b51: return setValueV3fArray; // _VEC3
+		case 0x8b52: return setValueV4fArray; // _VEC4
 
-		case 0x8b5a: return setValueM2a; // _MAT2
-		case 0x8b5b: return setValueM3a; // _MAT3
-		case 0x8b5c: return setValueM4a; // _MAT4
+		case 0x8b5a: return setValueM2Array; // _MAT2
+		case 0x8b5b: return setValueM3Array; // _MAT3
+		case 0x8b5c: return setValueM4Array; // _MAT4
 
-		case 0x8b5e: return setValueT1a; // SAMPLER_2D
-		case 0x8b60: return setValueT6a; // SAMPLER_CUBE
+		case 0x8b5e: return setValueT1Array; // SAMPLER_2D
+		case 0x8b60: return setValueT6Array; // SAMPLER_CUBE
 
-		case 0x1404: case 0x8b56: return setValueV1ia; // INT, BOOL
-		case 0x8b53: case 0x8b57: return setValueV2ia; // _VEC2
-		case 0x8b54: case 0x8b58: return setValueV3ia; // _VEC3
-		case 0x8b55: case 0x8b59: return setValueV4ia; // _VEC4
+		case 0x1404: case 0x8b56: return setValueV1iArray; // INT, BOOL
+		case 0x8b53: case 0x8b57: return setValueV2iArray; // _VEC2
+		case 0x8b54: case 0x8b58: return setValueV3iArray; // _VEC3
+		case 0x8b55: case 0x8b59: return setValueV4iArray; // _VEC4
 
 	}
 


### PR DESCRIPTION
Address the issue exposed on https://github.com/mrdoob/three.js/issues/16355
Currently I'm removing the cache on the array of matrices, textures and vectors.
Babylon.js is using a similar approach, they just cache single elements: scalar, vector2, vector3, vector4 and matrix (actually just 4x4).

The only arrays left without caching are the `setValue2iv`, `setValue3iv` and `setValue4iv` as they are shared between [single](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLUniforms.js#L470-L493) and [pure array](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLUniforms.js#L652-L673) setters.

I don't have an strong opinion about these, but we could leave the current `setValue*iv` with cache for single setters and introduce `setValue*iva` for arrays without cache. Thoughts?
