### PR TITLE
package.json: Optimize usage of google-closure-compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "rollup -c",
     "build-test": "rollup -c test/rollup.unit.config.js",
-    "build-closure": "rollup -c && java -jar node_modules/google-closure-compiler-java/compiler.jar --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
+    "build-closure": "rollup -c && google-closure-compiler --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "build-examples": "rollup -c rollup-examples.config.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",


### PR DESCRIPTION
With this change, the closure compiler does not always use Java. On Mac OS or Linux, the compiler can use native binaries which is faster. If Java is not available, the compiler will fallback to the JS version.

I've realized that the `google-closure-compiler` package includes the JS version (related https://github.com/mrdoob/three.js/issues/16066#issuecomment-476879877). It is already possible to use the compiler in node like so:
```js
const ClosureCompiler = require('google-closure-compiler').jsCompiler;
``` 