### PR TITLE
Repair enum names in OrbitControl.d.ts

### DIFF
--- a/examples/jsm/controls/OrbitControls.d.ts
+++ b/examples/jsm/controls/OrbitControls.d.ts
@@ -44,7 +44,7 @@ export class OrbitControls {
 
 	enableKeys: boolean;
 	keys: { LEFT: number; UP: number; RIGHT: number; BOTTOM: number; };
-	mouseButtons: { ORBIT: MOUSE; ZOOM: MOUSE; PAN: MOUSE; };
+	mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE; };
 
 	rotateLeft(angle?: number): void;
 


### PR DESCRIPTION
mouseButton enum names was inconsistent with .js file