### PR TITLE
Object3D: added attachTo() method

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -217,6 +217,9 @@
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>Applies the rotation represented by the quaternion to the object.</p>
 
+		<h3>[method:this attachTo]( [param:Object3D object] )</h3>
+		<p>Adds this object as a child of the given object, while maintaining this object's world transform.</p>
+
 		<h3>[method:Object3D clone]( [param:Boolean recursive] )</h3>
 		<p>
 		recursive -- if true, descendants of the object are also cloned. Default is true.<br /><br />

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -265,6 +265,11 @@ export class Object3D extends EventDispatcher {
   lookAt(vector: Vector3 | number, y?: number, z?: number): void;
 
   /**
+   * Adds this object as a child of the given object, while maintaining this object's world transform
+   */
+  attachTo(object: Object3D): this;
+
+  /**
    * Adds object as child of this object.
    */
   add(...object: Object3D[]): this;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -359,6 +359,38 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	}(),
 
+	attachTo: function () {
+
+		// adds this object as a child of the given object, while maintaining this object's world transform
+
+		var m = new Matrix4();
+
+		return function attachTo( object ) {
+
+			object.updateWorldMatrix( true, false );
+
+			m.getInverse( object.matrixWorld );
+
+			if ( this.parent !== null ) {
+
+				this.parent.updateWorldMatrix( true, false );
+
+				m.multiply( this.parent.matrixWorld );
+
+			}
+
+			this.applyMatrix( m );
+
+			this.updateWorldMatrix( false, false );
+
+			object.add( this );
+
+			return this;
+
+		};
+
+	}(),
+
 	add: function ( object ) {
 
 		if ( arguments.length > 1 ) {


### PR DESCRIPTION
`Object3D.attachTo( object )` adds this object as a child of the given object, while maintaining this object's world transform.

Fixes #6426.

This method alleviates the need for `THREE.SceneUtils.attach/detach()`, which can be deprecated in a later PR.