### PR TITLE
Examples: Fixed pixel ratio computation in some post-processing examples.

### DIFF
--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -241,8 +241,8 @@
 				renderer.setSize( width, height );
 
 				var pixelRatio = renderer.getPixelRatio();
-				var newWidth = Math.floor( width / pixelRatio ) || 1;
-				var newHeight = Math.floor( height / pixelRatio ) || 1;
+				var newWidth = Math.floor( width * pixelRatio ) || 1;
+				var newHeight = Math.floor( height * pixelRatio ) || 1;
 				composer.setSize( newWidth, newHeight );
 
 			}

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -145,8 +145,8 @@
 				renderer.setSize( width, height );
 
 				var pixelRatio = renderer.getPixelRatio();
-				var newWidth = Math.floor( width / pixelRatio ) || 1;
-				var newHeight = Math.floor( height / pixelRatio ) || 1;
+				var newWidth = Math.floor( width * pixelRatio ) || 1;
+				var newHeight = Math.floor( height * pixelRatio ) || 1;
 				composer.setSize( newWidth, newHeight );
 
 			}

--- a/examples/webgl_postprocessing_ssaa_unbiased.html
+++ b/examples/webgl_postprocessing_ssaa_unbiased.html
@@ -206,8 +206,8 @@
 				renderer.setSize( width, height );
 
 				var pixelRatio = renderer.getPixelRatio();
-				var newWidth = Math.floor( width / pixelRatio ) || 1;
-				var newHeight = Math.floor( height / pixelRatio ) || 1;
+				var newWidth = Math.floor( width * pixelRatio ) || 1;
+				var newHeight = Math.floor( height * pixelRatio ) || 1;
 				composer.setSize( newWidth, newHeight );
 
 			}

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -174,8 +174,8 @@
 				renderer.setSize( width, height );
 
 				var pixelRatio = renderer.getPixelRatio();
-				var newWidth = Math.floor( width / pixelRatio ) || 1;
-				var newHeight = Math.floor( height / pixelRatio ) || 1;
+				var newWidth = Math.floor( width * pixelRatio ) || 1;
+				var newHeight = Math.floor( height * pixelRatio ) || 1;
 				composer.setSize( newWidth, newHeight );
 
 			}


### PR DESCRIPTION
I don't think it makes sense to divide `width` and `height` through the pixel ratio. Similar to the SMAA example, a multiplication is required:

https://github.com/mrdoob/three.js/blob/62a284a6f5b430947a431a51187313d599e5be24/examples/webgl_postprocessing_smaa.html#L96-L99