### PR TITLE
Call .dispose() in WebGLRenderTarget.copy()

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -67,6 +67,8 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 
 	copy: function ( source ) {
 
+		this.dispose();
+
 		this.width = source.width;
 		this.height = source.height;
 


### PR DESCRIPTION
In `WebGLRenderTarget.copy()`, `texture` is replaced with a new one and size can be changed. If I'm right we need to release old WebGL resources by calling `.dispose()` as `.setSize()` does.