### PR TITLE
fixed GLTFExporter process when mesh is set matrixAutoUpdate to false

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1740,7 +1740,10 @@ THREE.GLTFExporter.prototype = {
 
 			} else {
 
-				object.updateMatrix();
+				if (object.matrixAutoUpdate) {
+						object.updateMatrix();
+				}
+
 				if ( ! equalArray( object.matrix.elements, [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ] ) ) {
 
 					gltfNode.matrix = object.matrix.elements;


### PR DESCRIPTION
BUG: GLTFExporter with hand matrixes

fixed GLTFExporter process when mesh is set matrixAutoUpdate to false