### PR TITLE
AnimationAction: Update .time before firing events.

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -503,10 +503,18 @@ Object.assign( AnimationAction.prototype, {
 
 					time = 0;
 
-				} else break handle_stop;
+				} else {
+
+					this.time = time;
+
+					break handle_stop;
+
+				}
 
 				if ( this.clampWhenFinished ) this.paused = true;
 				else this.enabled = false;
+
+				this.time = time;
 
 				this._mixer.dispatchEvent( {
 					type: 'finished', action: this,
@@ -559,6 +567,8 @@ Object.assign( AnimationAction.prototype, {
 
 					time = deltaTime > 0 ? duration : 0;
 
+					this.time = time;
+
 					this._mixer.dispatchEvent( {
 						type: 'finished', action: this,
 						direction: deltaTime > 0 ? 1 : - 1
@@ -583,11 +593,17 @@ Object.assign( AnimationAction.prototype, {
 
 					this._loopCount = loopCount;
 
+					this.time = time;
+
 					this._mixer.dispatchEvent( {
 						type: 'loop', action: this, loopDelta: loopDelta
 					} );
 
 				}
+
+			} else {
+
+				this.time = time;
 
 			}
 
@@ -595,14 +611,12 @@ Object.assign( AnimationAction.prototype, {
 
 				// invert time for the "pong round"
 
-				this.time = time;
 				return duration - time;
 
 			}
 
 		}
 
-		this.time = time;
 		return time;
 
 	},


### PR DESCRIPTION
Fixes #9857

This PR adds the suggestion from here https://github.com/mrdoob/three.js/issues/9857#issuecomment-253872545 to ensure `AnimtionAction.time` is updated before the events `loop` or `finished` fire. This change should also solve @ehs035's issue in https://github.com/mrdoob/three.js/issues/11943#issuecomment-490621178.