### PR TITLE
Add shadowSide field to MaterialParameters type definition

### DIFF
--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -44,6 +44,7 @@ export interface MaterialParameters {
   dithering?: boolean;
   flatShading?: boolean;
   side?: Side;
+	shadowSide?: Side;
   transparent?: boolean;
   vertexColors?: Colors;
   vertexTangents?: boolean;


### PR DESCRIPTION
As documented here: https://threejs.org/docs/#api/en/materials/Material.shadowSide