### PR TITLE
Fix sprite raycasting bugs

### DIFF
--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -67,11 +67,11 @@
 			sprite.scale.set( 2, 5, 1 );
 			group.add( sprite );
 
-			var sprite = new THREE.Sprite( new THREE.SpriteMaterial( { color: '#69f' } ) );
+			var sprite = new THREE.Sprite( new THREE.SpriteMaterial( { color: '#69f', sizeAttenuation: false } ) );
 			sprite.material.rotation = Math.PI / 3 * 4;
 			sprite.position.set( 8, - 2, 2 );
 			sprite.center.set( 0.5, 0 );
-			sprite.scale.set( 1, - 5, 1 );
+			sprite.scale.set( .1, .5, .1 );
 			group.add( sprite );
 
 			var group2 = new THREE.Object3D();

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -79,11 +79,13 @@ Object.assign( Raycaster.prototype, {
 
 			this.ray.origin.setFromMatrixPosition( camera.matrixWorld );
 			this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
+			this.camera = camera;
 
 		} else if ( ( camera && camera.isOrthographicCamera ) ) {
 
 			this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
 			this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
+			this.camera = camera;
 
 		} else {
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -79,13 +79,13 @@ Object.assign( Raycaster.prototype, {
 
 			this.ray.origin.setFromMatrixPosition( camera.matrixWorld );
 			this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
-			this.camera = camera;
+			this._camera = camera;
 
 		} else if ( ( camera && camera.isOrthographicCamera ) ) {
 
 			this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
 			this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
-			this.camera = camera;
+			this._camera = camera;
 
 		} else {
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -101,8 +101,17 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		return function raycast( raycaster, intersects ) {
 
 			worldScale.setFromMatrixScale( this.matrixWorld );
-			viewWorldMatrix.getInverse( this.modelViewMatrix ).premultiply( this.matrixWorld );
+
+			viewWorldMatrix.copy( raycaster.camera.matrixWorld );
+			this.modelViewMatrix.multiplyMatrices( raycaster.camera.matrixWorldInverse, this.matrixWorld );
+
 			mvPosition.setFromMatrixPosition( this.modelViewMatrix );
+
+			if ( raycaster.camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
+
+				worldScale.multiplyScalar( - mvPosition.z );
+
+			}
 
 			var rotation = this.material.rotation;
 			var sin, cos;

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -102,12 +102,12 @@ Sprite.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			worldScale.setFromMatrixScale( this.matrixWorld );
 
-			viewWorldMatrix.copy( raycaster.camera.matrixWorld );
-			this.modelViewMatrix.multiplyMatrices( raycaster.camera.matrixWorldInverse, this.matrixWorld );
+			viewWorldMatrix.copy( raycaster._camera.matrixWorld );
+			this.modelViewMatrix.multiplyMatrices( raycaster._camera.matrixWorldInverse, this.matrixWorld );
 
 			mvPosition.setFromMatrixPosition( this.modelViewMatrix );
 
-			if ( raycaster.camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
+			if ( raycaster._camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
 
 				worldScale.multiplyScalar( - mvPosition.z );
 


### PR DESCRIPTION
Fixes #14936 and #14624.

Adding a reference to `camera` in `Raycaster.setFromCamera()` seems the least hacky approach I can think of.

/ping @06wj 
/ping @Mugen87 