### PR TITLE
LDrawLoader: Group object by Parts and smooth normals

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -338,9 +338,9 @@ THREE.LDrawLoader = ( function () {
 
 				function finalizeObject() {
 
-
 					// TODO: Handle smoothing
-					if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || ! parentParseScope.isFromParse ) {
+					var isRoot = ! parentParseScope.isFromParse;
+					if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || isRoot ) {
 
 						const objGroup = parseScope.groupObject;
 						if ( parseScope.triangles.length > 0 ) {
@@ -1125,7 +1125,8 @@ THREE.LDrawLoader = ( function () {
 										currentParseScope.optionalSegments = [];
 										currentParseScope.type = type;
 
-										if ( parentParseScope.isFromParse === false || scope.separateObjects && isPrimitiveType( type ) === false ) {
+										var isRoot = ! parentParseScope.isFromParse;
+										if ( isRoot || scope.separateObjects && ! isPrimitiveType( type ) ) {
 
 											currentParseScope.groupObject = new THREE.Group();
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -536,7 +536,9 @@ THREE.LDrawLoader = ( function () {
 
 						if ( parseScope.conditionalSegments.length > 0 ) {
 
-							objGroup.add( createObject( parseScope.conditionalSegments, 2 ) );
+							var lines = createObject( parseScope.conditionalSegments, 2 );
+							lines.isConditionalLine = true;
+							objGroup.add( lines );
 
 						}
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -273,6 +273,14 @@ THREE.LDrawLoader = ( function () {
 
 				var parentParseScope = scope.getParentParseScope();
 
+				// Set current matrix
+				if ( subobject ) {
+
+					parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
+					parseScope.matrix = subobject.matrix.clone();
+
+				}
+
 				// Add to cache
 				var currentFileName = parentParseScope.currentFileName;
 				if ( currentFileName !== null ) {
@@ -362,6 +370,33 @@ THREE.LDrawLoader = ( function () {
 
 					} else {
 
+						if ( scope.separateObjects ) {
+
+							parseScope.lineSegments.forEach( ls => {
+
+								ls.v0.applyMatrix4( parseScope.matrix );
+								ls.v1.applyMatrix4( parseScope.matrix );
+
+							} );
+
+							parseScope.optionalSegments.forEach( ls => {
+
+								ls.v0.applyMatrix4( parseScope.matrix );
+								ls.v1.applyMatrix4( parseScope.matrix );
+
+							} );
+
+							parseScope.triangles.forEach( ls => {
+
+								ls.v0 = ls.v0.clone().applyMatrix4( parseScope.matrix );
+								ls.v1 = ls.v1.clone().applyMatrix4( parseScope.matrix );
+								ls.v2 = ls.v2.clone().applyMatrix4( parseScope.matrix );
+
+							} );
+
+						}
+
+
 						// TODO: we need to multiple matrices here
 						// TODO: First, instead of tracking matrices anywhere else we
 						// should just multiple everything here.
@@ -388,12 +423,6 @@ THREE.LDrawLoader = ( function () {
 					parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
 					parseScope.currentFileName = subobject.originalFileName;
 
-					if ( ! scope.separateObjects ) {
-
-						// Set current matrix
-						parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
-
-					}
 
 					// If subobject was cached previously, use the cached one
 					var cached = scope.subobjectCache[ subobject.originalFileName.toLowerCase() ];
@@ -603,6 +632,7 @@ THREE.LDrawLoader = ( function () {
 				mainColourCode: topParseScope ? topParseScope.mainColourCode : '16',
 				mainEdgeColourCode: topParseScope ? topParseScope.mainEdgeColourCode : '24',
 				currentMatrix: new THREE.Matrix4(),
+				matrix: new THREE.Matrix4(),
 
 				// If false, it is a root material scope previous to parse
 				isFromParse: true,
@@ -1016,7 +1046,7 @@ THREE.LDrawLoader = ( function () {
 
 				if ( ! scope.separateObjects ) {
 
-					v.applyMatrix4( parentParseScope.currentMatrix );
+					v.applyMatrix4( currentParseScope.currentMatrix );
 
 				}
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -344,6 +344,12 @@ THREE.LDrawLoader = ( function () {
 					if ( scope.separateObjects && parseScope.type === 'Part' || ! parentParseScope.isFromParse ) {
 
 						const objGroup = parseScope.groupObject;
+						if ( parseScope.triangles.length > 0 ) {
+
+							objGroup.add( createObject( parseScope.triangles, 3 ) );
+
+						}
+
 						if ( parseScope.lineSegments.length > 0 ) {
 
 							objGroup.add( createObject( parseScope.lineSegments, 2 ) );
@@ -356,11 +362,6 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
-						if ( parseScope.triangles.length > 0 ) {
-
-							objGroup.add( createObject( parseScope.triangles, 3 ) );
-
-						}
 
 						if ( parentParseScope.groupObject ) {
 
@@ -400,9 +401,31 @@ THREE.LDrawLoader = ( function () {
 						// TODO: we need to multiple matrices here
 						// TODO: First, instead of tracking matrices anywhere else we
 						// should just multiple everything here.
-						parentParseScope.lineSegments.push( ...parseScope.lineSegments );
-						parentParseScope.optionalSegments.push( ...parseScope.optionalSegments );
-						parentParseScope.triangles.push( ...parseScope.triangles );
+						var parentLineSegments = parentParseScope.lineSegments;
+						var parentOptionalSegments = parentParseScope.optionalSegments;
+						var parentTriangles = parentParseScope.triangles;
+
+						var lineSegments = parseScope.lineSegments;
+						var optionalSegments = parseScope.optionalSegments;
+						var triangles = parseScope.triangles;
+
+						for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
+
+							parentLineSegments.push( lineSegments[ i ] );
+
+						}
+
+						for ( var i = 0, l = optionalSegments.length; i < l; i ++ ) {
+
+							parentOptionalSegments.push( optionalSegments[ i ] );
+
+						}
+
+						for ( var i = 0, l = triangles.length; i < l; i ++ ) {
+
+							parentTriangles.push( triangles[ i ] );
+
+						}
 
 					}
 
@@ -539,11 +562,13 @@ THREE.LDrawLoader = ( function () {
 
 				function addSubobject( subobject, subobjectGroup ) {
 
+					// TODO: Move this logic into finalize object if possible?
 					if ( scope.separateObjects ) {
 
 						subobjectGroup.name = subobject.fileName;
 						objGroup.add( subobjectGroup );
 						subobjectGroup.matrix.copy( subobject.matrix );
+						subobjectGroup.matrix.decompose( subobjectGroup.position, subobjectGroup.quaternion, subobjectGroup.scale );
 						subobjectGroup.matrixAutoUpdate = false;
 
 					}
@@ -1118,11 +1143,11 @@ THREE.LDrawLoader = ( function () {
 										currentParseScope.lineSegments = [];
 										currentParseScope.optionalSegments = [];
 										currentParseScope.groupObject = new THREE.Group();
+										currentParseScope.type = type;
 
 										triangles = currentParseScope.triangles;
 										lineSegments = currentParseScope.lineSegments;
 										optionalSegments = currentParseScope.optionalSegments;
-										currentParseScope.type = type;
 
 									}
 
@@ -1291,7 +1316,7 @@ THREE.LDrawLoader = ( function () {
 
 						// If the scale of the object is negated then the triangle winding order
 						// needs to be flipped.
-						if ( scope.separateObjects === false && matrix.determinant() < 0 ) {
+						if ( matrix.determinant() < 0 ) {
 
 							bfcInverted = ! bfcInverted;
 
@@ -1462,7 +1487,7 @@ THREE.LDrawLoader = ( function () {
 			groupObject.userData.keywords = keywords;
 			groupObject.userData.subobjects = subobjects;
 
-			return currentParseScope.groupObject;
+			return groupObject;
 
 		}
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1132,6 +1132,20 @@ THREE.LDrawLoader = ( function () {
 
 										}
 
+										// If the scale of the object is negated then the triangle winding order
+										// needs to be flipped.
+										var matrix = currentParseScope.matrix;
+										if (
+											matrix.determinant() < 0 && (
+												scope.separateObjects && isPrimitiveType( type ) ||
+												! scope.separateObjects
+											) ) {
+
+											currentParseScope.inverted = ! currentParseScope.inverted;
+
+										}
+
+
 										triangles = currentParseScope.triangles;
 										lineSegments = currentParseScope.lineSegments;
 										optionalSegments = currentParseScope.optionalSegments;
@@ -1298,14 +1312,6 @@ THREE.LDrawLoader = ( function () {
 								fileName = 'p/' + fileName;
 
 							}
-
-						}
-
-						// If the scale of the object is negated then the triangle winding order
-						// needs to be flipped.
-						if ( matrix.determinant() < 0 ) {
-
-							bfcInverted = ! bfcInverted;
 
 						}
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -550,6 +550,7 @@ THREE.LDrawLoader = ( function () {
 
 							var lines = createObject( parseScope.conditionalSegments, 2 );
 							lines.isConditionalLine = true;
+							lines.visible = false;
 							objGroup.add( lines );
 
 						}
@@ -557,9 +558,9 @@ THREE.LDrawLoader = ( function () {
 						if ( parentParseScope.groupObject ) {
 
 							objGroup.name = parseScope.fileName;
-							objGroup.matrix.copy( parseScope.matrix );
 							objGroup.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
-							objGroup.matrixAutoUpdate = false;
+							objGroup.userData.category = parseScope.category;
+							objGroup.userData.keywords = parseScope.keywords;
 
 							parentParseScope.groupObject.add( objGroup );
 
@@ -822,6 +823,8 @@ THREE.LDrawLoader = ( function () {
 				numSubobjects: 0,
 				subobjectIndex: 0,
 				inverted: false,
+				category: null,
+				keywords: null,
 
 				// Current subobject
 				currentFileName: null,

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -835,29 +835,20 @@ THREE.LDrawLoader = ( function () {
 			switch ( finishType ) {
 
 				case LDrawLoader.FINISH_TYPE_DEFAULT:
+
+					material = new THREE.MeshStandardMaterial( { color: colour, roughness: 0.3, envMapIntensity: 0.3, metalness: 0 } );
+					break;
+
 				case LDrawLoader.FINISH_TYPE_PEARLESCENT:
 
+					// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
 					var specular = new THREE.Color( colour );
-					var shininess = 35;
 					var hsl = specular.getHSL( { h: 0, s: 0, l: 0 } );
-
-					if ( finishType === LDrawLoader.FINISH_TYPE_DEFAULT ) {
-
-						// Default plastic material with shiny specular
-						hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.12 );
-
-					} else {
-
-						// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
-						hsl.h = ( hsl.h + 0.5 ) % 1;
-						hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
-						shininess = 10;
-
-					}
-
+					hsl.h = ( hsl.h + 0.5 ) % 1;
+					hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
 					specular.setHSL( hsl.h, hsl.s, hsl.l );
 
-					material = new THREE.MeshPhongMaterial( { color: colour, specular: specular, shininess: shininess, reflectivity: 0.3 } );
+					material = new THREE.MeshPhongMaterial( { color: colour, specular: specular, shininess: 10, reflectivity: 0.3 } );
 					break;
 
 				case LDrawLoader.FINISH_TYPE_CHROME:
@@ -869,7 +860,7 @@ THREE.LDrawLoader = ( function () {
 				case LDrawLoader.FINISH_TYPE_RUBBER:
 
 					// Rubber is best simulated with Lambert
-					material = new THREE.MeshLambertMaterial( { color: colour } );
+					material = new THREE.MeshStandardMaterial( { color: colour, roughness: 0.9, metalness: 0 } );
 					canHaveEnvMap = false;
 					break;
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -13,9 +13,12 @@ THREE.LDrawLoader = ( function () {
 
 		function hashVertex( v ) {
 
-			var x = ~ ~ ( v.x * 1e6 );
-			var y = ~ ~ ( v.y * 1e6 );
-			var z = ~ ~ ( v.z * 1e6 );
+			// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
+			// to be smoothed as expected (see minifig arms). The errors between edges
+			// could be due to matrix multiplication.
+			var x = ~ ~ ( v.x * 1e2 );
+			var y = ~ ~ ( v.y * 1e2 );
+			var z = ~ ~ ( v.z * 1e2 );
 			return `${ x },${ y },${ z }`;
 
 		}
@@ -116,6 +119,15 @@ THREE.LDrawLoader = ( function () {
 					var reverseHash = hashEdge( v1, v0 );
 					var otherTri = fullHalfEdgeList[ reverseHash ];
 					if ( otherTri ) {
+
+						// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
+						// hard edge. There are some cases where the line segments do not line up exactly
+						// with or span multiple triangle edges (see Lunar Vehicle wheels).
+						if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
+
+							continue;
+
+						}
 
 						// if this triangle has already been traversed then it won't be in
 						// the halfEdgeList. If it has not then add it to the queue and delete

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -558,9 +558,9 @@ THREE.LDrawLoader = ( function () {
 						if ( parentParseScope.groupObject ) {
 
 							objGroup.name = parseScope.fileName;
-							objGroup.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
 							objGroup.userData.category = parseScope.category;
 							objGroup.userData.keywords = parseScope.keywords;
+							parseScope.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
 
 							parentParseScope.groupObject.add( objGroup );
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -66,6 +66,13 @@ THREE.LDrawLoader = ( function () {
 
 		}
 
+		// NOTE: Some of the normals wind up being skewed in an unexpected way because
+		// quads provide more "influence" to some vertex normals than a triangle due to
+		// the fact that a quad is made up of two triangles and all triangles are weighted
+		// equally. To fix this quads could be tracked separately so their vertex normals
+		// are weighted appropriately or we could try only adding a normal direction
+		// once per normal.
+
 		// Iterate until we've tried to connect all triangles to share normals
 		while ( true ) {
 
@@ -150,11 +157,22 @@ THREE.LDrawLoader = ( function () {
 							var otherHash = hashEdge( otherV0, otherV1 );
 							if ( otherHash === reverseHash ) {
 
-								otherTri[ `n${ otherIndex }` ] = tri[ `n${ next }` ];
-								otherTri[ `n${ otherNext }` ] = tri[ `n${ index }` ];
+								if ( otherTri[ `n${ otherIndex }` ] === null ) {
 
-								tri[ `n${ next }` ].add( otherTri.faceNormal );
-								tri[ `n${ index }` ].add( otherTri.faceNormal );
+									var norm = tri[ `n${ next }` ];
+									otherTri[ `n${ otherIndex }` ] = norm;
+									norm.add( otherTri.faceNormal );
+
+								}
+
+								if ( otherTri[ `n${ otherNext }` ] === null ) {
+
+									var norm = tri[ `n${ index }` ];
+									otherTri[ `n${ otherNext }` ] = norm;
+									norm.add( otherTri.faceNormal );
+
+								}
+
 								break;
 
 							}

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -399,6 +399,9 @@ THREE.LDrawLoader = ( function () {
 		// If not (the default), only one object which contains all the merged primitives will be created.
 		this.separateObjects = false;
 
+		// If this flag is set to true the vertex normals will be smoothed.
+		this.smoothNormals = true;
+
 	}
 
 	// Special surface finish tag types.
@@ -508,7 +511,7 @@ THREE.LDrawLoader = ( function () {
 
 				function finalizeObject() {
 
-					if ( parseScope.type === 'Part' ) {
+					if ( scope.smoothNormals && parseScope.type === 'Part' ) {
 
 						smoothNormals( parseScope.triangles, parseScope.lineSegments );
 
@@ -531,9 +534,9 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
-						if ( parseScope.optionalSegments.length > 0 ) {
+						if ( parseScope.conditionalSegments.length > 0 ) {
 
-							objGroup.add( createObject( parseScope.optionalSegments, 2 ) );
+							objGroup.add( createObject( parseScope.conditionalSegments, 2 ) );
 
 						}
 
@@ -552,11 +555,11 @@ THREE.LDrawLoader = ( function () {
 
 						var separateObjects = scope.separateObjects;
 						var parentLineSegments = parentParseScope.lineSegments;
-						var parentOptionalSegments = parentParseScope.optionalSegments;
+						var parentConditionalSegments = parentParseScope.conditionalSegments;
 						var parentTriangles = parentParseScope.triangles;
 
 						var lineSegments = parseScope.lineSegments;
-						var optionalSegments = parseScope.optionalSegments;
+						var conditionalSegments = parseScope.conditionalSegments;
 						var triangles = parseScope.triangles;
 
 						for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
@@ -572,16 +575,16 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
-						for ( var i = 0, l = optionalSegments.length; i < l; i ++ ) {
+						for ( var i = 0, l = conditionalSegments.length; i < l; i ++ ) {
 
-							var os = optionalSegments[ i ];
+							var os = conditionalSegments[ i ];
 							if ( separateObjects ) {
 
 								os.v0.applyMatrix4( parseScope.matrix );
 								os.v1.applyMatrix4( parseScope.matrix );
 
 							}
-							parentOptionalSegments.push( os );
+							parentConditionalSegments.push( os );
 
 						}
 
@@ -818,7 +821,7 @@ THREE.LDrawLoader = ( function () {
 
 				triangles: null,
 				lineSegments: null,
-				optionalSegments: null,
+				conditionalSegments: null,
 			};
 
 			this.parseScopesStack.push( newParseScope );
@@ -1161,7 +1164,7 @@ THREE.LDrawLoader = ( function () {
 			// Parse result variables
 			var triangles;
 			var lineSegments;
-			var optionalSegments;
+			var conditionalSegments;
 
 			var subobjects = [];
 
@@ -1295,7 +1298,7 @@ THREE.LDrawLoader = ( function () {
 
 										currentParseScope.triangles = [];
 										currentParseScope.lineSegments = [];
-										currentParseScope.optionalSegments = [];
+										currentParseScope.conditionalSegments = [];
 										currentParseScope.type = type;
 
 										var isRoot = ! parentParseScope.isFromParse;
@@ -1320,7 +1323,7 @@ THREE.LDrawLoader = ( function () {
 
 										triangles = currentParseScope.triangles;
 										lineSegments = currentParseScope.lineSegments;
-										optionalSegments = currentParseScope.optionalSegments;
+										conditionalSegments = currentParseScope.conditionalSegments;
 
 									}
 
@@ -1503,12 +1506,12 @@ THREE.LDrawLoader = ( function () {
 						break;
 
 					// Line type 2: Line segment
-					// Line type 5: Optional Line segment
+					// Line type 5: Conditional Line segment
 					case '2':
 					case '5':
 
 						var material = parseColourCode( lp, true );
-						var arr = lineType === '2' ? lineSegments : optionalSegments;
+						var arr = lineType === '2' ? lineSegments : conditionalSegments;
 
 						arr.push( {
 							material: material.userData.edgeMaterial,

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -109,7 +109,9 @@
 				guiData = {
 					modelFileName: modelFileList[ 'Car' ],
 					envMapActivated: false,
-					separateObjects: false
+					separateObjects: false,
+					displayLines: true,
+					optionalLines: false
 				};
 
 				gui = new dat.GUI();
@@ -134,6 +136,17 @@
 
 				} );
 
+				gui.add( guiData, 'displayLines' ).name( 'Display Lines' ).onChange( function ( value ) {
+
+					model.children[ 1 ].visible = value;
+
+				} );
+
+				gui.add( guiData, 'optionalLines' ).name( 'Optional Lines' ).onChange( function ( value ) {
+
+					model.children[ 2 ].visible = value;
+
+				} );
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				progressBarDiv = document.createElement( 'div' );
@@ -217,6 +230,9 @@
 							}
 
 						}
+
+						model.children[ 1 ].visible = guiData.displayLines;
+						model.children[ 2 ].visible = guiData.optionalLines;
 
 						// Adjust camera and light
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -111,7 +111,8 @@
 					envMapActivated: false,
 					separateObjects: false,
 					displayLines: true,
-					optionalLines: false
+					optionalLines: false,
+					smoothNormals: true
 				};
 
 				gui = new dat.GUI();
@@ -136,15 +137,21 @@
 
 				} );
 
+				gui.add( guiData, 'smoothNormals' ).name( 'Smooth Normals' ).onChange( function ( value ) {
+
+					reloadObject( false );
+
+				} );
+
 				gui.add( guiData, 'displayLines' ).name( 'Display Lines' ).onChange( function ( value ) {
 
-					model.children[ 1 ].visible = value;
+					updateLineSegments();
 
 				} );
 
 				gui.add( guiData, 'optionalLines' ).name( 'Optional Lines' ).onChange( function ( value ) {
 
-					model.children[ 2 ].visible = value;
+					updateLineSegments();
 
 				} );
 				window.addEventListener( 'resize', onWindowResize, false );
@@ -166,6 +173,28 @@
 
 			}
 
+			function updateLineSegments() {
+
+				model.traverse( c => {
+
+					if ( c.isLineSegments ) {
+
+						if ( c.isConditionalLine ) {
+
+							c.visible = guiData.optionalLines;
+
+						} else {
+
+							c.visible = guiData.displayLines;
+
+						}
+
+					}
+
+				} );
+
+			}
+
 			function reloadObject( resetCamera ) {
 
 				if ( model ) {
@@ -181,6 +210,7 @@
 
 				var lDrawLoader = new THREE.LDrawLoader();
 				lDrawLoader.separateObjects = guiData.separateObjects;
+				lDrawLoader.smoothNormals = guiData.smoothNormals;
 				lDrawLoader
 					.setPath( ldrawPath )
 					.load( guiData.modelFileName, function ( group2 ) {
@@ -231,8 +261,7 @@
 
 						}
 
-						model.children[ 1 ].visible = guiData.displayLines;
-						model.children[ 2 ].visible = guiData.optionalLines;
+						updateLineSegments();
 
 						// Adjust camera and light
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -111,7 +111,7 @@
 					envMapActivated: false,
 					separateObjects: false,
 					displayLines: true,
-					optionalLines: false,
+					conditionalLines: false,
 					smoothNormals: true
 				};
 
@@ -149,7 +149,7 @@
 
 				} );
 
-				gui.add( guiData, 'optionalLines' ).name( 'Optional Lines' ).onChange( function ( value ) {
+				gui.add( guiData, 'conditionalLines' ).name( 'Conditional Lines' ).onChange( function ( value ) {
 
 					updateLineSegments();
 
@@ -181,7 +181,7 @@
 
 						if ( c.isConditionalLine ) {
 
-							c.visible = guiData.optionalLines;
+							c.visible = guiData.conditionalLines;
 
 						} else {
 


### PR DESCRIPTION
This PR groups geometry by [LDraw "Part"](https://www.ldraw.org/article/218.html) type which provides a more intuitive grouping of triangles (a "brick" is single piece of geometry representing a brick vs a collection of primitive geometric pieces), which could lead to other caching and geometry reuse in the future and adds support for smoothing normals and retaining hard edges where line segments are defined.

![image](https://user-images.githubusercontent.com/734200/57595730-ab3c9b80-74fb-11e9-9a4f-b96982c9853c.png)

It should be noted that smoothing normals adds significant overhead to the parsing and can be disabled by setting `loader.smoothNormals = false`. Maybe it can be improved in the future.

This PR reorganizes a few parts of the code to accomodate normal smoothing and adds support for displaying conditional lines, as well.

For testing:
https://raw.githack.com/gkjohnson/three.js/ldraw-group-parts/examples/webgl_loader_ldraw.html

Includes changes from #16383.

@yomboprime 