### PR TITLE
WebVRManager: Fix spurious events on the first update of the VR controllers.

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -153,6 +153,8 @@ function WebVRManager( renderer ) {
 
 				var buttonId = gamepad.id === 'Daydream Controller' ? 0 : 1;
 
+				if ( triggers[ i ] === undefined ) triggers[ i ] = false;
+
 				if ( triggers[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
 
 					triggers[ i ] = gamepad.buttons[ buttonId ].pressed;


### PR DESCRIPTION
When the VR controller is updated by `updateControllers()` *first time*, assuming the trigger is not being pressed, two spurious events (one `'selectend'` and one `'select'`) are always dispatched.  This patch eliminates them. (Tested with an Oculus Go controller.)
