### PR TITLE
GLTFLoader: fix cloneMaterial when texture is null

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -842,7 +842,7 @@ THREE.GLTFLoader = ( function () {
 				for ( var i = 0, il = params.length; i < il; i ++ ) {
 
 					var value = source[ params[ i ] ];
-					target[ params[ i ] ] = value.isColor ? value.clone() : value;
+					target[ params[ i ] ] = ( value && value.isColor ) ? value.clone() : value;
 
 				}
 


### PR DESCRIPTION
#16416 