### PR TITLE
ColladaLoader: Report xml parse errors

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3824,6 +3824,14 @@ THREE.ColladaLoader.prototype = {
 
 		var collada = getElementsByTagName( xml, 'COLLADA' )[ 0 ];
 
+		var parserError = xml.getElementsByTagName( 'parsererror' )[ 0 ];
+		if ( parserError !== undefined ) {
+
+			console.error( 'ColladaLoader: Failed to parse collada file.', parserError );
+			return null;
+
+		}
+
 		// metadata
 
 		var version = collada.getAttribute( 'version' );

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3814,6 +3814,32 @@ THREE.ColladaLoader.prototype = {
 
 		}
 
+		// convert the parser error element into text with each child elements text
+		// separated by new lines.
+		function parserErrorToText( parserError ) {
+
+			var result = '';
+			var stack = [ parserError ];
+			while ( stack.length ) {
+
+				var node = stack.shift();
+				if ( node.nodeType === Node.TEXT_NODE ) {
+
+					result += node.textContent;
+
+				} else {
+
+					result += '\n';
+					stack.push.apply( stack, node.childNodes );
+
+				}
+
+			}
+
+			return result.trim();
+
+		}
+
 		if ( text.length === 0 ) {
 
 			return { scene: new THREE.Scene() };
@@ -3827,7 +3853,21 @@ THREE.ColladaLoader.prototype = {
 		var parserError = xml.getElementsByTagName( 'parsererror' )[ 0 ];
 		if ( parserError !== undefined ) {
 
-			console.error( 'ColladaLoader: Failed to parse collada file.', parserError );
+			// Chrome will return parser error with a div in it
+			var errorElement = getElementsByTagName( parserError, 'div' )[ 0 ];
+			var errorText;
+			if ( errorElement ) {
+
+				errorText = errorElement.textContent;
+
+			} else {
+
+				errorText = parserErrorToText( parserError );
+
+			}
+
+			console.error( 'ColladaLoader: Failed to parse collada file.\n', errorText );
+
 			return null;
 
 		}


### PR DESCRIPTION
Fix #16443.

Logs an error in ColladaLoader if the browsers xml parser fails to parse the text. I'm not sure if there's a standard way to report errors in the loaders. Is logging an error good enough? Should it throw an error? It doesn't look like there's an `onError` function to call.

Each browser seems to format the parsererror differently so here's how it looks in different browsers:

#### Firefox
![image](https://user-images.githubusercontent.com/734200/57796544-4cdf0b00-76fd-11e9-9c71-e3f2f114afb7.png)

#### Chrome
![image](https://user-images.githubusercontent.com/734200/57796634-7861f580-76fd-11e9-8ff4-dadb44624c2f.png)

#### Edge

A still extremely unhelpful error...

![image](https://user-images.githubusercontent.com/734200/57796762-bfe88180-76fd-11e9-90c3-23615b96949d.png)

