### PR TITLE
OutlineEffect: remove redefinition of fog chunk

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -108,8 +108,6 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	var vertexShaderChunk = [
 
-		"#include <fog_pars_vertex>",
-
 		"uniform float outlineThickness;",
 
 		"vec4 calculateOutline( vec4 pos, vec3 objectNormal, vec4 skinned ) {",


### PR DESCRIPTION
This is a proposed fix to #16463. The solution may have to be material-specific.

Only tested on `webgl_loader_mmd.html`.

/ping @takahirox 