### PR TITLE
GLTFLoader.d.ts parse() parameter minor type fix

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -23,5 +23,5 @@ export class GLTFLoader {
   setResourcePath(path: string) : GLTFLoader;
   setCrossOrigin(value: string): void;
   setDRACOLoader(dracoLoader: object): void;
-  parse(data: ArrayBuffer, path: string, onLoad: (gltf: GLTF) => void, onError?: (event: ErrorEvent) => void) : void;
+  parse(data: ArrayBuffer | string, path: string, onLoad: (gltf: GLTF) => void, onError?: (event: ErrorEvent) => void) : void;
 }


### PR DESCRIPTION
According to three.js doc, GLTFLoader parse function's data field accepts array buffer or JSON string. 
Also, as discussed in Issue https://github.com/mrdoob/three.js/issues/12470, parse() has been supporting data passed in as string. 
However, the data type specified in GLTFLoader.d.ts is not updated, which causes typescript complie error when using the module.