### PR TITLE
modularize.js: Enable example dependencies.

### DIFF
--- a/examples/jsm/shaders/UnpackDepthRGBAShader.js
+++ b/examples/jsm/shaders/UnpackDepthRGBAShader.js
@@ -1,0 +1,53 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ *
+ * Unpack RGBA depth shader
+ * - show RGBA encoded depth as monochrome color
+ */
+
+
+
+var UnpackDepthRGBAShader = {
+
+	uniforms: {
+
+		"tDiffuse": { value: null },
+		"opacity":  { value: 1.0 }
+
+	},
+
+	vertexShader: [
+
+		"varying vec2 vUv;",
+
+		"void main() {",
+
+			"vUv = uv;",
+			"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+		"}"
+
+	].join( "\n" ),
+
+	fragmentShader: [
+
+		"uniform float opacity;",
+
+		"uniform sampler2D tDiffuse;",
+
+		"varying vec2 vUv;",
+
+		"#include <packing>",
+
+		"void main() {",
+
+			"float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );",
+			"gl_FragColor = vec4( vec3( depth ), opacity );",
+
+		"}"
+
+	].join( "\n" )
+
+};
+
+export { UnpackDepthRGBAShader };

--- a/examples/jsm/utils/ShadowMapViewer.js
+++ b/examples/jsm/utils/ShadowMapViewer.js
@@ -37,9 +37,9 @@ import {
 	Scene,
 	ShaderMaterial,
 	Texture,
-	UniformsUtils,
-	UnpackDepthRGBAShader
+	UniformsUtils
 } from "../../../build/three.module.js";
+import { UnpackDepthRGBAShader } from "../shaders/UnpackDepthRGBAShader.js";
 
 var ShadowMapViewer = function ( light ) {
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -51,7 +51,7 @@ var files = [
 	{ path: 'utils/GeometryUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/MathUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/SceneUtils.js', dependencies: [], ignoreList: [] },
-	{ path: 'utils/ShadowMapViewer.js', dependencies: [ { name: 'UnpackDepthRGBAShader', module: 'shaders/UnpackDepthRGBAShader' } ], ignoreList: [ 'DirectionalLight', 'SpotLight' ] },
+	{ path: 'utils/ShadowMapViewer.js', dependencies: [ { name: 'UnpackDepthRGBAShader', path: 'shaders/UnpackDepthRGBAShader.js' } ], ignoreList: [ 'DirectionalLight', 'SpotLight' ] },
 	{ path: 'utils/SkeletonUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/TypedArrayUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/UVsDebug.js', dependencies: [], ignoreList: [ 'SphereBufferGeometry' ] },
@@ -163,7 +163,7 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	for ( var dependency of exampleDependencies ) {
 
-		imports += `\nimport { ${dependency.name} } from "../${dependency.module}.js";`;
+		imports += `\nimport { ${dependency.name} } from "../${dependency.path}";`;
 
 	}
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -3,72 +3,75 @@
  */
 
 var fs = require( 'fs' );
+THREE = require( '../build/three.js' );
 
 var srcFolder = __dirname + '/../examples/js/';
 var dstFolder = __dirname + '/../examples/jsm/';
 
 var files = [
-	{ path: 'controls/DragControls.js', ignoreList: [] },
-	{ path: 'controls/DeviceOrientationControls.js', ignoreList: [] },
-	{ path: 'controls/EditorControls.js', ignoreList: [] },
-	{ path: 'controls/FirstPersonControls.js', ignoreList: [] },
-	{ path: 'controls/FlyControls.js', ignoreList: [] },
-	{ path: 'controls/OrbitControls.js', ignoreList: [] },
-	{ path: 'controls/MapControls.js', ignoreList: [] },
-	{ path: 'controls/OrthographicTrackballControls.js', ignoreList: [] },
-	{ path: 'controls/PointerLockControls.js', ignoreList: [] },
-	{ path: 'controls/TrackballControls.js', ignoreList: [] },
-	{ path: 'controls/TransformControls.js', ignoreList: [] },
+	{ path: 'controls/DragControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/DeviceOrientationControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/EditorControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/FirstPersonControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/FlyControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/OrbitControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/MapControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/OrthographicTrackballControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/PointerLockControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/TrackballControls.js', dependencies: [], ignoreList: [] },
+	{ path: 'controls/TransformControls.js', dependencies: [], ignoreList: [] },
 
-	{ path: 'exporters/GLTFExporter.js', ignoreList: [ 'AnimationClip', 'Camera', 'Geometry', 'Material', 'Mesh', 'Object3D', 'RGBFormat', 'Scenes', 'ShaderMaterial', 'VertexColors' ] },
-	{ path: 'exporters/MMDExporter.js', ignoreList: [] },
-	{ path: 'exporters/OBJExporter.js', ignoreList: [] },
-	{ path: 'exporters/PLYExporter.js', ignoreList: [] },
-	{ path: 'exporters/STLExporter.js', ignoreList: [] },
-	{ path: 'exporters/TypedGeometryExporter.js', ignoreList: [] },
+	{ path: 'exporters/GLTFExporter.js', dependencies: [], ignoreList: [ 'AnimationClip', 'Camera', 'Geometry', 'Material', 'Mesh', 'Object3D', 'RGBFormat', 'Scenes', 'ShaderMaterial', 'VertexColors' ] },
+	{ path: 'exporters/MMDExporter.js', dependencies: [], ignoreList: [] },
+	{ path: 'exporters/OBJExporter.js', dependencies: [], ignoreList: [] },
+	{ path: 'exporters/PLYExporter.js', dependencies: [], ignoreList: [] },
+	{ path: 'exporters/STLExporter.js', dependencies: [], ignoreList: [] },
+	{ path: 'exporters/TypedGeometryExporter.js', dependencies: [], ignoreList: [] },
 
-	{ path: 'loaders/BVHLoader.js', ignoreList: [ 'Bones' ] },
-	{ path: 'loaders/PCDLoader.js', ignoreList: [] },
-	{ path: 'loaders/GLTFLoader.js', ignoreList: [ 'NoSide', 'Matrix2', 'DDSLoader' ] },
-	{ path: 'loaders/OBJLoader.js', ignoreList: [] },
-	{ path: 'loaders/MTLLoader.js', ignoreList: [ 'BackSide', 'DoubleSide', 'ClampToEdgeWrapping', 'MirroredRepeatWrapping' ] },
-	{ path: 'loaders/PLYLoader.js', ignoreList: [ 'Mesh' ] },
-	{ path: 'loaders/STLLoader.js', ignoreList: [ 'Mesh', 'MeshPhongMaterial', 'VertexColors' ] },
-	{ path: 'loaders/SVGLoader.js', ignoreList: [] },
-	{ path: 'loaders/TGALoader.js', ignoreList: [] },
-	{ path: 'loaders/VRMLLoader.js', ignoreList: [] },
+	{ path: 'loaders/BVHLoader.js', dependencies: [], ignoreList: [ 'Bones' ] },
+	{ path: 'loaders/PCDLoader.js', dependencies: [], ignoreList: [] },
+	{ path: 'loaders/GLTFLoader.js', dependencies: [], ignoreList: [ 'NoSide', 'Matrix2', 'DDSLoader' ] },
+	{ path: 'loaders/OBJLoader.js', dependencies: [], ignoreList: [] },
+	{ path: 'loaders/MTLLoader.js', dependencies: [], ignoreList: [ 'BackSide', 'DoubleSide', 'ClampToEdgeWrapping', 'MirroredRepeatWrapping' ] },
+	{ path: 'loaders/PLYLoader.js', dependencies: [], ignoreList: [ 'Mesh' ] },
+	{ path: 'loaders/STLLoader.js', dependencies: [], ignoreList: [ 'Mesh', 'MeshPhongMaterial', 'VertexColors' ] },
+	{ path: 'loaders/SVGLoader.js', dependencies: [], ignoreList: [] },
+	{ path: 'loaders/TGALoader.js', dependencies: [], ignoreList: [] },
+	{ path: 'loaders/VRMLLoader.js', dependencies: [], ignoreList: [] },
 
-	{ path: 'pmrem/PMREMCubeUVPacker.js', ignoreList: [] },
-	{ path: 'pmrem/PMREMGenerator.js', ignoreList: [] },
+	{ path: 'pmrem/PMREMCubeUVPacker.js', dependencies: [], ignoreList: [] },
+	{ path: 'pmrem/PMREMGenerator.js', dependencies: [], ignoreList: [] },
 
-	{ path: 'renderers/CSS2DRenderer.js', ignoreList: [] },
-	{ path: 'renderers/CSS3DRenderer.js', ignoreList: [] },
+	{ path: 'shaders/UnpackDepthRGBAShader.js', dependencies: [], ignoreList: [] },
 
-	{ path: 'utils/BufferGeometryUtils.js', ignoreList: [] },
-	{ path: 'utils/GeometryUtils.js', ignoreList: [] },
-	{ path: 'utils/MathUtils.js', ignoreList: [] },
-	{ path: 'utils/SceneUtils.js', ignoreList: [] },
-	{ path: 'utils/ShadowMapViewer.js', ignoreList: [ 'DirectionalLight', 'SpotLight' ] },
-	{ path: 'utils/SkeletonUtils.js', ignoreList: [] },
-	{ path: 'utils/TypedArrayUtils.js', ignoreList: [] },
-	{ path: 'utils/UVsDebug.js', ignoreList: [ 'SphereBufferGeometry' ] },
+	{ path: 'renderers/CSS2DRenderer.js', dependencies: [], ignoreList: [] },
+	{ path: 'renderers/CSS3DRenderer.js', dependencies: [], ignoreList: [] },
+
+	{ path: 'utils/BufferGeometryUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/GeometryUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/MathUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/SceneUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/ShadowMapViewer.js', dependencies: [ { name: 'UnpackDepthRGBAShader', module: 'shaders/UnpackDepthRGBAShader' } ], ignoreList: [ 'DirectionalLight', 'SpotLight' ] },
+	{ path: 'utils/SkeletonUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/TypedArrayUtils.js', dependencies: [], ignoreList: [] },
+	{ path: 'utils/UVsDebug.js', dependencies: [], ignoreList: [ 'SphereBufferGeometry' ] },
 ];
 
 for ( var i = 0; i < files.length; i ++ ) {
 
 	var file = files[ i ];
-	convert( file.path, file.ignoreList );
+	convert( file.path, file.dependencies, file.ignoreList );
 
 }
 
 //
 
-function convert( path, ignoreList ) {
+function convert( path, exampleDependencies, ignoreList ) {
 
 	var contents = fs.readFileSync( srcFolder + path, 'utf8' );
 
 	var classNames = [];
-	var dependencies = {};
+	var coreDependencies = {};
 
 	// imports
 
@@ -97,7 +100,7 @@ function convert( path, ignoreList ) {
 
 		if ( p1 === 'Math' ) {
 
-			dependencies[ '_Math' ] = true;
+			coreDependencies[ '_Math' ] = true;
 
 			return '_Math.';
 
@@ -113,7 +116,7 @@ function convert( path, ignoreList ) {
 
 		if ( ignoreList.includes( p1 ) ) return match;
 
-		dependencies[ p1 ] = true;
+		if ( p1 in THREE ) coreDependencies[ p1 ] = true;
 
 		return `new ${p1}(`;
 
@@ -129,13 +132,13 @@ function convert( path, ignoreList ) {
 
 		if ( p2 === 'Math' || p2 === '_Math' ) {
 
-			dependencies[ '_Math' ] = true;
+			coreDependencies[ '_Math' ] = true;
 
 			return '_Math';
 
 		}
 
-		dependencies[ p2 ] = true;
+		if ( p2 in THREE ) coreDependencies[ p2 ] = true;
 
 		// console.log( match, p2 );
 
@@ -145,13 +148,27 @@ function convert( path, ignoreList ) {
 
 	//
 
-	var keys = Object.keys( dependencies )
+	var keys = Object.keys( coreDependencies )
 		.filter( value => ! classNames.includes( value ) )
 		.map( value => value === '_Math' ? 'Math as _Math' : value )
 		.map( value => '\n\t' + value )
 		.sort()
 		.toString();
+
+	// core imports
+
 	var imports = `import {${keys}\n} from "../../../build/three.module.js";`;
+
+	// example imports
+
+	for ( var dependency of exampleDependencies ) {
+
+		imports += `\nimport { ${dependency.name} } from "../${dependency.module}.js";`;
+
+	}
+
+	// exports
+
 	var exports = `export { ${classNames.join( ", " )} };\n`;
 
 	var output = contents.replace( '_IMPORTS_', keys ? imports : '' ) + '\n' + exports;


### PR DESCRIPTION
With this PR, it's now possible to convert modules like `ColladaLoader` that have dependencies to other modules. Interestingly, the new code revealed a bug in the module of `ShadowMapViewer` since `UnpackDepthRGBAShader` is no part of the core. 

The PR implements the suggestion mentioned by @mrdoob here: https://github.com/mrdoob/three.js/pull/16400/files#r284492725

It introduces per module an array that represents the dependencies to other example files. Per entry there is a key/value mapping that looks like: `classname`=>`path to module`. In this way, it's very flexibel to define dependencies since you not have a 1:1 relationship between class name and module name. E.g. it's now easy to define that `Pass` should be loaded from `EffectComposer.js` which would be not possible to derive only from code.