### PR TITLE
GLTFExporter: parseChunks (Without closure)

### DIFF
--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -128,16 +128,10 @@
 		The onComplete callback will be called with one argument, an object with the following properties: <br />
 		<ul>
 			<li>json — object. The glTF's JSON content.</li>
-			<li>buffers — Array<[page:Blob Blob]>. Blobs corresponding to the glTF's buffers array. Will be undefined if the buffer does not have a uri or it is not the glb buffer.</li>
-			<li>images — Array<[page:Blob Blob]>. Blobs corresponding to the glTF's images array. Will be undefined if the image does not have a uri.</li>
+			<li>buffers — Array<[page:Blob Blob]>. External Blobs referenced by the glTF "buffers" array. Undefined unless mode is "gltf".</li>
+			<li>images — Array<[page:Blob Blob]>. External Blobs referenced by the glTF "images" array. Undefined unless mode is "gltf".</li>
 		</ul>
-		</p>
-
-		<h3>[method:null createGLBBlob]( [param:Object3D input], [param:Function onCompleted], [param:Function onError] )</h3>
-		<p>
-		[page:Object chunks] — The chunks object returned by [page:Function parseChunks].<br />
-		[page:Function onCompleted] — Will be called when the export completes. The argument will be a blob containing the glb file's content.<br />
-		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
+		Filenames associated with buffers and images (which are needed to save files to disk) are in "json.buffers" and "json.images".
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -93,15 +93,14 @@
 			</li>
 		</ul>
 
-		[page:Function onCompleted] — Will be called when the export completes. The argument will be the generated glTF JSON or binary ArrayBuffer.<br />
+		[page:Function onCompleted] — Will be called when the export completes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
 		[page:Options options] — Export options<br />
 		<ul>
-			<li>trs - bool. Export position, rotation and scale instead of matrix per node. Default is false</li>
+			<li>mode - string. Export as "glb", "gltf", or "embedded" (gltf with images and binary data embedded as data uris). Default is "glb".</li>
+			<li>trs - bool. Export position, rotation and scale instead of matrix per node. Default is true</li>
 			<li>onlyVisible - bool. Export only visible objects. Default is true.</li>
 			<li>truncateDrawRange - bool. Export just the attributes within the drawRange, if defined, instead of exporting the whole array. Default is true.</li>
-			<li>binary - bool. Export in binary (.glb) format, returning an ArrayBuffer. Default is false.</li>
-			<li>embedImages - bool. Export with images embedded into the glTF asset. Default is true.</li>
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>forcePowerOfTwoTextures - bool. Export with images resized to POT size. This option works only if embedImages is true. Default is false.</li>
@@ -109,25 +108,36 @@
 		</ul>
 		</p>
 		<p>
-		Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
+		Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects).<br/>
+		The onComplete callback will be called with one argument with a different type depending on the mode: <br />
+		<ul>
+			<li>glb — Blob. The glb's file content.</li>
+			<li>gltf — Object. The chunks object returned by [page:Function parseChunks].</li>
+			<li>embedded — Object. The glTF's JSON content.</li>
+		</ul>
 		</p>
 
 		<h3>[method:null parseChunks]( [param:Object3D input], [param:Function onCompleted], [param:Function onError], [param:Object options] )</h3>
 		<p>
 		[page:Object input] — Scenes or objects to export.<br />
-		[page:Function onCompleted] — Will be called when the export completes. The argument will be the generated glTF JSON or binary ArrayBuffer.<br />
+		[page:Function onCompleted] — Will be called when the export completes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
 		[page:Options options] — Export options see <em>.parse</em><br />
 		</p>
 		<p>
-		Returns an object with the following properties: <br />
+		The onComplete callback will be called with one argument, an object with the following properties: <br />
 		<ul>
 			<li>json — object. The glTF's JSON content.</li>
-			<li>bin — Blob. The glTF's .bin file content. Or <em>undefined</em> if <em>options.binary</em> is set.</li>
-			<li>binFileName — string. The glTF's .bin file name, saved in the glTF's JSON content. Or <em>undefined</em> if <em>options.binary</em> is set. This property can be set with <em>options.binFileName</em></li>
-			<li>externalImageUrls — Array<[page:String String]>. The urls of the externally referenced images in the glTF file.</li>
-			<li>externalImageFileNames — Array<[page:String String]>. The file names of the externally referenced images in the glTF file.</li>
+			<li>buffers — Array<[page:Blob Blob]>. Blobs corresponding to the glTF's buffers array. Will be undefined if the buffer does not have a uri or it is not the glb buffer.</li>
+			<li>images — Array<[page:Blob Blob]>. Blobs corresponding to the glTF's images array. Will be undefined if the image does not have a uri.</li>
 		</ul>
+		</p>
+
+		<h3>[method:null createGLBBlob]( [param:Object3D input], [param:Function onCompleted], [param:Function onError] )</h3>
+		<p>
+		[page:Object chunks] — The chunks object returned by [page:Function parseChunks].<br />
+		[page:Function onCompleted] — Will be called when the export completes. The argument will be a blob containing the glb file's content.<br />
+		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/exporters/GLTFExporter.html
+++ b/docs/examples/exporters/GLTFExporter.html
@@ -41,10 +41,17 @@
 		var exporter = new THREE.GLTFExporter();
 
 		// Parse the input and generate the glTF output
-		exporter.parse( scene, function ( gltf ) {
-			console.log( gltf );
-			downloadJSON( gltf );
-		}, options );
+		exporter.parse(
+			scene,
+			function ( gltf ) {
+				console.log( gltf );
+				downloadJSON( gltf );
+			},
+			function ( error ) {
+				console.error(error);
+			},
+			options
+		);
 		</code>
 
 		[example:misc_exporter_gltf]
@@ -60,7 +67,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null parse]( [param:Object3D input], [param:Function onCompleted], [param:Object options] )</h3>
+		<h3>[method:null parse]( [param:Object3D input], [param:Function onCompleted], [param:Function onError], [param:Object options] )</h3>
 		<p>
 		[page:Object input] — Scenes or objects to export. Valid options:<br />
 		<ul>
@@ -87,6 +94,7 @@
 		</ul>
 
 		[page:Function onCompleted] — Will be called when the export completes. The argument will be the generated glTF JSON or binary ArrayBuffer.<br />
+		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
 		[page:Options options] — Export options<br />
 		<ul>
 			<li>trs - bool. Export position, rotation and scale instead of matrix per node. Default is false</li>
@@ -102,6 +110,24 @@
 		</p>
 		<p>
 		Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
+		</p>
+
+		<h3>[method:null parseChunks]( [param:Object3D input], [param:Function onCompleted], [param:Function onError], [param:Object options] )</h3>
+		<p>
+		[page:Object input] — Scenes or objects to export.<br />
+		[page:Function onCompleted] — Will be called when the export completes. The argument will be the generated glTF JSON or binary ArrayBuffer.<br />
+		[page:Function onError] — (optional) A function to be called if an error occurs during exporting. The function receives error as an argument.<br />
+		[page:Options options] — Export options see <em>.parse</em><br />
+		</p>
+		<p>
+		Returns an object with the following properties: <br />
+		<ul>
+			<li>json — object. The glTF's JSON content.</li>
+			<li>bin — Blob. The glTF's .bin file content. Or <em>undefined</em> if <em>options.binary</em> is set.</li>
+			<li>binFileName — string. The glTF's .bin file name, saved in the glTF's JSON content. Or <em>undefined</em> if <em>options.binary</em> is set. This property can be set with <em>options.binFileName</em></li>
+			<li>externalImageUrls — Array<[page:String String]>. The urls of the externally referenced images in the glTF file.</li>
+			<li>externalImageFileNames — Array<[page:String String]>. The file names of the externally referenced images in the glTF file.</li>
+		</ul>
 		</p>
 
 		<h2>Source</h2>

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -357,7 +357,13 @@ THREE.GLTFExporter.prototype = {
 		function getFileNameFromUri( uri ) {
 
 			var parts = uri.split( '#' ).shift().split( '?' ).shift().split( '/' ).pop().split( '.' );
-			parts.pop();
+
+			if ( parts.length > 1 ) {
+
+				parts.pop();
+
+			}
+
 			return parts.join();
 
 		}

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -2150,6 +2150,18 @@ THREE.GLTFExporter.prototype = {
 	 */
 	parse: function ( input, onDone, onError, options ) {
 
+		if ( typeof onError === "object" ) {
+
+			console.warn( 'THREE.GLTFExporter: .parse() now expects ( input, onDone, onError, options ).' );
+
+		}
+
+		if ( options && options.binary !== undefined ) {
+
+			console.warn( 'THREE.GLTFExporter: options.binary has been deprecated. Use options.mode = "glb" instead.' );
+
+		}
+
 		var scope = this;
 
 		this.parseChunks( input, function ( chunks ) {

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -76,56 +76,6 @@ THREE.GLTFExporter.prototype = {
 	constructor: THREE.GLTFExporter,
 
 	/**
-	 * Get the required size + padding for a buffer, rounded to the next 4-byte boundary.
-	 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
-	 *
-	 * @param {Integer} bufferSize The size the original buffer.
-	 * @returns {Integer} new buffer size with required padding.
-	 *
-	 */
-	_getPaddedBufferSize( bufferSize ) {
-
-		return Math.ceil( bufferSize / 4 ) * 4;
-
-	},
-
-	/**
-	 * Returns a buffer aligned to 4-byte boundary.
-	 *
-	 * @param {ArrayBuffer} arrayBuffer Buffer to pad
-	 * @param {Integer} paddingByte (Optional)
-	 * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
-	 */
-	_getPaddedArrayBuffer( arrayBuffer, paddingByte ) {
-
-		paddingByte = paddingByte || 0;
-
-		var paddedLength = this._getPaddedBufferSize( arrayBuffer.byteLength );
-
-		if ( paddedLength !== arrayBuffer.byteLength ) {
-
-			var array = new Uint8Array( paddedLength );
-			array.set( new Uint8Array( arrayBuffer ) );
-
-			if ( paddingByte !== 0 ) {
-
-				for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
-
-					array[ i ] = paddingByte;
-
-				}
-
-			}
-
-			return array.buffer;
-
-		}
-
-		return arrayBuffer;
-
-	},
-
-	/**
 	 * Parse scenes and generate an object containing the glTF JSON, buffers, and images.
 	 * @param  {THREE.Scene or [THREE.Scenes]} input   THREE.Scene or Array of THREE.Scenes
 	 * @param  {Function} onDone  Callback on completed
@@ -133,8 +83,6 @@ THREE.GLTFExporter.prototype = {
 	 * @param  {Object} options options
 	 */
 	parseChunks: function ( input, onDone, onError, options ) {
-
-		var self = this;
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
 
@@ -489,7 +437,7 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			var byteLength = self._getPaddedBufferSize( count * attribute.itemSize * componentSize );
+			var byteLength = THREE.GLTFExporter.Utils.getPaddedBufferSize( count * attribute.itemSize * componentSize );
 			var dataView = new DataView( new ArrayBuffer( byteLength ) );
 			var offset = 0;
 
@@ -577,7 +525,7 @@ THREE.GLTFExporter.prototype = {
 				reader.readAsArrayBuffer( blob );
 				reader.onloadend = function () {
 
-					var buffer = self._getPaddedArrayBuffer( reader.result );
+					var buffer = THREE.GLTFExporter.Utils.getPaddedArrayBuffer( reader.result );
 
 					var bufferView = {
 						buffer: processBuffer( buffer ),
@@ -2026,8 +1974,6 @@ THREE.GLTFExporter.prototype = {
 	 */
 	createGLBBlob: function ( chunks, onDone, onError ) {
 
-		var self = this;
-
 		if ( chunks.buffers.length > 1 ) {
 
 			onError( new Error( "GLTFExporter: exportGLB expects 0 or 1 buffers." ) );
@@ -2054,7 +2000,7 @@ THREE.GLTFExporter.prototype = {
 				reader.readAsArrayBuffer( blob );
 				reader.onloadend = function () {
 
-					var binaryChunk = self._getPaddedArrayBuffer( reader.result );
+					var binaryChunk = THREE.GLTFExporter.Utils.getPaddedArrayBuffer( reader.result );
 					resolve( binaryChunk );
 
 				};
@@ -2105,7 +2051,7 @@ THREE.GLTFExporter.prototype = {
 		blobParts.push( header );
 
 		// JSON chunk.
-		var jsonChunk = self._getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( chunks.json ) ), 0x20 );
+		var jsonChunk = THREE.GLTFExporter.Utils.getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( chunks.json ) ), 0x20 );
 		var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
 		jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
 		jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );
@@ -2184,6 +2130,56 @@ THREE.GLTFExporter.prototype = {
 };
 
 THREE.GLTFExporter.Utils = {
+
+	/**
+	 * Get the required size + padding for a buffer, rounded to the next 4-byte boundary.
+	 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
+	 *
+	 * @param {Integer} bufferSize The size the original buffer.
+	 * @returns {Integer} new buffer size with required padding.
+	 *
+	 */
+	getPaddedBufferSize( bufferSize ) {
+
+		return Math.ceil( bufferSize / 4 ) * 4;
+
+	},
+
+	/**
+	 * Returns a buffer aligned to 4-byte boundary.
+	 *
+	 * @param {ArrayBuffer} arrayBuffer Buffer to pad
+	 * @param {Integer} paddingByte (Optional)
+	 * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
+	 */
+	getPaddedArrayBuffer( arrayBuffer, paddingByte ) {
+
+		paddingByte = paddingByte || 0;
+
+		var paddedLength = THREE.GLTFExporter.Utils.getPaddedBufferSize( arrayBuffer.byteLength );
+
+		if ( paddedLength !== arrayBuffer.byteLength ) {
+
+			var array = new Uint8Array( paddedLength );
+			array.set( new Uint8Array( arrayBuffer ) );
+
+			if ( paddingByte !== 0 ) {
+
+				for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
+
+					array[ i ] = paddingByte;
+
+				}
+
+			}
+
+			return array.buffer;
+
+		}
+
+		return arrayBuffer;
+
+	},
 
 	insertKeyframe: function ( track, time ) {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -784,8 +784,9 @@ THREE.GLTFExporter.prototype = {
 
 			} else {
 
+				var fileName = getFileNameFromUri( image.src );
 				var extension = mimeType === "image/png" ? ".png" : ".jpg";
-				gltfImage.uri = getFileNameFromUri( image.src ) + extension;
+				gltfImage.uri = fileName + index + extension;
 
 				pending.push( new Promise( function ( resolve, reject ) {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -2028,11 +2028,21 @@ THREE.GLTFExporter.prototype = {
 
 				}
 
+				resolve();
+
 			} );
 
 		}
 
-		processInput( input );
+		try {
+
+			processInput( input );
+
+		} catch ( e ) {
+
+			onError( e );
+
+		}
 
 		Promise.all( pending ).then( postProcessBuffers ).then( function () {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -808,10 +808,6 @@ THREE.GLTFExporter.prototype = {
 
 				} ) );
 
-			} else if ( options.mode === "embedded" ) {
-
-				gltfImage.uri = canvas.toDataURL( mimeType );
-
 			} else {
 
 				var extension = mimeType === "image/png" ? ".png" : ".jpg";
@@ -2009,28 +2005,9 @@ THREE.GLTFExporter.prototype = {
 
 						outputJSON.buffers[ 0 ].uri = "scene.bin";
 
-					} else if ( options.mode === "embedded" ) {
-
-						var reader = new window.FileReader();
-						reader.readAsDataURL( blob );
-						reader.onloadend = function () {
-
-							var base64data = reader.result;
-							outputJSON.buffers[ 0 ].uri = base64data;
-							outputBuffers.push( undefined );
-							resolve();
-
-						};
-						reader.onerror = reject;
-
 					}
 
-					if ( options.mode !== "embedded" ) {
-
-						outputBuffers.push( blob );
-						resolve();
-
-					}
+					outputBuffers.push( blob );
 
 				}
 
@@ -2176,10 +2153,6 @@ THREE.GLTFExporter.prototype = {
 			if ( options.mode === "gltf" ) {
 
 				onDone( chunks );
-
-			} else if ( options.mode === "embedded" ) {
-
-				onDone( chunks.json );
 
 			} else {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -65,19 +65,22 @@ THREE.GLTFExporter.prototype = {
 	constructor: THREE.GLTFExporter,
 
 	/**
-	 * Parse scenes and generate GLTF output
+	 * Parse scenes and generate an object containing the glTF JSON, bin blob, and image urls/file names.
 	 * @param  {THREE.Scene or [THREE.Scenes]} input   THREE.Scene or Array of THREE.Scenes
 	 * @param  {Function} onDone  Callback on completed
+	 * @param  {Function} onError Callback on error
 	 * @param  {Object} options options
 	 */
-	parse: function ( input, onDone, options ) {
+	parseChunks: function ( input, onDone, onError, options ) {
 
 		var DEFAULT_OPTIONS = {
 			binary: false,
-			trs: false,
+			binFileName: "scene.bin",
+			trs: true,
 			onlyVisible: true,
 			truncateDrawRange: true,
-			embedImages: true,
+			embedImages: false,
+			useImageFileNames: true,
 			animations: [],
 			forceIndices: false,
 			forcePowerOfTwoTextures: false,
@@ -120,6 +123,8 @@ THREE.GLTFExporter.prototype = {
 			images: new Map()
 
 		};
+		var externalImageUrls = [];
+		var externalImageFilenames = [];
 
 		var cachedCanvas;
 
@@ -348,6 +353,12 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			return arrayBuffer;
+
+		}
+
+		function getFileNameFromUri( uri ) {
+
+			return uri.split( '#' ).shift().split( '?' ).shift().split( '/' ).pop();
 
 		}
 
@@ -776,7 +787,7 @@ THREE.GLTFExporter.prototype = {
 
 				if ( options.binary === true ) {
 
-					pending.push( new Promise( function ( resolve ) {
+					pending.push( new Promise( function ( resolve, reject ) {
 
 						canvas.toBlob( function ( blob ) {
 
@@ -786,7 +797,7 @@ THREE.GLTFExporter.prototype = {
 
 								resolve();
 
-							} );
+							} ).catch( reject );
 
 						}, mimeType );
 
@@ -797,6 +808,12 @@ THREE.GLTFExporter.prototype = {
 					gltfImage.uri = canvas.toDataURL( mimeType );
 
 				}
+
+			} else if ( options.useImageFileNames ) {
+
+				gltfImage.uri = getFileNameFromUri( image.src );
+				externalImageUrls.push( image.src );
+				externalImageFilenames.push( gltfImage.uri );
 
 			} else {
 
@@ -1971,8 +1988,7 @@ THREE.GLTFExporter.prototype = {
 
 		Promise.all( pending ).then( function () {
 
-			// Merge buffers.
-			var blob = new Blob( buffers, { type: 'application/octet-stream' } );
+			var blob, binFileName;
 
 			// Declare extensions.
 			var extensionsUsedList = Object.keys( extensionsUsed );
@@ -1980,86 +1996,121 @@ THREE.GLTFExporter.prototype = {
 
 			if ( outputJSON.buffers && outputJSON.buffers.length > 0 ) {
 
+				// Merge buffers
+				blob = new Blob( buffers, { type: 'application/octet-stream' } );
+
 				// Update bytelength of the single buffer.
 				outputJSON.buffers[ 0 ].byteLength = blob.size;
 
-				var reader = new window.FileReader();
+				if ( ! options.binary ) {
 
-				if ( options.binary === true ) {
-
-					// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
-
-					var GLB_HEADER_BYTES = 12;
-					var GLB_HEADER_MAGIC = 0x46546C67;
-					var GLB_VERSION = 2;
-
-					var GLB_CHUNK_PREFIX_BYTES = 8;
-					var GLB_CHUNK_TYPE_JSON = 0x4E4F534A;
-					var GLB_CHUNK_TYPE_BIN = 0x004E4942;
-
-					reader.readAsArrayBuffer( blob );
-					reader.onloadend = function () {
-
-						// Binary chunk.
-						var binaryChunk = getPaddedArrayBuffer( reader.result );
-						var binaryChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
-						binaryChunkPrefix.setUint32( 0, binaryChunk.byteLength, true );
-						binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
-
-						// JSON chunk.
-						var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ) ), 0x20 );
-						var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
-						jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
-						jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );
-
-						// GLB header.
-						var header = new ArrayBuffer( GLB_HEADER_BYTES );
-						var headerView = new DataView( header );
-						headerView.setUint32( 0, GLB_HEADER_MAGIC, true );
-						headerView.setUint32( 4, GLB_VERSION, true );
-						var totalByteLength = GLB_HEADER_BYTES
-							+ jsonChunkPrefix.byteLength + jsonChunk.byteLength
-							+ binaryChunkPrefix.byteLength + binaryChunk.byteLength;
-						headerView.setUint32( 8, totalByteLength, true );
-
-						var glbBlob = new Blob( [
-							header,
-							jsonChunkPrefix,
-							jsonChunk,
-							binaryChunkPrefix,
-							binaryChunk
-						], { type: 'application/octet-stream' } );
-
-						var glbReader = new window.FileReader();
-						glbReader.readAsArrayBuffer( glbBlob );
-						glbReader.onloadend = function () {
-
-							onDone( glbReader.result );
-
-						};
-
-					};
-
-				} else {
-
-					reader.readAsDataURL( blob );
-					reader.onloadend = function () {
-
-						var base64data = reader.result;
-						outputJSON.buffers[ 0 ].uri = base64data;
-						onDone( outputJSON );
-
-					};
+					binFileName = options.binFileName;
+					outputJSON.buffers[ 0 ].uri = binFileName;
 
 				}
 
+			}
+
+			onDone( {
+				json: outputJSON,
+				bin: blob,
+				binFileName: binFileName,
+				externalImageUrls: externalImageUrls,
+				externalImageFileNames: externalImageFilenames
+			} );
+
+		} ).catch( onError );
+
+	},
+
+	/**
+	 * Parse scenes and generate GLTF output
+	 * @param  {THREE.Scene or [THREE.Scenes]} input   THREE.Scene or Array of THREE.Scenes
+	 * @param  {Function} onDone  Callback on completed
+	 * @param  {Function} onError  Callback on error
+	 * @param  {Object} options options
+	 */
+	parse: function ( input, onDone, onError, options ) {
+
+		this.parseChunks( input, function ( parts ) {
+
+			var outputJSON = parts.json;
+			var blob = parts.bin;
+
+			var reader = new window.FileReader();
+
+			if ( options.binary === true ) {
+
+				// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
+
+				var GLB_HEADER_BYTES = 12;
+				var GLB_HEADER_MAGIC = 0x46546C67;
+				var GLB_VERSION = 2;
+
+				var GLB_CHUNK_PREFIX_BYTES = 8;
+				var GLB_CHUNK_TYPE_JSON = 0x4E4F534A;
+				var GLB_CHUNK_TYPE_BIN = 0x004E4942;
+
+				reader.readAsArrayBuffer( blob );
+				reader.onloadend = function () {
+
+					// Binary chunk.
+					var binaryChunk = getPaddedArrayBuffer( reader.result );
+					var binaryChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
+					binaryChunkPrefix.setUint32( 0, binaryChunk.byteLength, true );
+					binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
+
+					// JSON chunk.
+					var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ) ), 0x20 );
+					var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
+					jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
+					jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );
+
+					// GLB header.
+					var header = new ArrayBuffer( GLB_HEADER_BYTES );
+					var headerView = new DataView( header );
+					headerView.setUint32( 0, GLB_HEADER_MAGIC, true );
+					headerView.setUint32( 4, GLB_VERSION, true );
+					var totalByteLength = GLB_HEADER_BYTES
+						+ jsonChunkPrefix.byteLength + jsonChunk.byteLength
+						+ binaryChunkPrefix.byteLength + binaryChunk.byteLength;
+					headerView.setUint32( 8, totalByteLength, true );
+
+					var glbBlob = new Blob( [
+						header,
+						jsonChunkPrefix,
+						jsonChunk,
+						binaryChunkPrefix,
+						binaryChunk
+					], { type: 'application/octet-stream' } );
+
+					var glbReader = new window.FileReader();
+					glbReader.readAsArrayBuffer( glbBlob );
+					glbReader.onloadend = function () {
+
+						onDone( glbReader.result );
+
+					};
+					glbReader.onerror = onError;
+
+				};
+
 			} else {
 
-				onDone( outputJSON );
+				reader.readAsDataURL( blob );
+				reader.onloadend = function () {
+
+					var base64data = reader.result;
+					outputJSON.buffers[ 0 ].uri = base64data;
+					onDone( outputJSON );
+
+				};
 
 			}
 
-		} );
+			reader.onerror = onError;
+
+		}, onError, options );
 
 	}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -356,7 +356,9 @@ THREE.GLTFExporter.prototype = {
 
 		function getFileNameFromUri( uri ) {
 
-			return uri.split( '#' ).shift().split( '?' ).shift().split( '/' ).pop();
+			var parts = uri.split( '#' ).shift().split( '?' ).shift().split( '/' ).pop().split( '.' );
+			parts.pop();
+			return parts.join();
 
 		}
 
@@ -806,7 +808,8 @@ THREE.GLTFExporter.prototype = {
 
 			} else {
 
-				gltfImage.uri = getFileNameFromUri( image.src );
+				var extension = mimeType === "image/png" ? ".png" : ".jpg";
+				gltfImage.uri = getFileNameFromUri( image.src ) + extension;
 
 				pending.push( new Promise( function ( resolve, reject ) {
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -55,6 +55,95 @@ var PATH_PROPERTIES = {
 	morphTargetInfluences: 'weights'
 };
 
+var DEFAULT_OPTIONS = {
+	mode: "glb",
+	trs: true,
+	onlyVisible: true,
+	truncateDrawRange: true,
+	animations: [],
+	forceIndices: false,
+	forcePowerOfTwoTextures: false,
+	includeCustomExtensions: false
+};
+
+/**
+ * Get the required size + padding for a buffer, rounded to the next 4-byte boundary.
+ * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
+ *
+ * @param {Integer} bufferSize The size the original buffer.
+ * @returns {Integer} new buffer size with required padding.
+ *
+ */
+function getPaddedBufferSize( bufferSize ) {
+
+	return Math.ceil( bufferSize / 4 ) * 4;
+
+}
+
+/**
+ * Returns a buffer aligned to 4-byte boundary.
+ *
+ * @param {ArrayBuffer} arrayBuffer Buffer to pad
+ * @param {Integer} paddingByte (Optional)
+ * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
+ */
+function getPaddedArrayBuffer( arrayBuffer, paddingByte ) {
+
+	paddingByte = paddingByte || 0;
+
+	var paddedLength = getPaddedBufferSize( arrayBuffer.byteLength );
+
+	if ( paddedLength !== arrayBuffer.byteLength ) {
+
+		var array = new Uint8Array( paddedLength );
+		array.set( new Uint8Array( arrayBuffer ) );
+
+		if ( paddingByte !== 0 ) {
+
+			for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
+
+				array[ i ] = paddingByte;
+
+			}
+
+		}
+
+		return array.buffer;
+
+	}
+
+	return arrayBuffer;
+
+}
+
+/**
+ * Converts a string to an ArrayBuffer.
+ * @param  {string} text
+ * @return {ArrayBuffer}
+ */
+function stringToArrayBuffer( text ) {
+
+	if ( window.TextEncoder !== undefined ) {
+
+		return new TextEncoder().encode( text ).buffer;
+
+	}
+
+	var array = new Uint8Array( new ArrayBuffer( text.length ) );
+
+	for ( var i = 0, il = text.length; i < il; i ++ ) {
+
+		var value = text.charCodeAt( i );
+
+		// Replacing multi-byte character with space(0x20).
+		array[ i ] = value > 0xFF ? 0x20 : value;
+
+	}
+
+	return array.buffer;
+
+}
+
 //------------------------------------------------------------------------------
 // GLTF Exporter
 //------------------------------------------------------------------------------
@@ -65,27 +154,13 @@ THREE.GLTFExporter.prototype = {
 	constructor: THREE.GLTFExporter,
 
 	/**
-	 * Parse scenes and generate an object containing the glTF JSON, bin blob, and image urls/file names.
+	 * Parse scenes and generate an object containing the glTF JSON, buffers, and images.
 	 * @param  {THREE.Scene or [THREE.Scenes]} input   THREE.Scene or Array of THREE.Scenes
 	 * @param  {Function} onDone  Callback on completed
 	 * @param  {Function} onError Callback on error
 	 * @param  {Object} options options
 	 */
 	parseChunks: function ( input, onDone, onError, options ) {
-
-		var DEFAULT_OPTIONS = {
-			binary: false,
-			binFileName: "scene.bin",
-			trs: true,
-			onlyVisible: true,
-			truncateDrawRange: true,
-			embedImages: false,
-			useImageFileNames: true,
-			animations: [],
-			forceIndices: false,
-			forcePowerOfTwoTextures: false,
-			includeCustomExtensions: false
-		};
 
 		options = Object.assign( {}, DEFAULT_OPTIONS, options );
 
@@ -107,6 +182,9 @@ THREE.GLTFExporter.prototype = {
 
 		};
 
+		var outputBuffers = [];
+		var outputImages = [];
+
 		var byteOffset = 0;
 		var buffers = [];
 		var pending = [];
@@ -123,8 +201,6 @@ THREE.GLTFExporter.prototype = {
 			images: new Map()
 
 		};
-		var externalImageUrls = [];
-		var externalImageFilenames = [];
 
 		var cachedCanvas;
 
@@ -158,34 +234,6 @@ THREE.GLTFExporter.prototype = {
 				return element === array2[ index ];
 
 			} );
-
-		}
-
-		/**
-		 * Converts a string to an ArrayBuffer.
-		 * @param  {string} text
-		 * @return {ArrayBuffer}
-		 */
-		function stringToArrayBuffer( text ) {
-
-			if ( window.TextEncoder !== undefined ) {
-
-				return new TextEncoder().encode( text ).buffer;
-
-			}
-
-			var array = new Uint8Array( new ArrayBuffer( text.length ) );
-
-			for ( var i = 0, il = text.length; i < il; i ++ ) {
-
-				var value = text.charCodeAt( i );
-
-				// Replacing multi-byte character with space(0x20).
-				array[ i ] = value > 0xFF ? 0x20 : value;
-
-			}
-
-			return array.buffer;
 
 		}
 
@@ -303,56 +351,6 @@ THREE.GLTFExporter.prototype = {
 			cachedData.attributesNormalized.set( normal, attribute );
 
 			return attribute;
-
-		}
-
-		/**
-		 * Get the required size + padding for a buffer, rounded to the next 4-byte boundary.
-		 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
-		 *
-		 * @param {Integer} bufferSize The size the original buffer.
-		 * @returns {Integer} new buffer size with required padding.
-		 *
-		 */
-		function getPaddedBufferSize( bufferSize ) {
-
-			return Math.ceil( bufferSize / 4 ) * 4;
-
-		}
-
-		/**
-		 * Returns a buffer aligned to 4-byte boundary.
-		 *
-		 * @param {ArrayBuffer} arrayBuffer Buffer to pad
-		 * @param {Integer} paddingByte (Optional)
-		 * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
-		 */
-		function getPaddedArrayBuffer( arrayBuffer, paddingByte ) {
-
-			paddingByte = paddingByte || 0;
-
-			var paddedLength = getPaddedBufferSize( arrayBuffer.byteLength );
-
-			if ( paddedLength !== arrayBuffer.byteLength ) {
-
-				var array = new Uint8Array( paddedLength );
-				array.set( new Uint8Array( arrayBuffer ) );
-
-				if ( paddingByte !== 0 ) {
-
-					for ( var i = arrayBuffer.byteLength; i < paddedLength; i ++ ) {
-
-						array[ i ] = paddingByte;
-
-					}
-
-				}
-
-				return array.buffer;
-
-			}
-
-			return arrayBuffer;
 
 		}
 
@@ -757,73 +755,75 @@ THREE.GLTFExporter.prototype = {
 			}
 
 			var gltfImage = { mimeType: mimeType };
+			var index = outputJSON.images.length;
 
-			if ( options.embedImages ) {
+			var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
 
-				var canvas = cachedCanvas = cachedCanvas || document.createElement( 'canvas' );
+			canvas.width = image.width;
+			canvas.height = image.height;
 
-				canvas.width = image.width;
-				canvas.height = image.height;
+			if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( image ) ) {
 
-				if ( options.forcePowerOfTwoTextures && ! isPowerOfTwo( image ) ) {
+				console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
 
-					console.warn( 'GLTFExporter: Resized non-power-of-two image.', image );
+				canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
+				canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
 
-					canvas.width = THREE.Math.floorPowerOfTwo( canvas.width );
-					canvas.height = THREE.Math.floorPowerOfTwo( canvas.height );
+			}
 
-				}
+			var ctx = canvas.getContext( '2d' );
 
-				var ctx = canvas.getContext( '2d' );
+			if ( flipY === true ) {
 
-				if ( flipY === true ) {
+				ctx.translate( 0, canvas.height );
+				ctx.scale( 1, - 1 );
 
-					ctx.translate( 0, canvas.height );
-					ctx.scale( 1, - 1 );
+			}
 
-				}
+			ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
 
-				ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
+			if ( options.mode === "glb" ) {
 
-				if ( options.binary === true ) {
+				pending.push( new Promise( function ( resolve, reject ) {
 
-					pending.push( new Promise( function ( resolve, reject ) {
+					canvas.toBlob( function ( blob ) {
 
-						canvas.toBlob( function ( blob ) {
+						processBufferViewImage( blob ).then( function ( bufferViewIndex ) {
 
-							processBufferViewImage( blob ).then( function ( bufferViewIndex ) {
+							gltfImage.bufferView = bufferViewIndex;
 
-								gltfImage.bufferView = bufferViewIndex;
+							resolve();
 
-								resolve();
+						} ).catch( reject );
 
-							} ).catch( reject );
+					}, mimeType );
 
-						}, mimeType );
+				} ) );
 
-					} ) );
+			} else if ( options.mode === "embedded" ) {
 
-				} else {
-
-					gltfImage.uri = canvas.toDataURL( mimeType );
-
-				}
-
-			} else if ( options.useImageFileNames ) {
-
-				gltfImage.uri = getFileNameFromUri( image.src );
-				externalImageUrls.push( image.src );
-				externalImageFilenames.push( gltfImage.uri );
+				gltfImage.uri = canvas.toDataURL( mimeType );
 
 			} else {
 
-				gltfImage.uri = image.src;
+				gltfImage.uri = getFileNameFromUri( image.src );
+
+				pending.push( new Promise( function ( resolve, reject ) {
+
+					canvas.toBlob( function ( blob ) {
+
+						outputImages[ index ] = blob;
+
+						resolve();
+
+					}, mimeType );
+
+				} ) );
 
 			}
 
 			outputJSON.images.push( gltfImage );
 
-			var index = outputJSON.images.length - 1;
 			cachedImages[ key ] = index;
 
 			return index;
@@ -1984,40 +1984,158 @@ THREE.GLTFExporter.prototype = {
 
 		}
 
+		function postProcessBuffers() {
+
+			return new Promise( function ( resolve, reject ) {
+
+				if ( outputJSON.buffers && outputJSON.buffers.length > 0 ) {
+
+					// Merge buffers
+					var blob = new Blob( buffers, { type: 'application/octet-stream' } );
+
+					// Update bytelength of the single buffer.
+					outputJSON.buffers[ 0 ].byteLength = blob.size;
+
+					if ( options.mode === "gltf" ) {
+
+						outputJSON.buffers[ 0 ].uri = "scene.bin";
+
+					} else if ( options.mode === "embedded" ) {
+
+						var reader = new window.FileReader();
+						reader.readAsDataURL( blob );
+						reader.onloadend = function () {
+
+							var base64data = reader.result;
+							outputJSON.buffers[ 0 ].uri = base64data;
+							outputBuffers.push( undefined );
+							resolve();
+
+						};
+						reader.onerror = reject;
+
+					}
+
+					if ( options.mode !== "embedded" ) {
+
+						outputBuffers.push( blob );
+						resolve();
+
+					}
+
+				}
+
+			} );
+
+		}
+
 		processInput( input );
 
-		Promise.all( pending ).then( function () {
-
-			var blob, binFileName;
+		Promise.all( pending ).then( postProcessBuffers ).then( function () {
 
 			// Declare extensions.
 			var extensionsUsedList = Object.keys( extensionsUsed );
 			if ( extensionsUsedList.length > 0 ) outputJSON.extensionsUsed = extensionsUsedList;
 
-			if ( outputJSON.buffers && outputJSON.buffers.length > 0 ) {
-
-				// Merge buffers
-				blob = new Blob( buffers, { type: 'application/octet-stream' } );
-
-				// Update bytelength of the single buffer.
-				outputJSON.buffers[ 0 ].byteLength = blob.size;
-
-				if ( ! options.binary ) {
-
-					binFileName = options.binFileName;
-					outputJSON.buffers[ 0 ].uri = binFileName;
-
-				}
-
-			}
-
 			onDone( {
 				json: outputJSON,
-				bin: blob,
-				binFileName: binFileName,
-				externalImageUrls: externalImageUrls,
-				externalImageFileNames: externalImageFilenames
+				buffers: outputBuffers,
+				images: outputImages
 			} );
+
+		} ).catch( onError );
+
+	},
+
+	/**
+	 * Given a chunks object returned by GLTFLoader.parseChunks, create a blob storing a valid .glb.
+	 * @param  {Object} chunks  chunks object returned by GLTFLoader.parseChunks
+	 * @param  {Function} onDone  Callback on completed
+	 * @param  {Function} onError  Callback on error
+	 */
+	createGLBBlob: function ( chunks, onDone, onError ) {
+
+		if ( chunks.buffers.length > 1 ) {
+
+			onError( new Error( "GLTFExporter: exportGLB expects 0 or 1 buffers." ) );
+			return;
+
+		}
+
+		// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
+
+		var GLB_HEADER_BYTES = 12;
+		var GLB_HEADER_MAGIC = 0x46546C67;
+		var GLB_VERSION = 2;
+
+		var GLB_CHUNK_PREFIX_BYTES = 8;
+		var GLB_CHUNK_TYPE_JSON = 0x4E4F534A;
+		var GLB_CHUNK_TYPE_BIN = 0x004E4942;
+
+		function readBinArrayBuffer( blob ) {
+
+			return new Promise( function ( resolve, reject ) {
+
+				var reader = new window.FileReader();
+
+				reader.readAsArrayBuffer( blob );
+				reader.onloadend = function () {
+
+					var binaryChunk = getPaddedArrayBuffer( reader.result );
+					resolve( binaryChunk );
+
+				};
+
+				reader.onerror = reject;
+
+			} );
+
+		}
+
+		var pending = [];
+		var blobParts = [];
+
+		// GLB header.
+		var header = new ArrayBuffer( GLB_HEADER_BYTES );
+		var headerView = new DataView( header );
+		headerView.setUint32( 0, GLB_HEADER_MAGIC, true );
+		headerView.setUint32( 4, GLB_VERSION, true );
+
+		blobParts.push( header );
+
+		// JSON chunk.
+		var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( chunks.json ) ), 0x20 );
+		var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
+		jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
+		jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );
+
+		blobParts.push( jsonChunkPrefix, jsonChunk );
+
+		if ( chunks.buffers.length !== 0 ) {
+
+			var pendingBinChunk = readBinArrayBuffer( chunks.buffers[ 0 ] ).then( function ( binaryChunk ) {
+
+				var binaryChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
+				binaryChunkPrefix.setUint32( 0, binaryChunk.byteLength, true );
+				binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
+
+				var totalByteLength = GLB_HEADER_BYTES
+					+ jsonChunkPrefix.byteLength + jsonChunk.byteLength
+					+ binaryChunkPrefix.byteLength + binaryChunk.byteLength;
+				headerView.setUint32( 8, totalByteLength, true );
+
+				blobParts.push( binaryChunkPrefix, binaryChunk );
+
+			} );
+
+			pending.push( pendingBinChunk );
+
+		}
+
+		Promise.all( pending ).then( function ( ) {
+
+			var glbBlob = new Blob( blobParts, { type: 'application/octet-stream' } );
+			onDone( glbBlob );
 
 		} ).catch( onError );
 
@@ -2032,83 +2150,23 @@ THREE.GLTFExporter.prototype = {
 	 */
 	parse: function ( input, onDone, onError, options ) {
 
-		this.parseChunks( input, function ( parts ) {
+		var scope = this;
 
-			var outputJSON = parts.json;
-			var blob = parts.bin;
+		this.parseChunks( input, function ( chunks ) {
 
-			var reader = new window.FileReader();
+			if ( options.mode === "gltf" ) {
 
-			if ( options.binary === true ) {
+				onDone( chunks );
 
-				// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
+			} else if ( options.mode === "embedded" ) {
 
-				var GLB_HEADER_BYTES = 12;
-				var GLB_HEADER_MAGIC = 0x46546C67;
-				var GLB_VERSION = 2;
-
-				var GLB_CHUNK_PREFIX_BYTES = 8;
-				var GLB_CHUNK_TYPE_JSON = 0x4E4F534A;
-				var GLB_CHUNK_TYPE_BIN = 0x004E4942;
-
-				reader.readAsArrayBuffer( blob );
-				reader.onloadend = function () {
-
-					// Binary chunk.
-					var binaryChunk = getPaddedArrayBuffer( reader.result );
-					var binaryChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
-					binaryChunkPrefix.setUint32( 0, binaryChunk.byteLength, true );
-					binaryChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_BIN, true );
-
-					// JSON chunk.
-					var jsonChunk = getPaddedArrayBuffer( stringToArrayBuffer( JSON.stringify( outputJSON ) ), 0x20 );
-					var jsonChunkPrefix = new DataView( new ArrayBuffer( GLB_CHUNK_PREFIX_BYTES ) );
-					jsonChunkPrefix.setUint32( 0, jsonChunk.byteLength, true );
-					jsonChunkPrefix.setUint32( 4, GLB_CHUNK_TYPE_JSON, true );
-
-					// GLB header.
-					var header = new ArrayBuffer( GLB_HEADER_BYTES );
-					var headerView = new DataView( header );
-					headerView.setUint32( 0, GLB_HEADER_MAGIC, true );
-					headerView.setUint32( 4, GLB_VERSION, true );
-					var totalByteLength = GLB_HEADER_BYTES
-						+ jsonChunkPrefix.byteLength + jsonChunk.byteLength
-						+ binaryChunkPrefix.byteLength + binaryChunk.byteLength;
-					headerView.setUint32( 8, totalByteLength, true );
-
-					var glbBlob = new Blob( [
-						header,
-						jsonChunkPrefix,
-						jsonChunk,
-						binaryChunkPrefix,
-						binaryChunk
-					], { type: 'application/octet-stream' } );
-
-					var glbReader = new window.FileReader();
-					glbReader.readAsArrayBuffer( glbBlob );
-					glbReader.onloadend = function () {
-
-						onDone( glbReader.result );
-
-					};
-					glbReader.onerror = onError;
-
-				};
+				onDone( chunks.json );
 
 			} else {
 
-				reader.readAsDataURL( blob );
-				reader.onloadend = function () {
-
-					var base64data = reader.result;
-					outputJSON.buffers[ 0 ].uri = base64data;
-					onDone( outputJSON );
-
-				};
+				scope.createGLBBlob( chunks, onDone, onError );
 
 			}
-
-			reader.onerror = onError;
 
 		}, onError, options );
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -130,8 +130,6 @@
 
 				}
 
-				console.log( "exportChunks", input );
-
 				gltfExporter.parseChunks( input, onComplete, onError, options );
 
 			}

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -29,12 +29,18 @@
 			<button id="export_obj">Export WaltHead</button>
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
-			<button id="export_chunks">Export all Scene1 files</button>
 			<br/>
+			<label>
+				Mode:
+				<select id="option_mode" value="glb">
+					<option value="glb">glb (binary)</option>
+					<option value="gltf">gltf</option>
+					<option value="embedded">gltf embedded</option>
+				</select>
+			</label>
 			<label><input id="option_trs" name="trs" type="checkbox" checked="checked"/>TRS</label>
 			<label><input id="option_visible" name="visible" type="checkbox" checked="checked"/>Only Visible</label>
 			<label><input id="option_drawrange" name="visible" type="checkbox" checked="checked"/>Truncate drawRange</label>
-			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
 			<label><input id="option_forceindices" name="visible" type="checkbox">Force indices</label>
 			<label><input id="option_forcepot" name="visible" type="checkbox">Force POT textures</label>
 		</div>
@@ -50,10 +56,10 @@
 			function getOptions () {
 
 				return {
+					mode: document.getElementById('option_mode').value,
 					trs: document.getElementById('option_trs').checked,
 					onlyVisible: document.getElementById('option_visible').checked,
 					truncateDrawRange: document.getElementById('option_drawrange').checked,
-					binary: document.getElementById('option_binary').checked,
 					forceIndices: document.getElementById('option_forceindices').checked,
 					forcePowerOfTwoTextures: document.getElementById('option_forcepot').checked
 				};
@@ -66,61 +72,47 @@
 
 				var options = getOptions();
 
-				function onComplete ( result ) {
-
-						if ( result instanceof ArrayBuffer ) {
-
-							saveArrayBuffer( result, 'scene.glb' );
-
-						} else {
-
-							var output = JSON.stringify( result, null, 2 );
-							console.log( output );
-							saveString( output, 'scene.gltf' );
-
-						}
-
-				}
-
-				function onError ( error ) {
-
-					console.error( error );
-
-				}
-
-				gltfExporter.parse( input, onComplete, onError, options );
-
-			}
-
-			function exportChunks ( input ) {
-
-				var gltfExporter = new THREE.GLTFExporter();
-
-				var options = getOptions();
+				console.log( options );
 
 				function onComplete ( result ) {
 
-						console.log( result );
+					if ( options.mode === "glb" ) {
 
-						var output = JSON.stringify( result.json, null, 2 );
+						saveBlob( result, 'scene.glb' );
 
+					} else if ( options.mode === "gltf" ) {
+
+						var json = result.json;
+						var buffers = result.buffers;
+						var images = result.images;
+
+						var output = JSON.stringify( json, null, 2 );
+						console.log( output );
 						saveString( output, 'scene.gltf' );
 
-						if ( result.bin ) {
-							saveBlob( result.bin, result.binFileName );
-						}
+						for ( var i = 0; i < buffers.length; i++ ) {
 
-						var imageUrls = result.externalImageUrls;
-						var imageFileNames = result.externalImageFileNames;
-
-						for ( var i = 0; i < imageUrls.length; i ++ ) {
-
-							var imageUrl = imageUrls[ i ];
-							var imageFileName = imageFileNames[ i ];
-
-							saveUrl( imageUrl, imageFileName );
+							var buffer = buffers[ i ];
+							var bufferUri = json.buffers[ i ].uri;
+							saveBlob( buffer, bufferUri );
 
 						}
+
+						for ( var j = 0; j < images.length; j++ ) {
+
+							var image = images[ j ];
+							var imageUri = json.images[ j ].uri;
+							saveBlob( image, imageUri );
+
+						}
+
+					} else {
+
+						var output = JSON.stringify( result, null, 2 );
+						console.log( output );
+						saveString( output, 'scene.gltf' );
+
+					}
 
 				}
 
@@ -129,8 +121,8 @@
 					console.error( error );
 
 				}
-
-				gltfExporter.parseChunks( input, onComplete, onError, options );
+				
+				gltfExporter.parse( input, onComplete, onError, options );
 
 			}
 
@@ -170,30 +162,18 @@
 
 			} );
 
-			document.getElementById( 'export_chunks' ).addEventListener( 'click', function () {
-
-				exportChunks( [ scene1 ] );
-
-			} );
-
 
 			var link = document.createElement( 'a' );
 			link.style.display = 'none';
 			document.body.appendChild( link ); // Firefox workaround, see #6594
 
-			function saveUrl( url, filename ) {
-
-				link.href = url;
-				link.download = filename;
-				link.click();
-
-			}
-
 			function saveBlob( blob, filename ) {
 
 				var url = URL.createObjectURL( blob );
 				
-				saveUrl( url, filename );
+				link.href = url;
+				link.download = filename;
+				link.click();
 
 				// URL.revokeObjectURL( url ); breaks Firefox...
 
@@ -202,12 +182,6 @@
 			function saveString( text, filename ) {
 
 				saveBlob( new Blob( [ text ], { type: 'text/plain' } ), filename );
-
-			}
-
-			function saveArrayBuffer( buffer, filename ) {
-
-				saveBlob( new Blob( [ buffer ], { type: 'application/octet-stream' } ), filename );
 
 			}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -35,7 +35,6 @@
 				<select id="option_mode" value="glb">
 					<option value="glb">glb (binary)</option>
 					<option value="gltf">gltf</option>
-					<option value="embedded">gltf embedded</option>
 				</select>
 			</label>
 			<label><input id="option_trs" name="trs" type="checkbox" checked="checked"/>TRS</label>
@@ -80,7 +79,7 @@
 
 						saveBlob( result, 'scene.glb' );
 
-					} else if ( options.mode === 'gltf' ) {
+					} else {
 
 						var json = result.json;
 						var buffers = result.buffers;
@@ -105,12 +104,6 @@
 							saveBlob( image, imageUri );
 
 						}
-
-					} else {
-
-						var output = JSON.stringify( result, null, 2 );
-						console.log( output );
-						saveString( output, 'scene.gltf' );
 
 					}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -76,11 +76,11 @@
 
 				function onComplete ( result ) {
 
-					if ( options.mode === "glb" ) {
+					if ( options.mode === 'glb' ) {
 
 						saveBlob( result, 'scene.glb' );
 
-					} else if ( options.mode === "gltf" ) {
+					} else if ( options.mode === 'gltf' ) {
 
 						var json = result.json;
 						var buffers = result.buffers;

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -29,8 +29,9 @@
 			<button id="export_obj">Export WaltHead</button>
 			<button id="export_objects">Export Sphere and Grid</button>
 			<button id="export_scene_object">Export Scene1 and Sphere</button>
-			<br/><br/>
-			<label><input id="option_trs" name="trs" type="checkbox"/>TRS</label>
+			<button id="export_chunks">Export all Scene1 files</button>
+			<br/>
+			<label><input id="option_trs" name="trs" type="checkbox" checked="checked"/>TRS</label>
 			<label><input id="option_visible" name="visible" type="checkbox" checked="checked"/>Only Visible</label>
 			<label><input id="option_drawrange" name="visible" type="checkbox" checked="checked"/>Truncate drawRange</label>
 			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
@@ -46,33 +47,92 @@
 
 		<script>
 
+			function getOptions () {
+
+				return {
+					trs: document.getElementById('option_trs').checked,
+					onlyVisible: document.getElementById('option_visible').checked,
+					truncateDrawRange: document.getElementById('option_drawrange').checked,
+					binary: document.getElementById('option_binary').checked,
+					forceIndices: document.getElementById('option_forceindices').checked,
+					forcePowerOfTwoTextures: document.getElementById('option_forcepot').checked
+				};
+
+			}
+
 			function exportGLTF( input ) {
 
 				var gltfExporter = new THREE.GLTFExporter();
 
-				var options = {
-					trs: document.getElementById( 'option_trs' ).checked,
-					onlyVisible: document.getElementById( 'option_visible' ).checked,
-					truncateDrawRange: document.getElementById( 'option_drawrange' ).checked,
-					binary: document.getElementById( 'option_binary' ).checked,
-					forceIndices: document.getElementById( 'option_forceindices' ).checked,
-					forcePowerOfTwoTextures: document.getElementById( 'option_forcepot' ).checked
-				};
-				gltfExporter.parse( input, function ( result ) {
+				var options = getOptions();
 
-					if ( result instanceof ArrayBuffer ) {
+				function onComplete ( result ) {
 
-						saveArrayBuffer( result, 'scene.glb' );
+						if ( result instanceof ArrayBuffer ) {
 
-					} else {
+							saveArrayBuffer( result, 'scene.glb' );
 
-						var output = JSON.stringify( result, null, 2 );
-						console.log( output );
+						} else {
+
+							var output = JSON.stringify( result, null, 2 );
+							console.log( output );
+							saveString( output, 'scene.gltf' );
+
+						}
+
+				}
+
+				function onError ( error ) {
+
+					console.error( error );
+
+				}
+
+				gltfExporter.parse( input, onComplete, onError, options );
+
+			}
+
+			function exportChunks ( input ) {
+
+				var gltfExporter = new THREE.GLTFExporter();
+
+				var options = getOptions();
+
+				function onComplete ( result ) {
+
+						console.log( result );
+
+						var output = JSON.stringify( result.json, null, 2 );
+
 						saveString( output, 'scene.gltf' );
 
-					}
+						if ( result.bin ) {
+							saveBlob( result.bin, result.binFileName );
+						}
 
-				}, options );
+						var imageUrls = result.externalImageUrls;
+						var imageFileNames = result.externalImageFileNames;
+
+						for ( var i = 0; i < imageUrls.length; i ++ ) {
+
+							var imageUrl = imageUrls[ i ];
+							var imageFileName = imageFileNames[ i ];
+
+							saveUrl( imageUrl, imageFileName );
+
+						}
+
+				}
+
+				function onError ( error ) {
+
+					console.error( error );
+
+				}
+
+				console.log( "exportChunks", input );
+
+				gltfExporter.parseChunks( input, onComplete, onError, options );
 
 			}
 
@@ -112,16 +172,30 @@
 
 			} );
 
+			document.getElementById( 'export_chunks' ).addEventListener( 'click', function () {
+
+				exportChunks( [ scene1 ] );
+
+			} );
+
 
 			var link = document.createElement( 'a' );
 			link.style.display = 'none';
 			document.body.appendChild( link ); // Firefox workaround, see #6594
 
-			function save( blob, filename ) {
+			function saveUrl( url, filename ) {
 
-				link.href = URL.createObjectURL( blob );
+				link.href = url;
 				link.download = filename;
 				link.click();
+
+			}
+
+			function saveBlob( blob, filename ) {
+
+				var url = URL.createObjectURL( blob );
+				
+				saveUrl( url, filename );
 
 				// URL.revokeObjectURL( url ); breaks Firefox...
 
@@ -129,14 +203,13 @@
 
 			function saveString( text, filename ) {
 
-				save( new Blob( [ text ], { type: 'text/plain' } ), filename );
+				saveBlob( new Blob( [ text ], { type: 'text/plain' } ), filename );
 
 			}
 
-
 			function saveArrayBuffer( buffer, filename ) {
 
-				save( new Blob( [ buffer ], { type: 'application/octet-stream' } ), filename );
+				saveBlob( new Blob( [ buffer ], { type: 'application/octet-stream' } ), filename );
 
 			}
 

--- a/test/unit/example/exporters/GLTFExporter.tests.js
+++ b/test/unit/example/exporters/GLTFExporter.tests.js
@@ -129,7 +129,7 @@ export default QUnit.module( 'Exporters', () => {
 
         done();
 
-      }, { animations: [ clip1, clip2 ] } );
+      }, undefined, { animations: [ clip1, clip2 ] } );
 
     } );
 


### PR DESCRIPTION
Continuation from my previous work in https://github.com/mrdoob/three.js/pull/14485

This PR add the `parseChunks` API without wrapping the GLTFExporter in a closure to avoid exposing helper functions to the global scope.