### PR TITLE
Remove mousemove event onPointerMove function in TransformControls

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -119,6 +119,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 		domElement.removeEventListener( "mousedown", onPointerDown );
 		domElement.removeEventListener( "touchstart", onPointerDown );
 		domElement.removeEventListener( "mousemove", onPointerHover );
+		document.removeEventListener( "mousemove", onPointerMove );
 		domElement.removeEventListener( "touchmove", onPointerHover );
 		domElement.removeEventListener( "touchmove", onPointerMove );
 		document.removeEventListener( "mouseup", onPointerUp );


### PR DESCRIPTION
This PR remove mousemove event onPointerMove function in TransformControls. A bug [we ran into](https://github.com/exokitxr/exokit/pull/1065) at https://github.com/exokitxr/exokit/pull/1065 while using TransformControls.