### PR TITLE
Add support for linting typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "test"
   },
   "eslintConfig": {
+    "parser": "@typescript-eslint/parser",
     "extends": "mdcs",
     "plugins": [
       "html"
@@ -38,7 +39,7 @@
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",
     "start": "npm run dev",
-    "lint": "eslint src",
+    "lint": "eslint src --ext js --ext ts",
     "test": "npm run build-test && qunit test/unit/three.source.unit.js",
     "travis": "npm run lint && npm test"
   },
@@ -59,6 +60,8 @@
     "eslint": "^5.16.0",
     "eslint-config-mdcs": "^4.2.3",
     "eslint-plugin-html": "^5.0.3",
+    "@typescript-eslint/parser": "^1.9.0",
+    "typescript": "^3.4.5",
     "google-closure-compiler": "20190415.0.0",
     "http-server": "^0.11.1",
     "qunit": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,12 @@
     "parser": "@typescript-eslint/parser",
     "extends": "mdcs",
     "plugins": [
-      "html"
-    ]
+      "html",
+      "@typescript-eslint"
+    ],
+    "rules": {
+      "@typescript-eslint/no-unused-vars": 1
+    }
   },
   "scripts": {
     "build": "rollup -c",
@@ -61,6 +65,7 @@
     "eslint-config-mdcs": "^4.2.3",
     "eslint-plugin-html": "^5.0.3",
     "@typescript-eslint/parser": "^1.9.0",
+    "@typescript-eslint/eslint-plugin": "^1.9.0",
     "typescript": "^3.4.5",
     "google-closure-compiler": "20190415.0.0",
     "http-server": "^0.11.1",


### PR DESCRIPTION
As discussed in #16449 this PR adds support for linting the typescript definition files using the existing eslint rules. This means that Travis builds will fail if the typescript definition files in `/src` are not linted properly and the `.d.ts` files can be automatically fixed using `npm run lint -- --fix`.

In order to get VSCode to display lint errors inline I had to add "typescript" to the `"eslint.validate"` options like so:
```js
"eslint.validate": [ "javascript", "javascriptreact", "html", "typescript" ]
```

~The caveat here is that in `d.ts` files the linter seems to see the imported objects as "unused-variables" for some reason even when they're used in function signatures. For example:~

If this is merged then `--fix` should be run and then the `d.ts` changes committed into the `dev` branch.

Edit:  I've fixed the caveat