### PR TITLE
Matrix4: support .setPosition( x, y, z )

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -375,6 +375,7 @@ x, y, 1, 0,
 		</p>
 
 		<h3>[method:this setPosition]( [param:Vector3 v] )</h3>
+		<h3>[method:this setPosition]( [param:Float x], [param:Float y], [param:Float z] ) // optional API</h3>
 		<p>
 			Sets the position component for this matrix from vector [page:Vector3 v], without affecting the
 			rest of the matrix - i.e. if the matrix is currently:

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -122,7 +122,7 @@ export class Matrix4 implements Matrix {
   /**
    * Sets the position component for this matrix from vector v.
    */
-  setPosition(v: Vector3): Matrix4;
+  setPosition(v: Vector3 | number, y?: number, z?: number): Matrix4;
 
   /**
    * Sets this matrix to the inverse of matrix m.

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -519,13 +519,23 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	setPosition: function ( v ) {
+	setPosition: function ( x, y, z ) {
 
 		var te = this.elements;
 
-		te[ 12 ] = v.x;
-		te[ 13 ] = v.y;
-		te[ 14 ] = v.z;
+		if ( x.isVector3 ) {
+
+			te[ 12 ] = x.x;
+			te[ 13 ] = x.y;
+			te[ 14 ] = x.z;
+
+		} else {
+
+			te[ 12 ] = x;
+			te[ 13 ] = y;
+			te[ 14 ] = z;
+
+		}
 
 		return this;
 


### PR DESCRIPTION
Previously, only `.setPosition( v )` was supported.

This is now consistent with how we handle the args for `Object3D.lookAt()`.