### PR TITLE
Docs: Add styles for inline code tags

### DIFF
--- a/docs/page.css
+++ b/docs/page.css
@@ -92,7 +92,7 @@ body {
 
 table,
 pre,
-code {
+code:not(.inline) {
 	margin-left: -24px;
 	margin-right: -24px;
 	margin-top: 20px;
@@ -131,6 +131,13 @@ code {
 	white-space: pre-wrap;
 	overflow: auto;
 	box-sizing: border-box;
+}
+
+code.inline {
+	display: inline-block;
+	vertical-align: middle;
+	border-radius: 4px;
+	padding: 2px 5px;
 }
 
 iframe {


### PR DESCRIPTION
Based on this issue, https://github.com/mrdoob/three.js/issues/16515 I added some styles to support inline code blocks.

This is the result when using for example `<code class="inline">PerspectiveCamera</code>`
![image](https://user-images.githubusercontent.com/6048794/58234383-ae772900-7d3e-11e9-948d-be2419d0ca08.png)
