### PR TITLE
removed legacy utils/builds readme

### DIFF
--- a/utils/build/README.md
+++ b/utils/build/README.md
@@ -1,8 +1,0 @@
-## Setup
-
-- Install [Node.js](https://nodejs.org/)
-- Execute `npm install`
-
-## Build
-
-- Execute `npm run build` (`npm run build-closure` to compile using the [Google Closure Compiler](https://developers.google.com/closure/compiler/))

--- a/utils/build/README.md
+++ b/utils/build/README.md
@@ -5,4 +5,4 @@
 
 ## Build
 
-- Execute `npm run build` (`npm run build-closure` or `npm run build-uglify` for minifying)
+- Execute `npm run build` (`npm run build-closure` to compile using the [Google Closure Compiler](https://developers.google.com/closure/compiler/))


### PR DESCRIPTION
removing legacy `npm run build-uglify` from utils/build readme.

perhaps would be best to simply remove `readme.md` or refer to Wiki's [Build Instructions](https://github.com/mrdoob/three.js/wiki/Build-instructions).

