### PR TITLE
SVGRenderer: added overdraw support

### DIFF
--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -227,6 +227,14 @@ THREE.SVGRenderer = function () {
 				_v2.positionScreen.x *= _svgWidthHalf; _v2.positionScreen.y *= - _svgHeightHalf;
 				_v3.positionScreen.x *= _svgWidthHalf; _v3.positionScreen.y *= - _svgHeightHalf;
 
+				if ( this.overdraw > 0 ) {
+
+					expand( _v1.positionScreen, _v2.positionScreen, this.overdraw );
+					expand( _v2.positionScreen, _v3.positionScreen, this.overdraw );
+					expand( _v3.positionScreen, _v1.positionScreen, this.overdraw );
+
+				}
+
 				_elemBox.setFromPoints( [
 					_v1.positionScreen,
 					_v2.positionScreen,
@@ -448,6 +456,24 @@ THREE.SVGRenderer = function () {
 		}
 
 		addPath( style, path );
+
+	}
+
+	// Hide anti-alias gaps
+
+	function expand( v1, v2, pixels ) {
+
+		var x = v2.x - v1.x, y = v2.y - v1.y,
+			det = x * x + y * y, idet;
+
+		if ( det === 0 ) return;
+
+		idet = pixels / Math.sqrt( det );
+
+		x *= idet; y *= idet;
+
+		v2.x += x; v2.y += y;
+		v1.x -= x; v1.y -= y;
 
 	}
 


### PR DESCRIPTION
Fixes #16540.

Usage:
```js
const renderer = new THREE.SVGRenderer();
renderer.overdraw = 0.5; // in units of fractional pixels, between 0 and 1
```
Unlike with `CanvasRenderer`, `overdraw` is a property of the renderer instead of the material. I think this is adequate.

/ping @nathancarter

Docs, further mods after preliminary approval.