### PR TITLE
SVGRenderer: added overdraw property

### DIFF
--- a/docs/examples/renderers/SVGRenderer.html
+++ b/docs/examples/renderers/SVGRenderer.html
@@ -61,6 +61,13 @@
 
 		<h3>[name]()</h3>
 
+		<h2>Properties</h2>
+
+		<h3>[property:Number overdraw]</h3>
+		<p>
+		Number of fractional pixels to enlarge polygons in order to prevent anti-aliasing gaps. Range is [0..1]. Default is *0.5*.
+		</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:null clear]()</h3>

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -57,6 +57,8 @@ THREE.SVGRenderer = function () {
 	this.sortObjects = true;
 	this.sortElements = true;
 
+	this.overdraw = 0.5;
+
 	this.info = {
 
 		render: {


### PR DESCRIPTION
Follow-on to #16541.

`.overdraw` defaults to 0.5, so the anti-aliasing artifacts should be eliminated by default.