### PR TITLE
EffectComposer: Clock instead of Date

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -58,7 +58,7 @@ THREE.EffectComposer = function ( renderer, renderTarget ) {
 
 	this.copyPass = new THREE.ShaderPass( THREE.CopyShader );
 
-	this._previousFrameTime = Date.now();
+	this.clock = new THREE.Clock();
 
 };
 
@@ -109,11 +109,9 @@ Object.assign( THREE.EffectComposer.prototype, {
 
 		if ( deltaTime === undefined ) {
 
-			deltaTime = ( Date.now() - this._previousFrameTime ) * 0.001;
+			deltaTime = this.clock.getDelta();
 
 		}
-
-		this._previousFrameTime = Date.now();
 
 		var currentRenderTarget = this.renderer.getRenderTarget();
 

--- a/examples/jsm/postprocessing/EffectComposer.d.ts
+++ b/examples/jsm/postprocessing/EffectComposer.d.ts
@@ -1,4 +1,5 @@
 import {
+	Clock,
   WebGLRenderer,
   WebGLRenderTarget,
 } from '../../../src/Three';
@@ -15,6 +16,7 @@ export class EffectComposer {
   readBuffer: WebGLRenderTarget;
   passes: Pass[];
   copyPass: ShaderPass;
+	clock: Clock;
 
   swapBuffers(): void;
   addPass(pass: Pass): void;

--- a/examples/jsm/postprocessing/EffectComposer.d.ts
+++ b/examples/jsm/postprocessing/EffectComposer.d.ts
@@ -16,7 +16,7 @@ export class EffectComposer {
   readBuffer: WebGLRenderTarget;
   passes: Pass[];
   copyPass: ShaderPass;
-	clock: Clock;
+  clock: Clock;
 
   swapBuffers(): void;
   addPass(pass: Pass): void;

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -9,6 +9,7 @@ import {
 	PlaneBufferGeometry,
 	RGBAFormat,
 	Vector2,
+	Clock,
 	WebGLRenderTarget
 } from "../../../build/three.module.js";
 import { CopyShader } from "../shaders/CopyShader.js";
@@ -72,7 +73,7 @@ var EffectComposer = function ( renderer, renderTarget ) {
 
 	this.copyPass = new ShaderPass( CopyShader );
 
-	this._previousFrameTime = Date.now();
+	this.clock = new Clock();
 
 };
 
@@ -123,11 +124,9 @@ Object.assign( EffectComposer.prototype, {
 
 		if ( deltaTime === undefined ) {
 
-			deltaTime = ( Date.now() - this._previousFrameTime ) * 0.001;
+			deltaTime = this.clock.getDelta();
 
 		}
-
-		this._previousFrameTime = Date.now();
 
 		var currentRenderTarget = this.renderer.getRenderTarget();
 


### PR DESCRIPTION
Should be more accurate than what we had before, for cases where `performance` is available.