### PR TITLE
Fix WebVR viewport size when presenting

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -69,16 +69,16 @@ function WebVRManager( renderer ) {
 		if ( isPresenting() ) {
 
 			var eyeParameters = device.getEyeParameters( 'left' );
-			renderWidth = eyeParameters.renderWidth * framebufferScaleFactor;
+			renderWidth = 2 * eyeParameters.renderWidth * framebufferScaleFactor;
 			renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
 
 			currentPixelRatio = renderer.getPixelRatio();
 			renderer.getSize( currentSize );
 
-			renderer.setDrawingBufferSize( renderWidth * 2, renderHeight, 1 );
+			renderer.setDrawingBufferSize( renderWidth, renderHeight, 1 );
 
-			cameraL.viewport.set( 0, 0, renderWidth, renderHeight );
-			cameraR.viewport.set( renderWidth, 0, renderWidth, renderHeight );
+			cameraL.viewport.set( 0, 0, renderWidth / 2, renderHeight );
+			cameraR.viewport.set( renderWidth / 2, 0, renderWidth / 2, renderHeight );
 
 			animation.start();
 


### PR DESCRIPTION
WebVR stereo rendering is currently broken on dev because of same changes I introduced on this PR https://github.com/mrdoob/three.js/pull/16367 (sorry 😢)
Basically I was setting the viewport size correctly on https://github.com/mrdoob/three.js/blob/dev/src/renderers/webvr/WebVRManager.js#L72-L81
*please notice that I was using `renderWidth` as one eye's width and no the whole render width for both eyes, that's why I multiplied by 2 when calling `setDrawingBufferSize` https://github.com/mrdoob/three.js/blob/dev/src/renderers/webvr/WebVRManager.js#L78

The problem is that if bounds were provided by the WebVR API, `updateViewportFromBounds` is being called and it's assuming that `renderWidth` is the whole render size and not just one eye
https://github.com/mrdoob/three.js/blob/dev/src/renderers/webvr/WebVRManager.js#L185-L193

That's why currently everything is rendering in one eye, and half (1/4 actually) for each eye.

* Tested on Quest, Go and WebVR emulator