### PR TITLE
Remove preventDefault() and console.log from mousedown handlers.

### DIFF
--- a/examples/css3d_panorama.html
+++ b/examples/css3d_panorama.html
@@ -129,14 +129,14 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 
 			}
 
 			function onDocumentMouseMove( event ) {
+
+				event.preventDefault();
 
 				var movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
 				var movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -119,8 +119,6 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 	function onDocumentMouseDown( event ) {
 
-		event.preventDefault();
-
 		_raycaster.setFromCamera( _mouse, _camera );
 
 		var intersects = _raycaster.intersectObjects( _objects );

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -81,13 +81,6 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 	this.onMouseDown = function ( event ) {
 
-		if ( this.domElement !== document ) {
-
-			this.domElement.focus();
-
-		}
-
-		event.preventDefault();
 		event.stopPropagation();
 
 		if ( this.activeLook ) {
@@ -142,8 +135,6 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 	};
 
 	this.onKeyDown = function ( event ) {
-
-		//event.preventDefault();
 
 		switch ( event.keyCode ) {
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -37,8 +37,6 @@ THREE.FlyControls = function ( object, domElement ) {
 
 		}
 
-		//event.preventDefault();
-
 		switch ( event.keyCode ) {
 
 			case 16: /* shift */ this.movementSpeedMultiplier = .1; break;
@@ -101,13 +99,6 @@ THREE.FlyControls = function ( object, domElement ) {
 
 	this.mousedown = function ( event ) {
 
-		if ( this.domElement !== document ) {
-
-			this.domElement.focus();
-
-		}
-
-		event.preventDefault();
 		event.stopPropagation();
 
 		if ( this.dragToLook ) {

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -771,8 +771,6 @@ THREE.MapControls = function ( object, domElement ) {
 
 		if ( scope.enabled === false ) return;
 
-		event.preventDefault();
-
 		switch ( event.button ) {
 
 			case scope.mouseButtons.LEFT:

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -429,15 +429,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function handleMouseDownRotate( event ) {
 
-		//console.log( 'handleMouseDownRotate' );
-
 		rotateStart.set( event.clientX, event.clientY );
 
 	}
 
 	function handleMouseDownDolly( event ) {
-
-		//console.log( 'handleMouseDownDolly' );
 
 		dollyStart.set( event.clientX, event.clientY );
 
@@ -445,15 +441,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function handleMouseDownPan( event ) {
 
-		//console.log( 'handleMouseDownPan' );
-
 		panStart.set( event.clientX, event.clientY );
 
 	}
 
 	function handleMouseMoveRotate( event ) {
-
-		//console.log( 'handleMouseMoveRotate' );
 
 		rotateEnd.set( event.clientX, event.clientY );
 
@@ -472,8 +464,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	}
 
 	function handleMouseMoveDolly( event ) {
-
-		//console.log( 'handleMouseMoveDolly' );
 
 		dollyEnd.set( event.clientX, event.clientY );
 
@@ -496,8 +486,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	}
 
 	function handleMouseMovePan( event ) {
-
-		//console.log( 'handleMouseMovePan' );
 
 		panEnd.set( event.clientX, event.clientY );
 
@@ -536,8 +524,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	}
 
 	function handleKeyDown( event ) {
-
-		// console.log( 'handleKeyDown' );
 
 		var needsUpdate = false;
 
@@ -579,15 +565,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function handleTouchStartRotate( event ) {
 
-		//console.log( 'handleTouchStartRotate' );
-
 		rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
 
 	}
 
 	function handleTouchStartDollyPan( event ) {
-
-		//console.log( 'handleTouchStartDollyPan' );
 
 		if ( scope.enableZoom ) {
 
@@ -613,8 +595,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function handleTouchMoveRotate( event ) {
 
-		//console.log( 'handleTouchMoveRotate' );
-
 		rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
 
 		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
@@ -632,8 +612,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	}
 
 	function handleTouchMoveDollyPan( event ) {
-
-		//console.log( 'handleTouchMoveDollyPan' );
 
 		if ( scope.enableZoom ) {
 
@@ -673,8 +651,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function handleTouchEnd( event ) {
 
-		//console.log( 'handleTouchEnd' );
-
 	}
 
 	//
@@ -684,15 +660,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	function onMouseDown( event ) {
 
 		if ( scope.enabled === false ) return;
-
-		// Prevent the browser from scrolling.
-
-		event.preventDefault();
-
-		// Manually set the focus since calling preventDefault above
-		// prevents the browser from setting it automatically.
-
-		scope.domElement.focus ? scope.domElement.focus() : window.focus();
 
 		switch ( event.button ) {
 

--- a/examples/js/controls/OrthographicTrackballControls.js
+++ b/examples/js/controls/OrthographicTrackballControls.js
@@ -407,7 +407,6 @@ THREE.OrthographicTrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		event.preventDefault();
 		event.stopPropagation();
 
 		if ( _state === STATE.NONE ) {

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -384,7 +384,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		if ( _this.enabled === false ) return;
 
-		event.preventDefault();
 		event.stopPropagation();
 
 		if ( _state === STATE.NONE ) {

--- a/examples/webgl_camera_logarithmicdepthbuffer.html
+++ b/examples/webgl_camera_logarithmicdepthbuffer.html
@@ -319,19 +319,20 @@
 				window.addEventListener( "mousemove", onBorderMouseMove );
 				window.addEventListener( "mouseup", onBorderMouseUp );
 				ev.stopPropagation();
-				ev.preventDefault();
 
 			}
 
 			function onBorderMouseMove( ev ) {
 
 				screensplit = Math.max( 0, Math.min( 1, ev.clientX / window.innerWidth ) );
+				ev.preventDefault();
 				ev.stopPropagation();
 
 			}
 
 			function onBorderMouseUp() {
 
+				screensplit = 0.5;
 				window.removeEventListener( "mousemove", onBorderMouseMove );
 				window.removeEventListener( "mouseup", onBorderMouseUp );
 

--- a/examples/webgl_geometry_nurbs.html
+++ b/examples/webgl_geometry_nurbs.html
@@ -206,8 +206,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 				document.addEventListener( 'mouseout', onDocumentMouseOut, false );

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -399,8 +399,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 				document.addEventListener( 'mouseout', onDocumentMouseOut, false );

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -470,8 +470,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 				document.addEventListener( 'mouseout', onDocumentMouseOut, false );

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -266,8 +266,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 				document.addEventListener( 'mouseup', onDocumentMouseUp, false );
 				document.addEventListener( 'mouseout', onDocumentMouseOut, false );

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -128,8 +128,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				onPointerDownPointerX = event.clientX;
 				onPointerDownPointerY = event.clientY;
 

--- a/examples/webgl_panorama_dualfisheye.html
+++ b/examples/webgl_panorama_dualfisheye.html
@@ -134,8 +134,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				isUserInteracting = true;
 
 				onPointerDownPointerX = event.clientX;

--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -112,8 +112,6 @@
 
 			function onDocumentMouseDown( event ) {
 
-				event.preventDefault();
-
 				isUserInteracting = true;
 
 				onPointerDownPointerX = event.clientX;


### PR DESCRIPTION
It turns out that calling `preventDefault()` on `mousedown` event prevents capture of `mouseup` event on window/document if the pointer is outside the iframe hosting the document. This causes many examples (inside iframe) to break if mouse pointer is released outside the frame/window. For example, examples that use `OrbitControls` turn sticky if you drag and release outside the frame.

I am not sure why so many examples call `preventDefault()` on `mousedown`. In my quick tests everything appears to work fine once I removed the lines with `preventDefault()`.
