### PR TITLE
Fix SkeletonUtils d.ts

### DIFF
--- a/examples/jsm/utils/SkeletonUtils.d.ts
+++ b/examples/jsm/utils/SkeletonUtils.d.ts
@@ -1,32 +1,32 @@
 import {AnimationClip, Bone, Matrix4, Object3D, Skeleton, SkeletonHelper} from "../../..";
 
-export class SkeletonUtils {
-	retarget(target: Object3D | Skeleton,
+export namespace SkeletonUtils {
+	export function retarget(target: Object3D | Skeleton,
 					 source: Object3D | Skeleton,
-					 options: {})
+					 options: {}): void;
 
-	retargetClip(target: Skeleton | Object3D,
+	export function retargetClip(target: Skeleton | Object3D,
 							 source: Skeleton | Object3D,
 							 clip: AnimationClip,
 							 options: {}): AnimationClip;
 
-	getHelperFromSkeleton(skeleton: Skeleton): SkeletonHelper;
+	export function getHelperFromSkeleton(skeleton: Skeleton): SkeletonHelper;
 
-	getSkeletonOffsets(target: Object3D | Skeleton,
+	export function getSkeletonOffsets(target: Object3D | Skeleton,
 										 source: Object3D | Skeleton,
 										 options: {}): Matrix4[];
 
-	renameBones(skeleton: Skeleton, names: {}): any;
+	export function renameBones(skeleton: Skeleton, names: {}): any;
 
-	getBones(skeleton: Skeleton | Bone[]): Bone[];
+	export function getBones(skeleton: Skeleton | Bone[]): Bone[];
 
-	getBoneByName(name: string, skeleton: Skeleton): Bone;
+	export function getBoneByName(name: string, skeleton: Skeleton): Bone;
 
-	getNearestBone(bone: Bone, names: {}): Bone;
+	export function getNearestBone(bone: Bone, names: {}): Bone;
 
-	findBoneTrackData(name: string, tracks: any[]): {};
+	export function findBoneTrackData(name: string, tracks: any[]): {};
 
-	getEqualsBonesNames(skeleton: Skeleton, targetSkeleton: Skeleton);
+	export function getEqualsBonesNames(skeleton: Skeleton, targetSkeleton: Skeleton): string[];
 
-	clone(source: Skeleton): Skeleton;
+  export function clone(source: Object3D | Skeleton): Object3D | Skeleton;
 }


### PR DESCRIPTION
Fixed type definition to match [implementation](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/utils/SkeletonUtils.js)

 - SkeletonUtils is not a class but a group of functions
 - Missing some return types
 - clone should also accept Object3D