### PR TITLE
docs: remove flatshading update info

### DIFF
--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -178,8 +178,6 @@ geometry.tangentsNeedUpdate = true;
 
 			<p>Also GLstate related parameters can change any time (depthTest, blending, polygonOffset, etc).</p>
 
-			<p>Flat / smooth shading is baked into normals. You need to reset normals buffer (see above).</p>
-
 			<p>The following properties can't be easily changed at runtime (once the material is rendered at least once):</p>
 			<ul>
 				<li>numbers and types of uniforms</li>


### PR DESCRIPTION
> Flat / smooth shading is baked into normals. You need to reset normals buffer (see above).

This information makes it seems like every material needs to reset normals buffer when updating `flatShading` parameter, this isn't true. 

This would only apply `MeshLambertMaterial`, but even with `geometry.normalsNeedUpdate = true` `flatShading` isn't working correctly on this material.