### PR TITLE
Specify opacity in LineMaterial object properties

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -3,6 +3,7 @@
  *
  * parameters = {
  *  color: <hex>,
+ *  opacity: <float>,
  *  linewidth: <float>,
  *  dashed: <boolean>,
  *  dashScale: <float>,
@@ -267,6 +268,24 @@ THREE.LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.diffuse.value = value;
+
+			}
+
+		},
+
+		opacity: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.opacity.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.opacity.value = value;
 
 			}
 


### PR DESCRIPTION
**Change**

When using `LineMaterial` I would like to specify an opacity value to create transparent lines. Currently, you must dive into the uniforms to set the opacity like this:
```
// To initialise a LineMaterial with an opacity value
var matLine = new THREE.LineMaterial({
  color: 0xff0000,
  transparent: true,
  linewidth: 5
});
matLine.uniforms.opacity.value = 0.5;

// To update a LineMaterial's opacity
matLine.uniforms.opacity.value = 0.25;
```

This pull request changes `LineMaterial` so that a more direct approach can be used to set the opacity:
```
// To initialise a LineMaterial with an opacity value
var matLine = new THREE.LineMaterial({
  color: 0xff0000,
  transparent: true,
  opacity: 0.5,
  linewidth: 5
});

// To update a LineMaterial's opacity
matLine.opacity = 0.25;
```

This change makes `LineMaterial` more consistent with existing materials, despite not being properly "wired-in" as a built-in material yet (https://github.com/mrdoob/three.js/pull/11349#issue-120934417).

**Testing**

To test this change you can modify the `webgl_lines_fat_wireframe.html` example. E.g: Add `transparent: true` and `opacity: 0.1` to `matLine` which is defined on line 102. 