### PR TITLE
LDrawLoader: Make lines honor material opacity

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1288,7 +1288,11 @@ THREE.LDrawLoader = ( function () {
 			if ( ! edgeMaterial ) {
 
 				// This is the material used for edges
-				edgeMaterial = new THREE.LineBasicMaterial( { color: edgeColour } );
+				edgeMaterial = new THREE.LineBasicMaterial( {
+					color: edgeColour,
+					transparent: isTransparent,
+					opacity: alpha
+				} );
 				edgeMaterial.userData.code = code;
 				edgeMaterial.name = name + " - Edge";
 				edgeMaterial.userData.canHaveEnvMap = false;

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1273,6 +1273,7 @@ THREE.LDrawLoader = ( function () {
 			material.transparent = isTransparent;
 			material.premultipliedAlpha = true;
 			material.opacity = alpha;
+			material.depthWrite = ! isTransparent;
 
 			material.polygonOffset = true;
 			material.polygonOffsetFactor = 1;
@@ -1291,7 +1292,8 @@ THREE.LDrawLoader = ( function () {
 				edgeMaterial = new THREE.LineBasicMaterial( {
 					color: edgeColour,
 					transparent: isTransparent,
-					opacity: alpha
+					opacity: alpha,
+					depthWrite: ! isTransparent
 				} );
 				edgeMaterial.userData.code = code;
 				edgeMaterial.name = name + " - Edge";
@@ -1308,7 +1310,9 @@ THREE.LDrawLoader = ( function () {
 						opacity: {
 							value: alpha
 						}
-					}
+					},
+					transparent: isTransparent,
+					depthWrite: ! isTransparent
 				} );
 				edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
 


### PR DESCRIPTION
This is noticeable in the car headlights, or the X-Wing exhausts for example.

Current version: https://raw.githack.com/mrdoob/three.js/dev/examples/webgl_loader_ldraw.html