### PR TITLE
WebGLLights: Simplified hash value

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1441,8 +1441,7 @@ function WebGLRenderer( parameters ) {
 		var lights = currentRenderState.state.lights;
 		var shadowsArray = currentRenderState.state.shadowsArray;
 
-		var lightsHash = materialProperties.lightsHash;
-		var lightsStateHash = lights.state.hash;
+		var lightsStateVersion = lights.state.version;
 
 		var parameters = programCache.getParameters(
 			material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object );
@@ -1462,11 +1461,9 @@ function WebGLRenderer( parameters ) {
 			// changed glsl or parameters
 			releaseMaterialProgramReference( material );
 
-		} else if ( lightsHash.stateID !== lightsStateHash.stateID ||
-			lightsHash.version !== lightsStateHash.version ) {
+		} else if ( materialProperties.lightsStateVersion !== lightsStateVersion ) {
 
-			lightsHash.stateID = lightsStateHash.stateID;
-			lightsHash.version = lightsStateHash.version;
+			materialProperties.lightsStateVersion = lightsStateVersion;
 
 			programChange = false;
 
@@ -1567,14 +1564,8 @@ function WebGLRenderer( parameters ) {
 		materialProperties.fog = fog;
 
 		// store the light setup it was created for
-		if ( lightsHash === undefined ) {
 
-			materialProperties.lightsHash = lightsHash = {};
-
-		}
-
-		lightsHash.stateID = lightsStateHash.stateID;
-		lightsHash.version = lightsStateHash.version;
+		materialProperties.lightsStateVersion = lightsStateVersion;
 
 		if ( material.lights ) {
 
@@ -1613,9 +1604,6 @@ function WebGLRenderer( parameters ) {
 		var materialProperties = properties.get( material );
 		var lights = currentRenderState.state.lights;
 
-		var lightsHash = materialProperties.lightsHash;
-		var lightsStateHash = lights.state.hash;
-
 		if ( _clippingEnabled ) {
 
 			if ( _localClippingEnabled || camera !== _currentCamera ) {
@@ -1645,8 +1633,7 @@ function WebGLRenderer( parameters ) {
 
 				material.needsUpdate = true;
 
-			} else if ( material.lights && ( lightsHash.stateID !== lightsStateHash.stateID ||
-				lightsHash.version !== lightsStateHash.version ) ) {
+			} else if ( material.lights && materialProperties.lightsStateVersion !== lights.state.version ) {
 
 				material.needsUpdate = true;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1463,20 +1463,10 @@ function WebGLRenderer( parameters ) {
 			releaseMaterialProgramReference( material );
 
 		} else if ( lightsHash.stateID !== lightsStateHash.stateID ||
-			lightsHash.directionalLength !== lightsStateHash.directionalLength ||
-			lightsHash.pointLength !== lightsStateHash.pointLength ||
-			lightsHash.spotLength !== lightsStateHash.spotLength ||
-			lightsHash.rectAreaLength !== lightsStateHash.rectAreaLength ||
-			lightsHash.hemiLength !== lightsStateHash.hemiLength ||
-			lightsHash.shadowsLength !== lightsStateHash.shadowsLength ) {
+			lightsHash.value !== lightsStateHash.directionalLength ) {
 
 			lightsHash.stateID = lightsStateHash.stateID;
-			lightsHash.directionalLength = lightsStateHash.directionalLength;
-			lightsHash.pointLength = lightsStateHash.pointLength;
-			lightsHash.spotLength = lightsStateHash.spotLength;
-			lightsHash.rectAreaLength = lightsStateHash.rectAreaLength;
-			lightsHash.hemiLength = lightsStateHash.hemiLength;
-			lightsHash.shadowsLength = lightsStateHash.shadowsLength;
+			lightsHash.value = lightsStateHash.value;
 
 			programChange = false;
 
@@ -1584,12 +1574,7 @@ function WebGLRenderer( parameters ) {
 		}
 
 		lightsHash.stateID = lightsStateHash.stateID;
-		lightsHash.directionalLength = lightsStateHash.directionalLength;
-		lightsHash.pointLength = lightsStateHash.pointLength;
-		lightsHash.spotLength = lightsStateHash.spotLength;
-		lightsHash.rectAreaLength = lightsStateHash.rectAreaLength;
-		lightsHash.hemiLength = lightsStateHash.hemiLength;
-		lightsHash.shadowsLength = lightsStateHash.shadowsLength;
+		lightsHash.value = lightsStateHash.value;
 
 		if ( material.lights ) {
 
@@ -1661,12 +1646,7 @@ function WebGLRenderer( parameters ) {
 				material.needsUpdate = true;
 
 			} else if ( material.lights && ( lightsHash.stateID !== lightsStateHash.stateID ||
-				lightsHash.directionalLength !== lightsStateHash.directionalLength ||
-				lightsHash.pointLength !== lightsStateHash.pointLength ||
-				lightsHash.spotLength !== lightsStateHash.spotLength ||
-				lightsHash.rectAreaLength !== lightsStateHash.rectAreaLength ||
-				lightsHash.hemiLength !== lightsStateHash.hemiLength ||
-				lightsHash.shadowsLength !== lightsStateHash.shadowsLength ) ) {
+				lightsHash.value !== lightsStateHash.value ) ) {
 
 				material.needsUpdate = true;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1463,10 +1463,10 @@ function WebGLRenderer( parameters ) {
 			releaseMaterialProgramReference( material );
 
 		} else if ( lightsHash.stateID !== lightsStateHash.stateID ||
-			lightsHash.value !== lightsStateHash.value ) {
+			lightsHash.version !== lightsStateHash.version ) {
 
 			lightsHash.stateID = lightsStateHash.stateID;
-			lightsHash.value = lightsStateHash.value;
+			lightsHash.version = lightsStateHash.version;
 
 			programChange = false;
 
@@ -1574,7 +1574,7 @@ function WebGLRenderer( parameters ) {
 		}
 
 		lightsHash.stateID = lightsStateHash.stateID;
-		lightsHash.value = lightsStateHash.value;
+		lightsHash.version = lightsStateHash.version;
 
 		if ( material.lights ) {
 
@@ -1646,7 +1646,7 @@ function WebGLRenderer( parameters ) {
 				material.needsUpdate = true;
 
 			} else if ( material.lights && ( lightsHash.stateID !== lightsStateHash.stateID ||
-				lightsHash.value !== lightsStateHash.value ) ) {
+				lightsHash.version !== lightsStateHash.version ) ) {
 
 				material.needsUpdate = true;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1463,7 +1463,7 @@ function WebGLRenderer( parameters ) {
 			releaseMaterialProgramReference( material );
 
 		} else if ( lightsHash.stateID !== lightsStateHash.stateID ||
-			lightsHash.value !== lightsStateHash.directionalLength ) {
+			lightsHash.value !== lightsStateHash.value ) {
 
 			lightsHash.stateID = lightsStateHash.stateID;
 			lightsHash.value = lightsStateHash.value;

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -118,7 +118,7 @@ function WebGLLights() {
 			rectAreaLength: - 1,
 			hemiLength: - 1,
 			shadowsLength: - 1,
-			value: 0
+			version: 0
 		},
 
 		ambient: [ 0, 0, 0 ],
@@ -355,7 +355,7 @@ function WebGLLights() {
 			hash.hemiLength = hemiLength;
 			hash.shadowsLength = shadows.length;
 
-			hash.value ++;
+			hash.version ++;
 
 		}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -352,7 +352,7 @@ function WebGLLights() {
 			hash.hemiLength = hemiLength;
 			hash.shadowsLength = shadows.length;
 
-			state.version = nextVersion++;
+			state.version = nextVersion ++;
 
 		}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -100,7 +100,7 @@ function UniformsCache() {
 
 }
 
-var count = 0;
+var nextVersion = 0;
 
 function WebGLLights() {
 
@@ -108,17 +108,15 @@ function WebGLLights() {
 
 	var state = {
 
-		id: count ++,
+		version: 0,
 
 		hash: {
-			stateID: - 1,
 			directionalLength: - 1,
 			pointLength: - 1,
 			spotLength: - 1,
 			rectAreaLength: - 1,
 			hemiLength: - 1,
 			shadowsLength: - 1,
-			version: 0
 		},
 
 		ambient: [ 0, 0, 0 ],
@@ -347,7 +345,6 @@ function WebGLLights() {
 			state.point.length = pointLength;
 			state.hemi.length = hemiLength;
 
-			hash.stateID = state.id;
 			hash.directionalLength = directionalLength;
 			hash.pointLength = pointLength;
 			hash.spotLength = spotLength;
@@ -355,7 +352,7 @@ function WebGLLights() {
 			hash.hemiLength = hemiLength;
 			hash.shadowsLength = shadows.length;
 
-			hash.version ++;
+			state.version = nextVersion++;
 
 		}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -117,7 +117,8 @@ function WebGLLights() {
 			spotLength: - 1,
 			rectAreaLength: - 1,
 			hemiLength: - 1,
-			shadowsLength: - 1
+			shadowsLength: - 1,
+			value: 0
 		},
 
 		ambient: [ 0, 0, 0 ],
@@ -331,19 +332,32 @@ function WebGLLights() {
 		state.ambient[ 1 ] = g;
 		state.ambient[ 2 ] = b;
 
-		state.directional.length = directionalLength;
-		state.spot.length = spotLength;
-		state.rectArea.length = rectAreaLength;
-		state.point.length = pointLength;
-		state.hemi.length = hemiLength;
+		var hash = state.hash;
 
-		state.hash.stateID = state.id;
-		state.hash.directionalLength = directionalLength;
-		state.hash.pointLength = pointLength;
-		state.hash.spotLength = spotLength;
-		state.hash.rectAreaLength = rectAreaLength;
-		state.hash.hemiLength = hemiLength;
-		state.hash.shadowsLength = shadows.length;
+		if ( hash.directionalLength !== directionalLength ||
+			hash.pointLength !== pointLength ||
+			hash.spotLength !== spotLength ||
+			hash.rectAreaLength !== rectAreaLength ||
+			hash.hemiLength !== hemiLength ||
+			hash.shadowsLength !== shadows.length ) {
+
+			state.directional.length = directionalLength;
+			state.spot.length = spotLength;
+			state.rectArea.length = rectAreaLength;
+			state.point.length = pointLength;
+			state.hemi.length = hemiLength;
+
+			hash.stateID = state.id;
+			hash.directionalLength = directionalLength;
+			hash.pointLength = pointLength;
+			hash.spotLength = spotLength;
+			hash.rectAreaLength = rectAreaLength;
+			hash.hemiLength = hemiLength;
+			hash.shadowsLength = shadows.length;
+
+			hash.value++;
+
+		}
 
 	}
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -355,7 +355,7 @@ function WebGLLights() {
 			hash.hemiLength = hemiLength;
 			hash.shadowsLength = shadows.length;
 
-			hash.value++;
+			hash.value ++;
 
 		}
 


### PR DESCRIPTION

Summarise lights hash to a single sequence value and simplify renderer hash checks.
Also only truncate lights arrays when lengths have changed.

