### PR TITLE
Typescript ESLint: Add indent rule for d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,14 @@
       "@typescript-eslint"
     ],
     "rules": {
-      "@typescript-eslint/no-unused-vars": 1
+      "@typescript-eslint/no-unused-vars": 1,
+      "@typescript-eslint/indent": [
+        "error",
+        "tab",
+        {
+          "SwitchCase": 1
+        }
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
Related to https://github.com/mrdoob/three.js/pull/16494#issuecomment-496343108

Adds another rule to catch inconsistent indents in the `d.ts` files. I'm a little confused as to why I've had to add the `@typescript-eslint/indent` when `indent` is already defined in the `mdcs` base config but I'll look into it a bit more and maybe make an issue in the [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) repo later to see if it's a bug. It's possible that some rules just aren't / can't be shared.

In the mean time, though, this will ensure that the indentation is consistent.

And as with #16494 this PR is expected to fail the Travics CI check until `npm run lint -- --fix` is run.