### PR TITLE
Triangle: include isFrontFacing

### DIFF
--- a/src/math/Triangle.d.ts
+++ b/src/math/Triangle.d.ts
@@ -30,6 +30,7 @@ export class Triangle {
 	getPlane( target: Vector3 ): Plane;
 	getBarycoord( point: Vector3, target: Vector3 ): Vector3;
 	containsPoint( point: Vector3 ): boolean;
+	isFrontFacing( direction: Vector3 ): boolean;
 	closestPointToPoint( point: Vector3, target: Vector3 ): Vector3;
 	equals( triangle: Triangle ): boolean;
 
@@ -51,6 +52,12 @@ export class Triangle {
 		a: Vector3,
 		b: Vector3,
 		c: Vector3
+	): boolean;
+	static isFrontFacing(
+		a: Vector3,
+		b: Vector3,
+		c: Vector3,
+		direction: Vector3
 	): boolean;
 
 }

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -125,6 +125,23 @@ Object.assign( Triangle, {
 
 		};
 
+	}(),
+
+	isFrontFacing: function () {
+
+		var v0 = new Vector3();
+		var v1 = new Vector3();
+
+		return function isFrontFacing( a, b, c, direction ) {
+
+			v0.subVectors( c, b );
+			v1.subVectors( a, b );
+
+			// strictly front facing
+			return ( v0.cross( v1 ).dot( direction ) < 0 ) ? true : false;
+
+		};
+
 	}()
 
 } );
@@ -230,6 +247,12 @@ Object.assign( Triangle.prototype, {
 	getUV: function ( point, uv1, uv2, uv3, result ) {
 
 		return Triangle.getUV( point, this.a, this.b, this.c, uv1, uv2, uv3, result );
+
+	},
+
+	isFrontFacing: function ( direction ) {
+
+		return Triangle.isFrontFacing( this.a, this.b, this.c, direction );
 
 	},
 

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -305,6 +305,21 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "isFrontFacing", ( assert ) => {
+
+			var a = new Triangle();
+			var dir = new Vector3();
+			assert.ok( ! a.isFrontFacing( dir ), "Passed!" );
+
+			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
+			var dir = new Vector3( 0, 0, - 1 );
+			assert.ok( a.isFrontFacing( dir ), "Passed!" );
+
+			var a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 1, 0, 0 ) );
+			assert.ok( ! a.isFrontFacing( dir ), "Passed!" );
+
+		} );
+
 		QUnit.test( "equals", ( assert ) => {
 
 			var a = new Triangle(


### PR DESCRIPTION
#16585

Includes `isFrontFacing` method to math Triangle. 
Can be a useful test for cutting number of iterations on faces related processes
```
direction.subVectors( target, camera.position );
// ...
if ( triangle.isFrontFacing( direction ) ) process();
```
[live example](https://rawcdn.githack.com/sciecode/three.js/0daa97cd4bfba628176dfd2fc3a070e1cbe58ed5/examples/misc_example.html)