### PR TITLE
LDrawLoader: Use renderOrder instead of depthWrite for transparency.

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -469,6 +469,9 @@ THREE.LDrawLoader = ( function () {
 
 		}
 
+		// Draw lines before transparent meshes
+		object3d.renderOrder = elementSize;
+
 		if ( isConditionalSegments ) {
 
 			object3d.isConditionalLine = true;
@@ -1273,7 +1276,6 @@ THREE.LDrawLoader = ( function () {
 			material.transparent = isTransparent;
 			material.premultipliedAlpha = true;
 			material.opacity = alpha;
-			material.depthWrite = ! isTransparent;
 
 			material.polygonOffset = true;
 			material.polygonOffsetFactor = 1;
@@ -1292,8 +1294,7 @@ THREE.LDrawLoader = ( function () {
 				edgeMaterial = new THREE.LineBasicMaterial( {
 					color: edgeColour,
 					transparent: isTransparent,
-					opacity: alpha,
-					depthWrite: ! isTransparent
+					opacity: alpha
 				} );
 				edgeMaterial.userData.code = code;
 				edgeMaterial.name = name + " - Edge";
@@ -1311,8 +1312,7 @@ THREE.LDrawLoader = ( function () {
 							value: alpha
 						}
 					},
-					transparent: isTransparent,
-					depthWrite: ! isTransparent
+					transparent: isTransparent
 				} );
 				edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
 


### PR DESCRIPTION
This sets `Object3D.renderOrder` to a lower value for lines and higher for meshes, so they are rendered in that order, and lines are correctly seen through translucent meshes.

This avoids the use of `depthWrite=true` which is hacky and can lead to artifacts or side effects. Note the rear stop and blinker lights of the car.

Temporary live link: https://raw.githack.com/yomboprime/three.js/ldraw_opacity_order/examples/webgl_loader_ldraw.html

Current version: https://raw.githack.com/mrdoob/three.js/dev/examples/webgl_loader_ldraw.html