### PR TITLE
Accomodate WebXR API changes (Chrome m76)

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -81,7 +81,7 @@ var WEBVR = {
 
 				if ( currentSession === null ) {
 
-					navigator.xr.requestSession( { mode: 'immersive-vr' } ).then( onSessionStarted );
+					navigator.xr.requestSession( 'immersive-vr' ).then( onSessionStarted );
 
 				} else {
 
@@ -131,14 +131,14 @@ var WEBVR = {
 
 		}
 
-		if ( 'xr' in navigator && 'requestDevice' in navigator.xr ) {
+		if ( 'xr' in navigator ) {
 
 			var button = document.createElement( 'button' );
 			button.style.display = 'none';
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSessionMode( 'immersive-vr' ).then( showEnterXR );
+			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR );
 
 			return button;
 

--- a/examples/webvr_paint.html
+++ b/examples/webvr_paint.html
@@ -125,30 +125,12 @@
 
 				document.body.appendChild( WEBVR.createButton( renderer ) );
 
-				// controllers
-
-				function onSelectStart() {
-
-					this.userData.isSelecting = true;
-
-				}
-
-				function onSelectEnd() {
-
-					this.userData.isSelecting = false;
-
-				}
-
 				controller1 = renderer.vr.getController( 0 );
-				controller1.addEventListener( 'selectstart', onSelectStart );
-				controller1.addEventListener( 'selectend', onSelectEnd );
 				controller1.userData.points = [ new THREE.Vector3(), new THREE.Vector3() ];
 				controller1.userData.matrices = [ new THREE.Matrix4(), new THREE.Matrix4() ];
 				scene.add( controller1 );
 
 				controller2 = renderer.vr.getController( 1 );
-				controller2.addEventListener( 'selectstart', onSelectStart );
-				controller2.addEventListener( 'selectend', onSelectEnd );
 				controller2.userData.points = [ new THREE.Vector3(), new THREE.Vector3() ];
 				controller2.userData.matrices = [ new THREE.Matrix4(), new THREE.Matrix4() ];
 				scene.add( controller2 );
@@ -386,6 +368,28 @@
 			function handleController( controller ) {
 
 				var pivot = controller.getObjectByName( 'pivot' );
+
+				var gamepad;
+
+				controller.userData.isSelecting = false;
+
+				if ( controller.userData.inputSource ) {
+
+					gamepad = controller.userData.inputSource.gamepad;
+
+					for (var i = 0; i < gamepad.buttons.length; ++i) {
+
+	          if (gamepad.buttons[i].pressed) {
+
+	          	controller.userData.isSelecting = true;
+
+	          	break;
+
+	          }
+
+	        }
+
+				}
 
 				if ( pivot ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -311,7 +311,7 @@ function WebGLRenderer( parameters ) {
 
 	// vr
 
-	var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator && 'requestDevice' in navigator.xr ) ? new WebXRManager( _this ) : new WebVRManager( _this );
+	var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator ) ? new WebXRManager( _this ) : new WebVRManager( _this );
 
 	this.vr = vr;
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -85,8 +85,16 @@ function WebXRManager( renderer ) {
 
 	function onSessionEvent( event ) {
 
-		var controller = controllers[ inputSources.indexOf( event.inputSource ) ];
-		if ( controller ) controller.dispatchEvent( { type: event.type } );
+		for ( var i = 0; i < inputSources.length; ++ i ) {
+
+			if ( inputSources === event.inputSource ) {
+
+				controller.dispatchEvent( { type: event.type } );
+				return;
+
+			}
+
+		}
 
 	}
 
@@ -132,15 +140,15 @@ function WebXRManager( renderer ) {
 
 			session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl ) } );
 
-			session.requestReferenceSpace( { type: 'stationary', subtype: 'eye-level' } ).then( onRequestFrameOfReference );
+			session.requestReferenceSpace( 'local-floor' ).then( onRequestFrameOfReference );
 
 			//
 
-			inputSources = session.getInputSources();
+			inputSources = session.inputSources;
 
 			session.addEventListener( 'inputsourceschange', function () {
 
-				inputSources = session.getInputSources();
+				inputSources = session.inputSources;
 				console.log( inputSources );
 
 				for ( var i = 0; i < controllers.length; i ++ ) {
@@ -229,8 +237,8 @@ function WebXRManager( renderer ) {
 			for ( var i = 0; i < views.length; i ++ ) {
 
 				var view = views[ i ];
-				var viewport = layer.getViewport( view );
-				var viewMatrix = view.transform.inverse().matrix;
+				var viewport = session.renderState.baseLayer.getViewport( view );
+				var viewMatrix = view.transform.inverse.matrix;
 
 				var camera = cameraVR.cameras[ i ];
 				camera.matrix.fromArray( viewMatrix ).getInverse( camera.matrix );
@@ -261,8 +269,7 @@ function WebXRManager( renderer ) {
 
 				if ( inputPose !== null ) {
 
-					var targetRay = new XRRay( inputPose.transform );
-					controller.matrix.elements = targetRay.matrix;
+					controller.matrix.elements = inputPose.transform.matrix;
 
 					controller.matrix.decompose( controller.position, controller.rotation, controller.scale );
 					controller.visible = true;


### PR DESCRIPTION
I saw https://github.com/mrdoob/three.js/pull/15604 merge.

There are some additional changes that landed since. Implementation should be close to stable now. This PR brings compatibility with Chrome m76 (Canary). 

To test you will need to go to `crhome://flags`:

 - Enable `WebXR Device API`
 - Enable `Oculus hardware support`, `OpenVR hardware support` or `Windows Mixed Reality support` depending on your headset and preferences.
 - Disable `XR device sandboxing`

Tested on `webvr_cubes.html` and `webvr_paint.html`