### PR TITLE
Math: includes missing *.d.ts methods.

### DIFF
--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -17,6 +17,8 @@ export class Color {
 	constructor( color?: Color | string | number );
 	constructor( r: number, g: number, b: number );
 
+	isColor: boolean;
+
 	/**
    * Red channel value between 0 and 1. Default is 1.
    */
@@ -94,6 +96,28 @@ export class Color {
    * Converts this color from linear to gamma space.
    */
 	convertLinearToGamma(): Color;
+
+	/**
+   * Copies given color making conversion from sRGB to linear space.
+   * @param color Color to copy.
+   */
+	copySRGBToLinear(): Color;
+
+	/**
+	 * Copies given color making conversion from linear to sRGB space.
+	 * @param color Color to copy.
+	 */
+	copyLinearToSRGB(): Color;
+
+	/**
+	 * Converts this color from sRGB to linear space.
+	 */
+	convertSRGBToLinear(): Color;
+
+	/**
+	 * Converts this color from linear to sRGB space.
+	 */
+	convertLinearToSRGB(): Color;
 
 	/**
    * Returns the hexadecimal value of this color.

--- a/src/math/Cylindrical.d.ts
+++ b/src/math/Cylindrical.d.ts
@@ -12,5 +12,6 @@ export class Cylindrical {
 	copy( other: Cylindrical ): this;
 	set( radius: number, theta: number, y: number ): this;
 	setFromVector3( vec3: Vector3 ): this;
+	setFromCartesianCoords( x: number, y: number, z: number ): this;
 
 }

--- a/src/math/Frustum.d.ts
+++ b/src/math/Frustum.d.ts
@@ -37,7 +37,7 @@ export class Frustum {
 	copy( frustum: Frustum ): this;
 	setFromMatrix( m: Matrix4 ): Frustum;
 	intersectsObject( object: Object3D ): boolean;
-	intersectsObject( sprite: Sprite ): boolean;
+	intersectsSprite( sprite: Sprite ): boolean;
 	intersectsSphere( sphere: Sphere ): boolean;
 	intersectsBox( box: Box3 ): boolean;
 	containsPoint( point: Vector3 ): boolean;

--- a/src/math/Plane.d.ts
+++ b/src/math/Plane.d.ts
@@ -27,6 +27,7 @@ export class Plane {
 	intersectLine( line: Line3, target: Vector3 ): Vector3;
 	intersectsLine( line: Line3 ): boolean;
 	intersectsBox( box: Box3 ): boolean;
+	intersectsSphere( sphere: Sphere ): boolean;
 	coplanarPoint( target: Vector3 ): Vector3;
 	applyMatrix4( matrix: Matrix4, optionalNormalMatrix?: Matrix3 ): Plane;
 	translate( offset: Vector3 ): Plane;

--- a/src/math/Triangle.d.ts
+++ b/src/math/Triangle.d.ts
@@ -1,5 +1,6 @@
 import { Vector3 } from './Vector3';
 import { Plane } from './Plane';
+import { Box3 } from './Box3';
 
 export interface SplineControlPoint {
 	x: number;
@@ -29,7 +30,9 @@ export class Triangle {
 	getNormal( target: Vector3 ): Vector3;
 	getPlane( target: Vector3 ): Plane;
 	getBarycoord( point: Vector3, target: Vector3 ): Vector3;
+	getUV( point: Vector3, uv1: Vector2, uv2: Vector2, uv3: Vector2, target: Vector2 ): Vector2;
 	containsPoint( point: Vector3 ): boolean;
+	intersectsBox( box: Box3 ): boolean;
 	isFrontFacing( direction: Vector3 ): boolean;
 	closestPointToPoint( point: Vector3, target: Vector3 ): Vector3;
 	equals( triangle: Triangle ): boolean;
@@ -53,6 +56,16 @@ export class Triangle {
 		b: Vector3,
 		c: Vector3
 	): boolean;
+	static getUV(
+		point: Vector3,
+		p1: Vector3,
+		p2: Vector3,
+		p3: Vector3,
+		uv1: Vector2,
+		uv2: Vector2,
+		uv3: Vector2,
+		target: Vector2
+	): Vector2;
 	static isFrontFacing(
 		a: Vector3,
 		b: Vector3,

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -238,15 +238,15 @@ Object.assign( Triangle.prototype, {
 
 	},
 
-	containsPoint: function ( point ) {
+	getUV: function ( point, uv1, uv2, uv3, target ) {
 
-		return Triangle.containsPoint( point, this.a, this.b, this.c );
+		return Triangle.getUV( point, this.a, this.b, this.c, uv1, uv2, uv3, target );
 
 	},
 
-	getUV: function ( point, uv1, uv2, uv3, result ) {
+	containsPoint: function ( point ) {
 
-		return Triangle.getUV( point, this.a, this.b, this.c, uv1, uv2, uv3, result );
+		return Triangle.containsPoint( point, this.a, this.b, this.c );
 
 	},
 


### PR DESCRIPTION
Also, a few methods are missing on the documentation.
I suspect some of these were intentionally left out, like `Triangle.GetUV()`.

If that's not the case, I can include those on a follow-up PR.