### PR TITLE
Fixed bug with nested FunctionNodes (or ExpressionNodes) looping infinitely

### DIFF
--- a/examples/js/nodes/core/FunctionNode.js
+++ b/examples/js/nodes/core/FunctionNode.js
@@ -85,7 +85,13 @@ FunctionNode.prototype.generate = function ( builder, output ) {
 
 	}
 
-	while ( match = propertiesRegexp.exec( this.src ) ) {
+	var matches = [];
+
+	while ( match = propertiesRegexp.exec( this.src ) ) matches.push( match );
+
+	for ( var i = 0; i < matches.length; i++ ) {
+
+		var match = matches[i];
 
 		var prop = match[ 0 ],
 			isGlobal = this.isMethod ? ! this.getInputByName( prop ) : true,

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2198,11 +2198,14 @@
 
 						var speed = new THREE.FloatNode( .5 );
 
-						mtl.color = new THREE.ExpressionNode( "myCustomUv + (sin(time*speed)*.5) + (position * .05)", "vec3" );
-						mtl.color.keywords[ "speed" ] = speed;
+						var myspeed = new THREE.ExpressionNode( "speed * time", "float" );
+						myspeed.keywords[ "speed" ] = speed;
 
-						mtl.position = new THREE.ExpressionNode( "mod(time*speed,1.0) < 0.5 ? position + (worldNormal*(1.0+sin(time*speed*1.0))*3.0) : position + sin( position.x * sin(time*speed*2.0))", "vec3" );
-						mtl.position.keywords[ "speed" ] = speed;
+						mtl.color = new THREE.ExpressionNode( "myCustomUv + (sin(myspeed)*.5) + (position * .05)", "vec3" );
+						mtl.color.keywords[ "myspeed" ] = myspeed;
+
+						mtl.position = new THREE.ExpressionNode( "mod(myspeed,1.0) < 0.5 ? position + (worldNormal*(1.0+sin(myspeed*1.0))*3.0) : position + sin( position.x * sin(myspeed*2.0))", "vec3" );
+						mtl.position.keywords[ "myspeed" ] = myspeed;
 
 						// add global keyword ( variable or const )
 						THREE.NodeLib.addKeyword( 'myCustomUv', function () {


### PR DESCRIPTION
FunctionNode.generate uses stateful RegEx (`propertiesRegexp.exec`) to loop through its dependencies, performing a DFS to also replace child dependencies. Since the `propertiesRegexp` pattern is shared across scopes, the nested function call at the 2nd level will reset the initial state of the expression, so when the 2nd level nested function call terminates and steps upwards, the 1st level function call will restart it's loop at 0, infinitely.

To test this, only checkout `examples/webgl_materials_nodes.html` and try selecting the `adv / expression` option from the dropdown. The expected behaviour is for the browser to freeze. The changes to FunctionNode will fix this.