### PR TITLE
LDrawLoader: Implement construction STEP directive

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -593,13 +593,7 @@ THREE.LDrawLoader = ( function () {
 			fileLoader.setPath( this.path );
 			fileLoader.load( url, function ( text ) {
 
-				processObject( text, function onMainObjectProcessed( model ) {
-
-					scope.computeConstructionSteps( model );
-
-					onLoad( model );
-
-				} );
+				processObject( text, onLoad );
 
 			}, onProgress, onError );
 
@@ -766,6 +760,13 @@ THREE.LDrawLoader = ( function () {
 							parentTriangles.push( tri );
 
 						}
+
+					}
+
+					// If it is root object, compute construction steps
+					if ( ! parentParseScope.isFromParse ) {
+
+						scope.computeConstructionSteps( parseScope.groupObject );
 
 					}
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -980,7 +980,7 @@ THREE.LDrawLoader = ( function () {
 				lineSegments: null,
 				conditionalSegments: null,
 
-				constructionStep: 0
+				constructionStep: false
 
 			};
 
@@ -1381,9 +1381,7 @@ THREE.LDrawLoader = ( function () {
 			var bfcCull = true;
 			var type = '';
 
-			var currentConstructionStep = 0;
-			var geometrySinceStartFlag = false;
-			var geometrySinceLastStepFlag = false;
+			var currentConstructionStep = false;
 
 			var scope = this;
 			function parseColourCode( lineParser, forEdge ) {
@@ -1628,13 +1626,7 @@ THREE.LDrawLoader = ( function () {
 
 								case 'STEP':
 
-									if ( isRoot && geometrySinceStartFlag ) {
-
-										currentParseScope.groupObject.userData.numConstructionSteps = ++ currentConstructionStep;
-
-										geometrySinceLastStepFlag = false;
-
-									}
+									currentConstructionStep = true;
 
 									break;
 
@@ -1708,9 +1700,7 @@ THREE.LDrawLoader = ( function () {
 						} );
 
 						bfcInverted = false;
-
-						geometrySinceStartFlag = true;
-						geometrySinceLastStepFlag = true;
+						currentConstructionStep = false;
 
 						break;
 
@@ -1727,9 +1717,6 @@ THREE.LDrawLoader = ( function () {
 						};
 
 						lineSegments.push( segment );
-
-						geometrySinceStartFlag = true;
-						geometrySinceLastStepFlag = true;
 
 						break;
 
@@ -1748,9 +1735,6 @@ THREE.LDrawLoader = ( function () {
 						};
 
 						conditionalSegments.push( segment );
-
-						geometrySinceStartFlag = true;
-						geometrySinceLastStepFlag = true;
 
 						break;
 
@@ -1811,9 +1795,6 @@ THREE.LDrawLoader = ( function () {
 							} );
 
 						}
-
-						geometrySinceStartFlag = true;
-						geometrySinceLastStepFlag = true;
 
 						break;
 
@@ -1901,9 +1882,6 @@ THREE.LDrawLoader = ( function () {
 
 						}
 
-						geometrySinceStartFlag = true;
-						geometrySinceLastStepFlag = true;
-
 						break;
 
 					default:
@@ -1911,12 +1889,6 @@ THREE.LDrawLoader = ( function () {
 						break;
 
 				}
-
-			}
-
-			if ( isRoot && geometrySinceLastStepFlag ) {
-
- 				currentParseScope.groupObject.userData.numConstructionSteps = ++ currentConstructionStep;
 
 			}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -30,7 +30,8 @@
 
 	<body>
 		<div id="info">
-		<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - LDrawLoader
+		<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - LDrawLoader<br/>
+		Activate Separate option to enable model construction animation
 		</div>
 
 		<script src="../build/three.js"></script>
@@ -112,48 +113,11 @@
 					separateObjects: false,
 					displayLines: true,
 					conditionalLines: true,
-					smoothNormals: true
+					smoothNormals: true,
+					constructionStep: 0,
+					noConstructionSteps: "No steps."
 				};
 
-				gui = new dat.GUI();
-
-				gui.add( guiData, 'modelFileName', modelFileList ).name( 'Model' ).onFinishChange( function () {
-
-					reloadObject( true );
-
-				} );
-
-				gui.add( guiData, 'envMapActivated' ).name( 'Env. map' ).onChange( function ( value ) {
-
-					envMapActivated = value;
-
-					reloadObject( false );
-
-				} );
-
-				gui.add( guiData, 'separateObjects' ).name( 'Separate Objects' ).onChange( function ( value ) {
-
-					reloadObject( false );
-
-				} );
-
-				gui.add( guiData, 'smoothNormals' ).name( 'Smooth Normals' ).onChange( function ( value ) {
-
-					reloadObject( false );
-
-				} );
-
-				gui.add( guiData, 'displayLines' ).name( 'Display Lines' ).onChange( function ( value ) {
-
-					updateLineSegments();
-
-				} );
-
-				gui.add( guiData, 'conditionalLines' ).name( 'Conditional Lines' ).onChange( function ( value ) {
-
-					updateLineSegments();
-
-				} );
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				progressBarDiv = document.createElement( 'div' );
@@ -173,7 +137,7 @@
 
 			}
 
-			function updateLineSegments() {
+			function updateObjectsVisibility() {
 
 				model.traverse( c => {
 
@@ -188,6 +152,12 @@
 							c.visible = guiData.displayLines;
 
 						}
+
+					}
+					else if ( c.isGroup ) {
+
+						// Hide objects with construction step > gui setting
+						c.visible = c.userData.constructionStep <= guiData.constructionStep;
 
 					}
 
@@ -261,7 +231,9 @@
 
 						}
 
-						updateLineSegments();
+						guiData.constructionStep = model.userData.numConstructionSteps - 1;
+
+						updateObjectsVisibility();
 
 						// Adjust camera and light
 
@@ -277,6 +249,8 @@
 
 						}
 
+						createGUI();
+
 						hideProgressBar();
 
 					}, onProgress, onError );
@@ -289,6 +263,80 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function createGUI() {
+
+				if ( gui ) {
+
+					gui.destroy();
+
+				}
+
+				gui = new dat.GUI();
+
+				gui.add( guiData, 'modelFileName', modelFileList ).name( 'Model' ).onFinishChange( function () {
+
+					reloadObject( true );
+
+				} );
+
+				gui.add( guiData, 'separateObjects' ).name( 'Separate Objects' ).onChange( function ( value ) {
+
+					reloadObject( false );
+
+				} );
+
+				if ( guiData.separateObjects ) {
+
+						if ( model.userData.numConstructionSteps > 1  ) {
+
+							gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( function ( value ) {
+
+								updateObjectsVisibility();
+
+							} );
+
+						}
+						else {
+
+							var dummyControl = gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( function ( value ) {
+
+								guiData.noConstructionSteps = "No steps.";
+								//dummyControl.setValue( guiData.noConstructionSteps );
+
+							} );
+
+						}
+
+				}
+
+				gui.add( guiData, 'envMapActivated' ).name( 'Env. map' ).onChange( function ( value ) {
+
+					envMapActivated = value;
+
+					reloadObject( false );
+
+				} );
+
+				gui.add( guiData, 'smoothNormals' ).name( 'Smooth Normals' ).onChange( function ( value ) {
+
+					reloadObject( false );
+
+				} );
+
+				gui.add( guiData, 'displayLines' ).name( 'Display Lines' ).onChange( function ( value ) {
+
+					updateObjectsVisibility();
+
+				} );
+
+				gui.add( guiData, 'conditionalLines' ).name( 'Conditional Lines' ).onChange( function ( value ) {
+
+					updateObjectsVisibility();
+
+				} );
 
 			}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -47,7 +47,7 @@
 
 			var camera, scene, renderer, controls, gui, guiData;
 
-			var modelFileList, model, textureCube;
+			var modelFileList, model, numberOfConstructionSteps, textureCube;
 
 			var envMapActivated = false;
 
@@ -134,6 +134,33 @@
 				// load materials and then the model
 
 				reloadObject( true );
+
+			}
+
+			function processConstructionSteps( model ) {
+
+				// Returns total construction steps number
+
+				var stepNumber = 0;
+
+				model.traverse( c => {
+
+					if ( c.isGroup ) {
+
+						if ( c.userData.constructionStep ) {
+
+							stepNumber ++;
+
+						}
+
+						// Overwrite userData.constructionStep boolean flag with step number
+						c.userData.constructionStep = stepNumber;
+
+					}
+
+				} );
+
+				return stepNumber + 1;
 
 			}
 
@@ -231,7 +258,9 @@
 
 						}
 
-						guiData.constructionStep = model.userData.numConstructionSteps - 1;
+						numberOfConstructionSteps = processConstructionSteps( model );
+
+						guiData.constructionStep = numberOfConstructionSteps - 1;
 
 						updateObjectsVisibility();
 
@@ -290,9 +319,9 @@
 
 				if ( guiData.separateObjects ) {
 
-						if ( model.userData.numConstructionSteps > 1  ) {
+						if ( numberOfConstructionSteps > 1  ) {
 
-							gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( function ( value ) {
+							gui.add( guiData, 'constructionStep', 0, numberOfConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( function ( value ) {
 
 								updateObjectsVisibility();
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -301,10 +301,9 @@
 						}
 						else {
 
-							var dummyControl = gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( function ( value ) {
+							gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( function ( value ) {
 
 								guiData.noConstructionSteps = "No steps.";
-								//dummyControl.setValue( guiData.noConstructionSteps );
 
 							} );
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -47,7 +47,7 @@
 
 			var camera, scene, renderer, controls, gui, guiData;
 
-			var modelFileList, model, numberOfConstructionSteps, textureCube;
+			var modelFileList, model, textureCube;
 
 			var envMapActivated = false;
 
@@ -134,33 +134,6 @@
 				// load materials and then the model
 
 				reloadObject( true );
-
-			}
-
-			function processConstructionSteps( model ) {
-
-				// Returns total construction steps number
-
-				var stepNumber = 0;
-
-				model.traverse( c => {
-
-					if ( c.isGroup ) {
-
-						if ( c.userData.constructionStep ) {
-
-							stepNumber ++;
-
-						}
-
-						// Overwrite userData.constructionStep boolean flag with step number
-						c.userData.constructionStep = stepNumber;
-
-					}
-
-				} );
-
-				return stepNumber + 1;
 
 			}
 
@@ -258,9 +231,7 @@
 
 						}
 
-						numberOfConstructionSteps = processConstructionSteps( model );
-
-						guiData.constructionStep = numberOfConstructionSteps - 1;
+						guiData.constructionStep = model.userData.numConstructionSteps - 1;
 
 						updateObjectsVisibility();
 
@@ -319,9 +290,9 @@
 
 				if ( guiData.separateObjects ) {
 
-						if ( numberOfConstructionSteps > 1  ) {
+						if ( model.userData.numConstructionSteps > 1  ) {
 
-							gui.add( guiData, 'constructionStep', 0, numberOfConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( function ( value ) {
+							gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( function ( value ) {
 
 								updateObjectsVisibility();
 


### PR DESCRIPTION
The STEP directive of the LDraw format is used to separate the objects into consecutive 'drawing steps', or 'construction steps', which are stages in the manual construction of the model with real pieces. This PR adds implementation of construction steps.

For this to work, the `Separate` option must be checked in the gui.

Each `THREE.Group` inside the model is assigned a `.userData.constructionStep`, with a value from 0 to `numConstructionSteps - 1`
The total number of steps is stored in `rootGroup.userData.numConstructionSteps`.

The example has a slider in the gui (when `Separate` is enabled) that lets you change the displayed construction step. It simply changes the visibility of the model parts.

Roughly half of the model files have STEP directives. As Separate option is slow, you can disable Smooth option to speed up the loading, specially with the big AT-ST.

Current version: https://raw.githack.com/mrdoob/three.js/dev/examples/webgl_loader_ldraw.html

Edit: If  #16598 is merged before this, I will redo this PR.

/ping @gkjohnson 