### PR TITLE
GLTFLoader: Fix U8/U16 skinning weights

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2613,7 +2613,13 @@ THREE.GLTFLoader = ( function () {
 							? new THREE.SkinnedMesh( geometry, material )
 							: new THREE.Mesh( geometry, material );
 
-						if ( mesh.isSkinnedMesh === true ) mesh.normalizeSkinWeights(); // #15319
+						if ( mesh.isSkinnedMesh === true && !mesh.geometry.attributes.skinWeight.normalized ) {
+
+							// we normalize floating point skin weight array to fix malformed assets (see #15319)
+							// it's important to skip this for non-float32 data since normalizeSkinWeights assumes non-normalized inputs
+							mesh.normalizeSkinWeights();
+
+						}
 
 						if ( primitive.mode === WEBGL_CONSTANTS.TRIANGLE_STRIP ) {
 


### PR DESCRIPTION
Before this change, U8/U16 skinning weights didn't work - we attempted
to normalize the skinning weights, but normalizeSkinWeights doesn't work
for normalized integer data; it would divide weights by 255/65535 which
would usually result in weights equal to 0.

It's not *actually* necessary to normalize weights except to handle some
models that violate the spec (that says that weights need to add up to
1). For this reason it seems fair to limit the scope of the
normalization to just unnormalized inputs.

Contributes to #15319.