### PR TITLE
Update skeleton only once in a frame

### DIFF
--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -16,6 +16,8 @@ function Skeleton( bones, boneInverses ) {
 	this.bones = bones.slice( 0 );
 	this.boneMatrices = new Float32Array( this.bones.length * 16 );
 
+	this.version = - 1;
+
 	// use the supplied bone inverses or calculate the inverses
 
 	if ( boneInverses === undefined ) {

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -16,7 +16,7 @@ function Skeleton( bones, boneInverses ) {
 	this.bones = bones.slice( 0 );
 	this.boneMatrices = new Float32Array( this.bones.length * 16 );
 
-	this.version = - 1;
+	this.frame = - 1;
 
 	// use the supplied bone inverses or calculate the inverses
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1306,7 +1306,14 @@ function WebGLRenderer( parameters ) {
 
 				if ( object.isSkinnedMesh ) {
 
-					object.skeleton.update();
+					// update skeleton only once in a frame
+
+					if ( object.skeleton.version !== info.render.frame ) {
+
+						object.skeleton.update();
+						object.skeleton.version = info.render.frame;
+
+					}
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1308,10 +1308,10 @@ function WebGLRenderer( parameters ) {
 
 					// update skeleton only once in a frame
 
-					if ( object.skeleton.version !== info.render.frame ) {
+					if ( object.skeleton.frame !== info.render.frame ) {
 
 						object.skeleton.update();
-						object.skeleton.version = info.render.frame;
+						object.skeleton.frame = info.render.frame;
 
 					}
 


### PR DESCRIPTION
Following up #16608

Currently `skeleton.update()` is unnecessarily called multiple times in a frame if skeleton is shared among multiple `SkinnedMesh`. This PR ensures that `skeleton.update()` is called only once in a frame.