### PR TITLE
RGBELoader: Set encoding based on output type

### DIFF
--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -391,3 +391,37 @@ THREE.RGBELoader.prototype.setType = function ( value ) {
 	return this;
 
 };
+
+THREE.RGBELoader.prototype.load = function ( url, onLoad, onProgress, onError ) {
+
+	function onLoadCallback( texture, texData ) {
+
+		switch ( texture.type ) {
+
+			case THREE.UnsignedByteType:
+
+				texture.encoding = THREE.RGBEEncoding;
+				texture.minFilter = THREE.NearestFilter;
+				texture.magFilter = THREE.NearestFilter;
+				texture.generateMipmaps = false;
+				texture.flipY = true;
+				break;
+
+			case THREE.FloatType:
+
+				texture.encoding = THREE.LinearEncoding;
+				texture.minFilter = THREE.LinearFilter;
+				texture.magFilter = THREE.LinearFilter;
+				texture.generateMipmaps = false;
+				texture.flipY = true;
+				break;
+
+		}
+
+		if ( onLoad ) onLoad( texture, texData );
+
+	}
+
+	return THREE.DataTextureLoader.prototype.load.call( this, url, onLoadCallback, onProgress, onError );
+
+};

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -54,33 +54,9 @@
 
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
-				var type = THREE.UnsignedByteType;
-				//var type = THREE.FloatType;
-
 				new THREE.RGBELoader()
-					.setType( type )
+					.setType( THREE.UnsignedByteType ) // alt: THREE.FloatType
 					.load( 'textures/memorial.hdr', function ( texture, textureData ) {
-
-						switch ( type ) {
-
-							case THREE.UnsignedByteType:
-
-								texture.encoding = THREE.RGBEEncoding;
-								texture.minFilter = THREE.NearestFilter;
-								texture.magFilter = THREE.NearestFilter;
-								break;
-
-							case THREE.FloatType:
-
-								texture.encoding = THREE.LinearEncoding;
-								texture.minFilter = THREE.LinearFilter;
-								texture.magFilter = THREE.LinearFilter;
-								break;
-
-						}
-
-						texture.generateMipmaps = false;
-						texture.flipY = true;
 
 						//console.log( textureData );
 						//console.log( texture );


### PR DESCRIPTION
Currently, the output type can be `UnsignedByteType` with `RGBE` encoding or `FloatType` with linear encoding.

This PR sets the encoding to one that makes sense based on the output type.