### PR TITLE
Examples: Make sure layout looks fine, even when using outdated links

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -165,7 +165,7 @@
 
 		}
 
-		if ( window.location.hash !== '' ) {
+		if ( window.location.hash !== '' && links[ window.location.hash.substring( 1 ) ] ) {
 
 			loadFile( window.location.hash.substring( 1 ) );
 


### PR DESCRIPTION
https://threejs.org/examples/#canvas_geometry_cube is an obsolete link from a canvas example. It breaks the list of examples because the hash doesn't exist anymore. 


