### PR TITLE
GLTFLoader: Deduplicate node names.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3413,6 +3413,9 @@ THREE.GLTFLoader = ( function () {
 
 		var nodeDef = json.nodes[ nodeIndex ];
 
+		// reserve node's name before its dependencies, so the root has the intended name.
+		var nodeName = nodeDef.name ? parser.createUniqueName( nodeDef.name ) : '';
+
 		return ( function () {
 
 			var pending = [];
@@ -3504,8 +3507,7 @@ THREE.GLTFLoader = ( function () {
 			if ( nodeDef.name ) {
 
 				node.userData.name = nodeDef.name;
-
-				node.name = parser.createUniqueName( nodeDef.name );
+				node.name = nodeName;
 
 			}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -451,7 +451,7 @@ THREE.GLTFLoader = ( function () {
 
 		if ( lightDef.intensity !== undefined ) lightNode.intensity = lightDef.intensity;
 
-		lightNode.name = lightDef.name || ( 'light_' + lightIndex );
+		lightNode.name = parser.createUniqueName( lightDef.name || ( 'light_' + lightIndex ) );
 
 		dependency = Promise.resolve( lightNode );
 
@@ -2671,9 +2671,10 @@ THREE.GLTFLoader = ( function () {
 
 	};
 
-	GLTFParser.prototype.assignUniqueName = function ( object, originalName ) {
+	/** When Object3D instances are targeted by animation, they need unique names. */
+	GLTFParser.prototype.createUniqueName = function ( originalName ) {
 
-		var name = originalName;
+		var name = THREE.PropertyBinding.sanitizeNodeName( originalName || '' );
 
 		for ( var i = 1; this.nodeNamesUsed[ name ]; ++ i ) {
 
@@ -2683,7 +2684,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.nodeNamesUsed[ name ] = true;
 
-		object.name = name;
+		return name;
 
 	};
 
@@ -3110,7 +3111,7 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
-				parser.assignUniqueName( mesh, meshDef.name || ( 'mesh_' + meshIndex ) );
+				mesh.name = parser.createUniqueName( meshDef.name || ( 'mesh_' + meshIndex ) );
 
 				if ( geometries.length > 1 ) mesh.name += '_' + i;
 
@@ -3170,7 +3171,7 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
-		if ( cameraDef.name ) this.assignUniqueName( camera, cameraDef.name );
+		if ( cameraDef.name ) camera.name = this.createUniqueName( cameraDef.name );
 
 		assignExtrasToUserData( camera, cameraDef );
 
@@ -3504,7 +3505,7 @@ THREE.GLTFLoader = ( function () {
 
 				node.userData.name = nodeDef.name;
 
-				parser.assignUniqueName( node, THREE.PropertyBinding.sanitizeNodeName( nodeDef.name ) );
+				node.name = parser.createUniqueName( nodeDef.name );
 
 			}
 
@@ -3663,7 +3664,7 @@ THREE.GLTFLoader = ( function () {
 			// Loader returns Group, not Scene.
 			// See: https://github.com/mrdoob/three.js/issues/18342#issuecomment-578981172
 			var scene = new THREE.Group();
-			if ( sceneDef.name ) parser.assignUniqueName( scene, sceneDef.name );
+			if ( sceneDef.name ) scene.name = parser.createUniqueName( sceneDef.name );
 
 			assignExtrasToUserData( scene, sceneDef );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3476,6 +3476,9 @@ var GLTFLoader = ( function () {
 
 		var nodeDef = json.nodes[ nodeIndex ];
 
+		// reserve node's name before its dependencies, so the root has the intended name.
+		var nodeName = nodeDef.name ? parser.createUniqueName( nodeDef.name ) : '';
+
 		return ( function () {
 
 			var pending = [];
@@ -3567,8 +3570,7 @@ var GLTFLoader = ( function () {
 			if ( nodeDef.name ) {
 
 				node.userData.name = nodeDef.name;
-
-				node.name = parser.createUniqueName( nodeDef.name );
+				node.name = nodeName;
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -514,7 +514,7 @@ var GLTFLoader = ( function () {
 
 		if ( lightDef.intensity !== undefined ) lightNode.intensity = lightDef.intensity;
 
-		lightNode.name = lightDef.name || ( 'light_' + lightIndex );
+		lightNode.name = parser.createUniqueName( lightDef.name || ( 'light_' + lightIndex ) );
 
 		dependency = Promise.resolve( lightNode );
 
@@ -2734,9 +2734,10 @@ var GLTFLoader = ( function () {
 
 	};
 
-	GLTFParser.prototype.assignUniqueName = function ( object, originalName ) {
+	/** When Object3D instances are targeted by animation, they need unique names. */
+	GLTFParser.prototype.createUniqueName = function ( originalName ) {
 
-		var name = originalName;
+		var name = PropertyBinding.sanitizeNodeName( originalName || '' );
 
 		for ( var i = 1; this.nodeNamesUsed[ name ]; ++ i ) {
 
@@ -2746,7 +2747,7 @@ var GLTFLoader = ( function () {
 
 		this.nodeNamesUsed[ name ] = true;
 
-		object.name = name;
+		return name;
 
 	};
 
@@ -3173,7 +3174,7 @@ var GLTFLoader = ( function () {
 
 				}
 
-				parser.assignUniqueName( mesh, meshDef.name || ( 'mesh_' + meshIndex ) );
+				mesh.name = parser.createUniqueName( meshDef.name || ( 'mesh_' + meshIndex ) );
 
 				if ( geometries.length > 1 ) mesh.name += '_' + i;
 
@@ -3233,7 +3234,7 @@ var GLTFLoader = ( function () {
 
 		}
 
-		if ( cameraDef.name ) this.assignUniqueName( camera, cameraDef.name );
+		if ( cameraDef.name ) camera.name = this.createUniqueName( cameraDef.name );
 
 		assignExtrasToUserData( camera, cameraDef );
 
@@ -3567,7 +3568,7 @@ var GLTFLoader = ( function () {
 
 				node.userData.name = nodeDef.name;
 
-				parser.assignUniqueName( node, PropertyBinding.sanitizeNodeName( nodeDef.name ) );
+				node.name = parser.createUniqueName( nodeDef.name );
 
 			}
 
@@ -3726,7 +3727,7 @@ var GLTFLoader = ( function () {
 			// Loader returns Group, not Scene.
 			// See: https://github.com/mrdoob/three.js/issues/18342#issuecomment-578981172
 			var scene = new Group();
-			if ( sceneDef.name ) parser.assignUniqueName( scene, sceneDef.name );
+			if ( sceneDef.name ) scene.name = parser.createUniqueName( sceneDef.name );
 
 			assignExtrasToUserData( scene, sceneDef );
 


### PR DESCRIPTION
Fixes #15087.

/cc @takahirox 