### PR TITLE
WebGLTextures: CubeTexture from CompressedTextures signature bug

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -370,7 +370,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 
-				var isCompressed = ( texture && texture.isCompressedTexture );
+				var isCompressed = ( texture.image[ 0 ] && texture.image[ 0 ].isCompressedTexture );
 				var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
 
 				var cubeImage = [];


### PR DESCRIPTION
Issue explained here: https://github.com/mrdoob/three.js/issues/16584
Discussed here: https://discourse.threejs.org/t/three-cubetexture-using-three-compressedtexture/7868