### PR TITLE
WebGLRenderTarget: add image.width/height to texture property

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -28,6 +28,10 @@ function WebGLRenderTarget( width, height, options ) {
 
 	this.texture = new Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
+	this.texture.image = {};
+	this.texture.image.width = width;
+	this.texture.image.height = height;
+
 	this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
 	this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;
 
@@ -49,6 +53,9 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 
 			this.width = width;
 			this.height = height;
+
+			this.texture.image.width = width;
+			this.texture.image.height = height;
 
 			this.dispose();
 


### PR DESCRIPTION
Because of the familiar warning

>don't use render targets as textures. Use their .texture property instead.

we now pass  `renderTarget.texture` instead of `renderTarget` itself.

Thing is, in passing the texture, we have no access to the texture dimensions, which are properties of the render target.

This PR uses the same approach as is used with [`DataTexture`](https://github.com/mrdoob/three.js/blob/dev/src/textures/DataTexture.js#L12) to solve this problem.