### PR TITLE
TransformControls TS definitions issue

### DIFF
--- a/examples/jsm/controls/TransformControls.d.ts
+++ b/examples/jsm/controls/TransformControls.d.ts
@@ -28,7 +28,7 @@ export class TransformControls extends Object3D {
   isTransformControls: boolean;
   visible: boolean;
 
-  attach(object: Object3D): void;
+  attach(object: Object3D): this;
   detach(): void;
   pointerHover(pointer: Object): void;
   pointerDown(pointer: Object): void;


### PR DESCRIPTION
Object3d.attach returns this
TransformControls.attach returns void
TransformControls extends Object3d so it doesn't compile