### PR TITLE
Easier getting started 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 8080
+  onOpen: open-preview
+tasks:
+- init: npm install
+  command: npm start

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The aim of the project is to create an easy to use, lightweight, 3D library with
 [Gitter](https://gitter.im/mrdoob/three.js) &mdash;
 [Slack](https://threejs-slack.herokuapp.com/)
 
+You can open this repository in Gitpod, a free online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mrdoob/three.js)
+
+
 ### Usage ###
 
 Download the [minified library](http://threejs.org/build/three.min.js) and include it in your HTML, or install and import it as a [module](http://threejs.org/docs/#manual/introduction/Import-via-modules),


### PR DESCRIPTION
This PR adds a small config for gitpod, a free for open-source service. We've developed it to provide dev environments with a single click. 

I have made the configuration so that
 - `npm install` and
 - `npm start`

are executed and when the dev server serves on port 8080, the root is opened in the preview.

I think it is useful for both three.js users and contributors to play around with the examples, create PRs or provide reproducibles. Note, that you can start workspace from any GitHub context (issues, files, branches and PRs) by prefixing the github URL with `gitpod.io/#` or install the browser extension. It will open a fresh dev environment with the right git state checked out. The three.js repo is quite large which makes the starting time a bit longer than usual.

<img width="1459" alt="Screenshot 2019-06-02 at 14 47 01" src="https://user-images.githubusercontent.com/372735/58761755-eb65cb80-8547-11e9-8b74-adbf356b9a2c.png">

Let me know if you think this could be useful for your community and if I should change anything (e.g. I wasn't sure where to put the Open in Gitpod button). ❤️ 