### PR TITLE
GLTFLoader: Fix handling of normalized animation outputs

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2869,12 +2869,31 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
+				var outputArray = outputAccessor.array;
+
+				if ( outputAccessor.normalized ) {
+
+					var bits = outputAccessor.array.BYTES_PER_ELEMENT * 8;
+					var scale = 1 / ((1 << (bits - 1)) - 1);
+
+					var scaled = new Float32Array( outputArray.length );
+
+					for ( var j = 0, jl = outputArray.length; j < jl; j ++ ) {
+
+						scaled[j] = outputArray[j] * scale;
+
+					}
+
+					outputArray = scaled;
+
+				}
+
 				for ( var j = 0, jl = targetNames.length; j < jl; j ++ ) {
 
 					var track = new TypedKeyframeTrack(
 						targetNames[ j ] + '.' + PATH_PROPERTIES[ target.path ],
 						inputAccessor.array,
-						outputAccessor.array,
+						outputArray,
 						interpolation
 					);
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2873,8 +2873,29 @@ THREE.GLTFLoader = ( function () {
 
 				if ( outputAccessor.normalized ) {
 
-					var bits = outputAccessor.array.BYTES_PER_ELEMENT * 8;
-					var scale = 1 / ((1 << (bits - 1)) - 1);
+					var scale;
+
+					if ( outputArray.constructor === Int8Array ) {
+
+						scale = 1 / 127;
+
+					} else if ( outputArray.constructor === Uint8Array ) {
+
+						scale = 1 / 255;
+
+					} else if ( outputArray.constructor == Int16Array ) {
+
+						scale = 1 / 32767;
+
+					} else if ( outputArray.constructor === Uint16Array ) {
+
+						scale = 1 / 65535;
+
+					} else {
+
+						throw new Error( 'THREE.GLTFLoader: Unsupported output accessor component type.' );
+
+					}
 
 					var scaled = new Float32Array( outputArray.length );
 


### PR DESCRIPTION
Per GLTF spec, rotation and weight animation outputs can use normalized
BYTE/SHORT/etc. accessors. However, the animation tracks don't support
normalized values, which results in erroneous playback.

This change manually renormalizes the array elements before handing them
to the animation system to fix this.

Fixes #16658.