### PR TITLE
Fix typing issues in ParametricGeometries and SMAAShader.

### DIFF
--- a/examples/jsm/geometries/ParametricGeometries.d.ts
+++ b/examples/jsm/geometries/ParametricGeometries.d.ts
@@ -18,7 +18,7 @@ export namespace ParametricGeometries  {
   }
 
   export class SphereGeometry {
-    constructor(size: number, u: number, v): number;
+    constructor(size: number, u: number, v);
   }
 
   export class PlaneGeometry {

--- a/examples/jsm/shaders/SMAAShader.d.ts
+++ b/examples/jsm/shaders/SMAAShader.d.ts
@@ -30,3 +30,13 @@ export interface SMAAWeightsShader {
   vertexShader: string;
   fragmentShader: string;
 }
+
+export interface SMAABlendShader {
+  uniforms: {
+    tDiffuse: Uniform;
+    tColor: Uniform;
+    resolution: Uniform;
+  };
+  vertexShader: string;
+  fragmentShader: string;
+}

--- a/examples/jsm/shaders/SMAAShader.d.ts
+++ b/examples/jsm/shaders/SMAAShader.d.ts
@@ -30,13 +30,3 @@ export interface SMAAWeightsShader {
   vertexShader: string;
   fragmentShader: string;
 }
-
-export interface SMAAWeightsShader {
-  uniforms: {
-    tDiffuse: Uniform;
-    tColor: Uniform;
-    resolution: Uniform;
-  };
-  vertexShader: string;
-  fragmentShader: string;
-}


### PR DESCRIPTION
This addresses the following typing errors:

node_modules/three/examples/jsm/geometries/ParametricGeometries.d.ts(21,46): error TS1093: Type annotation cannot appear on a constructor declaration.

node_modules/three/examples/jsm/shaders/SMAAShader.d.ts(35,3): error TS2717: Subsequent property declarations must have the same type.  Property 'uniforms' must be of type '{ tDiffuse: Uniform; tArea: Uniform; tSearch: Uniform; resolution: Uniform; }', but here has type '{ tDiffuse: Uniform; tColor: Uniform; resolution: Uniform; }'.