### PR TITLE
Specify output type with RGBELoader

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -53,13 +53,10 @@
 
 				scene = new THREE.Scene();
 
-				var loader = new THREE.RGBELoader().setPath( 'textures/equirectangular/' );
-				loader.load( 'pedestrian_overpass_2k.hdr', function ( texture ) {
-
-					texture.encoding = THREE.RGBEEncoding;
-					texture.minFilter = THREE.NearestFilter;
-					texture.magFilter = THREE.NearestFilter;
-					texture.flipY = true;
+				new THREE.RGBELoader()
+					.setType( THREE.UnsignedByteType )
+					.setPath( 'textures/equirectangular/' )
+					.load( 'pedestrian_overpass_2k.hdr', function ( texture ) {
 
 					var cubeGenerator = new THREE.EquirectangularToCubeGenerator( texture, { resolution: 1024 } );
 					cubeGenerator.update( renderer );

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -154,13 +154,10 @@
 
 				// Load background and generate envMap
 
-				var loader = new THREE.RGBELoader().setPath( 'textures/equirectangular/' );
-				loader.load( 'venice_sunset_2k.hdr', function ( texture ) {
-
-					texture.encoding = THREE.RGBEEncoding;
-					texture.minFilter = THREE.NearestFilter;
-					texture.magFilter = THREE.NearestFilter;
-					texture.flipY = true;
+				new THREE.RGBELoader()
+					.setType( THREE.UnsignedByteType )
+					.setPath( 'textures/equirectangular/' )
+					.load( 'venice_sunset_2k.hdr', function ( texture ) {
 
 					var cubeGenerator = new THREE.EquirectangularToCubeGenerator( texture, { resolution: 1024 } );
 					cubeGenerator.update( renderer );

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -55,7 +55,7 @@
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
 				new THREE.RGBELoader()
-					.setType( THREE.UnsignedByteType ) // alt: THREE.FloatType
+					.setType( THREE.UnsignedByteType ) // alt: THREE.FloatType, THREE.HalfFloatType
 					.load( 'textures/memorial.hdr', function ( texture, textureData ) {
 
 						//console.log( textureData );


### PR DESCRIPTION
The loader should return proper texture properties now. Previously it returned property values that were inconsistent with the desired texture type.
