### PR TITLE
Fix Node Materials Not Compiling

### DIFF
--- a/examples/js/nodes/materials/NodeMaterial.js
+++ b/examples/js/nodes/materials/NodeMaterial.js
@@ -18,6 +18,22 @@ function NodeMaterial( vertex, fragment ) {
 
 	this.updaters = [];
 
+	// onBeforeCompile can't be in the prototype because onBeforeCompile.toString varies per material
+
+	this.onBeforeCompile = function ( shader, renderer ) {
+
+		if ( this.needsUpdate ) {
+
+			this.build( { renderer: renderer } );
+
+			shader.uniforms = this.uniforms;
+			shader.vertexShader = this.vertexShader;
+			shader.fragmentShader = this.fragmentShader;
+
+		}
+
+	};
+
 	// it fix the programCache and share the code with others materials
 
 	this.onBeforeCompile.toString = function() {
@@ -69,20 +85,6 @@ NodeMaterial.prototype.updateFrame = function ( frame ) {
 	for ( var i = 0; i < this.updaters.length; ++ i ) {
 
 		frame.updateNode( this.updaters[ i ] );
-
-	}
-
-};
-
-NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
-
-	if ( this.needsUpdate ) {
-
-		this.build( { renderer: renderer } );
-
-		shader.uniforms = this.uniforms;
-		shader.vertexShader = this.vertexShader;
-		shader.fragmentShader = this.fragmentShader;
 
 	}
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -981,9 +981,6 @@
 
 							mtl.needsUpdate = true;
 
-							var killer = new THREE.PhongNodeMaterial();
-							killer.needsUpdate = false; // this is used mtl.onBeforeCompile
-
 						} );
 
 						break;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -981,6 +981,9 @@
 
 							mtl.needsUpdate = true;
 
+							var killer = new THREE.PhongNodeMaterial();
+							killer.needsUpdate = false; // this is used mtl.onBeforeCompile
+
 						} );
 
 						break;


### PR DESCRIPTION
I've been using @sunag's awesome node graph system plenty as of late, and have stumbled across another bug

Testing:
- Checkout the 1st commit (dca1fac "Broke `webgl_materials_nodes.html` to expose bug")
- Load up `webgl_materials_nodes.html`
- Switch to bump material from the drop down
- The 'color' checkbox won't do anything anymore
--- The 2nd commit will fix the bug
--- The 3rd commit will undo the first commit (exposing the bug)

Explanation of cause:
77: `NodeMaterial.prototype.onBeforeCompile` belongs to the prototype, so all instances of NodeMaterial share it (per the exact same subclass, eg. PhongNodeMaterial, since each subclass duplicates the prototype)
39: `this.onBeforeCompile.toString` treats `onBeforeCompile` as being uniquely instanced for each class, but actually when you override `onBeforeCompile.toString` it overrides it for all instances
Therefore, all instances of the same subclass will share the same, most recent instance of onBeforeCompile.toString, which is used by WebGLRenderer to decide whether or not the recompile is *actually* needed