### PR TITLE
Remove indent size from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,6 @@ insert_final_newline = true
 [*.{js,ts,html}]
 charset = utf-8
 indent_style = tab
-indent_size = 2
 
 [*.{js,ts}]
 trim_trailing_whitespace = true


### PR DESCRIPTION
Per @gkjohnson's comment (https://github.com/mrdoob/three.js/pull/15954#discussion_r264482520), I don't think `.editorconfig` should be changing visual configuration, as this doesn't affect PRs and is more subject to authors' preferences.