### PR TITLE
DRAFT: Load LWOLoader.js from the github.com/threejs/lwoloader repo

### DIFF
--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -14,7 +14,15 @@
 		</div>
 
 		<script src="../build/three.js"></script>
-		<script src="js/loaders/LWOLoader.js"></script>
+
+		<!--
+
+			NB raw.githack for demo only. In production, we could set up github pages, allowing something like:
+			<script src="https://threejs.github.io/LWOLoader/build/js/LWOLoader.js"></script>
+
+		-->
+		<script src="https://raw.githack.com/threejs/lwoloader/master/build/js/LWOLoader.js"></script>
+
 		<script src="js/controls/OrbitControls.js"></script>
 
 		<script src="js/WebGL.js"></script>


### PR DESCRIPTION
_Note: this PR is not intended to be merged, for discussion only_

Recently myself and @sciecode moved the development of the `LWOLoader` out of this repo and into it's own repo under the three.js org: [github.com/threejs/lwoloader](https://github.com/threejs/lwoloader). 

This has given us a whole range of benefits, such as a proper testing environment with lots of [LWO test models](https://raw.githack.com/threejs/lwoloader/master/index.html). We were also able to adopt a modern, modular approach to developing the loader rather than having to keep everything in one file. 

But, we now have two versions of the loader. One on this repo, and one on the remote repo. Not only that, but with the modularize script here, we now are developing the loader using modules, bundling them into a single ES5 compatible script file to put in the `examples/js` directory... and _then_ running `modularize.js` on that to get back an ES6 module! Pretty crazy 😅 

This is a quick demo of how we can get around that and load [LWOLoader.js](https://github.com/threejs/lwoloader/blob/master/build/js/LWOLoader.js) script directly from the remote repo, without making any major changes to the example file (just a single line changed). 

Note: I'm using raw.githack for this quick demo. A better approach would be to set up github pages for the [github.com/threejs](https://github.com/threejs) org and serve the files from there. 

### [Live](https://raw.githack.com/looeee/three.js/lwoloader-remote-example-test/examples/webgl_loader_lwo.html)