### PR TITLE
Fix skinning precision issue on iOS

### DIFF
--- a/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
@@ -6,7 +6,7 @@ export default /* glsl */`
 
 	#ifdef BONE_TEXTURE
 
-		uniform sampler2D boneTexture;
+		uniform highp sampler2D boneTexture;
 		uniform int boneTextureSize;
 
 		mat4 getBoneMatrix( const in float i ) {


### PR DESCRIPTION
On iOS, by default the bones that are sampled from the bone texture look
like they are using mediump. This can result in noticeable jitter or
other more severe issues depending on the bone transformation matrix.

Fix this by explicitly declaring the sampler as highp.

Here's the motivating video showing the precision issues:
https://twitter.com/zeuxcg/status/1136158107573211136

Curiously, you can see this in official three.js examples, it's just not as extreme -
if you open animation/skinning/blending sample on an iPhone (I've tested this
on iPhone X with latest iOS 12 update), if you look closely, the head of the soldier
jitters during animation. This is the same precision issue, and this change fixes the
problem.

Fixes #13288.