### PR TITLE
Add sizeAttenuation to SpriteMaterial typing.

### DIFF
--- a/src/materials/SpriteMaterial.d.ts
+++ b/src/materials/SpriteMaterial.d.ts
@@ -6,6 +6,7 @@ export interface SpriteMaterialParameters extends MaterialParameters {
 	color?: Color | string | number;
 	map?: Texture;
 	rotation?: number;
+	sizeAttenuation?: boolean;
 }
 
 export class SpriteMaterial extends Material {
@@ -15,6 +16,7 @@ export class SpriteMaterial extends Material {
 	color: Color;
 	map: Texture | null;
 	rotation: number;
+	sizeAttenuation: boolean;
 	isSpriteMaterial: true;
 
 	setValues( parameters: SpriteMaterialParameters ): void;


### PR DESCRIPTION
The underlying `sizeAttenuation` property was added in https://github.com/mrdoob/three.js/pull/14636