### PR TITLE
Add capability to disable shadow maps per light type

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -248,6 +248,15 @@
 		<h3>[property:Boolean shadowMap.enabled]</h3>
 		<p>If set, use shadow maps in the scene. Default is *false*.</p>
 
+		<h3>[property:Boolean shadowMap.pointLightEnabled]</h3>
+		<p>If set and shadow maps are enabled in general, use shadow maps for point lights. Setting this to *false* makes it possible to have a lot of point lights in the scene while still using shadow maps for other types of lights. Default is *true*.</p>
+
+		<h3>[property:Boolean shadowMap.spotLightEnabled]</h3>
+		<p>If set and shadow maps are enabled in general, use shadow maps for spot lights. Setting this to *false* makes it possible to have a lot of spot lights in the scene while still using shadow maps for other types of lights. Default is *true*.</p>
+
+		<h3>[property:Boolean shadowMap.directionalLightEnabled]</h3>
+		<p>If set and shadow maps are enabled in general, use shadow maps for directional lights. Setting this to *false* makes it possible to have a lot of directional lights in the scene while still using shadow maps for other types of lights. Default is *true*.</p>
+
 		<h3>[property:Boolean shadowMap.autoUpdate]</h3>
 		<p>Enables automatic updates to the shadows in the scene. Default is *true*.</p>
 		<p>If you do not require dynamic lighting / shadows, you may set this to *false* when the renderer is instantiated.</p>

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -33,7 +33,7 @@ IncidentLight directLight;
 
 		getPointDirectLightIrradiance( pointLight, geometry, directLight );
 
-		#ifdef USE_SHADOWMAP
+		#if defined(USE_SHADOWMAP) && defined(USE_SHADOWMAP_POINT_LIGHT)
 		directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
 		#endif
 
@@ -54,7 +54,7 @@ IncidentLight directLight;
 
 		getSpotDirectLightIrradiance( spotLight, geometry, directLight );
 
-		#ifdef USE_SHADOWMAP
+		#if defined(USE_SHADOWMAP) && defined(USE_SHADOWMAP_SPOT_LIGHT)
 		directLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
 		#endif
 
@@ -75,7 +75,7 @@ IncidentLight directLight;
 
 		getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
-		#ifdef USE_SHADOWMAP
+		#if defined(USE_SHADOWMAP) && defined(USE_SHADOWMAP_DIR_LIGHT)
 		directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
-	#if NUM_DIR_LIGHTS > 0
+	#if NUM_DIR_LIGHTS > 0 && defined(USE_SHADOWMAP_DIR_LIGHT)
 
 		uniform sampler2D directionalShadowMap[ NUM_DIR_LIGHTS ];
 		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
 
 	#endif
 
-	#if NUM_SPOT_LIGHTS > 0
+	#if NUM_SPOT_LIGHTS > 0 && defined(USE_SHADOWMAP_SPOT_LIGHT)
 
 		uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];
 		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
 
 	#endif
 
-	#if NUM_POINT_LIGHTS > 0
+	#if NUM_POINT_LIGHTS > 0 && defined(USE_SHADOWMAP_POINT_LIGHT)
 
 		uniform sampler2D pointShadowMap[ NUM_POINT_LIGHTS ];
 		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_vertex.glsl.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
-	#if NUM_DIR_LIGHTS > 0
+	#if NUM_DIR_LIGHTS > 0 && defined(USE_SHADOWMAP_DIR_LIGHT)
 
 		uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];
 		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];
 
 	#endif
 
-	#if NUM_SPOT_LIGHTS > 0
+	#if NUM_SPOT_LIGHTS > 0 && defined(USE_SHADOWMAP_SPOT_LIGHT)
 
 		uniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHTS ];
 		varying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];
 
 	#endif
 
-	#if NUM_POINT_LIGHTS > 0
+	#if NUM_POINT_LIGHTS > 0 && defined(USE_SHADOWMAP_POINT_LIGHT)
 
 		uniform mat4 pointShadowMatrix[ NUM_POINT_LIGHTS ];
 		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_SHADOWMAP
 
-	#if NUM_DIR_LIGHTS > 0
+	#if NUM_DIR_LIGHTS > 0 && defined(USE_SHADOWMAP_DIR_LIGHT)
 
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
@@ -12,7 +12,7 @@ export default /* glsl */`
 
 	#endif
 
-	#if NUM_SPOT_LIGHTS > 0
+	#if NUM_SPOT_LIGHTS > 0 && defined(USE_SHADOWMAP_SPOT_LIGHT)
 
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
@@ -23,7 +23,7 @@ export default /* glsl */`
 
 	#endif
 
-	#if NUM_POINT_LIGHTS > 0
+	#if NUM_POINT_LIGHTS > 0 && defined(USE_SHADOWMAP_POINT_LIGHT)
 
 	#pragma unroll_loop
 	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {

--- a/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
@@ -5,7 +5,7 @@ float getShadowMask() {
 
 	#ifdef USE_SHADOWMAP
 
-	#if NUM_DIR_LIGHTS > 0
+	#if NUM_DIR_LIGHTS > 0 && defined(USE_SHADOWMAP_DIR_LIGHT)
 
 	DirectionalLight directionalLight;
 
@@ -19,7 +19,7 @@ float getShadowMask() {
 
 	#endif
 
-	#if NUM_SPOT_LIGHTS > 0
+	#if NUM_SPOT_LIGHTS > 0 && defined(USE_SHADOWMAP_SPOT_LIGHT)
 
 	SpotLight spotLight;
 
@@ -33,7 +33,7 @@ float getShadowMask() {
 
 	#endif
 
-	#if NUM_POINT_LIGHTS > 0
+	#if NUM_POINT_LIGHTS > 0 && defined(USE_SHADOWMAP_POINT_LIGHT)
 
 	PointLight pointLight;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -405,6 +405,9 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			parameters.shadowMapEnabled ? '#define USE_SHADOWMAP' : '',
 			parameters.shadowMapEnabled ? '#define ' + shadowMapTypeDefine : '',
+			parameters.directionalLightShadowMapEnabled ? '#define USE_SHADOWMAP_DIR_LIGHT' : '',
+			parameters.pointLightShadowMapEnabled ? '#define USE_SHADOWMAP_POINT_LIGHT' : '',
+			parameters.spotLightShadowMapEnabled ? '#define USE_SHADOWMAP_SPOT_LIGHT' : '',
 
 			parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
@@ -517,6 +520,9 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			parameters.shadowMapEnabled ? '#define USE_SHADOWMAP' : '',
 			parameters.shadowMapEnabled ? '#define ' + shadowMapTypeDefine : '',
+			parameters.directionalLightShadowMapEnabled ? '#define USE_SHADOWMAP_DIR_LIGHT' : '',
+			parameters.pointLightShadowMapEnabled ? '#define USE_SHADOWMAP_POINT_LIGHT' : '',
+			parameters.spotLightShadowMapEnabled ? '#define USE_SHADOWMAP_SPOT_LIGHT' : '',
 
 			parameters.premultipliedAlpha ? '#define PREMULTIPLIED_ALPHA' : '',
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -36,7 +36,8 @@ function WebGLPrograms( renderer, extensions, capabilities, textures ) {
 		"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 		"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
 		"numDirLights", "numPointLights", "numSpotLights", "numHemiLights", "numRectAreaLights",
-		"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
+		"shadowMapEnabled", "directionalLightShadowMapEnabled", "pointLightShadowMapEnabled", "spotLightShadowMapEnabled",
+		"shadowMapType", "toneMapping", 'physicallyCorrectLights',
 		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering"
 	];
 
@@ -196,6 +197,9 @@ function WebGLPrograms( renderer, extensions, capabilities, textures ) {
 			dithering: material.dithering,
 
 			shadowMapEnabled: renderer.shadowMap.enabled && object.receiveShadow && shadows.length > 0,
+			directionalLightShadowMapEnabled: renderer.shadowMap.directionalLightEnabled,
+			pointLightShadowMapEnabled: renderer.shadowMap.pointLightEnabled,
+			spotLightShadowMapEnabled: renderer.shadowMap.spotLightEnabled,
 			shadowMapType: renderer.shadowMap.type,
 
 			toneMapping: renderer.toneMapping,

--- a/src/renderers/webgl/WebGLShadowMap.d.ts
+++ b/src/renderers/webgl/WebGLShadowMap.d.ts
@@ -13,6 +13,9 @@ export class WebGLShadowMap {
 	);
 
 	enabled: boolean;
+	directionalLightEnabled: boolean;
+	pointLightEnabled: boolean;
+	spotLightEnabled: boolean;
 	autoUpdate: boolean;
 	needsUpdate: boolean;
 	type: ShadowMapType;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -88,6 +88,10 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	this.enabled = false;
 
+	this.directionalLightEnabled = true;
+	this.pointLightEnabled = true;
+	this.spotLightEnabled = true;
+
 	this.autoUpdate = true;
 	this.needsUpdate = false;
 


### PR DESCRIPTION
This will save texture uniform slots in case shadow maps are only used for some types of lights but not others.

Right now this only toggles shadow maps in the shader code, same as WebGLShadowMap.enabled. Shadow map related uniforms are kept in the uniform data structures regardless of the settings. To optimize this further in the future, the uniform uploads could be completely disabled as well in case shadow maps are not in use.

A typical use case would be in a scene that has one primary directional light with shadows enabled and a bunch of smaller local point and spot lights without shadows.