### PR TITLE
sanitize even simplehttpserver

### DIFF
--- a/utils/servers/simplehttpserver.js
+++ b/utils/servers/simplehttpserver.js
@@ -30,7 +30,7 @@ var port = 8000,
 		"mp4": "video/mp4",
 		"txt": "text/plain",
 		"bin": "application/octet-stream"
-  };
+	};
 
 // https://github.com/parshap/node-sanitize-filename/blob/master/index.js#L33-L47
 var illegalRe = /[\?<>:\*\|":]/g;
@@ -39,15 +39,17 @@ var reservedRe = /^\.+$/;
 var windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
 var windowsTrailingRe = /[\. ]+$/;
 
-function sanitize(input) {
-  var sanitized = input
-	.replace(/\//g, "\\")
-	.replace(illegalRe, "")
-	.replace(controlRe, "")
-	.replace(reservedRe, "")
-	.replace(windowsReservedRe, "")
-	.replace(windowsTrailingRe, "");
-  return sanitized;
+function sanitize( input ) {
+
+	var sanitized = input
+		.replace( /\//g, "\\" )
+		.replace( illegalRe, "" )
+		.replace( controlRe, "" )
+		.replace( reservedRe, "" )
+		.replace( windowsReservedRe, "" )
+		.replace( windowsTrailingRe, "" );
+	return sanitized;
+
 }
 
 
@@ -56,8 +58,8 @@ port = process.argv[ 2 ] ? parseInt( process.argv[ 2 ], 0 ) : port;
 
 function handleRequest( request, response ) {
 
-  var urlObject = urlParser.parse( request.url, true );
-  var pathname = decodeURIComponent( sanitize( urlObject.pathname ) );
+	var urlObject = urlParser.parse( request.url, true );
+	var pathname = decodeURIComponent( sanitize( urlObject.pathname ) );
 
 	console.log( '[' + ( new Date() ).toUTCString() + '] ' + '"' + request.method + ' ' + pathname + '"' );
 
@@ -119,7 +121,7 @@ function handleRequest( request, response ) {
 				files.forEach( function ( item ) {
 
 				  var urlpath = path.join( pathname, item ),
-					itemStats = fs.statSync( path.join( currentDir, urlpath ) );
+						itemStats = fs.statSync( path.join( currentDir, urlpath ) );
 
 					if ( itemStats.isDirectory() ) {
 
@@ -144,7 +146,7 @@ function handleRequest( request, response ) {
 
 http.createServer( handleRequest ).listen( port );
 
-require( 'dns' ).lookup( require( 'os' ).hostname(), function ( err, addr, fam ) {
+require( 'dns' ).lookup( require( 'os' ).hostname(), function ( err, addr ) {
 
  	console.log( 'Running at http://' + addr + ( ( port === 80 ) ? '' : ':' ) + port + '/' );
 


### PR DESCRIPTION
Make sure the HTTP server can't leave the three.js repository. It also removes an [lgtm](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/323908cdfce6498aa4aba9148cd47b0a18a38ebd/files/utils/servers/simplehttpserver.js?sort=name&dir=ASC&mode=heatmap#x9821b40c78494e77:1) error.

It protects the users of simplehttpserver to not accidentally leave their complete filesystem open and also not require any extra actions.