### PR TITLE
LWOLoader: Make sure GLOS blockID is correctly processed.

### DIFF
--- a/examples/js/loaders/LWOLoader.js
+++ b/examples/js/loaders/LWOLoader.js
@@ -545,7 +545,6 @@ LWO3Parser.prototype = {
 			case 'FLAG':
 
 			case 'TRNL':
-			case 'GLOS':
 			case 'SHRP':
 			case 'RFOP':
 			case 'RSAN':

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -574,7 +574,6 @@ LWO3Parser.prototype = {
 			case 'FLAG':
 
 			case 'TRNL':
-			case 'GLOS':
 			case 'SHRP':
 			case 'RFOP':
 			case 'RSAN':


### PR DESCRIPTION
The GLOS BlockID has code to be processed on [Line 739](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/LWOLoader.js#L739) but gets skipped due to [Line 548](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/LWOLoader.js#L548). This also solves [LGTM Error](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/323908cdfce6498aa4aba9148cd47b0a18a38ebd/files/examples/jsm/loaders/LWOLoader.js?sort=name&dir=ASC&mode=heatmap#x52b46a961f438bf0:2).
