### PR TITLE
cleanup LDrawLoader

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1045,8 +1045,6 @@ THREE.LDrawLoader = ( function () {
 			var mainColourCode = parentParseScope.mainColourCode;
 			var mainEdgeColourCode = parentParseScope.mainEdgeColourCode;
 
-			var url = parentParseScope.url;
-
 			var currentParseScope = this.getCurrentParseScope();
 
 			// Parse result variables
@@ -1356,7 +1354,7 @@ THREE.LDrawLoader = ( function () {
 							0, 0, 0, 1
 						);
 
-						var fileName = lp.getRemainingString().trim().replace( "\\", "/" );
+						var fileName = lp.getRemainingString().trim().replace( /\\/g, "/" );
 
 						if ( scope.fileMap[ fileName ] ) {
 


### PR DESCRIPTION
This cleans LDrawLoader from some [LGTM errors](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/323908cdfce6498aa4aba9148cd47b0a18a38ebd/files/examples/js/loaders/LDrawLoader.js?sort=name&dir=ASC&mode=heatmap). I did not remove [this LGTM error](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/323908cdfce6498aa4aba9148cd47b0a18a38ebd/files/examples/js/loaders/LDrawLoader.js?sort=name&dir=ASC&mode=heatmap#L1185) because it can be changed inside of the loop although the code could be less spaghetti code.