### PR TITLE
HDRCubeTextureLoader: add setType() method

### DIFF
--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -6,101 +6,60 @@
 THREE.HDRCubeTextureLoader = function ( manager ) {
 
 	this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
-	// override in sub classes
 	this.hdrLoader = new THREE.RGBELoader();
+	this.type = THREE.UnsignedByteType;
 
 };
 
-THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onProgress, onError ) {
+THREE.HDRCubeTextureLoader.prototype.load = function ( urls, onLoad, onProgress, onError ) {
 
-	var RGBEByteToRGBFloat = function ( sourceArray, sourceOffset, destArray, destOffset ) {
+	if ( ! Array.isArray( urls ) ) {
 
-		var e = sourceArray[ sourceOffset + 3 ];
-		var scale = Math.pow( 2.0, e - 128.0 ) / 255.0;
+		console.warn( 'THREE.HDRCubeTextureLoader signature has changed. Use .setType() instead.' );
 
-		destArray[ destOffset + 0 ] = sourceArray[ sourceOffset + 0 ] * scale;
-		destArray[ destOffset + 1 ] = sourceArray[ sourceOffset + 1 ] * scale;
-		destArray[ destOffset + 2 ] = sourceArray[ sourceOffset + 2 ] * scale;
+		this.setType( urls );
 
-	};
+		urls = onLoad;
+		onLoad = onProgress;
+		onProgress = onError;
+		onError = arguments[ 4 ];
 
-	var RGBEByteToRGBHalf = ( function () {
-
-		// Source: http://gamedev.stackexchange.com/questions/17326/conversion-of-a-number-from-single-precision-floating-point-representation-to-a/17410#17410
-
-		var floatView = new Float32Array( 1 );
-		var int32View = new Int32Array( floatView.buffer );
-
-		/* This method is faster than the OpenEXR implementation (very often
-		 * used, eg. in Ogre), with the additional benefit of rounding, inspired
-		 * by James Tursa?s half-precision code. */
-		function toHalf( val ) {
-
-			floatView[ 0 ] = val;
-			var x = int32View[ 0 ];
-
-			var bits = ( x >> 16 ) & 0x8000; /* Get the sign */
-			var m = ( x >> 12 ) & 0x07ff; /* Keep one extra bit for rounding */
-			var e = ( x >> 23 ) & 0xff; /* Using int is faster here */
-
-			/* If zero, or denormal, or exponent underflows too much for a denormal
-			 * half, return signed zero. */
-			if ( e < 103 ) return bits;
-
-			/* If NaN, return NaN. If Inf or exponent overflow, return Inf. */
-			if ( e > 142 ) {
-
-				bits |= 0x7c00;
-				/* If exponent was 0xff and one mantissa bit was set, it means NaN,
-						 * not Inf, so make sure we set one mantissa bit too. */
-				bits |= ( ( e == 255 ) ? 0 : 1 ) && ( x & 0x007fffff );
-				return bits;
-
-			}
-
-			/* If exponent underflows but not too much, return a denormal */
-			if ( e < 113 ) {
-
-				m |= 0x0800;
-				/* Extra rounding may overflow and set mantissa to 0 and exponent
-				 * to 1, which is OK. */
-				bits |= ( m >> ( 114 - e ) ) + ( ( m >> ( 113 - e ) ) & 1 );
-				return bits;
-
-			}
-
-			bits |= ( ( e - 112 ) << 10 ) | ( m >> 1 );
-			/* Extra rounding. An overflow will set mantissa to 0 and increment
-			 * the exponent, which is OK. */
-			bits += m & 1;
-			return bits;
-
-		}
-
-		return function ( sourceArray, sourceOffset, destArray, destOffset ) {
-
-			var e = sourceArray[ sourceOffset + 3 ];
-			var scale = Math.pow( 2.0, e - 128.0 ) / 255.0;
-
-			destArray[ destOffset + 0 ] = toHalf( sourceArray[ sourceOffset + 0 ] * scale );
-			destArray[ destOffset + 1 ] = toHalf( sourceArray[ sourceOffset + 1 ] * scale );
-			destArray[ destOffset + 2 ] = toHalf( sourceArray[ sourceOffset + 2 ] * scale );
-
-		};
-
-	} )();
-
-	//
+	}
 
 	var texture = new THREE.CubeTexture();
 
-	texture.type = type;
-	texture.encoding = ( type === THREE.UnsignedByteType ) ? THREE.RGBEEncoding : THREE.LinearEncoding;
-	texture.format = ( type === THREE.UnsignedByteType ) ? THREE.RGBAFormat : THREE.RGBFormat;
-	texture.minFilter = ( texture.encoding === THREE.RGBEEncoding ) ? THREE.NearestFilter : THREE.LinearFilter;
-	texture.magFilter = ( texture.encoding === THREE.RGBEEncoding ) ? THREE.NearestFilter : THREE.LinearFilter;
-	texture.generateMipmaps = ( texture.encoding !== THREE.RGBEEncoding );
-	texture.anisotropy = 0;
+	texture.type = this.type;
+
+	switch ( texture.type ) {
+
+		case THREE.UnsignedByteType:
+
+			texture.encoding = THREE.RGBEEncoding;
+			texture.format = THREE.RGBAFormat;
+			texture.minFilter = THREE.NearestFilter;
+			texture.magFilter = THREE.NearestFilter;
+			texture.generateMipmaps = false;
+			break;
+
+		case THREE.FloatType:
+
+			texture.encoding = THREE.LinearEncoding;
+			texture.format = THREE.RGBFormat;
+			texture.minFilter = THREE.LinearFilter;
+			texture.magFilter = THREE.LinearFilter;
+			texture.generateMipmaps = false;
+			break;
+
+		case THREE.HalfFloatType:
+
+			texture.encoding = THREE.LinearEncoding;
+			texture.format = THREE.RGBFormat;
+			texture.minFilter = THREE.LinearFilter;
+			texture.magFilter = THREE.LinearFilter;
+			texture.generateMipmaps = false;
+			break;
+
+	}
 
 	var scope = this;
 
@@ -108,71 +67,40 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onPro
 
 	function loadHDRData( i, onLoad, onProgress, onError ) {
 
-		var loader = new THREE.FileLoader( scope.manager );
-		loader.setPath( scope.path );
-		loader.setResponseType( 'arraybuffer' );
-		loader.load( urls[ i ], function ( buffer ) {
+		new THREE.FileLoader( scope.manager )
+			.setPath( scope.path )
+			.setResponseType( 'arraybuffer' )
+			.load( urls[ i ], function ( buffer ) {
 
-			loaded ++;
+				loaded ++;
 
-			var texData = scope.hdrLoader._parser( buffer );
+				var texData = scope.hdrLoader._parser( buffer );
 
-			if ( ! texData ) return;
+				if ( ! texData ) return;
 
-			if ( type === THREE.FloatType ) {
+				if ( texData.data !== undefined ) {
 
-				var numElements = ( texData.data.length / 4 ) * 3;
-				var floatdata = new Float32Array( numElements );
+					var dataTexture = new THREE.DataTexture( texData.data, texData.width, texData.height );
 
-				for ( var j = 0; j < numElements; j ++ ) {
+					dataTexture.type = texture.type;
+					dataTexture.encoding = texture.encoding;
+					dataTexture.format = texture.format;
+					dataTexture.minFilter = texture.minFilter;
+					dataTexture.magFilter = texture.magFilter;
+					dataTexture.generateMipmaps = texture.generateMipmaps;
 
-					RGBEByteToRGBFloat( texData.data, j * 4, floatdata, j * 3 );
-
-				}
-
-				texData.data = floatdata;
-
-			} else if ( type === THREE.HalfFloatType ) {
-
-				var numElements = ( texData.data.length / 4 ) * 3;
-				var halfdata = new Uint16Array( numElements );
-
-				for ( var j = 0; j < numElements; j ++ ) {
-
-					RGBEByteToRGBHalf( texData.data, j * 4, halfdata, j * 3 );
+					texture.images[ i ] = dataTexture;
 
 				}
 
-				texData.data = halfdata;
+				if ( loaded === 6 ) {
 
-			}
+					texture.needsUpdate = true;
+					if ( onLoad ) onLoad( texture );
 
-			if ( texData.image !== undefined ) {
+				}
 
-				texture[ i ].images = texData.image;
-
-			} else if ( texData.data !== undefined ) {
-
-				var dataTexture = new THREE.DataTexture( texData.data, texData.width, texData.height );
-				dataTexture.format = texture.format;
-				dataTexture.type = texture.type;
-				dataTexture.encoding = texture.encoding;
-				dataTexture.minFilter = texture.minFilter;
-				dataTexture.magFilter = texture.magFilter;
-				dataTexture.generateMipmaps = texture.generateMipmaps;
-
-				texture.images[ i ] = dataTexture;
-
-			}
-
-			if ( loaded === 6 ) {
-
-				texture.needsUpdate = true;
-				if ( onLoad ) onLoad( texture );
-
-			}
-
-		}, onProgress, onError );
+			}, onProgress, onError );
 
 	}
 
@@ -189,6 +117,14 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( type, urls, onLoad, onPro
 THREE.HDRCubeTextureLoader.prototype.setPath = function ( value ) {
 
 	this.path = value;
+	return this;
+
+};
+
+THREE.HDRCubeTextureLoader.prototype.setType = function ( value ) {
+
+	this.type = value;
+	this.hdrLoader.setType( value );
 	return this;
 
 };

--- a/examples/js/loaders/sea3d/SEA3DLoader.js
+++ b/examples/js/loaders/sea3d/SEA3DLoader.js
@@ -2470,7 +2470,9 @@ THREE.SEA3D.prototype.readCubeMapURL = function ( sea ) {
 
 		this.file.resume = ! usePMREM;
 
-		texture = new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, faces, function ( texture ) {
+		texture = new THREE.HDRCubeTextureLoader()
+			.setType( THREE.UnsignedByteType )
+			.load( faces, function ( texture ) {
 
 			if ( usePMREM ) {
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -88,9 +88,11 @@
 				scene.add( planeMesh );
 
 				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
+
 				hdrCubeMap = new THREE.HDRCubeTextureLoader()
 					.setPath( './textures/cube/pisaHDR/' )
-					.load( THREE.UnsignedByteType, hdrUrls, function () {
+					.setType( THREE.UnsignedByteType )
+					.load( hdrUrls, function () {
 
 						var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 						pmremGenerator.update( renderer );
@@ -113,7 +115,7 @@
 					.setPath( './textures/cube/pisa/' )
 					.load( ldrUrls, function () {
 
-						ldrCubeMap.encoding = THREE.GammaEncoding;
+						ldrCubeMap.encoding = THREE.sRGBEncoding;
 
 						var pmremGenerator = new THREE.PMREMGenerator( ldrCubeMap );
 						pmremGenerator.update( renderer );
@@ -158,7 +160,6 @@
 				container.appendChild( renderer.domElement );
 
 				//renderer.toneMapping = THREE.ReinhardToneMapping;
-				renderer.gammaInput = true; // ???
 				renderer.gammaOutput = true;
 
 				stats = new Stats();

--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -141,7 +141,10 @@
 	};
 
 				var hdrUrls = genCubeUrls( "./textures/cube/pisaHDR/", ".hdr" );
-				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
+
+				new THREE.HDRCubeTextureLoader()
+					.setType( THREE.UnsignedByteType )
+					.load( hdrUrls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );
@@ -187,7 +190,6 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 
 				stats = new Stats();

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -70,7 +70,9 @@
 				var hdrUrls = genCubeUrls( './textures/cube/pisaHDR/', '.hdr' );
 				var hdrCubeRenderTarget = null;
 
-				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
+				new THREE.HDRCubeTextureLoader()
+					.setType( THREE.UnsignedByteType )
+					.load( hdrUrls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );
@@ -185,7 +187,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 				renderer.toneMapping = THREE.Uncharted2ToneMapping;
 				renderer.toneMappingExposure = 0.75;

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -75,7 +75,9 @@
 				imgTexture.anisotropy = 16;
 				imgTexture = null;
 
-				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrUrls, function ( hdrCubeMap ) {
+				new THREE.HDRCubeTextureLoader()
+					.setType( THREE.UnsignedByteType )
+					.load( hdrUrls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );
@@ -190,7 +192,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.gammaInput = true;
 				renderer.gammaOutput = true;
 				renderer.toneMapping = THREE.Uncharted2ToneMapping;
 				renderer.toneMappingExposure = 0.75;

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -145,13 +145,15 @@
 				// Materials
 				var hdrpath = "textures/cube/pisaHDR/";
 				var hdrformat = '.hdr';
-				var hdrurls = [
+				var hdrUrls = [
 					hdrpath + 'px' + hdrformat, hdrpath + 'nx' + hdrformat,
 					hdrpath + 'py' + hdrformat, hdrpath + 'ny' + hdrformat,
 					hdrpath + 'pz' + hdrformat, hdrpath + 'nz' + hdrformat
 				];
 
-				new THREE.HDRCubeTextureLoader().load( THREE.UnsignedByteType, hdrurls, function ( hdrCubeMap ) {
+				new THREE.HDRCubeTextureLoader()
+					.setType( THREE.UnsignedByteType )
+					.load( hdrUrls, function ( hdrCubeMap ) {
 
 					var pmremGenerator = new THREE.PMREMGenerator( hdrCubeMap );
 					pmremGenerator.update( renderer );


### PR DESCRIPTION
With this change, the signature of of the `load()` method now is consistent with that of the other texture loaders.

```js
new THREE.HDRCubeTextureLoader()
	.setType( THREE.UnsignedByteType )
	.load( hdrUrls, function ( hdrCubeMap ) { ...
```

Also, `HDRCubeTextureLoader` now leverages the decoding capabilities of `RGBELoader`. `UnsignedByteType`, `FloatType`, and `HalfFloatType` are supported.

The examples are updated to accommodate the API change.

