### PR TITLE
remove redundant parameter from WebGLProgram(s)

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -288,7 +288,7 @@ function WebGLRenderer( parameters ) {
 		geometries = new WebGLGeometries( _gl, attributes, info );
 		objects = new WebGLObjects( geometries, info );
 		morphtargets = new WebGLMorphtargets( _gl );
-		programCache = new WebGLPrograms( _this, extensions, capabilities, textures );
+		programCache = new WebGLPrograms( _this, extensions, capabilities );
 		renderLists = new WebGLRenderLists();
 		renderStates = new WebGLRenderStates();
 

--- a/src/renderers/webgl/WebGLProgram.d.ts
+++ b/src/renderers/webgl/WebGLProgram.d.ts
@@ -3,7 +3,6 @@ import { ShaderMaterial } from './../../materials/ShaderMaterial';
 import { WebGLShader } from './WebGLShader';
 import { WebGLCapabilities } from './WebGLCapabilities';
 import { WebGLExtensions } from './WebGLExtensions';
-import { WebGLTextures } from './WebGLTextures';
 import { WebGLUniforms } from './WebGLUniforms';
 
 export class WebGLProgram {
@@ -15,8 +14,7 @@ export class WebGLProgram {
 		material: ShaderMaterial,
 		shader: WebGLShader,
 		parameters: WebGLRendererParameters,
-		capabilities: WebGLCapabilities,
-		textures: WebGLTextures
+		capabilities: WebGLCapabilities
 	);
 
 	id: number;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -236,7 +236,7 @@ function unrollLoops( string ) {
 
 }
 
-function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities, textures ) {
+function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities ) {
 
 	var gl = renderer.context;
 
@@ -705,7 +705,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 		if ( cachedUniforms === undefined ) {
 
-			cachedUniforms = new WebGLUniforms( gl, program, textures );
+			cachedUniforms = new WebGLUniforms( gl, program );
 
 		}
 

--- a/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/src/renderers/webgl/WebGLPrograms.d.ts
@@ -2,12 +2,11 @@ import { WebGLRenderer } from './../WebGLRenderer';
 import { WebGLProgram } from './WebGLProgram';
 import { WebGLCapabilities } from './WebGLCapabilities';
 import { WebGLExtensions } from './WebGLExtensions';
-import { WebGLTextures } from './WebGLTextures';
 import { ShaderMaterial } from './../../materials/ShaderMaterial';
 
 export class WebGLPrograms {
 
-	constructor( renderer: WebGLRenderer, extensions: WebGLExtensions, capabilities: WebGLCapabilities, textures: WebGLTextures );
+	constructor( renderer: WebGLRenderer, extensions: WebGLExtensions, capabilities: WebGLCapabilities );
 
 	programs: WebGLProgram[];
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -5,7 +5,7 @@
 import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping, GammaEncoding, LinearEncoding, ObjectSpaceNormalMap } from '../../constants.js';
 import { WebGLProgram } from './WebGLProgram.js';
 
-function WebGLPrograms( renderer, extensions, capabilities, textures ) {
+function WebGLPrograms( renderer, extensions, capabilities ) {
 
 	var programs = [];
 
@@ -279,7 +279,7 @@ function WebGLPrograms( renderer, extensions, capabilities, textures ) {
 
 		if ( program === undefined ) {
 
-			program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities, textures );
+			program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities );
 			programs.push( program );
 
 		}


### PR DESCRIPTION
remove unused 'texture' parameter from call to WebGLUniforms and calling path.
(noted by LGTM)