### PR TITLE
JSM: Added ColladaExporter to modularize.js

### DIFF
--- a/examples/js/exporters/ColladaExporter.js
+++ b/examples/js/exporters/ColladaExporter.js
@@ -17,7 +17,9 @@ THREE.ColladaExporter.prototype = {
 
 	constructor: THREE.ColladaExporter,
 
-	parse: function ( object, onDone, options = {} ) {
+	parse: function ( object, onDone, options ) {
+
+		options = options || {};
 
 		options = Object.assign( {
 			version: '1.4.1',
@@ -377,7 +379,7 @@ THREE.ColladaExporter.prototype = {
 				var reflectivity = m.reflectivity || 0;
 
 				// Do not export and alpha map for the reasons mentioned in issue (#13792)
-				// in THREE.js alpha maps are black and white, but collada expects the alpha
+				// in three.js alpha maps are black and white, but collada expects the alpha
 				// channel to specify the transparency
 				var transparencyNode = '';
 				if ( m.transparent === true ) {
@@ -586,7 +588,7 @@ THREE.ColladaExporter.prototype = {
 			'<asset>' +
 			(
 				'<contributor>' +
-				'<authoring_tool>THREE.js Collada Exporter</authoring_tool>' +
+				'<authoring_tool>three.js Collada Exporter</authoring_tool>' +
 				( options.author !== null ? `<author>${ options.author }</author>` : '' ) +
 				'</contributor>' +
 				`<created>${ ( new Date() ).toISOString() }</created>` +

--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -28,7 +28,9 @@ ColladaExporter.prototype = {
 
 	constructor: ColladaExporter,
 
-	parse: function ( object, onDone, options = {} ) {
+	parse: function ( object, onDone, options ) {
+
+		options = options || {};
 
 		options = Object.assign( {
 			version: '1.4.1',
@@ -388,7 +390,7 @@ ColladaExporter.prototype = {
 				var reflectivity = m.reflectivity || 0;
 
 				// Do not export and alpha map for the reasons mentioned in issue (#13792)
-				// in THREE.js alpha maps are black and white, but collada expects the alpha
+				// in three.js alpha maps are black and white, but collada expects the alpha
 				// channel to specify the transparency
 				var transparencyNode = '';
 				if ( m.transparent === true ) {
@@ -536,6 +538,7 @@ ColladaExporter.prototype = {
 				// the materials.
 				var mat = o.material || new MeshBasicMaterial();
 				var materials = Array.isArray( mat ) ? mat : [ mat ];
+
 				if ( geometry.groups.length > materials.length ) {
 
 					matidsArray = new Array( geometry.groups.length );
@@ -596,7 +599,7 @@ ColladaExporter.prototype = {
 			'<asset>' +
 			(
 				'<contributor>' +
-				'<authoring_tool>THREE.js Collada Exporter</authoring_tool>' +
+				'<authoring_tool>three.js Collada Exporter</authoring_tool>' +
 				( options.author !== null ? `<author>${ options.author }</author>` : '' ) +
 				'</contributor>' +
 				`<created>${ ( new Date() ).toISOString() }</created>` +

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -40,6 +40,7 @@ var files = [
 	{ path: 'effects/PeppersGhostEffect.js', dependencies: [], ignoreList: [] },
 	{ path: 'effects/StereoEffect.js', dependencies: [], ignoreList: [] },
 
+	{ path: 'exporters/ColladaExporter.js', dependencies: [], ignoreList: [] },
 	{ path: 'exporters/GLTFExporter.js', dependencies: [], ignoreList: [ 'AnimationClip', 'Camera', 'Geometry', 'Material', 'Mesh', 'Object3D', 'RGBFormat', 'Scenes', 'ShaderMaterial', 'VertexColors' ] },
 	{ path: 'exporters/MMDExporter.js', dependencies: [], ignoreList: [] },
 	{ path: 'exporters/OBJExporter.js', dependencies: [], ignoreList: [] },


### PR DESCRIPTION
This PR ensures `ColladaExporter` is actually generated via `modularize.js`.