### PR TITLE
GLTFLoader: Assign `extras` from the top-level of glTF definition to `userData` of the result object

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1578,6 +1578,8 @@ THREE.GLTFLoader = ( function () {
 
 			addUnknownExtensionsToUserData( extensions, result, json );
 
+			assignExtrasToUserData( result, json );
+
 			onLoad( result );
 
 		} ).catch( onError );


### PR DESCRIPTION
Hello,

GLTFLoader doesn't assign `extras` from the top-level glTF definition to `userData` of the result object.

According to the glTF 2.0 specification, `extras` is one of the properties of the root object for a glTF asset.

See: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-gltf

**Three.js version**
- [x] dev