### PR TITLE
Make Euler.onChange() and Quaternion.onChange() private

### DIFF
--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -58,29 +58,21 @@
 			to the <em>local</em> coordinate system. That is, for order 'XYZ', the rotation is first around the local-X
 			axis (which is the same as the world-X axis), then around local-Y (which may now be different from the
 			world Y-axis), then local-Z (which may be different from the world Z-axis).<br /><br />
-
-			If the order is changed, [page:.onChangeCallback onChangeCallback] will be called.
 		</p>
 
 		<h3>[property:Float x]</h3>
 		<p>
 			The current value of the x component.<br /><br />
-
-			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
 		</p>
 
 		<h3>[property:Float y]</h3>
 		<p>
 			The current value of the y component.<br /><br />
-
-			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
 		</p>
 
 		<h3>[property:Float z]</h3>
 		<p>
 			The current value of the z component.<br /><br />
-
-			If this is changed, [page:.onChangeCallback onChangeCallback] will be called.
 		</p>
 
 		<h2>Methods</h2>
@@ -104,18 +96,6 @@
 		Optionally assigns this euler's [page:.order order] to array[3].
 		</p>
 
-		<h3>[method:Euler onChange]( [param:Function onChangeCallback] )</h3>
-		<p>
-			[page:Function onChangeCallback] - set the value of the onChangeCallback() function.
-		</p>
-
-		<h3>[method:Euler onChangeCallback](  )</h3>
-		<p>
-			By default this is an empty function, however it can be set via [page:.onChange onChange]().<br />
-			It gets called after changing the [page:.x x], [page:.y y], [page:.z z] or [page:.order order] properties,
-			and also after calling most setter functions (see those for details).
-		</p>
-
 		<h3>[method:Euler reorder]( [param:String newOrder] )</h3>
 		<p>
 		Resets the euler angle with a new order by creating a quaternion from this euler angle
@@ -131,27 +111,23 @@
 			[page:.z z] - the angle of the z axis in radians.<br />
 			[page:.order order] - (optional) a string representing the order that the rotations are applied.<br /><br />
 
-			Sets the angles of this euler transform and optionally the [page:.order order] and then call [page:.onChangeCallback onChangeCallback]().
+			Sets the angles of this euler transform and optionally the [page:.order order].
 		</p>
 
-		<h3>[method:Euler setFromRotationMatrix]( [param:Matrix4 m], [param:String order], [param:Boolean update] )</h3>
+		<h3>[method:Euler setFromRotationMatrix]( [param:Matrix4 m], [param:String order] )</h3>
 		<p>
 		[page:Matrix4 m] - a [page:Matrix4] of which the upper 3x3 of matrix is a pure
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix rotation matrix] (i.e. unscaled).<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br />
-		[page:Boolean update] - (optional) whether to call [page:.onChangeCallback onChangeCallback]() after applying
-		the matrix.<br /><br />
 
 		Sets the angles of this euler transform from a pure rotation matrix based on the orientation
 		specified by order.
 		</p>
 
-		<h3>[method:Euler setFromQuaternion]( [param:Quaternion q], [param:String order], [param:Boolean update] )</h3>
+		<h3>[method:Euler setFromQuaternion]( [param:Quaternion q], [param:String order] )</h3>
 		<p>
 		[page:Quaternion q] - a normalized quaternion.<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br />
-		[page:Boolean update] - (optional) whether to call [page:.onChangeCallback onChangeCallback]() after applying
-		the matrix.<br /><br />
 
 		Sets the angles of this euler transform from a normalized quaternion based on the orientation
 		specified by [page:.order order].
@@ -163,8 +139,7 @@
 		[page:Vector3 vector] - [page:Vector3].<br />
 		[page:.order order] - (optional) a string representing the order that the rotations are applied.<br /><br />
 
-		Set the [page:.x x], [page:.y y] and [page:.z z], and optionally update the [page:.order order]. [page:.onChangeCallback onChangeCallback]()
-		is called after these changes are made.
+		Set the [page:.x x], [page:.y y] and [page:.z z], and optionally update the [page:.order order].
 		</p>
 
 

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -52,16 +52,12 @@
 		</p>
 
 		<h3>[property:Float x]</h3>
-		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float y]</h3>
-		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float z]</h3>
-		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 		<h3>[property:Float w]</h3>
-		<p>Changing this property will result in [page:.onChangeCallback onChangeCallback] being called.</p>
 
 
 		<h2>Methods</h2>
@@ -145,32 +141,6 @@
 		Sets this quaternion to [page:Quaternion a] x [page:Quaternion b].<br />
 		Adapted from the method outlined [link:http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm here].
 		</p>
-
-		<h3>[method:Quaternion onChange]( [param:Function onChangeCallback] )</h3>
-		<p>Sets the [page:.onChangeCallback onChangeCallback]() method.</p>
-
-		<h3>[method:Quaternion onChangeCallback]( )</h3>
-		<p>
-			This function is called whenever any of the following occurs:
-			<ul>
-				<li>
-					The [page:.x x], [page:.y y], [page:.z z] or
-				  [page:.w w] properties are changed.
-				</li>
-				<li>
-					The [page:.set set](), [page:.copy copy](), [page:.clone clone](),
-					[page:.setFromAxisAngle setFromAxisAngle](),  [page:.setFromRotationMatrix setFromRotationMatrix](),
-					[page:.conjugate conjugate](), [page:.normalize normalize](),
-					[page:.multiplyQuaternions multiplyQuaternions](), [page:.slerp slerp]() or [page:.fromArray fromArray]()
-					functions are called.
-				</li>
-				<li>
-					[page:.setFromEuler setFromEuler]() function is called with its *update* argument not set to false.
-				</li>
-			</ul>
-			By default it is the empty function, however you can change it if needed using [page:.onChange onChange]( [page:Function onChangeCallback] ).
-		</p>
-
 
 		<h3>[method:Quaternion premultiply]( [param:Quaternion q] )</h3>
 		<p>Pre-multiplies this quaternion by [page:Quaternion q].</p>

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -105,7 +105,7 @@
 					scale.y = Math.random() * 200 + 100;
 					scale.z = Math.random() * 200 + 100;
 
-					quaternion.setFromEuler( rotation, false );
+					quaternion.setFromEuler( rotation );
 					matrix.compose( position, quaternion, scale );
 
 					geometry.applyMatrix( matrix );

--- a/examples/webgl_interactive_instances_gpu.html
+++ b/examples/webgl_interactive_instances_gpu.html
@@ -451,7 +451,7 @@
 				rotation.y = Math.random() * 2 * Math.PI;
 				rotation.z = Math.random() * 2 * Math.PI;
 
-				quaternion.setFromEuler( rotation, false );
+				quaternion.setFromEuler( rotation );
 
 				scale.x = scale.y = scale.z = Math.random() * 1;
 

--- a/examples/webgl_postprocessing_crossfade.html
+++ b/examples/webgl_postprocessing_crossfade.html
@@ -143,7 +143,7 @@
 					rotation.x = Math.random() * 2 * Math.PI;
 					rotation.y = Math.random() * 2 * Math.PI;
 					rotation.z = Math.random() * 2 * Math.PI;
-					quaternion.setFromEuler( rotation, false );
+					quaternion.setFromEuler( rotation );
 
 					scale.x = Math.random() * 200 + 100;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -49,8 +49,8 @@ function Object3D() {
 
 	}
 
-	rotation.onChange( onRotationChange );
-	quaternion.onChange( onQuaternionChange );
+	rotation._onChange( onRotationChange );
+	quaternion._onChange( onQuaternionChange );
 
 	Object.defineProperties( this, {
 		position: {

--- a/src/math/Euler.d.ts
+++ b/src/math/Euler.d.ts
@@ -160,7 +160,7 @@ export class Euler {
 	y: number;
 	z: number;
 	order: string;
-	onChangeCallback: Function;
+	_onChangeCallback: Function;
 
 	set( x: number, y: number, z: number, order?: string ): Euler;
 	clone(): this;
@@ -173,7 +173,7 @@ export class Euler {
 	fromArray( xyzo: any[] ): Euler;
 	toArray( array?: number[], offset?: number ): number[];
 	toVector3( optionalResult?: Vector3 ): Vector3;
-	onChange( callback: Function ): this;
+	_onChange( callback: Function ): this;
 
 	static RotationOrders: string[];
 	static DefaultOrder: string;

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -35,7 +35,7 @@ Object.defineProperties( Euler.prototype, {
 		set: function ( value ) {
 
 			this._x = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -52,7 +52,7 @@ Object.defineProperties( Euler.prototype, {
 		set: function ( value ) {
 
 			this._y = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -69,7 +69,7 @@ Object.defineProperties( Euler.prototype, {
 		set: function ( value ) {
 
 			this._z = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -86,7 +86,7 @@ Object.defineProperties( Euler.prototype, {
 		set: function ( value ) {
 
 			this._order = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -105,7 +105,7 @@ Object.assign( Euler.prototype, {
 		this._z = z;
 		this._order = order || this._order;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -124,7 +124,7 @@ Object.assign( Euler.prototype, {
 		this._z = euler._z;
 		this._order = euler._order;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -247,7 +247,7 @@ Object.assign( Euler.prototype, {
 
 		this._order = order;
 
-		if ( update !== false ) this.onChangeCallback();
+		if ( update !== false ) this._onChangeCallback();
 
 		return this;
 
@@ -302,7 +302,7 @@ Object.assign( Euler.prototype, {
 		this._z = array[ 2 ];
 		if ( array[ 3 ] !== undefined ) this._order = array[ 3 ];
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -336,15 +336,15 @@ Object.assign( Euler.prototype, {
 
 	},
 
-	onChange: function ( callback ) {
+	_onChange: function ( callback ) {
 
-		this.onChangeCallback = callback;
+		this._onChangeCallback = callback;
 
 		return this;
 
 	},
 
-	onChangeCallback: function () {}
+	_onChangeCallback: function () {}
 
 } );
 

--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -100,8 +100,8 @@ export class Quaternion {
 	fromArray( xyzw: number[], offset?: number ): Quaternion;
 	toArray( xyzw?: number[], offset?: number ): number[];
 
-	onChange( callback: Function ): Quaternion;
-	onChangeCallback: Function;
+	_onChange( callback: Function ): Quaternion;
+	_onChangeCallback: Function;
 
 	/**
 	 * Adapted from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/.

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -101,7 +101,7 @@ Object.defineProperties( Quaternion.prototype, {
 		set: function ( value ) {
 
 			this._x = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -118,7 +118,7 @@ Object.defineProperties( Quaternion.prototype, {
 		set: function ( value ) {
 
 			this._y = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -135,7 +135,7 @@ Object.defineProperties( Quaternion.prototype, {
 		set: function ( value ) {
 
 			this._z = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -152,7 +152,7 @@ Object.defineProperties( Quaternion.prototype, {
 		set: function ( value ) {
 
 			this._w = value;
-			this.onChangeCallback();
+			this._onChangeCallback();
 
 		}
 
@@ -171,7 +171,7 @@ Object.assign( Quaternion.prototype, {
 		this._z = z;
 		this._w = w;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -190,7 +190,7 @@ Object.assign( Quaternion.prototype, {
 		this._z = quaternion.z;
 		this._w = quaternion.w;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -265,7 +265,7 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
-		if ( update !== false ) this.onChangeCallback();
+		if ( update !== false ) this._onChangeCallback();
 
 		return this;
 
@@ -284,7 +284,7 @@ Object.assign( Quaternion.prototype, {
 		this._z = axis.z * s;
 		this._w = Math.cos( halfAngle );
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -343,7 +343,7 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -426,7 +426,7 @@ Object.assign( Quaternion.prototype, {
 		this._y *= - 1;
 		this._z *= - 1;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -472,7 +472,7 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -509,7 +509,7 @@ Object.assign( Quaternion.prototype, {
 		this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
 		this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -576,7 +576,7 @@ Object.assign( Quaternion.prototype, {
 		this._y = ( y * ratioA + this._y * ratioB );
 		this._z = ( z * ratioA + this._z * ratioB );
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -597,7 +597,7 @@ Object.assign( Quaternion.prototype, {
 		this._z = array[ offset + 2 ];
 		this._w = array[ offset + 3 ];
 
-		this.onChangeCallback();
+		this._onChangeCallback();
 
 		return this;
 
@@ -617,15 +617,15 @@ Object.assign( Quaternion.prototype, {
 
 	},
 
-	onChange: function ( callback ) {
+	_onChange: function ( callback ) {
 
-		this.onChangeCallback = callback;
+		this._onChangeCallback = callback;
 
 		return this;
 
 	},
 
-	onChangeCallback: function () {}
+	_onChangeCallback: function () {}
 
 } );
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -202,7 +202,7 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "set/get properties, check callbacks", ( assert ) => {
 
 			var a = new Euler();
-			a.onChange( function () {
+			a._onChange( function () {
 
 				assert.step( "set: onChange called" );
 
@@ -237,8 +237,8 @@ export default QUnit.module( 'Maths', () => {
 				assert.ok( false );
 
 			};
-			a.onChange( cbFail );
-			b.onChange( cbFail );
+			a._onChange( cbFail );
+			b._onChange( cbFail );
 
 			// clone doesn't trigger onChange
 			a = b.clone();
@@ -246,7 +246,7 @@ export default QUnit.module( 'Maths', () => {
 
 			// copy triggers onChange once
 			a = new Euler( 1, 2, 3, "ZXY" );
-			a.onChange( cbSucceed );
+			a._onChange( cbSucceed );
 			a.copy( b );
 			assert.ok( a.equals( b ), "copy: check if a equals b" );
 			assert.verifySteps( [ "onChange called" ] );
@@ -290,7 +290,7 @@ export default QUnit.module( 'Maths', () => {
 				assert.step( "onChange called" );
 
 			};
-			a.onChange( cb );
+			a._onChange( cb );
 
 			a.fromArray( array );
 			assert.strictEqual( a.x, x, "No order: check x" );
@@ -300,7 +300,7 @@ export default QUnit.module( 'Maths', () => {
 
 			a = new Euler();
 			array = [ x, y, z, "ZXY" ];
-			a.onChange( cb );
+			a._onChange( cb );
 			a.fromArray( array );
 			assert.strictEqual( a.x, x, "With order: check x" );
 			assert.strictEqual( a.y, y, "With order: check y" );
@@ -311,13 +311,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( "onChange", ( assert ) => {
+		QUnit.todo( "_onChange", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.todo( "onChangeCallback", ( assert ) => {
+		QUnit.todo( "_onChangeCallback", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -206,7 +206,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.expect( 8 );
 
 			var a = new Quaternion();
-			a.onChange( function () {
+			a._onChange( function () {
 
 				assert.ok( true, "onChange called" );
 
@@ -558,13 +558,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( "onChange", ( assert ) => {
+		QUnit.todo( "_onChange", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 
 		} );
 
-		QUnit.todo( "onChangeCallback", ( assert ) => {
+		QUnit.todo( "_onChangeCallback", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 


### PR DESCRIPTION
`Euler.onChange()` and `Quaternion.onChange()` are used internally for synchronization, are not intended to be public.

As proposed in https://github.com/mrdoob/three.js/pull/16731#issuecomment-500110498.
