### PR TITLE
Serialize render target's texture when used as a scene background

### DIFF
--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -49,7 +49,20 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		var data = Object3D.prototype.toJSON.call( this, meta );
 
-		if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
+		if ( this.background !== null ) {
+
+			if ( this.background.texture ) {
+
+				data.object.background = this.background.texture.toJSON( meta );
+
+			} else {
+
+				data.object.background = this.background.toJSON( meta );
+
+			}
+
+		}
+
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
 
 		return data;


### PR DESCRIPTION
If using a render target for a scene's background, serialize the texture, not the render target which is not currently serializable. Requires #16763 fixed to not throw on serializing the render target's texture.

Reproducible here via `scene.toJSON()`: https://threejs.org/examples/webgl_loader_gltf.html