### PR TITLE
Vector4: Added width/height aliases

### DIFF
--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -78,6 +78,12 @@ var d = a.dot( b );
 
 		<h3>[property:Float w]</h3>
 
+		<h3>[property:Float width]</h3>
+		<p>Alias for [page:.z z].</p>
+
+		<h3>[property:Float height]</h3>
+		<p>Alias for [page:.w w].</p>
+
 
 		<h2>Methods</h2>
 

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -21,6 +21,8 @@ export class Vector4 implements Vector {
 	y: number;
 	z: number;
 	w: number;
+	width: number;
+	height: number;
 	isVector4: true;
 
 	/**

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -15,6 +15,42 @@ function Vector4( x, y, z, w ) {
 
 }
 
+Object.defineProperties( Vector4.prototype, {
+
+	"width": {
+
+		get: function () {
+
+			return this.z;
+
+		},
+
+		set: function ( value ) {
+
+			this.z = value;
+
+		}
+
+	},
+
+	"height": {
+
+		get: function () {
+
+			return this.w;
+
+		},
+
+		set: function ( value ) {
+
+			this.w = value;
+
+		}
+
+	}
+
+} );
+
 Object.assign( Vector4.prototype, {
 
 	isVector4: true,


### PR DESCRIPTION
A viewport is defined by `x`, `y`, `width`, `height`.

```js
var viewport = new THREE.Vector4();

renderer.getViewport( viewport );

var aspect = viewport.width / viewport.height; // instead of viewport.z / viewport.w
```

These new aliases are akin to the existing `Vector2.width` and `Vector2.height`.


