### PR TITLE
EXRLoader: support HalfFloatType output

### DIFF
--- a/examples/jsm/loaders/EXRLoader.d.ts
+++ b/examples/jsm/loaders/EXRLoader.d.ts
@@ -16,6 +16,8 @@ export interface EXR {
 
 export class EXRLoader extends DataTextureLoader {
   constructor(manager?: LoadingManager);
+  type: TextureDataType;
 
   _parser(buffer: ArrayBuffer) : EXR;
+  setType(type: TextureDataType): this;
 }

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -54,7 +54,9 @@
 
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
-				new THREE.EXRLoader().load( 'textures/memorial.exr', function ( texture, textureData ) {
+				new THREE.EXRLoader()
+					.setType( THREE.FloatType )
+					.load( 'textures/memorial.exr', function ( texture, textureData ) {
 
 					//console.log( textureData );
 					//console.log( texture );

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -83,7 +83,9 @@
 				planeMesh.rotation.x = - Math.PI * 0.5;
 				scene.add( planeMesh );
 
-				new THREE.EXRLoader().load( 'textures/piz_compressed.exr', function ( texture ) {
+				new THREE.EXRLoader()
+					.setType( THREE.FloatType )
+					.load( 'textures/piz_compressed.exr', function ( texture ) {
 
 					texture.minFilter = THREE.NearestFilter;
 					// texture.magFilter = THREE.NearestFilter;


### PR DESCRIPTION
Usage:
```js
new THREE.EXRLoader()
	.setType( THREE.FloatType ) // alt: THREE.HalfFloatType
	.load( 'file.hdr', function ( texture, textureData ) { ...
```