### PR TITLE
WebGLTextures: Used sized internal format for depth stencil

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -792,7 +792,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				var samples = getRenderTargetSamples( renderTarget );
 
-				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
+				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
 
 			} else {
 


### PR DESCRIPTION
Fixed #16756

gl.renderbufferStorageMultisample() requires a sized internal format specifier.  Chrome enforces this, firefox extends the behaviour of renderbufferStorage():

`To be backward compatible with WebGL 1, also accepts internal format DEPTH_STENCIL, which should be mapped to DEPTH24_STENCIL8 by implementations.`


to renderbufferStorageMultisample() which is not required by the spec. 