### PR TITLE
Euler and Quaternion: remove update flag from public API

### DIFF
--- a/src/math/Euler.d.ts
+++ b/src/math/Euler.d.ts
@@ -165,8 +165,8 @@ export class Euler {
 	set( x: number, y: number, z: number, order?: string ): Euler;
 	clone(): this;
 	copy( euler: Euler ): this;
-	setFromRotationMatrix( m: Matrix4, order?: string, update?: boolean ): Euler;
-	setFromQuaternion( q: Quaternion, order?: string, update?: boolean ): Euler;
+	setFromRotationMatrix( m: Matrix4, order?: string ): Euler;
+	setFromQuaternion( q: Quaternion, order?: string ): Euler;
 	setFromVector3( v: Vector3, order?: string ): Euler;
 	reorder( newOrder: string ): Euler;
 	equals( euler: Euler ): boolean;

--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -44,7 +44,7 @@ export class Quaternion {
 	/**
 	 * Sets this quaternion from rotation specified by Euler angles.
 	 */
-	setFromEuler( euler: Euler, update?: boolean ): Quaternion;
+	setFromEuler( euler: Euler ): Quaternion;
 
 	/**
 	 * Sets this quaternion from rotation specified by axis and angle.


### PR DESCRIPTION
Follow-up to #16755.

Migration docs updated separately.
