### PR TITLE
Reduce closures in Math library

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -11,6 +11,8 @@ function Box2( min, max ) {
 
 }
 
+var v1 = new Vector2();
+
 Object.assign( Box2.prototype, {
 
 	set: function ( min, max ) {
@@ -36,21 +38,15 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	setFromCenterAndSize: function () {
+	setFromCenterAndSize: function ( center, size ) {
 
-		var v1 = new Vector2();
+		var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
+		this.min.copy( center ).sub( halfSize );
+		this.max.copy( center ).add( halfSize );
 
-		return function setFromCenterAndSize( center, size ) {
+		return this;
 
-			var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
-			this.min.copy( center ).sub( halfSize );
-			this.max.copy( center ).add( halfSize );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 
@@ -192,18 +188,12 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	distanceToPoint: function () {
+	distanceToPoint: function ( point ) {
 
-		var v1 = new Vector2();
+		var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
+		return clampedPoint.sub( point ).length();
 
-		return function distanceToPoint( point ) {
-
-			var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
-			return clampedPoint.sub( point ).length();
-
-		};
-
-	}(),
+	},
 
 	intersect: function ( box ) {
 

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -11,6 +11,7 @@ function Box2( min, max ) {
 
 }
 
+// Used in setFromCenterAndSize() and distanceToPoint()
 var v1 = new Vector2();
 
 Object.assign( Box2.prototype, {

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -11,8 +11,10 @@ function Box3( min, max ) {
 	this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
 
 }
-
+// Used in traverse(), setFromCenterAndSize(), intersectsSphere(), distanceToPoint() and getBoundingSphere()
 var v1 = new Vector3();
+
+// Used in applyMatrix4()
 var points = [
 	new Vector3(),
 	new Vector3(),

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -42,6 +42,29 @@ function Color( r, g, b ) {
 
 }
 
+function hue2rgb( p, q, t ) {
+
+	if ( t < 0 ) t += 1;
+	if ( t > 1 ) t -= 1;
+	if ( t < 1 / 6 ) return p + ( q - p ) * 6 * t;
+	if ( t < 1 / 2 ) return q;
+	if ( t < 2 / 3 ) return p + ( q - p ) * 6 * ( 2 / 3 - t );
+	return p;
+
+}
+
+function SRGBToLinear( c ) {
+
+	return ( c < 0.04045 ) ? c * 0.0773993808 : Math.pow( c * 0.9478672986 + 0.0521327014, 2.4 );
+
+}
+
+function LinearToSRGB( c ) {
+
+	return ( c < 0.0031308 ) ? c * 12.92 : 1.055 * ( Math.pow( c, 0.41666 ) ) - 0.055;
+
+}
+
 Object.assign( Color.prototype, {
 
 	isColor: true,
@@ -100,46 +123,31 @@ Object.assign( Color.prototype, {
 
 	},
 
-	setHSL: function () {
+	setHSL: function ( h, s, l ) {
 
-		function hue2rgb( p, q, t ) {
+		// h,s,l ranges are in 0.0 - 1.0
+		h = _Math.euclideanModulo( h, 1 );
+		s = _Math.clamp( s, 0, 1 );
+		l = _Math.clamp( l, 0, 1 );
 
-			if ( t < 0 ) t += 1;
-			if ( t > 1 ) t -= 1;
-			if ( t < 1 / 6 ) return p + ( q - p ) * 6 * t;
-			if ( t < 1 / 2 ) return q;
-			if ( t < 2 / 3 ) return p + ( q - p ) * 6 * ( 2 / 3 - t );
-			return p;
+		if ( s === 0 ) {
+
+			this.r = this.g = this.b = l;
+
+		} else {
+
+			var p = l <= 0.5 ? l * ( 1 + s ) : l + s - ( l * s );
+			var q = ( 2 * l ) - p;
+
+			this.r = hue2rgb( q, p, h + 1 / 3 );
+			this.g = hue2rgb( q, p, h );
+			this.b = hue2rgb( q, p, h - 1 / 3 );
 
 		}
 
-		return function setHSL( h, s, l ) {
+		return this;
 
-			// h,s,l ranges are in 0.0 - 1.0
-			h = _Math.euclideanModulo( h, 1 );
-			s = _Math.clamp( s, 0, 1 );
-			l = _Math.clamp( l, 0, 1 );
-
-			if ( s === 0 ) {
-
-				this.r = this.g = this.b = l;
-
-			} else {
-
-				var p = l <= 0.5 ? l * ( 1 + s ) : l + s - ( l * s );
-				var q = ( 2 * l ) - p;
-
-				this.r = hue2rgb( q, p, h + 1 / 3 );
-				this.g = hue2rgb( q, p, h );
-				this.b = hue2rgb( q, p, h - 1 / 3 );
-
-			}
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	setStyle: function ( style ) {
 
@@ -329,45 +337,25 @@ Object.assign( Color.prototype, {
 
 	},
 
-	copySRGBToLinear: function () {
+	copySRGBToLinear: function ( color ) {
 
-		function SRGBToLinear( c ) {
+		this.r = SRGBToLinear( color.r );
+		this.g = SRGBToLinear( color.g );
+		this.b = SRGBToLinear( color.b );
 
-			return ( c < 0.04045 ) ? c * 0.0773993808 : Math.pow( c * 0.9478672986 + 0.0521327014, 2.4 );
+		return this;
 
-		}
+	},
 
-		return function copySRGBToLinear( color ) {
+	copyLinearToSRGB: function ( color ) {
 
-			this.r = SRGBToLinear( color.r );
-			this.g = SRGBToLinear( color.g );
-			this.b = SRGBToLinear( color.b );
+		this.r = LinearToSRGB( color.r );
+		this.g = LinearToSRGB( color.g );
+		this.b = LinearToSRGB( color.b );
 
-			return this;
+		return this;
 
-		};
-
-	}(),
-
-	copyLinearToSRGB: function () {
-
-		function LinearToSRGB( c ) {
-
-			return ( c < 0.0031308 ) ? c * 12.92 : 1.055 * ( Math.pow( c, 0.41666 ) ) - 0.055;
-
-		}
-
-		return function copyLinearToSRGB( color ) {
-
-			this.r = LinearToSRGB( color.r );
-			this.g = LinearToSRGB( color.g );
-			this.b = LinearToSRGB( color.b );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	convertSRGBToLinear: function () {
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -22,6 +22,10 @@ Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
 
 Euler.DefaultOrder = 'XYZ';
 
+
+var matrix = new Matrix4();
+var q = new Quaternion();
+
 Object.defineProperties( Euler.prototype, {
 
 	x: {
@@ -253,19 +257,13 @@ Object.assign( Euler.prototype, {
 
 	},
 
-	setFromQuaternion: function () {
+	setFromQuaternion: function ( q, order, update ) {
 
-		var matrix = new Matrix4();
+		matrix.makeRotationFromQuaternion( q );
 
-		return function setFromQuaternion( q, order, update ) {
+		return this.setFromRotationMatrix( matrix, order, update );
 
-			matrix.makeRotationFromQuaternion( q );
-
-			return this.setFromRotationMatrix( matrix, order, update );
-
-		};
-
-	}(),
+	},
 
 	setFromVector3: function ( v, order ) {
 
@@ -273,21 +271,13 @@ Object.assign( Euler.prototype, {
 
 	},
 
-	reorder: function () {
+	reorder: function ( newOrder ) {
 
-		// WARNING: this discards revolution information -bhouston
+		q.setFromEuler( this );
 
-		var q = new Quaternion();
+		return this.setFromQuaternion( q, newOrder );
 
-		return function reorder( newOrder ) {
-
-			q.setFromEuler( this );
-
-			return this.setFromQuaternion( q, newOrder );
-
-		};
-
-	}(),
+	},
 
 	equals: function ( euler ) {
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -22,8 +22,10 @@ Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
 
 Euler.DefaultOrder = 'XYZ';
 
-
+// Used in setFromQuaternion()
 var matrix = new Matrix4();
+
+// Used in reorder()
 var q = new Quaternion();
 
 Object.defineProperties( Euler.prototype, {

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -23,9 +23,10 @@ function Frustum( p0, p1, p2, p3, p4, p5 ) {
 
 }
 
-
-
+// Used in intersectsObject() and intersectsSprite()
 var sphere = new Sphere();
+
+// Used in intersectsBox()
 var p = new Vector3();
 
 Object.assign( Frustum.prototype, {

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -23,6 +23,11 @@ function Frustum( p0, p1, p2, p3, p4, p5 ) {
 
 }
 
+
+
+var sphere = new Sphere();
+var p = new Vector3();
+
 Object.assign( Frustum.prototype, {
 
 	set: function ( p0, p1, p2, p3, p4, p5 ) {
@@ -80,41 +85,29 @@ Object.assign( Frustum.prototype, {
 
 	},
 
-	intersectsObject: function () {
+	intersectsObject: function ( object ) {
 
-		var sphere = new Sphere();
+		var geometry = object.geometry;
 
-		return function intersectsObject( object ) {
+		if ( geometry.boundingSphere === null )
+			geometry.computeBoundingSphere();
 
-			var geometry = object.geometry;
+		sphere.copy( geometry.boundingSphere )
+			.applyMatrix4( object.matrixWorld );
 
-			if ( geometry.boundingSphere === null )
-				geometry.computeBoundingSphere();
+		return this.intersectsSphere( sphere );
 
-			sphere.copy( geometry.boundingSphere )
-				.applyMatrix4( object.matrixWorld );
+	},
 
-			return this.intersectsSphere( sphere );
+	intersectsSprite: function ( sprite ) {
 
-		};
+		sphere.center.set( 0, 0, 0 );
+		sphere.radius = 0.7071067811865476;
+		sphere.applyMatrix4( sprite.matrixWorld );
 
-	}(),
+		return this.intersectsSphere( sphere );
 
-	intersectsSprite: function () {
-
-		var sphere = new Sphere();
-
-		return function intersectsSprite( sprite ) {
-
-			sphere.center.set( 0, 0, 0 );
-			sphere.radius = 0.7071067811865476;
-			sphere.applyMatrix4( sprite.matrixWorld );
-
-			return this.intersectsSphere( sphere );
-
-		};
-
-	}(),
+	},
 
 	intersectsSphere: function ( sphere ) {
 
@@ -138,37 +131,31 @@ Object.assign( Frustum.prototype, {
 
 	},
 
-	intersectsBox: function () {
+	intersectsBox: function ( box ) {
 
-		var p = new Vector3();
+		var planes = this.planes;
 
-		return function intersectsBox( box ) {
+		for ( var i = 0; i < 6; i ++ ) {
 
-			var planes = this.planes;
+			var plane = planes[ i ];
 
-			for ( var i = 0; i < 6; i ++ ) {
+			// corner at max distance
 
-				var plane = planes[ i ];
+			p.x = plane.normal.x > 0 ? box.max.x : box.min.x;
+			p.y = plane.normal.y > 0 ? box.max.y : box.min.y;
+			p.z = plane.normal.z > 0 ? box.max.z : box.min.z;
 
-				// corner at max distance
+			if ( plane.distanceToPoint( p ) < 0 ) {
 
-				p.x = plane.normal.x > 0 ? box.max.x : box.min.x;
-				p.y = plane.normal.y > 0 ? box.max.y : box.min.y;
-				p.z = plane.normal.z > 0 ? box.max.z : box.min.z;
-
-				if ( plane.distanceToPoint( p ) < 0 ) {
-
-					return false;
-
-				}
+				return false;
 
 			}
 
-			return true;
+		}
 
-		};
+		return true;
 
-	}(),
+	},
 
 	containsPoint: function ( point ) {
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -12,8 +12,10 @@ function Line3( start, end ) {
 
 }
 
-
+// Used in closestPointToPointParameter()
 var startP = new Vector3();
+
+// Used in closestPointToPointParameter()
 var startEnd = new Vector3();
 
 Object.assign( Line3.prototype, {

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -12,6 +12,10 @@ function Line3( start, end ) {
 
 }
 
+
+var startP = new Vector3();
+var startEnd = new Vector3();
+
 Object.assign( Line3.prototype, {
 
 	set: function ( start, end ) {
@@ -89,32 +93,25 @@ Object.assign( Line3.prototype, {
 
 	},
 
-	closestPointToPointParameter: function () {
+	closestPointToPointParameter: function ( point, clampToLine ) {
 
-		var startP = new Vector3();
-		var startEnd = new Vector3();
+		startP.subVectors( point, this.start );
+		startEnd.subVectors( this.end, this.start );
 
-		return function closestPointToPointParameter( point, clampToLine ) {
+		var startEnd2 = startEnd.dot( startEnd );
+		var startEnd_startP = startEnd.dot( startP );
 
-			startP.subVectors( point, this.start );
-			startEnd.subVectors( this.end, this.start );
+		var t = startEnd_startP / startEnd2;
 
-			var startEnd2 = startEnd.dot( startEnd );
-			var startEnd_startP = startEnd.dot( startP );
+		if ( clampToLine ) {
 
-			var t = startEnd_startP / startEnd2;
+			t = _Math.clamp( t, 0, 1 );
 
-			if ( clampToLine ) {
+		}
 
-				t = _Math.clamp( t, 0, 1 );
+		return t;
 
-			}
-
-			return t;
-
-		};
-
-	}(),
+	},
 
 	closestPointToPoint: function ( point, clampToLine, target ) {
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -4,9 +4,9 @@
  */
 var lut = [];
 
-for (var i = 0; i < 256; i++) {
+for ( var i = 0; i < 256; i ++ ) {
 
-	lut[i] = (i < 16 ? '0' : '') + (i).toString(16);
+	lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
 
 }
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -2,41 +2,35 @@
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/
  */
+var lut = [];
+
+for (var i = 0; i < 256; i++) {
+
+	lut[i] = (i < 16 ? '0' : '') + (i).toString(16);
+
+}
 
 var _Math = {
 
 	DEG2RAD: Math.PI / 180,
 	RAD2DEG: 180 / Math.PI,
 
-	generateUUID: ( function () {
+	// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
+	generateUUID: function () {
 
-		// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
+		var d0 = Math.random() * 0xffffffff | 0;
+		var d1 = Math.random() * 0xffffffff | 0;
+		var d2 = Math.random() * 0xffffffff | 0;
+		var d3 = Math.random() * 0xffffffff | 0;
+		var uuid = lut[ d0 & 0xff ] + lut[ d0 >> 8 & 0xff ] + lut[ d0 >> 16 & 0xff ] + lut[ d0 >> 24 & 0xff ] + '-' +
+			lut[ d1 & 0xff ] + lut[ d1 >> 8 & 0xff ] + '-' + lut[ d1 >> 16 & 0x0f | 0x40 ] + lut[ d1 >> 24 & 0xff ] + '-' +
+			lut[ d2 & 0x3f | 0x80 ] + lut[ d2 >> 8 & 0xff ] + '-' + lut[ d2 >> 16 & 0xff ] + lut[ d2 >> 24 & 0xff ] +
+			lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
 
-		var lut = [];
+		// .toUpperCase() here flattens concatenated strings to save heap memory space.
+		return uuid.toUpperCase();
 
-		for ( var i = 0; i < 256; i ++ ) {
-
-			lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
-
-		}
-
-		return function generateUUID() {
-
-			var d0 = Math.random() * 0xffffffff | 0;
-			var d1 = Math.random() * 0xffffffff | 0;
-			var d2 = Math.random() * 0xffffffff | 0;
-			var d3 = Math.random() * 0xffffffff | 0;
-			var uuid = lut[ d0 & 0xff ] + lut[ d0 >> 8 & 0xff ] + lut[ d0 >> 16 & 0xff ] + lut[ d0 >> 24 & 0xff ] + '-' +
-				lut[ d1 & 0xff ] + lut[ d1 >> 8 & 0xff ] + '-' + lut[ d1 >> 16 & 0x0f | 0x40 ] + lut[ d1 >> 24 & 0xff ] + '-' +
-				lut[ d2 & 0x3f | 0x80 ] + lut[ d2 >> 8 & 0xff ] + '-' + lut[ d2 >> 16 & 0xff ] + lut[ d2 >> 24 & 0xff ] +
-				lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
-
-			// .toUpperCase() here flattens concatenated strings to save heap memory space.
-			return uuid.toUpperCase();
-
-		};
-
-	} )(),
+	},
 
 	clamp: function ( value, min, max ) {
 

--- a/src/math/Math.js
+++ b/src/math/Math.js
@@ -2,8 +2,9 @@
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/
  */
-var lut = [];
 
+// Used in generateUUID()
+var lut = [];
 for ( var i = 0; i < 256; i ++ ) {
 
 	lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -25,6 +25,10 @@ function Matrix3() {
 
 }
 
+
+var v1 = new Vector3();
+
+
 Object.assign( Matrix3.prototype, {
 
 	isMatrix3: true,
@@ -90,29 +94,23 @@ Object.assign( Matrix3.prototype, {
 
 	},
 
-	applyToBufferAttribute: function () {
+	applyToBufferAttribute: function ( attribute ) {
 
-		var v1 = new Vector3();
+		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-		return function applyToBufferAttribute( attribute ) {
+			v1.x = attribute.getX( i );
+			v1.y = attribute.getY( i );
+			v1.z = attribute.getZ( i );
 
-			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+			v1.applyMatrix3( this );
 
-				v1.x = attribute.getX( i );
-				v1.y = attribute.getY( i );
-				v1.z = attribute.getZ( i );
+			attribute.setXYZ( i, v1.x, v1.y, v1.z );
 
-				v1.applyMatrix3( this );
+		}
 
-				attribute.setXYZ( i, v1.x, v1.y, v1.z );
+		return attribute;
 
-			}
-
-			return attribute;
-
-		};
-
-	}(),
+	},
 
 	multiply: function ( m ) {
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -25,7 +25,7 @@ function Matrix3() {
 
 }
 
-
+// Used in applyToBufferAttribute()
 var v1 = new Vector3();
 
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -32,6 +32,13 @@ function Matrix4() {
 
 }
 
+var zero = new Vector3( 0, 0, 0 );
+var one = new Vector3( 1, 1, 1 );
+var x = new Vector3();
+var y = new Vector3();
+var z = new Vector3();
+var matrix = new Matrix4();
+
 Object.assign( Matrix4.prototype, {
 
 	isMatrix4: true,
@@ -119,46 +126,40 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	extractRotation: function () {
+	extractRotation: function ( m ) {
 
-		var v1 = new Vector3();
+		// this method does not support reflection matrices
 
-		return function extractRotation( m ) {
+		var te = this.elements;
+		var me = m.elements;
 
-			// this method does not support reflection matrices
+		var scaleX = 1 / x.setFromMatrixColumn( m, 0 ).length();
+		var scaleY = 1 / x.setFromMatrixColumn( m, 1 ).length();
+		var scaleZ = 1 / x.setFromMatrixColumn( m, 2 ).length();
 
-			var te = this.elements;
-			var me = m.elements;
+		te[ 0 ] = me[ 0 ] * scaleX;
+		te[ 1 ] = me[ 1 ] * scaleX;
+		te[ 2 ] = me[ 2 ] * scaleX;
+		te[ 3 ] = 0;
 
-			var scaleX = 1 / v1.setFromMatrixColumn( m, 0 ).length();
-			var scaleY = 1 / v1.setFromMatrixColumn( m, 1 ).length();
-			var scaleZ = 1 / v1.setFromMatrixColumn( m, 2 ).length();
+		te[ 4 ] = me[ 4 ] * scaleY;
+		te[ 5 ] = me[ 5 ] * scaleY;
+		te[ 6 ] = me[ 6 ] * scaleY;
+		te[ 7 ] = 0;
 
-			te[ 0 ] = me[ 0 ] * scaleX;
-			te[ 1 ] = me[ 1 ] * scaleX;
-			te[ 2 ] = me[ 2 ] * scaleX;
-			te[ 3 ] = 0;
+		te[ 8 ] = me[ 8 ] * scaleZ;
+		te[ 9 ] = me[ 9 ] * scaleZ;
+		te[ 10 ] = me[ 10 ] * scaleZ;
+		te[ 11 ] = 0;
 
-			te[ 4 ] = me[ 4 ] * scaleY;
-			te[ 5 ] = me[ 5 ] * scaleY;
-			te[ 6 ] = me[ 6 ] * scaleY;
-			te[ 7 ] = 0;
+		te[ 12 ] = 0;
+		te[ 13 ] = 0;
+		te[ 14 ] = 0;
+		te[ 15 ] = 1;
 
-			te[ 8 ] = me[ 8 ] * scaleZ;
-			te[ 9 ] = me[ 9 ] * scaleZ;
-			te[ 10 ] = me[ 10 ] * scaleZ;
-			te[ 11 ] = 0;
+		return this;
 
-			te[ 12 ] = 0;
-			te[ 13 ] = 0;
-			te[ 14 ] = 0;
-			te[ 15 ] = 1;
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	makeRotationFromEuler: function ( euler ) {
 
@@ -288,73 +289,58 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	makeRotationFromQuaternion: function () {
+	makeRotationFromQuaternion: function ( q ) {
 
-		var zero = new Vector3( 0, 0, 0 );
-		var one = new Vector3( 1, 1, 1 );
+		return this.compose( zero, q, one );
 
-		return function makeRotationFromQuaternion( q ) {
+	},
 
-			return this.compose( zero, q, one );
+	lookAt: function ( eye, target, up ) {
 
-		};
+		var te = this.elements;
 
-	}(),
+		z.subVectors( eye, target );
 
-	lookAt: function () {
+		if ( z.lengthSq() === 0 ) {
 
-		var x = new Vector3();
-		var y = new Vector3();
-		var z = new Vector3();
+			// eye and target are in the same position
 
-		return function lookAt( eye, target, up ) {
+			z.z = 1;
 
-			var te = this.elements;
+		}
 
-			z.subVectors( eye, target );
+		z.normalize();
+		x.crossVectors( up, z );
 
-			if ( z.lengthSq() === 0 ) {
+		if ( x.lengthSq() === 0 ) {
 
-				// eye and target are in the same position
+			// up and z are parallel
 
-				z.z = 1;
+			if ( Math.abs( up.z ) === 1 ) {
+
+				z.x += 0.0001;
+
+			} else {
+
+				z.z += 0.0001;
 
 			}
 
 			z.normalize();
 			x.crossVectors( up, z );
 
-			if ( x.lengthSq() === 0 ) {
+		}
 
-				// up and z are parallel
+		x.normalize();
+		y.crossVectors( z, x );
 
-				if ( Math.abs( up.z ) === 1 ) {
+		te[ 0 ] = x.x; te[ 4 ] = y.x; te[ 8 ] = z.x;
+		te[ 1 ] = x.y; te[ 5 ] = y.y; te[ 9 ] = z.y;
+		te[ 2 ] = x.z; te[ 6 ] = y.z; te[ 10 ] = z.z;
 
-					z.x += 0.0001;
+		return this;
 
-				} else {
-
-					z.z += 0.0001;
-
-				}
-
-				z.normalize();
-				x.crossVectors( up, z );
-
-			}
-
-			x.normalize();
-			y.crossVectors( z, x );
-
-			te[ 0 ] = x.x; te[ 4 ] = y.x; te[ 8 ] = z.x;
-			te[ 1 ] = x.y; te[ 5 ] = y.y; te[ 9 ] = z.y;
-			te[ 2 ] = x.z; te[ 6 ] = y.z; te[ 10 ] = z.z;
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	multiply: function ( m, n ) {
 
@@ -428,29 +414,23 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	applyToBufferAttribute: function () {
+	applyToBufferAttribute: function ( attribute ) {
 
-		var v1 = new Vector3();
+		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-		return function applyToBufferAttribute( attribute ) {
+			x.x = attribute.getX( i );
+			x.y = attribute.getY( i );
+			x.z = attribute.getZ( i );
 
-			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+			x.applyMatrix4( this );
 
-				v1.x = attribute.getX( i );
-				v1.y = attribute.getY( i );
-				v1.z = attribute.getZ( i );
+			attribute.setXYZ( i, x.x, x.y, x.z );
 
-				v1.applyMatrix4( this );
+		}
 
-				attribute.setXYZ( i, v1.x, v1.y, v1.z );
+		return attribute;
 
-			}
-
-			return attribute;
-
-		};
-
-	}(),
+	},
 
 	determinant: function () {
 
@@ -784,57 +764,50 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	decompose: function () {
+	decompose: function ( position, quaternion, scale ) {
 
-		var vector = new Vector3();
-		var matrix = new Matrix4();
+		var te = this.elements;
 
-		return function decompose( position, quaternion, scale ) {
+		var sx = x.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
+		var sy = x.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
+		var sz = x.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
 
-			var te = this.elements;
+		// if determine is negative, we need to invert one scale
+		var det = this.determinant();
+		if ( det < 0 ) sx = - sx;
 
-			var sx = vector.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
-			var sy = vector.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
-			var sz = vector.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
+		position.x = te[ 12 ];
+		position.y = te[ 13 ];
+		position.z = te[ 14 ];
 
-			// if determine is negative, we need to invert one scale
-			var det = this.determinant();
-			if ( det < 0 ) sx = - sx;
+		// scale the rotation part
+		matrix.copy( this );
 
-			position.x = te[ 12 ];
-			position.y = te[ 13 ];
-			position.z = te[ 14 ];
+		var invSX = 1 / sx;
+		var invSY = 1 / sy;
+		var invSZ = 1 / sz;
 
-			// scale the rotation part
-			matrix.copy( this );
+		matrix.elements[ 0 ] *= invSX;
+		matrix.elements[ 1 ] *= invSX;
+		matrix.elements[ 2 ] *= invSX;
 
-			var invSX = 1 / sx;
-			var invSY = 1 / sy;
-			var invSZ = 1 / sz;
+		matrix.elements[ 4 ] *= invSY;
+		matrix.elements[ 5 ] *= invSY;
+		matrix.elements[ 6 ] *= invSY;
 
-			matrix.elements[ 0 ] *= invSX;
-			matrix.elements[ 1 ] *= invSX;
-			matrix.elements[ 2 ] *= invSX;
+		matrix.elements[ 8 ] *= invSZ;
+		matrix.elements[ 9 ] *= invSZ;
+		matrix.elements[ 10 ] *= invSZ;
 
-			matrix.elements[ 4 ] *= invSY;
-			matrix.elements[ 5 ] *= invSY;
-			matrix.elements[ 6 ] *= invSY;
+		quaternion.setFromRotationMatrix( matrix );
 
-			matrix.elements[ 8 ] *= invSZ;
-			matrix.elements[ 9 ] *= invSZ;
-			matrix.elements[ 10 ] *= invSZ;
+		scale.x = sx;
+		scale.y = sy;
+		scale.z = sz;
 
-			quaternion.setFromRotationMatrix( matrix );
+		return this;
 
-			scale.x = sx;
-			scale.y = sy;
-			scale.z = sz;
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	makePerspective: function ( left, right, top, bottom, near, far ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -32,11 +32,22 @@ function Matrix4() {
 
 }
 
-var zero = new Vector3( 0, 0, 0 );
-var one = new Vector3( 1, 1, 1 );
+// Used in makeRotationFromQuaternion()
+var zero = new Vector3(0, 0, 0);
+
+// Used in makeRotationFromQuaternion()
+var one = new Vector3(1, 1, 1);
+
+// Used in extractRotation(), lookAt(), applyToBufferAttribute() and decompose()
 var x = new Vector3();
+
+// Used in lookAt()
 var y = new Vector3();
+
+// Used in lookAt()
 var z = new Vector3();
+
+// Used in decompose()
 var matrix = new Matrix4();
 
 Object.assign( Matrix4.prototype, {

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -33,10 +33,10 @@ function Matrix4() {
 }
 
 // Used in makeRotationFromQuaternion()
-var zero = new Vector3(0, 0, 0);
+var zero = new Vector3( 0, 0, 0 );
 
 // Used in makeRotationFromQuaternion()
-var one = new Vector3(1, 1, 1);
+var one = new Vector3( 1, 1, 1 );
 
 // Used in extractRotation(), lookAt(), applyToBufferAttribute() and decompose()
 var x = new Vector3();

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -14,8 +14,13 @@ function Plane( normal, constant ) {
 
 }
 
+// Used in setFromCoplanarPoints()
 var v1 = new Vector3();
+
+// Used in setFromCoplanarPoints()
 var v2 = new Vector3();
+
+// Used in applyMatrix4()
 var m1 = new Matrix3();
 
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -14,6 +14,11 @@ function Plane( normal, constant ) {
 
 }
 
+var v1 = new Vector3();
+var v2 = new Vector3();
+var m1 = new Matrix3();
+
+
 Object.assign( Plane.prototype, {
 
 	set: function ( normal, constant ) {
@@ -43,24 +48,17 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	setFromCoplanarPoints: function () {
+	setFromCoplanarPoints: function ( a, b, c ) {
 
-		var v1 = new Vector3();
-		var v2 = new Vector3();
+		var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
 
-		return function setFromCoplanarPoints( a, b, c ) {
+		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
 
-			var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
+		this.setFromNormalAndCoplanarPoint( normal, a );
 
-			// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+		return this;
 
-			this.setFromNormalAndCoplanarPoint( normal, a );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 
@@ -123,50 +121,44 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	intersectLine: function () {
+	intersectLine: function ( line, target ) {
 
-		var v1 = new Vector3();
+		if ( target === undefined ) {
 
-		return function intersectLine( line, target ) {
+			console.warn( 'THREE.Plane: .intersectLine() target is now required' );
+			target = new Vector3();
 
-			if ( target === undefined ) {
+		}
 
-				console.warn( 'THREE.Plane: .intersectLine() target is now required' );
-				target = new Vector3();
+		var direction = line.delta( v1 );
 
-			}
+		var denominator = this.normal.dot( direction );
 
-			var direction = line.delta( v1 );
+		if ( denominator === 0 ) {
 
-			var denominator = this.normal.dot( direction );
+			// line is coplanar, return origin
+			if ( this.distanceToPoint( line.start ) === 0 ) {
 
-			if ( denominator === 0 ) {
-
-				// line is coplanar, return origin
-				if ( this.distanceToPoint( line.start ) === 0 ) {
-
-					return target.copy( line.start );
-
-				}
-
-				// Unsure if this is the correct method to handle this case.
-				return undefined;
+				return target.copy( line.start );
 
 			}
 
-			var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
+			// Unsure if this is the correct method to handle this case.
+			return undefined;
 
-			if ( t < 0 || t > 1 ) {
+		}
 
-				return undefined;
+		var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
 
-			}
+		if ( t < 0 || t > 1 ) {
 
-			return target.copy( direction ).multiplyScalar( t ).add( line.start );
+			return undefined;
 
-		};
+		}
 
-	}(),
+		return target.copy( direction ).multiplyScalar( t ).add( line.start );
+
+	},
 
 	intersectsLine: function ( line ) {
 
@@ -204,26 +196,19 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	applyMatrix4: function () {
+	applyMatrix4: function ( matrix, optionalNormalMatrix ) {
 
-		var v1 = new Vector3();
-		var m1 = new Matrix3();
+		var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
 
-		return function applyMatrix4( matrix, optionalNormalMatrix ) {
+		var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
 
-			var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
+		var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
 
-			var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
+		this.constant = - referencePoint.dot( normal );
 
-			var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
+		return this;
 
-			this.constant = - referencePoint.dot( normal );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	translate: function ( offset ) {
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -10,14 +10,17 @@ function Ray( origin, direction ) {
 	this.direction = ( direction !== undefined ) ? direction : new Vector3();
 
 }
-
+//Used in distanceSqToPoint() and intersectSphere()
 var v1 = new Vector3();
 
+//Used in distanceSqToSegment()
 var segCenter = new Vector3();
 var segDir = new Vector3();
+
+//Used in distanceSqToSegment() and intersectTriangle()
 var diff = new Vector3();
 
-var diff = new Vector3();
+//Used in intersectTriangle()
 var edge1 = new Vector3();
 var edge2 = new Vector3();
 var normal = new Vector3();

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -11,6 +11,17 @@ function Ray( origin, direction ) {
 
 }
 
+var v1 = new Vector3();
+
+var segCenter = new Vector3();
+var segDir = new Vector3();
+var diff = new Vector3();
+
+var diff = new Vector3();
+var edge1 = new Vector3();
+var edge2 = new Vector3();
+var normal = new Vector3();
+
 Object.assign( Ray.prototype, {
 
 	set: function ( origin, direction ) {
@@ -58,19 +69,13 @@ Object.assign( Ray.prototype, {
 
 	},
 
-	recast: function () {
+	recast: function ( t ) {
 
-		var v1 = new Vector3();
+		this.origin.copy( this.at( t, v1 ) );
 
-		return function recast( t ) {
+		return this;
 
-			this.origin.copy( this.at( t, v1 ) );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	closestPointToPoint: function ( point, target ) {
 
@@ -101,94 +106,72 @@ Object.assign( Ray.prototype, {
 
 	},
 
-	distanceSqToPoint: function () {
+	distanceSqToPoint: function ( point ) {
 
-		var v1 = new Vector3();
+		var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
 
-		return function distanceSqToPoint( point ) {
+		// point behind the ray
 
-			var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
+		if ( directionDistance < 0 ) {
 
-			// point behind the ray
+			return this.origin.distanceToSquared( point );
 
-			if ( directionDistance < 0 ) {
+		}
 
-				return this.origin.distanceToSquared( point );
+		v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
-			}
+		return v1.distanceToSquared( point );
 
-			v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+	},
 
-			return v1.distanceToSquared( point );
+	distanceSqToSegment: function ( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
 
-		};
+		// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
+		// It returns the min distance between the ray and the segment
+		// defined by v0 and v1
+		// It can also set two optional targets :
+		// - The closest point on the ray
+		// - The closest point on the segment
 
-	}(),
+		segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
+		segDir.copy( v1 ).sub( v0 ).normalize();
+		diff.copy( this.origin ).sub( segCenter );
 
-	distanceSqToSegment: function () {
+		var segExtent = v0.distanceTo( v1 ) * 0.5;
+		var a01 = - this.direction.dot( segDir );
+		var b0 = diff.dot( this.direction );
+		var b1 = - diff.dot( segDir );
+		var c = diff.lengthSq();
+		var det = Math.abs( 1 - a01 * a01 );
+		var s0, s1, sqrDist, extDet;
 
-		var segCenter = new Vector3();
-		var segDir = new Vector3();
-		var diff = new Vector3();
+		if ( det > 0 ) {
 
-		return function distanceSqToSegment( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+			// The ray and segment are not parallel.
 
-			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
-			// It returns the min distance between the ray and the segment
-			// defined by v0 and v1
-			// It can also set two optional targets :
-			// - The closest point on the ray
-			// - The closest point on the segment
+			s0 = a01 * b1 - b0;
+			s1 = a01 * b0 - b1;
+			extDet = segExtent * det;
 
-			segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
-			segDir.copy( v1 ).sub( v0 ).normalize();
-			diff.copy( this.origin ).sub( segCenter );
+			if ( s0 >= 0 ) {
 
-			var segExtent = v0.distanceTo( v1 ) * 0.5;
-			var a01 = - this.direction.dot( segDir );
-			var b0 = diff.dot( this.direction );
-			var b1 = - diff.dot( segDir );
-			var c = diff.lengthSq();
-			var det = Math.abs( 1 - a01 * a01 );
-			var s0, s1, sqrDist, extDet;
+				if ( s1 >= - extDet ) {
 
-			if ( det > 0 ) {
+					if ( s1 <= extDet ) {
 
-				// The ray and segment are not parallel.
+						// region 0
+						// Minimum at interior points of ray and segment.
 
-				s0 = a01 * b1 - b0;
-				s1 = a01 * b0 - b1;
-				extDet = segExtent * det;
-
-				if ( s0 >= 0 ) {
-
-					if ( s1 >= - extDet ) {
-
-						if ( s1 <= extDet ) {
-
-							// region 0
-							// Minimum at interior points of ray and segment.
-
-							var invDet = 1 / det;
-							s0 *= invDet;
-							s1 *= invDet;
-							sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
-
-						} else {
-
-							// region 1
-
-							s1 = segExtent;
-							s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-						}
+						var invDet = 1 / det;
+						s0 *= invDet;
+						s1 *= invDet;
+						sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
 
 					} else {
 
-						// region 5
+						// region 1
 
-						s1 = - segExtent;
+						s1 = segExtent;
 						s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
 						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
@@ -196,97 +179,99 @@ Object.assign( Ray.prototype, {
 
 				} else {
 
-					if ( s1 <= - extDet ) {
+					// region 5
 
-						// region 4
-
-						s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
-						s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-					} else if ( s1 <= extDet ) {
-
-						// region 3
-
-						s0 = 0;
-						s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = s1 * ( s1 + 2 * b1 ) + c;
-
-					} else {
-
-						// region 2
-
-						s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
-						s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-					}
+					s1 = - segExtent;
+					s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
 				}
 
 			} else {
 
-				// Ray and segment are parallel.
+				if ( s1 <= - extDet ) {
 
-				s1 = ( a01 > 0 ) ? - segExtent : segExtent;
-				s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-				sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+					// region 4
+
+					s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
+					s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+				} else if ( s1 <= extDet ) {
+
+					// region 3
+
+					s0 = 0;
+					s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = s1 * ( s1 + 2 * b1 ) + c;
+
+				} else {
+
+					// region 2
+
+					s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
+					s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+				}
 
 			}
 
-			if ( optionalPointOnRay ) {
+		} else {
 
-				optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
+			// Ray and segment are parallel.
 
-			}
+			s1 = ( a01 > 0 ) ? - segExtent : segExtent;
+			s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+			sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
-			if ( optionalPointOnSegment ) {
+		}
 
-				optionalPointOnSegment.copy( segDir ).multiplyScalar( s1 ).add( segCenter );
+		if ( optionalPointOnRay ) {
 
-			}
+			optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
 
-			return sqrDist;
+		}
 
-		};
+		if ( optionalPointOnSegment ) {
 
-	}(),
+			optionalPointOnSegment.copy( segDir ).multiplyScalar( s1 ).add( segCenter );
 
-	intersectSphere: function () {
+		}
 
-		var v1 = new Vector3();
+		return sqrDist;
 
-		return function intersectSphere( sphere, target ) {
+	},
 
-			v1.subVectors( sphere.center, this.origin );
-			var tca = v1.dot( this.direction );
-			var d2 = v1.dot( v1 ) - tca * tca;
-			var radius2 = sphere.radius * sphere.radius;
+	intersectSphere: function ( sphere, target ) {
 
-			if ( d2 > radius2 ) return null;
+		v1.subVectors( sphere.center, this.origin );
+		var tca = v1.dot( this.direction );
+		var d2 = v1.dot( v1 ) - tca * tca;
+		var radius2 = sphere.radius * sphere.radius;
 
-			var thc = Math.sqrt( radius2 - d2 );
+		if ( d2 > radius2 ) return null;
 
-			// t0 = first intersect point - entrance on front of sphere
-			var t0 = tca - thc;
+		var thc = Math.sqrt( radius2 - d2 );
 
-			// t1 = second intersect point - exit point on back of sphere
-			var t1 = tca + thc;
+		// t0 = first intersect point - entrance on front of sphere
+		var t0 = tca - thc;
 
-			// test to see if both t0 and t1 are behind the ray - if so, return null
-			if ( t0 < 0 && t1 < 0 ) return null;
+		// t1 = second intersect point - exit point on back of sphere
+		var t1 = tca + thc;
 
-			// test to see if t0 is behind the ray:
-			// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
-			// in order to always return an intersect point that is in front of the ray.
-			if ( t0 < 0 ) return this.at( t1, target );
+		// test to see if both t0 and t1 are behind the ray - if so, return null
+		if ( t0 < 0 && t1 < 0 ) return null;
 
-			// else t0 is in front of the ray, so return the first collision point scaled by t0
-			return this.at( t0, target );
+		// test to see if t0 is behind the ray:
+		// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
+		// in order to always return an intersect point that is in front of the ray.
+		if ( t0 < 0 ) return this.at( t1, target );
 
-		};
+		// else t0 is in front of the ray, so return the first collision point scaled by t0
+		return this.at( t0, target );
 
-	}(),
+	},
 
 	intersectsSphere: function ( sphere ) {
 
@@ -430,100 +415,84 @@ Object.assign( Ray.prototype, {
 
 	},
 
-	intersectsBox: ( function () {
+	intersectsBox: function ( box ) {
 
-		var v = new Vector3();
+		return this.intersectBox( box, v1 ) !== null;
 
-		return function intersectsBox( box ) {
+	},
 
-			return this.intersectBox( box, v ) !== null;
+	intersectTriangle: function ( a, b, c, backfaceCulling, target ) {
 
-		};
+		// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
 
-	} )(),
+		edge1.subVectors( b, a );
+		edge2.subVectors( c, a );
+		normal.crossVectors( edge1, edge2 );
 
-	intersectTriangle: function () {
+		// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
+		// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
+		//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
+		//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
+		//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
+		var DdN = this.direction.dot( normal );
+		var sign;
 
-		// Compute the offset origin, edges, and normal.
-		var diff = new Vector3();
-		var edge1 = new Vector3();
-		var edge2 = new Vector3();
-		var normal = new Vector3();
+		if ( DdN > 0 ) {
 
-		return function intersectTriangle( a, b, c, backfaceCulling, target ) {
+			if ( backfaceCulling ) return null;
+			sign = 1;
 
-			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
+		} else if ( DdN < 0 ) {
 
-			edge1.subVectors( b, a );
-			edge2.subVectors( c, a );
-			normal.crossVectors( edge1, edge2 );
+			sign = - 1;
+			DdN = - DdN;
 
-			// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
-			// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
-			//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
-			//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
-			//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
-			var DdN = this.direction.dot( normal );
-			var sign;
+		} else {
 
-			if ( DdN > 0 ) {
+			return null;
 
-				if ( backfaceCulling ) return null;
-				sign = 1;
+		}
 
-			} else if ( DdN < 0 ) {
+		diff.subVectors( this.origin, a );
+		var DdQxE2 = sign * this.direction.dot( edge2.crossVectors( diff, edge2 ) );
 
-				sign = - 1;
-				DdN = - DdN;
+		// b1 < 0, no intersection
+		if ( DdQxE2 < 0 ) {
 
-			} else {
+			return null;
 
-				return null;
+		}
 
-			}
+		var DdE1xQ = sign * this.direction.dot( edge1.cross( diff ) );
 
-			diff.subVectors( this.origin, a );
-			var DdQxE2 = sign * this.direction.dot( edge2.crossVectors( diff, edge2 ) );
+		// b2 < 0, no intersection
+		if ( DdE1xQ < 0 ) {
 
-			// b1 < 0, no intersection
-			if ( DdQxE2 < 0 ) {
+			return null;
 
-				return null;
+		}
 
-			}
+		// b1+b2 > 1, no intersection
+		if ( DdQxE2 + DdE1xQ > DdN ) {
 
-			var DdE1xQ = sign * this.direction.dot( edge1.cross( diff ) );
+			return null;
 
-			// b2 < 0, no intersection
-			if ( DdE1xQ < 0 ) {
+		}
 
-				return null;
+		// Line intersects triangle, check if ray does.
+		var QdN = - sign * diff.dot( normal );
 
-			}
+		// t < 0, no intersection
+		if ( QdN < 0 ) {
 
-			// b1+b2 > 1, no intersection
-			if ( DdQxE2 + DdE1xQ > DdN ) {
+			return null;
 
-				return null;
+		}
 
-			}
+		// Ray intersects triangle.
+		return this.at( QdN / DdN, target );
 
-			// Line intersects triangle, check if ray does.
-			var QdN = - sign * diff.dot( normal );
-
-			// t < 0, no intersection
-			if ( QdN < 0 ) {
-
-				return null;
-
-			}
-
-			// Ray intersects triangle.
-			return this.at( QdN / DdN, target );
-
-		};
-
-	}(),
+	},
 
 	applyMatrix4: function ( matrix4 ) {
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -13,6 +13,8 @@ function Sphere( center, radius ) {
 
 }
 
+var box = new Box3();
+
 Object.assign( Sphere.prototype, {
 
 	set: function ( center, radius ) {
@@ -24,39 +26,33 @@ Object.assign( Sphere.prototype, {
 
 	},
 
-	setFromPoints: function () {
+	setFromPoints: function ( points, optionalCenter ) {
 
-		var box = new Box3();
+		var center = this.center;
 
-		return function setFromPoints( points, optionalCenter ) {
+		if ( optionalCenter !== undefined ) {
 
-			var center = this.center;
+			center.copy( optionalCenter );
 
-			if ( optionalCenter !== undefined ) {
+		} else {
 
-				center.copy( optionalCenter );
+			box.setFromPoints( points ).getCenter( center );
 
-			} else {
+		}
 
-				box.setFromPoints( points ).getCenter( center );
+		var maxRadiusSq = 0;
 
-			}
+		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
-			var maxRadiusSq = 0;
+			maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( points[ i ] ) );
 
-			for ( var i = 0, il = points.length; i < il; i ++ ) {
+		}
 
-				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( points[ i ] ) );
+		this.radius = Math.sqrt( maxRadiusSq );
 
-			}
+		return this;
 
-			this.radius = Math.sqrt( maxRadiusSq );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -13,6 +13,7 @@ function Sphere( center, radius ) {
 
 }
 
+// Used in setFromPoints()
 var box = new Box3();
 
 Object.assign( Sphere.prototype, {

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -13,136 +13,116 @@ function Triangle( a, b, c ) {
 
 }
 
+var v0 = new Vector3();
+var v1 = new Vector3();
+var v2 = new Vector3();
+var barycoord = new Vector3();
+
+var vab = new Vector3();
+var vac = new Vector3();
+var vbc = new Vector3();
+var vap = new Vector3();
+var vbp = new Vector3();
+var vcp = new Vector3();
+
+
 Object.assign( Triangle, {
 
-	getNormal: function () {
+	getNormal: function ( a, b, c, target ) {
 
-		var v0 = new Vector3();
+		if ( target === undefined ) {
 
-		return function getNormal( a, b, c, target ) {
+			console.warn( 'THREE.Triangle: .getNormal() target is now required' );
+			target = new Vector3();
 
-			if ( target === undefined ) {
+		}
 
-				console.warn( 'THREE.Triangle: .getNormal() target is now required' );
-				target = new Vector3();
+		target.subVectors( c, b );
+		v0.subVectors( a, b );
+		target.cross( v0 );
 
-			}
+		var targetLengthSq = target.lengthSq();
+		if ( targetLengthSq > 0 ) {
 
-			target.subVectors( c, b );
-			v0.subVectors( a, b );
-			target.cross( v0 );
+			return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
 
-			var targetLengthSq = target.lengthSq();
-			if ( targetLengthSq > 0 ) {
+		}
 
-				return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
+		return target.set( 0, 0, 0 );
 
-			}
-
-			return target.set( 0, 0, 0 );
-
-		};
-
-	}(),
+	},
 
 	// static/instance method to calculate barycentric coordinates
 	// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-	getBarycoord: function () {
+	getBarycoord: function ( point, a, b, c, target ) {
 
-		var v0 = new Vector3();
-		var v1 = new Vector3();
-		var v2 = new Vector3();
+		v0.subVectors( c, a );
+		v1.subVectors( b, a );
+		v2.subVectors( point, a );
 
-		return function getBarycoord( point, a, b, c, target ) {
+		var dot00 = v0.dot( v0 );
+		var dot01 = v0.dot( v1 );
+		var dot02 = v0.dot( v2 );
+		var dot11 = v1.dot( v1 );
+		var dot12 = v1.dot( v2 );
 
-			v0.subVectors( c, a );
-			v1.subVectors( b, a );
-			v2.subVectors( point, a );
+		var denom = ( dot00 * dot11 - dot01 * dot01 );
 
-			var dot00 = v0.dot( v0 );
-			var dot01 = v0.dot( v1 );
-			var dot02 = v0.dot( v2 );
-			var dot11 = v1.dot( v1 );
-			var dot12 = v1.dot( v2 );
+		if ( target === undefined ) {
 
-			var denom = ( dot00 * dot11 - dot01 * dot01 );
+			console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
+			target = new Vector3();
 
-			if ( target === undefined ) {
+		}
 
-				console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
-				target = new Vector3();
+		// collinear or singular triangle
+		if ( denom === 0 ) {
 
-			}
+			// arbitrary location outside of triangle?
+			// not sure if this is the best idea, maybe should be returning undefined
+			return target.set( - 2, - 1, - 1 );
 
-			// collinear or singular triangle
-			if ( denom === 0 ) {
+		}
 
-				// arbitrary location outside of triangle?
-				// not sure if this is the best idea, maybe should be returning undefined
-				return target.set( - 2, - 1, - 1 );
+		var invDenom = 1 / denom;
+		var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
+		var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
 
-			}
+		// barycentric coordinates must always sum to 1
+		return target.set( 1 - u - v, v, u );
 
-			var invDenom = 1 / denom;
-			var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
-			var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
+	},
 
-			// barycentric coordinates must always sum to 1
-			return target.set( 1 - u - v, v, u );
+	containsPoint: function ( point, a, b, c ) {
 
-		};
+		Triangle.getBarycoord(point, a, b, c, barycoord );
 
-	}(),
+		return (barycoord.x >= 0) && (barycoord.y >= 0) && ((barycoord.x + barycoord.y ) <= 1 );
 
-	containsPoint: function () {
+	},
 
-		var v1 = new Vector3();
+	getUV: function ( point, p1, p2, p3, uv1, uv2, uv3, target ) {
 
-		return function containsPoint( point, a, b, c ) {
+		this.getBarycoord( point, p1, p2, p3, barycoord );
 
-			Triangle.getBarycoord( point, a, b, c, v1 );
+		target.set( 0, 0 );
+		target.addScaledVector( uv1, barycoord.x );
+		target.addScaledVector( uv2, barycoord.y );
+		target.addScaledVector( uv3, barycoord.z );
 
-			return ( v1.x >= 0 ) && ( v1.y >= 0 ) && ( ( v1.x + v1.y ) <= 1 );
+		return target;
 
-		};
+	},
 
-	}(),
+	isFrontFacing: function ( a, b, c, direction ) {
 
-	getUV: function () {
+		v0.subVectors( c, b );
+		v1.subVectors( a, b );
 
-		var barycoord = new Vector3();
+		// strictly front facing
+		return ( v0.cross( v1 ).dot( direction ) < 0 ) ? true : false;
 
-		return function getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
-
-			this.getBarycoord( point, p1, p2, p3, barycoord );
-
-			target.set( 0, 0 );
-			target.addScaledVector( uv1, barycoord.x );
-			target.addScaledVector( uv2, barycoord.y );
-			target.addScaledVector( uv3, barycoord.z );
-
-			return target;
-
-		};
-
-	}(),
-
-	isFrontFacing: function () {
-
-		var v0 = new Vector3();
-		var v1 = new Vector3();
-
-		return function isFrontFacing( a, b, c, direction ) {
-
-			v0.subVectors( c, b );
-			v1.subVectors( a, b );
-
-			// strictly front facing
-			return ( v0.cross( v1 ).dot( direction ) < 0 ) ? true : false;
-
-		};
-
-	}()
+	}
 
 } );
 
@@ -186,19 +166,12 @@ Object.assign( Triangle.prototype, {
 
 	getArea: function () {
 
-		var v0 = new Vector3();
-		var v1 = new Vector3();
+		v0.subVectors( this.c, this.b );
+		v1.subVectors( this.a, this.b );
 
-		return function getArea() {
+		return v0.cross( v1 ).length() * 0.5;
 
-			v0.subVectors( this.c, this.b );
-			v1.subVectors( this.a, this.b );
-
-			return v0.cross( v1 ).length() * 0.5;
-
-		};
-
-	}(),
+	},
 
 	getMidpoint: function ( target ) {
 
@@ -262,103 +235,92 @@ Object.assign( Triangle.prototype, {
 
 	},
 
-	closestPointToPoint: function () {
+	closestPointToPoint: function ( p, target ) {
 
-		var vab = new Vector3();
-		var vac = new Vector3();
-		var vbc = new Vector3();
-		var vap = new Vector3();
-		var vbp = new Vector3();
-		var vcp = new Vector3();
+		if ( target === undefined ) {
 
-		return function closestPointToPoint( p, target ) {
+			console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
+			target = new Vector3();
 
-			if ( target === undefined ) {
+		}
 
-				console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
-				target = new Vector3();
+		var a = this.a, b = this.b, c = this.c;
+		var v, w;
 
-			}
+		// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
+		// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
+		// under the accompanying license; see chapter 5.1.5 for detailed explanation.
+		// basically, we're distinguishing which of the voronoi regions of the triangle
+		// the point lies in with the minimum amount of redundant computation.
 
-			var a = this.a, b = this.b, c = this.c;
-			var v, w;
+		vab.subVectors( b, a );
+		vac.subVectors( c, a );
+		vap.subVectors( p, a );
+		var d1 = vab.dot( vap );
+		var d2 = vac.dot( vap );
+		if ( d1 <= 0 && d2 <= 0 ) {
 
-			// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
-			// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
-			// under the accompanying license; see chapter 5.1.5 for detailed explanation.
-			// basically, we're distinguishing which of the voronoi regions of the triangle
-			// the point lies in with the minimum amount of redundant computation.
+			// vertex region of A; barycentric coords (1, 0, 0)
+			return target.copy( a );
 
-			vab.subVectors( b, a );
-			vac.subVectors( c, a );
-			vap.subVectors( p, a );
-			var d1 = vab.dot( vap );
-			var d2 = vac.dot( vap );
-			if ( d1 <= 0 && d2 <= 0 ) {
+		}
 
-				// vertex region of A; barycentric coords (1, 0, 0)
-				return target.copy( a );
+		vbp.subVectors( p, b );
+		var d3 = vab.dot( vbp );
+		var d4 = vac.dot( vbp );
+		if ( d3 >= 0 && d4 <= d3 ) {
 
-			}
+			// vertex region of B; barycentric coords (0, 1, 0)
+			return target.copy( b );
 
-			vbp.subVectors( p, b );
-			var d3 = vab.dot( vbp );
-			var d4 = vac.dot( vbp );
-			if ( d3 >= 0 && d4 <= d3 ) {
+		}
 
-				// vertex region of B; barycentric coords (0, 1, 0)
-				return target.copy( b );
+		var vc = d1 * d4 - d3 * d2;
+		if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
 
-			}
+			v = d1 / ( d1 - d3 );
+			// edge region of AB; barycentric coords (1-v, v, 0)
+			return target.copy( a ).addScaledVector( vab, v );
 
-			var vc = d1 * d4 - d3 * d2;
-			if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
+		}
 
-				v = d1 / ( d1 - d3 );
-				// edge region of AB; barycentric coords (1-v, v, 0)
-				return target.copy( a ).addScaledVector( vab, v );
+		vcp.subVectors( p, c );
+		var d5 = vab.dot( vcp );
+		var d6 = vac.dot( vcp );
+		if ( d6 >= 0 && d5 <= d6 ) {
 
-			}
+			// vertex region of C; barycentric coords (0, 0, 1)
+			return target.copy( c );
 
-			vcp.subVectors( p, c );
-			var d5 = vab.dot( vcp );
-			var d6 = vac.dot( vcp );
-			if ( d6 >= 0 && d5 <= d6 ) {
+		}
 
-				// vertex region of C; barycentric coords (0, 0, 1)
-				return target.copy( c );
+		var vb = d5 * d2 - d1 * d6;
+		if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
 
-			}
+			w = d2 / ( d2 - d6 );
+			// edge region of AC; barycentric coords (1-w, 0, w)
+			return target.copy( a ).addScaledVector( vac, w );
 
-			var vb = d5 * d2 - d1 * d6;
-			if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
+		}
 
-				w = d2 / ( d2 - d6 );
-				// edge region of AC; barycentric coords (1-w, 0, w)
-				return target.copy( a ).addScaledVector( vac, w );
+		var va = d3 * d6 - d5 * d4;
+		if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
 
-			}
+			vbc.subVectors( c, b );
+			w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
+			// edge region of BC; barycentric coords (0, 1-w, w)
+			return target.copy( b ).addScaledVector( vbc, w ); // edge region of BC
 
-			var va = d3 * d6 - d5 * d4;
-			if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
+		}
 
-				vbc.subVectors( c, b );
-				w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
-				// edge region of BC; barycentric coords (0, 1-w, w)
-				return target.copy( b ).addScaledVector( vbc, w ); // edge region of BC
+		// face region
+		var denom = 1 / ( va + vb + vc );
+		// u = va * denom
+		v = vb * denom;
+		w = vc * denom;
+		return target.copy( a ).addScaledVector( vab, v ).addScaledVector( vac, w );
 
-			}
-
-			// face region
-			var denom = 1 / ( va + vb + vc );
-			// u = va * denom
-			v = vb * denom;
-			w = vc * denom;
-			return target.copy( a ).addScaledVector( vab, v ).addScaledVector( vac, w );
-
-		};
-
-	}(),
+	},
 
 	equals: function ( triangle ) {
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -12,12 +12,19 @@ function Triangle( a, b, c ) {
 	this.c = ( c !== undefined ) ? c : new Vector3();
 
 }
-
+// Used in getNormal(), getBarycoord(), isFrontFacing() and getArea()
 var v0 = new Vector3();
+
+// Used in getBarycoord(), isFrontFacing() and getArea()
 var v1 = new Vector3();
+
+// Used in getBarycoord()
 var v2 = new Vector3();
+
+// Used in containsPoint() and getUV()
 var barycoord = new Vector3();
 
+// Used in closestPointToPoint()
 var vab = new Vector3();
 var vac = new Vector3();
 var vbc = new Vector3();

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -95,9 +95,9 @@ Object.assign( Triangle, {
 
 	containsPoint: function ( point, a, b, c ) {
 
-		Triangle.getBarycoord(point, a, b, c, barycoord );
+		Triangle.getBarycoord( point, a, b, c, barycoord );
 
-		return (barycoord.x >= 0) && (barycoord.y >= 0) && ((barycoord.x + barycoord.y ) <= 1 );
+		return ( barycoord.x >= 0 ) && ( barycoord.y >= 0 ) && ( ( barycoord.x + barycoord.y ) <= 1 );
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -18,6 +18,7 @@ function Vector3( x, y, z ) {
 
 }
 
+// Used in applyEuler() and applyAxisAngle()
 var quaternion = new Quaternion();
 
 Object.assign( Vector3.prototype, {

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -18,6 +18,8 @@ function Vector3( x, y, z ) {
 
 }
 
+var quaternion = new Quaternion();
+
 Object.assign( Vector3.prototype, {
 
 	isVector3: true,
@@ -231,35 +233,23 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	applyEuler: function () {
+	applyEuler: function ( euler ) {
 
-		var quaternion = new Quaternion();
+		if ( ! ( euler && euler.isEuler ) ) {
 
-		return function applyEuler( euler ) {
+			console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
 
-			if ( ! ( euler && euler.isEuler ) ) {
+		}
 
-				console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+		return this.applyQuaternion( quaternion.setFromEuler( euler ) );
 
-			}
+	},
 
-			return this.applyQuaternion( quaternion.setFromEuler( euler ) );
+	applyAxisAngle: function ( axis, angle ) {
 
-		};
+		return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
 
-	}(),
-
-	applyAxisAngle: function () {
-
-		var quaternion = new Quaternion();
-
-		return function applyAxisAngle( axis, angle ) {
-
-			return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
-
-		};
-
-	}(),
+	},
 
 	applyMatrix3: function ( m ) {
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -49,7 +49,7 @@ Object.defineProperties( Vector4.prototype, {
 
 	}
 
-});
+} );
 
 var min, max;
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -49,7 +49,9 @@ Object.defineProperties( Vector4.prototype, {
 
 	}
 
-} );
+});
+
+var min, max;
 
 Object.assign( Vector4.prototype, {
 
@@ -471,27 +473,21 @@ Object.assign( Vector4.prototype, {
 
 	},
 
-	clampScalar: function () {
+	clampScalar: function ( minVal, maxVal ) {
 
-		var min, max;
+		if ( min === undefined ) {
 
-		return function clampScalar( minVal, maxVal ) {
+			min = new Vector4();
+			max = new Vector4();
 
-			if ( min === undefined ) {
+		}
 
-				min = new Vector4();
-				max = new Vector4();
+		min.set( minVal, minVal, minVal, minVal );
+		max.set( maxVal, maxVal, maxVal, maxVal );
 
-			}
+		return this.clamp( min, max );
 
-			min.set( minVal, minVal, minVal, minVal );
-			max.set( maxVal, maxVal, maxVal, maxVal );
-
-			return this.clamp( min, max );
-
-		};
-
-	}(),
+	},
 
 	clampLength: function ( min, max ) {
 


### PR DESCRIPTION
This Pull Request removes a ton of closures in the math library of three.js. This is no longer needed because modules already enclose the variables. This should improve performance and reduce memory but this should still be tested. 

