### PR TITLE
WebGLTextures: Ensure OffscreenCanvas provides drawing context.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -10,9 +10,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	var _videoTextures = {};
 	var _canvas;
 
-	//
+	// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
+	// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
 
-	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
+	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+		&& (new OffscreenCanvas(1, 1).getContext("2d")) !== null;
 
 	function createCanvas( width, height ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -14,7 +14,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
 
 	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
-		&& (new OffscreenCanvas(1, 1).getContext("2d")) !== null;
+		&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
 
 	function createCanvas( width, height ) {
 


### PR DESCRIPTION
cordova iOS (as of 5.0) still uses UIWebView,
which provides OffscreenCanvas,
also OffscreenCanvas.getContext("webgl"),
but not OffscreenCanvas.getContext("2d")!