### PR TITLE
Add FailOnlyReporter to reduce unit test clutter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three",
-  "version": "0.104.0",
+  "version": "0.105.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -667,6 +667,37 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      }
+    },
+    "failonlyreporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/failonlyreporter/-/failonlyreporter-1.0.0.tgz",
+      "integrity": "sha512-daW559J4F/nWk0AiUPuxpCNCRXNa74yQdZNAVBIJt192VbsfKMNZocCqvRLjFIIp9BeBGu4gUhFJImmb4kSWOQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",
     "start": "npm run dev",
     "lint": "eslint src --ext js --ext ts",
-    "test": "npm run build-test && qunit test/unit/three.source.unit.js",
+    "test": "npm run build-test && qunit -r failonlyreporter test/unit/three.source.unit.js",
     "travis": "npm run lint && npm test"
   },
   "keywords": [
@@ -67,17 +67,18 @@
   },
   "homepage": "https://threejs.org/",
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.9.0",
+    "@typescript-eslint/parser": "^1.9.0",
     "concurrently": "^4.1.0",
     "eslint": "^5.16.0",
     "eslint-config-mdcs": "^4.2.3",
     "eslint-plugin-html": "^5.0.3",
-    "@typescript-eslint/parser": "^1.9.0",
-    "@typescript-eslint/eslint-plugin": "^1.9.0",
-    "typescript": "^3.4.5",
+    "failonlyreporter": "^1.0.0",
     "google-closure-compiler": "20190415.0.0",
     "http-server": "^0.11.1",
     "qunit": "^2.9.2",
-    "rollup": "^1.10.1"
+    "rollup": "^1.10.1",
+    "typescript": "^3.4.5"
   },
   "jspm": {
     "files": [


### PR DESCRIPTION
This adds FailOnlyReporter as a dev dependency to make sure that skipped and Todo tests are not visible.

This makes it so that only failed Tests are shown in the command line. This resulted in a console output in travis of around 500 lines. This was around 10000 lines before because ever todo test added 8 lines.
