### PR TITLE
VRMLLoader: Fix parsing of CoordIndex when not ending with -1

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -1860,7 +1860,7 @@ THREE.VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current face has ended and the next one begins
 
-					if ( index[ i + 3 ] === - 1 ) {
+					if ( index[ i + 3 ] === - 1 || i + 3 >= l ) {
 
 						i += 3;
 						start = i + 1;
@@ -1891,7 +1891,7 @@ THREE.VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current face has ended and the next one begins
 
-					if ( index[ i + 3 ] === - 1 ) {
+					if ( index[ i + 3 ] === - 1 || i + 3 >= l ) {
 
 						i += 3;
 						start ++;
@@ -1939,7 +1939,7 @@ THREE.VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current line has ended and the next one begins
 
-					if ( index[ i + 2 ] === - 1 ) {
+					if ( index[ i + 2 ] === - 1 || i + 2 >= l ) {
 
 						i += 2;
 
@@ -1969,7 +1969,7 @@ THREE.VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current line has ended and the next one begins
 
-					if ( index[ i + 2 ] === - 1 ) {
+					if ( index[ i + 2 ] === - 1 || i + 2 >= l ) {
 
 						i += 2;
 						start ++;

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -1893,7 +1893,7 @@ var VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current face has ended and the next one begins
 
-					if ( index[ i + 3 ] === - 1 ) {
+					if ( index[ i + 3 ] === - 1 || i + 3 >= l ) {
 
 						i += 3;
 						start = i + 1;
@@ -1924,7 +1924,7 @@ var VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current face has ended and the next one begins
 
-					if ( index[ i + 3 ] === - 1 ) {
+					if ( index[ i + 3 ] === - 1 || i + 3 >= l ) {
 
 						i += 3;
 						start ++;
@@ -1972,7 +1972,7 @@ var VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current line has ended and the next one begins
 
-					if ( index[ i + 2 ] === - 1 ) {
+					if ( index[ i + 2 ] === - 1 || i + 2 >= l ) {
 
 						i += 2;
 
@@ -2002,7 +2002,7 @@ var VRMLLoader = ( function () {
 
 					// an index of -1 indicates that the current line has ended and the next one begins
 
-					if ( index[ i + 2 ] === - 1 ) {
+					if ( index[ i + 2 ] === - 1 || i + 2 >= l ) {
 
 						i += 2;
 						start ++;


### PR DESCRIPTION
According to [[1]](http://www.graphics.stanford.edu/courses/cs248-98-fall/Assignments/Assignment3/VRML2_Specification/spec/part1/nodesRef.html#IndexedFaceSet):

 'The last face may (but does not have to be) followed by a -1.'