### PR TITLE
cleanup eslint warning/ weird statement

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -428,9 +428,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		delete bindingByName[ trackName ];
 
-		remove_empty_map: {
-
-			for ( var _ in bindingByName ) break remove_empty_map; // eslint-disable-line no-unused-vars
+		if ( Object.keys( bindingByName ).length === 0 ) {
 
 			delete bindingsByRoot[ rootUuid ];
 


### PR DESCRIPTION
This removes a eslint warning:
![image](https://user-images.githubusercontent.com/155535/59553665-642d4480-8f98-11e9-983d-b9b06f3e3cff.png)

I also believe the new statement is clearer.