### PR TITLE
Xloader can now use the defaultLoadingManager again

### DIFF
--- a/examples/js/loaders/XLoader.js
+++ b/examples/js/loaders/XLoader.js
@@ -204,7 +204,7 @@ THREE.XLoader = ( function () {
 			classCallCheck( this, XLoader );
 
 			this.debug = false;
-			this.manager = manager !== undefined ? manager : new THREE.DefaultLoadingManager();
+			this.manager = manager !== undefined ? manager : THREE.DefaultLoadingManager;
 			this.texloader = new THREE.TextureLoader( this.manager );
 			this.url = "";
 			this._putMatLength = 0;

--- a/examples/jsm/loaders/XLoader.js
+++ b/examples/jsm/loaders/XLoader.js
@@ -226,7 +226,7 @@ var XLoader = ( function () {
 			classCallCheck( this, XLoader );
 
 			this.debug = false;
-			this.manager = manager !== undefined ? manager : new DefaultLoadingManager();
+			this.manager = manager !== undefined ? manager : DefaultLoadingManager;
 			this.texloader = new TextureLoader( this.manager );
 			this.url = "";
 			this._putMatLength = 0;


### PR DESCRIPTION
DefaultLoadingManager is a global instance of LoadingManager. It can not be initialized again.

This PR also removes [LGTM Error](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/c5d07d3175373fa0d6c72d49fec9037b7ae6dbe8/files/examples/jsm/loaders/XLoader.js?sort=name&dir=ASC&mode=heatmap#x85d6e964fa247e11:1).