### PR TITLE
LightningStrike: remove unneccessary assignement

### DIFF
--- a/examples/js/geometries/LightningStrike.js
+++ b/examples/js/geometries/LightningStrike.js
@@ -831,8 +831,7 @@ THREE.LightningStrike.prototype.createDefaultSubrayCreationCallbacks = function 
 		var childSubraySeed = random1() * ( currentCycle + 1 );
 
 		var isActive = phase % period <= dutyCycle * period;
-
-		probability = lightningStrike.subrayProbability;
+		
 		var probability = 0;
 
 		if ( isActive ) {

--- a/examples/jsm/geometries/LightningStrike.js
+++ b/examples/jsm/geometries/LightningStrike.js
@@ -841,8 +841,7 @@ LightningStrike.prototype.createDefaultSubrayCreationCallbacks = function () {
 		var childSubraySeed = random1() * ( currentCycle + 1 );
 
 		var isActive = phase % period <= dutyCycle * period;
-
-		probability = lightningStrike.subrayProbability;
+		
 		var probability = 0;
 
 		if ( isActive ) {


### PR DESCRIPTION
This PR removes an unneccesary statement and removes [LGTM Error](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/c5d07d3175373fa0d6c72d49fec9037b7ae6dbe8/files/examples/jsm/geometries/LightningStrike.js?sort=name&dir=ASC&mode=heatmap).

