### PR TITLE
JSM: Added module and TS file for CTMLoader.

### DIFF
--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -169,6 +169,11 @@
 				</li>
 				<li>loaders
 					<ul>
+						<li>ctm
+							<ul>
+								<li>CTMLoader</li>
+							</ul>
+						</li>
 						<li>deprecated
 							<ul>
 								<li>LegacyGLTFLoader</li>

--- a/examples/jsm/loaders/ctm/CTMLoader.d.ts
+++ b/examples/jsm/loaders/ctm/CTMLoader.d.ts
@@ -1,0 +1,20 @@
+import {
+  BufferGeometry,
+  Material
+} from '../../../../src/Three';
+
+export interface CTMLoaderParameters {
+  basePath?: string;
+  offsets?: number[];
+  useWorker?: boolean;
+  worker?: object;
+}
+
+export class CTMLoader {
+  constructor();
+  workerPath: string;
+
+  load(url: string, onLoad: (geometry: BufferGeometry) => void, parameters: CTMLoaderParameters): void;
+  loadParts(url: string, onLoad: (geometries: BufferGeometry[], materials: Material[]) => void, parameters: CTMLoaderParameters): void;
+  setWorkerPath(value: string): this;
+}

--- a/examples/jsm/loaders/ctm/CTMLoader.js
+++ b/examples/jsm/loaders/ctm/CTMLoader.js
@@ -32,17 +32,24 @@
  *
  */
 
+import {
+	BufferAttribute,
+	BufferGeometry,
+	Loader,
+	LoaderUtils
+} from "../../../../build/three.module.js";
+
 /* global CTM */
 
-THREE.CTMLoader = function () {
+var CTMLoader = function () {
 
 	this.workerPath = null;
 
 };
 
-THREE.CTMLoader.prototype.constructor = THREE.CTMLoader;
+CTMLoader.prototype.constructor = CTMLoader;
 
-THREE.CTMLoader.prototype.setWorkerPath = function ( workerPath ) {
+CTMLoader.prototype.setWorkerPath = function ( workerPath ) {
 
 	this.workerPath = workerPath;
 
@@ -50,7 +57,7 @@ THREE.CTMLoader.prototype.setWorkerPath = function ( workerPath ) {
 
 // Load multiple CTM parts defined in JSON
 
-THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
+CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 	parameters = parameters || {};
 
@@ -58,7 +65,7 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 	var xhr = new XMLHttpRequest();
 
-	var basePath = parameters.basePath ? parameters.basePath : THREE.LoaderUtils.extractUrlBase( url );
+	var basePath = parameters.basePath ? parameters.basePath : LoaderUtils.extractUrlBase( url );
 
 	xhr.onreadystatechange = function () {
 
@@ -89,7 +96,7 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 
 				for ( var i = 0; i < jsonObject.materials.length; i ++ ) {
 
-					materials[ i ] = THREE.Loader.prototype.createMaterial( jsonObject.materials[ i ], basePath );
+					materials[ i ] = Loader.prototype.createMaterial( jsonObject.materials[ i ], basePath );
 
 				}
 
@@ -116,7 +123,7 @@ THREE.CTMLoader.prototype.loadParts = function ( url, callback, parameters ) {
 //		- url (required)
 //		- callback (required)
 
-THREE.CTMLoader.prototype.load = function ( url, callback, parameters ) {
+CTMLoader.prototype.load = function ( url, callback, parameters ) {
 
 	parameters = parameters || {};
 
@@ -220,9 +227,9 @@ THREE.CTMLoader.prototype.load = function ( url, callback, parameters ) {
 };
 
 
-THREE.CTMLoader.prototype._createGeometry = function ( file, callback ) {
+CTMLoader.prototype._createGeometry = function ( file, callback ) {
 
-	var geometry = new THREE.BufferGeometry();
+	var geometry = new BufferGeometry();
 
 	var indices = file.body.indices;
 	var positions = file.body.vertices;
@@ -246,24 +253,24 @@ THREE.CTMLoader.prototype._createGeometry = function ( file, callback ) {
 
 	}
 
-	geometry.setIndex( new THREE.BufferAttribute( indices, 1 ) );
-	geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+	geometry.setIndex( new BufferAttribute( indices, 1 ) );
+	geometry.addAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
 	if ( normals !== undefined ) {
 
-		geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
+		geometry.addAttribute( 'normal', new BufferAttribute( normals, 3 ) );
 
 	}
 
 	if ( uvs !== undefined ) {
 
-		geometry.addAttribute( 'uv', new THREE.BufferAttribute( uvs, 2 ) );
+		geometry.addAttribute( 'uv', new BufferAttribute( uvs, 2 ) );
 
 	}
 
 	if ( colors !== undefined ) {
 
-		geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 4 ) );
+		geometry.addAttribute( 'color', new BufferAttribute( colors, 4 ) );
 
 	}
 
@@ -277,3 +284,5 @@ THREE.CTMLoader.prototype._createGeometry = function ( file, callback ) {
 	callback( geometry );
 
 };
+
+export { CTMLoader };

--- a/examples/webgl_loader_ctm.html
+++ b/examples/webgl_loader_ctm.html
@@ -25,6 +25,12 @@
 
 		<script>
 
+			if ( WEBGL.isWebGLAvailable() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+
+			}
+
 			var SCREEN_WIDTH = window.innerWidth;
 			var SCREEN_HEIGHT = window.innerHeight;
 
@@ -127,6 +133,7 @@
 				}
 
 				var loader = new THREE.CTMLoader();
+				loader.setWorkerPath( "js/loaders/ctm/CTMWorker.js" );
 
 				loader.load( "models/ctm/ben.ctm", function ( geometry ) {
 

--- a/examples/webgl_loader_ctm_materials.html
+++ b/examples/webgl_loader_ctm_materials.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - baked illumination</title>
+		<title>three.js webgl - CTM loader materials</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
@@ -116,6 +116,8 @@
 				var scale = new THREE.Vector3( 30, 30, 30 );
 
 				var loader = new THREE.CTMLoader();
+				loader.setWorkerPath( "js/loaders/ctm/CTMWorker.js" );
+
 				loader.loadParts( "models/ctm/camaro/camaro.js", function ( geometries, materials ) {
 
 					hackMaterials( materials );

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -72,6 +72,7 @@ var files = [
 	{ path: 'lines/Wireframe.js', dependencies: [ { name: 'LineSegmentsGeometry', path: 'lines/LineSegmentsGeometry.js' }, { name: 'LineMaterial', path: 'lines/LineMaterial.js' } ], ignoreList: [] },
 	{ path: 'lines/WireframeGeometry2.js', dependencies: [ { name: 'LineSegmentsGeometry', path: 'lines/LineSegmentsGeometry.js' } ], ignoreList: [] },
 
+	{ path: 'loaders/ctm/CTMLoader.js', dependencies: [], ignoreList: [] },
 	{ path: 'loaders/deprecated/LegacyGLTFLoader.js', dependencies: [], ignoreList: [ 'AnimationMixer' ] },
 	{ path: 'loaders/deprecated/LegacyJSONLoader.js', dependencies: [], ignoreList: [ 'ObjectLoader' ] },
 	{ path: 'loaders/3MFLoader.js', dependencies: [], ignoreList: [] },


### PR DESCRIPTION
I've also introduced `CTMLoader.setWorkerPath()` since the previous path was hardly coded into the loader. Also refactored `CTMLoader.createModel()`. It's now `_createGeometry()` and returns an instance of `BufferGeometry`. A custom type `Model` is not necessary.