### PR TITLE
TS: Add missing useGroups parameter for BufferGeometryUtils.mergeBufferGeometries()

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -1,7 +1,7 @@
 import { BufferAttribute, BufferGeometry } from '../../../src/Three';
 
 export namespace BufferGeometryUtils {
-    export function mergeBufferGeometries(geometries: BufferGeometry[]): BufferGeometry;
+    export function mergeBufferGeometries(geometries: BufferGeometry[], useGroups: boolean): BufferGeometry;
     export function computeTangents(geometry: BufferGeometry): null;
     export function mergeBufferAttributes(attributes: BufferAttribute[]): BufferAttribute;
 }

--- a/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -1,7 +1,7 @@
 import { BufferAttribute, BufferGeometry } from '../../../src/Three';
 
 export namespace BufferGeometryUtils {
-    export function mergeBufferGeometries(geometries: BufferGeometry[], useGroups: boolean): BufferGeometry;
+    export function mergeBufferGeometries(geometries: BufferGeometry[], useGroups?: boolean): BufferGeometry;
     export function computeTangents(geometry: BufferGeometry): null;
     export function mergeBufferAttributes(attributes: BufferAttribute[]): BufferAttribute;
 }


### PR DESCRIPTION
Looks like the `useGroups` parameter did not make it in to `mergeBufferGeometries` in the `BufferGeometryUtils.d.ts`file.

I tested this locally, and it seemed to work. Not sure if this was omitted intentionally.