### PR TITLE
Change ImageUtils.getDataURL() to accept a non-renderable object 

### DIFF
--- a/src/extras/ImageUtils.d.ts
+++ b/src/extras/ImageUtils.d.ts
@@ -8,6 +8,12 @@ import { Texture } from '../textures/Texture';
  */
 export namespace ImageUtils {
 	/**
+	 */
+	export function getDataURL(
+		image: any,
+	): string;
+
+	/**
 	 * @deprecated
 	 */
 	export let crossOrigin: string;

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -35,7 +35,18 @@ var ImageUtils = {
 
 			} else {
 
-				context.drawImage( image, 0, 0, image.width, image.height );
+				try {
+
+					// Can throw if `image` is not a drawable type, e.g. HTMLImageElement, HTMLVideoElement,
+					// ImageBitmap; occurs for DataTextures, Textures from WebGLRenderTarget etc..
+
+					context.drawImage( image, 0, 0, image.width, image.height );
+
+				} catch ( e ) {
+
+					return '';
+
+				}
 
 			}
 


### PR DESCRIPTION
Change ImageUtils.getDataURL() to accept a non-renderable object  and return an empty string if a data URL cannot be generated. Allows the serialization of a scene with a DataTexture/WebGLRenderTarget after #16651 landed without throwing. Fixes #16763.