### PR TITLE
InterleavedAttribute: normalized defaults to false instead of true

### DIFF
--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -52,7 +52,7 @@
 
 		<h3>[property:Boolean normalized]</h3>
 		<p>
-			Default is *true*.
+			Default is *false*.
 		</p>
 
 		<h3>[property:Boolean isInterleavedBufferAttribute]</h3>


### PR DESCRIPTION
The docs are wrong. From the source: `this.normalized = normalized === true;`