### PR TITLE
Examples: Simplify webgl_modifier_subdivision and use modules.

### DIFF
--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -24,9 +24,10 @@
 
 		<script type="module">
 			import {
-				BoxGeometry,
 				BufferGeometry,
+				BufferGeometryLoader,
 				Color,
+				Geometry,
 				Mesh,
 				MeshBasicMaterial,
 				MeshPhongMaterial,
@@ -55,12 +56,11 @@
 			};
 
 			init();
-			animate();
 
 			function init() {
 
-				camera = new PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
-				camera.position.z = 2.5;
+				camera = new PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 500 );
+				camera.position.z = 100;
 
 				scene = new Scene();
 				scene.background = new Color( 0xf0f0f0 );
@@ -69,10 +69,32 @@
 				light.position.set( 1000, 1000, 2000 );
 				scene.add( light );
 
-				var geometry = new BoxGeometry( 1, 1, 1, 2, 2, 2 );
-				var material = new MeshBasicMaterial( { color: 0xcccccc, wireframe: true } );
-				var mesh = new Mesh( new BufferGeometry().fromGeometry( geometry ), material );
-				scene.add( mesh );
+				var loader = new BufferGeometryLoader();
+				loader.load( 'models/json/WaltHeadLo_buffergeometry.json', function ( bufferGeometry ) {
+
+					// converting to legacy Geometry because SubdivisionModifier only returns Geometry
+
+					var geometry = new Geometry().fromBufferGeometry( bufferGeometry );
+					geometry.mergeVertices();
+
+					var material = new MeshBasicMaterial( { color: 0xcccccc, wireframe: true } );
+					var mesh = new Mesh( bufferGeometry, material );
+					scene.add( mesh );
+
+					var gui = new GUI();
+
+					gui.add( params, 'subdivisions', 0, 4 ).step( 1 ).onChange( function ( subdivisions ) {
+
+						subdivide( geometry, subdivisions );
+
+					} );
+
+					//
+
+					subdivide( geometry, params.subdivisions );
+					animate();
+
+				} );
 
 				renderer = new WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -85,27 +107,16 @@
 				//
 
 				var controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
+				controls.minDistance = 50;
+				controls.maxDistance = 400;
 
 				window.addEventListener( 'resize', onWindowResize, false );
-
-				//
-
-				var gui = new GUI();
-
-				gui.add( params, 'subdivisions', 0, 6 ).step( 1 ).onChange( function ( subdivisions ) {
-
-					subdivide( geometry, subdivisions );
-
-				} );
 
 				//
 
 				smoothMesh = new Mesh( undefined, smoothMaterial );
 				wireframe = new Mesh( undefined, wireframeMaterial );
 				scene.add( smoothMesh, wireframe );
-
-				subdivide( geometry, params.subdivisions );
 
 			}
 
@@ -126,7 +137,7 @@
 						var vertexIndex = face[ faceIndices[ j ] ];
 						var vertex = smoothGeometry.vertices[ vertexIndex ];
 
-						var hue = vertex.y + 0.5;
+						var hue = ( vertex.y / 200 ) + 0.5;
 						var color = new Color().setHSL( hue, 1, 0.5 );
 						face.vertexColors[ j ] = color;
 

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -83,7 +83,7 @@
 
 					var gui = new GUI();
 
-					gui.add( params, 'subdivisions', 0, 4 ).step( 1 ).onChange( function ( subdivisions ) {
+					gui.add( params, 'subdivisions', 0, 3 ).step( 1 ).onChange( function ( subdivisions ) {
 
 						subdivide( geometry, subdivisions );
 

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -16,298 +16,144 @@
 		</style>
 	</head>
 	<body>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - subdivision modifier<br/ >
+			Original Geometry: <span id="original-vertex-count"></span> vertices and <span id="original-face-count"></span> faces<br/ >
+			Smooth Geometry: <span id="smooth-vertex-count"></span> vertices and <span id="smooth-face-count"></span> faces<br/ >
+		</div>
 
-		<script src="../build/three.js"></script>
-		<script src="js/controls/OrbitControls.js"></script>
-		<script src="js/modifiers/SubdivisionModifier.js"></script>
-		<script src="js/libs/stats.min.js"></script>
-		<script src="js/WebGL.js"></script>
+		<script type="module">
+			import {
+				BoxGeometry,
+				BufferGeometry,
+				Color,
+				Mesh,
+				MeshBasicMaterial,
+				MeshPhongMaterial,
+				PerspectiveCamera,
+				PointLight,
+				Scene,
+				VertexColors,
+				WebGLRenderer,
+			} from "../build/three.module.js";
 
-		<script>
+			import Stats from './jsm/libs/stats.module.js';
 
-			if ( WEBGL.isWebGLAvailable() === false ) {
+			import { GUI } from './jsm/libs/dat.gui.module.js';
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { SubdivisionModifier } from './jsm/modifiers/SubdivisionModifier.js';
 
-				document.body.appendChild( WEBGL.getWebGLErrorMessage() );
+			var camera, scene, renderer, stats, smoothMesh, wireframe;
 
-			}
+			var smoothMaterial = new MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: VertexColors } );
+			var wireframeMaterial = new MeshBasicMaterial( { color: 0x000000, wireframe: true, opacity: 0.15, transparent: true } );
 
-			var container, stats;
+			var faceIndices = [ 'a', 'b', 'c' ];
 
-			var camera, scene, renderer;
-
-			var cube, mesh, material, geometry, smooth, group;
-
-			// Create new object by parameters
-
-			var createSomething = function ( klass, args ) {
-
-				var F = function ( klass, args ) {
-
-					return klass.apply( this, args );
-
-				};
-
-				F.prototype = klass.prototype;
-
-				return new F( klass, args );
-
+			var params = {
+				subdivisions: 2
 			};
-
-			var wireframeMaterial = new THREE.MeshBasicMaterial( { color: 0x000000, wireframe: true, opacity: 0.15, transparent: true } );
-			var material = new THREE.MeshBasicMaterial( { color: 0xffffff, wireframe: true } );
-			var smoothMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: THREE.VertexColors } );
-
-			// Cube
-
-			var materials = [];
-
-			for ( var i = 0; i < 6; i ++ ) {
-
-				materials.push( [ new THREE.MeshBasicMaterial( { color: Math.random() * 0xffffff, wireframe: false } ) ] );
-
-			}
-
-
-
-			var geometriesParams = [
-
-				{ type: 'BoxGeometry', args: [ 200, 200, 200, 2, 2, 2, materials ] },
-				{ type: 'TorusGeometry', args: [ 100, 60, 4, 8, Math.PI * 2 ] },
-				{ type: 'TorusKnotGeometry', args: [ 100, 30 ], scale: 0.25, meshScale: 4 },
-				{ type: 'SphereGeometry', args: [ 100, 3, 3 ], meshScale: 2 },
-				{ type: 'IcosahedronGeometry', args: [ 100, 1 ], meshScale: 2 },
-				{ type: 'CylinderGeometry', args: [ 25, 75, 200, 8, 3 ] },
-				{ type: 'OctahedronGeometry', args: [ 200, 0 ], meshScale: 2 },
-				{ type: 'LatheGeometry', args: [[
-					new THREE.Vector2( 0, 0 ),
-					new THREE.Vector2( 50, 50 ),
-					new THREE.Vector2( 10, 100 ),
-					new THREE.Vector2( 50, 150 ),
-					new THREE.Vector2( 0, 200 ) ]] },
-				{ type: 'TextGeometry', args: [ '&', {
-					size: 200,
-					height: 50,
-					curveSegments: 1
-				} ] },
-				{ type: 'PlaneGeometry', args: [ 200, 200, 4, 4 ] }
-
-			];
-
-			var loader = new THREE.FontLoader();
-			loader.load( 'fonts/helvetiker_regular.typeface.json', function ( font ) {
-
-				geometriesParams[ 8 ].args[ 1 ].font = font;
-
-			} );
-
-			var loader = new THREE.BufferGeometryLoader();
-			loader.load( 'models/json/WaltHeadLo_buffergeometry.json', function ( geometry ) {
-
-				geometry = new THREE.Geometry().fromBufferGeometry( geometry );
-
-				geometriesParams.push( { type: 'WaltHead', args: [ ], meshScale: 6 } );
-
-				THREE.WaltHead = function () {
-
-					return geometry.clone();
-
-				};
-
-				updateInfo();
-
-			} );
-
-			var loader2 = new THREE.BufferGeometryLoader();
-			loader2.load( 'models/json/suzanne_buffergeometry.json', function ( geometry ) {
-
-				geometry = new THREE.Geometry().fromBufferGeometry( geometry );
-
-				geometriesParams.push( { type: 'Suzanne', args: [ ], scale: 100, meshScale: 2 } );
-
-				THREE.Suzanne = function () {
-
-					return geometry.clone();
-
-				};
-
-				updateInfo();
-
-			} );
-
-
-			var info;
-			var subdivisions = 2;
-			var geometryIndex = 0;
-
-			// start scene
 
 			init();
 			animate();
 
-			function nextSubdivision( x ) {
+			function init() {
 
-				subdivisions = Math.max( 0, subdivisions + x );
-				addStuff();
+				camera = new PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.z = 2.5;
 
-			}
+				scene = new Scene();
+				scene.background = new Color( 0xf0f0f0 );
 
-			function nextGeometry() {
+				var light = new PointLight( 0xffffff, 1.5 );
+				light.position.set( 1000, 1000, 2000 );
+				scene.add( light );
 
-				geometryIndex ++;
+				var geometry = new BoxGeometry( 1, 1, 1, 2, 2, 2 );
+				var material = new MeshBasicMaterial( { color: 0xcccccc, wireframe: true } );
+				var mesh = new Mesh( new BufferGeometry().fromGeometry( geometry ), material );
+				scene.add( mesh );
 
-				if ( geometryIndex > geometriesParams.length - 1 ) {
+				renderer = new WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
 
-					geometryIndex = 0;
+				stats = new Stats();
+				document.body.appendChild( stats.dom );
 
-				}
+				//
 
-				addStuff();
+				var controls = new OrbitControls( camera, renderer.domElement );
+				controls.minDistance = 1;
 
-			}
+				window.addEventListener( 'resize', onWindowResize, false );
 
-			function switchGeometry( i ) {
+				//
 
-				geometryIndex = i;
+				var gui = new GUI();
 
-				addStuff();
+				gui.add( params, 'subdivisions', 0, 6 ).step( 1 ).onChange( function ( subdivisions ) {
 
-			}
+					subdivide( geometry, subdivisions );
 
-			function updateInfo() {
+				} );
 
-				var params = geometriesParams[ geometryIndex ];
+				//
 
-				var dropdown = '<select id="dropdown" onchange="switchGeometry(this.value)">';
+				smoothMesh = new Mesh( undefined, smoothMaterial );
+				wireframe = new Mesh( undefined, wireframeMaterial );
+				scene.add( smoothMesh, wireframe );
 
-				for ( var i = 0; i < geometriesParams.length; i ++ ) {
-
-					dropdown += '<option value="' + i + '"';
-
-					dropdown += ( geometryIndex == i ) ? ' selected' : '';
-
-					dropdown += '>' + geometriesParams[ i ].type + '</option>';
-
-				}
-
-				dropdown += '</select>';
-
-				info.innerHTML = 'Drag to spin THREE.' + params.type +
-
-					'<br><br>Subdivisions: ' + subdivisions +
-					' <a href="#" onclick="nextSubdivision(1); return false;">more</a>/<a href="#" onclick="nextSubdivision(-1); return false;">less</a>' +
-					'<br>Geometry: ' + dropdown + ' <a href="#" onclick="nextGeometry();return false;">next</a>' +
-					'<br><br>Vertices count: before ' + geometry.vertices.length + ' after ' + smooth.vertices.length +
-					'<br>Face count: before ' + geometry.faces.length + ' after ' + smooth.faces.length;
+				subdivide( geometry, params.subdivisions );
 
 			}
 
-			function addStuff() {
+			function subdivide( geometry, subdivisions ) {
 
-				if ( cube !== undefined ) {
+				var modifier = new SubdivisionModifier( subdivisions );
 
-					geometry.dispose();
-					smooth.dispose();
+				var smoothGeometry = modifier.modify( geometry );
 
-					scene.remove( group );
-					scene.remove( cube );
+				// colorify faces
 
-				}
+				for ( var i = 0; i < smoothGeometry.faces.length; i ++ ) {
 
-				var modifier = new THREE.SubdivisionModifier( subdivisions );
-
-				var params = geometriesParams[ geometryIndex ];
-
-				geometry = createSomething( THREE[ params.type ], params.args );
-
-				// Scale Geometry
-
-				if ( params.scale ) {
-
-					geometry.scale( params.scale, params.scale, params.scale );
-
-				}
-
-				smooth = modifier.modify( geometry );
-
-				var faceIndices = [ 'a', 'b', 'c' ];
-
-				for ( var i = 0; i < smooth.faces.length; i ++ ) {
-
-					var face = smooth.faces[ i ];
+					var face = smoothGeometry.faces[ i ];
 
 					for ( var j = 0; j < 3; j ++ ) {
 
 						var vertexIndex = face[ faceIndices[ j ] ];
-						var vertex = smooth.vertices[ vertexIndex ];
+						var vertex = smoothGeometry.vertices[ vertexIndex ];
 
-						var hue = ( vertex.y / 200 ) + 0.5;
-						var color = new THREE.Color().setHSL( hue, 1, 0.5 );
-
+						var hue = vertex.y + 0.5;
+						var color = new Color().setHSL( hue, 1, 0.5 );
 						face.vertexColors[ j ] = color;
 
 					}
 
 				}
 
-				updateInfo();
+				// convert to BufferGeometry
 
-				group = new THREE.Group();
-				scene.add( group );
+				if ( smoothMesh.geometry ) smoothMesh.geometry.dispose();
 
-				mesh = new THREE.Mesh( new THREE.BufferGeometry().fromGeometry( geometry ), material );
-				group.add( mesh );
-
-				var smoothBufferGeometry = new THREE.BufferGeometry().fromGeometry( smooth );
-
-				cube = new THREE.Mesh( smoothBufferGeometry, smoothMaterial );
-				var wireframe = new THREE.Mesh( smoothBufferGeometry, wireframeMaterial );
-				cube.add( wireframe );
-
-				cube.scale.setScalar( params.meshScale ? params.meshScale : 1 );
-				scene.add( cube );
-
-				group.scale.copy( cube.scale );
-
-			}
-
-			function init() {
-
-				container = document.createElement( 'div' );
-				document.body.appendChild( container );
-
-				info = document.createElement( 'div' );
-				info.style.position = 'absolute';
-				info.style.top = '10px';
-				info.style.width = '100%';
-				info.style.textAlign = 'center';
-				info.innerHTML = 'Drag to spin the geometry ';
-				container.appendChild( info );
-
-				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.z = 500;
-
-				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0xf0f0f0 );
-
-				var light = new THREE.PointLight( 0xffffff, 1.5 );
-				light.position.set( 1000, 1000, 2000 );
-				scene.add( light );
-
-				addStuff();
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				container.appendChild( renderer.domElement );
-
-				stats = new Stats();
-				container.appendChild( stats.dom );
+				smoothMesh.geometry = new BufferGeometry().fromGeometry( smoothGeometry );
+				wireframe.geometry = smoothMesh.geometry;
 
 				//
 
-				var controls = new THREE.OrbitControls( camera, renderer.domElement );
+				updateUI( geometry, smoothGeometry );
 
-				window.addEventListener( 'resize', onWindowResize, false );
+			}
+
+			function updateUI( originalGeometry, smoothGeometry ) {
+
+				document.getElementById( 'original-vertex-count' ).textContent = originalGeometry.vertices.length;
+				document.getElementById( 'original-face-count' ).textContent = originalGeometry.faces.length;
+
+				document.getElementById( 'smooth-vertex-count' ).textContent = smoothGeometry.vertices.length;
+				document.getElementById( 'smooth-face-count' ).textContent = smoothGeometry.faces.length;
 
 			}
 
@@ -326,9 +172,8 @@
 
 				requestAnimationFrame( animate );
 
-				stats.begin();
 				render();
-				stats.end();
+				stats.update();
 
 			}
 


### PR DESCRIPTION
Removed some complicated elements and hacks (e.g. `createSomething()`) that made it hard to work with the example. The new version is more straightforward and also uses modules now.