### PR TITLE
Examples: Use Scene.background in webgl_water

### DIFF
--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -16,8 +16,6 @@
 		<script type="module">
 			import {
 				AmbientLight,
-				BackSide,
-				BoxBufferGeometry,
 				Clock,
 				CubeTextureLoader,
 				DirectionalLight,
@@ -28,8 +26,6 @@
 				PlaneBufferGeometry,
 				RepeatWrapping,
 				Scene,
-				ShaderLib,
-				ShaderMaterial,
 				TextureLoader,
 				TorusKnotBufferGeometry,
 				Vector2,
@@ -127,18 +123,7 @@
 					'pz.jpg', 'nz.jpg',
 				] );
 
-				var cubeShader = ShaderLib[ 'cube' ];
-				cubeShader.uniforms[ 'tCube' ].value = cubeTexture;
-
-				var skyBoxMaterial = new ShaderMaterial( {
-					fragmentShader: cubeShader.fragmentShader,
-					vertexShader: cubeShader.vertexShader,
-					uniforms: cubeShader.uniforms,
-					side: BackSide
-				} );
-
-				var skyBox = new Mesh( new BoxBufferGeometry( 1000, 1000, 1000 ), skyBoxMaterial );
-				scene.add( skyBox );
+				scene.background = cubeTexture;
 
 				// light
 
@@ -162,24 +147,24 @@
 
 				gui.addColor( params, 'color' ).onChange( function ( value ) {
 
-					water.material.uniforms[ "color" ].value.set( value );
+					water.material.uniforms[ 'color' ].value.set( value );
 
 				} );
 				gui.add( params, 'scale', 1, 10 ).onChange( function ( value ) {
 
-					water.material.uniforms[ "config" ].value.w = value;
+					water.material.uniforms[ 'config' ].value.w = value;
 
 				} );
 				gui.add( params, 'flowX', - 1, 1 ).step( 0.01 ).onChange( function ( value ) {
 
-					water.material.uniforms[ "flowDirection" ].value.x = value;
-					water.material.uniforms[ "flowDirection" ].value.normalize();
+					water.material.uniforms[ 'flowDirection' ].value.x = value;
+					water.material.uniforms[ 'flowDirection' ].value.normalize();
 
 				} );
 				gui.add( params, 'flowY', - 1, 1 ).step( 0.01 ).onChange( function ( value ) {
 
-					water.material.uniforms[ "flowDirection" ].value.y = value;
-					water.material.uniforms[ "flowDirection" ].value.normalize();
+					water.material.uniforms[ 'flowDirection' ].value.y = value;
+					water.material.uniforms[ 'flowDirection' ].value.normalize();
 
 				} );
 


### PR DESCRIPTION
When converting the examples I've noticed the background of `webgl_water` can be implemented much nicer...