### PR TITLE
WebVR: Catch xr.supportsSession() rejection

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -136,7 +136,7 @@ var WEBVR = {
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR );
+			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR ).catch( showVRNotFound );
 
 			return button;
 


### PR DESCRIPTION
`navigator.xr.supportsSession('immersive-vr')` returns rejected promise if the xr device doesn't support `immersive-vr` mode.

https://www.w3.org/TR/webxr/#xr-interface

So we should catch the rejection and show "VR NOT FOUND" button. Otherwise, uncaught exception is thrown and the button won't be displayed.