### PR TITLE
GLTFLoader: Introduce setDDSLoader().

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -58,7 +58,7 @@
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
 		THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
 		loader.setDRACOLoader( new THREE.DRACOLoader() );
-			
+
 		// Optional: Pre-fetch Draco WASM/JS module, to save time while parsing.
 		THREE.DRACOLoader.getDecoderModule();
 
@@ -205,6 +205,11 @@
 		</p>
 		<p>
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
+		</p>
+
+		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>
+		<p>
+		[page:DDSLoader ddsLoader] — Instance of THREE.DDSLoader, to be used for loading compressed textures with the MSFT_TEXTURE_DDS extension.
 		</p>
 
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -58,7 +58,7 @@
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
 		THREE.DRACOLoader.setDecoderPath( '/examples/js/libs/draco' );
 		loader.setDRACOLoader( new THREE.DRACOLoader() );
-			
+
 		// Optional: Pre-fetch Draco WASM/JS module, to save time while parsing.
 		THREE.DRACOLoader.getDecoderModule();
 
@@ -205,6 +205,11 @@
 		</p>
 		<p>
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
+		</p>
+
+		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>
+		<p>
+		[page:DDSLoader ddsLoader] — Instance of THREE.DDSLoader, to be used for loading compressed textures with the MSFT_TEXTURE_DDS extension.
 		</p>
 
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -12,6 +12,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 		this.dracoLoader = null;
+		this.ddsLoader = null;
 
 	}
 
@@ -124,6 +125,13 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
+		setDDSLoader: function ( ddsLoader ) {
+
+			this.ddsLoader = ddsLoader;
+			return this;
+
+		},
+
 		parse: function ( data, path, onLoad, onError ) {
 
 			var content;
@@ -195,7 +203,7 @@ THREE.GLTFLoader = ( function () {
 							break;
 
 						case EXTENSIONS.MSFT_TEXTURE_DDS:
-							extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension();
+							extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] = new GLTFTextureDDSExtension( this.ddsLoader );
 							break;
 
 						case EXTENSIONS.KHR_TEXTURE_TRANSFORM:
@@ -287,16 +295,16 @@ THREE.GLTFLoader = ( function () {
 	 * https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/MSFT_texture_dds
 	 *
 	 */
-	function GLTFTextureDDSExtension() {
+	function GLTFTextureDDSExtension( ddsLoader ) {
 
-		if ( ! THREE.DDSLoader ) {
+		if ( ! ddsLoader ) {
 
 			throw new Error( 'THREE.GLTFLoader: Attempting to load .dds texture without importing THREE.DDSLoader' );
 
 		}
 
 		this.name = EXTENSIONS.MSFT_TEXTURE_DDS;
-		this.ddsLoader = new THREE.DDSLoader();
+		this.ddsLoader = ddsLoader;
 
 	}
 
@@ -855,7 +863,7 @@ THREE.GLTFLoader = ( function () {
 			},
 
 			// Here's based on refreshUniformsCommon() and refreshUniformsStandard() in WebGLRenderer.
-			refreshUniforms: function ( renderer, scene, camera, geometry, material, group ) {
+			refreshUniforms: function ( renderer, scene, camera, geometry, material ) {
 
 				if ( material.isGLTFSpecularGlossinessMaterial !== true ) {
 
@@ -2549,7 +2557,7 @@ THREE.GLTFLoader = ( function () {
 							? new THREE.SkinnedMesh( geometry, material )
 							: new THREE.Mesh( geometry, material );
 
-						if ( mesh.isSkinnedMesh === true && !mesh.geometry.attributes.skinWeight.normalized ) {
+						if ( mesh.isSkinnedMesh === true && ! mesh.geometry.attributes.skinWeight.normalized ) {
 
 							// we normalize floating point skin weight array to fix malformed assets (see #15319)
 							// it's important to skip this for non-float32 data since normalizeSkinWeights assumes non-normalized inputs
@@ -2837,7 +2845,7 @@ THREE.GLTFLoader = ( function () {
 
 					for ( var j = 0, jl = outputArray.length; j < jl; j ++ ) {
 
-						scaled[j] = outputArray[j] * scale;
+						scaled[ j ] = outputArray[ j ] * scale;
 
 					}
 

--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -5,6 +5,9 @@ import {
   Scene
 } from '../../../src/Three';
 
+import { DRACOLoader } from './DRACOLoader';
+import { DDSLoader } from './DDSLoader';
+
 export interface GLTF {
   animations: AnimationClip[];
   scene: Scene;
@@ -16,12 +19,17 @@ export interface GLTF {
 export class GLTFLoader {
   constructor(manager?: LoadingManager);
   manager: LoadingManager;
+  dracoLoader: DRACOLoader | null;
+  ddsLoader: DDSLoader | null;
   path: string;
+  crossOrigin: string;
+  resourcePath: string;
 
   load(url: string, onLoad: (gltf: GLTF) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void) : void;
   setPath(path: string) : GLTFLoader;
   setResourcePath(path: string) : GLTFLoader;
   setCrossOrigin(value: string): GLTFLoader;
-  setDRACOLoader(dracoLoader: object): GLTFLoader;
+  setDRACOLoader(dracoLoader: DRACOLoader): GLTFLoader;
+  setDDSLoader(ddsLoader: DDSLoader): GLTFLoader;
   parse(data: ArrayBuffer | string, path: string, onLoad: (gltf: GLTF) => void, onError?: (event: ErrorEvent) => void) : void;
 }

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -269,6 +269,7 @@
 
 				THREE.DRACOLoader.setDecoderPath( 'js/libs/draco/gltf/' );
 				loader.setDRACOLoader( new THREE.DRACOLoader() );
+				loader.setDDSLoader( new THREE.DDSLoader() );
 
 				var url = sceneInfo.url.replace( /%s/g, state.extension );
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -90,7 +90,7 @@ var files = [
 	{ path: 'loaders/EquirectangularToCubeGenerator.js', dependencies: [], ignoreList: [] },
 	{ path: 'loaders/FBXLoader.js', dependencies: [ { name: 'Zlib', path: 'libs/inflate.min.js' }, { name: 'TGALoader', path: 'loaders/TGALoader.js' }, { name: 'NURBSCurve', path: 'curves/NURBSCurve.js' } ], ignoreList: [] },
 	{ path: 'loaders/GCodeLoader.js', dependencies: [], ignoreList: [] },
-	{ path: 'loaders/GLTFLoader.js', dependencies: [], ignoreList: [ 'NoSide', 'Matrix2', 'DDSLoader', 'Camera' ] },
+	{ path: 'loaders/GLTFLoader.js', dependencies: [], ignoreList: [ 'NoSide', 'Matrix2', 'Camera', 'Texture' ] },
 	{ path: 'loaders/HDRCubeTextureLoader.js', dependencies: [ { name: 'RGBELoader', path: 'loaders/RGBELoader.js' } ], ignoreList: [] },
 	{ path: 'loaders/KMZLoader.js', dependencies: [ { name: 'ColladaLoader', path: 'loaders/ColladaLoader.js' } ], ignoreList: [] },
 	{ path: 'loaders/LDrawLoader.js', dependencies: [], ignoreList: [ 'Cache', 'Material', 'Object3D' ] },


### PR DESCRIPTION
Otherwise `webgl_loader_gltf_extensions` can't be converted to a pure module version. It would depend on `js/loader/DDSLoader.js` since `GLTFLoader` expects `DDSLoader` in the `THREE` namespace.