### PR TITLE
Utils: Converters use now modules.

### DIFF
--- a/utils/converters/README.md
+++ b/utils/converters/README.md
@@ -1,4 +1,4 @@
-Utilities for converting model files to the Three.js JSON format. You have to install [esm](https://www.npmjs.com/package/esm) for executing the converters.
+Utilities for converting model files to the Three.js JSON format. You have to install [node.js](https://nodejs.org/en/) and [esm](https://www.npmjs.com/package/esm) for executing the converters.
 
 ## obj2three.js
 

--- a/utils/converters/README.md
+++ b/utils/converters/README.md
@@ -1,11 +1,11 @@
-Utilities for converting model files to the Three.js JSON format.
+Utilities for converting model files to the Three.js JSON format. You have to install [esm](https://www.npmjs.com/package/esm) for executing the converters.
 
 ## obj2three.js
 
 Usage:
 
 ```
-node obj2three.js model.obj
+node -r esm obj2three.js model.obj
 ```
 
 ## fbx2three.js
@@ -13,5 +13,5 @@ node obj2three.js model.obj
 Usage:
 
 ```
-node fbx2three.js model.fbx
+node -r esm fbx2three.js model.fbx
 ```

--- a/utils/converters/fbx2three.js
+++ b/utils/converters/fbx2three.js
@@ -18,11 +18,8 @@ function parseNumber( key, value ) {
 
 }
 
-THREE = require( '../../build/three.js' );
-require( '../../examples/js/curves/NURBSCurve.js' );
-require( '../../examples/js/curves/NURBSUtils.js' );
-require( '../../examples/js/loaders/FBXLoader.js' );
-global.Zlib = require( '../../examples/js/libs/inflate.min.js' ).Zlib;
+import { ImageLoader, ImageUtils, LoaderUtils, RGBAFormat } from "../../build/three.module.js";
+import { FBXLoader } from '../../examples/jsm/loaders/FBXLoader.js';
 
 global.window = {
 	innerWidth: 1024,
@@ -39,7 +36,7 @@ global.window = {
 };
 
 // HTML Images are not available, so use a Buffer instead.
-THREE.ImageLoader.prototype.load = function ( url, onLoad ) {
+ImageLoader.prototype.load = function ( url, onLoad ) {
 
 	if ( this.path !== undefined ) url = this.path + url;
 
@@ -56,7 +53,7 @@ THREE.ImageLoader.prototype.load = function ( url, onLoad ) {
 };
 
 // Convert image buffer to data URL.
-THREE.ImageUtils.getDataURL = function ( image ) {
+ImageUtils.getDataURL = function ( image ) {
 
 	if ( ! ( image instanceof Buffer ) ) {
 
@@ -65,7 +62,7 @@ THREE.ImageUtils.getDataURL = function ( image ) {
 	}
 
 	var dataURL = 'data:';
-	dataURL += this.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
+	dataURL += this.format === RGBAFormat ? 'image/png' : 'image/jpeg';
 	dataURL += ';base64,';
 	dataURL += image.toString( 'base64' );
 	return dataURL;
@@ -75,8 +72,8 @@ THREE.ImageUtils.getDataURL = function ( image ) {
 //
 
 var file = process.argv[ 2 ];
-var resourceDirectory = THREE.LoaderUtils.extractUrlBase( file );
-var loader = new THREE.FBXLoader();
+var resourceDirectory = LoaderUtils.extractUrlBase( file );
+var loader = new FBXLoader();
 
 var arraybuffer = fs.readFileSync( file ).buffer;
 var object = loader.parse( arraybuffer, resourceDirectory );

--- a/utils/converters/obj2three.js
+++ b/utils/converters/obj2three.js
@@ -18,11 +18,10 @@ function parseNumber( key, value ) {
 
 }
 
-THREE = require( '../../build/three.js' );
-require( '../../examples/js/loaders/OBJLoader.js' );
+import { OBJLoader } from '../../examples/jsm/loaders/OBJLoader.js';
 
 var file = process.argv[ 2 ];
-var loader = new THREE.OBJLoader();
+var loader = new OBJLoader();
 
 var text = fs.readFileSync( file, 'utf8' );
 


### PR DESCRIPTION
A lot of examples are already using modules. However, other parts of the repository like the converters (`fbx2three.js` and `obj2three.js`) require UMDs. They are node scripts where using ES6 modules is still experimental. Nevertheless, the ultimate goal is to avoid any duplicates in the code base.

After some research, I've realized that using [esm](https://www.npmjs.com/package/esm) works pretty well for this use case. It's possible to use the same coding patterns like in the examples. It's only necessary to install `esm` before executing the scripts and add `-r esm` to the node command.

Feedback and other ideas are welcome since I've not used this approach in production before.
