### PR TITLE
Expose CubeCamera.clear() to TS

### DIFF
--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -11,11 +11,8 @@ export class CubeCamera extends Object3D {
 
 	renderTarget: WebGLRenderTargetCube;
 
-	/**
-	 * @deprecated Use {@link CubeCamera#update .update()} instead
-	 */
-	//updateCubeMap(renderer: Renderer, scene: Scene): void;
-
 	update( renderer: WebGLRenderer, scene: Scene ): void;
+
+	clear( renderer: WebGLRenderer, color: boolean, depth: boolean, stencil: boolean ): void;
 
 }


### PR DESCRIPTION
Fixes #16866 

I also removed the line about deprecation, since that comment was being applied to the non-deprecated update function since the old one had been removed.