### PR TITLE
Examples: Fix initial height of camera in pointerlock example.

### DIFF
--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -101,6 +101,7 @@
 			function init() {
 
 				camera = new PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.y = 10;
 
 				scene = new Scene();
 				scene.background = new Color( 0xffffff );


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/commit/dc6d4bf49c0009a4cfb05c0aec70b6a01be48fa3#r33562304

Apart from the initial height of the camera, I think there is a bug in Chrome (75.0.3770.100): When you enable the pointer lock by clicking on the screen, the camera performs some sort of jump into a different orientation. I've debugged this and it seems that the initial movement data of the `mousemove` event (`movementX` and `movementY`) can be quite large. It actually depends on the screen position where you clicked with the mouse in order to enable the pointer lock. So when you click near the screen's border, the effect becomes particular visible.

I'm not able to reproduce this with Firefox and Safari on macOS. 