### PR TITLE
Fix typescript definition.

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -314,9 +314,10 @@ export class WebGLRenderer implements Renderer {
 	renderBufferDirect(
 		camera: Camera,
 		fog: Fog,
+		geometry: Geometry | BufferGeometry,
 		material: Material,
-		geometryGroup: any,
-		object: Object3D
+		object: Object3D,
+		geometryGroup: any
 	): void;
 
 	/**


### PR DESCRIPTION
I had some unexpected warnings while using three.js in a typescript project. I think this definition needs to be adjusted.