### PR TITLE
Tests: Clean up

### DIFF
--- a/test/unit/src/core/InstancedBufferAttribute.tests.js
+++ b/test/unit/src/core/InstancedBufferAttribute.tests.js
@@ -22,7 +22,7 @@ export default QUnit.module( 'Core', () => {
 			var instance = new InstancedBufferAttribute( new Float32Array( 10 ), 2 );
 			assert.ok( instance.meshPerAttribute === 1, "ok" );
 
-			var instance = new InstancedBufferAttribute( new Float32Array( 10 ), 2, 123 );
+			var instance = new InstancedBufferAttribute( new Float32Array( 10 ), 2, false, 123 );
 			assert.ok( instance.meshPerAttribute === 123, "ok" );
 
 		} );
@@ -31,11 +31,12 @@ export default QUnit.module( 'Core', () => {
 		QUnit.test( "copy", ( assert ) => {
 
 			var array = new Float32Array( [ 1, 2, 3, 7, 8, 9 ] );
-			var instance = new InstancedBufferAttribute( array, 2, 123 );
+			var instance = new InstancedBufferAttribute( array, 2, true, 123 );
 			var copiedInstance = instance.copy( instance );
 
 			assert.ok( copiedInstance instanceof InstancedBufferAttribute, "the clone has the correct type" );
 			assert.ok( copiedInstance.itemSize === 2, "itemSize was copied" );
+			assert.ok( copiedInstance.normalized === true, "normalized was copied" );
 			assert.ok( copiedInstance.meshPerAttribute === 123, "meshPerAttribute was copied" );
 
 			for ( var i = 0; i < array.length; i ++ ) {

--- a/test/unit/src/geometries/TextGeometry.tests.js
+++ b/test/unit/src/geometries/TextGeometry.tests.js
@@ -9,16 +9,7 @@ import {
 
 export default QUnit.module( 'Geometries', () => {
 
-	QUnit.module( 'TextBufferGeometry', ( hooks ) => {
-
-		var geometries = undefined;
-		hooks.beforeEach( function () {
-
-			geometries = [
-				new TextBufferGeometry()
-			];
-
-		} );
+	QUnit.module( 'TextBufferGeometry', () => {
 
 		// INHERITANCE
 		QUnit.todo( "Extending", ( assert ) => {

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -81,27 +81,19 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "getCenter", ( assert ) => {
 
+			var center = new Vector3();
 
 			var a = new Line3( zero3.clone(), two3.clone() );
-			assert.ok( a.getCenter().equals( one3.clone() ), "Passed" );
-
-
-			var a = new Line3( zero3.clone(), two3.clone() );
-			var b = new Vector3();
-			assert.ok( a.getCenter( b ).equals( one3.clone() ), "Passed" );
-
+			assert.ok( a.getCenter( center ).equals( one3.clone() ), "Passed" );
 
 		} );
 
 		QUnit.test( "delta", ( assert ) => {
 
+			var delta = new Vector3();
 
 			var a = new Line3( zero3.clone(), two3.clone() );
-			assert.ok( a.delta().equals( two3.clone() ), "Passed" );
-			var a = new Line3( one3.clone(), two3.clone() );
-			var b = new Vector3();
-			assert.ok( a.delta( b ).equals( one3.clone() ), "Passed" );
-
+			assert.ok( a.delta( delta ).equals( two3.clone() ), "Passed" );
 
 		} );
 


### PR DESCRIPTION
- Respect `normalized` when creating an instance of `InstancedBufferAttribute`
- `Line3.getCenter()` and `Line3.delta()` target parameter is now mandatory.
- Remove unnecessary object creation in `TextBufferGeometry` test file