### PR TITLE
examples: fix material_compile example for node object rename

### DIFF
--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -175,7 +175,7 @@
 				THREE.OperatorNode.MUL
 			);
 
-			var cycle = new THREE.Math1Node( sinCycleInSecs, THREE.Math1Node.SIN );
+			var cycle = new THREE.MathNode( sinCycleInSecs, THREE.MathNode.SIN );
 
 			var cycleColor = new THREE.OperatorNode(
 				cycle,
@@ -183,7 +183,7 @@
 				THREE.OperatorNode.MUL
 			);
 
-			var cos = new THREE.Math1Node( cycleColor, THREE.Math1Node.SIN );
+			var cos = new THREE.MathNode( cycleColor, THREE.MathNode.SIN );
 
 			mtl.color = new THREE.ColorNode( 0 );
 			mtl.emissive = cos;


### PR DESCRIPTION
Math1Node is now MathNode