### PR TITLE
Editor: Make editor parameter of Command class mandatory.

### DIFF
--- a/editor/docs/Implementing additional commands for undo-redo.md
+++ b/editor/docs/Implementing additional commands for undo-redo.md
@@ -25,15 +25,15 @@ Then there are separate commands for:
 Every command needs a constructor. In the constructor
 
 ```javascript
-	
-var DoSomethingCommand = function () {
 
-	Command.call( this ); // Required: Call default constructor
+var DoSomethingCommand = function ( editor ) {
+
+	Command.call( this, editor ); // Required: Call default constructor
 
 	this.type = 'DoSomethingCommand';            // Required: has to match the object-name!
 	this.name = 'Set/Do/Update Something'; // Required: description of the command, used in Sidebar.History
 
-	// TODO: store all the relevant information needed to 
+	// TODO: store all the relevant information needed to
 	// restore the old and the new state
 
 };
@@ -50,13 +50,13 @@ DoSomethingCommand.prototype = {
 
 	execute: function () {
 
-		// TODO: apply changes to 'object' to reach the new state 
+		// TODO: apply changes to 'object' to reach the new state
 
 	},
 
 	undo: function () {
 
-		// TODO: restore 'object' to old state 
+		// TODO: restore 'object' to old state
 
 	},
 

--- a/editor/docs/Writing unit tests for undo-redo commands.md
+++ b/editor/docs/Writing unit tests for undo-redo commands.md
@@ -68,7 +68,7 @@ test("Test DoSomethingCommand (Undo and Redo)", function() {
     // var perspectiveCamera = aPerspectiveCamera( 'Name your perspectiveCamera' );
 
     // in most cases you'll need to add the object to work with
-    editor.execute( new AddObjectCommand( box ) );
+    editor.execute( new AddObjectCommand( editor, box ) );
 
 
     // your test begins here...

--- a/editor/js/Command.js
+++ b/editor/js/Command.js
@@ -4,26 +4,19 @@
  */
 
 /**
- * @param editorRef pointer to main editor object used to initialize
+ * @param editor pointer to main editor object used to initialize
  *        each command object with a reference to the editor
  * @constructor
  */
 
-var Command = function ( editorRef ) {
+var Command = function ( editor ) {
 
 	this.id = - 1;
 	this.inMemory = false;
 	this.updatable = false;
 	this.type = '';
 	this.name = '';
-
-	if ( editorRef !== undefined ) {
-
-		Command.editor = editorRef;
-
-	}
-	this.editor = Command.editor;
-
+	this.editor = editor;
 
 };
 

--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -14,10 +14,6 @@ History = function ( editor ) {
 	this.historyDisabled = false;
 	this.config = editor.config;
 
-	//Set editor-reference in Command
-
-	Command( editor );
-
 	// signals
 
 	var scope = this;

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -66,7 +66,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.TDSLoader();
 					var object = loader.parse( event.target.result );
 
-					editor.execute( new AddObjectCommand( object ) );
+					editor.execute( new AddObjectCommand( editor, object ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -80,7 +80,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.AMFLoader();
 					var amfobject = loader.parse( event.target.result );
 
-					editor.execute( new AddObjectCommand( amfobject ) );
+					editor.execute( new AddObjectCommand( editor, amfobject ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -94,7 +94,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.AWDLoader();
 					var scene = loader.parse( event.target.result );
 
-					editor.execute( new SetSceneCommand( scene ) );
+					editor.execute( new SetSceneCommand( editor, scene ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -111,7 +111,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.BabylonLoader();
 					var scene = loader.parse( json );
 
-					editor.execute( new SetSceneCommand( scene ) );
+					editor.execute( new SetSceneCommand( editor, scene ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -133,7 +133,7 @@ var Loader = function ( editor ) {
 					var mesh = new THREE.Mesh( geometry, material );
 					mesh.name = filename;
 
-					editor.execute( new AddObjectCommand( mesh ) );
+					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -160,7 +160,7 @@ var Loader = function ( editor ) {
 						var mesh = new THREE.Mesh( geometry, material );
 						mesh.name = filename;
 
-						editor.execute( new AddObjectCommand( mesh ) );
+						editor.execute( new AddObjectCommand( editor, mesh ) );
 
 					} );
 
@@ -181,7 +181,7 @@ var Loader = function ( editor ) {
 					collada.scene.name = filename;
 
 					editor.addAnimation( collada.scene, collada.animations );
-					editor.execute( new AddObjectCommand( collada.scene ) );
+					editor.execute( new AddObjectCommand( editor, collada.scene ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -198,7 +198,7 @@ var Loader = function ( editor ) {
 					var object = loader.parse( contents );
 
 					editor.addAnimation( object, object.animations );
-					editor.execute( new AddObjectCommand( object ) );
+					editor.execute( new AddObjectCommand( editor, object ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -221,7 +221,7 @@ var Loader = function ( editor ) {
 						scene.name = filename;
 
 						editor.addAnimation( scene, result.animations );
-						editor.execute( new AddObjectCommand( scene ) );
+						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
 
@@ -254,7 +254,7 @@ var Loader = function ( editor ) {
 						scene.name = filename;
 
 						editor.addAnimation( scene, result.animations );
-						editor.execute( new AddObjectCommand( scene ) );
+						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
 
@@ -329,7 +329,7 @@ var Loader = function ( editor ) {
 
 					collada.scene.name = filename;
 
-					editor.execute( new AddObjectCommand( collada.scene ) );
+					editor.execute( new AddObjectCommand( editor, collada.scene ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -353,7 +353,7 @@ var Loader = function ( editor ) {
 					mesh.name = filename;
 
 					editor.addAnimation( mesh, geometry.animations );
-					editor.execute( new AddObjectCommand( mesh ) );
+					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -369,7 +369,7 @@ var Loader = function ( editor ) {
 					var object = new THREE.OBJLoader().parse( contents );
 					object.name = filename;
 
-					editor.execute( new AddObjectCommand( object ) );
+					editor.execute( new AddObjectCommand( editor, object ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -386,7 +386,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.PlayCanvasLoader();
 					var object = loader.parse( json );
 
-					editor.execute( new AddObjectCommand( object ) );
+					editor.execute( new AddObjectCommand( editor, object ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -408,7 +408,7 @@ var Loader = function ( editor ) {
 					var mesh = new THREE.Mesh( geometry, material );
 					mesh.name = filename;
 
-					editor.execute( new AddObjectCommand( mesh ) );
+					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );
@@ -430,7 +430,7 @@ var Loader = function ( editor ) {
 					var mesh = new THREE.Mesh( geometry, material );
 					mesh.name = filename;
 
-					editor.execute( new AddObjectCommand( mesh ) );
+					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
 
@@ -485,7 +485,7 @@ var Loader = function ( editor ) {
 
 					}
 
-					editor.execute( new AddObjectCommand( group ) );
+					editor.execute( new AddObjectCommand( editor, group ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -507,7 +507,7 @@ var Loader = function ( editor ) {
 					var mesh = new THREE.Mesh( geometry, material );
 					mesh.name = filename;
 
-					editor.execute( new AddObjectCommand( mesh ) );
+					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -522,7 +522,7 @@ var Loader = function ( editor ) {
 
 					var result = new THREE.VRMLLoader().parse( contents );
 
-					editor.execute( new SetSceneCommand( result ) );
+					editor.execute( new SetSceneCommand( editor, result ) );
 
 				}, false );
 				reader.readAsText( file );
@@ -579,7 +579,7 @@ var Loader = function ( editor ) {
 
 				var mesh = new THREE.Mesh( result );
 
-				editor.execute( new AddObjectCommand( mesh ) );
+				editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				break;
 
@@ -598,11 +598,11 @@ var Loader = function ( editor ) {
 
 				if ( result.isScene ) {
 
-					editor.execute( new SetSceneCommand( result ) );
+					editor.execute( new SetSceneCommand( editor, result ) );
 
 				} else {
 
-					editor.execute( new AddObjectCommand( result ) );
+					editor.execute( new AddObjectCommand( editor, result ) );
 
 				}
 
@@ -643,7 +643,7 @@ var Loader = function ( editor ) {
 
 			var materials = new THREE.MTLLoader().parse( zip.file( 'materials.mtl' ).asText() );
 			var object = new THREE.OBJLoader().setMaterials( materials ).parse( zip.file( 'model.obj' ).asText() );
-			editor.execute( new AddObjectCommand( object ) );
+			editor.execute( new AddObjectCommand( editor, object ) );
 
 		}
 
@@ -678,7 +678,7 @@ var Loader = function ( editor ) {
 					var loader = new THREE.FBXLoader( manager );
 					var object = loader.parse( file.asArrayBuffer() );
 
-					editor.execute( new AddObjectCommand( object ) );
+					editor.execute( new AddObjectCommand( editor, object ) );
 
 					break;
 
@@ -690,7 +690,7 @@ var Loader = function ( editor ) {
 						var scene = result.scene;
 
 						editor.addAnimation( scene, result.animations );
-						editor.execute( new AddObjectCommand( scene ) );
+						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -28,7 +28,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Group();
 		mesh.name = 'Group';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -48,7 +48,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Box';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -64,7 +64,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Circle';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -80,7 +80,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Cylinder';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -96,7 +96,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Icosahedron';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -126,7 +126,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial( { side: THREE.DoubleSide } ) );
 		mesh.name = 'Lathe';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -142,7 +142,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Octahedron';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -159,7 +159,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, material );
 		mesh.name = 'Plane';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option )
@@ -175,7 +175,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Ring';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -191,7 +191,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Sphere';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -206,7 +206,7 @@ Menubar.Add = function ( editor ) {
 		var sprite = new THREE.Sprite( new THREE.SpriteMaterial() );
 		sprite.name = 'Sprite';
 
-		editor.execute( new AddObjectCommand( sprite ) );
+		editor.execute( new AddObjectCommand( editor, sprite ) );
 
 	} );
 	options.add( option );
@@ -222,7 +222,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Tetrahedron';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -238,7 +238,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Torus';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -254,7 +254,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'TorusKnot';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -277,7 +277,7 @@ Menubar.Add = function ( editor ) {
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Tube';
 
-		editor.execute( new AddObjectCommand( mesh ) );
+		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
 	options.add( option );
@@ -327,7 +327,7 @@ Menubar.Add = function ( editor ) {
 		var light = new THREE.AmbientLight( color );
 		light.name = 'AmbientLight';
 
-		editor.execute( new AddObjectCommand( light ) );
+		editor.execute( new AddObjectCommand( editor, light ) );
 
 	} );
 	options.add( option );
@@ -348,7 +348,7 @@ Menubar.Add = function ( editor ) {
 
 		light.position.set( 5, 10, 7.5 );
 
-		editor.execute( new AddObjectCommand( light ) );
+		editor.execute( new AddObjectCommand( editor, light ) );
 
 	} );
 	options.add( option );
@@ -369,7 +369,7 @@ Menubar.Add = function ( editor ) {
 
 		light.position.set( 0, 10, 0 );
 
-		editor.execute( new AddObjectCommand( light ) );
+		editor.execute( new AddObjectCommand( editor, light ) );
 
 	} );
 	options.add( option );
@@ -388,7 +388,7 @@ Menubar.Add = function ( editor ) {
 		var light = new THREE.PointLight( color, intensity, distance );
 		light.name = 'PointLight';
 
-		editor.execute( new AddObjectCommand( light ) );
+		editor.execute( new AddObjectCommand( editor, light ) );
 
 	} );
 	options.add( option );
@@ -412,7 +412,7 @@ Menubar.Add = function ( editor ) {
 
 		light.position.set( 5, 10, 7.5 );
 
-		editor.execute( new AddObjectCommand( light ) );
+		editor.execute( new AddObjectCommand( editor, light ) );
 
 	} );
 	options.add( option );
@@ -431,7 +431,7 @@ Menubar.Add = function ( editor ) {
 		var camera = new THREE.OrthographicCamera();
 		camera.name = 'OrthographicCamera';
 
-		editor.execute( new AddObjectCommand( camera ) );
+		editor.execute( new AddObjectCommand( editor, camera ) );
 
 	} );
 	options.add( option );
@@ -446,7 +446,7 @@ Menubar.Add = function ( editor ) {
 		var camera = new THREE.PerspectiveCamera();
 		camera.name = 'PerspectiveCamera';
 
-		editor.execute( new AddObjectCommand( camera ) );
+		editor.execute( new AddObjectCommand( editor, camera ) );
 
 	} );
 	options.add( option );

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -97,7 +97,7 @@ Menubar.Edit = function ( editor ) {
 
 		object = object.clone();
 
-		editor.execute( new AddObjectCommand( object ) );
+		editor.execute( new AddObjectCommand( editor, object ) );
 
 	} );
 	options.add( option );
@@ -114,7 +114,7 @@ Menubar.Edit = function ( editor ) {
 		var parent = object.parent;
 		if ( parent === undefined ) return; // avoid deleting the camera or scene
 
-		editor.execute( new RemoveObjectCommand( object ) );
+		editor.execute( new RemoveObjectCommand( editor, object ) );
 
 	} );
 	options.add( option );
@@ -158,8 +158,8 @@ Menubar.Edit = function ( editor ) {
 					var shader = glslprep.minifyGlsl( [
 							material.vertexShader, material.fragmentShader ] );
 
-					cmds.push( new SetMaterialValueCommand( object, 'vertexShader', shader[ 0 ] ) );
-					cmds.push( new SetMaterialValueCommand( object, 'fragmentShader', shader[ 1 ] ) );
+					cmds.push( new SetMaterialValueCommand( editor, object, 'vertexShader', shader[ 0 ] ) );
+					cmds.push( new SetMaterialValueCommand( editor, object, 'fragmentShader', shader[ 1 ] ) );
 
 					++nMaterialsChanged;
 
@@ -189,7 +189,7 @@ Menubar.Edit = function ( editor ) {
 
 		if ( nMaterialsChanged > 0 ) {
 
-			editor.execute( new MultiCmdsCommand( cmds ), 'Minify Shaders' );
+			editor.execute( new MultiCmdsCommand( editor, cmds ), 'Minify Shaders' );
 
 		}
 

--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -86,7 +86,7 @@ var Script = function ( editor ) {
 
 				if ( value !== currentScript.source ) {
 
-					editor.execute( new SetScriptValueCommand( currentObject, currentScript, 'source', value ) );
+					editor.execute( new SetScriptValueCommand( editor, currentObject, currentScript, 'source', value ) );
 
 				}
 				return;
@@ -99,21 +99,21 @@ var Script = function ( editor ) {
 
 			if ( JSON.stringify( currentObject.material.defines ) !== JSON.stringify( json.defines ) ) {
 
-				var cmd = new SetMaterialValueCommand( currentObject, 'defines', json.defines );
+				var cmd = new SetMaterialValueCommand( editor, currentObject, 'defines', json.defines );
 				cmd.updatable = false;
 				editor.execute( cmd );
 
 			}
 			if ( JSON.stringify( currentObject.material.uniforms ) !== JSON.stringify( json.uniforms ) ) {
 
-				var cmd = new SetMaterialValueCommand( currentObject, 'uniforms', json.uniforms );
+				var cmd = new SetMaterialValueCommand( editor, currentObject, 'uniforms', json.uniforms );
 				cmd.updatable = false;
 				editor.execute( cmd );
 
 			}
 			if ( JSON.stringify( currentObject.material.attributes ) !== JSON.stringify( json.attributes ) ) {
 
-				var cmd = new SetMaterialValueCommand( currentObject, 'attributes', json.attributes );
+				var cmd = new SetMaterialValueCommand( editor, currentObject, 'attributes', json.attributes );
 				cmd.updatable = false;
 				editor.execute( cmd );
 

--- a/editor/js/Sidebar.Geometry.BoxGeometry.js
+++ b/editor/js/Sidebar.Geometry.BoxGeometry.js
@@ -77,7 +77,7 @@ Sidebar.Geometry.BoxGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			width.getValue(),
 			height.getValue(),
 			depth.getValue(),

--- a/editor/js/Sidebar.Geometry.CircleGeometry.js
+++ b/editor/js/Sidebar.Geometry.CircleGeometry.js
@@ -57,7 +57,7 @@ Sidebar.Geometry.CircleGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			segments.getValue(),
 			thetaStart.getValue() * THREE.Math.DEG2RAD,

--- a/editor/js/Sidebar.Geometry.CylinderGeometry.js
+++ b/editor/js/Sidebar.Geometry.CylinderGeometry.js
@@ -77,7 +77,7 @@ Sidebar.Geometry.CylinderGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radiusTop.getValue(),
 			radiusBottom.getValue(),
 			height.getValue(),

--- a/editor/js/Sidebar.Geometry.ExtrudeGeometry.js
+++ b/editor/js/Sidebar.Geometry.ExtrudeGeometry.js
@@ -113,7 +113,7 @@ Sidebar.Geometry.ExtrudeGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			parameters.shapes,
 			{
 				curveSegments: curveSegments.getValue(),
@@ -131,7 +131,7 @@ Sidebar.Geometry.ExtrudeGeometry = function ( editor, object ) {
 
 	function toShape() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE.ShapeBufferGeometry(
+		editor.execute( new SetGeometryCommand( editor, object, new THREE.ShapeBufferGeometry(
 			parameters.shapes,
 			options.curveSegments
 		) ) );

--- a/editor/js/Sidebar.Geometry.IcosahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.IcosahedronGeometry.js
@@ -38,7 +38,7 @@ Sidebar.Geometry.IcosahedronGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			detail.getValue()
 		) ) );

--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -55,7 +55,7 @@ Sidebar.Geometry.LatheGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			points.getValue(),
 			segments.getValue(),
 			phiStart.getValue() / 180 * Math.PI,

--- a/editor/js/Sidebar.Geometry.OctahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.OctahedronGeometry.js
@@ -38,7 +38,7 @@ Sidebar.Geometry.OctahedronGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			detail.getValue()
 		) ) );

--- a/editor/js/Sidebar.Geometry.PlaneGeometry.js
+++ b/editor/js/Sidebar.Geometry.PlaneGeometry.js
@@ -58,7 +58,7 @@ Sidebar.Geometry.PlaneGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			width.getValue(),
 			height.getValue(),
 			widthSegments.getValue(),

--- a/editor/js/Sidebar.Geometry.RingGeometry.js
+++ b/editor/js/Sidebar.Geometry.RingGeometry.js
@@ -77,7 +77,7 @@ Sidebar.Geometry.RingGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			innerRadius.getValue(),
 			outerRadius.getValue(),
 			thetaSegments.getValue(),

--- a/editor/js/Sidebar.Geometry.ShapeGeometry.js
+++ b/editor/js/Sidebar.Geometry.ShapeGeometry.js
@@ -31,7 +31,7 @@ Sidebar.Geometry.ShapeGeometry = function ( editor, object ) {
 
 	function changeShape() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			parameters.shapes,
 			curveSegments.getValue()
 		) ) );
@@ -40,7 +40,7 @@ Sidebar.Geometry.ShapeGeometry = function ( editor, object ) {
 
 	function toExtrude() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE.ExtrudeBufferGeometry(
+		editor.execute( new SetGeometryCommand( editor, object, new THREE.ExtrudeBufferGeometry(
 			parameters.shapes, {
 				curveSegments: curveSegments.getValue()
 			}

--- a/editor/js/Sidebar.Geometry.SphereGeometry.js
+++ b/editor/js/Sidebar.Geometry.SphereGeometry.js
@@ -88,7 +88,7 @@ Sidebar.Geometry.SphereGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			widthSegments.getValue(),
 			heightSegments.getValue(),

--- a/editor/js/Sidebar.Geometry.TetrahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.TetrahedronGeometry.js
@@ -39,7 +39,7 @@ Sidebar.Geometry.TetrahedronGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			detail.getValue()
 		) ) );

--- a/editor/js/Sidebar.Geometry.TorusGeometry.js
+++ b/editor/js/Sidebar.Geometry.TorusGeometry.js
@@ -68,7 +68,7 @@ Sidebar.Geometry.TorusGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			tube.getValue(),
 			radialSegments.getValue(),

--- a/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
+++ b/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
@@ -78,7 +78,7 @@ Sidebar.Geometry.TorusKnotGeometry = function ( editor, object ) {
 
 	function update() {
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			radius.getValue(),
 			tube.getValue(),
 			tubularSegments.getValue(),

--- a/editor/js/Sidebar.Geometry.TubeGeometry.js
+++ b/editor/js/Sidebar.Geometry.TubeGeometry.js
@@ -87,7 +87,7 @@ Sidebar.Geometry.TubeGeometry = function ( editor, object ) {
 
 		tensionRow.setDisplay( curveType.getValue() == 'catmullrom' ? '' : 'none' );
 
-		editor.execute( new SetGeometryCommand( object, new THREE[ geometry.type ](
+		editor.execute( new SetGeometryCommand( editor, object, new THREE[ geometry.type ](
 			new THREE.CatmullRomCurve3( points.getValue(), closed.getValue(), curveType.getValue(), tension.getValue() ),
 			tubularSegments.getValue(),
 			radius.getValue(),

--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -47,7 +47,7 @@ Sidebar.Geometry = function ( editor ) {
 
 				var newPosition = object.position.clone();
 				newPosition.sub( offset );
-				editor.execute( new SetPositionCommand( object, newPosition ) );
+				editor.execute( new SetPositionCommand( editor, object, newPosition ) );
 
 				editor.signals.geometryChanged.dispatch( object );
 
@@ -57,7 +57,7 @@ Sidebar.Geometry = function ( editor ) {
 
 				if ( geometry && geometry.isGeometry ) {
 
-					editor.execute( new SetGeometryCommand( object, new THREE.BufferGeometry().fromGeometry( geometry ) ) );
+					editor.execute( new SetGeometryCommand( editor, object, new THREE.BufferGeometry().fromGeometry( geometry ) ) );
 
 				}
 
@@ -69,12 +69,12 @@ Sidebar.Geometry = function ( editor ) {
 				newGeometry.uuid = geometry.uuid;
 				newGeometry.applyMatrix( object.matrix );
 
-				var cmds = [ new SetGeometryCommand( object, newGeometry ),
-					new SetPositionCommand( object, new THREE.Vector3( 0, 0, 0 ) ),
-					new SetRotationCommand( object, new THREE.Euler( 0, 0, 0 ) ),
-					new SetScaleCommand( object, new THREE.Vector3( 1, 1, 1 ) ) ];
+				var cmds = [ new SetGeometryCommand( editor, object, newGeometry ),
+					new SetPositionCommand( editor, object, new THREE.Vector3( 0, 0, 0 ) ),
+					new SetRotationCommand( editor, object, new THREE.Euler( 0, 0, 0 ) ),
+					new SetScaleCommand( editor, object, new THREE.Vector3( 1, 1, 1 ) ) ];
 
-				editor.execute( new MultiCmdsCommand( cmds ), 'Flatten Geometry' );
+				editor.execute( new MultiCmdsCommand( editor, cmds ), 'Flatten Geometry' );
 
 				break;
 
@@ -104,7 +104,7 @@ Sidebar.Geometry = function ( editor ) {
 
 		geometryUUID.setValue( THREE.Math.generateUUID() );
 
-		editor.execute( new SetGeometryValueCommand( editor.selected, 'uuid', geometryUUID.getValue() ) );
+		editor.execute( new SetGeometryValueCommand( editor, editor.selected, 'uuid', geometryUUID.getValue() ) );
 
 	} );
 
@@ -119,7 +119,7 @@ Sidebar.Geometry = function ( editor ) {
 	var geometryNameRow = new UI.Row();
 	var geometryName = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
-		editor.execute( new SetGeometryValueCommand( editor.selected, 'name', geometryName.getValue() ) );
+		editor.execute( new SetGeometryValueCommand( editor, editor.selected, 'name', geometryName.getValue() ) );
 
 	} );
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -40,7 +40,7 @@ Sidebar.Material = function ( editor ) {
 	managerRow.add( new UI.Button( strings.getKey( 'sidebar/material/new' ) ).onClick( function () {
 
 		var material = new THREE[ materialClass.getValue() ]();
-		editor.execute( new SetMaterialCommand( currentObject, material, currentMaterialSlot ), 'New Material: ' + materialClass.getValue() );
+		editor.execute( new SetMaterialCommand( editor, currentObject, material, currentMaterialSlot ), 'New Material: ' + materialClass.getValue() );
 		update();
 
 	} ) );
@@ -63,7 +63,7 @@ Sidebar.Material = function ( editor ) {
 
 		if ( copiedMaterial === undefined ) return;
 
-		editor.execute( new SetMaterialCommand( currentObject, copiedMaterial, currentMaterialSlot ), 'Pasted Material: ' + materialClass.getValue() );
+		editor.execute( new SetMaterialCommand( editor, currentObject, copiedMaterial, currentMaterialSlot ), 'Pasted Material: ' + materialClass.getValue() );
 		refreshUI();
 		update();
 
@@ -122,7 +122,7 @@ Sidebar.Material = function ( editor ) {
 	var materialNameRow = new UI.Row();
 	var materialName = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
-		editor.execute( new SetMaterialValueCommand( editor.selected, 'name', materialName.getValue(), currentMaterialSlot ) );
+		editor.execute( new SetMaterialValueCommand( editor, editor.selected, 'name', materialName.getValue(), currentMaterialSlot ) );
 
 	} );
 
@@ -575,7 +575,7 @@ Sidebar.Material = function ( editor ) {
 
 			if ( material.uuid !== undefined && material.uuid !== materialUUID.getValue() ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'uuid', materialUUID.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'uuid', materialUUID.getValue(), currentMaterialSlot ) );
 
 			}
 
@@ -589,7 +589,7 @@ Sidebar.Material = function ( editor ) {
 
 				}
 
-				editor.execute( new SetMaterialCommand( currentObject, material, currentMaterialSlot ), 'New Material: ' + materialClass.getValue() );
+				editor.execute( new SetMaterialCommand( editor, currentObject, material, currentMaterialSlot ), 'New Material: ' + materialClass.getValue() );
 				// TODO Copy other references in the scene graph
 				// keeping name and UUID then.
 				// Also there should be means to create a unique
@@ -600,49 +600,49 @@ Sidebar.Material = function ( editor ) {
 
 			if ( material.color !== undefined && material.color.getHex() !== materialColor.getHexValue() ) {
 
-				editor.execute( new SetMaterialColorCommand( currentObject, 'color', materialColor.getHexValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialColorCommand( editor, currentObject, 'color', materialColor.getHexValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.roughness !== undefined && Math.abs( material.roughness - materialRoughness.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'roughness', materialRoughness.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'roughness', materialRoughness.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.metalness !== undefined && Math.abs( material.metalness - materialMetalness.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'metalness', materialMetalness.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'metalness', materialMetalness.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.emissive !== undefined && material.emissive.getHex() !== materialEmissive.getHexValue() ) {
 
-				editor.execute( new SetMaterialColorCommand( currentObject, 'emissive', materialEmissive.getHexValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialColorCommand( editor, currentObject, 'emissive', materialEmissive.getHexValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.specular !== undefined && material.specular.getHex() !== materialSpecular.getHexValue() ) {
 
-				editor.execute( new SetMaterialColorCommand( currentObject, 'specular', materialSpecular.getHexValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialColorCommand( editor, currentObject, 'specular', materialSpecular.getHexValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.shininess !== undefined && Math.abs( material.shininess - materialShininess.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'shininess', materialShininess.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'shininess', materialShininess.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.clearCoat !== undefined && Math.abs( material.clearCoat - materialClearCoat.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'clearCoat', materialClearCoat.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'clearCoat', materialClearCoat.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.clearCoatRoughness !== undefined && Math.abs( material.clearCoatRoughness - materialClearCoatRoughness.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'clearCoatRoughness', materialClearCoatRoughness.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'clearCoatRoughness', materialClearCoatRoughness.getValue(), currentMaterialSlot ) );
 
 			}
 
@@ -652,7 +652,7 @@ Sidebar.Material = function ( editor ) {
 
 				if ( material.vertexColors !== vertexColors ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'vertexColors', vertexColors, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'vertexColors', vertexColors, currentMaterialSlot ) );
 
 				}
 
@@ -663,7 +663,7 @@ Sidebar.Material = function ( editor ) {
 				var depthPacking = parseInt( materialDepthPacking.getValue() );
 				if ( material.depthPacking !== depthPacking ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'depthPacking', depthPacking, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'depthPacking', depthPacking, currentMaterialSlot ) );
 
 				}
 
@@ -671,7 +671,7 @@ Sidebar.Material = function ( editor ) {
 
 			if ( material.skinning !== undefined && material.skinning !== materialSkinning.getValue() ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'skinning', materialSkinning.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'skinning', materialSkinning.getValue(), currentMaterialSlot ) );
 
 			}
 
@@ -684,7 +684,7 @@ Sidebar.Material = function ( editor ) {
 					var map = mapEnabled ? materialMap.getValue() : null;
 					if ( material.map !== map ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'map', map, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'map', map, currentMaterialSlot ) );
 
 					}
 
@@ -705,7 +705,7 @@ Sidebar.Material = function ( editor ) {
 					var matcap = mapEnabled ? materialMatcapMap.getValue() : null;
 					if ( material.matcap !== matcap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'matcap', matcap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'matcap', matcap, currentMaterialSlot ) );
 
 					}
 
@@ -726,7 +726,7 @@ Sidebar.Material = function ( editor ) {
 					var alphaMap = mapEnabled ? materialAlphaMap.getValue() : null;
 					if ( material.alphaMap !== alphaMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'alphaMap', alphaMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'alphaMap', alphaMap, currentMaterialSlot ) );
 
 					}
 
@@ -747,13 +747,13 @@ Sidebar.Material = function ( editor ) {
 					var bumpMap = bumpMapEnabled ? materialBumpMap.getValue() : null;
 					if ( material.bumpMap !== bumpMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'bumpMap', bumpMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'bumpMap', bumpMap, currentMaterialSlot ) );
 
 					}
 
 					if ( material.bumpScale !== materialBumpScale.getValue() ) {
 
-						editor.execute( new SetMaterialValueCommand( currentObject, 'bumpScale', materialBumpScale.getValue(), currentMaterialSlot ) );
+						editor.execute( new SetMaterialValueCommand( editor, currentObject, 'bumpScale', materialBumpScale.getValue(), currentMaterialSlot ) );
 
 					}
 
@@ -774,7 +774,7 @@ Sidebar.Material = function ( editor ) {
 					var normalMap = normalMapEnabled ? materialNormalMap.getValue() : null;
 					if ( material.normalMap !== normalMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'normalMap', normalMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'normalMap', normalMap, currentMaterialSlot ) );
 
 					}
 
@@ -795,13 +795,13 @@ Sidebar.Material = function ( editor ) {
 					var displacementMap = displacementMapEnabled ? materialDisplacementMap.getValue() : null;
 					if ( material.displacementMap !== displacementMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'displacementMap', displacementMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'displacementMap', displacementMap, currentMaterialSlot ) );
 
 					}
 
 					if ( material.displacementScale !== materialDisplacementScale.getValue() ) {
 
-						editor.execute( new SetMaterialValueCommand( currentObject, 'displacementScale', materialDisplacementScale.getValue(), currentMaterialSlot ) );
+						editor.execute( new SetMaterialValueCommand( editor, currentObject, 'displacementScale', materialDisplacementScale.getValue(), currentMaterialSlot ) );
 
 					}
 
@@ -822,7 +822,7 @@ Sidebar.Material = function ( editor ) {
 					var roughnessMap = roughnessMapEnabled ? materialRoughnessMap.getValue() : null;
 					if ( material.roughnessMap !== roughnessMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'roughnessMap', roughnessMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'roughnessMap', roughnessMap, currentMaterialSlot ) );
 
 					}
 
@@ -843,7 +843,7 @@ Sidebar.Material = function ( editor ) {
 					var metalnessMap = metalnessMapEnabled ? materialMetalnessMap.getValue() : null;
 					if ( material.metalnessMap !== metalnessMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'metalnessMap', metalnessMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'metalnessMap', metalnessMap, currentMaterialSlot ) );
 
 					}
 
@@ -864,7 +864,7 @@ Sidebar.Material = function ( editor ) {
 					var specularMap = specularMapEnabled ? materialSpecularMap.getValue() : null;
 					if ( material.specularMap !== specularMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'specularMap', specularMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'specularMap', specularMap, currentMaterialSlot ) );
 
 					}
 
@@ -884,7 +884,7 @@ Sidebar.Material = function ( editor ) {
 
 				if ( material.envMap !== envMap ) {
 
-					editor.execute( new SetMaterialMapCommand( currentObject, 'envMap', envMap, currentMaterialSlot ) );
+					editor.execute( new SetMaterialMapCommand( editor, currentObject, 'envMap', envMap, currentMaterialSlot ) );
 
 				}
 
@@ -896,7 +896,7 @@ Sidebar.Material = function ( editor ) {
 
 				if ( material.reflectivity !== reflectivity ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'reflectivity', reflectivity, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'reflectivity', reflectivity, currentMaterialSlot ) );
 
 				}
 
@@ -911,7 +911,7 @@ Sidebar.Material = function ( editor ) {
 					var lightMap = lightMapEnabled ? materialLightMap.getValue() : null;
 					if ( material.lightMap !== lightMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'lightMap', lightMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'lightMap', lightMap, currentMaterialSlot ) );
 
 					}
 
@@ -932,13 +932,13 @@ Sidebar.Material = function ( editor ) {
 					var aoMap = aoMapEnabled ? materialAOMap.getValue() : null;
 					if ( material.aoMap !== aoMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'aoMap', aoMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'aoMap', aoMap, currentMaterialSlot ) );
 
 					}
 
 					if ( material.aoMapIntensity !== materialAOScale.getValue() ) {
 
-						editor.execute( new SetMaterialValueCommand( currentObject, 'aoMapIntensity', materialAOScale.getValue(), currentMaterialSlot ) );
+						editor.execute( new SetMaterialValueCommand( editor, currentObject, 'aoMapIntensity', materialAOScale.getValue(), currentMaterialSlot ) );
 
 					}
 
@@ -959,7 +959,7 @@ Sidebar.Material = function ( editor ) {
 					var emissiveMap = emissiveMapEnabled ? materialEmissiveMap.getValue() : null;
 					if ( material.emissiveMap !== emissiveMap ) {
 
-						editor.execute( new SetMaterialMapCommand( currentObject, 'emissiveMap', emissiveMap, currentMaterialSlot ) );
+						editor.execute( new SetMaterialMapCommand( editor, currentObject, 'emissiveMap', emissiveMap, currentMaterialSlot ) );
 
 					}
 
@@ -979,7 +979,7 @@ Sidebar.Material = function ( editor ) {
 
 				if ( material.gradientMap !== gradientMap ) {
 
-					editor.execute( new SetMaterialMapCommand( currentObject, 'gradientMap', gradientMap, currentMaterialSlot ) );
+					editor.execute( new SetMaterialMapCommand( editor, currentObject, 'gradientMap', gradientMap, currentMaterialSlot ) );
 
 				}
 
@@ -990,7 +990,7 @@ Sidebar.Material = function ( editor ) {
 				var side = parseInt( materialSide.getValue() );
 				if ( material.side !== side ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'side', side, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'side', side, currentMaterialSlot ) );
 
 				}
 
@@ -1002,7 +1002,7 @@ Sidebar.Material = function ( editor ) {
 				var flatShading = materialShading.getValue();
 				if ( material.flatShading != flatShading ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'flatShading', flatShading, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'flatShading', flatShading, currentMaterialSlot ) );
 
 				}
 
@@ -1013,7 +1013,7 @@ Sidebar.Material = function ( editor ) {
 				var blending = parseInt( materialBlending.getValue() );
 				if ( material.blending !== blending ) {
 
-					editor.execute( new SetMaterialValueCommand( currentObject, 'blending', blending, currentMaterialSlot ) );
+					editor.execute( new SetMaterialValueCommand( editor, currentObject, 'blending', blending, currentMaterialSlot ) );
 
 				}
 
@@ -1021,31 +1021,31 @@ Sidebar.Material = function ( editor ) {
 
 			if ( material.opacity !== undefined && Math.abs( material.opacity - materialOpacity.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'opacity', materialOpacity.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'opacity', materialOpacity.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.transparent !== undefined && material.transparent !== materialTransparent.getValue() ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'transparent', materialTransparent.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'transparent', materialTransparent.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.alphaTest !== undefined && Math.abs( material.alphaTest - materialAlphaTest.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'alphaTest', materialAlphaTest.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'alphaTest', materialAlphaTest.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.wireframe !== undefined && material.wireframe !== materialWireframe.getValue() ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'wireframe', materialWireframe.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'wireframe', materialWireframe.getValue(), currentMaterialSlot ) );
 
 			}
 
 			if ( material.wireframeLinewidth !== undefined && Math.abs( material.wireframeLinewidth - materialWireframeLinewidth.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetMaterialValueCommand( currentObject, 'wireframeLinewidth', materialWireframeLinewidth.getValue(), currentMaterialSlot ) );
+				editor.execute( new SetMaterialValueCommand( editor, currentObject, 'wireframeLinewidth', materialWireframeLinewidth.getValue(), currentMaterialSlot ) );
 
 			}
 

--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -37,15 +37,15 @@ Sidebar.Object = function ( editor ) {
 		switch ( this.getValue() ) {
 
 			case 'Reset Position':
-				editor.execute( new SetPositionCommand( object, new THREE.Vector3( 0, 0, 0 ) ) );
+				editor.execute( new SetPositionCommand( editor, object, new THREE.Vector3( 0, 0, 0 ) ) );
 				break;
 
 			case 'Reset Rotation':
-				editor.execute( new SetRotationCommand( object, new THREE.Euler( 0, 0, 0 ) ) );
+				editor.execute( new SetRotationCommand( editor, object, new THREE.Euler( 0, 0, 0 ) ) );
 				break;
 
 			case 'Reset Scale':
-				editor.execute( new SetScaleCommand( object, new THREE.Vector3( 1, 1, 1 ) ) );
+				editor.execute( new SetScaleCommand( editor, object, new THREE.Vector3( 1, 1, 1 ) ) );
 				break;
 
 		}
@@ -74,7 +74,7 @@ Sidebar.Object = function ( editor ) {
 
 		objectUUID.setValue( THREE.Math.generateUUID() );
 
-		editor.execute( new SetUuidCommand( editor.selected, objectUUID.getValue() ) );
+		editor.execute( new SetUuidCommand( editor, editor.selected, objectUUID.getValue() ) );
 
 	} );
 
@@ -89,7 +89,7 @@ Sidebar.Object = function ( editor ) {
 	var objectNameRow = new UI.Row();
 	var objectName = new UI.Input().setWidth( '150px' ).setFontSize( '12px' ).onChange( function () {
 
-		editor.execute( new SetValueCommand( editor.selected, 'name', objectName.getValue() ) );
+		editor.execute( new SetValueCommand( editor, editor.selected, 'name', objectName.getValue() ) );
 
 	} );
 
@@ -415,62 +415,62 @@ Sidebar.Object = function ( editor ) {
 			var newPosition = new THREE.Vector3( objectPositionX.getValue(), objectPositionY.getValue(), objectPositionZ.getValue() );
 			if ( object.position.distanceTo( newPosition ) >= 0.01 ) {
 
-				editor.execute( new SetPositionCommand( object, newPosition ) );
+				editor.execute( new SetPositionCommand( editor, object, newPosition ) );
 
 			}
 
 			var newRotation = new THREE.Euler( objectRotationX.getValue() * THREE.Math.DEG2RAD, objectRotationY.getValue() * THREE.Math.DEG2RAD, objectRotationZ.getValue() * THREE.Math.DEG2RAD );
 			if ( object.rotation.toVector3().distanceTo( newRotation.toVector3() ) >= 0.01 ) {
 
-				editor.execute( new SetRotationCommand( object, newRotation ) );
+				editor.execute( new SetRotationCommand( editor, object, newRotation ) );
 
 			}
 
 			var newScale = new THREE.Vector3( objectScaleX.getValue(), objectScaleY.getValue(), objectScaleZ.getValue() );
 			if ( object.scale.distanceTo( newScale ) >= 0.01 ) {
 
-				editor.execute( new SetScaleCommand( object, newScale ) );
+				editor.execute( new SetScaleCommand( editor, object, newScale ) );
 
 			}
 
 			if ( object.fov !== undefined && Math.abs( object.fov - objectFov.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'fov', objectFov.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'fov', objectFov.getValue() ) );
 				object.updateProjectionMatrix();
 
 			}
 
 			if ( object.left !== undefined && Math.abs( object.left - objectLeft.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'left', objectLeft.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'left', objectLeft.getValue() ) );
 				object.updateProjectionMatrix();
 
 			}
 
 			if ( object.right !== undefined && Math.abs( object.right - objectRight.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'right', objectRight.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'right', objectRight.getValue() ) );
 				object.updateProjectionMatrix();
 
 			}
 
 			if ( object.top !== undefined && Math.abs( object.top - objectTop.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'top', objectTop.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'top', objectTop.getValue() ) );
 				object.updateProjectionMatrix();
 
 			}
 
 			if ( object.bottom !== undefined && Math.abs( object.bottom - objectBottom.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'bottom', objectBottom.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'bottom', objectBottom.getValue() ) );
 				object.updateProjectionMatrix();
 
 			}
 
 			if ( object.near !== undefined && Math.abs( object.near - objectNear.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'near', objectNear.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'near', objectNear.getValue() ) );
 				if ( object.isOrthographicCamera ) {
 
 					object.updateProjectionMatrix();
@@ -481,7 +481,7 @@ Sidebar.Object = function ( editor ) {
 
 			if ( object.far !== undefined && Math.abs( object.far - objectFar.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'far', objectFar.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'far', objectFar.getValue() ) );
 				if ( object.isOrthographicCamera ) {
 
 					object.updateProjectionMatrix();
@@ -492,74 +492,74 @@ Sidebar.Object = function ( editor ) {
 
 			if ( object.intensity !== undefined && Math.abs( object.intensity - objectIntensity.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'intensity', objectIntensity.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'intensity', objectIntensity.getValue() ) );
 
 			}
 
 			if ( object.color !== undefined && object.color.getHex() !== objectColor.getHexValue() ) {
 
-				editor.execute( new SetColorCommand( object, 'color', objectColor.getHexValue() ) );
+				editor.execute( new SetColorCommand( editor, object, 'color', objectColor.getHexValue() ) );
 
 			}
 
 			if ( object.groundColor !== undefined && object.groundColor.getHex() !== objectGroundColor.getHexValue() ) {
 
-				editor.execute( new SetColorCommand( object, 'groundColor', objectGroundColor.getHexValue() ) );
+				editor.execute( new SetColorCommand( editor, object, 'groundColor', objectGroundColor.getHexValue() ) );
 
 			}
 
 			if ( object.distance !== undefined && Math.abs( object.distance - objectDistance.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'distance', objectDistance.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'distance', objectDistance.getValue() ) );
 
 			}
 
 			if ( object.angle !== undefined && Math.abs( object.angle - objectAngle.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'angle', objectAngle.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'angle', objectAngle.getValue() ) );
 
 			}
 
 			if ( object.penumbra !== undefined && Math.abs( object.penumbra - objectPenumbra.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'penumbra', objectPenumbra.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'penumbra', objectPenumbra.getValue() ) );
 
 			}
 
 			if ( object.decay !== undefined && Math.abs( object.decay - objectDecay.getValue() ) >= 0.01 ) {
 
-				editor.execute( new SetValueCommand( object, 'decay', objectDecay.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'decay', objectDecay.getValue() ) );
 
 			}
 
 			if ( object.visible !== objectVisible.getValue() ) {
 
-				editor.execute( new SetValueCommand( object, 'visible', objectVisible.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'visible', objectVisible.getValue() ) );
 
 			}
 
 			if ( object.frustumCulled !== objectFrustumCulled.getValue() ) {
 
-				editor.execute( new SetValueCommand( object, 'frustumCulled', objectFrustumCulled.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'frustumCulled', objectFrustumCulled.getValue() ) );
 
 			}
 
 			if ( object.renderOrder !== objectRenderOrder.getValue() ) {
 
-				editor.execute( new SetValueCommand( object, 'renderOrder', objectRenderOrder.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'renderOrder', objectRenderOrder.getValue() ) );
 
 			}
 
 			if ( object.castShadow !== undefined && object.castShadow !== objectCastShadow.getValue() ) {
 
-				editor.execute( new SetValueCommand( object, 'castShadow', objectCastShadow.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'castShadow', objectCastShadow.getValue() ) );
 
 			}
 
 			if ( object.receiveShadow !== undefined && object.receiveShadow !== objectReceiveShadow.getValue() ) {
 
 				object.material.needsUpdate = true;
-				editor.execute( new SetValueCommand( object, 'receiveShadow', objectReceiveShadow.getValue() ) );
+				editor.execute( new SetValueCommand( editor, object, 'receiveShadow', objectReceiveShadow.getValue() ) );
 
 			}
 
@@ -567,7 +567,7 @@ Sidebar.Object = function ( editor ) {
 
 				if ( object.shadow.radius !== objectShadowRadius.getValue() ) {
 
-					editor.execute( new SetValueCommand( object.shadow, 'radius', objectShadowRadius.getValue() ) );
+					editor.execute( new SetValueCommand( editor, object.shadow, 'radius', objectShadowRadius.getValue() ) );
 
 				}
 
@@ -578,7 +578,7 @@ Sidebar.Object = function ( editor ) {
 				var userData = JSON.parse( objectUserData.getValue() );
 				if ( JSON.stringify( object.userData ) != JSON.stringify( userData ) ) {
 
-					editor.execute( new SetValueCommand( object, 'userData', userData ) );
+					editor.execute( new SetValueCommand( editor, object, 'userData', userData ) );
 
 				}
 

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -24,7 +24,7 @@ Sidebar.Script = function ( editor ) {
 	newScript.onClick( function () {
 
 		var script = { name: '', source: 'function update( event ) {}' };
-		editor.execute( new AddScriptCommand( editor.selected, script ) );
+		editor.execute( new AddScriptCommand( editor, editor.selected, script ) );
 
 	} );
 	container.add( newScript );
@@ -63,7 +63,7 @@ Sidebar.Script = function ( editor ) {
 					var name = new UI.Input( script.name ).setWidth( '130px' ).setFontSize( '12px' );
 					name.onChange( function () {
 
-						editor.execute( new SetScriptValueCommand( editor.selected, script, 'name', this.getValue() ) );
+						editor.execute( new SetScriptValueCommand( editor, editor.selected, script, 'name', this.getValue() ) );
 
 					} );
 					scriptsContainer.add( name );
@@ -83,7 +83,7 @@ Sidebar.Script = function ( editor ) {
 
 						if ( confirm( 'Are you sure?' ) ) {
 
-							editor.execute( new RemoveScriptCommand( editor.selected, script ) );
+							editor.execute( new RemoveScriptCommand( editor, editor.selected, script ) );
 
 						}
 

--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -108,7 +108,7 @@ Sidebar.Settings.Shortcuts = function ( editor ) {
 				if ( object === null ) return;
 
 				var parent = object.parent;
-				if ( parent !== null ) editor.execute( new RemoveObjectCommand( object ) );
+				if ( parent !== null ) editor.execute( new RemoveObjectCommand( editor, object ) );
 
 				break;
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -99,7 +99,7 @@ var Viewport = function ( editor ) {
 
 					if ( ! objectPositionOnDown.equals( object.position ) ) {
 
-						editor.execute( new SetPositionCommand( object, object.position, objectPositionOnDown ) );
+						editor.execute( new SetPositionCommand( editor, object, object.position, objectPositionOnDown ) );
 
 					}
 
@@ -109,7 +109,7 @@ var Viewport = function ( editor ) {
 
 					if ( ! objectRotationOnDown.equals( object.rotation ) ) {
 
-						editor.execute( new SetRotationCommand( object, object.rotation, objectRotationOnDown ) );
+						editor.execute( new SetRotationCommand( editor, object, object.rotation, objectRotationOnDown ) );
 
 					}
 
@@ -119,7 +119,7 @@ var Viewport = function ( editor ) {
 
 					if ( ! objectScaleOnDown.equals( object.scale ) ) {
 
-						editor.execute( new SetScaleCommand( object, object.scale, objectScaleOnDown ) );
+						editor.execute( new SetScaleCommand( editor, object, object.scale, objectScaleOnDown ) );
 
 					}
 

--- a/editor/js/commands/AddObjectCommand.js
+++ b/editor/js/commands/AddObjectCommand.js
@@ -4,13 +4,14 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @constructor
  */
 
-var AddObjectCommand = function ( object ) {
+var AddObjectCommand = function ( editor, object ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'AddObjectCommand';
 

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -4,14 +4,15 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param script javascript object
  * @constructor
  */
 
-var AddScriptCommand = function ( object, script ) {
+var AddScriptCommand = function ( editor, object, script ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'AddScriptCommand';
 	this.name = 'Add Script';

--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newParent THREE.Object3D
  * @param newBefore THREE.Object3D
  * @constructor
  */
 
-var MoveObjectCommand = function ( object, newParent, newBefore ) {
+var MoveObjectCommand = function ( editor, object, newParent, newBefore ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'MoveObjectCommand';
 	this.name = 'Move Object';

--- a/editor/js/commands/MultiCmdsCommand.js
+++ b/editor/js/commands/MultiCmdsCommand.js
@@ -4,13 +4,14 @@
  */
 
 /**
+ * @param editor Editor
  * @param cmdArray array containing command objects
  * @constructor
  */
 
-var MultiCmdsCommand = function ( cmdArray ) {
+var MultiCmdsCommand = function ( editor, cmdArray ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'MultiCmdsCommand';
 	this.name = 'Multiple Changes';

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -4,13 +4,14 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @constructor
  */
 
-var RemoveObjectCommand = function ( object ) {
+var RemoveObjectCommand = function ( editor, object ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'RemoveObjectCommand';
 	this.name = 'Remove Object';

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -4,14 +4,15 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param script javascript object
  * @constructor
  */
 
-var RemoveScriptCommand = function ( object, script ) {
+var RemoveScriptCommand = function ( editor, object, script ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'RemoveScriptCommand';
 	this.name = 'Remove Script';

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param attributeName string
  * @param newValue integer representing a hex color value
  * @constructor
  */
 
-var SetColorCommand = function ( object, attributeName, newValue ) {
+var SetColorCommand = function ( editor, object, attributeName, newValue ) {
 
-	Command.call( this );
+	Command.call( editor, this );
 
 	this.type = 'SetColorCommand';
 	this.name = 'Set ' + attributeName;

--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -4,14 +4,15 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newGeometry THREE.Geometry
  * @constructor
  */
 
-var SetGeometryCommand = function ( object, newGeometry ) {
+var SetGeometryCommand = function ( editor, object, newGeometry ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetGeometryCommand';
 	this.name = 'Set Geometry';

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param attributeName string
  * @param newValue number, string, boolean or object
  * @constructor
  */
 
-var SetGeometryValueCommand = function ( object, attributeName, newValue ) {
+var SetGeometryValueCommand = function ( editor, object, attributeName, newValue ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetGeometryValueCommand';
 	this.name = 'Set Geometry.' + attributeName;

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param attributeName string
  * @param newValue integer representing a hex color value
  * @constructor
  */
 
-var SetMaterialColorCommand = function ( object, attributeName, newValue, materialSlot ) {
+var SetMaterialColorCommand = function ( editor, object, attributeName, newValue, materialSlot ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetMaterialColorCommand';
 	this.name = 'Set Material.' + attributeName;

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -4,15 +4,15 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newMaterial THREE.Material
  * @constructor
  */
 
+var SetMaterialCommand = function ( editor, object, newMaterial, materialSlot ) {
 
-var SetMaterialCommand = function ( object, newMaterial, materialSlot ) {
-
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetMaterialCommand';
 	this.name = 'New Material';

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param mapName string
  * @param newMap THREE.Texture
  * @constructor
  */
 
-var SetMaterialMapCommand = function ( object, mapName, newMap, materialSlot ) {
+var SetMaterialMapCommand = function ( editor, object, mapName, newMap, materialSlot ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetMaterialMapCommand';
 	this.name = 'Set Material.' + mapName;

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param attributeName string
  * @param newValue number, string, boolean or object
  * @constructor
  */
 
-var SetMaterialValueCommand = function ( object, attributeName, newValue, materialSlot ) {
+var SetMaterialValueCommand = function ( editor, object, attributeName, newValue, materialSlot ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetMaterialValueCommand';
 	this.name = 'Set Material.' + attributeName;

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newPosition THREE.Vector3
  * @param optionalOldPosition THREE.Vector3
  * @constructor
  */
 
-var SetPositionCommand = function ( object, newPosition, optionalOldPosition ) {
+var SetPositionCommand = function ( editor, object, newPosition, optionalOldPosition ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetPositionCommand';
 	this.name = 'Set Position';

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newRotation THREE.Euler
  * @param optionalOldRotation THREE.Euler
  * @constructor
  */
 
-var SetRotationCommand = function ( object, newRotation, optionalOldRotation ) {
+var SetRotationCommand = function ( editor, object, newRotation, optionalOldRotation ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetRotationCommand';
 	this.name = 'Set Rotation';

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newScale THREE.Vector3
  * @param optionalOldScale THREE.Vector3
  * @constructor
  */
 
-var SetScaleCommand = function ( object, newScale, optionalOldScale ) {
+var SetScaleCommand = function ( editor, object, newScale, optionalOldScale ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetScaleCommand';
 	this.name = 'Set Scale';

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -4,13 +4,14 @@
  */
 
 /**
+ * @param editor Editor
  * @param scene containing children to import
  * @constructor
  */
 
-var SetSceneCommand = function ( scene ) {
+var SetSceneCommand = function ( editor, scene ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetSceneCommand';
 	this.name = 'Set Scene';
@@ -19,14 +20,14 @@ var SetSceneCommand = function ( scene ) {
 
 	if ( scene !== undefined ) {
 
-		this.cmdArray.push( new SetUuidCommand( this.editor.scene, scene.uuid ) );
-		this.cmdArray.push( new SetValueCommand( this.editor.scene, 'name', scene.name ) );
-		this.cmdArray.push( new SetValueCommand( this.editor.scene, 'userData', JSON.parse( JSON.stringify( scene.userData ) ) ) );
+		this.cmdArray.push( new SetUuidCommand( this.editor, this.editor.scene, scene.uuid ) );
+		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );
+		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'userData', JSON.parse( JSON.stringify( scene.userData ) ) ) );
 
 		while ( scene.children.length > 0 ) {
 
 			var child = scene.children.pop();
-			this.cmdArray.push( new AddObjectCommand( child ) );
+			this.cmdArray.push( new AddObjectCommand( this.editor, child ) );
 
 		}
 

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -4,6 +4,7 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param script javascript object
  * @param attributeName string
@@ -11,9 +12,9 @@
  * @constructor
  */
 
-var SetScriptValueCommand = function ( object, script, attributeName, newValue ) {
+var SetScriptValueCommand = function ( editor, object, script, attributeName, newValue ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetScriptValueCommand';
 	this.name = 'Set Script.' + attributeName;

--- a/editor/js/commands/SetUuidCommand.js
+++ b/editor/js/commands/SetUuidCommand.js
@@ -4,14 +4,15 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param newUuid string
  * @constructor
  */
 
-var SetUuidCommand = function ( object, newUuid ) {
+var SetUuidCommand = function ( editor, object, newUuid ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetUuidCommand';
 	this.name = 'Update UUID';

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -4,15 +4,16 @@
  */
 
 /**
+ * @param editor Editor
  * @param object THREE.Object3D
  * @param attributeName string
  * @param newValue number, string, boolean or object
  * @constructor
  */
 
-var SetValueCommand = function ( object, attributeName, newValue ) {
+var SetValueCommand = function ( editor, object, attributeName, newValue ) {
 
-	Command.call( this );
+	Command.call( this, editor );
 
 	this.type = 'SetValueCommand';
 	this.name = 'Set ' + attributeName;

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -365,7 +365,7 @@ UI.Outliner.prototype.setOptions = function ( options ) {
 
 		if ( newParentIsChild ) return;
 
-		editor.execute( new MoveObjectCommand( object, newParent, nextObject ) );
+		editor.execute( new MoveObjectCommand( editor, object, newParent, nextObject ) );
 
 		var changeEvent = document.createEvent( 'HTMLEvents' );
 		changeEvent.initEvent( 'change', true, true );


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/13982#issuecomment-391478027

It's now necessary to pass a reference to the editor instance to each command. In this way, the current hack in [History.js](https://github.com/mrdoob/three.js/blob/bffb09dbeb1f97e86c3164ff6dbde6974efc48ac/editor/js/History.js#L19) is not necessary anymore.