### PR TITLE
Docs: Correct ".data" description/typing of data textures.

### DIFF
--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -19,7 +19,7 @@
 
 		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy )</h3>
 		<p>
-			The data argument must be an ArrayBuffer or a typed array view.
+			The data argument must be an [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
 			Further parameters correspond to the properties inherited from [page:Texture], where both magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
 		</p>
 		<p>

--- a/docs/api/zh/textures/DataTexture.html
+++ b/docs/api/zh/textures/DataTexture.html
@@ -19,7 +19,7 @@
 
 		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy )</h3>
 		<p>
-			The data argument must be an ArrayBuffer or a typed array view.
+			The data argument must be an [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
 			Further parameters correspond to the properties inherited from [page:Texture], where both magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
 		</p>
 		<p>

--- a/src/textures/DataTexture.d.ts
+++ b/src/textures/DataTexture.d.ts
@@ -12,7 +12,7 @@ import { TypedArray } from '../polyfills';
 export class DataTexture extends Texture {
 
 	constructor(
-		data: ArrayBuffer | TypedArray,
+		data: TypedArray,
 		width: number,
 		height: number,
 		format?: PixelFormat,

--- a/src/textures/DataTexture2DArray.d.ts
+++ b/src/textures/DataTexture2DArray.d.ts
@@ -4,7 +4,7 @@ import { TypedArray } from '../polyfills';
 export class DataTexture2DArray extends Texture {
 
 	constructor(
-		data: ArrayBuffer | TypedArray,
+		data: TypedArray,
 		width: number,
 		height: number,
 		depth: number

--- a/src/textures/DataTexture3D.d.ts
+++ b/src/textures/DataTexture3D.d.ts
@@ -4,7 +4,7 @@ import { TypedArray } from '../polyfills';
 export class DataTexture3D extends Texture {
 
 	constructor(
-		data: ArrayBuffer | TypedArray,
+		data: TypedArray,
 		width: number,
 		height: number,
 		depth: number


### PR DESCRIPTION
see https://discourse.threejs.org/t/problem-with-constructing-a-datatexture-with-arraybuffer/8227

Passing a pure `ArrayBuffer` to a data texture is not supported. It has to be an `ArrayBufferView`.