### PR TITLE
Quaternion: Add missing call of _onChangeCallback in slerp().

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -562,7 +562,10 @@ Object.assign( Quaternion.prototype, {
 			this._y = s * y + t * this._y;
 			this._z = s * z + t * this._z;
 
-			return this.normalize();
+			this.normalize();
+			this._onChangeCallback();
+
+			return this;
 
 		}
 


### PR DESCRIPTION
Fixed #5860

Although this is just an edge case, it's the more correct implementation. It's not necessary to call `_onChangeCallback()` at the other [return](https://github.com/mrdoob/three.js/blob/6241186533d1a4dbdd80faaff7913361abb10d5d/src/math/Quaternion.js#L551) statement since the values do not change in this case.