### PR TITLE
Fix imports for WebGLRenderer.d.ts

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -17,6 +17,8 @@ import { Fog } from './../scenes/Fog';
 import { ToneMapping, ShadowMapType, CullFace } from '../constants';
 import { WebVRManager } from '../renderers/webvr/WebVRManager';
 import { RenderTarget } from './webgl/WebGLRenderLists';
+import { Geometry } from './core/Geometry';
+import { BufferGeometry } from './core/BufferGeometry';
 
 export interface Renderer {
 	domElement: HTMLCanvasElement;

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -17,8 +17,8 @@ import { Fog } from './../scenes/Fog';
 import { ToneMapping, ShadowMapType, CullFace } from '../constants';
 import { WebVRManager } from '../renderers/webvr/WebVRManager';
 import { RenderTarget } from './webgl/WebGLRenderLists';
-import { Geometry } from './core/Geometry';
-import { BufferGeometry } from './core/BufferGeometry';
+import { Geometry } from './../core/Geometry';
+import { BufferGeometry } from './../core/BufferGeometry';
 
 export interface Renderer {
 	domElement: HTMLCanvasElement;


### PR DESCRIPTION
Missing imports for Geometry and BufferGeometry causes issues in typescript projects. Line 314 defines method renderBufferDirect which references these types.

`	renderBufferDirect(
		camera: Camera,
		fog: Fog,
		geometry: Geometry | BufferGeometry,
		material: Material,
		object: Object3D,
		geometryGroup: any
	): void;`