### PR TITLE
TransformControls: Align .attach() method to Object3D.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -142,6 +142,8 @@ THREE.TransformControls = function ( camera, domElement ) {
 		this.object = object;
 		this.visible = true;
 
+		return this;
+
 	};
 
 	// Detatch from object
@@ -150,6 +152,8 @@ THREE.TransformControls = function ( camera, domElement ) {
 		this.object = undefined;
 		this.visible = false;
 		this.axis = null;
+
+		return this;
 
 	};
 

--- a/examples/jsm/controls/TransformControls.d.ts
+++ b/examples/jsm/controls/TransformControls.d.ts
@@ -29,7 +29,7 @@ export class TransformControls extends Object3D {
   visible: boolean;
 
   attach(object: Object3D): this;
-  detach(): void;
+  detach(): this;
   pointerHover(pointer: Object): void;
   pointerDown(pointer: Object): void;
   pointerMove(pointer: Object): void;

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -167,6 +167,8 @@ var TransformControls = function ( camera, domElement ) {
 		this.object = object;
 		this.visible = true;
 
+		return this;
+
 	};
 
 	// Detatch from object
@@ -175,6 +177,8 @@ var TransformControls = function ( camera, domElement ) {
 		this.object = undefined;
 		this.visible = false;
 		this.axis = null;
+
+		return this;
 
 	};
 


### PR DESCRIPTION
Fixed #16923