### PR TITLE
DecalGeometry: Fix normal data.

### DIFF
--- a/examples/js/geometries/DecalGeometry.js
+++ b/examples/js/geometries/DecalGeometry.js
@@ -149,6 +149,8 @@ THREE.DecalGeometry = function ( mesh, position, orientation, size ) {
 		vertex.applyMatrix4( mesh.matrixWorld );
 		vertex.applyMatrix4( projectorMatrixInverse );
 
+		normal.transformDirection( mesh.matrixWorld );
+
 		decalVertices.push( new THREE.DecalVertex( vertex.clone(), normal.clone() ) );
 
 	}

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -156,6 +156,8 @@ var DecalGeometry = function ( mesh, position, orientation, size ) {
 		vertex.applyMatrix4( mesh.matrixWorld );
 		vertex.applyMatrix4( projectorMatrixInverse );
 
+		normal.transformDirection( mesh.matrixWorld );
+
 		decalVertices.push( new DecalVertex( vertex.clone(), normal.clone() ) );
 
 	}


### PR DESCRIPTION
see https://discourse.threejs.org/t/problem-with-decal-normals/8257

Without this fix, normal data of decal meshes do not respect the transformation of their base mesh.