### PR TITLE
TS: Fix toArray method for Matrix3 and Matrix4: Add optional parameters array and offset

### DIFF
--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -101,7 +101,8 @@ export class Matrix3 implements Matrix {
 	 */
 	transposeIntoArray( r: number[] ): number[];
 	fromArray( array: number[], offset?: number ): Matrix3;
-	toArray(): number[];
+
+	toArray( array?: number[], offset?: number ): number[];
 
 	/**
 	 * Multiplies this matrix by m.

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -227,7 +227,8 @@ export class Matrix4 implements Matrix {
 	): Matrix4;
 	equals( matrix: Matrix4 ): boolean;
 	fromArray( array: number[], offset?: number ): Matrix4;
-	toArray(): number[];
+
+	toArray( array?: number[], offset?: number ): number[];
 
 	/**
 	 * @deprecated Use {@link Matrix4#copyPosition .copyPosition()} instead.


### PR DESCRIPTION
Optional parameters are supported in js file, but not present in definition file
```
	...
	toArray: function ( array, offset ) {

		if ( array === undefined ) array = [];
		if ( offset === undefined ) offset = 0;
		...
```