### PR TITLE
 MapControls: fix dolly_rotate with touch events

### DIFF
--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -650,8 +650,6 @@ THREE.MapControls = function ( object, domElement ) {
 
 		}
 
-		scope.update();
-
 	}
 
 	function handleTouchMovePan( event ) {
@@ -840,9 +838,6 @@ THREE.MapControls = function ( object, domElement ) {
 
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 
-				// handleTouchStartRotate( event );
-				// handleTouchStartDolly( event );
-
 				handleTouchStartDollyRotate( event );
 
 				state = STATE.DOLLY_ROTATE;
@@ -887,9 +882,6 @@ THREE.MapControls = function ( object, domElement ) {
 
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 				if ( ( state & STATE.DOLLY_ROTATE ) === 0 ) return; // is this needed?
-
-				// handleTouchMoveRotate( event );
-				// handleTouchMoveDolly( event );
 
 				handleTouchMoveDollyRotate( event );
 

--- a/examples/js/controls/MapControls.js
+++ b/examples/js/controls/MapControls.js
@@ -276,13 +276,8 @@ THREE.MapControls = function ( object, domElement ) {
 	var zoomChanged = false;
 
 	var rotateStart = new THREE.Vector2();
-	var rotateStart2 = new THREE.Vector2();
 	var rotateEnd = new THREE.Vector2();
-	var rotateEnd2 = new THREE.Vector2();
 	var rotateDelta = new THREE.Vector2();
-	var rotateDelta2 = new THREE.Vector2();
-	var rotateDeltaStartFingers = new THREE.Vector2();
-	var rotateDeltaEndFingers = new THREE.Vector2();
 
 	var panStart = new THREE.Vector2();
 	var panEnd = new THREE.Vector2();
@@ -581,23 +576,9 @@ THREE.MapControls = function ( object, domElement ) {
 
 	}
 
-	function handleTouchStartRotate( event ) {
-
-		// console.log( 'handleTouchStartRotate' );
-
-		// First finger
-		rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
-
-		// Second finger
-		rotateStart2.set( event.touches[ 1 ].pageX, event.touches[ 1 ].pageY );
-
-	}
-
-	function handleTouchStartDolly( event ) {
+	function handleTouchStartDollyRotate( event ) {
 
 		if ( scope.enableZoom ) {
-
-			// console.log( 'handleTouchStartDolly' );
 
 			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
 			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
@@ -605,6 +586,15 @@ THREE.MapControls = function ( object, domElement ) {
 			var distance = Math.sqrt( dx * dx + dy * dy );
 
 			dollyStart.set( 0, distance );
+
+		}
+
+		if ( scope.enableRotate ) {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			rotateStart.set( x, y );
 
 		}
 
@@ -622,121 +612,45 @@ THREE.MapControls = function ( object, domElement ) {
 
 	}
 
-	function handleTouchMoveRotate( event ) {
+	function handleTouchMoveDollyRotate( event ) {
 
-		if ( scope.enableRotate === false ) return;
-		if ( ( state & STATE.ROTATE ) === 0 ) return;
+		if ( scope.enableZoom ) {
 
-		// First finger
-		rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
 
-		// Second finger
-		rotateEnd2.set( event.touches[ 1 ].pageX, event.touches[ 1 ].pageY );
+			var distance = Math.sqrt( dx * dx + dy * dy );
 
-		rotateDelta.subVectors( rotateEnd, rotateStart );
-		rotateDelta2.subVectors( rotateEnd2, rotateStart2 );
-		rotateDeltaStartFingers.subVectors( rotateStart2, rotateStart );
-		rotateDeltaEndFingers.subVectors( rotateEnd2, rotateEnd );
+			dollyEnd.set( 0, distance );
 
-		if ( isRotateUp() ) {
+			dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
+
+			dollyIn( dollyDelta.y );
+
+			dollyStart.copy( dollyEnd );
+
+		}
+
+		if ( scope.enableRotate ) {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			rotateEnd.set( x, y );
+
+			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
 			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
-			// rotating up and down along whole screen attempts to go 360, but limited to 180
+			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
 			rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
 
-			// Start rotateUp ==> disable all movement to prevent flickering
-			state = STATE.ROTATE_UP;
-
-		} else if ( ( state & STATE.ROTATE_LEFT ) !== 0 ) {
-
-			rotateLeft( ( rotateDeltaStartFingers.angle() - rotateDeltaEndFingers.angle() ) * scope.rotateSpeed );
+			rotateStart.copy( rotateEnd );
 
 		}
 
-		rotateStart.copy( rotateEnd );
-		rotateStart2.copy( rotateEnd2 );
-
-	}
-
-	function isRotateUp() {
-
-		// At start, does the two fingers are aligned horizontally
-		if ( ! isHorizontal( rotateDeltaStartFingers ) ) {
-
-			return false;
-
-		}
-
-		// At end, does the two fingers are aligned horizontally
-		if ( ! isHorizontal( rotateDeltaEndFingers ) ) {
-
-			return false;
-
-		}
-
-		// does the first finger moved vertically between start and end
-		if ( ! isVertical( rotateDelta ) ) {
-
-			return false;
-
-		}
-
-		// does the second finger moved vertically between start and end
-		if ( ! isVertical( rotateDelta2 ) ) {
-
-			return false;
-
-		}
-
-		// Does the two finger moved in the same direction (prevent moving one finger vertically up while the other goes down)
-		return rotateDelta.dot( rotateDelta2 ) > 0;
-
-	}
-
-	var isHorizontal = function () {
-
-		var precision = Math.sin( Math.PI / 6 );
-
-		return function isHorizontal( vector ) {
-
-			return Math.abs( Math.sin( vector.angle() ) ) < precision;
-
-		};
-
-	}();
-
-	var isVertical = function () {
-
-		var precision = Math.cos( Math.PI / 2 - Math.PI / 6 );
-
-		return function isVertical( vector ) {
-
-			return Math.abs( Math.cos( vector.angle() ) ) < precision;
-
-		};
-
-	}();
-
-	function handleTouchMoveDolly( event ) {
-
-		if ( scope.enableZoom === false ) return;
-		if ( ( state & STATE.DOLLY ) === 0 ) return;
-
-		// console.log( 'handleTouchMoveDolly' );
-
-		var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
-		var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
-
-		var distance = Math.sqrt( dx * dx + dy * dy );
-
-		dollyEnd.set( 0, distance );
-
-		dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
-
-		dollyIn( dollyDelta.y );
-
-		dollyStart.copy( dollyEnd );
+		scope.update();
 
 	}
 
@@ -926,8 +840,10 @@ THREE.MapControls = function ( object, domElement ) {
 
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 
-				handleTouchStartRotate( event );
-				handleTouchStartDolly( event );
+				// handleTouchStartRotate( event );
+				// handleTouchStartDolly( event );
+
+				handleTouchStartDollyRotate( event );
 
 				state = STATE.DOLLY_ROTATE;
 
@@ -972,8 +888,10 @@ THREE.MapControls = function ( object, domElement ) {
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 				if ( ( state & STATE.DOLLY_ROTATE ) === 0 ) return; // is this needed?
 
-				handleTouchMoveRotate( event );
-				handleTouchMoveDolly( event );
+				// handleTouchMoveRotate( event );
+				// handleTouchMoveDolly( event );
+
+				handleTouchMoveDollyRotate( event );
 
 				scope.update();
 

--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -659,8 +659,6 @@ var MapControls = function ( object, domElement ) {
 
 		}
 
-		scope.update();
-
 	}
 
 	function handleTouchMovePan( event ) {
@@ -849,9 +847,6 @@ var MapControls = function ( object, domElement ) {
 
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 
-				// handleTouchStartRotate( event );
-				// handleTouchStartDolly( event );
-
 				handleTouchStartDollyRotate( event );
 
 				state = STATE.DOLLY_ROTATE;
@@ -896,9 +891,6 @@ var MapControls = function ( object, domElement ) {
 
 				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
 				if ( ( state & STATE.DOLLY_ROTATE ) === 0 ) return; // is this needed?
-
-				// handleTouchMoveRotate( event );
-				// handleTouchMoveDolly( event );
 
 				handleTouchMoveDollyRotate( event );
 

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -61,6 +61,8 @@
 
 				controls.screenSpacePanning = false;
 
+				controls.rotateSpeed = 0.8;
+
 				controls.minDistance = 100;
 				controls.maxDistance = 500;
 


### PR DESCRIPTION
Currently `dollyrotate` doesn't work properly with touch events. 
This PR modifies `dollyrotate` to the same approach used by `OrbitControls` `dollypan`.

[master example](https://threejs.org/examples/?q=mis#misc_controls_map)
[PR example](https://rawcdn.githack.com/sciecode/three.js/6ecc3df1b3efc6613f4e7a5636c4b1471a2384bb/examples/misc_controls_map.html)