### PR TITLE
Nodes: Fix missing return statement in copy functions

### DIFF
--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -202,6 +202,8 @@ CameraNode.prototype.copy = function ( source ) {
 
 	}
 
+	return this;
+
 };
 
 CameraNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/ColorsNode.js
+++ b/examples/jsm/nodes/accessors/ColorsNode.js
@@ -34,6 +34,8 @@ ColorsNode.prototype.copy = function ( source ) {
 
 	this.index = source.index;
 
+	return this;
+
 };
 
 ColorsNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/LightNode.js
+++ b/examples/jsm/nodes/accessors/LightNode.js
@@ -40,6 +40,8 @@ LightNode.prototype.copy = function ( source ) {
 
 	this.scope = source.scope;
 
+	return this;
+
 };
 
 LightNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -84,6 +84,8 @@ NormalNode.prototype.copy = function ( source ) {
 
 	this.scope = source.scope;
 
+	return this;
+
 };
 
 NormalNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/PositionNode.js
+++ b/examples/jsm/nodes/accessors/PositionNode.js
@@ -114,6 +114,8 @@ PositionNode.prototype.copy = function ( source ) {
 
 	this.scope = source.scope;
 
+	return this;
+
 };
 
 PositionNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/ResolutionNode.js
+++ b/examples/jsm/nodes/accessors/ResolutionNode.js
@@ -43,6 +43,8 @@ ResolutionNode.prototype.copy = function ( source ) {
 
 	this.renderer = source.renderer;
 
+	return this;
+
 };
 
 ResolutionNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/ScreenUVNode.js
+++ b/examples/jsm/nodes/accessors/ScreenUVNode.js
@@ -43,6 +43,8 @@ ScreenUVNode.prototype.copy = function ( source ) {
 
 	this.resolution = source.resolution;
 
+	return this;
+
 };
 
 ScreenUVNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/accessors/UVNode.js
+++ b/examples/jsm/nodes/accessors/UVNode.js
@@ -36,6 +36,8 @@ UVNode.prototype.copy = function ( source ) {
 
 	this.index = source.index;
 
+	return this;
+
 };
 
 UVNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/bsdfs/BlinnExponentToRoughnessNode.js
+++ b/examples/jsm/nodes/bsdfs/BlinnExponentToRoughnessNode.js
@@ -29,6 +29,8 @@ BlinnExponentToRoughnessNode.prototype.copy = function ( source ) {
 
 	this.blinnExponent = source.blinnExponent;
 
+	return this;
+
 };
 
 BlinnExponentToRoughnessNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/bsdfs/RoughnessToBlinnExponentNode.js
+++ b/examples/jsm/nodes/bsdfs/RoughnessToBlinnExponentNode.js
@@ -71,6 +71,8 @@ RoughnessToBlinnExponentNode.prototype.copy = function ( source ) {
 
 	this.texture = source.texture;
 
+	return this;
+
 };
 
 RoughnessToBlinnExponentNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/core/AttributeNode.js
+++ b/examples/jsm/nodes/core/AttributeNode.js
@@ -49,6 +49,8 @@ AttributeNode.prototype.copy = function ( source ) {
 
 	this.type = source.type;
 
+	return this;
+
 };
 
 AttributeNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/core/ConstNode.js
+++ b/examples/jsm/nodes/core/ConstNode.js
@@ -102,6 +102,8 @@ ConstNode.prototype.copy = function ( source ) {
 
 	this.parse( source.src, source.useDefine );
 
+	return this;
+
 };
 
 ConstNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/core/FunctionCallNode.js
+++ b/examples/jsm/nodes/core/FunctionCallNode.js
@@ -70,6 +70,8 @@ FunctionCallNode.prototype.copy = function ( source ) {
 
 	this.value = source.value;
 
+	return this;
+
 };
 
 FunctionCallNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/core/FunctionNode.js
+++ b/examples/jsm/nodes/core/FunctionNode.js
@@ -226,6 +226,8 @@ FunctionNode.prototype.copy = function ( source ) {
 
 	if ( source.type !== undefined ) this.type = source.type;
 
+	return this;
+
 };
 
 FunctionNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/core/InputNode.js
+++ b/examples/jsm/nodes/core/InputNode.js
@@ -38,6 +38,8 @@ InputNode.prototype.copy = function ( source ) {
 
 	if ( source.readonly !== undefined ) this.readonly = source.readonly;
 
+	return this;
+
 };
 
 InputNode.prototype.createJSONNode = function ( meta ) {

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -147,6 +147,8 @@ Node.prototype = {
 
 		if ( source.userData !== undefined ) this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
+		return this;
+
 	},
 
 	createJSONNode: function ( meta ) {

--- a/examples/jsm/nodes/core/VarNode.js
+++ b/examples/jsm/nodes/core/VarNode.js
@@ -43,6 +43,8 @@ VarNode.prototype.copy = function ( source ) {
 	this.type = source.type;
 	this.value = source.value;
 
+	return this;
+
 };
 
 VarNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/effects/BlurNode.js
+++ b/examples/jsm/nodes/effects/BlurNode.js
@@ -142,6 +142,8 @@ BlurNode.prototype.copy = function ( source ) {
 	this.blurX = source.blurX;
 	this.blurY = source.blurY;
 
+	return this;
+
 };
 
 BlurNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/effects/ColorAdjustmentNode.js
+++ b/examples/jsm/nodes/effects/ColorAdjustmentNode.js
@@ -113,6 +113,8 @@ ColorAdjustmentNode.prototype.copy = function ( source ) {
 	this.adjustment = source.adjustment;
 	this.method = source.method;
 
+	return this;
+
 };
 
 ColorAdjustmentNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/effects/LuminanceNode.js
+++ b/examples/jsm/nodes/effects/LuminanceNode.js
@@ -52,6 +52,8 @@ LuminanceNode.prototype.copy = function ( source ) {
 
 	this.rgb = source.rgb;
 
+	return this;
+
 };
 
 LuminanceNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/BoolNode.js
+++ b/examples/jsm/nodes/inputs/BoolNode.js
@@ -28,6 +28,8 @@ BoolNode.prototype.copy = function ( source ) {
 
 	this.value = source.value;
 
+	return this;
+
 };
 
 BoolNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/ColorNode.js
+++ b/examples/jsm/nodes/inputs/ColorNode.js
@@ -33,6 +33,8 @@ ColorNode.prototype.copy = function ( source ) {
 
 	this.value.copy( source );
 
+	return this;
+
 };
 
 ColorNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -84,6 +84,8 @@ CubeTextureNode.prototype.copy = function ( source ) {
 
 	if ( source.bias ) this.bias = source.bias;
 
+	return this;
+
 };
 
 CubeTextureNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/FloatNode.js
+++ b/examples/jsm/nodes/inputs/FloatNode.js
@@ -28,6 +28,8 @@ FloatNode.prototype.copy = function ( source ) {
 
 	this.value = source.value;
 
+	return this;
+
 };
 
 FloatNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/IntNode.js
+++ b/examples/jsm/nodes/inputs/IntNode.js
@@ -28,6 +28,8 @@ IntNode.prototype.copy = function ( source ) {
 
 	this.value = source.value;
 
+	return this;
+
 };
 
 IntNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/Matrix3Node.js
+++ b/examples/jsm/nodes/inputs/Matrix3Node.js
@@ -51,6 +51,8 @@ Matrix3Node.prototype.copy = function ( source ) {
 
 	this.value.fromArray( source.elements );
 
+	return this;
+
 };
 
 Matrix3Node.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/Matrix4Node.js
+++ b/examples/jsm/nodes/inputs/Matrix4Node.js
@@ -50,6 +50,8 @@ Matrix4Node.prototype.copy = function ( source ) {
 
 	this.scope.value.fromArray( source.elements );
 
+	return this;
+
 };
 
 Matrix4Node.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/RTTNode.js
+++ b/examples/jsm/nodes/inputs/RTTNode.js
@@ -135,6 +135,8 @@ RTTNode.prototype.copy = function ( source ) {
 
 	this.saveTo = source.saveTo;
 
+	return this;
+
 };
 
 RTTNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/ReflectorNode.js
+++ b/examples/jsm/nodes/inputs/ReflectorNode.js
@@ -67,6 +67,8 @@ ReflectorNode.prototype.copy = function ( source ) {
 
 	this.scope.mirror = source.mirror;
 
+	return this;
+
 };
 
 ReflectorNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/TextureNode.js
+++ b/examples/jsm/nodes/inputs/TextureNode.js
@@ -89,6 +89,8 @@ TextureNode.prototype.copy = function ( source ) {
 	if ( source.bias ) this.bias = source.bias;
 	if ( source.project !== undefined ) this.project = source.project;
 
+	return this;
+
 };
 
 TextureNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/Vector2Node.js
+++ b/examples/jsm/nodes/inputs/Vector2Node.js
@@ -33,6 +33,8 @@ Vector2Node.prototype.copy = function ( source ) {
 
 	this.value.copy( source );
 
+	return this;
+
 };
 
 Vector2Node.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/Vector3Node.js
+++ b/examples/jsm/nodes/inputs/Vector3Node.js
@@ -33,6 +33,8 @@ Vector3Node.prototype.copy = function ( source ) {
 
 	this.value.copy( source );
 
+	return this;
+
 };
 
 Vector3Node.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/inputs/Vector4Node.js
+++ b/examples/jsm/nodes/inputs/Vector4Node.js
@@ -33,6 +33,8 @@ Vector4Node.prototype.copy = function ( source ) {
 
 	this.value.copy( source );
 
+	return this;
+
 };
 
 Vector4Node.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -144,6 +144,8 @@ NodeMaterial.prototype.copy = function ( source ) {
 
 	}
 
+	return this;
+
 };
 
 NodeMaterial.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/materials/nodes/PhongNode.js
+++ b/examples/jsm/nodes/materials/nodes/PhongNode.js
@@ -372,6 +372,8 @@ PhongNode.prototype.copy = function ( source ) {
 	if ( source.environment ) this.environment = source.environment;
 	if ( source.environmentAlpha ) this.environmentAlpha = source.environmentAlpha;
 
+	return this;
+
 };
 
 PhongNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/materials/nodes/RawNode.js
+++ b/examples/jsm/nodes/materials/nodes/RawNode.js
@@ -41,6 +41,8 @@ RawNode.prototype.copy = function ( source ) {
 
 	this.value = source.value;
 
+	return this;
+
 };
 
 RawNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/materials/nodes/SpriteNode.js
+++ b/examples/jsm/nodes/materials/nodes/SpriteNode.js
@@ -202,6 +202,8 @@ SpriteNode.prototype.copy = function ( source ) {
 
 	if ( source.alpha ) this.alpha = source.alpha;
 
+	return this;
+
 };
 
 SpriteNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -459,6 +459,8 @@ StandardNode.prototype.copy = function ( source ) {
 
 	if ( source.environment ) this.environment = source.environment;
 
+	return this;
+
 };
 
 StandardNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/math/CondNode.js
+++ b/examples/jsm/nodes/math/CondNode.js
@@ -99,6 +99,8 @@ CondNode.prototype.copy = function ( source ) {
 	this.ifNode = source.ifNode;
 	this.elseNode = source.elseNode;
 
+	return this;
+
 };
 
 CondNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/math/MathNode.js
+++ b/examples/jsm/nodes/math/MathNode.js
@@ -243,6 +243,8 @@ MathNode.prototype.copy = function ( source ) {
 	this.c = source.c;
 	this.method = source.method;
 
+	return this;
+
 };
 
 MathNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -63,6 +63,8 @@ OperatorNode.prototype.copy = function ( source ) {
 	this.b = source.b;
 	this.op = source.op;
 
+	return this;
+
 };
 
 OperatorNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/misc/BumpMapNode.js
+++ b/examples/jsm/nodes/misc/BumpMapNode.js
@@ -144,6 +144,8 @@ BumpMapNode.prototype.copy = function ( source ) {
 	this.value = source.value;
 	this.scale = source.scale;
 
+	return this;
+
 };
 
 BumpMapNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -95,6 +95,8 @@ NormalMapNode.prototype.copy = function ( source ) {
 	this.value = source.value;
 	this.scale = source.scale;
 
+	return this;
+
 };
 
 NormalMapNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/postprocessing/NodePass.js
+++ b/examples/jsm/nodes/postprocessing/NodePass.js
@@ -52,6 +52,8 @@ NodePass.prototype.copy = function ( source ) {
 
 	this.input = source.input;
 
+	return this;
+
 };
 
 NodePass.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/postprocessing/NodePostProcessing.js
+++ b/examples/jsm/nodes/postprocessing/NodePostProcessing.js
@@ -97,6 +97,8 @@ NodePostProcessing.prototype = {
 
 		this.output = source.output;
 
+		return this;
+
 	},
 
 	toJSON: function ( meta ) {

--- a/examples/jsm/nodes/procedural/CheckerNode.js
+++ b/examples/jsm/nodes/procedural/CheckerNode.js
@@ -54,6 +54,8 @@ CheckerNode.prototype.copy = function ( source ) {
 
 	this.uv = source.uv;
 
+	return this;
+
 };
 
 CheckerNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/procedural/NoiseNode.js
+++ b/examples/jsm/nodes/procedural/NoiseNode.js
@@ -48,6 +48,8 @@ NoiseNode.prototype.copy = function ( source ) {
 
 	this.uv = source.uv;
 
+	return this;
+
 };
 
 NoiseNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/BypassNode.js
+++ b/examples/jsm/nodes/utils/BypassNode.js
@@ -62,6 +62,8 @@ BypassNode.prototype.copy = function ( source ) {
 	this.code = source.code;
 	this.value = source.value;
 
+	return this;
+
 };
 
 BypassNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/ColorSpaceNode.js
+++ b/examples/jsm/nodes/utils/ColorSpaceNode.js
@@ -295,6 +295,8 @@ ColorSpaceNode.prototype.copy = function ( source ) {
 	this.input = source.input;
 	this.method = source.method;
 
+	return this;
+
 };
 
 ColorSpaceNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/JoinNode.js
+++ b/examples/jsm/nodes/utils/JoinNode.js
@@ -78,6 +78,8 @@ JoinNode.prototype.copy = function ( source ) {
 
 	}
 
+	return this;
+
 };
 
 JoinNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/SwitchNode.js
+++ b/examples/jsm/nodes/utils/SwitchNode.js
@@ -80,6 +80,8 @@ SwitchNode.prototype.copy = function ( source ) {
 	this.node = source.node;
 	this.components = source.components;
 
+	return this;
+
 };
 
 SwitchNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/TimerNode.js
+++ b/examples/jsm/nodes/utils/TimerNode.js
@@ -75,6 +75,8 @@ TimerNode.prototype.copy = function ( source ) {
 
 	this.timeScale = source.timeScale;
 
+	return this;
+
 };
 
 TimerNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/UVTransformNode.js
+++ b/examples/jsm/nodes/utils/UVTransformNode.js
@@ -44,6 +44,8 @@ UVTransformNode.prototype.copy = function ( source ) {
 	this.uv = source.uv;
 	this.position = source.position;
 
+	return this;
+
 };
 
 UVTransformNode.prototype.toJSON = function ( meta ) {

--- a/examples/jsm/nodes/utils/VelocityNode.js
+++ b/examples/jsm/nodes/utils/VelocityNode.js
@@ -152,6 +152,8 @@ VelocityNode.prototype.copy = function ( source ) {
 
 	this.setParams( source.params );
 
+	return this;
+
 };
 
 VelocityNode.prototype.toJSON = function ( meta ) {


### PR DESCRIPTION
cc. @sunag 

The `clone` function implementation is:

```javascript
return new this.constructor().copy( this );
```

which means that the `copy` method needs to return `this`. It is missing in the Node classes.