### PR TITLE
Catch more d.ts error with the Typescript Compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",
     "start": "npm run dev",
-    "lint": "eslint src --ext js --ext ts",
+    "lint": "eslint src --ext js --ext ts && tsc src/Three.d.ts --noEmit",
     "test": "npm run build-test && qunit -r failonlyreporter test/unit/three.source.unit.js",
     "travis": "npm run lint && npm test"
   },


### PR DESCRIPTION
Add more linting and error checking to the `d.ts` files by using the `tsc` typescript compiler.

At the moment `tsc` does not support file globs so it's difficult to globally check all files (such as examples), but the `src/Three.d.ts` file seems to cover all of the core definitions for now. Maybe someone has some ideas on how to cleanly add globs to npm the script?

Related to https://github.com/mrdoob/three.js/issues/16926#issuecomment-506363792