### PR TITLE
Fix typing issues in Volume.d.ts and VolumeSlice.d.ts

### DIFF
--- a/examples/jsm/misc/Volume.d.ts
+++ b/examples/jsm/misc/Volume.d.ts
@@ -5,7 +5,7 @@ import {
 import { VolumeSlice } from "./VolumeSlice.js";
 
 export class Volume {
-  constructor( xLength?: number, yLength?: number, zLength?: number, type?:string, arrayBuffer: ArrayLike<number> );
+  constructor( xLength?: number, yLength?: number, zLength?: number, type?:string, arrayBuffer?: ArrayLike<number> );
 
   xLength: number;
   yLength: number;
@@ -27,7 +27,7 @@ export class Volume {
   access( i: number, j: number, k: number ): number;
   reverseAccess( index: number ): number[];
 
-  map( functionToMap: function, context: this ): this;
+  map( functionToMap: Function, context: this ): this;
 
   extractPerpendicularPlane ( axis: string, RASIndex: number ): object;
   extractSlice( axis: string, index: number ): VolumeSlice;

--- a/examples/jsm/misc/VolumeSlice.d.ts
+++ b/examples/jsm/misc/VolumeSlice.d.ts
@@ -3,7 +3,7 @@ import {
   Mesh,
 } from '../../../src/Three';
 
-import { volume } from './Volume';
+import { Volume } from './Volume';
 
 export class VolumeSlice {
   constructor( volume: Volume, index?: number, axis?: string );


### PR DESCRIPTION
Errors observed:

ERROR in node_modules/three/examples/jsm/misc/Volume.d.ts(8,84): error TS1016: A required parameter cannot follow an optional parameter.
node_modules/three/examples/jsm/misc/Volume.d.ts(30,23): error TS2304: Cannot find name 'function'.
node_modules/three/examples/jsm/misc/VolumeSlice.d.ts(6,10): error TS2724: Module '"./Volume"' has no exported member 'volume'. Did you mean 'Volume'?
node_modules/three/examples/jsm/misc/VolumeSlice.d.ts(9,24): error TS2304: Cannot find name 'Volume'.