### PR TITLE
EXRLoader, HDRCubeTextureLoader, RGBELoader: setType() -> setDataType()

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -82,10 +82,18 @@ THREE.EXRLoader = function ( manager ) {
 
 THREE.EXRLoader.prototype = Object.create( THREE.DataTextureLoader.prototype );
 
-THREE.EXRLoader.prototype.setType = function ( value ) {
+THREE.EXRLoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
 	return this;
+
+};
+
+THREE.EXRLoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.EXRLoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };
 

--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -15,9 +15,9 @@ THREE.HDRCubeTextureLoader.prototype.load = function ( urls, onLoad, onProgress,
 
 	if ( ! Array.isArray( urls ) ) {
 
-		console.warn( 'THREE.HDRCubeTextureLoader signature has changed. Use .setType() instead.' );
+		console.warn( 'THREE.HDRCubeTextureLoader signature has changed. Use .setDataType() instead.' );
 
-		this.setType( urls );
+		this.setDataType( urls );
 
 		urls = onLoad;
 		onLoad = onProgress;
@@ -121,10 +121,18 @@ THREE.HDRCubeTextureLoader.prototype.setPath = function ( value ) {
 
 };
 
-THREE.HDRCubeTextureLoader.prototype.setType = function ( value ) {
+THREE.HDRCubeTextureLoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
-	this.hdrLoader.setType( value );
+	this.hdrLoader.setDataType( value );
 	return this;
+
+};
+
+THREE.HDRCubeTextureLoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.HDRCubeTextureLoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };

--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -470,10 +470,18 @@ THREE.RGBELoader.prototype._parser = function ( buffer ) {
 
 };
 
-THREE.RGBELoader.prototype.setType = function ( value ) {
+THREE.RGBELoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
 	return this;
+
+};
+
+THREE.RGBELoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.RGBELoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };
 

--- a/examples/jsm/loaders/EXRLoader.d.ts
+++ b/examples/jsm/loaders/EXRLoader.d.ts
@@ -19,5 +19,5 @@ export class EXRLoader extends DataTextureLoader {
   type: TextureDataType;
 
   _parser(buffer: ArrayBuffer) : EXR;
-  setType(type: TextureDataType): this;
+  setDataType(type: TextureDataType): this;
 }

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -91,10 +91,18 @@ var EXRLoader = function ( manager ) {
 
 EXRLoader.prototype = Object.create( DataTextureLoader.prototype );
 
-EXRLoader.prototype.setType = function ( value ) {
+EXRLoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
 	return this;
+
+};
+
+EXRLoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.EXRLoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };
 

--- a/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
@@ -15,5 +15,5 @@ export class HDRCubeTextureLoader {
 
   load(url: string, onLoad: (texture: CubeTexture) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
   setPath(value: string): this;
-  setType(type: TextureDataType): this;
+  setDataType(type: TextureDataType): this;
 }

--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -32,9 +32,9 @@ HDRCubeTextureLoader.prototype.load = function ( urls, onLoad, onProgress, onErr
 
 	if ( ! Array.isArray( urls ) ) {
 
-		console.warn( 'THREE.HDRCubeTextureLoader signature has changed. Use .setType() instead.' );
+		console.warn( 'THREE.HDRCubeTextureLoader signature has changed. Use .setDataType() instead.' );
 
-		this.setType( urls );
+		this.setDataType( urls );
 
 		urls = onLoad;
 		onLoad = onProgress;
@@ -138,11 +138,19 @@ HDRCubeTextureLoader.prototype.setPath = function ( value ) {
 
 };
 
-HDRCubeTextureLoader.prototype.setType = function ( value ) {
+HDRCubeTextureLoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
-	this.hdrLoader.setType( value );
+	this.hdrLoader.setDataType( value );
 	return this;
+
+};
+
+HDRCubeTextureLoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.HDRCubeTextureLoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };
 

--- a/examples/jsm/loaders/RGBELoader.d.ts
+++ b/examples/jsm/loaders/RGBELoader.d.ts
@@ -21,5 +21,5 @@ export class RGBELoader extends DataTextureLoader {
   type: TextureDataType;
 
   _parser(buffer: ArrayBuffer): RGBE;
-  setType(type: TextureDataType): this;
+  setDataType(type: TextureDataType): this;
 }

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -484,10 +484,18 @@ RGBELoader.prototype._parser = function ( buffer ) {
 
 };
 
-RGBELoader.prototype.setType = function ( value ) {
+RGBELoader.prototype.setDataType = function ( value ) {
 
 	this.type = value;
 	return this;
+
+};
+
+RGBELoader.prototype.setType = function ( value ) {
+
+	console.warn( 'THREE.RGBELoader: .setType() has been renamed to .setDataType().' );
+
+	return this.setDataType( value );
 
 };
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -45,7 +45,7 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'pedestrian_overpass_2k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -155,7 +155,7 @@
 				// Load background and generate envMap
 
 				new RGBELoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'venice_sunset_2k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -48,7 +48,7 @@
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
 				new EXRLoader()
-					.setType( THREE.FloatType )
+					.setDataType( THREE.FloatType )
 					.load( 'textures/memorial.exr', function ( texture, textureData ) {
 
 						//console.log( textureData );

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -48,7 +48,7 @@
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
 				new RGBELoader()
-					.setType( THREE.UnsignedByteType ) // alt: FloatType, HalfFloatType
+					.setDataType( THREE.UnsignedByteType ) // alt: FloatType, HalfFloatType
 					.load( 'textures/memorial.hdr', function ( texture, textureData ) {
 
 						//console.log( textureData );

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -75,7 +75,7 @@
 				scene.add( planeMesh );
 
 				new EXRLoader()
-					.setType( THREE.FloatType )
+					.setDataType( THREE.FloatType )
 					.load( 'textures/piz_compressed.exr', function ( texture ) {
 
 						texture.minFilter = THREE.NearestFilter;

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -82,7 +82,7 @@
 
 				hdrCubeMap = new HDRCubeTextureLoader()
 					.setPath( './textures/cube/pisaHDR/' )
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function () {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );

--- a/examples/webgl_materials_envmaps_hdr_nodes.html
+++ b/examples/webgl_materials_envmaps_hdr_nodes.html
@@ -106,7 +106,7 @@
 				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
 				hdrCubeMap = new HDRCubeTextureLoader()
 					.setPath( './textures/cube/pisaHDR/' )
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function () {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );

--- a/examples/webgl_materials_envmaps_pmrem_nodes.html
+++ b/examples/webgl_materials_envmaps_pmrem_nodes.html
@@ -132,7 +132,7 @@
 				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
 				hdrCubeMap = new HDRCubeTextureLoader()
 					.setPath( './textures/cube/pisaHDR/' )
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function () {
 
 						generate( params.textureSize );

--- a/examples/webgl_materials_reflectivity.html
+++ b/examples/webgl_materials_reflectivity.html
@@ -126,7 +126,7 @@
 				var hdrUrls = genCubeUrls( "./textures/cube/pisaHDR/", ".hdr" );
 
 				new HDRCubeTextureLoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function ( hdrCubeMap ) {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -62,7 +62,7 @@
 				var hdrCubeRenderTarget = null;
 
 				new HDRCubeTextureLoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function ( hdrCubeMap ) {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -68,7 +68,7 @@
 				imgTexture = null;
 
 				new HDRCubeTextureLoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function ( hdrCubeMap ) {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -143,7 +143,7 @@
 				];
 
 				new HDRCubeTextureLoader()
-					.setType( THREE.UnsignedByteType )
+					.setDataType( THREE.UnsignedByteType )
 					.load( hdrUrls, function ( hdrCubeMap ) {
 
 						var pmremGenerator = new PMREMGenerator( hdrCubeMap );


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/16768#issuecomment-501529345.

I updated the TS flies. I'm assuming the JSM javascript files can be auto-generated.

I can update the examples if this is merged.
