### PR TITLE
MipMap -> Mipmap

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -87,11 +87,11 @@
 		<h2>Minification Filters</h2>
 		<code>
 		THREE.NearestFilter
-		THREE.NearestMipMapNearestFilter
-		THREE.NearestMipMapLinearFilter
+		THREE.NearestMipmapNearestFilter
+		THREE.NearestMipmapLinearFilter
 		THREE.LinearFilter
-		THREE.LinearMipMapNearestFilter
-		THREE.LinearMipMapLinearFilter
+		THREE.LinearMipmapNearestFilter
+		THREE.LinearMipmapLinearFilter
 		</code>
 
 		<p>
@@ -102,21 +102,21 @@
 		In addition to [page:constant NearestFilter] and [page:constant LinearFilter],
 		the following four functions can be used for minification:<br /><br />
 
-		[page:constant NearestMipMapNearestFilter] chooses the mipmap that most closely
+		[page:constant NearestMipmapNearestFilter] chooses the mipmap that most closely
 		matches the size of the pixel being textured
 		and uses the [page:constant NearestFilter] criterion (the texel nearest to the
 		center of the pixel) to produce a texture value.<br /><br />
 
-		[page:constant NearestMipMapLinearFilter] chooses the two mipmaps that most closely
+		[page:constant NearestMipmapLinearFilter] chooses the two mipmaps that most closely
 		match the size of the pixel being textured and uses the [page:constant NearestFilter] criterion to produce
 		a texture value from each mipmap. The final texture value is a weighted average of those two values.<br /><br />
 
-		[page:constant LinearMipMapNearestFilter] chooses the mipmap that most closely matches
+		[page:constant LinearMipmapNearestFilter] chooses the mipmap that most closely matches
 		the size of the pixel being textured and uses the [page:constant LinearFilter] criterion
 		(a weighted average of the four texels that are closest to the center of the pixel)
 		to produce a texture value.<br /><br />
 
-		[page:constant LinearMipMapLinearFilter] is the default and chooses the two mipmaps
+		[page:constant LinearMipmapLinearFilter] is the default and chooses the two mipmaps
 		that most closely match the size of the pixel being textured and uses the [page:constant LinearFilter] criterion
 		to produce a texture value from each mipmap. The final texture value is a weighted average of those two values.<br /><br />
 

--- a/docs/api/en/textures/CanvasTexture.html
+++ b/docs/api/en/textures/CanvasTexture.html
@@ -37,7 +37,7 @@
 		The default is [page:Textures THREE.LinearFilter]. See [page:Textures magnification filter constants] for other choices.<br />
 
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
-		 The default is [page:Textures THREE.LinearMipMapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
+		 The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
     [page:Constant format] -- The format used in the texture.
      See [page:Textures format constants] for other choices.<br />

--- a/docs/api/en/textures/CompressedTexture.html
+++ b/docs/api/en/textures/CompressedTexture.html
@@ -52,7 +52,7 @@
 		The default is [page:Textures THREE.LinearFilter]. See [page:Textures magnification filter constants] for other choices.<br />
 
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
-		 The default is [page:Textures THREE.LinearMipMapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
+		 The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
 		[page:Number anisotropy] -- The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap, at the cost of more texture samples being used.

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -105,7 +105,7 @@
 		<h3>[property:number minFilter]</h3>
 		<p>
 		How the texture is sampled when a texel covers less than one pixel. The default is
-		[page:Textures THREE.LinearMipMapLinearFilter], which uses mipmapping and a trilinear filter. <br /><br />
+		[page:Textures THREE.LinearMipmapLinearFilter], which uses mipmapping and a trilinear filter. <br /><br />
 
 		See the [page:Textures texture constants] page for all possible choices.
 		</p>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -51,7 +51,7 @@ texture.format = THREE.RGBFormat;
 		The default is [page:Textures THREE.LinearFilter]. See [page:Textures magnification filter constants] for other choices.<br />
 
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
-		 The default is [page:Textures THREE.LinearMipMapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
+		 The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
     [page:Constant format] -- The format used in the texture.
      See [page:Textures format constants] for other choices.<br />

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipMapLinearFilter, ClampToEdgeWrapping } from '../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, ClampToEdgeWrapping } from '../constants.js';
 import { FileLoader } from './FileLoader.js';
 import { DataTexture } from '../textures/DataTexture.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
@@ -51,7 +51,7 @@ Object.assign( DataTextureLoader.prototype, {
 			texture.wrapT = texData.wrapT !== undefined ? texData.wrapT : ClampToEdgeWrapping;
 
 			texture.magFilter = texData.magFilter !== undefined ? texData.magFilter : LinearFilter;
-			texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearMipMapLinearFilter;
+			texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearMipmapLinearFilter;
 
 			texture.anisotropy = texData.anisotropy !== undefined ? texData.anisotropy : 1;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -13,11 +13,11 @@ import {
 	MirroredRepeatWrapping,
 
 	NearestFilter,
-	NearestMipMapNearestFilter,
-	NearestMipMapLinearFilter,
+	NearestMipmapNearestFilter,
+	NearestMipmapLinearFilter,
 	LinearFilter,
-	LinearMipMapNearestFilter,
-	LinearMipMapLinearFilter
+	LinearMipmapNearestFilter,
+	LinearMipmapLinearFilter
 } from '../constants.js';
 import { Color } from '../math/Color.js';
 import { Object3D } from '../core/Object3D.js';
@@ -1013,11 +1013,11 @@ var TEXTURE_WRAPPING = {
 
 var TEXTURE_FILTER = {
 	NearestFilter: NearestFilter,
-	NearestMipMapNearestFilter: NearestMipMapNearestFilter,
-	NearestMipMapLinearFilter: NearestMipMapLinearFilter,
+	NearestMipmapNearestFilter: NearestMipmapNearestFilter,
+	NearestMipmapLinearFilter: NearestMipmapLinearFilter,
 	LinearFilter: LinearFilter,
-	LinearMipMapNearestFilter: LinearMipMapNearestFilter,
-	LinearMipMapLinearFilter: LinearMipMapLinearFilter
+	LinearMipmapNearestFilter: LinearMipmapNearestFilter,
+	LinearMipmapLinearFilter: LinearMipmapLinearFilter
 };
 
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipMapLinearFilter, NearestMipMapNearestFilter } from '../../constants.js';
+import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipmapLinearFilter, NearestMipmapNearestFilter } from '../../constants.js';
 import { _Math } from '../../math/Math.js';
 
 function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
@@ -167,7 +167,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	function filterFallback( f ) {
 
-		if ( f === NearestFilter || f === NearestMipMapNearestFilter || f === NearestMipMapLinearFilter ) {
+		if ( f === NearestFilter || f === NearestMipmapNearestFilter || f === NearestMipmapLinearFilter ) {
 
 			return _gl.NEAREST;
 

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -2,7 +2,7 @@
  * @author thespite / http://www.twitter.com/thespite
  */
 
-import { MaxEquation, MinEquation, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, SrcAlphaSaturateFactor, OneMinusDstColorFactor, DstColorFactor, OneMinusDstAlphaFactor, DstAlphaFactor, OneMinusSrcAlphaFactor, SrcAlphaFactor, OneMinusSrcColorFactor, SrcColorFactor, OneFactor, ZeroFactor, ReverseSubtractEquation, SubtractEquation, AddEquation, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, RGBFormat, AlphaFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, LinearMipMapLinearFilter, LinearMipMapNearestFilter, LinearFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, NearestFilter, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping } from '../../constants.js';
+import { MaxEquation, MinEquation, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, SrcAlphaSaturateFactor, OneMinusDstColorFactor, DstColorFactor, OneMinusDstAlphaFactor, DstAlphaFactor, OneMinusSrcAlphaFactor, SrcAlphaFactor, OneMinusSrcColorFactor, SrcColorFactor, OneFactor, ZeroFactor, ReverseSubtractEquation, SubtractEquation, AddEquation, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, RGBFormat, AlphaFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, LinearMipmapLinearFilter, LinearMipmapNearestFilter, LinearFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, NearestFilter, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping } from '../../constants.js';
 
 function WebGLUtils( gl, extensions, capabilities ) {
 
@@ -15,12 +15,12 @@ function WebGLUtils( gl, extensions, capabilities ) {
 		if ( p === MirroredRepeatWrapping ) return gl.MIRRORED_REPEAT;
 
 		if ( p === NearestFilter ) return gl.NEAREST;
-		if ( p === NearestMipMapNearestFilter ) return gl.NEAREST_MIPMAP_NEAREST;
-		if ( p === NearestMipMapLinearFilter ) return gl.NEAREST_MIPMAP_LINEAR;
+		if ( p === NearestMipmapNearestFilter ) return gl.NEAREST_MIPMAP_NEAREST;
+		if ( p === NearestMipmapLinearFilter ) return gl.NEAREST_MIPMAP_LINEAR;
 
 		if ( p === LinearFilter ) return gl.LINEAR;
-		if ( p === LinearMipMapNearestFilter ) return gl.LINEAR_MIPMAP_NEAREST;
-		if ( p === LinearMipMapLinearFilter ) return gl.LINEAR_MIPMAP_LINEAR;
+		if ( p === LinearMipmapNearestFilter ) return gl.LINEAR_MIPMAP_NEAREST;
+		if ( p === LinearMipmapLinearFilter ) return gl.LINEAR_MIPMAP_LINEAR;
 
 		if ( p === UnsignedByteType ) return gl.UNSIGNED_BYTE;
 		if ( p === UnsignedShort4444Type ) return gl.UNSIGNED_SHORT_4_4_4_4;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -12,7 +12,7 @@ import {
 	LinearEncoding,
 	UnsignedByteType,
 	RGBAFormat,
-	LinearMipMapLinearFilter,
+	LinearMipmapLinearFilter,
 	LinearFilter,
 	UVMapping
 } from '../constants.js';
@@ -40,7 +40,7 @@ function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, ty
 	this.wrapT = wrapT !== undefined ? wrapT : ClampToEdgeWrapping;
 
 	this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;
-	this.minFilter = minFilter !== undefined ? minFilter : LinearMipMapLinearFilter;
+	this.minFilter = minFilter !== undefined ? minFilter : LinearMipmapLinearFilter;
 
 	this.anisotropy = anisotropy !== undefined ? anisotropy : 1;
 


### PR DESCRIPTION
Follow-up to #16981.

This PR updates the core library to use the new nomenclature. It also updates the docs.

I do not have the ability to test TS, but the examples appear to work, so both the old and the new nomenclature is supported.

I assume we want to continue to support both the old and the new constant names -- at least for awhile.

I'll update the examples to use the new nomenclature if this goes well.