### PR TITLE
Added missing name property to BufferAttribute's typings.

### DIFF
--- a/src/core/BufferAttribute.d.ts
+++ b/src/core/BufferAttribute.d.ts
@@ -6,6 +6,7 @@ export class BufferAttribute {
 	constructor( array: ArrayLike<number>, itemSize: number, normalized?: boolean ); // array parameter should be TypedArray.
 
 	uuid: string;
+	name: string;
 	array: ArrayLike<number>;
 	itemSize: number;
 	dynamic: boolean;


### PR DESCRIPTION
Hi,

The name property is missing from BufferAttribute.

Thanks!