### PR TITLE
Fixed CubeTextureNode having incorrect roughness

### DIFF
--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -47,8 +47,15 @@ CubeTextureNode.prototype.generate = function ( builder, output ) {
 
 	var code;
 
-	if ( bias ) code = 'texCubeBias( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
-	else code = 'texCube( ' + cubetex + ', ' + uv + ' )';
+	if ( bias ) {
+
+		var renderer = builder.renderer;
+		var texLodExtension = renderer.capabilities.isWebGL2 || renderer.extensions.get( 'EXT_shader_texture_lod' ); // copied from WebGLProgram
+
+		if(texLodExtension) code = 'textureCubeLodEXT( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
+		else code = 'texCubeBias( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
+
+	} else code = 'texCube( ' + cubetex + ', ' + uv + ' )';
 
 	// add a custom context for fix incompatibility with the core
 	// include ColorSpace function only for vertex shader (in fragment shader color space functions is added automatically by core)

--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -47,15 +47,8 @@ CubeTextureNode.prototype.generate = function ( builder, output ) {
 
 	var code;
 
-	if ( bias ) {
-
-		var renderer = builder.renderer;
-		var texLodExtension = renderer.capabilities.isWebGL2 || renderer.extensions.get( 'EXT_shader_texture_lod' ); // copied from WebGLProgram
-
-		if(texLodExtension) code = 'textureCubeLodEXT( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
-		else code = 'texCubeBias( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
-
-	} else code = 'texCube( ' + cubetex + ', ' + uv + ' )';
+	if ( bias ) code = 'texCubeBias( ' + cubetex + ', ' + uv + ', ' + bias + ' )';
+	else code = 'texCube( ' + cubetex + ', ' + uv + ' )';
 
 	// add a custom context for fix incompatibility with the core
 	// include ColorSpace function only for vertex shader (in fragment shader color space functions is added automatically by core)

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2294,28 +2294,52 @@
 
 					case 'node-reflect':
 
-						// MATERIAL
+							// MATERIAL
 
-						var node = new Nodes.ReflectNode();
+							var node = new Nodes.ReflectNode();
 
-						mtl = new Nodes.PhongNodeMaterial();
-						mtl.environment = new Nodes.CubeTextureNode( cubemap, node );
+							var nodeMaterial = new Nodes.StandardNodeMaterial();
+							nodeMaterial.environment = new Nodes.CubeTextureNode( cubemap, node );
+							nodeMaterial.roughness = new Nodes.FloatNode(0);
+							nodeMaterial.metalness = new Nodes.FloatNode(1);
 
-						// GUI
+							var standardMaterial = new THREE.MeshStandardMaterial( {
+								envMap: cubemap,
+								roughness: 0,
+								metalness: 1
+							} );
 
-						addGui( 'scope', {
-							vector: Nodes.ReflectNode.VECTOR,
-							cube: Nodes.ReflectNode.CUBE,
-							sphere: Nodes.ReflectNode.SPHERE
-						}, function ( val ) {
+							mtl = nodeMaterial;
 
-							node.scope = val;
+							// GUI
 
-							mtl.needsUpdate = true;
+							addGui( 'scope', {
+								vector: Nodes.ReflectNode.VECTOR,
+								cube: Nodes.ReflectNode.CUBE,
+								sphere: Nodes.ReflectNode.SPHERE
+							}, function ( val ) {
 
-						} );
+								node.scope = val;
 
-						break;
+								nodeMaterial.needsUpdate = true;
+
+							} );
+
+							addGui( 'node', true, function ( val ) {
+
+								mtl = val ? nodeMaterial : standardMaterial;
+								mesh.material = mtl;
+
+							} );
+
+							addGui( 'roughness', 0, function ( val ) {
+
+								nodeMaterial.roughness.value = val;
+								standardMaterial.roughness = val;
+
+							}, false, 0, 1 );
+
+							break;
 
 
 					case 'varying':

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -121,7 +121,7 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 		( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || ( parameters.normalMap && ! parameters.objectSpaceNormalMap ) || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 		( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
-		( extensions.shaderTextureLOD ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+		( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
 
 	return chunks.filter( filterEmptyLine ).join( '\n' );
@@ -525,7 +525,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-			( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
+			( ( ! material.extensions || material.extensions.shaderTextureLOD ) || parameters.envMap ) && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -121,7 +121,7 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 		( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || ( parameters.normalMap && ! parameters.objectSpaceNormalMap ) || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 		( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
-		( extensions.shaderTextureLOD  ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+		( extensions.shaderTextureLOD ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
 
 	return chunks.filter( filterEmptyLine ).join( '\n' );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -525,7 +525,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-			parameters.envMap && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
+			( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -525,7 +525,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-			( ( ! material.extensions || material.extensions.shaderTextureLOD ) || parameters.envMap ) && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
+			( ( material.extensions ? material.extensions.shaderTextureLOD : false ) || parameters.envMap ) && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -121,7 +121,7 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 		( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || ( parameters.normalMap && ! parameters.objectSpaceNormalMap ) || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 		( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
-		( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+		( extensions.shaderTextureLOD  ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
 
 	return chunks.filter( filterEmptyLine ).join( '\n' );


### PR DESCRIPTION
Most devices support `EXT_shader_texture_lod`, so when doing the cube texture access in [envmap_physical_pars_fragment.glsl](https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js#L17) we make use of `textureCubeLodEXT()`. Since `textureCubeLodEXT()` takes in the exact lod instead of a bias (`texCube()` uses a bias), they are not interchangeable.

[CubeTextureNode](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/inputs/CubeTextureNode.js#L51) never tries to use `textureCubeLodEXT`, it always uses `texCube`. This effect is quite noticeable, thus causing a major inconsistency between the visual appearance of node materials and their counterparts. 

![12c1bef5e97d9c4b9cbe4a96b3a7a9e7](https://user-images.githubusercontent.com/2774286/60995411-793f8e00-a320-11e9-9dfd-903149d7dcbe.png)
![1c036541db66a4c2b6161db966e0b3a9](https://user-images.githubusercontent.com/2774286/60995416-7a70bb00-a320-11e9-97b7-c59481fefe6b.png)
