### PR TITLE
WebGLRenderer: removed .context property

### DIFF
--- a/docs/api/en/renderers/webgl/WebGLShader.html
+++ b/docs/api/en/renderers/webgl/WebGLShader.html
@@ -15,7 +15,7 @@
 		<h2>Example</h2>
 
 		<code>
-		var gl = renderer.context;
+		var gl = renderer.getContext();
 
 		var glVertexShader = new THREE.WebGLShader( gl, gl.VERTEX_SHADER, vertexSourceCode );
 		var glFragmentShader = new THREE.WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentSourceCode );

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -82,7 +82,7 @@ BasisTextureLoader.prototype = {
 
 	detectSupport: function ( renderer ) {
 
-		var context = renderer.context;
+		var context = renderer.getContext();
 		var config = this.workerConfig;
 
 		config.etcSupported = !! context.getExtension( 'WEBGL_compressed_texture_etc1' );

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -90,7 +90,7 @@ BloomPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 	render: function ( renderer, writeBuffer, readBuffer, deltaTime, maskActive ) {
 
-		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
+		if ( maskActive ) renderer.getContext().disable( renderer.getContext().STENCIL_TEST ); // avoid direct gl calls
 
 		// Render quad with blured scene into texture (convolution pass 1)
 
@@ -119,7 +119,7 @@ BloomPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetY.texture;
 
-		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
+		if ( maskActive ) renderer.getContext().enable( renderer.getContext().STENCIL_TEST ); // avoid direct gl calls
 
 		renderer.setRenderTarget( readBuffer );
 		if ( this.clear ) renderer.clear();

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -147,13 +147,13 @@ Object.assign( EffectComposer.prototype, {
 
 				if ( maskActive ) {
 
-					var context = this.renderer.context;
+					var context = this.renderer.getContext();
 
-					context.stencilFunc( context.NOTEQUAL, 1, 0xffffffff );
+					context.stencilFunc( context.NOTEQUAL, 1, 0xffffffff ); // avoid direct gl calls
 
 					this.copyPass.render( this.renderer, this.writeBuffer, this.readBuffer, deltaTime );
 
-					context.stencilFunc( context.EQUAL, 1, 0xffffffff );
+					context.stencilFunc( context.EQUAL, 1, 0xffffffff ); // avoid direct gl calls
 
 				}
 

--- a/examples/jsm/postprocessing/MaskPass.js
+++ b/examples/jsm/postprocessing/MaskPass.js
@@ -25,7 +25,7 @@ MaskPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 	render: function ( renderer, writeBuffer, readBuffer /*, deltaTime, maskActive */ ) {
 
-		var context = renderer.context;
+		var context = renderer.getContext();
 		var state = renderer.state;
 
 		// don't update color or depth

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -280,7 +280,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 			renderer.autoClear = false;
 
-			if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
+			if ( maskActive ) renderer.getContext().disable( renderer.getContext().STENCIL_TEST );
 
 			renderer.setClearColor( 0xffffff, 1 );
 
@@ -382,7 +382,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 			this.overlayMaterial.uniforms[ "usePatternTexture" ].value = this.usePatternTexture;
 
 
-			if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
+			if ( maskActive ) renderer.getContext().enable( renderer.getContext().STENCIL_TEST );
 
 			renderer.setRenderTarget( readBuffer );
 			this.fsQuad.render( renderer );

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -206,7 +206,7 @@ UnrealBloomPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 		renderer.setClearColor( this.clearColor, 0 );
 
-		if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
+		if ( maskActive ) renderer.getContext().disable( renderer.getContext().STENCIL_TEST );
 
 		// Render input to screen
 
@@ -271,7 +271,7 @@ UnrealBloomPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 		this.fsQuad.material = this.materialCopy;
 		this.copyUniforms[ "tDiffuse" ].value = this.renderTargetsHorizontal[ 0 ].texture;
 
-		if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
+		if ( maskActive ) renderer.getContext().enable( renderer.getContext().STENCIL_TEST );
 
 
 		if ( this.renderToScreen ) {

--- a/examples/jsm/renderers/WebGLDeferredRenderer.js
+++ b/examples/jsm/renderers/WebGLDeferredRenderer.js
@@ -159,7 +159,7 @@ var WebGLDeferredRenderer = function ( parameters ) {
 		_this.renderer = parameters.renderer !== undefined ? parameters.renderer : new WebGLRenderer();
 		_this.domElement = _this.renderer.domElement;
 
-		_context = _this.renderer.context;
+		_context = _this.renderer.getContext();
 		_state = _this.renderer.state;
 
 		_width = parameters.width !== undefined ? parameters.width : _this.renderer.getSize( new Vector2() ).width;

--- a/examples/webgl_shaders_ocean2.html
+++ b/examples/webgl_shaders_ocean2.html
@@ -36,8 +36,8 @@
 
 					this.ms_Renderer = new THREE.WebGLRenderer();
 					this.ms_Renderer.setPixelRatio( window.devicePixelRatio );
-					this.ms_Renderer.context.getExtension( 'OES_texture_float' );
-					this.ms_Renderer.context.getExtension( 'OES_texture_float_linear' );
+					this.ms_Renderer.getContext().getExtension( 'OES_texture_float' );
+					this.ms_Renderer.getContext().getExtension( 'OES_texture_float_linear' );
 
 					document.body.appendChild( this.ms_Renderer.domElement );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1549,7 +1549,16 @@ Object.defineProperties( WebGLRenderer.prototype, {
 			console.warn( 'THREE.WebGLRenderer: .shadowMapCullFace has been removed. Set Material.shadowSide instead.' );
 
 		}
+	},
+	context: {
+		get: function () {
+
+			console.warn( 'THREE.WebGLRenderer: .context has been removed. Use .getContext() instead.' );
+			return this.getContext();
+
+		}
 	}
+
 } );
 
 Object.defineProperties( WebGLShadowMap.prototype, {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -76,7 +76,6 @@ function WebGLRenderer( parameters ) {
 	// public properties
 
 	this.domElement = _canvas;
-	this.context = null;
 
 	// Debug configuration container
 	this.debug = {
@@ -299,7 +298,6 @@ function WebGLRenderer( parameters ) {
 
 		info.programs = programCache.programs;
 
-		_this.context = _gl;
 		_this.capabilities = capabilities;
 		_this.extensions = extensions;
 		_this.properties = properties;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -238,7 +238,7 @@ function unrollLoops( string ) {
 
 function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities ) {
 
-	var gl = renderer.context;
+	var gl = renderer.getContext();
 
 	var defines = material.defines;
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -15,7 +15,7 @@ function WebXRManager( renderer ) {
 
 	var scope = this;
 
-	var gl = renderer.context;
+	var gl = renderer.getContext();
 
 	var session = null;
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/16999#issuecomment-510280300.

Use `renderer.getContext()` instead.

