### PR TITLE
Updated usage section with a cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ The aim of the project is to create an easy to use, lightweight, 3D library with
 
 ### Usage ###
 
-Download the [minified library](http://threejs.org/build/three.min.js) and include it in your HTML, or install and import it as a [module](http://threejs.org/docs/#manual/introduction/Import-via-modules),
-Alternatively, see [how to build the library yourself](https://github.com/mrdoob/three.js/wiki/Build-instructions).
+Download the [minified library](http://threejs.org/build/three.min.js) and include it in your HTML:
 
 ```html
 <script src="js/three.min.js"></script>
 ```
+
+Alternatively, you can install and import it as a [module](http://threejs.org/docs/#manual/introduction/Import-via-modules), direct link to it from [three.js CDN](https://pagecdn.com/lib/three.js) or [build the library yourself](https://github.com/mrdoob/three.js/wiki/Build-instructions).
+
 
 This code creates a scene, a camera, and a geometric cube, and it adds the cube to the scene. It then creates a `WebGL` renderer for the scene and camera, and it adds that viewport to the `document.body` element. Finally, it animates the cube within the scene for the camera.
 


### PR DESCRIPTION
PageCDN creates a very tightly compressed `114KB` sized js file for three.min.js . Its a valuable addition to the docs.