### PR TITLE
Mesh: Add support for second set of uvs in raycast().

### DIFF
--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -161,7 +161,8 @@
 			[page:Face3 face] – intersected face<br />
 			[page:Integer faceIndex] – index of the intersected face<br />
 			[page:Object3D object] – the intersected object<br />
-			[page:Vector2 uv] - U,V coordinates at point of intersection
+			[page:Vector2 uv] - U,V coordinates at point of intersection<br />
+			[page:Vector2 uv2] - Second set of U,V coordinates at point of intersection
 		</p>
 		<p>
 		*Raycaster* delegates to the [page:Object3D.raycast raycast] method of the passed object, when evaluating whether the ray intersects the object or not. This allows [page:Mesh meshes] to respond differently to ray casting than [page:Line lines] and [page:Points pointclouds].

--- a/docs/api/zh/core/Raycaster.html
+++ b/docs/api/zh/core/Raycaster.html
@@ -161,7 +161,8 @@
 			[page:Face3 face] —— 相交的面<br />
 			[page:Integer faceIndex] —— 相交的面的索引<br />
 			[page:Object3D object] —— 相交的物体<br />
-			[page:Vector2 uv] —— 相交部分的点的UV坐标。
+			[page:Vector2 uv] —— 相交部分的点的UV坐标。<br />
+			[page:Vector2 uv2] - Second set of U,V coordinates at point of intersection
 		</p>
 		<p>
 			当计算这条射线是否和物体相交的时候，*Raycaster*将传入的对象委托给[page:Object3D.raycast raycast]方法。

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -168,7 +168,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
-		function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, uv, a, b, c ) {
+		function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c ) {
 
 			vA.fromBufferAttribute( position, a );
 			vB.fromBufferAttribute( position, b );
@@ -216,6 +216,16 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 					uvC.fromBufferAttribute( uv, c );
 
 					intersection.uv = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
+
+				}
+
+				if ( uv2 ) {
+
+					uvA.fromBufferAttribute( uv2, a );
+					uvB.fromBufferAttribute( uv2, b );
+					uvC.fromBufferAttribute( uv2, c );
+
+					intersection.uv2 = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
 
 				}
 
@@ -269,6 +279,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 				var position = geometry.attributes.position;
 				var morphPosition = geometry.morphAttributes.position;
 				var uv = geometry.attributes.uv;
+				var uv2 = geometry.attributes.uv2;
 				var groups = geometry.groups;
 				var drawRange = geometry.drawRange;
 				var i, j, il, jl;
@@ -295,7 +306,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 								b = index.getX( j + 1 );
 								c = index.getX( j + 2 );
 
-								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, a, b, c );
+								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
@@ -320,7 +331,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 							b = index.getX( i + 1 );
 							c = index.getX( i + 2 );
 
-							intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, a, b, c );
+							intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 							if ( intersection ) {
 
@@ -353,7 +364,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 								b = j + 1;
 								c = j + 2;
 
-								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, a, b, c );
+								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
@@ -378,7 +389,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 							b = i + 1;
 							c = i + 2;
 
-							intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, a, b, c );
+							intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 							if ( intersection ) {
 


### PR DESCRIPTION
Fixed #13649

Tested with `webgl_materials_lightmap`. `lightmap.json` provides a second set of uvs for the lightmap. Support is only added for `BufferGeometry`.