### PR TITLE
NodeMaterial: Clean up.

### DIFF
--- a/examples/jsm/nodes/effects/BlurNode.js
+++ b/examples/jsm/nodes/effects/BlurNode.js
@@ -16,7 +16,7 @@ function BlurNode( value, uv, radius, size ) {
 
 	this.value = value;
 	this.uv = uv || new UVNode();
-	this.radius = new Vector2Node( 1, 1 );
+	this.radius = radius || new Vector2Node( 1, 1 );
 
 	this.size = size;
 

--- a/examples/jsm/nodes/materials/nodes/MeshStandardNode.d.ts
+++ b/examples/jsm/nodes/materials/nodes/MeshStandardNode.d.ts
@@ -8,7 +8,7 @@ import { StandardNode } from './StandardNode';
 import { PropertyNode } from "../../inputs/PropertyNode";
 
 export class MeshStandardNode extends StandardNode {
-  constructor(value: Node);
+  constructor();
 
   properties: {
     color: Color;

--- a/examples/jsm/nodes/materials/nodes/PhongNode.d.ts
+++ b/examples/jsm/nodes/materials/nodes/PhongNode.d.ts
@@ -4,7 +4,7 @@ import { ColorNode } from '../../inputs/ColorNode';
 import { FloatNode } from '../../inputs/FloatNode';
 
 export class PhongNode extends Node {
-  constructor(value: Node);
+  constructor();
 
   color: ColorNode;
   specular: ColorNode;

--- a/examples/jsm/nodes/materials/nodes/SpriteNode.d.ts
+++ b/examples/jsm/nodes/materials/nodes/SpriteNode.d.ts
@@ -3,7 +3,7 @@ import { Node } from '../../core/Node';
 import { ColorNode } from '../../inputs/ColorNode';
 
 export class SpriteNode extends Node {
-  constructor(value: Node);
+  constructor();
 
   color: ColorNode;
   spherical: true;


### PR DESCRIPTION
Ensures the `radius` is honored when set in `BlurNode`s ctor. Also clean up some mistakes in the TS files.