### PR TITLE
OrbitControls: updated default dampingFactor

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -47,7 +47,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// Set to true to enable damping (inertia)
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
-	this.dampingFactor = 0.25;
+	this.dampingFactor = 0.05;
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -57,7 +57,7 @@ var OrbitControls = function ( object, domElement ) {
 	// Set to true to enable damping (inertia)
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
-	this.dampingFactor = 0.25;
+	this.dampingFactor = 0.05;
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -57,7 +57,7 @@
 				//controls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
 
 				controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				controls.screenSpacePanning = false;
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -55,7 +55,7 @@
 				//controls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
 
 				controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				controls.screenSpacePanning = false;
 

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -71,7 +71,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			var camera, scene, renderer, stats;
+			var camera, scene, renderer, controls, stats;
 			var target;
 			var postScene, postCamera;
 			var supportsExtension = true;
@@ -102,10 +102,9 @@
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.z = 4;
 
-				var controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera, renderer.domElement );
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
-				controls.rotateSpeed = 0.35;
+				controls.dampingFactor = 0.05;
 
 				// Create a multi render target with Float buffers
 				target = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight );
@@ -207,6 +206,8 @@
 				// render post FX
 				renderer.setRenderTarget( null );
 				renderer.render( postScene, postCamera );
+
+				controls.update(); // required because damping is enabled
 
 				stats.update();
 

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -340,7 +340,7 @@
 				var controls = new OrbitControls( scene.userData.camera, renderer.domElement );
 				controls.target.y = ( conesDistance + coneHeight ) * 0.5;
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				scene.userData.render = function ( time ) {
 
@@ -562,7 +562,7 @@
 				var controls = new OrbitControls( scene.userData.camera, renderer.domElement );
 				controls.target.copy( sphereMesh.position );
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				// THREE.Sphere mouse raycasting
 
@@ -764,7 +764,7 @@
 				var controls = new OrbitControls( scene.userData.camera, renderer.domElement );
 				controls.target.y = GROUND_SIZE * 0.05;
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				scene.userData.render = function ( time ) {
 

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -131,7 +131,7 @@
 				controls.maxDistance = 20;
 				controls.enablePan = false;
 				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
+				controls.dampingFactor = 0.05;
 
 				//
 


### PR DESCRIPTION
As mentioned in https://github.com/mrdoob/three.js/pull/17060#issue-299580212, with the improvement in the damping logic, a new default value of 0.05 for `dampingFactor` is appropriate.

In fact, this new value makes much more sense.



