### PR TITLE
WebVRManager: Fix VR camera before `VR ENTER`

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -256,7 +256,7 @@ function WebVRManager( renderer ) {
 
 		var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
 
-		if ( isPresenting() === false ) {
+		if ( device === null ) {
 
 			camera.position.set( 0, userHeight, 0 );
 			camera.rotation.set( 0, 0, 0 );
@@ -313,6 +313,8 @@ function WebVRManager( renderer ) {
 		}
 
 		poseObject.updateMatrixWorld();
+
+		if ( device.isPresenting === false ) return camera;
 
 		//
 


### PR DESCRIPTION
With my smartphone, VR does not work before pressing `VR ENTER` button made by `WEBVR.createButton`.
However when I tried an older release, it worked successfully even before `VR ENTER`.

This happens when `device !== null` and `device.isPresenting === false`, and it seems to be broken with the change in #15856.
So I reverted the change, and now it works successfully.