### PR TITLE
Use onBeforeCompile to customize shader for instancing

### DIFF
--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -84,6 +84,7 @@
 			`
 			#define LAMBERT
 
+			// instanced
 			attribute vec3 instanceOffset;
 			attribute vec3 instanceColor;
 			attribute float instanceScale;
@@ -128,8 +129,8 @@
 				#include <defaultnormal_vertex>
 
 				#include <begin_vertex>
-				// position instanced
 
+				// position instanced
 				transformed *= instanceScale;
 				transformed = transformed + instanceOffset;
 

--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -34,65 +34,58 @@
 		import { OrbitControls } from './jsm/controls/OrbitControls.js';
 		import { Curves } from './jsm/curves/CurveExtras.js';
 
-		var customDepthToRGBAShader = { // this is a cut-and-paste of the depth shader -- modified to accommodate instancing for this app
+		// this is a cut-and-paste of the depth shader -- modified to accommodate instancing for this app
+		var customDepthVertexShader = 
+			`
+			// instanced
+			#ifdef INSTANCED
 
-			uniforms: THREE.ShaderLib.depth.uniforms,
+				attribute vec3 instanceOffset;
+				attribute float instanceScale;
 
-			vertexShader:
-				`
-				// instanced
-				#ifdef INSTANCED
+			#endif
 
-					attribute vec3 instanceOffset;
-					attribute float instanceScale;
+			#include <common>
+			#include <uv_pars_vertex>
+			#include <displacementmap_pars_vertex>
+			#include <morphtarget_pars_vertex>
+			#include <skinning_pars_vertex>
+			#include <logdepthbuf_pars_vertex>
+			#include <clipping_planes_pars_vertex>
+
+			void main() {
+
+				#include <uv_vertex>
+
+				#include <skinbase_vertex>
+
+				#ifdef USE_DISPLACEMENTMAP
+
+					#include <beginnormal_vertex>
+					#include <morphnormal_vertex>
+					#include <skinnormal_vertex>
 
 				#endif
 
-				#include <common>
-				#include <uv_pars_vertex>
-				#include <displacementmap_pars_vertex>
-				#include <morphtarget_pars_vertex>
-				#include <skinning_pars_vertex>
-				#include <logdepthbuf_pars_vertex>
-				#include <clipping_planes_pars_vertex>
+				#include <begin_vertex>
 
-				void main() {
+				// instanced
+				#ifdef INSTANCED
 
-					#include <uv_vertex>
+					transformed *= instanceScale;
+					transformed = transformed + instanceOffset;
 
-					#include <skinbase_vertex>
+				#endif
 
-					#ifdef USE_DISPLACEMENTMAP
+				#include <morphtarget_vertex>
+				#include <skinning_vertex>
+				#include <displacementmap_vertex>
+				#include <project_vertex>
+				#include <logdepthbuf_vertex>
+				#include <clipping_planes_vertex>
 
-						#include <beginnormal_vertex>
-						#include <morphnormal_vertex>
-						#include <skinnormal_vertex>
-
-					#endif
-
-					#include <begin_vertex>
-
-					// instanced
-					#ifdef INSTANCED
-
-						transformed *= instanceScale;
-						transformed = transformed + instanceOffset;
-
-					#endif
-
-					#include <morphtarget_vertex>
-					#include <skinning_vertex>
-					#include <displacementmap_vertex>
-					#include <project_vertex>
-					#include <logdepthbuf_vertex>
-					#include <clipping_planes_vertex>
-
-				}
-			`,
-
-			fragmentShader: THREE.ShaderChunk.depth_frag
-
-		};
+			}
+			`;
 
 		// this is a cut-and-paste of the lambert shader -- modified to accommodate instancing for this app
 		var customLambertVertexShader =
@@ -286,27 +279,28 @@
 			} );
 
 			material.onBeforeCompile = function( shader ) {
+
 				shader.vertexShader = customLambertVertexShader;
+
 			};
+
 			material.defines = material.defines || {};
 			material.defines[ 'INSTANCED' ] = "";
 
 
 			// custom depth material - required for instanced shadows
 
-			var uniforms = THREE.UniformsUtils.clone( customDepthToRGBAShader.uniforms );
+			var customDepthMaterial = new THREE.MeshDepthMaterial();
 
-			var customDepthMaterial = new THREE.ShaderMaterial( {
+			customDepthMaterial.onBeforeCompile = function( shader ) {
 
-				defines: {
-					'INSTANCED': "",
-					'DEPTH_PACKING': THREE.RGBADepthPacking
-				},
-				uniforms: uniforms,
-				vertexShader: customDepthToRGBAShader.vertexShader,
-				fragmentShader: customDepthToRGBAShader.fragmentShader
+				shader.vertexShader = customDepthVertexShader;
 
-			} );
+			};
+
+			customDepthMaterial.depthPacking = THREE.RGBADepthPacking;
+			customDepthMaterial.defines = material.defines || {};
+			customDepthMaterial.defines[ 'INSTANCED' ] = "";
 
 			//
 

--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -34,7 +34,7 @@
 		import { OrbitControls } from './jsm/controls/OrbitControls.js';
 		import { Curves } from './jsm/curves/CurveExtras.js';
 
-		THREE.ShaderLib.customDepthRGBA = { // this is a cut-and-paste of the depth shader -- modified to accommodate instancing for this app
+		var customDepthToRGBAShader = { // this is a cut-and-paste of the depth shader -- modified to accommodate instancing for this app
 
 			uniforms: THREE.ShaderLib.depth.uniforms,
 
@@ -94,87 +94,80 @@
 
 		};
 
-		THREE.ShaderLib.lambert = { // this is a cut-and-paste of the lambert shader -- modified to accommodate instancing for this app
+		// this is a cut-and-paste of the lambert shader -- modified to accommodate instancing for this app
+		var customLambertVertexShader =
+			`
+			#define LAMBERT
 
-			uniforms: THREE.ShaderLib.lambert.uniforms,
+			#ifdef INSTANCED
+				attribute vec3 instanceOffset;
+				attribute vec3 instanceColor;
+				attribute float instanceScale;
+			#endif
 
-			vertexShader:
-				`
-				#define LAMBERT
+			varying vec3 vLightFront;
+			varying vec3 vIndirectFront;
+
+			#ifdef DOUBLE_SIDED
+				varying vec3 vLightBack;
+				varying vec3 vIndirectBack;
+			#endif
+
+			#include <common>
+			#include <uv_pars_vertex>
+			#include <uv2_pars_vertex>
+			#include <envmap_pars_vertex>
+			#include <bsdfs>
+			#include <lights_pars_begin>
+			#include <color_pars_vertex>
+			#include <fog_pars_vertex>
+			#include <morphtarget_pars_vertex>
+			#include <skinning_pars_vertex>
+			#include <shadowmap_pars_vertex>
+			#include <logdepthbuf_pars_vertex>
+			#include <clipping_planes_pars_vertex>
+
+			void main() {
+
+				#include <uv_vertex>
+				#include <uv2_vertex>
+				#include <color_vertex>
+
+				// vertex colors instanced
+				#ifdef INSTANCED
+					#ifdef USE_COLOR
+						vColor.xyz = instanceColor.xyz;
+					#endif
+				#endif
+
+				#include <beginnormal_vertex>
+				#include <morphnormal_vertex>
+				#include <skinbase_vertex>
+				#include <skinnormal_vertex>
+				#include <defaultnormal_vertex>
+
+				#include <begin_vertex>
+				// position instanced
 
 				#ifdef INSTANCED
-					attribute vec3 instanceOffset;
-					attribute vec3 instanceColor;
-					attribute float instanceScale;
+					transformed *= instanceScale;
+					transformed = transformed + instanceOffset;
 				#endif
 
-				varying vec3 vLightFront;
-				varying vec3 vIndirectFront;
+				#include <morphtarget_vertex>
+				#include <skinning_vertex>
+				#include <project_vertex>
+				#include <logdepthbuf_vertex>
+				#include <clipping_planes_vertex>
 
-				#ifdef DOUBLE_SIDED
-					varying vec3 vLightBack;
-					varying vec3 vIndirectBack;
-				#endif
+				#include <worldpos_vertex>
+				#include <envmap_vertex>
+				#include <lights_lambert_vertex>
+				#include <shadowmap_vertex>
+				#include <fog_vertex>
 
-				#include <common>
-				#include <uv_pars_vertex>
-				#include <uv2_pars_vertex>
-				#include <envmap_pars_vertex>
-				#include <bsdfs>
-				#include <lights_pars_begin>
-				#include <color_pars_vertex>
-				#include <fog_pars_vertex>
-				#include <morphtarget_pars_vertex>
-				#include <skinning_pars_vertex>
-				#include <shadowmap_pars_vertex>
-				#include <logdepthbuf_pars_vertex>
-				#include <clipping_planes_pars_vertex>
-
-				void main() {
-
-					#include <uv_vertex>
-					#include <uv2_vertex>
-					#include <color_vertex>
-
-					// vertex colors instanced
-					#ifdef INSTANCED
-						#ifdef USE_COLOR
-							vColor.xyz = instanceColor.xyz;
-						#endif
-					#endif
-
-					#include <beginnormal_vertex>
-					#include <morphnormal_vertex>
-					#include <skinbase_vertex>
-					#include <skinnormal_vertex>
-					#include <defaultnormal_vertex>
-
-					#include <begin_vertex>
-
-					// position instanced
-					#ifdef INSTANCED
-						transformed *= instanceScale;
-						transformed = transformed + instanceOffset;
-					#endif
-
-					#include <morphtarget_vertex>
-					#include <skinning_vertex>
-					#include <project_vertex>
-					#include <logdepthbuf_vertex>
-					#include <clipping_planes_vertex>
-
-					#include <worldpos_vertex>
-					#include <envmap_vertex>
-					#include <lights_lambert_vertex>
-					#include <shadowmap_vertex>
-					#include <fog_vertex>
-
-				}
-				`,
-
-			fragmentShader: THREE.ShaderLib.lambert.fragmentShader
-
-		};
+			}
+			`;
 
 
 		//
@@ -292,15 +285,16 @@
 
 			} );
 
+			material.onBeforeCompile = function( shader ) {
+				shader.vertexShader = customLambertVertexShader;
+			};
 			material.defines = material.defines || {};
 			material.defines[ 'INSTANCED' ] = "";
 
 
 			// custom depth material - required for instanced shadows
 
-			var shader = THREE.ShaderLib[ 'customDepthRGBA' ];
-
-			var uniforms = THREE.UniformsUtils.clone( shader.uniforms );
+			var uniforms = THREE.UniformsUtils.clone( customDepthToRGBAShader.uniforms );
 
 			var customDepthMaterial = new THREE.ShaderMaterial( {
 
@@ -309,8 +303,8 @@
 					'DEPTH_PACKING': THREE.RGBADepthPacking
 				},
 				uniforms: uniforms,
-				vertexShader: shader.vertexShader,
-				fragmentShader: shader.fragmentShader
+				vertexShader: customDepthToRGBAShader.vertexShader,
+				fragmentShader: customDepthToRGBAShader.fragmentShader
 
 			} );
 

--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -38,12 +38,8 @@
 		var customDepthVertexShader = 
 			`
 			// instanced
-			#ifdef INSTANCED
-
-				attribute vec3 instanceOffset;
-				attribute float instanceScale;
-
-			#endif
+			attribute vec3 instanceOffset;
+			attribute float instanceScale;
 
 			#include <common>
 			#include <uv_pars_vertex>
@@ -70,12 +66,8 @@
 				#include <begin_vertex>
 
 				// instanced
-				#ifdef INSTANCED
-
-					transformed *= instanceScale;
-					transformed = transformed + instanceOffset;
-
-				#endif
+				transformed *= instanceScale;
+				transformed = transformed + instanceOffset;
 
 				#include <morphtarget_vertex>
 				#include <skinning_vertex>
@@ -92,11 +84,9 @@
 			`
 			#define LAMBERT
 
-			#ifdef INSTANCED
-				attribute vec3 instanceOffset;
-				attribute vec3 instanceColor;
-				attribute float instanceScale;
-			#endif
+			attribute vec3 instanceOffset;
+			attribute vec3 instanceColor;
+			attribute float instanceScale;
 
 			varying vec3 vLightFront;
 			varying vec3 vIndirectFront;
@@ -127,10 +117,8 @@
 				#include <color_vertex>
 
 				// vertex colors instanced
-				#ifdef INSTANCED
-					#ifdef USE_COLOR
-						vColor.xyz = instanceColor.xyz;
-					#endif
+				#ifdef USE_COLOR
+					vColor.xyz = instanceColor.xyz;
 				#endif
 
 				#include <beginnormal_vertex>
@@ -142,10 +130,8 @@
 				#include <begin_vertex>
 				// position instanced
 
-				#ifdef INSTANCED
-					transformed *= instanceScale;
-					transformed = transformed + instanceOffset;
-				#endif
+				transformed *= instanceScale;
+				transformed = transformed + instanceOffset;
 
 				#include <morphtarget_vertex>
 				#include <skinning_vertex>
@@ -284,9 +270,6 @@
 
 			};
 
-			material.defines = material.defines || {};
-			material.defines[ 'INSTANCED' ] = "";
-
 
 			// custom depth material - required for instanced shadows
 
@@ -299,8 +282,6 @@
 			};
 
 			customDepthMaterial.depthPacking = THREE.RGBADepthPacking;
-			customDepthMaterial.defines = material.defines || {};
-			customDepthMaterial.defines[ 'INSTANCED' ] = "";
 
 			//
 


### PR DESCRIPTION
Replacing shaders in THREE.ShaderLib is a bad practice, as it interferes with normal operation of built-in materials. When materials need to be customized, it's better to use onBeforeCompile.