### PR TITLE
GridHelper: give different colors to X-centerLine and Z-centerLine

### DIFF
--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -32,8 +32,9 @@
 		<p>
 		size -- The size of the grid. Default is 10. <br />
 		divisions -- The number of divisions across the grid. Default is 10. <br />
-		colorCenterLine -- The color of the centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
-		colorGrid -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
+		colorXCenterLine -- The color of the X-centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
+		colorGrid -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888 <br />
+		colorZCenterLine -- The color of the Z-centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444
 		</p>
 		<p>
 		Creates a new [name] of size 'size' and divided into 'divisions' segments per side. Colors are optional.

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -30,17 +30,20 @@ function GridHelper( size, divisions, color1, color2, color3 ) {
 
 		var color = i === center ? color1 : color2;
 
-		if(i === center){
+		if( i === center ) {
+			
 			color1.toArray( colors, j ); j += 3;
 			color1.toArray( colors, j ); j += 3;
 			color3.toArray( colors, j ); j += 3;
 			color3.toArray( colors, j ); j += 3;
-		}
-		else{
+			
+		} else {
+			
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
+			
 		}
 
 	}

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -30,20 +30,20 @@ function GridHelper( size, divisions, color1, color2, color3 ) {
 
 		var color = i === center ? color1 : color2;
 
-		if( i === center ) {
-			
+		if ( i === center ) {
+
 			color1.toArray( colors, j ); j += 3;
 			color1.toArray( colors, j ); j += 3;
 			color3.toArray( colors, j ); j += 3;
 			color3.toArray( colors, j ); j += 3;
-			
+
 		} else {
-			
+
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
 			color.toArray( colors, j ); j += 3;
-			
+
 		}
 
 	}

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -9,12 +9,13 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Color } from '../math/Color.js';
 
-function GridHelper( size, divisions, color1, color2 ) {
+function GridHelper( size, divisions, color1, color2, color3 ) {
 
 	size = size || 10;
 	divisions = divisions || 10;
 	color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
 	color2 = new Color( color2 !== undefined ? color2 : 0x888888 );
+	color3 = new Color( color3 !== undefined ? color3 : 0x444444 );
 
 	var center = divisions / 2;
 	var step = size / divisions;
@@ -29,10 +30,18 @@ function GridHelper( size, divisions, color1, color2 ) {
 
 		var color = i === center ? color1 : color2;
 
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
+		if(i === center){
+			color1.toArray( colors, j ); j += 3;
+			color1.toArray( colors, j ); j += 3;
+			color3.toArray( colors, j ); j += 3;
+			color3.toArray( colors, j ); j += 3;
+		}
+		else{
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+		}
 
 	}
 


### PR DESCRIPTION
With this modification I added a third parameter to the GridHelper construction, giving the possibility to set different colors to X-centerLine and Z-centerLine, like in Blender 2.80. This could be useful to mark the X-centerLine with the color of x-axis and the Z-centerLine with the color of z-axis.

![image](https://user-images.githubusercontent.com/53224473/61723043-ac940b00-ad6b-11e9-8b05-0aa977f6021f.png)




