### PR TITLE
Math: Remove closures part I.

### DIFF
--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -9,6 +9,8 @@ import { _Math } from './Math.js';
  * @author bhouston / http://clara.io
  */
 
+var _matrix, _quaterion;
+
 function Euler( x, y, z, order ) {
 
 	this._x = x || 0;
@@ -253,19 +255,15 @@ Object.assign( Euler.prototype, {
 
 	},
 
-	setFromQuaternion: function () {
+	setFromQuaternion: function ( q, order, update ) {
 
-		var matrix = new Matrix4();
+		if ( _matrix === undefined ) _matrix = new Matrix4();
 
-		return function setFromQuaternion( q, order, update ) {
+		_matrix.makeRotationFromQuaternion( q );
 
-			matrix.makeRotationFromQuaternion( q );
+		return this.setFromRotationMatrix( _matrix, order, update );
 
-			return this.setFromRotationMatrix( matrix, order, update );
-
-		};
-
-	}(),
+	},
 
 	setFromVector3: function ( v, order ) {
 
@@ -273,21 +271,17 @@ Object.assign( Euler.prototype, {
 
 	},
 
-	reorder: function () {
+	reorder: function ( newOrder ) {
 
 		// WARNING: this discards revolution information -bhouston
 
-		var q = new Quaternion();
+		if ( _quaterion === undefined ) _quaterion = new Quaternion();
 
-		return function reorder( newOrder ) {
+		_quaterion.setFromEuler( this );
 
-			q.setFromEuler( this );
+		return this.setFromQuaternion( _quaterion, newOrder );
 
-			return this.setFromQuaternion( q, newOrder );
-
-		};
-
-	}(),
+	},
 
 	equals: function ( euler ) {
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -9,7 +9,7 @@ import { _Math } from './Math.js';
  * @author bhouston / http://clara.io
  */
 
-var _matrix, _quaterion;
+var _matrix, _quaternion;
 
 function Euler( x, y, z, order ) {
 
@@ -275,11 +275,11 @@ Object.assign( Euler.prototype, {
 
 		// WARNING: this discards revolution information -bhouston
 
-		if ( _quaterion === undefined ) _quaterion = new Quaternion();
+		if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
-		_quaterion.setFromEuler( this );
+		_quaternion.setFromEuler( this );
 
-		return this.setFromQuaternion( _quaterion, newOrder );
+		return this.setFromQuaternion( _quaternion, newOrder );
 
 	},
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -5,6 +5,8 @@ import { _Math } from './Math.js';
  * @author bhouston / http://clara.io
  */
 
+var _startP, _startEnd;
+
 function Line3( start, end ) {
 
 	this.start = ( start !== undefined ) ? start : new Vector3();
@@ -89,32 +91,32 @@ Object.assign( Line3.prototype, {
 
 	},
 
-	closestPointToPointParameter: function () {
+	closestPointToPointParameter: function ( point, clampToLine ) {
 
-		var startP = new Vector3();
-		var startEnd = new Vector3();
+		if ( _startP === undefined ) {
 
-		return function closestPointToPointParameter( point, clampToLine ) {
+			_startP = new Vector3();
+			_startEnd = new Vector3();
 
-			startP.subVectors( point, this.start );
-			startEnd.subVectors( this.end, this.start );
+		}
 
-			var startEnd2 = startEnd.dot( startEnd );
-			var startEnd_startP = startEnd.dot( startP );
+		_startP.subVectors( point, this.start );
+		_startEnd.subVectors( this.end, this.start );
 
-			var t = startEnd_startP / startEnd2;
+		var startEnd2 = _startEnd.dot( _startEnd );
+		var startEnd_startP = _startEnd.dot( _startP );
 
-			if ( clampToLine ) {
+		var t = startEnd_startP / startEnd2;
 
-				t = _Math.clamp( t, 0, 1 );
+		if ( clampToLine ) {
 
-			}
+			t = _Math.clamp( t, 0, 1 );
 
-			return t;
+		}
 
-		};
+		return t;
 
-	}(),
+	},
 
 	closestPointToPoint: function ( point, clampToLine, target ) {
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -7,6 +7,8 @@ import { Vector3 } from './Vector3.js';
  * @author tschw
  */
 
+var _vector;
+
 function Matrix3() {
 
 	this.elements = [
@@ -90,29 +92,25 @@ Object.assign( Matrix3.prototype, {
 
 	},
 
-	applyToBufferAttribute: function () {
+	applyToBufferAttribute: function ( attribute ) {
 
-		var v1 = new Vector3();
+		if ( _vector === undefined ) _vector = new Vector3();
 
-		return function applyToBufferAttribute( attribute ) {
+		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
-			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+			_vector.x = attribute.getX( i );
+			_vector.y = attribute.getY( i );
+			_vector.z = attribute.getZ( i );
 
-				v1.x = attribute.getX( i );
-				v1.y = attribute.getY( i );
-				v1.z = attribute.getZ( i );
+			_vector.applyMatrix3( this );
 
-				v1.applyMatrix3( this );
+			attribute.setXYZ( i, _vector.x, _vector.y, _vector.z );
 
-				attribute.setXYZ( i, v1.x, v1.y, v1.z );
+		}
 
-			}
+		return attribute;
 
-			return attribute;
-
-		};
-
-	}(),
+	},
 
 	multiply: function ( m ) {
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -6,6 +6,8 @@ import { Vector3 } from './Vector3.js';
  * @author mrdoob / http://mrdoob.com/
  */
 
+var _box;
+
 function Sphere( center, radius ) {
 
 	this.center = ( center !== undefined ) ? center : new Vector3();
@@ -24,39 +26,35 @@ Object.assign( Sphere.prototype, {
 
 	},
 
-	setFromPoints: function () {
+	setFromPoints: function ( points, optionalCenter ) {
 
-		var box = new Box3();
+		if ( _box === undefined ) _box = new Box3();
 
-		return function setFromPoints( points, optionalCenter ) {
+		var center = this.center;
 
-			var center = this.center;
+		if ( optionalCenter !== undefined ) {
 
-			if ( optionalCenter !== undefined ) {
+			center.copy( optionalCenter );
 
-				center.copy( optionalCenter );
+		} else {
 
-			} else {
+			_box.setFromPoints( points ).getCenter( center );
 
-				box.setFromPoints( points ).getCenter( center );
+		}
 
-			}
+		var maxRadiusSq = 0;
 
-			var maxRadiusSq = 0;
+		for ( var i = 0, il = points.length; i < il; i ++ ) {
 
-			for ( var i = 0, il = points.length; i < il; i ++ ) {
+			maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( points[ i ] ) );
 
-				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( points[ i ] ) );
+		}
 
-			}
+		this.radius = Math.sqrt( maxRadiusSq );
 
-			this.radius = Math.sqrt( maxRadiusSq );
+		return this;
 
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 


### PR DESCRIPTION
This is the first PR of a series of changes. My goal is to remove all IIFEs from the code base. This is a preparation for the actual long-term goal, the introduction of ES6 classes. Everything together will modernize the code base and improve tree-shaking capabilities in order to realize smaller bundle sizes. Both features were frequently requested by users.

I've started with just a few simple files. Helper variable declarations are now at the top of the modules. The naming convention of these variables are based on @bhouston's suggestion here https://github.com/mrdoob/three.js/pull/14695#issuecomment-414880386. A simple underscore as a prefix will make it much easier to detect module scope variables when reading the code (other/better suggestions are welcome^^). Besides, the variables are instantiated lazily when the methods are invoked.