### PR TITLE
Fix color space conversion issue for TextureNode

### DIFF
--- a/examples/jsm/nodes/inputs/TextureNode.js
+++ b/examples/jsm/nodes/inputs/TextureNode.js
@@ -65,7 +65,7 @@ TextureNode.prototype.generate = function ( builder, output ) {
 	builder.addContext( context );
 
 	this.colorSpace = this.colorSpace || new ColorSpaceNode( new ExpressionNode( '', outputType ) );
-	this.colorSpace.fromEncoding( builder.getTextureEncodingFromMap( this.value ) );
+	this.colorSpace.fromDecoding( builder.getTextureEncodingFromMap( this.value ) );
 	this.colorSpace.input.parse( code );
 
 	code = this.colorSpace.build( builder, outputType );


### PR DESCRIPTION
The color space conversion for textures is currently inverted. Using fromDecoding instead of fromEncoding produces the expected result.

See this [post](https://github.com/mrdoob/three.js/issues/17066) for more information.