### PR TITLE
Change rollup output format specifier for modules from es to esm

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -207,7 +207,7 @@ export default {
 			indent: '\t'
 		},
 		{
-			format: 'es',
+			format: 'esm',
 			file: 'build/three.module.js',
 			indent: '\t'
 		}


### PR DESCRIPTION
#17099 and https://github.com/rollup/rollup/pull/2102

So far only for the three module. I will see if I can throw in the others too without breaking anything. Wait a sec or two... OK, surprisingly I found no other occurences. So no ES modules for examples yet, even in jsm, then?