### PR TITLE
Fix color space conversion for CubeTextureNode

### DIFF
--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -61,7 +61,7 @@ CubeTextureNode.prototype.generate = function ( builder, output ) {
 	builder.addContext( context );
 
 	this.colorSpace = this.colorSpace || new ColorSpaceNode( new ExpressionNode( '', outputType ) );
-	this.colorSpace.fromEncoding( builder.getTextureEncodingFromMap( this.value ) );
+	this.colorSpace.fromDecoding( builder.getTextureEncodingFromMap( this.value ) );
 	this.colorSpace.input.parse( code );
 
 	code = this.colorSpace.build( builder, outputType );


### PR DESCRIPTION
Following up on the [update](https://github.com/mrdoob/three.js/pull/17094) of TextureNode, color space conversion _fromEncoding_ has been replaced by _fromDecoding_.