### PR TITLE
Docs: Object3D updateMatrix functions

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -438,7 +438,7 @@
 		</p>
 
 		<h3>[method:null updateMatrix]()</h3>
-		<p>Updates the local transform matrix, signals to update global transform matrix before rendering.</p>
+		<p>Updates the local transform matrix.</p>
 
 		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -438,11 +438,22 @@
 		</p>
 
 		<h3>[method:null updateMatrix]()</h3>
-		<p>Update the local transform.</p>
+		<p>Updates the local transform matrix, signals to update global transform matrix before rendering.</p>
 
 		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
-		<p>Update the global transform of the object and its children.</p>
+		<p>
+		force - immediately updates global transform of the object and its children.<br /><br />
 
+		Updates the local transform matrix and signals to update global transform matrix of the object and its children.
+		</p>
+
+		<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
+		<p>
+		updateParents - recursively updates local and global transform matrices of its parents.<br />
+		updateChildren - recursively updates local and global transform matrices of its children.<br /><br />
+
+		Immediately updates the local and global transform matrices of the object.
+		</p>
 
 		<h3>[method:Vector3 worldToLocal]( [param:Vector3 vector] )</h3>
 		<p>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -438,21 +438,19 @@
 		</p>
 
 		<h3>[method:null updateMatrix]()</h3>
-		<p>Updates the local transform matrix.</p>
+		<p>Updates the local transform.</p>
 
 		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
-		force - immediately updates global transform of the object and its children.<br /><br />
-
-		Updates the local transform matrix and signals to update global transform matrix of the object and its children.
+		Updates the global transform of the object and its ancestors.
 		</p>
 
 		<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 		<p>
-		updateParents - recursively updates local and global transform matrices of its parents.<br />
-		updateChildren - recursively updates local and global transform matrices of its children.<br /><br />
+		updateParents - recursively updates global transform of ancestors.<br />
+		updateChildren - recursively updates global transform of descendants.<br /><br />
 
-		Immediately updates the local and global transform matrices of the object.
+		Updates the global transform of the object.
 		</p>
 
 		<h3>[method:Vector3 worldToLocal]( [param:Vector3 vector] )</h3>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -441,9 +441,7 @@
 		<p>Updates the local transform.</p>
 
 		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
-		<p>
-		Updates the global transform of the object and its ancestors.
-		</p>
+		<p>Updates the global transform of the object and its descendants.</p>
 
 		<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 		<p>


### PR DESCRIPTION
Current documentation on `Object3D` matrix update functions doesn't contain enough information about the methods and it's also missing `.UpdateWorldMatrix()` definition.

I believe the proposed changes better reflects and exposes how these work.

[Object3D.updateMatrixWorld](https://rawcdn.githack.com/sciecode/three.js/5ba2ebd4944b9c0e135fe1084435a5edf35327cf/docs/#api/en/core/Object3D.updateMatrixWorld)