### PR TITLE
Default onBeforeCompile=null to reduce unnecessary calls to programCache.getProgramCode()

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -298,7 +298,7 @@
 		<h3>[method:null onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
 		<p>
 		An optional callback that is executed immediately before the shader program is compiled.
-		This function is called with the shader source code as a parameter. Useful for the modification of built-in materials.
+		This function is called with the shader source code as a parameter. Useful for the modification of built-in materials. Default is null.
 		</p>
 
 		<h3>[method:null setValues]( [param:object values] )</h3>

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -271,7 +271,7 @@ export class Material extends EventDispatcher {
 	dispose(): void;
 
 	/**
-	 * An optional callback that is executed immediately before the shader program is compiled. This function is called with the shader source code as a parameter. Useful for the modification of built-in materials.
+	 * An optional callback that is executed immediately before the shader program is compiled. This function is called with the shader source code as a parameter. Useful for the modification of built-in materials. Default is null.
 	 * @param shader Source code of the shader
 	 * @param renderer WebGLRenderer Context that is initializing the material
 	 */

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -74,7 +74,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	isMaterial: true,
 
-	onBeforeCompile: function () {},
+	onBeforeCompile: null,
 
 	setValues: function ( values ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1511,12 +1511,12 @@ function WebGLRenderer( parameters ) {
 			}
 
 			if ( material.onBeforeCompile ) {
-			
+
 				material.onBeforeCompile( materialProperties.shader, _this );
 
 				// Computing code again as onBeforeCompile may have changed the shaders
 				code = programCache.getProgramCode( material, parameters );
-			
+
 			}
 
 			program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1510,10 +1510,14 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-			material.onBeforeCompile( materialProperties.shader, _this );
+			if ( material.onBeforeCompile ) {
+			
+				material.onBeforeCompile( materialProperties.shader, _this );
 
-			// Computing code again as onBeforeCompile may have changed the shaders
-			code = programCache.getProgramCode( material, parameters );
+				// Computing code again as onBeforeCompile may have changed the shaders
+				code = programCache.getProgramCode( material, parameters );
+			
+			}
 
 			program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -247,7 +247,11 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 		}
 
-		array.push( material.onBeforeCompile.toString() );
+		if ( material.onBeforeCompile ) {
+
+			array.push( material.onBeforeCompile.toString() );
+
+		}
 
 		array.push( renderer.gammaOutput );
 


### PR DESCRIPTION
The price of the change is having to check for the existence of onBeforeCompile before calling it. The gain is avoiding an extra run of `programCache.getProgramCode` on each compile. This call may have a very small footprint compared to the typical compilation stage, but I woud expect the existence check to have an even smaller footprint. It looks like the extra  `programCache.getProgramCode` call was added *after* the decision was made to have an empty function as default. I have not tested performance in any different scenarios, though. Update: I have _tailored_ a scenario further down which demonstrates an improvement.

Also, I have not paid much consideration to the TypeScript declarations. A quick Google search tells that there is a flag for strict handling of `null` and `undefined` values, but otherwise they are valid values for anything.