### PR TITLE
Math: Remove closures part II.

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -4,6 +4,8 @@ import { Vector2 } from './Vector2.js';
  * @author bhouston / http://clara.io
  */
 
+var _vector;
+
 function Box2( min, max ) {
 
 	this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
@@ -36,21 +38,17 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	setFromCenterAndSize: function () {
+	setFromCenterAndSize: function ( center, size ) {
 
-		var v1 = new Vector2();
+		if ( _vector === undefined ) _vector = new Vector2();
 
-		return function setFromCenterAndSize( center, size ) {
+		var halfSize = _vector.copy( size ).multiplyScalar( 0.5 );
+		this.min.copy( center ).sub( halfSize );
+		this.max.copy( center ).add( halfSize );
 
-			var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
-			this.min.copy( center ).sub( halfSize );
-			this.max.copy( center ).add( halfSize );
+		return this;
 
-			return this;
-
-		};
-
-	}(),
+	},
 
 	clone: function () {
 
@@ -192,18 +190,14 @@ Object.assign( Box2.prototype, {
 
 	},
 
-	distanceToPoint: function () {
+	distanceToPoint: function ( point ) {
 
-		var v1 = new Vector2();
+		if ( _vector === undefined ) _vector = new Vector2();
 
-		return function distanceToPoint( point ) {
+		var clampedPoint = _vector.copy( point ).clamp( this.min, this.max );
+		return clampedPoint.sub( point ).length();
 
-			var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
-			return clampedPoint.sub( point ).length();
-
-		};
-
-	}(),
+	},
 
 	intersect: function ( box ) {
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -4,7 +4,7 @@ import { _Math } from './Math.js';
  * @author mrdoob / http://mrdoob.com/
  */
 
-var ColorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
+var _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
 	'beige': 0xF5F5DC, 'bisque': 0xFFE4C4, 'black': 0x000000, 'blanchedalmond': 0xFFEBCD, 'blue': 0x0000FF, 'blueviolet': 0x8A2BE2,
 	'brown': 0xA52A2A, 'burlywood': 0xDEB887, 'cadetblue': 0x5F9EA0, 'chartreuse': 0x7FFF00, 'chocolate': 0xD2691E, 'coral': 0xFF7F50,
 	'cornflowerblue': 0x6495ED, 'cornsilk': 0xFFF8DC, 'crimson': 0xDC143C, 'cyan': 0x00FFFF, 'darkblue': 0x00008B, 'darkcyan': 0x008B8B,
@@ -28,6 +28,9 @@ var ColorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0
 	'sienna': 0xA0522D, 'silver': 0xC0C0C0, 'skyblue': 0x87CEEB, 'slateblue': 0x6A5ACD, 'slategray': 0x708090, 'slategrey': 0x708090, 'snow': 0xFFFAFA,
 	'springgreen': 0x00FF7F, 'steelblue': 0x4682B4, 'tan': 0xD2B48C, 'teal': 0x008080, 'thistle': 0xD8BFD8, 'tomato': 0xFF6347, 'turquoise': 0x40E0D0,
 	'violet': 0xEE82EE, 'wheat': 0xF5DEB3, 'white': 0xFFFFFF, 'whitesmoke': 0xF5F5F5, 'yellow': 0xFFFF00, 'yellowgreen': 0x9ACD32 };
+
+var _hslA = { h: 0, s: 0, l: 0 };
+var _hslB = { h: 0, s: 0, l: 0 };
 
 function Color( r, g, b ) {
 
@@ -259,7 +262,7 @@ Object.assign( Color.prototype, {
 		if ( style && style.length > 0 ) {
 
 			// color keywords
-			var hex = ColorKeywords[ style ];
+			var hex = _colorKeywords[ style ];
 
 			if ( hex !== undefined ) {
 
@@ -441,23 +444,17 @@ Object.assign( Color.prototype, {
 
 	},
 
-	offsetHSL: function () {
+	offsetHSL: function ( h, s, l ) {
 
-		var hsl = {};
+		this.getHSL( _hslA );
 
-		return function ( h, s, l ) {
+		_hslA.h += h; _hslA.s += s; _hslA.l += l;
 
-			this.getHSL( hsl );
+		this.setHSL( _hslA.h, _hslA.s, _hslA.l );
 
-			hsl.h += h; hsl.s += s; hsl.l += l;
+		return this;
 
-			this.setHSL( hsl.h, hsl.s, hsl.l );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	add: function ( color ) {
 
@@ -529,27 +526,20 @@ Object.assign( Color.prototype, {
 
 	},
 
-	lerpHSL: function () {
+	lerpHSL: function ( color, alpha ) {
 
-		var hslA = { h: 0, s: 0, l: 0 };
-		var hslB = { h: 0, s: 0, l: 0 };
+		this.getHSL( _hslA );
+		color.getHSL( _hslB );
 
-		return function lerpHSL( color, alpha ) {
+		var h = _Math.lerp( _hslA.h, _hslB.h, alpha );
+		var s = _Math.lerp( _hslA.s, _hslB.s, alpha );
+		var l = _Math.lerp( _hslA.l, _hslB.l, alpha );
 
-			this.getHSL( hslA );
-			color.getHSL( hslB );
+		this.setHSL( h, s, l );
 
-			var h = _Math.lerp( hslA.h, hslB.h, alpha );
-			var s = _Math.lerp( hslA.s, hslB.s, alpha );
-			var l = _Math.lerp( hslA.l, hslB.l, alpha );
+		return this;
 
-			this.setHSL( h, s, l );
-
-			return this;
-
-		};
-
-	}(),
+	},
 
 	equals: function ( c ) {
 

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -8,6 +8,9 @@ import { Plane } from './Plane.js';
  * @author bhouston / http://clara.io
  */
 
+var _sphere;
+var _vector;
+
 function Frustum( p0, p1, p2, p3, p4, p5 ) {
 
 	this.planes = [
@@ -80,41 +83,29 @@ Object.assign( Frustum.prototype, {
 
 	},
 
-	intersectsObject: function () {
+	intersectsObject: function ( object ) {
 
-		var sphere = new Sphere();
+		if ( _sphere === undefined ) _sphere = new Sphere();
 
-		return function intersectsObject( object ) {
+		var geometry = object.geometry;
 
-			var geometry = object.geometry;
+		if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			if ( geometry.boundingSphere === null )
-				geometry.computeBoundingSphere();
+		_sphere.copy( geometry.boundingSphere ).applyMatrix4( object.matrixWorld );
 
-			sphere.copy( geometry.boundingSphere )
-				.applyMatrix4( object.matrixWorld );
+		return this.intersectsSphere( _sphere );
 
-			return this.intersectsSphere( sphere );
+	},
 
-		};
+	intersectsSprite: function ( sprite ) {
 
-	}(),
+		_sphere.center.set( 0, 0, 0 );
+		_sphere.radius = 0.7071067811865476;
+		_sphere.applyMatrix4( sprite.matrixWorld );
 
-	intersectsSprite: function () {
+		return this.intersectsSphere( _sphere );
 
-		var sphere = new Sphere();
-
-		return function intersectsSprite( sprite ) {
-
-			sphere.center.set( 0, 0, 0 );
-			sphere.radius = 0.7071067811865476;
-			sphere.applyMatrix4( sprite.matrixWorld );
-
-			return this.intersectsSphere( sphere );
-
-		};
-
-	}(),
+	},
 
 	intersectsSphere: function ( sphere ) {
 
@@ -138,37 +129,33 @@ Object.assign( Frustum.prototype, {
 
 	},
 
-	intersectsBox: function () {
+	intersectsBox: function ( box ) {
 
-		var p = new Vector3();
+		if ( _vector === undefined ) _vector = new Vector3();
 
-		return function intersectsBox( box ) {
+		var planes = this.planes;
 
-			var planes = this.planes;
+		for ( var i = 0; i < 6; i ++ ) {
 
-			for ( var i = 0; i < 6; i ++ ) {
+			var plane = planes[ i ];
 
-				var plane = planes[ i ];
+			// corner at max distance
 
-				// corner at max distance
+			_vector.x = plane.normal.x > 0 ? box.max.x : box.min.x;
+			_vector.y = plane.normal.y > 0 ? box.max.y : box.min.y;
+			_vector.z = plane.normal.z > 0 ? box.max.z : box.min.z;
 
-				p.x = plane.normal.x > 0 ? box.max.x : box.min.x;
-				p.y = plane.normal.y > 0 ? box.max.y : box.min.y;
-				p.z = plane.normal.z > 0 ? box.max.z : box.min.z;
+			if ( plane.distanceToPoint( _vector ) < 0 ) {
 
-				if ( plane.distanceToPoint( p ) < 0 ) {
-
-					return false;
-
-				}
+				return false;
 
 			}
 
-			return true;
+		}
 
-		};
+		return true;
 
-	}(),
+	},
 
 	containsPoint: function ( point ) {
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -5,6 +5,8 @@ import { Vector3 } from './Vector3.js';
  * @author bhouston / http://clara.io
  */
 
+var _vector1, _vector2, _normalMatrix;
+
 function Plane( normal, constant ) {
 
 	// normal is assumed to be normalized
@@ -45,24 +47,24 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	setFromCoplanarPoints: function () {
+	setFromCoplanarPoints: function ( a, b, c ) {
 
-		var v1 = new Vector3();
-		var v2 = new Vector3();
+		if ( _vector1 === undefined ) {
 
-		return function setFromCoplanarPoints( a, b, c ) {
+			_vector1 = new Vector3();
+			_vector2 = new Vector3();
 
-			var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
+		}
 
-			// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+		var normal = _vector1.subVectors( c, b ).cross( _vector2.subVectors( a, b ) ).normalize();
 
-			this.setFromNormalAndCoplanarPoint( normal, a );
+		// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
 
-			return this;
+		this.setFromNormalAndCoplanarPoint( normal, a );
 
-		};
+		return this;
 
-	}(),
+	},
 
 	clone: function () {
 
@@ -125,50 +127,46 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	intersectLine: function () {
+	intersectLine: function ( line, target ) {
 
-		var v1 = new Vector3();
+		if ( _vector1 === undefined ) _vector1 = new Vector3();
 
-		return function intersectLine( line, target ) {
+		if ( target === undefined ) {
 
-			if ( target === undefined ) {
+			console.warn( 'THREE.Plane: .intersectLine() target is now required' );
+			target = new Vector3();
 
-				console.warn( 'THREE.Plane: .intersectLine() target is now required' );
-				target = new Vector3();
+		}
 
-			}
+		var direction = line.delta( _vector1 );
 
-			var direction = line.delta( v1 );
+		var denominator = this.normal.dot( direction );
 
-			var denominator = this.normal.dot( direction );
+		if ( denominator === 0 ) {
 
-			if ( denominator === 0 ) {
+			// line is coplanar, return origin
+			if ( this.distanceToPoint( line.start ) === 0 ) {
 
-				// line is coplanar, return origin
-				if ( this.distanceToPoint( line.start ) === 0 ) {
-
-					return target.copy( line.start );
-
-				}
-
-				// Unsure if this is the correct method to handle this case.
-				return undefined;
+				return target.copy( line.start );
 
 			}
 
-			var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
+			// Unsure if this is the correct method to handle this case.
+			return undefined;
 
-			if ( t < 0 || t > 1 ) {
+		}
 
-				return undefined;
+		var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
 
-			}
+		if ( t < 0 || t > 1 ) {
 
-			return target.copy( direction ).multiplyScalar( t ).add( line.start );
+			return undefined;
 
-		};
+		}
 
-	}(),
+		return target.copy( direction ).multiplyScalar( t ).add( line.start );
+
+	},
 
 	intersectsLine: function ( line ) {
 
@@ -206,26 +204,26 @@ Object.assign( Plane.prototype, {
 
 	},
 
-	applyMatrix4: function () {
+	applyMatrix4: function ( matrix, optionalNormalMatrix ) {
 
-		var v1 = new Vector3();
-		var m1 = new Matrix3();
+		if ( _normalMatrix === undefined ) {
 
-		return function applyMatrix4( matrix, optionalNormalMatrix ) {
+			_normalMatrix = new Matrix3();
+			_vector1 = new Vector3();
 
-			var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
+		}
 
-			var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
+		var normalMatrix = optionalNormalMatrix || _normalMatrix.getNormalMatrix( matrix );
 
-			var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
+		var referencePoint = this.coplanarPoint( _vector1 ).applyMatrix4( matrix );
 
-			this.constant = - referencePoint.dot( normal );
+		var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
 
-			return this;
+		this.constant = - referencePoint.dot( normal );
 
-		};
+		return this;
 
-	}(),
+	},
 
 	translate: function ( offset ) {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -10,6 +10,8 @@ import { Quaternion } from './Quaternion.js';
  * @author WestLangley / http://github.com/WestLangley
  */
 
+var _vector, _quaternion;
+
 function Vector3( x, y, z ) {
 
 	this.x = x || 0;
@@ -231,35 +233,27 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	applyEuler: function () {
+	applyEuler: function ( euler ) {
 
-		var quaternion = new Quaternion();
+		if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
-		return function applyEuler( euler ) {
+		if ( ! ( euler && euler.isEuler ) ) {
 
-			if ( ! ( euler && euler.isEuler ) ) {
+			console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
 
-				console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+		}
 
-			}
+		return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
 
-			return this.applyQuaternion( quaternion.setFromEuler( euler ) );
+	},
 
-		};
+	applyAxisAngle: function ( axis, angle ) {
 
-	}(),
+		if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
-	applyAxisAngle: function () {
+		return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
 
-		var quaternion = new Quaternion();
-
-		return function applyAxisAngle( axis, angle ) {
-
-			return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
-
-		};
-
-	}(),
+	},
 
 	applyMatrix3: function ( m ) {
 
@@ -543,34 +537,26 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	projectOnPlane: function () {
+	projectOnPlane: function ( planeNormal ) {
 
-		var v1 = new Vector3();
+		if ( _vector === undefined ) _vector = new Vector3();
 
-		return function projectOnPlane( planeNormal ) {
+		_vector.copy( this ).projectOnVector( planeNormal );
 
-			v1.copy( this ).projectOnVector( planeNormal );
+		return this.sub( _vector );
 
-			return this.sub( v1 );
+	},
 
-		};
+	reflect: function ( normal ) {
 
-	}(),
-
-	reflect: function () {
+		if ( _vector === undefined ) _vector = new Vector3();
 
 		// reflect incident vector off plane orthogonal to normal
 		// normal is assumed to have unit length
 
-		var v1 = new Vector3();
+		return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
 
-		return function reflect( normal ) {
-
-			return this.sub( v1.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
-
-		};
-
-	}(),
+	},
 
 	angleTo: function ( v ) {
 


### PR DESCRIPTION
Conversion for `Box2`, `Color`, `Frustum`, `Plane` and `Vector3`.

In this PR, there are methods like `Box2.setFromCenterAndSize()` and `Box2.distanceToPoint()` which need the same type of helper variable. Since `Box2.setFromCenterAndSize()` is not called in the call hierarchy of `Box2.distanceToPoint()` and vice versa, it's safe to define a single module scope variable and share it.

I personally would favor this approach instead of defining module scope variables per method. Defining helper variables per method might be more safe however it will also clutter the file. 

In any event, we have unit tests to verify such cases so I think it's okay to share helper variables.