### PR TITLE
GLTFExporter: Support SpecularGlossiness materials

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -920,8 +920,8 @@ THREE.GLTFExporter.prototype = {
 				gltfMaterial.extensions = { KHR_materials_pbrSpecularGlossiness: {} };
 
 				extensionsUsed[ 'KHR_materials_pbrSpecularGlossiness' ] = true;
-			} 
-			else if ( ! material.isMeshStandardMaterial ) {
+
+			} else if ( ! material.isMeshStandardMaterial ) {
 
 				console.warn( 'GLTFExporter: Use MeshStandardMaterial or MeshBasicMaterial for best results.' );
 
@@ -956,9 +956,11 @@ THREE.GLTFExporter.prototype = {
 			// pbrSpecularGlossiness diffuse, specular and glossiness factor
 			if ( material.isGLTFSpecularGlossinessMaterial ) {
 				
-				var diffuseFactor = [ 1, 1, 1, 1 ];
-				material.color.toArray( diffuseFactor, 0 );
-				gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness.diffuseFactor = diffuseFactor;
+				if ( gltfMaterial.pbrMetallicRoughness.baseColorFactor ) {
+
+					gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness.diffuseFactor = gltfMaterial.pbrMetallicRoughness.baseColorFactor;
+				  
+				}
 
 				var specularFactor = [ 1, 1, 1 ];
 				material.specular.toArray( specularFactor, 0 );
@@ -995,16 +997,14 @@ THREE.GLTFExporter.prototype = {
 
 					gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness.diffuseTexture = baseColorMapDef;
 
-				} else {
-
-					gltfMaterial.pbrMetallicRoughness.baseColorTexture = baseColorMapDef;
-
 				}
+
+				gltfMaterial.pbrMetallicRoughness.baseColorTexture = baseColorMapDef;
 				
 			}
 
 			// pbrSpecularGlossiness specular map
-			if ( material.specularMap ) {
+			if ( material.isGLTFSpecularGlossinessMaterial && material.specularMap ) {
 
 				var specularMapDef = { index: processTexture( material.specularMap ) };
 				applyTextureTransform( specularMapDef, material.specularMap );


### PR DESCRIPTION
This pull request enables support for exporting spec/gloss PBR materials. It is based on another closed pull request (#16413) with some modifications and matching the styleguide.

It fixes #15351. Here there are some models that were exporting without materials but are now working:

https://sketchfab.com/models/c438e81e796d41d9a6ae4cc147ef8d4f
https://sketchfab.com/models/fb847d79fdfa465894f30475c6cfbf05
https://sketchfab.com/models/f5abe05ff2124527a6871060b2809bb2
https://sketchfab.com/models/58e93896d1a14eb9af7b776272a48ed6