### PR TITLE
Hotfix: Temporarily disable stencil materials

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -677,14 +677,16 @@ function WebGLState( gl, extensions, utils, capabilities ) {
 		depthBuffer.setMask( material.depthWrite );
 		colorBuffer.setMask( material.colorWrite );
 
-		var stencilWrite = material.stencilWrite;
-		stencilBuffer.setTest( stencilWrite );
-		if ( stencilWrite ) {
+		// temporarily disable stencil materials.
+		// see https://github.com/mrdoob/three.js/pull/15611#discussion_r309189045
+		// var stencilWrite = material.stencilWrite;
+		// stencilBuffer.setTest( stencilWrite );
+		// if ( stencilWrite ) {
 
-			stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilMask );
-			stencilBuffer.setOp( material.stencilFail, material.stencilZFail, material.stencilZPass );
+		// 	stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilMask );
+		// 	stencilBuffer.setOp( material.stencilFail, material.stencilZFail, material.stencilZPass );
 
-		}
+		// }
 
 		setPolygonOffset( material.polygonOffset, material.polygonOffsetFactor, material.polygonOffsetUnits );
 


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/pull/15611#discussion_r309189045

An option to fix MaskPass no longer working after #15611 was merged by just commenting out the problematic code. Another options is reverting the change: #17135.

#17136 proposes a change to fix this issue generally and make MaskPass inter-operate with stencil materials.