### PR TITLE
Examples: prevent pointer events on info div

### DIFF
--- a/examples/main.css
+++ b/examples/main.css
@@ -10,6 +10,7 @@ body {
 a {
 	color: #ff0;
 	text-decoration: none;
+	pointer-events: auto;
 }
 
 a:hover {
@@ -36,6 +37,7 @@ canvas {
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	pointer-events: none;
 	z-index: 1; /* TODO Solve this in HTML */
 }
 


### PR DESCRIPTION
Info `div` was interfering with camera controls. Info links are still clickable.
