### PR TITLE
NodeMaterial: Added energy preservation flag

### DIFF
--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -20,6 +20,8 @@ function StandardNode() {
 	this.roughness = new FloatNode( 0.5 );
 	this.metalness = new FloatNode( 0.5 );
 
+	this.energyPreservation = true;
+
 }
 
 StandardNode.prototype = Object.create( Node.prototype );
@@ -31,6 +33,8 @@ StandardNode.prototype.build = function ( builder ) {
 	var code;
 
 	builder.define( this.clearCoat || this.clearCoatRoughness ? 'PHYSICAL' : 'STANDARD' );
+
+	if ( this.energyPreservation ) builder.define( 'ENERGY_PRESERVATION' );
 
 	builder.requires.lights = true;
 

--- a/src/materials/MeshStandardMaterial.d.ts
+++ b/src/materials/MeshStandardMaterial.d.ts
@@ -29,6 +29,7 @@ export interface MeshStandardMaterialParameters extends MaterialParameters {
 	alphaMap?: Texture;
 	envMap?: Texture;
 	envMapIntensity?: number;
+	energyPreservation: boolean;
 	refractionRatio?: number;
 	wireframe?: boolean;
 	wireframeLinewidth?: number;
@@ -66,6 +67,7 @@ export class MeshStandardMaterial extends Material {
 	alphaMap: Texture | null;
 	envMap: Texture | null;
 	envMapIntensity: number;
+	energyPreservation: boolean;
 	refractionRatio: number;
 	wireframe: boolean;
 	wireframeLinewidth: number;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -44,6 +44,8 @@ import { Color } from '../math/Color.js';
  *  envMap: new THREE.CubeTexture( [posx, negx, posy, negy, posz, negz] ),
  *  envMapIntensity: <float>
  *
+ *  energyPreservation: <bool>,
+ *
  *  refractionRatio: <float>,
  *
  *  wireframe: <boolean>,
@@ -98,6 +100,8 @@ function MeshStandardMaterial( parameters ) {
 
 	this.envMap = null;
 	this.envMapIntensity = 1.0;
+
+	this.energyPreservation = true;
 
 	this.refractionRatio = 0.98;
 
@@ -160,6 +164,8 @@ MeshStandardMaterial.prototype.copy = function ( source ) {
 
 	this.envMap = source.envMap;
 	this.envMapIntensity = source.envMapIntensity;
+
+	this.energyPreservation = source.energyPreservation;
 
 	this.refractionRatio = source.refractionRatio;
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -98,7 +98,7 @@ void RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricCo
 
 	// Defer to the IndirectSpecular function to compute
 	// the indirectDiffuse if energy preservation is enabled.
-	#ifndef ENVMAP_TYPE_CUBE_UV
+	#ifndef ENERGY_PRESERVATION
 
 		reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
@@ -120,7 +120,7 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 
 	// Both indirect specular and diffuse light accumulate here
 	// if energy preservation enabled, and PMREM provided.
-	#if defined( ENVMAP_TYPE_CUBE_UV )
+	#if defined( ENERGY_PRESERVATION )
 
 		vec3 singleScattering = vec3( 0.0 );
 		vec3 multiScattering = vec3( 0.0 );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -522,6 +522,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
+			parameters.energyPreservation ? '#define ENERGY_PRESERVATION' : '',
+
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
 			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -201,6 +201,8 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			toneMapping: renderer.toneMapping,
 			physicallyCorrectLights: renderer.physicallyCorrectLights,
 
+			energyPreservation: material.energyPreservation,
+
 			premultipliedAlpha: material.premultipliedAlpha,
 
 			alphaTest: material.alphaTest,


### PR DESCRIPTION
### Description
`Energy Preservation` is a characteristic of global light, not only IBL PREM how is today defined. This makes customized materials like NodeMaterial do not use these important equations for Physically-Based Material.

Although it is a subtle difference, it can be noted an improvement in the incidence of lights in the fresnel area. Now, this can be applied in materials than use dynamic lights too, not only if have IBL PREM for example.

> This is easy to enforce in a shading system: one simply subtracts reflected light before allowing the diffuse shading to occur. This means highly reflective objects will show little to no diffuse light, simply because little to no light penetrates the surface, having been mostly reflected. The converse is also true: if an object has bright diffusion, it cannot be especially reflective.

> Energy conservation of this sort is an important aspect of physically-based shading. It allows the artist to work with reflectivity and albedo values for a material without accidentally violating the laws of physics (which tends to look bad). While enforcing these constraints in code isn’t strictly necessary to producing good looking art, it does serve a useful role as a kind of “nanny physicist” that will prevent artwork from bending the rules too far or becoming inconsistent under different lighting conditions.

Quote: https://marmoset.co/posts/basic-theory-of-physically-based-rendering/

### References
`Energy Compensation` in #16977 Enterprise PBR
`Energy conservation` in https://learnopengl.com/PBR/Theory
`ENERGY CONSERVATION` in https://marmoset.co/posts/basic-theory-of-physically-based-rendering/

### Others
Issue https://github.com/mrdoob/three.js/issues/17102

Images bellow in this case is used a simple cube map.

/ping @WestLangley @bhouston 

----
```javascript
material.energyPreservation = true;
```
![energyPreservation=on](https://user-images.githubusercontent.com/502810/62406372-6caa0080-b581-11e9-8476-845db401c2b0.png)
----
```javascript
material.energyPreservation = false;
```
![energyPreservation=off](https://user-images.githubusercontent.com/502810/62406373-6ddb2d80-b581-11e9-9e7e-edc5d335199b.png)
