### PR TITLE
StereoCamera: Fix caching in update().

### DIFF
--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -48,20 +48,21 @@ Object.assign( StereoCamera.prototype, {
 				near = camera.near;
 				far = camera.far;
 				zoom = camera.zoom;
+				eyeSep = this.eyeSep;
 
 				// Off-axis stereoscopic effect based on
 				// http://paulbourke.net/stereographics/stereorender/
 
 				var projectionMatrix = camera.projectionMatrix.clone();
-				eyeSep = this.eyeSep / 2;
-				var eyeSepOnProjection = eyeSep * near / focus;
+				var eyeSepHalf = eyeSep / 2;
+				var eyeSepOnProjection = eyeSepHalf * near / focus;
 				var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / zoom;
 				var xmin, xmax;
 
 				// translate xOffset
 
-				eyeLeft.elements[ 12 ] = - eyeSep;
-				eyeRight.elements[ 12 ] = eyeSep;
+				eyeLeft.elements[ 12 ] = - eyeSepHalf;
+				eyeRight.elements[ 12 ] = eyeSepHalf;
 
 				// for left eye
 


### PR DESCRIPTION
`StereoCamera.update()` should only compute projection matrices for the right and left camera if necessary. However, because of wrong caching, the expensive computation is done per frame. You can verify this with the official example. Just set a breakpoint in the respective `update()` method: https://threejs.org/examples/webgl_effects_stereo

The evaluation `eyeSep !== this.eyeSep` is always `true` since `eyeSep` represents the half value of `this.eyeSep`. The PR fixes this so the computation is only done if parameters have actually changed.