### PR TITLE
WebGLShadowMap: Ensure to use the latest instance of WebGLObjects.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -214,6 +214,11 @@
 			Keep in mind that the standard materials only allow 4 MorphNormals.
 		</p>
 
+		<h3>[property:Object objects]</h3>
+		<p>
+		Used internally by the renderer to manage the geometry data of 3D objects.
+		</p>
+
 		<h3>[property:Boolean physicallyCorrectLights]</h3>
 		<p>
 		Whether to use physically correct lighting mode. Default is *false*.

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -5,6 +5,7 @@ import { WebGLInfo } from './webgl/WebGLInfo';
 import { WebGLShadowMap } from './webgl/WebGLShadowMap';
 import { WebGLCapabilities } from './webgl/WebGLCapabilities';
 import { WebGLProperties } from './webgl/WebGLProperties';
+import { WebGLObjects } from './webgl/WebGLObjects';
 import { WebGLRenderLists } from './webgl/WebGLRenderLists';
 import { WebGLState } from './webgl/WebGLState';
 import { Vector2 } from './../math/Vector2';
@@ -194,6 +195,7 @@ export class WebGLRenderer implements Renderer {
 	properties: WebGLProperties;
 	renderLists: WebGLRenderLists;
 	state: WebGLState;
+	objects: WebGLObjects;
 
 	vr: WebVRManager;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -304,6 +304,7 @@ function WebGLRenderer( parameters ) {
 		_this.renderLists = renderLists;
 		_this.state = state;
 		_this.info = info;
+		_this.objects = objects;
 
 	}
 
@@ -317,7 +318,7 @@ function WebGLRenderer( parameters ) {
 
 	// shadow map
 
-	var shadowMap = new WebGLShadowMap( _this, objects, capabilities.maxTextureSize );
+	var shadowMap = new WebGLShadowMap( _this, capabilities.maxTextureSize );
 
 	this.shadowMap = shadowMap;
 

--- a/src/renderers/webgl/WebGLShadowMap.d.ts
+++ b/src/renderers/webgl/WebGLShadowMap.d.ts
@@ -7,9 +7,7 @@ export class WebGLShadowMap {
 
 	constructor(
 		_renderer: WebGLRenderer,
-		_lights: any[],
-		_objects: any[],
-		capabilities: any
+		maxTextureSize: number
 	);
 
 	enabled: boolean;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -13,7 +13,7 @@ import { Vector2 } from '../../math/Vector2.js';
 import { Matrix4 } from '../../math/Matrix4.js';
 import { Frustum } from '../../math/Frustum.js';
 
-function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
+function WebGLShadowMap( _renderer, maxTextureSize ) {
 
 	var _frustum = new Frustum(),
 		_projScreenMatrix = new Matrix4(),
@@ -386,7 +386,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 
-				var geometry = _objects.update( object );
+				var geometry = _renderer.objects.update( object );
 				var material = object.material;
 
 				if ( Array.isArray( material ) ) {


### PR DESCRIPTION
Fixed #17161