### PR TITLE
Fix shadow artifacts in example by subdividing ground plane

### DIFF
--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -143,8 +143,15 @@
 				// camera
 
 				camera = new THREE.PerspectiveCamera( 30, window.innerWidth / window.innerHeight, 1, 10000 );
-				camera.position.y = 5;
-				camera.position.z = 15;
+
+				// We use this particular camera position in order to expose a bug that can sometimes happen presumably
+				// due to lack of precision when interpolating values over really large triangles.
+				// It reproduced on at least NVIDIA GTX 1080 and GTX 1050 Ti GPUs when the ground plane was not
+				// subdivided into segments.
+				camera.position.x = 7;
+				camera.position.y = 13;
+				camera.position.z = 7;
+
 				scene.add( camera );
 
 				// lights
@@ -191,7 +198,7 @@
 
 				var groundMaterial = new THREE.MeshPhongMaterial( { color: 0x404040, specular: 0x111111 } );
 
-				var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 20000, 20000 ), groundMaterial );
+				var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 20000, 20000, 8, 8 ), groundMaterial );
 				mesh.rotation.x = - Math.PI / 2;
 				mesh.receiveShadow = true;
 				scene.add( mesh );


### PR DESCRIPTION
Without the subdivision some artifacts were visible in the test with certain camera angles. The artifacts reproduced on NVIDIA GeForce GTX 10xx series GPUs, presumably due to lack of varying interpolation precision.

Here's an example of the artifacts (emphasis added):
![image](https://user-images.githubusercontent.com/453050/62516926-f500fd80-b82e-11e9-85ef-0ae23e0ac7a5.png)
