### PR TITLE
MtlObjBridge methods return type fix in typings

### DIFF
--- a/examples/jsm/loaders/obj2/bridge/MtlObjBridge.d.ts
+++ b/examples/jsm/loaders/obj2/bridge/MtlObjBridge.d.ts
@@ -4,5 +4,5 @@ import {
 
 export namespace MtlObjBridge {
   export function link(processResult: object, assetLoader: object): void;
-  export function addMaterialsFromMtlLoader(materialCreator: MaterialCreator): void;
+  export function addMaterialsFromMtlLoader(materialCreator: MaterialCreator): object;
 }


### PR DESCRIPTION
Return type of function addMaterialsFromMtlLoader in MtlObjBridge.d.ts is void, while in same function in MtlObjBridge.js returns object.