### PR TITLE
GLTFLoader: Fix PointsMaterial to use pixel-sized points

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2131,6 +2131,7 @@ THREE.GLTFLoader = ( function () {
 				pointsMaterial.color.copy( material.color );
 				pointsMaterial.map = material.map;
 				pointsMaterial.lights = false; // PointsMaterial doesn't support lights yet
+				pointsMaterial.sizeAttenuation = false; // glTF spec says points should be 1px
 
 				this.cache.add( cacheKey, pointsMaterial );
 


### PR DESCRIPTION
glTF spec mentions the expected implementation in a non-normative
section:

> This specification does not define size and style of non-triangular
> primitives (such as POINTS or LINES) at this time, and applications may
> use various techniques to render these primitives as appropriate.
> However, the following recommendations are provided for consistency:

> POINTS and LINES should have widths of 1px in viewport space.