### PR TITLE
Added "Made with three.js"

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -56,6 +56,8 @@ function WebGLRenderer( parameters ) {
 
 	parameters = parameters || {};
 
+	if ( ! parameters.silent ) console.log( 'Made with three.js', REVISION );
+
 	var _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' ),
 		_context = parameters.context !== undefined ? parameters.context : null,
 


### PR DESCRIPTION
Because a few users don't want the log in their personal project, the rest of the users are now unable to see it in ANY project. This fixes that.

Usage:
```js
renderer = new THREE.WebGLRenderer( { antialias: true, silent: true } );
```

The previous log "THREE.WebGLRenderer` would be ok, too.

