### PR TITLE
WIP: Added Texture.contain, .cover, .fill

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -2842,6 +2842,53 @@
 
 		},
 
+		contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
+
+	        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+	        // and does so without distortion. Akin to CSS object-fit: contain.
+
+	        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+	        if ( aspect > imageAspect ) {
+
+	                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+	        } else {
+
+	                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+	        }
+
+	        this.matrixAutoUpdate = false;
+
+		},
+
+		cover: function ( aspect ) {
+
+	        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+	        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+
+	        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+	        if ( aspect < imageAspect ) {
+
+	                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+	        } else {
+
+	                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+	        }
+
+	        this.matrixAutoUpdate = false;
+
+		},
+
+		fill: function () {
+
+			this.matrix.identity();
+		},
+
 		copy: function ( source ) {
 
 			this.name = source.name;
@@ -14460,7 +14507,7 @@
 
 	var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );\n#endif";
 
-	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tif ( vUv.x < 0.0 || vUv.x > 1.0 ) discard;\tif ( vUv.y < 0.0 || vUv.y > 1.0 ) discard;\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
 
 	var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
 

--- a/build/three.js
+++ b/build/three.js
@@ -2844,49 +2844,50 @@
 
 		contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
 
-	        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
-	        // and does so without distortion. Akin to CSS object-fit: contain.
+			// Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+			// and does so without distortion. Akin to CSS object-fit: contain.
 
-	        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+			var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-	        if ( aspect > imageAspect ) {
+			if ( aspect > imageAspect ) {
 
-	                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+				this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-	        } else {
+			} else {
 
-	                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+				this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-	        }
+			}
 
-	        this.matrixAutoUpdate = false;
+			this.matrixAutoUpdate = false;
 
 		},
 
 		cover: function ( aspect ) {
 
-	        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
-	        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+			// Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+			// and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
 
-	        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+			var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-	        if ( aspect < imageAspect ) {
+			if ( aspect < imageAspect ) {
 
-	                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+				this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-	        } else {
+			} else {
 
-	                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+				this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-	        }
+			}
 
-	        this.matrixAutoUpdate = false;
+			this.matrixAutoUpdate = false;
 
 		},
 
 		fill: function () {
 
 			this.matrix.identity();
+
 		},
 
 		copy: function ( source ) {
@@ -3066,6 +3067,7 @@
 							uv.x = uv.x - Math.floor( uv.x );
 
 						}
+
 						break;
 
 				}
@@ -3097,6 +3099,7 @@
 							uv.y = uv.y - Math.floor( uv.y );
 
 						}
+
 						break;
 
 				}

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -2836,6 +2836,53 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	},
 
+	contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
+
+        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+        // and does so without distortion. Akin to CSS object-fit: contain.
+
+        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+        if ( aspect > imageAspect ) {
+
+                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+        } else {
+
+                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+        }
+
+        this.matrixAutoUpdate = false;
+
+	},
+
+	cover: function ( aspect ) {
+
+        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+
+        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+        if ( aspect < imageAspect ) {
+
+                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+        } else {
+
+                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+        }
+
+        this.matrixAutoUpdate = false;
+
+	},
+
+	fill: function () {
+
+		this.matrix.identity();
+	},
+
 	copy: function ( source ) {
 
 		this.name = source.name;
@@ -14454,7 +14501,7 @@ var uv2_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvUv2 = 
 
 var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );\n#endif";
 
-var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tif ( vUv.x < 0.0 || vUv.x > 1.0 ) discard;\tif ( vUv.y < 0.0 || vUv.y > 1.0 ) discard;\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
 
 var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -2838,49 +2838,50 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
 
-        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
-        // and does so without distortion. Akin to CSS object-fit: contain.
+		// Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+		// and does so without distortion. Akin to CSS object-fit: contain.
 
-        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+		var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-        if ( aspect > imageAspect ) {
+		if ( aspect > imageAspect ) {
 
-                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-        } else {
+		} else {
 
-                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-        }
+		}
 
-        this.matrixAutoUpdate = false;
+		this.matrixAutoUpdate = false;
 
 	},
 
 	cover: function ( aspect ) {
 
-        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
-        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+		// Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+		// and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
 
-        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+		var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-        if ( aspect < imageAspect ) {
+		if ( aspect < imageAspect ) {
 
-                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-        } else {
+		} else {
 
-                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-        }
+		}
 
-        this.matrixAutoUpdate = false;
+		this.matrixAutoUpdate = false;
 
 	},
 
 	fill: function () {
 
 		this.matrix.identity();
+
 	},
 
 	copy: function ( source ) {
@@ -3060,6 +3061,7 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 						uv.x = uv.x - Math.floor( uv.x );
 
 					}
+
 					break;
 
 			}
@@ -3091,6 +3093,7 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 						uv.y = uv.y - Math.floor( uv.y );
 
 					}
+
 					break;
 
 			}

--- a/examples/webgl_background_cover.html
+++ b/examples/webgl_background_cover.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - background</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Scene Background<br/>
+		</div>
+
+		<div id="container"></div>
+
+		<script type="module">
+
+			import * as THREE from '../build/three.module.js';
+
+			import { GUI } from './jsm/libs/dat.gui.module.js';
+
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { RGBELoader } from './jsm/loaders/RGBELoader.js';
+
+			var renderer, scene, camera;
+
+			var gui, FIT;
+
+			var API = {
+				fit: 'cover',
+				toneMapping: true,
+				exposure: 1.0
+			};
+
+			init();
+
+			function init() {
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setClearColor( 0x302005, 1 );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
+
+				renderer.toneMapping = THREE.ReinhardToneMapping;
+				renderer.toneMappingExposure = API.exposure;
+
+				renderer.gammaOutput = true;
+
+				scene = new THREE.Scene();
+
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 15, 20, 30 );
+
+				new RGBELoader()
+					.setDataType( THREE.UnsignedByteType )
+					.load( 'textures/memorial.hdr', function ( texture ) {
+
+						scene.background = texture;
+
+						initGui();
+
+						window.addEventListener( 'resize', onWindowResize, false );
+
+						onWindowResize();
+
+					} );
+
+			}
+
+			function onWindowResize() {
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+				var aspect = ( window.innerWidth ) / ( window.innerHeight );
+
+				camera.aspect = aspect;
+
+				camera.updateProjectionMatrix();
+
+				var bg = scene.background;
+
+				if ( bg && bg.isTexture ) {
+
+					var bgAspect = bg.image.width / bg.image.height;
+
+					switch ( API.fit ) {
+
+						case 'cover': // clip to fit
+
+							bg.cover( aspect );
+							break;
+
+						case 'contain': // shrink to fit
+
+							bg.contain( aspect );
+							break;
+
+						case 'fill': // strech to fit
+
+							bg.fill();
+							break;
+
+					}
+
+				}
+
+				render();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
+
+			}
+
+			function initGui() {
+
+				gui = new GUI();
+
+				var fl = gui.addFolder( 'BACKGROUND' );
+
+				fl.add( API, 'fit', [ 'cover', 'contain', 'fill' ] )
+					.name( 'texture fit')
+					.onChange( onWindowResize );
+
+				fl.open();
+
+				var fl = gui.addFolder( 'TONEMAPPING' );
+
+				fl.add( API, 'toneMapping' )
+					.onChange( function( value ) {
+						renderer.toneMapping = value ? DefaultToneMapping : THREE.NoToneMapping;
+						textureViewer.update();
+						render();
+					} );
+
+				fl.add( API, 'exposure', 0, 2, 0.1 )
+					.onChange( function() { renderer.toneMappingExposure = API.exposure; render(); } );
+
+				fl.open();
+
+			}
+
+		</script>
+	</body>
+</html>

--- a/examples/webgl_background_cover.html
+++ b/examples/webgl_background_cover.html
@@ -42,7 +42,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				renderer.toneMapping = THREE.ReinhardToneMapping;
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = API.exposure;
 
 				renderer.gammaOutput = true;
@@ -122,27 +122,33 @@
 				var fl = gui.addFolder( 'BACKGROUND' );
 
 				fl.add( API, 'fit', [ 'cover', 'contain', 'fill' ] )
-					.name( 'texture fit')
+					.name( 'texture fit' )
 					.onChange( onWindowResize );
 
 				fl.open();
 
 				var fl = gui.addFolder( 'TONEMAPPING' );
 
-				fl.add( API, 'toneMapping' )
-					.onChange( function( value ) {
-						renderer.toneMapping = value ? DefaultToneMapping : THREE.NoToneMapping;
-						textureViewer.update();
-						render();
-					} );
+				//fl.add( API, 'toneMapping' )
+				//	.onChange( function ( value ) {
+
+				//		renderer.toneMapping = value ? THREE.ACESFilmicToneMapping : THREE.NoToneMapping;
+				//		// doesn't work - no needsUpdate available for background material
+				//		render();
+
+				//	} );
 
 				fl.add( API, 'exposure', 0, 2, 0.1 )
-					.onChange( function() { renderer.toneMappingExposure = API.exposure; render(); } );
+					.onChange( function ( value ) {
+
+						renderer.toneMappingExposure = value;
+						render();
+
+					} );
 
 				fl.open();
 
 			}
-
 		</script>
 	</body>
 </html>

--- a/src/renderers/shaders/ShaderLib/background_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/background_frag.glsl.js
@@ -5,6 +5,9 @@ varying vec2 vUv;
 
 void main() {
 
+	if ( vUv.x < 0.0 || vUv.x > 1.0 ) discard; // works, but it messes up repeated textures in other use cases
+	if ( vUv.y < 0.0 || vUv.y > 1.0 ) discard;
+
 	vec4 texColor = texture2D( t2D, vUv );
 
 	gl_FragColor = mapTexelToLinear( texColor );

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -92,6 +92,54 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	},
 
+	contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
+
+        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+        // and does so without distortion. Akin to CSS object-fit: contain.
+
+        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+        if ( aspect > imageAspect ) {
+
+                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+        } else {
+
+                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+        }
+
+        this.matrixAutoUpdate = false;
+
+	},
+
+	cover: function ( aspect ) {
+
+        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+
+        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+
+        if ( aspect < imageAspect ) {
+
+                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+
+        } else {
+
+                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+
+        }
+
+        this.matrixAutoUpdate = false;
+
+	},
+
+	fill: function () {
+
+		this.matrix.identity();;
+
+	},
+
 	copy: function ( source ) {
 
 		this.name = source.name;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -94,49 +94,49 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	contain: function ( aspect ) { // requires pixels to be discarded if uv is outside [ 0, 1 ]
 
-        // Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
-        // and does so without distortion. Akin to CSS object-fit: contain.
+		// Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
+		// and does so without distortion. Akin to CSS object-fit: contain.
 
-        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+		var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-        if ( aspect > imageAspect ) {
+		if ( aspect > imageAspect ) {
 
-                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-        } else {
+		} else {
 
-                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-        }
+		}
 
-        this.matrixAutoUpdate = false;
+		this.matrixAutoUpdate = false;
 
 	},
 
 	cover: function ( aspect ) {
 
-        // Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
-        // and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
+		// Sets the matrix uv transform so the texture image covers a region having the specified aspect ratio,
+		// and does so without distortion. Image may be cropped. Akin to CSS object-fit: cover.
 
-        var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
+		var imageAspect = ( this.image && this.image.width ) ? this.image.width / this.image.height : 1;
 
-        if ( aspect < imageAspect ) {
+		if ( aspect < imageAspect ) {
 
-                this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, aspect / imageAspect, 1, 0, 0.5, 0.5 );
 
-        } else {
+		} else {
 
-                this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
+			this.matrix.setUvTransform( 0, 0, 1, imageAspect / aspect, 0, 0.5, 0.5 );
 
-        }
+		}
 
-        this.matrixAutoUpdate = false;
+		this.matrixAutoUpdate = false;
 
 	},
 
 	fill: function () {
 
-		this.matrix.identity();;
+		this.matrix.identity();
 
 	},
 
@@ -317,6 +317,7 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 						uv.x = uv.x - Math.floor( uv.x );
 
 					}
+
 					break;
 
 			}
@@ -348,6 +349,7 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 						uv.y = uv.y - Math.floor( uv.y );
 
 					}
+
 					break;
 
 			}


### PR DESCRIPTION
When a flat texture is set as the scene.background, it stretches to fit by default.

I'm trying to find the right API to support something like the CSS object-fit "cover" and "contain" properties.

(This feature does not have to be supported by adding new methods to `Texture` as I have done. I could just show an example.)

Suggestions welcome...
