### PR TITLE
Add missing property to BufferGeometry.d.ts

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -43,6 +43,7 @@ export class BufferGeometry extends EventDispatcher {
 	boundingSphere: Sphere;
 	drawRange: { start: number; count: number };
 	userData: {[key: string]: any};
+	isBufferGeometry: boolean;
 
 	getIndex(): BufferAttribute;
 	setIndex( index: BufferAttribute | number[] ): void;

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -49,6 +49,8 @@ export class Geometry extends EventDispatcher {
 	id: number;
 
 	uuid: string;
+	
+	isGeometry: boolean;
 
 	/**
 	 * Name for this geometry. Default is an empty string.

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -49,7 +49,7 @@ export class Geometry extends EventDispatcher {
 	id: number;
 
 	uuid: string;
-	
+
 	isGeometry: boolean;
 
 	/**


### PR DESCRIPTION
Property `isBufferGeometry` is missing from the BufferGeometry typescript definitions.