### PR TITLE
Update Matrix4.html

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -56,7 +56,7 @@
 
 			This means that calling
 		<code>
-var m = new Matrix4();
+var m = new THREE.Matrix4();
 
 m.set( 11, 12, 13, 14,
        21, 22, 23, 24,


### PR DESCRIPTION
It appears to me that "THREE." is missing from the Matrix4 documentation when showing instantiation of a new Matrix4 object.  I changed "var m = new Matrix4();" to "var m = new THREE.Matrix4();".  Thanks.