### PR TITLE
STL loader improve memory usage

### DIFF
--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -149,7 +149,7 @@ THREE.STLLoader.prototype = {
 					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
 					hasColors = true;
-					colors = new Float32Array(faces * 3 * 3);
+					colors = new Float32Array( faces * 3 * 3 );
 
 					defaultR = reader.getUint8( index + 6 ) / 255;
 					defaultG = reader.getUint8( index + 7 ) / 255;
@@ -165,8 +165,8 @@ THREE.STLLoader.prototype = {
 
 			var geometry = new THREE.BufferGeometry();
 
-			var vertices = new Float32Array(faces * 3 * 3);
-			var normals = new Float32Array(faces * 3 * 3);
+			var vertices = new Float32Array( faces * 3 * 3 );
+			var normals = new Float32Array( faces * 3 * 3 );
 
 			for ( var face = 0; face < faces; face ++ ) {
 
@@ -200,21 +200,21 @@ THREE.STLLoader.prototype = {
 				for ( var i = 1; i <= 3; i ++ ) {
 
 					var vertexstart = start + i * 12;
-					var componentIdx = (face * 3 * 3) + ((i - 1) * 3);
+					var componentIdx = ( face * 3 * 3 ) + ( ( i - 1 ) * 3 );
 					
-					vertices[componentIdx] = reader.getFloat32( vertexstart, true );
-					vertices[componentIdx + 1] = reader.getFloat32( vertexstart + 4, true );
-					vertices[componentIdx + 2] = reader.getFloat32( vertexstart + 8, true );
+					vertices[ componentIdx ] = reader.getFloat32( vertexstart, true );
+					vertices[ componentIdx + 1 ] = reader.getFloat32( vertexstart + 4, true );
+					vertices[ componentIdx + 2 ] = reader.getFloat32( vertexstart + 8, true );
 
-					normals[componentIdx] = normalX;
-					normals[componentIdx + 1] = normalY;
-					normals[componentIdx + 2] = normalZ;
+					normals[ componentIdx ] = normalX;
+					normals[ componentIdx + 1 ] = normalY;
+					normals[ componentIdx + 2 ] = normalZ;
 
 					if ( hasColors ) {
 
-						colors[componentIdx] = r;
-						colors[componentIdx + 1] = g;
-						colors[componentIdx + 2] = b;
+						colors[ componentIdx ] = r;
+						colors[ componentIdx + 1 ] = g;
+						colors[ componentIdx + 2 ] = b;
 
 					}
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -200,20 +200,21 @@ THREE.STLLoader.prototype = {
 				for ( var i = 1; i <= 3; i ++ ) {
 
 					var vertexstart = start + i * 12;
+					var componentIdx = (face * 3 * 3) + ((i - 1) * 3);
+					
+					vertices[componentIdx] = reader.getFloat32( vertexstart, true );
+					vertices[componentIdx + 1] = reader.getFloat32( vertexstart + 4, true );
+					vertices[componentIdx + 2] = reader.getFloat32( vertexstart + 8, true );
 
-					vertices[face * 3 * 3] = reader.getFloat32( vertexstart, true );
-					vertices[(face * 3 * 3) + 1] = reader.getFloat32( vertexstart + 4, true );
-					vertices[(face * 3 * 3) + 2] = reader.getFloat32( vertexstart + 8, true );
-
-					normals[face * 3 * 3] = normalX;
-					normals[(face * 3 * 3) + 1] = normalY;
-					normals[(face * 3 * 3) + 2] = normalZ;
+					normals[componentIdx] = normalX;
+					normals[componentIdx + 1] = normalY;
+					normals[componentIdx + 2] = normalZ;
 
 					if ( hasColors ) {
 
-						colors[face * 3 * 3] = r;
-						colors[(face * 3 * 3) + 1] = g;
-						colors[(face * 3 * 3) + 2] = b;
+						colors[componentIdx] = r;
+						colors[componentIdx + 1] = g;
+						colors[componentIdx + 2] = b;
 
 					}
 

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -3,6 +3,7 @@
  * @author mrdoob / http://mrdoob.com/
  * @author gero3 / https://github.com/gero3
  * @author Mugen87 / https://github.com/Mugen87
+ * @author neverhood311 / https://github.com/neverhood311
  *
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.
  *
@@ -148,7 +149,7 @@ THREE.STLLoader.prototype = {
 					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
 					hasColors = true;
-					colors = [];
+					colors = new Float32Array(faces * 3 * 3);
 
 					defaultR = reader.getUint8( index + 6 ) / 255;
 					defaultG = reader.getUint8( index + 7 ) / 255;
@@ -164,8 +165,8 @@ THREE.STLLoader.prototype = {
 
 			var geometry = new THREE.BufferGeometry();
 
-			var vertices = [];
-			var normals = [];
+			var vertices = new Float32Array(faces * 3 * 3);
+			var normals = new Float32Array(faces * 3 * 3);
 
 			for ( var face = 0; face < faces; face ++ ) {
 
@@ -200,15 +201,19 @@ THREE.STLLoader.prototype = {
 
 					var vertexstart = start + i * 12;
 
-					vertices.push( reader.getFloat32( vertexstart, true ) );
-					vertices.push( reader.getFloat32( vertexstart + 4, true ) );
-					vertices.push( reader.getFloat32( vertexstart + 8, true ) );
+					vertices[face * 3 * 3] = reader.getFloat32( vertexstart, true );
+					vertices[(face * 3 * 3) + 1] = reader.getFloat32( vertexstart + 4, true );
+					vertices[(face * 3 * 3) + 2] = reader.getFloat32( vertexstart + 8, true );
 
-					normals.push( normalX, normalY, normalZ );
+					normals[face * 3 * 3] = normalX;
+					normals[(face * 3 * 3) + 1] = normalY;
+					normals[(face * 3 * 3) + 2] = normalZ;
 
 					if ( hasColors ) {
 
-						colors.push( r, g, b );
+						colors[face * 3 * 3] = r;
+						colors[(face * 3 * 3) + 1] = g;
+						colors[(face * 3 * 3) + 2] = b;
 
 					}
 
@@ -216,12 +221,12 @@ THREE.STLLoader.prototype = {
 
 			}
 
-			geometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
-			geometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( normals ), 3 ) );
+			geometry.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
+			geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
 
 			if ( hasColors ) {
 
-				geometry.addAttribute( 'color', new THREE.BufferAttribute( new Float32Array( colors ), 3 ) );
+				geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
 				geometry.hasColors = true;
 				geometry.alpha = alpha;
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2205,6 +2205,7 @@ var GLTFLoader = ( function () {
 				pointsMaterial.color.copy( material.color );
 				pointsMaterial.map = material.map;
 				pointsMaterial.lights = false; // PointsMaterial doesn't support lights yet
+				pointsMaterial.sizeAttenuation = false; // glTF spec says points should be 1px
 
 				this.cache.add( cacheKey, pointsMaterial );
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -159,7 +159,7 @@ STLLoader.prototype = {
 					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
 					hasColors = true;
-					colors = new Float32Array(faces * 3 * 3);
+					colors = new Float32Array( faces * 3 * 3 );
 
 					defaultR = reader.getUint8( index + 6 ) / 255;
 					defaultG = reader.getUint8( index + 7 ) / 255;
@@ -173,10 +173,10 @@ STLLoader.prototype = {
 			var dataOffset = 84;
 			var faceLength = 12 * 4 + 2;
 
-			var geometry = new THREE.BufferGeometry();
+			var geometry = new BufferGeometry();
 
-			var vertices = new Float32Array(faces * 3 * 3);
-			var normals = new Float32Array(faces * 3 * 3);
+			var vertices = new Float32Array( faces * 3 * 3 );
+			var normals = new Float32Array( faces * 3 * 3 );
 
 			for ( var face = 0; face < faces; face ++ ) {
 
@@ -210,21 +210,21 @@ STLLoader.prototype = {
 				for ( var i = 1; i <= 3; i ++ ) {
 
 					var vertexstart = start + i * 12;
-					var componentIdx = (face * 3 * 3) + ((i - 1) * 3);
+					var componentIdx = ( face * 3 * 3 ) + ( ( i - 1 ) * 3 );
 					
-					vertices[componentIdx] = reader.getFloat32( vertexstart, true );
-					vertices[componentIdx + 1] = reader.getFloat32( vertexstart + 4, true );
-					vertices[componentIdx + 2] = reader.getFloat32( vertexstart + 8, true );
+					vertices[ componentIdx ] = reader.getFloat32( vertexstart, true );
+					vertices[ componentIdx + 1 ] = reader.getFloat32( vertexstart + 4, true );
+					vertices[ componentIdx + 2 ] = reader.getFloat32( vertexstart + 8, true );
 
-					normals[componentIdx] = normalX;
-					normals[componentIdx + 1] = normalY;
-					normals[componentIdx + 2] = normalZ;
+					normals[ componentIdx ] = normalX;
+					normals[ componentIdx + 1 ] = normalY;
+					normals[ componentIdx + 2 ] = normalZ;
 
 					if ( hasColors ) {
 
-						colors[componentIdx] = r;
-						colors[componentIdx + 1] = g;
-						colors[componentIdx + 2] = b;
+						colors[ componentIdx ] = r;
+						colors[ componentIdx + 1 ] = g;
+						colors[ componentIdx + 2 ] = b;
 
 					}
 
@@ -232,12 +232,12 @@ STLLoader.prototype = {
 
 			}
 
-			geometry.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
-			geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
+			geometry.addAttribute( 'position', new BufferAttribute( vertices, 3 ) );
+			geometry.addAttribute( 'normal', new BufferAttribute( normals, 3 ) );
 
 			if ( hasColors ) {
 
-				geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
+				geometry.addAttribute( 'color', new BufferAttribute( colors, 3 ) );
 				geometry.hasColors = true;
 				geometry.alpha = alpha;
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -158,7 +158,7 @@ STLLoader.prototype = {
 					( reader.getUint8( index + 5 ) == 0x3D /*'='*/ ) ) {
 
 					hasColors = true;
-					colors = [];
+					colors = new Float32Array(faces * 3 * 3);
 
 					defaultR = reader.getUint8( index + 6 ) / 255;
 					defaultG = reader.getUint8( index + 7 ) / 255;
@@ -172,10 +172,10 @@ STLLoader.prototype = {
 			var dataOffset = 84;
 			var faceLength = 12 * 4 + 2;
 
-			var geometry = new BufferGeometry();
+			var geometry = new THREE.BufferGeometry();
 
-			var vertices = [];
-			var normals = [];
+			var vertices = new Float32Array(faces * 3 * 3);
+			var normals = new Float32Array(faces * 3 * 3);
 
 			for ( var face = 0; face < faces; face ++ ) {
 
@@ -210,15 +210,19 @@ STLLoader.prototype = {
 
 					var vertexstart = start + i * 12;
 
-					vertices.push( reader.getFloat32( vertexstart, true ) );
-					vertices.push( reader.getFloat32( vertexstart + 4, true ) );
-					vertices.push( reader.getFloat32( vertexstart + 8, true ) );
+					vertices[face * 3 * 3] = reader.getFloat32( vertexstart, true );
+					vertices[(face * 3 * 3) + 1] = reader.getFloat32( vertexstart + 4, true );
+					vertices[(face * 3 * 3) + 2] = reader.getFloat32( vertexstart + 8, true );
 
-					normals.push( normalX, normalY, normalZ );
+					normals[face * 3 * 3] = normalX;
+					normals[(face * 3 * 3) + 1] = normalY;
+					normals[(face * 3 * 3) + 2] = normalZ;
 
 					if ( hasColors ) {
 
-						colors.push( r, g, b );
+						colors[face * 3 * 3] = r;
+						colors[(face * 3 * 3) + 1] = g;
+						colors[(face * 3 * 3) + 2] = b;
 
 					}
 
@@ -226,12 +230,12 @@ STLLoader.prototype = {
 
 			}
 
-			geometry.addAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
-			geometry.addAttribute( 'normal', new BufferAttribute( new Float32Array( normals ), 3 ) );
+			geometry.addAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
+			geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
 
 			if ( hasColors ) {
 
-				geometry.addAttribute( 'color', new BufferAttribute( new Float32Array( colors ), 3 ) );
+				geometry.addAttribute( 'color', new THREE.BufferAttribute( colors, 3 ) );
 				geometry.hasColors = true;
 				geometry.alpha = alpha;
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -3,6 +3,7 @@
  * @author mrdoob / http://mrdoob.com/
  * @author gero3 / https://github.com/gero3
  * @author Mugen87 / https://github.com/Mugen87
+ * @author neverhood311 / https://github.com/neverhood311
  *
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.
  *
@@ -209,20 +210,21 @@ STLLoader.prototype = {
 				for ( var i = 1; i <= 3; i ++ ) {
 
 					var vertexstart = start + i * 12;
+					var componentIdx = (face * 3 * 3) + ((i - 1) * 3);
+					
+					vertices[componentIdx] = reader.getFloat32( vertexstart, true );
+					vertices[componentIdx + 1] = reader.getFloat32( vertexstart + 4, true );
+					vertices[componentIdx + 2] = reader.getFloat32( vertexstart + 8, true );
 
-					vertices[face * 3 * 3] = reader.getFloat32( vertexstart, true );
-					vertices[(face * 3 * 3) + 1] = reader.getFloat32( vertexstart + 4, true );
-					vertices[(face * 3 * 3) + 2] = reader.getFloat32( vertexstart + 8, true );
-
-					normals[face * 3 * 3] = normalX;
-					normals[(face * 3 * 3) + 1] = normalY;
-					normals[(face * 3 * 3) + 2] = normalZ;
+					normals[componentIdx] = normalX;
+					normals[componentIdx + 1] = normalY;
+					normals[componentIdx + 2] = normalZ;
 
 					if ( hasColors ) {
 
-						colors[face * 3 * 3] = r;
-						colors[(face * 3 * 3) + 1] = g;
-						colors[(face * 3 * 3) + 2] = b;
+						colors[componentIdx] = r;
+						colors[componentIdx + 1] = g;
+						colors[componentIdx + 2] = b;
 
 					}
 


### PR DESCRIPTION
Instead of dynamically creating a Javascript array of 64-bit floats, then copying them into a Float32Array, let's just create Float32Arrays at the start, then populate them as we load the STL file.