### PR TITLE
Points: Avoid object creation in raycast().

### DIFF
--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -10,7 +10,7 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
  * @author alteredq / http://alteredqualia.com/
  */
 
-var _inverseMatrix, _ray, _sphere;
+var _inverseMatrix, _ray, _sphere, _position;
 
 function Points( geometry, material ) {
 
@@ -38,10 +38,10 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			_inverseMatrix = new Matrix4();
 			_ray = new Ray();
 			_sphere = new Sphere();
+			_position = new Vector3();
 
 		}
 
-		var object = this;
 		var geometry = this.geometry;
 		var matrixWorld = this.matrixWorld;
 		var threshold = raycaster.params.Points.threshold;
@@ -63,36 +63,6 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
 		var localThresholdSq = localThreshold * localThreshold;
-		var position = new Vector3();
-		var intersectPoint = new Vector3();
-
-		function testPoint( point, index ) {
-
-			var rayPointDistanceSq = _ray.distanceSqToPoint( point );
-
-			if ( rayPointDistanceSq < localThresholdSq ) {
-
-				_ray.closestPointToPoint( point, intersectPoint );
-				intersectPoint.applyMatrix4( matrixWorld );
-
-				var distance = raycaster.ray.origin.distanceTo( intersectPoint );
-
-				if ( distance < raycaster.near || distance > raycaster.far ) return;
-
-				intersects.push( {
-
-					distance: distance,
-					distanceToRay: Math.sqrt( rayPointDistanceSq ),
-					point: intersectPoint.clone(),
-					index: index,
-					face: null,
-					object: object
-
-				} );
-
-			}
-
-		}
 
 		if ( geometry.isBufferGeometry ) {
 
@@ -108,9 +78,9 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 					var a = indices[ i ];
 
-					position.fromArray( positions, a * 3 );
+					_position.fromArray( positions, a * 3 );
 
-					testPoint( position, a );
+					testPoint( _position, a, localThresholdSq, matrixWorld, raycaster, intersects, this );
 
 				}
 
@@ -118,9 +88,9 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 				for ( var i = 0, l = positions.length / 3; i < l; i ++ ) {
 
-					position.fromArray( positions, i * 3 );
+					_position.fromArray( positions, i * 3 );
 
-					testPoint( position, i );
+					testPoint( _position, i, localThresholdSq, matrixWorld, raycaster, intersects, this );
 
 				}
 
@@ -132,7 +102,7 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			for ( var i = 0, l = vertices.length; i < l; i ++ ) {
 
-				testPoint( vertices[ i ], i );
+				testPoint( vertices[ i ], i, localThresholdSq, matrixWorld, raycaster, intersects, this );
 
 			}
 
@@ -193,5 +163,35 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	}
 
 } );
+
+function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, intersects, object ) {
+
+	var rayPointDistanceSq = _ray.distanceSqToPoint( point );
+
+	if ( rayPointDistanceSq < localThresholdSq ) {
+
+		var intersectPoint = new Vector3();
+
+		_ray.closestPointToPoint( point, intersectPoint );
+		intersectPoint.applyMatrix4( matrixWorld );
+
+		var distance = raycaster.ray.origin.distanceTo( intersectPoint );
+
+		if ( distance < raycaster.near || distance > raycaster.far ) return;
+
+		intersects.push( {
+
+			distance: distance,
+			distanceToRay: Math.sqrt( rayPointDistanceSq ),
+			point: intersectPoint,
+			index: index,
+			face: null,
+			object: object
+
+		} );
+
+	}
+
+}
 
 export { Points };


### PR DESCRIPTION
When introducing module scope variables, I've noticed that `Points.raycast()` creates unnecessary entities like a function (`testPoint()`) on each method invocation.