### PR TITLE
Add color channel input in BumpMapNode

### DIFF
--- a/examples/jsm/nodes/misc/BumpMapNode.d.ts
+++ b/examples/jsm/nodes/misc/BumpMapNode.d.ts
@@ -5,10 +5,11 @@ import { FunctionNode } from '../core/FunctionNode';
 import { TextureNode } from '../inputs/TextureNode';
 
 export class BumpMapNode extends TempNode {
-  constructor(value: TextureNode, scale?: FloatNode);
+  constructor(value: TextureNode, scale?: FloatNode, channel?: string);
 
   value: TextureNode;
   scale: FloatNode;
+  channel: string;
   toNormalMap: boolean;
   nodeType: string;
 


### PR DESCRIPTION
BumpMapNode currently uses the red channel of the texture to compute the normals.
However, when multiple non-color data sets are all packed into the one texture it may be useful to have the possibility to select which channel of the texture shall be used for computation.

With this modification, the available input values are r, g, b and a. Red channel remains the default value if none are specified.

Use case example for a bump map contained in the blue channel of a texture:
`mtl.normal = new BumpMapNode(texture, scale, 'b');`

/ping @sunag 