### PR TITLE
PointerLockControls: Revert #16171.

### DIFF
--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -18,7 +18,14 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 	var lockEvent = { type: 'lock' };
 	var unlockEvent = { type: 'unlock' };
 
-	var euler = new THREE.Euler( 0, 0, 0, 'YXZ' );
+	camera.rotation.set( 0, 0, 0 );
+
+	var pitchObject = new THREE.Object3D();
+	pitchObject.add( camera );
+
+	var yawObject = new THREE.Object3D();
+	yawObject.position.y = 10;
+	yawObject.add( pitchObject );
 
 	var PI_2 = Math.PI / 2;
 
@@ -29,14 +36,10 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 		var movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
 		var movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
 
-		euler.setFromQuaternion( camera.quaternion );
+		yawObject.rotation.y -= movementX * 0.002;
+		pitchObject.rotation.x -= movementY * 0.002;
 
-		euler.y -= movementX * 0.002;
-		euler.x -= movementY * 0.002;
-
-		euler.x = Math.max( - PI_2, Math.min( PI_2, euler.x ) );
-
-		camera.quaternion.setFromEuler( euler );
+		pitchObject.rotation.x = Math.max( - PI_2, Math.min( PI_2, pitchObject.rotation.x ) );
 
 		scope.dispatchEvent( changeEvent );
 
@@ -88,19 +91,24 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 
 	};
 
-	this.getObject = function () { // retaining this method for backward compatibility
+	this.getObject = function () {
 
-		return camera;
+		return yawObject;
 
 	};
 
 	this.getDirection = function () {
 
+		// assumes the camera itself is not rotated
+
 		var direction = new THREE.Vector3( 0, 0, - 1 );
+		var rotation = new THREE.Euler( 0, 0, 0, 'YXZ' );
 
 		return function ( v ) {
 
-			return v.copy( direction ).applyQuaternion( camera.quaternion );
+			rotation.set( pitchObject.rotation.x, yawObject.rotation.y, 0 );
+
+			return v.copy( direction ).applyEuler( rotation );
 
 		};
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -6,6 +6,7 @@
 import {
 	Euler,
 	EventDispatcher,
+	Object3D,
 	Vector3
 } from "../../../build/three.module.js";
 
@@ -24,7 +25,14 @@ var PointerLockControls = function ( camera, domElement ) {
 	var lockEvent = { type: 'lock' };
 	var unlockEvent = { type: 'unlock' };
 
-	var euler = new Euler( 0, 0, 0, 'YXZ' );
+	camera.rotation.set( 0, 0, 0 );
+
+	var pitchObject = new Object3D();
+	pitchObject.add( camera );
+
+	var yawObject = new Object3D();
+	yawObject.position.y = 10;
+	yawObject.add( pitchObject );
 
 	var PI_2 = Math.PI / 2;
 
@@ -35,14 +43,10 @@ var PointerLockControls = function ( camera, domElement ) {
 		var movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
 		var movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
 
-		euler.setFromQuaternion( camera.quaternion );
+		yawObject.rotation.y -= movementX * 0.002;
+		pitchObject.rotation.x -= movementY * 0.002;
 
-		euler.y -= movementX * 0.002;
-		euler.x -= movementY * 0.002;
-
-		euler.x = Math.max( - PI_2, Math.min( PI_2, euler.x ) );
-
-		camera.quaternion.setFromEuler( euler );
+		pitchObject.rotation.x = Math.max( - PI_2, Math.min( PI_2, pitchObject.rotation.x ) );
 
 		scope.dispatchEvent( changeEvent );
 
@@ -94,19 +98,24 @@ var PointerLockControls = function ( camera, domElement ) {
 
 	};
 
-	this.getObject = function () { // retaining this method for backward compatibility
+	this.getObject = function () {
 
-		return camera;
+		return yawObject;
 
 	};
 
 	this.getDirection = function () {
 
+		// assumes the camera itself is not rotated
+
 		var direction = new Vector3( 0, 0, - 1 );
+		var rotation = new Euler( 0, 0, 0, 'YXZ' );
 
 		return function ( v ) {
 
-			return v.copy( direction ).applyQuaternion( camera.quaternion );
+			rotation.set( pitchObject.rotation.x, yawObject.rotation.y, 0 );
+
+			return v.copy( direction ).applyEuler( rotation );
 
 		};
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -86,7 +86,6 @@
 			function init() {
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.y = 10;
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xffffff );
@@ -318,7 +317,7 @@
 
 					}
 					controls.getObject().translateX( velocity.x * delta );
-					controls.getObject().position.y += ( velocity.y * delta ); // new behavior
+					controls.getObject().translateY( velocity.y * delta );
 					controls.getObject().translateZ( velocity.z * delta );
 
 					if ( controls.getObject().position.y < 10 ) {


### PR DESCRIPTION
The PR reverts a refactoring of `PointerLockControls` which did not took the primary usage of the control class into account: The control of a First-Person camera.

The distinction between a yaw and pitch object was done on purpose. It enables a clean implementation of FPS controls in the example or application layer. Why? Because the `yaw` object only represents the rotation around the y-axis whereas `pitch` represents the rotation along the x-axis. This approach easily ensures that the player always moves along the xz-plane which is unfortunately not true with #16171 anymore. However, this is the desired behavior for FPS controls.

Fixed #17216