### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -100,6 +100,8 @@
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				container.appendChild( renderer.domElement );
 
+				renderer.gammaOutput = true;
+				renderer.gammaFactor = 2.2;
 				renderer.autoClear = false;
 
 				//
@@ -137,7 +139,7 @@
 				// GROUND
 
 				var geometry = new THREE.PlaneBufferGeometry( 100, 100 );
-				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffdd99 } );
+				var planeMaterial = new THREE.MeshPhongMaterial( { color: 0xffb851 } );
 
 				var ground = new THREE.Mesh( geometry, planeMaterial );
 


### PR DESCRIPTION
Compared to [webgl_shadowmap](https://threejs.org/examples/webgl_shadowmap), [webgl_shadowmap_performance](https://threejs.org/examples/webgl_shadowmap_performance) looks too dark. This PR applies the same setting to the renderer and ground color.