### PR TITLE
Examples: Fix TranslucentShader.

### DIFF
--- a/examples/js/shaders/TranslucentShader.js
+++ b/examples/js/shaders/TranslucentShader.js
@@ -62,6 +62,7 @@ THREE.TranslucentShader = {
 
 	fragmentShader: [
 		"#define USE_UV",
+		"#define USE_MAP",
 		"#define PHONG",
 		"#define TRANSLUCENT",
 		"#include <common>",

--- a/examples/js/shaders/TranslucentShader.js
+++ b/examples/js/shaders/TranslucentShader.js
@@ -61,7 +61,7 @@ THREE.TranslucentShader = {
 	].join( "\n" ),
 
 	fragmentShader: [
-		"#define USE_MAP",
+		"#define USE_UV",
 		"#define PHONG",
 		"#define TRANSLUCENT",
 		"#include <common>",
@@ -137,7 +137,7 @@ THREE.TranslucentShader = {
 
 		"			RE_Direct( directLight, geometry, material, reflectedLight );",
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_MAP )",
+		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
 		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
 		"			#endif",
 		"		}",
@@ -159,7 +159,7 @@ THREE.TranslucentShader = {
 
 		"			RE_Direct( directLight, geometry, material, reflectedLight );",
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_MAP )",
+		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
 		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
 		"			#endif",
 		"		}",

--- a/examples/jsm/shaders/TranslucentShader.js
+++ b/examples/jsm/shaders/TranslucentShader.js
@@ -69,6 +69,7 @@ var TranslucentShader = {
 
 	fragmentShader: [
 		"#define USE_UV",
+		"#define USE_MAP",
 		"#define PHONG",
 		"#define TRANSLUCENT",
 		"#include <common>",

--- a/examples/jsm/shaders/TranslucentShader.js
+++ b/examples/jsm/shaders/TranslucentShader.js
@@ -68,7 +68,7 @@ var TranslucentShader = {
 	].join( "\n" ),
 
 	fragmentShader: [
-		"#define USE_MAP",
+		"#define USE_UV",
 		"#define PHONG",
 		"#define TRANSLUCENT",
 		"#include <common>",
@@ -144,7 +144,7 @@ var TranslucentShader = {
 
 		"			RE_Direct( directLight, geometry, material, reflectedLight );",
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_MAP )",
+		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
 		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
 		"			#endif",
 		"		}",
@@ -166,7 +166,7 @@ var TranslucentShader = {
 
 		"			RE_Direct( directLight, geometry, material, reflectedLight );",
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_MAP )",
+		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
 		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
 		"			#endif",
 		"		}",


### PR DESCRIPTION
Fixed #17221

The error was introduced by 8da85fa372bdd7a12cb73c8e56850e24376b1921 since `TranslucentShader` defines `USE_MAP` and relies on the respective creation of `vUv`.