### PR TITLE
Node clearcoat normals

### DIFF
--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -14,6 +14,7 @@ function NormalNode( scope ) {
 }
 
 NormalNode.LOCAL = 'local';
+NormalNode.CLEARCOAT = 'clearcoat';
 NormalNode.WORLD = 'world';
 
 NormalNode.prototype = Object.create( TempNode.prototype );
@@ -37,6 +38,12 @@ NormalNode.prototype.generate = function ( builder, output ) {
 		case NormalNode.LOCAL:
 
 			result = 'normal';
+
+			break;
+
+		case NormalNode.CLEARCOAT:
+
+			result = 'clearCoatNormal';
 
 			break;
 
@@ -89,6 +96,12 @@ NormalNode.prototype.toJSON = function ( meta ) {
 NodeLib.addKeyword( 'normal', function () {
 
 	return new NormalNode();
+
+} );
+
+NodeLib.addKeyword( 'clearCoatNormal' , function () {
+
+	return new NormalNode(NormalNode.CLEARCOAT);
 
 } );
 

--- a/examples/jsm/nodes/accessors/ReflectNode.js
+++ b/examples/jsm/nodes/accessors/ReflectNode.js
@@ -3,12 +3,14 @@
  */
 
 import { TempNode } from '../core/TempNode.js';
+import { NormalNode } from './NormalNode.js';
 
-function ReflectNode( scope ) {
+function ReflectNode( scope, normal ) {
 
-	TempNode.call( this, 'v3', { unique: true } );
+	TempNode.call( this, 'v3' );
 
 	this.scope = scope || ReflectNode.CUBE;
+	this.normal = normal || new NormalNode();
 
 }
 
@@ -44,29 +46,25 @@ ReflectNode.prototype.generate = function ( builder, output ) {
 
 			case ReflectNode.VECTOR:
 
-				builder.addNodeCode( 'vec3 reflectVec = inverseTransformDirection( reflect( -normalize( vViewPosition ), normal ), viewMatrix );' );
-
-				result = 'reflectVec';
+				var normal = this.normal.build( builder, 'v3' );
+				
+				result = 'inverseTransformDirection( reflect( -normalize( vViewPosition ), ' + normal + ' ), viewMatrix )';
 
 				break;
 
 			case ReflectNode.CUBE:
 
-				var reflectVec = new ReflectNode( ReflectNode.VECTOR ).build( builder, 'v3' );
+				var reflectVec = new ReflectNode( ReflectNode.VECTOR, this.normal ).build( builder, 'v3' );
 
-				builder.addNodeCode( 'vec3 reflectCubeVec = vec3( -1.0 * ' + reflectVec + '.x, ' + reflectVec + '.yz );' );
-
-				result = 'reflectCubeVec';
+				result = 'vec3( -1.0 * ' + reflectVec + '.x, ' + reflectVec + '.yz )';
 
 				break;
 
 			case ReflectNode.SPHERE:
 
-				var reflectVec = new ReflectNode( ReflectNode.VECTOR ).build( builder, 'v3' );
+				var reflectVec = new ReflectNode( ReflectNode.VECTOR, this.normal ).build( builder, 'v3' );
 
-				builder.addNodeCode( 'vec2 reflectSphereVec = normalize( ( viewMatrix * vec4( ' + reflectVec + ', 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) ).xy * 0.5 + 0.5;' );
-
-				result = 'reflectSphereVec';
+				result = 'normalize( ( viewMatrix * vec4( ' + reflectVec + ', 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) ).xy * 0.5 + 0.5';
 
 				break;
 

--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -12,7 +12,7 @@ function CubeTextureNode( value, uv, bias ) {
 	InputNode.call( this, 'v4', { shared: true } );
 
 	this.value = value;
-	this.uv = uv || new ReflectNode();
+	this.uv = uv;
 	this.bias = bias;
 
 }
@@ -36,7 +36,11 @@ CubeTextureNode.prototype.generate = function ( builder, output ) {
 	}
 
 	var cubetex = this.getTexture( builder, output );
-	var uv = this.uv.build( builder, 'v3' );
+	
+	var uv = this.uv || builder.context.uv || new ReflectNode();
+	
+	uv = uv.build( builder, 'v3' ) ;
+
 	var bias = this.bias ? this.bias.build( builder, 'f' ) : undefined;
 
 	if ( bias === undefined && builder.context.bias ) {

--- a/examples/jsm/nodes/inputs/CubeTextureNode.js
+++ b/examples/jsm/nodes/inputs/CubeTextureNode.js
@@ -36,9 +36,17 @@ CubeTextureNode.prototype.generate = function ( builder, output ) {
 	}
 
 	var cubetex = this.getTexture( builder, output );
+
 	
-	var uv = this.uv || builder.context.uv || new ReflectNode();
-	
+	var uv = this.uv || builder.context.cubeUv || new ReflectNode();
+
+	if ( !uv ){
+
+		var normal =  builder.context.cubeNormal || new NormalNode();
+		uv = new ReflectNode( ReflectNode.CUBE, normal);
+
+	}
+
 	uv = uv.build( builder, 'v3' ) ;
 
 	var bias = this.bias ? this.bias.build( builder, 'f' ) : undefined;

--- a/examples/jsm/nodes/materials/StandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/StandardNodeMaterial.js
@@ -28,6 +28,7 @@ NodeUtils.addShortcuts( StandardNodeMaterial.prototype, 'fragment', [
 	'clearCoat',
 	'clearCoatRoughness',
 	'normal',
+	'clearCoatNormal',
 	'emissive',
 	'ambient',
 	'light',

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -11,7 +11,6 @@ import { Node } from '../../core/Node.js';
 import { ColorNode } from '../../inputs/ColorNode.js';
 import { FloatNode } from '../../inputs/FloatNode.js';
 import { RoughnessToBlinnExponentNode } from '../../bsdfs/RoughnessToBlinnExponentNode.js';
-import { ReflectNode } from '../../accessors/ReflectNode.js';
 import { NormalNode } from '../../accessors/NormalNode.js';
 
 function StandardNode() {
@@ -35,8 +34,6 @@ StandardNode.prototype.build = function ( builder ) {
 	var code;
 
 	builder.define( this.clearCoat || this.clearCoatRoughness ? 'PHYSICAL' : 'STANDARD' );
-
-	if ( this.energyPreservation ) builder.define( 'ENERGY_PRESERVATION' );
 
 	if( this.clearCoatNormal ){ builder.define('USE_CLEARCOAT_NORMALMAP'); }
 

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -11,7 +11,6 @@ import { Node } from '../../core/Node.js';
 import { ColorNode } from '../../inputs/ColorNode.js';
 import { FloatNode } from '../../inputs/FloatNode.js';
 import { RoughnessToBlinnExponentNode } from '../../bsdfs/RoughnessToBlinnExponentNode.js';
-import { ReflectNode } from '../../accessors/ReflectNode.js';
 import { NormalNode } from '../../accessors/NormalNode.js';
 
 function StandardNode() {

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -146,6 +146,10 @@ StandardNode.prototype.build = function ( builder ) {
 			gamma: true
 		};
 
+		var contextClearCoatNormal = {
+			normal: new NormalNode( NormalNode.CLEARCOAT )
+		}
+
 		var useClearCoat = ! builder.isDefined( 'STANDARD' );
 
 		// analyze all nodes to reuse generate codes
@@ -162,7 +166,7 @@ StandardNode.prototype.build = function ( builder ) {
 
 		if ( this.clearCoat ) this.clearCoat.analyze( builder );
 		if ( this.clearCoatRoughness ) this.clearCoatRoughness.analyze( builder );
-		if ( this.clearCoatNormal ) this.clearCoatNormal.analyze( builder );
+		if ( this.clearCoatNormal ) this.clearCoatNormal.analyze( builder, { context: contextClearCoatNormal } );
 
 		if ( this.reflectivity ) this.reflectivity.analyze( builder );
 
@@ -217,7 +221,7 @@ StandardNode.prototype.build = function ( builder ) {
 
 		var clearCoat = this.clearCoat ? this.clearCoat.flow( builder, 'f' ) : undefined;
 		var clearCoatRoughness = this.clearCoatRoughness ? this.clearCoatRoughness.flow( builder, 'f' ) : undefined;
-		var clearCoatNormal = this.clearCoatNormal ? this.clearCoatNormal.flow( builder, 'v3' ) : undefined;
+		var clearCoatNormal = this.clearCoatNormal ? this.clearCoatNormal.flow( builder, 'v3', { context: contextClearCoatNormal } ) : undefined;
 
 		var reflectivity = this.reflectivity ? this.reflectivity.flow( builder, 'f' ) : undefined;
 

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -136,7 +136,7 @@ StandardNode.prototype.build = function ( builder ) {
 
 			bias: RoughnessToBlinnExponentNode,
 			gamma: true,
-			uv: new ReflectNode( undefined, new NormalNode( NormalNode.CLEARCOAT ) )
+			cubeNormal: new NormalNode( NormalNode.CLEARCOAT )
 
 		}
 

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -9,13 +9,13 @@ import { UVNode } from '../accessors/UVNode.js';
 import { NormalNode } from '../accessors/NormalNode.js';
 import { PositionNode } from '../accessors/PositionNode.js';
 
-function NormalMapNode( value, scale ) {
+function NormalMapNode( value, scale, normal ) {
 
 	TempNode.call( this, 'v3' );
 
 	this.value = value;
 	this.scale = scale || new Vector2Node( 1, 1 );
-
+	this.normal = normal || new NormalNode();
 }
 
 NormalMapNode.Nodes = ( function () {
@@ -68,7 +68,6 @@ NormalMapNode.prototype.generate = function ( builder, output ) {
 
 		var perturbNormal2Arb = builder.include( NormalMapNode.Nodes.perturbNormal2Arb );
 
-		this.normal = this.normal || new NormalNode();
 		this.position = this.position || new PositionNode( PositionNode.VIEW );
 		this.uv = this.uv || new UVNode();
 

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -15,7 +15,7 @@ function NormalMapNode( value, scale, normal ) {
 
 	this.value = value;
 	this.scale = scale || new Vector2Node( 1, 1 );
-	this.normal = normal || new NormalNode();
+	this.normal = normal;
 }
 
 NormalMapNode.Nodes = ( function () {
@@ -71,8 +71,14 @@ NormalMapNode.prototype.generate = function ( builder, output ) {
 		this.position = this.position || new PositionNode( PositionNode.VIEW );
 		this.uv = this.uv || new UVNode();
 
+		var normal = this.normal || builder.context.normal || new NormalNode();
+
+		if(this.normal){
+			console.log(this.normal);
+		}
+
 		return builder.format( perturbNormal2Arb + '( -' + this.position.build( builder, 'v3' ) + ', ' +
-			this.normal.build( builder, 'v3' ) + ', ' +
+			normal.build( builder, 'v3' ) + ', ' +
 			this.value.build( builder, 'v3' ) + ', ' +
 			this.uv.build( builder, 'v2' ) + ', ' +
 			this.scale.build( builder, 'v2' ) + ' )', this.getType( builder ), output );

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -73,10 +73,6 @@ NormalMapNode.prototype.generate = function ( builder, output ) {
 
 		var normal = this.normal || builder.context.normal || new NormalNode();
 
-		if(this.normal){
-			console.log(this.normal);
-		}
-
 		return builder.format( perturbNormal2Arb + '( -' + this.position.build( builder, 'v3' ) + ', ' +
 			normal.build( builder, 'v3' ) + ', ' +
 			this.value.build( builder, 'v3' ) + ', ' +

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -44,6 +44,7 @@
 			var serialized = false;
 			var textures = {
 				brick: { url: 'textures/brick_diffuse.jpg' },
+				carbon: { url: 'textures/carbon/Carbon_Normal.png' },
 				grass: { url: 'textures/terrain/grasslight-big.jpg' },
 				grassNormal: { url: 'textures/terrain/grasslight-big-nm.jpg' },
 				decalDiffuse: { url: 'textures/decal/decal-diffuse.png' },
@@ -52,7 +53,7 @@
 				spherical: { url: 'textures/envmap.png' }
 			};
 
-			var param = { example: new URL( window.location.href ).searchParams.get( 'e' ) || 'mesh-standard' };
+			var param = { example: 'physical' };
 
 			function getTexture( name ) {
 
@@ -754,6 +755,7 @@
 						var mask = new Nodes.SwitchNode( new Nodes.TextureNode( getTexture( "decalDiffuse" ) ), 'w' );
 
 						var normalScale = new Nodes.FloatNode( .3 );
+						var clearCoatNormalScale = new Nodes.FloatNode( .1 );
 
 						var roughnessA = new Nodes.FloatNode( .5 );
 						var metalnessA = new Nodes.FloatNode( .5 );
@@ -785,6 +787,12 @@
 							Nodes.OperatorNode.MUL
 						);
 
+						var clearCoatNormalMask = new Nodes.OperatorNode(
+							mask,
+							clearCoatNormalScale,
+							Nodes.OperatorNode.MUL
+						);
+
 						mtl.color = new Nodes.ColorNode( 0xEEEEEE );
 						mtl.roughness = roughness;
 						mtl.metalness = metalness;
@@ -794,6 +802,8 @@
 						mtl.environment = new Nodes.CubeTextureNode( cubemap );
 						mtl.normal = new Nodes.NormalMapNode( new Nodes.TextureNode( getTexture( "grassNormal" ) ) );
 						mtl.normal.scale = normalMask;
+						mtl.clearCoatNormal =  new Nodes.NormalMapNode( new Nodes.TextureNode( getTexture( "carbon" ) ) ),
+						mtl.clearCoatNormal.scale = clearCoatNormalMask;
 
 						// GUI
 
@@ -848,6 +858,12 @@
 						addGui( 'normalScale', normalScale.value, function ( val ) {
 
 							normalScale.value = val;
+
+						}, false, 0, 1 );
+
+						addGui( 'clearCoatNormalScale', clearCoatNormalScale.value, function ( val ) {
+
+							clearCoatNormalScale.value = val;
 
 						}, false, 0, 1 );
 

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_begin.glsl.js
@@ -1,7 +1,3 @@
 export default /* glsl */`
-#ifdef USE_CLEARCOAT_NORMALMAP
-
-  vec3 clearCoatNormal = geometryNormal;
-
-#endif
+vec3 clearCoatNormal = geometryNormal;
 `;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -20,13 +20,9 @@ geometry.position = - vViewPosition;
 geometry.normal = normal;
 geometry.viewDir = normalize( vViewPosition );
 
-#ifdef USE_CLEARCOAT_NORMALMAP
+#ifdef PHYSICAL
 
 	geometry.clearCoatNormal = clearCoatNormal;
-
-#else
-
-	geometry.clearCoatNormal = geometryNormal;
 
 #endif
 


### PR DESCRIPTION
Added clearcoat normals to nodes.

I had to rework part of the logic of ReflectNode, which assumed there was only one possible normal.

Now, when accessing the environment map, there is a contextual cubeNormal parameter that enables a parent node to switch which normal lights is being reflected of. I had to do the same for the normal map nodes.

Finally, I changed the way geometry.clearCoatNormal is being assigned. This way is equivalent, but it allows us to have `clearCoatNormal` as a node output if necessary.

I've added clear coat normal options to the physical material demo. It's also possible to just move them

/ping @sunag 