### PR TITLE
PointerLockControls: added .moveForward(), .moveRight() methods

### DIFF
--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -22,6 +22,8 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 
 	var PI_2 = Math.PI / 2;
 
+	var vec = new Vector3();
+
 	function onMouseMove( event ) {
 
 		if ( scope.isLocked === false ) return;
@@ -105,6 +107,27 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 		};
 
 	}();
+
+	this.moveForward = function ( distance ) {
+
+		// move forward parallel to the xz-plane
+		// assumes camera.up is y-up
+
+		vec.setFromMatrixColumn( camera.matrix, 0 );
+
+		vec.crossVectors( camera.up, vec );
+
+		camera.position.addScaledVector( vec, distance );
+
+	};
+
+	this.moveRight = function ( distance ) {
+
+		vec.setFromMatrixColumn( camera.matrix, 0 );
+
+		camera.position.addScaledVector( vec, distance );
+
+	};
 
 	this.lock = function () {
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -28,6 +28,8 @@ var PointerLockControls = function ( camera, domElement ) {
 
 	var PI_2 = Math.PI / 2;
 
+	var vec = new Vector3();
+
 	function onMouseMove( event ) {
 
 		if ( scope.isLocked === false ) return;
@@ -111,6 +113,27 @@ var PointerLockControls = function ( camera, domElement ) {
 		};
 
 	}();
+
+	this.moveForward = function ( distance ) {
+
+		// move forward parallel to the xz-plane
+		// assumes camera.up is y-up
+
+		vec.setFromMatrixColumn( camera.matrix, 0 );
+
+		vec.crossVectors( camera.up, vec );
+
+		camera.position.addScaledVector( vec, distance );
+
+	};
+
+	this.moveRight = function ( distance ) {
+
+		vec.setFromMatrixColumn( camera.matrix, 0 );
+
+		camera.position.addScaledVector( vec, distance );
+
+	};
 
 	this.lock = function () {
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -299,17 +299,11 @@
 					var time = performance.now();
 					var delta = ( time - prevTime ) / 1000;
 
-					velocity.x -= velocity.x * 10.0 * delta;
-					velocity.z -= velocity.z * 10.0 * delta;
-
 					velocity.y -= 9.8 * 100.0 * delta; // 100.0 = mass
 
 					direction.z = Number( moveForward ) - Number( moveBackward );
-					direction.x = Number( moveLeft ) - Number( moveRight );
+					direction.x = Number( moveRight ) - Number( moveLeft );
 					direction.normalize(); // this ensures consistent movements in all directions
-
-					if ( moveForward || moveBackward ) velocity.z -= direction.z * 400.0 * delta;
-					if ( moveLeft || moveRight ) velocity.x -= direction.x * 400.0 * delta;
 
 					if ( onObject === true ) {
 
@@ -317,9 +311,11 @@
 						canJump = true;
 
 					}
-					controls.getObject().translateX( velocity.x * delta );
+
+					controls.moveRight( direction.x * 400.0 * delta );
+					controls.moveForward( direction.z * 400.0 * delta );
+
 					controls.getObject().position.y += ( velocity.y * delta ); // new behavior
-					controls.getObject().translateZ( velocity.z * delta );
 
 					if ( controls.getObject().position.y < 10 ) {
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -299,11 +299,17 @@
 					var time = performance.now();
 					var delta = ( time - prevTime ) / 1000;
 
+					velocity.x -= velocity.x * 10.0 * delta;
+					velocity.z -= velocity.z * 10.0 * delta;
+
 					velocity.y -= 9.8 * 100.0 * delta; // 100.0 = mass
 
 					direction.z = Number( moveForward ) - Number( moveBackward );
 					direction.x = Number( moveRight ) - Number( moveLeft );
 					direction.normalize(); // this ensures consistent movements in all directions
+
+					if ( moveForward || moveBackward ) velocity.z -= direction.z * 400.0 * delta;
+					if ( moveLeft || moveRight ) velocity.x -= direction.x * 400.0 * delta;
 
 					if ( onObject === true ) {
 
@@ -312,8 +318,8 @@
 
 					}
 
-					controls.moveRight( direction.x * 400.0 * delta );
-					controls.moveForward( direction.z * 400.0 * delta );
+					controls.moveRight( - velocity.x * delta );
+					controls.moveForward( - velocity.z * delta );
 
 					controls.getObject().position.y += ( velocity.y * delta ); // new behavior
 


### PR DESCRIPTION
This is one way of addressing #17216.

To be honest, it is a bit confusing to me the way this example handles `velocity` and `direction`. I am not sure what behavior was intended... So maybe the changes made here are not what is preferred.

The two convenience methods should still be useful, however.

