### PR TITLE
Use WeakMap for geometries, render lists, and render states

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -8,13 +8,13 @@ import { arrayMax } from '../../utils.js';
 
 function WebGLGeometries( gl, attributes, info ) {
 
-	var geometries = {};
-	var wireframeAttributes = {};
+	var geometries = new WeakMap();
+	var wireframeAttributes = new WeakMap();
 
 	function onGeometryDispose( event ) {
 
 		var geometry = event.target;
-		var buffergeometry = geometries[ geometry.id ];
+		var buffergeometry = geometries.get( geometry );
 
 		if ( buffergeometry.index !== null ) {
 
@@ -30,14 +30,14 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		geometry.removeEventListener( 'dispose', onGeometryDispose );
 
-		delete geometries[ geometry.id ];
+		geometries.delete( geometry );
 
-		var attribute = wireframeAttributes[ buffergeometry.id ];
+		var attribute = wireframeAttributes.get( buffergeometry );
 
 		if ( attribute ) {
 
 			attributes.remove( attribute );
-			delete wireframeAttributes[ buffergeometry.id ];
+			wireframeAttributes.delete( buffergeometry );
 
 		}
 
@@ -49,7 +49,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 	function get( object, geometry ) {
 
-		var buffergeometry = geometries[ geometry.id ];
+		var buffergeometry = geometries.get( geometry );
 
 		if ( buffergeometry ) return buffergeometry;
 
@@ -71,7 +71,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		}
 
-		geometries[ geometry.id ] = buffergeometry;
+		geometries.set( geometry , buffergeometry );
 
 		info.memory.geometries ++;
 
@@ -161,19 +161,19 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		//
 
-		var previousAttribute = wireframeAttributes[ geometry.id ];
+		var previousAttribute = wireframeAttributes.get( geometry );
 
 		if ( previousAttribute ) attributes.remove( previousAttribute );
 
 		//
 
-		wireframeAttributes[ geometry.id ] = attribute;
+		wireframeAttributes.set( geometry , attribute );
 
 	}
 
 	function getWireframeAttribute( geometry ) {
 
-		var currentAttribute = wireframeAttributes[ geometry.id ];
+		var currentAttribute = wireframeAttributes.get( geometry );
 
 		if ( currentAttribute ) {
 
@@ -197,7 +197,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		}
 
-		return wireframeAttributes[ geometry.id ];
+		return wireframeAttributes.get( geometry );
 
 	}
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -71,7 +71,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		}
 
-		geometries.set( geometry , buffergeometry );
+		geometries.set( geometry, buffergeometry );
 
 		info.memory.geometries ++;
 
@@ -167,7 +167,7 @@ function WebGLGeometries( gl, attributes, info ) {
 
 		//
 
-		wireframeAttributes.set( geometry , attribute );
+		wireframeAttributes.set( geometry, attribute );
 
 	}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -171,7 +171,7 @@ function WebGLRenderLists() {
 		if ( cameras === undefined ) {
 
 			list = new WebGLRenderList();
-			lists.set( scene , new WeakMap() );
+			lists.set( scene, new WeakMap() );
 			lists.get( scene ).set( camera, list );
 
 			scene.addEventListener( 'dispose', onSceneDispose );

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -152,7 +152,7 @@ function WebGLRenderList() {
 
 function WebGLRenderLists() {
 
-	var lists = {};
+	var lists = new WeakMap();
 
 	function onSceneDispose( event ) {
 
@@ -160,29 +160,29 @@ function WebGLRenderLists() {
 
 		scene.removeEventListener( 'dispose', onSceneDispose );
 
-		delete lists[ scene.id ];
+		lists.delete( scene );
 
 	}
 
 	function get( scene, camera ) {
 
-		var cameras = lists[ scene.id ];
+		var cameras = lists.get( scene );
 		var list;
 		if ( cameras === undefined ) {
 
 			list = new WebGLRenderList();
-			lists[ scene.id ] = {};
-			lists[ scene.id ][ camera.id ] = list;
+			lists.set( scene , new WeakMap() );
+			lists.get( scene ).set( camera, list );
 
 			scene.addEventListener( 'dispose', onSceneDispose );
 
 		} else {
 
-			list = cameras[ camera.id ];
+			list = cameras.get( camera );
 			if ( list === undefined ) {
 
 				list = new WebGLRenderList();
-				cameras[ camera.id ] = list;
+				cameras.set( camera, list );
 
 			}
 
@@ -194,7 +194,7 @@ function WebGLRenderLists() {
 
 	function dispose() {
 
-		lists = {};
+		lists = new WeakMap();
 
 	}
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -56,7 +56,7 @@ function WebGLRenderState() {
 
 function WebGLRenderStates() {
 
-	var renderStates = {};
+	var renderStates = new WeakMap();
 
 	function onSceneDispose( event ) {
 
@@ -64,32 +64,31 @@ function WebGLRenderStates() {
 
 		scene.removeEventListener( 'dispose', onSceneDispose );
 
-		delete renderStates[ scene.id ];
-
+		renderStates.delete( scene );
 	}
 
 	function get( scene, camera ) {
 
 		var renderState;
 
-		if ( renderStates[ scene.id ] === undefined ) {
+		if ( !renderStates.has( scene ) ) {
 
 			renderState = new WebGLRenderState();
-			renderStates[ scene.id ] = {};
-			renderStates[ scene.id ][ camera.id ] = renderState;
+			renderStates.set( scene , new WeakMap());
+			renderStates.get( scene ).set( camera , renderState);
 
 			scene.addEventListener( 'dispose', onSceneDispose );
 
 		} else {
 
-			if ( renderStates[ scene.id ][ camera.id ] === undefined ) {
+			if ( !renderStates.get( scene ).has( camera ) ) {
 
 				renderState = new WebGLRenderState();
-				renderStates[ scene.id ][ camera.id ] = renderState;
+				renderStates.get( scene ).set( camera , renderState);
 
 			} else {
 
-				renderState = renderStates[ scene.id ][ camera.id ];
+				renderState = renderStates.get( scene ).get( camera );
 
 			}
 
@@ -101,7 +100,7 @@ function WebGLRenderStates() {
 
 	function dispose() {
 
-		renderStates = {};
+		renderStates = new WeakMap();
 
 	}
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -72,7 +72,7 @@ function WebGLRenderStates() {
 
 		var renderState;
 
-		if ( ! renderStates.has( scene ) ) {
+		if ( renderStates.has( scene ) === false ) {
 
 			renderState = new WebGLRenderState();
 			renderStates.set( scene, new WeakMap() );
@@ -82,7 +82,7 @@ function WebGLRenderStates() {
 
 		} else {
 
-			if ( ! renderStates.get( scene ).has( camera ) ) {
+			if ( renderStates.get( scene ).has( camera ) === false ) {
 
 				renderState = new WebGLRenderState();
 				renderStates.get( scene ).set( camera, renderState );

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -65,26 +65,27 @@ function WebGLRenderStates() {
 		scene.removeEventListener( 'dispose', onSceneDispose );
 
 		renderStates.delete( scene );
+
 	}
 
 	function get( scene, camera ) {
 
 		var renderState;
 
-		if ( !renderStates.has( scene ) ) {
+		if ( ! renderStates.has( scene ) ) {
 
 			renderState = new WebGLRenderState();
-			renderStates.set( scene , new WeakMap());
-			renderStates.get( scene ).set( camera , renderState);
+			renderStates.set( scene, new WeakMap() );
+			renderStates.get( scene ).set( camera, renderState );
 
 			scene.addEventListener( 'dispose', onSceneDispose );
 
 		} else {
 
-			if ( !renderStates.get( scene ).has( camera ) ) {
+			if ( ! renderStates.get( scene ).has( camera ) ) {
 
 				renderState = new WebGLRenderState();
-				renderStates.get( scene ).set( camera , renderState);
+				renderStates.get( scene ).set( camera, renderState );
 
 			} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -7,7 +7,7 @@ import { _Math } from '../../math/Math.js';
 
 function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
 
-	var _videoTextures = {};
+	var _videoTextures = new WeakMap();
 	var _canvas;
 
 	//
@@ -189,7 +189,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( texture.isVideoTexture ) {
 
-			delete _videoTextures[ texture.id ];
+			_videoTextures.delete( texture );
 
 		}
 
@@ -1098,14 +1098,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	function updateVideoTexture( texture ) {
 
-		var id = texture.id;
 		var frame = info.render.frame;
 
 		// Check the last frame we updated the VideoTexture
 
-		if ( _videoTextures[ id ] !== frame ) {
+		if ( _videoTextures.get( texture ) !== frame ) {
 
-			_videoTextures[ id ] = frame;
+			_videoTextures.set( texture, frame );
 			texture.update();
 
 		}


### PR DESCRIPTION
Today I learned that you had to dispose geometries otherwise they would leak. I was curious as to why that was, and it lead me to an object being used as a map, where a `WeakMap` looks like it would also work fine. Swapping it out for a `WeakMap` seems to have fixed the memory leak in my game, without me having to manually track geometries and call `.dispose` on them. I found a few other places where the same pattern was being used, and changed them there too.

This assumes that the JavaScript wrappers for Object3Ds are never reused with new ids. It doesn't look to be the case, but I couldn't find any specific documentation on this.

Assuming this works as I think it does and is merged, it raises the question of why does the manual `geometry.dispose` exist at all? Maybe it has some use for avoiding some gc funkiness, but it looks like the only side effect of not calling dispose would be `WebGLInfo` having the wrong count.