### PR TITLE
Examples: Fixed malformed jsdoc comment blocks.

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / https://github.com/zz85
  * @author mrdoob / http://mrdoob.com
  * Running this will allow you to drag three.js objects around the screen.

--- a/examples/js/curves/CurveExtras.js
+++ b/examples/js/curves/CurveExtras.js
@@ -1,4 +1,4 @@
-/*
+/**
  * A bunch of parametric curves
  * @author zz85
  *

--- a/examples/js/effects/AsciiEffect.js
+++ b/examples/js/effects/AsciiEffect.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / https://github.com/zz85
  *
  * Ascii generation is based on http://www.nihilogic.dk/labs/jsascii/

--- a/examples/js/geometries/ParametricGeometries.js
+++ b/examples/js/geometries/ParametricGeometries.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85
  *
  * Experimenting of primitive geometry creation using Surface Parametric equations

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author tamarintech / https://tamarintech.com
  *
  * Description: Early release of an AMF Loader following the pattern of the

--- a/examples/js/loaders/DDSLoader.js
+++ b/examples/js/loaders/DDSLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author mrdoob / http://mrdoob.com/
  */
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Autodesk 3DS three.js file loader, based on lib3ds.
  *
  * Loads geometry with uv and materials basic properties with texture support.

--- a/examples/js/loaders/TGALoader.js
+++ b/examples/js/loaders/TGALoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author Daosheng Mu / https://github.com/DaoshengMu/
  * @author mrdoob / http://mrdoob.com/
  * @author takahirox / https://github.com/takahirox/

--- a/examples/js/modifiers/SimplifyModifier.js
+++ b/examples/js/modifiers/SimplifyModifier.js
@@ -1,4 +1,4 @@
-/*
+/**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *
  *	Simplification Geometry Modifier

--- a/examples/js/modifiers/SubdivisionModifier.js
+++ b/examples/js/modifiers/SubdivisionModifier.js
@@ -1,4 +1,4 @@
-/*
+/**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *	@author centerionware / http://www.centerionware.com
  *

--- a/examples/js/utils/UVsDebug.js
+++ b/examples/js/utils/UVsDebug.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / http://github.com/zz85
  * @author WestLangley / http://github.com/WestLangley
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / https://github.com/zz85
  * @author mrdoob / http://mrdoob.com
  * Running this will allow you to drag three.js objects around the screen.

--- a/examples/jsm/curves/CurveExtras.js
+++ b/examples/jsm/curves/CurveExtras.js
@@ -1,4 +1,4 @@
-/*
+/**
  * A bunch of parametric curves
  * @author zz85
  *

--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / https://github.com/zz85
  *
  * Ascii generation is based on http://www.nihilogic.dk/labs/jsascii/

--- a/examples/jsm/geometries/ParametricGeometries.js
+++ b/examples/jsm/geometries/ParametricGeometries.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85
  *
  * Experimenting of primitive geometry creation using Surface Parametric equations

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author tamarintech / https://tamarintech.com
  *
  * Description: Early release of an AMF Loader following the pattern of the

--- a/examples/jsm/loaders/DDSLoader.js
+++ b/examples/jsm/loaders/DDSLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author mrdoob / http://mrdoob.com/
  */
 

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Autodesk 3DS three.js file loader, based on lib3ds.
  *
  * Loads geometry with uv and materials basic properties with texture support.

--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author Daosheng Mu / https://github.com/DaoshengMu/
  * @author mrdoob / http://mrdoob.com/
  * @author takahirox / https://github.com/takahirox/

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -1,4 +1,4 @@
-/*
+/**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *
  *	Simplification Geometry Modifier

--- a/examples/jsm/modifiers/SubdivisionModifier.js
+++ b/examples/jsm/modifiers/SubdivisionModifier.js
@@ -1,4 +1,4 @@
-/*
+/**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *	@author centerionware / http://www.centerionware.com
  *

--- a/examples/jsm/utils/UVsDebug.js
+++ b/examples/jsm/utils/UVsDebug.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author zz85 / http://github.com/zz85
  * @author WestLangley / http://github.com/WestLangley
  * @author Mugen87 / https://github.com/Mugen87

--- a/utils/packLDrawModel.js
+++ b/utils/packLDrawModel.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @author yomboprime / https://github.com/yomboprime/
  *
  * LDraw object packer


### PR DESCRIPTION
Added an asterisk to comment blocks that started with only one asterisk, and contained the `@author` annotation.