### PR TITLE
Fix Object3D variable instantiation regression bug

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -277,14 +277,13 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		// This method does not support objects having non-uniformly-scaled parent(s)
 
-		if ( _position === undefined ) {
+		if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
-			_q1 = new Quaternion();
-			_m1 = new Matrix4();
-			_target = new Vector3();
-			_position = new Vector3();
+		if ( _m1 === undefined ) _m1 = new Matrix4();
 
-		}
+		if ( _target === undefined ) _target = new Vector3();
+
+		if ( _position === undefined ) _position = new Vector3();
 
 		if ( x.isVector3 ) {
 
@@ -475,12 +474,9 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	getWorldQuaternion: function ( target ) {
 
-		if ( _scale === undefined ) {
+		if ( _position === undefined ) _position = new Vector3();
 
-			_position = new Vector3();
-			_scale = new Vector3();
-
-		}
+		if ( _scale === undefined ) _scale = new Vector3();
 
 		if ( target === undefined ) {
 
@@ -499,12 +495,9 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	getWorldScale: function ( target ) {
 
-		if ( _quaternion === undefined ) {
+		if ( _position === undefined ) _position = new Vector3();
 
-			_position = new Vector3();
-			_quaternion = new Quaternion();
-
-		}
+		if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
 		if ( target === undefined ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -277,13 +277,14 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		// This method does not support objects having non-uniformly-scaled parent(s)
 
-		if ( _quaternion === undefined ) _quaternion = new Quaternion();
+		if ( _position === undefined ) {
 
-		if ( _m1 === undefined ) _m1 = new Matrix4();
+			_q1 = new Quaternion();
+			_m1 = new Matrix4();
+			_target = new Vector3();
+			_position = new Vector3();
 
-		if ( _target === undefined ) _target = new Vector3();
-
-		if ( _position === undefined ) _position = new Vector3();
+		}
 
 		if ( x.isVector3 ) {
 
@@ -474,9 +475,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	getWorldQuaternion: function ( target ) {
 
-		if ( _position === undefined ) _position = new Vector3();
+		if ( _scale === undefined ) {
 
-		if ( _scale === undefined ) _scale = new Vector3();
+			_position = new Vector3();
+			_scale = new Vector3();
+
+		}
 
 		if ( target === undefined ) {
 
@@ -495,9 +499,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	getWorldScale: function ( target ) {
 
-		if ( _position === undefined ) _position = new Vector3();
+		if ( _quaternion === undefined ) {
 
-		if ( _quaternion === undefined ) _quaternion = new Quaternion();
+			_position = new Vector3();
+			_quaternion = new Quaternion();
+
+		}
 
 		if ( target === undefined ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -277,7 +277,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		// This method does not support objects having non-uniformly-scaled parent(s)
 
-		if ( _position === undefined ) {
+		if ( _target === undefined ) {
 
 			_q1 = new Quaternion();
 			_m1 = new Matrix4();

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -416,6 +416,35 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( "localTransformVariableInstantiation", ( assert ) => {
+
+			var a = new Object3D();
+			var b = new Object3D();
+			var c = new Object3D();
+			var d = new Object3D();
+
+			a.getWorldDirection( new Vector3() );
+			a.lookAt( new Vector3( 0, - 1, 1 ) );
+
+			assert.ok( true, "Calling lookAt after getWorldDirection does not create errors" );
+
+			b.getWorldPosition( new Vector3() );
+			b.lookAt( new Vector3( 0, - 1, 1 ) );
+
+			assert.ok( true, "Calling lookAt after getWorldPosition does not create errors" );
+
+			c.getWorldQuaternion( new Quaternion() );
+			c.lookAt( new Vector3( 0, - 1, 1 ) );
+
+			assert.ok( true, "Calling lookAt after getWorldQuaternion does not create errors" );
+
+			d.getWorldScale( new Vector3() );
+			d.lookAt( new Vector3( 0, - 1, 1 ) );
+
+			assert.ok( true, "Calling lookAt after getWorldScale does not create errors" );
+
+		} );
+
 		QUnit.todo( "raycast", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );


### PR DESCRIPTION
Occurs when calling lookAt after getWorldQuaternion (_m1 and _target would be undefined)

I think checking all necessary local variables should be the way to go, since it is less error prone. Not sure though if the cod style without blocks collides with [Mr.doob's Code Style™](https://github.com/mrdoob/three.js/wiki/Mr.doob%27s-Code-Style%E2%84%A2).

```
if ( _q1 === undefined ) _q1 = new Quaternion();
```
vs.

```
if ( _q1 === undefined ) {

	_q1 = new Quaternion();

}
```

I chose the first style since there where already some cases in tthe class that had that styling.