### PR TITLE
Add type definition for cartesian conversion methods

### DIFF
--- a/src/math/Spherical.d.ts
+++ b/src/math/Spherical.d.ts
@@ -8,10 +8,11 @@ export class Spherical {
 	phi: number;
 	theta: number;
 
-	set( radius: number, phi: number, theta: number ): Spherical;
+	set( radius: number, phi: number, theta: number ): this;
 	clone(): this;
 	copy( other: Spherical ): this;
 	makeSafe(): void;
-	setFromVector3( vec3: Vector3 ): Spherical;
+	setFromVector3( v: Vector3 ): this;
+	setFromCartesianCoords( x: number, y: number, z: number ): this;
 
 }

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -236,7 +236,9 @@ export class Vector3 implements Vector {
 	distanceToManhattan( v: Vector3 ): number;
 
 	setFromSpherical( s: Spherical ): this;
+	setFromSphericalCoords( r: number, phi: number, theta:number ): this;
 	setFromCylindrical( s: Cylindrical ): this;
+	setFromCylindricalCoords( radius: number, theta: number, y: number ): this;
 	setFromMatrixPosition( m: Matrix4 ): this;
 	setFromMatrixScale( m: Matrix4 ): this;
 	setFromMatrixColumn( matrix: Matrix4, index: number ): this;


### PR DESCRIPTION
Methods were originally added by #14684 but the type definitions were never updated, so I figured I'd do it myself