### PR TITLE
Fix definition file for TransformControls

### DIFF
--- a/examples/jsm/controls/TransformControls.d.ts
+++ b/examples/jsm/controls/TransformControls.d.ts
@@ -42,8 +42,8 @@ export class TransformControls extends Object3D {
   pointerUp(pointer: Object): void;
   getMode(): string;
   setMode(mode: string): void;
-  setTranslationSnap(translationSnap: Vector3): void;
-  setRotationSnap(rotationSnap: Euler): void;
+  setTranslationSnap(translationSnap: Number | null): void;
+  setRotationSnap(rotationSnap: Number | null): void;
   setSize(size: number): void;
   setSpace(space: string): void;
   dispose(): void;


### PR DESCRIPTION
TransformControls definition: Snapping methods take a number or null as input
Null is also valid since there are checks for null and with setting null it is possible to disable snapping again.

Here is a fiddle to play around with (with Vector3 input the script breaks).
https://jsfiddle.net/JohannesDeml/jucrbpf9/