### PR TITLE
Fix startTime property on Audio always getting overwritten in play()

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -93,12 +93,17 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
+		if ( this.startTime < this.context.currentTime ) {
+
+			this.startTime = this.context.currentTime;
+
+		}
+
 		var source = this.context.createBufferSource();
 
 		source.buffer = this.buffer;
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
-		this.startTime = this.context.currentTime;
 		source.start( this.startTime, this.offset, this.duration );
 
 		this.isPlaying = true;


### PR DESCRIPTION
The `startTime` property of the `Audio` class is documented as:

> The time at which the sound should begin to play. Same as the when paramter of AudioBufferSourceNode.start(). Default is 0.

However, the `startTime` property is always overwritten in `play()` and is therefore not usable.

This PR fixes `play()` to only overwrite `startTime` when it's in the past. This allows to set `startTime` to a future time to schedule the playback, as it's described in the docs.

If `startTime` isn't set, the behavior is unchanged. As it will always be 0 or a time in the past and therefore be set to `currentTime` as before.