### PR TITLE
Audio: Added duration property

### DIFF
--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -91,6 +91,9 @@
 		<h3>[property:Number offset]</h3>
 		<p>An offset to the time within the audio buffer that playback should begin. Same as the *offset* paramter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *0*.</p>
 
+		<h3>[property:Number duration]</h3>
+		<p>Overrides the duration of the audio. Same as the *duration* paramter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *undefined* to play the whole buffer.</p>
+
 		<h3>[property:String source]</h3>
 		<p>An [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] created
 		using [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</p>

--- a/src/audio/Audio.d.ts
+++ b/src/audio/Audio.d.ts
@@ -17,6 +17,7 @@ export class Audio extends Object3D {
 	loop: boolean;
 	startTime: number;
 	offset: number;
+	duration: number | undefined;
 	playbackRate: number;
 	isPlaying: boolean;
 	hasPlaybackControl: boolean;

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -24,6 +24,7 @@ function Audio( listener ) {
 	this.loop = false;
 	this.startTime = 0;
 	this.offset = 0;
+	this.duration = undefined;
 	this.playbackRate = 1;
 	this.isPlaying = false;
 	this.hasPlaybackControl = true;
@@ -98,7 +99,7 @@ Audio.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		source.loop = this.loop;
 		source.onended = this.onEnded.bind( this );
 		this.startTime = this.context.currentTime;
-		source.start( this.startTime, this.offset );
+		source.start( this.startTime, this.offset, this.duration );
 
 		this.isPlaying = true;
 


### PR DESCRIPTION
This PR adds a `duration` property to the `Audio` class to precisely set how long the buffer should be played.

With this PR (and the fix in #17268), all parameters of `AudioBufferSourceNode.start()` will be usable through properties of the `Audio` class, which was the intention of my outdated PR #10254.

As mentioned in the previous PR, I need to set the duration in my implementation of audio sprites. Just calling `stop()` in JS events is unfortunately not precise enough.