### PR TITLE
Simplify FogExp2 GLSL, correct documentation and rename internal fogExp param. to fogExp2

### DIFF
--- a/docs/api/en/scenes/FogExp2.html
+++ b/docs/api/en/scenes/FogExp2.html
@@ -10,7 +10,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<p class="desc">This class contains the parameters that define exponential fog, i.e., that grows exponentially denser with the distance.</p>
+		<p class="desc">This class contains the parameters that define exponential squared fog, which gives a clear view near the camera and a faster than exponentially densening fog farther from the camera.</p>
 
 
 		<h2>Constructor</h2>

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 
 	#ifdef FOG_EXP2
 
-		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth ) );
+		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 
 	#ifdef FOG_EXP2
 
-		float fogFactor = whiteCompliment( exp2( - fogDensity * fogDensity * fogDepth * fogDepth * LOG2 ) );
+		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth ) );
 
 	#else
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -373,7 +373,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			'#define MAX_BONES ' + parameters.maxBones,
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-			( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
+			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
 			parameters.map ? '#define USE_MAP' : '',
 			parameters.envMap ? '#define USE_ENVMAP' : '',
@@ -486,7 +486,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-			( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
+			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
 			parameters.map ? '#define USE_MAP' : '',
 			parameters.matcap ? '#define USE_MATCAP' : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -31,7 +31,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 		"precision", "supportsVertexTextures", "map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding",
 		"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "displacementMap", "specularMap",
 		"roughnessMap", "metalnessMap", "gradientMap",
-		"alphaMap", "combine", "vertexColors", "vertexTangents", "fog", "useFog", "fogExp",
+		"alphaMap", "combine", "vertexColors", "vertexTangents", "fog", "useFog", "fogExp2",
 		"flatShading", "sizeAttenuation", "logarithmicDepthBuffer", "skinning",
 		"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 		"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -168,7 +168,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 			fog: !! fog,
 			useFog: material.fog,
-			fogExp: ( fog && fog.isFogExp2 ),
+			fogExp2: ( fog && fog.isFogExp2 ),
 
 			flatShading: material.flatShading,
 


### PR DESCRIPTION
Background: #17264

This is the first step, intended to be uncontroversial.

The simplification is equivalent and clearer, and saves a potentially branching operation.

The documentation was wrong stating that FogExp2 is exponentially densening fog. It is now called exponential squared fog, following http://in2gpu.com/2014/07/22/create-fog-shader/.

The parameter renaming lays the foundation for a later PR introducing proper exponential fog.