### PR TITLE
Fix THREE.Math.degToRad in example

### DIFF
--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -83,7 +83,7 @@
 
 						case 17: // Ctrl
 							control.setTranslationSnap( 100 );
-							control.setRotationSnap( Math.degToRad( 15 ) );
+							control.setRotationSnap( THREE.Math.degToRad( 15 ) );
 							break;
 
 						case 87: // W


### PR DESCRIPTION
Reproduce:

1. https://threejs.org/examples/misc_controls_transform.html
2. Rotate <kbd>e</kbd>
3. Snap grid <kbd>ctrl</kbd> 
4. `Uncaught TypeError: Math.degToRad is not a function`


Sorry for disturbing. This is very little contribution but who else but me? 