### PR TITLE
Examples: Load cubemap mipmaps with level

### DIFF
--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -36,7 +36,7 @@
 				var mipmaps = [];
 				var maxLevel = 8;
 
-				async function loadCubeTexture( urls, width ) {
+				async function loadCubeTexture( urls ) {
 
 					return new Promise( function ( resolve, reject) {
 

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -28,7 +28,7 @@
 			init();
 			animate();
 
-			//load custmized cube texture
+			//load customized cube texture
 			async function loadCubeTextureWithMipmaps() {
 
 				var path = 'textures/cube/angus/';

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -40,11 +40,9 @@
 
 					return new Promise( function ( resolve, reject) {
 
-						new THREE.CubeTextureLoader().load( urls,function ( cubeTexture ) {
+						new THREE.CubeTextureLoader().load( urls, function ( cubeTexture ) {
 
 							resolve( cubeTexture );
-
-						}, function ( error ) {
 
 						} );
 

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -34,14 +34,17 @@
 				var path = 'textures/cube/angus/';
 				var format = '.jpg';
 				var mipmaps = [];
+				var maxLevel = 8;
 
-				async function loadCubeTexture( urls ) {
+				async function loadCubeTexture( urls, width ) {
 
 					return new Promise( function ( resolve, reject) {
 
-						new THREE.CubeTextureLoader().load( urls, function ( cubeTexture ) {
+						new THREE.CubeTextureLoader().load( urls,function ( cubeTexture ) {
 
 							resolve( cubeTexture );
+
+						}, function ( error ) {
 
 						} );
 
@@ -53,7 +56,7 @@
 				// load mipmaps
 				var pendings = [];
 
-				for ( var level = 0; level < 9; ++ level ) {
+				for ( var level = 0; level <= maxLevel; ++ level ) {
 
 					var urls = [];
 
@@ -63,9 +66,11 @@
 
 					}
 
+					let mipmapLevel = level;
+
 					pendings.push( loadCubeTexture( urls ).then( function ( cubeTexture ) {
 
-						mipmaps.push( cubeTexture );
+						mipmaps[ mipmapLevel ] = cubeTexture;
 
 					} ) );
 


### PR DESCRIPTION
Load cubemap mipmaps with mipmap level.
Make sure each level of cubemap was loaded to the correct mipmap slot.

#17072 