### PR TITLE
TransformControls: fix bug when bind on orthographic camera

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -216,7 +216,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		} else if ( this.camera instanceof THREE.OrthographicCamera ) {
 
-			eye.copy( cameraPosition ).normalize();
+			eye.copy( cameraPosition ).sub( worldPosition ).normalize();
 
 		}
 


### PR DESCRIPTION
when the transformcontrols  bind to the orthographic camera, the eye direction  is also the subtraction of camera position and object world position;