### PR TITLE
OBJLoader2 V3.0.0

### DIFF
--- a/examples/jsm/loaders/OBJLoader2.d.ts
+++ b/examples/jsm/loaders/OBJLoader2.d.ts
@@ -4,43 +4,28 @@ import {
   Object3D
 } from '../../../src/Three';
 
+import { OBJLoader2Parser } from './obj2/worker/parallel/OBJLoader2Parser';
 import { MaterialHandler } from './obj2/shared/MaterialHandler';
 import { MeshReceiver} from './obj2/shared/MeshReceiver';
 
-export class OBJLoader2 {
+export class OBJLoader2 extends OBJLoader2Parser {
   constructor(manager?: LoadingManager);
   manager: LoadingManager;
-  logging: {
-    enabled: boolean;
-    debug: boolean;
-  };
   modelName: string;
   instanceNo: number;
   path: string;
   resourcePath: string;
-  useIndices: boolean;
-  disregardNormals: boolean;
-  materialPerSmoothingGroup: boolean;
-  useOAsMesh: boolean;
   baseObject3d: Group;
-  callbacks: {
-    onParseProgress: Function;
-    genericErrorHandler: Function;
-  };
   materialHandler: MaterialHandler;
   meshReceiver: MeshReceiver;
 
-  addMaterials(materials: object): void;
-  load(url: string, onLoad: (group: Group) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void, onMeshAlter?: (meshData: object) => void): void;
-  parse(content: ArrayBuffer | string): void;
-  setLogging(enabled: boolean, debug: boolean): this;
   setModelName(modelName: string): this;
   setPath(path: string): this;
   setResourcePath(path: string): this;
   setBaseObject3d(baseObject3d: Object3D): this;
-  setUseIndices(useIndices: boolean): this;
-  setDisregardNormals(disregardNormals: boolean): this;
-  setMaterialPerSmoothingGroup(materialPerSmoothingGroup: boolean): this;
-  setUseOAsMesh(useOAsMesh: boolean): this;
-  setGenericErrorHandler(genericErrorHandler: Function): void;
+  addMaterials(materials: object): this;
+  setCallbackOnMeshAlter(onMeshAlter: Function): this;
+  setCallbackOnLoadMaterials(onLoadMaterials: Function): this;
+  load(url: string, onLoad: (group: Group) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void, onMeshAlter?: (meshData: object) => void): void;
+  parse(content: ArrayBuffer | string): void;
 }

--- a/examples/jsm/loaders/OBJLoader2.js
+++ b/examples/jsm/loaders/OBJLoader2.js
@@ -21,412 +21,265 @@ import { MaterialHandler } from "./obj2/shared/MaterialHandler.js";
  */
 const OBJLoader2 = function ( manager ) {
 
+	OBJLoader2Parser.call( this );
 	this.manager = ( manager !== undefined && manager !== null ) ? manager : DefaultLoadingManager;
-	this.logging = {
-		enabled: true,
-		debug: false
-	};
 
 	this.modelName = '';
 	this.instanceNo = 0;
 	this.path = undefined;
 	this.resourcePath = undefined;
-	this.useIndices = false;
-	this.disregardNormals = false;
-	this.materialPerSmoothingGroup = false;
-	this.useOAsMesh = false;
 	this.baseObject3d = new Group();
-
-	this.callbacks = {
-		onParseProgress: undefined,
-		genericErrorHandler: undefined
-	};
 
 	this.materialHandler = new MaterialHandler();
 	this.meshReceiver = new MeshReceiver( this.materialHandler );
 
 };
-OBJLoader2.OBJLOADER2_VERSION = '3.0.0-beta2';
+OBJLoader2.OBJLOADER2_VERSION = '3.0.0';
 console.info( 'Using OBJLoader2 version: ' + OBJLoader2.OBJLOADER2_VERSION );
 
-OBJLoader2.prototype = {
-
-	constructor: OBJLoader2,
-
-	/**
-	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
-	 *
-	 * @param {boolean} enabled True or false.
-	 * @param {boolean} debug True or false.
-	 */
-	setLogging: function ( enabled, debug ) {
-
-		this.logging.enabled = enabled === true;
-		this.logging.debug = debug === true;
-		return this;
-
-	},
-
-	/**
-	 * Set the name of the model.
-	 *
-	 * @param {string} modelName
-	 */
-	setModelName: function ( modelName ) {
-
-		this.modelName = modelName ? modelName : this.modelName;
-		return this;
-
-	},
-
-	/**
-	 * The URL of the base path.
-	 *
-	 * @param {string} path URL
-	 */
-	setPath: function ( path ) {
-
-		this.path = path ? path : this.path;
-		return this;
-
-	},
-
-
-	/**
-	 * Allow to specify resourcePath for dependencies of specified resource.
-	 * @param {string} resourcePath
-	 */
-	setResourcePath: function ( resourcePath ) {
-
-		this.resourcePath = resourcePath ? resourcePath : this.resourcePath;
-
-	},
-
-	/**
-	 * Set the node where the loaded objects will be attached directly.
-	 *
-	 * @param {Object3D} baseObject3d Object already attached to scenegraph where new meshes will be attached to
-	 */
-	setBaseObject3d: function ( baseObject3d ) {
-
-		this.baseObject3d = ( baseObject3d === undefined || baseObject3d === null ) ? this.baseObject3d : baseObject3d;
-		return this;
-
-	},
-
-	/**
-	 * Add materials as associated array.
-	 *
-	 * @param materials Object with named {@link Material}
-	 */
-	addMaterials: function ( materials ) {
-
-		this.materialHandler.addMaterials( materials );
-
-	},
-
-	/**
-	 * Instructs loaders to create indexed {@link BufferGeometry}.
-	 *
-	 * @param {boolean} useIndices=false
-	 */
-	setUseIndices: function ( useIndices ) {
-
-		this.useIndices = useIndices === true;
-		return this;
-
-	},
-
-	/**
-	 * Tells whether normals should be completely disregarded and regenerated.
-	 *
-	 * @param {boolean} disregardNormals=false
-	 */
-	setDisregardNormals: function ( disregardNormals ) {
-
-		this.disregardNormals = disregardNormals === true;
-		return this;
-
-	},
-
-	/**
-	 * Tells whether a material shall be created per smoothing group.
-	 *
-	 * @param {boolean} materialPerSmoothingGroup=false
-	 */
-	setMaterialPerSmoothingGroup: function ( materialPerSmoothingGroup ) {
-
-		this.materialPerSmoothingGroup = materialPerSmoothingGroup === true;
-		return this;
-
-	},
-
-	/**
-	 * Usually 'o' is meta-information and does not result in creation of new meshes, but mesh creation on occurrence of "o" can be enforced.
-	 *
-	 * @param {boolean} useOAsMesh=false
-	 */
-	setUseOAsMesh: function ( useOAsMesh ) {
-
-		this.useOAsMesh = useOAsMesh === true;
-		return this;
-
-	},
-
-	/**
-	 * Register an generic error handler that is called if available instead of throwing an exception
-	 * @param {Function} genericErrorHandler
-	 */
-	setGenericErrorHandler: function ( genericErrorHandler ) {
-
-		if ( genericErrorHandler !== undefined && genericErrorHandler !== null ) {
-
-			this.callbacks.genericErrorHandler = genericErrorHandler;
-
-		}
-
-	},
-
-	/**
-	 *
-	 * @private
-	 *
-	 * @param {Function} [onParseProgress]
-	 * @param {Function} [onMeshAlter]
-	 * @param {Function} [onLoadMaterials]
-	 * @private
-	 */
-	_setCallbacks: function ( onParseProgress, onMeshAlter, onLoadMaterials ) {
-
-		if ( onParseProgress !== undefined && onParseProgress !== null ) {
-
-			this.callbacks.onParseProgress = onParseProgress;
-
-		}
-		this.meshReceiver._setCallbacks( onParseProgress, onMeshAlter );
-		this.materialHandler._setCallbacks( onLoadMaterials );
-
-	},
-
-	/**
-	 * Announce feedback which is give to the registered callbacks.
-	 * @private
-	 *
-	 * @param {string} type The type of event
-	 * @param {string} text Textual description of the event
-	 * @param {number} numericalValue Numerical value describing the progress
-	 */
-	_onProgress: function ( type, text, numericalValue ) {
-
-		let message = text ? text : '';
-		let event = {
-			detail: {
-				type: type,
-				modelName: this.modelName,
-				instanceNo: this.instanceNo,
-				text: message,
-				numericalValue: numericalValue
-			}
-		};
-		if ( this.callbacks.onParseProgress ) {
-
-			this.callbacks.onParseProgress( event );
-
-		}
-		if ( this.logging.enabled && this.logging.debug ) {
-
-			console.log( message );
-
-		}
-
-	},
-
-	/**
-	 * Announce error feedback which is given to the generic error handler to the registered callbacks.
-	 * @private
-	 *
-	 * @param {String} errorMessage The event containing the error
-	 */
-	_onError: function ( errorMessage ) {
-
-		if ( this.callbacks.genericErrorHandler ) {
-
-			this.callbacks.genericErrorHandler( errorMessage );
-
-		}
-		if ( this.logging.enabled && this.logging.debug ) {
-
-			console.log( errorMessage );
-
-		}
-
-	},
-
-	/**
-	 * Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
-	 *
-	 * @param {string}  url A string containing the path/URL of the file to be loaded.
-	 * @param {function} onLoad A function to be called after loading is successfully completed. The function receives loaded Object3D as an argument.
-	 * @param {function} [onFileLoadProgress] A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains total and Integer bytes.
-	 * @param {function} [onError] A function to be called if an error occurs during loading. The function receives the error as an argument.
-	 * @param {function} [onMeshAlter] Called after every single mesh is made available by the parser
-	 */
-	load: function ( url, onLoad, onFileLoadProgress, onError, onMeshAlter ) {
-
-		let scope = this;
-		if ( onError === null || onError === undefined ) {
-
-			onError = function ( event ) {
-
-				let errorMessage = event;
-				if ( event.currentTarget && event.currentTarget.statusText !== null ) {
-
-					 errorMessage = 'Error occurred while downloading!\nurl: ' + event.currentTarget.responseURL + '\nstatus: ' + event.currentTarget.statusText;
-
-				}
-				scope._onError( errorMessage );
-
-			};
-
-		}
-		if ( ! url ) {
-
-			onError( 'An invalid url was provided. Unable to continue!' );
-
-		}
-		let urlFull = new URL( url, window.location.href ).href;
-		let filename = urlFull;
-		let urlParts = urlFull.split( '/' );
-		if ( urlParts.length > 2 ) {
-
-			filename = urlParts[ urlParts.length - 1 ];
-			let urlPartsPath = urlParts.slice( 0, urlParts.length - 1 ).join( '/' ) + '/';
-			if ( urlPartsPath !== undefined && urlPartsPath !== null ) this.path = urlPartsPath;
-
-		}
-		if ( onFileLoadProgress === null || onFileLoadProgress === undefined ) {
-
-			let numericalValueRef = 0;
-			let numericalValue = 0;
-			onFileLoadProgress = function ( event ) {
-
-				if ( ! event.lengthComputable ) return;
-
-				numericalValue = event.loaded / event.total;
-				if ( numericalValue > numericalValueRef ) {
-
-					numericalValueRef = numericalValue;
-					let output = 'Download of "' + url + '": ' + ( numericalValue * 100 ).toFixed( 2 ) + '%';
-					scope._onProgress( 'progressLoad', output, numericalValue );
-
-				}
-
-			};
-
-		}
-		this._setCallbacks( null, onMeshAlter, null );
-		let fileLoaderOnLoad = function ( content ) {
-
-			onLoad( scope.parse( content ) );
-
-		};
-		let fileLoader = new FileLoader( this.manager );
-		fileLoader.setPath( this.path || this.resourcePath );
-		fileLoader.setResponseType( 'arraybuffer' );
-		fileLoader.load( filename, fileLoaderOnLoad, onFileLoadProgress, onError );
-
-	},
-
-	/**
-	 * Parses OBJ data synchronously from arraybuffer or string.
-	 *
-	 * @param {arraybuffer|string} content OBJ data as Uint8Array or String
-	 */
-	parse: function ( content ) {
-
-		// fast-fail in case of illegal data
-		if ( content === null || content === undefined ) {
-
-			throw 'Provided content is not a valid ArrayBuffer or String. Unable to continue parsing';
-
-		}
-		if ( this.logging.enabled ) {
-
-			console.time( 'OBJLoader parse: ' + this.modelName );
-
-		}
-		let parser = new OBJLoader2Parser();
-		parser.setLogging( this.logging.enabled, this.logging.debug );
-		parser.setMaterialPerSmoothingGroup( this.materialPerSmoothingGroup );
-		parser.setUseOAsMesh( this.useOAsMesh );
-		parser.setUseIndices( this.useIndices );
-		parser.setDisregardNormals( this.disregardNormals );
-		// sync code works directly on the material references
-		parser.setMaterials( this.materialHandler.getMaterials() );
-
-		let scope = this;
-		let scopedOnAssetAvailable = function ( payload ) {
-
-			scope._onAssetAvailable( payload );
-
-		};
-		let onProgressScoped = function ( text, numericalValue ) {
-
-			scope._onProgress( 'progressParse', text, numericalValue );
-
-		};
-		let onErrorScoped = function ( message ) {
-
-			scope._onError( message );
-
-		};
-		parser.setCallbackOnAssetAvailable( scopedOnAssetAvailable );
-		parser.setCallbackOnProgress( onProgressScoped );
-		parser.setCallbackOnError( onErrorScoped );
-		if ( content instanceof ArrayBuffer || content instanceof Uint8Array ) {
-
-			if ( this.logging.enabled ) console.info( 'Parsing arrayBuffer...' );
-			parser.parse( content );
-
-		} else if ( typeof ( content ) === 'string' || content instanceof String ) {
-
-			if ( this.logging.enabled ) console.info( 'Parsing text...' );
-			parser.parseText( content );
-
-		} else {
-
-			scope._onError( 'Provided content was neither of type String nor Uint8Array! Aborting...' );
-
-		}
-		if ( this.logging.enabled ) {
-
-			console.timeEnd( 'OBJLoader parse: ' + this.modelName );
-
-		}
-		return this.baseObject3d;
-
-	},
-
-	_onAssetAvailable: function ( payload ) {
-
-		if ( payload.cmd !== 'assetAvailable' ) return;
-
-		if ( payload.type === 'mesh' ) {
-
-			let meshes = this.meshReceiver.buildMeshes( payload );
-			for ( let mesh of meshes ) {
-
-				this.baseObject3d.add( mesh );
-
-			}
-
-		} else if ( payload.type === 'material' ) {
-
-			this.materialHandler.addPayloadMaterials( payload );
-
-		}
+OBJLoader2.prototype = Object.create( OBJLoader2Parser.prototype );
+OBJLoader2.prototype.constructor = OBJLoader2;
+
+
+/**
+ * Set the name of the model.
+ *
+ * @param {string} modelName
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setModelName = function ( modelName ) {
+
+	this.modelName = modelName ? modelName : this.modelName;
+	return this;
+
+};
+
+/**
+ * The URL of the base path.
+ *
+ * @param {string} path URL
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setPath = function ( path ) {
+
+	this.path = path ? path : this.path;
+	return this;
+
+};
+
+/**
+ * Allow to specify resourcePath for dependencies of specified resource.
+ *
+ * @param {string} resourcePath
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setResourcePath = function ( resourcePath ) {
+
+	this.resourcePath = resourcePath ? resourcePath : this.resourcePath;
+	return this;
+
+};
+
+/**
+ * Set the node where the loaded objects will be attached directly.
+ *
+ * @param {Object3D} baseObject3d Object already attached to scenegraph where new meshes will be attached to
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setBaseObject3d = function ( baseObject3d ) {
+
+	this.baseObject3d = ( baseObject3d === undefined || baseObject3d === null ) ? this.baseObject3d : baseObject3d;
+	return this;
+
+};
+
+/**
+ * Add materials as associated array.
+ *
+ * @param {Object} materials Object with named {@link Material}
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.addMaterials = function ( materials ) {
+
+	this.materialHandler.addMaterials( materials );
+	return this;
+
+};
+
+/**
+ * Register a function that is called once a single mesh is available and it could be altered by the supplied function.
+ *
+ * @param {Function} [onMeshAlter]
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setCallbackOnMeshAlter = function ( onMeshAlter ) {
+
+	this.meshReceiver._setCallbacks( this.callbacks.onProgress, onMeshAlter );
+	return this;
+
+};
+
+/**
+ * Register a function that is called once all materials have been loaded and they could be altered by the supplied function.
+ *
+ * @param {Function} [onLoadMaterials]
+ * @return {OBJLoader2}
+ */
+OBJLoader2.prototype.setCallbackOnLoadMaterials = function ( onLoadMaterials ) {
+
+	this.materialHandler._setCallbacks( onLoadMaterials );
+	return this;
+
+};
+
+/**
+ * Use this convenient method to load a file at the given URL. By default the fileLoader uses an ArrayBuffer.
+ *
+ * @param {string}  url A string containing the path/URL of the file to be loaded.
+ * @param {function} onLoad A function to be called after loading is successfully completed. The function receives loaded Object3D as an argument.
+ * @param {function} [onFileLoadProgress] A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains total and Integer bytes.
+ * @param {function} [onError] A function to be called if an error occurs during loading. The function receives the error as an argument.
+ * @param {function} [onMeshAlter] Called after every single mesh is made available by the parser
+ */
+OBJLoader2.prototype.load = function ( url, onLoad, onFileLoadProgress, onError, onMeshAlter ) {
+
+	let scope = this;
+	if ( onLoad === null || onLoad === undefined || ! ( onLoad instanceof Function ) ) {
+
+		let errorMessage = 'onLoad is not a function! Aborting...';
+		scope.callbacks.onError( errorMessage );
+		throw errorMessage
 
 	}
+	if ( onError === null || onError === undefined || ! ( onError instanceof Function ) ) {
+
+		onError = function ( event ) {
+
+			let errorMessage = event;
+			if ( event.currentTarget && event.currentTarget.statusText !== null ) {
+
+				 errorMessage = 'Error occurred while downloading!\nurl: ' + event.currentTarget.responseURL + '\nstatus: ' + event.currentTarget.statusText;
+
+			}
+			scope.callbacks.onError( errorMessage );
+
+		};
+
+	}
+	if ( ! url ) {
+
+		onError( 'An invalid url was provided. Unable to continue!' );
+
+	}
+	let urlFull = new URL( url, window.location.href ).href;
+	let filename = urlFull;
+	let urlParts = urlFull.split( '/' );
+	if ( urlParts.length > 2 ) {
+
+		filename = urlParts[ urlParts.length - 1 ];
+		let urlPartsPath = urlParts.slice( 0, urlParts.length - 1 ).join( '/' ) + '/';
+		if ( urlPartsPath !== undefined && urlPartsPath !== null ) this.path = urlPartsPath;
+
+	}
+	if ( onFileLoadProgress === null || onFileLoadProgress === undefined || ! ( onFileLoadProgress instanceof Function ) ) {
+
+		let numericalValueRef = 0;
+		let numericalValue = 0;
+		onFileLoadProgress = function ( event ) {
+
+			if ( ! event.lengthComputable ) return;
+
+			numericalValue = event.loaded / event.total;
+			if ( numericalValue > numericalValueRef ) {
+
+				numericalValueRef = numericalValue;
+				let output = 'Download of "' + url + '": ' + ( numericalValue * 100 ).toFixed( 2 ) + '%';
+				scope.callbacks.onProgress( 'progressLoad', output, numericalValue );
+
+			}
+
+		};
+
+	}
+
+	this.setCallbackOnMeshAlter( onMeshAlter );
+	let fileLoaderOnLoad = function ( content ) {
+
+		onLoad( scope.parse( content ) );
+
+	};
+	let fileLoader = new FileLoader( this.manager );
+	fileLoader.setPath( this.path || this.resourcePath );
+	fileLoader.setResponseType( 'arraybuffer' );
+	fileLoader.load( filename, fileLoaderOnLoad, onFileLoadProgress, onError );
+
+};
+
+/**
+ * Parses OBJ data synchronously from arraybuffer or string.
+ *
+ * @param {arraybuffer|string} content OBJ data as Uint8Array or String
+ */
+OBJLoader2.prototype.parse = function ( content ) {
+
+	// fast-fail in case of illegal data
+	if ( content === null || content === undefined ) {
+
+		throw 'Provided content is not a valid ArrayBuffer or String. Unable to continue parsing';
+
+	}
+	if ( this.logging.enabled ) {
+
+		console.time( 'OBJLoader parse: ' + this.modelName );
+
+	}
+
+	// sync code works directly on the material references
+	this._setMaterials( this.materialHandler.getMaterials() );
+
+	if ( content instanceof ArrayBuffer || content instanceof Uint8Array ) {
+
+		if ( this.logging.enabled ) console.info( 'Parsing arrayBuffer...' );
+		this.execute( content );
+
+	} else if ( typeof ( content ) === 'string' || content instanceof String ) {
+
+		if ( this.logging.enabled ) console.info( 'Parsing text...' );
+		this.executeLegacy( content );
+
+	} else {
+
+		this.callbacks.onError( 'Provided content was neither of type String nor Uint8Array! Aborting...' );
+
+	}
+	if ( this.logging.enabled ) {
+
+		console.timeEnd( 'OBJLoader parse: ' + this.modelName );
+
+	}
+	return this.baseObject3d;
+
+};
+
+OBJLoader2.prototype._onAssetAvailable = function ( payload ) {
+
+	if ( payload.cmd !== 'assetAvailable' ) return;
+
+	if ( payload.type === 'mesh' ) {
+
+		let meshes = this.meshReceiver.buildMeshes( payload );
+		for ( let mesh of meshes ) {
+
+			this.baseObject3d.add( mesh );
+
+		}
+
+	} else if ( payload.type === 'material' ) {
+
+		this.materialHandler.addPayloadMaterials( payload );
+
+	}
+
 };
 
 export { OBJLoader2 };

--- a/examples/jsm/loaders/OBJLoader2Parallel.d.ts
+++ b/examples/jsm/loaders/OBJLoader2Parallel.d.ts
@@ -1,7 +1,7 @@
 import {
   LoadingManager
 } from '../../../src/Three';
-import { OBJLoader2 } from './OBJLoader2.js';
+import { OBJLoader2 } from './OBJLoader2';
 
 import { WorkerExecutionSupport} from './obj2/worker/main/WorkerExecutionSupport';
 

--- a/examples/jsm/loaders/OBJLoader2Parallel.js
+++ b/examples/jsm/loaders/OBJLoader2Parallel.js
@@ -39,8 +39,8 @@ const OBJLoader2Parallel = function ( manager ) {
 OBJLoader2Parallel.prototype = Object.create( OBJLoader2.prototype );
 OBJLoader2Parallel.prototype.constructor = OBJLoader2Parallel;
 
-OBJLoader2.OBJLOADER2_PARALLEL_VERSION = '3.0.0-beta2';
-console.info( 'Using OBJLoader2Parallel version: ' + OBJLoader2.OBJLOADER2_PARALLEL_VERSION );
+OBJLoader2Parallel.OBJLOADER2_PARALLEL_VERSION = '3.0.0';
+console.info( 'Using OBJLoader2Parallel version: ' + OBJLoader2Parallel.OBJLOADER2_PARALLEL_VERSION );
 
 
 OBJLoader2Parallel.prototype.setPreferJsmWorker = function ( preferJsmWorker ) {

--- a/examples/jsm/loaders/obj2/shared/MaterialHandler.js
+++ b/examples/jsm/loaders/obj2/shared/MaterialHandler.js
@@ -46,7 +46,7 @@ MaterialHandler.prototype = {
 
 	_setCallbacks: function ( onLoadMaterials ) {
 
-		if ( onLoadMaterials !== undefined && onLoadMaterials !== null ) {
+		if ( onLoadMaterials !== undefined && onLoadMaterials !== null && onLoadMaterials instanceof Function ) {
 
 			this.callbacks.onLoadMaterials = onLoadMaterials;
 
@@ -175,6 +175,12 @@ MaterialHandler.prototype = {
 				if ( this.logging.enabled ) console.info( 'Material with name "' + materialName + '" was added.' );
 
 			}
+
+		}
+
+		if ( this.callbacks.onLoadMaterials ) {
+
+			this.callbacks.onLoadMaterials( newMaterials );
 
 		}
 		return newMaterials;

--- a/examples/jsm/loaders/obj2/shared/MeshReceiver.js
+++ b/examples/jsm/loaders/obj2/shared/MeshReceiver.js
@@ -25,7 +25,7 @@ const MeshReceiver = function ( materialHandler ) {
 	};
 
 	this.callbacks = {
-		onParseProgress: null,
+		onProgress: null,
 		onMeshAlter: null
 	};
 	this.materialHandler = materialHandler;
@@ -51,18 +51,18 @@ MeshReceiver.prototype = {
 
 	/**
 	 *
-	 * @param {Function} onParseProgress
+	 * @param {Function} onProgress
 	 * @param {Function} onMeshAlter
 	 * @private
 	 */
-	_setCallbacks: function ( onParseProgress, onMeshAlter ) {
+	_setCallbacks: function ( onProgress, onMeshAlter ) {
 
-		if ( onParseProgress !== undefined && onParseProgress !== null ) {
+		if ( onProgress !== null && onProgress !== undefined && onProgress instanceof Function ) {
 
-			this.callbacks.onParseProgress = onParseProgress;
+			this.callbacks.onProgress = onProgress;
 
 		}
-		if ( onMeshAlter !== undefined && onMeshAlter !== null ) {
+		if ( onMeshAlter !== null && onMeshAlter !== undefined && onMeshAlter instanceof Function ) {
 
 			this.callbacks.onMeshAlter = onMeshAlter;
 
@@ -145,14 +145,13 @@ MeshReceiver.prototype = {
 
 		let meshes = [];
 		let mesh;
-		let callbackOnMeshAlter = this.callbacks.onMeshAlter;
 		let callbackOnMeshAlterResult;
 		let useOrgMesh = true;
 		let geometryType = meshPayload.geometryType === null ? 0 : meshPayload.geometryType;
 
-		if ( callbackOnMeshAlter ) {
+		if ( this.callbacks.onMeshAlter ) {
 
-			callbackOnMeshAlterResult = callbackOnMeshAlter(
+			callbackOnMeshAlterResult = this.callbacks.onMeshAlter(
 				{
 					detail: {
 						meshName: meshName,
@@ -224,10 +223,9 @@ MeshReceiver.prototype = {
 			progressMessage += ' (' + ( meshPayload.progress.numericalValue * 100 ).toFixed( 2 ) + '%)';
 
 		}
-		let callbackOnParseProgress = this.callbacks.onParseProgress;
-		if ( callbackOnParseProgress ) {
+		if ( this.callbacks.onProgress ) {
 
-			callbackOnParseProgress( 'progress', progressMessage, meshPayload.progress.numericalValue );
+			this.callbacks.onProgress( 'progress', progressMessage, meshPayload.progress.numericalValue );
 
 		}
 

--- a/examples/jsm/loaders/obj2/worker/main/WorkerExecutionSupport.js
+++ b/examples/jsm/loaders/obj2/worker/main/WorkerExecutionSupport.js
@@ -127,7 +127,7 @@ const WorkerExecutionSupport = function () {
 	this._reset();
 
 };
-WorkerExecutionSupport.WORKER_SUPPORT_VERSION = '3.0.0-beta2';
+WorkerExecutionSupport.WORKER_SUPPORT_VERSION = '3.0.0';
 console.info( 'Using WorkerSupport version: ' + WorkerExecutionSupport.WORKER_SUPPORT_VERSION );
 
 

--- a/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.d.ts
+++ b/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.d.ts
@@ -55,27 +55,15 @@ export class OBJLoader2Parser {
     debug: boolean;
   };
 
-  resetRawMesh(): void;
-  setMaterialPerSmoothingGroup(materialPerSmoothingGroup: boolean): void;
-  setUseOAsMesh(useOAsMesh: boolean): void;
-  setUseIndices(useIndices: boolean): void;
-  setDisregardNormals(disregardNormals: boolean): void;
-  setMaterials(materials: object): void;
-  setCallbackOnAssetAvailable(onAssetAvailable: Function): void;
-  setCallbackOnProgress(onProgress: Function): void;
-  setCallbackOnError(onError: Function): void;
-  setLogging(enabled: boolean, debug: boolean): void;
-  configure(): void;
-  parse(arrayBuffer: Uint8Array): void;
-  parseText(text: string): void;
-  processLine(buffer: string[], bufferPointer: number, slashesCount: number): void;
-  pushSmoothingGroup(smoothingGroup: object): void;
-  checkFaceType(faceType: number): void;
-  checkSubGroup(): void;
-  buildFace(faceIndexV: string, faceIndexU: string, faceIndexN: string): void;
-  createRawMeshReport(inputObjectCount: number): void;
-  finalizeRawMesh(): object;
-  processCompletedMesh(): boolean;
-  buildMesh(result: object): void;
-  finalizeParsing(): void;
+  setMaterialPerSmoothingGroup(materialPerSmoothingGroup: boolean): this;
+  setUseOAsMesh(useOAsMesh: boolean): this;
+  setUseIndices(useIndices: boolean): this;
+  setDisregardNormals(disregardNormals: boolean): this;
+
+  setCallbackOnAssetAvailable(onAssetAvailable: Function): this;
+  setCallbackOnProgress(onProgress: Function): this;
+  setCallbackOnError(onError: Function): this;
+  setLogging(enabled: boolean, debug: boolean): this;
+  execute(arrayBuffer: Uint8Array): void;
+  executeLegacy(text: string): void;
 }

--- a/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.js
+++ b/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.js
@@ -8,10 +8,17 @@
  */
 const OBJLoader2Parser = function () {
 
+	let scope = this;
 	this.callbacks = {
-		onProgress: null,
-		onAssetAvailable: null,
-		onError: null
+		onProgress: function ( type, text, numericalValue ) {
+			scope._onProgress( type, text, numericalValue )
+		},
+		onAssetAvailable: function ( payload ) {
+			scope._onAssetAvailable( payload )
+		},
+		onError: function ( errorMessage ) {
+			scope._onError( errorMessage )
+		}
 	};
 	this.contentRef = null;
 	this.legacyMode = false;
@@ -72,7 +79,7 @@ OBJLoader2Parser.prototype = {
 
 	constructor: OBJLoader2Parser,
 
-	resetRawMesh: function () {
+	_resetRawMesh: function () {
 
 		// faces are stored according combined index of group, material and smoothingGroup (0 or not)
 		this.rawMesh.subGroups = [];
@@ -81,7 +88,7 @@ OBJLoader2Parser.prototype = {
 		this.rawMesh.smoothingGroup.real = - 1;
 
 		// this default index is required as it is possible to define faces without 'g' or 'usemtl'
-		this.pushSmoothingGroup( 1 );
+		this._pushSmoothingGroup( 1 );
 
 		this.rawMesh.counts.doubleIndicesCount = 0;
 		this.rawMesh.counts.faceCount = 0;
@@ -90,31 +97,59 @@ OBJLoader2Parser.prototype = {
 
 	},
 
+	/**
+	 * Tells whether a material shall be created per smoothing group.
+	 *
+	 * @param {boolean} materialPerSmoothingGroup=false
+	 * @return {OBJLoader2Parser}
+	 */
 	setMaterialPerSmoothingGroup: function ( materialPerSmoothingGroup ) {
 
-		this.materialPerSmoothingGroup = materialPerSmoothingGroup;
+		this.materialPerSmoothingGroup = materialPerSmoothingGroup === true;
+		return this;
 
 	},
 
+	/**
+	 * Usually 'o' is meta-information and does not result in creation of new meshes, but mesh creation on occurrence of "o" can be enforced.
+	 *
+	 * @param {boolean} useOAsMesh=false
+	 * @return {OBJLoader2Parser}
+	 */
 	setUseOAsMesh: function ( useOAsMesh ) {
 
-		this.useOAsMesh = useOAsMesh;
+		this.useOAsMesh = useOAsMesh === true;
+		return this;
 
 	},
 
+	/**
+	 * Instructs loaders to create indexed {@link BufferGeometry}.
+	 *
+	 * @param {boolean} useIndices=false
+	 * @return {OBJLoader2Parser}
+	 */
 	setUseIndices: function ( useIndices ) {
 
-		this.useIndices = useIndices;
+		this.useIndices = useIndices === true;
+		return this;
 
 	},
 
+	/**
+	 * Tells whether normals should be completely disregarded and regenerated.
+	 *
+	 * @param {boolean} disregardNormals=false
+	 * @return {OBJLoader2Parser}
+	 */
 	setDisregardNormals: function ( disregardNormals ) {
 
-		this.disregardNormals = disregardNormals;
+		this.disregardNormals = disregardNormals === true;
+		return this;
 
 	},
 
-	setMaterials: function ( materials ) {
+	_setMaterials: function ( materials ) {
 
 		if ( materials === undefined || materials === null ) return;
 
@@ -130,60 +165,129 @@ OBJLoader2Parser.prototype = {
 
 	},
 
+	/**
+	 * Register a function that is called once an asset (mesh/material) becomes available.
+	 *
+	 * @param onAssetAvailable
+	 * @return {OBJLoader2Parser}
+	 */
 	setCallbackOnAssetAvailable: function ( onAssetAvailable ) {
 
-		if ( onAssetAvailable !== null && onAssetAvailable !== undefined ) {
+		if ( onAssetAvailable !== null && onAssetAvailable !== undefined && onAssetAvailable instanceof Function ) {
 
 			this.callbacks.onAssetAvailable = onAssetAvailable;
 
 		}
+		return this;
 
 	},
 
+	/**
+	 * Register a function that is used to report overall processing progress.
+	 *
+	 * @param {Function} onProgress
+	 * @return {OBJLoader2Parser}
+	 */
 	setCallbackOnProgress: function ( onProgress ) {
 
-		if ( onProgress !== null && onProgress !== undefined ) {
+		if ( onProgress !== null && onProgress !== undefined && onProgress instanceof Function ) {
 
 			this.callbacks.onProgress = onProgress;
 
 		}
+		return this;
 
 	},
 
+	/**
+	 * Register an error handler function that is called if errors occur. It can decide to just log or to throw an exception.
+	 *
+	 * @param {Function} onError
+	 * @return {OBJLoader2Parser}
+	 */
 	setCallbackOnError: function ( onError ) {
 
-		if ( onError !== null && onError !== undefined ) {
+		if ( onError !== null && onError !== undefined && onError instanceof Function ) {
 
 			this.callbacks.onError = onError;
 
 		}
+		return this;
 
 	},
 
+	/**
+	 * Announce feedback which is give to the registered callbacks.
+	 * @private
+	 *
+	 * @param {string} type The type of event
+	 * @param {string} text Textual description of the event
+	 * @param {number} numericalValue Numerical value describing the progress
+	 */
+	_onProgress: function ( type, text, numericalValue ) {
+
+		let message = text ? text : '';
+		let event = {
+			detail: {
+				type: type,
+				modelName: this.modelName,
+				instanceNo: this.instanceNo,
+				text: message,
+				numericalValue: numericalValue
+			}
+		};
+
+		if ( this.logging.enabled && this.logging.debug ) {
+
+			console.log( message );
+
+		}
+
+	},
+
+	/**
+	 * Announce error feedback which is given to the generic error handler to the registered callbacks.
+	 * @private
+	 *
+	 * @param {String} errorMessage The event containing the error
+	 */
+	_onError: function ( errorMessage ) {
+
+		if ( this.logging.enabled && this.logging.debug ) {
+
+			console.error( errorMessage );
+
+		}
+
+	},
+
+	_onAssetAvailable: function ( payload ) {
+
+		let errorMessage = 'OBJLoader2Parser does not provide implementation for onAssetAvailable. Aborting...';
+		this.callbacks.onError( errorMessage );
+		throw errorMessage;
+
+	},
+
+	/**
+	 * Enable or disable logging in general (except warn and error), plus enable or disable debug logging.
+	 *
+	 * @param {boolean} enabled True or false.
+	 * @param {boolean} debug True or false.
+	 *
+	 * @return {OBJLoader2Parser}
+	 */
 	setLogging: function ( enabled, debug ) {
 
 		this.logging.enabled = enabled === true;
 		this.logging.debug = debug === true;
+		return this;
 
 	},
 
-	configure: function () {
+	_configure: function () {
 
-		if ( this.callbacks.onAssetAvailable === null ) {
-
-			let errorMessage = 'Unable to run as no callback for building meshes is set.';
-			if ( this.callbacks.onError !== null ) {
-
-				this.callbacks.onError( errorMessage );
-
-			} else {
-
-				throw errorMessage;
-
-			}
-
-		}
-		this.pushSmoothingGroup( 1 );
+		this._pushSmoothingGroup( 1 );
 		if ( this.logging.enabled ) {
 
 			let matKeys = Object.keys( this.materials );
@@ -194,21 +298,9 @@ OBJLoader2Parser.prototype = {
 				+ '\n\tuseOAsMesh: ' + this.useOAsMesh
 				+ '\n\tuseIndices: ' + this.useIndices
 				+ '\n\tdisregardNormals: ' + this.disregardNormals;
-			if ( this.callbacks.onProgress !== null ) {
-
-				printedConfig += '\n\tcallbacks.onProgress: ' + this.callbacks.onProgress.name;
-
-			}
-			if ( this.callbacks.onAssetAvailable !== null ) {
-
-				printedConfig += '\n\tcallbacks.onAssetAvailable: ' + this.callbacks.onAssetAvailable.name;
-
-			}
-			if ( this.callbacks.onError !== null ) {
-
-				printedConfig += '\n\tcallbacks.onError: ' + this.callbacks.onError.name;
-
-			}
+			printedConfig += '\n\tcallbacks.onProgress: ' + this.callbacks.onProgress.name;
+			printedConfig += '\n\tcallbacks.onAssetAvailable: ' + this.callbacks.onAssetAvailable.name;
+			printedConfig += '\n\tcallbacks.onError: ' + this.callbacks.onError.name;
 			console.info( printedConfig );
 
 		}
@@ -220,10 +312,10 @@ OBJLoader2Parser.prototype = {
 	 *
 	 * @param {Uint8Array} arrayBuffer OBJ data as Uint8Array
 	 */
-	parse: function ( arrayBuffer ) {
+	execute: function ( arrayBuffer ) {
 
-		if ( this.logging.enabled ) console.time( 'OBJLoader.Parser.parse' );
-		this.configure();
+		if ( this.logging.enabled ) console.time( 'OBJLoader2Parser.execute' );
+		this._configure();
 
 		let arrayBufferView = new Uint8Array( arrayBuffer );
 		this.contentRef = arrayBufferView;
@@ -254,7 +346,7 @@ OBJLoader2Parser.prototype = {
 					word = '';
 					this.globalCounts.lineByte = this.globalCounts.currentByte;
 					this.globalCounts.currentByte = i;
-					this.processLine( buffer, bufferPointer, slashesCount );
+					this._processLine( buffer, bufferPointer, slashesCount );
 					bufferPointer = 0;
 					slashesCount = 0;
 					break;
@@ -270,8 +362,8 @@ OBJLoader2Parser.prototype = {
 			}
 
 		}
-		this.finalizeParsing();
-		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader.Parser.parse' );
+		this._finalizeParsing();
+		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader2Parser.execute' );
 
 	},
 
@@ -280,10 +372,10 @@ OBJLoader2Parser.prototype = {
 	 *
 	 * @param {string} text OBJ data as string
 	 */
-	parseText: function ( text ) {
+	executeLegacy: function ( text ) {
 
-		if ( this.logging.enabled ) console.time( 'OBJLoader.Parser.parseText' );
-		this.configure();
+		if ( this.logging.enabled ) console.time( 'OBJLoader2Parser.executeLegacy' );
+		this._configure();
 		this.legacyMode = true;
 		this.contentRef = text;
 		let length = text.length;
@@ -311,7 +403,7 @@ OBJLoader2Parser.prototype = {
 					word = '';
 					this.globalCounts.lineByte = this.globalCounts.currentByte;
 					this.globalCounts.currentByte = i;
-					this.processLine( buffer, bufferPointer, slashesCount );
+					this._processLine( buffer, bufferPointer, slashesCount );
 					bufferPointer = 0;
 					slashesCount = 0;
 					break;
@@ -325,12 +417,12 @@ OBJLoader2Parser.prototype = {
 			}
 
 		}
-		this.finalizeParsing();
-		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader.Parser.parseText' );
+		this._finalizeParsing();
+		if ( this.logging.enabled ) console.timeEnd( 'OBJLoader2Parser.executeLegacy' );
 
 	},
 
-	processLine: function ( buffer, bufferPointer, slashesCount ) {
+	_processLine: function ( buffer, bufferPointer, slashesCount ) {
 
 		if ( bufferPointer < 1 ) return;
 
@@ -391,12 +483,12 @@ OBJLoader2Parser.prototype = {
 				// "f vertex ..."
 				if ( slashesCount === 0 ) {
 
-					this.checkFaceType( 0 );
+					this._checkFaceType( 0 );
 					for ( i = 2, length = bufferLength; i < length; i ++ ) {
 
-						this.buildFace( buffer[ 1 ] );
-						this.buildFace( buffer[ i ] );
-						this.buildFace( buffer[ i + 1 ] );
+						this._buildFace( buffer[ 1 ] );
+						this._buildFace( buffer[ i ] );
+						this._buildFace( buffer[ i + 1 ] );
 
 					}
 
@@ -404,12 +496,12 @@ OBJLoader2Parser.prototype = {
 
 				} else if ( bufferLength === slashesCount * 2 ) {
 
-					this.checkFaceType( 1 );
+					this._checkFaceType( 1 );
 					for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
 
-						this.buildFace( buffer[ 1 ], buffer[ 2 ] );
-						this.buildFace( buffer[ i ], buffer[ i + 1 ] );
-						this.buildFace( buffer[ i + 2 ], buffer[ i + 3 ] );
+						this._buildFace( buffer[ 1 ], buffer[ 2 ] );
+						this._buildFace( buffer[ i ], buffer[ i + 1 ] );
+						this._buildFace( buffer[ i + 2 ], buffer[ i + 3 ] );
 
 					}
 
@@ -417,12 +509,12 @@ OBJLoader2Parser.prototype = {
 
 				} else if ( bufferLength * 2 === slashesCount * 3 ) {
 
-					this.checkFaceType( 2 );
+					this._checkFaceType( 2 );
 					for ( i = 4, length = bufferLength - 3; i < length; i += 3 ) {
 
-						this.buildFace( buffer[ 1 ], buffer[ 2 ], buffer[ 3 ] );
-						this.buildFace( buffer[ i ], buffer[ i + 1 ], buffer[ i + 2 ] );
-						this.buildFace( buffer[ i + 3 ], buffer[ i + 4 ], buffer[ i + 5 ] );
+						this._buildFace( buffer[ 1 ], buffer[ 2 ], buffer[ 3 ] );
+						this._buildFace( buffer[ i ], buffer[ i + 1 ], buffer[ i + 2 ] );
+						this._buildFace( buffer[ i + 3 ], buffer[ i + 4 ], buffer[ i + 5 ] );
 
 					}
 
@@ -430,12 +522,12 @@ OBJLoader2Parser.prototype = {
 
 				} else {
 
-					this.checkFaceType( 3 );
+					this._checkFaceType( 3 );
 					for ( i = 3, length = bufferLength - 2; i < length; i += 2 ) {
 
-						this.buildFace( buffer[ 1 ], undefined, buffer[ 2 ] );
-						this.buildFace( buffer[ i ], undefined, buffer[ i + 1 ] );
-						this.buildFace( buffer[ i + 2 ], undefined, buffer[ i + 3 ] );
+						this._buildFace( buffer[ 1 ], undefined, buffer[ 2 ] );
+						this._buildFace( buffer[ i ], undefined, buffer[ i + 1 ] );
+						this._buildFace( buffer[ i + 2 ], undefined, buffer[ i + 3 ] );
 
 					}
 
@@ -447,30 +539,30 @@ OBJLoader2Parser.prototype = {
 				bufferLength = bufferPointer - 1;
 				if ( bufferLength === slashesCount * 2 ) {
 
-					this.checkFaceType( 4 );
-					for ( i = 1, length = bufferLength + 1; i < length; i += 2 ) this.buildFace( buffer[ i ], buffer[ i + 1 ] );
+					this._checkFaceType( 4 );
+					for ( i = 1, length = bufferLength + 1; i < length; i += 2 ) this._buildFace( buffer[ i ], buffer[ i + 1 ] );
 
 				} else {
 
-					this.checkFaceType( ( lineDesignation === 'l' ) ? 5 : 6 );
-					for ( i = 1, length = bufferLength + 1; i < length; i ++ ) this.buildFace( buffer[ i ] );
+					this._checkFaceType( ( lineDesignation === 'l' ) ? 5 : 6 );
+					for ( i = 1, length = bufferLength + 1; i < length; i ++ ) this._buildFace( buffer[ i ] );
 
 				}
 				break;
 
 			case 's':
-				this.pushSmoothingGroup( buffer[ 1 ] );
+				this._pushSmoothingGroup( buffer[ 1 ] );
 				break;
 
 			case 'g':
 				// 'g' leads to creation of mesh if valid data (faces declaration was done before), otherwise only groupName gets set
-				this.processCompletedMesh();
+				this._processCompletedMesh();
 				this.rawMesh.groupName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
 				break;
 
 			case 'o':
 				// 'o' is meta-information and usually does not result in creation of new meshes, but can be enforced with "useOAsMesh"
-				if ( this.useOAsMesh ) this.processCompletedMesh();
+				if ( this.useOAsMesh ) this._processCompletedMesh();
 				this.rawMesh.objectName = reconstructString( this.contentRef, this.legacyMode, this.globalCounts.lineByte + 2, this.globalCounts.currentByte );
 				break;
 
@@ -484,7 +576,7 @@ OBJLoader2Parser.prototype = {
 
 					this.rawMesh.activeMtlName = mtlName;
 					this.rawMesh.counts.mtlCount ++;
-					this.checkSubGroup();
+					this._checkSubGroup();
 
 				}
 				break;
@@ -496,7 +588,7 @@ OBJLoader2Parser.prototype = {
 
 	},
 
-	pushSmoothingGroup: function ( smoothingGroup ) {
+	_pushSmoothingGroup: function ( smoothingGroup ) {
 
 		let smoothingGroupInt = parseInt( smoothingGroup );
 		if ( isNaN( smoothingGroupInt ) ) {
@@ -512,7 +604,7 @@ OBJLoader2Parser.prototype = {
 		if ( smoothCheck !== smoothingGroupInt ) {
 
 			this.rawMesh.counts.smoothingGroupCount ++;
-			this.checkSubGroup();
+			this._checkSubGroup();
 
 		}
 
@@ -528,19 +620,19 @@ OBJLoader2Parser.prototype = {
 	 * faceType = 5: "l vertex ..."
 	 * faceType = 6: "p vertex ..."
 	 */
-	checkFaceType: function ( faceType ) {
+	_checkFaceType: function ( faceType ) {
 
 		if ( this.rawMesh.faceType !== faceType ) {
 
-			this.processCompletedMesh();
+			this._processCompletedMesh();
 			this.rawMesh.faceType = faceType;
-			this.checkSubGroup();
+			this._checkSubGroup();
 
 		}
 
 	},
 
-	checkSubGroup: function () {
+	_checkSubGroup: function () {
 
 		let index = this.rawMesh.activeMtlName + '|' + this.rawMesh.smoothingGroup.normalized;
 		this.rawMesh.subGroupInUse = this.rawMesh.subGroups[ index ];
@@ -567,7 +659,7 @@ OBJLoader2Parser.prototype = {
 
 	},
 
-	buildFace: function ( faceIndexV, faceIndexU, faceIndexN ) {
+	_buildFace: function ( faceIndexV, faceIndexU, faceIndexN ) {
 
 		let subGroupInUse = this.rawMesh.subGroupInUse;
 		let scope = this;
@@ -640,7 +732,7 @@ OBJLoader2Parser.prototype = {
 
 	},
 
-	createRawMeshReport: function ( inputObjectCount ) {
+	_createRawMeshReport: function ( inputObjectCount ) {
 
 		return 'Input Object number: ' + inputObjectCount +
 			'\n\tObject name: ' + this.rawMesh.objectName +
@@ -658,7 +750,7 @@ OBJLoader2Parser.prototype = {
 	/**
 	 * Clear any empty subGroup and calculate absolute vertex, normal and uv counts
 	 */
-	finalizeRawMesh: function () {
+	_finalizeRawMesh: function () {
 
 		let meshOutputGroupTemp = [];
 		let meshOutputGroup;
@@ -717,33 +809,25 @@ OBJLoader2Parser.prototype = {
 
 	},
 
-	processCompletedMesh: function () {
+	_processCompletedMesh: function () {
 
-		let result = this.finalizeRawMesh();
+		let result = this._finalizeRawMesh();
 		let haveMesh = result !== null;
 		if ( haveMesh ) {
 
 			if ( this.colors.length > 0 && this.colors.length !== this.vertices.length ) {
 
-				if ( this.callbacks.onError !== null ) {
-
-					this.callbacks.onError( 'Vertex Colors were detected, but vertex count and color count do not match!' );
-
-				}
+				this.callbacks.onError( 'Vertex Colors were detected, but vertex count and color count do not match!' );
 
 			}
-			if ( this.logging.enabled && this.logging.debug ) console.debug( this.createRawMeshReport( this.inputObjectCount ) );
+			if ( this.logging.enabled && this.logging.debug ) console.debug( this._createRawMeshReport( this.inputObjectCount ) );
 			this.inputObjectCount ++;
 
-			this.buildMesh( result );
+			this._buildMesh( result );
 			let progressBytesPercent = this.globalCounts.currentByte / this.globalCounts.totalBytes;
-			if ( this.callbacks.onProgress !== null ) {
-
-				this.callbacks.onProgress( 'Completed [o: ' + this.rawMesh.objectName + ' g:' + this.rawMesh.groupName + '' +
+			this._onProgress( 'progressParse', 'Completed [o: ' + this.rawMesh.objectName + ' g:' + this.rawMesh.groupName + '' +
 					'] Total progress: ' + ( progressBytesPercent * 100 ).toFixed( 2 ) + '%', progressBytesPercent );
-
-			}
-			this.resetRawMesh();
+			this._resetRawMesh();
 
 		}
 		return haveMesh;
@@ -756,7 +840,7 @@ OBJLoader2Parser.prototype = {
 	 *
 	 * @param result
 	 */
-	buildMesh: function ( result ) {
+	_buildMesh: function ( result ) {
 
 		let meshOutputGroups = result.subGroups;
 
@@ -965,10 +1049,10 @@ OBJLoader2Parser.prototype = {
 
 	},
 
-	finalizeParsing: function () {
+	_finalizeParsing: function () {
 
 		if ( this.logging.enabled ) console.info( 'Global output object count: ' + this.outputObjectCount );
-		if ( this.processCompletedMesh() && this.logging.enabled ) {
+		if ( this._processCompletedMesh() && this.logging.enabled ) {
 
 			let parserFinalReport = 'Overall counts: ' +
 				'\n\tVertices: ' + this.globalCounts.vertices +

--- a/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
+++ b/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
@@ -64,15 +64,15 @@ DefaultWorkerPayloadHandler.prototype = {
 
 			}
 
-			let parseFunctionName = 'parse';
-			if ( typeof parser.getParseFunctionName === 'function' ) parseFunctionName = parser.getParseFunctionName();
+			let executeFunctionName = 'execute';
+			if ( typeof parser.getParseFunctionName === 'function' ) executeFunctionName = parser.getParseFunctionName();
 			if ( payload.usesMeshDisassembler ) {
 
 				// TODO: Allow to plug and use generic MeshDisassembler
 
 			} else {
 
-				parser[ parseFunctionName ]( arraybuffer, payload.data.options );
+				parser[ executeFunctionName ]( arraybuffer, payload.data.options );
 
 			}
 			if ( this.logging.enabled ) console.log( 'WorkerRunner: Run complete!' );

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -286,7 +286,7 @@
 
 						return override;
 					}
-					objLoader2Parallel._setCallbacks( null, callbackMeshAlter );
+					objLoader2Parallel.setCallbackOnMeshAlter( callbackMeshAlter );
 
 					let scope = this;
 					function callbackOnLoad ( message ) {


### PR DESCRIPTION
It is finally time to remove the beta status from `OBJLoader2` V3. I changed the following things:
- `OBJLoader2`: It now extends OBJLoader2Parser: Moved common functions (parser configuration and callback) to `OBJLoader2Parser`. Here aim was to remove redundant function definitions in both the independent parser code and in `OBJLoader2`
- `OBJLoader2Parser`: All private functions are now identified by "_". Provides functions and members for extensions
- Aligned typescript definitions with latest code changes and updated code documentation where needed.
- Polished code
- Set versions to 3.0.0

Bottom line: `OBJLoader2` and `OBJLoader2Parallel` logic are so much reduced that they can be generically addressed. Hopefully, I have time to continue to work on this in the coming weeks. See **code** of working concept if you are interested: https://github.com/kaisalmen/WWOBJLoader/blob/dev/test/assetPipelineLoader/main.src.html#L104-L132