### PR TITLE
TS: add Vector2/3/4 toArray and fromArray function types with array-likes

### DIFF
--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -396,11 +396,18 @@ export class Vector2 implements Vector {
 	equals( v: Vector2 ): boolean;
 
 	/**
-	 * Sets this vector's x value to be array[offset] and y value to be array[offset + 1].
+	 * Sets this vector's x and y value from the provided array.
 	 * @param array the source array.
 	 * @param offset (optional) offset into the array. Default is 0.
 	 */
 	fromArray( array: number[], offset?: number ): this;
+
+	/**
+	 * Sets this vector's x and y value from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
 
 	/**
 	 * Returns an array [x, y], or copies x and y into the provided array.

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -248,7 +248,19 @@ export class Vector3 implements Vector {
 	 */
 	equals( v: Vector3 ): boolean;
 
-	fromArray( xyz: number[], offset?: number ): Vector3;
+	/**
+	 * Sets this vector's x, y and z value from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
+	fromArray( array: number[], offset?: number ): this;
+
+	/**
+	 * Sets this vector's x, y and z value from the provided array-lik.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
 
 	/**
 	 * Returns an array [x, y, z], or copies x, y and z into the provided array.
@@ -256,7 +268,7 @@ export class Vector3 implements Vector {
 	 * @param offset (optional) optional offset into the array.
 	 * @return The created or provided array.
 	 */
-	toArray( xyz?: number[], offset?: number ): number[];
+	toArray( array?: number[], offset?: number ): number[];
 
 	/**
 	 * Copies x, y and z into the provided array-like.
@@ -264,7 +276,7 @@ export class Vector3 implements Vector {
 	 * @param offset (optional) optional offset into the array.
 	 * @return The provided array-like.
 	 */
-	toArray( xyz: ArrayLike<number>, offset?: number ): ArrayLike<number>;
+	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	fromBufferAttribute(
 		attribute: BufferAttribute,

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -174,9 +174,35 @@ export class Vector4 implements Vector {
 	 */
 	equals( v: Vector4 ): boolean;
 
-	fromArray( xyzw: number[], offset?: number ): this;
+	/**
+	 * Sets this vector's x, y, z and w value from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
+	fromArray( array: number[], offset?: number ): this;
 
-	toArray( xyzw?: number[], offset?: number ): number[];
+	/**
+	 * Sets this vector's x, y, z and w value from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
+
+	/**
+	 * Returns an array [x, y, z, w], or copies x, y, z and w into the provided array.
+	 * @param array (optional) array to store the vector to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
+	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Copies x, y, z and w into the provided array-like.
+	 * @param array array-like to store the vector to.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The provided array-like.
+	 */
+	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	fromBufferAttribute(
 		attribute: BufferAttribute,


### PR DESCRIPTION
This commit does the following:
- add arraylike variant of the fromArray function to Vector2, Vector3 and Vector4
- add arraylike variant of the toArray function to Vector4 (Vector2 and Vector 3 already had it)

I also unified the comments and parameter names.