### PR TITLE
Matching js material class names with glsl defines

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -75,8 +75,8 @@
 			<code>
 				{
 
+					'STANDARD': ''
 					'PHYSICAL': '',
-					'ADVANCED_PHYSICAL': ''
 			
 				};
 			</code>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -122,7 +122,7 @@
 		<h3>[property:Object defines]</h3>
 		<p>An object of the form:
 			<code>
-				{ 'PHYSICAL': '' };
+				{ 'STANDARD': '' };
 			</code>
 
 			This is used by the [page:WebGLRenderer] for selecting shaders.

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -69,8 +69,8 @@
 			<code>
 				{
 
+					'STANDARD': ''
 					'PHYSICAL': '',
-					'ADVANCED_PHYSICAL': ''
 			
 				};
 			</code>

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -97,7 +97,7 @@
 		<h3>[property:Object defines]</h3>
 		<p>如下形式的对象:
 			<code>
-				{ 'PHYSICAL': '' };
+				{ 'STANDARD': '' };
 			</code>
 			[page:WebGLRenderer]使用它来选择shaders。
 		</p>

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -125,7 +125,7 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 
 	var vertexShaderChunk2 = [
 
-		"#if ! defined( LAMBERT ) && ! defined( PHONG ) && ! defined( TOON ) && ! defined( PHYSICAL )",
+		"#if ! defined( LAMBERT ) && ! defined( PHONG ) && ! defined( TOON ) && ! defined( STANDARD )",
 		"	#ifndef USE_ENVMAP",
 		"		vec3 objectNormal = normalize( normal );",
 		"	#endif",

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -726,7 +726,7 @@ THREE.GLTFLoader = ( function () {
 				materialParams.vertexShader = shader.vertexShader;
 				materialParams.fragmentShader = fragmentShader;
 				materialParams.uniforms = uniforms;
-				materialParams.defines = { 'PHYSICAL': '' }
+				materialParams.defines = { 'STANDARD': '' }
 
 				materialParams.color = new THREE.Color( 1.0, 1.0, 1.0 );
 				materialParams.opacity = 1.0;

--- a/examples/jsm/effects/OutlineEffect.js
+++ b/examples/jsm/effects/OutlineEffect.js
@@ -132,7 +132,7 @@ var OutlineEffect = function ( renderer, parameters ) {
 
 	var vertexShaderChunk2 = [
 
-		"#if ! defined( LAMBERT ) && ! defined( PHONG ) && ! defined( TOON ) && ! defined( PHYSICAL )",
+		"#if ! defined( LAMBERT ) && ! defined( PHONG ) && ! defined( TOON ) && ! defined( STANDARD )",
 		"	#ifndef USE_ENVMAP",
 		"		vec3 objectNormal = normalize( normal );",
 		"	#endif",

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -791,7 +791,7 @@ var GLTFLoader = ( function () {
 				materialParams.vertexShader = shader.vertexShader;
 				materialParams.fragmentShader = fragmentShader;
 				materialParams.uniforms = uniforms;
-				materialParams.defines = { 'PHYSICAL': '' }
+				materialParams.defines = { 'STANDARD': '' }
 
 				materialParams.color = new Color( 1.0, 1.0, 1.0 );
 				materialParams.opacity = 1.0;

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -33,7 +33,7 @@ StandardNode.prototype.build = function ( builder ) {
 
 	var code;
 
-	builder.define('PHYSICAL');
+	builder.define('STANDARD');
 
 	var useClearcoat = this.clearcoat || this.clearcoatRoughness || this.clearCoatNormal;
 

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -23,8 +23,8 @@ function MeshPhysicalMaterial( parameters ) {
 
 	this.defines = {
 
-		'PHYSICAL': '',
-		'ADVANCED_PHYSICAL': ''
+		'STANDARD': '',
+		'PHYSICAL': ''
 
 	};
 
@@ -55,8 +55,8 @@ MeshPhysicalMaterial.prototype.copy = function ( source ) {
 
 	this.defines = {
 
-		'PHYSICAL': '',
-		'ADVANCED_PHYSICAL': ''
+		'STANDARD': '',
+		'PHYSICAL': ''
 
 	};
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -59,7 +59,7 @@ function MeshStandardMaterial( parameters ) {
 
 	Material.call( this );
 
-	this.defines = { 'PHYSICAL': '' };
+	this.defines = { 'STANDARD': '' };
 
 	this.type = 'MeshStandardMaterial';
 
@@ -123,7 +123,7 @@ MeshStandardMaterial.prototype.copy = function ( source ) {
 
 	Material.prototype.copy.call( this, source );
 
-	this.defines = { 'PHYSICAL': '' };
+	this.defines = { 'STANDARD': '' };
 
 	this.color.copy( source.color );
 	this.roughness = source.roughness;

--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
@@ -6,7 +6,7 @@ export default /* glsl */`
 
 	reflectedLight.indirectDiffuse *= ambientOcclusion;
 
-	#if defined( USE_ENVMAP ) && defined( PHYSICAL )
+	#if defined( USE_ENVMAP ) && defined( STANDARD )
 
 		float dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );
 

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0
 
-	#if ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )
+	#if ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP )
 		varying vec3 vViewPosition;
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )
+#if NUM_CLIPPING_PLANES > 0 && ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP )
 	varying vec3 vViewPosition;
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )
+#if NUM_CLIPPING_PLANES > 0 && ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP )
 	vViewPosition = - mvPosition.xyz;
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -15,7 +15,7 @@ export default /* glsl */`
 
 	#endif
 
-	#if defined( USE_ENVMAP ) && defined( PHYSICAL ) && defined( ENVMAP_TYPE_CUBE_UV )
+	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
 
 		irradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, maxMipLevel );
 

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -1,13 +1,7 @@
 export default /* glsl */`
-#define PHYSICAL_REFLECTION
+#define STANDARD
 
 #ifdef PHYSICAL
-
-	#define CLEARCOAT
-
-#endif
-
-#ifdef ADVANCED_PHYSICAL
 	#define REFLECTIVITY
 	#define CLEARCOAT
 #endif

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#define PHYSICAL
+#define STANDARD
 
 varying vec3 vViewPosition;
 


### PR DESCRIPTION
As discussed in #17295, the defines for standard/physical materials now match the class names.

Also corrected an error I had slipped in at the top of _meshphysical_frag.glsl.js_