### PR TITLE
TS: add more fromArray and toArray function types

### DIFF
--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -152,8 +152,35 @@ export class Color {
 	lerp( color: Color, alpha: number ): this;
 	lerpHSL( color: Color, alpha: number ): this;
 	equals( color: Color ): boolean;
-	fromArray( rgb: number[], offset?: number ): this;
+
+	/**
+	 * Sets this color's red, green and blue value from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
+	fromArray( array: number[], offset?: number ): this;
+
+	/**
+	 * Sets this color's red, green and blue value from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
+
+	/**
+	 * Returns an array [red, green, blue], or copies red, green and blue into the provided array.
+	 * @param array (optional) array to store the color to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
 	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Copies red, green and blue into the provided array-like.
+	 * @param array array-like to store the color to.
+	 * @param offset (optional) optional offset into the array-like.
+	 * @return The provided array-like.
+	 */
 	toArray( xyz: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 }

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -111,9 +111,35 @@ export class Matrix3 implements Matrix {
 
 	equals( matrix: Matrix3 ): boolean;
 
+	/**
+	 * Sets the values of this matrix from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
 	fromArray( array: number[], offset?: number ): Matrix3;
 
+	/**
+	 * Sets the values of this matrix from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): Matrix3;
+
+	/**
+	 * Returns an array with the values of this matrix, or copies them into the provided array.
+	 * @param array (optional) array to store the matrix to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
 	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Copies he values of this matrix into the provided array-like.
+	 * @param array array-like to store the matrix to.
+	 * @param offset (optional) optional offset into the array-like.
+	 * @return The provided array-like.
+	 */
+	toArray( array?: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	/**
 	 * Multiplies this matrix by m.

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -226,9 +226,36 @@ export class Matrix4 implements Matrix {
 		far: number
 	): Matrix4;
 	equals( matrix: Matrix4 ): boolean;
+
+	/**
+	 * Sets the values of this matrix from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
 	fromArray( array: number[], offset?: number ): Matrix4;
 
+	/**
+	 * Sets the values of this matrix from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): Matrix4;
+
+	/**
+	 * Returns an array with the values of this matrix, or copies them into the provided array.
+	 * @param array (optional) array to store the matrix to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
 	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Copies he values of this matrix into the provided array-like.
+	 * @param array array-like to store the matrix to.
+	 * @param offset (optional) optional offset into the array-like.
+	 * @return The provided array-like.
+	 */
+	toArray( array?: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	/**
 	 * @deprecated Use {@link Matrix4#copyPosition .copyPosition()} instead.

--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -94,11 +94,36 @@ export class Quaternion {
 
 	slerp( qb: Quaternion, t: number ): Quaternion;
 	equals( v: Quaternion ): boolean;
-	fromArray( n: number[] ): Quaternion;
-	toArray(): number[];
 
-	fromArray( xyzw: number[], offset?: number ): Quaternion;
-	toArray( xyzw?: number[], offset?: number ): number[];
+	/**
+	 * Sets this quaternion's x, y, z and w value from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
+	fromArray( array: number[], offset?: number ): this;
+
+	/**
+	 * Sets this quaternion's x, y, z and w value from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
+
+	/**
+	 * Returns an array [x, y, z, w], or copies x, y, z and w into the provided array.
+	 * @param array (optional) array to store the quaternion to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
+	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Copies x, y, z and w into the provided array-like.
+	 * @param array array-like to store the quaternion to.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The provided array-like.
+	 */
+	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	_onChange( callback: Function ): Quaternion;
 	_onChangeCallback: Function;

--- a/src/math/SphericalHarmonics3.d.ts
+++ b/src/math/SphericalHarmonics3.d.ts
@@ -15,8 +15,36 @@ export class SphericalHarmonics3 {
 	equals( sh: SphericalHarmonics3 ): boolean;
 	copy( sh: SphericalHarmonics3 ): SphericalHarmonics3;
 	clone(): SphericalHarmonics3;
-	fromArray( array: number[] ): SphericalHarmonics3;
-	toArray(): number[];
+
+	/**
+	 * Sets the values of this spherical harmonics from the provided array.
+	 * @param array the source array.
+	 * @param offset (optional) offset into the array. Default is 0.
+	 */
+	fromArray( array: number[], offset?: number ): this;
+
+	/**
+	 * Sets the values of this spherical harmonics from the provided array-like.
+	 * @param array the source array-like.
+	 * @param offset (optional) offset into the array-like. Default is 0.
+	 */
+	fromArray( array: ArrayLike<number>, offset?: number ): this;
+
+	/**
+	 * Returns an array with the values of this spherical harmonics, or copies them into the provided array.
+	 * @param array (optional) array to store the spherical harmonics to. If this is not provided, a new array will be created.
+	 * @param offset (optional) optional offset into the array.
+	 * @return The created or provided array.
+	 */
+	toArray( array?: number[], offset?: number ): number[];
+
+	/**
+	 * Returns an array with the values of this spherical harmonics, or copies them into the provided array-like.
+	 * @param array array-like to store the spherical harmonics to.
+	 * @param offset (optional) optional offset into the array-like.
+	 * @return The provided array-like.
+	 */
+	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	getAt( normal: Vector3, target: Vector3 ) : Vector3;
 	getIrradianceAt( normal: Vector3, target: Vector3 ) : Vector3;

--- a/src/math/SphericalHarmonics3.js
+++ b/src/math/SphericalHarmonics3.js
@@ -177,13 +177,15 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 	},
 
-	fromArray: function ( array ) {
+	fromArray: function ( array, offset ) {
+
+		if ( offset === undefined ) offset = 0;
 
 		var coefficients = this.coefficients;
 
 		for ( var i = 0; i < 9; i ++ ) {
 
-			coefficients[ i ].fromArray( array, i * 3 );
+			coefficients[ i ].fromArray( array, offset + ( i * 3 ) );
 
 		}
 
@@ -191,14 +193,16 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 	},
 
-	toArray: function () {
+	toArray: function ( array, offset ) {
 
-		var array = [];
+		if ( array === undefined ) array = [];
+		if ( offset === undefined ) offset = 0;
+
 		var coefficients = this.coefficients;
 
 		for ( var i = 0; i < 9; i ++ ) {
 
-			coefficients[ i ].toArray( array, i * 3 );
+			coefficients[ i ].toArray( array, offset + ( i * 3 ) );
 
 		}
 

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -256,7 +256,7 @@ export class Vector3 implements Vector {
 	fromArray( array: number[], offset?: number ): this;
 
 	/**
-	 * Sets this vector's x, y and z value from the provided array-lik.
+	 * Sets this vector's x, y and z value from the provided array-like.
 	 * @param array the source array-like.
 	 * @param offset (optional) offset into the array-like. Default is 0.
 	 */
@@ -273,7 +273,7 @@ export class Vector3 implements Vector {
 	/**
 	 * Copies x, y and z into the provided array-like.
 	 * @param array array-like to store the vector to.
-	 * @param offset (optional) optional offset into the array.
+	 * @param offset (optional) optional offset into the array-like.
 	 * @return The provided array-like.
 	 */
 	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -199,7 +199,7 @@ export class Vector4 implements Vector {
 	/**
 	 * Copies x, y, z and w into the provided array-like.
 	 * @param array array-like to store the vector to.
-	 * @param offset (optional) optional offset into the array.
+	 * @param offset (optional) optional offset into the array-like.
 	 * @return The provided array-like.
 	 */
 	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;


### PR DESCRIPTION
This commit does the following:
- add arraylike variant of the fromArray function to Color, Matrix3, Matrix4, Quaternion, SphericalHarmonics3
- add arraylike variant of the toArray function to Matrix3, Matrix4, Quaternion, SphericalHarmonics3 (Color already had it)
- add the missing offset functionality to SphericalHarmonic3's fromArray and toArray function, also the toArray function can now insert into an existing array or array-like.

Also I added some comments and fixed existing ones.