### PR TITLE
WIP: Three.JS Shader Language Proposal

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -7,13 +7,16 @@ import {
 	LessEqualDepth,
 	NoColors,
 	NormalBlending,
-	ShaderMaterial
+	ShaderMaterial,
+	ShaderChunk
 } from '../../../../build/three.module.js';
 
 import { NodeBuilder } from '../core/NodeBuilder.js';
 import { ColorNode } from '../inputs/ColorNode.js';
 import { PositionNode } from '../accessors/PositionNode.js';
 import { RawNode } from './nodes/RawNode.js';
+
+import Parser from '../../parser/Parser.js';
 
 function NodeMaterial( vertex, fragment ) {
 
@@ -32,11 +35,17 @@ function NodeMaterial( vertex, fragment ) {
 
 		if ( this.needsUpdate ) {
 
+			var parser = new Parser( Parser.UNEMIT );
+			parser.addLibrary( ShaderChunk );
+
 			this.build( { renderer: renderer } );
 
 			shader.uniforms = this.uniforms;
 			shader.vertexShader = this.vertexShader;
 			shader.fragmentShader = this.fragmentShader;
+			
+			shader.vertexShader = parser.compile( shader.vertexShader );
+			shader.fragmentShader = parser.compile( shader.fragmentShader );
 
 		}
 

--- a/examples/jsm/parser/Analyzer.js
+++ b/examples/jsm/parser/Analyzer.js
@@ -15,30 +15,18 @@ const QualifierRegExp = /^(in|out|inout|highp|mediump|lowp|const)$/;
 
 class ShaderNode {
 	
-	isNode = true;
-	
 	constructor( token, property = undefined ) {
 		
 		this.token = token;
 		this.property = property;
-		
+	
+		this.isNode = true;
+	
 	}
 	
 }
 
 class ShaderProperty {
-	
-	isProperty = true;
-	
-	start = undefined;
-	end = undefined;
-	
-	nameToken = undefined;
-	typeToken = undefined;
-	
-	calls = [];
-	
-	properties = [];
 	
 	constructor( parent, type, name, qualifiers = [], length = undefined ) {
 		
@@ -48,7 +36,19 @@ class ShaderProperty {
 		this.name = name;
 		this.qualifiers = qualifiers;
 		
-		this.length = undefined;
+		this.length = length;
+		
+		this.start = undefined;
+		this.end = undefined;
+		
+		this.nameToken = undefined;
+		this.typeToken = undefined;
+		
+		this.calls = [];
+		
+		this.properties = [];
+		
+		this.isProperty = true;
 			
 	}
 	
@@ -207,13 +207,13 @@ class ShaderProperty {
 
 class ShaderBlock extends ShaderProperty {
 	
-	isBlock = true;
-	
-	nodes = []
-	
 	constructor( parent, type, name, qualifiers ) {
 		
 		super( parent, type, name, qualifiers );
+		
+		this.nodes = [];
+		
+		this.isBlock = true;
 		
 	}
 	
@@ -231,11 +231,11 @@ class ShaderBlock extends ShaderProperty {
 
 class ShaderNamespace extends ShaderBlock {
 	
-	isNamespace = true;
-	
 	constructor( parent, name ) {
 		
 		super( parent, 'namespace', name );
+			
+		this.isNamespace = true;
 			
 	}
 	
@@ -243,25 +243,25 @@ class ShaderNamespace extends ShaderBlock {
 
 class ShaderStruct extends ShaderBlock {
 	
-	isStruct = true;
-	
 	constructor( parent, name ) {
 		
 		super( parent, 'struct', name );
-			
+	
+		this.isStruct = true;
+		
 	}
 	
 }
 
 class ShaderFunction extends ShaderBlock {
 	
-	isFunction = true;
-	
 	constructor( parent, type, name, qualifiers, args = [] ) {
 		
 		super( parent, type, name, qualifiers );
 		
 		this.args = args;
+		
+		this.isFunction = true;
 			
 	}
 	
@@ -269,18 +269,20 @@ class ShaderFunction extends ShaderBlock {
 
 class ShaderEnvironment extends ShaderBlock {
 	
-	isEnvironment = true;
 	
-	declarations = [];
-	
-	attributes = [];
-	uniforms = [];
 	
 	constructor( tokenizer ) {
 		
 		super(undefined, 'env', 'Environment');
 		
 		this.tokenizer = tokenizer;
+		
+		this.declarations = [];
+		
+		this.attributes = [];
+		this.uniforms = [];
+		
+		this.isEnvironment = true;
 		
 	}
 	

--- a/examples/jsm/parser/Analyzer.js
+++ b/examples/jsm/parser/Analyzer.js
@@ -1,0 +1,568 @@
+/**
+ * @author sunag / http://www.sunag.com.br/
+ */
+
+const TypeRegExp = new RegExp( '^(' + [
+	'void', 
+	'bool', 'int', 'uint', 'float',
+	'mat2', 'mat3', 'mat4', 
+	'vec2', 'vec3', 'vec4', 
+	'ivec2', 'ivec3', 'ivec4',
+	'bvec2', 'bvec3', 'bvec4'
+].join('|') + ')$' );
+
+const QualifierRegExp = /^(in|out|inout|highp|mediump|lowp|const)$/;
+
+class ShaderNode {
+	
+	isNode = true;
+	
+	constructor( token, property = undefined ) {
+		
+		this.token = token;
+		this.property = property;
+		
+	}
+	
+}
+
+class ShaderProperty {
+	
+	isProperty = true;
+	
+	start = undefined;
+	end = undefined;
+	
+	nameToken = undefined;
+	typeToken = undefined;
+	
+	calls = [];
+	
+	properties = [];
+	
+	constructor( parent, type, name, qualifiers = [], length = undefined ) {
+		
+		this.parent = parent;
+			
+		this.type = type;
+		this.name = name;
+		this.qualifiers = qualifiers;
+		
+		this.length = undefined;
+			
+	}
+	
+	findProperty( property, findParents = true ) {
+		
+		var names = property.split('.');
+		var name = names.shift();
+		
+		var prop;
+		
+		for(var i = 0; i < this.properties.length; i++) {
+			
+			if ( this.properties[i].name === name ) {
+				
+				prop = this.properties[i];
+				
+				break;
+				
+			}
+			
+		}
+		
+		if ( findParents && !prop && this.parent ) {
+			
+			prop = this.parent.findProperty( name );
+			
+		}
+		
+		if (prop && names.length > 0) {
+
+			return prop.findProperty( names.join('.'), false );
+			
+		}
+		
+		return prop;
+		
+		
+	}
+	
+	addProperty( prop ) {
+		
+		this.properties.push( prop );
+		
+	}
+	
+	getNamespace() {
+		
+		var scope = this;
+		
+		while(scope) {
+			
+			if (scope.isNamespace) break;
+			
+			scope = scope.parent;
+			
+		}
+		
+		return scope;
+		
+	}
+	
+	getBlock() {
+		
+		var scope = this;
+		
+		while(scope) {
+			
+			if (scope.isBlock) break;
+			
+			scope = scope.parent;
+			
+		}
+		
+		return scope;
+		
+	}
+	
+	getName() {
+		
+		var ns = '';
+		var scope = this.parent;
+		
+		while(scope) {
+			
+			if (scope.isNamespace) {
+				
+				// namespace prefix
+				if (!ns) ns = 'ns_'
+				
+				ns = ns + scope.name + '_';
+				
+			}
+			
+			scope = scope.parent;
+			
+		}
+		
+		return ns + this.name;
+		
+	}
+	
+	getSource() {
+		
+		var ns = this.getNamespace();
+		
+		var start = this.start.pos;
+		var end = this.end.endPos;
+		var offset = 0;
+		
+		var source = this.start.tokenizer.source.substring( start, end );
+		
+		var nodes = this.nodes;
+		
+		function replaceAt(absoluteStart, absoluteEnd, str) {
+			
+			var len = source.length;
+			
+			source = source.substring( 0, (absoluteStart - start) + offset ) + str + source.substring( (absoluteEnd - start) + offset );
+			
+			offset += source.length - len;
+			
+		}
+		
+		for(var i = 0; i < nodes.length; i++) {
+			
+			if (nodes[i].property) {
+				
+				var token = nodes[i].token;
+				var realName = nodes[i].property.getName();
+				
+				if (token.str !== realName) {
+				
+					replaceAt(token.pos, token.endPos, realName);
+					
+				}
+				
+			}
+			
+		}
+		
+		if (ns) {
+			
+			replaceAt(this.nameToken.pos, this.nameToken.endPos, this.getName());
+			
+		}
+
+		return source;
+		
+	}
+	
+}
+
+class ShaderBlock extends ShaderProperty {
+	
+	isBlock = true;
+	
+	nodes = []
+	
+	constructor( parent, type, name, qualifiers ) {
+		
+		super( parent, type, name, qualifiers );
+		
+	}
+	
+	addNode( node ) {
+		
+		this.nodes.push( node );
+		
+		return this;
+		
+	}
+	
+	
+	
+}
+
+class ShaderNamespace extends ShaderBlock {
+	
+	isNamespace = true;
+	
+	constructor( parent, name ) {
+		
+		super( parent, 'namespace', name );
+			
+	}
+	
+}
+
+class ShaderStruct extends ShaderBlock {
+	
+	isStruct = true;
+	
+	constructor( parent, name ) {
+		
+		super( parent, 'struct', name );
+			
+	}
+	
+}
+
+class ShaderFunction extends ShaderBlock {
+	
+	isFunction = true;
+	
+	constructor( parent, type, name, qualifiers, args = [] ) {
+		
+		super( parent, type, name, qualifiers );
+		
+		this.args = args;
+			
+	}
+	
+}
+
+class ShaderEnvironment extends ShaderBlock {
+	
+	isEnvironment = true;
+	
+	declarations = [];
+	
+	attributes = [];
+	uniforms = [];
+	
+	constructor( tokenizer ) {
+		
+		super(undefined, 'env', 'Environment');
+		
+		this.tokenizer = tokenizer;
+		
+	}
+	
+	addDeclaration( property ) {
+		
+		this.declarations.push( property );
+		
+		return this;
+		
+	}
+	
+	addAttribute( node ) {
+		
+		this.attributes.push( node );
+		
+		return this.addProperty( node );
+		
+	}
+	
+	addUniform( node ) {
+		
+		this.uniforms.push( node );
+		
+		return this.addProperty( node );
+		
+	}
+	
+	getSource() {
+		
+		return this.tokenizer.source;
+		
+	}
+	
+}
+
+export class Analyzer {
+	
+	constructor( tokenizer ) {
+		
+		this.tokenizer = tokenizer;
+		
+		this.tokens = tokenizer.tokens;
+		this.position = 0;
+		
+		this.env = new ShaderEnvironment( this.tokenizer );
+		
+		this.scope = this.env;
+		
+	}
+	
+	readToken() {
+		
+		return this.tokens[ this.position++ ];
+		
+	}
+	
+	readPropertyOrFunction( currentToken = undefined ) {
+		
+		var qualifiers = [];
+		
+		currentToken = currentToken || this.readToken();
+		
+		while ( QualifierRegExp.test( currentToken.str ) ) {
+			
+			qualifiers.push( currentToken.str );
+			
+			currentToken = this.readToken();
+			
+		}
+		
+		var type = currentToken;
+		var name = this.readToken();
+
+		var prop;
+
+		var currentToken = this.getToken();
+
+		if (currentToken.str === '(') {
+			
+			this.readToken();
+			
+			var args = [];
+			
+			while( this.getToken().str !== ')' ) {
+				
+				args.push( this.readPropertyOrFunction() );
+
+				if (this.getToken().str === ',') this.readToken();
+
+			}
+
+			// skip `)` token
+			this.readToken();
+
+			prop = new ShaderFunction( this.scope, type.str, name.str, qualifiers, args );
+			
+		} else {
+			
+			var length;
+			
+			if (currentToken === '[') {
+				
+				// skip `[` token
+				this.readToken();
+				
+				length = parseInt( this.readToken() );
+				
+				// skip `]` token
+				this.readToken();
+				
+			}
+			
+			prop = new ShaderProperty( this.scope, type.str, name.str, qualifiers, length );
+			
+		}
+		
+		var structProp = this.scope.findProperty( type.str );
+		
+		if (structProp) {
+			
+			prop.calls.push( structProp );
+			
+		}
+		
+		prop.nameToken = name;
+		prop.typeToken = type;
+		
+		return prop;
+		
+	}
+	
+	getToken( offset = 0 ) {
+		
+		return this.tokens[ this.position + offset ];
+		
+	}
+	
+	analyze() {
+		
+		var blockOpened = 0;
+		
+		var codeBlock;
+		var groupBlocks = [];
+		
+		while(this.position < this.tokens.length) {
+			
+			var token = this.readToken();
+
+			if (token.isLiteralString) {
+				
+				if (token.str === 'namespace') {
+					
+					var block = new ShaderNamespace( this.scope, this.readToken().str );
+					block.start = token;
+
+					this.scope.addProperty( block );
+					this.env.addDeclaration( block );
+					
+					this.scope = block;
+						
+					this.analyze();
+					
+					this.scope = block.parent;
+					
+					block.end = this.getToken(-1);
+					
+				} else if (token.str === 'attribute') {
+					
+					codeBlock = this.readPropertyOrFunction();
+					codeBlock.start = token;
+					
+					this.scope.addProperty( codeBlock );
+					this.env.addDeclaration( codeBlock );
+					
+				} else if (token.str === 'uniform') {
+					
+					codeBlock = this.readPropertyOrFunction();
+					codeBlock.start = token;
+					
+					this.scope.addProperty( codeBlock );
+					this.env.addDeclaration( codeBlock );
+					
+				} else if (token.str === 'struct') {
+					
+					var block = new ShaderStruct( this.scope, this.readToken().str );
+					block.start = token;
+
+					this.scope.addProperty( block );
+					this.env.addDeclaration( block );
+					
+					this.scope = block;
+						
+					this.analyze();
+					
+					this.scope = block.parent;
+					
+					if (this.getToken().str === ';') block.end = this.getToken();
+					else block.end = this.getToken(-1);
+					
+				} else if (this.getToken().isLiteralString && 
+					(this.scope.findProperty( token.str ) instanceof ShaderStruct || QualifierRegExp.test( token.str ) || TypeRegExp.test( token.str ))) {
+					
+					while( true ) {
+					
+						codeBlock = this.readPropertyOrFunction( token );
+						codeBlock.start = token;
+						
+						groupBlocks.push( codeBlock );
+						
+						this.scope.addProperty( codeBlock );
+						this.env.addDeclaration( codeBlock );
+						
+						if (this.getToken().str === ',') {
+							
+							// skip `,` token
+							this.readToken();
+
+						} else break;
+						
+					}
+					
+					if ( this.getToken().str === '{' ) {
+						
+						this.scope = codeBlock;
+						
+						this.analyze();
+						
+						this.scope = codeBlock.parent;
+						
+						codeBlock.end = this.getToken(-1);
+						
+						codeBlock = undefined;
+						groupBlocks = [];
+						
+					}
+				
+				} else {
+					
+					var prop = this.scope.findProperty( token.str );
+					
+					this.scope.addNode( new ShaderNode( token, prop ) );
+					
+					if (prop) {
+	
+						if (codeBlock) codeBlock.calls.push( prop );
+						
+						this.scope.calls.push( prop );
+						
+					}
+					
+				}
+				
+			} else if (token.isOperator) {
+				
+				if (token.str === '}') {
+					
+					blockOpened--;
+					
+					if (blockOpened === 0) return this;
+					
+				} else if (token.str === '{') {
+					
+					blockOpened++;
+					
+				} else if (token.str === ';' && codeBlock) {
+					
+					codeBlock.end = token;
+					
+					for(var i = 0; i < groupBlocks.length; i++) {
+						
+						groupBlocks[i].start = groupBlocks[0].start;
+						groupBlocks[i].end = token;
+						
+					}
+					
+					codeBlock = undefined;
+					groupBlocks = [];
+					
+				}
+				
+			}
+			
+		}
+		
+		return this;
+		
+	}
+ 	
+}

--- a/examples/jsm/parser/Analyzer.js
+++ b/examples/jsm/parser/Analyzer.js
@@ -160,8 +160,6 @@ class ShaderProperty {
 		
 		var source = this.start.tokenizer.source.substring( start, end );
 		
-		var nodes = this.nodes;
-		
 		function replaceAt(absoluteStart, absoluteEnd, str) {
 			
 			var len = source.length;
@@ -172,16 +170,22 @@ class ShaderProperty {
 			
 		}
 		
-		for(var i = 0; i < nodes.length; i++) {
-			
-			if (nodes[i].property) {
+		var nodes = this.nodes;
+		
+		if (nodes) {
+		
+			for(var i = 0; i < nodes.length; i++) {
 				
-				var token = nodes[i].token;
-				var realName = nodes[i].property.getName();
-				
-				if (token.str !== realName) {
-				
-					replaceAt(token.pos, token.endPos, realName);
+				if (nodes[i].property) {
+					
+					var token = nodes[i].token;
+					var realName = nodes[i].property.getName();
+					
+					if (token.str !== realName) {
+					
+						replaceAt(token.pos, token.endPos, realName);
+						
+					}
 					
 				}
 				
@@ -288,19 +292,19 @@ class ShaderEnvironment extends ShaderBlock {
 		
 	}
 	
-	addAttribute( node ) {
+	addAttribute( property ) {
 		
-		this.attributes.push( node );
+		this.attributes.push( property );
 		
-		return this.addProperty( node );
+		return this.addProperty( property );
 		
 	}
 	
-	addUniform( node ) {
+	addUniform( property ) {
 		
-		this.uniforms.push( node );
+		this.uniforms.push( property );
 		
-		return this.addProperty( node );
+		return this.addProperty( property );
 		
 	}
 	
@@ -448,7 +452,7 @@ export class Analyzer {
 					codeBlock = this.readPropertyOrFunction();
 					codeBlock.start = token;
 					
-					this.scope.addProperty( codeBlock );
+					this.scope.addAttribute( codeBlock );
 					this.env.addDeclaration( codeBlock );
 					
 				} else if (token.str === 'uniform') {
@@ -456,7 +460,7 @@ export class Analyzer {
 					codeBlock = this.readPropertyOrFunction();
 					codeBlock.start = token;
 					
-					this.scope.addProperty( codeBlock );
+					this.scope.addUniform( codeBlock );
 					this.env.addDeclaration( codeBlock );
 					
 				} else if (token.str === 'struct') {

--- a/examples/jsm/parser/Emitter.js
+++ b/examples/jsm/parser/Emitter.js
@@ -1,0 +1,105 @@
+/**
+ * @author sunag / http://www.sunag.com.br/
+ */
+
+export class Emitter {
+	
+	constructor( analyzer ) {
+		
+		this.analyzer = analyzer;
+		this.scope = analyzer.env;
+		
+		this.flowDict = new Map();
+		this.source = '';
+		
+	}
+	
+	flow( node ) {
+		
+		if (this.flowDict.get( node )) return;
+		
+		this.flowDict.set( node, true );
+		
+		for(var i = 0; i < node.calls.length; i++) {
+			
+			var callBlock = node.calls[i].getBlock();
+			
+			if (callBlock !== node) {
+				
+				this.flow( callBlock );
+				
+			}
+			
+		}
+		
+		this.source += node.getSource() + '\n\n';
+		
+	}
+	
+	emitArray( list ) {
+		
+		for(var i = 0; i < list.length; i++) {
+			
+			this.source += list[i].getSource() + '\n';
+			
+		}
+		
+		if ( list.length ) this.source += '\n';
+		
+	}
+	
+	inFlow( node ) {
+		
+		while( node && ! this.flowDict.get( node ) ) {
+			
+			node = node.parent;
+			
+		}
+		
+		return !!node;
+		
+	}
+	
+	unemit(name = undefined) {
+		
+		this.emit( name );
+		
+		var source = this.scope.getSource();
+		var offset = 0;
+		
+		for(var i = 0; i < this.scope.declarations.length; i++) {
+			
+			var node = this.scope.declarations[i];
+			
+			if ( ! this.inFlow( node ) ) {
+				
+				var start = node.start.pos;
+				var end = node.end.endPos;
+				var length = end - start;
+				
+				source = source.substring( 0, start ) + ' '.repeat(length) + source.substring( end );
+				
+			}
+			
+		}
+		
+		this.source = source;
+		
+		return this;
+		
+	}
+	
+	emit(name = 'main') {
+
+		var node = this.scope.findProperty( name );
+		
+		//this.emitArray( this.scope.attributes );
+		//this.emitArray( this.scope.uniforms );
+		
+		this.flow( node );
+		
+		return this;
+		
+	}
+ 	
+}

--- a/examples/jsm/parser/Emitter.js
+++ b/examples/jsm/parser/Emitter.js
@@ -93,8 +93,8 @@ export class Emitter {
 
 		var node = this.scope.findProperty( name );
 		
-		//this.emitArray( this.scope.attributes );
-		//this.emitArray( this.scope.uniforms );
+		this.emitArray( this.scope.attributes );
+		this.emitArray( this.scope.uniforms );
 		
 		this.flow( node );
 		

--- a/examples/jsm/parser/Parser.js
+++ b/examples/jsm/parser/Parser.js
@@ -61,13 +61,15 @@ function parseIncludes( source, libs ) {
 	
 }
 
+
+
+
 class ParsePreprocessor {
-	
-	libraries = [];
 	
 	constructor( source ) {
 		
 		this.source = source;
+		this.libraries = [];
 		
 	}
 	
@@ -91,15 +93,11 @@ class ParsePreprocessor {
 }
 
 export default class Parser {
-	
-	static EMIT = 'emit';
-	static UNEMIT = 'unemit';
-	
-	libraries = [];
-	
-	constructor( method = Parser.EMIT ) {
+
+	constructor( method = 'emit' ) {
 		
 		this.method = method;
+		this.libraries = [];
 		
 	}
 	
@@ -125,3 +123,6 @@ export default class Parser {
 	}
 	
 }
+
+Parser.EMIT = 'emit';
+Parser.UNEMIT = 'unemit';

--- a/examples/jsm/parser/Parser.js
+++ b/examples/jsm/parser/Parser.js
@@ -1,0 +1,127 @@
+/**
+ * @author sunag / http://www.sunag.com.br/
+ */
+
+import { Tokenizer } from './Tokenizer.js';
+import { Analyzer } from './Analyzer.js';
+import { Emitter } from './Emitter.js';
+
+function parseDefines( source ) {
+		
+	const pattern = /^[ \t]*#define +([\w]+) +(.*)/gm;
+
+	var matches = [];
+	var match;
+
+	while ( match = pattern.exec( source ) ) matches.push( match );
+
+	function replace( m ) {
+
+		return m.substr(0, 1) + match[2] + m.substr(-1);
+
+	}
+
+	for ( var i = 0; i < matches.length; i ++ ) {
+		
+		match = matches[i];
+		
+		source = source.replace( new RegExp( '\\W' + match[1] + '\\W', 'g' ), replace );
+
+	}
+		
+	return source.replace( /^[ \t]*#define +.*/gm, '' );
+
+}
+
+function parseIncludes( source, libs ) {
+	
+	function replace( match, include ) {
+
+		var replace;
+
+		for( var i = 0; i < libs.length; i++ ) {
+			
+			replace = libs[i][ include ];
+			
+			if ( replace === undefined ) break;
+			
+		}
+
+		if ( replace === undefined ) {
+
+			throw new Error( 'Can not resolve #include <' + include + '>' );
+
+		}
+
+		return parseIncludes( replace, libs );
+
+	}
+
+	return source.replace( /^[ \t]*#include +<([\w./]+)>/gm, replace );
+	
+}
+
+class ParsePreprocessor {
+	
+	libraries = [];
+	
+	constructor( source ) {
+		
+		this.source = source;
+		
+	}
+	
+	setLibraries( libraries ) {
+		
+		this.libraries = libraries;
+		
+		return this;
+		
+	}
+
+	parse() {
+
+		this.source = parseIncludes( this.source, this.libraries );
+		this.source = parseDefines( this.source );
+
+		return this;
+
+	}
+	
+}
+
+export default class Parser {
+	
+	static EMIT = 'emit';
+	static UNEMIT = 'unemit';
+	
+	libraries = [];
+	
+	constructor( method = Parser.EMIT ) {
+		
+		this.method = method;
+		
+	}
+	
+	addLibrary( lib ) {
+		
+		this.libraries.push( lib );
+		
+	}
+	
+	compile( source ) {
+		
+		source = new ParsePreprocessor( source ).setLibraries( this.libraries ).parse().source;
+		
+		var tokenizer = new Tokenizer( source ).tokenize();
+		var analyzer = new Analyzer( tokenizer ).analyze();
+		var emitter = new Emitter( analyzer );
+
+		if (this.method === Parser.UNEMIT) emitter.unemit();
+		else emitter.emit();
+
+		return emitter.source;
+		
+	}
+	
+}

--- a/examples/jsm/parser/Tokenizer.js
+++ b/examples/jsm/parser/Tokenizer.js
@@ -2,8 +2,8 @@
  * @author sunag / http://www.sunag.com.br/
  */
 
-const SpaceRegExp = /^\s*/s;
-const CommentRegExp = /^\/\*.*?\*\//s;
+const SpaceRegExp = /^\s*/;
+const CommentRegExp = /^\/\*.*?\*\//;
 const InlineCommentRegExp = /^\/\/.*?(\n|$)/;
 
 const PreprocessorRegExp = /^\#.*?(\n|$)/;
@@ -19,12 +19,6 @@ const OperatorsRegExp = new RegExp( '^(\\' + [
 ].join('$').split('').join('\\').replace(/\\\$/g, '|') + ')' );
 
 class Token {
-	
-	static PREPROCESSOR = 'preprocessor';
-	static NUMBER = 'number';
-	static STRING = 'string';
-	static LITERAL_STRING = 'literalString';
-	static OPERATOR = 'operator';
 	
 	constructor( tokenizer, type, str, pos ) {
 		
@@ -74,6 +68,12 @@ class Token {
 	}
 	
 }
+
+Token.PREPROCESSOR = 'preprocessor';
+Token.NUMBER = 'number';
+Token.STRING = 'string';
+Token.LITERAL_STRING = 'literalString';
+Token.OPERATOR = 'operator';
 
 const TokenParserList = [
 	{ type: Token.PREPROCESSOR, regexp: PreprocessorRegExp },

--- a/examples/jsm/parser/Tokenizer.js
+++ b/examples/jsm/parser/Tokenizer.js
@@ -1,0 +1,164 @@
+/**
+ * @author sunag / http://www.sunag.com.br/
+ */
+
+const SpaceRegExp = /^\s*/s;
+const CommentRegExp = /^\/\*.*?\*\//s;
+const InlineCommentRegExp = /^\/\/.*?(\n|$)/;
+
+const PreprocessorRegExp = /^\#.*?(\n|$)/;
+const NumberRegExp = /^((\.\d)|\d)(\d*)(\.)?(\d*)/;
+const StringDoubleRegExp = /^(\"((?:[^"\\]|\\.)*)\")/;
+const StringSingleRegExp = /^(\'((?:[^'\\]|\\.)*)\')/;
+const LiteralStringRegExp = /^[A-Za-z](\w|\.)*/;
+const OperatorsRegExp = new RegExp( '^(\\' + [
+    '<<=', '>>=', '++', '--', '<<', '>>', '+=', '-=', '*=', '/=', '%=', '&=', '^^', '^=', '|=',
+	'<=', '>=', '==', '!=', '&&', '||', 
+	'(', ')', '[', ']', '{', '}', 
+	'.', ',', ';', '!', '=', '~', '*', '/', '%', '+', '-', '<', '>', '&', '^', '|', '?', ':', '#'
+].join('$').split('').join('\\').replace(/\\\$/g, '|') + ')' );
+
+class Token {
+	
+	static PREPROCESSOR = 'preprocessor';
+	static NUMBER = 'number';
+	static STRING = 'string';
+	static LITERAL_STRING = 'literalString';
+	static OPERATOR = 'operator';
+	
+	constructor( tokenizer, type, str, pos ) {
+		
+		this.tokenizer = tokenizer;
+		
+		this.type = type
+		
+		this.str = str;
+		this.pos = pos;
+		
+	}
+	
+	get endPos() {
+		
+		return this.pos + this.str.length;
+		
+	}
+	
+	get isPreprocessor() {
+		
+		return this.type === Token.PREPROCESSOR;
+		
+	}
+	
+	get isNumber() {
+		
+		return this.type === Token.NUMBER;
+		
+	}
+	
+	get isString() {
+		
+		return this.type === Token.STRING;
+		
+	}
+	
+	get isLiteralString() {
+		
+		return this.type === Token.LITERAL_STRING;
+		
+	}
+	
+	get isOperator() {
+		
+		return this.type === Token.OPERATOR;
+		
+	}
+	
+}
+
+const TokenParserList = [
+	{ type: Token.PREPROCESSOR, regexp: PreprocessorRegExp },
+	{ type: Token.NUMBER, regexp: NumberRegExp },
+	{ type: Token.STRING, regexp: StringDoubleRegExp, group: 2 },
+	{ type: Token.STRING, regexp: StringSingleRegExp, group: 2 },
+	{ type: Token.LITERAL_STRING, regexp: LiteralStringRegExp },
+	{ type: Token.OPERATOR, regexp: OperatorsRegExp }
+];
+
+export class Tokenizer {
+	
+	constructor( source ) {
+		
+		this.source = source;
+		this.position = 0;
+		
+		this.tokens = [];
+		
+	}
+	
+	tokenize() {
+		
+		var token = this.readToken();
+		
+		while ( token ) {
+
+			this.tokens.push( token );
+			
+			token = this.readToken();
+			
+		}
+		
+		return this;
+		
+	}
+
+	skip() {
+		
+		var remainingCode = this.source.substr( this.position );
+		var i = arguments.length;
+		
+		while( i-- ) {
+		
+			var skip = arguments[i].exec( remainingCode );
+			var skipLength = skip ? skip[0].length : 0;
+			
+			if (skipLength > 0) {
+
+				this.position += skipLength;
+					
+				remainingCode = this.source.substr( this.position );
+			
+				// re-skip, new remainingCode is generated
+				// maybe exist previous regexp non detected
+				i = arguments.length;
+					
+			}
+			
+		}
+		
+		return remainingCode;
+		
+	}
+	
+	readToken() {
+		
+		var remainingCode = this.skip( SpaceRegExp, CommentRegExp, InlineCommentRegExp );
+		
+		for(var i = 0; i < TokenParserList.length; i++) {
+			
+			var parser = TokenParserList[i];
+			var result = parser.regexp.exec( remainingCode );
+			
+			if (result) {
+				
+				var token = new Token( this, parser.type, result[ parser.group || 0 ], this.position );
+				
+				this.position += token.str.length;
+				
+				return token;
+				
+			}
+		}
+
+	}
+	
+}

--- a/examples/webgl_nodes.html
+++ b/examples/webgl_nodes.html
@@ -23,6 +23,8 @@
 
 				var source = `
 
+uniform vec3 position;
+
 namespace threejs {
 
 	void hello_world() { vec3 abc; }

--- a/examples/webgl_nodes.html
+++ b/examples/webgl_nodes.html
@@ -32,10 +32,18 @@ namespace threejs {
 	void not_call_not_compile() {  }
 
 }
-				
+		
+	highp float rand( const in vec2 uv ) {
+		const highp float a = 12.9898, b = 78.233, c = 43758.5453;
+		highp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );
+		return fract(sin(sn) * c);
+	}
+		
 void main() {
 
 	threejs.hello_world();
+
+	rand( vec2( 2.0 ) )
 
 	//threejs.not_call_not_compile();
 

--- a/examples/webgl_nodes.html
+++ b/examples/webgl_nodes.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - node material</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+
+		<div id="container"></div>
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Node-Based Material<br />
+			Serialized using <a href="webgl_materials_nodes.html">webgl_materials_nodes.html</a>
+		</div>
+
+		<script type="module">
+
+				import * as THREE from '../build/three.module.js';
+
+
+				import Parser from './jsm/parser/Parser.js';
+
+				var source = `
+
+namespace threejs {
+
+	void hello_world() { vec3 abc; }
+	
+	void not_call_not_compile() {  }
+
+}
+				
+void main() {
+
+	threejs.hello_world();
+
+	//threejs.not_call_not_compile();
+
+}
+
+`;
+				
+				
+			var parser = new Parser();
+			parser.addLibrary( THREE.ShaderChunk );
+			console.log( parser.compile( source ) );
+
+
+/*uniform vec3 position;
+
+float test = 123;
+
+#ifdef TEST
+
+#endif
+
+//#include <common>
+
+const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
+const float UnpackDownscale = 255. / 256.; // 0..1 -> fraction (excluding 1)
+const vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );
+
+struct GeometricContext {
+	vec3 position;
+	vec3 normal;
+	vec3 viewDir;
+	vec3 clearCoatNormal;
+};
+
+highp float rand( const in vec2 uv ) {
+	const highp float a = 12.9898, b = 78.233, c = 43758.5453;
+	highp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );
+	//test;
+	//GeometricContext;
+	UnpackFactors;
+	return fract(sin(sn) * c);
+}
+
+highp float rand2( const in vec2 uv ) {
+	const highp float a = 12.9898, b = 78.233, c = 43758.5453;
+	highp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );
+	return fract(sin(sn) * c);
+}
+
+void main() {
+
+	rand(2);
+	position;
+
+}*/
+
+
+/*environment {
+
+	//precision mediump float;
+
+	attribute vec4 a_position;
+	uniform vec4 u_offset;
+	
+	varying vec4 v_positionWithOffset;
+
+}
+
+vertex { 
+
+	void main() {
+	
+	  gl_Position = a_position + u_offset;
+	  v_positionWithOffset = a_position + u_offset;
+	  
+	}
+
+}
+
+fragment {
+
+	void main() {
+	
+	  // convert from clipspace (-1 <-> +1) to color space (0 -> 1).
+	  vec4 color = v_positionWithOffset * 0.5 + 0.5
+	  gl_FragColor = color;
+	  
+	}
+
+}*/
+	
+				//parser.parse(`'test '`);
+				//parser.parse(`"test\\" "`);
+
+		</script>
+	</body>
+</html>

--- a/examples/webgl_performance_nodes.html
+++ b/examples/webgl_performance_nodes.html
@@ -52,6 +52,8 @@
 
 			var mouseX = 0, mouseY = 0;
 
+			var defaultCount = parseInt( new URL( window.location.href ).searchParams.get( 'count' ) ) || 70;
+
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
 
@@ -62,7 +64,7 @@
 
 			function createScene( MaterialClass, count ) {
 
-				count = count !== undefined ? count : 70;
+				count = count !== undefined ? count : defaultCount;
 
 				var i = 0;
 


### PR DESCRIPTION
## Some motivations

- Custom syntax for creation of more specifics and advanced shaders
- Auto `GLSL` `chunk` core conversion for `Nodes` and `NodeMaterial System`
( I think that the last hard change to merger NodeMaterial to the core )
- Simplifying the current shader creation model
- ~~More performance~~
- Easy integration with WebGL2

## Optimization

### EDITED -> CHROME WINDOWS ONLY

The flow system of the parser optimize GLSL call tree, I make a test optimizing using `NodeMaterial` (current performance 1/1), adding the parse, its excluding functions and properties not used in code. **The result was 2x at 3x faster** (2.5~/1) than the current material.

### Link to benchmark 
https://rawgit.com/sunag/three.js/dev-shader-parser/examples/webgl_performance_nodes.html?count=10
__count=10 program per material__

## Namespace Proposal

The idea is to replace the chunks for namespaces, making it more organized and clean to work. 
For example:

### Example source-code only ( Open console )
https://rawgit.com/sunag/three.js/dev-shader-parser/examples/webgl_nodes.html

### Example 
```glsl

namespace brdf {

	vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) { }

}

namespace common {

	highp float rand( const in vec2 uv ) {
		const highp float a = 12.9898, b = 78.233, c = 43758.5453;
		highp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );
		return fract(sin(sn) * c);
	}

}

void main() {

	// rand is generated as `_common_rand` to GLSL conversion
	// rand function is only declared if is called in flow of the main()
	// this feature is the real reponsible by optimize the code compile 2x at 3x faster
	// integrateSpecularBRDF although declared, is not emited to GLSL code

	common.rand( vec2( 2.0 ) );

}
```
### Material property preprocessor

Now we no longer have to worry about hiding functions using `defines` since we have `namespace`. The idea is to use the same `preprocessor` to detect materials properties in shader code, using `#ifprop` for example.

```glsl
#ifprop normalMap

	uniform sampler2D normalMap;
	uniform vec2 normalScale;

#endifprop
```

### CODE IS WIP