### PR TITLE
Shaders: Added precisionSafeLength()

### DIFF
--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -22,6 +22,16 @@ highp float rand( const in vec2 uv ) {
 	return fract(sin(sn) * c);
 }
 
+#ifdef HIGH_PRECISION
+	float precisionSafeLength( vec3 v ) { return length( v ); }
+#else
+	float max3( vec3 v ) { return max( max( v.x, v.y ), v.z ); }
+	float precisionSafeLength( vec3 v ) {
+		float maxComponent = max3( abs( v ) );
+		return length( v / maxComponent ) * maxComponent;
+	}
+#endif
+
 struct IncidentLight {
 	vec3 color;
 	vec3 direction;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -370,6 +370,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			'precision ' + parameters.precision + ' float;',
 			'precision ' + parameters.precision + ' int;',
 
+			( parameters.precision === 'highp' ) ? '#define HIGH_PRECISION' : '',
+
 			'#define SHADER_NAME ' + shader.name,
 
 			customDefines,
@@ -487,6 +489,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 
 			'precision ' + parameters.precision + ' float;',
 			'precision ' + parameters.precision + ' int;',
+
+			( parameters.precision === 'highp' ) ? '#define HIGH_PRECISION' : '',
 
 			'#define SHADER_NAME ' + shader.name,
 


### PR DESCRIPTION
As proposed in https://github.com/mrdoob/three.js/pull/14752#issuecomment-414863463.

This is easily-reverted if it turns out we don't need it...