### PR TITLE
fix: examples/HDRCubeTextureLoader.d.ts

### DIFF
--- a/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
@@ -13,7 +13,7 @@ export class HDRCubeTextureLoader {
   path: string;
   type: TextureDataType;
 
-  load(url: string, onLoad: (texture: CubeTexture) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
+  load(urls: string[], onLoad: (texture: CubeTexture) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
   setPath(value: string): this;
   setDataType(type: TextureDataType): this;
 }


### PR DESCRIPTION
fix the parameter type declaration of HDRCubeTextureLoader.d.ts