### PR TITLE
Relax class testing in TransformControls

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -210,7 +210,15 @@ THREE.TransformControls = function ( camera, domElement ) {
 		this.camera.updateMatrixWorld();
 		this.camera.matrixWorld.decompose( cameraPosition, cameraQuaternion, cameraScale );
 
-		eye.copy( cameraPosition ).sub( worldPosition ).normalize();
+		if ( this.camera.isPerspectiveCamera ) {
+
+			eye.copy( cameraPosition ).sub( worldPosition ).normalize();
+
+		} else if ( this.camera.isOrthographicCamera ) {
+
+			eye.copy( cameraPosition ).normalize();
+
+		}
 
 		THREE.Object3D.prototype.updateMatrixWorld.call( this );
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -233,7 +233,15 @@ var TransformControls = function ( camera, domElement ) {
 		this.camera.updateMatrixWorld();
 		this.camera.matrixWorld.decompose( cameraPosition, cameraQuaternion, cameraScale );
 
-		eye.copy( cameraPosition ).sub( worldPosition ).normalize();
+		if ( this.camera.isPerspectiveCamera ) {
+
+			eye.copy( cameraPosition ).sub( worldPosition ).normalize();
+
+		} else if ( this.camera.isOrthographicCamera ) {
+
+			eye.copy( cameraPosition ).normalize();
+
+		}
 
 		Object3D.prototype.updateMatrixWorld.call( this );
 


### PR DESCRIPTION
Check only string properties (isPerspectiveCamera, isOrthographicCamera) rather than class membership in TransformControls to allow use different instances of camera classes. Most checks for three objects only test the `isFoo` properties, where `instanceof` is seldom used, outside of some internal classes.

Without this patch, a camera from a different THREE namespace than the TransformControls results in strangely broken controls.