### PR TITLE
Devtools: Expose revision

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -1,4 +1,5 @@
 import './polyfills.js';
+import { REVISION } from './constants.js';
 
 export { WebGLMultisampleRenderTarget } from './renderers/WebGLMultisampleRenderTarget.js';
 export { WebGLRenderTargetCube } from './renderers/WebGLRenderTargetCube.js';
@@ -158,3 +159,13 @@ export { ShapeUtils } from './extras/ShapeUtils.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 export * from './constants.js';
 export * from './Three.Legacy.js';
+
+if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+	/* eslint-disable no-undef */
+	__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
+		revision: REVISION,
+	} } ) );
+	/* eslint-enable no-undef */
+
+}


### PR DESCRIPTION
With the removal of the console.log messaging of the revision (https://github.com/mrdoob/three.js/commit/1013fbb9d8f25751c9f17a43f2ce654224e024bd#diff-c0e88b98497597a015ecf238e91ac3a0), there's no way to discover what version three is running when moduleified programmatically. One isn't really using three.js without using the renderer, and I think that'd be a good place to expose the revision, where it can be interpreted by devtools or folks debugging a page. Similarly removed the console.log messaging for `WebGL2Renderer`.

I don't feel strongly regarding `.REVISION` vs `.revision`, other than the capitalized form only makes sense if you're familiar with `THREE.REVISION`, but in the context of a renderer, `.revision` seems more appropriate.