### PR TITLE
GLTFExporter: export texture names

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -867,6 +867,10 @@ THREE.GLTFExporter.prototype = {
 
 			};
 
+			if ( map.name ) {
+				gltfTexture.name = map.name;
+			}
+
 			outputJSON.textures.push( gltfTexture );
 
 			var index = outputJSON.textures.length - 1;

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -868,7 +868,9 @@ THREE.GLTFExporter.prototype = {
 			};
 
 			if ( map.name ) {
+
 				gltfTexture.name = map.name;
+
 			}
 
 			outputJSON.textures.push( gltfTexture );

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -892,7 +892,9 @@ GLTFExporter.prototype = {
 			};
 
 			if ( map.name ) {
+
 				gltfTexture.name = map.name;
+
 			}
 
 			outputJSON.textures.push( gltfTexture );

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -891,6 +891,10 @@ GLTFExporter.prototype = {
 
 			};
 
+			if ( map.name ) {
+				gltfTexture.name = map.name;
+			}
+
 			outputJSON.textures.push( gltfTexture );
 
 			var index = outputJSON.textures.length - 1;


### PR DESCRIPTION
The GLTF specification allows for a name property, and the importer already supports this.

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#texture