### PR TITLE
Examples SkyShader: Fix parameter order

### DIFF
--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -50,9 +50,9 @@
 				var effectController = {
 					turbidity: 10,
 					rayleigh: 2,
+					luminance: 1,
 					mieCoefficient: 0.005,
 					mieDirectionalG: 0.8,
-					luminance: 1,
 					inclination: 0.49, // elevation / inclination
 					azimuth: 0.25, // Facing front,
 					sun: ! true
@@ -103,8 +103,6 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 100, 2000000 );
 				camera.position.set( 0, 100, 2000 );
-
-				//camera.setLens(20);
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -50,9 +50,9 @@
 				var effectController = {
 					turbidity: 10,
 					rayleigh: 2,
-					luminance: 1,
 					mieCoefficient: 0.005,
 					mieDirectionalG: 0.8,
+					luminance: 1,
 					inclination: 0.49, // elevation / inclination
 					azimuth: 0.25, // Facing front,
 					sun: ! true
@@ -65,10 +65,10 @@
 					var uniforms = sky.material.uniforms;
 					uniforms[ "turbidity" ].value = effectController.turbidity;
 					uniforms[ "rayleigh" ].value = effectController.rayleigh;
-					uniforms[ "luminance" ].value = effectController.luminance;
 					uniforms[ "mieCoefficient" ].value = effectController.mieCoefficient;
 					uniforms[ "mieDirectionalG" ].value = effectController.mieDirectionalG;
-
+					uniforms[ "luminance" ].value = effectController.luminance;
+					
 					var theta = Math.PI * ( effectController.inclination - 0.5 );
 					var phi = 2 * Math.PI * ( effectController.azimuth - 0.5 );
 


### PR DESCRIPTION
I stumbled upon this one argument thats not in order with the others, this has no effect on the user.
Also there is no method `setLens` in THREE.Camera, so this comment should be removed.