### PR TITLE
Docs: OBJLoader2 is now a module

### DIFF
--- a/docs/examples/en/loaders/OBJLoader2.html
+++ b/docs/examples/en/loaders/OBJLoader2.html
@@ -35,7 +35,6 @@
 
 		[example:webgl_loader_obj2] - Simple example <br>
 		[example:webgl_loader_obj2_options] - Example for multiple use-cases (parse, load and run with instructions (sync and async)<br>
-		[example:webgl_loader_obj2_run_director] - Advanced example using [page:LoaderSupport.LoaderWorkerDirector] for orchestration of multiple workers.
 
 
 		<h2>Constructor</h2>
@@ -206,7 +205,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader2.js examples/js/loaders/OBJLoader2.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/OBJLoader2.js examples/jsm/loaders/OBJLoader2.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/OBJLoader2.html
+++ b/docs/examples/zh/loaders/OBJLoader2.html
@@ -35,7 +35,6 @@
 
 		[example:webgl_loader_obj2] - Simple example <br>
 		[example:webgl_loader_obj2_options] - Example for multiple use-cases (parse, load and run with instructions (sync and async)<br>
-		[example:webgl_loader_obj2_run_director] - Advanced example using [page:LoaderSupport.LoaderWorkerDirector] for orchestration of multiple workers.
 
 
 		<h2>Constructor</h2>
@@ -206,7 +205,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader2.js examples/js/loaders/OBJLoader2.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/OBJLoader2.js examples/jsm/loaders/OBJLoader2.js]
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
Fix path and remove link to example which doesnt exist anymore.