### PR TITLE
Roughness & environment maps

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -63,6 +63,9 @@ export default /* glsl */ `
 
 		  vec3 reflectVec = reflect( -viewDir, normal );
 
+		  // Mixing the reflection with the normal is more accurate and keeps rough objects from gathering light from behind their tangent plane.
+		  reflectVec = normalize( mix( reflectVec, normal, roughness * roughness) );
+
 		#else
 
 		  vec3 reflectVec = refract( -viewDir, normal, refractionRatio );

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* glsl */ `
 #if defined( RE_IndirectDiffuse )
 
 	#ifdef USE_LIGHTMAP
@@ -25,11 +25,11 @@ export default /* glsl */`
 
 #if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )
 
-	radiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.normal, Material_BlinnShininessExponent( material ), maxMipLevel );
+	radiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.normal, material.specularRoughness, maxMipLevel );
 
 	#ifdef CLEARCOAT
 
-		clearcoatRadiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.clearcoatNormal, Material_Clearcoat_BlinnShininessExponent( material ), maxMipLevel );
+		clearcoatRadiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.clearcoatNormal, material.clearCoatRoughness, maxMipLevel );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* glsl */ `
 struct PhysicalMaterial {
 
 	vec3	diffuseColor;
@@ -160,9 +160,6 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 #define RE_Direct_RectArea		RE_Direct_RectArea_Physical
 #define RE_IndirectDiffuse		RE_IndirectDiffuse_Physical
 #define RE_IndirectSpecular		RE_IndirectSpecular_Physical
-
-#define Material_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.specularRoughness )
-#define Material_Clearcoat_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.clearcoatRoughness )
 
 // ref: https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
 float computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {


### PR DESCRIPTION
This is my first attempt  to upstream a rendering improvement from [\<model-viewer>](https://github.com/GoogleWebComponents/model-viewer) to three. This is based on some analysis I've done showing that sampling the environment should not be done at the reflection vector for rough materials, but rather at the normal vector (as for the diffuse term). I fit equations to the Trowbridge-Reitz distribution to handle both interpolating the sample vector based on roughness as well as looking up the proper mip (since before it was based on Blinn-Phong, which isn't consistent with GGX). This roughness remapping only affects the non-PMREM version, as I'm still working on an improved PMREM based on this line of reasoning. The remapping has the effect of making materials appear a bit less shiny, which brings it closer to other renderers.

As an example of sample vector change, note the before image where, ignoring the lack of self-shadowing, we see strong reflection of the sun, even where the material is not facing the sun:

![threeBefore](https://user-images.githubusercontent.com/1649964/63722574-4ab23f80-c808-11e9-8455-e0ce5398f288.png)

Versus with this change:

![threeAfter](https://user-images.githubusercontent.com/1649964/63722807-bf857980-c808-11e9-9281-e591b4afe986.png)

A writeup of my analysis, including future work (please excuse the poor formatting, I've filed a bug):
[elalishPMREM.pdf](https://github.com/mrdoob/three.js/files/3543081/elalishPMREM.pdf)
