### PR TITLE
Shaders: decouple light probe irradiance from other indirect light sources

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
@@ -7,7 +7,7 @@ export default /* glsl */`
 
 #if defined( RE_IndirectSpecular )
 
-	RE_IndirectSpecular( radiance, irradiance, clearcoatRadiance, geometry, material, reflectedLight );
+	RE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometry, material, reflectedLight );
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -15,9 +15,11 @@ export default /* glsl */`
 
 	#endif
 
+	vec3 iblIrradiance = vec3( 0.0 );
+
 	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
 
-		irradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, maxMipLevel );
+		iblIrradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry, maxMipLevel );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -117,6 +117,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 void RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
 
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 }
 


### PR DESCRIPTION
Fixes #17253.

As suggested in https://github.com/mrdoob/three.js/issues/17102#issuecomment-518053612 and https://github.com/mrdoob/three.js/issues/17253#issuecomment-522624543.

This also fixes an unreported bug. The multi-scattering, energy-preservation model introduced in #15644 should only have been applied to irradiance from IBLs, but it was applied to all indirect diffuse light sources.

/ping @jsantell 
/ping @elalish  
/ping @sunag 
/ping @bhouston 
