### PR TITLE
DRACOLoader: Fix remaining calls to removed static methods.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -182,10 +182,11 @@ var Loader = function ( editor ) {
 
 					var contents = event.target.result;
 
-					THREE.DRACOLoader.setDecoderPath( '../examples/js/libs/draco/gltf/' );
+					var dracoLoader = new THREE.DRACOLoader();
+					dracoLoader.setDecoderPath( '../examples/js/libs/draco/gltf/' );
 
 					var loader = new THREE.GLTFLoader();
-					loader.setDRACOLoader( new THREE.DRACOLoader() );
+					loader.setDRACOLoader( dracoLoader );
 					loader.parse( contents, '', function ( result ) {
 
 						var scene = result.scene;

--- a/examples/js/libs/draco/README.md
+++ b/examples/js/libs/draco/README.md
@@ -20,9 +20,9 @@ Each file is provided in two variations:
 Either variation may be used with `THREE.DRACOLoader`:
 
 ```js
-THREE.DRACOLoader.setDecoderPath('path/to/decoders/');
-THREE.DRACOLoader.setDecoderConfig({type: 'js'}); // (Optional) Override detection of WASM support.
 var dracoLoader = new THREE.DRACOLoader();
+dracoLoader.setDecoderPath('path/to/decoders/');
+dracoLoader.setDecoderConfig({type: 'js'}); // (Optional) Override detection of WASM support.
 ```
 
 Further [documentation on GitHub](https://github.com/google/draco/tree/master/javascript/example#static-loading-javascript-decoder).

--- a/examples/webgl_materials_cars.html
+++ b/examples/webgl_materials_cars.html
@@ -140,10 +140,11 @@
 
 			function initCar() {
 
-				DRACOLoader.setDecoderPath( 'js/libs/draco/gltf/' );
+				var dracoLoader = new DRACOLoader();
+				dracoLoader.setDecoderPath( 'js/libs/draco/gltf/' );
 
 				var loader = new GLTFLoader();
-				loader.setDRACOLoader( new DRACOLoader() );
+				loader.setDRACOLoader( dracoLoader );
 
 				loader.load( 'models/gltf/ferrari.glb', function ( gltf ) {
 


### PR DESCRIPTION
Mostly fixes the _materials • cars_ example. A remaining issue is that the dropdowns are not selectable, I think that was a side effect of 04b554e8ab.