### PR TITLE
Enables smooth scrolling of docs side-panel on iOS devices

### DIFF
--- a/files/main.css
+++ b/files/main.css
@@ -254,6 +254,7 @@ h1 a {
 		flex: 1;
 		overflow-y: auto;
 		overflow-x: hidden;
+		-webkit-overflow-scrolling: touch;
 		padding: 0 var(--panel-padding) var(--panel-padding) var(--panel-padding);
 	}
 


### PR DESCRIPTION
I'm using an iOS smartphone, every time I visit three.js website I stumble upon the side menu panel not scrolling smoothly (no easing out the native way): scrolling is cumbersome.  I also checked an Android device, but there this doesn't seem to be an issue, only with iOS.