### PR TITLE
Clone Proposal: Add ID cache to Object3D, DirectionalLight copy and clone functions

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -802,9 +802,9 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	clone: function ( recursive ) {
+	clone: function ( recursive, cache ) {
 
-		return new this.constructor().copy( this, recursive );
+		return new this.constructor().copy( this, recursive, cache );
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -808,9 +808,13 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	copy: function ( source, recursive ) {
+	copy: function ( source, recursive, cache ) {
 
 		if ( recursive === undefined ) recursive = true;
+
+		if ( cache === undefined ) cache = {};
+
+		cache[ source.uuid ] = this;
 
 		this.name = source.name;
 
@@ -842,7 +846,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			for ( var i = 0; i < source.children.length; i ++ ) {
 
 				var child = source.children[ i ];
-				this.add( child.clone() );
+				this.add( cache[ child.uuid ] || child.clone( recursive, cache ) );
 
 			}
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -36,7 +36,7 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 		if ( ( source.target.uuid in cache ) === false ) {
 
-			cache[ source.target.uuid ] = source.target.clone();
+			cache[ source.target.uuid ] = source.target.clone( recursive, cache );
 
 		}
 		this.target = cache[ source.target.uuid ];

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -28,11 +28,18 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 	isDirectionalLight: true,
 
-	copy: function ( source ) {
+	copy: function ( source, recursive, cache ) {
 
-		Light.prototype.copy.call( this, source );
+		if ( cache === undefined ) cache = {};
 
-		this.target = source.target.clone();
+		Light.prototype.copy.call( this, source, recursive, cache );
+
+		if ( ( source.target.uuid in cache ) === false ) {
+
+			cache[ source.target.uuid ] = source.target.clone();
+
+		}
+		this.target = cache[ source.target.uuid ];
 
 		this.shadow = source.shadow.clone();
 

--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -36,7 +36,7 @@ DirectionalLight.prototype = Object.assign( Object.create( Light.prototype ), {
 
 		if ( ( source.target.uuid in cache ) === false ) {
 
-			cache[ source.target.uuid ] = source.target.clone( recursive, cache );
+			source.target.clone( recursive, cache );
 
 		}
 		this.target = cache[ source.target.uuid ];

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -27,8 +27,6 @@ Light.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	copy: function ( source, recursive, cache ) {
 
-		if ( cache === undefined ) cache = {};
-
 		Object3D.prototype.copy.call( this, source, recursive, cache );
 
 		this.color.copy( source.color );

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -25,9 +25,11 @@ Light.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	isLight: true,
 
-	copy: function ( source ) {
+	copy: function ( source, recursive, cache ) {
 
-		Object3D.prototype.copy.call( this, source );
+		if ( cache === undefined ) cache = {};
+
+		Object3D.prototype.copy.call( this, source, recursive, cache );
 
 		this.color.copy( source.color );
 		this.intensity = source.intensity;


### PR DESCRIPTION
Related to https://github.com/mrdoob/three.js/issues/17299#issuecomment-525441729

This adds an id cache to the Object3D `copy` and `clone` functions to fix the clone issues described in the above issue and updates `Light.copy` and `DirectionalLight.copy` to take advantage of it.

The short of the problem is that if objects have separate references to objects that live in the scene (such as `DirectionalLight.target`) then clone a subtree with the objects results in losing the relationship between those objects after the clone / copy (as happens with the light and target). Here's some code demonstrating the problem:

```js
const obj = new THREE.Object3D();
const directionalLight = new THREE.DirectionalLight();
obj.add( directionalLight, directionalLight.target );

const clone = obj.clone();

const objEqual = obj.children[ 0 ].target === obj.children[ 1 ];
const cloneEqual = clone.children[ 0 ].target === clone.children[ 1 ];

console.log( objEqual, cloneEqual );

// in dev: "true false" is logged
// this PR: "true true" is logged
```

The proposed pattern enables the following behavior with DirectionalLight, which should extend to other objects:
- If `target` is not parented to anything then the directional light is cloned with a new `target` object also unparented.
- If `target` is parented within the subtree that is being copied / cloned then `target` is cloned and is parented at the same position in the hierarchy in the new subtree.
- If `target` is parented _outside_ the subtree that is being copied / cloned then `target` is cloned but is left unparented.