### PR TITLE
Clearcoat Example: Added tone mapping

### DIFF
--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -66,6 +66,7 @@
 						var textureLoader = new THREE.TextureLoader();
 
 						var diffuse = textureLoader.load( "textures/carbon/Carbon.png" );
+						diffuse.encoding = THREE.sRGBEncoding;
 						diffuse.wrapS = THREE.RepeatWrapping;
 						diffuse.wrapT = THREE.RepeatWrapping;
 						diffuse.repeat.x = 10;
@@ -183,7 +184,11 @@
 
 			//
 
-			renderer.gammaInput = true;
+			renderer.toneMapping = THREE.ACESFilmicToneMapping;
+			renderer.toneMappingExposure = 1;
+
+			//
+
 			renderer.gammaOutput = true;
 
 			//


### PR DESCRIPTION
Tone mapping is advisable when using an HDR environment map.

Without it, colors are blown-out -- as in this screenshot:

![Screen Shot 2019-08-29 at 12 55 12 AM](https://user-images.githubusercontent.com/1000017/63911599-e4404380-c9f8-11e9-8b0f-12f1f9a8eee8.png)
