### PR TITLE
Physical Shader: properly group indirect diffuse and indirect specular terms

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -140,8 +140,7 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 
 	float clearcoatInv = 1.0 - clearcoatDHR;
 
-	// Both indirect specular and diffuse light accumulate here
-	// if energy preservation enabled, and PMREM provided.
+	// Both indirect specular and indirect diffuse light accumulate here
 
 	vec3 singleScattering = vec3( 0.0 );
 	vec3 multiScattering = vec3( 0.0 );
@@ -152,7 +151,8 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 	vec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );
 
 	reflectedLight.indirectSpecular += clearcoatInv * radiance * singleScattering;
-	reflectedLight.indirectDiffuse += multiScattering * cosineWeightedIrradiance;
+	reflectedLight.indirectSpecular += multiScattering * cosineWeightedIrradiance;
+
 	reflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;
 
 }


### PR DESCRIPTION
The `multiscattering` term is a function of the specular reflectance of the material, and models specularl-reflected light.

This refactoring does not affect the rendered output.

/ping @jsantell 
/ping @elalish 
/ping @sunag 