### PR TITLE
LightningStrike: Make plasma sphere use physical transparency

### DIFF
--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -422,12 +422,11 @@
 
 				var sphereMaterial = new THREE.MeshPhysicalMaterial( {
 					transparent: true,
+					transparency: .96,
 					depthWrite: false,
-					opacity: 0.15,
-					color: 0,
-					metalness: 1,
+					color: 'white',
+					metalness: 0,
 					roughness: 0,
-					reflectivity: 0,
 					envMap: textureCube
 				} );
 


### PR DESCRIPTION
It looks much better now.

For testing: [Live link](https://raw.githack.com/yomboprime/three.js/crystal_plasma/examples/webgl_lightningstrike.html) (select the second scene)