### PR TITLE
Remove use of gl_fragDepth extension when using Logarithmic Depth Buffer

### DIFF
--- a/src/renderers/shaders/ShaderChunk.d.ts
+++ b/src/renderers/shaders/ShaderChunk.d.ts
@@ -58,8 +58,6 @@ export let ShaderChunk: {
 	lights_fragment_begin: string;
 	lights_fragment_maps: string;
 	lights_fragment_end: string;
-	logdepthbuf_fragment: string;
-	logdepthbuf_pars_fragment: string;
 	logdepthbuf_pars_vertex: string;
 	logdepthbuf_vertex: string;
 	map_fragment: string;

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -46,8 +46,6 @@ import lights_physical_pars_fragment from './ShaderChunk/lights_physical_pars_fr
 import lights_fragment_begin from './ShaderChunk/lights_fragment_begin.glsl.js';
 import lights_fragment_maps from './ShaderChunk/lights_fragment_maps.glsl.js';
 import lights_fragment_end from './ShaderChunk/lights_fragment_end.glsl.js';
-import logdepthbuf_fragment from './ShaderChunk/logdepthbuf_fragment.glsl.js';
-import logdepthbuf_pars_fragment from './ShaderChunk/logdepthbuf_pars_fragment.glsl.js';
 import logdepthbuf_pars_vertex from './ShaderChunk/logdepthbuf_pars_vertex.glsl.js';
 import logdepthbuf_vertex from './ShaderChunk/logdepthbuf_vertex.glsl.js';
 import map_fragment from './ShaderChunk/map_fragment.glsl.js';

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -170,8 +170,6 @@ export var ShaderChunk = {
 	lights_fragment_begin: lights_fragment_begin,
 	lights_fragment_maps: lights_fragment_maps,
 	lights_fragment_end: lights_fragment_end,
-	logdepthbuf_fragment: logdepthbuf_fragment,
-	logdepthbuf_pars_fragment: logdepthbuf_pars_fragment,
 	logdepthbuf_pars_vertex: logdepthbuf_pars_vertex,
 	logdepthbuf_vertex: logdepthbuf_vertex,
 	map_fragment: map_fragment,

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
@@ -1,7 +1,0 @@
-export default /* glsl */`
-#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
-
-	gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;
-
-#endif
-`;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
@@ -1,8 +1,0 @@
-export default /* glsl */`
-#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
-
-	uniform float logDepthBufFC;
-	varying float vFragDepth;
-
-#endif
-`;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
@@ -1,15 +1,7 @@
 export default /* glsl */`
 #ifdef USE_LOGDEPTHBUF
 
-	#ifdef USE_LOGDEPTHBUF_EXT
-
-		varying float vFragDepth;
-
-	#else
-
-		uniform float logDepthBufFC;
-
-	#endif
+	uniform float logDepthBufFC;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
@@ -1,17 +1,9 @@
 export default /* glsl */`
 #ifdef USE_LOGDEPTHBUF
 
-	#ifdef USE_LOGDEPTHBUF_EXT
+	gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
 
-		vFragDepth = 1.0 + gl_Position.w;
-
-	#else
-
-		gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
-
-		gl_Position.z *= gl_Position.w;
-
-	#endif
+	gl_Position.z *= gl_Position.w;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderLib/depth_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth_frag.glsl.js
@@ -10,7 +10,6 @@ export default /* glsl */`
 #include <uv_pars_fragment>
 #include <map_pars_fragment>
 #include <alphamap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -28,8 +27,6 @@ void main() {
 	#include <map_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
-
-	#include <logdepthbuf_fragment>
 
 	#if DEPTH_PACKING == 3200
 

--- a/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
@@ -10,7 +10,6 @@ varying float vLineDistance;
 #include <common>
 #include <color_pars_fragment>
 #include <fog_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -26,7 +25,6 @@ void main() {
 	vec3 outgoingLight = vec3( 0.0 );
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
-	#include <logdepthbuf_fragment>
 	#include <color_fragment>
 
 	outgoingLight = diffuseColor.rgb; // simple shader

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -20,7 +20,6 @@ uniform float opacity;
 #include <envmap_pars_fragment>
 #include <fog_pars_fragment>
 #include <specularmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -29,7 +28,6 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
 	#include <alphamap_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -31,7 +31,6 @@ varying vec3 vIndirectFront;
 #include <shadowmap_pars_fragment>
 #include <shadowmask_pars_fragment>
 #include <specularmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -42,7 +41,6 @@ void main() {
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 	vec3 totalEmissiveRadiance = emissive;
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
 	#include <alphamap_fragment>

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -21,7 +21,6 @@ varying vec3 vViewPosition;
 #include <fog_pars_fragment>
 #include <bumpmap_pars_fragment>
 #include <normalmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -30,7 +29,6 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -29,7 +29,6 @@ uniform float opacity;
 #include <bumpmap_pars_fragment>
 #include <normalmap_pars_fragment>
 #include <specularmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -40,7 +39,6 @@ void main() {
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 	vec3 totalEmissiveRadiance = emissive;
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
 	#include <alphamap_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -69,7 +69,6 @@ varying vec3 vViewPosition;
 #include <clearcoat_normalmap_pars_fragment>
 #include <roughnessmap_pars_fragment>
 #include <metalnessmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -80,7 +79,6 @@ void main() {
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 	vec3 totalEmissiveRadiance = emissive;
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
 	#include <alphamap_fragment>

--- a/src/renderers/shaders/ShaderLib/normal_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/normal_frag.glsl.js
@@ -26,13 +26,11 @@ uniform float opacity;
 #include <uv_pars_fragment>
 #include <bumpmap_pars_fragment>
 #include <normalmap_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
 
 	#include <clipping_planes_fragment>
-	#include <logdepthbuf_fragment>
 	#include <normal_fragment_begin>
 	#include <normal_fragment_maps>
 

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl.js
@@ -6,7 +6,6 @@ uniform float opacity;
 #include <color_pars_fragment>
 #include <map_particle_pars_fragment>
 #include <fog_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -16,7 +15,6 @@ void main() {
 	vec3 outgoingLight = vec3( 0.0 );
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
-	#include <logdepthbuf_fragment>
 	#include <map_particle_fragment>
 	#include <color_fragment>
 	#include <alphatest_fragment>

--- a/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
@@ -6,7 +6,6 @@ uniform float opacity;
 #include <uv_pars_fragment>
 #include <map_pars_fragment>
 #include <fog_pars_fragment>
-#include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
 
 void main() {
@@ -16,7 +15,6 @@ void main() {
 	vec3 outgoingLight = vec3( 0.0 );
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
-	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <alphatest_fragment>
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -426,7 +426,6 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 			'uniform mat4 modelMatrix;',
 			'uniform mat4 modelViewMatrix;',
@@ -547,7 +546,6 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters,
 			parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 			( ( material.extensions ? material.extensions.shaderTextureLOD : false ) || parameters.envMap ) && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -121,7 +121,7 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 
 	var chunks = [
 		( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
-		( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
+		( extensions.fragDepth ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 		( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
 		( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];


### PR DESCRIPTION
Fix #17384

Simplifies the logarithmic depth buffer implementation and enables the [early depth test](https://www.khronos.org/opengl/wiki/Early_Fragment_Test) optimization when it is enabled.