### PR TITLE
Fix depthTexture types in WebGLRenderTarget.d.ts

### DIFF
--- a/src/renderers/WebGLRenderTarget.d.ts
+++ b/src/renderers/WebGLRenderTarget.d.ts
@@ -1,5 +1,6 @@
 import { Vector4 } from './../math/Vector4';
 import { Texture } from './../textures/Texture';
+import { DepthTexture } from './../textures/DepthTexture';
 import { EventDispatcher } from './../core/EventDispatcher';
 import { Wrapping, TextureFilter, TextureDataType } from '../constants';
 
@@ -14,6 +15,7 @@ export interface WebGLRenderTargetOptions {
 	depthBuffer?: boolean; // true;
 	stencilBuffer?: boolean; // true;
 	generateMipmaps?: boolean; // true;
+	depthTexture?: DepthTexture;
 }
 
 export class WebGLRenderTarget extends EventDispatcher {
@@ -33,7 +35,7 @@ export class WebGLRenderTarget extends EventDispatcher {
 	texture: Texture;
 	depthBuffer: boolean;
 	stencilBuffer: boolean;
-	depthTexture: Texture;
+	depthTexture: DepthTexture;
 	/**
 	 * @deprecated Use {@link Texture#wrapS texture.wrapS} instead.
 	 */


### PR DESCRIPTION
I noticed a few missing type definitions for render targets.
In this change:
- Added missing depthTexture argument to WebGLRenderTargetOptions.
- Changed depthTexture property on WebGLRenderTarget to be of DepthTexture type instead of Texture type.

I took a look inside of WebGLTextures and noticed the depthTexture property of a render target is a required to be a DepthTexture rather than just a Texture:

```js
if ( ! ( renderTarget.depthTexture && renderTarget.depthTexture.isDepthTexture ) ) {

	throw new Error( 'renderTarget.depthTexture must be an instance of THREE.DepthTexture' );

}
```