### PR TITLE
Docs: Update logarithmicDepthBuffer with performance caveat

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -66,7 +66,8 @@
 
 		[page:Boolean logarithmicDepthBuffer] -  whether to use a logarithmic depth buffer. It may
 		be neccesary to use this if dealing with huge differences in scale in a single scene. Note that this setting
-		uses gl_FragDepth if available which disables certain rendering optimizations.
+		uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
+		optimization and can cause a decrease in performance.
 		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
 		</p>
 

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -65,7 +65,8 @@
 		Default is *true*.<br />
 
 		[page:Boolean logarithmicDepthBuffer] -  whether to use a logarithmic depth buffer. It may
-		be neccesary to use this if dealing with huge differences in scale in a single scene.
+		be neccesary to use this if dealing with huge differences in scale in a single scene. Note that this setting
+		uses gl_FragDepth if available which disables certain rendering optimizations.
 		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
 		</p>
 

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -54,7 +54,8 @@
 		默认是*true*.<br />
 
 		[page:Boolean logarithmicDepthBuffer] -  是否使用对数深度缓存。如果要在单个场景中处理巨大的比例差异，就有必要使用。
-		Note that this setting uses gl_FragDepth if available which disables certain rendering optimizations.
+		Note that this setting uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
+		optimization and can cause a decrease in performance.
 		默认是*false*。 示例：[example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer]
 		</p>
 

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -54,6 +54,7 @@
 		默认是*true*.<br />
 
 		[page:Boolean logarithmicDepthBuffer] -  是否使用对数深度缓存。如果要在单个场景中处理巨大的比例差异，就有必要使用。
+		Note that this setting uses gl_FragDepth if available which disables certain rendering optimizations.
 		默认是*false*。 示例：[example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer]
 		</p>
 


### PR DESCRIPTION
See #17384 and https://github.com/mrdoob/three.js/issues/17384#issuecomment-526470873

I'm not sure if people feel it's important to include an inline comment about the need for gl_FragDepth [like there used to be](https://github.com/mrdoob/three.js/pull/4566/files#diff-c78fde2d3da4f38bf2a6d6365b5422e4R1669-R1675) but at least the docs should note it.