### PR TITLE
deprecate changing buffer size with setArray()

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -53,7 +53,15 @@ Object.assign( BufferAttribute.prototype, {
 
 		}
 
-		this.count = array !== undefined ? array.length / this.itemSize : 0;
+		var count = array !== undefined ? array.length / this.itemSize : 0;
+
+		if ( count !== this.count ) {
+
+			console.warn( 'THREE.BufferAttribute: Changing the size of an attribute with .setArray() has been deprecated. Replace with a new buffer instead.' );
+
+		}
+
+		this.count = count;
 		this.array = array;
 
 		return this;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -40,7 +40,15 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		}
 
-		this.count = array !== undefined ? array.length / this.stride : 0;
+		var count = array !== undefined ? array.length / this.stride : 0;
+
+		if ( count !== this.count ) {
+
+			console.warn( 'THREE.InterleavedBuffer: Changing the size of an attribute with .setArray() has been deprecated. Replace with a new buffer instead.' );
+
+		}
+
+		this.count = count;
 		this.array = array;
 
 		return this;


### PR DESCRIPTION
Relating to #14730 issues with BufferAttribute.dynamic flag overloading.

Deprecate changing a BufferAttribute's size with .setArray() as a prelude to removing this ability.

Now all internal renderer and GPU state relating to BufferAttributes is weakly referenced with the use of a WeakMap, an attrribute can simply be resized by overwriting with a new BufferAttribute  with Geometry.addAttribute() without long term memory leaks, this has little additional overhead over using setArray() to resize an attribute.  #17063 would allow users explict control over heap usage if waiting for GC , but is not a strict requirement.

After one or more releases this warning can be replaced with an exception, and WebGLBufferATtribute simplified to restore the dynamic flag to it's original purpose.

