### PR TITLE
Update OBJLoader2.html

### DIFF
--- a/docs/examples/en/loaders/OBJLoader2.html
+++ b/docs/examples/en/loaders/OBJLoader2.html
@@ -25,8 +25,8 @@
 		var loader = new THREE.OBJLoader2();
 
 		// function called on successful load
-		var callbackOnLoad = function ( event ) {
-			scene.add( event.detail.loaderRootNode );
+		var callbackOnLoad = function ( object3d ) {
+			scene.add( object3d );
 		};
 
 		// load a resource from provided URL synchronously


### PR DESCRIPTION
In the code of the documentation  is "event.detail.loaderRootNode", but it returns a object3d as in the live example.