### PR TITLE
WebXR: add "mode" and "sessionInit" options to createButton

### DIFF
--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -70,11 +70,13 @@ renderer.setAnimationLoop( function () {
 	<code>
 let options = {
 	mode: 'immersive-ar', // Default is "immersive-vr"
+	referenceSpaceType: 'local', // Default is "local-floor"
 	sessionInit: {
 		// These options are passed as-is to WebXR's "createSession" call,
 		// use them to request non-default reference space types or potential future features.
-		requiredFeatures: ['local-floor'],
-		optionalFeatures: ['bounded-floor', 'unbounded']
+		// The requested referenceSpaceType is automatically added to requiredFeatures.
+		requiredFeatures: [],
+		optionalFeatures: ['unbounded']
 	}
 };
 document.body.appendChild( WEBVR.createButton( renderer, options ) );

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -63,6 +63,24 @@ renderer.setAnimationLoop( function () {
 	<h2>Next Steps</h2>
 
 	<p>
+		By default, the WebXR button creates an "immersive-vr" session
+		with no required or optional features. If you need to override
+		this, you can pass an extra options argument to createButton:
+	</p>
+	<code>
+let options = {
+	mode: 'immersive-ar', // Default is "immersive-vr"
+	sessionInit: {
+		// These options are passed as-is to WebXR's "createSession" call,
+		// use them to request non-default reference space types or potential future features.
+		requiredFeatures: ['local-floor'],
+		optionalFeatures: ['bounded-floor', 'unbounded']
+	}
+};
+document.body.appendChild( WEBVR.createButton( renderer, options ) );
+	</code>
+
+	<p>
 		Have a look at one of the official WebVR examples to see this workflow in action.<br /><br />
 
 		[example:webvr_ballshooter WebVR / ballshoter]<br />

--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -47,6 +47,33 @@ THREE.WEBVR = {
 
 		}
 
+		function getXRSessionInit( mode, options) {
+			var space = (options || {}).referenceSpaceType || 'local-floor';
+			var sessionInit = options.sessionInit || {};
+
+			// Nothing to do for default features.
+			if ( space == 'viewer' )
+				return sessionInit;
+			if ( space == 'local' && mode.startsWith('immersive' ) )
+				return sessionInit;
+
+			// If the user already specified the space as an optional or required feature, don't do anything.
+			if ( sessionInit.optionalFeatures && sessionInit.optionalFeatures.includes(space) )
+				return sessionInit;
+			if ( sessionInit.requiredFeatures && sessionInit.requiredFeatures.includes(space) )
+				return sessionInit;
+
+			// The user didn't request the reference space type as a feature. Add it to a shallow copy
+			// of the user-supplied sessionInit requiredFeatures (if any) to ensure it's valid to
+			// request it later.
+			var newInit = Object.assign( {}, sessionInit );
+			newInit.requiredFeatures = [ space ];
+			if ( sessionInit.requiredFeatures ) {
+				newInit.requiredFeatures = newInit.requiredFeatures.concat( sessionInit.requiredFeatures );
+			}
+			return newSessionInit;
+		}
+
 		function showEnterXR( /*device*/ ) {
 
 			var currentSession = null;
@@ -100,7 +127,7 @@ THREE.WEBVR = {
 				if ( currentSession === null ) {
 
 					var mode = options.mode || 'immersive-vr';
-					var sessionInit = options.sessionInit || {};
+					var sessionInit = getXRSessionInit( mode, options );
 					navigator.xr.requestSession( mode, sessionInit ).then( onSessionStarted );
 
 				} else {

--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -99,7 +99,9 @@ THREE.WEBVR = {
 
 				if ( currentSession === null ) {
 
-					navigator.xr.requestSession( 'immersive-vr' ).then( onSessionStarted );
+					var mode = options.mode || 'immersive-vr';
+					var sessionInit = options.sessionInit || {};
+					navigator.xr.requestSession( mode, sessionInit ).then( onSessionStarted );
 
 				} else {
 
@@ -168,7 +170,8 @@ THREE.WEBVR = {
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR ).catch( showXRNotFound );
+			var mode = options.mode || 'immersive-vr';
+			navigator.xr.supportsSession( mode ).then( showEnterXR ).catch( showXRNotFound );
 
 			return button;
 

--- a/examples/jsm/vr/WebVR.js
+++ b/examples/jsm/vr/WebVR.js
@@ -101,7 +101,9 @@ var WEBVR = {
 
 				if ( currentSession === null ) {
 
-					navigator.xr.requestSession( 'immersive-vr' ).then( onSessionStarted );
+					var mode = options.mode || 'immersive-vr';
+					var sessionInit = options.sessionInit || {};
+					navigator.xr.requestSession( mode, sessionInit ).then( onSessionStarted );
 
 				} else {
 
@@ -170,7 +172,8 @@ var WEBVR = {
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR ).catch( showXRNotFound );
+			var mode = options.mode || 'immersive-vr';
+			navigator.xr.supportsSession( mode ).then( showEnterXR ).catch( showXRNotFound );
 
 			return button;
 


### PR DESCRIPTION
This should help make WebXR support more flexible and future-proof by providing a way to specify the mode and sessionInit required/optional features directly. The default behavior is unchanged.