### PR TITLE
Enable method chaining EventDispatcher

### DIFF
--- a/docs/api/en/core/EventDispatcher.html
+++ b/docs/api/en/core/EventDispatcher.html
@@ -57,7 +57,7 @@ car.start();
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:this addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - The type of event to listen to.<br />
 		listener - The function that gets called when the event is fired.
@@ -75,7 +75,7 @@ car.start();
 		Checks if listener is added to an event type.
 		</p>
 
-		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:this removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - The type of the listener that gets removed.<br />
 		listener - The listener function that gets removed.
@@ -84,7 +84,7 @@ car.start();
 		Removes a listener from an event type.
 		</p>
 
-		<h3>[method:null dispatchEvent]( [param:object event] )</h3>
+		<h3>[method:this dispatchEvent]( [param:object event] )</h3>
 		<p>
 		event - The event that gets fired.
 		</p>

--- a/docs/api/zh/core/EventDispatcher.html
+++ b/docs/api/zh/core/EventDispatcher.html
@@ -57,7 +57,7 @@ car.start();
 
 		<h2>方法</h2>
 
-		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:this addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 需要添加监听的事件类型。<br />
 		listener - 事件发生时被调用到的函数。
@@ -75,7 +75,7 @@ car.start();
 		检查监听函数是否已经添加到指定事件。
 		</p>
 
-		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:this removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 需要移除监听的事件类型。<br />
 		listener - 需要被移除的监听函数。
@@ -84,7 +84,7 @@ car.start();
 		从指定事件类型中移除监听函数。
 		</p>
 
-		<h3>[method:null dispatchEvent]( [param:object event] )</h3>
+		<h3>[method:this dispatchEvent]( [param:object event] )</h3>
 		<p>
 		event - 将被触发的事件。
 		</p>

--- a/src/core/DirectGeometry.d.ts
+++ b/src/core/DirectGeometry.d.ts
@@ -5,12 +5,11 @@ import { Vector4 } from './../math/Vector4';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Geometry } from './Geometry';
-import { EventDispatcher } from './EventDispatcher';
 import { MorphTarget } from './Geometry';
 /**
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/DirectGeometry.js">src/core/DirectGeometry.js</a>
  */
-export class DirectGeometry extends EventDispatcher {
+export class DirectGeometry {
 
 	constructor();
 

--- a/src/core/DirectGeometry.d.ts
+++ b/src/core/DirectGeometry.d.ts
@@ -5,7 +5,6 @@ import { Vector4 } from './../math/Vector4';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Geometry } from './Geometry';
-import { Event } from './Face3';
 import { EventDispatcher } from './EventDispatcher';
 import { MorphTarget } from './Geometry';
 /**
@@ -42,11 +41,5 @@ export class DirectGeometry extends EventDispatcher {
 	computeGroups( geometry: Geometry ): void;
 	fromGeometry( geometry: Geometry ): DirectGeometry;
 	dispose(): void;
-
-	// EventDispatcher mixins
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
-	hasEventListener( type: string, listener: ( event: Event ) => void ): boolean;
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
 
 }

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -2,7 +2,6 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-import { EventDispatcher } from './EventDispatcher.js';
 import { Vector2 } from '../math/Vector2.js';
 
 function DirectGeometry() {
@@ -35,7 +34,7 @@ function DirectGeometry() {
 
 }
 
-DirectGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
+Object.assign( DirectGeometry.prototype, {
 
 	computeGroups: function ( geometry ) {
 

--- a/src/core/DirectGeometry.js
+++ b/src/core/DirectGeometry.js
@@ -2,6 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
+import { EventDispatcher } from './EventDispatcher.js';
 import { Vector2 } from '../math/Vector2.js';
 
 function DirectGeometry() {
@@ -34,7 +35,7 @@ function DirectGeometry() {
 
 }
 
-Object.assign( DirectGeometry.prototype, {
+DirectGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	computeGroups: function ( geometry ) {
 

--- a/src/core/EventDispatcher.d.ts
+++ b/src/core/EventDispatcher.d.ts
@@ -17,7 +17,7 @@ export class EventDispatcher {
 	 * @param type The type of event to listen to.
 	 * @param listener The function that gets called when the event is fired.
 	 */
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
+	addEventListener( type: string, listener: ( event: Event ) => void ): EventDispatcher;
 
 	/**
 	 * Checks if listener is added to an event type.
@@ -31,12 +31,12 @@ export class EventDispatcher {
 	 * @param type The type of the listener that gets removed.
 	 * @param listener The listener function that gets removed.
 	 */
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
+	removeEventListener( type: string, listener: ( event: Event ) => void ): EventDispatcher;
 
 	/**
 	 * Fire an event type.
 	 * @param type The type of event that gets fired.
 	 */
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
+	dispatchEvent( event: { type: string; [attachment: string]: any } ): EventDispatcher;
 
 }

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -24,6 +24,8 @@ Object.assign( EventDispatcher.prototype, {
 
 		}
 
+		return this;
+
 	},
 
 	hasEventListener: function ( type, listener ) {
@@ -55,6 +57,8 @@ Object.assign( EventDispatcher.prototype, {
 
 		}
 
+		return this;
+
 	},
 
 	dispatchEvent: function ( event ) {
@@ -77,6 +81,8 @@ Object.assign( EventDispatcher.prototype, {
 			}
 
 		}
+
+		return this;
 
 	}
 

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -1,6 +1,6 @@
 import { Vector3 } from './../math/Vector3';
 import { Color } from './../math/Color';
-import { Face3, Event } from './Face3';
+import { Face3 } from './Face3';
 import { Vector2 } from './../math/Vector2';
 import { Vector4 } from './../math/Vector4';
 import { Box3 } from './../math/Box3';
@@ -251,11 +251,5 @@ export class Geometry extends EventDispatcher {
 	bones: Bone[];
 	animation: AnimationClip;
 	animations: AnimationClip[];
-
-	// EventDispatcher mixins
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
-	hasEventListener( type: string, listener: ( event: Event ) => void ): boolean;
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
 
 }


### PR DESCRIPTION
I think it'd be useful if `EventDispatcher`'s methods support method chaining. This PR enables it.

```javascript
const object = new Foo()
    .addEventListener('foo', (event) => { ... })
    .addEventListener('bar', (event) => { ... });
```