### PR TITLE
Loader: Remove Handlers.

### DIFF
--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -77,31 +77,6 @@
 			[page:String resourcePath] — Set the base path for dependent resources like textures.
 		</p>
 
-		<h2>Handlers</h2>
-
-		<p>
-		*[name].Handlers* is a special object normally used by other loaders like [page:GLTFLoader] or [page:MTLLoader]. It provides an
-		API that allows the definition of special mappings: What loaders should be used in order to load specific files. A typical use case
-		is to overwrite the default loader for textures.<br /><br />
-
-		Note: It's only possible to use *[name].Handlers* if the respective loader support the usage.
-		</p>
-
-		<h3>[method:null add]( [param:Object regex], [param:Loader loader] )</h3>
-		<p>
-		[page:Object regex] — A regular expression.<br />
-		[page:Loader loader] — The loader.
-		<p>
-		Registers a loader with the given regular expression.
-		</p>
-
-		<h3>[method:null get]( [param:String file] )</h3>
-		<p>
-		[page:String file] — The file path.
-		<p>
-		Can be used to retrieve the registered loader for the given file path.
-		</p>
-
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -198,12 +198,34 @@
 		This should be called by any loader using the manager when the loader ended loading an url.
 		</p>
 
-
 		<h3>[method:null itemError]( [param:String url] )</h3>
 		<p>
 		[page:String url] — the loaded url<br /><br />
 
 		This should be called by any loader using the manager when the loader errors loading an url.
+		</p>
+
+		<h3>[method:LoadingManager addHandler]( [param:Object regex], [param:Loader loader] )</h3>
+		<p>
+		[page:Object regex] — A regular expression.<br />
+		[page:Loader loader] — The loader.
+		<p>
+		Registers a loader with the given regular expression. Can be used to define what loader should be used in
+		order to load specific files. A typical use case is to overwrite the default loader for textures.
+		</p>
+
+		<h3>[method:LoadingManager removeHandler]( [param:Object regex] )</h3>
+		<p>
+		[page:Object regex] — A regular expression.
+		<p>
+		Removes the loader for the given regular expression.
+		</p>
+
+		<h3>[method:null getHandler]( [param:String file] )</h3>
+		<p>
+		[page:String file] — The file path.
+		<p>
+		Can be used to retrieve the registered loader for the given file path.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/zh/loaders/Loader.html
+++ b/docs/api/zh/loaders/Loader.html
@@ -77,31 +77,6 @@
 			[page:String resourcePath] — Set the base path for dependent resources like textures.
 		</p>
 
-		<h2>Handlers</h2>
-
-		<p>
-		*[name].Handlers* is a special object normally used by other loaders like [page:GLTFLoader] or [page:MTLLoader]. It provides an
-		API that allows the definition of special mappings: What loaders should be used in order to load specific files. A typical use case
-		is to overwrite the default loader for textures.<br /><br />
-
-		Note: It's only possible to use *[name].Handlers* if the respective loader support the usage.
-		</p>
-
-		<h3>[method:null add]( [param:Object regex], [param:Loader loader] )</h3>
-		<p>
-		[page:Object regex] — A regular expression.<br />
-		[page:Loader loader] — The loader.
-		<p>
-		Registers a loader with the given regular expression.
-		</p>
-
-		<h3>[method:null get]( [param:String file] )</h3>
-		<p>
-		[page:String file] — The file path.
-		<p>
-		Can be used to retrieve the registered loader for the given file path.
-		</p>
-
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/zh/loaders/managers/LoadingManager.html
+++ b/docs/api/zh/loaders/managers/LoadingManager.html
@@ -202,6 +202,29 @@
             任何使用管理器的加载器都会调用此方法， 当加载器出现加载错误时。
 		</p>
 
+		<h3>[method:LoadingManager addHandler]( [param:Object regex], [param:Loader loader] )</h3>
+		<p>
+		[page:Object regex] — A regular expression.<br />
+		[page:Loader loader] — The loader.
+		<p>
+		Registers a loader with the given regular expression. Can be used to define what loader should be used in
+		order to load specific files. A typical use case is to overwrite the default loader for textures.
+		</p>
+
+		<h3>[method:LoadingManager removeHandler]( [param:Object regex] )</h3>
+		<p>
+		[page:Object regex] — A regular expression.
+		<p>
+		Removes the loader for the given regular expression.
+		</p>
+
+		<h3>[method:null getHandler]( [param:String file] )</h3>
+		<p>
+		[page:String file] — The file path.
+		<p>
+		Can be used to retrieve the registered loader for the given file path.
+		</p>
+
 		<h2>源</h2>
 
 		[link:https://github.com/mrdoob/three.js/blob/master/src/loaders/LoadingManager.js src/loaders/LoadingManager.js]

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -97,16 +97,17 @@ THREE.FBXLoader = ( function () {
 
 			var textureLoader = new THREE.TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
-			return new FBXTreeParser( textureLoader ).parse( fbxTree );
+			return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
 
 		}
 
 	} );
 
 	// Parse the FBXTree object returned by the BinaryParser or TextParser and return a THREE.Group
-	function FBXTreeParser( textureLoader ) {
+	function FBXTreeParser( textureLoader, manager ) {
 
 		this.textureLoader = textureLoader;
+		this.manager = manager;
 
 	}
 
@@ -265,7 +266,7 @@ THREE.FBXLoader = ( function () {
 
 				case 'tga':
 
-					if ( THREE.Loader.Handlers.get( '.tga' ) === null ) {
+					if ( this.manager.getHandler( '.tga' ) === null ) {
 
 						console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
 
@@ -378,7 +379,7 @@ THREE.FBXLoader = ( function () {
 
 			if ( extension === 'tga' ) {
 
-				var loader = THREE.Loader.Handlers.get( '.tga' );
+				var loader = this.manager.getHandler( '.tga' );
 
 				if ( loader === null ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1986,7 +1986,7 @@ THREE.GLTFLoader = ( function () {
 
 			// Load Texture resource.
 
-			var loader = THREE.Loader.Handlers.get( sourceURI );
+			var loader = options.manager.getHandler( sourceURI );
 
 			if ( ! loader ) {
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1305,7 +1305,7 @@ THREE.MMDLoader = ( function () {
 
 			if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
 
-			var loader = THREE.Loader.Handlers.get( fullPath );
+			var loader = this.manager.getHandler( fullPath );
 
 			if ( loader === null ) {
 

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -510,8 +510,8 @@ THREE.MTLLoader.MaterialCreator.prototype = {
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {
 
 		var texture;
-		var loader = THREE.Loader.Handlers.get( url );
 		var manager = ( this.manager !== undefined ) ? this.manager : THREE.DefaultLoadingManager;
+		var loader = manager.getHandler( url );
 
 		if ( loader === null ) {
 

--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -1079,7 +1079,7 @@ THREE.LegacyGLTFLoader = ( function () {
 
 						}
 
-						var textureLoader = options.manager.getHanlder( sourceUri );
+						var textureLoader = options.manager.getHandler( sourceUri );
 
 						if ( textureLoader === null ) {
 

--- a/examples/js/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/js/loaders/deprecated/LegacyGLTFLoader.js
@@ -1079,7 +1079,7 @@ THREE.LegacyGLTFLoader = ( function () {
 
 						}
 
-						var textureLoader = THREE.Loader.Handlers.get( sourceUri );
+						var textureLoader = options.manager.getHanlder( sourceUri );
 
 						if ( textureLoader === null ) {
 

--- a/examples/js/loaders/deprecated/LegacyJSONLoader.js
+++ b/examples/js/loaders/deprecated/LegacyJSONLoader.js
@@ -77,13 +77,13 @@ THREE.LegacyJSONLoader = ( function () {
 			var _textureLoader = new THREE.TextureLoader();
 			var _materialLoader = new THREE.MaterialLoader();
 
-			function initMaterials( materials, texturePath, crossOrigin ) {
+			function initMaterials( materials, texturePath, crossOrigin, manager ) {
 
 				var array = [];
 
 				for ( var i = 0; i < materials.length; ++ i ) {
 
-					array[ i ] = createMaterial( materials[ i ], texturePath, crossOrigin );
+					array[ i ] = createMaterial( materials[ i ], texturePath, crossOrigin, manager );
 
 				}
 
@@ -91,7 +91,7 @@ THREE.LegacyJSONLoader = ( function () {
 
 			}
 
-			function createMaterial( m, texturePath, crossOrigin ) {
+			function createMaterial( m, texturePath, crossOrigin, manager ) {
 
 				// convert from old material format
 
@@ -143,7 +143,7 @@ THREE.LegacyJSONLoader = ( function () {
 							if ( value.toLowerCase() === 'standard' ) json.type = 'MeshStandardMaterial';
 							break;
 						case 'mapDiffuse':
-							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy, textures, texturePath, crossOrigin );
+							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapDiffuseRepeat':
 						case 'mapDiffuseOffset':
@@ -151,7 +151,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapDiffuseAnisotropy':
 							break;
 						case 'mapEmissive':
-							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy, textures, texturePath, crossOrigin );
+							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapEmissiveRepeat':
 						case 'mapEmissiveOffset':
@@ -159,7 +159,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapEmissiveAnisotropy':
 							break;
 						case 'mapLight':
-							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy, textures, texturePath, crossOrigin );
+							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapLightRepeat':
 						case 'mapLightOffset':
@@ -167,7 +167,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapLightAnisotropy':
 							break;
 						case 'mapAO':
-							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy, textures, texturePath, crossOrigin );
+							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapAORepeat':
 						case 'mapAOOffset':
@@ -175,7 +175,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapAOAnisotropy':
 							break;
 						case 'mapBump':
-							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy, textures, texturePath, crossOrigin );
+							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapBumpScale':
 							json.bumpScale = value;
@@ -186,7 +186,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapBumpAnisotropy':
 							break;
 						case 'mapNormal':
-							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy, textures, texturePath, crossOrigin );
+							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapNormalFactor':
 							json.normalScale = value;
@@ -197,7 +197,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapNormalAnisotropy':
 							break;
 						case 'mapSpecular':
-							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy, textures, texturePath, crossOrigin );
+							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapSpecularRepeat':
 						case 'mapSpecularOffset':
@@ -205,7 +205,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapSpecularAnisotropy':
 							break;
 						case 'mapMetalness':
-							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy, textures, texturePath, crossOrigin );
+							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapMetalnessRepeat':
 						case 'mapMetalnessOffset':
@@ -213,7 +213,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapMetalnessAnisotropy':
 							break;
 						case 'mapRoughness':
-							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy, textures, texturePath, crossOrigin );
+							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapRoughnessRepeat':
 						case 'mapRoughnessOffset':
@@ -221,7 +221,7 @@ THREE.LegacyJSONLoader = ( function () {
 						case 'mapRoughnessAnisotropy':
 							break;
 						case 'mapAlpha':
-							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy, textures, texturePath, crossOrigin );
+							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapAlphaRepeat':
 						case 'mapAlphaOffset':
@@ -271,10 +271,10 @@ THREE.LegacyJSONLoader = ( function () {
 
 			}
 
-			function loadTexture( path, repeat, offset, wrap, anisotropy, textures, texturePath, crossOrigin ) {
+			function loadTexture( path, repeat, offset, wrap, anisotropy, textures, texturePath, crossOrigin, manager ) {
 
 				var fullPath = texturePath + path;
-				var loader = THREE.Loader.Handlers.get( fullPath );
+				var loader = manager.getHandler( fullPath );
 
 				var texture;
 
@@ -804,7 +804,7 @@ THREE.LegacyJSONLoader = ( function () {
 
 				} else {
 
-					var materials = initMaterials( json.materials, this.resourcePath || path, this.crossOrigin );
+					var materials = initMaterials( json.materials, this.resourcePath || path, this.crossOrigin, this.manager );
 
 					return { geometry: geometry, materials: materials };
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -145,16 +145,17 @@ var FBXLoader = ( function () {
 
 			var textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
-			return new FBXTreeParser( textureLoader ).parse( fbxTree );
+			return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
 
 		}
 
 	} );
 
 	// Parse the FBXTree object returned by the BinaryParser or TextParser and return a Group
-	function FBXTreeParser( textureLoader ) {
+	function FBXTreeParser( textureLoader, manager ) {
 
 		this.textureLoader = textureLoader;
+		this.manager = manager;
 
 	}
 
@@ -313,7 +314,7 @@ var FBXLoader = ( function () {
 
 				case 'tga':
 
-					if ( Loader.Handlers.get( '.tga' ) === null ) {
+					if ( this.manager.getHandler( '.tga' ) === null ) {
 
 						console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
 
@@ -426,7 +427,7 @@ var FBXLoader = ( function () {
 
 			if ( extension === 'tga' ) {
 
-				var loader = Loader.Handlers.get( '.tga' );
+				var loader = this.manager.getHandler( '.tga' );
 
 				if ( loader === null ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2050,7 +2050,7 @@ var GLTFLoader = ( function () {
 
 			// Load Texture resource.
 
-			var loader = Loader.Handlers.get( sourceURI );
+			var loader = options.manager.getHandler( sourceURI );
 
 			if ( ! loader ) {
 

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -1341,7 +1341,7 @@ var MMDLoader = ( function () {
 
 			if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
 
-			var loader = Loader.Handlers.get( fullPath );
+			var loader = this.manager.getHandler( fullPath );
 
 			if ( loader === null ) {
 

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -523,8 +523,8 @@ MTLLoader.MaterialCreator.prototype = {
 	loadTexture: function ( url, mapping, onLoad, onProgress, onError ) {
 
 		var texture;
-		var loader = Loader.Handlers.get( url );
 		var manager = ( this.manager !== undefined ) ? this.manager : DefaultLoadingManager;
+		var loader = manager.getHandler( url );
 
 		if ( loader === null ) {
 

--- a/examples/jsm/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/jsm/loaders/deprecated/LegacyGLTFLoader.js
@@ -1169,7 +1169,7 @@ var LegacyGLTFLoader = ( function () {
 
 						}
 
-						var textureLoader = Loader.Handlers.get( sourceUri );
+						var textureLoader = options.manager.getHanlder( sourceUri );
 
 						if ( textureLoader === null ) {
 

--- a/examples/jsm/loaders/deprecated/LegacyGLTFLoader.js
+++ b/examples/jsm/loaders/deprecated/LegacyGLTFLoader.js
@@ -1169,7 +1169,7 @@ var LegacyGLTFLoader = ( function () {
 
 						}
 
-						var textureLoader = options.manager.getHanlder( sourceUri );
+						var textureLoader = options.manager.getHandler( sourceUri );
 
 						if ( textureLoader === null ) {
 

--- a/examples/jsm/loaders/deprecated/LegacyJSONLoader.js
+++ b/examples/jsm/loaders/deprecated/LegacyJSONLoader.js
@@ -105,13 +105,13 @@ var LegacyJSONLoader = ( function () {
 			var _textureLoader = new TextureLoader();
 			var _materialLoader = new MaterialLoader();
 
-			function initMaterials( materials, texturePath, crossOrigin ) {
+			function initMaterials( materials, texturePath, crossOrigin, manager ) {
 
 				var array = [];
 
 				for ( var i = 0; i < materials.length; ++ i ) {
 
-					array[ i ] = createMaterial( materials[ i ], texturePath, crossOrigin );
+					array[ i ] = createMaterial( materials[ i ], texturePath, crossOrigin, manager );
 
 				}
 
@@ -119,7 +119,7 @@ var LegacyJSONLoader = ( function () {
 
 			}
 
-			function createMaterial( m, texturePath, crossOrigin ) {
+			function createMaterial( m, texturePath, crossOrigin, manager ) {
 
 				// convert from old material format
 
@@ -171,7 +171,7 @@ var LegacyJSONLoader = ( function () {
 							if ( value.toLowerCase() === 'standard' ) json.type = 'MeshStandardMaterial';
 							break;
 						case 'mapDiffuse':
-							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy, textures, texturePath, crossOrigin );
+							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapDiffuseRepeat':
 						case 'mapDiffuseOffset':
@@ -179,7 +179,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapDiffuseAnisotropy':
 							break;
 						case 'mapEmissive':
-							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy, textures, texturePath, crossOrigin );
+							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapEmissiveRepeat':
 						case 'mapEmissiveOffset':
@@ -187,7 +187,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapEmissiveAnisotropy':
 							break;
 						case 'mapLight':
-							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy, textures, texturePath, crossOrigin );
+							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapLightRepeat':
 						case 'mapLightOffset':
@@ -195,7 +195,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapLightAnisotropy':
 							break;
 						case 'mapAO':
-							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy, textures, texturePath, crossOrigin );
+							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapAORepeat':
 						case 'mapAOOffset':
@@ -203,7 +203,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapAOAnisotropy':
 							break;
 						case 'mapBump':
-							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy, textures, texturePath, crossOrigin );
+							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapBumpScale':
 							json.bumpScale = value;
@@ -214,7 +214,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapBumpAnisotropy':
 							break;
 						case 'mapNormal':
-							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy, textures, texturePath, crossOrigin );
+							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapNormalFactor':
 							json.normalScale = value;
@@ -225,7 +225,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapNormalAnisotropy':
 							break;
 						case 'mapSpecular':
-							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy, textures, texturePath, crossOrigin );
+							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapSpecularRepeat':
 						case 'mapSpecularOffset':
@@ -233,7 +233,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapSpecularAnisotropy':
 							break;
 						case 'mapMetalness':
-							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy, textures, texturePath, crossOrigin );
+							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapMetalnessRepeat':
 						case 'mapMetalnessOffset':
@@ -241,7 +241,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapMetalnessAnisotropy':
 							break;
 						case 'mapRoughness':
-							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy, textures, texturePath, crossOrigin );
+							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapRoughnessRepeat':
 						case 'mapRoughnessOffset':
@@ -249,7 +249,7 @@ var LegacyJSONLoader = ( function () {
 						case 'mapRoughnessAnisotropy':
 							break;
 						case 'mapAlpha':
-							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy, textures, texturePath, crossOrigin );
+							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy, textures, texturePath, crossOrigin, manager );
 							break;
 						case 'mapAlphaRepeat':
 						case 'mapAlphaOffset':
@@ -299,10 +299,10 @@ var LegacyJSONLoader = ( function () {
 
 			}
 
-			function loadTexture( path, repeat, offset, wrap, anisotropy, textures, texturePath, crossOrigin ) {
+			function loadTexture( path, repeat, offset, wrap, anisotropy, textures, texturePath, crossOrigin, manager ) {
 
 				var fullPath = texturePath + path;
-				var loader = Loader.Handlers.get( fullPath );
+				var loader = manager.getHandler( fullPath );
 
 				var texture;
 
@@ -832,7 +832,7 @@ var LegacyJSONLoader = ( function () {
 
 				} else {
 
-					var materials = initMaterials( json.materials, this.resourcePath || path, this.crossOrigin );
+					var materials = initMaterials( json.materials, this.resourcePath || path, this.crossOrigin, this.manager );
 
 					return { geometry: geometry, materials: materials };
 

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -68,15 +68,16 @@
 
 				var onError = function () { };
 
-				THREE.Loader.Handlers.add( /\.dds$/i, new DDSLoader() );
+				var manager = new THREE.LoadingManager();
+				manager.addHandler( /\.dds$/i, new DDSLoader() );
 
-				new MTLLoader()
+				new MTLLoader( manager )
 					.setPath( 'models/obj/male02/' )
 					.load( 'male02_dds.mtl', function ( materials ) {
 
 						materials.preload();
 
-						new OBJLoader()
+						new OBJLoader( manager )
 							.setMaterials( materials )
 							.setPath( 'models/obj/male02/' )
 							.load( 'male02.obj', function ( object ) {

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -424,6 +424,22 @@ Object.assign( Loader.prototype, {
 
 } );
 
+Loader.Handlers = {
+
+	add: function ( /* regex, loader */ ) {
+
+		console.error( 'THREE.Loader: Handlers.add() has been removed. Use LoadingManager.addHandler() instead.' );
+
+	},
+
+	get: function ( /* file */ ) {
+
+		console.error( 'THREE.Loader: Handlers.get() has been removed. Use LoadingManager.getHandler() instead.' );
+
+	}
+
+};
+
 export function XHRLoader( manager ) {
 
 	console.warn( 'THREE.XHRLoader has been renamed to THREE.FileLoader.' );

--- a/src/loaders/Loader.d.ts
+++ b/src/loaders/Loader.d.ts
@@ -21,6 +21,4 @@ export class Loader {
 	setPath( path: string ): this;
 	setResourcePath( resourcePath: string ): this;
 
-	static Handlers: LoaderHandler;
-
 }

--- a/src/loaders/Loader.d.ts
+++ b/src/loaders/Loader.d.ts
@@ -24,12 +24,3 @@ export class Loader {
 	static Handlers: LoaderHandler;
 
 }
-
-// LoaderHandler
-
-export interface LoaderHandler {
-	handlers: ( RegExp | Loader )[];
-
-	add( regex: RegExp, loader: Loader ): void;
-	get( file: string ): Loader | null;
-}

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -43,40 +43,4 @@ Object.assign( Loader.prototype, {
 
 } );
 
-//
-
-Loader.Handlers = {
-
-	handlers: [],
-
-	add: function ( regex, loader ) {
-
-		this.handlers.push( regex, loader );
-
-	},
-
-	get: function ( file ) {
-
-		var handlers = this.handlers;
-
-		for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
-
-			var regex = handlers[ i ];
-			var loader = handlers[ i + 1 ];
-
-			if ( regex.test( file ) ) {
-
-				return loader;
-
-			}
-
-		}
-
-		return null;
-
-	}
-
-};
-
-
 export { Loader };

--- a/src/loaders/LoadingManager.d.ts
+++ b/src/loaders/LoadingManager.d.ts
@@ -37,7 +37,7 @@ export class LoadingManager {
 	 * This behavior can be used to load assets from .ZIP files, drag-and-drop APIs, and Data URIs.
 	 * @param callback URL modifier callback. Called with url argument, and must return resolvedURL.
 	 */
-	setURLModifier( callback?: ( url: string ) => string ): void;
+	setURLModifier( callback?: ( url: string ) => string ): this;
 
 	/**
 	 * Given a URL, uses the URL modifier callback (if any) and returns a resolved URL.
@@ -49,5 +49,11 @@ export class LoadingManager {
 	itemStart( url: string ): void;
 	itemEnd( url: string ): void;
 	itemError( url: string ): void;
+
+	// handlers
+
+	addHandler( regex: RegExp, loader: Loader ): this;
+	removeHandler( regex: RegExp ): this;
+	getHandler( file: string ): Loader | null;
 
 }

--- a/src/loaders/LoadingManager.d.ts
+++ b/src/loaders/LoadingManager.d.ts
@@ -1,3 +1,5 @@
+import { Loader } from './Loader';
+
 export const DefaultLoadingManager: LoadingManager;
 
 /**

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -10,6 +10,7 @@ function LoadingManager( onLoad, onProgress, onError ) {
 	var itemsLoaded = 0;
 	var itemsTotal = 0;
 	var urlModifier = undefined;
+	var handlers = [];
 
 	// Refer to #5689 for the reason why we don't set .onStart
 	// in the constructor
@@ -86,7 +87,49 @@ function LoadingManager( onLoad, onProgress, onError ) {
 	this.setURLModifier = function ( transform ) {
 
 		urlModifier = transform;
+
 		return this;
+
+	};
+
+	this.addHandler = function ( regex, loader ) {
+
+		handlers.push( regex, loader );
+
+		return this;
+
+	};
+
+	this.removeHandler = function ( regex ) {
+
+		var index = handlers.indexOf( regex );
+
+		if ( index !== - 1 ) {
+
+			handlers.splice( index, 2 );
+
+		}
+
+		return this;
+
+	};
+
+	this.getHandler = function ( file ) {
+
+		for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
+
+			var regex = handlers[ i ];
+			var loader = handlers[ i + 1 ];
+
+			if ( regex.test( file ) ) {
+
+				return loader;
+
+			}
+
+		}
+
+		return null;
 
 	};
 

--- a/test/unit/src/loaders/Loader.tests.js
+++ b/test/unit/src/loaders/Loader.tests.js
@@ -3,27 +3,12 @@
  */
 /* global QUnit */
 
-import { Loader } from '../../../../src/loaders/Loader';
-
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'Loader', () => {
 
 		// INSTANCING
 		QUnit.todo( "Instancing", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		// STATIC STUFF
-		QUnit.todo( "Handlers.add", ( assert ) => {
-
-			assert.ok( false, "everything's gonna be alright" );
-
-		} );
-
-		QUnit.todo( "Handlers.get", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 


### PR DESCRIPTION
Fixed #15953

This PR removes `Loader.Handler` and enhances the API of `LoadingManager` instead. The following methods are introduced:

- `.addHandler()`
- `.removeHandler()`
- `.getHandler()`