### PR TITLE
Cleanup Geometry and DirectGeometry TS

### DIFF
--- a/src/core/DirectGeometry.d.ts
+++ b/src/core/DirectGeometry.d.ts
@@ -5,13 +5,11 @@ import { Vector4 } from './../math/Vector4';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Geometry } from './Geometry';
-import { Event } from './Face3';
-import { EventDispatcher } from './EventDispatcher';
 import { MorphTarget } from './Geometry';
 /**
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/DirectGeometry.js">src/core/DirectGeometry.js</a>
  */
-export class DirectGeometry extends EventDispatcher {
+export class DirectGeometry {
 
 	constructor();
 
@@ -42,11 +40,5 @@ export class DirectGeometry extends EventDispatcher {
 	computeGroups( geometry: Geometry ): void;
 	fromGeometry( geometry: Geometry ): DirectGeometry;
 	dispose(): void;
-
-	// EventDispatcher mixins
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
-	hasEventListener( type: string, listener: ( event: Event ) => void ): boolean;
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
 
 }

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -1,6 +1,6 @@
 import { Vector3 } from './../math/Vector3';
 import { Color } from './../math/Color';
-import { Face3, Event } from './Face3';
+import { Face3 } from './Face3';
 import { Vector2 } from './../math/Vector2';
 import { Vector4 } from './../math/Vector4';
 import { Box3 } from './../math/Box3';
@@ -251,11 +251,5 @@ export class Geometry extends EventDispatcher {
 	bones: Bone[];
 	animation: AnimationClip;
 	animations: AnimationClip[];
-
-	// EventDispatcher mixins
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
-	hasEventListener( type: string, listener: ( event: Event ) => void ): boolean;
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
 
 }


### PR DESCRIPTION
From #17430 

This PR cleans up `Geometry` and `DirectGeometry` TS.

- `Geometry.d.ts` unnecessarily redefines `EventDispatcher` methods. Removing them.
- `DirectGeometry.d.ts` inherits `EventDispatcher` but JS doesn't inherit. Removing the inheritance.
