### PR TITLE
Fix logarithmic depth buffer result when rendering with OrthographicCamera

### DIFF
--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -107,4 +107,10 @@ float linearToRelativeLuminance( const in vec3 color ) {
 	return dot( weights, color.rgb );
 
 }
+
+bool isPerspectiveMatrix( mat4 projectionMatrix ) {
+
+  return projectionMatrix[ 2 ][ 3 ] == - 1.0;
+
+}
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
@@ -1,15 +1,7 @@
 export default /* glsl */`
 #if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
 
-	if ( skipLogDepth == 1.0 ) {
-
-		gl_FragDepthEXT = gl_FragCoord.z;
-
-	} else {
-
-		gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;
-
-	}
+	gl_FragDepthEXT = vIsPerspective == 1.0 ? log2( vFragDepth ) * logDepthBufFC * 0.5 : gl_FragCoord.z;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
@@ -1,7 +1,15 @@
 export default /* glsl */`
 #if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )
 
-	gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;
+	if ( skipLogDepth == 1.0 ) {
+
+		gl_FragDepthEXT = gl_FragCoord.z;
+
+	} else {
+
+		gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;
+
+	}
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
@@ -3,6 +3,7 @@ export default /* glsl */`
 
 	uniform float logDepthBufFC;
 	varying float vFragDepth;
+	varying float skipLogDepth;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_fragment.glsl.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 
 	uniform float logDepthBufFC;
 	varying float vFragDepth;
-	varying float skipLogDepth;
+	varying float vIsPerspective;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
@@ -4,6 +4,7 @@ export default /* glsl */`
 	#ifdef USE_LOGDEPTHBUF_EXT
 
 		varying float vFragDepth;
+		varying float skipLogDepth;
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_pars_vertex.glsl.js
@@ -4,7 +4,7 @@ export default /* glsl */`
 	#ifdef USE_LOGDEPTHBUF_EXT
 
 		varying float vFragDepth;
-		varying float skipLogDepth;
+		varying float vIsPerspective;
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
@@ -4,7 +4,7 @@ export default /* glsl */`
 	#ifdef USE_LOGDEPTHBUF_EXT
 
 		vFragDepth = 1.0 + gl_Position.w;
-		skipLogDepth = isPerspectiveMatrix( projectionMatrix ) ? 0.0 : 1.0;
+		vIsPerspective = float( isPerspectiveMatrix( projectionMatrix ) );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_vertex.glsl.js
@@ -4,12 +4,17 @@ export default /* glsl */`
 	#ifdef USE_LOGDEPTHBUF_EXT
 
 		vFragDepth = 1.0 + gl_Position.w;
+		skipLogDepth = isPerspectiveMatrix( projectionMatrix ) ? 0.0 : 1.0;
 
 	#else
 
-		gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
+		if ( isPerspectiveMatrix( projectionMatrix ) ) {
 
-		gl_Position.z *= gl_Position.w;
+			gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
+
+			gl_Position.z *= gl_Position.w;
+
+		}
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/points_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_vert.glsl.js
@@ -20,7 +20,7 @@ void main() {
 
 	#ifdef USE_SIZEATTENUATION
 
-		bool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );
+		bool isPerspective = isPerspectiveMatrix( projectionMatrix );
 
 		if ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );
 

--- a/src/renderers/shaders/ShaderLib/sprite_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_vert.glsl.js
@@ -20,7 +20,7 @@ void main() {
 
 	#ifndef USE_SIZEATTENUATION
 
-		bool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );
+		bool isPerspective = isPerspectiveMatrix( projectionMatrix );
 
 		if ( isPerspective ) scale *= - mvPosition.z;
 


### PR DESCRIPTION
Fix #9108

Moves the orthographic camera detection shader code into a shared function and uses the default fragment depth when using an orthographic camera. I've tested this with the logarithmic depth buffer enabled and an orthographic camera in my application and it no longer causes the draw-through effect.

Some things to note:
- This disables the logarithmic depth buffer when using an orthographic projection matrix so there are no benefits to using a logarithmic depth buffer with an ortho camera. It just changes the shader code to produce sensible results.
- `gl_FragDepth` is _still_ written to when using an orthographic camera meaning the performance penalties are still incurred, which is not ideal but the other option of using defines would require recompiling all materials in the scene. I don't believe there's anything else in the library that automatically triggers a recompilation of shaders as far as I'm aware?
- If the `gl_FragDepth = gl_FragCoord.z` code path is enabled for perspective camera (which should be the same as disabling logdepth) we can see a bit of a different artifact in the large depth values demo but this could be due to how and when the gpu is able to discard fragments due to depth:

![image](https://user-images.githubusercontent.com/734200/64468641-0a8e6f00-d0dc-11e9-98f4-92f6b871d2ee.png)

And lastly [here](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/gl_FragDepth.xhtml) is the relevant documentation that states that this is the right way to get the default depth value

> If depth buffering is enabled and no shader writes to gl_FragDepth, then the fixed function value for depth will be used (this value is contained in the z component of gl_FragCoord)
