### PR TITLE
Stencil Params: Add Stencil Compare and Write Mask Material Parameters

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -128,6 +128,11 @@
 		Whether rendering this material has any effect on the stencil buffer. Default is *false*.
 		</p>
 
+		<h3>[property:Boolean stencilWriteMask]</h3>
+		<p>
+		The bit mask to use when writing to the stencil buffer. Default is *0xFF*.
+		</p>
+
 		<h3>[property:Boolean stencilFunc]</h3>
 		<p>
 		The stencil comparison function to use. Default is [page:Materials AlwaysStencilFunc]. See stencil function [page:Materials constants] for all possible values.
@@ -138,9 +143,9 @@
 		The value to use when performing stencil comparisons or stencil operations. Default is *0*.
 		</p>
 
-		<h3>[property:Boolean stencilMask]</h3>
+		<h3>[property:Boolean stencilFuncMask]</h3>
 		<p>
-		The bit mask to use when comparing against or writing to the stencil buffer. Default is *0xFF*.
+		The bit mask to use when comparing against the stencil buffer. Default is *0xFF*.
 		</p>
 
 		<h3>[property:Integer stencilFail]</h3>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -108,6 +108,11 @@
 Whether rendering this material has any effect on the stencil buffer. Default is *false*.
 </p>
 
+<h3>[property:Boolean stencilWriteMask]</h3>
+<p>
+The bit mask to use when writing to the stencil buffer. Default is *0xFF*.
+</p>
+
 <h3>[property:Boolean stencilFunc]</h3>
 <p>
 The stencil comparison function to use. Default is [page:Materials AlwaysStencilFunc]. See stencil function [page:Materials constants] for all possible values.
@@ -118,9 +123,9 @@ The stencil comparison function to use. Default is [page:Materials AlwaysStencil
 The value to use when performing stencil comparisons or stencil operations. Default is *0*.
 </p>
 
-<h3>[property:Boolean stencilMask]</h3>
+<h3>[property:Boolean stencilFuncMask]</h3>
 <p>
-The bit mask to use when comparing against or writing to the stencil buffer. Default is *0xFF*.
+The bit mask to use when comparing against the stencil buffer. Default is *0xFF*.
 </p>
 
 <h3>[property:Integer stencilFail]</h3>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1312,6 +1312,21 @@ Object.defineProperties( Material.prototype, {
 			this.flatShading = ( value === FlatShading );
 
 		}
+	},
+
+	stencilMask: {
+		get: function () {
+
+			console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+			return this.stencilFuncMask;
+
+		},
+		set: function ( value ) {
+
+			console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+			this.stencilFuncMask = value;
+
+		}
 	}
 
 } );

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -78,6 +78,16 @@ MaterialLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
 		if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
+
+		if ( json.stencilWrite !== undefined ) material.stencilWrite = json.stencilWrite;
+		if ( json.stencilWriteMask !== undefined ) material.stencilWriteMask = json.stencilWriteMask;
+		if ( json.stencilFunc !== undefined ) material.stencilFunc = json.stencilFunc;
+		if ( json.stencilRef !== undefined ) material.stencilRef = json.stencilRef;
+		if ( json.stencilFuncMask !== undefined ) material.stencilFuncMask = json.stencilFuncMask;
+		if ( json.stencilFail !== undefined ) material.stencilFail = json.stencilFail;
+		if ( json.stencilZFail !== undefined ) material.stencilZFail = json.stencilZFail;
+		if ( json.stencilZPass !== undefined ) material.stencilZPass = json.stencilZPass;
+
 		if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 		if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;
 		if ( json.wireframeLinecap !== undefined ) material.wireframeLinecap = json.wireframeLinecap;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -41,9 +41,10 @@ function Material() {
 	this.depthTest = true;
 	this.depthWrite = true;
 
+	this.stencilWriteMask = 0xff;
 	this.stencilFunc = AlwaysStencilFunc;
+	this.stencilFuncMask = 0xff;
 	this.stencilRef = 0;
-	this.stencilMask = 0xff;
 	this.stencilFail = KeepStencilOp;
 	this.stencilZFail = KeepStencilOp;
 	this.stencilZPass = KeepStencilOp;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -43,8 +43,8 @@ function Material() {
 
 	this.stencilWriteMask = 0xff;
 	this.stencilFunc = AlwaysStencilFunc;
-	this.stencilFuncMask = 0xff;
 	this.stencilRef = 0;
+	this.stencilFuncMask = 0xff;
 	this.stencilFail = KeepStencilOp;
 	this.stencilZFail = KeepStencilOp;
 	this.stencilZPass = KeepStencilOp;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -52,14 +52,14 @@ function Material() {
 
 	Object.defineProperty( this, 'stencilMask', {
 
-		set: function( value ) {
+		set: function ( value ) {
 
 			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
 			this.stencilFuncMask = value;
 
 		},
 
-		get: function() {
+		get: function () {
 
 			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
 			return this.stencilFuncMask;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -50,24 +50,6 @@ function Material() {
 	this.stencilZPass = KeepStencilOp;
 	this.stencilWrite = false;
 
-	Object.defineProperty( this, 'stencilMask', {
-
-		set: function ( value ) {
-
-			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
-			this.stencilFuncMask = value;
-
-		},
-
-		get: function () {
-
-			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
-			return this.stencilFuncMask;
-
-		}
-
-	} );
-
 	this.clippingPlanes = null;
 	this.clipIntersection = false;
 	this.clipShadows = false;
@@ -277,9 +259,10 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		data.depthWrite = this.depthWrite;
 
 		data.stencilWrite = this.stencilWrite;
+		data.stencilWriteMask = this.stencilWriteMask;
 		data.stencilFunc = this.stencilFunc;
 		data.stencilRef = this.stencilRef;
-		data.stencilMask = this.stencilMask;
+		data.stencilFuncMask = this.stencilFuncMask;
 		data.stencilFail = this.stencilFail;
 		data.stencilZFail = this.stencilZFail;
 		data.stencilZPass = this.stencilZPass;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -381,9 +381,10 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.depthWrite = source.depthWrite;
 
 		this.stencilWrite = source.stencilWrite;
+		this.stencilWriteMask = source.stencilWriteMask;
 		this.stencilFunc = source.stencilFunc;
 		this.stencilRef = source.stencilRef;
-		this.stencilMask = source.stencilMask;
+		this.stencilFuncMask = source.stencilFuncMask;
 		this.stencilFail = source.stencilFail;
 		this.stencilZFail = source.stencilZFail;
 		this.stencilZPass = source.stencilZPass;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -50,6 +50,24 @@ function Material() {
 	this.stencilZPass = KeepStencilOp;
 	this.stencilWrite = false;
 
+	Object.defineProperty( this, 'stencilMask', {
+
+		set: function( value ) {
+
+			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
+			this.stencilFuncMask = value;
+
+		},
+
+		get: function() {
+
+			console.warn( 'Material.stencilMask has been removed. Use Material.stencilFuncMask instead.' );
+			return this.stencilFuncMask;
+
+		}
+
+	} );
+
 	this.clippingPlanes = null;
 	this.clipIntersection = false;
 	this.clipShadows = false;

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -685,7 +685,8 @@ function WebGLState( gl, extensions, utils, capabilities ) {
 		stencilBuffer.setTest( stencilWrite );
 		if ( stencilWrite ) {
 
-			stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilMask );
+			stencilBuffer.setMask( material.stencilWriteMask );
+			stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilFuncMask );
 			stencilBuffer.setOp( material.stencilFail, material.stencilZFail, material.stencilZPass );
 
 		}


### PR DESCRIPTION
Fix #17419

Changes `stencilMask` to `stencilFuncMask` and adds `stencilWriteMask` (corresponding to the [stencilMask](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/stencilMask) function).

For the moment the setter and getter for `stencilMask` will log a warning they are used.