### PR TITLE
Deprecate BufferAttribute  and InterleavedBuffer .setArray 

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -178,13 +178,6 @@
 		being a [page:TypedArray].
 		</p>
 
-		<h3>[method:BufferAttribute setArray] ( [param:TypedArray array] ) </h3>
-		<p>
-		[page:BufferAttribute.array array] to the TypedArray passed in here.<br /><br />
-
-		After setting the array, [page:BufferAttribute.needsUpdate needsUpdate] should be set to true.
-		</p>
-
 		<h3>[method:BufferAttribute setDynamic] ( [param:Boolean value] ) </h3>
 		<p>Set [page:BufferAttribute.dynamic dynamic] to value.</p>
 

--- a/docs/api/en/core/InterleavedBuffer.html
+++ b/docs/api/en/core/InterleavedBuffer.html
@@ -81,11 +81,6 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:InterleavedBuffer setArray] ( [param:TypedArray array] ) </h3>
-		<p>
-		 array - must be  a Typed Array.
-		</p>
-
 		<h3>[method:InterleavedBuffer setDynamic] ( [param:Boolean value] ) </h3>
 		<p>
 			Set [page:InterleavedBuffer.dynamic dynamic] to value.

--- a/docs/api/zh/core/BufferAttribute.html
+++ b/docs/api/zh/core/BufferAttribute.html
@@ -158,13 +158,6 @@
 		特别的, 对将 [page:Array value] 转为  [page:TypedArray] 的要求详见上述链接。
 		</p>
 
-		<h3>[method:BufferAttribute setArray] ( [param:TypedArray array] ) </h3>
-		<p>
-		[page:BufferAttribute.array array] 被赋值的 TypedArray 队列。<br /><br />
-
-		队列被复制后，[page:BufferAttribute.needsUpdate needsUpdate] 应当被设置为 true。
-		</p>
-
 		<h3>[method:BufferAttribute setDynamic] ( [param:Boolean value] ) </h3>
 		<p>将 [page:BufferAttribute.dynamic dynamic] 设置为 value.</p>
 

--- a/docs/api/zh/core/InterleavedBuffer.html
+++ b/docs/api/zh/core/InterleavedBuffer.html
@@ -81,11 +81,6 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:InterleavedBuffer setArray] ( [param:TypedArray array] ) </h3>
-		<p>
-		 array - 必须是一个类型化的队列。
-		</p>
-
 		<h3>[method:InterleavedBuffer setDynamic] ( [param:Boolean value] ) </h3>
 		<p>
 			根据输入参数设置 [page:InterleavedBuffer.dynamic dynamic] 的值。

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -19,6 +19,7 @@ import {
 	BufferAttribute
 } from './core/BufferAttribute.js';
 import { BufferGeometry } from './core/BufferGeometry.js';
+import { InterleavedBuffer } from './core/InterleavedBuffer.js';
 import { Face3 } from './core/Face3.js';
 import { Geometry } from './core/Geometry.js';
 import { Object3D } from './core/Object3D.js';
@@ -1228,6 +1229,27 @@ Object.defineProperties( BufferGeometry.prototype, {
 
 		}
 	}
+
+} );
+
+Object.assign( InterleavedBuffer.prototype, {
+
+	setArray: function ( array ) {
+
+		if ( Array.isArray( array ) ) {
+
+			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
+
+		}
+
+		console.warn( 'THREE.InterleavedBuffer: .setArray has been deprecatted. Use BufferGeometry.setAttribute to replace/resize attribute buffers' );
+
+		this.count = array !== undefined ? array.length / this.stride : 0;
+		this.array = array;
+
+		return this;
+
+	},
 
 } );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1169,6 +1169,7 @@ Object.defineProperties( BufferAttribute.prototype, {
 } );
 
 Object.assign( BufferAttribute.prototype, {
+
 	copyIndicesArray: function ( /* indices */ ) {
 
 		console.error( 'THREE.BufferAttribute: .copyIndicesArray() has been removed.' );
@@ -1182,12 +1183,15 @@ Object.assign( BufferAttribute.prototype, {
 
 		}
 
+		console.warn( 'THREE.BufferAttribute: .setArray has been deprecated. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
+
 		this.count = array !== undefined ? array.length / this.itemSize : 0;
 		this.array = array;
 
 		return this;
 
-	},
+	}
+
 } );
 
 Object.assign( BufferGeometry.prototype, {
@@ -1259,14 +1263,14 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		}
 
-		console.warn( 'THREE.InterleavedBuffer: .setArray has been deprecatted. Use BufferGeometry.setAttribute to replace/resize attribute buffers' );
+		console.warn( 'THREE.InterleavedBuffer: .setArray has been deprecated. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
 
 		this.count = array !== undefined ? array.length / this.stride : 0;
 		this.array = array;
 
 		return this;
 
-	},
+	}
 
 } );
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1164,13 +1164,30 @@ Object.defineProperties( BufferAttribute.prototype, {
 			return this.array.length;
 
 		}
-	},
+	}
+
+} );
+
+Object.assign( BufferAttribute.prototype, {
 	copyIndicesArray: function ( /* indices */ ) {
 
 		console.error( 'THREE.BufferAttribute: .copyIndicesArray() has been removed.' );
 
-	}
+	},
+	setArray: function ( array ) {
 
+		if ( Array.isArray( array ) ) {
+
+			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
+
+		}
+
+		this.count = array !== undefined ? array.length / this.itemSize : 0;
+		this.array = array;
+
+		return this;
+
+	},
 } );
 
 Object.assign( BufferGeometry.prototype, {

--- a/src/core/BufferAttribute.d.ts
+++ b/src/core/BufferAttribute.d.ts
@@ -16,7 +16,6 @@ export class BufferAttribute {
 	count: number;
 	onUpload: Function;
 
-	setArray( array?: ArrayBufferView ): void;
 	setDynamic( dynamic: boolean ): BufferAttribute;
 	clone(): this;
 	copy( source: BufferAttribute ): this;

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -45,21 +45,6 @@ Object.assign( BufferAttribute.prototype, {
 
 	onUploadCallback: function () {},
 
-	setArray: function ( array ) {
-
-		if ( Array.isArray( array ) ) {
-
-			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-		}
-
-		this.count = array !== undefined ? array.length / this.itemSize : 0;
-		this.array = array;
-
-		return this;
-
-	},
-
 	setDynamic: function ( value ) {
 
 		this.dynamic = value;

--- a/src/core/InterleavedBuffer.d.ts
+++ b/src/core/InterleavedBuffer.d.ts
@@ -16,7 +16,6 @@ export class InterleavedBuffer {
 	count: number;
 	needsUpdate: boolean;
 
-	setArray( array?: ArrayBufferView ): void;
 	setDynamic( dynamic: boolean ): InterleavedBuffer;
 	clone(): this;
 	copy( source: InterleavedBuffer ): this;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -32,21 +32,6 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	onUploadCallback: function () {},
 
-	setArray: function ( array ) {
-
-		if ( Array.isArray( array ) ) {
-
-			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-		}
-
-		this.count = array !== undefined ? array.length / this.stride : 0;
-		this.array = array;
-
-		return this;
-
-	},
-
 	setDynamic: function ( value ) {
 
 		this.dynamic = value;

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -42,28 +42,6 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "setArray", ( assert ) => {
-
-			var f32a = new Float32Array( [ 1, 2, 3, 4 ] );
-			var a = new BufferAttribute( f32a, 2, false );
-
-			a.setArray( f32a, 2 );
-
-			assert.strictEqual( a.count, 2, "Check item count" );
-			assert.strictEqual( a.array, f32a, "Check array" );
-
-			assert.throws(
-				function () {
-
-					a.setArray( [ 1, 2, 3, 4 ] );
-
-				},
-				/array should be a Typed Array/,
-				"Calling setArray with a simple array throws Error"
-			);
-
-		} );
-
 		QUnit.todo( "setDynamic", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );

--- a/test/unit/src/core/InterleavedBuffer.tests.js
+++ b/test/unit/src/core/InterleavedBuffer.tests.js
@@ -49,34 +49,6 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "setArray", ( assert ) => {
-
-			var f32a = new Float32Array( [ 1, 2, 3, 4 ] );
-			var f32b = new Float32Array( [] );
-			var a = new InterleavedBuffer( f32a, 2, false );
-
-			a.setArray( f32a );
-
-			assert.strictEqual( a.count, 2, "Check item count for non-empty array" );
-			assert.strictEqual( a.array, f32a, "Check array itself" );
-
-			a.setArray( f32b );
-
-			assert.strictEqual( a.count, 0, "Check item count for empty array" );
-			assert.strictEqual( a.array, f32b, "Check array itself" );
-
-			assert.throws(
-				function () {
-
-					a.setArray( [ 1, 2, 3, 4 ] );
-
-				},
-				/array should be a Typed Array/,
-				"Calling setArray with a non-typed array throws Error"
-			);
-
-		} );
-
 		QUnit.todo( "setDynamic", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );


### PR DESCRIPTION
As discussed #17418 etc. 

Precursor to #17445 after which .setArray will fail if used to change the size of a buffer.