### PR TITLE
WebGLGeometries: Announce stop of THREE.Geometry support.

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -63,6 +63,8 @@ function WebGLGeometries( gl, attributes, info ) {
 
 			if ( geometry._bufferGeometry === undefined ) {
 
+				console.warn( 'THREE.WebGLGeometries: three.js will stop rendering geometries of type "THREE.Geometry" in R111. Please use "THREE.BufferGeometry" instead.' );
+
 				geometry._bufferGeometry = new BufferGeometry().setFromObject( object );
 
 			}


### PR DESCRIPTION
Instead of directly stop rendering `THREE.Geometry` (see #15514), it might be more acceptable to announce this change so users can easier prepare for it. 

The warning is logged once for each automatic geometry conversion of `WebGLRenderer`.