### PR TITLE
ArrowHelper: Make .setLength() more robust.

### DIFF
--- a/src/helpers/ArrowHelper.js
+++ b/src/helpers/ArrowHelper.js
@@ -97,7 +97,7 @@ ArrowHelper.prototype.setLength = function ( length, headLength, headWidth ) {
 	if ( headLength === undefined ) headLength = 0.2 * length;
 	if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-	this.line.scale.set( 1, Math.max( 0, length - headLength ), 1 );
+	this.line.scale.set( 1, Math.max( 0.0001, length - headLength ), 1 ); // see #17458
 	this.line.updateMatrix();
 
 	this.cone.scale.set( headWidth, headLength, headWidth );


### PR DESCRIPTION
see https://discourse.threejs.org/t/cant-get-the-animation-to-work-three-matrix3-getinverse-cant-invert-matrix-determinant-is-0/5249/3?u=mugen87

This change will avoid the following warning if `headLength` is bigger than `length`.

> THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0