### PR TITLE
ShaderChunk: Use transformed UV when reading displacement map

### DIFF
--- a/src/renderers/shaders/ShaderChunk/displacementmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/displacementmap_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_DISPLACEMENTMAP
 
-	transformed += normalize( objectNormal ) * ( texture2D( displacementMap, uv ).x * displacementScale + displacementBias );
+	transformed += normalize( objectNormal ) * ( texture2D( displacementMap, vUv ).x * displacementScale + displacementBias );
 
 #endif
 `;


### PR DESCRIPTION
All other textures which use the first uv slot use the transformed UVs (eg, after offset / repeat / rotation are applied) when sampling from the texture, but displacementMap uses the untransformed uvs, leading to a visual mismatch if the textures are supposed to line up.  This patch changes the behavior to be consistent.