### PR TITLE
add toString to Vector3 prototype

### DIFF
--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -284,4 +284,9 @@ export class Vector3 implements Vector {
 		offset?: number
 	): this;
 
+	/**
+	 * Convert this vector to string.
+	 */
+	toString(): string;
+
 }

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -692,6 +692,12 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
+	},
+
+	toString: function () {
+
+		return `{x: ${this.x}, y: ${this.y}, z: ${this.z}}`;
+
 	}
 
 } );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -696,7 +696,7 @@ Object.assign( Vector3.prototype, {
 
 	toString: function () {
 
-		return `{x: ${this.x}, y: ${this.y}, z: ${this.z}}`;
+		return '{x: ' + this.x + ', y: ' + this.y + ', z: ' + this.z + '}';
 
 	}
 


### PR DESCRIPTION
I found this can be useful when we need to set a Vector3 as an Object key. Especially when we want to eliminate vertices which share same positions in bufferGeometry.