### PR TITLE
TS: Add missing method saveState type in OrbitControl.d.ts

### DIFF
--- a/examples/jsm/controls/OrbitControls.d.ts
+++ b/examples/jsm/controls/OrbitControls.d.ts
@@ -63,6 +63,8 @@ export class OrbitControls {
 
 	update(): void;
 
+	saveState(): void;
+
 	reset(): void;
 
 	dispose(): void;


### PR DESCRIPTION
Fix missing method saveState type in OrbitControl.d.ts