### PR TITLE
WebGLRenderer: Make .setFramebuffer() more robust.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2454,7 +2454,7 @@ function WebGLRenderer( parameters ) {
 	//
 	this.setFramebuffer = function ( value ) {
 
-		if ( _framebuffer !== value ) _gl.bindFramebuffer( _gl.FRAMEBUFFER, value );
+		if ( _framebuffer !== value && _currentRenderTarget === null ) _gl.bindFramebuffer( _gl.FRAMEBUFFER, value );
 
 		_framebuffer = value;
 


### PR DESCRIPTION
#15604 enhanced `WebGLRenderer.setFramebuffer()`, however the feedback in https://github.com/mrdoob/three.js/pull/16118/files#r270820744 was missed.