### PR TITLE
TS: add typings for stats module

### DIFF
--- a/examples/jsm/libs/stats.module.d.ts
+++ b/examples/jsm/libs/stats.module.d.ts
@@ -1,0 +1,7 @@
+export default class Stats {
+	constructor();
+	dom: HTMLElement;
+	begin(): void;
+	end(): void;
+	update(): void;
+}


### PR DESCRIPTION
This fixes build error in TypeScript files when you
```ts
import Stats from 'three/examples/jsm/libs/stats.module';
```