### PR TITLE
Linting: Lint JSM Example Files

### DIFF
--- a/examples/jsm/loaders/OBJLoader2.js
+++ b/examples/jsm/loaders/OBJLoader2.js
@@ -21,6 +21,7 @@ import { MaterialHandler } from "./obj2/shared/MaterialHandler.js";
  * @constructor
  */
 const OBJLoader2 = function ( manager ) {
+
 	Loader.call( this, manager );
 
 	this.parser = new OBJLoader2Parser();
@@ -35,9 +36,12 @@ const OBJLoader2 = function ( manager ) {
 	// as OBJLoader2 is no longer derived from OBJLoader2Parser, we need to override the default onAssetAvailable callback
 	let scope = this;
 	let defaultOnAssetAvailable = function ( payload ) {
-		scope._onAssetAvailable( payload )
+
+		scope._onAssetAvailable( payload );
+
 	};
 	this.parser.setCallbackOnAssetAvailable( defaultOnAssetAvailable );
+
 };
 
 OBJLoader2.OBJLOADER2_VERSION = '3.1.0';
@@ -124,7 +128,7 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 	 */
 	setBaseObject3d: function ( baseObject3d ) {
 
-		this.baseObject3d = (baseObject3d === undefined || baseObject3d === null) ? this.baseObject3d : baseObject3d;
+		this.baseObject3d = ( baseObject3d === undefined || baseObject3d === null ) ? this.baseObject3d : baseObject3d;
 		return this;
 
 	},
@@ -224,19 +228,18 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 	load: function ( url, onLoad, onFileLoadProgress, onError, onMeshAlter ) {
 
 		let scope = this;
-		if ( onLoad === null || onLoad === undefined || !(onLoad instanceof Function) ) {
+		if ( onLoad === null || onLoad === undefined || ! ( onLoad instanceof Function ) ) {
 
 			let errorMessage = 'onLoad is not a function! Aborting...';
 			scope.parser.callbacks.onError( errorMessage );
-			throw errorMessage
+			throw errorMessage;
 
-		}
-		else {
+		} else {
 
 			this.parser.setCallbackOnLoad( onLoad );
 
 		}
-		if ( onError === null || onError === undefined || !(onError instanceof Function) ) {
+		if ( onError === null || onError === undefined || ! ( onError instanceof Function ) ) {
 
 			onError = function ( event ) {
 
@@ -251,7 +254,7 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 			};
 
 		}
-		if ( !url ) {
+		if ( ! url ) {
 
 			onError( 'An invalid url was provided. Unable to continue!' );
 
@@ -266,19 +269,19 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 			if ( urlPartsPath !== undefined && urlPartsPath !== null ) this.path = urlPartsPath;
 
 		}
-		if ( onFileLoadProgress === null || onFileLoadProgress === undefined || !(onFileLoadProgress instanceof Function) ) {
+		if ( onFileLoadProgress === null || onFileLoadProgress === undefined || ! ( onFileLoadProgress instanceof Function ) ) {
 
 			let numericalValueRef = 0;
 			let numericalValue = 0;
 			onFileLoadProgress = function ( event ) {
 
-				if ( !event.lengthComputable ) return;
+				if ( ! event.lengthComputable ) return;
 
 				numericalValue = event.loaded / event.total;
 				if ( numericalValue > numericalValueRef ) {
 
 					numericalValueRef = numericalValue;
-					let output = 'Download of "' + url + '": ' + (numericalValue * 100).toFixed( 2 ) + '%';
+					let output = 'Download of "' + url + '": ' + ( numericalValue * 100 ).toFixed( 2 ) + '%';
 					scope.parser.callbacks.onProgress( 'progressLoad', output, numericalValue );
 
 				}
@@ -331,7 +334,7 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 			if ( this.parser.logging.enabled ) console.info( 'Parsing arrayBuffer...' );
 			this.parser.execute( content );
 
-		} else if ( typeof (content) === 'string' || content instanceof String ) {
+		} else if ( typeof ( content ) === 'string' || content instanceof String ) {
 
 			if ( this.parser.logging.enabled ) console.info( 'Parsing text...' );
 			this.parser.executeLegacy( content );

--- a/examples/jsm/loaders/OBJLoader2Parallel.js
+++ b/examples/jsm/loaders/OBJLoader2Parallel.js
@@ -120,7 +120,7 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 	load: function ( content, onLoad, onFileLoadProgress, onError, onMeshAlter ) {
 
  		let scope = this;
-		function interceptOnLoad ( object3d, message ) {
+		function interceptOnLoad( object3d, message ) {
 
 			if ( object3d.name === 'OBJLoader2ParallelDummy' ) {
 
@@ -130,8 +130,7 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 
 				}
 
-			}
-			else {
+			} else {
 
 				onLoad( object3d, message );
 
@@ -169,7 +168,9 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 
 				};
 				function scopedOnLoad( message ) {
+
 					scope.parser.callbacks.onLoad( scope.baseObject3d, message );
+
 				}
 
 				this.workerExecutionSupport.updateCallbacks( scopedOnAssetAvailable, scopedOnLoad );
@@ -180,31 +181,31 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 			this.materialHandler.createDefaultMaterials( false );
 
 			this.workerExecutionSupport.executeParallel(
-			{
-				params: {
-					modelName: this.modelName,
-					instanceNo: this.instanceNo,
-					useIndices: this.parser.useIndices,
-					disregardNormals: this.parser.disregardNormals,
-					materialPerSmoothingGroup: this.parser.materialPerSmoothingGroup,
-					useOAsMesh: this.parser.useOAsMesh,
-				},
-				materials: this.materialHandler.getMaterialsJSON(),
-				data: {
-					input: content,
-					options: null
-				},
-				logging: {
-					enabled: this.parser.logging.enabled,
-					debug: this.parser.logging.debug
-				}
-			} );
+				{
+					params: {
+						modelName: this.modelName,
+						instanceNo: this.instanceNo,
+						useIndices: this.parser.useIndices,
+						disregardNormals: this.parser.disregardNormals,
+						materialPerSmoothingGroup: this.parser.materialPerSmoothingGroup,
+						useOAsMesh: this.parser.useOAsMesh,
+					},
+					materials: this.materialHandler.getMaterialsJSON(),
+					data: {
+						input: content,
+						options: null
+					},
+					logging: {
+						enabled: this.parser.logging.enabled,
+						debug: this.parser.logging.debug
+					}
+				} );
 
 			let dummy = new Object3D();
 			dummy.name = 'OBJLoader2ParallelDummy';
 			return dummy;
-		}
-		else {
+
+		} else {
 
 			return OBJLoader2.prototype.parse.call( this, content );
 

--- a/examples/jsm/loaders/obj2/shared/MaterialHandler.js
+++ b/examples/jsm/loaders/obj2/shared/MaterialHandler.js
@@ -114,7 +114,7 @@ MaterialHandler.prototype = {
 
 			} else {
 
-				if ( this.logging.enabled) {
+				if ( this.logging.enabled ) {
 
 					console.info( 'Requested material "' + materialNameOrg + '" is not available!' );
 
@@ -255,7 +255,9 @@ MaterialHandler.prototype = {
 	 * Removes all materials
 	 */
 	clearMaterials: function () {
+
 		this.materials = {};
+
 	}
 
 };

--- a/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.js
+++ b/examples/jsm/loaders/obj2/worker/parallel/OBJLoader2Parser.js
@@ -16,16 +16,24 @@ const OBJLoader2Parser = function () {
 	let scope = this;
 	this.callbacks = {
 		onProgress: function ( text ) {
-			scope._onProgress( text )
+
+			scope._onProgress( text );
+
 		},
 		onAssetAvailable: function ( payload ) {
-			scope._onAssetAvailable( payload )
+
+			scope._onAssetAvailable( payload );
+
 		},
 		onError: function ( errorMessage ) {
-			scope._onError( errorMessage )
+
+			scope._onError( errorMessage );
+
 		},
 		onLoad: function ( object3d, message ) {
-			scope._onLoad( object3d, message )
+
+			scope._onLoad( object3d, message );
+
 		},
 	};
 	this.contentRef = null;

--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -45,15 +45,15 @@ NormalNode.prototype.generate = function ( builder, output ) {
 		case NormalNode.LOCAL:
 
 			if ( builder.isShader( 'vertex' ) ) {
-				
+
 				result = 'objectNormal';
-				
+
 			} else {
-				
+
 				builder.requires.normal = true;
-				
+
 				result = 'vObjectNormal';
-				
+
 			}
 
 			break;

--- a/examples/jsm/nodes/accessors/ReflectNode.js
+++ b/examples/jsm/nodes/accessors/ReflectNode.js
@@ -24,7 +24,7 @@ ReflectNode.prototype.nodeType = "Reflect";
 
 ReflectNode.prototype.getUnique = function ( builder ) {
 
-	return !builder.context.viewNormal;
+	return ! builder.context.viewNormal;
 
 };
 

--- a/examples/jsm/nodes/core/FunctionNode.js
+++ b/examples/jsm/nodes/core/FunctionNode.js
@@ -209,7 +209,7 @@ FunctionNode.prototype.parse = function ( src, includes, extensions, keywords ) 
 
 			}
 
-			this.isInterface = this.src.indexOf('{') === -1;
+			this.isInterface = this.src.indexOf( '{' ) === - 1;
 
 		} else {
 

--- a/examples/jsm/nodes/materials/nodes/StandardNode.js
+++ b/examples/jsm/nodes/materials/nodes/StandardNode.js
@@ -33,11 +33,11 @@ StandardNode.prototype.build = function ( builder ) {
 
 	var code;
 
-	builder.define('STANDARD');
+	builder.define( 'STANDARD' );
 
 	var useClearcoat = this.clearcoat || this.clearcoatRoughness || this.clearCoatNormal;
 
-	if( useClearcoat ){
+	if ( useClearcoat ) {
 
 		builder.define( 'CLEARCOAT' );
 
@@ -129,13 +129,13 @@ StandardNode.prototype.build = function ( builder ) {
 
 	} else {
 
-		var specularRoughness = new ExpressionNode('material.specularRoughness', 'f' );
-		var clearcoatRoughness = new ExpressionNode('material.clearcoatRoughness', 'f' );
+		var specularRoughness = new ExpressionNode( 'material.specularRoughness', 'f' );
+		var clearcoatRoughness = new ExpressionNode( 'material.clearcoatRoughness', 'f' );
 
 		var contextEnvironment = {
 			roughness: specularRoughness,
 			bias: new SpecularMIPLevelNode( specularRoughness ),
-			viewNormal: new ExpressionNode('normal', 'v3'),
+			viewNormal: new ExpressionNode( 'normal', 'v3' ),
 			gamma: true
 		};
 
@@ -146,7 +146,7 @@ StandardNode.prototype.build = function ( builder ) {
 		var contextClearcoatEnvironment = {
 			roughness: clearcoatRoughness,
 			bias: new SpecularMIPLevelNode( clearcoatRoughness ),
-			viewNormal: new ExpressionNode('clearcoatNormal', 'v3'),
+			viewNormal: new ExpressionNode( 'clearcoatNormal', 'v3' ),
 			gamma: true
 		};
 

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -20,12 +20,12 @@ function NormalMapNode( value, scale ) {
 
 NormalMapNode.Nodes = ( function () {
 
-	var perturbNormal2Arb = new FunctionNode( 
+	var perturbNormal2Arb = new FunctionNode(
 
-// Per-Pixel Tangent Space Normal Mapping
-// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
-	
-`vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 vUv, vec2 normalScale ) {
+		// Per-Pixel Tangent Space Normal Mapping
+		// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
+
+		`vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 map, vec2 vUv, vec2 normalScale ) {
 
 	// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 

--- a/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
+++ b/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
@@ -42,7 +42,7 @@ SpecularMIPLevelNode.prototype = Object.create( TempNode.prototype );
 SpecularMIPLevelNode.prototype.constructor = SpecularMIPLevelNode;
 SpecularMIPLevelNode.prototype.nodeType = "SpecularMIPLevel";
 
-SpecularMIPLevelNode.prototype.setTexture = function( texture ) {
+SpecularMIPLevelNode.prototype.setTexture = function ( texture ) {
 
 	this.texture = texture;
 

--- a/examples/jsm/nodes/utils/SubSlotNode.js
+++ b/examples/jsm/nodes/utils/SubSlotNode.js
@@ -26,7 +26,7 @@ SubSlotNode.prototype.generate = function ( builder, output ) {
 
 	if ( this.slots[ builder.slot ] ) {
 
-		return this.slots[ builder.slot ].build( builder, output )
+		return this.slots[ builder.slot ].build( builder, output );
 
 	}
 


### PR DESCRIPTION
Follow up to #17539

Fixes linter errors in the `js` files in the `examples/jsm` folder by using `eslint --fix`