### PR TITLE
Added missing parameters to ShaderMaterialParameters interface

### DIFF
--- a/src/materials/ShaderMaterial.d.ts
+++ b/src/materials/ShaderMaterial.d.ts
@@ -25,6 +25,12 @@ export interface ShaderMaterialParameters extends MaterialParameters {
 	skinning?: boolean;
 	morphTargets?: boolean;
 	morphNormals?: boolean;
+	extensions?: {
+		derivatives?: boolean;
+		fragDepth?: boolean;
+		drawBuffers?: boolean;
+		shaderTextureLOD?: boolean;
+	};
 }
 
 export class ShaderMaterial extends Material {


### PR DESCRIPTION
The extensions were missing from the type defs file.