### PR TITLE
Examples: Deprecate examples/js scripts

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1,4 +1,4 @@
-console.warn( "THREE example script 'js/controls/OrbitControls.js' is no longer maintained or updated. Use the ES module version instead: 'jsm/controls/OrbitControls.js'." );
+console.warn( 'THREE example script "js/controls/OrbitControls.js" is deprecated and will soon be removed. Use the ES module version instead: "jsm/controls/OrbitControls.js".' );
 
 /**
  * @author qiao / https://github.com/qiao

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1,3 +1,5 @@
+console.warn( "THREE example script 'js/controls/OrbitControls.js' is no longer maintained or updated. Use ES module version instead: 'jsm/controls/OrbitControls.js'." );
+
 /**
  * @author qiao / https://github.com/qiao
  * @author mrdoob / http://mrdoob.com

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1,4 +1,4 @@
-console.warn( "THREE example script 'js/controls/OrbitControls.js' is no longer maintained or updated. Use ES module version instead: 'jsm/controls/OrbitControls.js'." );
+console.warn( "THREE example script 'js/controls/OrbitControls.js' is no longer maintained or updated. Use the ES module version instead: 'jsm/controls/OrbitControls.js'." );
 
 /**
  * @author qiao / https://github.com/qiao

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -269,6 +269,11 @@ function convert( path, exampleDependencies, ignoreList ) {
 	var classNames = [];
 	var coreDependencies = {};
 
+	// strip warning
+
+	contents = contents.replace( /^\s*console\.warn\(.*?\);\n/, '' );
+
+
 	// imports
 
 	contents = contents.replace( /^\/\*+[^*]*\*+(?:[^/*][^*]*\*+)*\//, function ( match ) {

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -271,7 +271,7 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	// strip warning
 
-	contents = contents.replace( /^\s*console\.warn\(.*?\);\n/, '' );
+	contents = contents.replace( /^\s*console\.warn\(.*?\);\s*/, '' );
 
 
 	// imports


### PR DESCRIPTION
When using a script from the `examples/js/*` directory a deprecation warning will be logged in the console (See https://github.com/mrdoob/three.js/pull/16920#issuecomment-532746836):

> THREE example script "js/controls/OrbitControls.js" is deprecated and will soon be removed. Use the ES module version instead: "jsm/controls/OrbitControls.js".

If this message feels right then I'll add it to all the files and update the PR.

_edit: updated warning text, strip it in modularize.js_