### PR TITLE
All DataTextures needs updates at start

### DIFF
--- a/src/textures/DataTexture2DArray.js
+++ b/src/textures/DataTexture2DArray.js
@@ -19,6 +19,8 @@ function DataTexture2DArray( data, width, height, depth ) {
 	this.generateMipmaps = false;
 	this.flipY = false;
 
+	this.needsUpdate = true;
+
 }
 
 DataTexture2DArray.prototype = Object.create( Texture.prototype );

--- a/src/textures/DataTexture3D.js
+++ b/src/textures/DataTexture3D.js
@@ -27,6 +27,9 @@ function DataTexture3D( data, width, height, depth ) {
 	this.generateMipmaps = false;
 	this.flipY = false;
 
+	this.needsUpdate = true;
+
+
 }
 
 DataTexture3D.prototype = Object.create( Texture.prototype );


### PR DESCRIPTION
This continues the change from https://github.com/mrdoob/three.js/commit/d3a37f37d395010111f384fe0e9f73c072ad7384 . 
Since that broke following examples: 
- [webgl2_materials_texture2darray dev example](https://rawgit.com/mrdoob/three.js/dev/examples/webgl2_materials_texture2darray.html)
- [webgl2_materials_texture3d dev example](https://rawgit.com/mrdoob/three.js/dev/examples/webgl2_materials_texture3d.html)

Simply by making sure that the texture updates, the examples work again.

