### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -90,11 +90,11 @@
 				textureMap.anisotropy = 16;
 
 				// REFLECTION MAP
-				var path = "textures/cube/skybox/";
+				var path = "textures/cube/pisa/";
 				var urls = [
-					path + "px.jpg", path + "nx.jpg",
-					path + "py.jpg", path + "ny.jpg",
-					path + "pz.jpg", path + "nz.jpg"
+					path + "px.png", path + "nx.png",
+					path + "py.png", path + "ny.png",
+					path + "pz.png", path + "nz.png"
 				];
 
 				textureCube = new THREE.CubeTextureLoader().load( urls );

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -84,11 +84,11 @@
 				textureMap.anisotropy = 16;
 
 				// REFLECTION MAP
-				var path = "textures/cube/skybox/";
+				var path = "textures/cube/pisa/";
 				var urls = [
-					path + "px.jpg", path + "nx.jpg",
-					path + "py.jpg", path + "ny.jpg",
-					path + "pz.jpg", path + "nz.jpg"
+					path + "px.png", path + "nx.png",
+					path + "py.png", path + "ny.png",
+					path + "pz.png", path + "nz.png"
 				];
 
 				textureCube = new THREE.CubeTextureLoader().load( urls );

--- a/examples/webgl_nearestneighbour.html
+++ b/examples/webgl_nearestneighbour.html
@@ -82,7 +82,7 @@
 				// add a skybox background
 				var cubeTextureLoader = new THREE.CubeTextureLoader();
 
-				cubeTextureLoader.setPath( 'textures/cube/skybox/' );
+				cubeTextureLoader.setPath( 'textures/cube/skyboxsun25deg/' );
 
 				var cubeTexture = cubeTextureLoader.load( [
 					'px.jpg', 'nx.jpg',

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -100,12 +100,12 @@
 				// skybox
 
 				var cubeTextureLoader = new THREE.CubeTextureLoader();
-				cubeTextureLoader.setPath( 'textures/cube/skybox/' );
+				cubeTextureLoader.setPath( 'textures/cube/Park2/' );
 
 				var cubeTexture = cubeTextureLoader.load( [
-					'px.jpg', 'nx.jpg',
-					'py.jpg', 'ny.jpg',
-					'pz.jpg', 'nz.jpg',
+					"posx.jpg", "negx.jpg",
+					"posy.jpg", "negy.jpg",
+					"posz.jpg", "negz.jpg"
 				] );
 
 				scene.background = cubeTexture;


### PR DESCRIPTION
While testing the examples in `dev`, I've noticed this little bug. Since `textures/cube/skybox/` has been removed, I've changed to other skyboxes.