### PR TITLE
NormalMap Shader: fix Adreno work-around

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -39,14 +39,8 @@ export default /* glsl */`
 		#ifdef DOUBLE_SIDED
 
 			// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
-			// http://hacksoflife.blogspot.com/2009/11/per-pixel-tangent-space-normal-mapping.html?showComment=1522254677437#c5087545147696715943
-			vec3 NfromST = cross( S, T );
-			if( dot( NfromST, N ) > 0.0 ) {
 
-				S *= -1.0;
-				T *= -1.0;
-
-			}
+			if ( dot( cross( S, T ), N ) < 0.0 ) mapN.xy *= - 1.0;
 
 		#else
 


### PR DESCRIPTION
We need a test to replace `gl_FrontFacing`. I believe this change is correct.

It appears to work correctly even if the geometry and/or UVs are mirrored -- that is, even if the winding order of the UVs is clockwise when the winding order of the vertices is counterclockwise.