### PR TITLE
Force context loss in renderer.dispose

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -577,6 +577,8 @@ function WebGLRenderer( parameters ) {
 
 		animation.stop();
 
+		this.forceContextLoss();
+
 	};
 
 	// Events


### PR DESCRIPTION
👋 @mrdoob, consider this snippet:

```js
for (let i = 0; i < 16; i++) {
  const renderer = new THREE.WebGLRenderer();
  renderer.setSize(100, 100);
  document.body.appendChild(renderer.domElement);
  renderer.dispose();
}
```

This will produce the following warning in Firefox 70 console:

```
Error: WebGL warning: <SetDimensions>: Exceeded 16 live WebGL contexts for this principal, losing the least recently used one.
```

This suggests disposed contexts are kept dangling, unnecessarily taking up browser resources. Adding `forceContextLoss` gets rid of the warning without having any side effects, since a renderer instance won't be used after disposing it.

Discovered this while playing with Three.js on Observable. Maybe I'm missing something, but thought I'd submit a PR anyway. Thank you!