### PR TITLE
fix double WebGLUniforms upload for ShaderMaterial if uniformsNeedUpdate

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1982,9 +1982,7 @@ function WebGLRenderer( parameters ) {
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 
-		}
-
-		if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
+		} else if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 			material.uniformsNeedUpdate = false;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1982,7 +1982,15 @@ function WebGLRenderer( parameters ) {
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 
-		} else if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
+			if ( material.isShaderMaterial ) {
+
+				material.uniformsNeedUpdate = false;
+
+			}
+
+		}
+
+		if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 			material.uniformsNeedUpdate = false;


### PR DESCRIPTION
I use mostly ShaderMaterials and have encountered such a problem on mobile devices very where a limited number of texture units, in the sources found that if the shader material is set to uniformsNeedUpdate = true, there is a double update of uniformity which is generally not critical, but since the first upgrade took a certain number of texture units to second update is already missing them.