### PR TITLE
VRMLLoader: Make normal computation more robust.

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -1228,7 +1228,7 @@ THREE.VRMLLoader = ( function () {
 			function buildIndexedFaceSetNode( node ) {
 
 				var color, coord, normal, texCoord;
-				var ccw = true, solid = true, creaseAngle;
+				var ccw = true, solid = true, creaseAngle = 0;
 				var colorIndex, coordIndex, normalIndex, texCoordIndex;
 				var colorPerVertex = true, normalPerVertex = true;
 
@@ -2161,13 +2161,21 @@ THREE.VRMLLoader = ( function () {
 
 			function weightedNormal( normals, vector, creaseAngle ) {
 
-				var normal = vector.clone();
+				var normal = new THREE.Vector3();
 
-				for ( var i = 0, l = normals.length; i < l; i ++ ) {
+				if ( creaseAngle === 0 ) {
 
-					if ( normals[ i ].angleTo( vector ) < creaseAngle ) {
+					normal.copy( vector );
 
-						normal.add( normals[ i ] );
+				} else {
+
+					for ( var i = 0, l = normals.length; i < l; i ++ ) {
+
+						if ( normals[ i ].angleTo( vector ) < creaseAngle ) {
+
+							normal.add( normals[ i ] );
+
+						}
 
 					}
 

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -1262,7 +1262,7 @@ var VRMLLoader = ( function () {
 			function buildIndexedFaceSetNode( node ) {
 
 				var color, coord, normal, texCoord;
-				var ccw = true, solid = true, creaseAngle;
+				var ccw = true, solid = true, creaseAngle = 0;
 				var colorIndex, coordIndex, normalIndex, texCoordIndex;
 				var colorPerVertex = true, normalPerVertex = true;
 
@@ -2195,13 +2195,21 @@ var VRMLLoader = ( function () {
 
 			function weightedNormal( normals, vector, creaseAngle ) {
 
-				var normal = vector.clone();
+				var normal = new Vector3();
 
-				for ( var i = 0, l = normals.length; i < l; i ++ ) {
+				if ( creaseAngle === 0 ) {
 
-					if ( normals[ i ].angleTo( vector ) < creaseAngle ) {
+					normal.copy( vector );
 
-						normal.add( normals[ i ] );
+				} else {
+
+					for ( var i = 0, l = normals.length; i < l; i ++ ) {
+
+						if ( normals[ i ].angleTo( vector ) < creaseAngle ) {
+
+							normal.add( normals[ i ] );
+
+						}
 
 					}
 


### PR DESCRIPTION
Avoids invalid arguments to `Vector3.angleTo()`.