### PR TITLE
WebXRManager: Clean up.

### DIFF
--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -17,7 +17,7 @@ function WebXRManager( renderer, gl ) {
 
 	var session = null;
 
-	var framebufferScaleFactor = 1.0;
+	// var framebufferScaleFactor = 1.0;
 
 	var referenceSpace = null;
 	var referenceSpaceType = 'local-floor';
@@ -106,9 +106,9 @@ function WebXRManager( renderer, gl ) {
 
 	}
 
-	this.setFramebufferScaleFactor = function ( value ) {
+	this.setFramebufferScaleFactor = function ( /* value */ ) {
 
-		framebufferScaleFactor = value;
+		// framebufferScaleFactor = value;
 
 	};
 
@@ -135,6 +135,7 @@ function WebXRManager( renderer, gl ) {
 			session.addEventListener( 'selectend', onSessionEvent );
 			session.addEventListener( 'end', onSessionEnd );
 
+			// eslint-disable-next-line no-undef
 			session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl ) } );
 
 			session.requestReferenceSpace( referenceSpaceType ).then( onRequestReferenceSpace );


### PR DESCRIPTION
`framebufferScaleFactor` is currently not used. Commenting it out for clarity and to avoid a linter issue.