### PR TITLE
Remove dup paragraph in disposing objects doc

### DIFF
--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -92,11 +92,6 @@
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 
-	<p>
-		Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
-		nothing happens. No resources were allocated so there is also no need for clean up.
-	</p>
-
 	<h3>What happens when you call *dispose()* on a texture but the image is not loaded yet?</h3>
 
 	<p>


### PR DESCRIPTION
I deleted a duplicate paragraph from the "How to dispose of objects" page in the docs.