### PR TITLE
Update WebGLRenderer.d.ts

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -188,7 +188,7 @@ export class WebGLRenderer implements Renderer {
 
 	shadowMap: WebGLShadowMap;
 
-	pixelRation: number;
+	pixelRatio: number;
 
 	capabilities: WebGLCapabilities;
 	properties: WebGLProperties;


### PR DESCRIPTION
Fixes a typo where the `WebGLRendererParameters` exposes `pixelRation` rather than `pixelRatio`.