### PR TITLE
Global constant faceDirection instead of gl_FrontFacing

### DIFF
--- a/examples/jsm/nodes/misc/BumpMapNode.js
+++ b/examples/jsm/nodes/misc/BumpMapNode.js
@@ -119,7 +119,7 @@ BumpMapNode.prototype.generate = function ( builder, output ) {
 
 			var derivativeHeightCode = derivativeHeight + '( ' + this.value.build( builder, 'sampler2D' ) + ', ' +
 				this.value.uv.build( builder, 'v2' ) + ', ' +
-				this.scale.build( builder, 'f' ) + ' )';
+				this.scale.build( builder, 'f' ) + ' * faceDirection )';
 
 			return builder.format( perturbNormalArb + '( -' + this.position.build( builder, 'v3' ) + ', ' +
 				this.normal.build( builder, 'v3' ) + ', ' +

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -48,18 +48,6 @@ NormalMapNode.Nodes = ( function () {
 
 	mapN.xy *= normalScale;
 
-	#ifdef DOUBLE_SIDED
-
-		// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
-
-		if ( dot( cross( S, T ), N ) < 0.0 ) mapN.xy *= - 1.0;
-
-	#else
-
-		mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
-
-	#endif
-
 	mat3 tsn = mat3( S, T, N );
 	return normalize( tsn * mapN );
 
@@ -97,7 +85,7 @@ NormalMapNode.prototype.generate = function ( builder, output ) {
 			this.normal.build( builder, 'v3' ) + ', ' +
 			this.value.build( builder, 'v3' ) + ', ' +
 			this.uv.build( builder, 'v2' ) + ', ' +
-			scale + ' )', this.getType( builder ), output );
+			scale + ' * faceDirection )', this.getType( builder ), output );
 
 	} else {
 

--- a/examples/jsm/nodes/misc/NormalMapNode.js
+++ b/examples/jsm/nodes/misc/NormalMapNode.js
@@ -75,12 +75,6 @@ NormalMapNode.prototype.generate = function ( builder, output ) {
 
 		var scale = this.scale.build( builder, 'v2' );
 
-		if ( builder.material.side === BackSide ) {
-
-			scale = '-' + scale;
-
-		}
-
 		return builder.format( perturbNormal2Arb + '( -' + this.position.build( builder, 'v3' ) + ', ' +
 			this.normal.build( builder, 'v3' ) + ', ' +
 			this.value.build( builder, 'v3' ) + ', ' +

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -159,7 +159,7 @@
 				light.position.set( - 1, 0.75, - 0.5 );
 				lightGroup.add( light );
 
-				teapot = new TeapotBufferGeometry( 15, 18 );
+				teapot = new TeapotBufferGeometry( 15, 18, false, false );
 
 				mesh = new THREE.Mesh( teapot );
 				scene.add( mesh );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2254,7 +2254,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
-			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2262,7 +2261,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 
@@ -2315,7 +2313,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
-			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2323,7 +2320,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 
@@ -2359,12 +2355,6 @@ function WebGLRenderer( parameters ) {
 			uniforms.clearcoatNormalScale.value.copy( material.clearcoatNormalScale );
 			uniforms.clearcoatNormalMap.value = material.clearcoatNormalMap;
 
-			if ( material.side === BackSide ) {
-
-				uniforms.clearcoatNormalScale.value.negate();
-
-			}
-
 		}
 
 		uniforms.transparency.value = material.transparency;
@@ -2383,7 +2373,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
-			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2391,7 +2380,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 
@@ -2439,7 +2427,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.bumpMap.value = material.bumpMap;
 			uniforms.bumpScale.value = material.bumpScale;
-			if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
 
 		}
 
@@ -2447,7 +2434,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.normalMap.value = material.normalMap;
 			uniforms.normalScale.value.copy( material.normalScale );
-			if ( material.side === BackSide ) uniforms.normalScale.value.negate();
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
@@ -35,7 +35,7 @@ export default /* glsl */`
 
 		float fDet = dot( vSigmaX, R1 );
 
-		fDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+		fDet *= faceDirection;
 
 		vec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );
 		return normalize( abs( fDet ) * surf_norm - vGrad );

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
@@ -35,8 +35,6 @@ export default /* glsl */`
 
 		float fDet = dot( vSigmaX, R1 );
 
-		fDet *= faceDirection;
-
 		vec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );
 		return normalize( abs( fDet ) * surf_norm - vGrad );
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -33,7 +33,7 @@ vec3 faceNormal = normalize( cross( fdx, fdy ) );
 
 	#ifdef DOUBLE_SIDED
 
-		normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+		normal *= faceDirection;
 
 	#endif
 
@@ -44,8 +44,8 @@ vec3 faceNormal = normalize( cross( fdx, fdy ) );
 
 		#ifdef DOUBLE_SIDED
 
-			tangent = tangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
-			bitangent = bitangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+			tangent *= faceDirection;
+			bitangent *= faceDirection;
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -10,7 +10,7 @@ vec3 faceNormal = normalize( cross( fdx, fdy ) );
 
 	// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
 
-	float faceDirection = dot (vViewPosition, faceNormal) > 0. ? 1. : -1.;
+	float faceDirection = dot (vNormal, faceNormal) > 0. ? 1. : -1.;
 	//float faceDirection = gl_FrontFacing ? 1. : -1.;
 
 #elif defined( FLIP_SIDED )

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -6,6 +6,23 @@ vec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPo
 vec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );
 vec3 faceNormal = normalize( cross( fdx, fdy ) );
 
+#ifdef DOUBLE_SIDED
+
+	// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
+
+	float faceDirection = dot (vViewPosition, faceNormal) > 0. ? 1. : -1.;
+	//float faceDirection = gl_FrontFacing ? 1. : -1.;
+
+#elif defined( FLIP_SIDED )
+
+	float faceDirection = -1.;
+
+#else
+
+	float faceDirection = 1.;
+
+#endif
+
 #ifdef FLAT_SHADED
 
 	vec3 normal = faceNormal;
@@ -39,22 +56,5 @@ vec3 faceNormal = normalize( cross( fdx, fdy ) );
 // non perturbed normal for clearcoat among others
 
 vec3 geometryNormal = normal;
-
-#ifdef DOUBLE_SIDED
-
-	// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
-
-	float faceDirection = dot (vViewPosition, faceNormal) > 0. ? 1. : -1.;
-	//float faceDirection = gl_FrontFacing ? 1. : -1.;
-
-#elif FLIP_SIDED
-
-	float faceDirection = -1.;
-
-#else
-
-	float faceDirection = 1.;
-
-#endif
 
 `;

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -35,7 +35,7 @@ export default /* glsl */`
 
 #elif defined( USE_BUMPMAP )
 
-	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );
+	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() * faceDirection );
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -12,7 +12,7 @@ export default /* glsl */`
 
 	#ifdef DOUBLE_SIDED
 
-		normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+		normal = normal * faceDirection;
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -29,7 +29,7 @@ export default /* glsl */`
 
 	#else
 
-		normal = perturbNormal2Arb( -vViewPosition, normal, normalScale, normalMap );
+		normal = perturbNormal2Arb( -vViewPosition, normal, normalScale * faceDirection, normalMap );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -4,15 +4,9 @@ export default /* glsl */`
 
 	normal = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0; // overrides both flatShading and attribute normals
 
-	#ifdef FLIP_SIDED
+	#ifdef defined( DOUBLE_SIDED ) || defined( FLIP_SIDED ) 
 
-		normal = - normal;
-
-	#endif
-
-	#ifdef DOUBLE_SIDED
-
-		normal = normal * faceDirection;
+		normal *= faceDirection;
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -36,20 +36,6 @@ export default /* glsl */`
 
 		mapN.xy *= normalScale;
 
-		#ifdef DOUBLE_SIDED
-
-			// Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
-
-			bool frontFacing = dot( cross( S, T ), N ) > 0.0;
-
-			mapN.xy *= ( float( frontFacing ) * 2.0 - 1.0 );
-
-		#else
-
-			mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
-
-		#endif
-
 		mat3 tsn = mat3( S, T, N );
 		return normalize( tsn * mapN );
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -120,7 +120,7 @@ function generateExtensions( extensions, parameters, rendererExtensions ) {
 	extensions = extensions || {};
 
 	var chunks = [
-		( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+		( true /*for now*/ || extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
 		( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
 		( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''


### PR DESCRIPTION
Still I did not make any deep-test... but I can finish. Apparently work for normal/bump maps.

Considering that Adreno GPUs not work property `gl_FrontFacing`, otherwise, it can be more simple.

https://github.com/mrdoob/three.js/pull/17598

**This is a WIP**

/ping @WestLangley @mrdoob