### PR TITLE
BasisTextureLoader: Fix basisFile.transcodeImage parameters

### DIFF
--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -476,8 +476,8 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 				0,
 				mip,
 				config.format,
-				hasAlpha,
-				0
+				0,
+				hasAlpha
 			);
 
 			if ( ! status ) {

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -489,8 +489,8 @@ BasisTextureLoader.BasisWorker = function () {
 				0,
 				mip,
 				config.format,
-				hasAlpha,
-				0
+				0,
+				hasAlpha
 			);
 
 			if ( ! status ) {


### PR DESCRIPTION
As pointed out by @nh2 in the thread of #17546 
The input parameter for `basisFile.transcodeImage` should match that of the transcoder definition.
https://github.com/BinomialLLC/basis_universal/blob/master/webgl/transcoder/basis_wrappers.cpp#L261