### PR TITLE
Typedefinition add EquirectangularToCubeGenerator variables

### DIFF
--- a/examples/jsm/loaders/EquirectangularToCubeGenerator.d.ts
+++ b/examples/jsm/loaders/EquirectangularToCubeGenerator.d.ts
@@ -23,6 +23,7 @@ export interface EquirectangularToCubeGeneratorOptions {
 export class CubemapGenerator {
 
 	constructor( renderer: WebGLRenderer );
+	renderer: WebGLRenderer;
 
 	fromEquirectangular( texture: Texture, options?: CubemapGeneratorOptions ): WebGLRenderTargetCube;
 

--- a/examples/jsm/loaders/EquirectangularToCubeGenerator.d.ts
+++ b/examples/jsm/loaders/EquirectangularToCubeGenerator.d.ts
@@ -31,6 +31,9 @@ export class CubemapGenerator {
 export class EquirectangularToCubeGenerator {
 
 	constructor( sourceTexture: Texture, options?: EquirectangularToCubeGeneratorOptions );
+	sourceTexture: Texture;
+	resolution: number;
+	renderTarget: WebGLRenderTargetCube;
 
 	dispose(): void;
 	update( renderer: WebGLRenderer ): Texture;


### PR DESCRIPTION
Adding class variables to type definition, especially renderTarget is interesting to access.