### PR TITLE
WebVRManager: Account for both left and right eye parameters when computing render buffer size

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -69,9 +69,10 @@ function WebVRManager( renderer ) {
 
 		if ( isPresenting() ) {
 
-			var eyeParameters = device.getEyeParameters( 'left' );
-			renderWidth = 2 * eyeParameters.renderWidth * framebufferScaleFactor;
-			renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
+			var eyeParametersL = device.getEyeParameters( 'left' );
+			var eyeParametersR = device.getEyeParameters( 'right' );
+			renderWidth = (eyeParametersL.renderWidth + eyeParametersR.renderWidth) * framebufferScaleFactor;
+			renderHeight = Math.max(eyeParametersL.renderHeight, eyeParametersR.renderHeight) * framebufferScaleFactor;
 
 			currentPixelRatio = renderer.getPixelRatio();
 			renderer.getSize( currentSize );

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -71,8 +71,8 @@ function WebVRManager( renderer ) {
 
 			var eyeParametersL = device.getEyeParameters( 'left' );
 			var eyeParametersR = device.getEyeParameters( 'right' );
-			renderWidth = (eyeParametersL.renderWidth + eyeParametersR.renderWidth) * framebufferScaleFactor;
-			renderHeight = Math.max(eyeParametersL.renderHeight, eyeParametersR.renderHeight) * framebufferScaleFactor;
+			renderWidth = ( eyeParametersL.renderWidth + eyeParametersR.renderWidth ) * framebufferScaleFactor;
+			renderHeight = Math.max( eyeParametersL.renderHeight, eyeParametersR.renderHeight ) * framebufferScaleFactor;
 
 			currentPixelRatio = renderer.getPixelRatio();
 			renderer.getSize( currentSize );


### PR DESCRIPTION
Currently, when WebVRManager determines the size of the underlying render buffer, it only looks at the left eye's parameters and assumes the right eye's parameters are the same.  This patch accounts for both eyes when computing buffer size.

This fixes rendering issues encountered when using newer versions of Three.js with Exokit.