### PR TITLE
WebGLPrograms: Add displacementMap to list of texture attributes which cause vUv to be defined.

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -176,7 +176,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 			vertexTangents: ( material.normalMap && material.vertexTangents ),
 			vertexColors: material.vertexColors,
-			vertexUvs: !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatNormalMap,
+			vertexUvs: !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatNormalMap || !! material.displacementMap,
 
 			fog: !! fog,
 			useFog: material.fog,


### PR DESCRIPTION
This pull request fixes one of the concerns @WestLangley raised in #17487 about vUv being undefined if other qualifying textures aren't defined.  This is fixed by checking for the presence of material.displacementMap when deciding whether to ```#define USE_UV```

There's still some concern that this is a change from previous behavior.  Would it help to have a define which lets us toggle between using transformed vs untransformed UVs for the displacementMap?