### PR TITLE
Examples: CSS - Prevent overscroll bouncy behavior

### DIFF
--- a/examples/main.css
+++ b/examples/main.css
@@ -5,6 +5,7 @@ body {
 	font-family: Monospace;
 	font-size: 13px;
 	line-height: 24px;
+	overscroll-behavior: none;
 }
 
 a {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior.

For some reason, if the example uses `OrbitControls`, there is no bouncy behavior (even without this change).

I am not a CSS expert, so I am not sure of the side-effects of doing this...
