### PR TITLE
FileLoader: Fix error response bodies being cached as results

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -172,8 +172,6 @@ FileLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				var response = this.response;
 
-				Cache.add( url, response );
-
 				var callbacks = loading[ url ];
 
 				delete loading[ url ];
@@ -184,6 +182,10 @@ FileLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 					// e.g. 'file://' or 'data://'. Handle as success.
 
 					if ( this.status === 0 ) console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
+
+					// Add to cache only on HTTP success, so that we do not cache
+					// error response bodies as proper responses to requests.
+					Cache.add( url, response );
 
 					for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 


### PR DESCRIPTION
Fixes #17635.

Commit message contains a summary.