### PR TITLE
Logarithmic Depth Buffer: Include <common> shader chunk in normal material

### DIFF
--- a/src/renderers/shaders/ShaderLib/normal_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/normal_vert.glsl.js
@@ -20,6 +20,7 @@ export default /* glsl */`
 
 #endif
 
+#include <common>
 #include <uv_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <morphtarget_pars_vertex>


### PR DESCRIPTION
Fix #17629

Adds `#include <common>` to the normal material vertex shader which is needed for the logarithmic depth buffer.

Tested by setting the [webgl_instancing_suzanne](https://threejs.org/examples/?q=suza#webgl_instancing_suzanne) example to use logarithmic depth buffer, which breaks the example before applying this fix.