### PR TITLE
Add missing optional argument to CubeCamera constructor

### DIFF
--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -5,7 +5,7 @@ import { Object3D } from './../core/Object3D';
 
 export class CubeCamera extends Object3D {
 
-	constructor( near?: number, far?: number, cubeResolution?: number );
+	constructor( near?: number, far?: number, cubeResolution?: number, options?: WebGLRenderTargetOptions );
 
 	type: 'CubeCamera';
 

--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -5,7 +5,12 @@ import { Object3D } from './../core/Object3D';
 
 export class CubeCamera extends Object3D {
 
-	constructor( near?: number, far?: number, cubeResolution?: number, options?: WebGLRenderTargetOptions );
+	constructor(
+		near?: number,
+		 far?: number,
+		 cubeResolution?: number,
+		 options?: WebGLRenderTargetOptions
+	);
 
 	type: 'CubeCamera';
 

--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -1,4 +1,5 @@
 import { WebGLRenderTargetCube } from './../renderers/WebGLRenderTargetCube';
+import { WebGLRenderTargetOptions } from './../renderers/WebGLRenderTarget';
 import { Scene } from './../scenes/Scene';
 import { WebGLRenderer } from './../renderers/WebGLRenderer';
 import { Object3D } from './../core/Object3D';


### PR DESCRIPTION
[CubeCamera source](https://github.com/mrdoob/three.js/blob/master/src/cameras/CubeCamera.js#L54) shows that the fourth constructor option is passed into the [WebGLRenderTargetCube constructor](https://github.com/mrdoob/three.js/blob/master/src/renderers/WebGLRenderTargetCube.d.ts#L11), so should be of type `WebGLRenderTargetOptions`.