### PR TITLE
Object orientation added to VolumeShader clipping

### DIFF
--- a/examples/js/shaders/VolumeShader.js
+++ b/examples/js/shaders/VolumeShader.js
@@ -67,8 +67,8 @@ THREE.VolumeRenderShader1 = {
 		"		void main() {",
 		// Prepare transforms to map to "camera view". See also:
 		// https://threejs.org/docs/#api/renderers/webgl/WebGLProgram
-		"				mat4 viewtransformf = viewMatrix;",
-		"				mat4 viewtransformi = inversemat(viewMatrix);",
+		"				mat4 viewtransformf = modelViewMatrix;",
+		"				mat4 viewtransformi = inversemat(modelViewMatrix);",
 
 		// Project local vertex coordinate to camera position. Then do a step
 		// backward (in cam coords) to the near clipping plane, and project back. Do

--- a/examples/jsm/shaders/VolumeShader.js
+++ b/examples/jsm/shaders/VolumeShader.js
@@ -72,8 +72,8 @@ var VolumeRenderShader1 = {
 		"		void main() {",
 		// Prepare transforms to map to "camera view". See also:
 		// https://threejs.org/docs/#api/renderers/webgl/WebGLProgram
-		"				mat4 viewtransformf = viewMatrix;",
-		"				mat4 viewtransformi = inversemat(viewMatrix);",
+		"				mat4 viewtransformf = modelViewMatrix;",
+		"				mat4 viewtransformi = inversemat(modelViewMatrix);",
 
 		// Project local vertex coordinate to camera position. Then do a step
 		// backward (in cam coords) to the near clipping plane, and project back. Do


### PR DESCRIPTION
This fixes a bug in VolumeShader where it wasn't taking into account the object orientation when calculating the near and far clipping planes. What I was seeing was it not rendering the correct back face from some angles so some of the volume was missing sometimes.

This is my first PR here so let me know if I'm missing something. I tried to create an example of the issue based off of this example: https://threejs.org/examples/#webgl2_materials_texture3d but it seems I can't access the data. I just wanted to add the same volume again, just rotated by some not insignificant amount.

