### PR TITLE
Fix SVGLoader strokes not rendering in Firefox

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -814,13 +814,13 @@ SVGLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			function clamp( v ) {
 
-				return Math.max( 0, Math.min( 1, v ) );
+				return Math.max( 0, Math.min( 1, parseFloat( v ) ) );
 
 			}
 
 			function positive( v ) {
 
-				return Math.max( 0, v );
+				return Math.max( 0, parseFloat( v ) );
 
 			}
 


### PR DESCRIPTION
In Firefox the ```strokeWidth``` style property parsed by ```SVGLoader``` is being added the string "px" at the end, which results in NaN values inserted in the stroke geometry.

This fixes #17647

To be corrected when SVG units are implemented in #17630