### PR TITLE
Fix typings for Ray intersects*

### DIFF
--- a/src/math/Ray.d.ts
+++ b/src/math/Ray.d.ts
@@ -26,12 +26,12 @@ export class Ray {
 		optionalPointOnRay?: Vector3,
 		optionalPointOnSegment?: Vector3
 	): number;
-	intersectSphere( sphere: Sphere, target: Vector3 ): Vector3;
+	intersectSphere( sphere: Sphere, target: Vector3 ): Vector3 | null;
 	intersectsSphere( sphere: Sphere ): boolean;
 	distanceToPlane( plane: Plane ): number;
-	intersectPlane( plane: Plane, target: Vector3 ): Vector3;
+	intersectPlane( plane: Plane, target: Vector3 ): Vector3 | null;
 	intersectsPlane( plane: Plane ): boolean;
-	intersectBox( box: Box3, target: Vector3 ): Vector3;
+	intersectBox( box: Box3, target: Vector3 ): Vector3 | null;
 	intersectsBox( box: Box3 ): boolean;
 	intersectTriangle(
 		a: Vector3,
@@ -39,7 +39,7 @@ export class Ray {
 		c: Vector3,
 		backfaceCulling: boolean,
 		target: Vector3
-	): Vector3;
+	): Vector3 | null;
 	applyMatrix4( matrix4: Matrix4 ): Ray;
 	equals( ray: Ray ): boolean;
 


### PR DESCRIPTION
According to the [docs](https://threejs.org/docs/#api/en/math/Ray), these 4 methods can return `null`... and in practice I can confirm that sometimes null is returned. 
I've added `| null` to all of them so nobody gets bitten by that again :)