### PR TITLE
WebXR API: Replace supportsSession with isSessionSupported

### DIFF
--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -177,11 +177,17 @@ THREE.WEBVR = {
 			stylizeElement( button );
 
 			navigator.xr.isSessionSupported( 'immersive-vr' ).then( funciton ( supported ) {
+
 				if ( supported ) {
+
 					showEnterXR();
+
 				} else {
+
 					showXRNotFound();
+
 				}
+
 			} );
 
 			return button;

--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -176,7 +176,7 @@ THREE.WEBVR = {
 
 			stylizeElement( button );
 
-			navigator.xr.isSessionSupported( 'immersive-vr' ).then( funciton ( supported ) {
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
 
 				if ( supported ) {
 

--- a/examples/js/vr/WebVR.js
+++ b/examples/js/vr/WebVR.js
@@ -169,14 +169,20 @@ THREE.WEBVR = {
 
 		}
 
-		if ( 'xr' in navigator && 'supportsSession' in navigator.xr ) {
+		if ( 'xr' in navigator && 'isSessionSupported' in navigator.xr ) {
 
 			var button = document.createElement( 'button' );
 			button.style.display = 'none';
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR ).catch( showXRNotFound );
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( funciton ( supported ) {
+				if ( supported ) {
+					showEnterXR();
+				} else {
+					showXRNotFound();
+				}
+			} );
 
 			return button;
 

--- a/examples/jsm/vr/WebVR.js
+++ b/examples/jsm/vr/WebVR.js
@@ -171,14 +171,26 @@ var WEBVR = {
 
 		}
 
-		if ( 'xr' in navigator && 'supportsSession' in navigator.xr ) {
+		if ( 'xr' in navigator && 'isSessionSupported' in navigator.xr ) {
 
 			var button = document.createElement( 'button' );
 			button.style.display = 'none';
 
 			stylizeElement( button );
 
-			navigator.xr.supportsSession( 'immersive-vr' ).then( showEnterXR ).catch( showXRNotFound );
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( funciton ( supported ) {
+
+				if ( supported ) {
+
+					showEnterXR();
+
+				} else {
+
+					showXRNotFound();
+
+				}
+
+			} );
 
 			return button;
 

--- a/examples/jsm/vr/WebVR.js
+++ b/examples/jsm/vr/WebVR.js
@@ -178,7 +178,7 @@ var WEBVR = {
 
 			stylizeElement( button );
 
-			navigator.xr.isSessionSupported( 'immersive-vr' ).then( funciton ( supported ) {
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
 
 				if ( supported ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -309,7 +309,7 @@ function WebGLRenderer( parameters ) {
 
 	// vr
 
-	var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator && 'supportsSession' in navigator.xr ) ? new WebXRManager( _this, _gl ) : new WebVRManager( _this );
+	var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator && 'isSessionSupported' in navigator.xr ) ? new WebXRManager( _this, _gl ) : new WebVRManager( _this );
 
 	this.vr = vr;
 


### PR DESCRIPTION
This PR replaces `navigator.xr.supportsSession()` with `navigator.xr.isSessionSupported()` to follow the latest WebXR API spec.

https://immersive-web.github.io/webxr/#xr-interface

The latest Chrome Canary and webxr-polyfill support `isSessionSupported()`.

Fixes #17682

(How do you maintain jsm directory now? Should I also manually update jsm/vr/WebVR.js?)