### PR TITLE
Docs: Fix gamedev.net link in Matrix4 page.

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -219,7 +219,7 @@ zAxis = (c, g, k)
 		Sets this matrix as rotation transform around [page:Vector3 axis] by [page:Float theta] radians.<br />
 
 		This is a somewhat controversial but mathematically sound alternative to rotating via [page:Quaternions].
-		See the discussion [link:http://www.gamedev.net/reference/articles/article1199.asp here].
+		See the discussion [link:https://www.gamedev.net/articles/programming/math-and-physics/do-we-really-need-quaternions-r1199 here].
 		</p>
 
 		<h3>[method:this makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>


### PR DESCRIPTION
the current link does not redirect correctly