### PR TITLE
PointsMaterial: add alphaMap support

### DIFF
--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -65,6 +65,17 @@ scene.add( starField );
 		<h2>Properties</h2>
 		<p>See the base [page:Material] class for common properties.</p>
 
+		<h3>[property:Texture alphaMap]</h3>
+		<p>The alpha map is a grayscale texture that controls the opacity across the surface
+			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+
+			Only the color of the texture is used, ignoring the alpha channel if one exists.
+			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
+			green channel when sampling this texture due to the extra bit of precision provided
+			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
+			luminance/alpha textures will also still work as expected.
+		</p>
+
 		<h3>[property:Color color]</h3>
 		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
 

--- a/src/materials/PointsMaterial.d.ts
+++ b/src/materials/PointsMaterial.d.ts
@@ -25,7 +25,8 @@ export class MultiMaterial extends Material {
 
 export interface PointsMaterialParameters extends MaterialParameters {
 	color?: Color | string | number;
-	map?: Texture;
+	map?: Texture | null;
+	alphaMap?: Texture | null;
 	size?: number;
 	sizeAttenuation?: boolean;
 }
@@ -36,6 +37,7 @@ export class PointsMaterial extends Material {
 
 	color: Color;
 	map: Texture | null;
+	alphaMap: Texture | null;
 	size: number;
 	sizeAttenuation: boolean;
 

--- a/src/materials/PointsMaterial.js
+++ b/src/materials/PointsMaterial.js
@@ -9,6 +9,7 @@ import { Color } from '../math/Color.js';
  *  color: <hex>,
  *  opacity: <float>,
  *  map: new THREE.Texture( <Image> ),
+ *  alphaMap: new THREE.Texture( <Image> ),
  *
  *  size: <float>,
  *  sizeAttenuation: <bool>
@@ -26,6 +27,8 @@ function PointsMaterial( parameters ) {
 	this.color = new Color( 0xffffff );
 
 	this.map = null;
+
+	this.alphaMap = null;
 
 	this.size = 1;
 	this.sizeAttenuation = true;
@@ -48,6 +51,8 @@ PointsMaterial.prototype.copy = function ( source ) {
 	this.color.copy( source.color );
 
 	this.map = source.map;
+
+	this.alphaMap = source.alphaMap;
 
 	this.size = source.size;
 	this.sizeAttenuation = source.sizeAttenuation;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2181,17 +2181,43 @@ function WebGLRenderer( parameters ) {
 		uniforms.size.value = material.size * _pixelRatio;
 		uniforms.scale.value = _height * 0.5;
 
-		uniforms.map.value = material.map;
+		if ( material.map ) {
 
-		if ( material.map !== null ) {
+			uniforms.map.value = material.map;
 
-			if ( material.map.matrixAutoUpdate === true ) {
+		}
 
-				material.map.updateMatrix();
+		if ( material.alphaMap ) {
+
+			uniforms.alphaMap.value = material.alphaMap;
+
+		}
+
+		// uv repeat and offset setting priorities
+		// 1. color map
+		// 2. alpha map
+
+		var uvScaleMap;
+
+		if ( material.map ) {
+
+			uvScaleMap = material.map;
+
+		} else if ( material.alphaMap ) {
+
+			uvScaleMap = material.alphaMap;
+
+		}
+
+		if ( uvScaleMap !== undefined ) {
+
+			if ( uvScaleMap.matrixAutoUpdate === true ) {
+
+				uvScaleMap.updateMatrix();
 
 			}
 
-			uniforms.uvTransform.value.copy( material.map.matrix );
+			uniforms.uvTransform.value.copy( uvScaleMap.matrix );
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/map_particle_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_particle_fragment.glsl.js
@@ -1,9 +1,20 @@
 export default /* glsl */`
-#ifdef USE_MAP
+#if defined( USE_MAP ) || defined( USE_ALPHAMAP )
 
 	vec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;
+
+#endif
+
+#ifdef USE_MAP
+
 	vec4 mapTexel = texture2D( map, uv );
 	diffuseColor *= mapTexelToLinear( mapTexel );
+
+#endif
+
+#ifdef USE_ALPHAMAP
+
+	diffuseColor.a *= texture2D( alphaMap, uv ).g;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_particle_pars_fragment.glsl.js
@@ -1,8 +1,19 @@
 export default /* glsl */`
-#ifdef USE_MAP
+#if defined( USE_MAP ) || defined( USE_ALPHAMAP )
 
 	uniform mat3 uvTransform;
+
+#endif
+
+#ifdef USE_MAP
+
 	uniform sampler2D map;
+
+#endif
+
+#ifdef USE_ALPHAMAP
+
+	uniform sampler2D alphaMap;
 
 #endif
 `;

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -182,6 +182,7 @@ var UniformsLib = {
 		size: { value: 1.0 },
 		scale: { value: 1.0 },
 		map: { value: null },
+		alphaMap: { value: null },
 		uvTransform: { value: new Matrix3() }
 
 	},


### PR DESCRIPTION
This support for alpha maps is consistent with the implementation of the other built-in materials.

Alpha maps are particularly appropriate for controlling the shape of `Points`. Single-channel (`Luminance`) alpha maps are supported -- as they are elsewhere in the library.

UV `offset/repeat` of the map and alpha map continues to be coupled. This is a current limitation of the library.