### PR TITLE
ObjLoader2Parser materials are not applied in worker

### DIFF
--- a/examples/jsm/loaders/OBJLoader2.d.ts
+++ b/examples/jsm/loaders/OBJLoader2.d.ts
@@ -30,7 +30,7 @@ export class OBJLoader2 extends Loader {
 	setPath( path: string ): this;
 	setResourcePath( path: string ): this;
 	setBaseObject3d( baseObject3d: Object3D ): this;
-	addMaterials( materials: object ): this;
+	addMaterials( materials: object, overrideExisting: boolean ): this;
 
 	setCallbackOnAssetAvailable( onAssetAvailable: Function ): this;
 	setCallbackOnProgress( onProgress: Function ): this;

--- a/examples/jsm/loaders/OBJLoader2.js
+++ b/examples/jsm/loaders/OBJLoader2.js
@@ -43,7 +43,7 @@ const OBJLoader2 = function ( manager ) {
 
 };
 
-OBJLoader2.OBJLOADER2_VERSION = '3.1.0';
+OBJLoader2.OBJLOADER2_VERSION = '3.1.1';
 console.info( 'Using OBJLoader2 version: ' + OBJLoader2.OBJLOADER2_VERSION );
 
 
@@ -136,11 +136,12 @@ OBJLoader2.prototype = Object.assign( Object.create( Loader.prototype ), {
 	 * Add materials as associated array.
 	 *
 	 * @param {Object} materials Object with named {@link Material}
+	 * @param overrideExisting boolean Override existing material
 	 * @return {OBJLoader2}
 	 */
-	addMaterials: function ( materials ) {
+	addMaterials: function ( materials, overrideExisting ) {
 
-		this.materialHandler.addMaterials( materials );
+		this.materialHandler.addMaterials( materials, overrideExisting );
 		return this;
 
 	},

--- a/examples/jsm/loaders/OBJLoader2Parallel.js
+++ b/examples/jsm/loaders/OBJLoader2Parallel.js
@@ -40,7 +40,7 @@ const OBJLoader2Parallel = function ( manager ) {
 
 };
 
-OBJLoader2Parallel.OBJLOADER2_PARALLEL_VERSION = '3.1.0';
+OBJLoader2Parallel.OBJLOADER2_PARALLEL_VERSION = '3.1.1';
 console.info( 'Using OBJLoader2Parallel version: ' + OBJLoader2Parallel.OBJLOADER2_PARALLEL_VERSION );
 
 
@@ -92,7 +92,7 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 		let codeBuilderInstructions = new CodeBuilderInstructions( true, true, this.preferJsmWorker );
 		if ( codeBuilderInstructions.isSupportsJsmWorker() ) {
 
-			codeBuilderInstructions.setJsmWorkerFile( '../../src/loaders/worker/parallel/jsm/OBJLoader2Worker.js' );
+			codeBuilderInstructions.setJsmWorkerFile( '../examples/loaders/jsm/obj2/worker/parallel/jsm/OBJLoader2Worker.js' );
 
 		}
 		if ( codeBuilderInstructions.isSupportsStandardWorker() ) {
@@ -189,8 +189,8 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 						disregardNormals: this.parser.disregardNormals,
 						materialPerSmoothingGroup: this.parser.materialPerSmoothingGroup,
 						useOAsMesh: this.parser.useOAsMesh,
+						materials: this.materialHandler.getMaterialsJSON()
 					},
-					materials: this.materialHandler.getMaterialsJSON(),
 					data: {
 						input: content,
 						options: null

--- a/examples/jsm/loaders/obj2/shared/MaterialHandler.d.ts
+++ b/examples/jsm/loaders/obj2/shared/MaterialHandler.d.ts
@@ -15,7 +15,7 @@ export class MaterialHandler {
 	materials: object;
 
 	createDefaultMaterials( overrideExisting: boolean ): void;
-	addMaterials( materials: object, overrideExisting: boolean, newMaterials: object ): object;
+	addMaterials( materials: object, overrideExisting: boolean, newMaterials?: object ): object;
 	addPayloadMaterials( materialPayload: object ): object;
 	setLogging( enabled: boolean, debug: boolean ): void;
 	getMaterials(): object;

--- a/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
+++ b/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
@@ -49,9 +49,8 @@ DefaultWorkerPayloadHandler.prototype = {
 				parser.setLogging( this.logging.enabled, this.logging.debug );
 
 			}
-			ObjectManipulator.applyProperties( parser, payload.params );
-			ObjectManipulator.applyProperties( parser, payload.materials );
-			ObjectManipulator.applyProperties( parser, callbacks );
+			ObjectManipulator.applyProperties( parser, payload.params, false );
+			ObjectManipulator.applyProperties( parser, callbacks, false );
 
 			let arraybuffer;
 			if ( payload.params && payload.params.index !== undefined && payload.params.index !== null ) {

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -130,7 +130,7 @@
 					let onLoadMtl = function ( mtlParseResult ) {
 						objLoader2.setModelName( modelName );
 						objLoader2.setLogging( true, true );
-						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ) );
+						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ), true );
 						objLoader2.load( 'models/obj/female02/female02.obj', callbackOnLoad, null, null, null );
 					};
 					let mtlLoader = new MTLLoader();

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -141,7 +141,7 @@
 
 					let scope = this;
 					function onLoadMtl ( mtlParseResult ) {
-						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ) );
+						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ), true );
 
 						let fileLoader = new THREE.FileLoader();
 						fileLoader.setPath( '' );
@@ -173,9 +173,14 @@
 						scope._reportProgress( { detail: { text: 'Loading of ' + modelName + 'completed: ' + message } } );
 					}
 
+					let materials = {
+						tester: new THREE.MeshStandardMaterial();
+					};
+
 					let objLoader2Parallel = new OBJLoader2Parallel()
 						.setModelName( modelName )
-						.setCallbackOnLoad( callbackOnLoad );
+						.setCallbackOnLoad( callbackOnLoad )
+						.addMaterials( materials, true );
 
 					let fileLoader = new THREE.FileLoader();
 					fileLoader.setPath( '' );
@@ -207,7 +212,7 @@
 					}
 
 					function onLoadMtl ( mtlParseResult ) {
-						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ) );
+						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ), true );
 						objLoader2.load( 'models/obj/male02/male02.obj', callbackOnLoad, null, null, null );
 					}
 
@@ -235,7 +240,7 @@
 						scope._reportProgress( { detail: { text: 'Loading of ' + modelName + 'completed: ' + message } } );
 					}
 					function onLoadMtl ( mtlParseResult ) {
-						objLoader2Parallel.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ) );
+						objLoader2Parallel.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ), true );
 						objLoader2Parallel.load( 'models/obj/walt/WaltHead.obj', callbackOnLoad );
 					}
 


### PR DESCRIPTION
Fixes #17615 Material assignment is no properly done when Parser is run in worker.
Additionally, allow material override from OBJLoader2.addMaterials to MaterialHandler.addMaterials