### PR TITLE
Layers for WebVR

### DIFF
--- a/examples/webvr_panorama.html
+++ b/examples/webvr_panorama.html
@@ -29,6 +29,8 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.vr.enabled = true;
+				renderer.vr.leftLayers.disable( 2 );
+				renderer.vr.rightLayers.disable( 1 );
 				document.body.appendChild( renderer.domElement );
 
 				document.body.appendChild( WEBVR.createButton( renderer, { referenceSpaceType: 'local' } ) );
@@ -39,6 +41,7 @@
 
 				camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.layers.enable( 1 );
+				camera.layers.enable( 2 );
 
 				var geometry = new THREE.BoxBufferGeometry( 100, 100, 100 );
 				geometry.scale( 1, 1, - 1 );

--- a/examples/webvr_video.html
+++ b/examples/webvr_video.html
@@ -43,7 +43,8 @@
 				} );
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 2000 );
-				camera.layers.enable( 1 ); // render left view when no stereo available
+				camera.layers.enable( 1 );
+				camera.layers.enable( 2 );
 
 				// video
 
@@ -117,6 +118,8 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.vr.enabled = true;
+				renderer.vr.leftLayers.set( 2 );
+				renderer.vr.rightLayers.set( 1 );
 				container.appendChild( renderer.domElement );
 
 				document.body.appendChild( WEBVR.createButton( renderer, { referenceSpaceType: 'local' } ) );

--- a/src/renderers/webvr/WebVRManager.d.ts
+++ b/src/renderers/webvr/WebVRManager.d.ts
@@ -8,6 +8,8 @@ export class WebVRManager {
 
 	constructor( renderer: any );
 
+	leftLayers: Layers;
+	rightLayers: Layers;
 	enabled: boolean;
 	getController( id: number ): Group;
 	getDevice(): VRDisplay | null;

--- a/src/renderers/webvr/WebVRManager.d.ts
+++ b/src/renderers/webvr/WebVRManager.d.ts
@@ -3,7 +3,7 @@ import { Group } from '../../objects/Group';
 import { PerspectiveCamera } from '../../cameras/PerspectiveCamera';
 import { ArrayCamera } from '../../cameras/ArrayCamera';
 import { Matrix4 } from '../../math/Matrix4';
-import { Layers } from './Layers';
+import { Layers } from '../../core/Layers';
 
 export class WebVRManager {
 

--- a/src/renderers/webvr/WebVRManager.d.ts
+++ b/src/renderers/webvr/WebVRManager.d.ts
@@ -3,6 +3,7 @@ import { Group } from '../../objects/Group';
 import { PerspectiveCamera } from '../../cameras/PerspectiveCamera';
 import { ArrayCamera } from '../../cameras/ArrayCamera';
 import { Matrix4 } from '../../math/Matrix4';
+import { Layers } from './Layers';
 
 export class WebVRManager {
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -45,15 +45,13 @@ function WebVRManager( renderer ) {
 
 	var cameraL = new PerspectiveCamera();
 	cameraL.viewport = new Vector4();
-	cameraL.layers.enable( 1 );
+	cameraL.layers.enableAll();
 
 	var cameraR = new PerspectiveCamera();
 	cameraR.viewport = new Vector4();
-	cameraR.layers.enable( 2 );
+	cameraR.layers.enableAll();
 
 	var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
-	cameraVR.layers.enable( 1 );
-	cameraVR.layers.enable( 2 );
 
 	//
 
@@ -325,6 +323,8 @@ function WebVRManager( renderer ) {
 
 		cameraL.matrixWorldInverse.fromArray( frameData.leftViewMatrix );
 		cameraR.matrixWorldInverse.fromArray( frameData.rightViewMatrix );
+
+		cameraVR.layers.mask = camera.layers.mask;
 
 		// TODO (mrdoob) Double check this code
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -46,10 +46,12 @@ function WebVRManager( renderer ) {
 	var cameraL = new PerspectiveCamera();
 	cameraL.viewport = new Vector4();
 	cameraL.layers.enableAll();
+	this.leftLayers = cameraL.layers;
 
 	var cameraR = new PerspectiveCamera();
 	cameraR.viewport = new Vector4();
 	cameraR.layers.enableAll();
+	this.rightLayers = cameraR.layers;
 
 	var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
 


### PR DESCRIPTION
Before the VR camera was hardcoded to only show layer 0 and 1 in the left eye, and layer 0 and 2 in the right eye. Because of this, layers were unusable since the layers set on the original perspective camera was not carried over to the new VR camera.

This is very confusing if you do not know about this since it simply seems like layers are broken in VR mode. Most people using this functionality probably want to use layers normally and not render different views for different eyes. If they do, they will now have to use the new leftLayers and rightLayers fields.