### PR TITLE
Examples: Change from HalfFloat to Float in envMap EXR demo.

### DIFF
--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -74,7 +74,7 @@
 				scene.add( planeMesh );
 
 				new EXRLoader()
-					.setDataType( THREE.HalfFloatType )
+					.setDataType( THREE.FloatType )
 					.load( 'textures/piz_compressed.exr', function ( texture ) {
 
 						texture.minFilter = THREE.NearestFilter;


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/17708#discussion_r334387333

The example already works fine in Chrome but Safari has problems processing the `THREE.HalfFloatType` texture loaded by `EXRLoader` in `WebGLRenderTargetCube.fromEquirectangularTexture()`.