### PR TITLE
ParametricGeometry: Added serialization/deserialization support.

### DIFF
--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -33,6 +33,16 @@ function ParametricGeometry( func, slices, stacks ) {
 ParametricGeometry.prototype = Object.create( Geometry.prototype );
 ParametricGeometry.prototype.constructor = ParametricGeometry;
 
+ParametricGeometry.prototype.toJSON = function () {
+
+	var data = Geometry.prototype.toJSON.call( this );
+
+	data.func = this.parameters.func.toString();
+
+	return data;
+
+};
+
 // ParametricBufferGeometry
 
 function ParametricBufferGeometry( func, slices, stacks ) {
@@ -159,5 +169,14 @@ function ParametricBufferGeometry( func, slices, stacks ) {
 ParametricBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
 ParametricBufferGeometry.prototype.constructor = ParametricBufferGeometry;
 
+ParametricBufferGeometry.prototype.toJSON = function () {
+
+	var data = BufferGeometry.prototype.toJSON.call( this );
+
+	data.func = this.parameters.func.toString();
+
+	return data;
+
+};
 
 export { ParametricGeometry, ParametricBufferGeometry };

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -408,6 +408,19 @@ ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 						break;
 
+					case 'ParametricGeometry':
+					case 'ParametricBufferGeometry':
+
+						var func = new Function( 'return ' + data.func )();
+
+						geometry = new Geometries[ data.type ](
+							func,
+							data.slices,
+							data.stacks
+						);
+
+						break;
+
 					case 'BufferGeometry':
 					case 'InstancedBufferGeometry':
 


### PR DESCRIPTION
Fixed #17381

The assumption of this PR is that `ParametricBufferGeometry.func` is a self-contained function (like the ones from [THREE.ParametricGeometries](https://github.com/mrdoob/three.js/blob/697f63c572a081e1d7dc119a6d6e8d9da8b57c4c/examples/jsm/geometries/ParametricGeometries.js#L17-L99)).