### PR TITLE
WebGLProgram: camera-specific shader define.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1059,13 +1059,13 @@ function WebGLRenderer( parameters ) {
 
 					for ( var i = 0; i < object.material.length; i ++ ) {
 
-						initMaterial( object.material[ i ], scene.fog, object );
+						initMaterial( object.material[ i ], scene.fog, object, camera );
 
 					}
 
 				} else {
 
-					initMaterial( object.material, scene.fog, object );
+					initMaterial( object.material, scene.fog, object, camera );
 
 				}
 
@@ -1485,7 +1485,7 @@ function WebGLRenderer( parameters ) {
 
 	}
 
-	function initMaterial( material, fog, object ) {
+	function initMaterial( material, fog, object, camera ) {
 
 		var materialProperties = properties.get( material );
 
@@ -1495,7 +1495,7 @@ function WebGLRenderer( parameters ) {
 		var lightsStateVersion = lights.state.version;
 
 		var parameters = programCache.getParameters(
-			material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object );
+			material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object, camera );
 
 		var code = programCache.getProgramCode( material, parameters );
 
@@ -1701,7 +1701,7 @@ function WebGLRenderer( parameters ) {
 
 		if ( material.needsUpdate ) {
 
-			initMaterial( material, fog, object );
+			initMaterial( material, fog, object, camera );
 			material.needsUpdate = false;
 
 		}

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -449,6 +449,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
 			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
+			parameters.orthographic ? '#define ORTHO ' : '',
+
 			parameters.map ? '#define USE_MAP' : '',
 			parameters.envMap ? '#define USE_ENVMAP' : '',
 			parameters.envMap ? '#define ' + envMapModeDefine : '',
@@ -570,6 +572,8 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
 			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
+
+			parameters.orthographic ? '#define ORTHO ' : '',
 
 			parameters.map ? '#define USE_MAP' : '',
 			parameters.matcap ? '#define USE_MATCAP' : '',

--- a/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/src/renderers/webgl/WebGLPrograms.d.ts
@@ -15,7 +15,8 @@ export class WebGLPrograms {
 		lights: any,
 		fog: any,
 		nClipPlanes: number,
-		object: any
+		object: any,
+		camera: any,
 	): any;
 	getProgramCode( material: ShaderMaterial, parameters: any ): string;
 	acquireProgram(

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -150,7 +150,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			precision: precision,
 
 			instancing: object.isInstancedMesh === true,
-			orthographic: camera.isOrthographicCamera === true, 
+			orthographic: camera.isOrthographicCamera === true,
 
 			supportsVertexTextures: vertexTextures,
 			numMultiviewViews: numMultiviewViews,

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -117,7 +117,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 	}
 
-	this.getParameters = function ( material, lights, shadows, fog, nClipPlanes, nClipIntersection, object ) {
+	this.getParameters = function ( material, lights, shadows, fog, nClipPlanes, nClipIntersection, object, camera ) {
 
 		var shaderID = shaderIDs[ material.type ];
 
@@ -150,6 +150,8 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			precision: precision,
 
 			instancing: object.isInstancedMesh === true,
+
+			orthographic: camera.isOrthographicCamera, 
 
 			supportsVertexTextures: vertexTextures,
 			numMultiviewViews: numMultiviewViews,

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -150,8 +150,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			precision: precision,
 
 			instancing: object.isInstancedMesh === true,
-
-			orthographic: camera.isOrthographicCamera, 
+			orthographic: camera.isOrthographicCamera === true, 
 
 			supportsVertexTextures: vertexTextures,
 			numMultiviewViews: numMultiviewViews,


### PR DESCRIPTION
As per suggested on https://github.com/mrdoob/three.js/issues/17662#issuecomment-541164744

This PR introduces `#define ORTHO` on programShaders. In my opinion this is long overdue.

As noted by @EliasHasle, this would facilitate a lot the handling of orthographic projection specific behavior inside `ShaderChunks`. It would also solve the issue of `varying vIsPerspective` hardware dependant calculation, dismiss the problems involved in colliding varyings and avoid several conditional branching currently happening inside the shaders to deal with orthographic cameras.

I'm also waiting for this change to push a fix for https://github.com/mrdoob/three.js/issues/17379 and https://github.com/mrdoob/three.js/issues/17662

**sidenote**: went for `ORTHO` instead of `ORTHOGRAPHIC` for shorter notation, but open to suggestions.