### PR TITLE
WebGLRenderer: fixed copyFramebufferToTexture

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -399,13 +399,23 @@ export class WebGLRenderer implements Renderer {
 
 	/**
 	 * Copies a region of the currently bound framebuffer into the selected mipmap level of the selected texture.
-	 * This region is defined by the size of the texture's mip level and starts at the input position.
-	 * 
+	 * This region is defined by the size of the destination texture's mip level, offset by the input position.
+	 *
 	 * @param position Specifies the pixel offset from which to copy out of the framebuffer.
 	 * @param texture Specifies the destination texture.
 	 * @param level Specifies the destination mipmap level of the texture.
 	 */
-	copyFramebufferToTexture( position: Vector2, texture: Texture, level: number ): void;
+	copyFramebufferToTexture( position: Vector2, texture: Texture, level?: number ): void;
+
+	/**
+	 * Copies srcTexture to the specified level of dstTexture, offset by the input position.
+	 *
+	 * @param position Specifies the pixel offset into the dstTexture where the copy will occur.
+	 * @param srcTexture Specifies the source texture.
+	 * @param dstTexture Specifies the destination texture.
+	 * @param level Specifies the destination mipmap level of the texture.
+	 */
+	copyTextureToTexture( position: Vector2, srcTexture: Texture, dstTexture: Texture, level?: number ): void;
 
 	/**
 	 * @deprecated

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -19,6 +19,7 @@ import { WebVRManager } from '../renderers/webvr/WebVRManager';
 import { RenderTarget } from './webgl/WebGLRenderLists';
 import { Geometry } from './../core/Geometry';
 import { BufferGeometry } from './../core/BufferGeometry';
+import { Texture } from '../textures/Texture';
 
 export interface Renderer {
 	domElement: HTMLCanvasElement;
@@ -395,6 +396,8 @@ export class WebGLRenderer implements Renderer {
 		buffer: any,
 		activeCubeFaceIndex?: number
 	): void;
+
+	copyFramebufferToTexture( position: Vector2, texture: Texture, level: number ): void;
 
 	/**
 	 * @deprecated

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -397,6 +397,14 @@ export class WebGLRenderer implements Renderer {
 		activeCubeFaceIndex?: number
 	): void;
 
+	/**
+	 * Copies a region of the currently bound framebuffer into the selected mipmap level of the selected texture.
+	 * This region is defined by the size of the texture's mip level and starts at the input position.
+	 * 
+	 * @param position Specifies the pixel offset from which to copy out of the framebuffer.
+	 * @param texture Specifies the destination texture.
+	 * @param level Specifies the destination mipmap level of the texture.
+	 */
 	copyFramebufferToTexture( position: Vector2, texture: Texture, level: number ): void;
 
 	/**

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2719,7 +2719,7 @@ function WebGLRenderer( parameters ) {
 
 	this.copyFramebufferToTexture = function ( position, texture, level ) {
 
-		var levelScale = Math.pow( 2, -1.0 * level );
+		var levelScale = Math.pow( 2, - level );
 		var width = texture.image.width * levelScale;
 		var height = texture.image.height * levelScale;
 		var glFormat = utils.convert( texture.format );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2728,7 +2728,7 @@ function WebGLRenderer( parameters ) {
 
 		textures.setTexture2D( texture, 0 );
 
-		_gl.copyTexImage2D( _gl.TEXTURE_2D, level || 0, glFormat, position.x, position.y, width, height, 0 );
+		_gl.copyTexImage2D( _gl.TEXTURE_2D, level, glFormat, position.x, position.y, width, height, 0 );
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2719,8 +2719,9 @@ function WebGLRenderer( parameters ) {
 
 	this.copyFramebufferToTexture = function ( position, texture, level ) {
 
-		var width = texture.image.width;
-		var height = texture.image.height;
+		var levelScale = Math.pow( 2, -1.0 * level );
+		var width = texture.image.width * levelScale;
+		var height = texture.image.height * levelScale;
 		var glFormat = utils.convert( texture.format );
 
 		textures.setTexture2D( texture, 0 );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2719,9 +2719,11 @@ function WebGLRenderer( parameters ) {
 
 	this.copyFramebufferToTexture = function ( position, texture, level ) {
 
+		level = level || 0;
+
 		var levelScale = Math.pow( 2, - level );
-		var width = texture.image.width * levelScale;
-		var height = texture.image.height * levelScale;
+		var width = Math.floor( texture.image.width * levelScale );
+		var height = Math.floor( texture.image.height * levelScale );
 		var glFormat = utils.convert( texture.format );
 
 		textures.setTexture2D( texture, 0 );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2719,7 +2719,7 @@ function WebGLRenderer( parameters ) {
 
 	this.copyFramebufferToTexture = function ( position, texture, level ) {
 
-		level = level || 0;
+		if ( level === undefined ) level = 0;
 
 		var levelScale = Math.pow( 2, - level );
 		var width = Math.floor( texture.image.width * levelScale );


### PR DESCRIPTION
I was happy to discover the method I needed for making a custom mipmapping shader exists in three, only to find that it didn't actually work with any level except zero. I've fixed that and added it to the TS declaration side. I believe the same problem exists with the method right below it, copyTextureToTexture, but I'm not actually using that one. If you'd like me to update it here as well, I'd be happy to.