### PR TITLE
Rename WebGLProgram "code" to "cacheKey"

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1497,7 +1497,7 @@ function WebGLRenderer( parameters ) {
 		var parameters = programCache.getParameters(
 			material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object );
 
-		var code = programCache.getProgramCode( material, parameters );
+		var programCacheKey = programCache.getProgramCacheKey( material, parameters );
 
 		var program = materialProperties.program;
 		var programChange = true;
@@ -1507,7 +1507,7 @@ function WebGLRenderer( parameters ) {
 			// new material
 			material.addEventListener( 'dispose', onMaterialDispose );
 
-		} else if ( program.code !== code ) {
+		} else if ( program.cacheKey !== programCacheKey ) {
 
 			// changed glsl or parameters
 			releaseMaterialProgramReference( material );
@@ -1556,10 +1556,10 @@ function WebGLRenderer( parameters ) {
 
 			material.onBeforeCompile( materialProperties.shader, _this );
 
-			// Computing code again as onBeforeCompile may have changed the shaders
-			code = programCache.getProgramCode( material, parameters );
+			// Computing cache key again as onBeforeCompile may have changed the shaders
+			programCacheKey = programCache.getProgramCacheKey( material, parameters );
 
-			program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );
+			program = programCache.acquireProgram( material, materialProperties.shader, parameters, programCacheKey );
 
 			materialProperties.program = program;
 			material.program = program;

--- a/src/renderers/webgl/WebGLProgram.d.ts
+++ b/src/renderers/webgl/WebGLProgram.d.ts
@@ -9,14 +9,14 @@ export class WebGLProgram {
 	constructor(
 		renderer: WebGLRenderer,
 		extensions: WebGLExtensions,
-		code: string,
+		cacheKey: string,
 		material: ShaderMaterial,
 		shader: WebGLShader,
 		parameters: WebGLRendererParameters
 	);
 
 	id: number;
-	code: string;
+	cacheKey: string; // unique identifier for this program, used for looking up compiled programs from cache.
 	usedTimes: number;
 	program: any;
 	vertexShader: WebGLShader;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -377,7 +377,7 @@ function generateEnvMapBlendingDefine( parameters ) {
 
 }
 
-function WebGLProgram( renderer, extensions, code, material, shader, parameters ) {
+function WebGLProgram( renderer, extensions, cacheKey, material, shader, parameters ) {
 
 	var gl = renderer.getContext();
 
@@ -884,7 +884,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 	this.name = shader.name;
 	this.id = programIdCount ++;
-	this.code = code;
+	this.cacheKey = cacheKey;
 	this.usedTimes = 1;
 	this.program = program;
 	this.vertexShader = glVertexShader;

--- a/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/src/renderers/webgl/WebGLPrograms.d.ts
@@ -2,7 +2,7 @@ import { WebGLRenderer } from './../WebGLRenderer';
 import { WebGLProgram } from './WebGLProgram';
 import { WebGLCapabilities } from './WebGLCapabilities';
 import { WebGLExtensions } from './WebGLExtensions';
-import { ShaderMaterial } from './../../materials/ShaderMaterial';
+import { Material } from './../../materials/Material';
 
 export class WebGLPrograms {
 
@@ -11,17 +11,17 @@ export class WebGLPrograms {
 	programs: WebGLProgram[];
 
 	getParameters(
-		material: ShaderMaterial,
+		material: Material,
 		lights: any,
 		fog: any,
 		nClipPlanes: number,
 		object: any
 	): any;
-	getProgramCode( material: ShaderMaterial, parameters: any ): string;
+	getProgramCacheKey( material: Material, parameters: any ): string;
 	acquireProgram(
-		material: ShaderMaterial,
+		material: Material,
 		parameters: any,
-		code: string
+		cacheKey: string
 	): WebGLProgram;
 	releaseProgram( program: WebGLProgram ): void;
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -240,7 +240,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 	};
 
-	this.getProgramCode = function ( material, parameters ) {
+	this.getProgramCacheKey = function ( material, parameters ) {
 
 		var array = [];
 
@@ -282,18 +282,18 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 	};
 
-	this.acquireProgram = function ( material, shader, parameters, code ) {
+	this.acquireProgram = function ( material, shader, parameters, cacheKey ) {
 
 		var program;
 
 		// Check if code has been already compiled
 		for ( var p = 0, pl = programs.length; p < pl; p ++ ) {
 
-			var programInfo = programs[ p ];
+			var preexistingProgram = programs[ p ];
 
-			if ( programInfo.code === code ) {
+			if ( preexistingProgram.cacheKey === cacheKey ) {
 
-				program = programInfo;
+				program = preexistingProgram;
 				++ program.usedTimes;
 
 				break;
@@ -304,7 +304,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 		if ( program === undefined ) {
 
-			program = new WebGLProgram( renderer, extensions, code, material, shader, parameters );
+			program = new WebGLProgram( renderer, extensions, cacheKey, material, shader, parameters );
 			programs.push( program );
 
 		}


### PR DESCRIPTION
This name is clearer since "code" can be easily confused to mean shader code in this context.

Settling on a good name here is important because we want to expose the ability to customize the hash through the API. ( #17567 )