### PR TITLE
Add return type to createButton for WebVR typings.

### DIFF
--- a/examples/jsm/vr/WebVR.d.ts
+++ b/examples/jsm/vr/WebVR.d.ts
@@ -7,5 +7,5 @@ export interface WEBVROptions {
 }
 
 export namespace WEBVR {
-	export function createButton( renderer: WebGLRenderer, options?: WEBVROptions );
+	export function createButton( renderer: WebGLRenderer, options?: WEBVROptions ): HTMLElement;
 }


### PR DESCRIPTION
The function can return either a button or an `<a>` element. `HTMLElement` is a simple generalization in case the implementation changes again.