### PR TITLE
WebGLProgram: Add isOrthographic uniform.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1753,6 +1753,8 @@ function WebGLRenderer( parameters ) {
 
 				_currentCamera = camera;
 
+				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
+
 				// lighting uniforms depend on the camera so enforce an update
 				// now, in case this material supports lights - or later, when
 				// the next material that does gets activated:

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -495,6 +495,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 			'uniform mat4 viewMatrix;',
 			'uniform mat3 normalMatrix;',
 			'uniform vec3 cameraPosition;',
+			'uniform bool isOrthographic;',
 
 			'#ifdef USE_INSTANCING',
 
@@ -617,6 +618,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',
+			'uniform bool isOrthographic;',
 
 			( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
 			( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below


### PR DESCRIPTION
Alternative to #17742 

Based on https://github.com/mrdoob/three.js/pull/17742#issuecomment-542796736, <del> makes  `varying isPerspective` no longer needed and </del> sets up for future orthographic behavior handling.

@gkjohnson @Mugen87 Does it look ok to you guys?