### PR TITLE
WebGLCapabilities: Add support for WebGL2ComputeRenderingContext.

### DIFF
--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -56,8 +56,10 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
+	/* eslint-disable no-undef */
 	var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
 				   ( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
+	/* eslint-enable no-undef */
 
 	var precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 	var maxPrecision = getMaxPrecision( precision );

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -56,7 +56,8 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-	var isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+	var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
+				   ( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
 
 	var precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 	var maxPrecision = getMaxPrecision( precision );

--- a/utils/build/externs.js
+++ b/utils/build/externs.js
@@ -5,4 +5,5 @@ var exports;
 var performance;
 var createImageBitmap;
 var WebGL2RenderingContext;
+var WebGL2ComputeRenderingContext;
 var XRWebGLLayer;


### PR DESCRIPTION
I wrote an experimental example to use WebGL2ComputeRenderingContext: https://github.com/hsimpson/three_particles

To have WebGL 2 detected I have to use the detection of the WebGL2ComputeRenderingContext in three.js