### PR TITLE
Added  parameter to raycaster.intersectObject/s

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -42,9 +42,9 @@ function ascSort( a, b ) {
 
 }
 
-function intersectObject( object, raycaster, intersects, recursive ) {
+function intersectObject( object, raycaster, intersects, recursive, ignoreVisibility ) {
 
-	if ( object.visible === false ) return;
+	if ( ignoreVisibility !== true && object.visible === false ) return;
 
 	object.raycast( raycaster, intersects );
 
@@ -54,7 +54,7 @@ function intersectObject( object, raycaster, intersects, recursive ) {
 
 		for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-			intersectObject( children[ i ], raycaster, intersects, true );
+			intersectObject( children[ i ], raycaster, intersects, true, ignoreVisibility );
 
 		}
 
@@ -96,11 +96,11 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObject: function ( object, recursive, optionalTarget ) {
+	intersectObject: function ( object, recursive, optionalTarget, ignoreVisibility ) {
 
 		var intersects = optionalTarget || [];
 
-		intersectObject( object, this, intersects, recursive );
+		intersectObject( object, this, intersects, recursive, ignoreVisibility );
 
 		intersects.sort( ascSort );
 
@@ -108,7 +108,7 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObjects: function ( objects, recursive, optionalTarget ) {
+	intersectObjects: function ( objects, recursive, optionalTarget, ignoreVisibility ) {
 
 		var intersects = optionalTarget || [];
 
@@ -121,7 +121,7 @@ Object.assign( Raycaster.prototype, {
 
 		for ( var i = 0, l = objects.length; i < l; i ++ ) {
 
-			intersectObject( objects[ i ], this, intersects, recursive );
+			intersectObject( objects[ i ], this, intersects, recursive, ignoreVisibility );
 
 		}
 


### PR DESCRIPTION
Many times I have been facing this issue and I just hacked the raycaster code. Basically you have a scene with one mesh as a collider, but you have it invisible but you still want to do raycasting against it.
I added an `ignoreVisibility` parameter, if `true` it will just skip the `object.visible === false` check, otherwise it will act as till now.

Maybe we could also transform the extra/optional parameters as an object:
```javascript
intersectObject( object, raycaster, params ) {}

intersectObject( object, raycaster, {
  intersects: intersects,
  recursive: false,
  ignoreVisibility: true
});
```