### PR TITLE
ShaderChunks: Fix orthographic view direction

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1785,6 +1785,16 @@ function WebGLRenderer( parameters ) {
 				material.isMeshLambertMaterial ||
 				material.isMeshBasicMaterial ||
 				material.isMeshStandardMaterial ||
+				material.isShaderMaterial ) {
+
+				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
+
+			}
+
+			if ( material.isMeshPhongMaterial ||
+				material.isMeshLambertMaterial ||
+				material.isMeshBasicMaterial ||
+				material.isMeshStandardMaterial ||
 				material.isShaderMaterial ||
 				material.skinning ) {
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -7,7 +7,7 @@ export default /* glsl */`
 		
 		if ( isOrthographic ) {
 
-			cameraToFrag = normalize( vec3( -viewMatrix[ 0 ][ 2 ], -viewMatrix[ 1 ][ 2 ], -viewMatrix[ 2 ][ 2 ] ) );
+			cameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );
 
 		}  else {
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -3,18 +3,28 @@ export default /* glsl */`
 
 	#ifdef ENV_WORLDPOS
 
-		vec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );
+		vec3 cameraToFrag;
+		
+		if ( isOrthographic ) {
+
+			cameraToFrag = normalize( vec3( -viewMatrix[0][2], -viewMatrix[1][2], -viewMatrix[2][2] ) );
+
+		}  else {
+
+			cameraToFrag = normalize( vWorldPosition - cameraPosition );
+
+		}
 
 		// Transforming Normal Vectors with the Inverse Transformation
 		vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
 
 		#ifdef ENVMAP_MODE_REFLECTION
 
-			vec3 reflectVec = reflect( cameraToVertex, worldNormal );
+			vec3 reflectVec = reflect( cameraToFrag, worldNormal );
 
 		#else
 
-			vec3 reflectVec = refract( cameraToVertex, worldNormal, refractionRatio );
+			vec3 reflectVec = refract( cameraToFrag, worldNormal, refractionRatio );
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -7,7 +7,7 @@ export default /* glsl */`
 		
 		if ( isOrthographic ) {
 
-			cameraToFrag = normalize( vec3( -viewMatrix[0][2], -viewMatrix[1][2], -viewMatrix[2][2] ) );
+			cameraToFrag = normalize( vec3( -viewMatrix[ 0 ][ 2 ], -viewMatrix[ 1 ][ 2 ], -viewMatrix[ 2 ][ 2 ] ) );
 
 		}  else {
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
@@ -7,7 +7,17 @@ export default /* glsl */`
 
 	#else
 
-		vec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
+		vec3 cameraToVertex;
+
+		if ( isOrthographic ) { 
+
+			cameraToVertex = normalize( vec3( -viewMatrix[0][2], -viewMatrix[1][2], -viewMatrix[2][2] ) );
+
+		} else {
+
+			cameraToVertex = normalize( worldPosition.xyz - cameraPosition );
+
+		}
 
 		vec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
@@ -11,7 +11,7 @@ export default /* glsl */`
 
 		if ( isOrthographic ) { 
 
-			cameraToVertex = normalize( vec3( -viewMatrix[0][2], -viewMatrix[1][2], -viewMatrix[2][2] ) );
+			cameraToVertex = normalize( vec3( -viewMatrix[ 0 ][ 2 ], -viewMatrix[ 1 ][ 2 ], -viewMatrix[ 2 ][ 2 ] ) );
 
 		} else {
 

--- a/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_vertex.glsl.js
@@ -11,7 +11,7 @@ export default /* glsl */`
 
 		if ( isOrthographic ) { 
 
-			cameraToVertex = normalize( vec3( -viewMatrix[ 0 ][ 2 ], -viewMatrix[ 1 ][ 2 ], -viewMatrix[ 2 ][ 2 ] ) );
+			cameraToVertex = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );
 
 		} else {
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -18,7 +18,7 @@ GeometricContext geometry;
 
 geometry.position = - vViewPosition;
 geometry.normal = normal;
-geometry.viewDir = normalize( vViewPosition );
+geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
 #ifdef CLEARCOAT
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
@@ -4,7 +4,7 @@ vec3 diffuse = vec3( 1.0 );
 GeometricContext geometry;
 geometry.position = mvPosition.xyz;
 geometry.normal = normalize( transformedNormal );
-geometry.viewDir = normalize( -mvPosition.xyz );
+geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( -mvPosition.xyz );
 
 GeometricContext backGeometry;
 backGeometry.position = geometry.position;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -495,6 +495,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 			'uniform mat4 viewMatrix;',
 			'uniform mat3 normalMatrix;',
 			'uniform vec3 cameraPosition;',
+			'uniform bool isOrthographic;',
 
 			'#ifdef USE_INSTANCING',
 
@@ -617,6 +618,7 @@ function WebGLProgram( renderer, extensions, code, material, shader, parameters 
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',
+			'uniform bool isOrthographic;',
 
 			( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
 			( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below


### PR DESCRIPTION
Fixes #17379.

Based on #17662.

Adds `isOrthographic`uniform only for light/view dependant built-in materials.
Correctly handles view direction for orthographic projection, specular lighting and environment maps.