### PR TITLE
DataTextureLoader: changed default minFilter

### DIFF
--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -52,7 +52,7 @@ DataTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), 
 			texture.wrapT = texData.wrapT !== undefined ? texData.wrapT : ClampToEdgeWrapping;
 
 			texture.magFilter = texData.magFilter !== undefined ? texData.magFilter : LinearFilter;
-			texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearMipmapLinearFilter;
+			texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearFilter;
 
 			texture.anisotropy = texData.anisotropy !== undefined ? texData.anisotropy : 1;
 
@@ -70,6 +70,7 @@ DataTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), 
 			if ( texData.mipmaps !== undefined ) {
 
 				texture.mipmaps = texData.mipmaps;
+				texture.minFilter = LinearMipmapLinearFilter; // presumably...
 
 			}
 


### PR DESCRIPTION
`DataTexture.generateMipmaps` defaults to `false`. Also, a data texture is not necessarily a POT.

Setting `minFilter` to `LinearFilter` is consistent with the other settings.