### PR TITLE
updated TS and docs for shadows

### DIFF
--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -73,7 +73,9 @@
 			Setting this to values greater than 1 will blur the edges of the shadow.<br />
 
 			High values will cause unwanted banding effects in the shadows - a greater [page:.mapSize mapSize]
-			will allow for a higher value to be used here before these effects become visible.<br /><br />
+			will allow for a higher value to be used here before these effects become visible.<br />
+			If [page:WebGLRenderer.shadowMap.type] is set to [page:Renderer PCFSoftShadowMap], it is recommended to
+			leave radius at 1 and increase softness by decreasing [page:.mapSize mapSize] instead.<br /><br />
 
 			Note that this has no effect if the [page:WebGLRenderer.shadowMap.type] is set to [page:Renderer BasicShadowMap].
 		</p>
@@ -86,13 +88,11 @@
 		Used internally by the renderer to extend the shadow map to contain all viewports
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light], [param:Camera viewCamera], [param:number viewportIndex])</h3>
+		<h3>[method:null updateMatrices]( [param:Light light] )</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 
-		light -- the light for which the shadow is being rendered.<br />
-		viewCamera -- the camera view for which the shadow is being rendered.<br />
-		viewportIndex -- calculates the matrix for this viewport
+		light -- the light for which the shadow is being rendered.
 		</p>
 
 		<h3>[method:Frustum getFrustum]()</h3>

--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -70,6 +70,15 @@ scene.add( helper );
 		</p>
 
 		<h2>Methods</h2>
+		
+		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
+		<p>
+		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
+
+		light -- the light for which the shadow is being rendered.<br />
+		viewportIndex -- calculates the matrix for this viewport
+		</p>
+
 		<p>
 			See the base [page:LightShadow LightShadow] class for common methods.
 		</p>

--- a/docs/api/zh/lights/shadows/LightShadow.html
+++ b/docs/api/zh/lights/shadows/LightShadow.html
@@ -83,13 +83,11 @@
 		Used internally by the renderer to extend the shadow map to contain all viewports
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light], [param:Camera viewCamera], [param:number viewportIndex])</h3>
+		<h3>[method:null updateMatrices]( [param:Light light] )</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 
-		light -- the light for which the shadow is being rendered.<br />
-		viewCamera -- the camera view for which the shadow is being rendered.<br />
-		viewportIndex -- calculates the matrix for this viewport
+		light -- the light for which the shadow is being rendered.
 		</p>
 
 		<h3>[method:Frustum getFrustum]()</h3>

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -69,6 +69,15 @@ scene.add( helper );
 		</p>
 
 		<h2>方法</h2>
+
+		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
+		<p>
+		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
+
+		light -- the light for which the shadow is being rendered.<br />
+		viewportIndex -- calculates the matrix for this viewport
+		</p>
+		
 		<p>
 			共有方法请参见其基类[page:LightShadow LightShadow]。
 		</p>

--- a/src/lights/DirectionalLightShadow.js
+++ b/src/lights/DirectionalLightShadow.js
@@ -17,9 +17,9 @@ DirectionalLightShadow.prototype = Object.assign( Object.create( LightShadow.pro
 
 	isDirectionalLightShadow: true,
 
-	updateMatrices: function ( light, viewCamera, viewportIndex ) {
+	updateMatrices: function ( light ) {
 
-		LightShadow.prototype.updateMatrices.call( this, light, viewCamera, viewportIndex );
+		LightShadow.prototype.updateMatrices.call( this, light );
 
 	}
 

--- a/src/lights/LightShadow.d.ts
+++ b/src/lights/LightShadow.d.ts
@@ -21,7 +21,7 @@ export class LightShadow {
 	clone( recursive?: boolean ): this;
 	toJSON(): any;
 	getFrustum(): number;
-	updateMatrices( light: Light ): void;
+	updateMatrices( light: Light, viewportIndex?: number ): void;
 	getViewport( viewportIndex: number ): Vector4;
 	getFrameExtents(): Vector2;
 

--- a/src/lights/LightShadow.d.ts
+++ b/src/lights/LightShadow.d.ts
@@ -21,7 +21,7 @@ export class LightShadow {
 	clone( recursive?: boolean ): this;
 	toJSON(): any;
 	getFrustum(): number;
-	updateMatrices( light: Light, viewCamera: Camera, viewportIndex: number ): void;
+	updateMatrices( light: Light ): void;
 	getViewport( viewportIndex: number ): Vector4;
 	getFrameExtents(): Vector2;
 

--- a/src/lights/PointLightShadow.d.ts
+++ b/src/lights/PointLightShadow.d.ts
@@ -5,6 +5,4 @@ export class PointLightShadow extends LightShadow {
 
 	camera: PerspectiveCamera;
 
-	updateMatrices( light: Light, viewportIndex: number ): void;
-
 }

--- a/src/lights/PointLightShadow.d.ts
+++ b/src/lights/PointLightShadow.d.ts
@@ -5,4 +5,6 @@ export class PointLightShadow extends LightShadow {
 
 	camera: PerspectiveCamera;
 
+	updateMatrices( light: Light, viewportIndex: number ): void;
+
 }

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -58,7 +58,7 @@ PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype
 
 	isPointLightShadow: true,
 
-	updateMatrices: function ( light, viewportIndex ) {
+	updateMatrices: function ( light, viewportIndex = 0 ) {
 
 		var camera = this.camera,
 			shadowMatrix = this.matrix,

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -58,7 +58,9 @@ PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype
 
 	isPointLightShadow: true,
 
-	updateMatrices: function ( light, viewportIndex = 0 ) {
+	updateMatrices: function ( light, viewportIndex ) {
+
+		if ( viewportIndex === undefined ) viewportIndex = 0;
 
 		var camera = this.camera,
 			shadowMatrix = this.matrix,

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -58,7 +58,7 @@ PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype
 
 	isPointLightShadow: true,
 
-	updateMatrices: function ( light, viewCamera, viewportIndex ) {
+	updateMatrices: function ( light, viewportIndex ) {
 
 		var camera = this.camera,
 			shadowMatrix = this.matrix,

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -18,7 +18,7 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 
 	isSpotLightShadow: true,
 
-	updateMatrices: function ( light, viewCamera, viewportIndex ) {
+	updateMatrices: function ( light ) {
 
 		var camera = this.camera;
 
@@ -35,7 +35,7 @@ SpotLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype 
 
 		}
 
-		LightShadow.prototype.updateMatrices.call( this, light, viewCamera, viewportIndex );
+		LightShadow.prototype.updateMatrices.call( this, light );
 
 	}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -181,7 +181,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				_state.viewport( _viewport );
 
-				shadow.updateMatrices( light, camera, vp );
+				shadow.updateMatrices( light, vp );
 
 				_frustum = shadow.getFrustum();
 


### PR DESCRIPTION
In using Three's shadows in `<model-viewer>`, I found some issues with the TS signature of updateMatrices, which I've resolved here. I also updated the docs to represent that it's really best to leave radius at 1 when using PCFSoftShadowMap, as that completely avoids banding and actually does a pretty nice job when the resolution is reduced (I'm liking 64x64 personally, assuming the shadowMap roughly fills the viewport).