### PR TITLE
Persp/Orhto Camera: Added .set() methods.

### DIFF
--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -130,6 +130,11 @@ scene.add( camera );</code>
 		Updates the camera projection matrix. Must be called after any change of parameters.
 		</p>
 
+		<h3>[method:OrthographicCamera set]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far], [param:Float zoom], [param:Object view] )</h3>
+		<p>
+		Sets the properties of this orthographic camera and updates the projection matrix.
+		</p>
+
 		<h3>[method:Object toJSON]([param:object meta])</h3>
 		<p>
 		meta -- object containing metadata such as textures or images in objects' descendants.<br />

--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -190,6 +190,11 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 		Updates the camera projection matrix. Must be called after any change of parameters.
 		</p>
 
+		<h3>[method:PerspectiveCamera set]( [param:Float fov], [param:Float aspect], [param:Float near], [param:Float far], [param:Float zoom], [param:Object view], [param:Float focus], [param:Float filmGauge], [param:Float filmOffset] )</h3>
+		<p>
+		Sets the properties of this perspective camera and updates the projection matrix.
+		</p>
+
 		<h3>[method:Object toJSON]([param:object meta])</h3>
 		<p>
 		meta -- object containing metadata such as textures or images in objects' descendants.<br />

--- a/docs/api/zh/cameras/OrthographicCamera.html
+++ b/docs/api/zh/cameras/OrthographicCamera.html
@@ -137,6 +137,11 @@ scene.add( camera );</code>
 
 		</p>
 
+		<h3>[method:OrthographicCamera set]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far], [param:Float zoom], [param:Object view] )</h3>
+		<p>
+		Sets the properties of this orthographic camera and updates the projection matrix.
+		</p>
+
 		<h3>[method:Object toJSON]([param:object meta])</h3>
 		<p>
 		meta -- 包含有元数据的对象，例如对象后代中的纹理或图像<br />

--- a/docs/api/zh/cameras/PerspectiveCamera.html
+++ b/docs/api/zh/cameras/PerspectiveCamera.html
@@ -185,6 +185,12 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 		更新摄像机投影矩阵。在任何参数被改变以后必须被调用。
 		</p>
 
+		<h3>[method:PerspectiveCamera set]( [param:Float fov], [param:Float aspect], [param:Float near], [param:Float far], [param:Float zoom], [param:Object view], [param:Float focus], [param:Float filmGauge], [param:Float filmOffset] )</h3>
+		<p>
+		Sets the properties of this perspective camera and updates the projection matrix.
+		</p>
+
+
 		<h3>[method:Object toJSON]([param:object meta])</h3>
 		<p>
 		meta -- 包含有元数据的对象，例如对象后代中的纹理或图像<br />

--- a/src/cameras/OrthographicCamera.d.ts
+++ b/src/cameras/OrthographicCamera.d.ts
@@ -73,6 +73,7 @@ export class OrthographicCamera extends Camera {
 	 */
 	far: number;
 
+	set( left: number, right: number, top: number, bottom: number, near: number, far: number, zoom: number, view: object ): this;
 	/**
 	 * Updates the camera projection matrix. Must be called after change of parameters.
 	 */

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -33,6 +33,25 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	isOrthographicCamera: true,
 
+	set: function ( left, right, top, bottom, near, far, zoom, view ) {
+
+		this.zoom = zoom;
+		this.view = view;
+
+		this.left = left;
+		this.right = right;
+		this.top = top;
+		this.bottom = bottom;
+
+		this.near = near;
+		this.far = far;
+
+		this.updateProjectionMatrix();
+
+		return this;
+
+	},
+
 	copy: function ( source, recursive ) {
 
 		Camera.prototype.copy.call( this, source, recursive );

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -35,16 +35,16 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 	set: function ( left, right, top, bottom, near, far, zoom, view ) {
 
-		this.zoom = zoom;
-		this.view = view;
+		if ( left !== undefined ) this.left = left;
+		if ( right !== undefined ) this.right = right;
+		if ( top !== undefined ) this.top = top;
+		if ( bottom !== undefined ) this.bottom = bottom;
 
-		this.left = left;
-		this.right = right;
-		this.top = top;
-		this.bottom = bottom;
+		if ( near !== undefined ) this.near = near;
+		if ( far !== undefined ) this.far = far;
 
-		this.near = near;
-		this.far = far;
+		if ( zoom !== undefined ) this.zoom = zoom;
+		if ( view !== undefined ) this.view = view;
 
 		this.updateProjectionMatrix();
 

--- a/src/cameras/PerspectiveCamera.d.ts
+++ b/src/cameras/PerspectiveCamera.d.ts
@@ -54,6 +54,7 @@ export class PerspectiveCamera extends Camera {
 	filmGauge: number;
 	filmOffset: number;
 
+	set( fov: number, aspect: number, near: number, far: number, zoom: number, view: object, focus: number, filmGauge: number, filmOffset: number ): this;
 	setFocalLength( focalLength: number ): void;
 	getFocalLength(): number;
 	getEffectiveFOV(): number;

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -38,6 +38,27 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	isPerspectiveCamera: true,
 
+	set: function ( fov, aspect, near, far, zoom, view, focus, filmGauge, filmOffset ) {
+
+		this.fov = fov;
+		this.zoom = zoom;
+
+		this.near = near;
+		this.far = far;
+		this.focus = focus;
+
+		this.aspect = aspect;
+		this.view = view;
+
+		this.filmGauge = filmGauge;
+		this.filmOffset = filmOffset;
+
+		this.updateProjectionMatrix();
+
+		return this;
+
+	},
+
 	copy: function ( source, recursive ) {
 
 		Camera.prototype.copy.call( this, source, recursive );

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -40,18 +40,17 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	set: function ( fov, aspect, near, far, zoom, view, focus, filmGauge, filmOffset ) {
 
-		this.fov = fov;
-		this.zoom = zoom;
+		if ( fov !== undefined ) this.fov = fov;
+		if ( aspect !== undefined ) this.aspect = aspect;
+		if ( near !== undefined ) this.near = near;
+		if ( far !== undefined ) this.far = far;
 
-		this.near = near;
-		this.far = far;
-		this.focus = focus;
+		if ( zoom !== undefined ) this.zoom = zoom;
+		if ( view !== undefined ) this.view = view;
 
-		this.aspect = aspect;
-		this.view = view;
-
-		this.filmGauge = filmGauge;
-		this.filmOffset = filmOffset;
+		if ( focus !== undefined ) this.focus = focus;
+		if ( filmGauge !== undefined ) this.filmGauge = filmGauge;
+		if ( filmOffset !== undefined ) this.filmOffset = filmOffset;
 
 		this.updateProjectionMatrix();
 


### PR DESCRIPTION
see #15043

@mrdoob I've honored all properties in `set()` for consistency reasons (because the math classes also do so). Do you think certain parameters are unnecessary?