### PR TITLE
Material: added vertexTangents to material clone

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -346,6 +346,7 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.blending = source.blending;
 		this.side = source.side;
 		this.flatShading = source.flatShading;
+		this.vertexTangents = source.vertexTangents;
 		this.vertexColors = source.vertexColors;
 
 		this.opacity = source.opacity;
@@ -362,7 +363,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.depthTest = source.depthTest;
 		this.depthWrite = source.depthWrite;
 
-		this.stencilWrite = source.stencilWrite;
 		this.stencilWriteMask = source.stencilWriteMask;
 		this.stencilFunc = source.stencilFunc;
 		this.stencilRef = source.stencilRef;
@@ -370,6 +370,26 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.stencilFail = source.stencilFail;
 		this.stencilZFail = source.stencilZFail;
 		this.stencilZPass = source.stencilZPass;
+		this.stencilWrite = source.stencilWrite;
+
+		var srcPlanes = source.clippingPlanes,
+			dstPlanes = null;
+
+		if ( srcPlanes !== null ) {
+
+			var n = srcPlanes.length;
+			dstPlanes = new Array( n );
+
+			for ( var i = 0; i !== n; ++ i )
+				dstPlanes[ i ] = srcPlanes[ i ].clone();
+
+		}
+
+		this.clippingPlanes = dstPlanes;
+		this.clipIntersection = source.clipIntersection;
+		this.clipShadows = source.clipShadows;
+
+		this.shadowSide = source.shadowSide;
 
 		this.colorWrite = source.colorWrite;
 
@@ -389,26 +409,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.toneMapped = source.toneMapped;
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
-
-		this.clipShadows = source.clipShadows;
-		this.clipIntersection = source.clipIntersection;
-
-		var srcPlanes = source.clippingPlanes,
-			dstPlanes = null;
-
-		if ( srcPlanes !== null ) {
-
-			var n = srcPlanes.length;
-			dstPlanes = new Array( n );
-
-			for ( var i = 0; i !== n; ++ i )
-				dstPlanes[ i ] = srcPlanes[ i ].clone();
-
-		}
-
-		this.clippingPlanes = dstPlanes;
-
-		this.shadowSide = source.shadowSide;
 
 		return this;
 


### PR DESCRIPTION
In looking into #11438, I found part of the problem I was seeing was due to supplied tangents not being used at all, which was because vertexTangents wasn't being cloned. In addition to fixing that, I changed the order of the cloned parameters to match the constructor to hopefully make it easier to find ones that are missing in the future.