### PR TITLE
EXRLoader: added load() method

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -85,13 +85,6 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 	constructor: THREE.EXRLoader,
 
-	setDataType: function ( value ) {
-
-		this.type = value;
-		return this;
-
-	},
-
 	parse: function ( buffer ) {
 
 		const USHORT_RANGE = ( 1 << 16 );
@@ -1230,6 +1223,47 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			format: EXRHeader.channels.length == 4 ? THREE.RGBAFormat : THREE.RGBFormat,
 			type: this.type
 		};
+
+	},
+
+	setDataType: function ( value ) {
+
+		this.type = value;
+		return this;
+
+	},
+
+	load: function ( url, onLoad, onProgress, onError ) {
+
+		function onLoadCallback( texture, texData ) {
+
+			switch ( texture.type ) {
+
+				case THREE.FloatType:
+
+					texture.encoding = THREE.LinearEncoding;
+					texture.minFilter = THREE.LinearFilter;
+					texture.magFilter = THREE.LinearFilter;
+					texture.generateMipmaps = false;
+					texture.flipY = false;
+					break;
+
+				case THREE.HalfFloatType:
+
+					texture.encoding = THREE.LinearEncoding;
+					texture.minFilter = THREE.LinearFilter;
+					texture.magFilter = THREE.LinearFilter;
+					texture.generateMipmaps = false;
+					texture.flipY = false;
+					break;
+
+			}
+
+			if ( onLoad ) onLoad( texture, texData );
+
+		}
+
+		return THREE.DataTextureLoader.prototype.load.call( this, url, onLoadCallback, onProgress, onError );
 
 	}
 

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -51,17 +51,15 @@
 					.setDataType( THREE.FloatType )
 					.load( 'textures/memorial.exr', function ( texture, textureData ) {
 
+						// memorial.exr is NPOT
+
 						//console.log( textureData );
 						//console.log( texture );
 
-						texture.minFilter = THREE.NearestFilter;
-						texture.magFilter = THREE.NearestFilter;
-
-						// these setting are currently set correctly by default
-						//texture.encoding = LinearEncoding;
-						//texture.minFilter = LinearMipmapLinearFilter;
+						// EXRLoader sets these default settings
+						//texture.generateMipmaps = false;
+						//texture.minFilter = LinearFilter;
 						//texture.magFilter = LinearFilter;
-						//texture.flipY = true;
 
 						var material = new THREE.MeshBasicMaterial( { map: texture } );
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -77,10 +77,13 @@
 					.setDataType( THREE.FloatType )
 					.load( 'textures/piz_compressed.exr', function ( texture ) {
 
-						texture.minFilter = THREE.NearestFilter;
-						texture.encoding = THREE.LinearEncoding;
+						var options = {
+							generateMipmaps: false,
+							minFilter: THREE.LinearFilter,
+							magFilter: THREE.LinearFilter
+						};
 
-						exrBackground = new THREE.WebGLRenderTargetCube( 512, 512 ).fromEquirectangularTexture( renderer, texture );
+						exrBackground = new THREE.WebGLRenderTargetCube( 512, 512, options ).fromEquirectangularTexture( renderer, texture );
 
 						var pmremGenerator = new PMREMGenerator( exrBackground.texture );
 						pmremGenerator.update( renderer );


### PR DESCRIPTION
Improves `EXRLoader` by setting more reasonable texture parameters.

I have modified the relevant examples, too. We will just have to see how how well this works --  or if there are device issues.
