### PR TITLE
Line2 Example: Remove copy function overrides

### DIFF
--- a/examples/js/lines/Line2.js
+++ b/examples/js/lines/Line2.js
@@ -18,14 +18,6 @@ THREE.Line2.prototype = Object.assign( Object.create( THREE.LineSegments2.protot
 
 	constructor: THREE.Line2,
 
-	isLine2: true,
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	isLine2: true
 
 } );

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -381,9 +381,13 @@ THREE.LineMaterial.prototype.copy = function ( source ) {
 
 	this.linewidth = source.linewidth;
 
-	this.resolution = source.resolution;
+	this.dashScale = source.dashScale;
 
-	// todo
+	this.dashSize = source.dashSize;
+
+	this.gapSize = source.gapSize;
+
+	this.resolution = source.resolution;
 
 	return this;
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -373,23 +373,3 @@ THREE.LineMaterial.prototype.constructor = THREE.LineMaterial;
 
 THREE.LineMaterial.prototype.isLineMaterial = true;
 
-THREE.LineMaterial.prototype.copy = function ( source ) {
-
-	THREE.ShaderMaterial.prototype.copy.call( this, source );
-
-	this.color.copy( source.color );
-
-	this.linewidth = source.linewidth;
-
-	this.dashScale = source.dashScale;
-
-	this.dashSize = source.dashSize;
-
-	this.gapSize = source.gapSize;
-
-	this.resolution = source.resolution;
-
-	return this;
-
-};
-

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -52,14 +52,6 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 
 		};
 
-	}() ),
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	}() )
 
 } );

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -239,20 +239,6 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		// todo
 
-	},
-
-	clone: function () {
-
-		// todo
-
-	},
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
 	}
 
 } );

--- a/examples/js/lines/Wireframe.js
+++ b/examples/js/lines/Wireframe.js
@@ -52,14 +52,6 @@ THREE.Wireframe.prototype = Object.assign( Object.create( THREE.Mesh.prototype )
 
 		};
 
-	}() ),
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	}() )
 
 } );

--- a/examples/js/lines/WireframeGeometry2.js
+++ b/examples/js/lines/WireframeGeometry2.js
@@ -19,14 +19,6 @@ THREE.WireframeGeometry2.prototype = Object.assign( Object.create( THREE.LineSeg
 
 	constructor: THREE.WireframeGeometry2,
 
-	isWireframeGeometry2: true,
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	isWireframeGeometry2: true
 
 } );

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -23,15 +23,7 @@ Line2.prototype = Object.assign( Object.create( LineSegments2.prototype ), {
 
 	constructor: Line2,
 
-	isLine2: true,
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	isLine2: true
 
 } );
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -389,9 +389,13 @@ LineMaterial.prototype.copy = function ( source ) {
 
 	this.linewidth = source.linewidth;
 
-	this.resolution = source.resolution;
+	this.dashScale = source.dashScale;
 
-	// todo
+	this.dashSize = source.dashSize;
+
+	this.gapSize = source.gapSize;
+
+	this.resolution = source.resolution;
 
 	return this;
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -381,25 +381,5 @@ LineMaterial.prototype.constructor = LineMaterial;
 
 LineMaterial.prototype.isLineMaterial = true;
 
-LineMaterial.prototype.copy = function ( source ) {
-
-	ShaderMaterial.prototype.copy.call( this, source );
-
-	this.color.copy( source.color );
-
-	this.linewidth = source.linewidth;
-
-	this.dashScale = source.dashScale;
-
-	this.dashSize = source.dashSize;
-
-	this.gapSize = source.gapSize;
-
-	this.resolution = source.resolution;
-
-	return this;
-
-};
-
 
 export { LineMaterial };

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -61,15 +61,7 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		};
 
-	}() ),
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	}() )
 
 } );
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -250,20 +250,6 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		// todo
 
-	},
-
-	clone: function () {
-
-		// todo
-
-	},
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
 	}
 
 } );

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -61,15 +61,7 @@ Wireframe.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		};
 
-	}() ),
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	}() )
 
 } );
 

--- a/examples/jsm/lines/WireframeGeometry2.js
+++ b/examples/jsm/lines/WireframeGeometry2.js
@@ -24,15 +24,7 @@ WireframeGeometry2.prototype = Object.assign( Object.create( LineSegmentsGeometr
 
 	constructor: WireframeGeometry2,
 
-	isWireframeGeometry2: true,
-
-	copy: function ( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
+	isWireframeGeometry2: true
 
 } );
 


### PR DESCRIPTION
I'm planning to finish out some of the example Line2 implementation and eventually add a proper raycast function to the object, as well.

This PR starts by removing some unnecessary no op copy function overrides so that the copy implementation behaves like other `Mesh` sub classes. I couldn't see any reason why the line object implementations should need a special handling for copy but please correct me if I'm wrong!

~It also adds support for some missing fields to the `LineMaterial` copy function.~

@WestLangley