### PR TITLE
3MFLoader: Add basic support for textures.

### DIFF
--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -62,7 +62,9 @@
 
 				//
 
-				var loader = new ThreeMFLoader();
+				var manager = new THREE.LoadingManager();
+
+				var loader = new ThreeMFLoader( manager );
 				loader.load( './models/3mf/truck.3mf', function ( object ) {
 
 					object.quaternion.setFromEuler( new THREE.Euler( - Math.PI / 2, 0, 0 ) ); 	// z-up conversion
@@ -75,9 +77,15 @@
 
 					scene.add( object );
 
+				} );
+
+				//
+
+				manager.onLoad = function () {
+
 					render();
 
-				} );
+				};
 
 				//
 


### PR DESCRIPTION
This PR adds support for the 3MF Materials and Properties Extension _Texture 2D_ and _Texture 2D Groups_.

That means the loader can now parse texture coordinates and diffuse textures. The existing `truck.3mf` model already contains a texture which is now correctly loaded. Besides, the missing texture in #17780 does also show up after this change.

#17780 is not yet completely solved since the model also contains a specular texture which is not parsed so far. 3MF defines specular textures as color textures whereas in `three.js` they are just grayscale textures (#7290). So even if the loader parses the texture and adds it to the material, the visual result will be different.