### PR TITLE
Allow TrackballControls to work in a static scene like OrbitControls does

### DIFF
--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -16,6 +16,8 @@
 			<p>
 				[name] is similar to [page:OrbitControls]. However, it does not maintain a constant camera [page:Object3D.up up] vector.
 				That means if the camera orbits over the “north” and “south” poles, it does not flip to stay "right side up".
+				
+				If using [name] in a static scene, make sure to disable the damping effect by setting [page:.staticMoving staticMoving] to *true*.
 			</p>
 		</p>
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -515,6 +515,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 			_panEnd.copy( getMouseOnScreen( event.pageX, event.pageY ) );
 
 		}
+		
+		_this.update();
 
 	}
 
@@ -563,6 +565,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		_this.dispatchEvent( startEvent );
 		_this.dispatchEvent( endEvent );
+		_this.update();
 
 	}
 
@@ -623,6 +626,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 				break;
 
 		}
+		
+		_this.update();
 
 	}
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -523,6 +523,8 @@ var TrackballControls = function ( object, domElement ) {
 			_panEnd.copy( getMouseOnScreen( event.pageX, event.pageY ) );
 
 		}
+		
+		_this.update();
 
 	}
 
@@ -571,6 +573,7 @@ var TrackballControls = function ( object, domElement ) {
 
 		_this.dispatchEvent( startEvent );
 		_this.dispatchEvent( endEvent );
+		_this.update();
 
 	}
 
@@ -631,6 +634,8 @@ var TrackballControls = function ( object, domElement ) {
 				break;
 
 		}
+		
+		_this.update();
 
 	}
 


### PR DESCRIPTION
Adds `_this.update()` to `mousewheel()`, `mousemove()` and `touchmove()` events in `TrackballControls`.

From the documentation, TrackballControls and OrbitControls look like they're drop-in replacements for one another, they both have the same constructor, etc. However, unlike OrbitControls, TrackballControls does not work in a static scene with no animation loop present.

See this [Stack Overflow thread](https://stackoverflow.com/questions/28746354/trackballcontrols-change-events) for a discussion.

PR would allow TrackballControls to work in static scenes.