### PR TITLE
Mesh: Add drawMode warning in .raycast().

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -165,6 +165,15 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		}
 
+		// check unsupported draw modes
+
+		if ( this.drawMode !== TrianglesDrawMode ) {
+
+			console.warn( 'THREE.Mesh: TriangleStripDrawMode and TriangleFanDrawMode are not supported by .raycast().' );
+			return;
+
+		}
+
 		var intersection;
 
 		if ( geometry.isBufferGeometry ) {


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/issues/9869#issuecomment-545348705

The idea is to warn users if they are going to use `Mesh.raycast()` with an unsupported draw mode.