### PR TITLE
Fix simultaneous usage of clearcoat and tangent data

### DIFF
--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
@@ -1,16 +1,17 @@
 export default /* glsl */`
 #ifdef USE_CLEARCOAT_NORMALMAP
 
+	vec3 clearcoatMapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
+	clearcoatMapN.xy *= clearcoatNormalScale;
+
 	#ifdef USE_TANGENT
 
-		mat3 vTBN = mat3( tangent, bitangent, clearcoatNormal );
-		vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
-		mapN.xy = clearcoatNormalScale * mapN.xy;
-		clearcoatNormal = normalize( vTBN * mapN );
+		mat3 vClearcoatTBN = mat3( tangent, bitangent, clearcoatNormal );
+		clearcoatNormal = normalize( vClearcoatTBN * clearcoatMapN );
 
 	#else
 
-		clearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatNormalScale, clearcoatNormalMap );
+		clearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatMapN );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_CLEARCOAT_NORMALMAP
 
-	vec3 clearcoatMapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
+	vec3 clearcoatMapN = texture2D( clearcoatNormalMap, vUv ).xyz * 2.0 - 1.0;
 	clearcoatMapN.xy *= clearcoatNormalScale;
 
 	#ifdef USE_TANGENT

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
@@ -6,8 +6,7 @@ export default /* glsl */`
 
 	#ifdef USE_TANGENT
 
-		mat3 vClearcoatTBN = mat3( tangent, bitangent, clearcoatNormal );
-		clearcoatNormal = normalize( vClearcoatTBN * clearcoatMapN );
+		clearcoatNormal = normalize( vTBN * clearcoatMapN );
 
 	#else
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -29,6 +29,12 @@ export default /* glsl */`
 
 		#endif
 
+		#if defined( TANGENTSPACE_NORMALMAP ) || defined( USE_CLEARCOAT_NORMALMAP )
+
+			mat3 vTBN = mat3( tangent, bitangent, normal );
+
+		#endif
+
 	#endif
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -20,16 +20,17 @@ export default /* glsl */`
 
 #elif defined( TANGENTSPACE_NORMALMAP )
 
+	vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
+	mapN.xy *= normalScale;
+
 	#ifdef USE_TANGENT
 
 		mat3 vTBN = mat3( tangent, bitangent, normal );
-		vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
-		mapN.xy = normalScale * mapN.xy;
 		normal = normalize( vTBN * mapN );
 
 	#else
 
-		normal = perturbNormal2Arb( -vViewPosition, normal, normalScale, normalMap );
+		normal = perturbNormal2Arb( -vViewPosition, normal, mapN );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -25,7 +25,6 @@ export default /* glsl */`
 
 	#ifdef USE_TANGENT
 
-		mat3 vTBN = mat3( tangent, bitangent, normal );
 		normal = normalize( vTBN * mapN );
 
 	#else

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -17,7 +17,7 @@ export default /* glsl */`
 	// Per-Pixel Tangent Space Normal Mapping
 	// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
 
-	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec2 normalScale, in sampler2D normalMap ) {
+	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {
 
 		// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
@@ -31,10 +31,6 @@ export default /* glsl */`
 		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
 		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
 		vec3 N = normalize( surf_norm );
-
-		vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
-
-		mapN.xy *= normalScale;
 
 		#ifdef DOUBLE_SIDED
 


### PR DESCRIPTION
Clearcoat normals need to use temporary variable names that are different from regular normals so that there's no name conflict. This also moves sampling of the normal map outside of the normal perturbation helper function so that there isn't as much duplicate code.