### PR TITLE
rename export const from `VolumeShader` to `VolumeRenderShader1`

### DIFF
--- a/examples/jsm/shaders/VolumeShader.d.ts
+++ b/examples/jsm/shaders/VolumeShader.d.ts
@@ -2,7 +2,7 @@ import {
 	Uniform
 } from '../../../src/Three';
 
-export const VolumeShader: {
+export const VolumeRenderShader1: {
 	uniforms: {
 		u_size: Uniform;
 		u_renderstyle: Uniform;


### PR DESCRIPTION
exported const in `examples/jsm/shaders/VolumeShader.js` is `VolumeRenderShader1`, but is `VolumeShader` in `examples/jsm/shaders/VolumeShader.d.ts` , just rename it to make the them sync.