### PR TITLE
Examples: WebKit prevent <video> auto fullscreen iPhone.

### DIFF
--- a/examples/webgl_kinect.html
+++ b/examples/webgl_kinect.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 
-		<video id="video" loop muted crossOrigin="anonymous" webkit-playsinline style="display:none">
+		<video id="video" loop muted crossOrigin="anonymous" playsinline style="display:none">
 			<source src="textures/kinect.webm">
 			<source src="textures/kinect.mp4">
 		</video>

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -57,7 +57,7 @@
 			playing <a href="http://durian.blender.org/" target="_blank" rel="noopener">sintel</a> trailer
 		</div>
 
-		<video id="video" loop crossOrigin="anonymous" webkit-playsinline style="display:none">
+		<video id="video" loop crossOrigin="anonymous" playsinline style="display:none">
 			<source src="textures/sintel.ogv" type='video/ogg; codecs="theora, vorbis"'>
 			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
 		</video>

--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -13,7 +13,7 @@
 
 		<div id="container"></div>
 
-		<video id="video" loop muted crossOrigin="anonymous" webkit-playsinline style="display:none">
+		<video id="video" loop muted crossOrigin="anonymous" playsinline style="display:none">
 			<source src="textures/pano.webm">
 			<source src="textures/pano.mp4">
 		</video>

--- a/examples/webvr_video.html
+++ b/examples/webvr_video.html
@@ -18,7 +18,7 @@
 
 		<script src="js/vr/HelioWebXRPolyfill.js"></script>
 
-		<video id="video" loop muted crossOrigin="anonymous" webkit-playsinline style="display:none">
+		<video id="video" loop muted crossOrigin="anonymous" playsinline style="display:none">
 			<source src="textures/MaryOculus.webm">
 			<source src="textures/MaryOculus.mp4">
 		</video>


### PR DESCRIPTION
fixes https://github.com/mrdoob/three.js/issues/17757

based on https://github.com/mrdoob/three.js/issues/17757#issuecomment-548571257

Updates `webkit-playsinline` -> `playsinline` in order to prevent context hijack by iOS. Still waiting for others to confirm the patch fixes behavior across multiple devices, but it did work on my device.

[dev branch](https://rawcdn.githack.com/mrdoob/three.js/8cc6e04282021e3462260c788b0c5bcf32f52c1e/examples/webgl_materials_video.html)
[PR branch](https://rawcdn.githack.com/sciecode/three.js/4609001bebe140d21a96f55d1baf8949754dbaa8/examples/webgl_materials_video.html)