### PR TITLE
Batch shader

### DIFF
--- a/examples/js/shaders/BatchPhongShader.js
+++ b/examples/js/shaders/BatchPhongShader.js
@@ -1,0 +1,180 @@
+/**
+ * @author Min.H
+ *
+ * just for MeshPhongMaterial
+ *
+ * add batchMap,use map color decide the diffuse color, it cost more memory to cut draw call number.
+ */
+
+THREE.BatchPhongShader = {
+
+	uniforms: THREE.UniformsUtils.merge([
+
+		THREE.ShaderLib.phong.uniforms,
+
+		{
+			batchMap: {value: null},
+			batchWidth: {value: null}
+		}
+
+	]),
+
+	vertexShader: [
+		"#define PHONG",
+
+		"varying vec3 vViewPosition;",
+
+		"#ifndef FLAT_SHADED",
+			"varying vec3 vNormal;",
+		"#endif",
+
+		"#ifdef USE_BATCHMAP",
+			"uniform sampler2D batchMap;",
+			"attribute float batchId;",
+			"varying float vbatchId;",
+		"#endif",
+
+		THREE.ShaderChunk.common,
+		THREE.ShaderChunk.uv_pars_vertex,
+		THREE.ShaderChunk.uv2_pars_vertex,
+		THREE.ShaderChunk.displacementmap_pars_vertex,
+		THREE.ShaderChunk.envmap_pars_vertex,
+		THREE.ShaderChunk.color_pars_vertex,
+		THREE.ShaderChunk.fog_pars_vertex,
+		THREE.ShaderChunk.morphtarget_pars_vertex,
+		THREE.ShaderChunk.skinning_pars_vertex,
+		THREE.ShaderChunk.shadowmap_pars_vertex,
+		THREE.ShaderChunk.logdepthbuf_pars_vertex,
+		THREE.ShaderChunk.clipping_planes_pars_vertex,
+
+		"void main() {",
+
+			"#ifdef USE_BATCHMAP",
+				"vbatchId = batchId;",
+			"#endif",
+
+			THREE.ShaderChunk.uv_vertex,
+			THREE.ShaderChunk.uv2_vertex,
+			THREE.ShaderChunk.color_vertex,
+			THREE.ShaderChunk.beginnormal_vertex,
+			THREE.ShaderChunk.morphnormal_vertex,
+			THREE.ShaderChunk.skinbase_vertex,
+			THREE.ShaderChunk.skinnormal_vertex,
+			THREE.ShaderChunk.defaultnormal_vertex,
+
+			"#ifndef FLAT_SHADED",
+				"vNormal = normalize( transformedNormal );",
+			"#endif",
+
+			THREE.ShaderChunk.begin_vertex,
+			THREE.ShaderChunk.morphtarget_vertex,
+			THREE.ShaderChunk.skinning_vertex,
+			THREE.ShaderChunk.displacementmap_vertex,
+			THREE.ShaderChunk.project_vertex,
+			THREE.ShaderChunk.logdepthbuf_vertex,
+			THREE.ShaderChunk.clipping_planes_vertex,
+
+			"vViewPosition = - mvPosition.xyz;",
+
+			THREE.ShaderChunk.worldpos_vertex,
+			THREE.ShaderChunk.envmap_vertex,
+			THREE.ShaderChunk.shadowmap_vertex,
+			THREE.ShaderChunk.fog_vertex,
+
+		"}",
+	].join("\n"),
+
+	fragmentShader: [
+		"#define PHON",
+
+		"uniform vec3 diffuse;",
+		"uniform vec3 emissive;",
+		"uniform vec3 specular;",
+		"uniform float shininess;",
+		"uniform float opacity;",
+
+		"#ifdef USE_BATCHMAP",
+			"uniform sampler2D batchMap;",
+			"uniform float batchWidth;",
+			"varying float vbatchId;",
+		"#endif",
+
+		THREE.ShaderChunk.common,
+		THREE.ShaderChunk.packing,
+		THREE.ShaderChunk.dithering_pars_fragment,
+		THREE.ShaderChunk.color_pars_fragment,
+		THREE.ShaderChunk.uv_pars_fragment,
+		THREE.ShaderChunk.uv2_pars_fragment,
+		THREE.ShaderChunk.map_pars_fragment,
+		THREE.ShaderChunk.alphamap_pars_fragment,
+		THREE.ShaderChunk.aomap_pars_fragment,
+		THREE.ShaderChunk.lightmap_pars_fragment,
+		THREE.ShaderChunk.emissivemap_pars_fragment,
+		THREE.ShaderChunk.envmap_pars_fragment,
+		THREE.ShaderChunk.gradientmap_pars_fragment,
+		THREE.ShaderChunk.fog_pars_fragment,
+		THREE.ShaderChunk.bsdfs,
+		THREE.ShaderChunk.lights_pars_begin,
+		THREE.ShaderChunk.lights_phong_pars_fragment,
+		THREE.ShaderChunk.shadowmap_pars_fragment,
+		THREE.ShaderChunk.bumpmap_pars_fragment,
+		THREE.ShaderChunk.normalmap_pars_fragment,
+		THREE.ShaderChunk.specularmap_pars_fragment,
+		THREE.ShaderChunk.logdepthbuf_pars_fragment,
+		THREE.ShaderChunk.clipping_planes_pars_fragment,
+
+		"void main() {",
+
+			THREE.ShaderChunk.clipping_planes_fragment,
+
+			"vec4 diffuseColor = vec4( diffuse, opacity );",
+
+			"#ifdef USE_BATCHMAP",
+				"vec4 batchColor;",
+				"if (vbatchId >= batchWidth){",
+					"float u_v = (vbatchId+0.5) / batchWidth;",
+					"float u_v_i = floor(u_v);",
+					"float v = u_v_i / batchWidth;",
+					"float u = u_v - u_v_i;",
+					"batchColor = texture2D( batchMap,vec2( u,v ) );",
+				"}else{",
+					"batchColor = texture2D( batchMap,vec2( (vbatchId+0.5)/batchWidth,0.0 ) );",
+				"};",
+				"if ( batchColor.w == 0.0 )",
+					"discard;",
+				"else",
+					"diffuseColor *= batchColor;",
+			"#endif",
+
+			"ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
+			"vec3 totalEmissiveRadiance = emissive;",
+
+			THREE.ShaderChunk.logdepthbuf_fragment,
+			THREE.ShaderChunk.map_fragment,
+			THREE.ShaderChunk.color_fragment,
+			THREE.ShaderChunk.alphamap_fragment,
+			THREE.ShaderChunk.alphatest_fragment,
+			THREE.ShaderChunk.specularmap_fragment,
+			THREE.ShaderChunk.normal_fragment_begin,
+			THREE.ShaderChunk.normal_fragment_maps,
+			THREE.ShaderChunk.emissivemap_fragment,
+			THREE.ShaderChunk.lights_phong_fragment,
+			THREE.ShaderChunk.lights_fragment_begin,
+			THREE.ShaderChunk.lights_fragment_maps,
+			THREE.ShaderChunk.lights_fragment_end,
+			THREE.ShaderChunk.aomap_fragment,
+
+			"vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
+
+			THREE.ShaderChunk.envmap_fragment,
+
+			"gl_FragColor = vec4( outgoingLight, diffuseColor.a );",
+
+			THREE.ShaderChunk.tonemapping_fragment,
+			THREE.ShaderChunk.encodings_fragment,
+			THREE.ShaderChunk.fog_fragment,
+			THREE.ShaderChunk.premultiplied_alpha_fragment,
+			THREE.ShaderChunk.dithering_fragment,
+		"}",
+	].join("\n")
+};

--- a/examples/jsm/shaders/BatchPhongShader.d.ts
+++ b/examples/jsm/shaders/BatchPhongShader.d.ts
@@ -1,0 +1,12 @@
+import {
+	Uniform
+} from '../../../src/Three';
+
+export const BasicShader: {
+	uniforms: {
+        batchMap: Uniform;
+        batchWidth: Uniform;
+    };
+	vertexShader: string;
+	fragmentShader: string;
+};

--- a/examples/jsm/shaders/BatchPhongShader.js
+++ b/examples/jsm/shaders/BatchPhongShader.js
@@ -1,0 +1,188 @@
+/**
+ * @author Min.H
+ *
+ * just for MeshPhongMaterial
+ *
+ * add batchMap,use map color decide the diffuse color, it cost more memory to cut draw call number.
+ */
+
+import {
+	ShaderChunk,
+	ShaderLib,
+	UniformsUtils
+} from "../../../build/three.module.js";
+
+var BatchPhongShader = {
+
+	uniforms: UniformsUtils.merge([
+
+		ShaderLib.phong.uniforms,
+
+		{
+			batchMap: {value: null},
+			batchWidth: {value: null}
+		}
+
+	]),
+
+	vertexShader: [
+		"#define PHONG",
+
+		"varying vec3 vViewPosition;",
+
+		"#ifndef FLAT_SHADED",
+			"varying vec3 vNormal;",
+		"#endif",
+
+		"#ifdef USE_BATCHMAP",
+			"uniform sampler2D batchMap;",
+			"attribute float batchId;",
+			"varying float vbatchId;",
+		"#endif",
+
+		ShaderChunk.common,
+		ShaderChunk.uv_pars_vertex,
+		ShaderChunk.uv2_pars_vertex,
+		ShaderChunk.displacementmap_pars_vertex,
+		ShaderChunk.envmap_pars_vertex,
+		ShaderChunk.color_pars_vertex,
+		ShaderChunk.fog_pars_vertex,
+		ShaderChunk.morphtarget_pars_vertex,
+		ShaderChunk.skinning_pars_vertex,
+		ShaderChunk.shadowmap_pars_vertex,
+		ShaderChunk.logdepthbuf_pars_vertex,
+		ShaderChunk.clipping_planes_pars_vertex,
+
+		"void main() {",
+
+			"#ifdef USE_BATCHMAP",
+				"vbatchId = batchId;",
+			"#endif",
+
+			ShaderChunk.uv_vertex,
+			ShaderChunk.uv2_vertex,
+			ShaderChunk.color_vertex,
+			ShaderChunk.beginnormal_vertex,
+			ShaderChunk.morphnormal_vertex,
+			ShaderChunk.skinbase_vertex,
+			ShaderChunk.skinnormal_vertex,
+			ShaderChunk.defaultnormal_vertex,
+
+			"#ifndef FLAT_SHADED",
+				"vNormal = normalize( transformedNormal );",
+			"#endif",
+
+			ShaderChunk.begin_vertex,
+			ShaderChunk.morphtarget_vertex,
+			ShaderChunk.skinning_vertex,
+			ShaderChunk.displacementmap_vertex,
+			ShaderChunk.project_vertex,
+			ShaderChunk.logdepthbuf_vertex,
+			ShaderChunk.clipping_planes_vertex,
+
+			"vViewPosition = - mvPosition.xyz;",
+
+			ShaderChunk.worldpos_vertex,
+			ShaderChunk.envmap_vertex,
+			ShaderChunk.shadowmap_vertex,
+			ShaderChunk.fog_vertex,
+
+		"}",
+	].join("\n"),
+
+	fragmentShader: [
+		"#define PHON",
+
+		"uniform vec3 diffuse;",
+		"uniform vec3 emissive;",
+		"uniform vec3 specular;",
+		"uniform float shininess;",
+		"uniform float opacity;",
+
+		"#ifdef USE_BATCHMAP",
+			"uniform sampler2D batchMap;",
+			"uniform float batchWidth;",
+			"varying float vbatchId;",
+		"#endif",
+
+		ShaderChunk.common,
+		ShaderChunk.packing,
+		ShaderChunk.dithering_pars_fragment,
+		ShaderChunk.color_pars_fragment,
+		ShaderChunk.uv_pars_fragment,
+		ShaderChunk.uv2_pars_fragment,
+		ShaderChunk.map_pars_fragment,
+		ShaderChunk.alphamap_pars_fragment,
+		ShaderChunk.aomap_pars_fragment,
+		ShaderChunk.lightmap_pars_fragment,
+		ShaderChunk.emissivemap_pars_fragment,
+		ShaderChunk.envmap_pars_fragment,
+		ShaderChunk.gradientmap_pars_fragment,
+		ShaderChunk.fog_pars_fragment,
+		ShaderChunk.bsdfs,
+		ShaderChunk.lights_pars_begin,
+		ShaderChunk.lights_phong_pars_fragment,
+		ShaderChunk.shadowmap_pars_fragment,
+		ShaderChunk.bumpmap_pars_fragment,
+		ShaderChunk.normalmap_pars_fragment,
+		ShaderChunk.specularmap_pars_fragment,
+		ShaderChunk.logdepthbuf_pars_fragment,
+		ShaderChunk.clipping_planes_pars_fragment,
+
+		"void main() {",
+
+			ShaderChunk.clipping_planes_fragment,
+
+			"vec4 diffuseColor = vec4( diffuse, opacity );",
+
+			"#ifdef USE_BATCHMAP",
+				"vec4 batchColor;",
+				"if (vbatchId >= batchWidth){",
+					"float u_v = (vbatchId+0.5) / batchWidth;",
+					"float u_v_i = floor(u_v);",
+					"float v = u_v_i / batchWidth;",
+					"float u = u_v - u_v_i;",
+					"batchColor = texture2D( batchMap,vec2( u,v ) );",
+				"}else{",
+					"batchColor = texture2D( batchMap,vec2( (vbatchId+0.5)/batchWidth,0.0 ) );",
+				"};",
+				"if ( batchColor.w == 0.0 )",
+					"discard;",
+				"else",
+					"diffuseColor *= batchColor;",
+			"#endif",
+
+			"ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
+			"vec3 totalEmissiveRadiance = emissive;",
+
+			ShaderChunk.logdepthbuf_fragment,
+			ShaderChunk.map_fragment,
+			ShaderChunk.color_fragment,
+			ShaderChunk.alphamap_fragment,
+			ShaderChunk.alphatest_fragment,
+			ShaderChunk.specularmap_fragment,
+			ShaderChunk.normal_fragment_begin,
+			ShaderChunk.normal_fragment_maps,
+			ShaderChunk.emissivemap_fragment,
+			ShaderChunk.lights_phong_fragment,
+			ShaderChunk.lights_fragment_begin,
+			ShaderChunk.lights_fragment_maps,
+			ShaderChunk.lights_fragment_end,
+			ShaderChunk.aomap_fragment,
+
+			"vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
+
+			ShaderChunk.envmap_fragment,
+
+			"gl_FragColor = vec4( outgoingLight, diffuseColor.a );",
+
+			ShaderChunk.tonemapping_fragment,
+			ShaderChunk.encodings_fragment,
+			ShaderChunk.fog_fragment,
+			ShaderChunk.premultiplied_alpha_fragment,
+			ShaderChunk.dithering_fragment,
+		"}",
+	].join("\n")
+};
+
+export { BatchPhongShader };

--- a/examples/webgl_materials_batch_map.html
+++ b/examples/webgl_materials_batch_map.html
@@ -239,10 +239,10 @@
 		let indexArray = new Uint16Array(planeGeometry.index.count * number);
 
 		let bufferGeometry = new THREE.BufferGeometry();
-		bufferGeometry.addAttribute("position", new THREE.BufferAttribute(positionArray, 3));
-		bufferGeometry.addAttribute("normal", new THREE.BufferAttribute(normalArray, 3));
-		bufferGeometry.addAttribute("uv", new THREE.BufferAttribute(uvArray, 2));
-		bufferGeometry.addAttribute("batchId", new THREE.BufferAttribute(batchIdArray, 1));
+		bufferGeometry.setAttribute("position", new THREE.BufferAttribute(positionArray, 3));
+		bufferGeometry.setAttribute("normal", new THREE.BufferAttribute(normalArray, 3));
+		bufferGeometry.setAttribute("uv", new THREE.BufferAttribute(uvArray, 2));
+		bufferGeometry.setAttribute("batchId", new THREE.BufferAttribute(batchIdArray, 1));
 		bufferGeometry.setIndex(new THREE.BufferAttribute(indexArray, 1));
 
 		for (let i = 0; i < number; i++) {

--- a/examples/webgl_materials_batch_map.html
+++ b/examples/webgl_materials_batch_map.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>three.js webgl - batchMap shader</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link type="text/css" rel="stylesheet" href="main.css">
+</head>
+<body>
+<div id="info">
+	<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - batchMap shader depend on
+	MeshPhongMaterial<br/>
+	<label>Use batchId attribute and batchMap works like vertex color.</label>
+	<canvas id="batchMap" style="width: 128px;height: 128px"></canvas>
+</div>
+<script type="module">
+
+	import * as THREE from '../build/three.module.js';
+	import Stats from './jsm/libs/stats.module.js';
+	import {BatchPhongShader} from "./jsm/shaders/BatchPhongShader.js";
+	import {OrbitControls} from "./jsm/controls/OrbitControls.js";
+	import {GUI} from "./jsm/libs/dat.gui.module.js";
+
+	var camera, scene, controls, renderer, stats, gui;
+
+	var canvas, context, imageData, planeGeometry, batchMap;
+	var offscreenCanvas, offscreenContext, offscreenImageData;
+	var normalCanvas, normalContext, normalImageData;
+
+	// batchMapSize need to be 2^x,bigger than 16384 will get error.
+	// when batchId value bigger than that ,can draw the color to the next line ,and need +1 to batchMapHeight value
+
+	var batchMapSize = 128;
+	var batchMapHeight = 1;
+	var planeWidth = 5;
+
+	var config = {};
+	config.useOffscreenCanvas = true;
+	config.autoUpdateBatchMap = false;
+
+	// batchMap shader
+
+	function BatchPhongMaterial(parameters) {
+
+		THREE.MeshPhongMaterial.call(this);
+
+		this.defines = {USE_BATCHMAP: ""};
+
+		this.type = 'BatchMeshPhongMaterial';
+		this.uniforms = BatchPhongShader.uniforms;
+
+		this.vertexShader = BatchPhongShader.vertexShader;
+		this.fragmentShader = BatchPhongShader.fragmentShader;
+
+		this.setBatchMap = function (texture) {
+			this.uniforms.batchMap.value = texture;
+			this.uniforms.batchWidth.value = texture.image.width;
+		};
+
+		this.setValues(parameters);
+	}
+
+	BatchPhongMaterial.prototype = Object.create(THREE.MeshPhongMaterial.prototype);
+
+	init();
+	animate();
+
+	function init() {
+
+		var container = document.createElement('div');
+		document.body.appendChild(container);
+
+		//
+
+		camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 1, 10000);
+
+		scene = new THREE.Scene();
+		scene.background = new THREE.Color(0x242a34);
+
+		//
+
+		scene.add(new THREE.AmbientLight(0x333344));
+
+		var directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+		directionalLight.position.set(500, 0, 500);
+
+		scene.add(directionalLight);
+
+		// basic geometry
+
+		planeGeometry = new THREE.PlaneBufferGeometry(planeWidth, planeWidth);
+
+		//canvas used to draw batchMap, OffscreenCanvas can draw faster than normal canvas,but support not very well
+		//https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas
+
+		canvas = offscreenCanvas = new OffscreenCanvas(batchMapSize, batchMapHeight);
+		offscreenCanvas.width = batchMapSize;
+		offscreenCanvas.height = batchMapHeight;
+		context = offscreenContext = offscreenCanvas.getContext("2d");
+		imageData = offscreenImageData = offscreenContext.createImageData(batchMapSize, batchMapHeight);
+		// Offscreen image draw to canvas
+		// let batchMapCanvas = document.getElementById("batchMap");
+		// batchMapCanvas.width = batchMapSize;
+		// batchMapCanvas.height = batchMapHeight;
+		// let batchMapContext = batchMapCanvas.getContext("bitmaprenderer");
+
+		normalCanvas = document.getElementById("batchMap");
+		normalCanvas.width = batchMapSize;
+		normalCanvas.height = batchMapHeight;
+		normalContext = normalCanvas.getContext("2d");
+		normalImageData = normalContext.createImageData(batchMapSize, batchMapHeight);
+
+		// init batchMap
+
+		batchMap = new THREE.Texture();
+		batchMap.format = THREE.RGBAFormat;
+		batchMap.onUpdate = function () {
+			// check the bathMap
+			var image = batchMap.image;
+			// batchMapContext.transferFromImageBitmap(image);
+		};
+
+		// init mesh
+
+		batchMap.image = drawBatchImage([
+			[255, 0, 0, 255], //batchMap color will blend with materialColor
+			[0, 255, 0, 255],
+			[0, 0, 255, 255],
+			[0, 0, 0, 0], // a=0 discard
+			[255, 255, 255, 255] // support map transparent
+		]);
+		batchMap.needsUpdate = true;
+		var bufferGeometry = createGeometry(5);
+		var batchPhongMaterial = new BatchPhongMaterial();
+		batchPhongMaterial.setBatchMap(batchMap);
+
+		// if need enable alpha ,set the flow option. this will make threejs sort the meshes , probably draw from far to near, do not use this if not necessary
+
+		batchPhongMaterial.transparent = true;
+
+		var mesh = new THREE.Mesh(bufferGeometry, batchPhongMaterial);
+		scene.add(mesh);
+
+		let backGroud = new THREE.Mesh(planeGeometry, new THREE.MeshPhongMaterial({color: new THREE.Color(1, 1, 0)}));
+		backGroud.position.set(20, 0, -5);
+		backGroud.scale.set(5, 5, 0);
+		scene.add(backGroud);
+
+		//
+
+		renderer = new THREE.WebGLRenderer({antialias: true});
+		renderer.setPixelRatio(window.devicePixelRatio);
+		renderer.setSize(window.innerWidth, window.innerHeight);
+		container.appendChild(renderer.domElement);
+		renderer.autoClear = false;
+
+		//
+
+		stats = new Stats();
+		container.appendChild(stats.dom);
+
+		//
+
+		gui = new GUI();
+		gui.add(config, "autoUpdateBatchMap");
+		gui.add(config, "useOffscreenCanvas").onChange(function () {
+			if (config.useOffscreenCanvas) {
+				canvas = offscreenCanvas;
+				context = offscreenContext;
+				imageData = offscreenImageData;
+			} else {
+				canvas = normalCanvas;
+				context = normalContext;
+				imageData = normalImageData;
+			}
+		});
+
+		//
+
+		controls = new OrbitControls(camera, container);
+		camera.position.set(20, 0, 50);
+		controls.target.set(20, 0, 0);
+
+		//
+
+		document.addEventListener('click', onDocumentMouseClick, false);
+		window.addEventListener('resize', onWindowResize, false);
+	}
+
+	// canvas draw function,color's length should equal 4 which value between [0,255]
+
+	function drawBatchImage(colors, offset) {
+		if (!offset) offset = 0;
+		for (let i = 0; i < colors.length; i++) {
+			const color = colors[i];
+			let dataOffset = (i + offset) * 4;
+			for (let j = 0; j < color.length; j++) {
+				imageData.data[dataOffset + j] = color[j]
+			}
+		}
+
+		context.putImageData(imageData, 0, 0);
+
+		if (config.useOffscreenCanvas)
+			return canvas.transferToImageBitmap();
+		else {
+			let image = new Image();
+			image.src = canvas.toDataURL();
+			image.width = canvas.width;
+			image.height = canvas.height;
+			return image;
+		}
+	}
+
+	/**
+	 * _ _ _ _ _ +y
+	 * |
+	 * |
+	 * |
+	 * +x
+	 */
+
+	function drawPix(imageDate, x, y, r, g, b, a) {
+		var offset = (imageDate.width * x + y) * 4;
+		imageDate.data[offset] = r;
+		imageDate.data[offset + 1] = g;
+		imageDate.data[offset + 2] = b;
+		imageDate.data[offset + 3] = a;
+	}
+
+	// create batch geometry for batchMap
+
+	function createGeometry(number) {
+		let pointCount = planeGeometry.attributes.position.count;
+		let positionArray = new Float32Array(pointCount * number * 3);
+		let normalArray = new Float32Array(pointCount * number * 3);
+		let uvArray = new Float32Array(pointCount * number * 2);
+		let batchIdArray = new Float32Array(pointCount * number);
+		let indexArray = new Uint16Array(planeGeometry.index.count * number);
+
+		let bufferGeometry = new THREE.BufferGeometry();
+		bufferGeometry.addAttribute("position", new THREE.BufferAttribute(positionArray, 3));
+		bufferGeometry.addAttribute("normal", new THREE.BufferAttribute(normalArray, 3));
+		bufferGeometry.addAttribute("uv", new THREE.BufferAttribute(uvArray, 2));
+		bufferGeometry.addAttribute("batchId", new THREE.BufferAttribute(batchIdArray, 1));
+		bufferGeometry.setIndex(new THREE.BufferAttribute(indexArray, 1));
+
+		for (let i = 0; i < number; i++) {
+			for (let j = 0; j < pointCount; j++) {
+				positionArray[(i * pointCount + j) * 3] = planeGeometry.attributes.position.array[j * 3] + planeWidth * 2 * i;
+				positionArray[(i * pointCount + j) * 3 + 1] = planeGeometry.attributes.position.array[j * 3 + 1];
+				positionArray[(i * pointCount + j) * 3 + 2] = planeGeometry.attributes.position.array[j * 3 + 2];
+
+				normalArray[(i * pointCount + j) * 3] = planeGeometry.attributes.normal.array[j * 3];
+				normalArray[(i * pointCount + j) * 3 + 1] = planeGeometry.attributes.normal.array[j * 3 + 1];
+				normalArray[(i * pointCount + j) * 3 + 2] = planeGeometry.attributes.normal.array[j * 3 + 2];
+
+				uvArray[(i * pointCount + j) * 2] = planeGeometry.attributes.uv.array[j * 2];
+				uvArray[(i * pointCount + j) * 2 + 1] = planeGeometry.attributes.uv.array[j * 2 + 1];
+
+				// each plane use the same batchId
+
+				batchIdArray[i * pointCount + j] = i;
+			}
+			for (let j = 0; j < planeGeometry.index.count; j++) {
+				indexArray[i * planeGeometry.index.count + j] = planeGeometry.index.array[j] + pointCount * i;
+			}
+		}
+
+		return bufferGeometry;
+	}
+
+	//
+
+	function onWindowResize() {
+
+		renderer.setSize(window.innerWidth, window.innerHeight);
+		camera.aspect = window.innerWidth / window.innerHeight;
+		camera.updateProjectionMatrix();
+
+	}
+
+	//
+
+	function onDocumentMouseClick(event) {
+		batchMap.image = drawBatchImage([
+			[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+			[255, 0, 0, Math.random() * 255],
+			[255, 0, 0, 255],
+			[255, 255, 255, 255],
+			[255, 255, 255, 100],
+		]);
+		batchMap.needsUpdate = true;
+	}
+
+	function animate() {
+
+		requestAnimationFrame(animate);
+
+		render();
+
+		stats.update();
+
+	}
+
+	function render() {
+
+		renderer.clear();
+
+		if (config.autoUpdateBatchMap) {
+			batchMap.image = drawBatchImage([
+				[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+				[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+				[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+				[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+				[Math.random() * 255, Math.random() * 255, Math.random() * 255, Math.random() * 255],
+			]);
+			batchMap.needsUpdate = true;
+		}
+
+		renderer.render(scene, camera);
+
+	}
+
+</script>
+</body>
+</html>

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -180,6 +180,7 @@ var files = [
 
 	{ path: 'shaders/AfterimageShader.js', dependencies: [], ignoreList: [] },
 	{ path: 'shaders/BasicShader.js', dependencies: [], ignoreList: [] },
+	{ path: 'shaders/BatchPhongShader.js', dependencies: [], ignoreList: [] },
 	{ path: 'shaders/BleachBypassShader.js', dependencies: [], ignoreList: [] },
 	{ path: 'shaders/BlendShader.js', dependencies: [], ignoreList: [] },
 	{ path: 'shaders/BokehShader.js', dependencies: [], ignoreList: [] },


### PR DESCRIPTION
Use batchmap and batchId control the shader diffuse color, work like vertex color.
https://raw.githack.com/1147079942/three.js/batch_shader/examples/webgl_materials_batch_map.html

The `THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0` warring is come from new version.I don't get that in the early threejs version. I use the `PlaneBufferGeometry` in the example.