### PR TITLE
TrackballControls: extends OrbitControls - API refactor

### DIFF
--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -29,7 +29,7 @@
 			import Stats from './jsm/libs/stats.module.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 
-			import { TrackballControls } from './jsm/controls/TrackballControls.js';
+			import { TrackballControls } from './jsm/controls/OrbitControls.js';
 
 			var perspectiveCamera, orthographicCamera, controls, scene, renderer, stats;
 
@@ -141,8 +141,6 @@
 				orthographicCamera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
-
-				controls.handleResize();
 
 			}
 


### PR DESCRIPTION
Based on @WestLangley's https://github.com/mrdoob/three.js/pull/17842#issuecomment-548659998

Similar to what was done to `MapControls` on https://github.com/mrdoob/three.js/pull/16961

____
**Notes:**

- Introduces `fixedUp` which controls whether or not to maintain `camera.up` direction on rotation. 

- Noticeable `rotationSpeed` changes, due to the different mouse coordinates used in `OrbitControls`.

- Implements @Mugen87's backwards compatibility changes on #17842

