### PR TITLE
Examples: Avoid delayed updating of cube cameras in webgl_materials_cubemap_dynamic.

### DIFF
--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -178,25 +178,21 @@
 
 				camera.lookAt( scene.position );
 
-				sphere.visible = false;
-
 				// pingpong
 
 				if ( count % 2 === 0 ) {
 
+					cubeCamera1.update( renderer, scene );
 					material.envMap = cubeCamera1.renderTarget.texture;
-					cubeCamera2.update( renderer, scene );
 
 				} else {
 
+					cubeCamera2.update( renderer, scene );
 					material.envMap = cubeCamera2.renderTarget.texture;
-					cubeCamera1.update( renderer, scene );
 
 				}
 
 				count ++;
-
-				sphere.visible = true;
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
- we can update the unattached cube camera just before attaching it to avoid the unnessary delay
- we don't need to hide the sphere temporarily as we're using single sided materials