### PR TITLE
TS: add alphaMap to MeshDistanceMaterial

### DIFF
--- a/src/materials/MeshDistanceMaterial.d.ts
+++ b/src/materials/MeshDistanceMaterial.d.ts
@@ -6,6 +6,7 @@ export interface MeshDistanceMaterialParameters extends MaterialParameters {
 	referencePosition?: Vector3;
 	nearDistance?: number;
 	farDistance?: number;
+	alphaMap?: Texture | null;
 	displacementMap?: Texture | null;
 	displacementScale?: number;
 	displacementBias?: number;


### PR DESCRIPTION
This support for alpha maps is consistent with the implementation of the other built-in materials.

When i use the three 0.109.0 version and try https://threejs.org/examples/#webgl_shadowmap_pointlight this demo, it crashed.
add alphaMap support can fixed this bug.