### PR TITLE
Docs: Use a dark color theme for code snippets in dark mode

### DIFF
--- a/docs/prettify/threejs.css
+++ b/docs/prettify/threejs.css
@@ -1,15 +1,28 @@
-pre .str, code .str { color: #BB55FF; } /* string */
+pre .str, code .str { color: #8000ff; } /* string */
 pre .kwd, code .kwd { color: #30b030; } /* keyword */
-pre .com, code .com { color: #666666; } /* comment */
+pre .com, code .com { color: #999999; } /* comment */
 pre .typ, code .typ { color: #2194ce; } /* type */
-pre .lit, code .lit { color: #ff3399; } /* literal */
+pre .lit, code .lit { color: #ff0080; } /* literal */
 pre .pun, code .pun { color: #888888; } /* punctuation */
-pre .pln, code .pln { color: #aaaaaa; } /* plaintext */
+pre .pln, code .pln { color: #444444; } /* plaintext */
 pre .dec, code .dec { color: #22c0c4; } /* decimal */
 
 
 
 pre.prettyprint, code.prettyprint {
-	background-color: #333333;
+	background-color: #F5F5F5;
 	font-family: 'Roboto Mono', monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+
+	pre .str, code .str { color: #BB55FF; } /* string */
+	pre .com, code .com { color: #666666; } /* comment */
+	pre .lit, code .lit { color: #ff3399; } /* literal */
+	pre .pln, code .pln { color: #aaaaaa; } /* plaintext */
+
+	pre.prettyprint, code.prettyprint {
+		background-color: #333333;
+	}
+
 }

--- a/docs/prettify/threejs.css
+++ b/docs/prettify/threejs.css
@@ -1,15 +1,15 @@
-pre .str, code .str { color: #8000ff; } /* string */
+pre .str, code .str { color: #BB55FF; } /* string */
 pre .kwd, code .kwd { color: #30b030; } /* keyword */
-pre .com, code .com { color: #999999; } /* comment */
+pre .com, code .com { color: #666666; } /* comment */
 pre .typ, code .typ { color: #2194ce; } /* type */
-pre .lit, code .lit { color: #ff0080; } /* literal */
+pre .lit, code .lit { color: #ff3399; } /* literal */
 pre .pun, code .pun { color: #888888; } /* punctuation */
-pre .pln, code .pln { color: #444444; } /* plaintext */
+pre .pln, code .pln { color: #aaaaaa; } /* plaintext */
 pre .dec, code .dec { color: #22c0c4; } /* decimal */
 
 
 
 pre.prettyprint, code.prettyprint {
-	background-color: #F5F5F5;
+	background-color: #333333;
 	font-family: 'Roboto Mono', monospace;
 }


### PR DESCRIPTION
Updates the colors for the docs code snippets when using a dark color scheme. Here's a before and after:

![image](https://user-images.githubusercontent.com/734200/68152514-abd94c00-fef8-11e9-97c6-bf57ec28ace3.png)

[Current Docs Link](https://threejs.org/docs/#api/en/objects/SkinnedMesh), [PR Docs Link](https://raw.githack.com/gkjohnson/three.js/dark-code-docs/docs/index.html#api/en/objects/SkinnedMesh)