### PR TITLE
(Re-)added AnimationAction import to Three.js

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -89,6 +89,7 @@ export { AnimationUtils } from './animation/AnimationUtils.js';
 export { AnimationObjectGroup } from './animation/AnimationObjectGroup.js';
 export { AnimationMixer } from './animation/AnimationMixer.js';
 export { AnimationClip } from './animation/AnimationClip.js';
+export { AnimationAction } from './animation/AnimationAction.js';
 export { Uniform } from './core/Uniform.js';
 export { InstancedBufferGeometry } from './core/InstancedBufferGeometry.js';
 export { BufferGeometry } from './core/BufferGeometry.js';


### PR DESCRIPTION
The AnimationAction-module is listed in the TypeScript-definition file of Three.js, but actually missing in Three.js itself. As I actually would expect it be imported there I (re-)added it.