### PR TITLE
Added missing constructor in AnimationAction.d.ts

### DIFF
--- a/src/animation/AnimationAction.d.ts
+++ b/src/animation/AnimationAction.d.ts
@@ -1,9 +1,12 @@
 import { AnimationMixer } from './AnimationMixer';
 import { AnimationClip } from './AnimationClip';
 import { AnimationActionLoopStyles } from '../constants';
+import { Object3D } from '../core/Object3D';
 // Animation ////////////////////////////////////////////////////////////////////////////////////////
 
 export class AnimationAction {
+
+	constructor( mixer: AnimationMixer, clip: AnimationClip, localRoot?: Object3D );
 
 	loop: AnimationActionLoopStyles;
 	time: number;


### PR DESCRIPTION
The constructor of AnimationAction is missing in its TypeScript definition. So it's not possible to create a new instance (without casting the class to any) when using TypeScript.