### PR TITLE
Specified datatype of root object in AnimationMixer.d.ts

### DIFF
--- a/src/animation/AnimationMixer.d.ts
+++ b/src/animation/AnimationMixer.d.ts
@@ -1,22 +1,23 @@
 import { AnimationClip } from './AnimationClip';
 import { AnimationAction } from './AnimationAction';
 import { EventDispatcher } from './../core/EventDispatcher';
+import { Object3D } from '../core/Object3D';
 
 export class AnimationMixer extends EventDispatcher {
 
-	constructor( root: any );
+	constructor( root: Object3D );
 
 	time: number;
 	timeScale: number;
 
-	clipAction( clip: AnimationClip, root?: any ): AnimationAction;
-	existingAction( clip: AnimationClip, root?: any ): AnimationAction;
+	clipAction( clip: AnimationClip, root?: Object3D ): AnimationAction;
+	existingAction( clip: AnimationClip, root?: Object3D ): AnimationAction;
 	stopAllAction(): AnimationMixer;
 	update( deltaTime: number ): AnimationMixer;
 	setTime( timeInSeconds: number ): AnimationMixer;
-	getRoot(): any;
+	getRoot(): Object3D;
 	uncacheClip( clip: AnimationClip ): void;
-	uncacheRoot( root: any ): void;
-	uncacheAction( clip: AnimationClip, root?: any ): void;
+	uncacheRoot( root: Object3D ): void;
+	uncacheAction( clip: AnimationClip, root?: Object3D ): void;
 
 }


### PR DESCRIPTION
According to the documentation the root-object is of type Object3D, but in the TypeScript definition file of AnimationMixer it is set to the unspecific "any"-type. I think it shouldn't do any harm to set this type accordingly.