### PR TITLE
Removed invalid Animation reference from Three.d.ts

### DIFF
--- a/examples/jsm/misc/MorphAnimMesh.d.ts
+++ b/examples/jsm/misc/MorphAnimMesh.d.ts
@@ -1,5 +1,5 @@
+import { AnimationAction } from '../../../src/animation/AnimationAction'
 import {
-	AnimationAction,
 	AnimationMixer,
 	BufferGeometry,
 	Geometry,

--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -86,7 +86,6 @@ export * from './animation/AnimationUtils';
 export * from './animation/AnimationObjectGroup';
 export * from './animation/AnimationMixer';
 export * from './animation/AnimationClip';
-export * from './animation/AnimationAction';
 export * from './core/Uniform';
 export * from './core/InstancedBufferGeometry';
 export * from './core/BufferGeometry';


### PR DESCRIPTION
AnimationAction is not available in Three.js as it is not necessary to access it directly. But it's referenced in the TypeScript definition file of Three.js which can lead to confusion and faulty imports like this:

```
import { AnimationAction } from 'three'
console.log(AnimationAction) // -> undefined
```

So this reference should be removed from Three.d.ts.