### PR TITLE
Add xrCompatible:true attribute in multiview example

### DIFF
--- a/examples/webvr_multiview.html
+++ b/examples/webvr_multiview.html
@@ -58,7 +58,7 @@
 				// as soon as that will get solved we will update the code so it will be
 				// transparent for the user and you could use this extension with or without multisampled
 				// contexts
-				var context = canvas.getContext( 'webgl2', { antialias: false } );
+				var context = canvas.getContext( 'webgl2', { antialias: false, xrCompatible: true } );
 
 				renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
 


### PR DESCRIPTION
WebVR multiview example creates WebGL context out of `WebGLRenderer`. Let's add `xrCompatible: true` to `canvas.getContext()` in the example [as `WebGLRenderer` does](https://github.com/mrdoob/three.js/blob/r110/src/renderers/WebGLRenderer.js#L204) for better WebXR compatibility. Actually the latest [WebXR emulator extension](https://github.com/MozillaReality/WebXR-emulator-extension) needs it.

Refer to [WebXR API spec](https://www.w3.org/TR/webxr/#contextcompatibility) for `xrCompatible`.

CC @fernandojsg 