### PR TITLE
EXRLoader: Fix for Firefox by only returning RGBA textures

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1081,18 +1081,36 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 		var width = EXRHeader.dataWindow.xMax - EXRHeader.dataWindow.xMin + 1;
 		var height = EXRHeader.dataWindow.yMax - EXRHeader.dataWindow.yMin + 1;
-		var numChannels = EXRHeader.channels.length;
+		// Firefox only supports RGBA (half) float textures
+		// var numChannels = EXRHeader.channels.length;
+		var numChannels = 4;
+		var size = width * height * numChannels;
 
+		// Fill initially with 1s for the alpha value if the texture is not RGBA, RGB values will be overwritten
 		switch ( this.type ) {
 
 			case THREE.FloatType:
 
-				var byteArray = new Float32Array( width * height * numChannels );
+				var byteArray = new Float32Array( size );
+
+				if ( EXRHeader.channels.length < numChannels ) {
+
+					byteArray.fill( 1, 0, size );
+
+				}
+
 				break;
 
 			case THREE.HalfFloatType:
 
-				var byteArray = new Uint16Array( width * height * numChannels );
+				var byteArray = new Uint16Array( size );
+
+				if ( EXRHeader.channels.length < numChannels ) {
+
+					byteArray.fill( 0x3C00, 0, size ); // Uint16Array holds half float data, 0x3C00 is 1
+
+				}
+
 				break;
 
 			default:
@@ -1163,7 +1181,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 				var tmpBuffer = new Uint16Array( tmpBufferSize );
 				var tmpOffset = { value: 0 };
 
-				decompressPIZ( tmpBuffer, tmpOffset, uInt8Array, bufferDataView, offset, tmpBufferSize, numChannels, EXRHeader.channels, width, scanlineBlockSize );
+				decompressPIZ( tmpBuffer, tmpOffset, uInt8Array, bufferDataView, offset, tmpBufferSize, EXRHeader.channels.length, EXRHeader.channels, width, scanlineBlockSize );
 
 				for ( var line_y = 0; line_y < scanlineBlockSize; line_y ++ ) {
 
@@ -1220,7 +1238,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			width: width,
 			height: height,
 			data: byteArray,
-			format: EXRHeader.channels.length == 4 ? THREE.RGBAFormat : THREE.RGBFormat,
+			format: numChannels == 4 ? THREE.RGBAFormat : THREE.RGBFormat,
 			type: this.type
 		};
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1091,18 +1091,36 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 		var width = EXRHeader.dataWindow.xMax - EXRHeader.dataWindow.xMin + 1;
 		var height = EXRHeader.dataWindow.yMax - EXRHeader.dataWindow.yMin + 1;
-		var numChannels = EXRHeader.channels.length;
+		// Firefox only supports RGBA (half) float textures
+		// var numChannels = EXRHeader.channels.length;
+		var numChannels = 4;
+		var size = width * height * numChannels;
 
+		// Fill initially with 1s for the alpha value if the texture is not RGBA, RGB values will be overwritten
 		switch ( this.type ) {
 
 			case FloatType:
 
-				var byteArray = new Float32Array( width * height * numChannels );
+				var byteArray = new Float32Array( size );
+
+				if ( EXRHeader.channels.length < numChannels ) {
+
+					byteArray.fill( 1, 0, size );
+
+				}
+
 				break;
 
 			case HalfFloatType:
 
-				var byteArray = new Uint16Array( width * height * numChannels );
+				var byteArray = new Uint16Array( size );
+
+				if ( EXRHeader.channels.length < numChannels ) {
+
+					byteArray.fill( 0x3C00, 0, size ); // Uint16Array holds half float data, 0x3C00 is 1
+
+				}
+
 				break;
 
 			default:
@@ -1173,7 +1191,7 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 				var tmpBuffer = new Uint16Array( tmpBufferSize );
 				var tmpOffset = { value: 0 };
 
-				decompressPIZ( tmpBuffer, tmpOffset, uInt8Array, bufferDataView, offset, tmpBufferSize, numChannels, EXRHeader.channels, width, scanlineBlockSize );
+				decompressPIZ( tmpBuffer, tmpOffset, uInt8Array, bufferDataView, offset, tmpBufferSize, EXRHeader.channels.length, EXRHeader.channels, width, scanlineBlockSize );
 
 				for ( var line_y = 0; line_y < scanlineBlockSize; line_y ++ ) {
 
@@ -1230,7 +1248,7 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 			width: width,
 			height: height,
 			data: byteArray,
-			format: EXRHeader.channels.length == 4 ? RGBAFormat : RGBFormat,
+			format: numChannels == 4 ? RGBAFormat : RGBFormat,
 			type: this.type
 		};
 


### PR DESCRIPTION
Fixes #16778.

I quite literally implemented what @Mugen87 suggested https://github.com/mrdoob/three.js/issues/16778#issuecomment-537948960.

This works for Firefox and many other browsers and platforms. I didn't test the `PIZ_COMPRESSION` case, but I adjusted the argument to the original number of channels. I think PR #17883 that's just in also works with this change.