### PR TITLE
Add parameter 'digits' to vector*.round() + update tests and docs

### DIFF
--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -285,8 +285,12 @@
 			Rotates the vector around [page:Vector2 center] by [page:float angle] radians.
 		</p>
 
-		<h3>[method:this round]()</h3>
-		<p>The components of the vector are rounded to the nearest integer value.</p>
+		<h3>[method:this round]( [param:Integer digits] )</h3>
+		<p>
+			[page:Integer digits] - the number of digits to round to after the decimal point.<br /><br />
+
+			The components of the vector are rounded.
+		</p>
 
 		<h3>[method:this roundToZero]()</h3>
 		<p>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -331,8 +331,12 @@ var d = a.distanceTo( b );
 		have unit length.
 		</p>
 
-		<h3>[method:this round]()</h3>
-		<p>The components of the vector are rounded to the nearest integer value.</p>
+		<h3>[method:this round]( [param:Integer digits] )</h3>
+		<p>
+			[page:Integer digits] - the number of digits to round to after the decimal point.<br /><br />
+
+			The components of the vector are rounded.
+		</p>
 
 		<h3>[method:this roundToZero]()</h3>
 		<p>

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -252,8 +252,12 @@ var d = a.dot( b );
 		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies this vector by scalar [page:Float s].</p>
 
-		<h3>[method:this round]()</h3>
-		<p>The components of the vector are rounded to the nearest integer value.</p>
+		<h3>[method:this round]( [param:Integer digits] )</h3>
+		<p>
+			[page:Integer digits] - the number of digits to round to after the decimal point.<br /><br />
+
+			The components of the vector are rounded.
+		</p>
 
 		<h3>[method:this roundToZero]()</h3>
 		<p>

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -286,9 +286,10 @@ export class Vector2 implements Vector {
 	ceil(): this;
 
 	/**
-	 * The components of the vector are rounded to the nearest integer value.
+	 * The components of the vector are rounded.
+	 * @param digits the number of digits to round to after decimal point.
 	 */
-	round(): this;
+	round( digits: number ): this;
 
 	/**
 	 * The components of the vector are rounded towards zero (up if negative, down if positive) to an integer value.

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -313,10 +313,12 @@ Object.assign( Vector2.prototype, {
 
 	},
 
-	round: function () {
+	round: function ( digits ) {
 
-		this.x = Math.round( this.x );
-		this.y = Math.round( this.y );
+		var e = Math.pow( 10, digits || 0 );
+
+		this.x = Math.round( this.x * e ) / e;
+		this.y = Math.round( this.y * e ) / e;
 
 		return this;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -416,11 +416,13 @@ Object.assign( Vector3.prototype, {
 
 	},
 
-	round: function () {
+	round: function ( digits ) {
 
-		this.x = Math.round( this.x );
-		this.y = Math.round( this.y );
-		this.z = Math.round( this.z );
+		var e = Math.pow( 10, digits || 0 );
+
+		this.x = Math.round( this.x * e ) / e;
+		this.y = Math.round( this.y * e ) / e;
+		this.z = Math.round( this.z * e ) / e;
 
 		return this;
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -512,12 +512,14 @@ Object.assign( Vector4.prototype, {
 
 	},
 
-	round: function () {
+	round: function ( digits ) {
 
-		this.x = Math.round( this.x );
-		this.y = Math.round( this.y );
-		this.z = Math.round( this.z );
-		this.w = Math.round( this.w );
+		var e = Math.pow( 10, digits || 0 );
+
+		this.x = Math.round( this.x * e ) / e;
+		this.y = Math.round( this.y * e ) / e;
+		this.z = Math.round( this.z * e ) / e;
+		this.w = Math.round( this.w * e ) / e;
 
 		return this;
 

--- a/test/unit/src/math/Vector2.tests.js
+++ b/test/unit/src/math/Vector2.tests.js
@@ -576,6 +576,9 @@ export default QUnit.module( 'Maths', () => {
 			assert.deepEqual( new Vector2( - 0.1, 0.1 ).round(), new Vector2( 0, 0 ), "round .1" );
 			assert.deepEqual( new Vector2( - 0.5, 0.5 ).round(), new Vector2( 0, 1 ), "round .5" );
 			assert.deepEqual( new Vector2( - 0.9, 0.9 ).round(), new Vector2( - 1, 1 ), "round .9" );
+			assert.deepEqual( new Vector2( - 0.51, 0.51 ).round( 1 ), new Vector2( - 0.5, 0.5 ), "round .51" );
+			assert.deepEqual( new Vector2( - 0.55, 0.55 ).round( 1 ), new Vector2( - 0.5, 0.6 ), "round .55" );
+			assert.deepEqual( new Vector2( - 0.0009, 0.1 ).round( 3 ), new Vector2( - 0.001, 0.1 ), "round 0.0009" );
 
 			assert.deepEqual( new Vector2( - 0.1, 0.1 ).roundToZero(), new Vector2( 0, 0 ), "roundToZero .1" );
 			assert.deepEqual( new Vector2( - 0.5, 0.5 ).roundToZero(), new Vector2( 0, 0 ), "roundToZero .5" );


### PR DESCRIPTION
following #17873

I tried to follow the [contribution instructions](https://github.com/mrdoob/three.js/wiki/How-to-contribute-to-three.js), but it's my first time contributing to three.js, so pardon me for any obvious mistake...

@Mugen87 you mentioned in the issue that you prefer to remove the tests and implement the methods instead, but I didn't get what you meant... So I've only updated the tests, but I'm happy to change it you explain me what you want in a bit more detail.