### PR TITLE
Add Object3D.onBeforeShadow

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -128,6 +128,9 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	onBeforeRender: function () {},
 	onAfterRender: function () {},
 
+	onBeforeShadow: function () {},
+	onAfterShadow: function () {},
+
 	applyMatrix: function ( matrix ) {
 
 		if ( this.matrixAutoUpdate ) this.updateMatrix();

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -129,7 +129,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	onAfterRender: function () {},
 
 	onBeforeShadow: function () {},
-	onAfterShadow: function () {},
 
 	applyMatrix: function ( matrix ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -427,7 +427,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 						if ( groupMaterial && groupMaterial.visible ) {
 
 							var depthMaterial = getDepthMaterial( object, groupMaterial, light, shadowCamera.near, shadowCamera.far, type );
-
+							object.onBeforeShadow( shadowCamera, geometry, depthMaterial );
 							_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
 
 						}
@@ -437,7 +437,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 				} else if ( material.visible ) {
 
 					var depthMaterial = getDepthMaterial( object, material, light, shadowCamera.near, shadowCamera.far, type );
-
+					object.onBeforeShadow( shadowCamera, geometry, depthMaterial );
 					_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
 
 				}


### PR DESCRIPTION
This PR is a result of a conversation about #14921.

I suggest closing the small gap in shadowmap building: some objects that use `onBeforeRender` to update their material uniforms in cases when it cannot be done in every other place suffers from an impossibility of update the uniforms for shadowmap building step.
So I've added `Object3D.onBeforeShadow` function and used it during shadowmap building. It works.

We use procedural sprites for rendering cylinders and spheres and I want them to cast shadows.
I've prepared an online example with three modes (you can change the mode at the script beginning): 
GEO - geometry cylinders
SPRITE - common sprites with textures
and Z_SPRITE representing our procedural sprites. 

Here you can find online example,  which uses your threejs lib https://jsfiddle.net/NataliaDSmirnova/pqeyft5o/
And here is the same example, which uses threejs library with suggested changes
https://jsfiddle.net/NataliaDSmirnova/e4awmk62/
As you can see the shadow appears!