### PR TITLE
packing.glsl: fix HalfToRGBA artifacts

### DIFF
--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -39,6 +39,7 @@ vec4 encodeHalfRGBA ( vec2 v ) {
 }
 
 vec2 decodeHalfRGBA( vec4 v ) {
+	v = floor( v * 255.0 + 0.5 ) / 255.0;
 	return vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );
 }
 

--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -25,20 +25,11 @@ float unpackRGBAToDepth( const in vec4 v ) {
 	return dot( v, UnpackFactors );
 }
 
-vec4 encodeHalfRGBA ( vec2 v ) {
-	vec4 encoded = vec4( 0.0 );
-	const vec2 offset = vec2( 1.0 / 255.0, 0.0 );
-
-	encoded.xy = vec2( v.x, fract( v.x * 255.0 ) );
-	encoded.xy = encoded.xy - ( encoded.yy * offset );
-
-	encoded.zw = vec2( v.y, fract( v.y * 255.0 ) );
-	encoded.zw = encoded.zw - ( encoded.ww * offset );
-
-	return encoded;
+vec4 packHalfToRGBA( vec2 v ) {
+	vec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ));
+	return vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w);
 }
-
-vec2 decodeHalfRGBA( vec4 v ) {
+vec2 unpackHalfToRGBA( vec4 v ) {
 	v = floor( v * 255.0 + 0.5 ) / 255.0;
 	return vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );
 }

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -38,7 +38,7 @@ export default /* glsl */`
 
 	vec2 texture2DDistribution( sampler2D shadow, vec2 uv ) {
 
-		return decodeHalfRGBA( texture2D( shadow, uv ) );
+		return unpackHalfToRGBA( texture2D( shadow, uv ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
@@ -9,7 +9,7 @@ void main() {
 
   float mean = 0.0;
   float squared_mean = 0.0;
-  
+
 	// This seems totally useless but it's a crazy work around for a Adreno compiler bug
 	float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy  ) / resolution ) );
 
@@ -17,7 +17,7 @@ void main() {
 
     #ifdef HORIZONAL_PASS
 
-      vec2 distribution = decodeHalfRGBA ( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
+      vec2 distribution = unpackHalfToRGBA ( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
       mean += distribution.x;
       squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;
 


### PR DESCRIPTION
This PR is fixing artifacts that appears on some iPhone's, Androids, iPads.
Related bug: https://github.com/mapbox/webgl-wind/issues/12

Here live examples where you can see how it works:
before fix: https://codepen.io/munrocket/pen/yLLQBxB
after fix: https://codepen.io/munrocket/pen/zYYMOeK

I am sure this solution can solve also this #9092 but I don't have robust solution for packDepthToRGBA right now.