### PR TITLE
Added squeeze* input events for WebVR and WebXR Managers

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -104,6 +104,7 @@ function WebVRManager( renderer ) {
 	//
 
 	var triggers = [];
+	var grips = [];
 
 	function findGamepad( id ) {
 
@@ -174,6 +175,29 @@ function WebVRManager( renderer ) {
 
 						controller.dispatchEvent( { type: 'selectend' } );
 						controller.dispatchEvent( { type: 'select' } );
+
+					}
+
+				}
+
+				// Grip
+
+				buttonId = gamepad.buttons.length > 2 ? 2 : 0;
+
+				if ( grips[ i ] === undefined ) grips[ i ] = false;
+
+				if ( grips[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
+
+					grips[ i ] = gamepad.buttons[ buttonId ].pressed;
+
+					if ( grips[ i ] === true ) {
+
+						controller.dispatchEvent( { type: 'squeezestart' } );
+
+					} else {
+
+						controller.dispatchEvent( { type: 'squeezeend' } );
+						controller.dispatchEvent( { type: 'squeeze' } );
 
 					}
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -181,23 +181,27 @@ function WebVRManager( renderer ) {
 				}
 
 				// Grip
-
-				buttonId = gamepad.buttons.length > 2 ? 2 : 0;
+				buttonId = 2;
 
 				if ( grips[ i ] === undefined ) grips[ i ] = false;
 
-				if ( grips[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
+				// Skip if the grip button doesn't exist on this controller
+				if ( gamepad.buttons[ buttonId ] !== undefined ) {
 
-					grips[ i ] = gamepad.buttons[ buttonId ].pressed;
+					if ( grips[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
 
-					if ( grips[ i ] === true ) {
+						grips[ i ] = gamepad.buttons[ buttonId ].pressed;
 
-						controller.dispatchEvent( { type: 'squeezestart' } );
+						if ( grips[ i ] === true ) {
 
-					} else {
+							controller.dispatchEvent( { type: 'squeezestart' } );
 
-						controller.dispatchEvent( { type: 'squeezeend' } );
-						controller.dispatchEvent( { type: 'squeeze' } );
+						} else {
+
+							controller.dispatchEvent( { type: 'squeezeend' } );
+							controller.dispatchEvent( { type: 'squeeze' } );
+
+						}
 
 					}
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -133,6 +133,9 @@ function WebXRManager( renderer, gl ) {
 			session.addEventListener( 'select', onSessionEvent );
 			session.addEventListener( 'selectstart', onSessionEvent );
 			session.addEventListener( 'selectend', onSessionEvent );
+			session.addEventListener( 'squeeze', onSessionEvent );
+			session.addEventListener( 'squeezestart', onSessionEvent );
+			session.addEventListener( 'squeezeend', onSessionEvent );
 			session.addEventListener( 'end', onSessionEnd );
 
 			// eslint-disable-next-line no-undef


### PR DESCRIPTION
The new WebXR API introduces a set of new events for input: `squeezestart`, `squeezeend`, and `squeeze` when using the `grip` (https://immersive-web.github.io/webxr/#eventdef-xrsession-squeezestart) similar to the previously existing `selectstart`, `selectend`, and `select`.
Added them to the `WebXRManager`, and a fallback to the WebVRManager, using the `grip` button ID that in the current controllers is on number 2 (Oculus, WMR, Vive) if the controller has enough buttons, otherwise use just the index 0 button.