### PR TITLE
Optimize Box3.expandByObject

### DIFF
--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -138,6 +138,7 @@
 
 		Expands the boundaries of this box to include [page:Object3D object] and its children,
 		accounting for the object's, and children's, world transforms.
+		The function may result in a larger box than strictly necessary.
 
 		</p>
 
@@ -279,6 +280,7 @@
 
 		Computes the world-axis-aligned bounding box of an [page:Object3D] (including its children),
 		accounting for the object's, and children's, world transforms.
+		The function may result in a larger box than strictly necessary.
 
 		</p>
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -41,6 +41,8 @@ function Box3( min, max ) {
 
 }
 
+var _box = new Box3();
+
 Object.assign( Box3.prototype, {
 
 	isBox3: true,
@@ -257,13 +259,11 @@ Object.assign( Box3.prototype, {
 
 			}
 
-			var box = new Box3();
+			_box.copy( geometry.boundingBox );
+			_box.applyMatrix4( object.matrixWorld );
 
-			box.copy( geometry.boundingBox );
-			box.applyMatrix4( object.matrixWorld );
-
-			this.expandByPoint( box.min );
-			this.expandByPoint( box.max );
+			this.expandByPoint( _box.min );
+			this.expandByPoint( _box.max );
 
 		}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -257,11 +257,13 @@ Object.assign( Box3.prototype, {
 
 			}
 
-			_box.copy( geometry.boundingBox );
-			_box.applyMatrix4( object.matrixWorld );
+			var box = new Box3();
 
-			this.expandByPoint( _box.min );
-			this.expandByPoint( _box.max );
+			box.copy( geometry.boundingBox );
+			box.applyMatrix4( object.matrixWorld );
+
+			this.expandByPoint( box.min );
+			this.expandByPoint( box.max );
 
 		}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -251,36 +251,17 @@ Object.assign( Box3.prototype, {
 
 		if ( geometry !== undefined ) {
 
-			if ( geometry.isGeometry ) {
+			if ( geometry.boundingBox === null ) {
 
-				var vertices = geometry.vertices;
-
-				for ( i = 0, l = vertices.length; i < l; i ++ ) {
-
-					_vector.copy( vertices[ i ] );
-					_vector.applyMatrix4( object.matrixWorld );
-
-					this.expandByPoint( _vector );
-
-				}
-
-			} else if ( geometry.isBufferGeometry ) {
-
-				var attribute = geometry.attributes.position;
-
-				if ( attribute !== undefined ) {
-
-					for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-						_vector.fromBufferAttribute( attribute, i ).applyMatrix4( object.matrixWorld );
-
-						this.expandByPoint( _vector );
-
-					}
-
-				}
+				geometry.computeBoundingBox();
 
 			}
+
+			_box.copy( geometry.boundingBox );
+			_box.applyMatrix4( object.matrixWorld );
+
+			this.expandByPoint( _box.min );
+			this.expandByPoint( _box.max );
 
 		}
 


### PR DESCRIPTION
Instead of recomputing the bounding box every time, we now use the
cached bounding box from the object, and transform it by the world
transform.

Note that this results in slightly less accurate bounding box compared
to the previous implementation. This seems like a fair tradeoff -
it's possible to get the precise box by using Box3.setFromBufferAttribute
if desired.

In addition to making the box calculation faster, this honors morph target
data and supports arbitrary future improvements to object bounding box
computation automatically.

Related to #17937.