### PR TITLE
packing.glsl: fix RGBAToDepth artifacts

### DIFF
--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -22,7 +22,7 @@ vec4 packDepthToRGBA( const in float v ) {
 }
 
 float unpackRGBAToDepth( const in vec4 v ) {
-	return dot( v, UnpackFactors );
+	return dot( floor( v * 255.0 + 0.5 ) / 255.0, UnpackFactors );
 }
 
 vec4 encodeHalfRGBA ( vec2 v ) {


### PR DESCRIPTION
Related to #9092, but actually low precision and line artifacts is different bugs. This PR fix only lines, but leave the same packing algorithm.