### PR TITLE
Document the copy behavior of .set in math classes

### DIFF
--- a/docs/api/en/math/Box2.html
+++ b/docs/api/en/math/Box2.html
@@ -174,7 +174,8 @@
 			[page:Vector2 min] - (required ) [page:Vector2] representing the lower (x, y) boundary of the box. <br>
 			[page:Vector2 max]  - (required) [page:Vector2] representing the upper (x, y) boundary of the box. <br /><br />
 
-			Sets the lower and upper (x, y) boundaries of this box.
+			Sets the lower and upper (x, y) boundaries of this box.<br>
+			Please note that this method only copies the values from the given objects.
 		</p>
 
 		<h3>[method:Box2 setFromCenterAndSize]( [param:Vector2 center], [param:Vector2 size] )</h3>

--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -247,7 +247,8 @@
 		[page:Vector3 min] - [page:Vector3] representing the lower (x, y, z) boundary of the box.<br />
 		[page:Vector3 max] - [page:Vector3] representing the lower upper (x, y, z) boundary of the box.<br /><br />
 
-		Sets the lower and upper (x, y, z) boundaries of this box.
+		Sets the lower and upper (x, y, z) boundaries of this box.<br>
+		Please note that this method only copies the values from the given objects.
 		</p>
 
 		<h3>[method:Box3 setFromArray]( [param:Array array] ) [param:Box3 this]</h3>

--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -91,7 +91,8 @@
 
 		<h3>[method:Frustum set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
 		<p>
-		Sets the current frustum from the passed planes. No plane order is implicitely implied.
+		Sets the current frustum from the passed planes. No plane order is implicitely implied.<br>
+		Please note that this method only copies the values from the given objects.
 		</p>
 
 		<h3>[method:Frustum setFromMatrix]( [param:Matrix4 matrix] )</h3>

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -113,7 +113,8 @@
 		[page:Vector3 start] - set the [page:.start start point] of the line.<br />
 		[page:Vector3 end] - set the [page:.end end point] of the line.<br /><br />
 
-		Sets the start and end values by copying the provided vectors.
+		Sets the start and end values by copying the provided vectors.<br>
+		Please note that this method only copies the values from the given objects.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -113,8 +113,7 @@
 		[page:Vector3 start] - set the [page:.start start point] of the line.<br />
 		[page:Vector3 end] - set the [page:.end end point] of the line.<br /><br />
 
-		Sets the start and end values by copying the provided vectors.<br>
-		Please note that this method only copies the values from the given objects.
+		Sets the start and end values by copying the provided vectors.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -130,8 +130,7 @@
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 			[page:Float constant] - the signed distance from the origin to the plane. Default is *0*.<br /><br />
 
-			Sets the plane's [page:.normal normal] and [page:.constant constant] properties.<br>
-			Please note that this method only copies the values from the given normal.
+			Sets this plane's [page:.normal normal] and [page:.constant constant] properties by copying the values from the given normal.
 		</p>
 
 		<h3>[method:Plane setComponents]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -130,7 +130,8 @@
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
 			[page:Float constant] - the signed distance from the origin to the plane. Default is *0*.<br /><br />
 
-			 Sets the plane's [page:.normal normal] and [page:.constant constant] properties.
+			Sets the plane's [page:.normal normal] and [page:.constant constant] properties.<br>
+			Please note that this method only copies the values from the given normal.
 		</p>
 
 		<h3>[method:Plane setComponents]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>

--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -202,7 +202,8 @@
 		properly.<br /><br />
 
 		Copy the parameters to the [page:.origin origin] and [page:.direction direction] properties
-		of this ray.
+		of this ray.<br>
+		Please note that this method only copies the values from the given objects.
 		</p>
 
 

--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -201,9 +201,7 @@
 		This must be normalized (with [page:Vector3.normalize]) for the methods to operate
 		properly.<br /><br />
 
-		Copy the parameters to the [page:.origin origin] and [page:.direction direction] properties
-		of this ray.<br>
-		Please note that this method only copies the values from the given objects.
+		Sets this ray's [page:.origin origin] and [page:.direction direction] properties by copying the values from the given objects.
 		</p>
 
 

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -114,7 +114,8 @@
 			[page:Vector3 center] - center of the sphere.<br />
 			[page:Float radius] - radius of the sphere.<br /><br />
 
-		Sets the [page:.center center] and [page:.radius radius] properties of this sphere.
+		Sets the [page:.center center] and [page:.radius radius] properties of this sphere.<br>
+		Please note that this method only copies the values from the given center.
 		</p>
 
 		<h3>[method:Sphere setFromPoints]( [param:Array points], [param:Vector3 optionalCenter] )</h3>

--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -123,7 +123,8 @@
 
 		<h3>[method:Triangle set]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] ) [param:Triangle this]</h3>
 		<p>
-		Sets the triangle's [page:.a a], [page:.b b] and [page:.c c] properties to the passed [page:vector3 vector3s].
+		Sets the triangle's [page:.a a], [page:.b b] and [page:.c c] properties to the passed [page:vector3 vector3s].<br>
+		Please note that this method only copies the values from the given objects.
 		</p>
 
 		<h3>[method:Triangle setFromPointsAndIndices]( [param:Array points], [param:Integer i0], [param:Integer i1], [param:Integer i2] ) [param:Triangle this]</h3>


### PR DESCRIPTION
As mentioned in #17738, math classes keep the arguments passed in their
constructor as references, but when they provide a .set() method,
that one only copies the values from the passed objects.
This behavior is now documented in the relevant classes.