### PR TITLE
revert and refactor 2HalfToRGBA

### DIFF
--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -22,15 +22,14 @@ vec4 packDepthToRGBA( const in float v ) {
 }
 
 float unpackRGBAToDepth( const in vec4 v ) {
-	return dot( floor( v * 255.0 + 0.5 ) / 255.0, UnpackFactors );
+	return dot( v, UnpackFactors );
 }
 
-vec4 packHalfToRGBA( vec2 v ) {
+vec4 pack2HalfToRGBA( vec2 v ) {
 	vec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ));
 	return vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w);
 }
-vec2 unpackHalfToRGBA( vec4 v ) {
-	v = floor( v * 255.0 + 0.5 ) / 255.0;
+vec2 unpack2HalfToRGBA( vec4 v ) {
 	return vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );
 }
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -38,7 +38,7 @@ export default /* glsl */`
 
 	vec2 texture2DDistribution( sampler2D shadow, vec2 uv ) {
 
-		return unpackHalfToRGBA( texture2D( shadow, uv ) );
+		return unpack2HalfToRGBA( texture2D( shadow, uv ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
@@ -17,7 +17,7 @@ void main() {
 
     #ifdef HORIZONAL_PASS
 
-      vec2 distribution = unpackHalfToRGBA ( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
+      vec2 distribution = unpack2HalfToRGBA ( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
       mean += distribution.x;
       squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;
 
@@ -34,9 +34,9 @@ void main() {
   mean = mean * HALF_SAMPLE_RATE;
   squared_mean = squared_mean * HALF_SAMPLE_RATE;
 
-  float std_dev = pow( squared_mean - mean * mean, 0.5 );
+  float std_dev = sqrt( squared_mean - mean * mean );
 
-  gl_FragColor = packHalfToRGBA( vec2( mean, std_dev ) );
+  gl_FragColor = pack2HalfToRGBA( vec2( mean, std_dev ) );
 
 }
 `;


### PR DESCRIPTION
Related to #17935. This PR revert back old 2HalfToRGBA implementation, but save refactoring and brings small optimization pow(x 0.5) -> sqrt(x).