### PR TITLE
Material: Introduce version property.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -186,8 +186,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Specifies that the material needs to be recompiled.<br />
-		This property is automatically set to *true* when instancing a new material.
+		Specifies that the material needs to be recompiled.
 		</p>
 
 		<h3>[property:Float opacity]</h3>
@@ -294,6 +293,11 @@
 		<p>
 		[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this material instance.
 		This gets automatically assigned, so this shouldn't be edited.
+		</p>
+
+		<h3>[property:Integer version]</h3>
+		<p>
+		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
 		</p>
 
 		<h3>[property:Integer vertexColors]</h3>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -163,8 +163,7 @@ Which stencil operation to perform when the comparison function returns true and
 <p>对象的可选名称（不必是唯一的）。默认值为空字符串。</p>
 
 <h3>[property:Boolean needsUpdate]</h3>
-<p>指定需要重新编译材质。<br/>
-	实例化新材质时，此属性自动设置为true。
+<p>指定需要重新编译材质。
 </p>
 
 <h3>[property:Float opacity]</h3>
@@ -253,6 +252,11 @@ Defines whether this material is tone mapped according to the renderer's [page:W
 
 <h3>[property:String uuid]</h3>
 <p> 此材质实例的[link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID]，会自动分配，不应该被更改。
+</p>
+
+<h3>[property:Integer version]</h3>
+<p>
+This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
 </p>
 
 <h3>[property:Integer vertexColors]</h3>

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -30,7 +30,9 @@ function NodeMaterial( vertex, fragment ) {
 
 	this.onBeforeCompile = function ( shader, renderer ) {
 
-		if ( this.needsUpdate ) {
+		var materialProperties = renderer.properties.get( this );
+
+		if ( this.version !== materialProperties.__version ) {
 
 			this.build( { renderer: renderer } );
 
@@ -74,6 +76,7 @@ Object.defineProperties( NodeMaterial.prototype, {
 
 		set: function ( value ) {
 
+			if ( value === true ) this.version ++;
 			this.needsCompile = value;
 
 		},
@@ -119,8 +122,6 @@ NodeMaterial.prototype.build = function ( params ) {
 	this.lights = builder.requires.lights;
 
 	this.transparent = builder.requires.transparent || this.blending > NormalBlending;
-
-	this.needsUpdate = false;
 
 	return this;
 

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -294,6 +294,11 @@ export class Material extends EventDispatcher {
 	userData: any;
 
 	/**
+	 * This starts at 0 and counts how many times .needsUpdate is set to true.
+	 */
+	version: number;
+
+	/**
 	 * Return a new material with the same parameters as this material.
 	 */
 	clone(): this;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -74,7 +74,7 @@ function Material() {
 
 	this.userData = {};
 
-	this.needsUpdate = true;
+	this.version = 0;
 
 }
 
@@ -422,5 +422,14 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 } );
 
+Object.defineProperty( Material.prototype, 'needsUpdate', {
+
+	set: function ( value ) {
+
+		if ( value === true ) this.version ++;
+
+	}
+
+} );
 
 export { Material };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1675,7 +1675,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( material.needsUpdate === false ) {
+		if ( material.version === materialProperties.__version ) {
 
 			if ( materialProperties.program === undefined ) {
 
@@ -1699,10 +1699,10 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( material.needsUpdate ) {
+		if ( material.version !== materialProperties.__version ) {
 
 			initMaterial( material, fog, object );
-			material.needsUpdate = false;
+			materialProperties.__version = material.version;
 
 		}
 


### PR DESCRIPTION
Fixed #12132

As suggested by @mrdoob here https://github.com/mrdoob/three.js/issues/12132#issuecomment-555626203, introducing `Material.version` avoids problems when rendering an updated material with multiple renderers.

@sunag  This PR would break `NodeMaterial` so it was necessary to make a few changes. Please review the changes in `NodeMaterial.js`.

Note: We should add this change to the migration guide since it's not possible to use `Material.needsUpdate` in conditional statements anymore (like in `NodeMaterial`). Setting `Material.needsUpdate` to `true` now just increases the `version` counter.