### PR TITLE
Update typedef for WebGLGeometries and others

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/src/renderers/webgl/WebGLAttributes.d.ts
@@ -1,11 +1,19 @@
+import { BufferAttribute } from "../../core/BufferAttribute";
+import { InterleavedBufferAttribute } from "../../core/InterleavedBufferAttribute";
+
 export class WebGLAttributes {
 
 	constructor( gl: WebGLRenderingContext | WebGL2RenderingContext );
 
-	get( attribute: any ): any;
+	get( attribute: BufferAttribute | InterleavedBufferAttribute ): {
+		buffer: WebGLBuffer,
+		type: GLenum,
+		bytesPerElement: number,
+		version: number
+	};
 
-	remove( attribute: any ): void;
+	remove( attribute: BufferAttribute | InterleavedBufferAttribute ): void;
 
-	update( attribute: any, bufferType: Array<any> ): void;
+	update( attribute: BufferAttribute | InterleavedBufferAttribute, bufferType: GLenum ): void;
 
 }

--- a/src/renderers/webgl/WebGLGeometries.d.ts
+++ b/src/renderers/webgl/WebGLGeometries.d.ts
@@ -1,9 +1,17 @@
+import { WebGLAttributes } from './WebGLAttributes';
+import { WebGLInfo } from './WebGLInfo';
+import { BufferAttribute } from '../../core/BufferAttribute';
+import { BufferGeometry } from '../../core/BufferGeometry';
+import { Geometry } from '../../core/Geometry';
+import { Object3D } from '../../core/Object3D';
+
 export class WebGLGeometries {
 
-	constructor( gl: WebGLRenderingContext, attributes: any, info: any );
+	constructor( gl: WebGLRenderingContext, attributes: WebGLAttributes, info: WebGLInfo );
 
-	get( object: any, geometry: any ): any;
-	update( geometry: any ): any;
-	getWireframeAttribute( geometry: any ): any;
+	get( object: Object3D, geometry: Geometry | BufferGeometry ): BufferGeometry;
+	update( geometry: Geometry | BufferGeometry );
+	updateWireframeAttribute( geometry: Geometry | BufferGeometry );
+	getWireframeAttribute( geometry: Geometry | BufferGeometry ): BufferAttribute;
 
 }

--- a/src/renderers/webgl/WebGLGeometries.d.ts
+++ b/src/renderers/webgl/WebGLGeometries.d.ts
@@ -10,8 +10,8 @@ export class WebGLGeometries {
 	constructor( gl: WebGLRenderingContext, attributes: WebGLAttributes, info: WebGLInfo );
 
 	get( object: Object3D, geometry: Geometry | BufferGeometry ): BufferGeometry;
-	update( geometry: Geometry | BufferGeometry );
-	updateWireframeAttribute( geometry: Geometry | BufferGeometry );
+	update( geometry: Geometry | BufferGeometry ): void;
+	updateWireframeAttribute( geometry: Geometry | BufferGeometry ): void;
 	getWireframeAttribute( geometry: Geometry | BufferGeometry ): BufferAttribute;
 
 }

--- a/src/renderers/webgl/WebGLGeometries.d.ts
+++ b/src/renderers/webgl/WebGLGeometries.d.ts
@@ -11,7 +11,6 @@ export class WebGLGeometries {
 
 	get( object: Object3D, geometry: Geometry | BufferGeometry ): BufferGeometry;
 	update( geometry: Geometry | BufferGeometry ): void;
-	updateWireframeAttribute( geometry: Geometry | BufferGeometry ): void;
 	getWireframeAttribute( geometry: Geometry | BufferGeometry ): BufferAttribute;
 
 }

--- a/src/renderers/webgl/WebGLInfo.d.ts
+++ b/src/renderers/webgl/WebGLInfo.d.ts
@@ -20,7 +20,7 @@ export class WebGLInfo {
 		points: number;
 		triangles: number;
 	};
-	update( count: any, mode: any, instanceCount: any ): void;
+	update( count: number, mode: GLenum, instanceCount: number ): void;
 	reset(): void;
 
 }


### PR DESCRIPTION
Updated following type definitions based on implementations:

- [WebGLGeometries](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLGeometries.js)
- [WebGLAttributes](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLAttributes.js)
- [WebGLInfo](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLInfo.js)

This is just my learning process of internal architecture of Three.js...