### PR TITLE
WebGLRenderer: Gracefully handle geometries in initial state.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -742,6 +742,14 @@ function WebGLRenderer( parameters ) {
 
 		var index = geometry.index;
 		var position = geometry.attributes.position;
+
+		//
+
+		if ( index !== null && index.count === 0 ) return;
+		if ( position === undefined || position.count === 0 ) return;
+
+		//
+
 		var rangeFactor = 1;
 
 		if ( material.wireframe === true ) {


### PR DESCRIPTION
Fixed #13601

also see https://github.com/mrdoob/three.js/issues/17967#issuecomment-555924922

BTW: There is already an early-out implemented a few lines below. If `drawRange` is zero, no draw calls are performed.