### PR TITLE
DRACOLoader: Add preload method

### DIFF
--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -36,6 +36,9 @@
 		// Specify path to a folder containing WASM/JS decoding libraries.
 		loader.setDecoderPath( '/examples/js/libs/draco' );
 
+		// Optional: Pre-fetch Draco WASM/JS module.
+		loader.preload();
+
 		// Load a Draco geometry
 		loader.load(
 			// resource URL
@@ -126,6 +129,11 @@
 		Sets the maximum number of [link:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers Web Workers]
 		to be used during decoding. A lower limit may be preferable if workers are also for other tasks
 		in the application.
+		</p>
+
+		<h3>[method:Promise preload]()</h3>
+		<p>
+		Requests the decoder libraries, if not already loaded.
 		</p>
 
 		<h3>[method:this dispose]()</h3>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -131,7 +131,7 @@
 		in the application.
 		</p>
 
-		<h3>[method:Promise preload]()</h3>
+		<h3>[method:this preload]()</h3>
 		<p>
 		Requests the decoder libraries, if not already loaded.
 		</p>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -36,6 +36,9 @@
 		// Specify path to a folder containing WASM/JS decoding libraries.
 		loader.setDecoderPath( '/examples/js/libs/draco' );
 
+		// Optional: Pre-fetch Draco WASM/JS module.
+		loader.preload();
+
 		// Load a Draco geometry
 		loader.load(
 			// resource URL
@@ -126,6 +129,11 @@
 		Sets the maximum number of [link:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers Web Workers]
 		to be used during decoding. A lower limit may be preferable if workers are also for other tasks
 		in the application.
+		</p>
+
+		<h3>[method:Promise preload]()</h3>
+		<p>
+		Requests the decoder libraries, if not already loaded.
 		</p>
 
 		<h3>[method:this dispose]()</h3>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -131,7 +131,7 @@
 		in the application.
 		</p>
 
-		<h3>[method:Promise preload]()</h3>
+		<h3>[method:this preload]()</h3>
 		<p>
 		Requests the decoder libraries, if not already loaded.
 		</p>

--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -220,7 +220,7 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	},
 
-	_initDecoder: function () {
+	preload: function () {
 
 		if ( this.decoderPending ) return this.decoderPending;
 
@@ -269,7 +269,7 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	_getWorker: function ( taskID, taskCost ) {
 
-		return this._initDecoder().then( () => {
+		return this.preload().then( () => {
 
 			if ( this.workerPool.length < this.workerLimit ) {
 

--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -222,6 +222,14 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	preload: function () {
 
+		this._initDecoder();
+
+		return this;
+
+	},
+
+	_initDecoder: function () {
+
 		if ( this.decoderPending ) return this.decoderPending;
 
 		var useJS = typeof WebAssembly !== 'object' || this.decoderConfig.type === 'js';
@@ -269,7 +277,7 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	_getWorker: function ( taskID, taskCost ) {
 
-		return this.preload().then( () => {
+		return this._initDecoder().then( () => {
 
 			if ( this.workerPool.length < this.workerLimit ) {
 

--- a/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/examples/jsm/loaders/DRACOLoader.d.ts
@@ -12,6 +12,7 @@ export class DRACOLoader extends Loader {
 	setDecoderPath( path: string ): DRACOLoader;
 	setDecoderConfig( config: object ): DRACOLoader;
 	setWorkerLimit( workerLimit: number ): DRACOLoader;
+	preload(): Promise<void>;
 	dispose(): DRACOLoader;
 
 }

--- a/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/examples/jsm/loaders/DRACOLoader.d.ts
@@ -12,7 +12,7 @@ export class DRACOLoader extends Loader {
 	setDecoderPath( path: string ): DRACOLoader;
 	setDecoderConfig( config: object ): DRACOLoader;
 	setWorkerLimit( workerLimit: number ): DRACOLoader;
-	preload(): Promise<void>;
+	preload(): DRACOLoader;
 	dispose(): DRACOLoader;
 
 }

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -227,7 +227,7 @@ DRACOLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	},
 
-	_initDecoder: function () {
+	preload: function () {
 
 		if ( this.decoderPending ) return this.decoderPending;
 
@@ -276,7 +276,7 @@ DRACOLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	_getWorker: function ( taskID, taskCost ) {
 
-		return this._initDecoder().then( () => {
+		return this.preload().then( () => {
 
 			if ( this.workerPool.length < this.workerLimit ) {
 

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -229,6 +229,14 @@ DRACOLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	preload: function () {
 
+		this._initDecoder();
+
+		return this;
+
+	},
+
+	_initDecoder: function () {
+
 		if ( this.decoderPending ) return this.decoderPending;
 
 		var useJS = typeof WebAssembly !== 'object' || this.decoderConfig.type === 'js';
@@ -276,7 +284,7 @@ DRACOLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	_getWorker: function ( taskID, taskCost ) {
 
-		return this.preload().then( () => {
+		return this._initDecoder().then( () => {
 
 			if ( this.workerPool.length < this.workerLimit ) {
 


### PR DESCRIPTION
Addresses #17970.

This PR adds the public method `preload` to DRACOLoader (previously a private method `_initDecoder`). This allows the DRACO libraries to be loaded before loading any assets, similar to the behavior achieved in past releases using `DRACOLoader.getDecoderModule`.

I took the documentation from the old documentation for `getDecoderModule`, but there may be a better description we could use.