### PR TITLE
GLTFLoader: Cache default material in the same way as we do for other materials

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1202,24 +1202,26 @@ THREE.GLTFLoader = ( function () {
 
 	}
 
-	var defaultMaterial;
-
 	/**
 	 * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#default-material
 	 */
-	function createDefaultMaterial() {
+	function createDefaultMaterial( cache ) {
 
-		defaultMaterial = defaultMaterial || new THREE.MeshStandardMaterial( {
-			color: 0xFFFFFF,
-			emissive: 0x000000,
-			metalness: 1,
-			roughness: 1,
-			transparent: false,
-			depthTest: true,
-			side: THREE.FrontSide
-		} );
+		if ( cache[ 'DefaultMaterial' ] === undefined ) {
 
-		return defaultMaterial;
+			cache[ 'DefaultMaterial' ] = new THREE.MeshStandardMaterial( {
+				color: 0xFFFFFF,
+				emissive: 0x000000,
+				metalness: 1,
+				roughness: 1,
+				transparent: false,
+				depthTest: true,
+				side: THREE.FrontSide
+			} );
+
+		}
+
+		return cache[ 'DefaultMaterial' ];
 
 	}
 
@@ -2482,7 +2484,7 @@ THREE.GLTFLoader = ( function () {
 		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
 
 			var material = primitives[ i ].material === undefined
-				? createDefaultMaterial()
+				? createDefaultMaterial( this.cache )
 				: this.getDependency( 'material', primitives[ i ].material );
 
 			pending.push( material );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1269,24 +1269,26 @@ var GLTFLoader = ( function () {
 
 	}
 
-	var defaultMaterial;
-
 	/**
 	 * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#default-material
 	 */
-	function createDefaultMaterial() {
+	function createDefaultMaterial( cache ) {
 
-		defaultMaterial = defaultMaterial || new MeshStandardMaterial( {
-			color: 0xFFFFFF,
-			emissive: 0x000000,
-			metalness: 1,
-			roughness: 1,
-			transparent: false,
-			depthTest: true,
-			side: FrontSide
-		} );
+		if ( cache[ 'DefaultMaterial' ] === undefined ) {
 
-		return defaultMaterial;
+			cache[ 'DefaultMaterial' ] = new MeshStandardMaterial( {
+				color: 0xFFFFFF,
+				emissive: 0x000000,
+				metalness: 1,
+				roughness: 1,
+				transparent: false,
+				depthTest: true,
+				side: FrontSide
+			} );
+
+		}
+
+		return cache[ 'DefaultMaterial' ];
 
 	}
 
@@ -2549,7 +2551,7 @@ var GLTFLoader = ( function () {
 		for ( var i = 0, il = primitives.length; i < il; i ++ ) {
 
 			var material = primitives[ i ].material === undefined
-				? createDefaultMaterial()
+				? createDefaultMaterial( this.cache )
 				: this.getDependency( 'material', primitives[ i ].material );
 
 			pending.push( material );


### PR DESCRIPTION
**Problem**

If gltf contains [default material](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#default-material) the default material instance included in the result returned by `GLTFLoader.load()` is always the same instance, even you use a new loader instance.

So, for example if user loads the same assets twice and updates the property of default material instance only in the first loaded asset it'll have an effect to the second loaded asset. This behavior may be confusing to users.

```javascript
// load an asset and redden the materials of it
new GLTFLoader().load(assetPath, gltf => {
  gltf.scene.traverse(child => {
    if (child.material && child.material.emissive) {
      child.material.emissive.setRGB(1, 0, 0);
    }
  });
  // load the same asset with a new loader
  // and add it to scene without changing the color
  new GLTFLoader().load(assetPath, gltf2 => {
    scene.add(gltf2);
    // reddened asset will be rendered although
    // we don't change the color of gltf2
  });
});
```

And this behavior is different from non-default materials. Each `.load()` creates new non-default material instances. The difference also may be confusing.

**Solution**

`GLTFLoader` [clears the cache in `.parse()`](https://github.com/mrdoob/three.js/blob/r110/examples/js/loaders/GLTFLoader.js#L1548) then each `.load()` creates a new non-default material instances. But it saves the default material instance differently [here](https://github.com/mrdoob/three.js/blob/r110/examples/js/loaders/GLTFLoader.js#L1189) and it won't clear. So it always returns the same default material instance even with a new loader.

I'd like to suggest that it saves the default material instance in the way as it does for non-default materials. The default material instance will be created in each `.load()` as non-default material instances are. I think the consistent behavior is less confusing.