### PR TITLE
Add .type property to shader

### DIFF
--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -170,6 +170,7 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 	function createMaterial() {
 
 		return new THREE.ShaderMaterial( {
+			type: 'OutlineEffect',
 			uniforms: THREE.UniformsUtils.merge( [
 				THREE.UniformsLib[ 'fog' ],
 				THREE.UniformsLib[ 'displacementmap' ],

--- a/examples/jsm/effects/OutlineEffect.js
+++ b/examples/jsm/effects/OutlineEffect.js
@@ -178,6 +178,7 @@ var OutlineEffect = function ( renderer, parameters ) {
 	function createMaterial() {
 
 		return new ShaderMaterial( {
+			type: 'OutlineEffect',
 			uniforms: UniformsUtils.merge( [
 				UniformsLib[ 'fog' ],
 				UniformsLib[ 'displacementmap' ],


### PR DESCRIPTION
Helpful when inspecting `renderer.info.programs`.

We also do this for the scene background shaders and PMREM.