### PR TITLE
Ray: Set direction to 0, 0, -1 by default.

### DIFF
--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -25,7 +25,7 @@
 		<p>
 		[page:Vector3 origin] - (optional) the origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).<br />
 		[page:Vector3 direction] - [page:Vector3] The direction of the [page:Ray]. This must be normalized
-		 (with [page:Vector3.normalize]) for the methods to operate properly.  Default is a [page:Vector3] at (0, 0, 0).<br /><br />
+		 (with [page:Vector3.normalize]) for the methods to operate properly.  Default is a [page:Vector3] at (0, 0, -1).<br /><br />
 
 		Creates a new [name].
 		</p>
@@ -38,7 +38,7 @@
 		<h3>[property:Vector3 direction]</h3>
 		<p>
 		The direction of the [page:Ray]. This must be normalized (with [page:Vector3.normalize])
-		for the methods to operate properly. Default is a [page:Vector3] at (0, 0, 0).
+		for the methods to operate properly. Default is a [page:Vector3] at (0, 0, -1).
 		</p>
 
 

--- a/docs/api/zh/math/Ray.html
+++ b/docs/api/zh/math/Ray.html
@@ -24,7 +24,7 @@
 		<p>
 		[page:Vector3 origin] - （可选）[page:Ray]（射线）的原点，默认值是一个位于(0, 0, 0)的[page:Vector3]。<br />
 		[page:Vector3 direction] - [page:Vector3] [page:Ray]（射线）的方向。该向量必须经过标准化（使用[page:Vector3.normalize]），这样才能使方法正常运行。
-		默认值是一个位于(0, 0, 0)的[page:Vector3]。<br /><br />
+		默认值是一个位于(0, 0, -1)的[page:Vector3]。<br /><br />
 
 		创建一个新的[name]。
 		</p>
@@ -37,7 +37,7 @@
 		<h3>[property:Vector3 direction]</h3>
 		<p>
 		[page:Ray]（射线）的方向。该向量必须经过标准化（使用[page:Vector3.normalize]），这样才能使方法正常运行。
-		默认值是一个位于(0, 0, 0)的[page:Vector3]。
+		默认值是一个位于(0, 0, -1)的[page:Vector3]。
 		</p>
 
 
@@ -190,7 +190,7 @@
 		<p>
 		[page:Vector3 origin] - [page:Ray]（射线）的[page:.origin origin]（原点）。<br />
 		[page:Vector3 origin] - [page:Ray]（射线）的[page:.direction direction]（方向）。
-		
+
 		该向量必须经过标准化（使用[page:Vector3.normalize]），这样才能使方法正常运行。
 		<br /><br />
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -16,7 +16,7 @@ var _normal = new Vector3();
 function Ray( origin, direction ) {
 
 	this.origin = ( origin !== undefined ) ? origin : new Vector3();
-	this.direction = ( direction !== undefined ) ? direction : new Vector3();
+	this.direction = ( direction !== undefined ) ? direction : new Vector3( 0, 0, - 1 );
 
 }
 

--- a/test/unit/src/math/Ray.tests.js
+++ b/test/unit/src/math/Ray.tests.js
@@ -27,7 +27,7 @@ export default QUnit.module( 'Maths', () => {
 
 			var a = new Ray();
 			assert.ok( a.origin.equals( zero3 ), "Passed!" );
-			assert.ok( a.direction.equals( zero3 ), "Passed!" );
+			assert.ok( a.direction.equals( new Vector3( 0, 0, - 1 ) ), "Passed!" );
 
 			var a = new Ray( two3.clone(), one3.clone() );
 			assert.ok( a.origin.equals( two3 ), "Passed!" );


### PR DESCRIPTION
Every time I user `Ray` I find myself setting the direction to `0, 0, -1`
Also, I doubt `0, 0, 0` as direction is any use so people are probably changing it anyway?

@WestLangley @Mugen87 what do you guys think?