### PR TITLE
Web*RManager: Do not modify camera when not presenting.

### DIFF
--- a/examples/webvr_ballshooter.html
+++ b/examples/webvr_ballshooter.html
@@ -44,6 +44,7 @@
 				scene.background = new THREE.Color( 0x505050 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 
 				room = new THREE.LineSegments(
 					new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ),

--- a/examples/webvr_cubes.html
+++ b/examples/webvr_cubes.html
@@ -46,6 +46,7 @@
 				scene.background = new THREE.Color( 0x505050 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 				scene.add( camera );
 
 				crosshair = new THREE.Mesh(

--- a/examples/webvr_dragging.html
+++ b/examples/webvr_dragging.html
@@ -42,6 +42,7 @@
 				scene.background = new THREE.Color( 0x808080 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				var material = new THREE.MeshStandardMaterial( {

--- a/examples/webvr_lorenzattractor.html
+++ b/examples/webvr_lorenzattractor.html
@@ -82,6 +82,7 @@
 				scene = new THREE.Scene();
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 
 				//
 

--- a/examples/webvr_multiview.html
+++ b/examples/webvr_multiview.html
@@ -82,6 +82,7 @@
 				scene.background = new THREE.Color( 0x505050 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 
 				room = new THREE.LineSegments(
 					new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ),

--- a/examples/webvr_paint.html
+++ b/examples/webvr_paint.html
@@ -48,6 +48,7 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				var material = new THREE.MeshStandardMaterial( {

--- a/examples/webvr_panorama.html
+++ b/examples/webvr_panorama.html
@@ -39,6 +39,7 @@
 
 				camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.layers.enable( 1 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.BoxBufferGeometry( 100, 100, 100 );
 				geometry.scale( 1, 1, - 1 );

--- a/examples/webvr_panorama_depth.html
+++ b/examples/webvr_panorama_depth.html
@@ -41,10 +41,7 @@
 				scene.add( light );
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 2000 );
-				var cameraRig = new THREE.Object3D();
-				cameraRig.position.y = - 1.6;
-				cameraRig.add( camera );
-				scene.add( cameraRig );
+				scene.add( camera );
 
 				// Create the panoramic sphere geometery
 				var panoSphereGeo = new THREE.SphereBufferGeometry( 6, 256, 256 );
@@ -93,7 +90,7 @@
 				renderer.vr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( WEBVR.createButton( renderer ) );
+				document.body.appendChild( WEBVR.createButton( renderer, { referenceSpaceType: 'local' } ) );
 
 				//
 
@@ -120,7 +117,7 @@
 
 				// If we are not presenting move the camera a little so the effect is visible
 
-				if ( ! renderer.vr.isPresenting() ) {
+				if ( renderer.vr.isPresenting() === false ) {
 
 					var time = clock.getElapsedTime();
 

--- a/examples/webvr_sandbox.html
+++ b/examples/webvr_sandbox.html
@@ -38,6 +38,7 @@
 				scene.background = background;
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.TorusKnotBufferGeometry( 0.4, 0.15, 150, 20 );
 				var material = new THREE.MeshStandardMaterial( { roughness: 0.01, metalness: 0.2, envMap: background } );

--- a/examples/webvr_sculpt.html
+++ b/examples/webvr_sculpt.html
@@ -44,6 +44,7 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.02, 50 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				var material = new THREE.MeshStandardMaterial( {

--- a/examples/webvr_video.html
+++ b/examples/webvr_video.html
@@ -44,6 +44,7 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 2000 );
 				camera.layers.enable( 1 ); // render left view when no stereo available
+				camera.position.set( 0, 1.6, 0 );
 
 				// video
 

--- a/examples/webvr_vive_paint.html
+++ b/examples/webvr_vive_paint.html
@@ -51,6 +51,7 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				var material = new THREE.MeshStandardMaterial( {

--- a/examples/webvr_vive_sculpt.html
+++ b/examples/webvr_vive_sculpt.html
@@ -46,6 +46,7 @@
 				scene.background = new THREE.Color( 0x222222 );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
+				camera.position.set( 0, 1.6, 0 );
 
 				var geometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				var material = new THREE.MeshStandardMaterial( {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1153,7 +1153,7 @@ function WebGLRenderer( parameters ) {
 
 		if ( camera.parent === null ) camera.updateMatrixWorld();
 
-		if ( vr.enabled ) {
+		if ( vr.enabled && vr.isPresenting() ) {
 
 			camera = vr.getCamera( camera );
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -285,15 +285,6 @@ function WebVRManager( renderer ) {
 
 		var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
 
-		if ( isPresenting() === false ) {
-
-			camera.position.set( 0, userHeight, 0 );
-			camera.rotation.set( 0, 0, 0 );
-
-			return camera;
-
-		}
-
 		device.depthNear = camera.near;
 		device.depthFar = camera.far;
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -199,38 +199,32 @@ function WebXRManager( renderer, gl ) {
 
 	this.getCamera = function ( camera ) {
 
-		if ( isPresenting() ) {
+		var parent = camera.parent;
+		var cameras = cameraVR.cameras;
 
-			var parent = camera.parent;
-			var cameras = cameraVR.cameras;
+		updateCamera( cameraVR, parent );
 
-			updateCamera( cameraVR, parent );
+		for ( var i = 0; i < cameras.length; i ++ ) {
 
-			for ( var i = 0; i < cameras.length; i ++ ) {
-
-				updateCamera( cameras[ i ], parent );
-
-			}
-
-			// update camera and its children
-
-			camera.matrixWorld.copy( cameraVR.matrixWorld );
-
-			var children = camera.children;
-
-			for ( var i = 0, l = children.length; i < l; i ++ ) {
-
-				children[ i ].updateMatrixWorld( true );
-
-			}
-
-			setProjectionFromUnion( cameraVR, cameraL, cameraR );
-
-			return cameraVR;
+			updateCamera( cameras[ i ], parent );
 
 		}
 
-		return camera;
+		// update camera and its children
+
+		camera.matrixWorld.copy( cameraVR.matrixWorld );
+
+		var children = camera.children;
+
+		for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+			children[ i ].updateMatrixWorld( true );
+
+		}
+
+		setProjectionFromUnion( cameraVR, cameraL, cameraR );
+
+		return cameraVR;
 
 	};
 


### PR DESCRIPTION
This "feature" ended up being confusing and limiting.

We should now be able to use, say, `OrbitControls` when not presenting.

FYI @fernandojsg @takahirox @toji @dmarcos 