### PR TITLE
OBJLoader: Better handle "usemap" identifier.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -10,6 +10,8 @@ THREE.OBJLoader = ( function () {
 	var material_library_pattern = /^mtllib /;
 	// usemtl material_name
 	var material_use_pattern = /^usemtl /;
+	// usemap map_name
+	var map_use_pattern = /^usemap /;
 
 	function ParserState() {
 
@@ -569,6 +571,13 @@ THREE.OBJLoader = ( function () {
 					// mtl file
 
 					state.materialLibraries.push( line.substring( 7 ).trim() );
+
+				} else if ( map_use_pattern.test( line ) ) {
+
+					// the line is parsed but ignored since the loader assumes textures are defined MTL files
+					// (according to https://www.okino.com/conv/imp_wave.htm, 'usemap' is the old-style Wavefront texture reference method)
+
+					console.warn( 'THREE.OBJLoader: Rendering identifier "usemap" not supported. Textures must be defined in MTL files.' );
 
 				} else if ( lineFirstChar === 's' ) {
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -27,6 +27,8 @@ var OBJLoader = ( function () {
 	var material_library_pattern = /^mtllib /;
 	// usemtl material_name
 	var material_use_pattern = /^usemtl /;
+	// usemap map_name
+	var map_use_pattern = /^usemap /;
 
 	function ParserState() {
 
@@ -586,6 +588,13 @@ var OBJLoader = ( function () {
 					// mtl file
 
 					state.materialLibraries.push( line.substring( 7 ).trim() );
+
+				} else if ( map_use_pattern.test( line ) ) {
+
+					// the line is parsed but ignored since the loader assumes textures are defined MTL files
+					// (according to https://www.okino.com/conv/imp_wave.htm, 'usemap' is the old-style Wavefront texture reference method)
+
+					console.warn( 'THREE.OBJLoader: Rendering identifier "usemap" not supported. Textures must be defined in MTL files.' );
 
 				} else if ( lineFirstChar === 's' ) {
 


### PR DESCRIPTION
Some OBJ exporters still write `usemap` in `OBJ` files. However, `OBJLoader` is not able to parse this line so far. The problem was once discussed here:

https://www.reddit.com/r/threejs/comments/6hbbnt/trouble_with_mtl_obj_import/

Another user encounters now the same issue with the same asset package:

https://stackoverflow.com/questions/59010593/cannot-display-object-in-threejs-getting-error-three-objloader-unexpected-lin

This little patch ensures `OBJLoader` does not produce a runtime error but just ignores `usemap`. The [assets](https://www.kenney.nl/assets/space-kit) are loaded correctly now since they define their textures in MTL files, too. So it looks like a redundant definition of the used exporter.