### PR TITLE
WebVRManager: Align with WebXRManager.

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -41,6 +41,8 @@ function WebVRManager( renderer ) {
 	var tempQuaternion = new Quaternion();
 	var tempPosition = new Vector3();
 
+	var tempCamera = new PerspectiveCamera();
+
 	var cameraL = new PerspectiveCamera();
 	cameraL.viewport = new Vector4();
 	cameraL.layers.enable( 1 );
@@ -303,14 +305,13 @@ function WebVRManager( renderer ) {
 
 		var pose = frameData.pose;
 
-		// We want to manipulate camera by its position and quaternion components since users may rely on them.
-		camera.matrix.copy( standingMatrix );
-		camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+		tempCamera.matrix.copy( standingMatrix );
+		tempCamera.matrix.decompose( tempCamera.position, tempCamera.quaternion, tempCamera.scale );
 
 		if ( pose.orientation !== null ) {
 
 			tempQuaternion.fromArray( pose.orientation );
-			camera.quaternion.multiply( tempQuaternion );
+			tempCamera.quaternion.multiply( tempQuaternion );
 
 		}
 
@@ -319,11 +320,23 @@ function WebVRManager( renderer ) {
 			tempQuaternion.setFromRotationMatrix( standingMatrix );
 			tempPosition.fromArray( pose.position );
 			tempPosition.applyQuaternion( tempQuaternion );
-			camera.position.add( tempPosition );
+			tempCamera.position.add( tempPosition );
 
 		}
 
-		camera.updateMatrixWorld();
+		tempCamera.updateMatrixWorld();
+
+		//
+
+		camera.matrixWorld.copy( tempCamera.matrixWorld );
+
+		var children = camera.children;
+
+		for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+			children[ i ].updateMatrixWorld( true );
+
+		}
 
 		//
 

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -22,8 +22,6 @@ function WebVRManager( renderer ) {
 	var device = null;
 	var frameData = null;
 
-	var poseTarget = null;
-
 	var controllers = [];
 	var standingMatrix = new Matrix4();
 	var standingMatrixInverse = new Matrix4();
@@ -275,12 +273,6 @@ function WebVRManager( renderer ) {
 
 	};
 
-	this.setPoseTarget = function ( object ) {
-
-		if ( object !== undefined ) poseTarget = object;
-
-	};
-
 	this.getCamera = function ( camera ) {
 
 		var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
@@ -310,16 +302,15 @@ function WebVRManager( renderer ) {
 
 
 		var pose = frameData.pose;
-		var poseObject = poseTarget !== null ? poseTarget : camera;
 
-		// We want to manipulate poseObject by its position and quaternion components since users may rely on them.
-		poseObject.matrix.copy( standingMatrix );
-		poseObject.matrix.decompose( poseObject.position, poseObject.quaternion, poseObject.scale );
+		// We want to manipulate camera by its position and quaternion components since users may rely on them.
+		camera.matrix.copy( standingMatrix );
+		camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 
 		if ( pose.orientation !== null ) {
 
 			tempQuaternion.fromArray( pose.orientation );
-			poseObject.quaternion.multiply( tempQuaternion );
+			camera.quaternion.multiply( tempQuaternion );
 
 		}
 
@@ -328,11 +319,11 @@ function WebVRManager( renderer ) {
 			tempQuaternion.setFromRotationMatrix( standingMatrix );
 			tempPosition.fromArray( pose.position );
 			tempPosition.applyQuaternion( tempQuaternion );
-			poseObject.position.add( tempPosition );
+			camera.position.add( tempPosition );
 
 		}
 
-		poseObject.updateMatrixWorld();
+		camera.updateMatrixWorld();
 
 		//
 
@@ -356,7 +347,7 @@ function WebVRManager( renderer ) {
 
 		}
 
-		var parent = poseObject.parent;
+		var parent = camera.parent;
 
 		if ( parent !== null ) {
 


### PR DESCRIPTION
AFAIK, A-Frame was the only user of `setPoseTarget()` and [sounds like they no longer rely on it](https://github.com/mrdoob/three.js/pull/17990#issuecomment-557961240).

Additionally, `WebVRManager` no longer modifies the `camera.position` and `camera.quaternion` so the camera is in now a normal state when leaving VR.

This aligns the behaviour and eases the transition for its removal in ~2 months.