### PR TITLE
WebGLAttributes: Add uploadCallback when attribute gets updated

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -70,6 +70,8 @@ function WebGLAttributes( gl ) {
 
 		gl.bindBuffer( bufferType, buffer );
 
+		attribute.onUploadCallback();
+
 		if ( updateRange.count === - 1 ) {
 
 			// Not using update ranges

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -70,8 +70,6 @@ function WebGLAttributes( gl ) {
 
 		gl.bindBuffer( bufferType, buffer );
 
-		attribute.onUploadCallback();
-
 		if ( updateRange.count === - 1 ) {
 
 			// Not using update ranges
@@ -86,6 +84,8 @@ function WebGLAttributes( gl ) {
 			updateRange.count = - 1; // reset range
 
 		}
+
+		attribute.onUploadCallback();
 
 	}
 

--- a/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLAttributes.tests.js
@@ -37,6 +37,27 @@ export default QUnit.module( 'Renderers', () => {
 
 			} );
 
+			QUnit.test( "update", ( assert ) => {
+
+				const noop = () => {};
+				let count = 0;
+				const onUploadCallback = () => {
+
+					count ++;
+
+				};
+				const attribute = { onUploadCallback, array: { subarray: noop }, usage: {}, version: 0, updateRange: {} };
+				const webglAttribute = WebGLAttributes( { createBuffer: noop, bindBuffer: noop, bufferData: noop, bufferSubData: noop } );
+
+				webglAttribute.update( attribute, );
+				assert.equal( count, 1, ".onUploadCallback should be called when created" );
+
+				attribute.version ++;
+				webglAttribute.update( attribute, );
+				assert.equal( count, 2, ".onUploadCallback should be called when updated" );
+
+			} );
+
 		} );
 
 	} );


### PR DESCRIPTION
Ensure `.onUploadCallback` gets called when attribute gets updated. 
Context: https://discourse.threejs.org/t/how-to-dispose-bufferattribute-array-on-updates/11044/2