### PR TITLE
Examples: Consolidate redundant CSS.

### DIFF
--- a/examples/css3d_panorama_deviceorientation.html
+++ b/examples/css3d_panorama_deviceorientation.html
@@ -5,42 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-
-		</style>
 	</head>
 	<body>
 		<div id="overlay">

--- a/examples/main.css
+++ b/examples/main.css
@@ -52,3 +52,36 @@ a, button, input, select {
 	user-select: none;
 	z-index: 2 !important; /* TODO Solve this in HTML */
 }
+
+#overlay {
+	position: absolute;
+	z-index: 2;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height:100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 1;
+	background-color: #000000;
+	color: #ffffff;
+}
+
+#overlay > div {
+	text-align: center;
+}
+
+#overlay > div > button {
+	height: 20px;
+	background: transparent;
+	color: #ffffff;
+	outline: 1px solid #ffffff;
+	border: 0px;
+	cursor: pointer;
+}
+
+#overlay > div > p {
+	color: #777777;
+	font-size: 12px;
+}

--- a/examples/misc_controls_deviceorientation.html
+++ b/examples/misc_controls_deviceorientation.html
@@ -5,42 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-
-		</style>
 	</head>
 	<body>
 		<div id="overlay">

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -5,39 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#overlay {
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				z-index: 1;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-		</style>
 	</head>
 <body>
 

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -5,40 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-		</style>
 	</head>
 	<body>
 		<div id="overlay">

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -5,40 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-		</style>
 	</head>
 <body>
 

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -5,40 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-		</style>
 
 		<script id="vertexShader" type="x-shader/x-vertex">
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
 		<style>
-			#overlay {
+			#selection {
 				position: fixed;
 				display: flex;
 				flex-direction: column;
@@ -18,7 +18,7 @@
 				z-index: 999;
 			}
 
-			#overlay > div {
+			#selection > div {
 				height: 128px;
 				width: 128px;
 				border: 1px solid white;
@@ -31,7 +31,7 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> framebuffer to texture
 		</div>
 
-		<div id="overlay">
+		<div id="selection">
 			<div></div>
 		</div>
 
@@ -114,8 +114,8 @@
 
 				//
 
-				var overlay = document.getElementById( 'overlay' );
-				var controls = new OrbitControls( camera, overlay );
+				var selection = document.getElementById( 'selection' );
+				var controls = new OrbitControls( camera, selection );
 				controls.enablePan = false;
 
 				//

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -5,42 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-
-			#overlay {
-				position: absolute;
-				z-index: 1;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height:100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				opacity: 1;
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-			#overlay > div {
-				text-align: center;
-			}
-
-			#overlay > div > button {
-				height: 20px;
-				background: transparent;
-				color: #ffffff;
-				outline: 1px solid #ffffff;
-				border: 0px;
-				cursor: pointer;
-			}
-
-			#overlay > div > p {
-				color: #777777;
-				font-size: 12px;
-			}
-
-		</style>
 	</head>
 	<body>
 


### PR DESCRIPTION
I think it's time to consolidate the overlay related CSS into `main.css` to avoid redundant code.