### PR TITLE
preventing 0 scale objects render processing

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1286,7 +1286,7 @@ function WebGLRenderer( parameters ) {
 
 	function projectObject( object, camera, groupOrder, sortObjects ) {
 
-		if ( object.scale.x === 0 || object.scale.y === 0 || object.scale.z === 0) return;
+		if ( object.scale.x === 0 || object.scale.y === 0 || object.scale.z === 0 ) return;
 		if ( object.visible === false ) return;
 
 		var visible = object.layers.test( camera.layers );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1286,6 +1286,7 @@ function WebGLRenderer( parameters ) {
 
 	function projectObject( object, camera, groupOrder, sortObjects ) {
 
+		if ( object.scale.x === 0 || object.scale.y === 0 || object.scale.z === 0) return;
 		if ( object.visible === false ) return;
 
 		var visible = object.layers.test( camera.layers );


### PR DESCRIPTION
In glTF generated by Adobe Animate we have some nodes which have Zero scale and should not be part of render processing returning early for such nodes. It gives us a lot of performance benefit.