### PR TITLE
Make `extractUrlBase()` return empty string for data URIs

### DIFF
--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -40,6 +40,12 @@ var LoaderUtils = {
 
 	extractUrlBase: function ( url ) {
 
+		if ( /^data:.*,.*$/i.test( url ) ) {
+
+			return '';
+
+		}
+
 		var index = url.lastIndexOf( '/' );
 
 		if ( index === - 1 ) return './';

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -25,6 +25,7 @@ export default QUnit.module( 'Loaders', () => {
 			assert.equal( '/path/to/', LoaderUtils.extractUrlBase( '/path/to/model.glb' ) );
 			assert.equal( './', LoaderUtils.extractUrlBase( 'model.glb' ) );
 			assert.equal( '/', LoaderUtils.extractUrlBase( '/model.glb' ) );
+			assert.equal( '', LoaderUtils.extractUrlBase( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOAgMAAABrzWU4AAAACVBMVEUAAABS////UlJlNLqiAAAALUlEQVQIHQXBQQ0AIAwEsF7CJIAeLPCYBCThlxZkMA6zWZd6pKne0iQkJFSBD2pCAzD7/lbiAAAAAElFTkSuQmCC' ) );
 
 		} );
 


### PR DESCRIPTION
This fixes an issue where the resource path for GLTFLoader (and others) would be incorrect when loading a model from a data URI, which would cause trouble if the GLTF data contained relative paths to textures and buffers.

e.g. my GLTF contains the following:
```
    "buffers" : [
        {
            "byteLength" : 140,
            "uri" : "back-wall.bin"
        }
    ]
```

If I convert the GLTF to base64 and use a LoadingManager to inspect the URLs that get passed

```js
var manager = new THREE.LoadingManager();
manager.setURLModifier(function (url) {
  console.log(url);
  return url;
});
var loader = new THREE.GLTFLoader(manager);
loader.load('data:application/octet-stream;base64,ewogICAg...........', function () {});
```

It tries to load the URL `data:application/back-wall.bin` where it should have used `back-wall.bin`

![image](https://user-images.githubusercontent.com/569607/69872364-818b6c00-12b5-11ea-8485-56a7024ffa0c.png)
