### PR TITLE
Handle UA with partial OffscreenCanvas more gracefully

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -18,9 +18,20 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
 	// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
+	// Some implementations may only implement OffscreenCanvas partially (e.g. lacking 2d).
 
-	var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
-		&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
+	var useOffscreenCanvas = false;
+
+	try {
+
+		useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+			&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
+
+	} catch ( err ) {
+
+		// Ignore any errors
+
+	}
 
 	function createCanvas( width, height ) {
 


### PR DESCRIPTION
Related to https://github.com/mrdoob/three.js/issues/17642

I understand that I enabled this flag myself, but it would be cool if three.js would handle this more gracefully. I tried to keep to overhead small, by doing the check only once. I [verified][1] that it works by patching a r111 build file directly. If you'd like a different style or approach I'm open to adjust the PR.

Thanks for the great library and keep up the good work!

[1]: http://ocbnet.ch/milkyway-poc-01/demo/