### PR TITLE
Geometric anti-aliasing

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -1,7 +1,13 @@
 export default /* glsl */`
 PhysicalMaterial material;
 material.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );
-material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );
+
+vec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );
+float geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );
+
+material.specularRoughness = max( roughnessFactor, 0.0525 );// 0.0525 corresponds to the base mip of a 256 cubemap.
+material.specularRoughness += geometryRoughness;
+material.specularRoughness = min( material.specularRoughness, 1.0 );
 
 #ifdef REFLECTIVITY
 
@@ -16,7 +22,9 @@ material.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );
 #ifdef CLEARCOAT
 
 	material.clearcoat = saturate( clearcoat ); // Burley clearcoat model
-	material.clearcoatRoughness = clamp( clearcoatRoughness, 0.04, 1.0 );
+	material.clearcoatRoughness = max( roughnessFactor, 0.0525 );
+	material.clearcoatRoughness += geometryRoughness;
+	material.clearcoatRoughness = min( material.clearcoatRoughness, 1.0 );
 
 #endif
 #ifdef USE_SHEEN


### PR DESCRIPTION
This is a small follow-on to my PMREM revamp, also upstreaming existing work from `<model-viewer>`. Since the new PMREM uses custom filtering and no standard mipmaps, it needs this anti-aliasing to be added manually. Here I am simply increasing the roughness (which equates to looking up a deeper mip level) according to the screen space derivatives of the geometric normal, just like standard mipmapping would. I am approximating the relationship between normal variation and roughness as linear, when it should probably be square, but I didn't think the extra sqrt would be worth the difference. 

It might seem natural to use the actual normal variation (including the normal map) here instead of just the vertex normals, however I found that the structural errors from texture interpolation simply manifested as their own source of aliasing rather than fixing the problem. I'll have another PR coming shortly to address the roughness component from normal map variation. 