### PR TITLE
WebGLRenderer: Enable rendering of geometries with just an index.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -742,8 +742,15 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		if ( index !== null && index.count === 0 ) return;
-		if ( position === undefined || position.count === 0 ) return;
+		if ( index === null ) {
+
+			if ( position === undefined || position.count === 0 ) return;
+
+		} else if ( index.count === 0 ) {
+
+			return;
+
+		}
 
 		//
 


### PR DESCRIPTION
This recently added graceful-failcheck, from https://github.com/mrdoob/three.js/pull/17982, assumes an attribute called "position". One of our projects loads custom geometry that compute position in the vertex shader based on other attributes. With this small change/rollback, this graceful-failcheck should still work based simply on detecting a lack of index, which all standard and custom geometries need.