### PR TITLE
Several PMREMGenerator fixes

### DIFF
--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -90,6 +90,7 @@ THREE.PMREMGenerator = ( function () {
 			}
 			_applyPMREM( cubeUVRenderTarget );
 			_cleanup();
+			cubeUVRenderTarget.scissorTest = false;
 
 			return cubeUVRenderTarget;
 
@@ -121,6 +122,7 @@ THREE.PMREMGenerator = ( function () {
 			_textureToCubeUV( cubemap, cubeUVRenderTarget );
 			_applyPMREM( cubeUVRenderTarget );
 			_cleanup();
+			cubeUVRenderTarget.scissorTest = false;
 
 			return cubeUVRenderTarget;
 
@@ -363,6 +365,7 @@ THREE.PMREMGenerator = ( function () {
 		new THREE.WebGLRenderTarget( 3 * SIZE_MAX, 3 * SIZE_MAX, params );
 		cubeUVRenderTarget.texture.mapping = THREE.CubeUVReflectionMapping;
 		cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
+		cubeUVRenderTarget.scissorTest = true;
 		return cubeUVRenderTarget;
 
 	}

--- a/examples/js/pmrem/PMREMGenerator.js
+++ b/examples/js/pmrem/PMREMGenerator.js
@@ -369,8 +369,13 @@ THREE.PMREMGenerator = ( function () {
 
 	function _setViewport( x, y, width, height ) {
 
-		var dpr = _renderer.getPixelRatio();
-		_renderer.setViewport( x / dpr, y / dpr, width / dpr, height / dpr );
+		var invDpr = 1.0 / _renderer.getPixelRatio();
+		x *= invDpr;
+		y *= invDpr;
+		width *= invDpr;
+		height *= invDpr;
+		_renderer.setViewport( x, y, width, height );
+		_renderer.setScissor( x, y, width, height );
 
 	}
 

--- a/examples/js/postprocessing/CubeTexturePass.js
+++ b/examples/js/postprocessing/CubeTexturePass.js
@@ -44,8 +44,8 @@ THREE.CubeTexturePass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		this.cubeCamera.projectionMatrix.copy( this.camera.projectionMatrix );
 		this.cubeCamera.quaternion.setFromRotationMatrix( this.camera.matrixWorld );
 
-		this.cubeMesh.material.uniforms[ "tCube" ].value = this.envMap;
-		this.cubeMesh.material.uniforms[ "opacity" ].value = this.opacity;
+		this.cubeMesh.material.envMap = this.envMap;
+		this.cubeMesh.material.opacity = this.opacity;
 		this.cubeMesh.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );

--- a/examples/jsm/pmrem/PMREMGenerator.js
+++ b/examples/jsm/pmrem/PMREMGenerator.js
@@ -395,8 +395,13 @@ var PMREMGenerator = ( function () {
 
 	function _setViewport( x, y, width, height ) {
 
-		var dpr = _renderer.getPixelRatio();
-		_renderer.setViewport( x / dpr, y / dpr, width / dpr, height / dpr );
+		var invDpr = 1.0 / _renderer.getPixelRatio();
+		x *= invDpr;
+		y *= invDpr;
+		width *= invDpr;
+		height *= invDpr;
+		_renderer.setViewport( x, y, width, height );
+		_renderer.setScissor( x, y, width, height );
 
 	}
 

--- a/examples/jsm/pmrem/PMREMGenerator.js
+++ b/examples/jsm/pmrem/PMREMGenerator.js
@@ -116,6 +116,7 @@ var PMREMGenerator = ( function () {
 			}
 			_applyPMREM( cubeUVRenderTarget );
 			_cleanup();
+			cubeUVRenderTarget.scissorTest = false;
 
 			return cubeUVRenderTarget;
 
@@ -147,6 +148,7 @@ var PMREMGenerator = ( function () {
 			_textureToCubeUV( cubemap, cubeUVRenderTarget );
 			_applyPMREM( cubeUVRenderTarget );
 			_cleanup();
+			cubeUVRenderTarget.scissorTest = false;
 
 			return cubeUVRenderTarget;
 
@@ -389,6 +391,7 @@ var PMREMGenerator = ( function () {
 		new WebGLRenderTarget( 3 * SIZE_MAX, 3 * SIZE_MAX, params );
 		cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
 		cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
+		cubeUVRenderTarget.scissorTest = true;
 		return cubeUVRenderTarget;
 
 	}

--- a/examples/jsm/postprocessing/CubeTexturePass.js
+++ b/examples/jsm/postprocessing/CubeTexturePass.js
@@ -55,8 +55,8 @@ CubeTexturePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 		this.cubeCamera.projectionMatrix.copy( this.camera.projectionMatrix );
 		this.cubeCamera.quaternion.setFromRotationMatrix( this.camera.matrixWorld );
 
-		this.cubeMesh.material.uniforms[ "tCube" ].value = this.envMap;
-		this.cubeMesh.material.uniforms[ "opacity" ].value = this.opacity;
+		this.cubeMesh.material.envMap = this.envMap;
+		this.cubeMesh.material.opacity = this.opacity;
 		this.cubeMesh.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -105,17 +105,8 @@
 					side: THREE.BackSide
 				} );
 
-				cubeMaterial.uniforms[ "tCube" ].value = textureCube;
-				Object.defineProperty( cubeMaterial, 'map', {
-
-					get: function () {
-
-						return this.uniforms.tCube.value;
-
-					}
-
-				} );
-
+				cubeMaterial.envMap = textureCube;
+				
 				// Skybox
 
 				cubeMesh = new THREE.Mesh( new THREE.BoxBufferGeometry( 100, 100, 100 ), cubeMaterial );

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -36,11 +36,43 @@
 			var container, stats;
 			var camera, scene, renderer, controls;
 			var torusMesh, planeMesh;
-			var ldrCubeRenderTarget, hdrCubeRenderTarget, rgbmCubeRenderTarget;
+			var generatedCubeRenderTarget, ldrCubeRenderTarget, hdrCubeRenderTarget, rgbmCubeRenderTarget;
 			var ldrCubeMap, hdrCubeMap, rgbmCubeMap;
 
 			init();
 			animate();
+
+			function getEnvScene() {
+
+				var envScene = new THREE.Scene();
+
+				var geometry = new THREE.BoxBufferGeometry();
+    			geometry.deleteAttribute('uv');
+    			var roomMaterial = new THREE.MeshStandardMaterial({metalness: 0, side: THREE.BackSide});
+				var room = new THREE.Mesh(geometry, roomMaterial);
+				room.scale.setScalar(10);
+				envScene.add(room);
+
+				var mainLight = new THREE.PointLight(0xffffff, 1.0, 0, 2);
+				mainLight.position.set(0, 4.5, 0);
+				envScene.add(mainLight);
+
+				var lightMaterial = new THREE.MeshBasicMaterial();
+				lightMaterial.color.setScalar(20);
+
+				var light1 = new THREE.Mesh(geometry, lightMaterial);
+				light1.position.set(-5, 2, 0);
+				light1.scale.set(0.1, 1, 1);
+				envScene.add(light1);
+
+				var light2 = new THREE.Mesh(geometry, lightMaterial);
+				light2.position.set(0, 5, 0);
+				light2.scale.set(1, 0.1, 1);
+				envScene.add(light2);
+
+				return envScene;
+
+			}
 
 			function init() {
 
@@ -83,6 +115,9 @@
 					pmremGenerator.dispose();
 
 				}
+
+				var envScene = getEnvScene();
+				generatedCubeRenderTarget = pmremGenerator.fromScene( envScene );
 
 				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
 				hdrCubeMap = new HDRCubeTextureLoader()
@@ -142,7 +177,7 @@
 
 				var gui = new GUI();
 
-				gui.add( params, 'envMap', [ 'LDR', 'HDR', 'RGBM16' ] );
+				gui.add( params, 'envMap', [ 'Generated', 'LDR', 'HDR', 'RGBM16' ] );
 				gui.add( params, 'roughness', 0, 1, 0.01 );
 				gui.add( params, 'metalness', 0, 1, 0.01 );
 				gui.add( params, 'exposure', 0, 2, 0.01 );
@@ -182,6 +217,10 @@
 
 				switch ( params.envMap ) {
 
+					case 'Generated':
+						renderTarget = generatedCubeRenderTarget;
+						cubeMap = generatedCubeRenderTarget;
+						break;
 					case 'LDR':
 						renderTarget = ldrCubeRenderTarget;
 						cubeMap = ldrCubeMap;

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -53,8 +53,8 @@
 				room.scale.setScalar(10);
 				envScene.add(room);
 
-				var mainLight = new THREE.PointLight(0xffffff, 1.0, 0, 2);
-				mainLight.position.set(0, 4.5, 0);
+				var mainLight = new THREE.PointLight(0xffffff, 0.2, 0, 2);
+				mainLight.position.set(0, 0, 0);
 				envScene.add(mainLight);
 
 				var lightMaterial = new THREE.MeshBasicMaterial();
@@ -68,6 +68,11 @@
 				var light2 = new THREE.Mesh(geometry, lightMaterial);
 				light2.position.set(0, 5, 0);
 				light2.scale.set(1, 0.1, 1);
+				envScene.add(light2);
+
+				var light2 = new THREE.Mesh(geometry, lightMaterial);
+				light2.position.set(2, 1, 5);
+				light2.scale.set(1.5, 2, 0.1);
 				envScene.add(light2);
 
 				return envScene;
@@ -117,7 +122,7 @@
 				}
 
 				var envScene = getEnvScene();
-				generatedCubeRenderTarget = pmremGenerator.fromScene( envScene );
+				generatedCubeRenderTarget = pmremGenerator.fromScene( envScene, 0.04 );
 
 				var hdrUrls = [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ];
 				hdrCubeMap = new HDRCubeTextureLoader()
@@ -219,7 +224,7 @@
 
 					case 'Generated':
 						renderTarget = generatedCubeRenderTarget;
-						cubeMap = generatedCubeRenderTarget;
+						cubeMap = generatedCubeRenderTarget.texture;
 						break;
 					case 'LDR':
 						renderTarget = ldrCubeRenderTarget;

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -159,13 +159,13 @@
 
 				} );
 
-				cubeTexturePassP = new CubeTexturePass( cameraP );
-				composer.addPass( cubeTexturePassP );
+				cubeTexturePassP = null;
 
 				var ldrUrls = genCubeUrls( "textures/cube/pisa/", ".png" );
 				new THREE.CubeTextureLoader().load( ldrUrls, function ( ldrCubeMap ) {
 
-					cubeTexturePassP.envMap = ldrCubeMap;
+					cubeTexturePassP = new CubeTexturePass( cameraP, ldrCubeMap );
+					composer.insertPass( cubeTexturePassP, 2 );
 
 				} );
 
@@ -222,8 +222,10 @@
 				texturePass.enabled = params.texturePass;
 				texturePass.opacity = params.texturePassOpacity;
 
-				cubeTexturePassP.enabled = params.cubeTexturePass;
-				cubeTexturePassP.opacity = params.cubeTexturePassOpacity;
+				if ( cubeTexturePassP != null ) {
+					cubeTexturePassP.enabled = params.cubeTexturePass;
+					cubeTexturePassP.opacity = params.cubeTexturePassOpacity;
+				}
 
 				renderPass.enabled = params.renderPass;
 

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -86,7 +86,6 @@
 				textureCube.format = THREE.RGBFormat;
 
 				var shader = THREE.ShaderLib[ 'cube' ];
-				shader.uniforms[ 'tCube' ].value = textureCube;
 
 				var skyMaterial = new THREE.ShaderMaterial( {
 
@@ -97,6 +96,8 @@
 					side: THREE.BackSide
 
 				} );
+
+				skyMaterial.envMap = textureCube;
 
 				var sky = new THREE.Mesh( new THREE.BoxBufferGeometry( 1000, 1000, 1000 ), skyMaterial );
 				scene.add( sky );

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -92,7 +92,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 					get: function () {
 
-						return this.envMap.value;
+						return this.envMap;
 
 					}
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -92,7 +92,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 					get: function () {
 
-						return this.envMap;
+						return this.envMap.value;
 
 					}
 


### PR DESCRIPTION
Fixes #18029 

I found a better way to fix the above issue was correctly using the scissor test, thus preserving any desired clearing behavior. In addition I found several uses of the cube shader I had forgotten to update, so this fixes several examples that were broken by my last change.

I also added a `Generated` option to the webgl_materials_envmaps_hdr example to serve as an example for using PMREMGenerator.fromScene() and to act as a test for the issue that was fixed here.