### PR TITLE
Example: Fix typos in unreal bloom demo

### DIFF
--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -13,8 +13,8 @@
 		<div id="info">
 			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - Bloom pass by <a href="http://eduperiment.com" target="_blank" rel="noopener">Prashant Sharma</a> and <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>
 			<p>
-				This Bloom Pass is inspired by the bloom pass of the Unreal Engine. It creates a mip map chain of bloom textures and blur them
-				with different radii.<br /> Because of the weigted combination of mips, and since larger blurs are done on higher mips, this bloom
+				This Bloom Pass is inspired by the bloom pass of Unreal Engine. It creates a mip map chain of bloom textures and blurs them
+				with different radii. Because of the weighted combination of mips, and since larger blurs are done on higher mips, this bloom
 				is better in quality and performance.
 			</p>
 			Model: <a href="https://blog.sketchfab.com/art-spotlight-primary-ion-drive/" target="_blank" rel="noopener">Primary Ion Drive</a> by

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -5,6 +5,13 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
+		<style>
+		#info > * {
+			max-width: 650px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+		</style>
 	</head>
 	<body>
 


### PR DESCRIPTION
Demo: https://raw.githack.com/mrdoob/three.js/donmccurdy-bloom-typos/examples/webgl_postprocessing_unreal_bloom.html

^Might be worth putting shared `#info` styles in `main.css` later? Good to have a consistent way to add a bit of text that will be responsive on desktop and mobile.