### PR TITLE
PLYExporter: Make exported data more compatible with other software.

### DIFF
--- a/examples/js/exporters/PLYExporter.js
+++ b/examples/js/exporters/PLYExporter.js
@@ -537,7 +537,7 @@ THREE.PLYExporter.prototype = {
 
 			} );
 
-			result = `${ header }${vertexList}\n${ includeIndices ? `${faceList}\n` : '' }`;
+			result = `${ header }${vertexList}${ includeIndices ? `${faceList}\n` : '\n' }`;
 
 		}
 

--- a/examples/js/exporters/PLYExporter.js
+++ b/examples/js/exporters/PLYExporter.js
@@ -205,7 +205,7 @@ THREE.PLYExporter.prototype = {
 			// faces
 			header +=
 				`element face ${faceCount}\n` +
-				`property list uchar uint${ indexByteCount * 8 } vertex_index\n`;
+				`property list uchar int vertex_index\n`;
 
 		}
 

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -543,7 +543,7 @@ PLYExporter.prototype = {
 
 			} );
 
-			result = `${ header }${vertexList}\n${ includeIndices ? `${faceList}\n` : '' }`;
+			result = `${ header }${vertexList}${ includeIndices ? `${faceList}\n` : '\n' }`;
 
 		}
 

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -211,7 +211,7 @@ PLYExporter.prototype = {
 			// faces
 			header +=
 				`element face ${faceCount}\n` +
-				`property list uchar uint${ indexByteCount * 8 } vertex_index\n`;
+				`property list uchar int vertex_index\n`;
 
 		}
 


### PR DESCRIPTION
While investigating #18049, I've realized that the exporter's output can't be loaded in Blender, MeshLab and Quicklook 3D (Mac). The class currently adds an additional blank line after the vertex data definitions which is actually not necessary. It seems `PLYLoader` has no problems with this but Blender does. Besides, just using `int` as data type seems to fix MeshLab and Quicklook 3D.

Before:
```
ply
format ascii 1.0
element vertex 24
property float x
property float y
property float z
property float nx
property float ny
property float nz
property float s
property float t
element face 12
property list uchar uint8 vertex_index
end_header
100 100 100 1 0 0 0 1
100 100 -100 1 0 0 1 1
100 -100 100 1 0 0 0 0
100 -100 -100 1 0 0 1 0
-100 100 -100 -1 0 0 0 1
-100 100 100 -1 0 0 1 1
-100 -100 -100 -1 0 0 0 0
-100 -100 100 -1 0 0 1 0
-100 100 -100 0 1 0 0 1
100 100 -100 0 1 0 1 1
-100 100 100 0 1 0 0 0
100 100 100 0 1 0 1 0
-100 -100 100 0 -1 0 0 1
100 -100 100 0 -1 0 1 1
-100 -100 -100 0 -1 0 0 0
100 -100 -100 0 -1 0 1 0
-100 100 100 0 0 1 0 1
100 100 100 0 0 1 1 1
-100 -100 100 0 0 1 0 0
100 -100 100 0 0 1 1 0
100 100 -100 0 0 -1 0 1
-100 100 -100 0 0 -1 1 1
100 -100 -100 0 0 -1 0 0
-100 -100 -100 0 0 -1 1 0

3 0 2 1
3 2 3 1
3 4 6 5
3 6 7 5
3 8 10 9
3 10 11 9
3 12 14 13
3 14 15 13
3 16 18 17
3 18 19 17
3 20 22 21
3 22 23 21
```
After:
```
ply
format ascii 1.0
element vertex 24
property float x
property float y
property float z
property float nx
property float ny
property float nz
property float s
property float t
element face 12
property list uchar int vertex_index
end_header
100 100 100 1 0 0 0 1
100 100 -100 1 0 0 1 1
100 -100 100 1 0 0 0 0
100 -100 -100 1 0 0 1 0
-100 100 -100 -1 0 0 0 1
-100 100 100 -1 0 0 1 1
-100 -100 -100 -1 0 0 0 0
-100 -100 100 -1 0 0 1 0
-100 100 -100 0 1 0 0 1
100 100 -100 0 1 0 1 1
-100 100 100 0 1 0 0 0
100 100 100 0 1 0 1 0
-100 -100 100 0 -1 0 0 1
100 -100 100 0 -1 0 1 1
-100 -100 -100 0 -1 0 0 0
100 -100 -100 0 -1 0 1 0
-100 100 100 0 0 1 0 1
100 100 100 0 0 1 1 1
-100 -100 100 0 0 1 0 0
100 -100 100 0 0 1 1 0
100 100 -100 0 0 -1 0 1
-100 100 -100 0 0 -1 1 1
100 -100 -100 0 0 -1 0 0
-100 -100 -100 0 0 -1 1 0
3 0 2 1
3 2 3 1
3 4 6 5
3 6 7 5
3 8 10 9
3 10 11 9
3 12 14 13
3 14 15 13
3 16 18 17
3 18 19 17
3 20 22 21
3 22 23 21
```