### PR TITLE
BufferGeometry.setIndex: Improve type definition

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -48,8 +48,8 @@ export class BufferGeometry extends EventDispatcher {
 	userData: {[key: string]: any};
 	isBufferGeometry: boolean;
 
-	getIndex(): BufferAttribute;
-	setIndex( index: BufferAttribute | number[] ): void;
+	getIndex(): BufferAttribute | null;
+	setIndex( index: BufferAttribute | number[] | null ): void;
 
 	setAttribute( name: string, attribute: BufferAttribute | InterleavedBufferAttribute ): BufferGeometry;
 	getAttribute( name: string ): BufferAttribute | InterleavedBufferAttribute;


### PR DESCRIPTION
Note that this is a backward-incompatible change concerning the type definition. The following code used to compile but it won't anymore:

```TypeScript
const geometry = new THREE.BufferGeometry();

const idx = geometry.getIndex();

console.log(idx.array.length);  // Now idx can be null, so this code does not compile
```

Should fix #18051