### PR TITLE
WebGLRenderer: Call WebGLState.setMaterial() after onBeforeCompile() was executed.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -713,9 +713,9 @@ function WebGLRenderer( parameters ) {
 
 		var frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
-		state.setMaterial( material, frontFaceCW );
-
 		var program = setProgram( camera, fog, material, object );
+
+		state.setMaterial( material, frontFaceCW );
 
 		var updateBuffers = false;
 
@@ -1472,9 +1472,9 @@ function WebGLRenderer( parameters ) {
 
 		if ( object.isImmediateRenderObject ) {
 
-			state.setMaterial( material );
-
 			var program = setProgram( camera, scene.fog, material, object );
+
+			state.setMaterial( material );
 
 			_currentGeometryProgram.geometry = null;
 			_currentGeometryProgram.program = null;


### PR DESCRIPTION
Fix possible changes in `material` after `onBeforeCompile`

- `material.side`
- `material.blending`
- `material.polygonOffset`

This not fix completely this issue ( https://github.com/mrdoob/three.js/issues/18038 ) but is a step forward.
