### PR TITLE
Helpers Example: added VertexTangentsHelper

### DIFF
--- a/examples/webgl_helpers.html
+++ b/examples/webgl_helpers.html
@@ -17,9 +17,12 @@
 
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 
+			//import { BufferGeometryUtils } from './jsm/utils/BufferGeometryUtils.js';
+
 			var scene, renderer;
 			var camera, light;
 			var vnh;
+			//var vth;
 
 			init();
 			animate();
@@ -59,6 +62,8 @@
 
 					var mesh = gltf.scene.children[ 0 ];
 
+					//BufferGeometryUtils.computeTangents( mesh.geometry ); // generates bad data due to degenerate UVs
+
 					var group = new THREE.Group();
 					group.scale.multiplyScalar( 50 );
 					scene.add( group );
@@ -70,6 +75,9 @@
 
 					vnh = new THREE.VertexNormalsHelper( mesh, 5 );
 					scene.add( vnh );
+
+					//vth = new THREE.VertexTangentsHelper( mesh, 5 );
+					//scene.add( vth );
 
 					scene.add( new THREE.BoxHelper( mesh ) );
 
@@ -127,6 +135,7 @@
 				light.position.z = Math.cos( time * 1.3 ) * 300;
 
 				if ( vnh ) vnh.update();
+				//if ( vth ) vth.update();
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
As proposed in https://github.com/mrdoob/three.js/pull/17991#issuecomment-558009465.

`VertexTangentsHelper` is added, but the additions are commented out for now because `computeTangents()` generates bad tangent data with the Lee Perry Smith model.

This is not a problem with the helper, but with the model, and it will have to be addressed separately.

