### PR TITLE
Fix rendering of objects without morph target influences with morph materials

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -727,7 +727,7 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( object.morphTargetInfluences ) {
+		if ( material.morphTargets || material.morphNormals ) {
 
 			morphtargets.update( object, geometry, material, program );
 

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -18,15 +18,10 @@ function WebGLMorphtargets( gl ) {
 
 		var objectInfluences = object.morphTargetInfluences;
 
-		if ( objectInfluences === undefined ) {
+		// When object doesn't have morph target influences defined, we treat it as a 0-length array
+		// This is important to make sure we set up morphTargetBaseInfluence / morphTargetInfluences
 
-			program.getUniforms().setValue( gl, 'morphTargetBaseInfluence', 1.0 );
-			program.getUniforms().setValue( gl, 'morphTargetInfluences', morphInfluencesZero );
-			return;
-
-		}
-
-		var length = objectInfluences.length;
+		var length = objectInfluences === undefined ? 0 : objectInfluences.length;
 
 		var influences = influencesList[ geometry.id ];
 

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -12,7 +12,6 @@ function WebGLMorphtargets( gl ) {
 
 	var influencesList = {};
 	var morphInfluences = new Float32Array( 8 );
-	var morphInfluencesZero = new Float32Array( 8 );
 
 	function update( object, geometry, material, program ) {
 

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -12,10 +12,19 @@ function WebGLMorphtargets( gl ) {
 
 	var influencesList = {};
 	var morphInfluences = new Float32Array( 8 );
+	var morphInfluencesZero = new Float32Array( 8 );
 
 	function update( object, geometry, material, program ) {
 
 		var objectInfluences = object.morphTargetInfluences;
+
+		if ( objectInfluences === undefined ) {
+
+			program.getUniforms().setValue( gl, 'morphTargetBaseInfluence', 1.0 );
+			program.getUniforms().setValue( gl, 'morphTargetInfluences', morphInfluencesZero );
+			return;
+
+		}
 
 		var length = objectInfluences.length;
 


### PR DESCRIPTION
When using a material that has morph target support, we need to supply
morph target weights, and - crucially, as of r111 - base target weight.

Before r111, using a material with morph targets and an object without
morph target influences resulted in us not setting up morph weights
which in most cases would result in rendering the object normally.

After r111, in this situation we'd accidentally use default (0) base
influence which resulted in object not rendering at all.

This change now calls morph target update if the material needs morph
target setup; the update method sets up dummy weights (1 base and 0
for each target) to make sure the shader outputs the value of the base
attribute only.

Fixes #18062.