### PR TITLE
Docs: Clarify texture filtering for gradient maps.

### DIFF
--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -130,7 +130,8 @@
 		</p>
 
 		<h3>[property:Texture gradientMap]</h3>
-		<p>Gradient map for toon shading. Default is *null*.</p>
+		<p>Gradient map for toon shading. It's required to set [page:Texture.minFilter] and [page:Texture.magFilter] to
+			[page:Textures THREE.NearestFilter] when using this type of texture. Default is *null*.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs,

--- a/docs/api/zh/materials/MeshToonMaterial.html
+++ b/docs/api/zh/materials/MeshToonMaterial.html
@@ -130,7 +130,8 @@
 		</p>
 
 		<h3>[property:Texture gradientMap]</h3>
-		<p>Gradient map for toon shading. Default is *null*.</p>
+		<p>Gradient map for toon shading. It's required to set [page:Texture.minFilter] and [page:Texture.magFilter] to
+			[page:Textures THREE.NearestFilter] when using this type of texture. Default is *null*.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs,


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/issues/14558#issuecomment-562239829

In order to produce the typical cel shading look, gradient textures should be configured with nearest texture filtering.