### PR TITLE
Stop support for Internet Explorer

### DIFF
--- a/docs/examples/en/loaders/BasisTextureLoader.html
+++ b/docs/examples/en/loaders/BasisTextureLoader.html
@@ -64,10 +64,6 @@
 		<p>
 			Transcoding to PVRTC1 (for iOS) requires square power-of-two textures.
 		</p>
-		<p>
-			This loader relies on ES6 Promises and Web Assembly, which are not
-			supported in IE11.
-		</p>
 
 		<br>
 		<hr>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -70,12 +70,9 @@
 
 		<h2>Browser compatibility</h2>
 
-		<p>DRACOLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement. DRACOLoader will automatically use
-		either the JS or the WASM decoding library, based on browser
-		capabilities.</p>
+		<p>
+			DRACOLoader will automatically use either the JS or the WASM decoding library, based on browser capabilities.
+		</p>
 
 		<br>
 		<hr>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -95,13 +95,6 @@
 
 		[example:webgl_loader_gltf]
 
-		<h2>Browser compatibility</h2>
-
-		<p>GLTFLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement.</p>
-
 		<h2>Textures</h2>
 
 		<p>Textures containing color information (.map, .emissiveMap, and .specularMap) always use sRGB colorspace in

--- a/docs/examples/zh/loaders/BasisTextureLoader.html
+++ b/docs/examples/zh/loaders/BasisTextureLoader.html
@@ -64,10 +64,6 @@
 		<p>
 			Transcoding to PVRTC1 (for iOS) requires square power-of-two textures.
 		</p>
-		<p>
-			This loader relies on ES6 Promises and Web Assembly, which are not
-			supported in IE11.
-		</p>
 
 		<br>
 		<hr>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -70,12 +70,9 @@
 
 		<h2>Browser compatibility</h2>
 
-		<p>DRACOLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement. DRACOLoader will automatically use
-		either the JS or the WASM decoding library, based on browser
-		capabilities.</p>
+		<p>
+			DRACOLoader will automatically use either the JS or the WASM decoding library, based on browser capabilities.
+		</p>
 
 		<br>
 		<hr>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -94,12 +94,6 @@
 
 		[example:webgl_loader_gltf]
 
-		<h2>浏览器兼容性</h2>
-
-		<p>GLTFLoader 依赖 ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises]，
-		这一特性不支持IE11。若要在IE11中使用该加载器，你必须引入polyfill（[link:https://github.com/stefanpenner/es6-promise include a polyfill]）
-		来提供一个Promise的替代方案。</p>
-
 		<h2>纹理</h2>
 
 		<p>纹理中包含的颜色信息（.map, .emissiveMap, 和 .specularMap）在glTF中总是使用sRGB颜色空间，而顶点颜色和材质属性（.color, .emissive, .specular）

--- a/docs/manual/en/introduction/Browser-support.html
+++ b/docs/manual/en/introduction/Browser-support.html
@@ -13,17 +13,14 @@
 	<h2>Overview</h2>
 	<div>
 		<p>
-			Three.js can use WebGL to render your scenes on all modern browsers. For older browsers, especially Internet Explorer 10 and below, you may have to fallback to one of the other [link:https://github.com/mrdoob/three.js/tree/master/examples/js/renderers renderers] (CSS2DRenderer, CSS3DRenderer, SVGRenderer). Additionally, you may have to include some polyfills, especially if you are using files from the [link:https://github.com/mrdoob/three.js/tree/master/examples /examples] folder.
-		</p>
-		<p>
-			Note: if you don't need to support these old browsers, then it is not recommended to use the other renderers as they are slower and support less features than the WebGLRenderer.
+			Three.js can use WebGL to render your scenes on all modern browsers. Additionally, you may have to include some polyfills, especially if you are using files from the [link:https://github.com/mrdoob/three.js/tree/master/examples /examples] folder.
 		</p>
 	</div>
 
 	<h2>Browsers that support WebGL</h2>
 	<div>
 		<p>
-			Google Chrome 9+, Firefox 4+, Opera 15+, Safari 5.1+, Internet Explorer 11 and Microsoft Edge. You can find which browsers support WebGL at [link:https://caniuse.com/#feat=webgl Can I use WebGL].
+			Google Chrome 9+, Firefox 4+, Opera 15+, Safari 5.1+ and Microsoft Edge. You can find which browsers support WebGL at [link:https://caniuse.com/#feat=webgl Can I use WebGL].
 		</p>
 	</div>
 
@@ -91,15 +88,6 @@
 	</div>
 
 	<h2>Polyfills</h2>
-	<div>
-		<p>Just import polyfills based on your requirements. Taking IE9 as an example, you need to polyfill at least these features:</p>
-		<ul>
-			<li>Typed Arrays</li>
-			<li>Blob</li>
-		</ul>
-	</div>
-
-	<h3>Suggested polyfills</h3>
 	<div>
 		<ul>
 			<li>

--- a/docs/manual/zh/introduction/Browser-support.html
+++ b/docs/manual/zh/introduction/Browser-support.html
@@ -13,17 +13,14 @@
 	<h2>总览</h2>
 	<div>
 		<p>
-            在所有现代浏览器中，Three.js可以使用WebGL来渲染场景。对于较旧的浏览器，特别是Internet Explorer 10或者更低版本浏览器，你将需要回落到其它[link:https://github.com/mrdoob/three.js/tree/master/examples/js/renderers renderers]（CSS2DRenderer、CSS3DRenderer、SVGRenderer）。此外，你或许不得不包含一些额外的“填充物”来解决兼容性问题，特别是当你使用[link:https://github.com/mrdoob/three.js/tree/master/examples /examples]目录中的文件时。
-		</p>
-		<p>
-            注意：如果你并不需要支持较旧的浏览器，那就不推荐使用其他渲染器来进行渲染，因为与WebGLRenderer相比，其它渲染器渲染较慢，并且不支持WebGL的诸多特性。
+            在所有现代浏览器中，Three.js可以使用WebGL来渲染场景。此外，你或许不得不包含一些额外的“填充物”来解决兼容性问题，特别是当你使用[link:https://github.com/mrdoob/three.js/tree/master/examples /examples]目录中的文件时。
 		</p>
 	</div>
 
 	<h2>支持WebGL的浏览器</h2>
 	<div>
 		<p>
-			Google Chrome 9+、Firefox 4+、Opera 15+、Safari 5.1+、Internet Explorer 11 和 Microsoft Edge。你可以点击[link:https://caniuse.com/#feat=webgl Can I use WebGL]来查阅各个浏览器对WebGL的支持性。
+			Google Chrome 9+、Firefox 4+、Opera 15+、Safari 5.1+ 和 Microsoft Edge。你可以点击[link:https://caniuse.com/#feat=webgl Can I use WebGL]来查阅各个浏览器对WebGL的支持性。
 		</p>
 	</div>
 
@@ -93,15 +90,6 @@
 	</div>
 
 	<h2>关于用于解决兼容性问题的“填充物”</h2>
-	<div>
-		<p>根据你的需求，引入相关的“填充物”即可。以IE9为例，你至少需要来使用“填充物”完成以下的功能。</p>
-		<ul>
-			<li>Typed Arrays</li>
-			<li>Blob</li>
-		</ul>
-	</div>
-
-	<h3>建议的“填充物”</h3>
 	<div>
 		<ul>
 			<li>

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -65,8 +65,6 @@ THREE.CSS3DRenderer = function () {
 
 	domElement.appendChild( cameraElement );
 
-	var isIE = /Trident/i.test( navigator.userAgent );
-
 	this.getSize = function () {
 
 		return {
@@ -122,7 +120,7 @@ THREE.CSS3DRenderer = function () {
 
 	}
 
-	function getObjectCSSMatrix( matrix, cameraCSSMatrix ) {
+	function getObjectCSSMatrix( matrix ) {
 
 		var elements = matrix.elements;
 		var matrix3d = 'matrix3d(' +
@@ -143,15 +141,6 @@ THREE.CSS3DRenderer = function () {
 			epsilon( elements[ 14 ] ) + ',' +
 			epsilon( elements[ 15 ] ) +
 		')';
-
-		if ( isIE ) {
-
-			return 'translate(-50%,-50%)' +
-				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
-				cameraCSSMatrix +
-				matrix3d;
-
-		}
 
 		return 'translate(-50%,-50%)' + matrix3d;
 
@@ -177,11 +166,11 @@ THREE.CSS3DRenderer = function () {
 				matrix.elements[ 11 ] = 0;
 				matrix.elements[ 15 ] = 1;
 
-				style = getObjectCSSMatrix( matrix, cameraCSSMatrix );
+				style = getObjectCSSMatrix( matrix );
 
 			} else {
 
-				style = getObjectCSSMatrix( object.matrixWorld, cameraCSSMatrix );
+				style = getObjectCSSMatrix( object.matrixWorld );
 
 			}
 
@@ -194,12 +183,6 @@ THREE.CSS3DRenderer = function () {
 				element.style.transform = style;
 
 				var objectData = { style: style };
-
-				if ( isIE ) {
-
-					objectData.distanceToCameraSquared = getDistanceToSquared( camera, object );
-
-				}
 
 				cache.objects.set( object, objectData );
 
@@ -216,57 +199,6 @@ THREE.CSS3DRenderer = function () {
 		for ( var i = 0, l = object.children.length; i < l; i ++ ) {
 
 			renderObject( object.children[ i ], camera, cameraCSSMatrix );
-
-		}
-
-	}
-
-	var getDistanceToSquared = function () {
-
-		var a = new THREE.Vector3();
-		var b = new THREE.Vector3();
-
-		return function ( object1, object2 ) {
-
-			a.setFromMatrixPosition( object1.matrixWorld );
-			b.setFromMatrixPosition( object2.matrixWorld );
-
-			return a.distanceToSquared( b );
-
-		};
-
-	}();
-
-	function filterAndFlatten( scene ) {
-
-		var result = [];
-
-		scene.traverse( function ( object ) {
-
-			if ( object instanceof THREE.CSS3DObject ) result.push( object );
-
-		} );
-
-		return result;
-
-	}
-
-	function zOrder( scene ) {
-
-		var sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
-
-			var distanceA = cache.objects.get( a ).distanceToCameraSquared;
-			var distanceB = cache.objects.get( b ).distanceToCameraSquared;
-
-			return distanceA - distanceB;
-
-		} );
-
-		var zMax = sorted.length;
-
-		for ( var i = 0, l = sorted.length; i < l; i ++ ) {
-
-			sorted[ i ].element.style.zIndex = zMax - i;
 
 		}
 
@@ -312,7 +244,7 @@ THREE.CSS3DRenderer = function () {
 		var style = cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-		if ( cache.camera.style !== style && ! isIE ) {
+		if ( cache.camera.style !== style ) {
 
 			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.transform = style;
@@ -322,16 +254,6 @@ THREE.CSS3DRenderer = function () {
 		}
 
 		renderObject( scene, camera, cameraCSSMatrix );
-
-		if ( isIE ) {
-
-			// IE10 and 11 does not support 'preserve-3d'.
-			// Thus, z-order in 3D will not work.
-			// We have to calc z-order manually and set CSS z-index for IE.
-			// FYI: z-index can't handle object intersection
-			zOrder( scene );
-
-		}
 
 	};
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -6,8 +6,7 @@
 
 import {
 	Matrix4,
-	Object3D,
-	Vector3
+	Object3D
 } from "../../../build/three.module.js";
 
 var CSS3DObject = function ( element ) {
@@ -71,8 +70,6 @@ var CSS3DRenderer = function () {
 
 	domElement.appendChild( cameraElement );
 
-	var isIE = /Trident/i.test( navigator.userAgent );
-
 	this.getSize = function () {
 
 		return {
@@ -128,7 +125,7 @@ var CSS3DRenderer = function () {
 
 	}
 
-	function getObjectCSSMatrix( matrix, cameraCSSMatrix ) {
+	function getObjectCSSMatrix( matrix ) {
 
 		var elements = matrix.elements;
 		var matrix3d = 'matrix3d(' +
@@ -149,15 +146,6 @@ var CSS3DRenderer = function () {
 			epsilon( elements[ 14 ] ) + ',' +
 			epsilon( elements[ 15 ] ) +
 		')';
-
-		if ( isIE ) {
-
-			return 'translate(-50%,-50%)' +
-				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)' +
-				cameraCSSMatrix +
-				matrix3d;
-
-		}
 
 		return 'translate(-50%,-50%)' + matrix3d;
 
@@ -183,11 +171,11 @@ var CSS3DRenderer = function () {
 				matrix.elements[ 11 ] = 0;
 				matrix.elements[ 15 ] = 1;
 
-				style = getObjectCSSMatrix( matrix, cameraCSSMatrix );
+				style = getObjectCSSMatrix( matrix );
 
 			} else {
 
-				style = getObjectCSSMatrix( object.matrixWorld, cameraCSSMatrix );
+				style = getObjectCSSMatrix( object.matrixWorld );
 
 			}
 
@@ -200,12 +188,6 @@ var CSS3DRenderer = function () {
 				element.style.transform = style;
 
 				var objectData = { style: style };
-
-				if ( isIE ) {
-
-					objectData.distanceToCameraSquared = getDistanceToSquared( camera, object );
-
-				}
 
 				cache.objects.set( object, objectData );
 
@@ -222,57 +204,6 @@ var CSS3DRenderer = function () {
 		for ( var i = 0, l = object.children.length; i < l; i ++ ) {
 
 			renderObject( object.children[ i ], camera, cameraCSSMatrix );
-
-		}
-
-	}
-
-	var getDistanceToSquared = function () {
-
-		var a = new Vector3();
-		var b = new Vector3();
-
-		return function ( object1, object2 ) {
-
-			a.setFromMatrixPosition( object1.matrixWorld );
-			b.setFromMatrixPosition( object2.matrixWorld );
-
-			return a.distanceToSquared( b );
-
-		};
-
-	}();
-
-	function filterAndFlatten( scene ) {
-
-		var result = [];
-
-		scene.traverse( function ( object ) {
-
-			if ( object instanceof CSS3DObject ) result.push( object );
-
-		} );
-
-		return result;
-
-	}
-
-	function zOrder( scene ) {
-
-		var sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
-
-			var distanceA = cache.objects.get( a ).distanceToCameraSquared;
-			var distanceB = cache.objects.get( b ).distanceToCameraSquared;
-
-			return distanceA - distanceB;
-
-		} );
-
-		var zMax = sorted.length;
-
-		for ( var i = 0, l = sorted.length; i < l; i ++ ) {
-
-			sorted[ i ].element.style.zIndex = zMax - i;
 
 		}
 
@@ -318,7 +249,7 @@ var CSS3DRenderer = function () {
 		var style = cameraCSSMatrix +
 			'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-		if ( cache.camera.style !== style && ! isIE ) {
+		if ( cache.camera.style !== style ) {
 
 			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.transform = style;
@@ -328,16 +259,6 @@ var CSS3DRenderer = function () {
 		}
 
 		renderObject( scene, camera, cameraCSSMatrix );
-
-		if ( isIE ) {
-
-			// IE10 and 11 does not support 'preserve-3d'.
-			// Thus, z-order in 3D will not work.
-			// We have to calc z-order manually and set CSS z-index for IE.
-			// FYI: z-index can't handle object intersection
-			zOrder( scene );
-
-		}
 
 	};
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -138,8 +138,7 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 var TYPED_ARRAYS = {
 	Int8Array: Int8Array,
 	Uint8Array: Uint8Array,
-	// Workaround for IE11 pre KB2929437. See #11440
-	Uint8ClampedArray: typeof Uint8ClampedArray !== 'undefined' ? Uint8ClampedArray : Uint8Array,
+	Uint8ClampedArray: Uint8ClampedArray,
 	Int16Array: Int16Array,
 	Uint16Array: Uint16Array,
 	Int32Array: Int32Array,

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2713,7 +2713,7 @@ function WebGLRenderer( parameters ) {
 
 				}
 
-				if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // IE11, Edge and Chrome Mac < 52 (#9513)
+				if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // Edge and Chrome Mac < 52 (#9513)
 					! ( textureType === FloatType && ( capabilities.isWebGL2 || extensions.get( 'OES_texture_float' ) || extensions.get( 'WEBGL_color_buffer_float' ) ) ) && // Chrome Mac >= 52 and Firefox
 					! ( textureType === HalfFloatType && ( capabilities.isWebGL2 ? extensions.get( 'EXT_color_buffer_float' ) : extensions.get( 'EXT_color_buffer_half_float' ) ) ) ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -132,8 +132,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		var textureProperties = properties.get( texture );
 
-		// Note: Math.log( x ) * Math.LOG2E used instead of Math.log2( x ) which is not supported by IE11
-		textureProperties.__maxMipLevel = Math.log( Math.max( width, height ) ) * Math.LOG2E;
+		textureProperties.__maxMipLevel = Math.log2( Math.max( width, height ) );
 
 	}
 


### PR DESCRIPTION
I think the upcoming turn of the year is a good opportunity to officially stop support for Internet Explorer. The PR removes any references to IE from the docs and also any IE related workarounds from the core and the examples.

- The `Uint8ClampedArray` hack only affected older builds of IE11. So latest versions don't need it anyway.
- `Math.log2` can be polyfilled by users if necessary.
- Removed all hacks from `CSS3DRenderer`.