### PR TITLE
Implement support for texture matrix for uv2

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2161,6 +2161,40 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		// uv repeat and offset setting priorities for uv2
+		// 1. ao map
+		// 2. light map
+
+		var uv2ScaleMap;
+
+		if ( material.aoMap ) {
+
+			uv2ScaleMap = material.aoMap;
+
+		} else if ( material.lightMap ) { 
+
+			uv2ScaleMap = material.lightMap;
+
+		}
+
+		if ( uvScaleMap !== undefined ) {
+
+			// backwards compatibility
+			if ( uv2ScaleMap.isWebGLRenderTarget ) {
+
+				uv2ScaleMap = uv2ScaleMap.texture;
+
+			}
+
+			if ( uv2ScaleMap.matrixAutoUpdate === true ) {
+
+				uv2ScaleMap.updateMatrix();
+
+			}
+
+			uniforms.uv2Transform.value.copy( uv2ScaleMap.matrix );
+
+		}
 	}
 
 	function refreshUniformsLine( uniforms, material ) {

--- a/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv2_pars_vertex.glsl.js
@@ -4,5 +4,7 @@ export default /* glsl */`
 	attribute vec2 uv2;
 	varying vec2 vUv2;
 
+	uniform mat3 uv2Transform;
+
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/uv2_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv2_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )
 
-	vUv2 = uv2;
+	vUv2 = ( uv2Transform * vec3( uv2, 1 ) ).xy;
 
 #endif
 `;

--- a/src/renderers/shaders/UniformsLib.d.ts
+++ b/src/renderers/shaders/UniformsLib.d.ts
@@ -8,6 +8,7 @@ export let UniformsLib: {
 		opacity: IUniform;
 		map: IUniform;
 		uvTransform: IUniform;
+		uv2Transform: IUniform;
 		alphaMap: IUniform;
 	};
 	specularmap: {

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -15,6 +15,7 @@ var UniformsLib = {
 
 		map: { value: null },
 		uvTransform: { value: new Matrix3() },
+		uv2Transform: { value: new Matrix3() },
 
 		alphaMap: { value: null },
 


### PR DESCRIPTION
Before this change, we only supported one texture matrix for the
material that was applied to uv data based on the first texture, in
priority order, that needed it.

This change adds equivalent support for uv2 - we now transform second UV
channel with a second UV transform that is grabbed from aoMap or
lightMap (that are the only two textures using it atm).

This fixes glTF rendering for files that use KHR_texture_transform on
the occlusion texture, including ones produced by gltfpack.

Fixes #18088.