### PR TITLE
BufferGeometryUtils: Make computeTangents() more robust

### DIFF
--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -96,6 +96,14 @@ THREE.BufferGeometryUtils = {
 				( s1 * z2 - s2 * z1 ) * r
 			);
 
+			// silently ignore degenerate uvs/triangles that yield NaN/Infinite intermediary values
+			if ( ! ( isFinite( sdir.x ) && isFinite( sdir.y ) && isFinite( sdir.z ) &&
+					 isFinite( tdir.x ) && isFinite( tdir.y ) && isFinite( tdir.z ) ) ) {
+
+				return;
+
+			}
+
 			tan1[ a ].add( sdir );
 			tan1[ b ].add( sdir );
 			tan1[ c ].add( sdir );

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -108,6 +108,14 @@ var BufferGeometryUtils = {
 				( s1 * z2 - s2 * z1 ) * r
 			);
 
+			// silently ignore degenerate uvs/triangles that yield NaN/Infinite intermediary values
+			if ( ! ( isFinite( sdir.x ) && isFinite( sdir.y ) && isFinite( sdir.z ) &&
+					 isFinite( tdir.x ) && isFinite( tdir.y ) && isFinite( tdir.z ) ) ) {
+
+				return;
+
+			}
+
 			tan1[ a ].add( sdir );
 			tan1[ b ].add( sdir );
 			tan1[ c ].add( sdir );

--- a/examples/webgl_helpers.html
+++ b/examples/webgl_helpers.html
@@ -17,12 +17,12 @@
 
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 
-			//import { BufferGeometryUtils } from './jsm/utils/BufferGeometryUtils.js';
+			import { BufferGeometryUtils } from './jsm/utils/BufferGeometryUtils.js';
 
 			var scene, renderer;
 			var camera, light;
 			var vnh;
-			//var vth;
+			var vth;
 
 			init();
 			animate();
@@ -62,7 +62,7 @@
 
 					var mesh = gltf.scene.children[ 0 ];
 
-					//BufferGeometryUtils.computeTangents( mesh.geometry ); // generates bad data due to degenerate UVs
+					BufferGeometryUtils.computeTangents( mesh.geometry ); // generates bad data due to degenerate UVs
 
 					var group = new THREE.Group();
 					group.scale.multiplyScalar( 50 );
@@ -76,8 +76,8 @@
 					vnh = new THREE.VertexNormalsHelper( mesh, 5 );
 					scene.add( vnh );
 
-					//vth = new THREE.VertexTangentsHelper( mesh, 5 );
-					//scene.add( vth );
+					vth = new THREE.VertexTangentsHelper( mesh, 5 );
+					scene.add( vth );
 
 					scene.add( new THREE.BoxHelper( mesh ) );
 
@@ -135,7 +135,7 @@
 				light.position.z = Math.cos( time * 1.3 ) * 300;
 
 				if ( vnh ) vnh.update();
-				//if ( vth ) vth.update();
+				if ( vth ) vth.update();
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
Degenerate triangles and/or degenerate uvs can result in `NaN` or `Infinite` intermediary calculations in the `computeTangents()` method.

This PR sidesteps that issue by ignoring those triangles.

The helpers example is also modified to compute tangents on a problematic model (Lee Perry Smith).
