### PR TITLE
 Default Normal Shader: transform tangents with modelViewMatrix

### DIFF
--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -17,7 +17,7 @@ transformedNormal = normalMatrix * transformedNormal;
 
 #ifdef USE_TANGENT
 
-	vec3 transformedTangent = normalMatrix * objectTangent;
+	vec3 transformedTangent = ( modelViewMatrix * vec4( objectTangent, 0.0 ) ).xyz;
 
 	#ifdef FLIP_SIDED
 


### PR DESCRIPTION
resolves #18005.

As mentioned in #18005, an alternate approach is:

```glsl
vec3 transformedTangent = transformDirection( objectTangent, modelViewMatrix ); // normalized
```

which we can implement later if needed.
