### PR TITLE
GLTFLoader: Flip normalScale without tangents.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2262,8 +2262,7 @@ THREE.GLTFLoader = ( function () {
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
 
-			// Normal map textures use OpenGL conventions:
-			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
+			// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
 			if ( material.normalScale && ! material.vertexTangents ) {
 
 				material.normalScale.y = - material.normalScale.y;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2262,6 +2262,14 @@ THREE.GLTFLoader = ( function () {
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
 
+			// Normal map textures use OpenGL conventions:
+			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
+			if ( material.normalScale && ! material.vertexTangents ) {
+
+				material.normalScale.y = - material.normalScale.y;
+
+			}
+
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = THREE.sRGBEncoding;
 			if ( material.emissiveMap ) material.emissiveMap.encoding = THREE.sRGBEncoding;

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2111,6 +2111,13 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
+		// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
+		if ( material.normalScale && ! useVertexTangents ) {
+
+			material.normalScale.y = - material.normalScale.y;
+
+		}
+
 		mesh.material = material;
 
 	};
@@ -2261,13 +2268,6 @@ THREE.GLTFLoader = ( function () {
 			}
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
-
-			// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
-			if ( material.normalScale && ! material.vertexTangents ) {
-
-				material.normalScale.y = - material.normalScale.y;
-
-			}
 
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = THREE.sRGBEncoding;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2329,8 +2329,7 @@ var GLTFLoader = ( function () {
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
 
-			// Normal map textures use OpenGL conventions:
-			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
+			// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
 			if ( material.normalScale && ! material.vertexTangents ) {
 
 				material.normalScale.y = - material.normalScale.y;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2178,6 +2178,13 @@ var GLTFLoader = ( function () {
 
 		}
 
+		// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
+		if ( material.normalScale && ! useVertexTangents ) {
+
+			material.normalScale.y = - material.normalScale.y;
+
+		}
+
 		mesh.material = material;
 
 	};
@@ -2328,13 +2335,6 @@ var GLTFLoader = ( function () {
 			}
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
-
-			// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
-			if ( material.normalScale && ! material.vertexTangents ) {
-
-				material.normalScale.y = - material.normalScale.y;
-
-			}
 
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2329,6 +2329,14 @@ var GLTFLoader = ( function () {
 
 			if ( materialDef.name !== undefined ) material.name = materialDef.name;
 
+			// Normal map textures use OpenGL conventions:
+			// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#materialnormaltexture
+			if ( material.normalScale && ! material.vertexTangents ) {
+
+				material.normalScale.y = - material.normalScale.y;
+
+			}
+
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;


### PR DESCRIPTION
Fixes #11438 

After reading this [comment](https://github.com/mrdoob/three.js/issues/11438#issuecomment-545651421) I applied this change to model-viewer. It appears to be the right change, given all the models I've seen. I think it also makes sense given the chain rule explanation given in that thread as well.