### PR TITLE
Handle getting a detached ArrayBuffer from Cache

### DIFF
--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -26,6 +26,7 @@ var Cache = {
 
 			// This ArrayBuffer may be in a detached state, so it's unusable.
 			// A buffer can enter detached state when it is transferred to a worker for example.
+			console.warn( 'THREE.Cache: could not get a loaded ArrayBuffer from cache since it may have been in detached state. This can result from the ArrayBuffer having been transferred to a worker for processing. Cache key: ' + key );
 			this.remove( key );
 
 		}

--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -22,6 +22,14 @@ var Cache = {
 
 		if ( this.enabled === false ) return;
 
+		if ( this.files[ key ] !== undefined && this.files[ key ] instanceof ArrayBuffer && this.files[ key ].byteLength === 0 ) {
+
+			// This ArrayBuffer may be in a detached state, so it's unusable.
+			// A buffer can enter detached state when it is transferred to a worker for example.
+			this.remove( key );
+
+		}
+
 		// console.log( 'THREE.Cache', 'Checking key:', key );
 
 		return this.files[ key ];


### PR DESCRIPTION
ArrayBuffers that are stored in the Cache may not remain valid in case they end up in a detached state. Buffers can enter detached state when transferred to a web worker for example.

This fixes feeding the same URL multiple times to FileLoader when using DRACOLoader, that offloads decoding files to a worker.