### PR TITLE
TS: Add Material.defines

### DIFF
--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -126,7 +126,7 @@ export class Material extends EventDispatcher {
 	 * Whether to render the material's color. This can be used in conjunction with a mesh's .renderOrder property to create invisible objects that occlude other objects. Default is true.
 	 */
 	colorWrite: boolean;
-	
+
 	/**
 	 * Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. 
 	 * The pairs are defined in both vertex and fragment shaders. Default is undefined.

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -30,6 +30,7 @@ export interface MaterialParameters {
 	clippingPlanes?: Plane[];
 	clipShadows?: boolean;
 	colorWrite?: boolean;
+	defines?: any;
 	depthFunc?: DepthModes;
 	depthTest?: boolean;
 	depthWrite?: boolean;
@@ -125,6 +126,12 @@ export class Material extends EventDispatcher {
 	 * Whether to render the material's color. This can be used in conjunction with a mesh's .renderOrder property to create invisible objects that occlude other objects. Default is true.
 	 */
 	colorWrite: boolean;
+	
+	/**
+	 * Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. 
+	 * The pairs are defined in both vertex and fragment shaders. Default is undefined.
+	 */
+	defines: any;
 
 	/**
 	 * Which depth function to use. Default is {@link LessEqualDepth}. See the depth mode constants for all possible values.

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -128,7 +128,7 @@ export class Material extends EventDispatcher {
 	colorWrite: boolean;
 
 	/**
-	 * Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. 
+	 * Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }.
 	 * The pairs are defined in both vertex and fragment shaders. Default is undefined.
 	 */
 	defines: any;

--- a/src/materials/MeshPhysicalMaterial.d.ts
+++ b/src/materials/MeshPhysicalMaterial.d.ts
@@ -22,7 +22,6 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 	constructor( parameters: MeshPhysicalMaterialParameters );
 
-	defines: any;
 	reflectivity: number;
 	clearcoat: number;
 	clearcoatRoughness: number;

--- a/src/materials/MeshStandardMaterial.d.ts
+++ b/src/materials/MeshStandardMaterial.d.ts
@@ -41,7 +41,6 @@ export class MeshStandardMaterial extends Material {
 
 	constructor( parameters?: MeshStandardMaterialParameters );
 
-	defines: any;
 	color: Color;
 	roughness: number;
 	metalness: number;

--- a/src/materials/ShaderMaterial.d.ts
+++ b/src/materials/ShaderMaterial.d.ts
@@ -12,7 +12,6 @@ import { MaterialParameters, Material } from './Material';
  */
 
 export interface ShaderMaterialParameters extends MaterialParameters {
-	defines?: any;
 	uniforms?: any;
 	vertexShader?: string;
 	fragmentShader?: string;
@@ -36,7 +35,6 @@ export class ShaderMaterial extends Material {
 
 	constructor( parameters?: ShaderMaterialParameters );
 
-	defines: any;
 	uniforms: { [uniform: string]: IUniform };
 	vertexShader: string;
 	fragmentShader: string;


### PR DESCRIPTION
In the documentation there's a `defines` property in the Material class but it's not referenced in the typescript declaration file. Now it is!