### PR TITLE
CSS3DRenderer: pointer-events should be with cameraElement

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -56,7 +56,6 @@ THREE.CSS3DRenderer = function () {
 
 	var domElement = document.createElement( 'div' );
 	domElement.style.overflow = 'hidden';
-	domElement.style.pointerEvents = 'none';
 
 	this.domElement = domElement;
 
@@ -64,6 +63,7 @@ THREE.CSS3DRenderer = function () {
 
 	cameraElement.style.WebkitTransformStyle = 'preserve-3d';
 	cameraElement.style.transformStyle = 'preserve-3d';
+	cameraElement.style.pointerEvents = 'none';
 
 	domElement.appendChild( cameraElement );
 


### PR DESCRIPTION
I noticed `pointer-events` will also disable mouse dragging of camera controls
(added at https://github.com/mrdoob/three.js/pull/18144. sorry🙇‍♂️ )

I moved `pointer-events` from `domElement` to `cameraElement`.