### PR TITLE
remove SSAOPass.quad.dispose

### DIFF
--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -153,10 +153,6 @@ THREE.SSAOPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 		this.ssaoRenderTarget.dispose();
 		this.blurRenderTarget.dispose();
 
-		// dispose geometry
-
-		this.quad.geometry.dispose();
-
 		// dispose materials
 
 		this.normalMaterial.dispose();

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -183,10 +183,6 @@ SSAOPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 		this.ssaoRenderTarget.dispose();
 		this.blurRenderTarget.dispose();
 
-		// dispose geometry
-
-		this.quad.geometry.dispose();
-
 		// dispose materials
 
 		this.normalMaterial.dispose();


### PR DESCRIPTION
There is no `this.quad`, neither in SSAOPass, nor in Pass. Must have been a left-over.

Fixes #18148