### PR TITLE
Implemented THREE.CubeTextureBackground

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -52,7 +52,7 @@
 						var envMap = pmremGenerator.fromEquirectangular( texture ).texture;
 						pmremGenerator.dispose();
 
-						scene.background = envMap;
+						scene.background = new THREE.CubeTextureBackground( envMap );
 
 						// model
 
@@ -65,7 +65,6 @@
 
 								if ( child.isMesh ) {
 
-									child.material.envMap = envMap;
 									roughnessMipmapper.generateMipmaps( child.material );
 
 								}

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -30,7 +30,7 @@
 
 			var orbitControls;
 			var container, camera, scene, renderer, loader;
-			var gltf, background, envMap, mixer, gui, extensionControls;
+			var gltf, envMap, mixer, gui, extensionControls;
 
 			var clock = new THREE.Clock();
 
@@ -160,8 +160,6 @@
 						var pmremGenerator = new PMREMGenerator( renderer );
 						envMap = pmremGenerator.fromEquirectangular( texture ).texture;
 						pmremGenerator.dispose();
-
-						background = envMap;
 
 						//
 
@@ -317,19 +315,7 @@
 
 					if ( sceneInfo.addEnvMap ) {
 
-						object.traverse( function ( node ) {
-
-							if ( node.material && ( node.material.isMeshStandardMaterial ||
-								 ( node.material.isShaderMaterial && node.material.envMap !== undefined ) ) ) {
-
-								node.material.envMap = envMap;
-								node.material.envMapIntensity = 1.5; // boombox seems too dark otherwise
-
-							}
-
-						} );
-
-						scene.background = background;
+						scene.background = new THREE.CubeTextureBackground( envMap );
 
 					}
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -73,7 +73,7 @@
 						envMap = pmremGenerator.fromEquirectangular( texture ).texture;
 						pmremGenerator.dispose();
 
-						scene.background = envMap;
+						scene.background = new THREE.CubeTextureBackground( envMap );
 
 						//
 
@@ -125,16 +125,6 @@
 				loader.load( 'models/gltf/ferrari.glb', function ( gltf ) {
 
 					carModel = gltf.scene.children[ 0 ];
-
-					carModel.traverse( function ( child ) {
-
-						if ( child.isMesh ) {
-
-							child.material.envMap = envMap;
-
-						}
-
-					} );
 
 					// shadow
 					var texture = new THREE.TextureLoader().load( 'models/gltf/ferrari_ao.png' );

--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -1,245 +1,239 @@
 <!DOCTYPE html>
 <html lang="en">
+	<head>
+		<title>three.js webgl - materials - clearcoat</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - materials - clearcoat
+		</div>
 
-<head>
-	<title>three.js webgl - materials - clearcoat</title>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-	<link type="text/css" rel="stylesheet" href="main.css">
-</head>
+		<script type="module">
 
-<body>
-	<div id="info">
-		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - materials - clearcoat
-	</div>
+			import * as THREE from '../build/three.module.js';
 
-	<script type="module">
+			import Stats from './jsm/libs/stats.module.js';
 
-		import * as THREE from '../build/three.module.js';
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { HDRCubeTextureLoader } from './jsm/loaders/HDRCubeTextureLoader.js';
+			import { PMREMGenerator } from './jsm/pmrem/PMREMGenerator.js';
 
-		import Stats from './jsm/libs/stats.module.js';
+			var container, stats;
 
-		import { OrbitControls } from './jsm/controls/OrbitControls.js';
-		import { RGBELoader } from './jsm/loaders/RGBELoader.js';
-		import { PMREMGenerator } from './jsm/pmrem/PMREMGenerator.js';
+			var camera, scene, renderer;
 
-		var container, stats;
+			var particleLight;
+			var group;
 
-		var camera, scene, renderer;
+			init();
+			animate();
 
-		var particleLight;
-		var group;
+			function init() {
 
-		init();
-		animate();
+				container = document.createElement( 'div' );
+				document.body.appendChild( container );
 
-		function init() {
+				camera = new THREE.PerspectiveCamera( 27, window.innerWidth / window.innerHeight, 1, 10000 );
+				camera.position.z = 1000;
 
-			container = document.createElement( 'div' );
-			document.body.appendChild( container );
+				scene = new THREE.Scene();
 
-			camera = new THREE.PerspectiveCamera( 27, window.innerWidth / window.innerHeight, 1, 10000 );
-			camera.position.z = 1000;
+				group = new THREE.Group();
+				scene.add( group );
 
-			scene = new THREE.Scene();
-
-			group = new THREE.Group();
-			scene.add( group );
-
-			new RGBELoader()
+				new HDRCubeTextureLoader()
 					.setDataType( THREE.UnsignedByteType )
-					.setPath( 'textures/equirectangular/' )
-					.load( 'pedestrian_overpass_1k.hdr', function ( hdrCubeMap ) {
+					.setPath( './textures/cube/pisaHDR/' )
+					.load( [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ],
+						function ( hdrCubeMap ) {
 
-						var pmremGenerator = new PMREMGenerator( renderer );
-						var hdrCubeRenderTarget = pmremGenerator.fromCubemap( hdrCubeMap );
-						hdrCubeMap.dispose();
-						pmremGenerator.dispose();
+							var pmremGenerator = new PMREMGenerator( renderer );
+							var hdrCubeRenderTarget = pmremGenerator.fromCubemap( hdrCubeMap );
+							hdrCubeMap.dispose();
+							pmremGenerator.dispose();
 
-						var geometry = new THREE.SphereBufferGeometry( 80, 64, 32 );
+							var geometry = new THREE.SphereBufferGeometry( 80, 64, 32 );
 
-						var textureLoader = new THREE.TextureLoader();
+							var textureLoader = new THREE.TextureLoader();
 
-						var diffuse = textureLoader.load( "textures/carbon/Carbon.png" );
-						diffuse.encoding = THREE.sRGBEncoding;
-						diffuse.wrapS = THREE.RepeatWrapping;
-						diffuse.wrapT = THREE.RepeatWrapping;
-						diffuse.repeat.x = 10;
-						diffuse.repeat.y = 10;
+							var diffuse = textureLoader.load( "textures/carbon/Carbon.png" );
+							diffuse.encoding = THREE.sRGBEncoding;
+							diffuse.wrapS = THREE.RepeatWrapping;
+							diffuse.wrapT = THREE.RepeatWrapping;
+							diffuse.repeat.x = 10;
+							diffuse.repeat.y = 10;
 
-						var normalMap = textureLoader.load( "textures/carbon/Carbon_Normal.png" );
-						normalMap.wrapS = THREE.RepeatWrapping;
-						normalMap.wrapT = THREE.RepeatWrapping;
+							var normalMap = textureLoader.load( "textures/carbon/Carbon_Normal.png" );
+							normalMap.wrapS = THREE.RepeatWrapping;
+							normalMap.wrapT = THREE.RepeatWrapping;
 
-						var normalMap2 = textureLoader.load( "textures/water/Water_1_M_Normal.jpg" );
+							var normalMap2 = textureLoader.load( "textures/water/Water_1_M_Normal.jpg" );
 
-						var normalMap3 = textureLoader.load( "textures/flakes.png" );
-						normalMap3.wrapS = THREE.RepeatWrapping;
-						normalMap3.wrapT = THREE.RepeatWrapping;
-						normalMap3.repeat.x = 10;
-						normalMap3.repeat.y = 10;
-						normalMap3.anisotropy = 16;
+							var normalMap3 = textureLoader.load( "textures/flakes.png" );
+							normalMap3.wrapS = THREE.RepeatWrapping;
+							normalMap3.wrapT = THREE.RepeatWrapping;
+							normalMap3.repeat.x = 10;
+							normalMap3.repeat.y = 10;
+							normalMap3.anisotropy = 16;
 
-						var normalMap4 = textureLoader.load( "textures/golfball.jpg" );
+							var normalMap4 = textureLoader.load( "textures/golfball.jpg" );
 
-						var clearcoatNormaMap = textureLoader.load( "textures/pbr/Scratched_gold/Scratched_gold_01_1K_Normal.png" );
+							var clearcoatNormaMap = textureLoader.load( "textures/pbr/Scratched_gold/Scratched_gold_01_1K_Normal.png" );
 
-						// car paint
+							// car paint
 
-						var material = new THREE.MeshPhysicalMaterial( {
-							clearcoat: 1.0,
-							clearcoatRoughness: 0.1,
-							metalness: 0.9,
-							roughness: 0.5,
-							color: 0x0000ff,
-							envMap: hdrCubeRenderTarget.texture,
-							normalMap: normalMap3,
-							normalScale: new THREE.Vector2( 0.1, 0.1 )
-						} );
+							var material = new THREE.MeshPhysicalMaterial( {
+								clearcoat: 1.0,
+								clearcoatRoughness: 0.1,
+								metalness: 0.9,
+								roughness: 0.5,
+								color: 0x0000ff,
+								normalMap: normalMap3,
+								normalScale: new THREE.Vector2( 0.1, 0.1 )
+							} );
 
-						var mesh = new THREE.Mesh( geometry, material );
-						mesh.position.x = - 100;
-						mesh.position.y = 100;
-						group.add( mesh );
+							var mesh = new THREE.Mesh( geometry, material );
+							mesh.position.x = - 100;
+							mesh.position.y = 100;
+							group.add( mesh );
 
-						// fibers
+							// fibers
 
-						var material = new THREE.MeshPhysicalMaterial( {
-							clearcoat: 1.0,
-							clearcoatRoughness: 0.1,
-							envMap: hdrCubeRenderTarget.texture,
-							map: diffuse,
-							normalMap: normalMap
-						} );
-						var mesh = new THREE.Mesh( geometry, material );
-						mesh.position.x = 100;
-						mesh.position.y = 100;
-						group.add( mesh );
+							var material = new THREE.MeshPhysicalMaterial( {
+								clearcoat: 1.0,
+								clearcoatRoughness: 0.1,
+								map: diffuse,
+								normalMap: normalMap
+							} );
+							var mesh = new THREE.Mesh( geometry, material );
+							mesh.position.x = 100;
+							mesh.position.y = 100;
+							group.add( mesh );
 
-						// golf
+							// golf
 
-						var material = new THREE.MeshPhysicalMaterial( {
-							metalness: 0.0,
-							roughness: 0.1,
-							clearcoat: 1.0,
-							normalMap: normalMap4,
-							envMap: hdrCubeRenderTarget.texture,
-							clearcoatNormalMap: clearcoatNormaMap,
-							clearcoatNormalScale: new THREE.Vector2( 2.0, 2.0 )
-						} );
-						var mesh = new THREE.Mesh( geometry, material );
-						mesh.position.x = - 100;
-						mesh.position.y = - 100;
-						group.add( mesh );
+							var material = new THREE.MeshPhysicalMaterial( {
+								metalness: 0.0,
+								roughness: 0.1,
+								clearcoat: 1.0,
+								normalMap: normalMap4,
+								clearcoatNormalMap: clearcoatNormaMap,
+								clearcoatNormalScale: new THREE.Vector2( 2.0, 2.0 )
+							} );
+							var mesh = new THREE.Mesh( geometry, material );
+							mesh.position.x = - 100;
+							mesh.position.y = - 100;
+							group.add( mesh );
 
-						// clearcoat + normalmap
+							// clearcoat + normalmap
 
-						var material = new THREE.MeshPhysicalMaterial( {
-							clearcoat: 1.0,
-							metalness: 1.0,
-							color: 0xff0000,
-							envMap: hdrCubeRenderTarget.texture,
-							normalMap: normalMap2,
-							normalScale: new THREE.Vector2( 0.15, 0.15 ),
-							clearcoatNormalMap: clearcoatNormaMap,
-							clearcoatNormalScale: new THREE.Vector2( 2.0, 2.0 )
-						} );
-						var mesh = new THREE.Mesh( geometry, material );
-						mesh.position.x = 100;
-						mesh.position.y = - 100;
-						group.add( mesh );
+							var material = new THREE.MeshPhysicalMaterial( {
+								clearcoat: 1.0,
+								metalness: 1.0,
+								color: 0xff0000,
+								normalMap: normalMap2,
+								normalScale: new THREE.Vector2( 0.15, 0.15 ),
+								clearcoatNormalMap: clearcoatNormaMap,
+								clearcoatNormalScale: new THREE.Vector2( 2.0, 2.0 )
+							} );
+							var mesh = new THREE.Mesh( geometry, material );
+							mesh.position.x = 100;
+							mesh.position.y = - 100;
+							group.add( mesh );
 
-						//
+							//
 
-						scene.background = hdrCubeRenderTarget.texture;
+							scene.background = new THREE.CubeTextureBackground( hdrCubeRenderTarget.texture );
 
-					}
+						}
 
+					);
+
+				// LIGHTS
+
+				particleLight = new THREE.Mesh(
+					new THREE.SphereBufferGeometry( 4, 8, 8 ),
+					new THREE.MeshBasicMaterial( { color: 0xffffff } )
 				);
+				scene.add( particleLight );
 
-			// LIGHTS
+				particleLight.add( new THREE.PointLight( 0xffffff, 1 ) );
 
-			particleLight = new THREE.Mesh(
-				new THREE.SphereBufferGeometry( 4, 8, 8 ),
-				new THREE.MeshBasicMaterial( { color: 0xffffff } )
-			);
-			scene.add( particleLight );
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
 
-			particleLight.add( new THREE.PointLight( 0xffffff, 1 ) );
+				//
 
-			renderer = new THREE.WebGLRenderer();
-			renderer.setPixelRatio( window.devicePixelRatio );
-			renderer.setSize( window.innerWidth, window.innerHeight );
-			container.appendChild( renderer.domElement );
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 1;
 
-			//
+				//
 
-			renderer.toneMapping = THREE.ACESFilmicToneMapping;
-			renderer.toneMappingExposure = 1;
+				renderer.outputEncoding = THREE.sRGBEncoding;
 
-			//
+				//
 
-			renderer.outputEncoding = THREE.sRGBEncoding;
+				stats = new Stats();
+				container.appendChild( stats.dom );
 
-			//
+				// EVENTS
 
-			stats = new Stats();
-			container.appendChild( stats.dom );
+				new OrbitControls( camera, renderer.domElement );
 
-			// EVENTS
-
-			var controls = new OrbitControls( camera, renderer.domElement );
-
-			window.addEventListener( 'resize', onWindowResize, false );
-
-		}
-
-		//
-
-		function onWindowResize() {
-
-			var width = window.innerWidth;
-			var height = window.innerHeight;
-
-			camera.aspect = width / height;
-			camera.updateProjectionMatrix();
-
-			renderer.setSize( width, height );
-
-		}
-
-		//
-
-		function animate() {
-
-			requestAnimationFrame( animate );
-
-			render();
-
-			stats.update();
-
-		}
-
-		function render() {
-
-			var timer = Date.now() * 0.00025;
-
-			particleLight.position.x = Math.sin( timer * 7 ) * 300;
-			particleLight.position.y = Math.cos( timer * 5 ) * 400;
-			particleLight.position.z = Math.cos( timer * 3 ) * 300;
-
-			for ( var i = 0; i < group.children.length; i ++ ) {
-
-				var child = group.children[ i ];
-				child.rotation.y += 0.005;
+				window.addEventListener( 'resize', onWindowResize, false );
 
 			}
 
-			renderer.render( scene, camera );
+			//
 
-		}
+			function onWindowResize() {
 
+				var width = window.innerWidth;
+				var height = window.innerHeight;
 
-	</script>
-</body>
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+
+			}
+
+			//
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+				stats.update();
+
+			}
+
+			function render() {
+
+				var timer = Date.now() * 0.00025;
+
+				particleLight.position.x = Math.sin( timer * 7 ) * 300;
+				particleLight.position.y = Math.cos( timer * 5 ) * 400;
+				particleLight.position.z = Math.cos( timer * 3 ) * 300;
+
+				for ( var i = 0; i < group.children.length; i ++ ) {
+
+					var child = group.children[ i ];
+					child.rotation.y += 0.005;
+
+				}
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+	</body>
 </html>

--- a/src/Three.js
+++ b/src/Three.js
@@ -12,6 +12,7 @@ export { ShaderChunk } from './renderers/shaders/ShaderChunk.js';
 export { FogExp2 } from './scenes/FogExp2.js';
 export { Fog } from './scenes/Fog.js';
 export { Scene } from './scenes/Scene.js';
+export { CubeTextureBackground } from './scenes/backgrounds/CubeTextureBackground.js';
 export { Sprite } from './objects/Sprite.js';
 export { LOD } from './objects/LOD.js';
 export { SkinnedMesh } from './objects/SkinnedMesh.js';

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -110,7 +110,16 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 	}
 
-	this.getParameters = function ( material, lights, shadows, fog, nClipPlanes, nClipIntersection, object ) {
+	this.getParameters = function ( material, lights, shadows, scene, nClipPlanes, nClipIntersection, object ) {
+
+		var fog = scene.fog;
+		var envMap = material.envMap;
+
+		if ( material.isMeshStandardMaterial ) {
+
+			if ( scene.background && scene.background.isCubeTextureBackground ) envMap = scene.background.texture;
+
+		}
 
 		var shaderID = shaderIDs[ material.type ];
 
@@ -151,10 +160,10 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			mapEncoding: getTextureEncodingFromMap( material.map ),
 			matcap: !! material.matcap,
 			matcapEncoding: getTextureEncodingFromMap( material.matcap ),
-			envMap: !! material.envMap,
-			envMapMode: material.envMap && material.envMap.mapping,
-			envMapEncoding: getTextureEncodingFromMap( material.envMap ),
-			envMapCubeUV: ( !! material.envMap ) && ( ( material.envMap.mapping === CubeUVReflectionMapping ) || ( material.envMap.mapping === CubeUVRefractionMapping ) ),
+			envMap: !! envMap,
+			envMapMode: envMap && envMap.mapping,
+			envMapEncoding: getTextureEncodingFromMap( envMap ),
+			envMapCubeUV: ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) ),
 			lightMap: !! material.lightMap,
 			lightMapEncoding: getTextureEncodingFromMap( material.lightMap ),
 			aoMap: !! material.aoMap,

--- a/src/scenes/backgrounds/CubeTextureBackground.js
+++ b/src/scenes/backgrounds/CubeTextureBackground.js
@@ -1,0 +1,17 @@
+/**
+ * @author mrdoob / http://mrdoob.com/
+ */
+
+function CubeTextureBackground( texture ) {
+
+	this.texture = texture;
+
+}
+
+Object.assign( CubeTextureBackground.prototype, {
+
+	isCubeTextureBackground: true
+
+} );
+
+export { CubeTextureBackground };


### PR DESCRIPTION
As proposed in #17420. Not the prettiest code but it works.

When using this new class as `scene.background` any meshes in the scene using `MeshStandardMaterial` will use `scene.background.texture` was `envMap` at render time.

Unsolved issues:
* If the user changes `scene.background` we have to recompile the relevant materials somehow.