### PR TITLE
GLTFLoader: Make .computeBounds() more robust.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2295,6 +2295,8 @@ THREE.GLTFLoader = ( function () {
 			var min = accessor.min;
 			var max = accessor.max;
 
+			// glTF requires 'min' and 'max', but VRM (which extends glTF) currently ignores that requirement.
+
 			if ( min !== undefined && max !== undefined ) {
 
 				box.set(
@@ -2328,6 +2330,8 @@ THREE.GLTFLoader = ( function () {
 					var accessor = parser.json.accessors[ target.POSITION ];
 					var min = accessor.min;
 					var max = accessor.max;
+
+					// glTF requires 'min' and 'max', but VRM (which extends glTF) currently ignores that requirement.
 
 					if ( min !== undefined && max !== undefined ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2291,12 +2291,21 @@ THREE.GLTFLoader = ( function () {
 		if ( attributes.POSITION !== undefined ) {
 
 			var accessor = parser.json.accessors[ attributes.POSITION ];
+
 			var min = accessor.min;
 			var max = accessor.max;
 
-			box.set(
-				new THREE.Vector3( min[ 0 ], min[ 1 ], min[ 2 ] ),
-				new THREE.Vector3( max[ 0 ], max[ 1 ], max[ 2 ] ) );
+			if ( min !== undefined && max !== undefined ) {
+
+				box.set(
+					new THREE.Vector3( min[ 0 ], min[ 1 ], min[ 2 ] ),
+					new THREE.Vector3( max[ 0 ], max[ 1 ], max[ 2 ] ) );
+
+			} else {
+
+				return;
+
+			}
 
 		} else {
 
@@ -2320,12 +2329,16 @@ THREE.GLTFLoader = ( function () {
 					var min = accessor.min;
 					var max = accessor.max;
 
-					// we need to get max of absolute components because target weight is [-1,1]
-					vector.setX( Math.max( Math.abs( min[ 0 ] ), Math.abs( max[ 0 ] ) ) );
-					vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
-					vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
+					if ( min !== undefined && max !== undefined ) {
 
-					box.expandByVector( vector );
+						// we need to get max of absolute components because target weight is [-1,1]
+						vector.setX( Math.max( Math.abs( min[ 0 ] ), Math.abs( max[ 0 ] ) ) );
+						vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
+						vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
+
+						box.expandByVector( vector );
+
+					}
 
 				}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2362,11 +2362,17 @@ var GLTFLoader = ( function () {
 			var min = accessor.min;
 			var max = accessor.max;
 
+			// glTF requires 'min' and 'max', but VRM (which extends glTF) currently ignores that requirement.
+
 			if ( min !== undefined && max !== undefined ) {
 
 				box.set(
 					new Vector3( min[ 0 ], min[ 1 ], min[ 2 ] ),
 					new Vector3( max[ 0 ], max[ 1 ], max[ 2 ] ) );
+
+			} else {
+
+				return;
 
 			}
 
@@ -2391,6 +2397,8 @@ var GLTFLoader = ( function () {
 					var accessor = parser.json.accessors[ target.POSITION ];
 					var min = accessor.min;
 					var max = accessor.max;
+
+					// glTF requires 'min' and 'max', but VRM (which extends glTF) currently ignores that requirement.
 
 					if ( min !== undefined && max !== undefined ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2358,12 +2358,17 @@ var GLTFLoader = ( function () {
 		if ( attributes.POSITION !== undefined ) {
 
 			var accessor = parser.json.accessors[ attributes.POSITION ];
+
 			var min = accessor.min;
 			var max = accessor.max;
 
-			box.set(
-				new Vector3( min[ 0 ], min[ 1 ], min[ 2 ] ),
-				new Vector3( max[ 0 ], max[ 1 ], max[ 2 ] ) );
+			if ( min !== undefined && max !== undefined ) {
+
+				box.set(
+					new Vector3( min[ 0 ], min[ 1 ], min[ 2 ] ),
+					new Vector3( max[ 0 ], max[ 1 ], max[ 2 ] ) );
+
+			}
 
 		} else {
 
@@ -2387,12 +2392,16 @@ var GLTFLoader = ( function () {
 					var min = accessor.min;
 					var max = accessor.max;
 
-					// we need to get max of absolute components because target weight is [-1,1]
-					vector.setX( Math.max( Math.abs( min[ 0 ] ), Math.abs( max[ 0 ] ) ) );
-					vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
-					vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
+					if ( min !== undefined && max !== undefined ) {
 
-					box.expandByVector( vector );
+						// we need to get max of absolute components because target weight is [-1,1]
+						vector.setX( Math.max( Math.abs( min[ 0 ] ), Math.abs( max[ 0 ] ) ) );
+						vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
+						vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
+
+						box.expandByVector( vector );
+
+					}
 
 				}
 


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/17939#issuecomment-562857148

`webgl_loader_vrm` is now not broken anymore.