### PR TITLE
WebGLTextures: mipmapping now works with all texture types

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -805,7 +805,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-			generateMipmap( _gl.TEXTURE_2D, texture, image.width, image.height );
+			generateMipmap( textureType, texture, image.width, image.height );
 
 		}
 


### PR DESCRIPTION
The call to generateMipmap() at the bottom of uploadTexture() was previously assuming _gl.TEXTURE_2D as the texture type, which broke automatic mipmapping for other texture types.

Fixes #18134