### PR TITLE
Suggestion: Default group render order to not overwrite existing group order

### DIFF
--- a/src/objects/Group.js
+++ b/src/objects/Group.js
@@ -9,6 +9,7 @@ function Group() {
 	Object3D.call( this );
 
 	this.type = 'Group';
+	this.renderOrder = null;
 
 }
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1147,7 +1147,7 @@ function WebGLRenderer( parameters ) {
 		currentRenderList = renderLists.get( scene, camera );
 		currentRenderList.init();
 
-		projectObject( scene, camera, 0, _this.sortObjects );
+		projectObject( scene, camera, null, _this.sortObjects );
 
 		if ( _this.sortObjects === true ) {
 
@@ -1258,6 +1258,8 @@ function WebGLRenderer( parameters ) {
 
 		if ( object.visible === false ) return;
 
+		if ( groupOrder === null ) groupOrder = '';
+
 		var visible = object.layers.test( camera.layers );
 
 		if ( visible ) {
@@ -1266,7 +1268,8 @@ function WebGLRenderer( parameters ) {
 
 				if ( object.renderOrder !== null ) {
 
-					groupOrder = object.renderOrder;
+					// encode the hierarchy draw order as a string for quick comparisons
+					groupOrder += String.fromCharCode( object.renderOrder );
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1264,7 +1264,11 @@ function WebGLRenderer( parameters ) {
 
 			if ( object.isGroup ) {
 
-				groupOrder = object.renderOrder;
+				if ( object.renderOrder !== null ) {
+
+					groupOrder = object.renderOrder;
+
+				}
 
 			} else if ( object.isLOD ) {
 


### PR DESCRIPTION
I feel that the behavior of the `Group.renderOrder` attribute is not all that intuitive. I made a topic on the forum [here](https://discourse.threejs.org/t/help-understanding-group-renderorder-and-mesh-renderorder/10790) to discuss if you're interested in reading but my confusion stems from the fact the current behavior is that a Groups render order can only apply to the immediate child meshes and not nested child meshes.

In this case:
```
Group with render order -1
    └ Mesh A with render order 2
Mesh B with render order 0
```
Mesh A will render before Mesh B.

Inserting a new group like so without changing the default render order means that Mesh B will render before Mesh A:

```
Group with order -1
    └ Group with default order (0)
        └ Mesh A with render order 2
Mesh B with render order 0
```

However by default I would expect the default behavior to _not affect the draw order_. This happens because the WebGLRenderer always overwrites the last group order with no way of indicating that a group should not affect the sort. I think ideally a group with a new order would only affect the render order within that subtree (as opposed to globally as it does now) but that would be a much larger change and I think this is a step in the right direction. I can update the docs and do more testing if this has promise.

**TL;DR**
This PR defaults the `renderOrder` for `Group` to be `null` to indicate that it should not affect the child meshes draw order.

**Edit**
Added encoding of group order as string to account for whole hierarchy of parents draw orders.