### PR TITLE
Fixing wrong antialias, depth, stencil, alpha flags in WebXRManager

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -138,7 +138,14 @@ function WebXRManager( renderer, gl ) {
 			session.addEventListener( 'end', onSessionEnd );
 
 			// eslint-disable-next-line no-undef
-			session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl ) } );
+			session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl,
+				{
+					antialias: gl.getContextAttributes().antialias,
+					alpha: gl.getContextAttributes().alpha,
+					depth: gl.getContextAttributes().depth,
+					stencil: gl.getContextAttributes().stencil
+				}
+			) } );
 
 			session.requestReferenceSpace( referenceSpaceType ).then( onRequestReferenceSpace );
 


### PR DESCRIPTION
See issue https://github.com/mrdoob/three.js/issues/18159 for more details.

WebXRManager doesn't pass initialized object when XRWebGLLayer is created assuming that attributes like "antialias", "depth", "stencil", "alpha" will be taken from the passed gl context. However, it is not so.

There are the default values for XRWebGLLayer's initializer object's attributes (from https://www.w3.org/TR/webxr/#xrwebgllayer-interface):

```
dictionary XRWebGLLayerInit {
  boolean antialias = true;
  boolean depth = true;
  boolean stencil = false;
  boolean alpha = true;
  boolean ignoreDepthValues = false;
  double framebufferScaleFactor = 1.0;
};
```

For example, the default value of 'antialias' for the layer is true! And check the step #9 [here](https://www.w3.org/TR/webxr/#xrwebgllayer-interface), it suppose to take the AA attribute from the init object (as well as depth, stencil, and alpha) not from the context ("composition disabled" is set to false in this case).
