### PR TITLE
Fix naming of unpackRGBATo2Half

### DIFF
--- a/src/renderers/shaders/ShaderChunk/packing.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/packing.glsl.js
@@ -29,7 +29,7 @@ vec4 pack2HalfToRGBA( vec2 v ) {
 	vec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ));
 	return vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w);
 }
-vec2 unpack2HalfToRGBA( vec4 v ) {
+vec2 unpackRGBATo2Half( vec4 v ) {
 	return vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );
 }
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -38,7 +38,7 @@ export default /* glsl */`
 
 	vec2 texture2DDistribution( sampler2D shadow, vec2 uv ) {
 
-		return unpack2HalfToRGBA( texture2D( shadow, uv ) );
+		return unpackRGBATo2Half( texture2D( shadow, uv ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
@@ -17,7 +17,7 @@ void main() {
 
     #ifdef HORIZONAL_PASS
 
-      vec2 distribution = unpack2HalfToRGBA ( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
+      vec2 distribution = unpackRGBATo2Half( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
       mean += distribution.x;
       squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;
 


### PR DESCRIPTION
This function is unpacking an RGBA value into a vec2, not the other way around.