### PR TITLE
Expose the underlying XRInputSource for VR controllers

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -59,6 +59,7 @@ function WebXRManager( renderer, gl ) {
 			controller = new Group();
 			controller.matrixAutoUpdate = false;
 			controller.visible = false;
+			controller.inputSource = sortedInputSources.length > i ? sortedInputSources[i] : null;
 
 			controllers[ id ] = controller;
 
@@ -168,6 +169,13 @@ function WebXRManager( renderer, gl ) {
 		for ( var i = 0; i < controllers.length; i ++ ) {
 
 			sortedInputSources[ i ] = findInputSource( i );
+
+			if (controllers[ i ].inputSource != sortedInputSources[ i ]) {
+
+				controllers[ i ].inputSource = sortedInputSources[ i ];
+				controllers[ i ].dispatchEvent( { type: 'inputsourcechange' } );
+
+			}
 
 		}
 


### PR DESCRIPTION
Talked with @mrdoob about doing something like this, and this particular pattern has worked well for me in https://xrdinosaurs.com. The `XRInputSource` contains lots of metadata about VR controllers that's fairly critical for developers to visualize input devices properly. For example, the `targetRayMode` will tell you whether or not you should avoid rendering a target ray (when the value is `gaze`). Additionally, this will expose the `gamepad` attribute when it's available to give a more complete controller state and the `profiles` array to tell developers what type of controller is being used.

Biggest concern I have is that I'm not sure what Three's stance is on patching new attributes onto an object (like `Group` here).