### PR TITLE
TS: remove division parameter for Font.generateShapes

### DIFF
--- a/src/extras/core/Font.d.ts
+++ b/src/extras/core/Font.d.ts
@@ -4,6 +4,6 @@ export class Font {
 
 	data: string;
 
-	generateShapes( text: string, size: number, divisions: number ): any[];
+	generateShapes( text: string, size: number ): any[];
 
 }


### PR DESCRIPTION
Looks like Font.js had been updated but not the corresponding .d.ts file