### PR TITLE
[GPUComputationRenderer] check if webgl2 is used before checking for extension OES_texture_float

### DIFF
--- a/examples/js/misc/GPUComputationRenderer.js
+++ b/examples/js/misc/GPUComputationRenderer.js
@@ -148,8 +148,8 @@ THREE.GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 
 	this.init = function () {
 
-		if ( ! renderer.extensions.get( "OES_texture_float" ) &&
-			 ! renderer.capabilities.isWebGL2 ) {
+		if ( ! renderer.capabilities.isWebGL2 &&
+			 ! renderer.extensions.get( "OES_texture_float" ) ) {
 
 			return "No OES_texture_float support for float textures.";
 

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -163,8 +163,8 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 
 	this.init = function () {
 
-		if ( ! renderer.extensions.get( "OES_texture_float" ) &&
-			 ! renderer.capabilities.isWebGL2 ) {
+		if ( ! renderer.capabilities.isWebGL2 &&
+			 ! renderer.extensions.get( "OES_texture_float" ) ) {
 
 			return "No OES_texture_float support for float textures.";
 
@@ -209,7 +209,6 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 							}
 
 						}
-
 						if ( ! found ) {
 
 							return "Variable dependency not found. Variable=" + variable.name + ", dependency=" + depVar.name;
@@ -334,11 +333,8 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 
 	this.createTexture = function () {
 
-		var a = new Float32Array( sizeX * sizeY * 4 );
-		var texture = new DataTexture( a, sizeX, sizeY, RGBAFormat, FloatType );
-		texture.needsUpdate = true;
-
-		return texture;
+		var data = new Float32Array( sizeX * sizeY * 4 );
+		return new DataTexture( data, sizeX, sizeY, RGBAFormat, FloatType );
 
 	};
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -114,6 +114,7 @@ var files = [
 	{ path: 'math/SimplexNoise.js', dependencies: [], ignoreList: [] },
 
 	{ path: 'misc/ConvexObjectBreaker.js', dependencies: [ { name: 'ConvexBufferGeometry', path: 'geometries/ConvexGeometry.js' } ], ignoreList: [ 'Matrix4' ] },
+	{ path: 'misc/GPUComputationRenderer.js', dependencies: [], ignoreList: [] },
 	{ path: 'misc/Gyroscope.js', dependencies: [], ignoreList: [] },
 	{ path: 'misc/MD2Character.js', dependencies: [ { name: 'MD2Loader', path: 'loaders/MD2Loader.js' } ], ignoreList: [] },
 	{ path: 'misc/MD2CharacterComplex.js', dependencies: [ { name: 'MD2Loader', path: 'loaders/MD2Loader.js' }, { name: 'MorphBlendMesh', path: 'misc/MorphBlendMesh.js' } ], ignoreList: [] },


### PR DESCRIPTION
Currently GPUComputationRenderer checks for:
- first the extension OES_texture_float
- and second for webgl2

But this prints the following warning if webgl2 is used.
`THREE.WebGLRenderer: OES_texture_float extension not supported.`

So instead, I suggest inverting those checks, so `renderer.extensions.get` is only called if we are not already using webgl2, resulting in no warning printed out.
