### PR TITLE
MeshSurfaceSampler: Accept Mesh as parameter, not BufferGeometry

### DIFF
--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -17,8 +17,8 @@
 		<h2>Example</h2>
 
 		<code>
-		// Create a sampler for a BufferGeometry surface.
-		var sampler = new THREE.MeshSurfaceSampler( surfaceGeometry )
+		// Create a sampler for a Mesh surface.
+		var sampler = new THREE.MeshSurfaceSampler( surfaceMesh )
 			.setWeightAttribute( 'color' )
 			.build();
 
@@ -52,9 +52,9 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:BufferGeometry geometry] )</h3>
+		<h3>[name]( [param:Mesh mesh] )</h3>
 		<p>
-		[page:BufferGeometry geometry] — Surface geometry from which to sample.
+		[page:Mesh mesh] — Surface mesh from which to sample.
 		</p>
 		<p>
 		Creates a new [name]. If the input geometry is indexed, a non-indexed copy is made. After construction, the sampler is not able to return samples until [page:MeshSurfaceSampler.build build] is called.

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -18,7 +18,7 @@
 
 		<code>
 		// Create a sampler for a BufferGeometry surface.
-		var sampler = new THREE.MeshSurfaceSampler( surfaceGeometry )
+		var sampler = new THREE.MeshSurfaceSampler( surfaceMesh )
 			.setWeightAttribute( 'color' )
 			.build();
 
@@ -52,9 +52,9 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:BufferGeometry geometry] )</h3>
+		<h3>[name]( [param:Mesh mesh] )</h3>
 		<p>
-		[page:BufferGeometry geometry] — Surface geometry from which to sample.
+		[page:Mesh mesh] — Surface mesh from which to sample.
 		</p>
 		<p>
 		Creates a new [name]. If the input geometry is indexed, a non-indexed copy is made. After construction, the sampler is not able to return samples until [page:MeshSurfaceSampler.build build] is called.

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -20,7 +20,9 @@ var MeshSurfaceSampler = ( function () {
 
 	var _face = new Triangle();
 
-	function MeshSurfaceSampler ( geometry ) {
+	function MeshSurfaceSampler ( mesh ) {
+
+		var geometry = mesh.geometry;
 
 		if ( ! geometry.isBufferGeometry || geometry.attributes.position.itemSize !== 3 ) {
 

--- a/examples/webgl_instancing_scatter.html
+++ b/examples/webgl_instancing_scatter.html
@@ -181,7 +181,7 @@
 
 				console.time( '.build()' );
 
-				sampler = new MeshSurfaceSampler( surface.geometry )
+				sampler = new MeshSurfaceSampler( surface )
 					.setWeightAttribute( api.distribution === 'weighted' ? 'uv' : null )
 					.build();
 


### PR DESCRIPTION
Small API change to MeshSurfaceSampler before it gets released, taking a Mesh as a constructor parameter instead of a BufferGeometry. @Usnul pointed out that skinning support might be helpful in the future, which I agree with but don't have time to add right now. This just changes the API so that it's future-proof for adding that later, and perhaps for morph targets too.

> **EDIT:** Also it fits the name better anyway. 😅