### PR TITLE
SubdivisionModifier: Fix runtime error with empty uvs.

### DIFF
--- a/examples/js/modifiers/SubdivisionModifier.js
+++ b/examples/js/modifiers/SubdivisionModifier.js
@@ -169,7 +169,7 @@ THREE.SubdivisionModifier.prototype.modify = function ( geometry ) {
 		oldFaces = geometry.faces; // { a: oldVertex1, b: oldVertex2, c: oldVertex3 }
 		oldUvs = geometry.faceVertexUvs;
 
-		var hasUvs = oldUvs !== undefined && oldUvs.length > 0;
+		var hasUvs = oldUvs[ 0 ] !== undefined && oldUvs[ 0 ].length > 0;
 
 		if ( hasUvs ) {
 

--- a/examples/jsm/modifiers/SubdivisionModifier.js
+++ b/examples/jsm/modifiers/SubdivisionModifier.js
@@ -176,7 +176,7 @@ SubdivisionModifier.prototype.modify = function ( geometry ) {
 		oldFaces = geometry.faces; // { a: oldVertex1, b: oldVertex2, c: oldVertex3 }
 		oldUvs = geometry.faceVertexUvs;
 
-		var hasUvs = oldUvs !== undefined && oldUvs.length > 0;
+		var hasUvs = oldUvs[ 0 ] !== undefined && oldUvs[ 0 ].length > 0;
 
 		if ( hasUvs ) {
 


### PR DESCRIPTION
#18065 broke the official example. The PR assumed `Geometry.faceVertexUvs` is by default `undefined` (which is wrong since it's `[[]]`). Hence the current `hasUvs` check always evaluates to `true`.

/cc @ieskudero