### PR TITLE
CubeTexturePass: Fix usage of cube shader.

### DIFF
--- a/examples/js/postprocessing/CubeTexturePass.js
+++ b/examples/js/postprocessing/CubeTexturePass.js
@@ -23,6 +23,16 @@ THREE.CubeTexturePass = function ( camera, envMap, opacity ) {
 		} )
 	);
 
+	Object.defineProperty( this.cubeMesh.material, 'envMap', {
+
+		get: function () {
+
+			return this.uniforms.envMap.value;
+
+		}
+
+	} );
+
 	this.envMap = envMap;
 	this.opacity = ( opacity !== undefined ) ? opacity : 1.0;
 
@@ -44,8 +54,8 @@ THREE.CubeTexturePass.prototype = Object.assign( Object.create( THREE.Pass.proto
 		this.cubeCamera.projectionMatrix.copy( this.camera.projectionMatrix );
 		this.cubeCamera.quaternion.setFromRotationMatrix( this.camera.matrixWorld );
 
-		this.cubeMesh.material.envMap = this.envMap;
-		this.cubeMesh.material.opacity = this.opacity;
+		this.cubeMesh.material.uniforms.envMap.value = this.envMap;
+		this.cubeMesh.material.uniforms.opacity.value = this.opacity;
 		this.cubeMesh.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );

--- a/examples/jsm/postprocessing/CubeTexturePass.js
+++ b/examples/jsm/postprocessing/CubeTexturePass.js
@@ -34,6 +34,16 @@ var CubeTexturePass = function ( camera, envMap, opacity ) {
 		} )
 	);
 
+	Object.defineProperty( this.cubeMesh.material, 'envMap', {
+
+		get: function () {
+
+			return this.uniforms.envMap.value;
+
+		}
+
+	} );
+
 	this.envMap = envMap;
 	this.opacity = ( opacity !== undefined ) ? opacity : 1.0;
 
@@ -55,8 +65,8 @@ CubeTexturePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 		this.cubeCamera.projectionMatrix.copy( this.camera.projectionMatrix );
 		this.cubeCamera.quaternion.setFromRotationMatrix( this.camera.matrixWorld );
 
-		this.cubeMesh.material.envMap = this.envMap;
-		this.cubeMesh.material.opacity = this.opacity;
+		this.cubeMesh.material.uniforms.envMap.value = this.envMap;
+		this.cubeMesh.material.uniforms.opacity.value = this.opacity;
 		this.cubeMesh.material.transparent = ( this.opacity < 1.0 );
 
 		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );


### PR DESCRIPTION
`CubeTexturePass` is currently broken because of the way how the cube shader and `WebGLBackground` were changed during the PMREM upgrade.