### PR TITLE
TransformControls: Add domElement property.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -14,6 +14,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 	THREE.Object3D.call( this );
 
 	this.visible = false;
+	this.domElement = domElement;
 
 	var _gizmo = new THREE.TransformControlsGizmo();
 	this.add( _gizmo );


### PR DESCRIPTION
To match the documentation: https://threejs.org/docs/#examples/en/controls/TransformControls
TransformControls should expose a `domElement` property.

````
.domElement : HTMLDOMElement
The HTMLDOMElement used to listen for mouse / touch events. This must be passed in the constructor; changing it here will not set up new event listeners.
````