### PR TITLE
GLTFLoader: Use depthWrite=false for transparent materials

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2099,6 +2099,9 @@ THREE.GLTFLoader = ( function () {
 
 			materialParams.transparent = true;
 
+			// See: https://github.com/mrdoob/three.js/issues/17706
+			materialParams.depthWrite = false;
+
 		} else if ( alphaMode === ALPHA_MODES.MASK ) {
 
 			materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2162,6 +2162,9 @@ var GLTFLoader = ( function () {
 
 			materialParams.transparent = true;
 
+			// See: https://github.com/mrdoob/three.js/issues/17706
+			materialParams.depthWrite = false;
+
 		} else if ( alphaMode === ALPHA_MODES.MASK ) {
 
 			materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -92,11 +92,6 @@
 
 				scene.add( model );
 
-				// Mesh contains self-intersecting semi-transparent faces, which display
-				// z-fighting unless depthWrite is disabled.
-				var core = model.getObjectByName( 'geo1_HoloFillDark_0' );
-				core.material.depthWrite = false;
-
 				mixer = new THREE.AnimationMixer( model );
 				var clip = gltf.animations[ 0 ];
 				mixer.clipAction( clip.optimize() ).play();


### PR DESCRIPTION
> ~~**NOTE:** Let's wait until after the r112 release to merge this.~~

Based in part on https://github.com/mrdoob/three.js/issues/17706 and https://github.com/donmccurdy/three-gltf-viewer/issues/169, and more importantly by what other engines appear to be doing, I've come to the conclusion that we should set `depthWrite=false` for transparent materials in GLTFLoader.

### References

- **Khronos:** "The standard method for dealing with translucent objects ... involves disabling writes to the depth buffer and sorting transparent objects and/or polygons based on distance to the camera."
    - https://www.khronos.org/opengl/wiki/Transparency_Sorting#Translucency_and_the_depth_buffer
- **Unity:** "If you’re drawing solid objects, leave [ZWrite] on. If you’re drawing semitransparent effects, switch to ZWrite Off."
    - https://docs.unity3d.com/Manual/SL-CullAndDepth.html
- **Unreal:** Has separate PixelDepth, SceneDepth, and CustomDepth types. Translucent materials never write to SceneDepth, and only write to CustomDepth with an opt-in setting, “Allow Custom Depth Writes”.
    - https://www.tomlooman.com/the-many-uses-of-custom-depth-in-unreal-4/
    - https://docs.unrealengine.com/en-US/Engine/Rendering/Materials/ExpressionReference/Depth/index.html
    - https://forums.unrealengine.com/development-discussion/rendering/1630765-render-to-scenedepth-only
- **BabylonJS:** Depth write disabled for transparent materials unless "needDepthPrePass" option is enabled.
    - https://github.com/BabylonJS/Babylon.js/issues/2832#issuecomment-330893280

### Examples

- Car Windshield: https://github.com/donmccurdy/three-gltf-viewer/issues/169
    - ✅ Fixed by setting `depthWrite=false`. 
- Eye: https://github.com/mrdoob/three.js/issues/17706
    - ✅ Fixed by setting `depthWrite=false`.
- Glenfiddich Bottle: https://github.com/mrdoob/three.js/issues/13889
    - 🤷‍♂️ Imperfect either way, but a bit worse with `depthWrite` disabled.
- Curtains: https://github.com/mrdoob/three.js/issues/15293
    - 🤷‍♂️ Very imperfect either way, but a bit worse with `depthWrite` disabled.

For an illustration of where this makes something worse, here's the Glennfiddich Bottle from below. You see the stem of the bottle through the base of the bottle:

| depthWrite=true | depthWrite=false |
|---|---|
| ![scotch_depthWrite=true](https://user-images.githubusercontent.com/1848368/71336505-466b0a00-24fc-11ea-94f9-46f842b33dbc.png) | ![scotch_depthWrite=false](https://user-images.githubusercontent.com/1848368/71336506-4834cd80-24fc-11ea-9f42-c2f5a8478a58.png) |

### Exceptions

The "Glennfiddich Bottle" and "Curtains" examples above are (IMHO) not modeled appropriately for realtime rendering. The latter could be fixed without too much trouble, but I'm not sure how I'd fix the former. Enabled or disabled, depthWrite doesn't fix either.

The resources below describe a few situations where developers really may want to use `depthWrite=true` on transparent materials. Compared to the precedent set by other engines above, these exceptions seem minor enough to justify changing the default:

- https://developer.oculus.com/blog/translucent-vs-masked-rendering-in-real-time-applications/
- https://forums.unrealengine.com/development-discussion/rendering/18922-translucent-depth-buffer
- https://www.sjbaker.org/steve/omniv/alpha_sorting.html