### PR TITLE
DOF Example: Use Scene.background.

### DIFF
--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -85,22 +85,7 @@
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
 				textureCube.format = THREE.RGBFormat;
 
-				var shader = THREE.ShaderLib[ 'cube' ];
-
-				var skyMaterial = new THREE.ShaderMaterial( {
-
-					fragmentShader: shader.fragmentShader,
-					vertexShader: shader.vertexShader,
-					uniforms: shader.uniforms,
-					depthWrite: false,
-					side: THREE.BackSide
-
-				} );
-
-				skyMaterial.envMap = textureCube;
-
-				var sky = new THREE.Mesh( new THREE.BoxBufferGeometry( 1000, 1000, 1000 ), skyMaterial );
-				scene.add( sky );
+				scene.background = textureCube;
 
 				// plane particles
 
@@ -444,22 +429,17 @@
 
 					var intersects = raycaster.intersectObjects( scene.children, true );
 
+					var targetDistance = ( intersects.length > 0 ) ? intersects[ 0 ].distance : 1000;
 
-					if ( intersects.length > 0 ) {
+					distance += ( targetDistance - distance ) * 0.03;
 
-						var targetDistance = intersects[ 0 ].distance;
+					var sdistance = smoothstep( camera.near, camera.far, distance );
 
-						distance += ( targetDistance - distance ) * 0.03;
+					var ldistance = linearize( 1 - sdistance );
 
-						var sdistance = smoothstep( camera.near, camera.far, distance );
+					postprocessing.bokeh_uniforms[ 'focalDepth' ].value = ldistance;
 
-						var ldistance = linearize( 1 - sdistance );
-
-						postprocessing.bokeh_uniforms[ 'focalDepth' ].value = ldistance;
-
-						effectController[ 'focalDepth' ] = ldistance;
-
-					}
+					effectController[ 'focalDepth' ] = ldistance;
 
 				}
 


### PR DESCRIPTION
`webgl_postprocessing_dof2` still created manually a skybox so it was possible to "reset" the focus point when the user does not select an object. This is now done differently. If no intersection occurs, the target distance is set to a high value. The result is exactly like before but now via using `Scene.background`.