### PR TITLE
Added an ability to reset current state of Orbit controls

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -273,6 +273,11 @@ controls.touches = {
 			Get the current vertical rotation, in radians.
 		</p>
 
+		<h3>[method:null resetState] ()</h3>
+		<p>
+			Reset the current state of the controls.
+		</p>
+
 		<h3>[method:null reset] ()</h3>
 		<p>
 			Reset the controls to their state from either the last time the [page:.saveState] was called, or the initial state.

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -112,6 +112,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	};
 
+	this.resetState = function () {
+
+		state = STATE.NONE;
+
+	};
+
 	this.reset = function () {
 
 		scope.target.copy( scope.target0 );


### PR DESCRIPTION
The problem: 
==
I'm using Three.js and OrbitControls in WebWorker but the problem is that OrbitControls uses DOM. I added `mouseup` event listener to `document` and sent a message to my Worker that I want to unsubscribe from events in my controls to avoid this tiny bug.

![ezgif-4-4193cbe78b06](https://user-images.githubusercontent.com/17102399/71365486-3280e000-25b0-11ea-9a73-297a8074bc76.gif)

Solution:
==
I added `resetState` method to OrbitControls and this method will reset state to `STATE.NONE` value, but if I have to add something more, please, let me know. I think that I also have to dispatch `change` event, but not sure about it.
