### PR TITLE
change WebGLObjects.updateList to weakmap

### DIFF
--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -4,7 +4,7 @@
 
 function WebGLObjects( gl, geometries, attributes, info ) {
 
-	var updateList = {};
+	var updateMap = new WeakMap();
 
 	function update( object ) {
 
@@ -15,7 +15,7 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 		// Update once per frame
 
-		if ( updateList[ buffergeometry.id ] !== frame ) {
+		if ( updateMap.get( buffergeometry ) !== frame ) {
 
 			if ( geometry.isGeometry ) {
 
@@ -25,7 +25,7 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 			geometries.update( buffergeometry );
 
-			updateList[ buffergeometry.id ] = frame;
+			updateMap.set( buffergeometry, frame );
 
 		}
 
@@ -41,7 +41,7 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 	function dispose() {
 
-		updateList = {};
+		updateMap.clear();
 
 	}
 


### PR DESCRIPTION
Well, this is actually a bug report...

I encountered a weird bug that says and I'm not sure what is going on with my end:

```
TypeError: Cannot read property 'type' of undefined
    at WebGLIndexedBufferRenderer.setIndex (c:\Users\yutaka\Documents\Workspace\three.js\build\three.module.js:16190:1)
    at WebGLRenderer.renderBufferDirect (c:\Users\yutaka\Documents\Workspace\three.js\build\three.module.js:23990:1)
    at renderObject (c:\Users\yutaka\Documents\Workspace\three.js\build\three.module.js:24681:1)
    at renderObjects (c:\Users\yutaka\Documents\Workspace\three.js\build\three.module.js:24651:1)
    at WebGLRenderer.render (c:\Users\yutaka\Documents\Workspace\three.js\build\three.module.js:24430:1)
    at Inspector../src/Inspector.tsx.Inspector.update (c:\Users\yutaka\Documents\Workspace\three-vrm-inspector\src\Inspector.tsx:150:22)
    at update (c:\Users\yutaka\Documents\Workspace\three-vrm-inspector\src\InspectorContext.tsx:21:13)
```

![image](https://user-images.githubusercontent.com/7824814/71403834-4c83f680-2674-11ea-93ce-12008efc00a5.png)

It's weird that WebGLAttributes doesn't have corresponding buffer on it, it can happen with any types of helper objects:

![image](https://user-images.githubusercontent.com/7824814/71403856-632a4d80-2674-11ea-8f43-a32aea3576a8.png)

After I change the `updateList` of WebGLObjects to a WeakMap, the problem weirdly disappeared...

Is anyone there who knows about this? / Is the change valid?

---

- Three.js version: Dev / r111
- Browser: Chrome
- OS: Windows
- I'm building my project using webpack / typescript , this will happen regardless of minification
