### PR TITLE
Implemented envMapBlurriness

### DIFF
--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -70,6 +70,8 @@
 						var envMap = pmremGenerator.fromEquirectangular( texture ).texture;
 						pmremGenerator.dispose();
 
+						envMap.blurriness = 0.15;
+
 						scene.background = envMap;
 						scene.environment = envMap;
 

--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -145,6 +145,8 @@
 
 							//
 
+							hdrCubeRenderTarget.texture.blurriness = 0.2;
+
 							scene.background = hdrCubeRenderTarget.texture;
 							scene.environment = hdrCubeRenderTarget.texture;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2089,6 +2089,7 @@ function WebGLRenderer( parameters ) {
 		if ( envMap ) {
 
 			uniforms.envMap.value = envMap;
+			uniforms.envMapBlurriness.value = envMap.blurriness;
 
 			// don't flip CubeTexture envMaps, flip everything else:
 			//  WebGLRenderTargetCube will be flipped for backwards compatibility

--- a/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
@@ -1,6 +1,7 @@
 export default /* glsl */`
 #ifdef USE_ENVMAP
 
+	uniform float envMapBlurriness;
 	uniform float envMapIntensity;
 	uniform float flipEnvMap;
 	uniform int maxMipLevel;
@@ -10,6 +11,6 @@ export default /* glsl */`
 	#else
 		uniform sampler2D envMap;
 	#endif
-	
+
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -4,7 +4,7 @@ export default /* glsl */`
 	#ifdef ENV_WORLDPOS
 
 		vec3 cameraToFrag;
-		
+
 		if ( isOrthographic ) {
 
 			cameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );
@@ -40,7 +40,7 @@ export default /* glsl */`
 
 	#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-		vec4 envColor = textureCubeUV( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ), 0.0 );
+		vec4 envColor = textureCubeUV( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ), envMapBlurriness );
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -30,6 +30,7 @@ var UniformsLib = {
 	envmap: {
 
 		envMap: { value: null },
+		envMapBlurriness: { value: 0 },
 		flipEnvMap: { value: - 1 },
 		reflectivity: { value: 1.0 },
 		refractionRatio: { value: 0.98 },

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -105,6 +105,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 			var texture = background.isWebGLRenderTargetCube ? background.texture : background;
 
 			boxMesh.material.uniforms.envMap.value = texture;
+			boxMesh.material.uniforms.envMapBlurriness.value = texture.blurriness;
 			boxMesh.material.uniforms.flipEnvMap.value = texture.isCubeTexture ? - 1 : 1;
 
 			if ( currentBackground !== background ||

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -61,6 +61,8 @@ function Texture( image, mapping, wrapS, wrapT, magFilter, minFilter, format, ty
 	this.flipY = true;
 	this.unpackAlignment = 4;	// valid values: 1, 2, 4, 8 (see http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
 
+	this.blurriness = 0;
+
 	// Values of encoding !== THREE.LinearEncoding only supported on map, envMap and emissiveMap.
 	//
 	// Also changing the encoding after already used by a Material will not automatically make the Material


### PR DESCRIPTION
Alternative implementation to #16900

<img width="868" alt="Screen Shot 2019-12-25 at 6 48 56 AM" src="https://user-images.githubusercontent.com/97088/71434021-d79bd580-26e2-11ea-96d6-23381c00aafb.png">

Looks pretty good, but the background is kind of blocky..

<img width="867" alt="Screen Shot 2019-12-25 at 6 49 47 AM" src="https://user-images.githubusercontent.com/97088/71434029-e3879780-26e2-11ea-894b-dc4df6db6095.png">
