### PR TITLE
Temporary fix for broken things while the editor is beign moved to modules

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -67,7 +67,8 @@
 
 			//
 
-			var editor = new Editor();
+            var editor = new Editor();
+            window['editor'] = editor;
 
 			var viewport = new Viewport( editor );
 			document.body.appendChild( viewport.dom );


### PR DESCRIPTION
Many of the current implementations in editor rely on the global editor variable, due to move to modules for editor