### PR TITLE
Examples: Make CSS Renderers respect Scene.autoUpdate.

### DIFF
--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -162,7 +162,7 @@ THREE.CSS2DRenderer = function () {
 
 	this.render = function ( scene, camera ) {
 		
-		if (scene.autoUpdate === true) { scene.updateMatrixWorld(); }
+		if ( scene.autoUpdate === true ) { scene.updateMatrixWorld(); }
 
 		if ( camera.parent === null ) camera.updateMatrixWorld();
 

--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -161,8 +161,8 @@ THREE.CSS2DRenderer = function () {
 	};
 
 	this.render = function ( scene, camera ) {
-
-		scene.updateMatrixWorld();
+		
+		if (scene.autoUpdate === true) { scene.updateMatrixWorld(); }
 
 		if ( camera.parent === null ) camera.updateMatrixWorld();
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -296,7 +296,7 @@ THREE.CSS3DRenderer = function () {
 
 		}
 
-		scene.updateMatrixWorld();
+		if (scene.autoUpdate === true) { scene.updateMatrixWorld(); }
 
 		if ( camera.parent === null ) camera.updateMatrixWorld();
 

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -296,7 +296,7 @@ THREE.CSS3DRenderer = function () {
 
 		}
 
-		if (scene.autoUpdate === true) { scene.updateMatrixWorld(); }
+		if ( scene.autoUpdate === true ) { scene.updateMatrixWorld(); }
 
 		if ( camera.parent === null ) camera.updateMatrixWorld();
 


### PR DESCRIPTION
Currently CSS renderers don't allow control over scene graph updates. This is desired to enable increased efficiency with multiple renderers/renderpasses.

This minor pull request adds scene.autoUpdate support for CSS Renderers, harmonizing with WebGLRenderer.