### PR TITLE
BufferGeometryUtils.js: Non-breaking space replaced with normal space

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -636,7 +636,7 @@ var BufferGeometryUtils = {
 
 		}
 
-		if ( drawMode === TriangleFanDrawMode || drawMode === TriangleStripDrawMode ) {
+		if ( drawMode === TriangleFanDrawMode || drawMode === TriangleStripDrawMode ) {
 
 			var index = geometry.getIndex();
 


### PR DESCRIPTION
Not sure how this happened, but a non-breaking space (char code 160) snuck in to a spot where a normal space (32) should have been. This makes Webpack sad, causing a browser error at run-time.