### PR TITLE
Deprecate Matrix*.applyToBufferAttribute() methods

### DIFF
--- a/docs/api/en/deprecated/DeprecatedList.html
+++ b/docs/api/en/deprecated/DeprecatedList.html
@@ -253,7 +253,7 @@
 		<h3>[page:JSONLoader]</h3>
 		<p>JSONLoader has been removed from core.</p>
 
-		<h2>Maths</h2>
+		<h2>Math</h2>
 
 		<h3>[page:Box2]</h3>
 		<p>
@@ -293,15 +293,15 @@
 
 		<h3>[page:Matrix3]</h3>
 		<p>
-			Matrix3.flattenToArrayOffset is deprecated. Use [page:Matrix3.toArray]() instead.<br /><br />
+			Matrix3.flattenToArrayOffset() is deprecated. Use [page:Matrix3.toArray]() instead.<br /><br />
 
-			Matrix3.multiplyVector3 has been removed. Use vector.applyMatrix3( matrix ) instead.<br /><br />
+			Matrix3.multiplyVector3() has been removed. Use vector.applyMatrix3( matrix ) instead.<br /><br />
 
-			Matrix3.multiplyVector3Array has been renamed to [page:Matrix3.applyToVector3Array]( array ).<br /><br />
+			Matrix3.multiplyVector3Array() has been renamed to [page:Matrix3.applyToVector3Array]( array ).<br /><br />
 
-			Matrix3.applyToBuffer has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.<br /><br />
+			Matrix3.applyToBufferAttribute() has been removed. Use [page:BufferAttribute.applyMatrix3]( matrix ) instead.<br /><br />
 
-			Matrix3.applyToVector3Array has been removed.
+			Matrix3.applyToVector3Array() has been removed.
 		<p>
 
 		<h3>[page:Matrix4]</h3>
@@ -332,7 +332,7 @@
 
 			Matrix4.rotateByAxis() has been removed.<br /><br />
 
-			Matrix4.applyToBuffer() has been removed. Use matrix.applyToBufferAttribute() instead.<br /><br />
+			Matrix4.applyToBufferAttribute() has been removed. Use [page:BufferAttribute.applyMatrix4]( matrix ) instead.<br /><br />
 
 			Matrix4.applyToVector3Array() has been removed.<br /><br />
 

--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -65,14 +65,6 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<p>
-		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
-
-		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
-		</p>
-
-
 		<h3>[method:Matrix3 clone]()</h3>
 		<p>Creates a new Matrix3 and with identical elements to this one.</p>
 

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -101,14 +101,6 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<p>
-		[page:BufferAttribute attribute] - An attribute of floats that represent 3D vectors.<br /><br />
-
-		Multiplies (applies) this matrix to every 3D vector in the [page:BufferAttribute attribute].
-		</p>
-
-
 		<h3>[method:Matrix4 clone]()</h3>
 		<p>Creates a new Matrix4 with identical [page:.elements elements] to this one.</p>
 

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -62,14 +62,6 @@ m.elements = [ 11, 21, 31,
 
 		<h2>方法（Methods）</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<p>
-		[page:BufferAttribute attribute] - 表示三维向量缓存属性。<br /><br />
-
-		用这个矩阵乘以缓存属性[page:BufferAttribute attribute]里的所有3d向量。
-		</p>
-
-
 		<h3>[method:Matrix3 clone]()</h3>
 		<p>创建一个新的矩阵，元素 [page:.elements elements] 与该矩阵相同。</p>
 

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -93,14 +93,6 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>方法（Methods）</h2>
 
-		<h3>[method:Array applyToBufferAttribute]( [param:BufferAttribute attribute] )</h3>
-		<p>
-		[page:BufferAttribute attribute] - 表示三维向量缓存属性。<br /><br />
-
-		用这个矩阵乘以缓存属性[page:BufferAttribute attribute]里的所有3d向量。
-		</p>
-
-
 		<h3>[method:Matrix4 clone]()</h3>
 		<p>创建一个新的矩阵，元素[page:.elements elements]与该矩阵相同。</p>
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -588,10 +588,10 @@ Object.assign( Matrix3.prototype, {
 		console.error( 'THREE.Matrix3: .multiplyVector3Array() has been removed.' );
 
 	},
-	applyToBuffer: function ( buffer /*, offset, length */ ) {
+	applyToBufferAttribute: function ( attribute ) {
 
-		console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
-		return this.applyToBufferAttribute( buffer );
+		console.warn( 'THREE.Matrix3: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix3( matrix ) instead.' );
+		return attribute.applyMatrix3( this );
 
 	},
 	applyToVector3Array: function ( /* array, offset, length */ ) {
@@ -687,10 +687,10 @@ Object.assign( Matrix4.prototype, {
 		console.error( 'THREE.Matrix4: .rotateByAxis() has been removed.' );
 
 	},
-	applyToBuffer: function ( buffer /*, offset, length */ ) {
+	applyToBufferAttribute: function ( attribute ) {
 
-		console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
-		return this.applyToBufferAttribute( buffer );
+		console.warn( 'THREE.Matrix4: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix4( matrix ) instead.' );
+		return attribute.applyMatrix4( this );
 
 	},
 	applyToVector3Array: function ( /* array, offset, length */ ) {

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -74,18 +74,6 @@ export class Matrix3 implements Matrix {
 	clone(): this;
 	copy( m: Matrix3 ): this;
 	setFromMatrix4( m: Matrix4 ): Matrix3;
-
-	/**
-	 * @deprecated Use {@link Matrix3#applyToBufferAttribute matrix3.applyToBufferAttribute( attribute )} instead.
-	 */
-	applyToBuffer(
-		buffer: BufferAttribute,
-		offset?: number,
-		length?: number
-	): BufferAttribute;
-
-	applyToBufferAttribute( attribute: BufferAttribute ): BufferAttribute;
-
 	multiplyScalar( s: number ): Matrix3;
 	determinant(): number;
 	getInverse( matrix: Matrix3, throwOnDegenerate?: boolean ): Matrix3;

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -92,24 +92,6 @@ Object.assign( Matrix3.prototype, {
 
 	},
 
-	applyToBufferAttribute: function ( attribute ) {
-
-		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
-
-			_vector.x = attribute.getX( i );
-			_vector.y = attribute.getY( i );
-			_vector.z = attribute.getZ( i );
-
-			_vector.applyMatrix3( this );
-
-			attribute.setXYZ( i, _vector.x, _vector.y, _vector.z );
-
-		}
-
-		return attribute;
-
-	},
-
 	multiply: function ( m ) {
 
 		return this.multiplyMatrices( this, m );

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -99,17 +99,6 @@ export class Matrix4 implements Matrix {
 	multiplyScalar( s: number ): Matrix4;
 
 	/**
-	 * @deprecated Use {@link Matrix4#applyToBufferAttribute matrix4.applyToBufferAttribute( attribute )} instead.
-	 */
-	applyToBuffer(
-		buffer: BufferAttribute,
-		offset?: number,
-		length?: number
-	): BufferAttribute;
-
-	applyToBufferAttribute( attribute: BufferAttribute ): BufferAttribute;
-
-	/**
 	 * Computes determinant of this matrix.
 	 * Based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 	 */

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -415,24 +415,6 @@ Object.assign( Matrix4.prototype, {
 
 	},
 
-	applyToBufferAttribute: function ( attribute ) {
-
-		for ( var i = 0, l = attribute.count; i < l; i ++ ) {
-
-			_v1.x = attribute.getX( i );
-			_v1.y = attribute.getY( i );
-			_v1.z = attribute.getZ( i );
-
-			_v1.applyMatrix4( this );
-
-			attribute.setXYZ( i, _v1.x, _v1.y, _v1.z );
-
-		}
-
-		return attribute;
-
-	},
-
 	determinant: function () {
 
 		var te = this.elements;

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -163,18 +163,6 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "applyToBufferAttribute", ( assert ) => {
-
-			var a = new Matrix3().set( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
-			var attr = new Float32BufferAttribute( [ 1, 2, 1, 3, 0, 3 ], 3 );
-			var expected = new Float32Array( [ 8, 20, 32, 12, 30, 48 ] );
-
-			var applied = a.applyToBufferAttribute( attr );
-
-			assert.deepEqual( applied.array, expected, "Check resulting buffer" );
-
-		} );
-
 		QUnit.test( "multiply/premultiply", ( assert ) => {
 
 			// both simply just wrap multiplyMatrices

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -418,29 +418,6 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "applyToBufferAttribute", ( assert ) => {
-
-			var a = new Matrix4().set( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 );
-			var attr = new Float32BufferAttribute( [ 1, 2, 1, 3, 0, 3 ], 3 );
-			var expected = new Float32BufferAttribute( [
-				0.1666666716337204, 0.4444444477558136, 0.7222222089767456,
-				0.1599999964237213, 0.4399999976158142, 0.7200000286102295
-			], 3 );
-
-			var applied = a.applyToBufferAttribute( attr );
-
-			assert.strictEqual( expected.count, applied.count, "Applied buffer and expected buffer have the same number of entries" );
-
-			for ( var i = 0, l = expected.count; i < l; i ++ ) {
-
-				assert.ok( Math.abs( applied.getX( i ) - expected.getX( i ) ) <= eps, "Check x" );
-				assert.ok( Math.abs( applied.getY( i ) - expected.getY( i ) ) <= eps, "Check y" );
-				assert.ok( Math.abs( applied.getZ( i ) - expected.getZ( i ) ) <= eps, "Check z" );
-
-			}
-
-		} );
-
 		QUnit.test( "determinant", ( assert ) => {
 
 			var a = new Matrix4();


### PR DESCRIPTION
Follow on to #18006.

I think this is safe to do now.