### PR TITLE
Examples: Set DynamicDrawUsage on dynamic instancing examples

### DIFF
--- a/examples/webgl_instancing_dynamic.html
+++ b/examples/webgl_instancing_dynamic.html
@@ -44,6 +44,7 @@
 					// var material = new THREE.MeshBasicMaterial( { color: 0xff0000, opacity: 0.1, transparent: true } );
 
 					mesh = new THREE.InstancedMesh( geometry, material, count );
+					mesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage ); // will be updated every frame
 					scene.add( mesh );
 
 					//

--- a/examples/webgl_instancing_scatter.html
+++ b/examples/webgl_instancing_scatter.html
@@ -66,8 +66,11 @@
 				var _stemMesh = gltf.scene.getObjectByName('Stem');
 				var _blossomMesh = gltf.scene.getObjectByName('Blossom');
 
-				stemGeometry = _stemMesh.geometry;
-				blossomGeometry = _blossomMesh.geometry;
+				stemGeometry = new THREE.InstancedBufferGeometry();
+				blossomGeometry = new THREE.InstancedBufferGeometry();
+
+				THREE.BufferGeometry.prototype.copy.call( stemGeometry, _stemMesh.geometry );
+				THREE.BufferGeometry.prototype.copy.call( blossomGeometry, _blossomMesh.geometry );
 
 				var defaultTransform = new THREE.Matrix4()
 					.makeRotationX( Math.PI )
@@ -96,6 +99,10 @@
 
 				stemMesh = new THREE.InstancedMesh( stemGeometry, stemMaterial, count );
 				blossomMesh = new THREE.InstancedMesh( blossomGeometry, blossomMaterial, count );
+
+				// Instance matrices will be updated every frame.
+				stemMesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage );
+				blossomMesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage );
 
 				resample();
 


### PR DESCRIPTION
Fixes two issues that @WestLangley identified while discussing #18256 —

- `instancing / dynamic` and `instancing / scatter` should use DynamicDrawUsage
- `instancing / scatter` should only add instanced attributes to `InstancedBufferGeometry`, not `BufferGeometry`