### PR TITLE
WebGLRenderTargetCube -> WebGLCubeRenderTarget

### DIFF
--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -12,7 +12,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">Creates 6 cameras that render to a [page:WebGLRenderTargetCube].</p>
+		<p class="desc">Creates 6 cameras that render to a [page:WebGLCubeRenderTarget].</p>
 
 		<h2>Examples</h2>
 
@@ -47,7 +47,7 @@
 		near -- The near clipping distance. <br />
 		far -- The far clipping distance <br />
 		cubeResolution -- Sets the length of the cube's edges. <br />
-		options - (optional) object that holds texture parameters passed to the auto-generated WebGLRenderTargetCube.
+		options - (optional) object that holds texture parameters passed to the auto-generated WebGLCubeRenderTarget.
 		If not specified, the options default to:
 		<code>
 		{ format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter }
@@ -56,14 +56,14 @@
 		</p>
 		<p>
 		Constructs a CubeCamera that contains 6 [page:PerspectiveCamera PerspectiveCameras] that
-		render to a [page:WebGLRenderTargetCube].
+		render to a [page:WebGLCubeRenderTarget].
 		</p>
 
 
 		<h2>Properties</h2>
 		<p>See the base [page:Object3D] class for common properties.</p>
 
-		<h3>[property:WebGLRenderTargetCube renderTarget]</h3>
+		<h3>[property:WebGLCubeRenderTarget renderTarget]</h3>
 		<p>
 		The cube texture that gets generated.
 		</p>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -174,7 +174,7 @@
 		<p>
 		Note: only [link:https://threejs.org/docs/#api/textures/CubeTexture cube environment maps] are supported
 		for MeshStandardMaterial. If you want to use an equirectangular map you will need to use
-		[page:WebGLRenderTargetCube.fromEquirectangularTexture WebGLRenderTargetCube.fromEquirectangularTexture]().
+		[page:WebGLCubeRenderTarget.fromEquirectangularTexture WebGLCubeRenderTarget.fromEquirectangularTexture]().
 		See this [link:https://threejs.org/examples/webgl_materials_envmaps_exr.html example] for details.
 		</p>
 

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -35,7 +35,7 @@
 				using [page:BufferAttribute] instances to define custom attributes.
 			</li>
 			<li>
-				As of THREE r77, [page:WebGLRenderTarget] or [page:WebGLRenderTargetCube] instances
+				As of THREE r77, [page:WebGLRenderTarget] or [page:WebGLCubeRenderTarget] instances
 				are no longer supposed to be used as uniforms. Their [page:Texture texture] property
 				must be used instead.
 			</li>

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -57,7 +57,7 @@
 
 		<h3>See [page:WebGLRenderTarget] for inherited methods</h3>
 
-		<h3>[method:WebGLRenderTargetCube fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture] )</h3>
+		<h3>[method:WebGLCubeRenderTarget fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture] )</h3>
 		<p>
 			[page:WebGLRenderer renderer] — the renderer.<br/>
 			[page:Texture texture] — the equirectangular texture.

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -410,7 +410,7 @@
 		<p>buffer - Uint8Array is the only destination type supported in all cases, other types are renderTarget and platform dependent. See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.</p>
 		<p>Reads the pixel data from the renderTarget into the buffer you pass in. This is a wrapper around [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]().</p>
 		<p>See the [example:webgl_interactive_cubes_gpu interactive / cubes / gpu] example.</p>
-		<p>For reading out a [page:WebGLRenderTargetCube WebGLRenderTargetCube] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
+		<p>For reading out a [page:WebGLCubeRenderTarget WebGLCubeRenderTarget] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
 
 
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
@@ -451,7 +451,7 @@
 		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
 		<p>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated. When *null* is given, the canvas is set as the active render target instead.<br />
-		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLRenderTargetCube] (optional).<br />
+		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLCubeRenderTarget] (optional).<br />
 		activeMipmapLevel -- Specifies the active mipmap level (optional).<br /><br />
 		This method sets the active rendertarget.
 		</p>

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -33,7 +33,7 @@
 
 		<h3>[property:Object background]</h3>
 		<p>
-		If not null, sets the background used when rendering the scene, and is always rendered first. Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, or a cubemap as a [page:CubeTexture] or [page:WebGLRenderTargetCube]. Default is null.
+		If not null, sets the background used when rendering the scene, and is always rendered first. Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, or a cubemap as a [page:CubeTexture] or [page:WebGLCubeRenderTarget]. Default is null.
 		</p>
 
 		<h3>[property:Texture environment]</h3>

--- a/docs/api/zh/cameras/CubeCamera.html
+++ b/docs/api/zh/cameras/CubeCamera.html
@@ -13,7 +13,7 @@
 		<h1>立方相机（[name]）</h1>
 
 
-		<p class="desc">创建6个摄像机，并将它们所拍摄的场景渲染到[page:WebGLRenderTargetCube]上。</p>
+		<p class="desc">创建6个摄像机，并将它们所拍摄的场景渲染到[page:WebGLCubeRenderTarget]上。</p>
 
 		<h2>示例</h2>
 
@@ -54,7 +54,7 @@
 		cubeResolution -- 设置立方体边缘的长度
 		</p>
 		<p>
-			构造一个包含6个[page:PerspectiveCamera PerspectiveCameras]（透视摄像机）的立方摄像机，并将其拍摄的场景渲染到一个[page:WebGLRenderTargetCube]上。
+			构造一个包含6个[page:PerspectiveCamera PerspectiveCameras]（透视摄像机）的立方摄像机，并将其拍摄的场景渲染到一个[page:WebGLCubeRenderTarget]上。
 
 		</p>
 
@@ -62,7 +62,7 @@
 		<h2>属性</h2>
 		<p>共有属性请参见其基类[page:Object3D]。</p>
 
-		<h3>[property:WebGLRenderTargetCube renderTarget]</h3>
+		<h3>[property:WebGLCubeRenderTarget renderTarget]</h3>
 		<p>
 			生成的立方体纹理<br>
 			（译注：生成的立方体纹理保存在其中的.texture对象中，可作为贴图赋值给其他材质）

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -140,7 +140,7 @@
 			请确保将minFilter设置为其中一个MipMap选项，并且未强制禁用mip贴图。</p>
 		<p>
 			注意：MeshStandardMaterial 仅支持[link:https://threejs.org/docs/#api/textures/CubeTexture cube environment maps]。
-			如果要使用equirectangular贴图，则需要使用 [page:WebGLRenderTargetCube.fromEquirectangularTexture WebGLRenderTargetCube.fromEquirectangularTexture]().。
+			如果要使用equirectangular贴图，则需要使用 [page:WebGLCubeRenderTarget.fromEquirectangularTexture WebGLCubeRenderTarget.fromEquirectangularTexture]().。
 			详细信息请参阅此示例[link:https://threejs.org/examples/webgl_materials_envmaps_exr.html example]。
 		</p>
 

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -29,7 +29,7 @@
 			<li> 从 THREE r72开始，不再支持在ShaderMaterial中直接分配属性。
 				必须使用 [page:BufferGeometry]实例 (而不是 [page:Geometry] 实例)，使用[page:BufferAttribute]实例来定义自定义属性。
 			</li>
-			<li> 从 THREE r77开始，[page:WebGLRenderTarget] 或 [page:WebGLRenderTargetCube] 实例不再被用作uniforms。
+			<li> 从 THREE r77开始，[page:WebGLRenderTarget] 或 [page:WebGLCubeRenderTarget] 实例不再被用作uniforms。
 				必须使用它们的[page:Texture texture] 属性。
 			</li>
 			<li> 内置attributes和uniforms与代码一起传递到shaders。

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -54,7 +54,7 @@
 
 		<h3>继承方法，请参阅[page:WebGLRenderTarget]</h3>
 
-		<h3>[method:WebGLRenderTargetCube fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture] )</h3>
+		<h3>[method:WebGLCubeRenderTarget fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture] )</h3>
 		<p>
 			[page:WebGLRenderer renderer] — 渲染器。<br/>
 			[page:Texture texture] — equirectangular 纹理。

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -368,7 +368,7 @@
 		<p>buffer - Uint8Array is the only destination type supported in all cases, other types are renderTarget and platform dependent. See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.</p>
 		<p>将enderTarget中的像素数据读取到传入的缓冲区中。这是[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]()的包装器<br />
 		示例：[example:webgl_interactive_cubes_gpu interactive / cubes / gpu]</p>
-		<p>For reading out a [page:WebGLRenderTargetCube WebGLRenderTargetCube] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
+		<p>For reading out a [page:WebGLCubeRenderTarget WebGLCubeRenderTarget] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
 
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera], [param:WebGLRenderTarget renderTarget], [param:Boolean forceClear] )</h3>
 		<p>
@@ -408,7 +408,7 @@
 		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
 		<p>
 		renderTarget -- 需要被激活的[page:WebGLRenderTarget renderTarget](可选)。若此参数为空，则将canvas设置成活跃render target。<br />
-		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLRenderTargetCube] (optional).<br />
+		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLCubeRenderTarget] (optional).<br />
 		activeMipmapLevel -- Specifies the active mipmap level (optional).<br /><br />
 		该方法设置活跃rendertarget。
 		</p>

--- a/docs/list.js
+++ b/docs/list.js
@@ -312,7 +312,7 @@ var list = {
 				"WebGLMultisampleRenderTarget": "api/en/renderers/WebGLMultisampleRenderTarget",
 				"WebGLRenderer": "api/en/renderers/WebGLRenderer",
 				"WebGLRenderTarget": "api/en/renderers/WebGLRenderTarget",
-				"WebGLRenderTargetCube": "api/en/renderers/WebGLRenderTargetCube"
+				"WebGLCubeRenderTarget": "api/en/renderers/WebGLCubeRenderTarget"
 			},
 
 			"Renderers / Shaders": {
@@ -761,7 +761,7 @@ var list = {
 				"WebGLMultisampleRenderTarget": "api/zh/renderers/WebGLMultisampleRenderTarget",
 				"WebGLRenderer": "api/zh/renderers/WebGLRenderer",
 				"WebGLRenderTarget": "api/zh/renderers/WebGLRenderTarget",
-				"WebGLRenderTargetCube": "api/zh/renderers/WebGLRenderTargetCube"
+				"WebGLCubeRenderTarget": "api/zh/renderers/WebGLCubeRenderTarget"
 			},
 
 			"渲染器 / 着色器": {

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -947,9 +947,9 @@ THREE.GLTFLoader = ( function () {
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
 					// don't flip CubeTexture envMaps, flip everything else:
-					//  WebGLRenderTargetCube will be flipped for backwards compatibility
-					//  WebGLRenderTargetCube.texture will be flipped because it's a Texture and NOT a CubeTexture
-					// this check must be handled differently, or removed entirely, if WebGLRenderTargetCube uses a CubeTexture in the future
+					//  WebGLCubeRenderTarget will be flipped for backwards compatibility
+					//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
+					// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;

--- a/examples/jsm/lights/LightProbeGenerator.d.ts
+++ b/examples/jsm/lights/LightProbeGenerator.d.ts
@@ -2,12 +2,12 @@ import {
 	CubeTexture,
 	LightProbe,
 	WebGLRenderer,
-	WebGLRenderTargetCube,
+	WebGLCubeRenderTarget,
 } from '../../../src/Three';
 
 export namespace LightProbeGenerator {
 
 	export function fromCubeTexture( cubeTexture: CubeTexture ): LightProbe;
-	export function fromRenderTargetCube( renderer: WebGLRenderer, renderTargetCube: WebGLRenderTargetCube ): LightProbe;
+	export function fromRenderTargetCube( renderer: WebGLRenderer, renderTargetCube: WebGLCubeRenderTarget ): LightProbe;
 
 }

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1015,9 +1015,9 @@ var GLTFLoader = ( function () {
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
 					// don't flip CubeTexture envMaps, flip everything else:
-					//  WebGLRenderTargetCube will be flipped for backwards compatibility
-					//  WebGLRenderTargetCube.texture will be flipped because it's a Texture and NOT a CubeTexture
-					// this check must be handled differently, or removed entirely, if WebGLRenderTargetCube uses a CubeTexture in the future
+					//  WebGLCubeRenderTarget will be flipped for backwards compatibility
+					//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
+					// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -53,7 +53,7 @@
 					magFilter: THREE.LinearFilter
 				};
 
-				scene.background = new THREE.WebGLRenderTargetCube( 1024, 1024, options ).fromEquirectangularTexture( renderer, texture );
+				scene.background = new THREE.WebGLCubeRenderTarget( 1024, 1024, options ).fromEquirectangularTexture( renderer, texture );
 
 				//
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -82,7 +82,7 @@ import { Skeleton } from './objects/Skeleton.js';
 import { SkinnedMesh } from './objects/SkinnedMesh.js';
 import { WebGLRenderer } from './renderers/WebGLRenderer.js';
 import { WebGLRenderTarget } from './renderers/WebGLRenderTarget.js';
-import { WebGLRenderTargetCube } from './renderers/WebGLRenderTargetCube.js';
+import { WebGLCubeRenderTarget } from './renderers/WebGLCubeRenderTarget.js';
 import { WebGLShadowMap } from './renderers/webgl/WebGLShadowMap.js';
 import { ImageUtils } from './extras/ImageUtils.js';
 import { Shape } from './extras/core/Shape.js';
@@ -1794,19 +1794,29 @@ Object.defineProperties( WebGLShadowMap.prototype, {
 
 } );
 
+export function WebGLRenderTargetCube( width, height, options ) {
+
+	console.warn( 'THREE.WebGLRenderTargetCube has been renamed to WebGLCubeRenderTarget.' );
+	return new WebGLCubeRenderTarget( width, height, options );
+
+}
+
 //
+/*
+// commenting out for now. added in https://github.com/mrdoob/three.js/pull/15808.
+// todo: handle this legacy warning, or remove it.
 
 Object.defineProperties( WebGLRenderTargetCube.prototype, {
 
 	activeCubeFace: {
-		set: function ( /* value */ ) {
+		set: function () {
 
 			console.warn( 'THREE.WebGLRenderTargetCube: .activeCubeFace has been removed. It is now the second parameter of WebGLRenderer.setRenderTarget().' );
 
 		}
 	},
 	activeMipMapLevel: {
-		set: function ( /* value */ ) {
+		set: function () {
 
 			console.warn( 'THREE.WebGLRenderTargetCube: .activeMipMapLevel has been removed. It is now the third parameter of WebGLRenderer.setRenderTarget().' );
 
@@ -1815,6 +1825,7 @@ Object.defineProperties( WebGLRenderTargetCube.prototype, {
 
 } );
 
+*/
 //
 
 Object.defineProperties( WebGLRenderTarget.prototype, {

--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -1,6 +1,6 @@
 export * from './polyfills';
 export * from './renderers/WebGLMultisampleRenderTarget';
-export * from './renderers/WebGLRenderTargetCube';
+export * from './renderers/WebGLCubeRenderTarget';
 export * from './renderers/WebGLRenderTarget';
 export * from './renderers/WebGLRenderer';
 export * from './renderers/shaders/ShaderLib';

--- a/src/Three.js
+++ b/src/Three.js
@@ -2,7 +2,7 @@ import './polyfills.js';
 import { REVISION } from './constants.js';
 
 export { WebGLMultisampleRenderTarget } from './renderers/WebGLMultisampleRenderTarget.js';
-export { WebGLRenderTargetCube } from './renderers/WebGLRenderTargetCube.js';
+export { WebGLCubeRenderTarget } from './renderers/WebGLCubeRenderTarget.js';
 export { WebGLRenderTarget } from './renderers/WebGLRenderTarget.js';
 export { WebGLRenderer } from './renderers/WebGLRenderer.js';
 export { ShaderLib } from './renderers/shaders/ShaderLib.js';

--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -1,4 +1,4 @@
-import { WebGLRenderTargetCube } from './../renderers/WebGLRenderTargetCube';
+import { WebGLCubeRenderTarget } from './../renderers/WebGLCubeRenderTarget';
 import { WebGLRenderTargetOptions } from './../renderers/WebGLRenderTarget';
 import { Scene } from './../scenes/Scene';
 import { WebGLRenderer } from './../renderers/WebGLRenderer';
@@ -10,7 +10,7 @@ export class CubeCamera extends Object3D {
 
 	type: 'CubeCamera';
 
-	renderTarget: WebGLRenderTargetCube;
+	renderTarget: WebGLCubeRenderTarget;
 
 	update( renderer: WebGLRenderer, scene: Scene ): void;
 

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -1,5 +1,5 @@
 import { Object3D } from '../core/Object3D.js';
-import { WebGLRenderTargetCube } from '../renderers/WebGLRenderTargetCube.js';
+import { WebGLCubeRenderTarget } from '../renderers/WebGLCubeRenderTarget.js';
 import { LinearFilter, RGBFormat } from '../constants.js';
 import { Vector3 } from '../math/Vector3.js';
 import { PerspectiveCamera } from './PerspectiveCamera.js';
@@ -51,7 +51,7 @@ function CubeCamera( near, far, cubeResolution, options ) {
 
 	options = options || { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
 
-	this.renderTarget = new WebGLRenderTargetCube( cubeResolution, cubeResolution, options );
+	this.renderTarget = new WebGLCubeRenderTarget( cubeResolution, cubeResolution, options );
 	this.renderTarget.texture.name = "CubeCamera";
 
 	this.update = function ( renderer, scene ) {

--- a/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -2,7 +2,7 @@ import { WebGLRenderTargetOptions, WebGLRenderTarget } from './WebGLRenderTarget
 import { WebGLRenderer } from './WebGLRenderer';
 import { Texture } from './../textures/Texture';
 
-export class WebGLRenderTargetCube extends WebGLRenderTarget {
+export class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	constructor(
 		width: number,

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -12,18 +12,18 @@ import { CubeCamera } from '../cameras/CubeCamera.js';
  * @author WestLangley / http://github.com/WestLangley
  */
 
-function WebGLRenderTargetCube( width, height, options ) {
+function WebGLCubeRenderTarget( width, height, options ) {
 
 	WebGLRenderTarget.call( this, width, height, options );
 
 }
 
-WebGLRenderTargetCube.prototype = Object.create( WebGLRenderTarget.prototype );
-WebGLRenderTargetCube.prototype.constructor = WebGLRenderTargetCube;
+WebGLCubeRenderTarget.prototype = Object.create( WebGLRenderTarget.prototype );
+WebGLCubeRenderTarget.prototype.constructor = WebGLCubeRenderTarget;
 
-WebGLRenderTargetCube.prototype.isWebGLRenderTargetCube = true;
+WebGLCubeRenderTarget.prototype.isWebGLCubeRenderTarget = true;
 
-WebGLRenderTargetCube.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
+WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
 
 	this.texture.type = texture.type;
 	this.texture.format = texture.format;
@@ -116,4 +116,4 @@ WebGLRenderTargetCube.prototype.fromEquirectangularTexture = function ( renderer
 
 };
 
-export { WebGLRenderTargetCube };
+export { WebGLCubeRenderTarget };

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -387,7 +387,7 @@ export class WebGLRenderer implements Renderer {
 	 * Sets the active render target.
 	 *
 	 * @param renderTarget The {@link WebGLRenderTarget renderTarget} that needs to be activated. When `null` is given, the canvas is set as the active render target instead.
-	 * @param activeCubeFace Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of {@link WebGLRenderTargetCube}.
+	 * @param activeCubeFace Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of {@link WebGLCubeRenderTarget}.
 	 * @param activeMipmapLevel Specifies the active mipmap level.
 	 */
 	setRenderTarget( renderTarget: RenderTarget | null, activeCubeFace?: number, activeMipmapLevel?: number ): void;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2091,9 +2091,9 @@ function WebGLRenderer( parameters ) {
 			uniforms.envMap.value = envMap;
 
 			// don't flip CubeTexture envMaps, flip everything else:
-			//  WebGLRenderTargetCube will be flipped for backwards compatibility
-			//  WebGLRenderTargetCube.texture will be flipped because it's a Texture and NOT a CubeTexture
-			// this check must be handled differently, or removed entirely, if WebGLRenderTargetCube uses a CubeTexture in the future
+			//  WebGLCubeRenderTarget will be flipped for backwards compatibility
+			//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
+			// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 			uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
 
 			uniforms.reflectivity.value = material.reflectivity;
@@ -2682,7 +2682,7 @@ function WebGLRenderer( parameters ) {
 
 			var __webglFramebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-			if ( renderTarget.isWebGLRenderTargetCube ) {
+			if ( renderTarget.isWebGLCubeRenderTarget ) {
 
 				framebuffer = __webglFramebuffer[ activeCubeFace || 0 ];
 				isCube = true;
@@ -2740,7 +2740,7 @@ function WebGLRenderer( parameters ) {
 
 		var framebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-		if ( renderTarget.isWebGLRenderTargetCube && activeCubeFaceIndex !== undefined ) {
+		if ( renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined ) {
 
 			framebuffer = framebuffer[ activeCubeFaceIndex ];
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -60,7 +60,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 		}
 
-		if ( background && ( background.isCubeTexture || background.isWebGLRenderTargetCube || background.mapping === CubeUVReflectionMapping ) ) {
+		if ( background && ( background.isCubeTexture || background.isWebGLCubeRenderTarget || background.mapping === CubeUVReflectionMapping ) ) {
 
 			if ( boxMesh === undefined ) {
 
@@ -102,7 +102,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 			}
 
-			var texture = background.isWebGLRenderTargetCube ? background.texture : background;
+			var texture = background.isWebGLCubeRenderTarget ? background.texture : background;
 
 			boxMesh.material.uniforms.envMap.value = texture;
 			boxMesh.material.uniforms.flipEnvMap.value = texture.isCubeTexture ? - 1 : 1;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -269,7 +269,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		if ( renderTarget.isWebGLRenderTargetCube ) {
+		if ( renderTarget.isWebGLCubeRenderTarget ) {
 
 			for ( var i = 0; i < 6; i ++ ) {
 
@@ -903,7 +903,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	// Setup resources for a Depth Texture for a FBO (needs an extension)
 	function setupDepthTexture( framebuffer, renderTarget ) {
 
-		var isCube = ( renderTarget && renderTarget.isWebGLRenderTargetCube );
+		var isCube = ( renderTarget && renderTarget.isWebGLCubeRenderTarget );
 		if ( isCube ) throw new Error( 'Depth Texture with cube render targets is not supported' );
 
 		_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
@@ -950,7 +950,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		var renderTargetProperties = properties.get( renderTarget );
 
-		var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
+		var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
 
 		if ( renderTarget.depthTexture ) {
 
@@ -998,7 +998,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		info.memory.textures ++;
 
-		var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
+		var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
 		var isMultisample = ( renderTarget.isWebGLMultisampleRenderTarget === true );
 		var isMultiview = ( renderTarget.isWebGLMultiviewRenderTarget === true );
 		var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
@@ -1154,7 +1154,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-			var target = renderTarget.isWebGLRenderTargetCube ? _gl.TEXTURE_CUBE_MAP : _gl.TEXTURE_2D;
+			var target = renderTarget.isWebGLCubeRenderTarget ? _gl.TEXTURE_CUBE_MAP : _gl.TEXTURE_2D;
 			var webglTexture = properties.get( texture ).__webglTexture;
 
 			state.bindTexture( target, webglTexture );
@@ -1243,7 +1243,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	function safeSetTextureCube( texture, slot ) {
 
-		if ( texture && texture.isWebGLRenderTargetCube ) {
+		if ( texture && texture.isWebGLCubeRenderTarget ) {
 
 			if ( warnedTextureCube === false ) {
 
@@ -1256,7 +1256,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
+		// currently relying on the fact that WebGLCubeRenderTarget.texture is a Texture and NOT a CubeTexture
 		// TODO: unify these code paths
 		if ( ( texture && texture.isCubeTexture ) ||
 			( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
@@ -1268,7 +1268,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		} else {
 
-			// assumed: texture property of THREE.WebGLRenderTargetCube
+			// assumed: texture property of THREE.WebGLCubeRenderTarget
 			setTextureCubeDynamic( texture, slot );
 
 		}

--- a/test/unit/src/renderers/WebGLRenderTargetCube.tests.js
+++ b/test/unit/src/renderers/WebGLRenderTargetCube.tests.js
@@ -3,11 +3,11 @@
  */
 /* global QUnit */
 
-import { WebGLRenderTargetCube } from '../../../../src/renderers/WebGLRenderTargetCube';
+import { WebGLCubeRenderTarget } from '../../../../src/renderers/WebGLCubeRenderTarget';
 
 export default QUnit.module( 'Renderers', () => {
 
-	QUnit.module( 'WebGLRenderTargetCube', () => {
+	QUnit.module( 'WebGLCubeRenderTarget', () => {
 
 		// INSTANCING
 		QUnit.todo( "Instancing", ( assert ) => {
@@ -17,7 +17,7 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( "isWebGLRenderTargetCube", ( assert ) => {
+		QUnit.todo( "isWebGLCubeRenderTarget", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
 


### PR DESCRIPTION
>Hmm, we should rename THREE.WebGLRenderTargetCube to THREE.WebGLCubeRenderTarget also...

As suggested by @mrdoob in https://github.com/mrdoob/three.js/pull/15331#issuecomment-442908452.


