### PR TITLE
VTKLoader: fix POLYDATA comparison failing with unicode character

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -92,7 +92,7 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 			for ( var i in lines ) {
 
-				var line = lines[ i ];
+				var line = lines[ i ].trim();
 
 				if ( line.indexOf( 'DATASET' ) === 0 ) {
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -102,7 +102,7 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			for ( var i in lines ) {
 
-				var line = lines[ i ];
+				var line = lines[ i ].trim();
 
 				if ( line.indexOf( 'DATASET' ) === 0 ) {
 


### PR DESCRIPTION
* Fixes parsing failing on files saved with CRLF

The comparison:
```javascript
if ( dataset !== 'POLYDATA' ) throw new Error( 'Unsupported DATASET type: ' + dataset );
```
was failing when `line` had a unicode character. So, if your file is saved with CRLF, this comparison will fail, even though the `dataset` variable has the value `POLYDATA`.