### PR TITLE
LightProbeGenerator: rename method

### DIFF
--- a/examples/js/lights/LightProbeGenerator.js
+++ b/examples/js/lights/LightProbeGenerator.js
@@ -118,7 +118,7 @@ THREE.LightProbeGenerator = {
 
 	},
 
-	fromRenderTargetCube: function ( renderer, renderTargetCube ) {
+	fromCubeRenderTarget: function ( renderer, cubeRenderTarget ) {
 
 		// The renderTarget must be set to RGBA in order to make readRenderTargetPixels works
 		var norm, lengthSq, weight, totalWeight = 0;
@@ -136,9 +136,9 @@ THREE.LightProbeGenerator = {
 
 		for ( var faceIndex = 0; faceIndex < 6; faceIndex ++ ) {
 
-			var imageWidth = renderTargetCube.width; // assumed to be square
+			var imageWidth = cubeRenderTarget.width; // assumed to be square
 			var data = new Uint8Array( imageWidth * imageWidth * 4 );
-			renderer.readRenderTargetPixels( renderTargetCube, 0, 0, imageWidth, imageWidth, data, faceIndex );
+			renderer.readRenderTargetPixels( cubeRenderTarget, 0, 0, imageWidth, imageWidth, data, faceIndex );
 
 			var pixelSize = 2 / imageWidth;
 
@@ -148,7 +148,7 @@ THREE.LightProbeGenerator = {
 				color.setRGB( data[ i ] / 255, data[ i + 1 ] / 255, data[ i + 2 ] / 255 );
 
 				// convert to linear color space
-				convertColorToLinear( color, renderTargetCube.texture.encoding );
+				convertColorToLinear( color, cubeRenderTarget.texture.encoding );
 
 				// pixel coordinate on unit cube
 

--- a/examples/jsm/lights/LightProbeGenerator.d.ts
+++ b/examples/jsm/lights/LightProbeGenerator.d.ts
@@ -8,6 +8,6 @@ import {
 export namespace LightProbeGenerator {
 
 	export function fromCubeTexture( cubeTexture: CubeTexture ): LightProbe;
-	export function fromRenderTargetCube( renderer: WebGLRenderer, renderTargetCube: WebGLCubeRenderTarget ): LightProbe;
+	export function fromCubeRenderTarget( renderer: WebGLRenderer, cubeRenderTarget: WebGLCubeRenderTarget ): LightProbe;
 
 }

--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -127,7 +127,7 @@ var LightProbeGenerator = {
 
 	},
 
-	fromRenderTargetCube: function ( renderer, renderTargetCube ) {
+	fromCubeRenderTarget: function ( renderer, cubeRenderTarget ) {
 
 		// The renderTarget must be set to RGBA in order to make readRenderTargetPixels works
 		var norm, lengthSq, weight, totalWeight = 0;
@@ -145,9 +145,9 @@ var LightProbeGenerator = {
 
 		for ( var faceIndex = 0; faceIndex < 6; faceIndex ++ ) {
 
-			var imageWidth = renderTargetCube.width; // assumed to be square
+			var imageWidth = cubeRenderTarget.width; // assumed to be square
 			var data = new Uint8Array( imageWidth * imageWidth * 4 );
-			renderer.readRenderTargetPixels( renderTargetCube, 0, 0, imageWidth, imageWidth, data, faceIndex );
+			renderer.readRenderTargetPixels( cubeRenderTarget, 0, 0, imageWidth, imageWidth, data, faceIndex );
 
 			var pixelSize = 2 / imageWidth;
 
@@ -157,7 +157,7 @@ var LightProbeGenerator = {
 				color.setRGB( data[ i ] / 255, data[ i + 1 ] / 255, data[ i + 2 ] / 255 );
 
 				// convert to linear color space
-				convertColorToLinear( color, renderTargetCube.texture.encoding );
+				convertColorToLinear( color, cubeRenderTarget.texture.encoding );
 
 				// pixel coordinate on unit cube
 

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -79,7 +79,7 @@
 
 					cubeCamera.update( renderer, scene );
 
-					lightProbe.copy( LightProbeGenerator.fromRenderTargetCube( renderer, cubeCamera.renderTarget ) );
+					lightProbe.copy( LightProbeGenerator.fromCubeRenderTarget( renderer, cubeCamera.renderTarget ) );
 
 					scene.add( new LightProbeHelper( lightProbe, 5 ) );
 


### PR DESCRIPTION
Follows from #18286.

`LightProbeGenerator.fromRenderTargetCube()` ->  `.fromCubeRenderTarget()`.
