### PR TITLE
VTKLoader: fix float reading too greedy

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -52,6 +52,9 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 			var result;
 
+			// pattern for detecting the end of a number sequence
+			var patWord = /^[^\d.\s-]+/;
+
 			// pattern for reading vertices, 3 floats or integers
 			var pat3Floats = /(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)/g;
 
@@ -104,6 +107,8 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 					// get the vertices
 					while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+
+						if ( patWord.exec( line ) !== null ) break;
 
 						var x = parseFloat( result[ 1 ] );
 						var y = parseFloat( result[ 2 ] );
@@ -183,6 +188,8 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
 
+							if ( patWord.exec( line ) !== null ) break;
+
 							var r = parseFloat( result[ 1 ] );
 							var g = parseFloat( result[ 2 ] );
 							var b = parseFloat( result[ 3 ] );
@@ -195,6 +202,8 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 						// Get the normal vectors
 
 						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+
+							if ( patWord.exec( line ) !== null ) break;
 
 							var nx = parseFloat( result[ 1 ] );
 							var ny = parseFloat( result[ 2 ] );

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -62,7 +62,8 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			var result;
 
-			var patWord = /^[^0-9.\s-]+/;
+			// pattern for detecting the end of a number sequence
+			var patWord = /^[^\d.\s-]+/;
 
 			// pattern for reading vertices, 3 floats or integers
 			var pat3Floats = /(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)/g;

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -62,6 +62,8 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			var result;
 
+			var patWord = /^[^0-9.\s-]+/;
+
 			// pattern for reading vertices, 3 floats or integers
 			var pat3Floats = /(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)/g;
 
@@ -114,6 +116,8 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 					// get the vertices
 					while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+
+						if ( patWord.exec( line ) !== null ) break;
 
 						var x = parseFloat( result[ 1 ] );
 						var y = parseFloat( result[ 2 ] );
@@ -193,6 +197,8 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
 
+							if ( patWord.exec( line ) !== null ) break;
+
 							var r = parseFloat( result[ 1 ] );
 							var g = parseFloat( result[ 2 ] );
 							var b = parseFloat( result[ 3 ] );
@@ -205,6 +211,8 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 						// Get the normal vectors
 
 						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+
+							if ( patWord.exec( line ) !== null ) break;
 
 							var nx = parseFloat( result[ 1 ] );
 							var ny = parseFloat( result[ 2 ] );


### PR DESCRIPTION
This PR fixes the reading of **positions**, **normals**, and **colors**. The `patFloat3` regexp is too greedy, and tends to over-read after a section is over. This problem especially occurs when
there is a `METADATA` or `FIELD` section in the middle of the file.

Example:
```
# vtk DataFile Version 4.2
vtk output
ASCII
DATASET POLYDATA
POINTS 24 float
1 1 1 -1 1 1 -1 -1 1 
1 -1 1 1 -1 -1 1 -1 1 
-1 -1 1 -1 -1 -1 -1 -1 -1 
-1 -1 1 -1 1 1 -1 1 -1 
-1 1 -1 1 1 -1 1 -1 -1 
-1 -1 -1 1 1 -1 1 1 1 
1 -1 1 1 -1 -1 -1 1 -1 
-1 1 1 1 1 1 1 1 -1 

METADATA
INFORMATION 2
NAME L2_NORM_RANGE LOCATION vtkDataArray
DATA 2 100.0 100.0
NAME L2_NORM_FINITE_RANGE LOCATION vtkDataArray
DATA 2 100.0 100.0 

POLYGONS 12 48
3 0 1 2 
3 0 2 3 
3 4 5 6 
3 4 6 7 
3 8 9 10 
3 8 10 11 
3 12 13 14 
3 12 14 15 
3 16 17 18 
3 16 18 19 
3 20 21 22 
3 20 22 23 

POINT_DATA 24
COLOR_SCALARS RGBA 4
1 1 1 1 1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 1 1 1 1 
1 1 1 1 

NORMALS Normals float
0 0 1 0 0 1 0 0 1 
0 -0 1 0 -1 0 0 -1 0 
0 -1 0 0 -1 0 -1 -0 -0 
-1 -0 -0 -1 -0 -0 -1 -0 0 
0 0 -1 0 0 -1 0 0 -1 
0 0 -1 1 -0 0 1 -0 0 
1 -0 0 1 -0 0 0 1 0 
0 1 0 0 1 0 0 1 -0 
```

On this type of file (a valid file exported by Paraview), the positions the values `[100.0, 100.0, 100.0, 100.0 ]`, read in the **METADATA** section.

The fix will simply stop reading floats whenever it encounters some text. Having blank lines is still supported and will work.

I don't know what would be a better way to fix that. The loader is really state-based with a lot of booleans (the format is also section-based so I understand why). 