### PR TITLE
WebGLRenderer: Fixed shader compile error.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
@@ -52,7 +52,11 @@ vec4 RGBDToLinear( in vec4 value, in float maxRange ) {
 vec4 LinearToRGBD( in vec4 value, in float maxRange ) {
 	float maxRGB = max( value.r, max( value.g, value.b ) );
 	float D = max( maxRange / maxRGB, 1.0 );
-	D = min( floor( D ) / 255.0, 1.0 );
+	// NOTE: The implementation with min causes the shader to not compile on
+	// a common Alcatel A502DL in Chrome 78/Android 8.1. Some research suggests 
+	// that the chipset is Mediatek MT6739 w/ IMG PowerVR GE8100 GPU.
+	// D = min(floor(D)/255.0, 1.0);
+	D = clamp(floor(D)/255.0, 0.0, 1.0);
 	return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
 }
 


### PR DESCRIPTION
This is a port of this fix: https://github.com/GoogleWebComponents/model-viewer/pull/920
It was causing the PMREM shaders to fail compilation on an Alcatel A502DL, which I was able to repro on three's gltf loader example. Oddly, it does not fail the MeshStandardMaterial compilation, even though it uses the same shader fragment, so this is a pretty strange driver bug. It doesn't even give an error or line number when the compilation fails, which made finding this fix a bit tricky. Thanks to @cdata for his help hunting it down line by line when he was the only one with a repro device. 