### PR TITLE
WebGLCubeRenderTarget: simplify constructor signature

### DIFF
--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -24,10 +24,9 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
+		<h3>[name]([param:Number resolution], param:Object options])</h3>
 		<p>
-		[page:Float width] - The width of the renderTarget. <br />
-		[page:Float height] - The height of the renderTarget. <br />
+		[page:Float resolution] - The resolution of the renderTarget. <br />
 		options - (optional) object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -24,9 +24,9 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number resolution], param:Object options])</h3>
+		<h3>[name]([param:Number size], param:Object options])</h3>
 		<p>
-		[page:Float resolution] - The resolution of the renderTarget. <br />
+		[page:Float size] - the size, in pixels. <br />
 		options - (optional) object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -24,10 +24,9 @@
 		<h2>构造器</h2>
 
 
-		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
+		<h3>[name]([param:Number resolution], [param:Object options])</h3>
 		<p>
-		[page:Float width] - renderTarget的宽度 <br />
-		[page:Float height] - renderTarget的高度 <br />
+		[page:Float resolution] - The resolution of the renderTarget.<br />
 		options - (可选)一个保存着自动生成的目标纹理的纹理参数以及表示是否使用深度缓存/模板缓存的布尔值的对象。
 		有关纹理参数的说明，请参阅[page:Texture Texture]. 以下是合理选项：<br /><br />
 

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -24,9 +24,9 @@
 		<h2>构造器</h2>
 
 
-		<h3>[name]([param:Number resolution], [param:Object options])</h3>
+		<h3>[name]([param:Number size], [param:Object options])</h3>
 		<p>
-		[page:Float resolution] - The resolution of the renderTarget.<br />
+		[page:Float size] - the size, in pixels. <br />
 		options - (可选)一个保存着自动生成的目标纹理的纹理参数以及表示是否使用深度缓存/模板缓存的布尔值的对象。
 		有关纹理参数的说明，请参阅[page:Texture Texture]. 以下是合理选项：<br /><br />
 

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -53,7 +53,7 @@
 					magFilter: THREE.LinearFilter
 				};
 
-				scene.background = new THREE.WebGLCubeRenderTarget( 1024, 1024, options ).fromEquirectangularTexture( renderer, texture );
+				scene.background = new THREE.WebGLCubeRenderTarget( 1024, options ).fromEquirectangularTexture( renderer, texture );
 
 				//
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1796,7 +1796,7 @@ Object.defineProperties( WebGLShadowMap.prototype, {
 
 export function WebGLRenderTargetCube( width, height, options ) {
 
-	console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( resolution, options ).' );
+	console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( size, options ).' );
 	return new WebGLCubeRenderTarget( width, options );
 
 }

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1796,8 +1796,8 @@ Object.defineProperties( WebGLShadowMap.prototype, {
 
 export function WebGLRenderTargetCube( width, height, options ) {
 
-	console.warn( 'THREE.WebGLRenderTargetCube has been renamed to WebGLCubeRenderTarget.' );
-	return new WebGLCubeRenderTarget( width, height, options );
+	console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( resolution, options ).' );
+	return new WebGLCubeRenderTarget( width, options );
 
 }
 

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -51,7 +51,7 @@ function CubeCamera( near, far, cubeResolution, options ) {
 
 	options = options || { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
 
-	this.renderTarget = new WebGLCubeRenderTarget( cubeResolution, cubeResolution, options );
+	this.renderTarget = new WebGLCubeRenderTarget( cubeResolution, options );
 	this.renderTarget.texture.name = "CubeCamera";
 
 	this.update = function ( renderer, scene ) {

--- a/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -5,7 +5,7 @@ import { Texture } from './../textures/Texture';
 export class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	constructor(
-		resolution: number,
+		size: number,
 		options?: WebGLRenderTargetOptions
 	);
 

--- a/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -5,8 +5,7 @@ import { Texture } from './../textures/Texture';
 export class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	constructor(
-		width: number,
-		height: number,
+		resolution: number,
 		options?: WebGLRenderTargetOptions
 	);
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -12,9 +12,17 @@ import { CubeCamera } from '../cameras/CubeCamera.js';
  * @author WestLangley / http://github.com/WestLangley
  */
 
-function WebGLCubeRenderTarget( width, height, options ) {
+function WebGLCubeRenderTarget( resolution, options, dummy ) {
 
-	WebGLRenderTarget.call( this, width, height, options );
+	if ( Number.isInteger( options ) ) {
+
+		console.warn( 'THREE.WebGLCubeRenderTarget: constructor signature is now WebGLCubeRenderTarget( resolution, options )' );
+
+		options = dummy;
+
+	}
+
+	WebGLRenderTarget.call( this, resolution, resolution, options );
 
 }
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -12,17 +12,17 @@ import { CubeCamera } from '../cameras/CubeCamera.js';
  * @author WestLangley / http://github.com/WestLangley
  */
 
-function WebGLCubeRenderTarget( resolution, options, dummy ) {
+function WebGLCubeRenderTarget( size, options, dummy ) {
 
 	if ( Number.isInteger( options ) ) {
 
-		console.warn( 'THREE.WebGLCubeRenderTarget: constructor signature is now WebGLCubeRenderTarget( resolution, options )' );
+		console.warn( 'THREE.WebGLCubeRenderTarget: constructor signature is now WebGLCubeRenderTarget( size, options )' );
 
 		options = dummy;
 
 	}
 
-	WebGLRenderTarget.call( this, resolution, resolution, options );
+	WebGLRenderTarget.call( this, size, size, options );
 
 }
 


### PR DESCRIPTION
Since `width` and `height` must be the same, this PR simplifies the constructor signature:
```js
WebGLCubeRenderTarget( width, height, options )
```
is now
```js
WebGLCubeRenderTarget( resolution, options ).
```