### PR TITLE
OrthographicCamera: Simplify view offset calculation

### DIFF
--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -105,15 +105,13 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 		if ( this.view !== null && this.view.enabled ) {
 
-			var zoomW = this.zoom / ( this.view.width / this.view.fullWidth );
-			var zoomH = this.zoom / ( this.view.height / this.view.fullHeight );
-			var scaleW = ( this.right - this.left ) / this.view.width;
-			var scaleH = ( this.top - this.bottom ) / this.view.height;
+			var scaleW = ( this.right - this.left ) / this.view.fullWidth / this.zoom;
+			var scaleH = ( this.top - this.bottom ) / this.view.fullHeight / this.zoom;
 
-			left += scaleW * ( this.view.offsetX / zoomW );
-			right = left + scaleW * ( this.view.width / zoomW );
-			top -= scaleH * ( this.view.offsetY / zoomH );
-			bottom = top - scaleH * ( this.view.height / zoomH );
+			left += scaleW * this.view.offsetX;
+			right = left + scaleW * this.view.width;
+			top -= scaleH * this.view.offsetY;
+			bottom = top - scaleH * this.view.height;
 
 		}
 


### PR DESCRIPTION
This is about this block. -> https://github.com/mrdoob/three.js/blob/dev/src/cameras/OrthographicCamera.js#L106-L118

Every diff to be added to left, right, top and bottom contains (scaleW / zoomW) or (scaleH / zoomH) factor, but both the scale and the zoom contains same `this.view.{width, height}` term, so it can be divided.


[![Image from Gyazo](https://i.gyazo.com/81cd38c68708981a432567fc15fe79bf.png)](https://gyazo.com/81cd38c68708981a432567fc15fe79bf)