### PR TITLE
Examples: Avoid creating instances of LightShadow.

### DIFF
--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -87,8 +87,10 @@
 				scene.add( new THREE.AmbientLight( 0xf0f0f0 ) );
 				var light = new THREE.SpotLight( 0xffffff, 1.5 );
 				light.position.set( 0, 1500, 200 );
+				light.angle = Math.PI * 0.2;
 				light.castShadow = true;
-				light.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( 70, 1, 200, 2000 ) );
+				light.shadow.camera.near = 200;
+				light.shadow.camera.far = 2000;
 				light.shadow.bias = - 0.000222;
 				light.shadow.mapSize.width = 1024;
 				light.shadow.mapSize.height = 1024;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -43,7 +43,6 @@
 				shadowCameraVisible: false,
 				shadowCameraNear: 750,
 				shadowCameraFar: 4000,
-				shadowCameraFov: 30,
 				shadowBias: - 0.0002
 
 			};
@@ -191,9 +190,6 @@
 					var s = 200;
 					mesh.scale.set( s, s, s );
 
-					//morph.duration = 8000;
-					//morph.mirroredLoop = true;
-
 					mesh.castShadow = true;
 					mesh.receiveShadow = true;
 
@@ -209,12 +205,16 @@
 				pointLight = new THREE.PointLight( 0xffaa00, 1, 5000 );
 				scene.add( pointLight );
 
-				sunLight = new THREE.SpotLight( 0xffffff, 0.3, 0, Math.PI / 2 );
+				sunLight = new THREE.DirectionalLight( 0xffffff, 0.3 );
 				sunLight.position.set( 1000, 2000, 1000 );
-
 				sunLight.castShadow = true;
-
-				sunLight.shadow = new THREE.LightShadow( new THREE.PerspectiveCamera( shadowConfig.shadowCameraFov, 1, shadowConfig.shadowCameraNear, shadowConfig.shadowCameraFar ) );
+				sunLight.shadow.camera.top = 750;
+				sunLight.shadow.camera.bottom = - 750;
+				sunLight.shadow.camera.left = - 750;
+				sunLight.shadow.camera.right = 750;
+				sunLight.shadow.camera.near = shadowConfig.shadowCameraNear;
+				sunLight.shadow.camera.far = shadowConfig.shadowCameraFar;
+				sunLight.shadow.mapSize.set( 1024, 1024 );
 				sunLight.shadow.bias = shadowConfig.shadowBias;
 
 				scene.add( sunLight );
@@ -286,14 +286,6 @@
 				shadowGUI.add( shadowConfig, 'shadowCameraFar', 1501, 5000 ).onChange( function () {
 
 					sunLight.shadow.camera.far = shadowConfig.shadowCameraFar;
-					sunLight.shadow.camera.updateProjectionMatrix();
-					shadowCameraHelper.update();
-
-				} );
-
-				shadowGUI.add( shadowConfig, 'shadowCameraFov', 1, 120 ).onChange( function () {
-
-					sunLight.shadow.camera.fov = shadowConfig.shadowCameraFov;
 					sunLight.shadow.camera.updateProjectionMatrix();
 					shadowCameraHelper.update();
 


### PR DESCRIPTION
The example code should not recommend to overwrite `light.shadow`.

Besides, using a directional light in `webgl_shading_physical` seems more appropriate.