### PR TITLE
Shaders: clarified method limitations

### DIFF
--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -63,8 +63,10 @@ vec3 transformDirection( in vec3 dir, in mat4 matrix ) {
 
 }
 
-// http://en.wikibooks.org/wiki/GLSL_Programming/Applying_Matrix_Transformations
 vec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {
+
+	// dir can be either a direction vector or a normal vector
+	// upper-left 3x3 of matrix is assumed to be orthogonal
 
 	return normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );
 


### PR DESCRIPTION
`inverseTransformDirection()` only works in certain circumstances. The inline comment now makes that clear.

For the record, the method will also work if the matrix is a pure-rotation matrix with uniform-scale, but in our use case, the matrix is `viewMatrix`, which is orthogonal.