### PR TITLE
GLTFLoader example: clean up

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -19,18 +19,16 @@
 
 			import * as THREE from '../build/three.module.js';
 
-			import Stats from './jsm/libs/stats.module.js';
-
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 			import { RGBELoader } from './jsm/loaders/RGBELoader.js';
 			import { RoughnessMipmapper } from './jsm/utils/RoughnessMipmapper.js';
 
-			var container, stats, controls;
+			var container, controls;
 			var camera, scene, renderer;
 
 			init();
-			animate();
+			render();
 
 			function init() {
 
@@ -48,10 +46,14 @@
 					.load( 'royal_esplanade_1k.hdr', function ( texture ) {
 
 						var envMap = pmremGenerator.fromEquirectangular( texture ).texture;
-						pmremGenerator.dispose();
 
 						scene.background = envMap;
 						scene.environment = envMap;
+
+						texture.dispose();
+						pmremGenerator.dispose();
+
+						render();
 
 						// model
 
@@ -74,6 +76,8 @@
 
 							roughnessMipmapper.dispose();
 
+							render();
+
 						} );
 
 					} );
@@ -82,6 +86,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 0.8;
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
@@ -89,14 +94,13 @@
 				pmremGenerator.compileEquirectangularShader();
 
 				controls = new OrbitControls( camera, renderer.domElement );
+				controls.addEventListener( 'change', render ); // use if there is no animation loop
+				controls.minDistance = 2;
+				controls.maxDistance = 10
 				controls.target.set( 0, 0, - 0.2 );
 				controls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
-
-				// stats
-				stats = new Stats();
-				container.appendChild( stats.dom );
 
 			}
 
@@ -107,17 +111,15 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
 			//
 
-			function animate() {
-
-				requestAnimationFrame( animate );
+			function render() {
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 


### PR DESCRIPTION
1. Removed the animation loop since the scene is static.
2. Added exposure control.

IMO, the scene was over-bright. Just my opinion, of course.

Rather that reducing the environment intensity, which reduces the reflections, but leaves the background unchanged, I reduced the tonemapping exposure. I also added a gui.

/ping @donmccurdy