### PR TITLE
Docs: Add TypeScript setup guide.

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -460,6 +460,7 @@ var list = {
 				"浏览器支持": "manual/zh/introduction/Browser-support",
 				"WebGL兼容性检查": "manual/zh/introduction/WebGL-compatibility-check",
 				"如何在本地运行Three.js": "manual/zh/introduction/How-to-run-things-locally",
+				"Typescript setup": "manual/zh/introduction/Typescript-setup",
 				"如何使用WebGL 2": "manual/zh/introduction/How-to-use-WebGL2",
 				"画线": "manual/zh/introduction/Drawing-lines",
 				"创建文字": "manual/zh/introduction/Creating-text",

--- a/docs/list.js
+++ b/docs/list.js
@@ -10,6 +10,7 @@ var list = {
 				"Browser support": "manual/en/introduction/Browser-support",
 				"WebGL compatibility check": "manual/en/introduction/WebGL-compatibility-check",
 				"How to run things locally": "manual/en/introduction/How-to-run-things-locally",
+				"Typescript setup": "manual/en/introduction/Typescript-setup",
 				"How to use WebGL 2": "manual/en/introduction/How-to-use-WebGL2",
 				"Drawing lines": "manual/en/introduction/Drawing-lines",
 				"Creating text": "manual/en/introduction/Creating-text",

--- a/docs/manual/en/introduction/Typescript-setup.html
+++ b/docs/manual/en/introduction/Typescript-setup.html
@@ -11,10 +11,9 @@
 		<h1>[name]</h1>
 
 		<p>
-			three.js is a JavaScript-based library.
+			three.js is a JavaScript-based library. However, it's possible to use three.js in a TypeScript project, as the library
+			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html TypeScript declaration files] (*.d.ts* files).
 		</p>
-			However, it's possible to use three.js in a TypeScript project, as the library
-			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html TypeScript declaration files] (*.d.ts* files) making it usable in TypeScript projects.
 
 		<p>
 			A minimal configuration is required for the TypeScript compiler to
@@ -35,8 +34,7 @@
 		</code>
 
 		<p>
-			As of today, it's not yet possible to three.js in a TypeScript project
-			without using the [link:https://www.typescriptlang.org/docs/handbook/module-resolution.html node module resolution algorithm].
+			Note: As of today, it's not yet possible to use three.js typings without using those two options.
 		</p>
 
 		<p>

--- a/docs/manual/en/introduction/Typescript-setup.html
+++ b/docs/manual/en/introduction/Typescript-setup.html
@@ -11,15 +11,15 @@
 		<h1>[name]</h1>
 
 		<p>
-			three.js is a JavaScript-based library. However, it's possible to use three.js in a TypeScript project, as the library
-			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html TypeScript declaration files] (*.d.ts* files).
+			three.js is a JavaScript-based library. However, it's possible to use it in a TypeScript project, as the library
+			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html Declaration Files] (*d.ts* files).
 		</p>
 
 		<p>
 			A minimal configuration is required for the TypeScript compiler to
 			discover three.js types.<br>
 			You will need to set the [link:https://www.typescriptlang.org/docs/handbook/module-resolution.html moduleResolution]
-			option to *node*, and the [link:https://www.typescriptlang.org/docs/handbook/compiler-options.html target] to *es6* or newer.
+			option to *node*, and the [link:https://www.typescriptlang.org/docs/handbook/compiler-options.html target] option to *es6* or newer.
 		</p>
 
 		<code>
@@ -39,7 +39,7 @@
 
 		<p>
 			Note: It happens that some declarations are incorrect and/or missing.
-			Contributing to Types Declaration Files is really helpful for the community, making three.js
+			Contributing to Declaration Files is really helpful for the community, making three.js
 			typings better and more accurate.
 		</p>
 	</body>

--- a/docs/manual/en/introduction/Typescript-setup.html
+++ b/docs/manual/en/introduction/Typescript-setup.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<base href="../../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<p>
+			three.js is a JavaScript-based library.
+		</p>
+			However, it's possible to use three.js in a TypeScript project, as the library
+			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html TypeScript declaration files] (*.d.ts* files) making it usable in TypeScript projects.
+
+		<p>
+			A minimal configuration is required for the TypeScript compiler to
+			discover three.js types.<br>
+			You will need to set the [link:https://www.typescriptlang.org/docs/handbook/module-resolution.html moduleResolution]
+			option to *node*, and the [link:https://www.typescriptlang.org/docs/handbook/compiler-options.html target] to *es6* or newer.
+		</p>
+
+		<code>
+		// Example of minimal `tsconfig.json` file
+		{
+			"compilerOptions": {
+				"target": "es6",
+				"moduleResolution": "node",
+			},
+			"include": [ "./src/**/*.ts" ],
+		}
+		</code>
+
+		<p>
+			As of today, it's not yet possible to three.js in a TypeScript project
+			without using the [link:https://www.typescriptlang.org/docs/handbook/module-resolution.html node module resolution algorithm].
+		</p>
+
+		<p>
+			Note: It happens that some declarations are incorrect and/or missing.
+			Contributing to Types Declaration Files is really helpful for the community, making three.js
+			typings better and more accurate.
+		</p>
+	</body>
+</html>

--- a/docs/manual/zh/introduction/Typescript-setup.html
+++ b/docs/manual/zh/introduction/Typescript-setup.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<base href="../../../" />
+		<script src="list.js"></script>
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<p>
+			three.js is a JavaScript-based library. However, it's possible to use it in a TypeScript project, as the library
+			exposes [link:https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html Declaration Files] (*d.ts* files).
+		</p>
+
+		<p>
+			A minimal configuration is required for the TypeScript compiler to
+			discover three.js types.<br>
+			You will need to set the [link:https://www.typescriptlang.org/docs/handbook/module-resolution.html moduleResolution]
+			option to *node*, and the [link:https://www.typescriptlang.org/docs/handbook/compiler-options.html target] option to *es6* or newer.
+		</p>
+
+		<code>
+		// Example of minimal `tsconfig.json` file
+		{
+			"compilerOptions": {
+				"target": "es6",
+				"moduleResolution": "node",
+			},
+			"include": [ "./src/**/*.ts" ],
+		}
+		</code>
+
+		<p>
+			Note: As of today, it's not yet possible to use three.js typings without using those two options.
+		</p>
+
+		<p>
+			Note: It happens that some declarations are incorrect and/or missing.
+			Contributing to Declaration Files is really helpful for the community, making three.js
+			typings better and more accurate.
+		</p>
+	</body>
+</html>


### PR DESCRIPTION
This PR adds a page to explain what are the option needed to make the TypeScript compiler discovers `three.js` types.

This should solve the issue #18158. Nothing more fancy is needed to make the compiler discover the types. If more is needed, it's probably up to the user to understand more deeply its setup.