### PR TITLE
Add 'setMatrix' method to Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -145,6 +145,16 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
+	setMatrix: function ( m ) {
+
+		this.matrix.copy( m );
+
+		this.matrix.decompose( this.position, this.quaternion, this.scale );
+
+		this.matrixWorldNeedsUpdate = true;
+
+	},
+
 	setRotationFromAxisAngle: function ( axis, angle ) {
 
 		// assumes axis is normalized


### PR DESCRIPTION
This method updates the 'position', 'quaternion', and 'scale' properties
from the 'matrix' property, the inverse of 'updateMatrix'.