### PR TITLE
Camera: update `matrixWorldInverse` in `updateWorldMatrix()` method

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -65,6 +65,14 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	},
 
+	updateWorldMatrix: function ( updateParents, updateChildren ) {
+
+		Object3D.prototype.updateWorldMatrix.call( this, updateParents, updateChildren );
+
+		this.matrixWorldInverse.getInverse( this.matrixWorld );
+
+	},
+
 	clone: function () {
 
 		return new this.constructor().copy( this );


### PR DESCRIPTION
For people not using `matrixAutoUpdate`, and using `updateWorldMatrix()`, it's possible to end up in a case where the camera `matrixWorldInverse` is actually out-of-date.

This PR makes the `Camera` class override the `updateWorldMatrix()`.
