### PR TITLE
Fixes #18335 CodeSerializer works with uglified code

### DIFF
--- a/examples/jsm/loaders/OBJLoader2Parallel.js
+++ b/examples/jsm/loaders/OBJLoader2Parallel.js
@@ -97,17 +97,16 @@ OBJLoader2Parallel.prototype = Object.assign( Object.create( OBJLoader2.prototyp
 		}
 		if ( codeBuilderInstructions.isSupportsStandardWorker() ) {
 
-			let codeOBJLoader2Parser = CodeSerializer.serializeClass( 'OBJLoader2Parser', OBJLoader2Parser );
-			let codeObjectManipulator = CodeSerializer.serializeObject( 'ObjectManipulator', ObjectManipulator );
-			let codeParserPayloadHandler = CodeSerializer.serializeClass( 'DefaultWorkerPayloadHandler', DefaultWorkerPayloadHandler );
-			let codeWorkerRunner = CodeSerializer.serializeClass( 'WorkerRunner', WorkerRunner );
+			let objectManipulator = new ObjectManipulator();
+			let defaultWorkerPayloadHandler = new DefaultWorkerPayloadHandler( this.parser );
+			let workerRunner = new WorkerRunner( {} );
+			codeBuilderInstructions.addCodeFragment( CodeSerializer.serializeClass( OBJLoader2Parser, this.parser ) );
+			codeBuilderInstructions.addCodeFragment( CodeSerializer.serializeClass( ObjectManipulator, objectManipulator ) );
+			codeBuilderInstructions.addCodeFragment( CodeSerializer.serializeClass( DefaultWorkerPayloadHandler, defaultWorkerPayloadHandler ) );
+			codeBuilderInstructions.addCodeFragment( CodeSerializer.serializeClass( WorkerRunner, workerRunner ) );
 
-			codeBuilderInstructions.addCodeFragment( codeOBJLoader2Parser );
-			codeBuilderInstructions.addCodeFragment( codeObjectManipulator );
-			codeBuilderInstructions.addCodeFragment( codeParserPayloadHandler );
-			codeBuilderInstructions.addCodeFragment( codeWorkerRunner );
-
-			codeBuilderInstructions.addStartCode( 'new WorkerRunner( new DefaultWorkerPayloadHandler( new OBJLoader2Parser() ) );' );
+			let startCode = 'new ' + workerRunner.constructor.name + '( new ' + defaultWorkerPayloadHandler.constructor.name + '( new ' + this.parser.constructor.name + '() ) );';
+			codeBuilderInstructions.addStartCode( startCode );
 
 		}
 		return codeBuilderInstructions;

--- a/examples/jsm/loaders/obj2/utils/CodeSerializer.d.ts
+++ b/examples/jsm/loaders/obj2/utils/CodeSerializer.d.ts
@@ -1,6 +1,7 @@
 export namespace CodeSerializer {
-	export function serializeObject( fullName: string, serializationTarget: object ): string;
-	export function serializeClass( fullObjectName: string, serializationTarget: object, basePrototypeName?: string, overrideFunctions?: CodeSerializationInstruction[] ): string;
+
+	export function serializeClass( targetPrototype: object, targetPrototypeInstance: object, basePrototypeName?: string, overrideFunctions?: CodeSerializationInstruction[] ): string;
+
 }
 
 export class CodeSerializationInstruction {

--- a/examples/jsm/loaders/obj2/utils/CodeSerializer.js
+++ b/examples/jsm/loaders/obj2/utils/CodeSerializer.js
@@ -6,60 +6,19 @@
 const CodeSerializer = {
 
 	/**
-	 * Serialize an object without specific prototype definition.
-	 *
-	 * @param {String} fullObjectName complete object name
-	 * @param {Object} serializationTarget The object that should be serialized
-	 * @returns {String}
-	 */
-	serializeObject: function ( fullObjectName, serializationTarget ) {
-
-		let objectString = fullObjectName + ' = {\n\n';
-		let part;
-		for ( let name in serializationTarget ) {
-
-			part = serializationTarget[ name ];
-			if ( typeof ( part ) === 'string' || part instanceof String ) {
-
-				part = part.replace( /\n/g, '\\n' );
-				part = part.replace( /\r/g, '\\r' );
-				objectString += '\t' + name + ': "' + part + '",\n';
-
-			} else if ( part instanceof Array ) {
-
-				objectString += '\t' + name + ': [' + part + '],\n';
-
-			} else if ( typeof part === 'object' ) {
-
-				console.log( 'Omitting object "' + name + '" and replace it with empty object.' );
-				objectString += '\t' + name + ': {},\n';
-
-			} else {
-
-				objectString += '\t' + name + ': ' + part + ',\n';
-
-			}
-
-		}
-		objectString += '}\n\n';
-
-		return objectString;
-
-	},
-
-	/**
 	 * Serialize an object with specific prototype definition.
 	 *
-	 * @param {String} fullObjectName Specifies the complete object name
-	 * @param {Object} serializationTarget The object that should be serialized
+	 * @param {Object} targetPrototype The object that should be serialized
+	 * @param {Object} targetPrototypeInstance An instance of the oriobject that should be serialized
 	 * @param {String} [basePrototypeName] Name of the prototype
 	 * @param {Object} [overrideFunctions} Array of {@Link CodeSerializationInstruction} allows to replace or remove function with provided content
 	 *
 	 * @returns {String}
 	 */
-	serializeClass: function ( fullObjectName, serializationTarget, basePrototypeName, overrideFunctions ) {
+	serializeClass: function ( targetPrototype, targetPrototypeInstance, basePrototypeName, overrideFunctions ) {
 
 		let objectPart, constructorString, i, funcInstructions, funcTemp;
+		let fullObjectName = targetPrototypeInstance.constructor.name;
 		let prototypeFunctions = [];
 		let objectProperties = [];
 		let objectFunctions = [];
@@ -67,9 +26,9 @@ const CodeSerializer = {
 
 		if ( ! Array.isArray( overrideFunctions ) ) overrideFunctions = [];
 
-		for ( let name in serializationTarget.prototype ) {
+		for ( let name in targetPrototype.prototype ) {
 
-			objectPart = serializationTarget.prototype[ name ];
+			objectPart = targetPrototype.prototype[ name ];
 			funcInstructions = new CodeSerializationInstruction( name, fullObjectName + '.prototype.' + name );
 			funcInstructions.setCode( objectPart.toString() );
 
@@ -106,9 +65,9 @@ const CodeSerializer = {
 			}
 
 		}
-		for ( let name in serializationTarget ) {
+		for ( let name in targetPrototype ) {
 
-			objectPart = serializationTarget[ name ];
+			objectPart = targetPrototype[ name ];
 			funcInstructions = new CodeSerializationInstruction( name, fullObjectName + '.' + name );
 			if ( typeof objectPart === 'function' ) {
 

--- a/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.d.ts
+++ b/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.d.ts
@@ -1,6 +1,8 @@
-export namespace ObjectManipulator {
+export class ObjectManipulator {
 
-	export function applyProperties( objToAlter: object, params: object, forceCreation: boolean ): void;
+	constructor();
+
+	applyProperties( objToAlter: object, params: object, forceCreation: boolean ): void;
 
 }
 

--- a/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
+++ b/examples/jsm/loaders/obj2/worker/parallel/WorkerRunner.js
@@ -3,13 +3,19 @@
  * Development repository: https://github.com/kaisalmen/WWOBJLoader
  */
 
-const ObjectManipulator = {
+const ObjectManipulator = function () {
+};
+
+ObjectManipulator.prototype = {
+
+	constructor: ObjectManipulator,
 
 	/**
 	 * Applies values from parameter object via set functions or via direct assignment.
 	 *
 	 * @param {Object} objToAlter The objToAlter instance
 	 * @param {Object} params The parameter object
+	 * @param {boolean} forceCreation Force the creation of a property
 	 */
 	applyProperties: function ( objToAlter, params, forceCreation ) {
 
@@ -81,8 +87,9 @@ DefaultWorkerPayloadHandler.prototype = {
 				parser.setLogging( this.logging.enabled, this.logging.debug );
 
 			}
-			ObjectManipulator.applyProperties( parser, payload.params, false );
-			ObjectManipulator.applyProperties( parser, callbacks, false );
+			let objectManipulator = new ObjectManipulator();
+			objectManipulator.applyProperties( parser, payload.params, false );
+			objectManipulator.applyProperties( parser, callbacks, false );
 
 			let arraybuffer = payload.data.input;
 			let executeFunctionName = 'execute';

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -168,9 +168,14 @@
 					let modelName = 'female02_vertex' ;
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
+					let local = new THREE.Object3D();
+					local.name = 'Pivot_female02_vertex';
+					local.position.set( -75, 0, 0 );
+					this.pivot.add( local );
+
 					let scope = this;
 					function callbackOnLoad( object3d, message ) {
-						scope.scene.add( object3d );
+						local.add( object3d );
 						scope._reportProgress( { detail: { text: 'Loading of ' + modelName + 'completed: ' + message } } );
 					}
 
@@ -227,7 +232,7 @@
 
 					let local = new THREE.Object3D();
 					local.name = 'Pivot_WaltHead';
-					local.position.set( -125, 50, 0 );
+					local.position.set( -175, 50, 0 );
 					let scale = 0.5;
 					local.scale.set( scale, scale, scale );
 					this.pivot.add( local );
@@ -272,8 +277,8 @@
 
 				useLoadParallelMeshAlter: function () {
 					let local = new THREE.Object3D();
-					local.position.set( 125, 50, 0 );
-					local.name = 'Pivot_vive-controller';
+					local.position.set( 175, -100, 0 );
+					local.name = 'Pivot_ninjaHead';
 					this.pivot.add( local );
 
 					let objLoader2Parallel = new OBJLoader2Parallel()
@@ -287,8 +292,6 @@
 						let override = new LoadedMeshUserOverride( false, true );
 
 						let mesh = new THREE.Mesh( event.detail.bufferGeometry, event.detail.material );
-						let scale = 200.0;
-						mesh.scale.set( scale, scale, scale );
 						mesh.name = event.detail.meshName;
 						let helper = new VertexNormalsHelper( mesh, 2, 0x00ff00, 1 );
 						helper.name = 'VertexNormalsHelper';
@@ -305,7 +308,7 @@
 						scope._reportProgress( { detail: { text: 'Loading of ' + objLoader2Parallel.modelName + 'completed: ' + message } } );
 					}
 
-					objLoader2Parallel.load( 'models/obj/vive-controller/vr_controller_vive_1_5.obj', callbackOnLoad );
+					objLoader2Parallel.load( 'models/obj/ninja/ninjaHead_Low.obj', callbackOnLoad );
 				},
 
 				finalize: function () {


### PR DESCRIPTION
This fixes #18335:
Problem is that uglified code changes the name of objects and functions, You cannot expect a name to be there when working on loaded uglified code. This broke the `CodeSerializer` as it expected things to have a certain name when generating the code for a Worker. The name defined in written code may have changed and therefore it can no longer be an input to the function (this may have become `ab` instead of `OBJLoader2Parser`). 

For non-prototype objects there is no way to find the name of the object (not the one of the instance). Therefore serialization from now on only provided for prototypes (classes). Previously only the definition of the prototype as loaded in memory and the name was required. Now an instance of the prototype is required instead of the name. This way the name of the constructor can be read and it always fits the uglified name (e.g. `ab`).