### PR TITLE
Examples: Fix vertex color settings.

### DIFF
--- a/examples/webxr_vr_ballshooter.html
+++ b/examples/webxr_vr_ballshooter.html
@@ -146,7 +146,7 @@
 						geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( [ 0, 0, 0, 0, 0, - 1 ], 3 ) );
 						geometry.setAttribute( 'color', new THREE.Float32BufferAttribute( [ 0.5, 0.5, 0.5, 0, 0, 0 ], 3 ) );
 
-						var material = new THREE.LineBasicMaterial( { vertexColors: true, blending: THREE.AdditiveBlending } );
+						var material = new THREE.LineBasicMaterial( { vertexColors: THREE.VertexColors, blending: THREE.AdditiveBlending } );
 
 						return new THREE.Line( geometry, material );
 


### PR DESCRIPTION
`vertexColors` is unfortunately no boolean. Fixing the example by assigning `THREE.VertexColors`.

https://discourse.threejs.org/t/webxr-vr-ballshooter-html-example-ts-typing-question/11995