### PR TITLE
Expose the XRInputSource.gripSpace for XR controllers

### DIFF
--- a/src/renderers/webxr/WebXRManager.d.ts
+++ b/src/renderers/webxr/WebXRManager.d.ts
@@ -7,6 +7,7 @@ export class WebXRManager {
 
 	enabled: boolean;
 	getController( id: number ): Group;
+	getControllerGrip( id: number ): Group;
 	setFramebufferScaleFactor( value: number ): void;
 	setReferenceSpaceType( value: string ): void;
 	getSession(): any;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -52,15 +52,43 @@ function WebXRManager( renderer, gl ) {
 
 		if ( controller === undefined ) {
 
-			controller = new Group();
-			controller.matrixAutoUpdate = false;
-			controller.visible = false;
-
+			controller = {};
 			controllers[ id ] = controller;
 
 		}
 
-		return controller;
+		if ( controller.targetRay === undefined ) {
+
+			controller.targetRay = new Group();
+			controller.targetRay.matrixAutoUpdate = false;
+			controller.targetRay.visible = false;
+
+		}
+
+		return controller.targetRay;
+
+	};
+
+	this.getControllerGrip = function ( id ) {
+
+		var controller = controllers[ id ];
+
+		if ( controller === undefined ) {
+
+			controller = {};
+			controllers[ id ] = controller;
+
+		}
+
+		if ( controller.grip === undefined ) {
+
+			controller.grip = new Group();
+			controller.grip.matrixAutoUpdate = false;
+			controller.grip.visible = false;
+
+		}
+
+		return controller.grip;
 
 	};
 
@@ -72,7 +100,17 @@ function WebXRManager( renderer, gl ) {
 
 		if ( controller ) {
 
-			controller.dispatchEvent( { type: event.type } );
+			if ( controller.targetRay ) {
+
+				controller.targetRay.dispatchEvent( { type: event.type } );
+
+			}
+
+			if ( controller.grip ) {
+
+				controller.grip.dispatchEvent( { type: event.type } );
+
+			}
 
 		}
 
@@ -82,8 +120,19 @@ function WebXRManager( renderer, gl ) {
 
 		inputSourcesMap.forEach( function ( controller, inputSource ) {
 
-			controller.dispatchEvent( { type: 'disconnected', data: inputSource } );
-			controller.visible = false;
+			if ( controller.targetRay ) {
+
+				controller.targetRay.dispatchEvent( { type: 'disconnected', data: inputSource } );
+				controller.targetRay.visible = false;
+
+			}
+
+			if ( controller.grip ) {
+
+				controller.grip.dispatchEvent( { type: 'disconnected', data: inputSource } );
+				controller.grip.visible = false;
+
+			}
 
 		} );
 
@@ -197,7 +246,18 @@ function WebXRManager( renderer, gl ) {
 
 			if ( controller ) {
 
-				controller.dispatchEvent( { type: 'disconnected', data: inputSource } );
+				if ( controller.targetRay ) {
+
+					controller.targetRay.dispatchEvent( { type: 'disconnected', data: inputSource } );
+
+				}
+	
+				if ( controller.grip ) {
+
+					controller.grip.dispatchEvent( { type: 'disconnected', data: inputSource } );
+
+				}
+
 				inputSourcesMap.delete( inputSource );
 
 			}
@@ -213,7 +273,17 @@ function WebXRManager( renderer, gl ) {
 
 			if ( controller ) {
 
-				controller.dispatchEvent( { type: 'connected', data: inputSource } );
+				if ( controller.targetRay ) {
+
+					controller.targetRay.dispatchEvent( { type: 'connected', data: inputSource } );
+
+				}
+	
+				if ( controller.grip ) {
+
+					controller.grip.dispatchEvent( { type: 'connected', data: inputSource } );
+
+				}
 
 			}
 
@@ -375,23 +445,50 @@ function WebXRManager( renderer, gl ) {
 
 			var inputSource = inputSources[ i ];
 
+			var inputPose = null;
+			var gripPose = null;
+
 			if ( inputSource ) {
 
-				var inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
+				if ( controller.targetRay ) {
 
-				if ( inputPose !== null ) {
+					inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
 
-					controller.matrix.fromArray( inputPose.transform.matrix );
-					controller.matrix.decompose( controller.position, controller.rotation, controller.scale );
-					controller.visible = true;
+					if ( inputPose !== null ) {
 
-					continue;
+						controller.targetRay.matrix.fromArray( inputPose.transform.matrix );
+						controller.targetRay.matrix.decompose( controller.targetRay.position, controller.targetRay.rotation, controller.targetRay.scale );
+
+					}
+
+				}
+
+				if ( inputSource.gripSpace && controller.grip ) {
+
+					gripPose = frame.getPose( inputSource.gripSpace, referenceSpace );
+
+					if ( gripPose !== null ) {
+
+						controller.grip.matrix.fromArray( gripPose.transform.matrix );
+						controller.grip.matrix.decompose( controller.grip.position, controller.grip.rotation, controller.grip.scale );
+
+					}
 
 				}
 
 			}
 
-			controller.visible = false;
+			if ( controller.targetRay ) {
+
+				controller.targetRay.visible = inputPose !== null;
+
+			}
+
+			if ( controller.grip ) {
+
+				controller.grip.visible = gripPose !== null;
+
+			}
 
 		}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -251,7 +251,7 @@ function WebXRManager( renderer, gl ) {
 					controller.targetRay.dispatchEvent( { type: 'disconnected', data: inputSource } );
 
 				}
-	
+
 				if ( controller.grip ) {
 
 					controller.grip.dispatchEvent( { type: 'disconnected', data: inputSource } );
@@ -278,7 +278,7 @@ function WebXRManager( renderer, gl ) {
 					controller.targetRay.dispatchEvent( { type: 'connected', data: inputSource } );
 
 				}
-	
+
 				if ( controller.grip ) {
 
 					controller.grip.dispatchEvent( { type: 'connected', data: inputSource } );


### PR DESCRIPTION
Currently Three offers `navigator.xr.getController(index)`, which returns a `Group` that tracks the pose of a `targetRaySpace` of an `XRInputSource`. This is a good "default", because that space is guaranteed to be available for any `XRInputSource` and provides a unified way of tracking anything from touchscreen input to gaze cursors to full 6DoF controllers.

However many tracked controllers will also track a `gripSpace`, which will typically be very similar to the `targetRaySpace` with a slight offset and different angle for ergonomic reasons. This is also useful to expose because it's the space that should be used to track objects being held by the user. This PR adds a `navigator.xr.getControllerGrip(index)` method that returns a `Group` that tracks the `gripSpace`, and otherwise behaves identically to the original `getController()`.

Since the above couple of paragraphs can be confusing for anyone not immersed in WebXR lingo, I'll offer a couple of visual aids:

![spaces](https://user-images.githubusercontent.com/805273/72192544-08eef380-33bb-11ea-918e-4446501f090f.png)

In this screenshot of Oculus Home you can see a controller with a white pointing ray coming out of the tip. That ray is what you use to interact with the UI. When this controller is exposed to WebXR the `targetRaySpace` would be shown by the yellow arrow and the `gripSpace` would be shown by the blue arrow. The colored dots represent the space origin and the arrows show the direction of the negative Z axis.

If you had an app where you were holding something (lets say a Lightsaber) you'd want to model it so the hilt is at the origin and the blade is pointing down the Z axis. Then when you load it into your app and attach it to the `Group` returned by this new `getControllerGrip()` it would be in the right position to feel like you're holding it. If, however, you attached it to the `Group` returned by `getController()` the hilt would kind of float near your hand and the blade would point off at a funny angle.

On the other hand, if your app needs a pointing ray and you attach it to the `getControllerGrip()` `Group` it'll ALSO feel like a lightsaber, which it turns out isn't terribly ergonomic to do precision pointing with (imagine pointing at a screen with your thumb).

![both-grip](https://user-images.githubusercontent.com/805273/72193066-bb738600-33bc-11ea-8b42-bd2384c6981a.jpg)

So for apps that want to both show something in the users hand AND offer a pointing ray, you'll want to attached the handheld object to the `getControllerGrip()` `Group` and the ray to the `getController()` `Group`, which yields something that matches what the users see in the native UI much better:

![targetRay-and-grip](https://user-images.githubusercontent.com/805273/72193145-fd043100-33bc-11ea-8098-fe334d82ff2b.jpg)
