### PR TITLE
NodeMaterial: Add support for more than 2 uv layers.

### DIFF
--- a/examples/jsm/nodes/accessors/UVNode.js
+++ b/examples/jsm/nodes/accessors/UVNode.js
@@ -5,9 +5,6 @@
 import { TempNode } from '../core/TempNode.js';
 import { NodeLib } from '../core/NodeLib.js';
 
-var vertexDict = [ 'uv', 'uv2' ],
-	fragmentDict = [ 'vUv', 'vUv2' ];
-
 function UVNode( index ) {
 
 	TempNode.call( this, 'v2', { shared: false } );
@@ -24,7 +21,8 @@ UVNode.prototype.generate = function ( builder, output ) {
 
 	builder.requires.uv[ this.index ] = true;
 
-	var result = builder.isShader( 'vertex' ) ? vertexDict[ this.index ] : fragmentDict[ this.index ];
+	var uvIndex = this.index > 0 ? this.index + 1 : '';
+	var result = builder.isShader( 'vertex' ) ? 'uv' + uvIndex : 'vUv' + uvIndex;
 
 	return builder.format( result, this.getType( builder ), output );
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -164,20 +164,23 @@ NodeBuilder.prototype = {
 		this.buildShader( 'vertex', vertex );
 		this.buildShader( 'fragment', fragment );
 
-		if ( this.requires.uv[ 0 ] ) {
+		for ( var i = 0; i < this.requires.uv.length; i++ ) {
 
-			this.addVaryCode( 'varying vec2 vUv;' );
+			if ( this.requires.uv[ i ] ) {
 
-			this.addVertexFinalCode( 'vUv = uv;' );
+				var uvIndex = i > 0 ? i + 1 : '';
 
-		}
+				this.addVaryCode( 'varying vec2 vUv' + uvIndex + ';' );
 
-		if ( this.requires.uv[ 1 ] ) {
+				if ( i > 0 ) {
 
-			this.addVaryCode( 'varying vec2 vUv2;' );
-			this.addVertexParsCode( 'attribute vec2 uv2;' );
+					this.addVertexParsCode( 'attribute vec2 uv' + uvIndex + ';' );
 
-			this.addVertexFinalCode( 'vUv2 = uv2;' );
+				}
+
+				this.addVertexFinalCode( 'vUv' + uvIndex + ' = uv' + uvIndex +';' );
+
+			}
 
 		}
 


### PR DESCRIPTION
Currently, the node material system only handles two uv layers with index 0 and index 1.
The purpose of this pull request is to remove this limitation.

For vertex shaders, variables follow the usual naming style: uv, uv2, uv3, ...
Similarly for fragment shaders names are: vUv, vUv2, vUv3, ...

/ping @sunag 