### PR TITLE
Fix Matrix3.transposeIntoArray d.ts signature

### DIFF
--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -86,7 +86,7 @@ export class Matrix3 implements Matrix {
 	/**
 	 * Transposes this matrix into the supplied array r, and returns itself.
 	 */
-	transposeIntoArray( r: number[] ): number[];
+	transposeIntoArray( r: number[] ): Matrix3;
 
 	setUvTransform( tx: number, ty: number, sx: number, sy: number, rotation: number, cx: number, cy: number ): Matrix3;
 

--- a/src/math/Ray.d.ts
+++ b/src/math/Ray.d.ts
@@ -15,7 +15,7 @@ export class Ray {
 	clone(): this;
 	copy( ray: Ray ): this;
 	at( t: number, target: Vector3 ): Vector3;
-	lookAt( v: Vector3 ): Vector3;
+	lookAt( v: Vector3 ): Ray;
 	recast( t: number ): Ray;
 	closestPointToPoint( point: Vector3, target: Vector3 ): Vector3;
 	distanceToPoint( point: Vector3 ): number;


### PR DESCRIPTION
`Matrix3.transposeIntoArray` returns the matrix itself, not the array.
`Ray.lookAt` also returns the ray, not the vector