### PR TITLE
WebGLTextures: Add support for CubeTexture with compressed textures.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -412,7 +412,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 
-			var isCompressed = ( texture && texture.isCompressedTexture );
+			var isCompressed = ( texture && ( texture.isCompressedTexture || texture.image[ 0 ].isCompressedTexture ) );
 			var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
 
 			var cubeImage = [];


### PR DESCRIPTION
Fixed #16584.

Right now,  the only way to achieve a cube map based on compressed textures is  via `CompressedTextureLoader` by loading e.g. a single DDS file that stores the entire cube map.

With this small patch for `WebGLTextures`, it's now possible to  create an instance of `CubeTexture` out of six  `CompressedTexture` objects. This approach makes it easier to build a cube map out of six basis textures, see https://discourse.threejs.org/t/compressed-basis-textures-for-cube-maps-skybox/12016.

We've tried to fixed this once via #16648, however the change was not correct and reverted. 
