### PR TITLE
Fix d.ts for renderBufferImmediate and renderBufferDirect

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -5,6 +5,7 @@ import { WebGLInfo } from './webgl/WebGLInfo';
 import { WebGLShadowMap } from './webgl/WebGLShadowMap';
 import { WebGLCapabilities } from './webgl/WebGLCapabilities';
 import { WebGLProperties } from './webgl/WebGLProperties';
+import { WebGLProgram } from './webgl/WebGLProgram';
 import { WebGLRenderLists } from './webgl/WebGLRenderLists';
 import { WebGLState } from './webgl/WebGLState';
 import { Vector2 } from './../math/Vector2';
@@ -13,7 +14,6 @@ import { Color } from './../math/Color';
 import { WebGLRenderTarget } from './WebGLRenderTarget';
 import { Object3D } from './../core/Object3D';
 import { Material } from './../materials/Material';
-import { Fog } from './../scenes/Fog';
 import { ToneMapping, ShadowMapType, CullFace, TextureEncoding } from '../constants';
 import { WebXRManager } from '../renderers/webxr/WebXRManager';
 import { RenderTarget } from './webgl/WebGLRenderLists';
@@ -307,21 +307,14 @@ export class WebGLRenderer implements Renderer {
 	resetGLState(): void;
 	dispose(): void;
 
-	/**
-	 * Tells the shadow map plugin to update using the passed scene and camera parameters.
-	 *
-	 * @param scene an instance of Scene
-	 * @param camera — an instance of Camera
-	 */
 	renderBufferImmediate(
 		object: Object3D,
-		program: Object,
-		material: Material
+		program: WebGLProgram,
 	): void;
 
 	renderBufferDirect(
 		camera: Camera,
-		fog: Fog,
+		scene: Scene,
 		geometry: Geometry | BufferGeometry,
 		material: Material,
 		object: Object3D,


### PR DESCRIPTION
Fix renderBufferImmediate and renderBufferDirect signatures to match the Javascript implementation.

Also removed a JSDoc comment which seems misplaced and makes no sense.