### PR TITLE
[TS] `setFromBufferAttribute` missing in `Box3`

### DIFF
--- a/src/math/Box3.d.ts
+++ b/src/math/Box3.d.ts
@@ -1,3 +1,4 @@
+import { BufferAttribute } from './../core/BufferAttribute';
 import { Vector3 } from './Vector3';
 import { Object3D } from './../core/Object3D';
 import { Sphere } from './Sphere';
@@ -15,6 +16,7 @@ export class Box3 {
 
 	set( min: Vector3, max: Vector3 ): this;
 	setFromArray( array: ArrayLike<number> ): this;
+	setFromBufferAttribute( bufferAttribute: BufferAttribute ): this;
 	setFromPoints( points: Vector3[] ): this;
 	setFromCenterAndSize( center: Vector3, size: Vector3 ): this;
 	setFromObject( object: Object3D ): this;


### PR DESCRIPTION
It's in the Box3 class, but it's not in TypeScript definition file:
https://github.com/mrdoob/three.js/blob/dev/src/math/Box3.js#L94 