### PR TITLE
TS: Fix d.ts for WebGLProgram - vertexShader and fragmentShader

### DIFF
--- a/src/renderers/webgl/WebGLProgram.d.ts
+++ b/src/renderers/webgl/WebGLProgram.d.ts
@@ -15,8 +15,8 @@ export class WebGLProgram {
 	cacheKey: string; // unique identifier for this program, used for looking up compiled programs from cache.
 	usedTimes: number;
 	program: any;
-	vertexShader: WebGLShader;
-	fragmentShader: WebGLShader;
+	vertexShader: string;
+	fragmentShader: string;
 	numMultiviewViews: number;
 	/**
 	 * @deprecated Use {@link WebGLProgram#getUniforms getUniforms()} instead.


### PR DESCRIPTION
Fix d.ts for WebGLProgram - vertexShader and fragmentShader are plain strings, not WebGLShader objects