### PR TITLE
Font: Add hint for IE11 workaround.

### DIFF
--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -39,7 +39,7 @@ Object.assign( Font.prototype, {
 
 function createPaths( text, size, data ) {
 
-	var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // see #13988
+	var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // workaround for IE11, see #13988
 	var scale = size / data.resolution;
 	var line_height = ( data.boundingBox.yMax - data.boundingBox.yMin + data.underlineThickness ) * scale;
 


### PR DESCRIPTION
If support for Internet Explorer is stopped at some point (see #18091), the `Array.from()` fallback can be removed, too.