### PR TITLE
Build: switch to a custom class transform using Babel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,118 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.0.tgz",
+      "integrity": "sha512-3rqPi/bv/Xfu2YzHvBz4XqMI1fKVwnhntPA1/fjoECrSjrhbOCxlTrbVu5gUtr8zkxW+RpkDOa/HCW93gzS2Dw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.0",
+        "@babel/generator": "^7.8.0",
+        "@babel/helpers": "^7.8.0",
+        "@babel/parser": "^7.8.0",
+        "@babel/template": "^7.8.0",
+        "@babel/traverse": "^7.8.0",
+        "@babel/types": "^7.8.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+          "integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+          "integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+      "integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+      "integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.0",
+        "@babel/template": "^7.8.0",
+        "@babel/types": "^7.8.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+      "integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+      "integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+      "integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.0.tgz",
+      "integrity": "sha512-srWKpjAFbiut5JoCReZJ098hLqoZ9HufOnKZPggc7j74XaPuQ+9b3RYPV1M/HfjL63lCNd8uI1O487qIWxAFNA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.0",
+        "@babel/traverse": "^7.8.0",
+        "@babel/types": "^7.8.0"
+      }
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -22,6 +134,101 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+      "integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+      "integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.0",
+        "@babel/parser": "^7.8.0",
+        "@babel/types": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+          "integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+          "integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+      "integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.0",
+        "@babel/generator": "^7.8.0",
+        "@babel/helper-function-name": "^7.8.0",
+        "@babel/helper-split-export-declaration": "^7.8.0",
+        "@babel/parser": "^7.8.0",
+        "@babel/types": "^7.8.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+          "integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+          "integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+      "integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@types/eslint-visitor-keys": {
@@ -111,18 +318,6 @@
       "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
-      "dev": true
-    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -203,36 +398,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "buble": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
-      "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
-      "dev": true,
-      "requires": {
-        "acorn": "^6.1.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.0.1",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.3",
-        "minimist": "^1.2.0",
-        "os-homedir": "^2.0.0",
-        "regexpu-core": "^4.5.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "callsites": {
@@ -404,6 +569,15 @@
         "supports-color": "^6.1.0",
         "tree-kill": "^1.2.2",
         "yargs": "^13.3.0"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
       }
     },
     "core-util-is": {
@@ -831,6 +1005,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1166,9 +1346,9 @@
       }
     },
     "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -1188,6 +1368,23 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1220,15 +1417,6 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
-    },
-    "magic-string": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
-      "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "mime": {
       "version": "1.6.0",
@@ -1363,12 +1551,6 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
-    },
-    "os-homedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-      "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
-      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -1547,55 +1729,11 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
-    },
-    "regenerate-unicode-properties": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0"
-      }
-    },
     "regexpp": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
       "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
       "dev": true
-    },
-    "regexpu-core": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.1.0",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
-      }
-    },
-    "regjsgen": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -1672,20 +1810,20 @@
         "acorn": "^7.1.0"
       }
     },
-    "rollup-plugin-buble": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-buble/-/rollup-plugin-buble-0.19.8.tgz",
-      "integrity": "sha512-8J4zPk2DQdk3rxeZvxgzhHh/rm5nJkjwgcsUYisCQg1QbT5yagW+hehYEW7ZNns/NVbDCTv4JQ7h4fC8qKGOKw==",
+    "rollup-plugin-babel": {
+      "version": "5.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-5.0.0-alpha.1.tgz",
+      "integrity": "sha512-UDuSQCpHhgNvyVvtwLaqx00eGcj2uF9swdPcUJ3rBkDEvthwvKA2JoduTqUPbK5zUIvbKlLgqZ3KAHL8Eu027w==",
       "dev": true,
       "requires": {
-        "buble": "^0.19.8",
-        "rollup-pluginutils": "^2.3.3"
+        "@babel/helper-module-imports": "^7.7.4",
+        "rollup-pluginutils": "^2.8.2"
       }
     },
     "rollup-pluginutils": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-      "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
@@ -1775,12 +1913,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
       "dev": true
     },
     "spawn-command": {
@@ -1904,6 +2036,12 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -1944,34 +2082,6 @@
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
       "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
-      "dev": true
-    },
-    "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
-    },
-    "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
-      "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      }
-    },
-    "unicode-match-property-value-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-      "dev": true
-    },
-    "unicode-property-aliases-ecmascript": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
     "union": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "homepage": "https://threejs.org/",
   "devDependencies": {
+    "@babel/core": "^7.8.0",
     "@types/webgl2": "^0.0.5",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
@@ -84,7 +85,7 @@
     "http-server": "^0.12.0",
     "qunit": "^2.9.3",
     "rollup": "^1.28.0",
-    "rollup-plugin-buble": "^0.19.8",
+    "rollup-plugin-babel": "^5.0.0-alpha.1",
     "typescript": "^3.7.4"
   },
   "jspm": {

--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -11,92 +11,91 @@ import { WrapAroundEnding, ZeroCurvatureEnding, ZeroSlopeEnding, LoopPingPong, L
  *
  */
 
-function AnimationAction( mixer, clip, localRoot ) {
+class AnimationAction {
 
-	this._mixer = mixer;
-	this._clip = clip;
-	this._localRoot = localRoot || null;
+	constructor( mixer, clip, localRoot ) {
 
-	var tracks = clip.tracks,
-		nTracks = tracks.length,
-		interpolants = new Array( nTracks );
+		this._mixer = mixer;
+		this._clip = clip;
+		this._localRoot = localRoot || null;
 
-	var interpolantSettings = {
-		endingStart: ZeroCurvatureEnding,
-		endingEnd: ZeroCurvatureEnding
-	};
+		var tracks = clip.tracks,
+			nTracks = tracks.length,
+			interpolants = new Array( nTracks );
 
-	for ( var i = 0; i !== nTracks; ++ i ) {
+		var interpolantSettings = {
+			endingStart: ZeroCurvatureEnding,
+			endingEnd: ZeroCurvatureEnding
+		};
 
-		var interpolant = tracks[ i ].createInterpolant( null );
-		interpolants[ i ] = interpolant;
-		interpolant.settings = interpolantSettings;
+		for ( var i = 0; i !== nTracks; ++ i ) {
+
+			var interpolant = tracks[ i ].createInterpolant( null );
+			interpolants[ i ] = interpolant;
+			interpolant.settings = interpolantSettings;
+
+		}
+
+		this._interpolantSettings = interpolantSettings;
+
+		this._interpolants = interpolants; // bound by the mixer
+
+		// inside: PropertyMixer (managed by the mixer)
+		this._propertyBindings = new Array( nTracks );
+
+		this._cacheIndex = null; // for the memory manager
+		this._byClipCacheIndex = null; // for the memory manager
+
+		this._timeScaleInterpolant = null;
+		this._weightInterpolant = null;
+
+		this.loop = LoopRepeat;
+		this._loopCount = - 1;
+
+		// global mixer time when the action is to be started
+		// it's set back to 'null' upon start of the action
+		this._startTime = null;
+
+		// scaled local time of the action
+		// gets clamped or wrapped to 0..clip.duration according to loop
+		this.time = 0;
+
+		this.timeScale = 1;
+		this._effectiveTimeScale = 1;
+
+		this.weight = 1;
+		this._effectiveWeight = 1;
+
+		this.repetitions = Infinity; // no. of repetitions when looping
+
+		this.paused = false; // true -> zero effective time scale
+		this.enabled = true; // false -> zero effective weight
+
+		this.clampWhenFinished = false;// keep feeding the last frame?
+
+		this.zeroSlopeAtStart = true;// for smooth interpolation w/o separate
+		this.zeroSlopeAtEnd = true;// clips for start, loop and end
 
 	}
 
-	this._interpolantSettings = interpolantSettings;
-
-	this._interpolants = interpolants; // bound by the mixer
-
-	// inside: PropertyMixer (managed by the mixer)
-	this._propertyBindings = new Array( nTracks );
-
-	this._cacheIndex = null; // for the memory manager
-	this._byClipCacheIndex = null; // for the memory manager
-
-	this._timeScaleInterpolant = null;
-	this._weightInterpolant = null;
-
-	this.loop = LoopRepeat;
-	this._loopCount = - 1;
-
-	// global mixer time when the action is to be started
-	// it's set back to 'null' upon start of the action
-	this._startTime = null;
-
-	// scaled local time of the action
-	// gets clamped or wrapped to 0..clip.duration according to loop
-	this.time = 0;
-
-	this.timeScale = 1;
-	this._effectiveTimeScale = 1;
-
-	this.weight = 1;
-	this._effectiveWeight = 1;
-
-	this.repetitions = Infinity; // no. of repetitions when looping
-
-	this.paused = false; // true -> zero effective time scale
-	this.enabled = true; // false -> zero effective weight
-
-	this.clampWhenFinished = false;// keep feeding the last frame?
-
-	this.zeroSlopeAtStart = true;// for smooth interpolation w/o separate
-	this.zeroSlopeAtEnd = true;// clips for start, loop and end
-
-}
-
-Object.assign( AnimationAction.prototype, {
-
 	// State & Scheduling
-
-	play: function () {
+	play() {
 
 		this._mixer._activateAction( this );
 
 		return this;
 
-	},
+	}
 
-	stop: function () {
+	stop() {
 
 		this._mixer._deactivateAction( this );
 
 		return this.reset();
 
-	},
+	}
 
-	reset: function () {
+	reset() {
 
 		this.paused = false;
 		this.enabled = true;
@@ -107,45 +106,45 @@ Object.assign( AnimationAction.prototype, {
 
 		return this.stopFading().stopWarping();
 
-	},
+	}
 
-	isRunning: function () {
+	isRunning() {
 
 		return this.enabled && ! this.paused && this.timeScale !== 0 &&
 			this._startTime === null && this._mixer._isActiveAction( this );
 
-	},
+	}
 
 	// return true when play has been called
-	isScheduled: function () {
+	isScheduled() {
 
 		return this._mixer._isActiveAction( this );
 
-	},
+	}
 
-	startAt: function ( time ) {
+	startAt( time ) {
 
 		this._startTime = time;
 
 		return this;
 
-	},
+	}
 
-	setLoop: function ( mode, repetitions ) {
+	setLoop( mode, repetitions ) {
 
 		this.loop = mode;
 		this.repetitions = repetitions;
 
 		return this;
 
-	},
+	}
 
 	// Weight
 
 	// set the weight stopping any scheduled fading
 	// although .enabled = false yields an effective weight of zero, this
 	// method does *not* change .enabled, because it would be confusing
-	setEffectiveWeight: function ( weight ) {
+	setEffectiveWeight( weight ) {
 
 		this.weight = weight;
 
@@ -154,28 +153,28 @@ Object.assign( AnimationAction.prototype, {
 
 		return this.stopFading();
 
-	},
+	}
 
 	// return the weight considering fading and .enabled
-	getEffectiveWeight: function () {
+	getEffectiveWeight() {
 
 		return this._effectiveWeight;
 
-	},
+	}
 
-	fadeIn: function ( duration ) {
+	fadeIn( duration ) {
 
 		return this._scheduleFading( duration, 0, 1 );
 
-	},
+	}
 
-	fadeOut: function ( duration ) {
+	fadeOut( duration ) {
 
 		return this._scheduleFading( duration, 1, 0 );
 
-	},
+	}
 
-	crossFadeFrom: function ( fadeOutAction, duration, warp ) {
+	crossFadeFrom( fadeOutAction, duration, warp ) {
 
 		fadeOutAction.fadeOut( duration );
 		this.fadeIn( duration );
@@ -195,15 +194,15 @@ Object.assign( AnimationAction.prototype, {
 
 		return this;
 
-	},
+	}
 
-	crossFadeTo: function ( fadeInAction, duration, warp ) {
+	crossFadeTo( fadeInAction, duration, warp ) {
 
 		return fadeInAction.crossFadeFrom( this, duration, warp );
 
-	},
+	}
 
-	stopFading: function () {
+	stopFading() {
 
 		var weightInterpolant = this._weightInterpolant;
 
@@ -216,53 +215,53 @@ Object.assign( AnimationAction.prototype, {
 
 		return this;
 
-	},
+	}
 
 	// Time Scale Control
 
 	// set the time scale stopping any scheduled warping
 	// although .paused = true yields an effective time scale of zero, this
 	// method does *not* change .paused, because it would be confusing
-	setEffectiveTimeScale: function ( timeScale ) {
+	setEffectiveTimeScale( timeScale ) {
 
 		this.timeScale = timeScale;
 		this._effectiveTimeScale = this.paused ? 0 : timeScale;
 
 		return this.stopWarping();
 
-	},
+	}
 
 	// return the time scale considering warping and .paused
-	getEffectiveTimeScale: function () {
+	getEffectiveTimeScale() {
 
 		return this._effectiveTimeScale;
 
-	},
+	}
 
-	setDuration: function ( duration ) {
+	setDuration( duration ) {
 
 		this.timeScale = this._clip.duration / duration;
 
 		return this.stopWarping();
 
-	},
+	}
 
-	syncWith: function ( action ) {
+	syncWith( action ) {
 
 		this.time = action.time;
 		this.timeScale = action.timeScale;
 
 		return this.stopWarping();
 
-	},
+	}
 
-	halt: function ( duration ) {
+	halt( duration ) {
 
 		return this.warp( this._effectiveTimeScale, 0, duration );
 
-	},
+	}
 
-	warp: function ( startTimeScale, endTimeScale, duration ) {
+	warp( startTimeScale, endTimeScale, duration ) {
 
 		var mixer = this._mixer, now = mixer.time,
 			interpolant = this._timeScaleInterpolant,
@@ -287,9 +286,9 @@ Object.assign( AnimationAction.prototype, {
 
 		return this;
 
-	},
+	}
 
-	stopWarping: function () {
+	stopWarping() {
 
 		var timeScaleInterpolant = this._timeScaleInterpolant;
 
@@ -302,31 +301,31 @@ Object.assign( AnimationAction.prototype, {
 
 		return this;
 
-	},
+	}
 
 	// Object Accessors
 
-	getMixer: function () {
+	getMixer() {
 
 		return this._mixer;
 
-	},
+	}
 
-	getClip: function () {
+	getClip() {
 
 		return this._clip;
 
-	},
+	}
 
-	getRoot: function () {
+	getRoot() {
 
 		return this._localRoot || this._mixer._root;
 
-	},
+	}
 
 	// Interna
 
-	_update: function ( time, deltaTime, timeDirection, accuIndex ) {
+	_update( time, deltaTime, timeDirection, accuIndex ) {
 
 		// called by the mixer
 
@@ -383,9 +382,9 @@ Object.assign( AnimationAction.prototype, {
 
 		}
 
-	},
+	}
 
-	_updateWeight: function ( time ) {
+	_updateWeight( time ) {
 
 		var weight = 0;
 
@@ -420,9 +419,9 @@ Object.assign( AnimationAction.prototype, {
 		this._effectiveWeight = weight;
 		return weight;
 
-	},
+	}
 
-	_updateTimeScale: function ( time ) {
+	_updateTimeScale( time ) {
 
 		var timeScale = 0;
 
@@ -463,9 +462,9 @@ Object.assign( AnimationAction.prototype, {
 		this._effectiveTimeScale = timeScale;
 		return timeScale;
 
-	},
+	}
 
-	_updateTime: function ( deltaTime ) {
+	_updateTime( deltaTime ) {
 
 		var time = this.time + deltaTime;
 		var duration = this._clip.duration;
@@ -619,9 +618,9 @@ Object.assign( AnimationAction.prototype, {
 
 		return time;
 
-	},
+	}
 
-	_setEndings: function ( atStart, atEnd, pingPong ) {
+	_setEndings( atStart, atEnd, pingPong ) {
 
 		var settings = this._interpolantSettings;
 
@@ -656,9 +655,9 @@ Object.assign( AnimationAction.prototype, {
 
 		}
 
-	},
+	}
 
-	_scheduleFading: function ( duration, weightNow, weightThen ) {
+	_scheduleFading( duration, weightNow, weightThen ) {
 
 		var mixer = this._mixer, now = mixer.time,
 			interpolant = this._weightInterpolant;
@@ -682,7 +681,6 @@ Object.assign( AnimationAction.prototype, {
 
 	}
 
-} );
-
+}
 
 export { AnimationAction };

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -16,103 +16,96 @@ import { MathUtils } from '../math/MathUtils.js';
  * @author David Sarno / http://lighthaus.us/
  */
 
-function AnimationClip( name, duration, tracks ) {
+class AnimationClip {
 
-	this.name = name;
-	this.tracks = tracks;
-	this.duration = ( duration !== undefined ) ? duration : - 1;
+	constructor( name, duration, tracks ) {
 
-	this.uuid = MathUtils.generateUUID();
+		this.name = name;
+		this.tracks = tracks;
+		this.duration = ( duration !== undefined ) ? duration : - 1;
 
-	// this means it should figure out its duration by scanning the tracks
-	if ( this.duration < 0 ) {
+		this.uuid = MathUtils.generateUUID();
 
-		this.resetDuration();
+		// this means it should figure out its duration by scanning the tracks
+		if ( this.duration < 0 ) {
 
-	}
+			this.resetDuration();
 
-}
-
-function getTrackTypeForValueTypeName( typeName ) {
-
-	switch ( typeName.toLowerCase() ) {
-
-		case 'scalar':
-		case 'double':
-		case 'float':
-		case 'number':
-		case 'integer':
-
-			return NumberKeyframeTrack;
-
-		case 'vector':
-		case 'vector2':
-		case 'vector3':
-		case 'vector4':
-
-			return VectorKeyframeTrack;
-
-		case 'color':
-
-			return ColorKeyframeTrack;
-
-		case 'quaternion':
-
-			return QuaternionKeyframeTrack;
-
-		case 'bool':
-		case 'boolean':
-
-			return BooleanKeyframeTrack;
-
-		case 'string':
-
-			return StringKeyframeTrack;
+		}
 
 	}
 
-	throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
+	resetDuration() {
 
-}
+		var tracks = this.tracks, duration = 0;
 
-function parseKeyframeTrack( json ) {
+		for ( var i = 0, n = tracks.length; i !== n; ++ i ) {
 
-	if ( json.type === undefined ) {
+			var track = this.tracks[ i ];
 
-		throw new Error( 'THREE.KeyframeTrack: track type undefined, can not parse' );
+			duration = Math.max( duration, track.times[ track.times.length - 1 ] );
 
-	}
+		}
 
-	var trackType = getTrackTypeForValueTypeName( json.type );
+		this.duration = duration;
 
-	if ( json.times === undefined ) {
-
-		var times = [], values = [];
-
-		AnimationUtils.flattenJSON( json.keys, times, values, 'value' );
-
-		json.times = times;
-		json.values = values;
+		return this;
 
 	}
 
-	// derived classes can define a static parse method
-	if ( trackType.parse !== undefined ) {
+	trim() {
 
-		return trackType.parse( json );
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
 
-	} else {
+			this.tracks[ i ].trim( 0, this.duration );
 
-		// by default, we assume a constructor compatible with the base
-		return new trackType( json.name, json.times, json.values, json.interpolation );
+		}
+
+		return this;
 
 	}
 
-}
+	validate() {
 
-Object.assign( AnimationClip, {
+		var valid = true;
 
-	parse: function ( json ) {
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
+
+			valid = valid && this.tracks[ i ].validate();
+
+		}
+
+		return valid;
+
+	}
+
+	optimize() {
+
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
+
+			this.tracks[ i ].optimize();
+
+		}
+
+		return this;
+
+	}
+
+	clone() {
+
+		var tracks = [];
+
+		for ( var i = 0; i < this.tracks.length; i ++ ) {
+
+			tracks.push( this.tracks[ i ].clone() );
+
+		}
+
+		return new AnimationClip( this.name, this.duration, tracks );
+
+	}
+
+	static parse( json ) {
 
 		var tracks = [],
 			jsonTracks = json.tracks,
@@ -126,9 +119,9 @@ Object.assign( AnimationClip, {
 
 		return new AnimationClip( json.name, json.duration, tracks );
 
-	},
+	}
 
-	toJSON: function ( clip ) {
+	static toJSON( clip ) {
 
 		var tracks = [],
 			clipTracks = clip.tracks;
@@ -150,9 +143,9 @@ Object.assign( AnimationClip, {
 
 		return json;
 
-	},
+	}
 
-	CreateFromMorphTargetSequence: function ( name, morphTargetSequence, fps, noLoop ) {
+	static CreateFromMorphTargetSequence( name, morphTargetSequence, fps, noLoop ) {
 
 		var numMorphTargets = morphTargetSequence.length;
 		var tracks = [];
@@ -192,9 +185,9 @@ Object.assign( AnimationClip, {
 
 		return new AnimationClip( name, - 1, tracks );
 
-	},
+	}
 
-	findByName: function ( objectOrClipArray, name ) {
+	static findByName( objectOrClipArray, name ) {
 
 		var clipArray = objectOrClipArray;
 
@@ -217,9 +210,9 @@ Object.assign( AnimationClip, {
 
 		return null;
 
-	},
+	}
 
-	CreateClipsFromMorphTargetSequences: function ( morphTargets, fps, noLoop ) {
+	static CreateClipsFromMorphTargetSequences( morphTargets, fps, noLoop ) {
 
 		var animationToMorphTargets = {};
 
@@ -261,10 +254,10 @@ Object.assign( AnimationClip, {
 
 		return clips;
 
-	},
+	}
 
 	// parse the animation.hierarchy format
-	parseAnimation: function ( animation, bones ) {
+	static parseAnimation( animation, bones ) {
 
 		if ( ! animation ) {
 
@@ -387,81 +380,83 @@ Object.assign( AnimationClip, {
 
 	}
 
-} );
+}
 
-Object.assign( AnimationClip.prototype, {
+function getTrackTypeForValueTypeName( typeName ) {
 
-	resetDuration: function () {
+	switch ( typeName.toLowerCase() ) {
 
-		var tracks = this.tracks, duration = 0;
+		case 'scalar':
+		case 'double':
+		case 'float':
+		case 'number':
+		case 'integer':
 
-		for ( var i = 0, n = tracks.length; i !== n; ++ i ) {
+			return NumberKeyframeTrack;
 
-			var track = this.tracks[ i ];
+		case 'vector':
+		case 'vector2':
+		case 'vector3':
+		case 'vector4':
 
-			duration = Math.max( duration, track.times[ track.times.length - 1 ] );
+			return VectorKeyframeTrack;
 
-		}
+		case 'color':
 
-		this.duration = duration;
+			return ColorKeyframeTrack;
 
-		return this;
+		case 'quaternion':
 
-	},
+			return QuaternionKeyframeTrack;
 
-	trim: function () {
+		case 'bool':
+		case 'boolean':
 
-		for ( var i = 0; i < this.tracks.length; i ++ ) {
+			return BooleanKeyframeTrack;
 
-			this.tracks[ i ].trim( 0, this.duration );
+		case 'string':
 
-		}
-
-		return this;
-
-	},
-
-	validate: function () {
-
-		var valid = true;
-
-		for ( var i = 0; i < this.tracks.length; i ++ ) {
-
-			valid = valid && this.tracks[ i ].validate();
-
-		}
-
-		return valid;
-
-	},
-
-	optimize: function () {
-
-		for ( var i = 0; i < this.tracks.length; i ++ ) {
-
-			this.tracks[ i ].optimize();
-
-		}
-
-		return this;
-
-	},
-
-	clone: function () {
-
-		var tracks = [];
-
-		for ( var i = 0; i < this.tracks.length; i ++ ) {
-
-			tracks.push( this.tracks[ i ].clone() );
-
-		}
-
-		return new AnimationClip( this.name, this.duration, tracks );
+			return StringKeyframeTrack;
 
 	}
 
-} );
+	throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
 
+}
+
+function parseKeyframeTrack( json ) {
+
+	if ( json.type === undefined ) {
+
+		throw new Error( 'THREE.KeyframeTrack: track type undefined, can not parse' );
+
+	}
+
+	var trackType = getTrackTypeForValueTypeName( json.type );
+
+	if ( json.times === undefined ) {
+
+		var times = [], values = [];
+
+		AnimationUtils.flattenJSON( json.keys, times, values, 'value' );
+
+		json.times = times;
+		json.values = values;
+
+	}
+
+	// derived classes can define a static parse method
+	if ( trackType.parse !== undefined ) {
+
+		return trackType.parse( json );
+
+	} else {
+
+		// by default, we assume a constructor compatible with the base
+		return new trackType( json.name, json.times, json.values, json.interpolation );
+
+	}
+
+}
 
 export { AnimationClip };

--- a/utils/build/class-transform.js
+++ b/utils/build/class-transform.js
@@ -1,0 +1,172 @@
+const classTransform = ( { types: t, template } ) => {
+
+	const buildInheritingNodes = template.statements( `
+		SUBCLASS.prototype = Object.create( SUPERCLASS.prototype );
+		SUBCLASS.prototype.constructor = SUBCLASS;
+	` );
+
+	const buildMethodNode = template.statement( `
+		CLASS.prototype.METHOD_NAME = METHOD;
+	` );
+
+	const buildStaticMethodNode = template.statement( `
+		CLASS.METHOD_NAME = METHOD;
+	` );
+
+	return {
+		name: 'three.js-class-transform',
+		visitor: {
+			ClassExpression() {
+
+				throw new Error( 'Transforming ClassExpressions is not supported currently. Please make it a declaration.' );
+
+			},
+			ClassDeclaration( path ) {
+
+				const className = path.node.id.name;
+				const superClass = path.node.superClass;
+
+				const classBody = {
+					constructor: null,
+					methods: [],
+					staticMethods: [],
+				};
+
+				for ( let p of path.get( 'body.body' ) ) {
+
+					if ( ! t.isClassMethod( p.node ) ) {
+
+						throw new Error( 'Only transforming class methods is supported currently.' );
+
+					}
+
+					if ( p.node.computed ) {
+
+						throw new Error( 'Transforming computed method names is not supported currently.' );
+
+					}
+
+					switch ( p.node.kind ) {
+
+						case 'constructor':
+							classBody.constructor = p;
+							break;
+						case 'method':
+							if ( p.node.static ) {
+
+								classBody.staticMethods.push( p );
+
+							} else {
+
+								classBody.methods.push( p );
+
+							}
+							break;
+						default:
+							throw new Error( `Transforming a class method of kind "${p.node.kind}" is not supported currently.` );
+
+					}
+
+				}
+
+				if ( ! classBody.constructor ) {
+
+					throw new Error( 'Currently a class has to have an explicit constructor method.' );
+
+				}
+
+
+				if ( superClass ) {
+
+					if ( ! t.isIdentifier( superClass ) ) {
+
+						throw new Error( 'Only extending an identifier (a variable) is allowed.' );
+
+					}
+
+					// rewrite super(...args)
+					classBody.constructor.traverse( {
+
+						Function( path ) {
+
+							path.skip();
+
+						},
+
+						Super( path ) {
+
+							if ( ! path.parentPath.isCallExpression() ) {
+
+								throw new Error( '`super` can only be called currently (as calling super class\' constructor).' );
+
+							}
+
+							path.parentPath.node.arguments.unshift( t.thisExpression() );
+							path.parentPath.get( 'callee' ).replaceWith(
+								t.memberExpression(
+									t.cloneNode( superClass ),
+									t.identifier( 'call' ),
+								)
+							);
+
+						}
+					} );
+
+				}
+
+				const output = [
+					t.functionDeclaration(
+						t.identifier( className ),
+						classBody.constructor.node.params,
+						classBody.constructor.node.body
+					)
+				];
+
+				if ( superClass ) {
+
+					output.push(
+						...buildInheritingNodes( {
+							SUBCLASS: t.identifier( className ),
+							SUPERCLASS: t.cloneNode( superClass ),
+						} )
+					);
+
+				}
+
+				output.push(
+					...classBody.methods.map(
+						p => buildMethodNode( {
+							CLASS: t.identifier( className ),
+							METHOD_NAME: t.cloneNode( p.node.key ),
+							METHOD: t.functionExpression(
+								p.node.key,
+								p.node.params,
+								p.node.body,
+							)
+						} )
+					)
+				);
+
+				output.push(
+					...classBody.staticMethods.map(
+						p => buildStaticMethodNode( {
+							CLASS: t.identifier( className ),
+							METHOD_NAME: t.cloneNode( p.node.key ),
+							METHOD: t.functionExpression(
+								p.node.key,
+								p.node.params,
+								p.node.body,
+							)
+						} )
+					)
+				);
+
+				path.replaceWithMultiple( output );
+
+			}
+		}
+	};
+
+};
+
+export default classTransform;

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -1,4 +1,5 @@
-import buble from 'rollup-plugin-buble';
+import babel from 'rollup-plugin-babel';
+import classTransform from './class-transform';
 
 function glconstants() {
 
@@ -206,11 +207,12 @@ export default [
 		plugins: [
 			glconstants(),
 			glsl(),
-			buble( {
-				transforms: {
-					arrow: false,
-					classes: true
-				}
+			babel( {
+				babelrc: false,
+				configFile: false,
+				skipPreflightCheck: true,
+				babelHelpers: 'bundled',
+				plugins: [ classTransform ]
 			} )
 		],
 		output: [


### PR DESCRIPTION
After a short [Twitter discussion](https://twitter.com/mrdoob/status/1216138181189537794) about making Three more tree-shakeable and a private conversation with @mrdoob about it I've prepared this PR.

One of the greatest tree-shaking offenders are:
- top-level scope function calls
- top-level property reads & writes

So continuing to use a custom, hand-written, classes with prototypes manipulation you fall into this trap. The recommendation on this one is to just rewrite your classes to class syntax - you have a "legacy" build that has to support es5 environments though. So given the fact that various tools can produce a sub-optimal output for you (because they operate on a generic case, they often need to handle edge cases etc) and you are not so fond about that, the preferred way to handle this situation is to just write a custom class transform, which can output any code structure you like.

This PR doesn't implement all the stuff that is needed to **really** support transpiling ES classes, but I throw various errors in the transform itself, which should help you catch unsupported cases early. And the logic can always be extended to handle more.

I've also converted 2 classes - `AnimationClip` & `AnimationAction` - as it made my development of this easier (I had more test cases with them, so to speak).
