### PR TITLE
ColorSpaceNode: workaround for shader compile error

### DIFF
--- a/examples/jsm/nodes/utils/ColorSpaceNode.js
+++ b/examples/jsm/nodes/utils/ColorSpaceNode.js
@@ -128,7 +128,7 @@ ColorSpaceNode.Nodes = ( function () {
 
 		"	float maxRGB = max( value.x, max( value.g, value.b ) );",
 		"	float D      = max( maxRange / maxRGB, 1.0 );",
-		"	D            = min( floor( D ) / 255.0, 1.0 );",
+		"	D            = clamp( floor( D ) / 255.0, 0.0, 1.0 );",
 		"	return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );",
 
 		"}"


### PR DESCRIPTION
Follows from #18299.

Trying to keep Node in-sync.  :-)
