### PR TITLE
GLTFExporter: Add null check for skeleton while processing skinned mesh.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1648,7 +1648,7 @@ THREE.GLTFExporter.prototype = {
 			var skeleton = object.skeleton;
 			var rootJoint = object.skeleton.bones[ 0 ];
 
-			if ( rootJoint === undefined ) return null;
+			if ( skeleton === undefined || rootJoint === undefined ) return null;
 
 			var joints = [];
 			var inverseBindMatrices = new Float32Array( skeleton.bones.length * 16 );

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1646,9 +1646,12 @@ THREE.GLTFExporter.prototype = {
 			var node = outputJSON.nodes[ nodeMap.get( object ) ];
 
 			var skeleton = object.skeleton;
+
+			if ( skeleton === undefined ) return null;
+
 			var rootJoint = object.skeleton.bones[ 0 ];
 
-			if ( skeleton === undefined || rootJoint === undefined ) return null;
+			if ( rootJoint === undefined ) return null;
 
 			var joints = [];
 			var inverseBindMatrices = new Float32Array( skeleton.bones.length * 16 );


### PR DESCRIPTION
I have an situation where I have skinned meshes without the attached skeletons on export and need to check if skeleton is null before proceeding