### PR TITLE
Allow setting opacity in LineMaterial example

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -4,6 +4,7 @@
  * parameters = {
  *  color: <hex>,
  *  linewidth: <float>,
+ *  opacity: <float>,
  *  dashed: <boolean>,
  *  dashScale: <float>,
  *  dashSize: <float>,
@@ -16,6 +17,7 @@ THREE.UniformsLib.line = {
 
 	linewidth: { value: 1 },
 	resolution: { value: new THREE.Vector2( 1, 1 ) },
+	opacity: { value: 1 },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
 	gapSize: { value: 1 } // todo FIX - maybe change to totalSize
@@ -359,6 +361,24 @@ THREE.LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.resolution.value.copy( value );
+
+			}
+
+		},
+
+		opacity: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.opacity.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.opacity.value = value;
 
 			}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -4,6 +4,7 @@
  * parameters = {
  *  color: <hex>,
  *  linewidth: <float>,
+ *  opacity: <float>,
  *  dashed: <boolean>,
  *  dashScale: <float>,
  *  dashSize: <float>,
@@ -24,6 +25,7 @@ UniformsLib.line = {
 
 	linewidth: { value: 1 },
 	resolution: { value: new Vector2( 1, 1 ) },
+	opacity: { value: 1 },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
 	gapSize: { value: 1 } // todo FIX - maybe change to totalSize
@@ -367,6 +369,24 @@ var LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.resolution.value.copy( value );
+
+			}
+
+		},
+
+		opacity: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.opacity.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.opacity.value = value;
 
 			}
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -94,7 +94,8 @@
 					linewidth: 5, // in pixels
 					vertexColors: THREE.VertexColors,
 					//resolution:  // to be set by renderer, eventually
-					dashed: false
+					dashed: false,
+					transparent: true // needed for opacity
 
 				} );
 
@@ -195,6 +196,7 @@
 				var param = {
 					'line type': 0,
 					'width (px)': 5,
+					'opacity': 1,
 					'dashed': false,
 					'dash scale': 1,
 					'dash / gap': 1
@@ -226,6 +228,14 @@
 				gui.add( param, 'width (px)', 1, 10 ).onChange( function ( val ) {
 
 					matLine.linewidth = val;
+
+				} );
+
+				gui.add( param, 'opacity', 0, 1 ).onChange( function ( val ) {
+
+					matLine.opacity = val;
+					matLineBasic.opacity = val;
+					matLineDashed.opacity = val;
 
 				} );
 


### PR DESCRIPTION
This  PR adds support for setting the opacity of the example LineMaterial.

Code was changed in the `examples/js` directory and compiled to `examples/jsm` using the util script. However, I'm not sure if we're supposed to add this output to a PR.