### PR TITLE
WebGLRenderLists: Avoid possible memory leak when managing render items.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1173,6 +1173,8 @@ function WebGLRenderer( parameters ) {
 
 		projectObject( scene, camera, 0, _this.sortObjects );
 
+		currentRenderList.cleanup();
+
 		if ( _this.sortObjects === true ) {
 
 			currentRenderList.sort( _opaqueSort, _transparentSort );

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -137,6 +137,25 @@ function WebGLRenderList() {
 
 	}
 
+	// remove any dangling references to make sure no memory is leaked
+	// when the count of objects in a scene is reduced
+	function cleanup() {
+
+		for ( var i = renderItemsIndex; i < renderItems.length; i ++ ) {
+
+			var renderItem = renderItems[ i ];
+			if ( renderItem.id === null ) break;
+			renderItem.object = null;
+			renderItem.geometry = null;
+			renderItem.material = null;
+			renderItem.group = null;
+			renderItem.program = null;
+			renderItem.id = null;
+
+		}
+
+	}
+
 	return {
 		opaque: opaque,
 		transparent: transparent,
@@ -144,6 +163,7 @@ function WebGLRenderList() {
 		init: init,
 		push: push,
 		unshift: unshift,
+		cleanup: cleanup,
 
 		sort: sort
 	};


### PR DESCRIPTION
This is rework of #15036 and follow up to #12464, as the issue was either not fixed in #12464 or resurfaced.

Explanation of the issue
========================

When the application is rendering and scene with many objects and for some reason the count of the objects in the scene is reduced, the `WebGLRenderItemList` may contain `renderItems` which are no longer used, but never overwritten with a new content. Those `renderItems` contain several  references to various objects, esp. `object`, `geometry`, and `material`. If any of those referenced objects is no longer used, this introduces a memory leak.

While the issue is not probably met by a typical application, it can get quite serious in a degenerate case. Imagine an application with a procedurally generated content. When the user moves to a less complex part of the scene, the content used in previous frame is left lingering in memory.

Explanation of the fix
======================

The fix undestands the reason why `WebGLRenderItemList.renderItems` are not cleared in each frame - we want to reuse previous `renderItems` to avoid having to allocated new `RenderItem` objects. This behaviour is left intact, no `RenderItem` objects are released, only their references are set to `null` so that their existence is not forcing an existence of other objects.

Moreover, the fix behaviour is incremental, it only walks through the `renderItems` which were used in a previous frame but are not used in this one, and only until an already cleaned item is met (this was invented in #12464 by @takahirox). Therefore typical running time in a normal scene is extremely low. The only situation where any significant number of items is walked is when the scene is significantly reduced from previous frame. Therefore the impact of the fix for applications not experiencing this issue is almost zero.

Fixes #12447