### PR TITLE
Implement polygon offset possibility for shadows

### DIFF
--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - Shadows with a polygon offset example </title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+		<div id="info">
+		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Shadows with a polygon offset example by <a href="https://github.com/OndrejSpanel">Ondřej Španěl</a>
+		</div>
+
+		<script type="module">
+
+			import * as THREE from '../build/three.module.js';
+
+			import Stats from './jsm/libs/stats.module.js';
+			import { GUI } from './jsm/libs/dat.gui.module.js';
+
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+
+			var camera, scene, renderer, clock, stats;
+			var dirLight, spotLight;
+			var torusKnot, dirGroup;
+			var groundMaterial, objectMaterial;
+
+			var config = {
+				'Bias': 0,
+				'Offset factor': 4,
+				'Offset units': 3000,
+			};
+
+			init();
+			animate();
+
+			function init() {
+
+				initScene();
+				initMisc();
+				
+				// Init gui
+				var gui = new GUI();
+
+				gui.add( config, 'Bias', -0.001, 0.001, 0.00001 ).min( -0.005 ).max( 0.005 ).onChange( function ( value ) {
+
+					dirLight.shadow.bias = value;
+					spotLight.shadow.bias = value;
+
+				} );
+
+				gui.add( config, 'Offset factor' ).min( -10 ).max( 10 ).onChange( function ( value ) {
+
+					groundMaterial.shadowPolygonOffsetFactor = value;
+					objectMaterial.shadowPolygonOffsetFactor = value;
+
+				} );
+
+				gui.add( config, 'Offset units' ).min( -10000 ).max( 10000 ).onChange( function ( value ) {
+
+					groundMaterial.shadowPolygonOffsetUnits = value;
+					objectMaterial.shadowPolygonOffsetUnits = value;
+
+				} );
+
+				document.body.appendChild( renderer.domElement );
+				window.addEventListener( 'resize', onWindowResize, false );
+
+			}
+
+			function initScene() {
+
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0, 10, 30 );
+
+				scene = new THREE.Scene();
+				scene.fog = new THREE.Fog( 0xCCCCCC, 50, 100 );
+
+				// Lights
+
+				scene.add( new THREE.AmbientLight( 0x444444 ) );
+
+				spotLight = new THREE.SpotLight( 0x888888 );
+				spotLight.name = 'Spot Light';
+				spotLight.angle = Math.PI / 5;
+				spotLight.penumbra = 0.3;
+				spotLight.position.set( 8, 10, 5 );
+				spotLight.castShadow = true;
+				spotLight.shadow.camera.near = 8;
+				spotLight.shadow.camera.far = 200;
+				spotLight.shadow.mapSize.width = 256;
+				spotLight.shadow.mapSize.height = 256;
+				spotLight.shadow.bias = config['Bias'];
+				spotLight.shadow.radius = 2;
+				scene.add( spotLight );
+
+
+				dirLight = new THREE.DirectionalLight( 0xFFFFFF, 1 );
+				dirLight.name = 'Dir. Light';
+				dirLight.position.set( 3, 12, 17 );
+				dirLight.castShadow = true;
+				dirLight.shadow.camera.near = 0.1;
+				dirLight.shadow.camera.far = 500;
+				dirLight.shadow.camera.right = 17;
+				dirLight.shadow.camera.left = - 17;
+				dirLight.shadow.camera.top	= 17;
+				dirLight.shadow.camera.bottom = - 17;
+				dirLight.shadow.mapSize.width = 512;
+				dirLight.shadow.mapSize.height = 512;
+				dirLight.shadow.radius = 2;
+				dirLight.shadow.bias = config['Bias'];
+				scene.add( dirLight );
+
+				dirGroup = new THREE.Group();
+				dirGroup.add( dirLight );
+				scene.add( dirGroup );
+
+				// Geometry
+
+				var geometry = new THREE.TorusKnotBufferGeometry( 25, 8, 75, 20 );
+				objectMaterial = new THREE.MeshPhongMaterial( {
+					color: 0x999999,
+					shininess: 0,
+					specular: 0x222222,
+					shadowSide: THREE.FrontSide,
+					shadowPolygonOffsetFactor: config[ 'Offset factor' ],
+					shadowPolygonOffsetUnits: config[ 'Offset units' ]
+				} );
+
+				torusKnot = new THREE.Mesh( geometry, objectMaterial );
+				torusKnot.scale.multiplyScalar( 1 / 18 );
+				torusKnot.position.y = 3;
+				torusKnot.castShadow = true;
+				torusKnot.receiveShadow = true;
+				scene.add( torusKnot );
+
+				var geometry = new THREE.CylinderBufferGeometry( 0.75, 0.75, 7, 32 );
+
+				var pillar1 = new THREE.Mesh( geometry, objectMaterial );
+				pillar1.position.set( 10, 3.5, 10 );
+				pillar1.castShadow = true;
+				pillar1.receiveShadow = true;
+
+				var pillar2 = pillar1.clone();
+				pillar2.position.set( 10, 3.5, -10 );
+				var pillar3 = pillar1.clone();
+				pillar3.position.set( -10, 3.5, 10 );
+				var pillar4 = pillar1.clone();
+				pillar4.position.set( -10, 3.5, -10 );
+
+				scene.add( pillar1 );
+				scene.add( pillar2 );
+				scene.add( pillar3 );
+				scene.add( pillar4 );
+
+				var geometry = new THREE.PlaneBufferGeometry( 200, 200 );
+				groundMaterial = new THREE.MeshPhongMaterial( {
+					color: 0x999999,
+					shininess: 0,
+					specular: 0x111111,
+					shadowSide: THREE.FrontSide,
+					shadowPolygonOffsetFactor: config[ 'Offset factor' ],
+					shadowPolygonOffsetUnits: config[ 'Offset units' ]
+				} );
+
+				var ground = new THREE.Mesh( geometry, groundMaterial );
+				ground.rotation.x = -Math.PI/2;
+				ground.scale.multiplyScalar( 3 );
+				ground.castShadow = true;
+				ground.receiveShadow = true;
+				scene.add( ground );
+
+			}
+
+			function initMisc() {
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.shadowMap.enabled = true;
+				renderer.shadowMap.type = THREE.PCFShadowMap;
+
+				renderer.setClearColor( 0xCCCCCC, 1 );
+
+				// Mouse control
+				var controls = new OrbitControls( camera, renderer.domElement );
+				controls.target.set( 0, 2, 0 );
+				controls.update();
+
+				clock = new THREE.Clock();
+
+				stats = new Stats();
+				document.body.appendChild( stats.dom );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+				stats.update();
+
+			}
+
+			function renderScene() {
+
+				renderer.render( scene, camera );
+
+			}
+
+			function render() {
+
+				var delta = clock.getDelta();
+				var time = clock.elapsedTime;
+
+				renderScene();
+
+				torusKnot.rotation.x += 0.25 * delta;
+				torusKnot.rotation.y += 2 * delta;
+				torusKnot.rotation.z += 1 * delta;
+
+				dirGroup.rotation.y += 0.7 * delta;
+				dirLight.position.z = 17 + Math.sin(time*0.001)*5;
+
+			}
+
+		</script>
+	</body>
+</html>

--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -88,8 +88,8 @@
 				spotLight.castShadow = true;
 				spotLight.shadow.camera.near = 8;
 				spotLight.shadow.camera.far = 200;
-				spotLight.shadow.mapSize.width = 256;
-				spotLight.shadow.mapSize.height = 256;
+				spotLight.shadow.mapSize.width = 64;
+				spotLight.shadow.mapSize.height = 64;
 				spotLight.shadow.bias = config['Bias'];
 				spotLight.shadow.radius = 2;
 				scene.add( spotLight );
@@ -105,8 +105,8 @@
 				dirLight.shadow.camera.left = - 17;
 				dirLight.shadow.camera.top	= 17;
 				dirLight.shadow.camera.bottom = - 17;
-				dirLight.shadow.mapSize.width = 512;
-				dirLight.shadow.mapSize.height = 512;
+				dirLight.shadow.mapSize.width = 128;
+				dirLight.shadow.mapSize.height = 128;
 				dirLight.shadow.radius = 2;
 				dirLight.shadow.bias = config['Bias'];
 				scene.add( dirLight );
@@ -225,12 +225,14 @@
 
 				renderScene();
 
+				/*
 				torusKnot.rotation.x += 0.25 * delta;
 				torusKnot.rotation.y += 2 * delta;
 				torusKnot.rotation.z += 1 * delta;
 
 				dirGroup.rotation.y += 0.7 * delta;
 				dirLight.position.z = 17 + Math.sin(time*0.001)*5;
+				 */
 
 			}
 

--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -27,6 +27,7 @@
 
 			var config = {
 				'Bias': 0,
+				'Resolution': 256,
 				ground: {
 					'Offset factor': 3,
 					'Offset units': 1000,
@@ -109,6 +110,15 @@
 
 				} );
 
+				gui.add( config, 'Resolution', [ 256, 512, 1024, 2048] ).onChange( function ( value ) {
+
+					dirLight.shadow.mapSize.width = value;
+					dirLight.shadow.mapSize.height = value;
+					dirLight.shadow.map.dispose();
+					dirLight.shadow.map = null;
+
+				} );
+
 				var groundFolder = gui.addFolder("Ground");
 				var objectFolder = gui.addFolder("Object");
 				groundFolder.open();
@@ -177,10 +187,10 @@
 				dirLight.shadow.camera.left = - 17;
 				dirLight.shadow.camera.top	= 17;
 				dirLight.shadow.camera.bottom = - 17;
-				dirLight.shadow.mapSize.width = 256;
-				dirLight.shadow.mapSize.height = 256;
+				dirLight.shadow.mapSize.width = config[ 'Resolution' ];
+				dirLight.shadow.mapSize.height = config[ 'Resolution' ];
 				dirLight.shadow.radius = 2;
-				dirLight.shadow.bias = config['Bias'];
+				dirLight.shadow.bias = config[ 'Bias' ];
 				scene.add( dirLight );
 
 				dirGroup = new THREE.Group();

--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -21,20 +21,20 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
 			var camera, scene, renderer, clock, stats;
-			var dirLight, spotLight;
+			var dirLight;
 			var torusKnot, dirGroup;
 			var groundMaterial, objectMaterial;
 
 			var config = {
 				'Bias': 0,
 				ground: {
-					'Offset factor': 4,
-					'Offset units': 3000,
+					'Offset factor': 3,
+					'Offset units': 1000,
 					'Shadow side': 'Front',
 				},
 				objects: {
-					'Offset factor': 4,
-					'Offset units': 3000,
+					'Offset factor': 3,
+					'Offset units': 1000,
 					'Shadow side': 'Back',
 				},
 			};
@@ -46,15 +46,66 @@
 
 				initScene();
 				initMisc();
-				
-				// Init gui
-				var gui = new GUI();
 
+				var presets =
+								{
+									"preset": "Default",
+									"closed": false,
+									"remembered": {
+										"Default": {
+											"0": {
+												"Bias": 0
+											},
+											"1": {
+												"Shadow side": "Front",
+												"Offset factor": 3,
+												"Offset units": 1000
+											},
+											"2": {
+												"Shadow side": "Front",
+												"Offset factor": 3,
+												"Offset units": 1000
+											}
+										},
+										"Bias": {
+											"0": {
+												"Bias": 0.0001
+											},
+											"1": {
+												"Shadow side": "Back",
+												"Offset factor": 0,
+												"Offset units": 0
+											},
+											"2": {
+												"Shadow side": "Back",
+												"Offset factor": 0,
+												"Offset units": 0
+											}
+										}
+									},
+									"folders": {
+										"Ground": {
+											"preset": "Default",
+											"closed": false,
+											"folders": {}
+										},
+										"Object": {
+											"preset": "Default",
+											"closed": false,
+											"folders": {}
+										}
+									}
+								};
+				// Init gui
+				var gui = new GUI({ load: presets, preset: 'Default' });
+
+				gui.remember(config);
+				gui.remember(config.ground);
+				gui.remember(config.objects);
 
 				gui.add( config, 'Bias', -0.001, 0.001, 0.00001 ).min( -0.005 ).max( 0.005 ).onChange( function ( value ) {
 
 					dirLight.shadow.bias = value;
-					spotLight.shadow.bias = value;
 
 				} );
 
@@ -107,7 +158,7 @@
 			function initScene() {
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0, 10, 30 );
+				camera.position.set( -20, 20, 20 );
 
 				scene = new THREE.Scene();
 				scene.fog = new THREE.Fog( 0xCCCCCC, 50, 100 );
@@ -116,24 +167,9 @@
 
 				scene.add( new THREE.AmbientLight( 0x444444 ) );
 
-				spotLight = new THREE.SpotLight( 0x888888 );
-				spotLight.name = 'Spot Light';
-				spotLight.angle = Math.PI / 5;
-				spotLight.penumbra = 0.3;
-				spotLight.position.set( 8, 10, 5 );
-				spotLight.castShadow = true;
-				spotLight.shadow.camera.near = 8;
-				spotLight.shadow.camera.far = 200;
-				spotLight.shadow.mapSize.width = 64;
-				spotLight.shadow.mapSize.height = 64;
-				spotLight.shadow.bias = config['Bias'];
-				spotLight.shadow.radius = 2;
-				scene.add( spotLight );
-
-
-				dirLight = new THREE.DirectionalLight( 0xFFFFFF, 1 );
+				dirLight = new THREE.DirectionalLight( 0xFFFFFF, 2 );
 				dirLight.name = 'Dir. Light';
-				dirLight.position.set( 3, 12, 17 );
+				dirLight.position.set( 8, 5, 20 );
 				dirLight.castShadow = true;
 				dirLight.shadow.camera.near = 0.1;
 				dirLight.shadow.camera.far = 500;
@@ -141,8 +177,8 @@
 				dirLight.shadow.camera.left = - 17;
 				dirLight.shadow.camera.top	= 17;
 				dirLight.shadow.camera.bottom = - 17;
-				dirLight.shadow.mapSize.width = 128;
-				dirLight.shadow.mapSize.height = 128;
+				dirLight.shadow.mapSize.width = 256;
+				dirLight.shadow.mapSize.height = 256;
 				dirLight.shadow.radius = 2;
 				dirLight.shadow.bias = config['Bias'];
 				scene.add( dirLight );
@@ -153,7 +189,6 @@
 
 				// Geometry
 
-				var geometry = new THREE.TorusKnotBufferGeometry( 25, 8, 75, 20 );
 				objectMaterial = new THREE.MeshPhongMaterial( {
 					color: 0x999999,
 					shininess: 0,
@@ -163,31 +198,46 @@
 					shadowPolygonOffsetUnits: config.objects[ 'Offset units' ]
 				} );
 
-				torusKnot = new THREE.Mesh( geometry, objectMaterial );
-				torusKnot.scale.multiplyScalar( 1 / 18 );
-				torusKnot.position.y = 3;
-				torusKnot.castShadow = true;
-				torusKnot.receiveShadow = true;
-				scene.add( torusKnot );
-
 				var geometry = new THREE.CylinderBufferGeometry( 0.75, 0.75, 7, 32 );
 
 				var pillar1 = new THREE.Mesh( geometry, objectMaterial );
-				pillar1.position.set( 10, 3.5, 10 );
+				pillar1.position.set( 10, 3.5, 1 );
 				pillar1.castShadow = true;
 				pillar1.receiveShadow = true;
 
 				var pillar2 = pillar1.clone();
-				pillar2.position.set( 10, 3.5, -10 );
+				pillar2.position.set( 10, 3.5, -1 );
 				var pillar3 = pillar1.clone();
-				pillar3.position.set( -10, 3.5, 10 );
+				pillar3.position.set( -10, 0.75, 4 );
+				pillar3.rotateX( THREE.MathUtils.degToRad( 90 ) );
 				var pillar4 = pillar1.clone();
-				pillar4.position.set( -10, 3.5, -10 );
+				pillar4.position.set( -10, 3.5, -2 );
 
 				scene.add( pillar1 );
 				scene.add( pillar2 );
 				scene.add( pillar3 );
 				scene.add( pillar4 );
+
+				var geometry = new THREE.BoxBufferGeometry( 0.75, 2, 7 );
+
+				var box1 = new THREE.Mesh( geometry, objectMaterial );
+				box1.position.set( 1.5, 1, 5 );
+				box1.castShadow = true;
+				box1.receiveShadow = true;
+
+				var box2 = box1.clone();
+				box2.position.set( 1.5, 3.5, -2 );
+				box2.rotateX( THREE.MathUtils.degToRad( 90 ) );
+				var box3 = box1.clone();
+				box3.position.set( -1.5, 0.75/2, 5 );
+				box3.rotateZ( THREE.MathUtils.degToRad( 90 ) );
+				var box4 = box1.clone();
+				box4.position.set( -1.5, 1, -5 );
+
+				scene.add( box1 );
+				scene.add( box2 );
+				scene.add( box3 );
+				scene.add( box4 );
 
 				var geometry = new THREE.PlaneBufferGeometry( 200, 200 );
 				groundMaterial = new THREE.MeshPhongMaterial( {

--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -165,9 +165,9 @@
 
 				// Lights
 
-				scene.add( new THREE.AmbientLight( 0x444444 ) );
+				scene.add( new THREE.AmbientLight( 0x202020 ) );
 
-				dirLight = new THREE.DirectionalLight( 0xFFFFFF, 2 );
+				dirLight = new THREE.DirectionalLight( 0xF0F0F0, 1 );
 				dirLight.name = 'Dir. Light';
 				dirLight.position.set( 8, 5, 20 );
 				dirLight.castShadow = true;
@@ -265,6 +265,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFShadowMap;
+				renderer.outputEncoding = THREE.sRGBEncoding;
 
 				renderer.setClearColor( 0xCCCCCC, 1 );
 

--- a/examples/webgl_shadowmap_polygon_offset.html
+++ b/examples/webgl_shadowmap_polygon_offset.html
@@ -27,8 +27,16 @@
 
 			var config = {
 				'Bias': 0,
-				'Offset factor': 4,
-				'Offset units': 3000,
+				ground: {
+					'Offset factor': 4,
+					'Offset units': 3000,
+					'Shadow side': 'Front',
+				},
+				objects: {
+					'Offset factor': 4,
+					'Offset units': 3000,
+					'Shadow side': 'Back',
+				},
 			};
 
 			init();
@@ -42,6 +50,7 @@
 				// Init gui
 				var gui = new GUI();
 
+
 				gui.add( config, 'Bias', -0.001, 0.001, 0.00001 ).min( -0.005 ).max( 0.005 ).onChange( function ( value ) {
 
 					dirLight.shadow.bias = value;
@@ -49,16 +58,43 @@
 
 				} );
 
-				gui.add( config, 'Offset factor' ).min( -10 ).max( 10 ).onChange( function ( value ) {
+				var groundFolder = gui.addFolder("Ground");
+				var objectFolder = gui.addFolder("Object");
+				groundFolder.open();
+				objectFolder.open();
+
+				groundFolder.add( config.ground, 'Shadow side', ['Front', 'Back'] ).onChange( function ( value ) {
+
+					groundMaterial.shadowSide = value === 'Front' ? THREE.FrontSide : THREE.BackSide;
+
+				} );
+
+				groundFolder.add( config.ground, 'Offset factor' ).min( -10 ).max( 10 ).onChange( function ( value ) {
 
 					groundMaterial.shadowPolygonOffsetFactor = value;
+
+				} );
+
+				groundFolder.add( config.ground, 'Offset units' ).min( -10000 ).max( 10000 ).onChange( function ( value ) {
+
+					groundMaterial.shadowPolygonOffsetUnits = value;
+
+				} );
+
+				objectFolder.add( config.objects, 'Shadow side', ['Front', 'Back'] ).onChange( function ( value ) {
+
+					objectMaterial.shadowSide = value === 'Front' ? THREE.FrontSide : THREE.BackSide;
+
+				} );
+
+				objectFolder.add( config.objects, 'Offset factor' ).min( -10 ).max( 10 ).onChange( function ( value ) {
+
 					objectMaterial.shadowPolygonOffsetFactor = value;
 
 				} );
 
-				gui.add( config, 'Offset units' ).min( -10000 ).max( 10000 ).onChange( function ( value ) {
+				objectFolder.add( config.objects, 'Offset units' ).min( -10000 ).max( 10000 ).onChange( function ( value ) {
 
-					groundMaterial.shadowPolygonOffsetUnits = value;
 					objectMaterial.shadowPolygonOffsetUnits = value;
 
 				} );
@@ -122,9 +158,9 @@
 					color: 0x999999,
 					shininess: 0,
 					specular: 0x222222,
-					shadowSide: THREE.FrontSide,
-					shadowPolygonOffsetFactor: config[ 'Offset factor' ],
-					shadowPolygonOffsetUnits: config[ 'Offset units' ]
+					shadowSide: config.objects[ 'Shadow side' ],
+					shadowPolygonOffsetFactor: config.objects[ 'Offset factor' ],
+					shadowPolygonOffsetUnits: config.objects[ 'Offset units' ]
 				} );
 
 				torusKnot = new THREE.Mesh( geometry, objectMaterial );
@@ -158,9 +194,9 @@
 					color: 0x999999,
 					shininess: 0,
 					specular: 0x111111,
-					shadowSide: THREE.FrontSide,
-					shadowPolygonOffsetFactor: config[ 'Offset factor' ],
-					shadowPolygonOffsetUnits: config[ 'Offset units' ]
+					shadowSide: config.ground[ 'Shadow side' ],
+					shadowPolygonOffsetFactor: config.ground[ 'Offset factor' ],
+					shadowPolygonOffsetUnits: config.ground[ 'Offset units' ]
 				} );
 
 				var ground = new THREE.Mesh( geometry, groundMaterial );

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -46,6 +46,8 @@ export interface MaterialParameters {
 	flatShading?: boolean;
 	side?: Side;
 	shadowSide?: Side;
+	shadowPolygonOffsetFactor?: number;
+	shadowPolygonOffsetUnits?: number;
 	toneMapped?: boolean;
 	transparent?: boolean;
 	vertexColors?: Colors;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -54,6 +54,8 @@ function Material() {
 	this.clipShadows = false;
 
 	this.shadowSide = null;
+	this.shadowPolygonOffsetFactor = 0;
+	this.shadowPolygonOffsetUnits = 0;
 
 	this.colorWrite = true;
 
@@ -390,6 +392,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.clipShadows = source.clipShadows;
 
 		this.shadowSide = source.shadowSide;
+		this.shadowPolygonOffsetFactor = source.shadowPolygonOffsetFactor;
+		this.shadowPolygonOffsetUnits = source.shadowPolygonOffsetUnits;
 
 		this.colorWrite = source.colorWrite;
 

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -36,12 +36,18 @@ function MeshDepthMaterial( parameters ) {
 	this.morphTargets = false;
 
 	this.map = null;
+	this.extensions = {
+		derivatives: true
+	};
 
 	this.alphaMap = null;
 
 	this.displacementMap = null;
 	this.displacementScale = 1;
 	this.displacementBias = 0;
+
+	this.depthOffsetUnits = 0;
+	this.depthOffsetFactor = 0;
 
 	this.wireframe = false;
 	this.wireframeLinewidth = 1;
@@ -77,9 +83,11 @@ MeshDepthMaterial.prototype.copy = function ( source ) {
 	this.wireframe = source.wireframe;
 	this.wireframeLinewidth = source.wireframeLinewidth;
 
+	this.depthOffsetUnits = source.depthOffsetUnits;
+	this.depthOffsetFactor = source.depthOffsetFactor;
+
 	return this;
 
 };
-
 
 export { MeshDepthMaterial };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1798,6 +1798,7 @@ function WebGLRenderer( parameters ) {
 
 			}
 
+
 		}
 
 		// skinning uniforms must be set even if material didn't change
@@ -2541,9 +2542,6 @@ function WebGLRenderer( parameters ) {
 			uniforms.displacementBias.value = material.displacementBias;
 
 		}
-
-		uniforms.depthOffsetUnits.value = material.depthOffsetUnits;
-		uniforms.depthOffsetFactor.value = material.depthOffsetFactor;
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1855,6 +1855,13 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( material.isMeshDepthMaterial ) {
+
+			p_uniforms.setValue( _gl, 'depthOffsetUnits', material.depthOffsetUnits );
+			p_uniforms.setValue( _gl, 'depthOffsetFactor', material.depthOffsetFactor );
+
+		}
+
 		if ( refreshMaterial || materialProperties.receiveShadow !== object.receiveShadow ) {
 
 			materialProperties.receiveShadow = object.receiveShadow;
@@ -2534,6 +2541,9 @@ function WebGLRenderer( parameters ) {
 			uniforms.displacementBias.value = material.displacementBias;
 
 		}
+
+		uniforms.depthOffsetUnits.value = material.depthOffsetUnits;
+		uniforms.depthOffsetFactor.value = material.depthOffsetFactor;
 
 	}
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -182,7 +182,11 @@ var ShaderLib = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
-			UniformsLib.displacementmap
+			UniformsLib.displacementmap,
+			{
+				depthOffsetUnits: { value: 0.0 },
+				depthOffsetFactor: { value: 0.0 },
+			}
 		] ),
 
 		vertexShader: ShaderChunk.depth_vert,

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -182,11 +182,7 @@ var ShaderLib = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
-			UniformsLib.displacementmap,
-			{
-				depthOffsetUnits: { value: 0.0 },
-				depthOffsetFactor: { value: 0.0 },
-			}
+			UniformsLib.displacementmap
 		] ),
 
 		vertexShader: ShaderChunk.depth_vert,

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -635,6 +635,8 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 			parameters.lightMapEncoding ? getTexelDecodingFunction( 'lightMapTexelToLinear', parameters.lightMapEncoding ) : '',
 			parameters.outputEncoding ? getTexelEncodingFunction( 'linearToOutputTexel', parameters.outputEncoding ) : '',
 
+			parameters.depthOffsetFactor || parameters.depthOffsetUnits ? "#define USE_DEPTH_OFFSET" : "",
+
 			parameters.depthPacking ? '#define DEPTH_PACKING ' + parameters.depthPacking : '',
 
 			'\n'

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -49,7 +49,8 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 		"numDirLightShadows", "numPointLightShadows", "numSpotLightShadows",
 		"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
 		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering",
-		"sheen"
+		"sheen",
+		"depthOffsetFactor", "depthOffsetUnits"
 	];
 
 	function getShaderObject( material, shaderID ) {
@@ -265,6 +266,9 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 
 			shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,
+
+			depthOffsetFactor: material.depthOffsetFactor,
+			depthOffsetUnits: material.depthOffsetUnits,
 
 			toneMapping: material.toneMapped ? renderer.toneMapping : NoToneMapping,
 			physicallyCorrectLights: renderer.physicallyCorrectLights,

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -381,6 +381,10 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		}
 
+		result.polygonOffsetFactor = material.shadowPolygonOffsetFactor || 0;
+		result.polygonOffsetUnits = material.shadowPolygonOffsetUnits || 0;
+		result.polygonOffset = result.polygonOffsetFactor !== 0 || result.polygonOffsetUnits !== 0;
+
 		result.clipShadows = material.clipShadows;
 		result.clippingPlanes = material.clippingPlanes;
 		result.clipIntersection = material.clipIntersection;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -381,9 +381,8 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		}
 
-		result.polygonOffsetFactor = material.shadowPolygonOffsetFactor || 0;
-		result.polygonOffsetUnits = material.shadowPolygonOffsetUnits || 0;
-		result.polygonOffset = result.polygonOffsetFactor !== 0 || result.polygonOffsetUnits !== 0;
+		result.depthOffsetUnits = material.shadowPolygonOffsetUnits || 0;
+		result.depthOffsetFactor = material.shadowPolygonOffsetFactor || 0;
 
 		result.clipShadows = material.clipShadows;
 		result.clippingPlanes = material.clippingPlanes;


### PR DESCRIPTION
Polygon offset is an industry standard technique to help fighting shadow acne and Peter Panning effects. This PR allows per-material control over the polygon offset when rendering shadows. An example is added (derived from current VSM example) which allows to test various values.

Note: the example is using front face to cast shadows, because this way it is easier to demonstrate the polygon offset effect for the ground self-shadowing.

It would be possible to extend the sample to use different settings for ground / objects and to allow selecting front / back shadow casting for ground / objects separately, if desired.

Some notes: it seems polygon offset has some compatibility issues. It works only when I use OpenGL as ANGLE back-end on my Windows x64 Chrome, not when using DirectX 9 (which is default for me). When running on DX 9 ANGLE the example still runs, but the polygon offset settings have no effect at all. I currently do not see a way how could the sample test for this, there is no capability flag, no exception, only the functionality is broken.