### PR TITLE
WebGLRenderer: Avoid duplicate initialization of materials in compile()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1055,6 +1055,8 @@ function WebGLRenderer( parameters ) {
 
 		currentRenderState.setupLights( camera );
 
+		var visited = {};
+
 		scene.traverse( function ( object ) {
 
 			if ( object.material ) {
@@ -1063,13 +1065,19 @@ function WebGLRenderer( parameters ) {
 
 					for ( var i = 0; i < object.material.length; i ++ ) {
 
-						initMaterial( object.material[ i ], scene, object );
+						if ( ! visited[ object.material[ i ].uuid ] ) {
+
+							initMaterial( object.material[ i ], scene, object );
+							visited[ object.material[ i ].uuid ] = true;
+
+						}
 
 					}
 
-				} else {
+				} else if ( ! visited[ object.material.uuid ] ) {
 
 					initMaterial( object.material, scene, object );
+					visited[ object.material.uuid ] = true;
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1055,7 +1055,7 @@ function WebGLRenderer( parameters ) {
 
 		currentRenderState.setupLights( camera );
 
-		var visited = {};
+		var compiled = {};
 
 		scene.traverse( function ( object ) {
 
@@ -1065,19 +1065,19 @@ function WebGLRenderer( parameters ) {
 
 					for ( var i = 0; i < object.material.length; i ++ ) {
 
-						if ( ! visited[ object.material[ i ].uuid ] ) {
+						if ( ! object.material[ i ].uuid in compiled ) {
 
 							initMaterial( object.material[ i ], scene, object );
-							visited[ object.material[ i ].uuid ] = true;
+							compiled[ object.material[ i ].uuid ] = true;
 
 						}
 
 					}
 
-				} else if ( ! visited[ object.material.uuid ] ) {
+				} else if ( ! object.material.uuid in compiled ) {
 
 					initMaterial( object.material, scene, object );
-					visited[ object.material.uuid ] = true;
+					compiled[ object.material.uuid ] = true;
 
 				}
 


### PR DESCRIPTION
Replaces #17116. Tested with the materials/compile example. Not tested for performance.