### PR TITLE
WebGLAttributes: Reduce heap allocations when using WebGL2 and partial buffer updates.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -278,7 +278,7 @@ function WebGLRenderer( parameters ) {
 		info = new WebGLInfo( _gl );
 		properties = new WebGLProperties();
 		textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info );
-		attributes = new WebGLAttributes( _gl );
+		attributes = new WebGLAttributes( _gl, capabilities );
 		geometries = new WebGLGeometries( _gl, attributes, info );
 		objects = new WebGLObjects( _gl, geometries, attributes, info );
 		morphtargets = new WebGLMorphtargets( _gl );

--- a/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/src/renderers/webgl/WebGLAttributes.d.ts
@@ -1,9 +1,10 @@
+import { WebGLCapabilities } from "./WebGLCapabilities";
 import { BufferAttribute } from "../../core/BufferAttribute";
 import { InterleavedBufferAttribute } from "../../core/InterleavedBufferAttribute";
 
 export class WebGLAttributes {
 
-	constructor( gl: WebGLRenderingContext | WebGL2RenderingContext );
+	constructor( gl: WebGLRenderingContext | WebGL2RenderingContext, capabilities: WebGLCapabilities );
 
 	get( attribute: BufferAttribute | InterleavedBufferAttribute ): {
 		buffer: WebGLBuffer,

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -2,7 +2,7 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-function WebGLAttributes( gl ) {
+function WebGLAttributes( gl, capabilities ) {
 
 	var buffers = new WeakMap();
 
@@ -78,8 +78,17 @@ function WebGLAttributes( gl ) {
 
 		} else {
 
-			gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-				array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+			if ( capabilities.isWebGL2 ) {
+
+				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+					array, updateRange.offset, updateRange.count );
+
+			} else {
+
+				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+					array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+
+			}
 
 			updateRange.count = - 1; // reset range
 


### PR DESCRIPTION
Remove the need to create new TypedArray objects when using attribute.updateRange  by using the  bufferSubData() WebGL2 API which removes the need for TypedArray.subarray().

See #18387 for diagnosis and details.

Tested and reduces GC frequency 