### PR TITLE
PMREMGenerator/RoughnessMipmapper: Restore renderer state.

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -85,7 +85,6 @@ var RoughnessMipmapper = ( function () {
 
 			}
 
-			_renderer.setRenderTarget( _tempTarget );
 			_mipmapMaterial.uniforms.roughnessMap.value = roughnessMap;
 			_mipmapMaterial.uniforms.normalMap.value = normalMap;
 
@@ -104,6 +103,7 @@ var RoughnessMipmapper = ( function () {
 				var viewport = new Vector4( position.x, position.y, width / dpr, height / dpr );
 				_tempTarget.viewport.copy( viewport );
 				_tempTarget.scissor.copy( viewport );
+				_renderer.setRenderTarget( _tempTarget );
 				_renderer.render( _scene, _flatCamera );
 				_renderer.copyFramebufferToTexture( position, material.roughnessMap, mip );
 				_mipmapMaterial.uniforms.roughnessMap.value = material.roughnessMap;

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -38,6 +38,7 @@ import { Scene } from "../scenes/Scene.js";
 import { Vector2 } from "../math/Vector2.js";
 import { Vector3 } from "../math/Vector3.js";
 import { WebGLRenderTarget } from "../renderers/WebGLRenderTarget.js";
+import { Vector4 } from "../../build/three.module.js";
 
 var LOD_MIN = 4;
 var LOD_MAX = 8;
@@ -69,6 +70,8 @@ var _cubemapShader = null;
 var { _lodPlanes, _sizeLods, _sigmas } = _createPlanes();
 var _pingPongRenderTarget = null;
 var _renderer = null;
+
+var _oldTarget = null;
 
 // Golden Ratio
 var PHI = ( 1 + Math.sqrt( 5 ) ) / 2;
@@ -107,6 +110,7 @@ PMREMGenerator.prototype = {
 	 */
 	fromScene: function ( scene, sigma = 0, near = 0.1, far = 100 ) {
 
+		_oldTarget = _renderer.getRenderTarget();
 		var cubeUVRenderTarget = _allocateTargets();
 		_sceneToCubeUV( scene, near, far, cubeUVRenderTarget );
 		if ( sigma > 0 ) {
@@ -115,8 +119,7 @@ PMREMGenerator.prototype = {
 
 		}
 		_applyPMREM( cubeUVRenderTarget );
-		_cleanup();
-		cubeUVRenderTarget.scissorTest = false;
+		_cleanup( cubeUVRenderTarget );
 
 		return cubeUVRenderTarget;
 
@@ -144,11 +147,11 @@ PMREMGenerator.prototype = {
 	 */
 	fromCubemap: function ( cubemap ) {
 
+		_oldTarget = _renderer.getRenderTarget();
 		var cubeUVRenderTarget = _allocateTargets( cubemap );
 		_textureToCubeUV( cubemap, cubeUVRenderTarget );
 		_applyPMREM( cubeUVRenderTarget );
-		_cleanup();
-		cubeUVRenderTarget.scissorTest = false;
+		_cleanup( cubeUVRenderTarget );
 
 		return cubeUVRenderTarget;
 
@@ -298,12 +301,13 @@ function _allocateTargets( equirectangular ) {
 
 }
 
-function _cleanup() {
+function _cleanup( outputTarget ) {
 
 	_pingPongRenderTarget.dispose();
-	_renderer.setRenderTarget( null );
-	var size = _renderer.getSize( new Vector2() );
-	_renderer.setViewport( 0, 0, size.x, size.y );
+	_renderer.setRenderTarget( _oldTarget );
+	outputTarget.scissorTest = false;
+	// reset viewport and scissor
+	outputTarget.setSize( outputTarget.width, outputTarget.height );
 
 }
 
@@ -360,7 +364,7 @@ function _sceneToCubeUV( scene, near, far, cubeUVRenderTarget ) {
 			cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
 
 		}
-		_setViewport(
+		_setViewport( cubeUVRenderTarget,
 			col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
 		_renderer.render( scene, cubeCamera );
 
@@ -408,7 +412,7 @@ function _textureToCubeUV( texture, cubeUVRenderTarget ) {
 	uniforms[ 'outputEncoding' ].value = ENCODINGS[ texture.encoding ];
 
 	_renderer.setRenderTarget( cubeUVRenderTarget );
-	_setViewport( 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
+	_setViewport( cubeUVRenderTarget, 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
 	_renderer.render( scene, _flatCamera );
 
 }
@@ -431,15 +435,13 @@ function _createRenderTarget( params ) {
 
 }
 
-function _setViewport( x, y, width, height ) {
+function _setViewport( target, x, y, width, height ) {
 
-	var invDpr = 1.0 / _renderer.getPixelRatio();
-	x = ( x + 0.5 ) * invDpr;
-	y = ( y + 0.5 ) * invDpr;
-	width = ( width + 0.5 ) * invDpr;
-	height = ( height + 0.5 ) * invDpr;
-	_renderer.setViewport( x, y, width, height );
-	_renderer.setScissor( x, y, width, height );
+	var viewport = new Vector4( x, y, width, height );
+	viewport.addScalar( 0.5 ).divideScalar( _renderer.getPixelRatio() );
+
+	target.viewport.copy( viewport );
+	target.scissor.copy( viewport );
 
 }
 
@@ -569,7 +571,7 @@ function _halfBlur( targetIn, targetOut, lodIn, lodOut, sigmaRadians, direction,
 		( lodOut > LOD_MAX - LOD_MIN ? lodOut - LOD_MAX + LOD_MIN : 0 );
 
 	_renderer.setRenderTarget( targetOut );
-	_setViewport( x, y, 3 * outputSize, 2 * outputSize );
+	_setViewport( targetOut, x, y, 3 * outputSize, 2 * outputSize );
 	_renderer.render( blurScene, _flatCamera );
 
 }

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -344,7 +344,6 @@ function _sceneToCubeUV( scene, near, far, cubeUVRenderTarget ) {
 
 	}
 
-	_renderer.setRenderTarget( cubeUVRenderTarget );
 	for ( var i = 0; i < 6; i ++ ) {
 
 		var col = i % 3;
@@ -366,6 +365,7 @@ function _sceneToCubeUV( scene, near, far, cubeUVRenderTarget ) {
 		}
 		_setViewport( cubeUVRenderTarget,
 			col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
+		_renderer.setRenderTarget( cubeUVRenderTarget );
 		_renderer.render( scene, cubeCamera );
 
 	}
@@ -411,8 +411,8 @@ function _textureToCubeUV( texture, cubeUVRenderTarget ) {
 	uniforms[ 'inputEncoding' ].value = ENCODINGS[ texture.encoding ];
 	uniforms[ 'outputEncoding' ].value = ENCODINGS[ texture.encoding ];
 
-	_renderer.setRenderTarget( cubeUVRenderTarget );
 	_setViewport( cubeUVRenderTarget, 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
+	_renderer.setRenderTarget( cubeUVRenderTarget );
 	_renderer.render( scene, _flatCamera );
 
 }
@@ -570,8 +570,8 @@ function _halfBlur( targetIn, targetOut, lodIn, lodOut, sigmaRadians, direction,
 	2 * outputSize *
 		( lodOut > LOD_MAX - LOD_MIN ? lodOut - LOD_MAX + LOD_MIN : 0 );
 
-	_renderer.setRenderTarget( targetOut );
 	_setViewport( targetOut, x, y, 3 * outputSize, 2 * outputSize );
+	_renderer.setRenderTarget( targetOut );
 	_renderer.render( blurScene, _flatCamera );
 
 }


### PR DESCRIPTION
Fixes #18408
Fixes #18409 

Switched to using the render target's viewport and scissor instead of the renderer's, so as not to affect state. Also some minor cleanup.