### PR TITLE
WebGLBackground: prevent background material recompile in certain cases

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -18,8 +18,7 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 	var planeMesh;
 	var boxMesh;
-	// Store the current background texture and its `version`
-	// so we can recompile the material accordingly.
+
 	var currentBackground = null;
 	var currentBackgroundVersion = 0;
 	var currentTonemapping = null;
@@ -43,15 +42,11 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 		if ( background === null ) {
 
 			setClear( clearColor, clearAlpha );
-			currentBackground = null;
-			currentBackgroundVersion = 0;
 
 		} else if ( background && background.isColor ) {
 
 			setClear( background, 1 );
 			forceClear = true;
-			currentBackground = null;
-			currentBackgroundVersion = 0;
 
 		}
 


### PR DESCRIPTION
Typically, a single renderer is used to render not only the scene, but for inset viewports, for render-targets, for post-processing, etc. In each case, the rendered scene may or may not have a background. Also, there may be multiple scenes. This can cause the scene background material to be recompiled every frame. (To replicate, add a texture background in `/examples/webgl_shadowmap_viewer.html`.)

I am thinking `webGLBackground` may have to be redesigned, but this change in an improvement -- at least in the cases I have studied.
