### PR TITLE
Docs: Recommend Servez

### DIFF
--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -49,7 +49,14 @@
 				three.js application.
 			</p>
 
-			<h3>Node.js server</h3>
+			<h3>Servez</h3>
+			<div>
+				<p>
+					[link:https://greggman.github.io/servez Servez] is a simple server with a GUI.
+				</p>
+			</div>
+
+			<h3>Node.js http-server</h3>
 			<div>
 				<p>Node.js has a simple HTTP server package. To install:</p>
 				<code>npm install http-server -g</code>


### PR DESCRIPTION
1. Servez has an app version which some people find easier

2. http-server has been semi-abandoned. It has issued errors
   on windows for > 6 months and is using deprecated and
   discontinued libraries.

   In response to seeing it wasn't working well for windows
   users and that the maintainers showed no interested in fixing
   it I created a command-line version of
   [servez](https://www.npmjs.com/package/servez).