### PR TITLE
OutlinePass: Add support for skinning/morph targets.

### DIFF
--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -394,16 +394,24 @@ THREE.OutlinePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 			},
 
 			vertexShader: [
+				'#include <morphtarget_pars_vertex>',
+				'#include <skinning_pars_vertex>',
+
 				'varying vec4 projTexCoord;',
 				'varying vec4 vPosition;',
 				'uniform mat4 textureMatrix;',
 
 				'void main() {',
 
-				'	vPosition = modelViewMatrix * vec4( position, 1.0 );',
+				'	#include <skinbase_vertex>',
+				'	#include <begin_vertex>',
+				'	#include <morphtarget_vertex>',
+				'	#include <skinning_vertex>',
+				'	#include <project_vertex>',
+
+				'	vPosition = mvPosition;',
 				'	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
 				'	projTexCoord = textureMatrix * worldPosition;',
-				'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
 
 				'}'
 			].join( '\n' ),

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -414,16 +414,24 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 			},
 
 			vertexShader: [
+				'#include <morphtarget_pars_vertex>',
+				'#include <skinning_pars_vertex>',
+
 				'varying vec4 projTexCoord;',
 				'varying vec4 vPosition;',
 				'uniform mat4 textureMatrix;',
 
 				'void main() {',
 
-				'	vPosition = modelViewMatrix * vec4( position, 1.0 );',
+				'	#include <skinbase_vertex>',
+				'	#include <begin_vertex>',
+				'	#include <morphtarget_vertex>',
+				'	#include <skinning_vertex>',
+				'	#include <project_vertex>',
+
+				'	vPosition = mvPosition;',
 				'	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
 				'	projTexCoord = textureMatrix * worldPosition;',
-				'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
 
 				'}'
 			].join( '\n' ),


### PR DESCRIPTION
With this small patch, it's now possible to use the outline pass with animated meshes. The only thing users have to do at app level is to set `morphTargets` or `skinning` to `true` for `OutlinePass.depthMaterial` and `OutlinePass.prepareMaskMaterial`. That's of course still a manual effort but at least the more complicated shader enhancement is already done.

https://jsfiddle.net/2ybks7rd/