### PR TITLE
Examples: Add comment regarding the use of RoughnessMipmapper

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -57,6 +57,7 @@
 
 						// model
 
+						// use of RoughnessMipmapper is optional
 						var roughnessMipmapper = new RoughnessMipmapper( renderer );
 
 						var loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );


### PR DESCRIPTION
See the discussion in #18407.

Since users copy the patterns in the three.js examples, this PR adds a comment that the use of `RoughnessMipmapper` is optional.

The comment can be removed later -- maybe if we demonstrate a use case where its use is compelling.
