### PR TITLE
WebGLRenderer: removed outdated flipEnvMap comments

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -946,10 +946,6 @@ THREE.GLTFLoader = ( function () {
 					uniforms.envMap.value = material.envMap;
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
-					// don't flip CubeTexture envMaps, flip everything else:
-					//  WebGLCubeRenderTarget will be flipped for backwards compatibility
-					//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
-					// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1014,10 +1014,6 @@ var GLTFLoader = ( function () {
 					uniforms.envMap.value = material.envMap;
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
-					// don't flip CubeTexture envMaps, flip everything else:
-					//  WebGLCubeRenderTarget will be flipped for backwards compatibility
-					//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
-					// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2058,10 +2058,6 @@ function WebGLRenderer( parameters ) {
 
 			uniforms.envMap.value = envMap;
 
-			// don't flip CubeTexture envMaps, flip everything else:
-			//  WebGLCubeRenderTarget will be flipped for backwards compatibility
-			//  WebGLCubeRenderTarget.texture will be flipped because it's a Texture and NOT a CubeTexture
-			// this check must be handled differently, or removed entirely, if WebGLCubeRenderTarget uses a CubeTexture in the future
 			uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
 
 			uniforms.reflectivity.value = material.reflectivity;


### PR DESCRIPTION
The removed comments are not consistent with the current code.

I think this issue is well-understood now, since we use this pattern elsewhere without comment.
