### PR TITLE
Shaders: remove envMap flipping for CUBE_UV textures

### DIFF
--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -105,8 +105,7 @@
 
 					#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-						vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
-						vec4 envMapColor = textureCubeUV( envMap, queryVec, 1.0 );
+						vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
 
 					#else
 
@@ -172,8 +171,7 @@
 
 					#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-						vec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
-						vec4 envMapColor = textureCubeUV( envMap, queryReflectVec, roughness );
+						vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
 
 					#elif defined( ENVMAP_TYPE_EQUIREC )
 

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -40,7 +40,7 @@ export default /* glsl */`
 
 	#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-		vec4 envColor = textureCubeUV( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ), 0.0 );
+		vec4 envColor = textureCubeUV( envMap, reflectVec, 0.0 );
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -31,8 +31,7 @@ export default /* glsl */`
 
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-			vec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );
-			vec4 envMapColor = textureCubeUV( envMap, queryVec, 1.0 );
+			vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
 
 		#else
 
@@ -94,8 +93,7 @@ export default /* glsl */`
 
 		#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-			vec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );
-			vec4 envMapColor = textureCubeUV( envMap, queryReflectVec, roughness );
+			vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
 
 		#elif defined( ENVMAP_TYPE_EQUIREC )
 


### PR DESCRIPTION
Only `CubeTexture` is flipped.

Flat textures with `CubeUV*Mapping` are never flipped. ( `flipEnvMap` is always 1 in that case. )

/ping @elalish 
