### PR TITLE
PMREMGenerator: Fix viewport/scissor settings.

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -18,8 +18,7 @@ import {
 	RawShaderMaterial,
 	Scene,
 	Vector2,
-	WebGLRenderTarget,
-	Vector4
+	WebGLRenderTarget
 } from "../../../build/three.module.js";
 
 var RoughnessMipmapper = ( function () {
@@ -88,7 +87,6 @@ var RoughnessMipmapper = ( function () {
 			_mipmapMaterial.uniforms.roughnessMap.value = roughnessMap;
 			_mipmapMaterial.uniforms.normalMap.value = normalMap;
 
-			var dpr = _renderer.getPixelRatio();
 			var position = new Vector2( 0, 0 );
 			var texelSize = _mipmapMaterial.uniforms.texelSize.value;
 			for ( var mip = 0; width >= 1 && height >= 1;
@@ -100,9 +98,8 @@ var RoughnessMipmapper = ( function () {
 				texelSize.set( 1.0 / width, 1.0 / height );
 				if ( mip == 0 ) texelSize.set( 0.0, 0.0 );
 
-				var viewport = new Vector4( position.x, position.y, width / dpr, height / dpr );
-				_tempTarget.viewport.copy( viewport );
-				_tempTarget.scissor.copy( viewport );
+				_tempTarget.viewport.set( position.x, position.y, width, height );
+				_tempTarget.scissor.set( position.x, position.y, width, height );
 				_renderer.setRenderTarget( _tempTarget );
 				_renderer.render( _scene, _flatCamera );
 				_renderer.copyFramebufferToTexture( position, material.roughnessMap, mip );

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -38,7 +38,6 @@ import { Scene } from "../scenes/Scene.js";
 import { Vector2 } from "../math/Vector2.js";
 import { Vector3 } from "../math/Vector3.js";
 import { WebGLRenderTarget } from "../renderers/WebGLRenderTarget.js";
-import { Vector4 } from "../math/Vector4.js";
 
 var LOD_MIN = 4;
 var LOD_MAX = 8;
@@ -437,11 +436,8 @@ function _createRenderTarget( params ) {
 
 function _setViewport( target, x, y, width, height ) {
 
-	var viewport = new Vector4( x, y, width, height );
-	viewport.addScalar( 0.5 ).divideScalar( _renderer.getPixelRatio() );
-
-	target.viewport.copy( viewport );
-	target.scissor.copy( viewport );
+	target.viewport.set( x, y, width, height );
+	target.scissor.set( x, y, width, height );
 
 }
 


### PR DESCRIPTION
This should fix the broken `PMREMGenerator` on `dev` (for computer with device pixel ration > 1).

@elalish When using `WebGLRenderer.setViewport()`, the viewport is automatically multiplied with the device pixel ratio e.g.:

https://github.com/mrdoob/three.js/blob/9518d5e0d32c8c2a29d768ae4635246ed68b87c8/src/renderers/WebGLRenderer.js#L467

However, when you directly set `WebGLRenderTarget.viewport` and `WebGLRenderTarget.scissor`, it's not necessary to divide through the device pixel ratio because it's not respected in `WebGLRenderer.setRenderTarget()`.

https://github.com/mrdoob/three.js/blob/9518d5e0d32c8c2a29d768ae4635246ed68b87c8/src/renderers/WebGLRenderer.js#L2664-L2665