### PR TITLE
Core: rename .applyMatrix() to .applyMatrix4()

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -179,7 +179,7 @@
 		</p>
 
 
-		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -203,7 +203,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>Bakes matrix transform directly into vertex coordinates.</p>
 
 		<h3>[method:Geometry center] ()</h3>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -204,7 +204,7 @@
 		See [page:Group] for info on manually grouping objects.
 		</p>
 
-		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale.</p>
 
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>

--- a/docs/api/en/deprecated/DeprecatedList.html
+++ b/docs/api/en/deprecated/DeprecatedList.html
@@ -152,15 +152,7 @@
 
 
 
-		<h2>Geometry</h2>
-
-		<p>
-			Geometry.computeTangents() has been removed.<br /><br />
-
-			Geometry.computeLineDistances() has been removed. Use [page:Line.computeLineDistances] instead.<br /><br />
-		</p>
-
-		<h3>[page:BufferGeometry]</h3>
+		<h2>[page:BufferGeometry]</h2>
 		<p>
 			BufferGeometry.addIndex has been renamed to [page:BufferGeometry.setIndex].<br /><br />
 
@@ -176,13 +168,25 @@
 
 			BufferGeometry.offsets has been renamed to [page:BufferGeometry.groups].<br /><br />
 
+			BufferGeometry.applyMatrix() has been renamed to [page:BufferGeometry.applyMatrix4]().
 		</p>
+
+
+
 
 		<h3>[page:CubeGeometry]</h3>
 		<p>CubeGeometry has been renamed to [page:BoxGeometry].</p>
 
+
+
 		<h3>[page:Geometry]</h3>
-		<p>Geometry.computeTangents() has been removed.</p>
+		<p>
+			Geometry.computeTangents() has been removed.<br /><br />
+
+			Geometry.computeLineDistances() has been removed. Use [page:Line.computeLineDistances] instead.<br /><br />
+
+			Geometry.applyMatrix() has been renamed to [page:Geometry.applyMatrix4]().
+		</p>
 
 		<h3>[page:GeometryUtils]</h3>
 		<p>
@@ -458,7 +462,10 @@
 
 			Object3D.translate() has been removed. Use [page:Object3D.translateOnAxis]( axis, distance ) instead.<br /><br />
 
-			Object3D.useQuaternion has been removed. The library now uses quaternions by default.
+			Object3D.useQuaternion has been removed. The library now uses quaternions by default.<br /><br />
+
+			Object3D.applyMatrix() has been renamed to [page:Object3D.applyMatrix4]().
+
 		</p>
 
 		<h3>[page:LensFlare]</h3>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -162,7 +162,7 @@
 		</p>
 
 
-		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p> 用给定矩阵转换几何体的顶点坐标。</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>

--- a/docs/api/zh/core/Geometry.html
+++ b/docs/api/zh/core/Geometry.html
@@ -198,7 +198,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] 该类中可用的函数。</h3>
 
-		<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p> 将矩阵信息直接应用于几何体顶点坐标。</p>
 
 		<h3>[method:Geometry center] ()</h3>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -193,7 +193,7 @@
 		请参阅[page:Group]来查看手动编组对象的相关信息。
 	</p>
 
-	<h3>[method:null applyMatrix]( [param:Matrix4 matrix] )</h3>
+	<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 	<p>对当前物体应用这个变换矩阵，并更新物体的位置、旋转和缩放。</p>
 
 	<h3>[method:Object3D applyQuaternion]( [param:Quaternion quaternion] )</h3>

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -25,7 +25,7 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 	isLineSegmentsGeometry: true,
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix4: function ( matrix ) {
 
 		var start = this.attributes.instanceStart;
 		var end = this.attributes.instanceEnd;
@@ -238,6 +238,14 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 	toJSON: function () {
 
 		// todo
+
+	},
+
+	applyMatrix: function ( matrix ) {
+
+		console.warn( 'THREE.LineSegmentsGeometry: applyMatrix() has been renamed to applyMatrix4().' );
+
+		return this.applyMatrix4( matrix );
 
 	}
 

--- a/examples/jsm/lines/LineSegmentsGeometry.d.ts
+++ b/examples/jsm/lines/LineSegmentsGeometry.d.ts
@@ -12,7 +12,7 @@ export class LineSegmentsGeometry extends InstancedBufferGeometry {
 	constructor();
 	readonly isLineSegmentsGeometry: true;
 
-	applyMatrix( matrix: Matrix4 ): this;
+	applyMatrix4( matrix: Matrix4 ): this;
 	computeBoundingBox(): void;
 	computeBoundingSphere(): void;
 	fromEdgesGeometry( geometry: WireframeGeometry ): this;

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -36,7 +36,7 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 	isLineSegmentsGeometry: true,
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix4: function ( matrix ) {
 
 		var start = this.attributes.instanceStart;
 		var end = this.attributes.instanceEnd;
@@ -249,6 +249,14 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 	toJSON: function () {
 
 		// todo
+
+	},
+
+	applyMatrix: function ( matrix ) {
+
+		console.warn( 'THREE.LineSegmentsGeometry: applyMatrix() has been renamed to applyMatrix4().' );
+
+		return this.applyMatrix4( matrix );
 
 	}
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -930,6 +930,12 @@ Object.assign( Geometry.prototype, {
 
 		console.error( 'THREE.Geometry: .computeLineDistances() has been removed. Use THREE.Line.computeLineDistances() instead.' );
 
+	},
+	applyMatrix: function ( matrix ) {
+
+		console.warn( 'THREE.Geometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+		return this.applyMatrix4( matrix );
+
 	}
 
 } );
@@ -956,6 +962,12 @@ Object.assign( Object3D.prototype, {
 	getWorldRotation: function () {
 
 		console.error( 'THREE.Object3D: .getWorldRotation() has been removed. Use THREE.Object3D.getWorldQuaternion( target ) instead.' );
+
+	},
+	applyMatrix: function ( matrix ) {
+
+		console.warn( 'THREE.Object3D: .applyMatrix() has been renamed to .applyMatrix4().' );
+		return this.applyMatrix4( matrix );
 
 	}
 
@@ -1303,7 +1315,14 @@ Object.assign( BufferGeometry.prototype, {
 
 		return this.deleteAttribute( name );
 
+	},
+	applyMatrix: function ( matrix ) {
+
+		console.warn( 'THREE.BufferGeometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+		return this.applyMatrix4( matrix );
+
 	}
+
 } );
 
 Object.defineProperties( BufferGeometry.prototype, {

--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -63,7 +63,7 @@ export class BufferGeometry extends EventDispatcher {
 	/**
 	 * Bakes matrix transform directly into vertex coordinates.
 	 */
-	applyMatrix( matrix: Matrix4 ): BufferGeometry;
+	applyMatrix4( matrix: Matrix4 ): BufferGeometry;
 
 	rotateX( angle: number ): BufferGeometry;
 	rotateY( angle: number ): BufferGeometry;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -123,7 +123,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	},
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix4: function ( matrix ) {
 
 		var position = this.attributes.position;
 
@@ -179,7 +179,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_m1.makeRotationX( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -191,7 +191,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_m1.makeRotationY( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -203,7 +203,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_m1.makeRotationZ( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -215,7 +215,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_m1.makeTranslation( x, y, z );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -227,7 +227,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_m1.makeScale( x, y, z );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -239,7 +239,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		_obj.updateMatrix();
 
-		this.applyMatrix( _obj.matrix );
+		this.applyMatrix4( _obj.matrix );
 
 		return this;
 

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -166,7 +166,7 @@ export class Geometry extends EventDispatcher {
 	/**
 	 * Bakes matrix transform directly into vertex coordinates.
 	 */
-	applyMatrix( matrix: Matrix4 ): Geometry;
+	applyMatrix4( matrix: Matrix4 ): Geometry;
 
 	rotateX( angle: number ): Geometry;
 	rotateY( angle: number ): Geometry;

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -67,7 +67,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	isGeometry: true,
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix4: function ( matrix ) {
 
 		var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
@@ -116,7 +116,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_m1.makeRotationX( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -128,7 +128,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_m1.makeRotationY( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -140,7 +140,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_m1.makeRotationZ( angle );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -152,7 +152,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_m1.makeTranslation( x, y, z );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -164,7 +164,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_m1.makeScale( x, y, z );
 
-		this.applyMatrix( _m1 );
+		this.applyMatrix4( _m1 );
 
 		return this;
 
@@ -176,7 +176,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		_obj.updateMatrix();
 
-		this.applyMatrix( _obj.matrix );
+		this.applyMatrix4( _obj.matrix );
 
 		return this;
 
@@ -351,7 +351,7 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			0, 0, 0, 1
 		);
 
-		this.applyMatrix( matrix );
+		this.applyMatrix4( matrix );
 
 		return this;
 

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -180,7 +180,7 @@ export class Object3D extends EventDispatcher {
 	/**
 	 * This updates the position, rotation and scale with the matrix.
 	 */
-	applyMatrix( matrix: Matrix4 ): void;
+	applyMatrix4( matrix: Matrix4 ): void;
 
 	applyQuaternion( quaternion: Quaternion ): this;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -127,7 +127,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	onBeforeRender: function () {},
 	onAfterRender: function () {},
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix4: function ( matrix ) {
 
 		if ( this.matrixAutoUpdate ) this.updateMatrix();
 
@@ -394,7 +394,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
-		object.applyMatrix( _m1 );
+		object.applyMatrix4( _m1 );
 
 		object.updateWorldMatrix( false, false );
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -231,7 +231,7 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "applyMatrix", ( assert ) => {
+		QUnit.test( "applyMatrix4", ( assert ) => {
 
 			var geometry = new BufferGeometry();
 			geometry.setAttribute( "position", new BufferAttribute( new Float32Array( 6 ), 3 ) );
@@ -242,7 +242,7 @@ export default QUnit.module( 'Core', () => {
 				0, 0, 1, 3,
 				0, 0, 0, 1
 			);
-			geometry.applyMatrix( matrix );
+			geometry.applyMatrix4( matrix );
 
 			var position = geometry.attributes.position.array;
 			var m = matrix.elements;

--- a/test/unit/src/core/Geometry.tests.js
+++ b/test/unit/src/core/Geometry.tests.js
@@ -64,7 +64,7 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "applyMatrix", ( assert ) => {
+		QUnit.test( "applyMatrix4", ( assert ) => {
 
 			var geometry = getGeometry();
 			geometry.faces.push( new Face3( 0, 1, 2 ) );
@@ -79,7 +79,7 @@ export default QUnit.module( 'Core', () => {
 			m.makeRotationX( Math.PI / 2 );
 			m.setPosition( new Vector3( x, y, z ) );
 
-			geometry.applyMatrix( m );
+			geometry.applyMatrix4( m );
 
 			v0 = geometry.vertices[ 0 ];
 			v1 = geometry.vertices[ 1 ];
@@ -112,7 +112,7 @@ export default QUnit.module( 'Core', () => {
 			var matrix = new Matrix4();
 			matrix.makeRotationX( Math.PI / 2 ); // 90 degree
 
-			geometry.applyMatrix( matrix );
+			geometry.applyMatrix4( matrix );
 
 			var v0 = geometry.vertices[ 0 ], v1 = geometry.vertices[ 1 ], v2 = geometry.vertices[ 2 ];
 			assert.ok( v0.x === - 0.5 && v0.y === 0 && v0.z === 0, "first vertex was rotated" );
@@ -128,7 +128,7 @@ export default QUnit.module( 'Core', () => {
 			var matrix = new Matrix4();
 			matrix.makeRotationY( Math.PI ); // 180 degrees
 
-			geometry.applyMatrix( matrix );
+			geometry.applyMatrix4( matrix );
 
 			var v0 = geometry.vertices[ 0 ], v1 = geometry.vertices[ 1 ], v2 = geometry.vertices[ 2 ];
 			assert.ok( v0.x === 0.5 && v0.y === 0 && v0.z < Number.EPSILON, "first vertex was rotated" );
@@ -144,7 +144,7 @@ export default QUnit.module( 'Core', () => {
 			var matrix = new Matrix4();
 			matrix.makeRotationZ( Math.PI / 2 * 3 ); // 270 degrees
 
-			geometry.applyMatrix( matrix );
+			geometry.applyMatrix4( matrix );
 
 			var v0 = geometry.vertices[ 0 ], v1 = geometry.vertices[ 1 ], v2 = geometry.vertices[ 2 ];
 			assert.ok( v0.x < Number.EPSILON && v0.y === 0.5 && v0.z === 0, "first vertex was rotated" );

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -87,7 +87,7 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "applyMatrix", ( assert ) => {
+		QUnit.test( "applyMatrix4", ( assert ) => {
 
 			var a = new Object3D();
 			var m = new Matrix4();
@@ -97,7 +97,7 @@ export default QUnit.module( 'Core', () => {
 			m.makeRotationX( Math.PI / 2 );
 			m.setPosition( new Vector3( x, y, z ) );
 
-			a.applyMatrix( m );
+			a.applyMatrix4( m );
 
 			assert.deepEqual( a.position, expectedPos, "Position has the expected values" );
 			assert.ok(
@@ -392,7 +392,7 @@ export default QUnit.module( 'Core', () => {
 			var m = new Matrix4().makeScale( x, y, z );
 			var expected = new Vector3( x, y, z );
 
-			a.applyMatrix( m );
+			a.applyMatrix4( m );
 
 			assert.deepEqual( a.getWorldScale( new Vector3() ), expected, "WorldScale as expected" );
 


### PR DESCRIPTION
Following from the discussion in #18343, methods that take a matrix arg will now clearly identify the type of matrix.

I'll update the migration docs...