### PR TITLE
Frustum: .setFromMatrix() -> .setFromProjectionMatrix()

### DIFF
--- a/docs/api/en/deprecated/DeprecatedList.html
+++ b/docs/api/en/deprecated/DeprecatedList.html
@@ -152,7 +152,7 @@
 
 
 
-		<h2>[page:BufferGeometry]</h2>
+		<h3>[page:BufferGeometry]</h3>
 		<p>
 			BufferGeometry.addIndex has been renamed to [page:BufferGeometry.setIndex].<br /><br />
 
@@ -286,6 +286,9 @@
 
 		<h3>[page:Face4]</h3>
 		<p>Face4 has been removed. Use [page:Face3] instead.</p>
+
+		<h3>[page:Frustum]</h3>
+		<p>Frustum.setFromMatrix() has been renamed to [page:Frustum.setFromProjectionMatrix]().</p>
 
 		<h3>[page:Line3]</h3>
 		<p>Line3.center has been renamed to [page:Line3.getCenter]().</p>

--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -89,30 +89,17 @@
 			Checks whether the [page:Sprite sprite] is intersecting the Frustum.<br /><br />
 		</p>
 
-		<h3>[method:Frustum set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
+		<h3>[method:this set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
 		<p>
-		Sets the current frustum from the passed planes. No plane order is implicitely implied.<br>
-		Please note that this method only copies the values from the given objects.
+		Sets the frustum from the passed planes. No plane order is implied.<br>
+		Note that this method only copies the values from the given objects.
 		</p>
 
-		<h3>[method:Frustum setFromMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:this setFromProjectionMatrix]( [param:Matrix4 matrix] )</h3>
 		<p>
-			[page:Matrix4 matrix] - [page:Matrix4] used to set the [page:.planes planes]<br /><br />
-
-			This is used by the [page:WebGLRenderer] to set up the Frustum from a [page:Camera Camera]'s
-			[page:Camera.projectionMatrix projectionMatrix] and [page:Camera.matrixWorldInverse matrixWorldInverse].
+		[page:Matrix4 matrix] - Projection [page:Matrix4] used to set the [page:.planes planes]<br /><br />
+		Sets the frustum planes from the projection matrix.
 		</p>
-
-
-
-
-
-
-
-
-
-
-
 
 
 		<h2>Source</h2>

--- a/docs/api/zh/deprecated/DeprecatedList.html
+++ b/docs/api/zh/deprecated/DeprecatedList.html
@@ -263,6 +263,9 @@
 		<h3>[page:Face4]</h3>
 		<p>Face4 已被删除。 请使用[page:Face3]。</p>
 
+		<h3>[page:Frustum]</h3>
+		<p>Frustum.setFromMatrix() has been renamed to [page:Frustum.setFromProjectionMatrix]().</p>
+
 		<h3>[page:Line3]</h3>
 		<p>Line3.center 已被重命名为 [page:Line3.getCenter]()。</p>
 

--- a/docs/api/zh/math/Frustum.html
+++ b/docs/api/zh/math/Frustum.html
@@ -86,29 +86,17 @@
 			检查精灵[page:Sprite sprite]是否与截锥体相交。<br /><br />
 		</p>
 
-		<h3>[method:Frustum set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
+		<h3>[method:this set]( [param:Plane p0], [param:Plane p1], [param:Plane p2], [param:Plane p3], [param:Plane p4], [param:Plane p5] )</h3>
 		<p>
-			使用传入的平面设置当前视锥体。没有隐式的顺序。
+		Sets the frustum from the passed planes. No plane order is implied.<br>
+		Note that this method only copies the values from the given objects.
 		</p>
 
-		<h3>[method:Frustum setFromMatrix]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:this setFromProjectionMatrix]( [param:Matrix4 matrix] )</h3>
 		<p>
-			[page:Matrix4 matrix] - [page:Matrix4] 用于设置 [page:.planes planes]<br /><br />
-
-			[page:WebGLRenderer] 使用 [page:Camera Camera]的投影矩阵（[page:Camera.projectionMatrix projectionMatrix] ）
-			和相机世界变换矩阵的逆矩阵 [page:Camera.matrixWorldInverse matrixWorldInverse] 来设置视锥体。
-				</p>
-
-
-
-
-
-
-
-
-
-
-
+		[page:Matrix4 matrix] - Projection [page:Matrix4] used to set the [page:.planes planes]<br /><br />
+		Sets the frustum planes from the projection matrix.
+		</p>
 
 
 		<h2>Source</h2>

--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -412,7 +412,7 @@ THREE.Projector = function () {
 		_viewMatrix.copy( camera.matrixWorldInverse );
 		_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
 
-		_frustum.setFromMatrix( _viewProjectionMatrix );
+		_frustum.setFromProjectionMatrix( _viewProjectionMatrix );
 
 		//
 

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -436,7 +436,7 @@ var Projector = function () {
 		_viewMatrix.copy( camera.matrixWorldInverse );
 		_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
 
-		_frustum.setFromMatrix( _viewProjectionMatrix );
+		_frustum.setFromProjectionMatrix( _viewProjectionMatrix );
 
 		//
 

--- a/examples/webgl_nearestneighbour.html
+++ b/examples/webgl_nearestneighbour.html
@@ -193,7 +193,7 @@
 				var _projScreenMatrix = new THREE.Matrix4();
 
 				_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-				_frustum.setFromMatrix( _projScreenMatrix );
+				_frustum.setFromProjectionMatrix( _projScreenMatrix );
 
 				for ( var i = 0, il = imagePositionsInRange.length; i < il; i ++ ) {
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -62,6 +62,7 @@ import { ShaderMaterial } from './materials/ShaderMaterial.js';
 import { Box2 } from './math/Box2.js';
 import { Box3 } from './math/Box3.js';
 import { Color } from './math/Color.js';
+import { Frustum } from './math/Frustum.js';
 import { Line3 } from './math/Line3.js';
 import { MathUtils } from './math/MathUtils.js';
 import { Matrix3 } from './math/Matrix3.js';
@@ -537,6 +538,13 @@ Object.assign( Box3.prototype, {
 
 	}
 } );
+
+Frustum.prototype.setFromMatrix = function ( m ) {
+
+	console.warn( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );
+	return this.setFromProjectionMatrix( m );
+
+};
 
 Line3.prototype.center = function ( optionalTarget ) {
 

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -70,7 +70,7 @@ Object.assign( LightShadow.prototype, {
 		shadowCamera.updateMatrixWorld();
 
 		projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
-		this._frustum.setFromMatrix( projScreenMatrix );
+		this._frustum.setFromProjectionMatrix( projScreenMatrix );
 
 		shadowMatrix.set(
 			0.5, 0.0, 0.0, 0.5,

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -80,7 +80,7 @@ PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype
 		shadowMatrix.makeTranslation( - lightPositionWorld.x, - lightPositionWorld.y, - lightPositionWorld.z );
 
 		projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-		this._frustum.setFromMatrix( projScreenMatrix );
+		this._frustum.setFromProjectionMatrix( projScreenMatrix );
 
 	}
 

--- a/src/math/Frustum.d.ts
+++ b/src/math/Frustum.d.ts
@@ -35,7 +35,7 @@ export class Frustum {
 	): Frustum;
 	clone(): this;
 	copy( frustum: Frustum ): this;
-	setFromMatrix( m: Matrix4 ): Frustum;
+	setFromProjectionMatrix( m: Matrix4 ): this;
 	intersectsObject( object: Object3D ): boolean;
 	intersectsSprite( sprite: Sprite ): boolean;
 	intersectsSphere( sphere: Sphere ): boolean;

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -63,7 +63,7 @@ Object.assign( Frustum.prototype, {
 
 	},
 
-	setFromMatrix: function ( m ) {
+	setFromProjectionMatrix: function ( m ) {
 
 		var planes = this.planes;
 		var me = m.elements;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1163,7 +1163,7 @@ function WebGLRenderer( parameters ) {
 		scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
 
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-		_frustum.setFromMatrix( _projScreenMatrix );
+		_frustum.setFromProjectionMatrix( _projScreenMatrix );
 
 		_localClippingEnabled = this.localClippingEnabled;
 		_clippingEnabled = _clipping.init( this.clippingPlanes, _localClippingEnabled, camera );

--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -134,10 +134,10 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "setFromMatrix/makeOrthographic/containsPoint", ( assert ) => {
+		QUnit.test( "setFromProjectionMatrix/makeOrthographic/containsPoint", ( assert ) => {
 
 			var m = new Matrix4().makeOrthographic( - 1, 1, - 1, 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 
 			assert.ok( ! a.containsPoint( new Vector3( 0, 0, 0 ) ), "Passed!" );
 			assert.ok( a.containsPoint( new Vector3( 0, 0, - 50 ) ), "Passed!" );
@@ -155,10 +155,10 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "setFromMatrix/makePerspective/containsPoint", ( assert ) => {
+		QUnit.test( "setFromProjectionMatrix/makePerspective/containsPoint", ( assert ) => {
 
 			var m = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 
 			assert.ok( ! a.containsPoint( new Vector3( 0, 0, 0 ) ), "Passed!" );
 			assert.ok( a.containsPoint( new Vector3( 0, 0, - 50 ) ), "Passed!" );
@@ -176,10 +176,10 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "setFromMatrix/makePerspective/intersectsSphere", ( assert ) => {
+		QUnit.test( "setFromProjectionMatrix/makePerspective/intersectsSphere", ( assert ) => {
 
 			var m = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 
 			assert.ok( ! a.intersectsSphere( new Sphere( new Vector3( 0, 0, 0 ), 0 ) ), "Passed!" );
 			assert.ok( ! a.intersectsSphere( new Sphere( new Vector3( 0, 0, 0 ), 0.9 ) ), "Passed!" );
@@ -207,7 +207,7 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "intersectsObject", ( assert ) => {
 
 			var m = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 			var object = new Mesh( new BoxGeometry( 1, 1, 1 ) );
 			var intersects;
 
@@ -231,7 +231,7 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "intersectsSprite", ( assert ) => {
 
 			var m = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 			var sprite = new Sprite();
 			var intersects;
 
@@ -255,7 +255,7 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "intersectsBox", ( assert ) => {
 
 			var m = new Matrix4().makePerspective( - 1, 1, 1, - 1, 1, 100 );
-			var a = new Frustum().setFromMatrix( m );
+			var a = new Frustum().setFromProjectionMatrix( m );
 			var box = new Box3( zero3.clone(), one3.clone() );
 			var intersects;
 


### PR DESCRIPTION
```js
Frustum.setFromProjectionMatrix()
```
is consistent with our existing matrix-specific naming patterns, such as:
```js
Quaternion.setFromRotationMatrix()

Euler.setFromRotationMatrix()

BufferAttribute.applyNormalMatrix()
```
---

I have updated `src`, `.ts`, `docs/en`, `docs/zh`, `unit`,  `Legacy`, `DeprecatedList/en`, `DeprecatedList/zh`, `examples/html`, `examples/js`, `examples/jsm`, and `examples/ts`.

Oh, and for future reference, there is the `editor` -- and who knows, maybe something else...  :/

I will update the `Migration` docs after merging.