### PR TITLE
Editor: Avoid duplicated code in RemoveObjectCommand.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -144,7 +144,7 @@ Editor.prototype = {
 
 	//
 
-	addObject: function ( object ) {
+	addObject: function ( object, parent, index ) {
 
 		var scope = this;
 
@@ -158,7 +158,16 @@ Editor.prototype = {
 
 		} );
 
-		this.scene.add( object );
+		if ( parent === undefined ) {
+
+			this.scene.add( object );
+
+		} else {
+
+			parent.children.splice( index, 0, object );
+			object.parent = parent;
+
+		}
 
 		this.signals.objectAdded.dispatch( object );
 		this.signals.sceneGraphChanged.dispatch();

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -33,40 +33,15 @@ RemoveObjectCommand.prototype = {
 
 	execute: function () {
 
-		var scope = this.editor;
-		this.object.traverse( function ( child ) {
-
-			scope.removeHelper( child );
-
-		} );
-
-		this.parent.remove( this.object );
-		this.editor.select( this.parent );
-
-		this.editor.signals.objectRemoved.dispatch( this.object );
-		this.editor.signals.sceneGraphChanged.dispatch();
+		this.editor.removeObject( this.object );
+		this.editor.deselect();
 
 	},
 
 	undo: function () {
 
-		var scope = this.editor;
-
-		this.object.traverse( function ( child ) {
-
-			if ( child.geometry !== undefined ) scope.addGeometry( child.geometry );
-			if ( child.material !== undefined ) scope.addMaterial( child.material );
-
-			scope.addHelper( child );
-
-		} );
-
-		this.parent.children.splice( this.index, 0, this.object );
-		this.object.parent = this.parent;
+		this.editor.addObject( this.object, this.parent, this.index );
 		this.editor.select( this.object );
-
-		this.editor.signals.objectAdded.dispatch( this.object );
-		this.editor.signals.sceneGraphChanged.dispatch();
 
 	},
 


### PR DESCRIPTION
`RemoveObjectCommand` has duplicated some code from the `Editor` class. This PR tries to ensure that `RemoveObjectCommand` adds and removes objects via `Editor.addObject()` and `Editor.removeObject()`.

I've thought about #18308 and it seems preferable if the command classes do not perform actions that belong to `Editor`. That could make it easier to monitor changes in the scene graph, materials etc.