### PR TITLE
InstancedMesh: frustumCulled false by default.

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -20,6 +20,8 @@ function InstancedMesh( geometry, material, count ) {
 
 	this.count = count;
 
+	this.frustumCulled = false;
+
 }
 
 InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {


### PR DESCRIPTION
I think this is a better default until we figure out the right way to handle bounding boxes/spheres.

@WestLangley @Mugen87 @donmccurdy does this sound okay to you?