### PR TITLE
update SpecGloss refreshUniforms

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -941,17 +941,19 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
-				if ( material.envMap ) {
+				var envMap = material.envMap || scene.environment;
 
-					uniforms.envMap.value = material.envMap;
+				if ( envMap ) {
+
+					uniforms.envMap.value = envMap;
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
-					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
+					uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;
 					uniforms.refractionRatio.value = material.refractionRatio;
 
-					uniforms.maxMipLevel.value = renderer.properties.get( material.envMap ).__maxMipLevel;
+					uniforms.maxMipLevel.value = renderer.properties.get( envMap ).__maxMipLevel;
 
 				}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1009,17 +1009,19 @@ var GLTFLoader = ( function () {
 
 				}
 
-				if ( material.envMap ) {
+				var envMap = material.envMap || scene.environment;
 
-					uniforms.envMap.value = material.envMap;
+				if ( envMap ) {
+
+					uniforms.envMap.value = envMap;
 					uniforms.envMapIntensity.value = material.envMapIntensity;
 
-					uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
+					uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
 
 					uniforms.reflectivity.value = material.reflectivity;
 					uniforms.refractionRatio.value = material.refractionRatio;
 
-					uniforms.maxMipLevel.value = renderer.properties.get( material.envMap ).__maxMipLevel;
+					uniforms.maxMipLevel.value = renderer.properties.get( envMap ).__maxMipLevel;
 
 				}
 


### PR DESCRIPTION
Fixes #18463 

I really thought this would fix the problem, but it doesn't. Git bisect pointed to the scene.environment PR, which changed the refeshUniforms functions. I tried to mirror that here, but it seems to be not quite enough. I need to go home for the day, but if anyone else could take a look, it'd be great to fix this for r113.