### PR TITLE
Editor: Automatically remove unused materials from material browser.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -625,6 +625,8 @@ Editor.prototype = {
 		this.textures = {};
 		this.scripts = {};
 
+		this.materialsRefCounter.clear();
+
 		this.animations = {};
 		this.mixer.stopAllAction();
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -609,6 +609,18 @@ var SidebarMaterial = function ( editor ) {
 
 				}
 
+				if ( Array.isArray( currentObject.material ) ) {
+
+					// don't remove the entire multi-material. just the material of the selected slot
+
+					editor.removeMaterial( currentObject.material[ currentMaterialSlot ] );
+
+				} else {
+
+					editor.removeMaterial( currentObject.material );
+
+				}
+
 				editor.execute( new SetMaterialCommand( editor, currentObject, material, currentMaterialSlot ), 'New Material: ' + materialClass.getValue() );
 				editor.addMaterial( material );
 				// TODO Copy other references in the scene graph

--- a/editor/js/Sidebar.Project.js
+++ b/editor/js/Sidebar.Project.js
@@ -112,11 +112,6 @@ var SidebarProject = function ( editor ) {
 	materials.add( headerRow );
 
 	var listbox = new UIListbox();
-	signals.materialAdded.add( function () {
-
-		listbox.setItems( Object.values( editor.materials ) );
-
-	} );
 	materials.add( listbox );
 
 	var buttonsRow = new UIRow();
@@ -136,13 +131,25 @@ var SidebarProject = function ( editor ) {
 	var assignMaterial = new UIButton().setLabel( strings.getKey( 'sidebar/project/Assign' ) ).setMargin( '0px 5px' );
 	assignMaterial.onClick( function () {
 
-		if ( editor.selected !== null ) {
+		var selectedObject = editor.selected;
 
-			var material = editor.getMaterialById( parseInt( listbox.getValue() ) );
+		if ( selectedObject !== null ) {
 
-			if ( material !== undefined ) {
+			var oldMaterial = selectedObject.material;
 
-				editor.execute( new SetMaterialCommand( editor, editor.selected, material ) );
+			// only assing materials to objects with a material property (e.g. avoid assigning material to THREE.Group)
+
+			if ( oldMaterial !== undefined ) {
+
+				var material = editor.getMaterialById( parseInt( listbox.getValue() ) );
+
+				if ( material !== undefined ) {
+
+					editor.removeMaterial( oldMaterial );
+					editor.execute( new SetMaterialCommand( editor, selectedObject, material ) );
+					editor.addMaterial( material );
+
+				}
 
 			}
 
@@ -165,6 +172,15 @@ var SidebarProject = function ( editor ) {
 		}
 
 	} );
+
+	signals.materialAdded.add( refreshMaterialBrowserUI );
+	signals.materialRemoved.add( refreshMaterialBrowserUI );
+
+	function refreshMaterialBrowserUI() {
+
+		listbox.setItems( Object.values( editor.materials ) );
+
+	}
 
 	return container;
 


### PR DESCRIPTION
Fixed #18308.

The PR also ensures that you can only assign a material from the material browser to objects that have a material property (Otherwise it would be possible to select a group and assign a material to it).