### PR TITLE
Editor: Add support for background texture.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -122,7 +122,8 @@ Editor.prototype = {
 		this.scene.uuid = scene.uuid;
 		this.scene.name = scene.name;
 
-		if ( scene.background !== null ) this.scene.background = scene.background.clone();
+		this.scene.background = ( scene.background !== null ) ? scene.background.clone() : null;
+
 		if ( scene.fog !== null ) this.scene.fog = scene.fog.clone();
 
 		this.scene.userData = JSON.parse( JSON.stringify( scene.userData ) );
@@ -567,7 +568,7 @@ Editor.prototype = {
 		this.camera.copy( this.DEFAULT_CAMERA );
 		this.scene.name = "Scene";
 		this.scene.userData = {};
-		this.scene.background.setHex( 0xaaaaaa );
+		this.scene.background = new THREE.Color( 0xaaaaaa );
 		this.scene.fog = null;
 
 		var objects = this.scene.children;

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -294,6 +294,8 @@ var Viewport = function ( editor ) {
 	signals.editorCleared.add( function () {
 
 		controls.center.set( 0, 0, 0 );
+		currentBackgroundType = null;
+		currentFogType = null;
 		render();
 
 	} );
@@ -461,15 +463,42 @@ var Viewport = function ( editor ) {
 
 	} );
 
-	// fog
+	// background
 
-	signals.sceneBackgroundChanged.add( function ( backgroundColor ) {
+	var currentBackgroundType = null;
 
-		scene.background.setHex( backgroundColor );
+	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture ) {
+
+		if ( currentBackgroundType !== backgroundType ) {
+
+			switch ( backgroundType ) {
+
+				case 'None':
+					scene.background = null;
+					break;
+				case 'Color':
+					scene.background = new THREE.Color();
+					break;
+
+			}
+
+		}
+
+		if ( backgroundType === 'Color' ) {
+
+			scene.background.set( backgroundColor );
+
+		} else if ( backgroundType === 'Texture' ) {
+
+			scene.background = backgroundTexture;
+
+		}
 
 		render();
 
 	} );
+
+	// fog
 
 	var currentFogType = null;
 


### PR DESCRIPTION
It was already possible to define the background's color, now it's possible to define the background via a texture. The new select UI also enable to set the background to `null`.

![image](https://user-images.githubusercontent.com/12612165/73076835-378ec300-3ebf-11ea-8f20-0e1718af15d1.png)

This is actually a nice preparation to support more advanced scene backgrounds in the editor.

BTW: It's not yet possible to safe and reload a scene with a background texture since `ObjectLoader` is unable to serialize/deserialize such a scene. I'll have a look at this when the PR goes in 👍 