### PR TITLE
GammaCorrectionShader: use sRGB transfer function

### DIFF
--- a/examples/js/shaders/GammaCorrectionShader.js
+++ b/examples/js/shaders/GammaCorrectionShader.js
@@ -36,7 +36,7 @@ THREE.GammaCorrectionShader = {
 
 		"	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
 
-		"	gl_FragColor = LinearToGamma( tex, float( GAMMA_FACTOR ) );",
+		"	gl_FragColor = LinearTosRGB( tex );", // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
 
 		"}"
 

--- a/examples/jsm/shaders/GammaCorrectionShader.js
+++ b/examples/jsm/shaders/GammaCorrectionShader.js
@@ -38,7 +38,7 @@ var GammaCorrectionShader = {
 
 		"	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
 
-		"	gl_FragColor = LinearToGamma( tex, float( GAMMA_FACTOR ) );",
+		"	gl_FragColor = LinearTosRGB( tex );", // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
 
 		"}"
 


### PR DESCRIPTION
This change is OK for now, until we formalize our proposed post-processing workflow. See #18322.

The example that uses this shader decodes from sRGB anyway.

Fixes: #18468
