### PR TITLE
Scene: Add support for serialization/deserialization texture background.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -126,6 +126,8 @@ Editor.prototype = {
 
 		this.scene.background = ( scene.background !== null ) ? scene.background.clone() : null;
 
+		if ( this.scene.background && this.scene.background.isTexture ) this.scene.background.needsUpdate = true; // cloning a texture does not clone its version
+
 		if ( scene.fog !== null ) this.scene.fog = scene.fog.clone();
 
 		this.scene.userData = JSON.parse( JSON.stringify( scene.userData ) );
@@ -661,7 +663,13 @@ Editor.prototype = {
 		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
-		this.setScene( loader.parse( json.scene ) );
+		var scope = this;
+
+		loader.parse( json.scene, function ( scene ) {
+
+			scope.setScene( scene );
+
+		} );
 
 	},
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -540,17 +540,19 @@ var Loader = function ( editor ) {
 				var loader = new THREE.ObjectLoader();
 				loader.setResourcePath( scope.texturePath );
 
-				var result = loader.parse( data );
+				loader.parse( data, function ( result ) {
 
-				if ( result.isScene ) {
+					if ( result.isScene ) {
 
-					editor.execute( new SetSceneCommand( editor, result ) );
+						editor.execute( new SetSceneCommand( editor, result ) );
 
-				} else {
+					} else {
 
-					editor.execute( new AddObjectCommand( editor, result ) );
+						editor.execute( new AddObjectCommand( editor, result ) );
 
-				}
+					}
+
+				} );
 
 				break;
 

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -28,6 +28,22 @@ var SetSceneCommand = function ( editor, scene ) {
 		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );
 		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'userData', JSON.parse( JSON.stringify( scene.userData ) ) ) );
 
+		if ( scene.background !== null ) {
+
+			var background = scene.background.clone();
+
+			if ( background.isTexture ) background.needsUpdate = true; // cloning a texture does not clone its version
+
+			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'background', background ) );
+
+		}
+
+		if ( scene.fog !== null ) {
+
+			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'fog', scene.fog.clone() ) );
+
+		}
+
 		while ( scene.children.length > 0 ) {
 
 			var child = scene.children.pop();

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -688,6 +688,29 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
+		if ( this.isScene ) {
+
+			var background = this.background;
+
+			if ( background !== null ) {
+
+				if ( background.isColor ) {
+
+					object.background = background.toJSON();
+
+				} else if ( background.isTexture ) {
+
+					object.background = background.toJSON( meta ).uuid;
+
+				}
+
+			}
+
+			if ( this.environment !== null ) object.environment = this.environment.toJSON( meta );
+			if ( this.fog !== null ) object.fog = this.fog.toJSON();
+
+		}
+
 		//
 
 		function serialize( library, element ) {

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -127,7 +127,7 @@ ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		var textures = this.parseTextures( json.textures, images );
 		var materials = this.parseMaterials( json.materials, textures );
 
-		var object = this.parseObject( json.object, geometries, materials );
+		var object = this.parseObject( json.object, geometries, materials, textures );
 
 		if ( json.animations ) {
 
@@ -687,7 +687,7 @@ ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	},
 
-	parseObject: function ( data, geometries, materials ) {
+	parseObject: function ( data, geometries, materials, textures ) {
 
 		var object;
 
@@ -750,6 +750,10 @@ ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 					if ( Number.isInteger( data.background ) ) {
 
 						object.background = new Color( data.background );
+
+					} else {
+
+						object.background = textures[ data.background ] || null;
 
 					}
 
@@ -954,7 +958,7 @@ ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			for ( var i = 0; i < children.length; i ++ ) {
 
-				object.add( this.parseObject( children[ i ], geometries, materials ) );
+				object.add( this.parseObject( children[ i ], geometries, materials, textures ) );
 
 			}
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -49,18 +49,6 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	},
 
-	toJSON: function ( meta ) {
-
-		var data = Object3D.prototype.toJSON.call( this, meta );
-
-		if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
-		if ( this.environment !== null ) data.object.environment = this.environment.toJSON( meta );
-		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
-
-		return data;
-
-	},
-
 	dispose: function () {
 
 		this.dispatchEvent( { type: 'dispose' } );


### PR DESCRIPTION
It's not possible to safe and restores scenes with a background texture.

The PR also ensures that textured objects of loaded (JSON) scenes are not black in the editor anymore. So far, it was always necessary to interact with the viewport to trigger a redraw so the textures were visible. This happens now automatically.

Fixed #15180.
Fixed #16154.