### PR TITLE
Support esm on node with conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "JavaScript 3D library",
   "main": "build/three.js",
   "module": "build/three.module.js",
+  "exports": {
+    "require": "./build/three.js",
+    "import": "./build/three.mjs"
+  },
   "types": "src/Three.d.ts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "build/three.js",
   "module": "build/three.module.js",
   "exports": {
-    "require": "./build/three.js",
-    "import": "./build/three.mjs"
+    "import": "./build/three.mjs",
+    "default": "./build/three.js"
   },
   "types": "src/Three.d.ts",
   "repository": {

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -235,5 +235,19 @@ export default [
 				indent: '\t'
 			}
 		]
+	},
+	{
+		input: 'src/Three.js',
+		plugins: [
+			glconstants(),
+			glsl(),
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'build/three.mjs',
+				indent: '\t'
+			}
+		]
 	}
 ];


### PR DESCRIPTION
# What changes are included in this PR?

Since 13.6 node is able to load esm without the `--experimental-modules` flag, and since 13.7 node supports [conditional exports](https://nodejs.org/api/esm.html#esm_conditional_exports) unflagged as well.

I modified the build config to support importing three.js from node as an ES module. As such code like
```js
import { BufferGeometry } from 'three';
```
becomes possible on node. Without this only 
```js
import three from 'three';
```
is possible on node, which is a pity if you've written all your code to use named exports.

This approach implies that an additional build file is created called `three.mjs`. In theory we could use the `three.module.js` file as well, but there are some problems with this. Because there's no `package.json` with `"type": "module"` in the build folder, node will interpret `three.module.js` as a *cjs* module. There are a few imaginable solutions for this:
 - Rename `three.module.js` to `three.module.mjs` and change `"module": "build/three.module.js"` to `"module": "build/three.module.mjs"`. This breaks all code explicitly depending on the file though.
 - Add a `package.json` file with `{ "type": "module" }` in the build folder. This however would cause node to interpret all `.js` files in `/build` as an ES module, which has the same drawbacks if someone on node explicitly depends on `const three = require('three/build/three.js');`

Given that both solutions aren't ideal, I went with the option to simply create an entire new build, which is a duplicate though of `three.module.js`.

# Why does one need to import three.js on node?

Obviously three.js is meant to be run in a browser, but it may be useful to be able to run it on node as well for the sake of unit testing. As such one can run unit tests without a transpilation step, especially since mocha [experimentally supports esm](https://github.com/mochajs/mocha/pull/4038) as well.