### PR TITLE
Remove unused numXxxx members of WebGLLights

### DIFF
--- a/src/renderers/webgl/WebGLLights.d.ts
+++ b/src/renderers/webgl/WebGLLights.d.ts
@@ -30,10 +30,6 @@ export class WebGLLights {
 		pointShadowMap: Array<any>;
 		pointShadowMatrix: Array<any>;
 		hemi: Array<any>;
-
-		numDirectionalShadows: number;
-		numPointShadows: number;
-		numSpotShadows: number;
 	};
 
 	get( light: any ): any;

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -142,10 +142,6 @@ function WebGLLights() {
 		pointShadowMatrix: [],
 		hemi: [],
 
-		numDirectionalShadows: - 1,
-		numPointShadows: - 1,
-		numSpotShadows: - 1
-
 	};
 
 	for ( var i = 0; i < 9; i ++ ) state.probe.push( new Vector3() );


### PR DESCRIPTION
I think `WebGLLights.state` members `numDirectionalShadows`, `numPointShadows` and `numSpotShadows` are no longer used. Corresponding members of `hash` are used, as well as local variables with the same name.
