### PR TITLE
CSS3DRenderer.d.ts: Overwrite typescript signatures of onBeforeRender() and onAfterRender().

### DIFF
--- a/examples/jsm/renderers/CSS3DRenderer.d.ts
+++ b/examples/jsm/renderers/CSS3DRenderer.d.ts
@@ -9,6 +9,9 @@ export class CSS3DObject extends Object3D {
 	constructor( element: HTMLElement );
 	element: HTMLElement;
 
+	onBeforeRender: (renderer: CSS3DRenderer, scene: Scene, camera: Camera) => void;
+	onAfterRender: (renderer: CSS3DRenderer, scene: Scene, camera: Camera) => void;
+
 }
 
 export class CSS3DSprite extends CSS3DObject {


### PR DESCRIPTION
See #18502.