### PR TITLE
Vector3: support the zero vector in projections

### DIFF
--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -117,7 +117,7 @@ var d = a.distanceTo( b );
 
 		<h3>[method:Float angleTo]( [param:Vector3 v] )</h3>
 		<p>
-		Returns the angle between this vector and vector [page:Vector3 v] in radians. Neither this vector nor [page:Vector3 v] can be the zero vector.
+		Returns the angle between this vector and vector [page:Vector3 v] in radians.
 		</p>
 
 		<h3>[method:this ceil]()</h3>
@@ -317,7 +317,7 @@ var d = a.distanceTo( b );
 		</p>
 
 		<h3>[method:this projectOnVector]( [param:Vector3 v] )</h3>
-		<p>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto [page:Vector3 v]. [page:Vector3 v] cannot be the zero vector.</p>
+		<p>[link:https://en.wikipedia.org/wiki/Vector_projection Projects] this vector onto [page:Vector3 v].</p>
 
 		<h3>[method:this reflect]( [param:Vector3 normal] )</h3>
 		<p>

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -114,7 +114,7 @@ var d = a.distanceTo( b );
 
 		<h3>[method:Float angleTo]( [param:Vector3 v] )</h3>
 		<p>
-		以弧度返回该向量与向量[page:Vector3 v]之间的角度。 Neither this vector nor [page:Vector3 v] can be the zero vector.
+		以弧度返回该向量与向量[page:Vector3 v]之间的角度。
 		</p>
 
 		<h3>[method:this ceil]()</h3>
@@ -313,7 +313,7 @@ var d = a.distanceTo( b );
 		</p>
 
 		<h3>[method:this projectOnVector]( [param:Vector3] )</h3>
-		<p>投影（[link:https://en.wikipedia.org/wiki/Vector_projection Projects]）该向量到向量[page:Vector3 v]上。[page:Vector3 v]不能是零向量。</p>
+		<p>投影（[link:https://en.wikipedia.org/wiki/Vector_projection Projects]）该向量到向量[page:Vector3 v]上。</p>
 
 		<h3>[method:this reflect]( [param:Vector3 normal] )</h3>
 		<p>

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -534,9 +534,11 @@ Object.assign( Vector3.prototype, {
 
 	projectOnVector: function ( v ) {
 
-		// v cannot be the zero v
+		var denominator = v.lengthSq();
 
-		var scalar = v.dot( this ) / v.lengthSq();
+		if ( denominator === 0 ) return this.set( 0, 0, 0 );
+
+		var scalar = v.dot( this ) / denominator;
 
 		return this.copy( v ).multiplyScalar( scalar );
 
@@ -563,7 +565,7 @@ Object.assign( Vector3.prototype, {
 
 		var denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
 
-		if ( denominator === 0 ) console.error( 'THREE.Vector3: angleTo() can\'t handle zero length vectors.' );
+		if ( denominator === 0 ) return Math.PI / 2;
 
 		var theta = this.dot( v ) / denominator;
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/issues/17545#issuecomment-579721218.

The convention followed in this PR is the zero vector is orthogonal to every vector.

Following this convention prevents `NaN` from being returned in the related `Vector3` methods.