### PR TITLE
Editor: Add HDR support for UITexture and UICubeTexture.

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -124,6 +124,23 @@ var SidebarScene = function ( editor ) {
 
 	}
 
+	function onTextureChanged( texture ) {
+
+		texture.encoding = texture.isHDRTexture ? THREE.RGBEEncoding : THREE.sRGBEncoding;
+
+		if ( texture.isCubeTexture && texture.isHDRTexture ) {
+
+			texture.format = THREE.RGBAFormat;
+			texture.minFilter = THREE.NearestFilter;
+			texture.magFilter = THREE.NearestFilter;
+			texture.generateMipmaps = false;
+
+		}
+
+		onBackgroundChanged();
+
+	}
+
 	var backgroundRow = new UIRow();
 
 	var backgroundType = new UISelect().setOptions( {
@@ -163,7 +180,7 @@ var SidebarScene = function ( editor ) {
 	textureRow.setDisplay( 'none' );
 	textureRow.setMarginLeft( '90px' );
 
-	var backgroundTexture = new UITexture().onChange( onBackgroundChanged );
+	var backgroundTexture = new UITexture().onChange( onTextureChanged );
 	textureRow.add( backgroundTexture );
 
 	container.add( textureRow );
@@ -174,7 +191,7 @@ var SidebarScene = function ( editor ) {
 	cubeTextureRow.setDisplay( 'none' );
 	cubeTextureRow.setMarginLeft( '90px' );
 
-	var backgroundCubeTexture = new UICubeTexture().onChange( onBackgroundChanged );
+	var backgroundCubeTexture = new UICubeTexture().onChange( onTextureChanged );
 	cubeTextureRow.add( backgroundCubeTexture );
 
 	container.add( cubeTextureRow );

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -498,12 +498,6 @@ var Viewport = function ( editor ) {
 
 		}
 
-		if ( scene.background !== null && ( scene.background.isTexture || scene.background.isCubeTexture ) ) {
-
-			scene.background.encoding = THREE.sRGBEncoding;
-
-		}
-
 		render();
 
 	} );

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -936,6 +936,7 @@ function renderToCanvas( texture ) {
 
 	renderer.setSize( image.width, image.height, false );
 	renderer.toneMapping = THREE.ReinhardToneMapping;
+	renderer.toneMappingExposure = 2;
 	renderer.outputEncoding = THREE.sRGBEncoding;
 
 	var scene = new THREE.Scene();

--- a/editor/sw.js
+++ b/editor/sw.js
@@ -27,6 +27,7 @@ const assets = [
 	'../examples/jsm/loaders/OBJLoader.js',
 	'../examples/jsm/loaders/MTLLoader.js',
 	'../examples/jsm/loaders/PLYLoader.js',
+	'../examples/jsm/loaders/RGBELoader.js',
 	'../examples/jsm/loaders/STLLoader.js',
 	'../examples/jsm/loaders/SVGLoader.js',
 	'../examples/jsm/loaders/TGALoader.js',


### PR DESCRIPTION
This PR ass support for `RGBE`/`Radiance HDR images` to `UITexture` and `UICubeTexture` (this type of HDR texture has the `.hdr` extension). In the first step, only textures of data type `UnsignedByteType` are supported.

Next, I'd like to enhance the `PROJECT`-> `Renderer` section so tonemapping can be configured.