### PR TITLE
Fixed a spelling issue under the IIS section

### DIFF
--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -123,8 +123,8 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 			</div>
 			<h3>IIS</h3>
 			<div>
-				<p>If you are using Microsoft IIS as web server. Please add a MIME type settings regarding .fbx externsion before loading.</p>
-				<code>File name externsion: fbx        MIME Type: text/plain</code>
+				<p>If you are using Microsoft IIS as web server. Please add a MIME type settings regarding .fbx extension before loading.</p>
+				<code>File name extension: fbx        MIME Type: text/plain</code>
 				<p>By default, IIS blocks .fbx, .obj files downloads. You have to configure IIS to enable these kind of files can be download.</p>
 			</div>
 			<p>


### PR DESCRIPTION
As this is a documentation fix and there is no official format for such things, I just submitted this PR. There was a typo I noticed and it is fixed in this pull request.