### PR TITLE
CSS2DObject and CSS3DObject: Remove broken generics and make renderer parameter unknown

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.d.ts
+++ b/examples/jsm/renderers/CSS2DRenderer.d.ts
@@ -9,8 +9,8 @@ export class CSS2DObject extends Object3D {
 	constructor( element: HTMLElement );
 	element: HTMLElement;
 
-	onBeforeRender: <Renderer = CSS2DRenderer>(renderer: Renderer, scene: Scene, camera: Camera) => void;
- 	onAfterRender: <Renderer = CSS2DRenderer>(renderer: Renderer, scene: Scene, camera: Camera) => void;
+	onBeforeRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
+ 	onAfterRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
 
 }
 

--- a/examples/jsm/renderers/CSS3DRenderer.d.ts
+++ b/examples/jsm/renderers/CSS3DRenderer.d.ts
@@ -9,8 +9,8 @@ export class CSS3DObject extends Object3D {
 	constructor( element: HTMLElement );
 	element: HTMLElement;
 
-	onBeforeRender: <Renderer = CSS3DRenderer>(renderer: Renderer, scene: Scene, camera: Camera) => void;
-	onAfterRender: <Renderer = CSS3DRenderer>(renderer: Renderer, scene: Scene, camera: Camera) => void;
+	onBeforeRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
+	onAfterRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
 
 }
 

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -153,8 +153,8 @@ export class Object3D extends EventDispatcher {
 	/**
 	 * Calls before rendering object
 	 */
-	onBeforeRender: <Renderer = WebGLRenderer>(
-		renderer: Renderer,
+	onBeforeRender: (
+		renderer: WebGLRenderer,
 		scene: Scene,
 		camera: Camera,
 		geometry: Geometry | BufferGeometry,
@@ -165,8 +165,8 @@ export class Object3D extends EventDispatcher {
 	/**
 	 * Calls after rendering object
 	 */
-	onAfterRender: <Renderer = WebGLRenderer>(
-		renderer: Renderer,
+	onAfterRender: (
+		renderer: WebGLRenderer,
 		scene: Scene,
 		camera: Camera,
 		geometry: Geometry | BufferGeometry,


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/pull/18518#issuecomment-580511393