### PR TITLE
Use string templates(``) in example shaders

### DIFF
--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -54,63 +54,59 @@ THREE.AnaglyphEffect = function ( renderer, width, height ) {
 
 		},
 
-		vertexShader: [
+		vertexShader: /* glsl */`
+varying vec2 vUv;
 
-			"varying vec2 vUv;",
+void main() {
 
-			"void main() {",
+	vUv = vec2( uv.x, uv.y );
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-			"	vUv = vec2( uv.x, uv.y );",
-			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-			"}"
+		fragmentShader: /* glsl */`
+uniform sampler2D mapLeft;
+uniform sampler2D mapRight;
+varying vec2 vUv;
 
-		].join( "\n" ),
+uniform mat3 colorMatrixLeft;
+uniform mat3 colorMatrixRight;
 
-		fragmentShader: [
+// These functions implement sRGB linearization and gamma correction
 
-			"uniform sampler2D mapLeft;",
-			"uniform sampler2D mapRight;",
-			"varying vec2 vUv;",
+float lin( float c ) {
+	return c <= 0.04045 ? c * 0.0773993808 :
+			pow( c * 0.9478672986 + 0.0521327014, 2.4 );
+}
 
-			"uniform mat3 colorMatrixLeft;",
-			"uniform mat3 colorMatrixRight;",
+vec4 lin( vec4 c ) {
+	return vec4( lin( c.r ), lin( c.g ), lin( c.b ), c.a );
+}
 
-			// These functions implement sRGB linearization and gamma correction
-
-			"float lin( float c ) {",
-			"	return c <= 0.04045 ? c * 0.0773993808 :",
-			"			pow( c * 0.9478672986 + 0.0521327014, 2.4 );",
-			"}",
-
-			"vec4 lin( vec4 c ) {",
-			"	return vec4( lin( c.r ), lin( c.g ), lin( c.b ), c.a );",
-			"}",
-
-			"float dev( float c ) {",
-			"	return c <= 0.0031308 ? c * 12.92",
-			"			: pow( c, 0.41666 ) * 1.055 - 0.055;",
-			"}",
+float dev( float c ) {
+	return c <= 0.0031308 ? c * 12.92
+			: pow( c, 0.41666 ) * 1.055 - 0.055;
+}
 
 
-			"void main() {",
+void main() {
 
-			"	vec2 uv = vUv;",
+	vec2 uv = vUv;
 
-			"	vec4 colorL = lin( texture2D( mapLeft, uv ) );",
-			"	vec4 colorR = lin( texture2D( mapRight, uv ) );",
+	vec4 colorL = lin( texture2D( mapLeft, uv ) );
+	vec4 colorR = lin( texture2D( mapRight, uv ) );
 
-			"	vec3 color = clamp(",
-			"			colorMatrixLeft * colorL.rgb +",
-			"			colorMatrixRight * colorR.rgb, 0., 1. );",
+	vec3 color = clamp(
+			colorMatrixLeft * colorL.rgb +
+			colorMatrixRight * colorR.rgb, 0., 1. );
 
-			"	gl_FragColor = vec4(",
-			"			dev( color.r ), dev( color.g ), dev( color.b ),",
-			"			max( colorL.a, colorR.a ) );",
+	gl_FragColor = vec4(
+			dev( color.r ), dev( color.g ), dev( color.b ),
+			max( colorL.a, colorR.a ) );
 
-			"}"
-
-		].join( "\n" )
+}
+`
 
 	} );
 

--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -55,59 +55,58 @@ THREE.AnaglyphEffect = function ( renderer, width, height ) {
 		},
 
 		vertexShader: /* glsl */`
-varying vec2 vUv;
+			varying vec2 vUv;
 
-void main() {
+			void main() {
 
-	vUv = vec2( uv.x, uv.y );
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				vUv = vec2( uv.x, uv.y );
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+			}
+		`,
 
 		fragmentShader: /* glsl */`
-uniform sampler2D mapLeft;
-uniform sampler2D mapRight;
-varying vec2 vUv;
+			uniform sampler2D mapLeft;
+			uniform sampler2D mapRight;
+			varying vec2 vUv;
 
-uniform mat3 colorMatrixLeft;
-uniform mat3 colorMatrixRight;
+			uniform mat3 colorMatrixLeft;
+			uniform mat3 colorMatrixRight;
 
-// These functions implement sRGB linearization and gamma correction
+			// These functions implement sRGB linearization and gamma correction
 
-float lin( float c ) {
-	return c <= 0.04045 ? c * 0.0773993808 :
-			pow( c * 0.9478672986 + 0.0521327014, 2.4 );
-}
+			float lin( float c ) {
+				return c <= 0.04045 ? c * 0.0773993808 :
+						pow( c * 0.9478672986 + 0.0521327014, 2.4 );
+			}
 
-vec4 lin( vec4 c ) {
-	return vec4( lin( c.r ), lin( c.g ), lin( c.b ), c.a );
-}
+			vec4 lin( vec4 c ) {
+				return vec4( lin( c.r ), lin( c.g ), lin( c.b ), c.a );
+			}
 
-float dev( float c ) {
-	return c <= 0.0031308 ? c * 12.92
-			: pow( c, 0.41666 ) * 1.055 - 0.055;
-}
+			float dev( float c ) {
+				return c <= 0.0031308 ? c * 12.92
+						: pow( c, 0.41666 ) * 1.055 - 0.055;
+			}
 
 
-void main() {
+			void main() {
 
-	vec2 uv = vUv;
+				vec2 uv = vUv;
 
-	vec4 colorL = lin( texture2D( mapLeft, uv ) );
-	vec4 colorR = lin( texture2D( mapRight, uv ) );
+				vec4 colorL = lin( texture2D( mapLeft, uv ) );
+				vec4 colorR = lin( texture2D( mapRight, uv ) );
 
-	vec3 color = clamp(
-			colorMatrixLeft * colorL.rgb +
-			colorMatrixRight * colorR.rgb, 0., 1. );
+				vec3 color = clamp(
+						colorMatrixLeft * colorL.rgb +
+						colorMatrixRight * colorR.rgb, 0., 1. );
 
-	gl_FragColor = vec4(
-			dev( color.r ), dev( color.g ), dev( color.b ),
-			max( colorL.a, colorR.a ) );
+				gl_FragColor = vec4(
+						dev( color.r ), dev( color.g ), dev( color.b ),
+						max( colorL.a, colorR.a ) );
 
-}
-`
-
+			}
+		`
 	} );
 
 	var _mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), _material );

--- a/examples/js/effects/AsciiEffect.js
+++ b/examples/js/effects/AsciiEffect.js
@@ -66,10 +66,10 @@ THREE.AsciiEffect = function ( renderer, charSet, options ) {
 	// Throw in ascii library from http://www.nihilogic.dk/labs/jsascii/jsascii.js
 
 	/*
-	* jsAscii 0.1
-	* Copyright (c) 2008 Jacob Seidelin, jseidelin@nihilogic.dk, http://blog.nihilogic.dk/
-	* MIT License [http://www.nihilogic.dk/licenses/mit-license.txt]
-	*/
+	 * jsAscii 0.1
+	 * Copyright (c) 2008 Jacob Seidelin, jseidelin@nihilogic.dk, http://blog.nihilogic.dk/
+	 * MIT License [http://www.nihilogic.dk/licenses/mit-license.txt]
+	 */
 
 	function initAsciiSize() {
 

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -94,75 +94,75 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 	};
 
 	var vertexShader = /* glsl */`
-#include <common>
-#include <uv_pars_vertex>
-#include <displacementmap_pars_vertex>
-#include <fog_pars_vertex>
-#include <morphtarget_pars_vertex>
-#include <skinning_pars_vertex>
-#include <logdepthbuf_pars_vertex>
-#include <clipping_planes_pars_vertex>
+		#include <common>
+		#include <uv_pars_vertex>
+		#include <displacementmap_pars_vertex>
+		#include <fog_pars_vertex>
+		#include <morphtarget_pars_vertex>
+		#include <skinning_pars_vertex>
+		#include <logdepthbuf_pars_vertex>
+		#include <clipping_planes_pars_vertex>
 
-uniform float outlineThickness;
+		uniform float outlineThickness;
 
-vec4 calculateOutline( vec4 pos, vec3 normal, vec4 skinned ) {
-	float thickness = outlineThickness;
-	const float ratio = 1.0; // TODO: support outline thickness ratio for each vertex
-	vec4 pos2 = projectionMatrix * modelViewMatrix * vec4( skinned.xyz + normal, 1.0 );
-	// NOTE: subtract pos2 from pos because BackSide objectNormal is negative
-	vec4 norm = normalize( pos - pos2 );
-	return pos + norm * thickness * pos.w * ratio;
-}
+		vec4 calculateOutline( vec4 pos, vec3 normal, vec4 skinned ) {
+			float thickness = outlineThickness;
+			const float ratio = 1.0; // TODO: support outline thickness ratio for each vertex
+			vec4 pos2 = projectionMatrix * modelViewMatrix * vec4( skinned.xyz + normal, 1.0 );
+			// NOTE: subtract pos2 from pos because BackSide objectNormal is negative
+			vec4 norm = normalize( pos - pos2 );
+			return pos + norm * thickness * pos.w * ratio;
+		}
 
-void main() {
+		void main() {
 
-	#include <uv_vertex>
+			#include <uv_vertex>
 
-	#include <beginnormal_vertex>
-	#include <morphnormal_vertex>
-	#include <skinbase_vertex>
-	#include <skinnormal_vertex>
+			#include <beginnormal_vertex>
+			#include <morphnormal_vertex>
+			#include <skinbase_vertex>
+			#include <skinnormal_vertex>
 
-	#include <begin_vertex>
-	#include <morphtarget_vertex>
-	#include <skinning_vertex>
-	#include <displacementmap_vertex>
-	#include <project_vertex>
+			#include <begin_vertex>
+			#include <morphtarget_vertex>
+			#include <skinning_vertex>
+			#include <displacementmap_vertex>
+			#include <project_vertex>
 
-	vec3 outlineNormal = - objectNormal; // the outline material is always rendered with THREE.BackSide
+			vec3 outlineNormal = - objectNormal; // the outline material is always rendered with THREE.BackSide
 
-	gl_Position = calculateOutline( gl_Position, outlineNormal, vec4( transformed, 1.0 ) );
+			gl_Position = calculateOutline( gl_Position, outlineNormal, vec4( transformed, 1.0 ) );
 
-	#include <logdepthbuf_vertex>
-	#include <clipping_planes_vertex>
-	#include <fog_vertex>
+			#include <logdepthbuf_vertex>
+			#include <clipping_planes_vertex>
+			#include <fog_vertex>
 
-}
-`;
+		}
+	`;
 
 	var fragmentShader = /* glsl */`
-#include <common>
-#include <fog_pars_fragment>
-#include <logdepthbuf_pars_fragment>
-#include <clipping_planes_pars_fragment>
+		#include <common>
+		#include <fog_pars_fragment>
+		#include <logdepthbuf_pars_fragment>
+		#include <clipping_planes_pars_fragment>
 
-uniform vec3 outlineColor;
-uniform float outlineAlpha;
+		uniform vec3 outlineColor;
+		uniform float outlineAlpha;
 
-void main() {
+		void main() {
 
-	#include <clipping_planes_fragment>
-	#include <logdepthbuf_fragment>
+			#include <clipping_planes_fragment>
+			#include <logdepthbuf_fragment>
 
-	gl_FragColor = vec4( outlineColor, outlineAlpha );
+			gl_FragColor = vec4( outlineColor, outlineAlpha );
 
-	#include <tonemapping_fragment>
-	#include <encodings_fragment>
-	#include <fog_fragment>
-	#include <premultiplied_alpha_fragment>
+			#include <tonemapping_fragment>
+			#include <encodings_fragment>
+			#include <fog_fragment>
+			#include <premultiplied_alpha_fragment>
 
-}
-`;
+		}
+	`;
 
 	function createMaterial() {
 

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -93,79 +93,76 @@ THREE.OutlineEffect = function ( renderer, parameters ) {
 		outlineAlpha: { value: defaultAlpha }
 	};
 
-	var vertexShader = [
-		"#include <common>",
-		"#include <uv_pars_vertex>",
-		"#include <displacementmap_pars_vertex>",
-		"#include <fog_pars_vertex>",
-		"#include <morphtarget_pars_vertex>",
-		"#include <skinning_pars_vertex>",
-		"#include <logdepthbuf_pars_vertex>",
-		"#include <clipping_planes_pars_vertex>",
+	var vertexShader = /* glsl */`
+#include <common>
+#include <uv_pars_vertex>
+#include <displacementmap_pars_vertex>
+#include <fog_pars_vertex>
+#include <morphtarget_pars_vertex>
+#include <skinning_pars_vertex>
+#include <logdepthbuf_pars_vertex>
+#include <clipping_planes_pars_vertex>
 
-		"uniform float outlineThickness;",
+uniform float outlineThickness;
 
-		"vec4 calculateOutline( vec4 pos, vec3 normal, vec4 skinned ) {",
-		"	float thickness = outlineThickness;",
-		"	const float ratio = 1.0;", // TODO: support outline thickness ratio for each vertex
-		"	vec4 pos2 = projectionMatrix * modelViewMatrix * vec4( skinned.xyz + normal, 1.0 );",
-		// NOTE: subtract pos2 from pos because BackSide objectNormal is negative
-		"	vec4 norm = normalize( pos - pos2 );",
-		"	return pos + norm * thickness * pos.w * ratio;",
-		"}",
+vec4 calculateOutline( vec4 pos, vec3 normal, vec4 skinned ) {
+	float thickness = outlineThickness;
+	const float ratio = 1.0; // TODO: support outline thickness ratio for each vertex
+	vec4 pos2 = projectionMatrix * modelViewMatrix * vec4( skinned.xyz + normal, 1.0 );
+	// NOTE: subtract pos2 from pos because BackSide objectNormal is negative
+	vec4 norm = normalize( pos - pos2 );
+	return pos + norm * thickness * pos.w * ratio;
+}
 
-		"void main() {",
+void main() {
 
-		"	#include <uv_vertex>",
+	#include <uv_vertex>
 
-		"	#include <beginnormal_vertex>",
-		"	#include <morphnormal_vertex>",
-		"	#include <skinbase_vertex>",
-		"	#include <skinnormal_vertex>",
+	#include <beginnormal_vertex>
+	#include <morphnormal_vertex>
+	#include <skinbase_vertex>
+	#include <skinnormal_vertex>
 
-		"	#include <begin_vertex>",
-		"	#include <morphtarget_vertex>",
-		"	#include <skinning_vertex>",
-		"	#include <displacementmap_vertex>",
-		"	#include <project_vertex>",
+	#include <begin_vertex>
+	#include <morphtarget_vertex>
+	#include <skinning_vertex>
+	#include <displacementmap_vertex>
+	#include <project_vertex>
 
-		"	vec3 outlineNormal = - objectNormal;", // the outline material is always rendered with THREE.BackSide
+	vec3 outlineNormal = - objectNormal; // the outline material is always rendered with THREE.BackSide
 
-		"	gl_Position = calculateOutline( gl_Position, outlineNormal, vec4( transformed, 1.0 ) );",
+	gl_Position = calculateOutline( gl_Position, outlineNormal, vec4( transformed, 1.0 ) );
 
-		"	#include <logdepthbuf_vertex>",
-		"	#include <clipping_planes_vertex>",
-		"	#include <fog_vertex>",
+	#include <logdepthbuf_vertex>
+	#include <clipping_planes_vertex>
+	#include <fog_vertex>
 
-		"}",
+}
+`;
 
-	].join( "\n" );
+	var fragmentShader = /* glsl */`
+#include <common>
+#include <fog_pars_fragment>
+#include <logdepthbuf_pars_fragment>
+#include <clipping_planes_pars_fragment>
 
-	var fragmentShader = [
+uniform vec3 outlineColor;
+uniform float outlineAlpha;
 
-		"#include <common>",
-		"#include <fog_pars_fragment>",
-		"#include <logdepthbuf_pars_fragment>",
-		"#include <clipping_planes_pars_fragment>",
+void main() {
 
-		"uniform vec3 outlineColor;",
-		"uniform float outlineAlpha;",
+	#include <clipping_planes_fragment>
+	#include <logdepthbuf_fragment>
 
-		"void main() {",
+	gl_FragColor = vec4( outlineColor, outlineAlpha );
 
-		"	#include <clipping_planes_fragment>",
-		"	#include <logdepthbuf_fragment>",
+	#include <tonemapping_fragment>
+	#include <encodings_fragment>
+	#include <fog_fragment>
+	#include <premultiplied_alpha_fragment>
 
-		"	gl_FragColor = vec4( outlineColor, outlineAlpha );",
-
-		"	#include <tonemapping_fragment>",
-		"	#include <encodings_fragment>",
-		"	#include <fog_fragment>",
-		"	#include <premultiplied_alpha_fragment>",
-
-		"}"
-
-	].join( "\n" );
+}
+`;
 
 	function createMaterial() {
 

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -27,38 +27,37 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 		},
 
 		vertexShader: /* glsl */`
-varying vec2 vUv;
+			varying vec2 vUv;
 
-void main() {
+			void main() {
 
-	vUv = vec2( uv.x, uv.y );
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				vUv = vec2( uv.x, uv.y );
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+			}
+		`,
 
 		fragmentShader: /* glsl */`
-uniform sampler2D mapLeft;
-uniform sampler2D mapRight;
-varying vec2 vUv;
+			uniform sampler2D mapLeft;
+			uniform sampler2D mapRight;
+			varying vec2 vUv;
 
-void main() {
+			void main() {
 
-	vec2 uv = vUv;
+				vec2 uv = vUv;
 
-	if ( ( mod( gl_FragCoord.y, 2.0 ) ) > 1.00 ) {
+				if ( ( mod( gl_FragCoord.y, 2.0 ) ) > 1.00 ) {
 
-		gl_FragColor = texture2D( mapLeft, uv );
+					gl_FragColor = texture2D( mapLeft, uv );
 
-	} else {
+				} else {
 
-		gl_FragColor = texture2D( mapRight, uv );
+					gl_FragColor = texture2D( mapRight, uv );
 
-	}
+				}
 
-}
-`
-
+			}
+		`
 	} );
 
 	var mesh = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), _material );

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -26,42 +26,38 @@ THREE.ParallaxBarrierEffect = function ( renderer ) {
 
 		},
 
-		vertexShader: [
+		vertexShader: /* glsl */`
+varying vec2 vUv;
 
-			"varying vec2 vUv;",
+void main() {
 
-			"void main() {",
+	vUv = vec2( uv.x, uv.y );
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-			"	vUv = vec2( uv.x, uv.y );",
-			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-			"}"
+		fragmentShader: /* glsl */`
+uniform sampler2D mapLeft;
+uniform sampler2D mapRight;
+varying vec2 vUv;
 
-		].join( "\n" ),
+void main() {
 
-		fragmentShader: [
+	vec2 uv = vUv;
 
-			"uniform sampler2D mapLeft;",
-			"uniform sampler2D mapRight;",
-			"varying vec2 vUv;",
+	if ( ( mod( gl_FragCoord.y, 2.0 ) ) > 1.00 ) {
 
-			"void main() {",
+		gl_FragColor = texture2D( mapLeft, uv );
 
-			"	vec2 uv = vUv;",
+	} else {
 
-			"	if ( ( mod( gl_FragCoord.y, 2.0 ) ) > 1.00 ) {",
+		gl_FragColor = texture2D( mapRight, uv );
 
-			"		gl_FragColor = texture2D( mapLeft, uv );",
+	}
 
-			"	} else {",
-
-			"		gl_FragColor = texture2D( mapRight, uv );",
-
-			"	}",
-
-			"}"
-
-		].join( "\n" )
+}
+`
 
 	} );
 

--- a/examples/js/geometries/ParametricGeometries.js
+++ b/examples/js/geometries/ParametricGeometries.js
@@ -159,10 +159,10 @@ THREE.ParametricGeometries.TubeGeometry.prototype.constructor = THREE.Parametric
 
 
 /*********************************************
-  *
-  * Parametric Replacement for TorusKnotGeometry
-  *
-  *********************************************/
+ *
+ * Parametric Replacement for TorusKnotGeometry
+ *
+ *********************************************/
 THREE.ParametricGeometries.TorusKnotGeometry = function ( radius, tube, segmentsT, segmentsR, p, q ) {
 
 	this.radius = radius || 200;
@@ -210,10 +210,10 @@ THREE.ParametricGeometries.TorusKnotGeometry.prototype.constructor = THREE.Param
 
 
 /*********************************************
-  *
-  * Parametric Replacement for SphereGeometry
-  *
-  *********************************************/
+ *
+ * Parametric Replacement for SphereGeometry
+ *
+ *********************************************/
 THREE.ParametricGeometries.SphereGeometry = function ( size, u, v ) {
 
 	function sphere( u, v, target ) {
@@ -238,10 +238,10 @@ THREE.ParametricGeometries.SphereGeometry.prototype.constructor = THREE.Parametr
 
 
 /*********************************************
-  *
-  * Parametric Replacement for PlaneGeometry
-  *
-  *********************************************/
+ *
+ * Parametric Replacement for PlaneGeometry
+ *
+ *********************************************/
 
 THREE.ParametricGeometries.PlaneGeometry = function ( width, depth, segmentsWidth, segmentsDepth ) {
 

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1671,7 +1671,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 					bits |= 0x7c00;
 					/* If exponent was 0xff and one mantissa bit was set, it means NaN,
-							 * not Inf, so make sure we set one mantissa bit too. */
+					 * not Inf, so make sure we set one mantissa bit too. */
 					bits |= ( ( e == 255 ) ? 0 : 1 ) && ( x & 0x007fffff );
 					return bits;
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -617,47 +617,47 @@ THREE.GLTFLoader = ( function () {
 		this.isGLTFSpecularGlossinessMaterial = true;
 
 		//various chunks that need replacing
-		var specularMapParsFragmentChunk = [
-			'#ifdef USE_SPECULARMAP',
-			'	uniform sampler2D specularMap;',
-			'#endif'
-		].join( '\n' );
+		var specularMapParsFragmentChunk = /* glsl */`
+			#ifdef USE_SPECULARMAP
+				uniform sampler2D specularMap;
+			#endif
+		`;
 
-		var glossinessMapParsFragmentChunk = [
-			'#ifdef USE_GLOSSINESSMAP',
-			'	uniform sampler2D glossinessMap;',
-			'#endif'
-		].join( '\n' );
+		var glossinessMapParsFragmentChunk = /* glsl */`
+			#ifdef USE_GLOSSINESSMAP
+				uniform sampler2D glossinessMap;
+			#endif
+		`;
 
-		var specularMapFragmentChunk = [
-			'vec3 specularFactor = specular;',
-			'#ifdef USE_SPECULARMAP',
-			'	vec4 texelSpecular = texture2D( specularMap, vUv );',
-			'	texelSpecular = sRGBToLinear( texelSpecular );',
-			'	// reads channel RGB, compatible with a glTF Specular-Glossiness (RGBA) texture',
-			'	specularFactor *= texelSpecular.rgb;',
-			'#endif'
-		].join( '\n' );
+		var specularMapFragmentChunk = /* glsl */`
+			vec3 specularFactor = specular;
+			#ifdef USE_SPECULARMAP
+				vec4 texelSpecular = texture2D( specularMap, vUv );
+				texelSpecular = sRGBToLinear( texelSpecular );
+				// reads channel RGB, compatible with a glTF Specular-Glossiness (RGBA) texture
+				specularFactor *= texelSpecular.rgb;
+			#endif
+		`;
 
-		var glossinessMapFragmentChunk = [
-			'float glossinessFactor = glossiness;',
-			'#ifdef USE_GLOSSINESSMAP',
-			'	vec4 texelGlossiness = texture2D( glossinessMap, vUv );',
-			'	// reads channel A, compatible with a glTF Specular-Glossiness (RGBA) texture',
-			'	glossinessFactor *= texelGlossiness.a;',
-			'#endif'
-		].join( '\n' );
+		var glossinessMapFragmentChunk = /* glsl */`
+			float glossinessFactor = glossiness;
+			#ifdef USE_GLOSSINESSMAP
+				vec4 texelGlossiness = texture2D( glossinessMap, vUv );
+				// reads channel A, compatible with a glTF Specular-Glossiness (RGBA) texture
+				glossinessFactor *= texelGlossiness.a;
+			#endif
+		`;
 
-		var lightPhysicalFragmentChunk = [
-			'PhysicalMaterial material;',
-			'material.diffuseColor = diffuseColor.rgb;',
-			'vec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );',
-			'float geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );',
-			'material.specularRoughness = max( 1.0 - glossinessFactor, 0.0525 );// 0.0525 corresponds to the base mip of a 256 cubemap.',
-			'material.specularRoughness += geometryRoughness;',
-			'material.specularRoughness = min( material.specularRoughness, 1.0 );',
-			'material.specularColor = specularFactor.rgb;',
-		].join( '\n' );
+		var lightPhysicalFragmentChunk = /* glsl */`
+			PhysicalMaterial material;
+			material.diffuseColor = diffuseColor.rgb;
+			vec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );
+			float geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );
+			material.specularRoughness = max( 1.0 - glossinessFactor, 0.0525 );// 0.0525 corresponds to the base mip of a 256 cubemap.
+			material.specularRoughness += geometryRoughness;
+			material.specularRoughness = min( material.specularRoughness, 1.0 );
+			material.specularColor = specularFactor.rgb;
+		`;
 
 		var uniforms = {
 			specular: { value: new THREE.Color().setHex( 0xffffff ) },

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -9,79 +9,79 @@
 THREE.LDrawLoader = ( function () {
 
 	var conditionalLineVertShader = /* glsl */`
-	attribute vec3 control0;
-	attribute vec3 control1;
-	attribute vec3 direction;
-	varying float discardFlag;
+		attribute vec3 control0;
+		attribute vec3 control1;
+		attribute vec3 direction;
+		varying float discardFlag;
 
-	#include <common>
-	#include <color_pars_vertex>
-	#include <fog_pars_vertex>
-	#include <logdepthbuf_pars_vertex>
-	#include <clipping_planes_pars_vertex>
-	void main() {
-		#include <color_vertex>
+		#include <common>
+		#include <color_pars_vertex>
+		#include <fog_pars_vertex>
+		#include <logdepthbuf_pars_vertex>
+		#include <clipping_planes_pars_vertex>
+		void main() {
+			#include <color_vertex>
 
-		vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-		gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-		// Transform the line segment ends and control points into camera clip space
-		vec4 c0 = projectionMatrix * modelViewMatrix * vec4( control0, 1.0 );
-		vec4 c1 = projectionMatrix * modelViewMatrix * vec4( control1, 1.0 );
-		vec4 p0 = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-		vec4 p1 = projectionMatrix * modelViewMatrix * vec4( position + direction, 1.0 );
+			// Transform the line segment ends and control points into camera clip space
+			vec4 c0 = projectionMatrix * modelViewMatrix * vec4( control0, 1.0 );
+			vec4 c1 = projectionMatrix * modelViewMatrix * vec4( control1, 1.0 );
+			vec4 p0 = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vec4 p1 = projectionMatrix * modelViewMatrix * vec4( position + direction, 1.0 );
 
-		c0.xy /= c0.w;
-		c1.xy /= c1.w;
-		p0.xy /= p0.w;
-		p1.xy /= p1.w;
+			c0.xy /= c0.w;
+			c1.xy /= c1.w;
+			p0.xy /= p0.w;
+			p1.xy /= p1.w;
 
-		// Get the direction of the segment and an orthogonal vector
-		vec2 dir = p1.xy - p0.xy;
-		vec2 norm = vec2( -dir.y, dir.x );
+			// Get the direction of the segment and an orthogonal vector
+			vec2 dir = p1.xy - p0.xy;
+			vec2 norm = vec2( -dir.y, dir.x );
 
-		// Get control point directions from the line
-		vec2 c0dir = c0.xy - p1.xy;
-		vec2 c1dir = c1.xy - p1.xy;
+			// Get control point directions from the line
+			vec2 c0dir = c0.xy - p1.xy;
+			vec2 c1dir = c1.xy - p1.xy;
 
-		// If the vectors to the controls points are pointed in different directions away
-		// from the line segment then the line should not be drawn.
-		float d0 = dot( normalize( norm ), normalize( c0dir ) );
-		float d1 = dot( normalize( norm ), normalize( c1dir ) );
-		discardFlag = float( sign( d0 ) != sign( d1 ) );
+			// If the vectors to the controls points are pointed in different directions away
+			// from the line segment then the line should not be drawn.
+			float d0 = dot( normalize( norm ), normalize( c0dir ) );
+			float d1 = dot( normalize( norm ), normalize( c1dir ) );
+			discardFlag = float( sign( d0 ) != sign( d1 ) );
 
-		#include <logdepthbuf_vertex>
-		#include <clipping_planes_vertex>
-		#include <fog_vertex>
-	}
+			#include <logdepthbuf_vertex>
+			#include <clipping_planes_vertex>
+			#include <fog_vertex>
+		}
 	`;
 
 	var conditionalLineFragShader = /* glsl */`
-	uniform vec3 diffuse;
-	uniform float opacity;
-	varying float discardFlag;
+		uniform vec3 diffuse;
+		uniform float opacity;
+		varying float discardFlag;
 
-	#include <common>
-	#include <color_pars_fragment>
-	#include <fog_pars_fragment>
-	#include <logdepthbuf_pars_fragment>
-	#include <clipping_planes_pars_fragment>
-	void main() {
+		#include <common>
+		#include <color_pars_fragment>
+		#include <fog_pars_fragment>
+		#include <logdepthbuf_pars_fragment>
+		#include <clipping_planes_pars_fragment>
+		void main() {
 
-		if ( discardFlag > 0.5 ) discard;
+			if ( discardFlag > 0.5 ) discard;
 
-		#include <clipping_planes_fragment>
-		vec3 outgoingLight = vec3( 0.0 );
-		vec4 diffuseColor = vec4( diffuse, opacity );
-		#include <logdepthbuf_fragment>
-		#include <color_fragment>
-		outgoingLight = diffuseColor.rgb; // simple shader
-		gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-		#include <tonemapping_fragment>
-		#include <encodings_fragment>
-		#include <fog_fragment>
-		#include <premultiplied_alpha_fragment>
-	}
+			#include <clipping_planes_fragment>
+			vec3 outgoingLight = vec3( 0.0 );
+			vec4 diffuseColor = vec4( diffuse, opacity );
+			#include <logdepthbuf_fragment>
+			#include <color_fragment>
+			outgoingLight = diffuseColor.rgb; // simple shader
+			gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+			#include <tonemapping_fragment>
+			#include <encodings_fragment>
+			#include <fog_fragment>
+			#include <premultiplied_alpha_fragment>
+		}
 	`;
 
 

--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -357,7 +357,7 @@ THREE.RGBELoader.prototype = Object.assign( Object.create( THREE.DataTextureLoad
 
 					bits |= 0x7c00;
 					/* If exponent was 0xff and one mantissa bit was set, it means NaN,
-							 * not Inf, so make sure we set one mantissa bit too. */
+					 * not Inf, so make sure we set one mantissa bit too. */
 					bits |= ( ( e == 255 ) ? 0 : 1 ) && ( x & 0x007fffff );
 					return bits;
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -631,9 +631,9 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 		}
 
 		/*
-		* According to https://www.w3.org/TR/SVG/shapes.html#RectElementRXAttribute
-		* rounded corner should be rendered to elliptical arc, but bezier curve does the job well enough
-		*/
+		 * According to https://www.w3.org/TR/SVG/shapes.html#RectElementRXAttribute
+		 * rounded corner should be rendered to elliptical arc, but bezier curve does the job well enough
+		 */
 		function parseRectNode( node ) {
 
 			var x = parseFloatWithUnits( node.getAttribute( 'x' ) || 0 );

--- a/examples/js/objects/Fire.js
+++ b/examples/js/objects/Fire.js
@@ -506,46 +506,46 @@ THREE.Fire.SourceShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D sourceMap;
-uniform sampler2D densityMap;
+		uniform sampler2D sourceMap;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    vec4 source = texture2D( sourceMap, vUv );
-    vec4 current = texture2D( densityMap, vUv );
+		void main() {
+			vec4 source = texture2D( sourceMap, vUv );
+			vec4 current = texture2D( densityMap, vUv );
 
-    vec2 v0 = (current.gb - step(0.5, current.gb)) * 2.0;
-    vec2 v1 = (source.gb - step(0.5, source.gb)) * 2.0;
+			vec2 v0 = (current.gb - step(0.5, current.gb)) * 2.0;
+			vec2 v1 = (source.gb - step(0.5, source.gb)) * 2.0;
 
-    vec2 newVel = v0 + v1;
+			vec2 newVel = v0 + v1;
 
-    newVel = clamp(newVel, -0.99, 0.99);
-    newVel = newVel * 0.5 + step(0.0, -newVel);
+			newVel = clamp(newVel, -0.99, 0.99);
+			newVel = newVel * 0.5 + step(0.0, -newVel);
 
-    float newDensity = source.r + current.a;
-    float newTemp = source.r + current.r;
+			float newDensity = source.r + current.a;
+			float newTemp = source.r + current.r;
 
-    newDensity = clamp(newDensity, 0.0, 1.0);
-    newTemp = clamp(newTemp, 0.0, 1.0);
+			newDensity = clamp(newDensity, 0.0, 1.0);
+			newTemp = clamp(newTemp, 0.0, 1.0);
 
-    gl_FragColor = vec4(newTemp, newVel.xy, newDensity);
+			gl_FragColor = vec4(newTemp, newVel.xy, newDensity);
 
-}
-`
+		}
+	`
 };
 
 
@@ -582,77 +582,77 @@ THREE.Fire.DiffuseShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float oneOverWidth;
-uniform float oneOverHeight;
-uniform float diffuse;
-uniform float viscosity;
-uniform float expansion;
-uniform float swirl;
-uniform float burnRate;
-uniform float drag;
-uniform sampler2D densityMap;
+		uniform float oneOverWidth;
+		uniform float oneOverHeight;
+		uniform float diffuse;
+		uniform float viscosity;
+		uniform float expansion;
+		uniform float swirl;
+		uniform float burnRate;
+		uniform float drag;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-    vec4 dC = texture2D( densityMap, vUv );
-    vec4 dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) );
-    vec4 dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) );
-    vec4 dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) );
-    vec4 dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) );
-    vec4 dUL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y - oneOverHeight) );
-    vec4 dUR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y - oneOverHeight) );
-    vec4 dDL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y + oneOverHeight) );
-    vec4 dDR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y + oneOverHeight) );
+			vec4 dC = texture2D( densityMap, vUv );
+			vec4 dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) );
+			vec4 dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) );
+			vec4 dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) );
+			vec4 dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) );
+			vec4 dUL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y - oneOverHeight) );
+			vec4 dUR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y - oneOverHeight) );
+			vec4 dDL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y + oneOverHeight) );
+			vec4 dDR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y + oneOverHeight) );
 
-    dC.yz = (dC.yz - step(0.5, dC.yz)) * 2.0;
-    dL.yz = (dL.yz - step(0.5, dL.yz)) * 2.0;
-    dR.yz = (dR.yz - step(0.5, dR.yz)) * 2.0;
-    dU.yz = (dU.yz - step(0.5, dU.yz)) * 2.0;
-    dD.yz = (dD.yz - step(0.5, dD.yz)) * 2.0;
-    dUL.yz = (dUL.yz - step(0.5, dUL.yz)) * 2.0;
-    dUR.yz = (dUR.yz - step(0.5, dUR.yz)) * 2.0;
-    dDL.yz = (dDL.yz - step(0.5, dDL.yz)) * 2.0;
-    dDR.yz = (dDR.yz - step(0.5, dDR.yz)) * 2.0;
+			dC.yz = (dC.yz - step(0.5, dC.yz)) * 2.0;
+			dL.yz = (dL.yz - step(0.5, dL.yz)) * 2.0;
+			dR.yz = (dR.yz - step(0.5, dR.yz)) * 2.0;
+			dU.yz = (dU.yz - step(0.5, dU.yz)) * 2.0;
+			dD.yz = (dD.yz - step(0.5, dD.yz)) * 2.0;
+			dUL.yz = (dUL.yz - step(0.5, dUL.yz)) * 2.0;
+			dUR.yz = (dUR.yz - step(0.5, dUR.yz)) * 2.0;
+			dDL.yz = (dDL.yz - step(0.5, dDL.yz)) * 2.0;
+			dDR.yz = (dDR.yz - step(0.5, dDR.yz)) * 2.0;
 
-    vec4 result = (dC + vec4(diffuse, viscosity, viscosity, diffuse) * ( dL + dR + dU + dD + dUL + dUR + dDL + dDR )) / (1.0 + 8.0 * vec4(diffuse, viscosity, viscosity, diffuse)) - vec4(0.0, 0.0, 0.0, 0.001);
+			vec4 result = (dC + vec4(diffuse, viscosity, viscosity, diffuse) * ( dL + dR + dU + dD + dUL + dUR + dDL + dDR )) / (1.0 + 8.0 * vec4(diffuse, viscosity, viscosity, diffuse)) - vec4(0.0, 0.0, 0.0, 0.001);
 
-    float temperature = result.r;
-    temperature = clamp(temperature - burnRate, 0.0, 1.0);
+			float temperature = result.r;
+			temperature = clamp(temperature - burnRate, 0.0, 1.0);
 
-    vec2 velocity = result.yz;
+			vec2 velocity = result.yz;
 
-    vec2 expansionVec = vec2(dL.w - dR.w, dU.w - dD.w);
+			vec2 expansionVec = vec2(dL.w - dR.w, dU.w - dD.w);
 
-    vec2 swirlVec = vec2((dL.z - dR.z) * 0.5, (dU.y - dD.y) * 0.5);
+			vec2 swirlVec = vec2((dL.z - dR.z) * 0.5, (dU.y - dD.y) * 0.5);
 
-    velocity = velocity + (1.0 - expansion) * expansionVec + (1.0 - swirl) * swirlVec;
+			velocity = velocity + (1.0 - expansion) * expansionVec + (1.0 - swirl) * swirlVec;
 
-    velocity = velocity - (1.0 - drag) * velocity;
+			velocity = velocity - (1.0 - drag) * velocity;
 
-    gl_FragColor = vec4(temperature, velocity * 0.5 + step(0.0, -velocity), result.w);
+			gl_FragColor = vec4(temperature, velocity * 0.5 + step(0.0, -velocity), result.w);
 
-    gl_FragColor = gl_FragColor * step(oneOverWidth, vUv.x);
-    gl_FragColor = gl_FragColor * step(oneOverHeight, vUv.y);
-    gl_FragColor = gl_FragColor * step(vUv.x, 1.0 - oneOverWidth);
-    gl_FragColor = gl_FragColor * step(vUv.y, 1.0 - oneOverHeight);
+			gl_FragColor = gl_FragColor * step(oneOverWidth, vUv.x);
+			gl_FragColor = gl_FragColor * step(oneOverHeight, vUv.y);
+			gl_FragColor = gl_FragColor * step(vUv.x, 1.0 - oneOverWidth);
+			gl_FragColor = gl_FragColor * step(vUv.y, 1.0 - oneOverHeight);
 
-}
-`
+		}
+	`
 };
 
 THREE.Fire.DriftShader = {
@@ -676,60 +676,60 @@ THREE.Fire.DriftShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float oneOverWidth;
-uniform float oneOverHeight;
-uniform vec2 windVector;
-uniform float airSpeed;
-uniform sampler2D densityMap;
+		uniform float oneOverWidth;
+		uniform float oneOverHeight;
+		uniform vec2 windVector;
+		uniform float airSpeed;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    vec2 velocity = texture2D( densityMap, vUv ).gb;
-    velocity = (velocity - step(0.5, velocity)) * 2.0;
+		void main() {
+			vec2 velocity = texture2D( densityMap, vUv ).gb;
+			velocity = (velocity - step(0.5, velocity)) * 2.0;
 
-    velocity = velocity + windVector;
+			velocity = velocity + windVector;
 
-    vec2 sourcePos = vUv - airSpeed * vec2(oneOverWidth, oneOverHeight) * velocity;
+			vec2 sourcePos = vUv - airSpeed * vec2(oneOverWidth, oneOverHeight) * velocity;
 
-    vec2 units = sourcePos / vec2(oneOverWidth, oneOverHeight);
+			vec2 units = sourcePos / vec2(oneOverWidth, oneOverHeight);
 
-    vec2 intPos = floor(units);
-    vec2 frac = units - intPos;
-    intPos = intPos * vec2(oneOverWidth, oneOverHeight);
+			vec2 intPos = floor(units);
+			vec2 frac = units - intPos;
+			intPos = intPos * vec2(oneOverWidth, oneOverHeight);
 
-    vec4 dX0Y0 = texture2D( densityMap, intPos + vec2(0.0, -oneOverHeight) );
-    vec4 dX1Y0 = texture2D( densityMap, intPos + vec2(oneOverWidth, 0.0) );
-    vec4 dX0Y1 = texture2D( densityMap, intPos + vec2(0.0, oneOverHeight) );
-    vec4 dX1Y1 = texture2D( densityMap, intPos + vec2(oneOverWidth, oneOverHeight) );
+			vec4 dX0Y0 = texture2D( densityMap, intPos + vec2(0.0, -oneOverHeight) );
+			vec4 dX1Y0 = texture2D( densityMap, intPos + vec2(oneOverWidth, 0.0) );
+			vec4 dX0Y1 = texture2D( densityMap, intPos + vec2(0.0, oneOverHeight) );
+			vec4 dX1Y1 = texture2D( densityMap, intPos + vec2(oneOverWidth, oneOverHeight) );
 
 
-    dX0Y0.gb = (dX0Y0.gb - step(0.5, dX0Y0.gb)) * 2.0;
-    dX1Y0.gb = (dX1Y0.gb - step(0.5, dX1Y0.gb)) * 2.0;
-    dX0Y1.gb = (dX0Y1.gb - step(0.5, dX0Y1.gb)) * 2.0;
-    dX1Y1.gb = (dX1Y1.gb - step(0.5, dX1Y1.gb)) * 2.0;
+			dX0Y0.gb = (dX0Y0.gb - step(0.5, dX0Y0.gb)) * 2.0;
+			dX1Y0.gb = (dX1Y0.gb - step(0.5, dX1Y0.gb)) * 2.0;
+			dX0Y1.gb = (dX0Y1.gb - step(0.5, dX0Y1.gb)) * 2.0;
+			dX1Y1.gb = (dX1Y1.gb - step(0.5, dX1Y1.gb)) * 2.0;
 
-    vec4 source = mix(mix(dX0Y0, dX1Y0, frac.x), mix(dX0Y1, dX1Y1, frac.x), frac.y);
+			vec4 source = mix(mix(dX0Y0, dX1Y0, frac.x), mix(dX0Y1, dX1Y1, frac.x), frac.y);
 
-    source.gb = source.gb * 0.5 + step(0.0, -source.gb);
+			source.gb = source.gb * 0.5 + step(0.0, -source.gb);
 
-    gl_FragColor = source;
+			gl_FragColor = source;
 
-}
-`
+		}
+	`
 };
 
 
@@ -748,43 +748,43 @@ THREE.Fire.ProjectionShader1 = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float oneOverWidth;
-uniform float oneOverHeight;
-uniform sampler2D densityMap;
+		uniform float oneOverWidth;
+		uniform float oneOverHeight;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    float dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
-    float dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
-    float dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).b;
-    float dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).b;
+		void main() {
+			float dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+			float dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+			float dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).b;
+			float dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).b;
 
-    dL = (dL - step(0.5, dL)) * 2.0;
-    dR = (dR - step(0.5, dR)) * 2.0;
-    dU = (dU - step(0.5, dU)) * 2.0;
-    dD = (dD - step(0.5, dD)) * 2.0;
+			dL = (dL - step(0.5, dL)) * 2.0;
+			dR = (dR - step(0.5, dR)) * 2.0;
+			dU = (dU - step(0.5, dU)) * 2.0;
+			dD = (dD - step(0.5, dD)) * 2.0;
 
-    float h = (oneOverWidth + oneOverHeight) * 0.5;
-    float div = -0.5 * h * (dR - dL + dD - dU);
+			float h = (oneOverWidth + oneOverHeight) * 0.5;
+			float div = -0.5 * h * (dR - dL + dD - dU);
 
-    gl_FragColor = vec4( 0.0, 0.0, div * 0.5 + step(0.0, -div), 0.0);
+			gl_FragColor = vec4( 0.0, 0.0, div * 0.5 + step(0.0, -div), 0.0);
 
-}
-`
+		}
+	`
 };
 
 
@@ -803,44 +803,44 @@ THREE.Fire.ProjectionShader2 = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float oneOverWidth;
-uniform float oneOverHeight;
-uniform sampler2D densityMap;
+		uniform float oneOverWidth;
+		uniform float oneOverHeight;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    float div = texture2D( densityMap, vUv ).b;
-    float pL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
-    float pR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
-    float pU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
-    float pD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
+		void main() {
+			float div = texture2D( densityMap, vUv ).b;
+			float pL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+			float pR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+			float pU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
+			float pD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
 
-    float divNorm = (div - step(0.5, div)) * 2.0;
-    pL = (pL - step(0.5, pL)) * 2.0;
-    pR = (pR - step(0.5, pR)) * 2.0;
-    pU = (pU - step(0.5, pU)) * 2.0;
-    pD = (pD - step(0.5, pD)) * 2.0;
+			float divNorm = (div - step(0.5, div)) * 2.0;
+			pL = (pL - step(0.5, pL)) * 2.0;
+			pR = (pR - step(0.5, pR)) * 2.0;
+			pU = (pU - step(0.5, pU)) * 2.0;
+			pD = (pD - step(0.5, pD)) * 2.0;
 
-    float p = (divNorm + pR + pL + pD + pU) * 0.25;
+			float p = (divNorm + pR + pL + pD + pU) * 0.25;
 
-    gl_FragColor = vec4( 0.0, p * 0.5 + step(0.0, -p), div, 0.0);
+			gl_FragColor = vec4( 0.0, p * 0.5 + step(0.0, -p), div, 0.0);
 
-}
-`
+		}
+	`
 };
 
 
@@ -862,50 +862,50 @@ THREE.Fire.ProjectionShader3 = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float oneOverWidth;
-uniform float oneOverHeight;
-uniform sampler2D densityMap;
-uniform sampler2D projMap;
+		uniform float oneOverWidth;
+		uniform float oneOverHeight;
+		uniform sampler2D densityMap;
+		uniform sampler2D projMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    vec4 orig = texture2D(densityMap, vUv);
+		void main() {
+			vec4 orig = texture2D(densityMap, vUv);
 
-    float pL = texture2D( projMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
-    float pR = texture2D( projMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
-    float pU = texture2D( projMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
-    float pD = texture2D( projMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
+			float pL = texture2D( projMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+			float pR = texture2D( projMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+			float pU = texture2D( projMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
+			float pD = texture2D( projMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
 
-    float uNorm = (orig.g - step(0.5, orig.g)) * 2.0;
-    float vNorm = (orig.b - step(0.5, orig.b)) * 2.0;
+			float uNorm = (orig.g - step(0.5, orig.g)) * 2.0;
+			float vNorm = (orig.b - step(0.5, orig.b)) * 2.0;
 
-    pL = (pL - step(0.5, pL)) * 2.0;
-    pR = (pR - step(0.5, pR)) * 2.0;
-    pU = (pU - step(0.5, pU)) * 2.0;
-    pD = (pD - step(0.5, pD)) * 2.0;
+			pL = (pL - step(0.5, pL)) * 2.0;
+			pR = (pR - step(0.5, pR)) * 2.0;
+			pU = (pU - step(0.5, pU)) * 2.0;
+			pD = (pD - step(0.5, pD)) * 2.0;
 
-    float h = (oneOverWidth + oneOverHeight) * 0.5;
-    float u = uNorm - (0.5 * (pR - pL) / h);
-    float v = vNorm - (0.5 * (pD - pU) / h);
+			float h = (oneOverWidth + oneOverHeight) * 0.5;
+			float u = uNorm - (0.5 * (pR - pL) / h);
+			float v = vNorm - (0.5 * (pD - pU) / h);
 
-    gl_FragColor = vec4( orig.r, u * 0.5 + step(0.0, -u), v * 0.5 + step(0.0, -v), orig.a);
+			gl_FragColor = vec4( orig.r, u * 0.5 + step(0.0, -u), v * 0.5 + step(0.0, -v), orig.a);
 
-}
-`
+		}
+	`
 };
 
 THREE.Fire.ColorShader = {
@@ -929,39 +929,39 @@ THREE.Fire.ColorShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 color1;
-uniform vec3 color2;
-uniform vec3 color3;
-uniform float colorBias;
-uniform sampler2D densityMap;
+		uniform vec3 color1;
+		uniform vec3 color2;
+		uniform vec3 color3;
+		uniform float colorBias;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    float density = texture2D( densityMap, vUv ).a;
-    float temperature = texture2D( densityMap, vUv ).r;
+		void main() {
+			float density = texture2D( densityMap, vUv ).a;
+			float temperature = texture2D( densityMap, vUv ).r;
 
-    float bias = clamp(colorBias, 0.0001, 0.9999);
+			float bias = clamp(colorBias, 0.0001, 0.9999);
 
-    vec3 blend1 = mix(color3, color2, temperature / bias) * (1.0 - step(bias, temperature));
-    vec3 blend2 = mix(color2, color1, (temperature - bias) / (1.0 - bias) ) * step(bias, temperature);
+			vec3 blend1 = mix(color3, color2, temperature / bias) * (1.0 - step(bias, temperature));
+			vec3 blend2 = mix(color2, color1, (temperature - bias) / (1.0 - bias) ) * step(bias, temperature);
 
-    gl_FragColor = vec4(blend1 + blend2, density);
-}
-`
+			gl_FragColor = vec4(blend1 + blend2, density);
+		}
+	`
 };
 
 
@@ -986,38 +986,38 @@ THREE.Fire.DebugShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-     vUv = uv;
+			vUv = uv;
 
-     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-     gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D densityMap;
+		uniform sampler2D densityMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-    float density;
-    density = texture2D( densityMap, vUv ).a;
+		void main() {
+			float density;
+			density = texture2D( densityMap, vUv ).a;
 
-    vec2 vel = texture2D( densityMap, vUv ).gb;
+			vec2 vel = texture2D( densityMap, vUv ).gb;
 
-    vel = (vel - step(0.5, vel)) * 2.0;
+			vel = (vel - step(0.5, vel)) * 2.0;
 
-    float r = density;
-    float g = max(abs(vel.x), density * 0.5);
-    float b = max(abs(vel.y), density * 0.5);
-    float a = max(density * 0.5, max(abs(vel.x), abs(vel.y)));
+			float r = density;
+			float g = max(abs(vel.x), density * 0.5);
+			float b = max(abs(vel.y), density * 0.5);
+			float a = max(density * 0.5, max(abs(vel.x), abs(vel.y)));
 
-    gl_FragColor = vec4(r, g, b, a);
+			gl_FragColor = vec4(r, g, b, a);
 
-}
-`
+		}
+	`
 };

--- a/examples/js/objects/Fire.js
+++ b/examples/js/objects/Fire.js
@@ -505,49 +505,47 @@ THREE.Fire.SourceShader = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform sampler2D sourceMap;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform sampler2D sourceMap;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    vec4 source = texture2D( sourceMap, vUv );
+    vec4 current = texture2D( densityMap, vUv );
 
-		'void main() {',
-		'    vec4 source = texture2D( sourceMap, vUv );',
-		'    vec4 current = texture2D( densityMap, vUv );',
+    vec2 v0 = (current.gb - step(0.5, current.gb)) * 2.0;
+    vec2 v1 = (source.gb - step(0.5, source.gb)) * 2.0;
 
-		'    vec2 v0 = (current.gb - step(0.5, current.gb)) * 2.0;',
-		'    vec2 v1 = (source.gb - step(0.5, source.gb)) * 2.0;',
+    vec2 newVel = v0 + v1;
 
-		'    vec2 newVel = v0 + v1;',
+    newVel = clamp(newVel, -0.99, 0.99);
+    newVel = newVel * 0.5 + step(0.0, -newVel);
 
-		'    newVel = clamp(newVel, -0.99, 0.99);',
-		'    newVel = newVel * 0.5 + step(0.0, -newVel);',
+    float newDensity = source.r + current.a;
+    float newTemp = source.r + current.r;
 
-		'    float newDensity = source.r + current.a;',
-		'    float newTemp = source.r + current.r;',
+    newDensity = clamp(newDensity, 0.0, 1.0);
+    newTemp = clamp(newTemp, 0.0, 1.0);
 
-		'    newDensity = clamp(newDensity, 0.0, 1.0);',
-		'    newTemp = clamp(newTemp, 0.0, 1.0);',
+    gl_FragColor = vec4(newTemp, newVel.xy, newDensity);
 
-		'    gl_FragColor = vec4(newTemp, newVel.xy, newDensity);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 
@@ -583,80 +581,78 @@ THREE.Fire.DiffuseShader = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform float oneOverWidth;
+uniform float oneOverHeight;
+uniform float diffuse;
+uniform float viscosity;
+uniform float expansion;
+uniform float swirl;
+uniform float burnRate;
+uniform float drag;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform float oneOverWidth;',
-		'uniform float oneOverHeight;',
-		'uniform float diffuse;',
-		'uniform float viscosity;',
-		'uniform float expansion;',
-		'uniform float swirl;',
-		'uniform float burnRate;',
-		'uniform float drag;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
 
-		'void main() {',
+    vec4 dC = texture2D( densityMap, vUv );
+    vec4 dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) );
+    vec4 dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) );
+    vec4 dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) );
+    vec4 dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) );
+    vec4 dUL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y - oneOverHeight) );
+    vec4 dUR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y - oneOverHeight) );
+    vec4 dDL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y + oneOverHeight) );
+    vec4 dDR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y + oneOverHeight) );
 
-		'    vec4 dC = texture2D( densityMap, vUv );',
-		'    vec4 dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) );',
-		'    vec4 dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) );',
-		'    vec4 dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) );',
-		'    vec4 dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) );',
-		'    vec4 dUL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y - oneOverHeight) );',
-		'    vec4 dUR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y - oneOverHeight) );',
-		'    vec4 dDL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y + oneOverHeight) );',
-		'    vec4 dDR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y + oneOverHeight) );',
+    dC.yz = (dC.yz - step(0.5, dC.yz)) * 2.0;
+    dL.yz = (dL.yz - step(0.5, dL.yz)) * 2.0;
+    dR.yz = (dR.yz - step(0.5, dR.yz)) * 2.0;
+    dU.yz = (dU.yz - step(0.5, dU.yz)) * 2.0;
+    dD.yz = (dD.yz - step(0.5, dD.yz)) * 2.0;
+    dUL.yz = (dUL.yz - step(0.5, dUL.yz)) * 2.0;
+    dUR.yz = (dUR.yz - step(0.5, dUR.yz)) * 2.0;
+    dDL.yz = (dDL.yz - step(0.5, dDL.yz)) * 2.0;
+    dDR.yz = (dDR.yz - step(0.5, dDR.yz)) * 2.0;
 
-		'    dC.yz = (dC.yz - step(0.5, dC.yz)) * 2.0;',
-		'    dL.yz = (dL.yz - step(0.5, dL.yz)) * 2.0;',
-		'    dR.yz = (dR.yz - step(0.5, dR.yz)) * 2.0;',
-		'    dU.yz = (dU.yz - step(0.5, dU.yz)) * 2.0;',
-		'    dD.yz = (dD.yz - step(0.5, dD.yz)) * 2.0;',
-		'    dUL.yz = (dUL.yz - step(0.5, dUL.yz)) * 2.0;',
-		'    dUR.yz = (dUR.yz - step(0.5, dUR.yz)) * 2.0;',
-		'    dDL.yz = (dDL.yz - step(0.5, dDL.yz)) * 2.0;',
-		'    dDR.yz = (dDR.yz - step(0.5, dDR.yz)) * 2.0;',
+    vec4 result = (dC + vec4(diffuse, viscosity, viscosity, diffuse) * ( dL + dR + dU + dD + dUL + dUR + dDL + dDR )) / (1.0 + 8.0 * vec4(diffuse, viscosity, viscosity, diffuse)) - vec4(0.0, 0.0, 0.0, 0.001);
 
-		'    vec4 result = (dC + vec4(diffuse, viscosity, viscosity, diffuse) * ( dL + dR + dU + dD + dUL + dUR + dDL + dDR )) / (1.0 + 8.0 * vec4(diffuse, viscosity, viscosity, diffuse)) - vec4(0.0, 0.0, 0.0, 0.001);',
+    float temperature = result.r;
+    temperature = clamp(temperature - burnRate, 0.0, 1.0);
 
-		'    float temperature = result.r;',
-		'    temperature = clamp(temperature - burnRate, 0.0, 1.0);',
+    vec2 velocity = result.yz;
 
-		'    vec2 velocity = result.yz;',
+    vec2 expansionVec = vec2(dL.w - dR.w, dU.w - dD.w);
 
-		'    vec2 expansionVec = vec2(dL.w - dR.w, dU.w - dD.w);',
+    vec2 swirlVec = vec2((dL.z - dR.z) * 0.5, (dU.y - dD.y) * 0.5);
 
-		'    vec2 swirlVec = vec2((dL.z - dR.z) * 0.5, (dU.y - dD.y) * 0.5);',
+    velocity = velocity + (1.0 - expansion) * expansionVec + (1.0 - swirl) * swirlVec;
 
-		'    velocity = velocity + (1.0 - expansion) * expansionVec + (1.0 - swirl) * swirlVec;',
+    velocity = velocity - (1.0 - drag) * velocity;
 
-		'    velocity = velocity - (1.0 - drag) * velocity;',
+    gl_FragColor = vec4(temperature, velocity * 0.5 + step(0.0, -velocity), result.w);
 
-		'    gl_FragColor = vec4(temperature, velocity * 0.5 + step(0.0, -velocity), result.w);',
+    gl_FragColor = gl_FragColor * step(oneOverWidth, vUv.x);
+    gl_FragColor = gl_FragColor * step(oneOverHeight, vUv.y);
+    gl_FragColor = gl_FragColor * step(vUv.x, 1.0 - oneOverWidth);
+    gl_FragColor = gl_FragColor * step(vUv.y, 1.0 - oneOverHeight);
 
-		'    gl_FragColor = gl_FragColor * step(oneOverWidth, vUv.x);',
-		'    gl_FragColor = gl_FragColor * step(oneOverHeight, vUv.y);',
-		'    gl_FragColor = gl_FragColor * step(vUv.x, 1.0 - oneOverWidth);',
-		'    gl_FragColor = gl_FragColor * step(vUv.y, 1.0 - oneOverHeight);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 THREE.Fire.DriftShader = {
@@ -679,63 +675,61 @@ THREE.Fire.DriftShader = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform float oneOverWidth;
+uniform float oneOverHeight;
+uniform vec2 windVector;
+uniform float airSpeed;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform float oneOverWidth;',
-		'uniform float oneOverHeight;',
-		'uniform vec2 windVector;',
-		'uniform float airSpeed;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    vec2 velocity = texture2D( densityMap, vUv ).gb;
+    velocity = (velocity - step(0.5, velocity)) * 2.0;
 
-		'void main() {',
-		'    vec2 velocity = texture2D( densityMap, vUv ).gb;',
-		'    velocity = (velocity - step(0.5, velocity)) * 2.0;',
+    velocity = velocity + windVector;
 
-		'    velocity = velocity + windVector;',
+    vec2 sourcePos = vUv - airSpeed * vec2(oneOverWidth, oneOverHeight) * velocity;
 
-		'    vec2 sourcePos = vUv - airSpeed * vec2(oneOverWidth, oneOverHeight) * velocity;',
+    vec2 units = sourcePos / vec2(oneOverWidth, oneOverHeight);
 
-		'    vec2 units = sourcePos / vec2(oneOverWidth, oneOverHeight);',
+    vec2 intPos = floor(units);
+    vec2 frac = units - intPos;
+    intPos = intPos * vec2(oneOverWidth, oneOverHeight);
 
-		'    vec2 intPos = floor(units);',
-		'    vec2 frac = units - intPos;',
-		'    intPos = intPos * vec2(oneOverWidth, oneOverHeight);',
-
-		'    vec4 dX0Y0 = texture2D( densityMap, intPos + vec2(0.0, -oneOverHeight) );',
-		'    vec4 dX1Y0 = texture2D( densityMap, intPos + vec2(oneOverWidth, 0.0) );',
-		'    vec4 dX0Y1 = texture2D( densityMap, intPos + vec2(0.0, oneOverHeight) );',
-		'    vec4 dX1Y1 = texture2D( densityMap, intPos + vec2(oneOverWidth, oneOverHeight) );',
+    vec4 dX0Y0 = texture2D( densityMap, intPos + vec2(0.0, -oneOverHeight) );
+    vec4 dX1Y0 = texture2D( densityMap, intPos + vec2(oneOverWidth, 0.0) );
+    vec4 dX0Y1 = texture2D( densityMap, intPos + vec2(0.0, oneOverHeight) );
+    vec4 dX1Y1 = texture2D( densityMap, intPos + vec2(oneOverWidth, oneOverHeight) );
 
 
-		'    dX0Y0.gb = (dX0Y0.gb - step(0.5, dX0Y0.gb)) * 2.0;',
-		'    dX1Y0.gb = (dX1Y0.gb - step(0.5, dX1Y0.gb)) * 2.0;',
-		'    dX0Y1.gb = (dX0Y1.gb - step(0.5, dX0Y1.gb)) * 2.0;',
-		'    dX1Y1.gb = (dX1Y1.gb - step(0.5, dX1Y1.gb)) * 2.0;',
+    dX0Y0.gb = (dX0Y0.gb - step(0.5, dX0Y0.gb)) * 2.0;
+    dX1Y0.gb = (dX1Y0.gb - step(0.5, dX1Y0.gb)) * 2.0;
+    dX0Y1.gb = (dX0Y1.gb - step(0.5, dX0Y1.gb)) * 2.0;
+    dX1Y1.gb = (dX1Y1.gb - step(0.5, dX1Y1.gb)) * 2.0;
 
-		'    vec4 source = mix(mix(dX0Y0, dX1Y0, frac.x), mix(dX0Y1, dX1Y1, frac.x), frac.y);',
+    vec4 source = mix(mix(dX0Y0, dX1Y0, frac.x), mix(dX0Y1, dX1Y1, frac.x), frac.y);
 
-		'    source.gb = source.gb * 0.5 + step(0.0, -source.gb);',
+    source.gb = source.gb * 0.5 + step(0.0, -source.gb);
 
-		'    gl_FragColor = source;',
+    gl_FragColor = source;
 
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 
@@ -753,46 +747,44 @@ THREE.Fire.ProjectionShader1 = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform float oneOverWidth;
+uniform float oneOverHeight;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform float oneOverWidth;',
-		'uniform float oneOverHeight;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    float dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+    float dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+    float dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).b;
+    float dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).b;
 
-		'void main() {',
-		'    float dL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;',
-		'    float dR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;',
-		'    float dU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).b;',
-		'    float dD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).b;',
+    dL = (dL - step(0.5, dL)) * 2.0;
+    dR = (dR - step(0.5, dR)) * 2.0;
+    dU = (dU - step(0.5, dU)) * 2.0;
+    dD = (dD - step(0.5, dD)) * 2.0;
 
-		'    dL = (dL - step(0.5, dL)) * 2.0;',
-		'    dR = (dR - step(0.5, dR)) * 2.0;',
-		'    dU = (dU - step(0.5, dU)) * 2.0;',
-		'    dD = (dD - step(0.5, dD)) * 2.0;',
+    float h = (oneOverWidth + oneOverHeight) * 0.5;
+    float div = -0.5 * h * (dR - dL + dD - dU);
 
-		'    float h = (oneOverWidth + oneOverHeight) * 0.5;',
-		'    float div = -0.5 * h * (dR - dL + dD - dU);',
+    gl_FragColor = vec4( 0.0, 0.0, div * 0.5 + step(0.0, -div), 0.0);
 
-		'    gl_FragColor = vec4( 0.0, 0.0, div * 0.5 + step(0.0, -div), 0.0);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 
@@ -810,47 +802,45 @@ THREE.Fire.ProjectionShader2 = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform float oneOverWidth;
+uniform float oneOverHeight;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform float oneOverWidth;',
-		'uniform float oneOverHeight;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    float div = texture2D( densityMap, vUv ).b;
+    float pL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+    float pR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+    float pU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
+    float pD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
 
-		'void main() {',
-		'    float div = texture2D( densityMap, vUv ).b;',
-		'    float pL = texture2D( densityMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;',
-		'    float pR = texture2D( densityMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;',
-		'    float pU = texture2D( densityMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;',
-		'    float pD = texture2D( densityMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;',
+    float divNorm = (div - step(0.5, div)) * 2.0;
+    pL = (pL - step(0.5, pL)) * 2.0;
+    pR = (pR - step(0.5, pR)) * 2.0;
+    pU = (pU - step(0.5, pU)) * 2.0;
+    pD = (pD - step(0.5, pD)) * 2.0;
 
-		'    float divNorm = (div - step(0.5, div)) * 2.0;',
-		'    pL = (pL - step(0.5, pL)) * 2.0;',
-		'    pR = (pR - step(0.5, pR)) * 2.0;',
-		'    pU = (pU - step(0.5, pU)) * 2.0;',
-		'    pD = (pD - step(0.5, pD)) * 2.0;',
+    float p = (divNorm + pR + pL + pD + pU) * 0.25;
 
-		'    float p = (divNorm + pR + pL + pD + pU) * 0.25;',
+    gl_FragColor = vec4( 0.0, p * 0.5 + step(0.0, -p), div, 0.0);
 
-		'    gl_FragColor = vec4( 0.0, p * 0.5 + step(0.0, -p), div, 0.0);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 
@@ -871,53 +861,51 @@ THREE.Fire.ProjectionShader3 = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform float oneOverWidth;
+uniform float oneOverHeight;
+uniform sampler2D densityMap;
+uniform sampler2D projMap;
 
-	fragmentShader: [
-		'uniform float oneOverWidth;',
-		'uniform float oneOverHeight;',
-		'uniform sampler2D densityMap;',
-		'uniform sampler2D projMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    vec4 orig = texture2D(densityMap, vUv);
 
-		'void main() {',
-		'    vec4 orig = texture2D(densityMap, vUv);',
+    float pL = texture2D( projMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;
+    float pR = texture2D( projMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;
+    float pU = texture2D( projMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;
+    float pD = texture2D( projMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;
 
-		'    float pL = texture2D( projMap, vec2(vUv.x - oneOverWidth, vUv.y) ).g;',
-		'    float pR = texture2D( projMap, vec2(vUv.x + oneOverWidth, vUv.y) ).g;',
-		'    float pU = texture2D( projMap, vec2(vUv.x, vUv.y - oneOverHeight) ).g;',
-		'    float pD = texture2D( projMap, vec2(vUv.x, vUv.y + oneOverHeight) ).g;',
+    float uNorm = (orig.g - step(0.5, orig.g)) * 2.0;
+    float vNorm = (orig.b - step(0.5, orig.b)) * 2.0;
 
-		'    float uNorm = (orig.g - step(0.5, orig.g)) * 2.0;',
-		'    float vNorm = (orig.b - step(0.5, orig.b)) * 2.0;',
+    pL = (pL - step(0.5, pL)) * 2.0;
+    pR = (pR - step(0.5, pR)) * 2.0;
+    pU = (pU - step(0.5, pU)) * 2.0;
+    pD = (pD - step(0.5, pD)) * 2.0;
 
-		'    pL = (pL - step(0.5, pL)) * 2.0;',
-		'    pR = (pR - step(0.5, pR)) * 2.0;',
-		'    pU = (pU - step(0.5, pU)) * 2.0;',
-		'    pD = (pD - step(0.5, pD)) * 2.0;',
+    float h = (oneOverWidth + oneOverHeight) * 0.5;
+    float u = uNorm - (0.5 * (pR - pL) / h);
+    float v = vNorm - (0.5 * (pD - pU) / h);
 
-		'    float h = (oneOverWidth + oneOverHeight) * 0.5;',
-		'    float u = uNorm - (0.5 * (pR - pL) / h);',
-		'    float v = vNorm - (0.5 * (pD - pU) / h);',
+    gl_FragColor = vec4( orig.r, u * 0.5 + step(0.0, -u), v * 0.5 + step(0.0, -v), orig.a);
 
-		'    gl_FragColor = vec4( orig.r, u * 0.5 + step(0.0, -u), v * 0.5 + step(0.0, -v), orig.a);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };
 
 THREE.Fire.ColorShader = {
@@ -940,42 +928,40 @@ THREE.Fire.ColorShader = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform vec3 color1;
+uniform vec3 color2;
+uniform vec3 color3;
+uniform float colorBias;
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform vec3 color1;',
-		'uniform vec3 color2;',
-		'uniform vec3 color3;',
-		'uniform float colorBias;',
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    float density = texture2D( densityMap, vUv ).a;
+    float temperature = texture2D( densityMap, vUv ).r;
 
-		'void main() {',
-		'    float density = texture2D( densityMap, vUv ).a;',
-		'    float temperature = texture2D( densityMap, vUv ).r;',
+    float bias = clamp(colorBias, 0.0001, 0.9999);
 
-		'    float bias = clamp(colorBias, 0.0001, 0.9999);',
+    vec3 blend1 = mix(color3, color2, temperature / bias) * (1.0 - step(bias, temperature));
+    vec3 blend2 = mix(color2, color1, (temperature - bias) / (1.0 - bias) ) * step(bias, temperature);
 
-		'    vec3 blend1 = mix(color3, color2, temperature / bias) * (1.0 - step(bias, temperature));',
-		'    vec3 blend2 = mix(color2, color1, (temperature - bias) / (1.0 - bias) ) * step(bias, temperature);',
-
-		'    gl_FragColor = vec4(blend1 + blend2, density);',
-		'}'
-
-	].join( "\n" )
+    gl_FragColor = vec4(blend1 + blend2, density);
+}
+`
 };
 
 
@@ -999,41 +985,39 @@ THREE.Fire.DebugShader = {
 		}
 	},
 
-	vertexShader: [
-		'varying vec2 vUv;',
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		'void main() {',
+void main() {
 
-		'     vUv = uv;',
+     vUv = uv;
 
-		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-		'     gl_Position = projectionMatrix * mvPosition;',
+     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+     gl_Position = projectionMatrix * mvPosition;
 
-		'}'
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform sampler2D densityMap;
 
-	fragmentShader: [
-		'uniform sampler2D densityMap;',
+varying vec2 vUv;
 
-		'varying vec2 vUv;',
+void main() {
+    float density;
+    density = texture2D( densityMap, vUv ).a;
 
-		'void main() {',
-		'    float density;',
-		'    density = texture2D( densityMap, vUv ).a;',
+    vec2 vel = texture2D( densityMap, vUv ).gb;
 
-		'    vec2 vel = texture2D( densityMap, vUv ).gb;',
+    vel = (vel - step(0.5, vel)) * 2.0;
 
-		'    vel = (vel - step(0.5, vel)) * 2.0;',
+    float r = density;
+    float g = max(abs(vel.x), density * 0.5);
+    float b = max(abs(vel.y), density * 0.5);
+    float a = max(density * 0.5, max(abs(vel.x), abs(vel.y)));
 
-		'    float r = density;',
-		'    float g = max(abs(vel.x), density * 0.5);',
-		'    float b = max(abs(vel.y), density * 0.5);',
-		'    float a = max(density * 0.5, max(abs(vel.x), abs(vel.y)));',
+    gl_FragColor = vec4(r, g, b, a);
 
-		'    gl_FragColor = vec4(r, g, b, a);',
-
-		'}'
-
-	].join( "\n" )
+}
+`
 };

--- a/examples/js/objects/Fire.js
+++ b/examples/js/objects/Fire.js
@@ -510,7 +510,7 @@ THREE.Fire.SourceShader = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -588,7 +588,7 @@ THREE.Fire.DiffuseShader = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -684,7 +684,7 @@ THREE.Fire.DriftShader = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -758,7 +758,7 @@ THREE.Fire.ProjectionShader1 = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -815,7 +815,7 @@ THREE.Fire.ProjectionShader2 = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -876,7 +876,7 @@ THREE.Fire.ProjectionShader3 = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -945,7 +945,7 @@ THREE.Fire.ColorShader = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',
@@ -1004,7 +1004,7 @@ THREE.Fire.DebugShader = {
 
 		'void main() {',
 
-		' 	  vUv = uv;',
+		'     vUv = uv;',
 
 		'     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
 		'     gl_Position = projectionMatrix * mvPosition;',

--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -40,28 +40,28 @@ THREE.Lensflare = function () {
 			'screenPosition': { value: null }
 		},
 		vertexShader: /* glsl */`
-precision highp float;
+			precision highp float;
 
-uniform vec3 screenPosition;
-uniform vec2 scale;
+			uniform vec3 screenPosition;
+			uniform vec2 scale;
 
-attribute vec3 position;
+			attribute vec3 position;
 
-void main() {
+			void main() {
 
-	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
+				gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
 
-}
-`,
+			}
+		`,
 		fragmentShader: /* glsl */`
-precision highp float;
+			precision highp float;
 
-void main() {
+			void main() {
 
-	gl_FragColor = vec4( 1.0, 0.0, 1.0, 1.0 );
+				gl_FragColor = vec4( 1.0, 0.0, 1.0, 1.0 );
 
-}
-`,
+			}
+		`,
 		depthTest: true,
 		depthWrite: false,
 		transparent: false
@@ -74,37 +74,37 @@ void main() {
 			'screenPosition': { value: null }
 		},
 		vertexShader: /* glsl */`
-precision highp float;
+			precision highp float;
 
-uniform vec3 screenPosition;
-uniform vec2 scale;
+			uniform vec3 screenPosition;
+			uniform vec2 scale;
 
-attribute vec3 position;
-attribute vec2 uv;
+			attribute vec3 position;
+			attribute vec2 uv;
 
-varying vec2 vUV;
+			varying vec2 vUV;
 
-void main() {
+			void main() {
 
-	vUV = uv;
+				vUV = uv;
 
-	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
+				gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
 
-}
-`,
+			}
+		`,
 		fragmentShader: /* glsl */`
-precision highp float;
+			precision highp float;
 
-uniform sampler2D map;
+			uniform sampler2D map;
 
-varying vec2 vUV;
+			varying vec2 vUV;
 
-void main() {
+			void main() {
 
-	gl_FragColor = texture2D( map, vUV );
+				gl_FragColor = texture2D( map, vUV );
 
-}
-`,
+			}
+		`,
 		depthTest: false,
 		depthWrite: false,
 		transparent: false
@@ -284,63 +284,62 @@ THREE.LensflareElement.Shader = {
 	},
 
 	vertexShader: /* glsl */`
-precision highp float;
+		precision highp float;
 
-uniform vec3 screenPosition;
-uniform vec2 scale;
+		uniform vec3 screenPosition;
+		uniform vec2 scale;
 
-uniform sampler2D occlusionMap;
+		uniform sampler2D occlusionMap;
 
-attribute vec3 position;
-attribute vec2 uv;
+		attribute vec3 position;
+		attribute vec2 uv;
 
-varying vec2 vUV;
-varying float vVisibility;
+		varying vec2 vUV;
+		varying float vVisibility;
 
-void main() {
+		void main() {
 
-	vUV = uv;
+			vUV = uv;
 
-	vec2 pos = position.xy;
+			vec2 pos = position.xy;
 
-	vec4 visibility = texture2D( occlusionMap, vec2( 0.1, 0.1 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.5, 0.1 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.9, 0.1 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.9, 0.5 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.9, 0.9 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.5, 0.9 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.1, 0.9 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.1, 0.5 ) );
-	visibility += texture2D( occlusionMap, vec2( 0.5, 0.5 ) );
+			vec4 visibility = texture2D( occlusionMap, vec2( 0.1, 0.1 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.5, 0.1 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.9, 0.1 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.9, 0.5 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.9, 0.9 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.5, 0.9 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.1, 0.9 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.1, 0.5 ) );
+			visibility += texture2D( occlusionMap, vec2( 0.5, 0.5 ) );
 
-	vVisibility =        visibility.r / 9.0;
-	vVisibility *= 1.0 - visibility.g / 9.0;
-	vVisibility *=       visibility.b / 9.0;
+			vVisibility =        visibility.r / 9.0;
+			vVisibility *= 1.0 - visibility.g / 9.0;
+			vVisibility *=       visibility.b / 9.0;
 
-	gl_Position = vec4( ( pos * scale + screenPosition.xy ).xy, screenPosition.z, 1.0 );
+			gl_Position = vec4( ( pos * scale + screenPosition.xy ).xy, screenPosition.z, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-precision highp float;
+		precision highp float;
 
-uniform sampler2D map;
-uniform vec3 color;
+		uniform sampler2D map;
+		uniform vec3 color;
 
-varying vec2 vUV;
-varying float vVisibility;
+		varying vec2 vUV;
+		varying float vVisibility;
 
-void main() {
+		void main() {
 
-	vec4 texture = texture2D( map, vUV );
-	texture.a *= vVisibility;
-	gl_FragColor = texture;
-	gl_FragColor.rgb *= color;
+			vec4 texture = texture2D( map, vUV );
+			texture.a *= vVisibility;
+			gl_FragColor = texture;
+			gl_FragColor.rgb *= color;
 
-}
-`
-
+		}
+	`
 };
 
 THREE.Lensflare.Geometry = ( function () {

--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -39,33 +39,29 @@ THREE.Lensflare = function () {
 			'scale': { value: null },
 			'screenPosition': { value: null }
 		},
-		vertexShader: [
+		vertexShader: /* glsl */`
+precision highp float;
 
-			'precision highp float;',
+uniform vec3 screenPosition;
+uniform vec2 scale;
 
-			'uniform vec3 screenPosition;',
-			'uniform vec2 scale;',
+attribute vec3 position;
 
-			'attribute vec3 position;',
+void main() {
 
-			'void main() {',
+	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
 
-			'	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );',
+}
+`,
+		fragmentShader: /* glsl */`
+precision highp float;
 
-			'}'
+void main() {
 
-		].join( '\n' ),
-		fragmentShader: [
+	gl_FragColor = vec4( 1.0, 0.0, 1.0, 1.0 );
 
-			'precision highp float;',
-
-			'void main() {',
-
-			'	gl_FragColor = vec4( 1.0, 0.0, 1.0, 1.0 );',
-
-			'}'
-
-		].join( '\n' ),
+}
+`,
 		depthTest: true,
 		depthWrite: false,
 		transparent: false
@@ -77,42 +73,38 @@ THREE.Lensflare = function () {
 			'scale': { value: null },
 			'screenPosition': { value: null }
 		},
-		vertexShader: [
+		vertexShader: /* glsl */`
+precision highp float;
 
-			'precision highp float;',
+uniform vec3 screenPosition;
+uniform vec2 scale;
 
-			'uniform vec3 screenPosition;',
-			'uniform vec2 scale;',
+attribute vec3 position;
+attribute vec2 uv;
 
-			'attribute vec3 position;',
-			'attribute vec2 uv;',
+varying vec2 vUV;
 
-			'varying vec2 vUV;',
+void main() {
 
-			'void main() {',
+	vUV = uv;
 
-			'	vUV = uv;',
+	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );
 
-			'	gl_Position = vec4( position.xy * scale + screenPosition.xy, screenPosition.z, 1.0 );',
+}
+`,
+		fragmentShader: /* glsl */`
+precision highp float;
 
-			'}'
+uniform sampler2D map;
 
-		].join( '\n' ),
-		fragmentShader: [
+varying vec2 vUV;
 
-			'precision highp float;',
+void main() {
 
-			'uniform sampler2D map;',
+	gl_FragColor = texture2D( map, vUV );
 
-			'varying vec2 vUV;',
-
-			'void main() {',
-
-			'	gl_FragColor = texture2D( map, vUV );',
-
-			'}'
-
-		].join( '\n' ),
+}
+`,
 		depthTest: false,
 		depthWrite: false,
 		transparent: false
@@ -291,67 +283,63 @@ THREE.LensflareElement.Shader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+precision highp float;
 
-		'precision highp float;',
+uniform vec3 screenPosition;
+uniform vec2 scale;
 
-		'uniform vec3 screenPosition;',
-		'uniform vec2 scale;',
+uniform sampler2D occlusionMap;
 
-		'uniform sampler2D occlusionMap;',
+attribute vec3 position;
+attribute vec2 uv;
 
-		'attribute vec3 position;',
-		'attribute vec2 uv;',
+varying vec2 vUV;
+varying float vVisibility;
 
-		'varying vec2 vUV;',
-		'varying float vVisibility;',
+void main() {
 
-		'void main() {',
+	vUV = uv;
 
-		'	vUV = uv;',
+	vec2 pos = position.xy;
 
-		'	vec2 pos = position.xy;',
+	vec4 visibility = texture2D( occlusionMap, vec2( 0.1, 0.1 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.5, 0.1 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.9, 0.1 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.9, 0.5 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.9, 0.9 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.5, 0.9 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.1, 0.9 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.1, 0.5 ) );
+	visibility += texture2D( occlusionMap, vec2( 0.5, 0.5 ) );
 
-		'	vec4 visibility = texture2D( occlusionMap, vec2( 0.1, 0.1 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.5, 0.1 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.9, 0.1 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.9, 0.5 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.9, 0.9 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.5, 0.9 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.1, 0.9 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.1, 0.5 ) );',
-		'	visibility += texture2D( occlusionMap, vec2( 0.5, 0.5 ) );',
+	vVisibility =        visibility.r / 9.0;
+	vVisibility *= 1.0 - visibility.g / 9.0;
+	vVisibility *=       visibility.b / 9.0;
 
-		'	vVisibility =        visibility.r / 9.0;',
-		'	vVisibility *= 1.0 - visibility.g / 9.0;',
-		'	vVisibility *=       visibility.b / 9.0;',
+	gl_Position = vec4( ( pos * scale + screenPosition.xy ).xy, screenPosition.z, 1.0 );
 
-		'	gl_Position = vec4( ( pos * scale + screenPosition.xy ).xy, screenPosition.z, 1.0 );',
+}
+`,
 
-		'}'
+	fragmentShader: /* glsl */`
+precision highp float;
 
-	].join( '\n' ),
+uniform sampler2D map;
+uniform vec3 color;
 
-	fragmentShader: [
+varying vec2 vUV;
+varying float vVisibility;
 
-		'precision highp float;',
+void main() {
 
-		'uniform sampler2D map;',
-		'uniform vec3 color;',
+	vec4 texture = texture2D( map, vUV );
+	texture.a *= vVisibility;
+	gl_FragColor = texture;
+	gl_FragColor.rgb *= color;
 
-		'varying vec2 vUV;',
-		'varying float vVisibility;',
-
-		'void main() {',
-
-		'	vec4 texture = texture2D( map, vUV );',
-		'	texture.a *= vVisibility;',
-		'	gl_FragColor = texture;',
-		'	gl_FragColor.rgb *= color;',
-
-		'}'
-
-	].join( '\n' )
+}
+`
 
 };
 

--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -212,40 +212,40 @@ THREE.Reflector.ReflectorShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform mat4 textureMatrix;
-varying vec4 vUv;
+		uniform mat4 textureMatrix;
+		varying vec4 vUv;
 
-void main() {
+		void main() {
 
-	vUv = textureMatrix * vec4( position, 1.0 );
+			vUv = textureMatrix * vec4( position, 1.0 );
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 color;
-uniform sampler2D tDiffuse;
-varying vec4 vUv;
+		uniform vec3 color;
+		uniform sampler2D tDiffuse;
+		varying vec4 vUv;
 
-float blendOverlay( float base, float blend ) {
+		float blendOverlay( float base, float blend ) {
 
-	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
+			return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-}
+		}
 
-vec3 blendOverlay( vec3 base, vec3 blend ) {
+		vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
+			return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
 
-}
+		}
 
-void main() {
+		void main() {
 
-	vec4 base = texture2DProj( tDiffuse, vUv );
-	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
+			vec4 base = texture2DProj( tDiffuse, vUv );
+			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-}
-`
+		}
+	`
 };

--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -211,41 +211,41 @@ THREE.Reflector.ReflectorShader = {
 
 	},
 
-	vertexShader: [
-		'uniform mat4 textureMatrix;',
-		'varying vec4 vUv;',
+	vertexShader: /* glsl */`
+uniform mat4 textureMatrix;
+varying vec4 vUv;
 
-		'void main() {',
+void main() {
 
-		'	vUv = textureMatrix * vec4( position, 1.0 );',
+	vUv = textureMatrix * vec4( position, 1.0 );
 
-		'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		'}'
-	].join( '\n' ),
+}
+`,
 
-	fragmentShader: [
-		'uniform vec3 color;',
-		'uniform sampler2D tDiffuse;',
-		'varying vec4 vUv;',
+	fragmentShader: /* glsl */`
+uniform vec3 color;
+uniform sampler2D tDiffuse;
+varying vec4 vUv;
 
-		'float blendOverlay( float base, float blend ) {',
+float blendOverlay( float base, float blend ) {
 
-		'	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );',
+	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-		'}',
+}
 
-		'vec3 blendOverlay( vec3 base, vec3 blend ) {',
+vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-		'	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );',
+	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
 
-		'}',
+}
 
-		'void main() {',
+void main() {
 
-		'	vec4 base = texture2DProj( tDiffuse, vUv );',
-		'	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );',
+	vec4 base = texture2DProj( tDiffuse, vUv );
+	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-		'}'
-	].join( '\n' )
+}
+`
 };

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -270,48 +270,44 @@ THREE.Refractor.RefractorShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform mat4 textureMatrix;
 
-		'uniform mat4 textureMatrix;',
+varying vec4 vUv;
 
-		'varying vec4 vUv;',
+void main() {
 
-		'void main() {',
+	vUv = textureMatrix * vec4( position, 1.0 );
 
-		'	vUv = textureMatrix * vec4( position, 1.0 );',
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+}
+`,
 
-		'}'
+	fragmentShader: /* glsl */`
+uniform vec3 color;
+uniform sampler2D tDiffuse;
 
-	].join( '\n' ),
+varying vec4 vUv;
 
-	fragmentShader: [
+float blendOverlay( float base, float blend ) {
 
-		'uniform vec3 color;',
-		'uniform sampler2D tDiffuse;',
+	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-		'varying vec4 vUv;',
+}
 
-		'float blendOverlay( float base, float blend ) {',
+vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-		'	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );',
+	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
 
-		'}',
+}
 
-		'vec3 blendOverlay( vec3 base, vec3 blend ) {',
+void main() {
 
-		'	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );',
+	vec4 base = texture2DProj( tDiffuse, vUv );
 
-		'}',
+	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-		'void main() {',
-
-		'	vec4 base = texture2DProj( tDiffuse, vUv );',
-
-		'	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );',
-
-		'}'
-
-	].join( '\n' )
+}
+`
 };

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -271,43 +271,43 @@ THREE.Refractor.RefractorShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform mat4 textureMatrix;
+		uniform mat4 textureMatrix;
 
-varying vec4 vUv;
+		varying vec4 vUv;
 
-void main() {
+		void main() {
 
-	vUv = textureMatrix * vec4( position, 1.0 );
+			vUv = textureMatrix * vec4( position, 1.0 );
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 color;
-uniform sampler2D tDiffuse;
+		uniform vec3 color;
+		uniform sampler2D tDiffuse;
 
-varying vec4 vUv;
+		varying vec4 vUv;
 
-float blendOverlay( float base, float blend ) {
+		float blendOverlay( float base, float blend ) {
 
-	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
+			return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-}
+		}
 
-vec3 blendOverlay( vec3 base, vec3 blend ) {
+		vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
+			return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ), blendOverlay( base.b, blend.b ) );
 
-}
+		}
 
-void main() {
+		void main() {
 
-	vec4 base = texture2DProj( tDiffuse, vUv );
+			vec4 base = texture2DProj( tDiffuse, vUv );
 
-	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
+			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-}
-`
+		}
+	`
 };

--- a/examples/js/objects/Sky.js
+++ b/examples/js/objects/Sky.js
@@ -43,179 +43,179 @@ THREE.Sky.SkyShader = {
 		"up": { value: new THREE.Vector3( 0, 1, 0 ) }
 	},
 
-	vertexShader: [
-		'uniform vec3 sunPosition;',
-		'uniform float rayleigh;',
-		'uniform float turbidity;',
-		'uniform float mieCoefficient;',
-		'uniform vec3 up;',
+	vertexShader: /* glsl */`
+uniform vec3 sunPosition;
+uniform float rayleigh;
+uniform float turbidity;
+uniform float mieCoefficient;
+uniform vec3 up;
 
-		'varying vec3 vWorldPosition;',
-		'varying vec3 vSunDirection;',
-		'varying float vSunfade;',
-		'varying vec3 vBetaR;',
-		'varying vec3 vBetaM;',
-		'varying float vSunE;',
+varying vec3 vWorldPosition;
+varying vec3 vSunDirection;
+varying float vSunfade;
+varying vec3 vBetaR;
+varying vec3 vBetaM;
+varying float vSunE;
 
-		// constants for atmospheric scattering
-		'const float e = 2.71828182845904523536028747135266249775724709369995957;',
-		'const float pi = 3.141592653589793238462643383279502884197169;',
+// constants for atmospheric scattering
+const float e = 2.71828182845904523536028747135266249775724709369995957;
+const float pi = 3.141592653589793238462643383279502884197169;
 
-		// wavelength of used primaries, according to preetham
-		'const vec3 lambda = vec3( 680E-9, 550E-9, 450E-9 );',
-		// this pre-calcuation replaces older TotalRayleigh(vec3 lambda) function:
-		// (8.0 * pow(pi, 3.0) * pow(pow(n, 2.0) - 1.0, 2.0) * (6.0 + 3.0 * pn)) / (3.0 * N * pow(lambda, vec3(4.0)) * (6.0 - 7.0 * pn))
-		'const vec3 totalRayleigh = vec3( 5.804542996261093E-6, 1.3562911419845635E-5, 3.0265902468824876E-5 );',
+// wavelength of used primaries, according to preetham
+const vec3 lambda = vec3( 680E-9, 550E-9, 450E-9 );
+// this pre-calcuation replaces older TotalRayleigh(vec3 lambda) function:
+// (8.0 * pow(pi, 3.0) * pow(pow(n, 2.0) - 1.0, 2.0) * (6.0 + 3.0 * pn)) / (3.0 * N * pow(lambda, vec3(4.0)) * (6.0 - 7.0 * pn))
+const vec3 totalRayleigh = vec3( 5.804542996261093E-6, 1.3562911419845635E-5, 3.0265902468824876E-5 );
 
-		// mie stuff
-		// K coefficient for the primaries
-		'const float v = 4.0;',
-		'const vec3 K = vec3( 0.686, 0.678, 0.666 );',
-		// MieConst = pi * pow( ( 2.0 * pi ) / lambda, vec3( v - 2.0 ) ) * K
-		'const vec3 MieConst = vec3( 1.8399918514433978E14, 2.7798023919660528E14, 4.0790479543861094E14 );',
+// mie stuff
+// K coefficient for the primaries
+const float v = 4.0;
+const vec3 K = vec3( 0.686, 0.678, 0.666 );
+// MieConst = pi * pow( ( 2.0 * pi ) / lambda, vec3( v - 2.0 ) ) * K
+const vec3 MieConst = vec3( 1.8399918514433978E14, 2.7798023919660528E14, 4.0790479543861094E14 );
 
-		// earth shadow hack
-		// cutoffAngle = pi / 1.95;
-		'const float cutoffAngle = 1.6110731556870734;',
-		'const float steepness = 1.5;',
-		'const float EE = 1000.0;',
+// earth shadow hack
+// cutoffAngle = pi / 1.95;
+const float cutoffAngle = 1.6110731556870734;
+const float steepness = 1.5;
+const float EE = 1000.0;
 
-		'float sunIntensity( float zenithAngleCos ) {',
-		'	zenithAngleCos = clamp( zenithAngleCos, -1.0, 1.0 );',
-		'	return EE * max( 0.0, 1.0 - pow( e, -( ( cutoffAngle - acos( zenithAngleCos ) ) / steepness ) ) );',
-		'}',
+float sunIntensity( float zenithAngleCos ) {
+	zenithAngleCos = clamp( zenithAngleCos, -1.0, 1.0 );
+	return EE * max( 0.0, 1.0 - pow( e, -( ( cutoffAngle - acos( zenithAngleCos ) ) / steepness ) ) );
+}
 
-		'vec3 totalMie( float T ) {',
-		'	float c = ( 0.2 * T ) * 10E-18;',
-		'	return 0.434 * c * MieConst;',
-		'}',
+vec3 totalMie( float T ) {
+	float c = ( 0.2 * T ) * 10E-18;
+	return 0.434 * c * MieConst;
+}
 
-		'void main() {',
+void main() {
 
-		'	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
-		'	vWorldPosition = worldPosition.xyz;',
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+	vWorldPosition = worldPosition.xyz;
 
-		'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
-		'	gl_Position.z = gl_Position.w;', // set z to camera.far
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+	gl_Position.z = gl_Position.w; // set z to camera.far
 
-		'	vSunDirection = normalize( sunPosition );',
+	vSunDirection = normalize( sunPosition );
 
-		'	vSunE = sunIntensity( dot( vSunDirection, up ) );',
+	vSunE = sunIntensity( dot( vSunDirection, up ) );
 
-		'	vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );',
+	vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );
 
-		'	float rayleighCoefficient = rayleigh - ( 1.0 * ( 1.0 - vSunfade ) );',
+	float rayleighCoefficient = rayleigh - ( 1.0 * ( 1.0 - vSunfade ) );
 
-		// extinction (absorbtion + out scattering)
-		// rayleigh coefficients
-		'	vBetaR = totalRayleigh * rayleighCoefficient;',
+	// extinction (absorbtion + out scattering)
+	// rayleigh coefficients
+	vBetaR = totalRayleigh * rayleighCoefficient;
 
-		// mie coefficients
-		'	vBetaM = totalMie( turbidity ) * mieCoefficient;',
+	// mie coefficients
+	vBetaM = totalMie( turbidity ) * mieCoefficient;
 
-		'}'
-	].join( '\n' ),
+}
+`,
 
-	fragmentShader: [
-		'varying vec3 vWorldPosition;',
-		'varying vec3 vSunDirection;',
-		'varying float vSunfade;',
-		'varying vec3 vBetaR;',
-		'varying vec3 vBetaM;',
-		'varying float vSunE;',
+	fragmentShader: /* glsl */`
+varying vec3 vWorldPosition;
+varying vec3 vSunDirection;
+varying float vSunfade;
+varying vec3 vBetaR;
+varying vec3 vBetaM;
+varying float vSunE;
 
-		'uniform float luminance;',
-		'uniform float mieDirectionalG;',
-		'uniform vec3 up;',
+uniform float luminance;
+uniform float mieDirectionalG;
+uniform vec3 up;
 
-		'const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );',
+const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
 
-		// constants for atmospheric scattering
-		'const float pi = 3.141592653589793238462643383279502884197169;',
+// constants for atmospheric scattering
+const float pi = 3.141592653589793238462643383279502884197169;
 
-		'const float n = 1.0003;', // refractive index of air
-		'const float N = 2.545E25;', // number of molecules per unit volume for air at 288.15K and 1013mb (sea level -45 celsius)
+const float n = 1.0003; // refractive index of air
+const float N = 2.545E25; // number of molecules per unit volume for air at 288.15K and 1013mb (sea level -45 celsius)
 
-		// optical length at zenith for molecules
-		'const float rayleighZenithLength = 8.4E3;',
-		'const float mieZenithLength = 1.25E3;',
-		// 66 arc seconds -> degrees, and the cosine of that
-		'const float sunAngularDiameterCos = 0.999956676946448443553574619906976478926848692873900859324;',
+// optical length at zenith for molecules
+const float rayleighZenithLength = 8.4E3;
+const float mieZenithLength = 1.25E3;
+// 66 arc seconds -> degrees, and the cosine of that
+const float sunAngularDiameterCos = 0.999956676946448443553574619906976478926848692873900859324;
 
-		// 3.0 / ( 16.0 * pi )
-		'const float THREE_OVER_SIXTEENPI = 0.05968310365946075;',
-		// 1.0 / ( 4.0 * pi )
-		'const float ONE_OVER_FOURPI = 0.07957747154594767;',
+// 3.0 / ( 16.0 * pi )
+const float THREE_OVER_SIXTEENPI = 0.05968310365946075;
+// 1.0 / ( 4.0 * pi )
+const float ONE_OVER_FOURPI = 0.07957747154594767;
 
-		'float rayleighPhase( float cosTheta ) {',
-		'	return THREE_OVER_SIXTEENPI * ( 1.0 + pow( cosTheta, 2.0 ) );',
-		'}',
+float rayleighPhase( float cosTheta ) {
+	return THREE_OVER_SIXTEENPI * ( 1.0 + pow( cosTheta, 2.0 ) );
+}
 
-		'float hgPhase( float cosTheta, float g ) {',
-		'	float g2 = pow( g, 2.0 );',
-		'	float inverse = 1.0 / pow( 1.0 - 2.0 * g * cosTheta + g2, 1.5 );',
-		'	return ONE_OVER_FOURPI * ( ( 1.0 - g2 ) * inverse );',
-		'}',
+float hgPhase( float cosTheta, float g ) {
+	float g2 = pow( g, 2.0 );
+	float inverse = 1.0 / pow( 1.0 - 2.0 * g * cosTheta + g2, 1.5 );
+	return ONE_OVER_FOURPI * ( ( 1.0 - g2 ) * inverse );
+}
 
-		// Filmic ToneMapping http://filmicgames.com/archives/75
-		'const float A = 0.15;',
-		'const float B = 0.50;',
-		'const float C = 0.10;',
-		'const float D = 0.20;',
-		'const float E = 0.02;',
-		'const float F = 0.30;',
+// Filmic ToneMapping http://filmicgames.com/archives/75
+const float A = 0.15;
+const float B = 0.50;
+const float C = 0.10;
+const float D = 0.20;
+const float E = 0.02;
+const float F = 0.30;
 
-		'const float whiteScale = 1.0748724675633854;', // 1.0 / Uncharted2Tonemap(1000.0)
+const float whiteScale = 1.0748724675633854; // 1.0 / Uncharted2Tonemap(1000.0)
 
-		'vec3 Uncharted2Tonemap( vec3 x ) {',
-		'	return ( ( x * ( A * x + C * B ) + D * E ) / ( x * ( A * x + B ) + D * F ) ) - E / F;',
-		'}',
+vec3 Uncharted2Tonemap( vec3 x ) {
+	return ( ( x * ( A * x + C * B ) + D * E ) / ( x * ( A * x + B ) + D * F ) ) - E / F;
+}
 
 
-		'void main() {',
-		// optical length
-		// cutoff angle at 90 to avoid singularity in next formula.
-		'	float zenithAngle = acos( max( 0.0, dot( up, normalize( vWorldPosition - cameraPos ) ) ) );',
-		'	float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );',
-		'	float sR = rayleighZenithLength * inverse;',
-		'	float sM = mieZenithLength * inverse;',
+void main() {
+	// optical length
+	// cutoff angle at 90 to avoid singularity in next formula.
+	float zenithAngle = acos( max( 0.0, dot( up, normalize( vWorldPosition - cameraPos ) ) ) );
+	float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );
+	float sR = rayleighZenithLength * inverse;
+	float sM = mieZenithLength * inverse;
 
-		// combined extinction factor
-		'	vec3 Fex = exp( -( vBetaR * sR + vBetaM * sM ) );',
+	// combined extinction factor
+	vec3 Fex = exp( -( vBetaR * sR + vBetaM * sM ) );
 
-		// in scattering
-		'	float cosTheta = dot( normalize( vWorldPosition - cameraPos ), vSunDirection );',
+	// in scattering
+	float cosTheta = dot( normalize( vWorldPosition - cameraPos ), vSunDirection );
 
-		'	float rPhase = rayleighPhase( cosTheta * 0.5 + 0.5 );',
-		'	vec3 betaRTheta = vBetaR * rPhase;',
+	float rPhase = rayleighPhase( cosTheta * 0.5 + 0.5 );
+	vec3 betaRTheta = vBetaR * rPhase;
 
-		'	float mPhase = hgPhase( cosTheta, mieDirectionalG );',
-		'	vec3 betaMTheta = vBetaM * mPhase;',
+	float mPhase = hgPhase( cosTheta, mieDirectionalG );
+	vec3 betaMTheta = vBetaM * mPhase;
 
-		'	vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );',
-		'	Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );',
+	vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
+	Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
 
-		// nightsky
-		'	vec3 direction = normalize( vWorldPosition - cameraPos );',
-		'	float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]',
-		'	float phi = atan( direction.z, direction.x ); // azimuth --> x-axis [-pi/2, pi/2]',
-		'	vec2 uv = vec2( phi, theta ) / vec2( 2.0 * pi, pi ) + vec2( 0.5, 0.0 );',
-		'	vec3 L0 = vec3( 0.1 ) * Fex;',
+	// nightsky
+	vec3 direction = normalize( vWorldPosition - cameraPos );
+	float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]
+	float phi = atan( direction.z, direction.x ); // azimuth --> x-axis [-pi/2, pi/2]
+	vec2 uv = vec2( phi, theta ) / vec2( 2.0 * pi, pi ) + vec2( 0.5, 0.0 );
+	vec3 L0 = vec3( 0.1 ) * Fex;
 
-		// composition + solar disc
-		'	float sundisk = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta );',
-		'	L0 += ( vSunE * 19000.0 * Fex ) * sundisk;',
+	// composition + solar disc
+	float sundisk = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta );
+	L0 += ( vSunE * 19000.0 * Fex ) * sundisk;
 
-		'	vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );',
+	vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );
 
-		'	vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( luminance, 4.0 ) ) ) * texColor );',
-		'	vec3 color = curr * whiteScale;',
+	vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( luminance, 4.0 ) ) ) * texColor );
+	vec3 color = curr * whiteScale;
 
-		'	vec3 retColor = pow( color, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );',
+	vec3 retColor = pow( color, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );
 
-		'	gl_FragColor = vec4( retColor, 1.0 );',
+	gl_FragColor = vec4( retColor, 1.0 );
 
-		'}'
-	].join( '\n' )
+}
+`
 
 };

--- a/examples/js/objects/Sky.js
+++ b/examples/js/objects/Sky.js
@@ -44,178 +44,177 @@ THREE.Sky.SkyShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform vec3 sunPosition;
-uniform float rayleigh;
-uniform float turbidity;
-uniform float mieCoefficient;
-uniform vec3 up;
+		uniform vec3 sunPosition;
+		uniform float rayleigh;
+		uniform float turbidity;
+		uniform float mieCoefficient;
+		uniform vec3 up;
 
-varying vec3 vWorldPosition;
-varying vec3 vSunDirection;
-varying float vSunfade;
-varying vec3 vBetaR;
-varying vec3 vBetaM;
-varying float vSunE;
+		varying vec3 vWorldPosition;
+		varying vec3 vSunDirection;
+		varying float vSunfade;
+		varying vec3 vBetaR;
+		varying vec3 vBetaM;
+		varying float vSunE;
 
-// constants for atmospheric scattering
-const float e = 2.71828182845904523536028747135266249775724709369995957;
-const float pi = 3.141592653589793238462643383279502884197169;
+		// constants for atmospheric scattering
+		const float e = 2.71828182845904523536028747135266249775724709369995957;
+		const float pi = 3.141592653589793238462643383279502884197169;
 
-// wavelength of used primaries, according to preetham
-const vec3 lambda = vec3( 680E-9, 550E-9, 450E-9 );
-// this pre-calcuation replaces older TotalRayleigh(vec3 lambda) function:
-// (8.0 * pow(pi, 3.0) * pow(pow(n, 2.0) - 1.0, 2.0) * (6.0 + 3.0 * pn)) / (3.0 * N * pow(lambda, vec3(4.0)) * (6.0 - 7.0 * pn))
-const vec3 totalRayleigh = vec3( 5.804542996261093E-6, 1.3562911419845635E-5, 3.0265902468824876E-5 );
+		// wavelength of used primaries, according to preetham
+		const vec3 lambda = vec3( 680E-9, 550E-9, 450E-9 );
+		// this pre-calcuation replaces older TotalRayleigh(vec3 lambda) function:
+		// (8.0 * pow(pi, 3.0) * pow(pow(n, 2.0) - 1.0, 2.0) * (6.0 + 3.0 * pn)) / (3.0 * N * pow(lambda, vec3(4.0)) * (6.0 - 7.0 * pn))
+		const vec3 totalRayleigh = vec3( 5.804542996261093E-6, 1.3562911419845635E-5, 3.0265902468824876E-5 );
 
-// mie stuff
-// K coefficient for the primaries
-const float v = 4.0;
-const vec3 K = vec3( 0.686, 0.678, 0.666 );
-// MieConst = pi * pow( ( 2.0 * pi ) / lambda, vec3( v - 2.0 ) ) * K
-const vec3 MieConst = vec3( 1.8399918514433978E14, 2.7798023919660528E14, 4.0790479543861094E14 );
+		// mie stuff
+		// K coefficient for the primaries
+		const float v = 4.0;
+		const vec3 K = vec3( 0.686, 0.678, 0.666 );
+		// MieConst = pi * pow( ( 2.0 * pi ) / lambda, vec3( v - 2.0 ) ) * K
+		const vec3 MieConst = vec3( 1.8399918514433978E14, 2.7798023919660528E14, 4.0790479543861094E14 );
 
-// earth shadow hack
-// cutoffAngle = pi / 1.95;
-const float cutoffAngle = 1.6110731556870734;
-const float steepness = 1.5;
-const float EE = 1000.0;
+		// earth shadow hack
+		// cutoffAngle = pi / 1.95;
+		const float cutoffAngle = 1.6110731556870734;
+		const float steepness = 1.5;
+		const float EE = 1000.0;
 
-float sunIntensity( float zenithAngleCos ) {
-	zenithAngleCos = clamp( zenithAngleCos, -1.0, 1.0 );
-	return EE * max( 0.0, 1.0 - pow( e, -( ( cutoffAngle - acos( zenithAngleCos ) ) / steepness ) ) );
-}
+		float sunIntensity( float zenithAngleCos ) {
+			zenithAngleCos = clamp( zenithAngleCos, -1.0, 1.0 );
+			return EE * max( 0.0, 1.0 - pow( e, -( ( cutoffAngle - acos( zenithAngleCos ) ) / steepness ) ) );
+		}
 
-vec3 totalMie( float T ) {
-	float c = ( 0.2 * T ) * 10E-18;
-	return 0.434 * c * MieConst;
-}
+		vec3 totalMie( float T ) {
+			float c = ( 0.2 * T ) * 10E-18;
+			return 0.434 * c * MieConst;
+		}
 
-void main() {
+		void main() {
 
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
-	vWorldPosition = worldPosition.xyz;
+			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+			vWorldPosition = worldPosition.xyz;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-	gl_Position.z = gl_Position.w; // set z to camera.far
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position.z = gl_Position.w; // set z to camera.far
 
-	vSunDirection = normalize( sunPosition );
+			vSunDirection = normalize( sunPosition );
 
-	vSunE = sunIntensity( dot( vSunDirection, up ) );
+			vSunE = sunIntensity( dot( vSunDirection, up ) );
 
-	vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );
+			vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );
 
-	float rayleighCoefficient = rayleigh - ( 1.0 * ( 1.0 - vSunfade ) );
+			float rayleighCoefficient = rayleigh - ( 1.0 * ( 1.0 - vSunfade ) );
 
-	// extinction (absorbtion + out scattering)
-	// rayleigh coefficients
-	vBetaR = totalRayleigh * rayleighCoefficient;
+			// extinction (absorbtion + out scattering)
+			// rayleigh coefficients
+			vBetaR = totalRayleigh * rayleighCoefficient;
 
-	// mie coefficients
-	vBetaM = totalMie( turbidity ) * mieCoefficient;
+			// mie coefficients
+			vBetaM = totalMie( turbidity ) * mieCoefficient;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-varying vec3 vWorldPosition;
-varying vec3 vSunDirection;
-varying float vSunfade;
-varying vec3 vBetaR;
-varying vec3 vBetaM;
-varying float vSunE;
+		varying vec3 vWorldPosition;
+		varying vec3 vSunDirection;
+		varying float vSunfade;
+		varying vec3 vBetaR;
+		varying vec3 vBetaM;
+		varying float vSunE;
 
-uniform float luminance;
-uniform float mieDirectionalG;
-uniform vec3 up;
+		uniform float luminance;
+		uniform float mieDirectionalG;
+		uniform vec3 up;
 
-const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
+		const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
 
-// constants for atmospheric scattering
-const float pi = 3.141592653589793238462643383279502884197169;
+		// constants for atmospheric scattering
+		const float pi = 3.141592653589793238462643383279502884197169;
 
-const float n = 1.0003; // refractive index of air
-const float N = 2.545E25; // number of molecules per unit volume for air at 288.15K and 1013mb (sea level -45 celsius)
+		const float n = 1.0003; // refractive index of air
+		const float N = 2.545E25; // number of molecules per unit volume for air at 288.15K and 1013mb (sea level -45 celsius)
 
-// optical length at zenith for molecules
-const float rayleighZenithLength = 8.4E3;
-const float mieZenithLength = 1.25E3;
-// 66 arc seconds -> degrees, and the cosine of that
-const float sunAngularDiameterCos = 0.999956676946448443553574619906976478926848692873900859324;
+		// optical length at zenith for molecules
+		const float rayleighZenithLength = 8.4E3;
+		const float mieZenithLength = 1.25E3;
+		// 66 arc seconds -> degrees, and the cosine of that
+		const float sunAngularDiameterCos = 0.999956676946448443553574619906976478926848692873900859324;
 
-// 3.0 / ( 16.0 * pi )
-const float THREE_OVER_SIXTEENPI = 0.05968310365946075;
-// 1.0 / ( 4.0 * pi )
-const float ONE_OVER_FOURPI = 0.07957747154594767;
+		// 3.0 / ( 16.0 * pi )
+		const float THREE_OVER_SIXTEENPI = 0.05968310365946075;
+		// 1.0 / ( 4.0 * pi )
+		const float ONE_OVER_FOURPI = 0.07957747154594767;
 
-float rayleighPhase( float cosTheta ) {
-	return THREE_OVER_SIXTEENPI * ( 1.0 + pow( cosTheta, 2.0 ) );
-}
+		float rayleighPhase( float cosTheta ) {
+			return THREE_OVER_SIXTEENPI * ( 1.0 + pow( cosTheta, 2.0 ) );
+		}
 
-float hgPhase( float cosTheta, float g ) {
-	float g2 = pow( g, 2.0 );
-	float inverse = 1.0 / pow( 1.0 - 2.0 * g * cosTheta + g2, 1.5 );
-	return ONE_OVER_FOURPI * ( ( 1.0 - g2 ) * inverse );
-}
+		float hgPhase( float cosTheta, float g ) {
+			float g2 = pow( g, 2.0 );
+			float inverse = 1.0 / pow( 1.0 - 2.0 * g * cosTheta + g2, 1.5 );
+			return ONE_OVER_FOURPI * ( ( 1.0 - g2 ) * inverse );
+		}
 
-// Filmic ToneMapping http://filmicgames.com/archives/75
-const float A = 0.15;
-const float B = 0.50;
-const float C = 0.10;
-const float D = 0.20;
-const float E = 0.02;
-const float F = 0.30;
+		// Filmic ToneMapping http://filmicgames.com/archives/75
+		const float A = 0.15;
+		const float B = 0.50;
+		const float C = 0.10;
+		const float D = 0.20;
+		const float E = 0.02;
+		const float F = 0.30;
 
-const float whiteScale = 1.0748724675633854; // 1.0 / Uncharted2Tonemap(1000.0)
+		const float whiteScale = 1.0748724675633854; // 1.0 / Uncharted2Tonemap(1000.0)
 
-vec3 Uncharted2Tonemap( vec3 x ) {
-	return ( ( x * ( A * x + C * B ) + D * E ) / ( x * ( A * x + B ) + D * F ) ) - E / F;
-}
+		vec3 Uncharted2Tonemap( vec3 x ) {
+			return ( ( x * ( A * x + C * B ) + D * E ) / ( x * ( A * x + B ) + D * F ) ) - E / F;
+		}
 
 
-void main() {
-	// optical length
-	// cutoff angle at 90 to avoid singularity in next formula.
-	float zenithAngle = acos( max( 0.0, dot( up, normalize( vWorldPosition - cameraPos ) ) ) );
-	float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );
-	float sR = rayleighZenithLength * inverse;
-	float sM = mieZenithLength * inverse;
+		void main() {
+			// optical length
+			// cutoff angle at 90 to avoid singularity in next formula.
+			float zenithAngle = acos( max( 0.0, dot( up, normalize( vWorldPosition - cameraPos ) ) ) );
+			float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );
+			float sR = rayleighZenithLength * inverse;
+			float sM = mieZenithLength * inverse;
 
-	// combined extinction factor
-	vec3 Fex = exp( -( vBetaR * sR + vBetaM * sM ) );
+			// combined extinction factor
+			vec3 Fex = exp( -( vBetaR * sR + vBetaM * sM ) );
 
-	// in scattering
-	float cosTheta = dot( normalize( vWorldPosition - cameraPos ), vSunDirection );
+			// in scattering
+			float cosTheta = dot( normalize( vWorldPosition - cameraPos ), vSunDirection );
 
-	float rPhase = rayleighPhase( cosTheta * 0.5 + 0.5 );
-	vec3 betaRTheta = vBetaR * rPhase;
+			float rPhase = rayleighPhase( cosTheta * 0.5 + 0.5 );
+			vec3 betaRTheta = vBetaR * rPhase;
 
-	float mPhase = hgPhase( cosTheta, mieDirectionalG );
-	vec3 betaMTheta = vBetaM * mPhase;
+			float mPhase = hgPhase( cosTheta, mieDirectionalG );
+			vec3 betaMTheta = vBetaM * mPhase;
 
-	vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
-	Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
+			vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
+			Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
 
-	// nightsky
-	vec3 direction = normalize( vWorldPosition - cameraPos );
-	float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]
-	float phi = atan( direction.z, direction.x ); // azimuth --> x-axis [-pi/2, pi/2]
-	vec2 uv = vec2( phi, theta ) / vec2( 2.0 * pi, pi ) + vec2( 0.5, 0.0 );
-	vec3 L0 = vec3( 0.1 ) * Fex;
+			// nightsky
+			vec3 direction = normalize( vWorldPosition - cameraPos );
+			float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]
+			float phi = atan( direction.z, direction.x ); // azimuth --> x-axis [-pi/2, pi/2]
+			vec2 uv = vec2( phi, theta ) / vec2( 2.0 * pi, pi ) + vec2( 0.5, 0.0 );
+			vec3 L0 = vec3( 0.1 ) * Fex;
 
-	// composition + solar disc
-	float sundisk = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta );
-	L0 += ( vSunE * 19000.0 * Fex ) * sundisk;
+			// composition + solar disc
+			float sundisk = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta );
+			L0 += ( vSunE * 19000.0 * Fex ) * sundisk;
 
-	vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );
+			vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );
 
-	vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( luminance, 4.0 ) ) ) * texColor );
-	vec3 color = curr * whiteScale;
+			vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( luminance, 4.0 ) ) ) * texColor );
+			vec3 color = curr * whiteScale;
 
-	vec3 retColor = pow( color, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );
+			vec3 retColor = pow( color, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );
 
-	gl_FragColor = vec4( retColor, 1.0 );
+			gl_FragColor = vec4( retColor, 1.0 );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -84,100 +84,99 @@ THREE.Water = function ( geometry, options ) {
 		] ),
 
 		vertexShader: /* glsl */`
-uniform mat4 textureMatrix;
-uniform float time;
+			uniform mat4 textureMatrix;
+			uniform float time;
 
-varying vec4 mirrorCoord;
-varying vec4 worldPosition;
+			varying vec4 mirrorCoord;
+			varying vec4 worldPosition;
 
-#include <fog_pars_vertex>
-#include <shadowmap_pars_vertex>
+			#include <fog_pars_vertex>
+			#include <shadowmap_pars_vertex>
 
-void main() {
-	mirrorCoord = modelMatrix * vec4( position, 1.0 );
-	worldPosition = mirrorCoord.xyzw;
-	mirrorCoord = textureMatrix * mirrorCoord;
-	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );
-	gl_Position = projectionMatrix * mvPosition;
+			void main() {
+				mirrorCoord = modelMatrix * vec4( position, 1.0 );
+				worldPosition = mirrorCoord.xyzw;
+				mirrorCoord = textureMatrix * mirrorCoord;
+				vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );
+				gl_Position = projectionMatrix * mvPosition;
 
-	#include <fog_vertex>
-	#include <shadowmap_vertex>
+				#include <fog_vertex>
+				#include <shadowmap_vertex>
 
-}
-`,
+			}
+		`,
 
 		fragmentShader: /* glsl */`
-uniform sampler2D mirrorSampler;
-uniform float alpha;
-uniform float time;
-uniform float size;
-uniform float distortionScale;
-uniform sampler2D normalSampler;
-uniform vec3 sunColor;
-uniform vec3 sunDirection;
-uniform vec3 eye;
-uniform vec3 waterColor;
+			uniform sampler2D mirrorSampler;
+			uniform float alpha;
+			uniform float time;
+			uniform float size;
+			uniform float distortionScale;
+			uniform sampler2D normalSampler;
+			uniform vec3 sunColor;
+			uniform vec3 sunDirection;
+			uniform vec3 eye;
+			uniform vec3 waterColor;
 
-varying vec4 mirrorCoord;
-varying vec4 worldPosition;
+			varying vec4 mirrorCoord;
+			varying vec4 worldPosition;
 
-vec4 getNoise( vec2 uv ) {
-	vec2 uv0 = ( uv / 103.0 ) + vec2(time / 17.0, time / 29.0);
-	vec2 uv1 = uv / 107.0-vec2( time / -19.0, time / 31.0 );
-	vec2 uv2 = uv / vec2( 8907.0, 9803.0 ) + vec2( time / 101.0, time / 97.0 );
-	vec2 uv3 = uv / vec2( 1091.0, 1027.0 ) - vec2( time / 109.0, time / -113.0 );
-	vec4 noise = texture2D( normalSampler, uv0 ) +
-		texture2D( normalSampler, uv1 ) +
-		texture2D( normalSampler, uv2 ) +
-		texture2D( normalSampler, uv3 );
-	return noise * 0.5 - 1.0;
-}
+			vec4 getNoise( vec2 uv ) {
+				vec2 uv0 = ( uv / 103.0 ) + vec2(time / 17.0, time / 29.0);
+				vec2 uv1 = uv / 107.0-vec2( time / -19.0, time / 31.0 );
+				vec2 uv2 = uv / vec2( 8907.0, 9803.0 ) + vec2( time / 101.0, time / 97.0 );
+				vec2 uv3 = uv / vec2( 1091.0, 1027.0 ) - vec2( time / 109.0, time / -113.0 );
+				vec4 noise = texture2D( normalSampler, uv0 ) +
+					texture2D( normalSampler, uv1 ) +
+					texture2D( normalSampler, uv2 ) +
+					texture2D( normalSampler, uv3 );
+				return noise * 0.5 - 1.0;
+			}
 
-void sunLight( const vec3 surfaceNormal, const vec3 eyeDirection, float shiny, float spec, float diffuse, inout vec3 diffuseColor, inout vec3 specularColor ) {
-	vec3 reflection = normalize( reflect( -sunDirection, surfaceNormal ) );
-	float direction = max( 0.0, dot( eyeDirection, reflection ) );
-	specularColor += pow( direction, shiny ) * sunColor * spec;
-	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;
-}
+			void sunLight( const vec3 surfaceNormal, const vec3 eyeDirection, float shiny, float spec, float diffuse, inout vec3 diffuseColor, inout vec3 specularColor ) {
+				vec3 reflection = normalize( reflect( -sunDirection, surfaceNormal ) );
+				float direction = max( 0.0, dot( eyeDirection, reflection ) );
+				specularColor += pow( direction, shiny ) * sunColor * spec;
+				diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;
+			}
 
-#include <common>
-#include <packing>
-#include <bsdfs>
-#include <fog_pars_fragment>
-#include <lights_pars_begin>
-#include <shadowmap_pars_fragment>
-#include <shadowmask_pars_fragment>
+			#include <common>
+			#include <packing>
+			#include <bsdfs>
+			#include <fog_pars_fragment>
+			#include <lights_pars_begin>
+			#include <shadowmap_pars_fragment>
+			#include <shadowmask_pars_fragment>
 
-void main() {
-	vec4 noise = getNoise( worldPosition.xz * size );
-	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );
+			void main() {
+				vec4 noise = getNoise( worldPosition.xz * size );
+				vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );
 
-	vec3 diffuseLight = vec3(0.0);
-	vec3 specularLight = vec3(0.0);
+				vec3 diffuseLight = vec3(0.0);
+				vec3 specularLight = vec3(0.0);
 
-	vec3 worldToEye = eye-worldPosition.xyz;
-	vec3 eyeDirection = normalize( worldToEye );
-	sunLight( surfaceNormal, eyeDirection, 100.0, 2.0, 0.5, diffuseLight, specularLight );
+				vec3 worldToEye = eye-worldPosition.xyz;
+				vec3 eyeDirection = normalize( worldToEye );
+				sunLight( surfaceNormal, eyeDirection, 100.0, 2.0, 0.5, diffuseLight, specularLight );
 
-	float distance = length(worldToEye);
+				float distance = length(worldToEye);
 
-	vec2 distortion = surfaceNormal.xz * ( 0.001 + 1.0 / distance ) * distortionScale;
-	vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.w + distortion ) );
+				vec2 distortion = surfaceNormal.xz * ( 0.001 + 1.0 / distance ) * distortionScale;
+				vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.w + distortion ) );
 
-	float theta = max( dot( eyeDirection, surfaceNormal ), 0.0 );
-	float rf0 = 0.3;
-	float reflectance = rf0 + ( 1.0 - rf0 ) * pow( ( 1.0 - theta ), 5.0 );
-	vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;
-	vec3 albedo = mix( ( sunColor * diffuseLight * 0.3 + scatter ) * getShadowMask(), ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance);
-	vec3 outgoingLight = albedo;
-	gl_FragColor = vec4( outgoingLight, alpha );
+				float theta = max( dot( eyeDirection, surfaceNormal ), 0.0 );
+				float rf0 = 0.3;
+				float reflectance = rf0 + ( 1.0 - rf0 ) * pow( ( 1.0 - theta ), 5.0 );
+				vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;
+				vec3 albedo = mix( ( sunColor * diffuseLight * 0.3 + scatter ) * getShadowMask(), ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance);
+				vec3 outgoingLight = albedo;
+				gl_FragColor = vec4( outgoingLight, alpha );
 
-	#include <tonemapping_fragment>
-	#include <fog_fragment>
+				#include <tonemapping_fragment>
+				#include <fog_fragment>
 
-}
-`
-
+			}
+		`
 	};
 
 	var material = new THREE.ShaderMaterial( {

--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -83,100 +83,100 @@ THREE.Water = function ( geometry, options ) {
 			}
 		] ),
 
-		vertexShader: [
-			'uniform mat4 textureMatrix;',
-			'uniform float time;',
+		vertexShader: /* glsl */`
+uniform mat4 textureMatrix;
+uniform float time;
 
-			'varying vec4 mirrorCoord;',
-			'varying vec4 worldPosition;',
+varying vec4 mirrorCoord;
+varying vec4 worldPosition;
 
-			'#include <fog_pars_vertex>',
-			'#include <shadowmap_pars_vertex>',
+#include <fog_pars_vertex>
+#include <shadowmap_pars_vertex>
 
-			'void main() {',
-			'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
-			'	worldPosition = mirrorCoord.xyzw;',
-			'	mirrorCoord = textureMatrix * mirrorCoord;',
-			'	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
-			'	gl_Position = projectionMatrix * mvPosition;',
+void main() {
+	mirrorCoord = modelMatrix * vec4( position, 1.0 );
+	worldPosition = mirrorCoord.xyzw;
+	mirrorCoord = textureMatrix * mirrorCoord;
+	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );
+	gl_Position = projectionMatrix * mvPosition;
 
-			'	#include <fog_vertex>',
-			'	#include <shadowmap_vertex>',
+	#include <fog_vertex>
+	#include <shadowmap_vertex>
 
-			'}'
-		].join( '\n' ),
+}
+`,
 
-		fragmentShader: [
-			'uniform sampler2D mirrorSampler;',
-			'uniform float alpha;',
-			'uniform float time;',
-			'uniform float size;',
-			'uniform float distortionScale;',
-			'uniform sampler2D normalSampler;',
-			'uniform vec3 sunColor;',
-			'uniform vec3 sunDirection;',
-			'uniform vec3 eye;',
-			'uniform vec3 waterColor;',
+		fragmentShader: /* glsl */`
+uniform sampler2D mirrorSampler;
+uniform float alpha;
+uniform float time;
+uniform float size;
+uniform float distortionScale;
+uniform sampler2D normalSampler;
+uniform vec3 sunColor;
+uniform vec3 sunDirection;
+uniform vec3 eye;
+uniform vec3 waterColor;
 
-			'varying vec4 mirrorCoord;',
-			'varying vec4 worldPosition;',
+varying vec4 mirrorCoord;
+varying vec4 worldPosition;
 
-			'vec4 getNoise( vec2 uv ) {',
-			'	vec2 uv0 = ( uv / 103.0 ) + vec2(time / 17.0, time / 29.0);',
-			'	vec2 uv1 = uv / 107.0-vec2( time / -19.0, time / 31.0 );',
-			'	vec2 uv2 = uv / vec2( 8907.0, 9803.0 ) + vec2( time / 101.0, time / 97.0 );',
-			'	vec2 uv3 = uv / vec2( 1091.0, 1027.0 ) - vec2( time / 109.0, time / -113.0 );',
-			'	vec4 noise = texture2D( normalSampler, uv0 ) +',
-			'		texture2D( normalSampler, uv1 ) +',
-			'		texture2D( normalSampler, uv2 ) +',
-			'		texture2D( normalSampler, uv3 );',
-			'	return noise * 0.5 - 1.0;',
-			'}',
+vec4 getNoise( vec2 uv ) {
+	vec2 uv0 = ( uv / 103.0 ) + vec2(time / 17.0, time / 29.0);
+	vec2 uv1 = uv / 107.0-vec2( time / -19.0, time / 31.0 );
+	vec2 uv2 = uv / vec2( 8907.0, 9803.0 ) + vec2( time / 101.0, time / 97.0 );
+	vec2 uv3 = uv / vec2( 1091.0, 1027.0 ) - vec2( time / 109.0, time / -113.0 );
+	vec4 noise = texture2D( normalSampler, uv0 ) +
+		texture2D( normalSampler, uv1 ) +
+		texture2D( normalSampler, uv2 ) +
+		texture2D( normalSampler, uv3 );
+	return noise * 0.5 - 1.0;
+}
 
-			'void sunLight( const vec3 surfaceNormal, const vec3 eyeDirection, float shiny, float spec, float diffuse, inout vec3 diffuseColor, inout vec3 specularColor ) {',
-			'	vec3 reflection = normalize( reflect( -sunDirection, surfaceNormal ) );',
-			'	float direction = max( 0.0, dot( eyeDirection, reflection ) );',
-			'	specularColor += pow( direction, shiny ) * sunColor * spec;',
-			'	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;',
-			'}',
+void sunLight( const vec3 surfaceNormal, const vec3 eyeDirection, float shiny, float spec, float diffuse, inout vec3 diffuseColor, inout vec3 specularColor ) {
+	vec3 reflection = normalize( reflect( -sunDirection, surfaceNormal ) );
+	float direction = max( 0.0, dot( eyeDirection, reflection ) );
+	specularColor += pow( direction, shiny ) * sunColor * spec;
+	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;
+}
 
-			'#include <common>',
-			'#include <packing>',
-			'#include <bsdfs>',
-			'#include <fog_pars_fragment>',
-			'#include <lights_pars_begin>',
-			'#include <shadowmap_pars_fragment>',
-			'#include <shadowmask_pars_fragment>',
+#include <common>
+#include <packing>
+#include <bsdfs>
+#include <fog_pars_fragment>
+#include <lights_pars_begin>
+#include <shadowmap_pars_fragment>
+#include <shadowmask_pars_fragment>
 
-			'void main() {',
-			'	vec4 noise = getNoise( worldPosition.xz * size );',
-			'	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );',
+void main() {
+	vec4 noise = getNoise( worldPosition.xz * size );
+	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );
 
-			'	vec3 diffuseLight = vec3(0.0);',
-			'	vec3 specularLight = vec3(0.0);',
+	vec3 diffuseLight = vec3(0.0);
+	vec3 specularLight = vec3(0.0);
 
-			'	vec3 worldToEye = eye-worldPosition.xyz;',
-			'	vec3 eyeDirection = normalize( worldToEye );',
-			'	sunLight( surfaceNormal, eyeDirection, 100.0, 2.0, 0.5, diffuseLight, specularLight );',
+	vec3 worldToEye = eye-worldPosition.xyz;
+	vec3 eyeDirection = normalize( worldToEye );
+	sunLight( surfaceNormal, eyeDirection, 100.0, 2.0, 0.5, diffuseLight, specularLight );
 
-			'	float distance = length(worldToEye);',
+	float distance = length(worldToEye);
 
-			'	vec2 distortion = surfaceNormal.xz * ( 0.001 + 1.0 / distance ) * distortionScale;',
-			'	vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.w + distortion ) );',
+	vec2 distortion = surfaceNormal.xz * ( 0.001 + 1.0 / distance ) * distortionScale;
+	vec3 reflectionSample = vec3( texture2D( mirrorSampler, mirrorCoord.xy / mirrorCoord.w + distortion ) );
 
-			'	float theta = max( dot( eyeDirection, surfaceNormal ), 0.0 );',
-			'	float rf0 = 0.3;',
-			'	float reflectance = rf0 + ( 1.0 - rf0 ) * pow( ( 1.0 - theta ), 5.0 );',
-			'	vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;',
-			'	vec3 albedo = mix( ( sunColor * diffuseLight * 0.3 + scatter ) * getShadowMask(), ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance);',
-			'	vec3 outgoingLight = albedo;',
-			'	gl_FragColor = vec4( outgoingLight, alpha );',
+	float theta = max( dot( eyeDirection, surfaceNormal ), 0.0 );
+	float rf0 = 0.3;
+	float reflectance = rf0 + ( 1.0 - rf0 ) * pow( ( 1.0 - theta ), 5.0 );
+	vec3 scatter = max( 0.0, dot( surfaceNormal, eyeDirection ) ) * waterColor;
+	vec3 albedo = mix( ( sunColor * diffuseLight * 0.3 + scatter ) * getShadowMask(), ( vec3( 0.1 ) + reflectionSample * 0.9 + reflectionSample * specularLight ), reflectance);
+	vec3 outgoingLight = albedo;
+	gl_FragColor = vec4( outgoingLight, alpha );
 
-			'	#include <tonemapping_fragment>',
-			'	#include <fog_fragment>',
+	#include <tonemapping_fragment>
+	#include <fog_fragment>
 
-			'}'
-		].join( '\n' )
+}
+`
 
 	};
 

--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -90,8 +90,8 @@ THREE.Water = function ( geometry, options ) {
 			'varying vec4 mirrorCoord;',
 			'varying vec4 worldPosition;',
 
-			THREE.ShaderChunk[ 'fog_pars_vertex' ],
-			THREE.ShaderChunk[ 'shadowmap_pars_vertex' ],
+			'#include <fog_pars_vertex>',
+			'#include <shadowmap_pars_vertex>',
 
 			'void main() {',
 			'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
@@ -100,8 +100,8 @@ THREE.Water = function ( geometry, options ) {
 			'	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
 			'	gl_Position = projectionMatrix * mvPosition;',
 
-			THREE.ShaderChunk[ 'fog_vertex' ],
-			THREE.ShaderChunk[ 'shadowmap_vertex' ],
+			'	#include <fog_vertex>',
+			'	#include <shadowmap_vertex>',
 
 			'}'
 		].join( '\n' ),
@@ -140,13 +140,13 @@ THREE.Water = function ( geometry, options ) {
 			'	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;',
 			'}',
 
-			THREE.ShaderChunk[ 'common' ],
-			THREE.ShaderChunk[ 'packing' ],
-			THREE.ShaderChunk[ 'bsdfs' ],
-			THREE.ShaderChunk[ 'fog_pars_fragment' ],
-			THREE.ShaderChunk[ 'lights_pars_begin' ],
-			THREE.ShaderChunk[ 'shadowmap_pars_fragment' ],
-			THREE.ShaderChunk[ 'shadowmask_pars_fragment' ],
+			'#include <common>',
+			'#include <packing>',
+			'#include <bsdfs>',
+			'#include <fog_pars_fragment>',
+			'#include <lights_pars_begin>',
+			'#include <shadowmap_pars_fragment>',
+			'#include <shadowmask_pars_fragment>',
 
 			'void main() {',
 			'	vec4 noise = getNoise( worldPosition.xz * size );',
@@ -172,8 +172,8 @@ THREE.Water = function ( geometry, options ) {
 			'	vec3 outgoingLight = albedo;',
 			'	gl_FragColor = vec4( outgoingLight, alpha );',
 
-			THREE.ShaderChunk[ 'tonemapping_fragment' ],
-			THREE.ShaderChunk[ 'fog_fragment' ],
+			'	#include <tonemapping_fragment>',
+			'	#include <fog_fragment>',
 
 			'}'
 		].join( '\n' )

--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -234,110 +234,106 @@ THREE.Water.WaterShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+#include <fog_pars_vertex>
+#include <logdepthbuf_pars_vertex>
 
-		'#include <fog_pars_vertex>',
-		'#include <logdepthbuf_pars_vertex>',
+uniform mat4 textureMatrix;
 
-		'uniform mat4 textureMatrix;',
+varying vec4 vCoord;
+varying vec2 vUv;
+varying vec3 vToEye;
 
-		'varying vec4 vCoord;',
-		'varying vec2 vUv;',
-		'varying vec3 vToEye;',
+void main() {
 
-		'void main() {',
+	vUv = uv;
+	vCoord = textureMatrix * vec4( position, 1.0 );
 
-		'	vUv = uv;',
-		'	vCoord = textureMatrix * vec4( position, 1.0 );',
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+	vToEye = cameraPosition - worldPosition.xyz;
 
-		'	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
-		'	vToEye = cameraPosition - worldPosition.xyz;',
+	vec4 mvPosition =  viewMatrix * worldPosition; // used in fog_vertex
+	gl_Position = projectionMatrix * mvPosition;
 
-		'	vec4 mvPosition =  viewMatrix * worldPosition;', // used in fog_vertex
-		'	gl_Position = projectionMatrix * mvPosition;',
+	#include <logdepthbuf_vertex>
+	#include <fog_vertex>
 
-		'	#include <logdepthbuf_vertex>',
-		'	#include <fog_vertex>',
+}
+`,
 
-		'}'
+	fragmentShader: /* glsl */`
+#include <common>
+#include <fog_pars_fragment>
+#include <logdepthbuf_pars_fragment>
 
-	].join( '\n' ),
+uniform sampler2D tReflectionMap;
+uniform sampler2D tRefractionMap;
+uniform sampler2D tNormalMap0;
+uniform sampler2D tNormalMap1;
 
-	fragmentShader: [
+#ifdef USE_FLOWMAP
+	uniform sampler2D tFlowMap;
+#else
+	uniform vec2 flowDirection;
+#endif
 
-		'#include <common>',
-		'#include <fog_pars_fragment>',
-		'#include <logdepthbuf_pars_fragment>',
+uniform vec3 color;
+uniform float reflectivity;
+uniform vec4 config;
 
-		'uniform sampler2D tReflectionMap;',
-		'uniform sampler2D tRefractionMap;',
-		'uniform sampler2D tNormalMap0;',
-		'uniform sampler2D tNormalMap1;',
+varying vec4 vCoord;
+varying vec2 vUv;
+varying vec3 vToEye;
 
-		'#ifdef USE_FLOWMAP',
-		'	uniform sampler2D tFlowMap;',
-		'#else',
-		'	uniform vec2 flowDirection;',
-		'#endif',
+void main() {
 
-		'uniform vec3 color;',
-		'uniform float reflectivity;',
-		'uniform vec4 config;',
+	#include <logdepthbuf_fragment>
 
-		'varying vec4 vCoord;',
-		'varying vec2 vUv;',
-		'varying vec3 vToEye;',
+	float flowMapOffset0 = config.x;
+	float flowMapOffset1 = config.y;
+	float halfCycle = config.z;
+	float scale = config.w;
 
-		'void main() {',
+	vec3 toEye = normalize( vToEye );
 
-		'	#include <logdepthbuf_fragment>',
+	// determine flow direction
+	vec2 flow;
+	#ifdef USE_FLOWMAP
+		flow = texture2D( tFlowMap, vUv ).rg * 2.0 - 1.0;
+	#else
+		flow = flowDirection;
+	#endif
+	flow.x *= - 1.0;
 
-		'	float flowMapOffset0 = config.x;',
-		'	float flowMapOffset1 = config.y;',
-		'	float halfCycle = config.z;',
-		'	float scale = config.w;',
+	// sample normal maps (distort uvs with flowdata)
+	vec4 normalColor0 = texture2D( tNormalMap0, ( vUv * scale ) + flow * flowMapOffset0 );
+	vec4 normalColor1 = texture2D( tNormalMap1, ( vUv * scale ) + flow * flowMapOffset1 );
 
-		'	vec3 toEye = normalize( vToEye );',
+	// linear interpolate to get the final normal color
+	float flowLerp = abs( halfCycle - flowMapOffset0 ) / halfCycle;
+	vec4 normalColor = mix( normalColor0, normalColor1, flowLerp );
 
-		// determine flow direction
-		'	vec2 flow;',
-		'	#ifdef USE_FLOWMAP',
-		'		flow = texture2D( tFlowMap, vUv ).rg * 2.0 - 1.0;',
-		'	#else',
-		'		flow = flowDirection;',
-		'	#endif',
-		'	flow.x *= - 1.0;',
+	// calculate normal vector
+	vec3 normal = normalize( vec3( normalColor.r * 2.0 - 1.0, normalColor.b,  normalColor.g * 2.0 - 1.0 ) );
 
-		// sample normal maps (distort uvs with flowdata)
-		'	vec4 normalColor0 = texture2D( tNormalMap0, ( vUv * scale ) + flow * flowMapOffset0 );',
-		'	vec4 normalColor1 = texture2D( tNormalMap1, ( vUv * scale ) + flow * flowMapOffset1 );',
+	// calculate the fresnel term to blend reflection and refraction maps
+	float theta = max( dot( toEye, normal ), 0.0 );
+	float reflectance = reflectivity + ( 1.0 - reflectivity ) * pow( ( 1.0 - theta ), 5.0 );
 
-		// linear interpolate to get the final normal color
-		'	float flowLerp = abs( halfCycle - flowMapOffset0 ) / halfCycle;',
-		'	vec4 normalColor = mix( normalColor0, normalColor1, flowLerp );',
+	// calculate final uv coords
+	vec3 coord = vCoord.xyz / vCoord.w;
+	vec2 uv = coord.xy + coord.z * normal.xz * 0.05;
 
-		// calculate normal vector
-		'	vec3 normal = normalize( vec3( normalColor.r * 2.0 - 1.0, normalColor.b,  normalColor.g * 2.0 - 1.0 ) );',
+	vec4 reflectColor = texture2D( tReflectionMap, vec2( 1.0 - uv.x, uv.y ) );
+	vec4 refractColor = texture2D( tRefractionMap, uv );
 
-		// calculate the fresnel term to blend reflection and refraction maps
-		'	float theta = max( dot( toEye, normal ), 0.0 );',
-		'	float reflectance = reflectivity + ( 1.0 - reflectivity ) * pow( ( 1.0 - theta ), 5.0 );',
+	// multiply water color with the mix of both textures
+	gl_FragColor = vec4( color, 1.0 ) * mix( refractColor, reflectColor, reflectance );
 
-		// calculate final uv coords
-		'	vec3 coord = vCoord.xyz / vCoord.w;',
-		'	vec2 uv = coord.xy + coord.z * normal.xz * 0.05;',
+	#include <tonemapping_fragment>
+	#include <encodings_fragment>
+	#include <fog_fragment>
 
-		'	vec4 reflectColor = texture2D( tReflectionMap, vec2( 1.0 - uv.x, uv.y ) );',
-		'	vec4 refractColor = texture2D( tRefractionMap, uv );',
-
-		// multiply water color with the mix of both textures
-		'	gl_FragColor = vec4( color, 1.0 ) * mix( refractColor, reflectColor, reflectance );',
-
-		'	#include <tonemapping_fragment>',
-		'	#include <encodings_fragment>',
-		'	#include <fog_fragment>',
-
-		'}'
-
-	].join( '\n' )
+}
+`
 };

--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -235,105 +235,105 @@ THREE.Water.WaterShader = {
 	},
 
 	vertexShader: /* glsl */`
-#include <fog_pars_vertex>
-#include <logdepthbuf_pars_vertex>
+		#include <fog_pars_vertex>
+		#include <logdepthbuf_pars_vertex>
 
-uniform mat4 textureMatrix;
+		uniform mat4 textureMatrix;
 
-varying vec4 vCoord;
-varying vec2 vUv;
-varying vec3 vToEye;
+		varying vec4 vCoord;
+		varying vec2 vUv;
+		varying vec3 vToEye;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	vCoord = textureMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			vCoord = textureMatrix * vec4( position, 1.0 );
 
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
-	vToEye = cameraPosition - worldPosition.xyz;
+			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+			vToEye = cameraPosition - worldPosition.xyz;
 
-	vec4 mvPosition =  viewMatrix * worldPosition; // used in fog_vertex
-	gl_Position = projectionMatrix * mvPosition;
+			vec4 mvPosition =  viewMatrix * worldPosition; // used in fog_vertex
+			gl_Position = projectionMatrix * mvPosition;
 
-	#include <logdepthbuf_vertex>
-	#include <fog_vertex>
+			#include <logdepthbuf_vertex>
+			#include <fog_vertex>
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
-#include <fog_pars_fragment>
-#include <logdepthbuf_pars_fragment>
+		#include <common>
+		#include <fog_pars_fragment>
+		#include <logdepthbuf_pars_fragment>
 
-uniform sampler2D tReflectionMap;
-uniform sampler2D tRefractionMap;
-uniform sampler2D tNormalMap0;
-uniform sampler2D tNormalMap1;
+		uniform sampler2D tReflectionMap;
+		uniform sampler2D tRefractionMap;
+		uniform sampler2D tNormalMap0;
+		uniform sampler2D tNormalMap1;
 
-#ifdef USE_FLOWMAP
-	uniform sampler2D tFlowMap;
-#else
-	uniform vec2 flowDirection;
-#endif
+		#ifdef USE_FLOWMAP
+			uniform sampler2D tFlowMap;
+		#else
+			uniform vec2 flowDirection;
+		#endif
 
-uniform vec3 color;
-uniform float reflectivity;
-uniform vec4 config;
+		uniform vec3 color;
+		uniform float reflectivity;
+		uniform vec4 config;
 
-varying vec4 vCoord;
-varying vec2 vUv;
-varying vec3 vToEye;
+		varying vec4 vCoord;
+		varying vec2 vUv;
+		varying vec3 vToEye;
 
-void main() {
+		void main() {
 
-	#include <logdepthbuf_fragment>
+			#include <logdepthbuf_fragment>
 
-	float flowMapOffset0 = config.x;
-	float flowMapOffset1 = config.y;
-	float halfCycle = config.z;
-	float scale = config.w;
+			float flowMapOffset0 = config.x;
+			float flowMapOffset1 = config.y;
+			float halfCycle = config.z;
+			float scale = config.w;
 
-	vec3 toEye = normalize( vToEye );
+			vec3 toEye = normalize( vToEye );
 
-	// determine flow direction
-	vec2 flow;
-	#ifdef USE_FLOWMAP
-		flow = texture2D( tFlowMap, vUv ).rg * 2.0 - 1.0;
-	#else
-		flow = flowDirection;
-	#endif
-	flow.x *= - 1.0;
+			// determine flow direction
+			vec2 flow;
+			#ifdef USE_FLOWMAP
+				flow = texture2D( tFlowMap, vUv ).rg * 2.0 - 1.0;
+			#else
+				flow = flowDirection;
+			#endif
+			flow.x *= - 1.0;
 
-	// sample normal maps (distort uvs with flowdata)
-	vec4 normalColor0 = texture2D( tNormalMap0, ( vUv * scale ) + flow * flowMapOffset0 );
-	vec4 normalColor1 = texture2D( tNormalMap1, ( vUv * scale ) + flow * flowMapOffset1 );
+			// sample normal maps (distort uvs with flowdata)
+			vec4 normalColor0 = texture2D( tNormalMap0, ( vUv * scale ) + flow * flowMapOffset0 );
+			vec4 normalColor1 = texture2D( tNormalMap1, ( vUv * scale ) + flow * flowMapOffset1 );
 
-	// linear interpolate to get the final normal color
-	float flowLerp = abs( halfCycle - flowMapOffset0 ) / halfCycle;
-	vec4 normalColor = mix( normalColor0, normalColor1, flowLerp );
+			// linear interpolate to get the final normal color
+			float flowLerp = abs( halfCycle - flowMapOffset0 ) / halfCycle;
+			vec4 normalColor = mix( normalColor0, normalColor1, flowLerp );
 
-	// calculate normal vector
-	vec3 normal = normalize( vec3( normalColor.r * 2.0 - 1.0, normalColor.b,  normalColor.g * 2.0 - 1.0 ) );
+			// calculate normal vector
+			vec3 normal = normalize( vec3( normalColor.r * 2.0 - 1.0, normalColor.b,  normalColor.g * 2.0 - 1.0 ) );
 
-	// calculate the fresnel term to blend reflection and refraction maps
-	float theta = max( dot( toEye, normal ), 0.0 );
-	float reflectance = reflectivity + ( 1.0 - reflectivity ) * pow( ( 1.0 - theta ), 5.0 );
+			// calculate the fresnel term to blend reflection and refraction maps
+			float theta = max( dot( toEye, normal ), 0.0 );
+			float reflectance = reflectivity + ( 1.0 - reflectivity ) * pow( ( 1.0 - theta ), 5.0 );
 
-	// calculate final uv coords
-	vec3 coord = vCoord.xyz / vCoord.w;
-	vec2 uv = coord.xy + coord.z * normal.xz * 0.05;
+			// calculate final uv coords
+			vec3 coord = vCoord.xyz / vCoord.w;
+			vec2 uv = coord.xy + coord.z * normal.xz * 0.05;
 
-	vec4 reflectColor = texture2D( tReflectionMap, vec2( 1.0 - uv.x, uv.y ) );
-	vec4 refractColor = texture2D( tRefractionMap, uv );
+			vec4 reflectColor = texture2D( tReflectionMap, vec2( 1.0 - uv.x, uv.y ) );
+			vec4 refractColor = texture2D( tRefractionMap, uv );
 
-	// multiply water color with the mix of both textures
-	gl_FragColor = vec4( color, 1.0 ) * mix( refractColor, reflectColor, reflectance );
+			// multiply water color with the mix of both textures
+			gl_FragColor = vec4( color, 1.0 ) * mix( refractColor, reflectColor, reflectance );
 
-	#include <tonemapping_fragment>
-	#include <encodings_fragment>
-	#include <fog_fragment>
+			#include <tonemapping_fragment>
+			#include <encodings_fragment>
+			#include <fog_fragment>
 
-}
-`
+		}
+	`
 };

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -58,43 +58,43 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 			"delta": { value: 0.016 },
 			"tau": { value: 1.0 }
 		},
-		vertexShader: [
-			"varying vec2 vUv;",
+		vertexShader: /* glsl */`
+varying vec2 vUv;
 
-			"void main() {",
+void main() {
 
-			"	vUv = uv;",
-			"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-			"}"
-		].join( '\n' ),
-		fragmentShader: [
-			"varying vec2 vUv;",
+}
+`,
+		fragmentShader: /* glsl */`
+varying vec2 vUv;
 
-			"uniform sampler2D lastLum;",
-			"uniform sampler2D currentLum;",
-			"uniform float minLuminance;",
-			"uniform float delta;",
-			"uniform float tau;",
+uniform sampler2D lastLum;
+uniform sampler2D currentLum;
+uniform float minLuminance;
+uniform float delta;
+uniform float tau;
 
-			"void main() {",
+void main() {
 
-			"	vec4 lastLum = texture2D( lastLum, vUv, MIP_LEVEL_1X1 );",
-			"	vec4 currentLum = texture2D( currentLum, vUv, MIP_LEVEL_1X1 );",
+	vec4 lastLum = texture2D( lastLum, vUv, MIP_LEVEL_1X1 );
+	vec4 currentLum = texture2D( currentLum, vUv, MIP_LEVEL_1X1 );
 
-			"	float fLastLum = max( minLuminance, lastLum.r );",
-			"	float fCurrentLum = max( minLuminance, currentLum.r );",
+	float fLastLum = max( minLuminance, lastLum.r );
+	float fCurrentLum = max( minLuminance, currentLum.r );
 
-			//The adaption seems to work better in extreme lighting differences
-			//if the input luminance is squared.
-			"	fCurrentLum *= fCurrentLum;",
+	//The adaption seems to work better in extreme lighting differences
+	//if the input luminance is squared.
+	fCurrentLum *= fCurrentLum;
 
-			// Adapt the luminance using Pattanaik's technique
-			"	float fAdaptedLum = fLastLum + (fCurrentLum - fLastLum) * (1.0 - exp(-delta * tau));",
-			// "fAdaptedLum = sqrt(fAdaptedLum);",
-			"	gl_FragColor.r = fAdaptedLum;",
-			"}"
-		].join( '\n' )
+	// Adapt the luminance using Pattanaik's technique
+	float fAdaptedLum = fLastLum + (fCurrentLum - fLastLum) * (1.0 - exp(-delta * tau));
+	// "fAdaptedLum = sqrt(fAdaptedLum);",
+	gl_FragColor.r = fAdaptedLum;
+}
+`
 	};
 
 	this.materialAdaptiveLum = new THREE.ShaderMaterial( {

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -59,42 +59,42 @@ THREE.AdaptiveToneMappingPass = function ( adaptive, resolution ) {
 			"tau": { value: 1.0 }
 		},
 		vertexShader: /* glsl */`
-varying vec2 vUv;
+			varying vec2 vUv;
 
-void main() {
+			void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				vUv = uv;
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+			}
+		`,
 		fragmentShader: /* glsl */`
-varying vec2 vUv;
+			varying vec2 vUv;
 
-uniform sampler2D lastLum;
-uniform sampler2D currentLum;
-uniform float minLuminance;
-uniform float delta;
-uniform float tau;
+			uniform sampler2D lastLum;
+			uniform sampler2D currentLum;
+			uniform float minLuminance;
+			uniform float delta;
+			uniform float tau;
 
-void main() {
+			void main() {
 
-	vec4 lastLum = texture2D( lastLum, vUv, MIP_LEVEL_1X1 );
-	vec4 currentLum = texture2D( currentLum, vUv, MIP_LEVEL_1X1 );
+				vec4 lastLum = texture2D( lastLum, vUv, MIP_LEVEL_1X1 );
+				vec4 currentLum = texture2D( currentLum, vUv, MIP_LEVEL_1X1 );
 
-	float fLastLum = max( minLuminance, lastLum.r );
-	float fCurrentLum = max( minLuminance, currentLum.r );
+				float fLastLum = max( minLuminance, lastLum.r );
+				float fCurrentLum = max( minLuminance, currentLum.r );
 
-	//The adaption seems to work better in extreme lighting differences
-	//if the input luminance is squared.
-	fCurrentLum *= fCurrentLum;
+				//The adaption seems to work better in extreme lighting differences
+				//if the input luminance is squared.
+				fCurrentLum *= fCurrentLum;
 
-	// Adapt the luminance using Pattanaik's technique
-	float fAdaptedLum = fLastLum + (fCurrentLum - fLastLum) * (1.0 - exp(-delta * tau));
-	// "fAdaptedLum = sqrt(fAdaptedLum);",
-	gl_FragColor.r = fAdaptedLum;
-}
-`
+				// Adapt the luminance using Pattanaik's technique
+				float fAdaptedLum = fLastLum + (fCurrentLum - fLastLum) * (1.0 - exp(-delta * tau));
+				// "fAdaptedLum = sqrt(fAdaptedLum);",
+				gl_FragColor.r = fAdaptedLum;
+			}
+		`
 	};
 
 	this.materialAdaptiveLum = new THREE.ShaderMaterial( {

--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -393,45 +393,45 @@ THREE.OutlinePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 				"textureMatrix": { value: null }
 			},
 
-			vertexShader: [
-				'#include <morphtarget_pars_vertex>',
-				'#include <skinning_pars_vertex>',
+			vertexShader: /* glsl */`
+#include <morphtarget_pars_vertex>
+#include <skinning_pars_vertex>
 
-				'varying vec4 projTexCoord;',
-				'varying vec4 vPosition;',
-				'uniform mat4 textureMatrix;',
+varying vec4 projTexCoord;
+varying vec4 vPosition;
+uniform mat4 textureMatrix;
 
-				'void main() {',
+void main() {
 
-				'	#include <skinbase_vertex>',
-				'	#include <begin_vertex>',
-				'	#include <morphtarget_vertex>',
-				'	#include <skinning_vertex>',
-				'	#include <project_vertex>',
+	#include <skinbase_vertex>
+	#include <begin_vertex>
+	#include <morphtarget_vertex>
+	#include <skinning_vertex>
+	#include <project_vertex>
 
-				'	vPosition = mvPosition;',
-				'	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
-				'	projTexCoord = textureMatrix * worldPosition;',
+	vPosition = mvPosition;
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+	projTexCoord = textureMatrix * worldPosition;
 
-				'}'
-			].join( '\n' ),
+}
+`,
 
-			fragmentShader: [
-				'#include <packing>',
-				'varying vec4 vPosition;',
-				'varying vec4 projTexCoord;',
-				'uniform sampler2D depthTexture;',
-				'uniform vec2 cameraNearFar;',
+			fragmentShader: /* glsl */`
+#include <packing>
+varying vec4 vPosition;
+varying vec4 projTexCoord;
+uniform sampler2D depthTexture;
+uniform vec2 cameraNearFar;
 
-				'void main() {',
+void main() {
 
-				'	float depth = unpackRGBAToDepth(texture2DProj( depthTexture, projTexCoord ));',
-				'	float viewZ = - DEPTH_TO_VIEW_Z( depth, cameraNearFar.x, cameraNearFar.y );',
-				'	float depthTest = (-vPosition.z > viewZ) ? 1.0 : 0.0;',
-				'	gl_FragColor = vec4(0.0, depthTest, 1.0, 1.0);',
+	float depth = unpackRGBAToDepth(texture2DProj( depthTexture, projTexCoord ));
+	float viewZ = - DEPTH_TO_VIEW_Z( depth, cameraNearFar.x, cameraNearFar.y );
+	float depthTest = (-vPosition.z > viewZ) ? 1.0 : 0.0;
+	gl_FragColor = vec4(0.0, depthTest, 1.0, 1.0);
 
-				'}'
-			].join( '\n' )
+}
+`
 
 		} );
 

--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -448,36 +448,38 @@ void main() {
 				"hiddenEdgeColor": { value: new THREE.Vector3( 1.0, 1.0, 1.0 ) },
 			},
 
-			vertexShader:
-				"varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}",
+			vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-			fragmentShader:
-				"varying vec2 vUv;\
-				uniform sampler2D maskTexture;\
-				uniform vec2 texSize;\
-				uniform vec3 visibleEdgeColor;\
-				uniform vec3 hiddenEdgeColor;\
-				\
-				void main() {\n\
-					vec2 invSize = 1.0 / texSize;\
-					vec4 uvOffset = vec4(1.0, 0.0, 0.0, 1.0) * vec4(invSize, invSize);\
-					vec4 c1 = texture2D( maskTexture, vUv + uvOffset.xy);\
-					vec4 c2 = texture2D( maskTexture, vUv - uvOffset.xy);\
-					vec4 c3 = texture2D( maskTexture, vUv + uvOffset.yw);\
-					vec4 c4 = texture2D( maskTexture, vUv - uvOffset.yw);\
-					float diff1 = (c1.r - c2.r)*0.5;\
-					float diff2 = (c3.r - c4.r)*0.5;\
-					float d = length( vec2(diff1, diff2) );\
-					float a1 = min(c1.g, c2.g);\
-					float a2 = min(c3.g, c4.g);\
-					float visibilityFactor = min(a1, a2);\
-					vec3 edgeColor = 1.0 - visibilityFactor > 0.001 ? visibleEdgeColor : hiddenEdgeColor;\
-					gl_FragColor = vec4(edgeColor, 1.0) * vec4(d);\
-				}"
+			fragmentShader: /* glsl */`
+varying vec2 vUv;
+uniform sampler2D maskTexture;
+uniform vec2 texSize;
+uniform vec3 visibleEdgeColor;
+uniform vec3 hiddenEdgeColor;
+
+void main() {
+	vec2 invSize = 1.0 / texSize;
+	vec4 uvOffset = vec4(1.0, 0.0, 0.0, 1.0) * vec4(invSize, invSize);
+	vec4 c1 = texture2D( maskTexture, vUv + uvOffset.xy);
+	vec4 c2 = texture2D( maskTexture, vUv - uvOffset.xy);
+	vec4 c3 = texture2D( maskTexture, vUv + uvOffset.yw);
+	vec4 c4 = texture2D( maskTexture, vUv - uvOffset.yw);
+	float diff1 = (c1.r - c2.r)*0.5;
+	float diff2 = (c3.r - c4.r)*0.5;
+	float d = length( vec2(diff1, diff2) );
+	float a1 = min(c1.g, c2.g);
+	float a2 = min(c3.g, c4.g);
+	float visibilityFactor = min(a1, a2);
+	vec3 edgeColor = 1.0 - visibilityFactor > 0.001 ? visibleEdgeColor : hiddenEdgeColor;
+	gl_FragColor = vec4(edgeColor, 1.0) * vec4(d);
+}
+`
 		} );
 
 	},
@@ -497,40 +499,43 @@ void main() {
 				"kernelRadius": { value: 1.0 }
 			},
 
-			vertexShader:
-				"varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}",
+			vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-			fragmentShader:
-				"#include <common>\
-				varying vec2 vUv;\
-				uniform sampler2D colorTexture;\
-				uniform vec2 texSize;\
-				uniform vec2 direction;\
-				uniform float kernelRadius;\
-				\
-				float gaussianPdf(in float x, in float sigma) {\
-					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;\
-				}\
-				void main() {\
-					vec2 invSize = 1.0 / texSize;\
-					float weightSum = gaussianPdf(0.0, kernelRadius);\
-					vec4 diffuseSum = texture2D( colorTexture, vUv) * weightSum;\
-					vec2 delta = direction * invSize * kernelRadius/float(MAX_RADIUS);\
-					vec2 uvOffset = delta;\
-					for( int i = 1; i <= MAX_RADIUS; i ++ ) {\
-						float w = gaussianPdf(uvOffset.x, kernelRadius);\
-						vec4 sample1 = texture2D( colorTexture, vUv + uvOffset);\
-						vec4 sample2 = texture2D( colorTexture, vUv - uvOffset);\
-						diffuseSum += ((sample1 + sample2) * w);\
-						weightSum += (2.0 * w);\
-						uvOffset += delta;\
-					}\
-					gl_FragColor = diffuseSum/weightSum;\
-				}"
+			fragmentShader: /* glsl */`
+#include <common>
+varying vec2 vUv;
+uniform sampler2D colorTexture;
+uniform vec2 texSize;
+uniform vec2 direction;
+uniform float kernelRadius;
+
+float gaussianPdf(in float x, in float sigma) {
+	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
+}
+
+void main() {
+	vec2 invSize = 1.0 / texSize;
+	float weightSum = gaussianPdf(0.0, kernelRadius);
+	vec4 diffuseSum = texture2D( colorTexture, vUv) * weightSum;
+	vec2 delta = direction * invSize * kernelRadius/float(MAX_RADIUS);
+	vec2 uvOffset = delta;
+	for( int i = 1; i <= MAX_RADIUS; i ++ ) {
+		float w = gaussianPdf(uvOffset.x, kernelRadius);
+		vec4 sample1 = texture2D( colorTexture, vUv + uvOffset);
+		vec4 sample2 = texture2D( colorTexture, vUv - uvOffset);
+		diffuseSum += ((sample1 + sample2) * w);
+		weightSum += (2.0 * w);
+		uvOffset += delta;
+	}
+	gl_FragColor = diffuseSum/weightSum;
+}
+`
 		} );
 
 	},
@@ -549,35 +554,37 @@ void main() {
 				"usePatternTexture": { value: 0.0 }
 			},
 
-			vertexShader:
-				"varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}",
+			vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-			fragmentShader:
-				"varying vec2 vUv;\
-				uniform sampler2D maskTexture;\
-				uniform sampler2D edgeTexture1;\
-				uniform sampler2D edgeTexture2;\
-				uniform sampler2D patternTexture;\
-				uniform float edgeStrength;\
-				uniform float edgeGlow;\
-				uniform bool usePatternTexture;\
-				\
-				void main() {\
-					vec4 edgeValue1 = texture2D(edgeTexture1, vUv);\
-					vec4 edgeValue2 = texture2D(edgeTexture2, vUv);\
-					vec4 maskColor = texture2D(maskTexture, vUv);\
-					vec4 patternColor = texture2D(patternTexture, 6.0 * vUv);\
-					float visibilityFactor = 1.0 - maskColor.g > 0.0 ? 1.0 : 0.5;\
-					vec4 edgeValue = edgeValue1 + edgeValue2 * edgeGlow;\
-					vec4 finalColor = edgeStrength * maskColor.r * edgeValue;\
-					if(usePatternTexture)\
-						finalColor += + visibilityFactor * (1.0 - maskColor.r) * (1.0 - patternColor.r);\
-					gl_FragColor = finalColor;\
-				}",
+			fragmentShader: /* glsl */`
+varying vec2 vUv;
+uniform sampler2D maskTexture;
+uniform sampler2D edgeTexture1;
+uniform sampler2D edgeTexture2;
+uniform sampler2D patternTexture;
+uniform float edgeStrength;
+uniform float edgeGlow;
+uniform bool usePatternTexture;
+
+void main() {
+	vec4 edgeValue1 = texture2D(edgeTexture1, vUv);
+	vec4 edgeValue2 = texture2D(edgeTexture2, vUv);
+	vec4 maskColor = texture2D(maskTexture, vUv);
+	vec4 patternColor = texture2D(patternTexture, 6.0 * vUv);
+	float visibilityFactor = 1.0 - maskColor.g > 0.0 ? 1.0 : 0.5;
+	vec4 edgeValue = edgeValue1 + edgeValue2 * edgeGlow;
+	vec4 finalColor = edgeStrength * maskColor.r * edgeValue;
+	if(usePatternTexture)
+		finalColor += + visibilityFactor * (1.0 - maskColor.r) * (1.0 - patternColor.r);
+	gl_FragColor = finalColor;
+}
+`,
 			blending: THREE.AdditiveBlending,
 			depthTest: false,
 			depthWrite: false,

--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -394,45 +394,44 @@ THREE.OutlinePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 			},
 
 			vertexShader: /* glsl */`
-#include <morphtarget_pars_vertex>
-#include <skinning_pars_vertex>
+				#include <morphtarget_pars_vertex>
+				#include <skinning_pars_vertex>
 
-varying vec4 projTexCoord;
-varying vec4 vPosition;
-uniform mat4 textureMatrix;
+				varying vec4 projTexCoord;
+				varying vec4 vPosition;
+				uniform mat4 textureMatrix;
 
-void main() {
+				void main() {
 
-	#include <skinbase_vertex>
-	#include <begin_vertex>
-	#include <morphtarget_vertex>
-	#include <skinning_vertex>
-	#include <project_vertex>
+					#include <skinbase_vertex>
+					#include <begin_vertex>
+					#include <morphtarget_vertex>
+					#include <skinning_vertex>
+					#include <project_vertex>
 
-	vPosition = mvPosition;
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
-	projTexCoord = textureMatrix * worldPosition;
+					vPosition = mvPosition;
+					vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+					projTexCoord = textureMatrix * worldPosition;
 
-}
-`,
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-#include <packing>
-varying vec4 vPosition;
-varying vec4 projTexCoord;
-uniform sampler2D depthTexture;
-uniform vec2 cameraNearFar;
+				#include <packing>
+				varying vec4 vPosition;
+				varying vec4 projTexCoord;
+				uniform sampler2D depthTexture;
+				uniform vec2 cameraNearFar;
 
-void main() {
+				void main() {
 
-	float depth = unpackRGBAToDepth(texture2DProj( depthTexture, projTexCoord ));
-	float viewZ = - DEPTH_TO_VIEW_Z( depth, cameraNearFar.x, cameraNearFar.y );
-	float depthTest = (-vPosition.z > viewZ) ? 1.0 : 0.0;
-	gl_FragColor = vec4(0.0, depthTest, 1.0, 1.0);
+					float depth = unpackRGBAToDepth(texture2DProj( depthTexture, projTexCoord ));
+					float viewZ = - DEPTH_TO_VIEW_Z( depth, cameraNearFar.x, cameraNearFar.y );
+					float depthTest = (-vPosition.z > viewZ) ? 1.0 : 0.0;
+					gl_FragColor = vec4(0.0, depthTest, 1.0, 1.0);
 
-}
-`
-
+				}
+			`
 		} );
 
 	},
@@ -449,37 +448,37 @@ void main() {
 			},
 
 			vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+				varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-varying vec2 vUv;
-uniform sampler2D maskTexture;
-uniform vec2 texSize;
-uniform vec3 visibleEdgeColor;
-uniform vec3 hiddenEdgeColor;
+				varying vec2 vUv;
+				uniform sampler2D maskTexture;
+				uniform vec2 texSize;
+				uniform vec3 visibleEdgeColor;
+				uniform vec3 hiddenEdgeColor;
 
-void main() {
-	vec2 invSize = 1.0 / texSize;
-	vec4 uvOffset = vec4(1.0, 0.0, 0.0, 1.0) * vec4(invSize, invSize);
-	vec4 c1 = texture2D( maskTexture, vUv + uvOffset.xy);
-	vec4 c2 = texture2D( maskTexture, vUv - uvOffset.xy);
-	vec4 c3 = texture2D( maskTexture, vUv + uvOffset.yw);
-	vec4 c4 = texture2D( maskTexture, vUv - uvOffset.yw);
-	float diff1 = (c1.r - c2.r)*0.5;
-	float diff2 = (c3.r - c4.r)*0.5;
-	float d = length( vec2(diff1, diff2) );
-	float a1 = min(c1.g, c2.g);
-	float a2 = min(c3.g, c4.g);
-	float visibilityFactor = min(a1, a2);
-	vec3 edgeColor = 1.0 - visibilityFactor > 0.001 ? visibleEdgeColor : hiddenEdgeColor;
-	gl_FragColor = vec4(edgeColor, 1.0) * vec4(d);
-}
-`
+				void main() {
+					vec2 invSize = 1.0 / texSize;
+					vec4 uvOffset = vec4(1.0, 0.0, 0.0, 1.0) * vec4(invSize, invSize);
+					vec4 c1 = texture2D( maskTexture, vUv + uvOffset.xy);
+					vec4 c2 = texture2D( maskTexture, vUv - uvOffset.xy);
+					vec4 c3 = texture2D( maskTexture, vUv + uvOffset.yw);
+					vec4 c4 = texture2D( maskTexture, vUv - uvOffset.yw);
+					float diff1 = (c1.r - c2.r)*0.5;
+					float diff2 = (c3.r - c4.r)*0.5;
+					float d = length( vec2(diff1, diff2) );
+					float a1 = min(c1.g, c2.g);
+					float a2 = min(c3.g, c4.g);
+					float visibilityFactor = min(a1, a2);
+					vec3 edgeColor = 1.0 - visibilityFactor > 0.001 ? visibleEdgeColor : hiddenEdgeColor;
+					gl_FragColor = vec4(edgeColor, 1.0) * vec4(d);
+				}
+			`
 		} );
 
 	},
@@ -500,42 +499,42 @@ void main() {
 			},
 
 			vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+				varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-#include <common>
-varying vec2 vUv;
-uniform sampler2D colorTexture;
-uniform vec2 texSize;
-uniform vec2 direction;
-uniform float kernelRadius;
+				#include <common>
+				varying vec2 vUv;
+				uniform sampler2D colorTexture;
+				uniform vec2 texSize;
+				uniform vec2 direction;
+				uniform float kernelRadius;
 
-float gaussianPdf(in float x, in float sigma) {
-	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
-}
+				float gaussianPdf(in float x, in float sigma) {
+					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
+				}
 
-void main() {
-	vec2 invSize = 1.0 / texSize;
-	float weightSum = gaussianPdf(0.0, kernelRadius);
-	vec4 diffuseSum = texture2D( colorTexture, vUv) * weightSum;
-	vec2 delta = direction * invSize * kernelRadius/float(MAX_RADIUS);
-	vec2 uvOffset = delta;
-	for( int i = 1; i <= MAX_RADIUS; i ++ ) {
-		float w = gaussianPdf(uvOffset.x, kernelRadius);
-		vec4 sample1 = texture2D( colorTexture, vUv + uvOffset);
-		vec4 sample2 = texture2D( colorTexture, vUv - uvOffset);
-		diffuseSum += ((sample1 + sample2) * w);
-		weightSum += (2.0 * w);
-		uvOffset += delta;
-	}
-	gl_FragColor = diffuseSum/weightSum;
-}
-`
+				void main() {
+					vec2 invSize = 1.0 / texSize;
+					float weightSum = gaussianPdf(0.0, kernelRadius);
+					vec4 diffuseSum = texture2D( colorTexture, vUv) * weightSum;
+					vec2 delta = direction * invSize * kernelRadius/float(MAX_RADIUS);
+					vec2 uvOffset = delta;
+					for( int i = 1; i <= MAX_RADIUS; i ++ ) {
+						float w = gaussianPdf(uvOffset.x, kernelRadius);
+						vec4 sample1 = texture2D( colorTexture, vUv + uvOffset);
+						vec4 sample2 = texture2D( colorTexture, vUv - uvOffset);
+						diffuseSum += ((sample1 + sample2) * w);
+						weightSum += (2.0 * w);
+						uvOffset += delta;
+					}
+					gl_FragColor = diffuseSum/weightSum;
+				}
+			`
 		} );
 
 	},
@@ -555,36 +554,36 @@ void main() {
 			},
 
 			vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+				varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-varying vec2 vUv;
-uniform sampler2D maskTexture;
-uniform sampler2D edgeTexture1;
-uniform sampler2D edgeTexture2;
-uniform sampler2D patternTexture;
-uniform float edgeStrength;
-uniform float edgeGlow;
-uniform bool usePatternTexture;
+				varying vec2 vUv;
+				uniform sampler2D maskTexture;
+				uniform sampler2D edgeTexture1;
+				uniform sampler2D edgeTexture2;
+				uniform sampler2D patternTexture;
+				uniform float edgeStrength;
+				uniform float edgeGlow;
+				uniform bool usePatternTexture;
 
-void main() {
-	vec4 edgeValue1 = texture2D(edgeTexture1, vUv);
-	vec4 edgeValue2 = texture2D(edgeTexture2, vUv);
-	vec4 maskColor = texture2D(maskTexture, vUv);
-	vec4 patternColor = texture2D(patternTexture, 6.0 * vUv);
-	float visibilityFactor = 1.0 - maskColor.g > 0.0 ? 1.0 : 0.5;
-	vec4 edgeValue = edgeValue1 + edgeValue2 * edgeGlow;
-	vec4 finalColor = edgeStrength * maskColor.r * edgeValue;
-	if(usePatternTexture)
-		finalColor += + visibilityFactor * (1.0 - maskColor.r) * (1.0 - patternColor.r);
-	gl_FragColor = finalColor;
-}
-`,
+				void main() {
+					vec4 edgeValue1 = texture2D(edgeTexture1, vUv);
+					vec4 edgeValue2 = texture2D(edgeTexture2, vUv);
+					vec4 maskColor = texture2D(maskTexture, vUv);
+					vec4 patternColor = texture2D(patternTexture, 6.0 * vUv);
+					float visibilityFactor = 1.0 - maskColor.g > 0.0 ? 1.0 : 0.5;
+					vec4 edgeValue = edgeValue1 + edgeValue2 * edgeGlow;
+					vec4 finalColor = edgeStrength * maskColor.r * edgeValue;
+					if(usePatternTexture)
+						finalColor += + visibilityFactor * (1.0 - maskColor.r) * (1.0 - patternColor.r);
+					gl_FragColor = finalColor;
+				}
+			`,
 			blending: THREE.AdditiveBlending,
 			depthTest: false,
 			depthWrite: false,

--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -298,42 +298,42 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 			},
 
 			vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+				varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-#include <common>
-varying vec2 vUv;
+				#include <common>
+				varying vec2 vUv;
 
-uniform sampler2D colorTexture;
+				uniform sampler2D colorTexture;
 
-uniform vec2 texSize;
-uniform vec2 direction;
+				uniform vec2 texSize;
+				uniform vec2 direction;
 
-float gaussianPdf(in float x, in float sigma) {
-	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
-}
-void main() {
-	vec2 invSize = 1.0 / texSize;
-	float fSigma = float(SIGMA);
-	float weightSum = gaussianPdf(0.0, fSigma);
-	vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;
-	for( int i = 1; i < KERNEL_RADIUS; i ++ ) {
-		float x = float(i);
-		float w = gaussianPdf(x, fSigma);
-		vec2 uvOffset = direction * invSize * x;
-		vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;
-		vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;
-		diffuseSum += (sample1 + sample2) * w;
-		weightSum += 2.0 * w;
-	}
-	gl_FragColor = vec4(diffuseSum/weightSum, 1.0);
-}
-`
+				float gaussianPdf(in float x, in float sigma) {
+					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
+				}
+				void main() {
+					vec2 invSize = 1.0 / texSize;
+					float fSigma = float(SIGMA);
+					float weightSum = gaussianPdf(0.0, fSigma);
+					vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;
+					for( int i = 1; i < KERNEL_RADIUS; i ++ ) {
+						float x = float(i);
+						float w = gaussianPdf(x, fSigma);
+						vec2 uvOffset = direction * invSize * x;
+						vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;
+						vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;
+						diffuseSum += (sample1 + sample2) * w;
+						weightSum += 2.0 * w;
+					}
+					gl_FragColor = vec4(diffuseSum/weightSum, 1.0);
+				}
+			`
 		} );
 
 	},
@@ -360,39 +360,39 @@ void main() {
 			},
 
 			vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+				varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}
+			`,
 
 			fragmentShader: /* glsl */`
-varying vec2 vUv;
-uniform sampler2D blurTexture1;
-uniform sampler2D blurTexture2;
-uniform sampler2D blurTexture3;
-uniform sampler2D blurTexture4;
-uniform sampler2D blurTexture5;
-uniform sampler2D dirtTexture;
-uniform float bloomStrength;
-uniform float bloomRadius;
-uniform float bloomFactors[NUM_MIPS];
-uniform vec3 bloomTintColors[NUM_MIPS];
+				varying vec2 vUv;
+				uniform sampler2D blurTexture1;
+				uniform sampler2D blurTexture2;
+				uniform sampler2D blurTexture3;
+				uniform sampler2D blurTexture4;
+				uniform sampler2D blurTexture5;
+				uniform sampler2D dirtTexture;
+				uniform float bloomStrength;
+				uniform float bloomRadius;
+				uniform float bloomFactors[NUM_MIPS];
+				uniform vec3 bloomTintColors[NUM_MIPS];
 
-float lerpBloomFactor(const in float factor) {
-	float mirrorFactor = 1.2 - factor;
-	return mix(factor, mirrorFactor, bloomRadius);
-}
+				float lerpBloomFactor(const in float factor) {
+					float mirrorFactor = 1.2 - factor;
+					return mix(factor, mirrorFactor, bloomRadius);
+				}
 
-void main() {
-	gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) +
-									 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) +
-									 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) +
-									 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) +
-									 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );
-}
-`
+				void main() {
+					gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) +
+													lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) +
+													lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) +
+													lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) +
+													lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );
+				}
+			`
 		} );
 
 	}

--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -297,39 +297,43 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 				"direction": { value: new THREE.Vector2( 0.5, 0.5 ) }
 			},
 
-			vertexShader:
-				"varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}",
+			vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-			fragmentShader:
-				"#include <common>\
-				varying vec2 vUv;\n\
-				uniform sampler2D colorTexture;\n\
-				uniform vec2 texSize;\
-				uniform vec2 direction;\
-				\
-				float gaussianPdf(in float x, in float sigma) {\
-					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;\
-				}\
-				void main() {\n\
-					vec2 invSize = 1.0 / texSize;\
-					float fSigma = float(SIGMA);\
-					float weightSum = gaussianPdf(0.0, fSigma);\
-					vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;\
-					for( int i = 1; i < KERNEL_RADIUS; i ++ ) {\
-						float x = float(i);\
-						float w = gaussianPdf(x, fSigma);\
-						vec2 uvOffset = direction * invSize * x;\
-						vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;\
-						vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;\
-						diffuseSum += (sample1 + sample2) * w;\
-						weightSum += 2.0 * w;\
-					}\
-					gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n\
-				}"
+			fragmentShader: /* glsl */`
+#include <common>
+varying vec2 vUv;
+
+uniform sampler2D colorTexture;
+
+uniform vec2 texSize;
+uniform vec2 direction;
+
+float gaussianPdf(in float x, in float sigma) {
+	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
+}
+void main() {
+	vec2 invSize = 1.0 / texSize;
+	float fSigma = float(SIGMA);
+	float weightSum = gaussianPdf(0.0, fSigma);
+	vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;
+	for( int i = 1; i < KERNEL_RADIUS; i ++ ) {
+		float x = float(i);
+		float w = gaussianPdf(x, fSigma);
+		vec2 uvOffset = direction * invSize * x;
+		vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;
+		vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;
+		diffuseSum += (sample1 + sample2) * w;
+		weightSum += 2.0 * w;
+	}
+	gl_FragColor = vec4(diffuseSum/weightSum, 1.0);
+}
+`
 		} );
 
 	},
@@ -355,38 +359,40 @@ THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.proto
 				"bloomRadius": { value: 0.0 }
 			},
 
-			vertexShader:
-				"varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}",
+			vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-			fragmentShader:
-				"varying vec2 vUv;\
-				uniform sampler2D blurTexture1;\
-				uniform sampler2D blurTexture2;\
-				uniform sampler2D blurTexture3;\
-				uniform sampler2D blurTexture4;\
-				uniform sampler2D blurTexture5;\
-				uniform sampler2D dirtTexture;\
-				uniform float bloomStrength;\
-				uniform float bloomRadius;\
-				uniform float bloomFactors[NUM_MIPS];\
-				uniform vec3 bloomTintColors[NUM_MIPS];\
-				\
-				float lerpBloomFactor(const in float factor) { \
-					float mirrorFactor = 1.2 - factor;\
-					return mix(factor, mirrorFactor, bloomRadius);\
-				}\
-				\
-				void main() {\
-					gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + \
-													 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + \
-													 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + \
-													 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + \
-													 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );\
-				}"
+			fragmentShader: /* glsl */`
+varying vec2 vUv;
+uniform sampler2D blurTexture1;
+uniform sampler2D blurTexture2;
+uniform sampler2D blurTexture3;
+uniform sampler2D blurTexture4;
+uniform sampler2D blurTexture5;
+uniform sampler2D dirtTexture;
+uniform float bloomStrength;
+uniform float bloomRadius;
+uniform float bloomFactors[NUM_MIPS];
+uniform vec3 bloomTintColors[NUM_MIPS];
+
+float lerpBloomFactor(const in float factor) {
+	float mirrorFactor = 1.2 - factor;
+	return mix(factor, mirrorFactor, bloomRadius);
+}
+
+void main() {
+	gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) +
+									 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) +
+									 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) +
+									 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) +
+									 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );
+}
+`
 		} );
 
 	}

--- a/examples/js/shaders/AfterimageShader.js
+++ b/examples/js/shaders/AfterimageShader.js
@@ -17,40 +17,39 @@ THREE.AfterimageShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float damp;
+		uniform float damp;
 
-uniform sampler2D tOld;
-uniform sampler2D tNew;
+		uniform sampler2D tOld;
+		uniform sampler2D tNew;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-vec4 when_gt( vec4 x, float y ) {
+		vec4 when_gt( vec4 x, float y ) {
 
-	return max( sign( x - y ), 0.0 );
+			return max( sign( x - y ), 0.0 );
 
-}
+		}
 
-void main() {
+		void main() {
 
-	vec4 texelOld = texture2D( tOld, vUv );
-	vec4 texelNew = texture2D( tNew, vUv );
+			vec4 texelOld = texture2D( tOld, vUv );
+			vec4 texelNew = texture2D( tNew, vUv );
 
-	texelOld *= damp * when_gt( texelOld, 0.1 );
+			texelOld *= damp * when_gt( texelOld, 0.1 );
 
-	gl_FragColor = max(texelNew, texelOld);
+			gl_FragColor = max(texelNew, texelOld);
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/AfterimageShader.js
+++ b/examples/js/shaders/AfterimageShader.js
@@ -16,45 +16,41 @@ THREE.AfterimageShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float damp;
 
-	].join( "\n" ),
+uniform sampler2D tOld;
+uniform sampler2D tNew;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float damp;",
+vec4 when_gt( vec4 x, float y ) {
 
-		"uniform sampler2D tOld;",
-		"uniform sampler2D tNew;",
+	return max( sign( x - y ), 0.0 );
 
-		"varying vec2 vUv;",
+}
 
-		"vec4 when_gt( vec4 x, float y ) {",
+void main() {
 
-		"	return max( sign( x - y ), 0.0 );",
+	vec4 texelOld = texture2D( tOld, vUv );
+	vec4 texelNew = texture2D( tNew, vUv );
 
-		"}",
+	texelOld *= damp * when_gt( texelOld, 0.1 );
 
-		"void main() {",
+	gl_FragColor = max(texelNew, texelOld);
 
-		"	vec4 texelOld = texture2D( tOld, vUv );",
-		"	vec4 texelNew = texture2D( tNew, vUv );",
-
-		"	texelOld *= damp * when_gt( texelOld, 0.1 );",
-
-		"	gl_FragColor = max(texelNew, texelOld);",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BasicShader.js
+++ b/examples/js/shaders/BasicShader.js
@@ -8,24 +8,20 @@ THREE.BasicShader = {
 
 	uniforms: {},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+void main() {
 
-		"void main() {",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+void main() {
 
-	].join( "\n" ),
+	gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );
 
-	fragmentShader: [
-
-		"void main() {",
-
-		"	gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BasicShader.js
+++ b/examples/js/shaders/BasicShader.js
@@ -9,19 +9,18 @@ THREE.BasicShader = {
 	uniforms: {},
 
 	vertexShader: /* glsl */`
-void main() {
+		void main() {
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-void main() {
+		void main() {
 
-	gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );
+			gl_FragColor = vec4( 1.0, 0.0, 0.0, 0.5 );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/BleachBypassShader.js
+++ b/examples/js/shaders/BleachBypassShader.js
@@ -16,45 +16,44 @@ THREE.BleachBypassShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float opacity;
+		uniform float opacity;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 base = texture2D( tDiffuse, vUv );
+			vec4 base = texture2D( tDiffuse, vUv );
 
-	vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );
-	float lum = dot( lumCoeff, base.rgb );
-	vec3 blend = vec3( lum );
+			vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );
+			float lum = dot( lumCoeff, base.rgb );
+			vec3 blend = vec3( lum );
 
-	float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );
+			float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );
 
-	vec3 result1 = 2.0 * base.rgb * blend;
-	vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );
+			vec3 result1 = 2.0 * base.rgb * blend;
+			vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );
 
-	vec3 newColor = mix( result1, result2, L );
+			vec3 newColor = mix( result1, result2, L );
 
-	float A2 = opacity * base.a;
-	vec3 mixRGB = A2 * newColor.rgb;
-	mixRGB += ( ( 1.0 - A2 ) * base.rgb );
+			float A2 = opacity * base.a;
+			vec3 mixRGB = A2 * newColor.rgb;
+			mixRGB += ( ( 1.0 - A2 ) * base.rgb );
 
-	gl_FragColor = vec4( mixRGB, base.a );
+			gl_FragColor = vec4( mixRGB, base.a );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/BleachBypassShader.js
+++ b/examples/js/shaders/BleachBypassShader.js
@@ -15,50 +15,46 @@ THREE.BleachBypassShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float opacity;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float opacity;",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 base = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );
+	float lum = dot( lumCoeff, base.rgb );
+	vec3 blend = vec3( lum );
 
-		"void main() {",
+	float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );
 
-		"	vec4 base = texture2D( tDiffuse, vUv );",
+	vec3 result1 = 2.0 * base.rgb * blend;
+	vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );
 
-		"	vec3 lumCoeff = vec3( 0.25, 0.65, 0.1 );",
-		"	float lum = dot( lumCoeff, base.rgb );",
-		"	vec3 blend = vec3( lum );",
+	vec3 newColor = mix( result1, result2, L );
 
-		"	float L = min( 1.0, max( 0.0, 10.0 * ( lum - 0.45 ) ) );",
+	float A2 = opacity * base.a;
+	vec3 mixRGB = A2 * newColor.rgb;
+	mixRGB += ( ( 1.0 - A2 ) * base.rgb );
 
-		"	vec3 result1 = 2.0 * base.rgb * blend;",
-		"	vec3 result2 = 1.0 - 2.0 * ( 1.0 - blend ) * ( 1.0 - base.rgb );",
+	gl_FragColor = vec4( mixRGB, base.a );
 
-		"	vec3 newColor = mix( result1, result2, L );",
-
-		"	float A2 = opacity * base.a;",
-		"	vec3 mixRGB = A2 * newColor.rgb;",
-		"	mixRGB += ( ( 1.0 - A2 ) * base.rgb );",
-
-		"	gl_FragColor = vec4( mixRGB, base.a );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BlendShader.js
+++ b/examples/js/shaders/BlendShader.js
@@ -16,32 +16,31 @@ THREE.BlendShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float opacity;
-uniform float mixRatio;
+		uniform float opacity;
+		uniform float mixRatio;
 
-uniform sampler2D tDiffuse1;
-uniform sampler2D tDiffuse2;
+		uniform sampler2D tDiffuse1;
+		uniform sampler2D tDiffuse2;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 texel1 = texture2D( tDiffuse1, vUv );
-	vec4 texel2 = texture2D( tDiffuse2, vUv );
-	gl_FragColor = opacity * mix( texel1, texel2, mixRatio );
+			vec4 texel1 = texture2D( tDiffuse1, vUv );
+			vec4 texel2 = texture2D( tDiffuse2, vUv );
+			gl_FragColor = opacity * mix( texel1, texel2, mixRatio );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/BlendShader.js
+++ b/examples/js/shaders/BlendShader.js
@@ -15,37 +15,33 @@ THREE.BlendShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float opacity;
+uniform float mixRatio;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse1;
+uniform sampler2D tDiffuse2;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float opacity;",
-		"uniform float mixRatio;",
+void main() {
 
-		"uniform sampler2D tDiffuse1;",
-		"uniform sampler2D tDiffuse2;",
+	vec4 texel1 = texture2D( tDiffuse1, vUv );
+	vec4 texel2 = texture2D( tDiffuse2, vUv );
+	gl_FragColor = opacity * mix( texel1, texel2, mixRatio );
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	vec4 texel1 = texture2D( tDiffuse1, vUv );",
-		"	vec4 texel2 = texture2D( tDiffuse2, vUv );",
-		"	gl_FragColor = opacity * mix( texel1, texel2, mixRatio );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BokehShader.js
+++ b/examples/js/shaders/BokehShader.js
@@ -27,117 +27,116 @@ THREE.BokehShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform sampler2D tColor;
-uniform sampler2D tDepth;
+		uniform sampler2D tColor;
+		uniform sampler2D tDepth;
 
-uniform float maxblur; // max blur amount
-uniform float aperture; // aperture - bigger values for shallower depth of field
+		uniform float maxblur; // max blur amount
+		uniform float aperture; // aperture - bigger values for shallower depth of field
 
-uniform float nearClip;
-uniform float farClip;
+		uniform float nearClip;
+		uniform float farClip;
 
-uniform float focus;
-uniform float aspect;
+		uniform float focus;
+		uniform float aspect;
 
-#include <packing>
+		#include <packing>
 
-float getDepth( const in vec2 screenPosition ) {
-	#if DEPTH_PACKING == 1
-	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
-	#else
-	return texture2D( tDepth, screenPosition ).x;
-	#endif
-}
+		float getDepth( const in vec2 screenPosition ) {
+			#if DEPTH_PACKING == 1
+			return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+			#else
+			return texture2D( tDepth, screenPosition ).x;
+			#endif
+		}
 
-float getViewZ( const in float depth ) {
-	#if PERSPECTIVE_CAMERA == 1
-	return perspectiveDepthToViewZ( depth, nearClip, farClip );
-	#else
-	return orthographicDepthToViewZ( depth, nearClip, farClip );
-	#endif
-}
+		float getViewZ( const in float depth ) {
+			#if PERSPECTIVE_CAMERA == 1
+			return perspectiveDepthToViewZ( depth, nearClip, farClip );
+			#else
+			return orthographicDepthToViewZ( depth, nearClip, farClip );
+			#endif
+		}
 
 
-void main() {
+		void main() {
 
-	vec2 aspectcorrect = vec2( 1.0, aspect );
+			vec2 aspectcorrect = vec2( 1.0, aspect );
 
-	float viewZ = getViewZ( getDepth( vUv ) );
+			float viewZ = getViewZ( getDepth( vUv ) );
 
-	float factor = ( focus + viewZ ); // viewZ is <= 0, so this is a difference equation
+			float factor = ( focus + viewZ ); // viewZ is <= 0, so this is a difference equation
 
-	vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );
+			vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );
 
-	vec2 dofblur9 = dofblur * 0.9;
-	vec2 dofblur7 = dofblur * 0.7;
-	vec2 dofblur4 = dofblur * 0.4;
+			vec2 dofblur9 = dofblur * 0.9;
+			vec2 dofblur7 = dofblur * 0.7;
+			vec2 dofblur4 = dofblur * 0.4;
 
-	vec4 col = vec4( 0.0 );
+			vec4 col = vec4( 0.0 );
 
-	col += texture2D( tColor, vUv.xy );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );
 
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
 
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );
 
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
-	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
+			col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );
 
-	gl_FragColor = col / 41.0;
-	gl_FragColor.a = 1.0;
+			gl_FragColor = col / 41.0;
+			gl_FragColor.a = 1.0;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/BokehShader.js
+++ b/examples/js/shaders/BokehShader.js
@@ -26,121 +26,118 @@ THREE.BokehShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
-		"#include <common>",
+uniform sampler2D tColor;
+uniform sampler2D tDepth;
 
-		"varying vec2 vUv;",
+uniform float maxblur; // max blur amount
+uniform float aperture; // aperture - bigger values for shallower depth of field
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
+uniform float nearClip;
+uniform float farClip;
 
-		"uniform float maxblur;", // max blur amount
-		"uniform float aperture;", // aperture - bigger values for shallower depth of field
+uniform float focus;
+uniform float aspect;
 
-		"uniform float nearClip;",
-		"uniform float farClip;",
+#include <packing>
 
-		"uniform float focus;",
-		"uniform float aspect;",
+float getDepth( const in vec2 screenPosition ) {
+	#if DEPTH_PACKING == 1
+	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+	#else
+	return texture2D( tDepth, screenPosition ).x;
+	#endif
+}
 
-		"#include <packing>",
-
-		"float getDepth( const in vec2 screenPosition ) {",
-		"	#if DEPTH_PACKING == 1",
-		"	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );",
-		"	#else",
-		"	return texture2D( tDepth, screenPosition ).x;",
-		"	#endif",
-		"}",
-
-		"float getViewZ( const in float depth ) {",
-		"	#if PERSPECTIVE_CAMERA == 1",
-		"	return perspectiveDepthToViewZ( depth, nearClip, farClip );",
-		"	#else",
-		"	return orthographicDepthToViewZ( depth, nearClip, farClip );",
-		"	#endif",
-		"}",
+float getViewZ( const in float depth ) {
+	#if PERSPECTIVE_CAMERA == 1
+	return perspectiveDepthToViewZ( depth, nearClip, farClip );
+	#else
+	return orthographicDepthToViewZ( depth, nearClip, farClip );
+	#endif
+}
 
 
-		"void main() {",
+void main() {
 
-		"	vec2 aspectcorrect = vec2( 1.0, aspect );",
+	vec2 aspectcorrect = vec2( 1.0, aspect );
 
-		"	float viewZ = getViewZ( getDepth( vUv ) );",
+	float viewZ = getViewZ( getDepth( vUv ) );
 
-		"	float factor = ( focus + viewZ );", // viewZ is <= 0, so this is a difference equation
+	float factor = ( focus + viewZ ); // viewZ is <= 0, so this is a difference equation
 
-		"	vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );",
+	vec2 dofblur = vec2 ( clamp( factor * aperture, -maxblur, maxblur ) );
 
-		"	vec2 dofblur9 = dofblur * 0.9;",
-		"	vec2 dofblur7 = dofblur * 0.7;",
-		"	vec2 dofblur4 = dofblur * 0.4;",
+	vec2 dofblur9 = dofblur * 0.9;
+	vec2 dofblur7 = dofblur * 0.7;
+	vec2 dofblur4 = dofblur * 0.4;
 
-		"	vec4 col = vec4( 0.0 );",
+	vec4 col = vec4( 0.0 );
 
-		"	col += texture2D( tColor, vUv.xy );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );",
+	col += texture2D( tColor, vUv.xy );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur );
 
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );",
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.15,  0.37 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.37,  0.15 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.37, -0.15 ) * aspectcorrect ) * dofblur9 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.15, -0.37 ) * aspectcorrect ) * dofblur9 );
 
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );",
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.40,  0.0  ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur7 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur7 );
 
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );",
-		"	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );",
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,  -0.4  ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29,  0.29 ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.4,   0.0  ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2( -0.29, -0.29 ) * aspectcorrect ) * dofblur4 );
+	col += texture2D( tColor, vUv.xy + ( vec2(  0.0,   0.4  ) * aspectcorrect ) * dofblur4 );
 
-		"	gl_FragColor = col / 41.0;",
-		"	gl_FragColor.a = 1.0;",
+	gl_FragColor = col / 41.0;
+	gl_FragColor.a = 1.0;
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -49,309 +49,305 @@ THREE.BokehShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+uniform sampler2D tColor;
+uniform sampler2D tDepth;
+uniform float textureWidth;
+uniform float textureHeight;
 
-		"#include <common>",
+uniform float focalDepth;  //focal distance value in meters, but you may use autofocus option below
+uniform float focalLength; //focal length in mm
+uniform float fstop; //f-stop value
+uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)
 
-		"varying vec2 vUv;",
+/*
+make sure that these two values are the same for your camera, otherwise distances will be wrong.
+*/
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
-		"uniform float textureWidth;",
-		"uniform float textureHeight;",
+uniform float znear; // camera clipping start
+uniform float zfar; // camera clipping end
 
-		"uniform float focalDepth;  //focal distance value in meters, but you may use autofocus option below",
-		"uniform float focalLength; //focal length in mm",
-		"uniform float fstop; //f-stop value",
-		"uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)",
+//------------------------------------------
+//user variables
 
-		"/*",
-		"make sure that these two values are the same for your camera, otherwise distances will be wrong.",
-		"*/",
+const int samples = SAMPLES; //samples on the first ring
+const int rings = RINGS; //ring count
 
-		"uniform float znear; // camera clipping start",
-		"uniform float zfar; // camera clipping end",
+const int maxringsamples = rings * samples;
 
-		"//------------------------------------------",
-		"//user variables",
+uniform bool manualdof; // manual dof calculation
+float ndofstart = 1.0; // near dof blur start
+float ndofdist = 2.0; // near dof blur falloff distance
+float fdofstart = 1.0; // far dof blur start
+float fdofdist = 3.0; // far dof blur falloff distance
 
-		"const int samples = SAMPLES; //samples on the first ring",
-		"const int rings = RINGS; //ring count",
+float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)
 
-		"const int maxringsamples = rings * samples;",
+uniform bool vignetting; // use optical lens vignetting
 
-		"uniform bool manualdof; // manual dof calculation",
-		"float ndofstart = 1.0; // near dof blur start",
-		"float ndofdist = 2.0; // near dof blur falloff distance",
-		"float fdofstart = 1.0; // far dof blur start",
-		"float fdofdist = 3.0; // far dof blur falloff distance",
+float vignout = 1.3; // vignetting outer border
+float vignin = 0.0; // vignetting inner border
+float vignfade = 22.0; // f-stops till vignete fades
 
-		"float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)",
+uniform bool shaderFocus;
+// disable if you use external focalDepth value
 
-		"uniform bool vignetting; // use optical lens vignetting",
+uniform vec2 focusCoords;
+// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)
+// if center of screen use vec2(0.5, 0.5);
 
-		"float vignout = 1.3; // vignetting outer border",
-		"float vignin = 0.0; // vignetting inner border",
-		"float vignfade = 22.0; // f-stops till vignete fades",
+uniform float maxblur;
+//clamp value of max blur (0.0 = no blur, 1.0 default)
 
-		"uniform bool shaderFocus;",
-		"// disable if you use external focalDepth value",
+uniform float threshold; // highlight threshold;
+uniform float gain; // highlight gain;
 
-		"uniform vec2 focusCoords;",
-		"// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)",
-		"// if center of screen use vec2(0.5, 0.5);",
+uniform float bias; // bokeh edge bias
+uniform float fringe; // bokeh chromatic aberration / fringing
 
-		"uniform float maxblur;",
-		"//clamp value of max blur (0.0 = no blur, 1.0 default)",
+uniform bool noise; //use noise instead of pattern for sample dithering
 
-		"uniform float threshold; // highlight threshold;",
-		"uniform float gain; // highlight gain;",
+uniform float dithering;
 
-		"uniform float bias; // bokeh edge bias",
-		"uniform float fringe; // bokeh chromatic aberration / fringing",
+uniform bool depthblur; // blur the depth buffer
+float dbsize = 1.25; // depth blur size
 
-		"uniform bool noise; //use noise instead of pattern for sample dithering",
+/*
+next part is experimental
+not looking good with small sample and ring count
+looks okay starting from samples = 4, rings = 4
+*/
 
-		"uniform float dithering;",
+uniform bool pentagon; //use pentagon as bokeh shape?
+float feather = 0.4; //pentagon shape feather
 
-		"uniform bool depthblur; // blur the depth buffer",
-		"float dbsize = 1.25; // depth blur size",
+//------------------------------------------
 
-		"/*",
-		"next part is experimental",
-		"not looking good with small sample and ring count",
-		"looks okay starting from samples = 4, rings = 4",
-		"*/",
+float penta(vec2 coords) {
+	//pentagonal shape
+	float scale = float(rings) - 1.3;
+	vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);
+	vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);
+	vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);
+	vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);
+	vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);
+	vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);
 
-		"uniform bool pentagon; //use pentagon as bokeh shape?",
-		"float feather = 0.4; //pentagon shape feather",
+	vec4  one = vec4( 1.0 );
 
-		"//------------------------------------------",
+	vec4 P = vec4((coords),vec2(scale, scale));
 
-		"float penta(vec2 coords) {",
-		"	//pentagonal shape",
-		"	float scale = float(rings) - 1.3;",
-		"	vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);",
-		"	vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);",
-		"	vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);",
-		"	vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);",
-		"	vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);",
-		"	vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);",
+	vec4 dist = vec4(0.0);
+	float inorout = -4.0;
 
-		"	vec4  one = vec4( 1.0 );",
+	dist.x = dot( P, HS0 );
+	dist.y = dot( P, HS1 );
+	dist.z = dot( P, HS2 );
+	dist.w = dot( P, HS3 );
 
-		"	vec4 P = vec4((coords),vec2(scale, scale));",
+	dist = smoothstep( -feather, feather, dist );
 
-		"	vec4 dist = vec4(0.0);",
-		"	float inorout = -4.0;",
+	inorout += dot( dist, one );
 
-		"	dist.x = dot( P, HS0 );",
-		"	dist.y = dot( P, HS1 );",
-		"	dist.z = dot( P, HS2 );",
-		"	dist.w = dot( P, HS3 );",
+	dist.x = dot( P, HS4 );
+	dist.y = HS5.w - abs( P.z );
 
-		"	dist = smoothstep( -feather, feather, dist );",
+	dist = smoothstep( -feather, feather, dist );
+	inorout += dist.x;
 
-		"	inorout += dot( dist, one );",
+	return clamp( inorout, 0.0, 1.0 );
+}
 
-		"	dist.x = dot( P, HS4 );",
-		"	dist.y = HS5.w - abs( P.z );",
+float bdepth(vec2 coords) {
+	// Depth buffer blur
+	float d = 0.0;
+	float kernel[9];
+	vec2 offset[9];
 
-		"	dist = smoothstep( -feather, feather, dist );",
-		"	inorout += dist.x;",
+	vec2 wh = vec2(1.0/textureWidth,1.0/textureHeight) * dbsize;
 
-		"	return clamp( inorout, 0.0, 1.0 );",
-		"}",
+	offset[0] = vec2(-wh.x,-wh.y);
+	offset[1] = vec2( 0.0, -wh.y);
+	offset[2] = vec2( wh.x -wh.y);
 
-		"float bdepth(vec2 coords) {",
-		"	// Depth buffer blur",
-		"	float d = 0.0;",
-		"	float kernel[9];",
-		"	vec2 offset[9];",
+	offset[3] = vec2(-wh.x,  0.0);
+	offset[4] = vec2( 0.0,   0.0);
+	offset[5] = vec2( wh.x,  0.0);
 
-		"	vec2 wh = vec2(1.0/textureWidth,1.0/textureHeight) * dbsize;",
+	offset[6] = vec2(-wh.x, wh.y);
+	offset[7] = vec2( 0.0,  wh.y);
+	offset[8] = vec2( wh.x, wh.y);
 
-		"	offset[0] = vec2(-wh.x,-wh.y);",
-		"	offset[1] = vec2( 0.0, -wh.y);",
-		"	offset[2] = vec2( wh.x -wh.y);",
+	kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;
+	kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;
+	kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;
 
-		"	offset[3] = vec2(-wh.x,  0.0);",
-		"	offset[4] = vec2( 0.0,   0.0);",
-		"	offset[5] = vec2( wh.x,  0.0);",
 
-		"	offset[6] = vec2(-wh.x, wh.y);",
-		"	offset[7] = vec2( 0.0,  wh.y);",
-		"	offset[8] = vec2( wh.x, wh.y);",
+	for( int i=0; i<9; i++ ) {
+		float tmp = texture2D(tDepth, coords + offset[i]).r;
+		d += tmp * kernel[i];
+	}
 
-		"	kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;",
-		"	kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;",
-		"	kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;",
+	return d;
+}
 
 
-		"	for( int i=0; i<9; i++ ) {",
-		"		float tmp = texture2D(tDepth, coords + offset[i]).r;",
-		"		d += tmp * kernel[i];",
-		"	}",
+vec3 color(vec2 coords,float blur) {
+	//processing the sample
 
-		"	return d;",
-		"}",
+	vec3 col = vec3(0.0);
+	vec2 texel = vec2(1.0/textureWidth,1.0/textureHeight);
 
+	col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;
+	col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;
+	col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;
 
-		"vec3 color(vec2 coords,float blur) {",
-		"	//processing the sample",
+	vec3 lumcoeff = vec3(0.299,0.587,0.114);
+	float lum = dot(col.rgb, lumcoeff);
+	float thresh = max((lum-threshold)*gain, 0.0);
+	return col+mix(vec3(0.0),col,thresh*blur);
+}
 
-		"	vec3 col = vec3(0.0);",
-		"	vec2 texel = vec2(1.0/textureWidth,1.0/textureHeight);",
+vec3 debugFocus(vec3 col, float blur, float depth) {
+	float edge = 0.002*depth; //distance based edge smoothing
+	float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);
+	float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);
 
-		"	col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;",
-		"	col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;",
-		"	col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;",
+	col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);
+	col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);
 
-		"	vec3 lumcoeff = vec3(0.299,0.587,0.114);",
-		"	float lum = dot(col.rgb, lumcoeff);",
-		"	float thresh = max((lum-threshold)*gain, 0.0);",
-		"	return col+mix(vec3(0.0),col,thresh*blur);",
-		"}",
+	return col;
+}
 
-		"vec3 debugFocus(vec3 col, float blur, float depth) {",
-		"	float edge = 0.002*depth; //distance based edge smoothing",
-		"	float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);",
-		"	float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);",
+float linearize(float depth) {
+	return -zfar * znear / (depth * (zfar - znear) - zfar);
+}
 
-		"	col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);",
-		"	col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);",
 
-		"	return col;",
-		"}",
+float vignette() {
+	float dist = distance(vUv.xy, vec2(0.5,0.5));
+	dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);
+	return clamp(dist,0.0,1.0);
+}
 
-		"float linearize(float depth) {",
-		"	return -zfar * znear / (depth * (zfar - znear) - zfar);",
-		"}",
+float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {
+	float rings2 = float(rings);
+	float step = PI*2.0 / float(ringsamples);
+	float pw = cos(j*step)*i;
+	float ph = sin(j*step)*i;
+	float p = 1.0;
+	if (pentagon) {
+		p = penta(vec2(pw,ph));
+	}
+	col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;
+	return 1.0 * mix(1.0, i /rings2, bias) * p;
+}
 
+void main() {
+	//scene depth calculation
 
-		"float vignette() {",
-		"	float dist = distance(vUv.xy, vec2(0.5,0.5));",
-		"	dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);",
-		"	return clamp(dist,0.0,1.0);",
-		"}",
+	float depth = linearize(texture2D(tDepth,vUv.xy).x);
 
-		"float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {",
-		"	float rings2 = float(rings);",
-		"	float step = PI*2.0 / float(ringsamples);",
-		"	float pw = cos(j*step)*i;",
-		"	float ph = sin(j*step)*i;",
-		"	float p = 1.0;",
-		"	if (pentagon) {",
-		"		p = penta(vec2(pw,ph));",
-		"	}",
-		"	col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;",
-		"	return 1.0 * mix(1.0, i /rings2, bias) * p;",
-		"}",
+	// Blur depth?
+	if ( depthblur ) {
+		depth = linearize(bdepth(vUv.xy));
+	}
 
-		"void main() {",
-		"	//scene depth calculation",
+	//focal plane calculation
 
-		"	float depth = linearize(texture2D(tDepth,vUv.xy).x);",
+	float fDepth = focalDepth;
 
-		"	// Blur depth?",
-		"	if ( depthblur ) {",
-		"		depth = linearize(bdepth(vUv.xy));",
-		"	}",
+	if (shaderFocus) {
 
-		"	//focal plane calculation",
+		fDepth = linearize(texture2D(tDepth,focusCoords).x);
 
-		"	float fDepth = focalDepth;",
+	}
 
-		"	if (shaderFocus) {",
+	// dof blur factor calculation
 
-		"		fDepth = linearize(texture2D(tDepth,focusCoords).x);",
+	float blur = 0.0;
 
-		"	}",
+	if (manualdof) {
+		float a = depth-fDepth; // Focal plane
+		float b = (a-fdofstart)/fdofdist; // Far DoF
+		float c = (-a-ndofstart)/ndofdist; // Near Dof
+		blur = (a>0.0) ? b : c;
+	} else {
+		float f = focalLength; // focal length in mm
+		float d = fDepth*1000.0; // focal plane in mm
+		float o = depth*1000.0; // depth in mm
 
-		"	// dof blur factor calculation",
+		float a = (o*f)/(o-f);
+		float b = (d*f)/(d-f);
+		float c = (d-f)/(d*fstop*CoC);
 
-		"	float blur = 0.0;",
+		blur = abs(a-b)*c;
+	}
 
-		"	if (manualdof) {",
-		"		float a = depth-fDepth; // Focal plane",
-		"		float b = (a-fdofstart)/fdofdist; // Far DoF",
-		"		float c = (-a-ndofstart)/ndofdist; // Near Dof",
-		"		blur = (a>0.0) ? b : c;",
-		"	} else {",
-		"		float f = focalLength; // focal length in mm",
-		"		float d = fDepth*1000.0; // focal plane in mm",
-		"		float o = depth*1000.0; // depth in mm",
+	blur = clamp(blur,0.0,1.0);
 
-		"		float a = (o*f)/(o-f);",
-		"		float b = (d*f)/(d-f);",
-		"		float c = (d-f)/(d*fstop*CoC);",
+	// calculation of pattern for dithering
 
-		"		blur = abs(a-b)*c;",
-		"	}",
+	vec2 noise = vec2(rand(vUv.xy), rand( vUv.xy + vec2( 0.4, 0.6 ) ) )*dithering*blur;
 
-		"	blur = clamp(blur,0.0,1.0);",
+	// getting blur x and y step factor
 
-		"	// calculation of pattern for dithering",
+	float w = (1.0/textureWidth)*blur*maxblur+noise.x;
+	float h = (1.0/textureHeight)*blur*maxblur+noise.y;
 
-		"	vec2 noise = vec2(rand(vUv.xy), rand( vUv.xy + vec2( 0.4, 0.6 ) ) )*dithering*blur;",
+	// calculation of final color
 
-		"	// getting blur x and y step factor",
+	vec3 col = vec3(0.0);
 
-		"	float w = (1.0/textureWidth)*blur*maxblur+noise.x;",
-		"	float h = (1.0/textureHeight)*blur*maxblur+noise.y;",
+	if(blur < 0.05) {
+		//some optimization thingy
+		col = texture2D(tColor, vUv.xy).rgb;
+	} else {
+		col = texture2D(tColor, vUv.xy).rgb;
+		float s = 1.0;
+		int ringsamples;
 
-		"	// calculation of final color",
+		for (int i = 1; i <= rings; i++) {
+			/*unboxstart*/
+			ringsamples = i * samples;
 
-		"	vec3 col = vec3(0.0);",
+			for (int j = 0 ; j < maxringsamples ; j++) {
+				if (j >= ringsamples) break;
+				s += gather(float(i), float(j), ringsamples, col, w, h, blur);
+			}
+			/*unboxend*/
+		}
 
-		"	if(blur < 0.05) {",
-		"		//some optimization thingy",
-		"		col = texture2D(tColor, vUv.xy).rgb;",
-		"	} else {",
-		"		col = texture2D(tColor, vUv.xy).rgb;",
-		"		float s = 1.0;",
-		"		int ringsamples;",
+		col /= s; //divide by sample count
+	}
 
-		"		for (int i = 1; i <= rings; i++) {",
-		"			/*unboxstart*/",
-		"			ringsamples = i * samples;",
+	if (showFocus) {
+		col = debugFocus(col, blur, depth);
+	}
 
-		"			for (int j = 0 ; j < maxringsamples ; j++) {",
-		"				if (j >= ringsamples) break;",
-		"				s += gather(float(i), float(j), ringsamples, col, w, h, blur);",
-		"			}",
-		"			/*unboxend*/",
-		"		}",
+	if (vignetting) {
+		col *= vignette();
+	}
 
-		"		col /= s; //divide by sample count",
-		"	}",
-
-		"	if (showFocus) {",
-		"		col = debugFocus(col, blur, depth);",
-		"	}",
-
-		"	if (vignetting) {",
-		"		col *= vignette();",
-		"	}",
-
-		"	gl_FragColor.rgb = col;",
-		"	gl_FragColor.a = 1.0;",
-		"} "
-
-	].join( "\n" )
+	gl_FragColor.rgb = col;
+	gl_FragColor.a = 1.0;
+}
+`
 
 };
 
@@ -364,35 +360,31 @@ THREE.BokehDepthShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying float vViewZDepth;
 
-		"varying float vViewZDepth;",
+void main() {
 
-		"void main() {",
+	#include <begin_vertex>
+	#include <project_vertex>
 
-		"	#include <begin_vertex>",
-		"	#include <project_vertex>",
+	vViewZDepth = - mvPosition.z;
 
-		"	vViewZDepth = - mvPosition.z;",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float mNear;
+uniform float mFar;
 
-	].join( "\n" ),
+varying float vViewZDepth;
 
-	fragmentShader: [
+void main() {
 
-		"uniform float mNear;",
-		"uniform float mFar;",
+	float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );
+	gl_FragColor = vec4( vec3( color ), 1.0 );
 
-		"varying float vViewZDepth;",
-
-		"void main() {",
-
-		"	float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );",
-		"	gl_FragColor = vec4( vec3( color ), 1.0 );",
-
-		"} "
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -50,305 +50,304 @@ THREE.BokehShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform sampler2D tColor;
-uniform sampler2D tDepth;
-uniform float textureWidth;
-uniform float textureHeight;
+		uniform sampler2D tColor;
+		uniform sampler2D tDepth;
+		uniform float textureWidth;
+		uniform float textureHeight;
 
-uniform float focalDepth;  //focal distance value in meters, but you may use autofocus option below
-uniform float focalLength; //focal length in mm
-uniform float fstop; //f-stop value
-uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)
+		uniform float focalDepth;  //focal distance value in meters, but you may use autofocus option below
+		uniform float focalLength; //focal length in mm
+		uniform float fstop; //f-stop value
+		uniform bool showFocus; //show debug focus point and focal range (red = focal point, green = focal range)
 
-/*
-make sure that these two values are the same for your camera, otherwise distances will be wrong.
-*/
+		/*
+		make sure that these two values are the same for your camera, otherwise distances will be wrong.
+		*/
 
-uniform float znear; // camera clipping start
-uniform float zfar; // camera clipping end
+		uniform float znear; // camera clipping start
+		uniform float zfar; // camera clipping end
 
-//------------------------------------------
-//user variables
+		//------------------------------------------
+		//user variables
 
-const int samples = SAMPLES; //samples on the first ring
-const int rings = RINGS; //ring count
+		const int samples = SAMPLES; //samples on the first ring
+		const int rings = RINGS; //ring count
 
-const int maxringsamples = rings * samples;
+		const int maxringsamples = rings * samples;
 
-uniform bool manualdof; // manual dof calculation
-float ndofstart = 1.0; // near dof blur start
-float ndofdist = 2.0; // near dof blur falloff distance
-float fdofstart = 1.0; // far dof blur start
-float fdofdist = 3.0; // far dof blur falloff distance
+		uniform bool manualdof; // manual dof calculation
+		float ndofstart = 1.0; // near dof blur start
+		float ndofdist = 2.0; // near dof blur falloff distance
+		float fdofstart = 1.0; // far dof blur start
+		float fdofdist = 3.0; // far dof blur falloff distance
 
-float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)
+		float CoC = 0.03; //circle of confusion size in mm (35mm film = 0.03mm)
 
-uniform bool vignetting; // use optical lens vignetting
+		uniform bool vignetting; // use optical lens vignetting
 
-float vignout = 1.3; // vignetting outer border
-float vignin = 0.0; // vignetting inner border
-float vignfade = 22.0; // f-stops till vignete fades
+		float vignout = 1.3; // vignetting outer border
+		float vignin = 0.0; // vignetting inner border
+		float vignfade = 22.0; // f-stops till vignete fades
 
-uniform bool shaderFocus;
-// disable if you use external focalDepth value
+		uniform bool shaderFocus;
+		// disable if you use external focalDepth value
 
-uniform vec2 focusCoords;
-// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)
-// if center of screen use vec2(0.5, 0.5);
+		uniform vec2 focusCoords;
+		// autofocus point on screen (0.0,0.0 - left lower corner, 1.0,1.0 - upper right)
+		// if center of screen use vec2(0.5, 0.5);
 
-uniform float maxblur;
-//clamp value of max blur (0.0 = no blur, 1.0 default)
+		uniform float maxblur;
+		//clamp value of max blur (0.0 = no blur, 1.0 default)
 
-uniform float threshold; // highlight threshold;
-uniform float gain; // highlight gain;
+		uniform float threshold; // highlight threshold;
+		uniform float gain; // highlight gain;
 
-uniform float bias; // bokeh edge bias
-uniform float fringe; // bokeh chromatic aberration / fringing
+		uniform float bias; // bokeh edge bias
+		uniform float fringe; // bokeh chromatic aberration / fringing
 
-uniform bool noise; //use noise instead of pattern for sample dithering
+		uniform bool noise; //use noise instead of pattern for sample dithering
 
-uniform float dithering;
+		uniform float dithering;
 
-uniform bool depthblur; // blur the depth buffer
-float dbsize = 1.25; // depth blur size
+		uniform bool depthblur; // blur the depth buffer
+		float dbsize = 1.25; // depth blur size
 
-/*
-next part is experimental
-not looking good with small sample and ring count
-looks okay starting from samples = 4, rings = 4
-*/
+		/*
+		next part is experimental
+		not looking good with small sample and ring count
+		looks okay starting from samples = 4, rings = 4
+		*/
 
-uniform bool pentagon; //use pentagon as bokeh shape?
-float feather = 0.4; //pentagon shape feather
+		uniform bool pentagon; //use pentagon as bokeh shape?
+		float feather = 0.4; //pentagon shape feather
 
-//------------------------------------------
+		//------------------------------------------
 
-float penta(vec2 coords) {
-	//pentagonal shape
-	float scale = float(rings) - 1.3;
-	vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);
-	vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);
-	vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);
-	vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);
-	vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);
-	vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);
+		float penta(vec2 coords) {
+			//pentagonal shape
+			float scale = float(rings) - 1.3;
+			vec4  HS0 = vec4( 1.0,         0.0,         0.0,  1.0);
+			vec4  HS1 = vec4( 0.309016994, 0.951056516, 0.0,  1.0);
+			vec4  HS2 = vec4(-0.809016994, 0.587785252, 0.0,  1.0);
+			vec4  HS3 = vec4(-0.809016994,-0.587785252, 0.0,  1.0);
+			vec4  HS4 = vec4( 0.309016994,-0.951056516, 0.0,  1.0);
+			vec4  HS5 = vec4( 0.0        ,0.0         , 1.0,  1.0);
 
-	vec4  one = vec4( 1.0 );
+			vec4  one = vec4( 1.0 );
 
-	vec4 P = vec4((coords),vec2(scale, scale));
+			vec4 P = vec4((coords),vec2(scale, scale));
 
-	vec4 dist = vec4(0.0);
-	float inorout = -4.0;
+			vec4 dist = vec4(0.0);
+			float inorout = -4.0;
 
-	dist.x = dot( P, HS0 );
-	dist.y = dot( P, HS1 );
-	dist.z = dot( P, HS2 );
-	dist.w = dot( P, HS3 );
+			dist.x = dot( P, HS0 );
+			dist.y = dot( P, HS1 );
+			dist.z = dot( P, HS2 );
+			dist.w = dot( P, HS3 );
 
-	dist = smoothstep( -feather, feather, dist );
+			dist = smoothstep( -feather, feather, dist );
 
-	inorout += dot( dist, one );
+			inorout += dot( dist, one );
 
-	dist.x = dot( P, HS4 );
-	dist.y = HS5.w - abs( P.z );
+			dist.x = dot( P, HS4 );
+			dist.y = HS5.w - abs( P.z );
 
-	dist = smoothstep( -feather, feather, dist );
-	inorout += dist.x;
+			dist = smoothstep( -feather, feather, dist );
+			inorout += dist.x;
 
-	return clamp( inorout, 0.0, 1.0 );
-}
-
-float bdepth(vec2 coords) {
-	// Depth buffer blur
-	float d = 0.0;
-	float kernel[9];
-	vec2 offset[9];
-
-	vec2 wh = vec2(1.0/textureWidth,1.0/textureHeight) * dbsize;
-
-	offset[0] = vec2(-wh.x,-wh.y);
-	offset[1] = vec2( 0.0, -wh.y);
-	offset[2] = vec2( wh.x -wh.y);
-
-	offset[3] = vec2(-wh.x,  0.0);
-	offset[4] = vec2( 0.0,   0.0);
-	offset[5] = vec2( wh.x,  0.0);
-
-	offset[6] = vec2(-wh.x, wh.y);
-	offset[7] = vec2( 0.0,  wh.y);
-	offset[8] = vec2( wh.x, wh.y);
-
-	kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;
-	kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;
-	kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;
-
-
-	for( int i=0; i<9; i++ ) {
-		float tmp = texture2D(tDepth, coords + offset[i]).r;
-		d += tmp * kernel[i];
-	}
-
-	return d;
-}
-
-
-vec3 color(vec2 coords,float blur) {
-	//processing the sample
-
-	vec3 col = vec3(0.0);
-	vec2 texel = vec2(1.0/textureWidth,1.0/textureHeight);
-
-	col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;
-	col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;
-	col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;
-
-	vec3 lumcoeff = vec3(0.299,0.587,0.114);
-	float lum = dot(col.rgb, lumcoeff);
-	float thresh = max((lum-threshold)*gain, 0.0);
-	return col+mix(vec3(0.0),col,thresh*blur);
-}
-
-vec3 debugFocus(vec3 col, float blur, float depth) {
-	float edge = 0.002*depth; //distance based edge smoothing
-	float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);
-	float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);
-
-	col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);
-	col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);
-
-	return col;
-}
-
-float linearize(float depth) {
-	return -zfar * znear / (depth * (zfar - znear) - zfar);
-}
-
-
-float vignette() {
-	float dist = distance(vUv.xy, vec2(0.5,0.5));
-	dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);
-	return clamp(dist,0.0,1.0);
-}
-
-float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {
-	float rings2 = float(rings);
-	float step = PI*2.0 / float(ringsamples);
-	float pw = cos(j*step)*i;
-	float ph = sin(j*step)*i;
-	float p = 1.0;
-	if (pentagon) {
-		p = penta(vec2(pw,ph));
-	}
-	col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;
-	return 1.0 * mix(1.0, i /rings2, bias) * p;
-}
-
-void main() {
-	//scene depth calculation
-
-	float depth = linearize(texture2D(tDepth,vUv.xy).x);
-
-	// Blur depth?
-	if ( depthblur ) {
-		depth = linearize(bdepth(vUv.xy));
-	}
-
-	//focal plane calculation
-
-	float fDepth = focalDepth;
-
-	if (shaderFocus) {
-
-		fDepth = linearize(texture2D(tDepth,focusCoords).x);
-
-	}
-
-	// dof blur factor calculation
-
-	float blur = 0.0;
-
-	if (manualdof) {
-		float a = depth-fDepth; // Focal plane
-		float b = (a-fdofstart)/fdofdist; // Far DoF
-		float c = (-a-ndofstart)/ndofdist; // Near Dof
-		blur = (a>0.0) ? b : c;
-	} else {
-		float f = focalLength; // focal length in mm
-		float d = fDepth*1000.0; // focal plane in mm
-		float o = depth*1000.0; // depth in mm
-
-		float a = (o*f)/(o-f);
-		float b = (d*f)/(d-f);
-		float c = (d-f)/(d*fstop*CoC);
-
-		blur = abs(a-b)*c;
-	}
-
-	blur = clamp(blur,0.0,1.0);
-
-	// calculation of pattern for dithering
-
-	vec2 noise = vec2(rand(vUv.xy), rand( vUv.xy + vec2( 0.4, 0.6 ) ) )*dithering*blur;
-
-	// getting blur x and y step factor
-
-	float w = (1.0/textureWidth)*blur*maxblur+noise.x;
-	float h = (1.0/textureHeight)*blur*maxblur+noise.y;
-
-	// calculation of final color
-
-	vec3 col = vec3(0.0);
-
-	if(blur < 0.05) {
-		//some optimization thingy
-		col = texture2D(tColor, vUv.xy).rgb;
-	} else {
-		col = texture2D(tColor, vUv.xy).rgb;
-		float s = 1.0;
-		int ringsamples;
-
-		for (int i = 1; i <= rings; i++) {
-			/*unboxstart*/
-			ringsamples = i * samples;
-
-			for (int j = 0 ; j < maxringsamples ; j++) {
-				if (j >= ringsamples) break;
-				s += gather(float(i), float(j), ringsamples, col, w, h, blur);
-			}
-			/*unboxend*/
+			return clamp( inorout, 0.0, 1.0 );
 		}
 
-		col /= s; //divide by sample count
-	}
+		float bdepth(vec2 coords) {
+			// Depth buffer blur
+			float d = 0.0;
+			float kernel[9];
+			vec2 offset[9];
 
-	if (showFocus) {
-		col = debugFocus(col, blur, depth);
-	}
+			vec2 wh = vec2(1.0/textureWidth,1.0/textureHeight) * dbsize;
 
-	if (vignetting) {
-		col *= vignette();
-	}
+			offset[0] = vec2(-wh.x,-wh.y);
+			offset[1] = vec2( 0.0, -wh.y);
+			offset[2] = vec2( wh.x -wh.y);
 
-	gl_FragColor.rgb = col;
-	gl_FragColor.a = 1.0;
-}
-`
+			offset[3] = vec2(-wh.x,  0.0);
+			offset[4] = vec2( 0.0,   0.0);
+			offset[5] = vec2( wh.x,  0.0);
 
+			offset[6] = vec2(-wh.x, wh.y);
+			offset[7] = vec2( 0.0,  wh.y);
+			offset[8] = vec2( wh.x, wh.y);
+
+			kernel[0] = 1.0/16.0;   kernel[1] = 2.0/16.0;   kernel[2] = 1.0/16.0;
+			kernel[3] = 2.0/16.0;   kernel[4] = 4.0/16.0;   kernel[5] = 2.0/16.0;
+			kernel[6] = 1.0/16.0;   kernel[7] = 2.0/16.0;   kernel[8] = 1.0/16.0;
+
+
+			for( int i=0; i<9; i++ ) {
+				float tmp = texture2D(tDepth, coords + offset[i]).r;
+				d += tmp * kernel[i];
+			}
+
+			return d;
+		}
+
+
+		vec3 color(vec2 coords,float blur) {
+			//processing the sample
+
+			vec3 col = vec3(0.0);
+			vec2 texel = vec2(1.0/textureWidth,1.0/textureHeight);
+
+			col.r = texture2D(tColor,coords + vec2(0.0,1.0)*texel*fringe*blur).r;
+			col.g = texture2D(tColor,coords + vec2(-0.866,-0.5)*texel*fringe*blur).g;
+			col.b = texture2D(tColor,coords + vec2(0.866,-0.5)*texel*fringe*blur).b;
+
+			vec3 lumcoeff = vec3(0.299,0.587,0.114);
+			float lum = dot(col.rgb, lumcoeff);
+			float thresh = max((lum-threshold)*gain, 0.0);
+			return col+mix(vec3(0.0),col,thresh*blur);
+		}
+
+		vec3 debugFocus(vec3 col, float blur, float depth) {
+			float edge = 0.002*depth; //distance based edge smoothing
+			float m = clamp(smoothstep(0.0,edge,blur),0.0,1.0);
+			float e = clamp(smoothstep(1.0-edge,1.0,blur),0.0,1.0);
+
+			col = mix(col,vec3(1.0,0.5,0.0),(1.0-m)*0.6);
+			col = mix(col,vec3(0.0,0.5,1.0),((1.0-e)-(1.0-m))*0.2);
+
+			return col;
+		}
+
+		float linearize(float depth) {
+			return -zfar * znear / (depth * (zfar - znear) - zfar);
+		}
+
+
+		float vignette() {
+			float dist = distance(vUv.xy, vec2(0.5,0.5));
+			dist = smoothstep(vignout+(fstop/vignfade), vignin+(fstop/vignfade), dist);
+			return clamp(dist,0.0,1.0);
+		}
+
+		float gather(float i, float j, int ringsamples, inout vec3 col, float w, float h, float blur) {
+			float rings2 = float(rings);
+			float step = PI*2.0 / float(ringsamples);
+			float pw = cos(j*step)*i;
+			float ph = sin(j*step)*i;
+			float p = 1.0;
+			if (pentagon) {
+				p = penta(vec2(pw,ph));
+			}
+			col += color(vUv.xy + vec2(pw*w,ph*h), blur) * mix(1.0, i/rings2, bias) * p;
+			return 1.0 * mix(1.0, i /rings2, bias) * p;
+		}
+
+		void main() {
+			//scene depth calculation
+
+			float depth = linearize(texture2D(tDepth,vUv.xy).x);
+
+			// Blur depth?
+			if ( depthblur ) {
+				depth = linearize(bdepth(vUv.xy));
+			}
+
+			//focal plane calculation
+
+			float fDepth = focalDepth;
+
+			if (shaderFocus) {
+
+				fDepth = linearize(texture2D(tDepth,focusCoords).x);
+
+			}
+
+			// dof blur factor calculation
+
+			float blur = 0.0;
+
+			if (manualdof) {
+				float a = depth-fDepth; // Focal plane
+				float b = (a-fdofstart)/fdofdist; // Far DoF
+				float c = (-a-ndofstart)/ndofdist; // Near Dof
+				blur = (a>0.0) ? b : c;
+			} else {
+				float f = focalLength; // focal length in mm
+				float d = fDepth*1000.0; // focal plane in mm
+				float o = depth*1000.0; // depth in mm
+
+				float a = (o*f)/(o-f);
+				float b = (d*f)/(d-f);
+				float c = (d-f)/(d*fstop*CoC);
+
+				blur = abs(a-b)*c;
+			}
+
+			blur = clamp(blur,0.0,1.0);
+
+			// calculation of pattern for dithering
+
+			vec2 noise = vec2(rand(vUv.xy), rand( vUv.xy + vec2( 0.4, 0.6 ) ) )*dithering*blur;
+
+			// getting blur x and y step factor
+
+			float w = (1.0/textureWidth)*blur*maxblur+noise.x;
+			float h = (1.0/textureHeight)*blur*maxblur+noise.y;
+
+			// calculation of final color
+
+			vec3 col = vec3(0.0);
+
+			if(blur < 0.05) {
+				//some optimization thingy
+				col = texture2D(tColor, vUv.xy).rgb;
+			} else {
+				col = texture2D(tColor, vUv.xy).rgb;
+				float s = 1.0;
+				int ringsamples;
+
+				for (int i = 1; i <= rings; i++) {
+					/*unboxstart*/
+					ringsamples = i * samples;
+
+					for (int j = 0 ; j < maxringsamples ; j++) {
+						if (j >= ringsamples) break;
+						s += gather(float(i), float(j), ringsamples, col, w, h, blur);
+					}
+					/*unboxend*/
+				}
+
+				col /= s; //divide by sample count
+			}
+
+			if (showFocus) {
+				col = debugFocus(col, blur, depth);
+			}
+
+			if (vignetting) {
+				col *= vignette();
+			}
+
+			gl_FragColor.rgb = col;
+			gl_FragColor.a = 1.0;
+		}
+	`
 };
 
 THREE.BokehDepthShader = {
@@ -361,30 +360,29 @@ THREE.BokehDepthShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying float vViewZDepth;
+		varying float vViewZDepth;
 
-void main() {
+		void main() {
 
-	#include <begin_vertex>
-	#include <project_vertex>
+			#include <begin_vertex>
+			#include <project_vertex>
 
-	vViewZDepth = - mvPosition.z;
+			vViewZDepth = - mvPosition.z;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float mNear;
-uniform float mFar;
+		uniform float mNear;
+		uniform float mFar;
 
-varying float vViewZDepth;
+		varying float vViewZDepth;
 
-void main() {
+		void main() {
 
-	float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );
-	gl_FragColor = vec4( vec3( color ), 1.0 );
+			float color = 1.0 - smoothstep( mNear, mFar, vViewZDepth );
+			gl_FragColor = vec4( vec3( color ), 1.0 );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/BrightnessContrastShader.js
+++ b/examples/js/shaders/BrightnessContrastShader.js
@@ -17,42 +17,38 @@ THREE.BrightnessContrastShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float brightness;
+uniform float contrast;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float brightness;",
-		"uniform float contrast;",
+	gl_FragColor = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	gl_FragColor.rgb += brightness;
 
-		"void main() {",
+	if (contrast > 0.0) {
+		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;
+	} else {
+		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;
+	}
 
-		"	gl_FragColor = texture2D( tDiffuse, vUv );",
-
-		"	gl_FragColor.rgb += brightness;",
-
-		"	if (contrast > 0.0) {",
-		"		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;",
-		"	} else {",
-		"		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;",
-		"	}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/BrightnessContrastShader.js
+++ b/examples/js/shaders/BrightnessContrastShader.js
@@ -18,37 +18,36 @@ THREE.BrightnessContrastShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float brightness;
-uniform float contrast;
+		uniform sampler2D tDiffuse;
+		uniform float brightness;
+		uniform float contrast;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	gl_FragColor = texture2D( tDiffuse, vUv );
+			gl_FragColor = texture2D( tDiffuse, vUv );
 
-	gl_FragColor.rgb += brightness;
+			gl_FragColor.rgb += brightness;
 
-	if (contrast > 0.0) {
-		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;
-	} else {
-		gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;
-	}
+			if (contrast > 0.0) {
+				gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - contrast) + 0.5;
+			} else {
+				gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + contrast) + 0.5;
+			}
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/ColorCorrectionShader.js
+++ b/examples/js/shaders/ColorCorrectionShader.js
@@ -16,31 +16,30 @@ THREE.ColorCorrectionShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform vec3 powRGB;
-uniform vec3 mulRGB;
-uniform vec3 addRGB;
+		uniform sampler2D tDiffuse;
+		uniform vec3 powRGB;
+		uniform vec3 mulRGB;
+		uniform vec3 addRGB;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	gl_FragColor = texture2D( tDiffuse, vUv );
-	gl_FragColor.rgb = mulRGB * pow( ( gl_FragColor.rgb + addRGB ), powRGB );
+			gl_FragColor = texture2D( tDiffuse, vUv );
+			gl_FragColor.rgb = mulRGB * pow( ( gl_FragColor.rgb + addRGB ), powRGB );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/ColorCorrectionShader.js
+++ b/examples/js/shaders/ColorCorrectionShader.js
@@ -15,36 +15,32 @@ THREE.ColorCorrectionShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform vec3 powRGB;
+uniform vec3 mulRGB;
+uniform vec3 addRGB;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec3 powRGB;",
-		"uniform vec3 mulRGB;",
-		"uniform vec3 addRGB;",
+	gl_FragColor = texture2D( tDiffuse, vUv );
+	gl_FragColor.rgb = mulRGB * pow( ( gl_FragColor.rgb + addRGB ), powRGB );
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	gl_FragColor = texture2D( tDiffuse, vUv );",
-		"	gl_FragColor.rgb = mulRGB * pow( ( gl_FragColor.rgb + addRGB ), powRGB );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/ColorifyShader.js
+++ b/examples/js/shaders/ColorifyShader.js
@@ -14,32 +14,31 @@ THREE.ColorifyShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 color;
-uniform sampler2D tDiffuse;
+		uniform vec3 color;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 texel = texture2D( tDiffuse, vUv );
+			vec4 texel = texture2D( tDiffuse, vUv );
 
-	vec3 luma = vec3( 0.299, 0.587, 0.114 );
-	float v = dot( texel.xyz, luma );
+			vec3 luma = vec3( 0.299, 0.587, 0.114 );
+			float v = dot( texel.xyz, luma );
 
-	gl_FragColor = vec4( v * color, texel.w );
+			gl_FragColor = vec4( v * color, texel.w );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/ColorifyShader.js
+++ b/examples/js/shaders/ColorifyShader.js
@@ -13,37 +13,33 @@ THREE.ColorifyShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 color;
+uniform sampler2D tDiffuse;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform vec3 color;",
-		"uniform sampler2D tDiffuse;",
+	vec4 texel = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	vec3 luma = vec3( 0.299, 0.587, 0.114 );
+	float v = dot( texel.xyz, luma );
 
-		"void main() {",
+	gl_FragColor = vec4( v * color, texel.w );
 
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
-
-		"	vec3 luma = vec3( 0.299, 0.587, 0.114 );",
-		"	float v = dot( texel.xyz, luma );",
-
-		"	gl_FragColor = vec4( v * color, texel.w );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/ConvolutionShader.js
+++ b/examples/js/shaders/ConvolutionShader.js
@@ -23,48 +23,43 @@ THREE.ConvolutionShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform vec2 uImageIncrement;
 
-		"uniform vec2 uImageIncrement;",
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float cKernel[ KERNEL_SIZE_INT ];
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
+uniform vec2 uImageIncrement;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float cKernel[ KERNEL_SIZE_INT ];",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec2 uImageIncrement;",
+	vec2 imageCoord = vUv;
+	vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );
 
-		"varying vec2 vUv;",
+	for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {
 
-		"void main() {",
+		sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];
+		imageCoord += uImageIncrement;
 
-		"	vec2 imageCoord = vUv;",
-		"	vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );",
+	}
 
-		"	for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {",
+	gl_FragColor = sum;
 
-		"		sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];",
-		"		imageCoord += uImageIncrement;",
-
-		"	}",
-
-		"	gl_FragColor = sum;",
-
-		"}"
-
-
-	].join( "\n" ),
+}
+`,
 
 	buildKernel: function ( sigma ) {
 

--- a/examples/js/shaders/ConvolutionShader.js
+++ b/examples/js/shaders/ConvolutionShader.js
@@ -24,42 +24,42 @@ THREE.ConvolutionShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform vec2 uImageIncrement;
+		uniform vec2 uImageIncrement;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv - ( ( KERNEL_SIZE_FLOAT - 1.0 ) / 2.0 ) * uImageIncrement;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float cKernel[ KERNEL_SIZE_INT ];
+		uniform float cKernel[ KERNEL_SIZE_INT ];
 
-uniform sampler2D tDiffuse;
-uniform vec2 uImageIncrement;
+		uniform sampler2D tDiffuse;
+		uniform vec2 uImageIncrement;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec2 imageCoord = vUv;
-	vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );
+			vec2 imageCoord = vUv;
+			vec4 sum = vec4( 0.0, 0.0, 0.0, 0.0 );
 
-	for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {
+			for( int i = 0; i < KERNEL_SIZE_INT; i ++ ) {
 
-		sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];
-		imageCoord += uImageIncrement;
+				sum += texture2D( tDiffuse, imageCoord ) * cKernel[ i ];
+				imageCoord += uImageIncrement;
 
-	}
+			}
 
-	gl_FragColor = sum;
+			gl_FragColor = sum;
 
-}
-`,
+		}
+	`,
 
 	buildKernel: function ( sigma ) {
 

--- a/examples/js/shaders/CopyShader.js
+++ b/examples/js/shaders/CopyShader.js
@@ -13,34 +13,30 @@ THREE.CopyShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float opacity;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float opacity;",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 texel = texture2D( tDiffuse, vUv );
+	gl_FragColor = opacity * texel;
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
-		"	gl_FragColor = opacity * texel;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/CopyShader.js
+++ b/examples/js/shaders/CopyShader.js
@@ -14,29 +14,28 @@ THREE.CopyShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float opacity;
+		uniform float opacity;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 texel = texture2D( tDiffuse, vUv );
-	gl_FragColor = opacity * texel;
+			vec4 texel = texture2D( tDiffuse, vUv );
+			gl_FragColor = opacity * texel;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/DOFMipMapShader.js
+++ b/examples/js/shaders/DOFMipMapShader.js
@@ -18,37 +18,36 @@ THREE.DOFMipMapShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float focus;
-uniform float maxblur;
+		uniform float focus;
+		uniform float maxblur;
 
-uniform sampler2D tColor;
-uniform sampler2D tDepth;
+		uniform sampler2D tColor;
+		uniform sampler2D tDepth;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 depth = texture2D( tDepth, vUv );
+			vec4 depth = texture2D( tDepth, vUv );
 
-	float factor = depth.x - focus;
+			float factor = depth.x - focus;
 
-	vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );
+			vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );
 
-	gl_FragColor = col;
-	gl_FragColor.a = 1.0;
+			gl_FragColor = col;
+			gl_FragColor.a = 1.0;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/DOFMipMapShader.js
+++ b/examples/js/shaders/DOFMipMapShader.js
@@ -17,42 +17,38 @@ THREE.DOFMipMapShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float focus;
+uniform float maxblur;
 
-	].join( "\n" ),
+uniform sampler2D tColor;
+uniform sampler2D tDepth;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float focus;",
-		"uniform float maxblur;",
+void main() {
 
-		"uniform sampler2D tColor;",
-		"uniform sampler2D tDepth;",
+	vec4 depth = texture2D( tDepth, vUv );
 
-		"varying vec2 vUv;",
+	float factor = depth.x - focus;
 
-		"void main() {",
+	vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );
 
-		"	vec4 depth = texture2D( tDepth, vUv );",
+	gl_FragColor = col;
+	gl_FragColor.a = 1.0;
 
-		"	float factor = depth.x - focus;",
-
-		"	vec4 col = texture2D( tColor, vUv, 2.0 * maxblur * abs( focus - depth.x ) );",
-
-		"	gl_FragColor = col;",
-		"	gl_FragColor.a = 1.0;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/DepthLimitedBlurShader.js
+++ b/examples/js/shaders/DepthLimitedBlurShader.js
@@ -18,97 +18,96 @@ THREE.DepthLimitedBlurShader = {
 		"cameraFar": { value: 1000 },
 		"depthCutoff": { value: 10 },
 	},
-	vertexShader: [
-		"#include <common>",
+	vertexShader: /* glsl */`
+#include <common>
 
-		"uniform vec2 size;",
+uniform vec2 size;
 
-		"varying vec2 vUv;",
-		"varying vec2 vInvSize;",
+varying vec2 vUv;
+varying vec2 vInvSize;
 
-		"void main() {",
-		"	vUv = uv;",
-		"	vInvSize = 1.0 / size;",
+void main() {
+	vUv = uv;
+	vInvSize = 1.0 / size;
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"}"
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
+	fragmentShader: /* glsl */`
+#include <common>
+#include <packing>
 
-	].join( "\n" ),
-	fragmentShader: [
-		"#include <common>",
-		"#include <packing>",
+uniform sampler2D tDiffuse;
+uniform sampler2D tDepth;
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tDepth;",
+uniform float cameraNear;
+uniform float cameraFar;
+uniform float depthCutoff;
 
-		"uniform float cameraNear;",
-		"uniform float cameraFar;",
-		"uniform float depthCutoff;",
+uniform vec2 sampleUvOffsets[ KERNEL_RADIUS + 1 ];
+uniform float sampleWeights[ KERNEL_RADIUS + 1 ];
 
-		"uniform vec2 sampleUvOffsets[ KERNEL_RADIUS + 1 ];",
-		"uniform float sampleWeights[ KERNEL_RADIUS + 1 ];",
+varying vec2 vUv;
+varying vec2 vInvSize;
 
-		"varying vec2 vUv;",
-		"varying vec2 vInvSize;",
+float getDepth( const in vec2 screenPosition ) {
+	#if DEPTH_PACKING == 1
+	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+	#else
+	return texture2D( tDepth, screenPosition ).x;
+	#endif
+}
 
-		"float getDepth( const in vec2 screenPosition ) {",
-		"	#if DEPTH_PACKING == 1",
-		"	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );",
-		"	#else",
-		"	return texture2D( tDepth, screenPosition ).x;",
-		"	#endif",
-		"}",
+float getViewZ( const in float depth ) {
+	#if PERSPECTIVE_CAMERA == 1
+	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
+	#else
+	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
+	#endif
+}
 
-		"float getViewZ( const in float depth ) {",
-		"	#if PERSPECTIVE_CAMERA == 1",
-		"	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );",
-		"	#else",
-		"	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );",
-		"	#endif",
-		"}",
+void main() {
+	float depth = getDepth( vUv );
+	if( depth >= ( 1.0 - EPSILON ) ) {
+		discard;
+	}
 
-		"void main() {",
-		"	float depth = getDepth( vUv );",
-		"	if( depth >= ( 1.0 - EPSILON ) ) {",
-		"		discard;",
-		"	}",
+	float centerViewZ = -getViewZ( depth );
+	bool rBreak = false, lBreak = false;
 
-		"	float centerViewZ = -getViewZ( depth );",
-		"	bool rBreak = false, lBreak = false;",
+	float weightSum = sampleWeights[0];
+	vec4 diffuseSum = texture2D( tDiffuse, vUv ) * weightSum;
 
-		"	float weightSum = sampleWeights[0];",
-		"	vec4 diffuseSum = texture2D( tDiffuse, vUv ) * weightSum;",
+	for( int i = 1; i <= KERNEL_RADIUS; i ++ ) {
 
-		"	for( int i = 1; i <= KERNEL_RADIUS; i ++ ) {",
+		float sampleWeight = sampleWeights[i];
+		vec2 sampleUvOffset = sampleUvOffsets[i] * vInvSize;
 
-		"		float sampleWeight = sampleWeights[i];",
-		"		vec2 sampleUvOffset = sampleUvOffsets[i] * vInvSize;",
+		vec2 sampleUv = vUv + sampleUvOffset;
+		float viewZ = -getViewZ( getDepth( sampleUv ) );
 
-		"		vec2 sampleUv = vUv + sampleUvOffset;",
-		"		float viewZ = -getViewZ( getDepth( sampleUv ) );",
+		if( abs( viewZ - centerViewZ ) > depthCutoff ) rBreak = true;
 
-		"		if( abs( viewZ - centerViewZ ) > depthCutoff ) rBreak = true;",
+		if( ! rBreak ) {
+			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
+			weightSum += sampleWeight;
+		}
 
-		"		if( ! rBreak ) {",
-		"			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;",
-		"			weightSum += sampleWeight;",
-		"		}",
+		sampleUv = vUv - sampleUvOffset;
+		viewZ = -getViewZ( getDepth( sampleUv ) );
 
-		"		sampleUv = vUv - sampleUvOffset;",
-		"		viewZ = -getViewZ( getDepth( sampleUv ) );",
+		if( abs( viewZ - centerViewZ ) > depthCutoff ) lBreak = true;
 
-		"		if( abs( viewZ - centerViewZ ) > depthCutoff ) lBreak = true;",
+		if( ! lBreak ) {
+			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
+			weightSum += sampleWeight;
+		}
 
-		"		if( ! lBreak ) {",
-		"			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;",
-		"			weightSum += sampleWeight;",
-		"		}",
+	}
 
-		"	}",
-
-		"	gl_FragColor = diffuseSum / weightSum;",
-		"}"
-	].join( "\n" )
+	gl_FragColor = diffuseSum / weightSum;
+}
+`
 };
 
 THREE.BlurShaderUtils = {

--- a/examples/js/shaders/DepthLimitedBlurShader.js
+++ b/examples/js/shaders/DepthLimitedBlurShader.js
@@ -19,95 +19,95 @@ THREE.DepthLimitedBlurShader = {
 		"depthCutoff": { value: 10 },
 	},
 	vertexShader: /* glsl */`
-#include <common>
+		#include <common>
 
-uniform vec2 size;
+		uniform vec2 size;
 
-varying vec2 vUv;
-varying vec2 vInvSize;
+		varying vec2 vUv;
+		varying vec2 vInvSize;
 
-void main() {
-	vUv = uv;
-	vInvSize = 1.0 / size;
+		void main() {
+			vUv = uv;
+			vInvSize = 1.0 / size;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		}
+	`,
 	fragmentShader: /* glsl */`
-#include <common>
-#include <packing>
+		#include <common>
+		#include <packing>
 
-uniform sampler2D tDiffuse;
-uniform sampler2D tDepth;
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tDepth;
 
-uniform float cameraNear;
-uniform float cameraFar;
-uniform float depthCutoff;
+		uniform float cameraNear;
+		uniform float cameraFar;
+		uniform float depthCutoff;
 
-uniform vec2 sampleUvOffsets[ KERNEL_RADIUS + 1 ];
-uniform float sampleWeights[ KERNEL_RADIUS + 1 ];
+		uniform vec2 sampleUvOffsets[ KERNEL_RADIUS + 1 ];
+		uniform float sampleWeights[ KERNEL_RADIUS + 1 ];
 
-varying vec2 vUv;
-varying vec2 vInvSize;
+		varying vec2 vUv;
+		varying vec2 vInvSize;
 
-float getDepth( const in vec2 screenPosition ) {
-	#if DEPTH_PACKING == 1
-	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
-	#else
-	return texture2D( tDepth, screenPosition ).x;
-	#endif
-}
-
-float getViewZ( const in float depth ) {
-	#if PERSPECTIVE_CAMERA == 1
-	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
-	#else
-	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
-	#endif
-}
-
-void main() {
-	float depth = getDepth( vUv );
-	if( depth >= ( 1.0 - EPSILON ) ) {
-		discard;
-	}
-
-	float centerViewZ = -getViewZ( depth );
-	bool rBreak = false, lBreak = false;
-
-	float weightSum = sampleWeights[0];
-	vec4 diffuseSum = texture2D( tDiffuse, vUv ) * weightSum;
-
-	for( int i = 1; i <= KERNEL_RADIUS; i ++ ) {
-
-		float sampleWeight = sampleWeights[i];
-		vec2 sampleUvOffset = sampleUvOffsets[i] * vInvSize;
-
-		vec2 sampleUv = vUv + sampleUvOffset;
-		float viewZ = -getViewZ( getDepth( sampleUv ) );
-
-		if( abs( viewZ - centerViewZ ) > depthCutoff ) rBreak = true;
-
-		if( ! rBreak ) {
-			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
-			weightSum += sampleWeight;
+		float getDepth( const in vec2 screenPosition ) {
+			#if DEPTH_PACKING == 1
+			return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+			#else
+			return texture2D( tDepth, screenPosition ).x;
+			#endif
 		}
 
-		sampleUv = vUv - sampleUvOffset;
-		viewZ = -getViewZ( getDepth( sampleUv ) );
-
-		if( abs( viewZ - centerViewZ ) > depthCutoff ) lBreak = true;
-
-		if( ! lBreak ) {
-			diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
-			weightSum += sampleWeight;
+		float getViewZ( const in float depth ) {
+			#if PERSPECTIVE_CAMERA == 1
+			return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
+			#else
+			return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
+			#endif
 		}
 
-	}
+		void main() {
+			float depth = getDepth( vUv );
+			if( depth >= ( 1.0 - EPSILON ) ) {
+				discard;
+			}
 
-	gl_FragColor = diffuseSum / weightSum;
-}
-`
+			float centerViewZ = -getViewZ( depth );
+			bool rBreak = false, lBreak = false;
+
+			float weightSum = sampleWeights[0];
+			vec4 diffuseSum = texture2D( tDiffuse, vUv ) * weightSum;
+
+			for( int i = 1; i <= KERNEL_RADIUS; i ++ ) {
+
+				float sampleWeight = sampleWeights[i];
+				vec2 sampleUvOffset = sampleUvOffsets[i] * vInvSize;
+
+				vec2 sampleUv = vUv + sampleUvOffset;
+				float viewZ = -getViewZ( getDepth( sampleUv ) );
+
+				if( abs( viewZ - centerViewZ ) > depthCutoff ) rBreak = true;
+
+				if( ! rBreak ) {
+					diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
+					weightSum += sampleWeight;
+				}
+
+				sampleUv = vUv - sampleUvOffset;
+				viewZ = -getViewZ( getDepth( sampleUv ) );
+
+				if( abs( viewZ - centerViewZ ) > depthCutoff ) lBreak = true;
+
+				if( ! lBreak ) {
+					diffuseSum += texture2D( tDiffuse, sampleUv ) * sampleWeight;
+					weightSum += sampleWeight;
+				}
+
+			}
+
+			gl_FragColor = diffuseSum / weightSum;
+		}
+	`
 };
 
 THREE.BlurShaderUtils = {

--- a/examples/js/shaders/DigitalGlitch.js
+++ b/examples/js/shaders/DigitalGlitch.js
@@ -28,74 +28,73 @@ THREE.DigitalGlitch = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+		varying vec2 vUv;
+		void main() {
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform int byp; //should we apply the glitch ?
+		uniform int byp; //should we apply the glitch ?
 
-uniform sampler2D tDiffuse;
-uniform sampler2D tDisp;
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tDisp;
 
-uniform float amount;
-uniform float angle;
-uniform float seed;
-uniform float seed_x;
-uniform float seed_y;
-uniform float distortion_x;
-uniform float distortion_y;
-uniform float col_s;
+		uniform float amount;
+		uniform float angle;
+		uniform float seed;
+		uniform float seed_x;
+		uniform float seed_y;
+		uniform float distortion_x;
+		uniform float distortion_y;
+		uniform float col_s;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
 
-float rand(vec2 co){
-	return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
-}
+		float rand(vec2 co){
+			return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+		}
 
-void main() {
-	if(byp<1) {
-		vec2 p = vUv;
-		float xs = floor(gl_FragCoord.x / 0.5);
-		float ys = floor(gl_FragCoord.y / 0.5);
-		//based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
-		vec4 normal = texture2D (tDisp, p*seed*seed);
-		if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {
-			if(seed_x>0.){
-				p.y = 1. - (p.y + distortion_y);
+		void main() {
+			if(byp<1) {
+				vec2 p = vUv;
+				float xs = floor(gl_FragCoord.x / 0.5);
+				float ys = floor(gl_FragCoord.y / 0.5);
+				//based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
+				vec4 normal = texture2D (tDisp, p*seed*seed);
+				if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {
+					if(seed_x>0.){
+						p.y = 1. - (p.y + distortion_y);
+					}
+					else {
+						p.y = distortion_y;
+					}
+				}
+				if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {
+					if(seed_y>0.){
+						p.x=distortion_x;
+					}
+					else {
+						p.x = 1. - (p.x + distortion_x);
+					}
+				}
+				p.x+=normal.x*seed_x*(seed/5.);
+				p.y+=normal.y*seed_y*(seed/5.);
+				//base from RGB shift shader
+				vec2 offset = amount * vec2( cos(angle), sin(angle));
+				vec4 cr = texture2D(tDiffuse, p + offset);
+				vec4 cga = texture2D(tDiffuse, p);
+				vec4 cb = texture2D(tDiffuse, p - offset);
+				gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
+				//add noise
+				vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);
+				gl_FragColor = gl_FragColor+ snow;
 			}
 			else {
-				p.y = distortion_y;
+				gl_FragColor=texture2D (tDiffuse, vUv);
 			}
 		}
-		if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {
-			if(seed_y>0.){
-				p.x=distortion_x;
-			}
-			else {
-				p.x = 1. - (p.x + distortion_x);
-			}
-		}
-		p.x+=normal.x*seed_x*(seed/5.);
-		p.y+=normal.y*seed_y*(seed/5.);
-		//base from RGB shift shader
-		vec2 offset = amount * vec2( cos(angle), sin(angle));
-		vec4 cr = texture2D(tDiffuse, p + offset);
-		vec4 cga = texture2D(tDiffuse, p);
-		vec4 cb = texture2D(tDiffuse, p - offset);
-		gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
-		//add noise
-		vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);
-		gl_FragColor = gl_FragColor+ snow;
-	}
-	else {
-		gl_FragColor=texture2D (tDiffuse, vUv);
-	}
-}
-`
-
+	`
 };

--- a/examples/js/shaders/DigitalGlitch.js
+++ b/examples/js/shaders/DigitalGlitch.js
@@ -27,77 +27,75 @@ THREE.DigitalGlitch = {
 		"col_s": { value: 0.05 }
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
 
-		"varying vec2 vUv;",
-		"void main() {",
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"}"
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform int byp; //should we apply the glitch ?
 
-	fragmentShader: [
-		"uniform int byp;", //should we apply the glitch ?
+uniform sampler2D tDiffuse;
+uniform sampler2D tDisp;
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tDisp;",
+uniform float amount;
+uniform float angle;
+uniform float seed;
+uniform float seed_x;
+uniform float seed_y;
+uniform float distortion_x;
+uniform float distortion_y;
+uniform float col_s;
 
-		"uniform float amount;",
-		"uniform float angle;",
-		"uniform float seed;",
-		"uniform float seed_x;",
-		"uniform float seed_y;",
-		"uniform float distortion_x;",
-		"uniform float distortion_y;",
-		"uniform float col_s;",
-
-		"varying vec2 vUv;",
+varying vec2 vUv;
 
 
-		"float rand(vec2 co){",
-		"	return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);",
-		"}",
+float rand(vec2 co){
+	return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+}
 
-		"void main() {",
-		"	if(byp<1) {",
-		"		vec2 p = vUv;",
-		"		float xs = floor(gl_FragCoord.x / 0.5);",
-		"		float ys = floor(gl_FragCoord.y / 0.5);",
+void main() {
+	if(byp<1) {
+		vec2 p = vUv;
+		float xs = floor(gl_FragCoord.x / 0.5);
+		float ys = floor(gl_FragCoord.y / 0.5);
 		//based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
-		"		vec4 normal = texture2D (tDisp, p*seed*seed);",
-		"		if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {",
-		"			if(seed_x>0.){",
-		"				p.y = 1. - (p.y + distortion_y);",
-		"			}",
-		"			else {",
-		"				p.y = distortion_y;",
-		"			}",
-		"		}",
-		"		if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {",
-		"			if(seed_y>0.){",
-		"				p.x=distortion_x;",
-		"			}",
-		"			else {",
-		"				p.x = 1. - (p.x + distortion_x);",
-		"			}",
-		"		}",
-		"		p.x+=normal.x*seed_x*(seed/5.);",
-		"		p.y+=normal.y*seed_y*(seed/5.);",
+		vec4 normal = texture2D (tDisp, p*seed*seed);
+		if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {
+			if(seed_x>0.){
+				p.y = 1. - (p.y + distortion_y);
+			}
+			else {
+				p.y = distortion_y;
+			}
+		}
+		if(p.x<distortion_y+col_s && p.x>distortion_y-col_s*seed) {
+			if(seed_y>0.){
+				p.x=distortion_x;
+			}
+			else {
+				p.x = 1. - (p.x + distortion_x);
+			}
+		}
+		p.x+=normal.x*seed_x*(seed/5.);
+		p.y+=normal.y*seed_y*(seed/5.);
 		//base from RGB shift shader
-		"		vec2 offset = amount * vec2( cos(angle), sin(angle));",
-		"		vec4 cr = texture2D(tDiffuse, p + offset);",
-		"		vec4 cga = texture2D(tDiffuse, p);",
-		"		vec4 cb = texture2D(tDiffuse, p - offset);",
-		"		gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
+		vec2 offset = amount * vec2( cos(angle), sin(angle));
+		vec4 cr = texture2D(tDiffuse, p + offset);
+		vec4 cga = texture2D(tDiffuse, p);
+		vec4 cb = texture2D(tDiffuse, p - offset);
+		gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
 		//add noise
-		"		vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);",
-		"		gl_FragColor = gl_FragColor+ snow;",
-		"	}",
-		"	else {",
-		"		gl_FragColor=texture2D (tDiffuse, vUv);",
-		"	}",
-		"}"
-
-	].join( "\n" )
+		vec4 snow = 200.*amount*vec4(rand(vec2(xs * seed,ys * seed*50.))*0.2);
+		gl_FragColor = gl_FragColor+ snow;
+	}
+	else {
+		gl_FragColor=texture2D (tDiffuse, vUv);
+	}
+}
+`
 
 };

--- a/examples/js/shaders/DotScreenShader.js
+++ b/examples/js/shaders/DotScreenShader.js
@@ -19,46 +19,45 @@ THREE.DotScreenShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec2 center;
-uniform float angle;
-uniform float scale;
-uniform vec2 tSize;
+		uniform vec2 center;
+		uniform float angle;
+		uniform float scale;
+		uniform vec2 tSize;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-float pattern() {
+		float pattern() {
 
-	float s = sin( angle ), c = cos( angle );
+			float s = sin( angle ), c = cos( angle );
 
-	vec2 tex = vUv * tSize - center;
-	vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;
+			vec2 tex = vUv * tSize - center;
+			vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;
 
-	return ( sin( point.x ) * sin( point.y ) ) * 4.0;
+			return ( sin( point.x ) * sin( point.y ) ) * 4.0;
 
-}
+		}
 
-void main() {
+		void main() {
 
-	vec4 color = texture2D( tDiffuse, vUv );
+			vec4 color = texture2D( tDiffuse, vUv );
 
-	float average = ( color.r + color.g + color.b ) / 3.0;
+			float average = ( color.r + color.g + color.b ) / 3.0;
 
-	gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );
+			gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/DotScreenShader.js
+++ b/examples/js/shaders/DotScreenShader.js
@@ -18,51 +18,47 @@ THREE.DotScreenShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec2 center;
+uniform float angle;
+uniform float scale;
+uniform vec2 tSize;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform vec2 center;",
-		"uniform float angle;",
-		"uniform float scale;",
-		"uniform vec2 tSize;",
+float pattern() {
 
-		"uniform sampler2D tDiffuse;",
+	float s = sin( angle ), c = cos( angle );
 
-		"varying vec2 vUv;",
+	vec2 tex = vUv * tSize - center;
+	vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;
 
-		"float pattern() {",
+	return ( sin( point.x ) * sin( point.y ) ) * 4.0;
 
-		"	float s = sin( angle ), c = cos( angle );",
+}
 
-		"	vec2 tex = vUv * tSize - center;",
-		"	vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;",
+void main() {
 
-		"	return ( sin( point.x ) * sin( point.y ) ) * 4.0;",
+	vec4 color = texture2D( tDiffuse, vUv );
 
-		"}",
+	float average = ( color.r + color.g + color.b ) / 3.0;
 
-		"void main() {",
+	gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );
 
-		"	vec4 color = texture2D( tDiffuse, vUv );",
-
-		"	float average = ( color.r + color.g + color.b ) / 3.0;",
-
-		"	gl_FragColor = vec4( vec3( average * 10.0 - 5.0 + pattern() ), color.a );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/FXAAShader.js
+++ b/examples/js/shaders/FXAAShader.js
@@ -40,7 +40,7 @@ varying vec2 vUv;
 // FXAA 3.11 implementation by NVIDIA, ported to WebGL by Agost Biro (biro@archilogic.com)
 
 //----------------------------------------------------------------------------------
-// File:        es3-keplerFXAAassetsshaders/FXAA_DefaultES.frag
+// File:        es3-kepler\FXAA\assets\shaders/FXAA_DefaultES.frag
 // SDK Version: v3.00
 // Email:       gameworks@nvidia.com
 // Site:        http://developer.nvidia.com/
@@ -59,7 +59,7 @@ varying vec2 vUv;
 //    contributors may be used to endorse or promote products derived
 //    from this software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS \`\`AS IS'' AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 // PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR

--- a/examples/js/shaders/FXAAShader.js
+++ b/examples/js/shaders/FXAAShader.js
@@ -18,886 +18,858 @@ THREE.FXAAShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+        varying vec2 vUv;
 
-void main() {
+        void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+        }
+    `,
 
 	fragmentShader: /* glsl */`
-precision highp float;
+        precision highp float;
 
-uniform sampler2D tDiffuse;
+        uniform sampler2D tDiffuse;
 
-uniform vec2 resolution;
+        uniform vec2 resolution;
 
-varying vec2 vUv;
+        varying vec2 vUv;
 
-// FXAA 3.11 implementation by NVIDIA, ported to WebGL by Agost Biro (biro@archilogic.com)
+        // FXAA 3.11 implementation by NVIDIA, ported to WebGL by Agost Biro (biro@archilogic.com)
 
-//----------------------------------------------------------------------------------
-// File:        es3-kepler\FXAA\assets\shaders/FXAA_DefaultES.frag
-// SDK Version: v3.00
-// Email:       gameworks@nvidia.com
-// Site:        http://developer.nvidia.com/
-//
-// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of NVIDIA CORPORATION nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS \`\`AS IS'' AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-//----------------------------------------------------------------------------------
+        //----------------------------------------------------------------------------------
+        // File:        es3-kepler\FXAA\assets\shaders/FXAA_DefaultES.frag
+        // SDK Version: v3.00
+        // Email:       gameworks@nvidia.com
+        // Site:        http://developer.nvidia.com/
+        //
+        // Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
+        //
+        // Redistribution and use in source and binary forms, with or without
+        // modification, are permitted provided that the following conditions
+        // are met:
+        //  * Redistributions of source code must retain the above copyright
+        //    notice, this list of conditions and the following disclaimer.
+        //  * Redistributions in binary form must reproduce the above copyright
+        //    notice, this list of conditions and the following disclaimer in the
+        //    documentation and/or other materials provided with the distribution.
+        //  * Neither the name of NVIDIA CORPORATION nor the names of its
+        //    contributors may be used to endorse or promote products derived
+        //    from this software without specific prior written permission.
+        //
+        // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS \`\`AS IS'' AND ANY
+        // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        // PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+        // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+        // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+        // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+        // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+        // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        //
+        //----------------------------------------------------------------------------------
 
-#define FXAA_PC 1
-#define FXAA_GLSL_100 1
-#define FXAA_QUALITY_PRESET 12
+        #define FXAA_PC 1
+        #define FXAA_GLSL_100 1
+        #define FXAA_QUALITY_PRESET 12
 
-#define FXAA_GREEN_AS_LUMA 1
+        #define FXAA_GREEN_AS_LUMA 1
 
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_PC_CONSOLE
-    //
-    // The console algorithm for PC is included
-    // for developers targeting really low spec machines.
-    // Likely better to just run FXAA_PC, and use a really low preset.
-    //
-    #define FXAA_PC_CONSOLE 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_GLSL_120
-    #define FXAA_GLSL_120 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_GLSL_130
-    #define FXAA_GLSL_130 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_HLSL_3
-    #define FXAA_HLSL_3 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_HLSL_4
-    #define FXAA_HLSL_4 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_HLSL_5
-    #define FXAA_HLSL_5 0
-#endif
-/*==========================================================================*/
-#ifndef FXAA_GREEN_AS_LUMA
-    //
-    // For those using non-linear color,
-    // and either not able to get luma in alpha, or not wanting to,
-    // this enables FXAA to run using green as a proxy for luma.
-    // So with this enabled, no need to pack luma in alpha.
-    //
-    // This will turn off AA on anything which lacks some amount of green.
-    // Pure red and blue or combination of only R and B, will get no AA.
-    //
-    // Might want to lower the settings for both,
-    //    fxaaConsoleEdgeThresholdMin
-    //    fxaaQualityEdgeThresholdMin
-    // In order to insure AA does not get turned off on colors
-    // which contain a minor amount of green.
-    //
-    // 1 = On.
-    // 0 = Off.
-    //
-    #define FXAA_GREEN_AS_LUMA 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_EARLY_EXIT
-    //
-    // Controls algorithm's early exit path.
-    // On PS3 turning this ON adds 2 cycles to the shader.
-    // On 360 turning this OFF adds 10ths of a millisecond to the shader.
-    // Turning this off on console will result in a more blurry image.
-    // So this defaults to on.
-    //
-    // 1 = On.
-    // 0 = Off.
-    //
-    #define FXAA_EARLY_EXIT 1
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_DISCARD
-    //
-    // Only valid for PC OpenGL currently.
-    // Probably will not work when FXAA_GREEN_AS_LUMA = 1.
-    //
-    // 1 = Use discard on pixels which don't need AA.
-    //     For APIs which enable concurrent TEX+ROP from same surface.
-    // 0 = Return unchanged color on pixels which don't need AA.
-    //
-    #define FXAA_DISCARD 0
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_FAST_PIXEL_OFFSET
-    //
-    // Used for GLSL 120 only.
-    //
-    // 1 = GL API supports fast pixel offsets
-    // 0 = do not use fast pixel offsets
-    //
-    #ifdef GL_EXT_gpu_shader4
-        #define FXAA_FAST_PIXEL_OFFSET 1
-    #endif
-    #ifdef GL_NV_gpu_shader5
-        #define FXAA_FAST_PIXEL_OFFSET 1
-    #endif
-    #ifdef GL_ARB_gpu_shader5
-        #define FXAA_FAST_PIXEL_OFFSET 1
-    #endif
-    #ifndef FXAA_FAST_PIXEL_OFFSET
-        #define FXAA_FAST_PIXEL_OFFSET 0
-    #endif
-#endif
-/*--------------------------------------------------------------------------*/
-#ifndef FXAA_GATHER4_ALPHA
-    //
-    // 1 = API supports gather4 on alpha channel.
-    // 0 = API does not support gather4 on alpha channel.
-    //
-    #if (FXAA_HLSL_5 == 1)
-        #define FXAA_GATHER4_ALPHA 1
-    #endif
-    #ifdef GL_ARB_gpu_shader5
-        #define FXAA_GATHER4_ALPHA 1
-    #endif
-    #ifdef GL_NV_gpu_shader5
-        #define FXAA_GATHER4_ALPHA 1
-    #endif
-    #ifndef FXAA_GATHER4_ALPHA
-        #define FXAA_GATHER4_ALPHA 0
-    #endif
-#endif
-
-
-/*============================================================================
-                        FXAA QUALITY - TUNING KNOBS
-------------------------------------------------------------------------------
-NOTE the other tuning knobs are now in the shader function inputs!
-============================================================================*/
-#ifndef FXAA_QUALITY_PRESET
-    //
-    // Choose the quality preset.
-    // This needs to be compiled into the shader as it effects code.
-    // Best option to include multiple presets is to
-    // in each shader define the preset, then include this file.
-    //
-    // OPTIONS
-    // -----------------------------------------------------------------------
-    // 10 to 15 - default medium dither (10=fastest, 15=highest quality)
-    // 20 to 29 - less dither, more expensive (20=fastest, 29=highest quality)
-    // 39       - no dither, very expensive
-    //
-    // NOTES
-    // -----------------------------------------------------------------------
-    // 12 = slightly faster then FXAA 3.9 and higher edge quality (default)
-    // 13 = about same speed as FXAA 3.9 and better than 12
-    // 23 = closest to FXAA 3.9 visually and performance wise
-    //  _ = the lowest digit is directly related to performance
-    // _  = the highest digit is directly related to style
-    //
-    #define FXAA_QUALITY_PRESET 12
-#endif
-
-
-/*============================================================================
-
-                           FXAA QUALITY - PRESETS
-
-============================================================================*/
-
-/*============================================================================
-                     FXAA QUALITY - MEDIUM DITHER PRESETS
-============================================================================*/
-#if (FXAA_QUALITY_PRESET == 10)
-    #define FXAA_QUALITY_PS 3
-    #define FXAA_QUALITY_P0 1.5
-    #define FXAA_QUALITY_P1 3.0
-    #define FXAA_QUALITY_P2 12.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 11)
-    #define FXAA_QUALITY_PS 4
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 3.0
-    #define FXAA_QUALITY_P3 12.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 12)
-    #define FXAA_QUALITY_PS 5
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 4.0
-    #define FXAA_QUALITY_P4 12.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 13)
-    #define FXAA_QUALITY_PS 6
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 4.0
-    #define FXAA_QUALITY_P5 12.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 14)
-    #define FXAA_QUALITY_PS 7
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 4.0
-    #define FXAA_QUALITY_P6 12.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 15)
-    #define FXAA_QUALITY_PS 8
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 4.0
-    #define FXAA_QUALITY_P7 12.0
-#endif
-
-/*============================================================================
-                     FXAA QUALITY - LOW DITHER PRESETS
-============================================================================*/
-#if (FXAA_QUALITY_PRESET == 20)
-    #define FXAA_QUALITY_PS 3
-    #define FXAA_QUALITY_P0 1.5
-    #define FXAA_QUALITY_P1 2.0
-    #define FXAA_QUALITY_P2 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 21)
-    #define FXAA_QUALITY_PS 4
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 22)
-    #define FXAA_QUALITY_PS 5
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 23)
-    #define FXAA_QUALITY_PS 6
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 24)
-    #define FXAA_QUALITY_PS 7
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 3.0
-    #define FXAA_QUALITY_P6 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 25)
-    #define FXAA_QUALITY_PS 8
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 4.0
-    #define FXAA_QUALITY_P7 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 26)
-    #define FXAA_QUALITY_PS 9
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 2.0
-    #define FXAA_QUALITY_P7 4.0
-    #define FXAA_QUALITY_P8 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 27)
-    #define FXAA_QUALITY_PS 10
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 2.0
-    #define FXAA_QUALITY_P7 2.0
-    #define FXAA_QUALITY_P8 4.0
-    #define FXAA_QUALITY_P9 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 28)
-    #define FXAA_QUALITY_PS 11
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 2.0
-    #define FXAA_QUALITY_P7 2.0
-    #define FXAA_QUALITY_P8 2.0
-    #define FXAA_QUALITY_P9 4.0
-    #define FXAA_QUALITY_P10 8.0
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_QUALITY_PRESET == 29)
-    #define FXAA_QUALITY_PS 12
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.5
-    #define FXAA_QUALITY_P2 2.0
-    #define FXAA_QUALITY_P3 2.0
-    #define FXAA_QUALITY_P4 2.0
-    #define FXAA_QUALITY_P5 2.0
-    #define FXAA_QUALITY_P6 2.0
-    #define FXAA_QUALITY_P7 2.0
-    #define FXAA_QUALITY_P8 2.0
-    #define FXAA_QUALITY_P9 2.0
-    #define FXAA_QUALITY_P10 4.0
-    #define FXAA_QUALITY_P11 8.0
-#endif
-
-/*============================================================================
-                     FXAA QUALITY - EXTREME QUALITY
-============================================================================*/
-#if (FXAA_QUALITY_PRESET == 39)
-    #define FXAA_QUALITY_PS 12
-    #define FXAA_QUALITY_P0 1.0
-    #define FXAA_QUALITY_P1 1.0
-    #define FXAA_QUALITY_P2 1.0
-    #define FXAA_QUALITY_P3 1.0
-    #define FXAA_QUALITY_P4 1.0
-    #define FXAA_QUALITY_P5 1.5
-    #define FXAA_QUALITY_P6 2.0
-    #define FXAA_QUALITY_P7 2.0
-    #define FXAA_QUALITY_P8 2.0
-    #define FXAA_QUALITY_P9 2.0
-    #define FXAA_QUALITY_P10 4.0
-    #define FXAA_QUALITY_P11 8.0
-#endif
-
-
-
-/*============================================================================
-
-                                API PORTING
-
-============================================================================*/
-#if (FXAA_GLSL_100 == 1) || (FXAA_GLSL_120 == 1) || (FXAA_GLSL_130 == 1)
-    #define FxaaBool bool
-    #define FxaaDiscard discard
-    #define FxaaFloat float
-    #define FxaaFloat2 vec2
-    #define FxaaFloat3 vec3
-    #define FxaaFloat4 vec4
-    #define FxaaHalf float
-    #define FxaaHalf2 vec2
-    #define FxaaHalf3 vec3
-    #define FxaaHalf4 vec4
-    #define FxaaInt2 ivec2
-    #define FxaaSat(x) clamp(x, 0.0, 1.0)
-    #define FxaaTex sampler2D
-#else
-    #define FxaaBool bool
-    #define FxaaDiscard clip(-1)
-    #define FxaaFloat float
-    #define FxaaFloat2 float2
-    #define FxaaFloat3 float3
-    #define FxaaFloat4 float4
-    #define FxaaHalf half
-    #define FxaaHalf2 half2
-    #define FxaaHalf3 half3
-    #define FxaaHalf4 half4
-    #define FxaaSat(x) saturate(x)
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_GLSL_100 == 1)
-  #define FxaaTexTop(t, p) texture2D(t, p, 0.0)
-  #define FxaaTexOff(t, p, o, r) texture2D(t, p + (o * r), 0.0)
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_GLSL_120 == 1)
-    // Requires,
-    //  #version 120
-    // And at least,
-    //  #extension GL_EXT_gpu_shader4 : enable
-    //  (or set FXAA_FAST_PIXEL_OFFSET 1 to work like DX9)
-    #define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)
-    #if (FXAA_FAST_PIXEL_OFFSET == 1)
-        #define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)
-    #else
-        #define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)
-    #endif
-    #if (FXAA_GATHER4_ALPHA == 1)
-        // use #extension GL_ARB_gpu_shader5 : enable
-        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
-        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
-        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
-        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
-    #endif
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_GLSL_130 == 1)
-    // Requires "#version 130" or better
-    #define FxaaTexTop(t, p) textureLod(t, p, 0.0)
-    #define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
-    #if (FXAA_GATHER4_ALPHA == 1)
-        // use #extension GL_ARB_gpu_shader5 : enable
-        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
-        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
-        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
-        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
-    #endif
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_HLSL_3 == 1)
-    #define FxaaInt2 float2
-    #define FxaaTex sampler2D
-    #define FxaaTexTop(t, p) tex2Dlod(t, float4(p, 0.0, 0.0))
-    #define FxaaTexOff(t, p, o, r) tex2Dlod(t, float4(p + (o * r), 0, 0))
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_HLSL_4 == 1)
-    #define FxaaInt2 int2
-    struct FxaaTex { SamplerState smpl; Texture2D tex; };
-    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
-    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
-#endif
-/*--------------------------------------------------------------------------*/
-#if (FXAA_HLSL_5 == 1)
-    #define FxaaInt2 int2
-    struct FxaaTex { SamplerState smpl; Texture2D tex; };
-    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
-    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
-    #define FxaaTexAlpha4(t, p) t.tex.GatherAlpha(t.smpl, p)
-    #define FxaaTexOffAlpha4(t, p, o) t.tex.GatherAlpha(t.smpl, p, o)
-    #define FxaaTexGreen4(t, p) t.tex.GatherGreen(t.smpl, p)
-    #define FxaaTexOffGreen4(t, p, o) t.tex.GatherGreen(t.smpl, p, o)
-#endif
-
-
-/*============================================================================
-                   GREEN AS LUMA OPTION SUPPORT FUNCTION
-============================================================================*/
-#if (FXAA_GREEN_AS_LUMA == 0)
-    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.w; }
-#else
-    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.y; }
-#endif
-
-
-
-
-/*============================================================================
-
-                             FXAA3 QUALITY - PC
-
-============================================================================*/
-#if (FXAA_PC == 1)
-/*--------------------------------------------------------------------------*/
-FxaaFloat4 FxaaPixelShader(
-    //
-    // Use noperspective interpolation here (turn off perspective interpolation).
-    // {xy} = center of pixel
-    FxaaFloat2 pos,
-    //
-    // Used only for FXAA Console, and not used on the 360 version.
-    // Use noperspective interpolation here (turn off perspective interpolation).
-    // {xy_} = upper left of pixel
-    // {_zw} = lower right of pixel
-    FxaaFloat4 fxaaConsolePosPos,
-    //
-    // Input color texture.
-    // {rgb_} = color in linear or perceptual color space
-    // if (FXAA_GREEN_AS_LUMA == 0)
-    //     {__a} = luma in perceptual color space (not linear)
-    FxaaTex tex,
-    //
-    // Only used on the optimized 360 version of FXAA Console.
-    // For everything but 360, just use the same input here as for "tex".
-    // For 360, same texture, just alias with a 2nd sampler.
-    // This sampler needs to have an exponent bias of -1.
-    FxaaTex fxaaConsole360TexExpBiasNegOne,
-    //
-    // Only used on the optimized 360 version of FXAA Console.
-    // For everything but 360, just use the same input here as for "tex".
-    // For 360, same texture, just alias with a 3nd sampler.
-    // This sampler needs to have an exponent bias of -2.
-    FxaaTex fxaaConsole360TexExpBiasNegTwo,
-    //
-    // Only used on FXAA Quality.
-    // This must be from a constant/uniform.
-    // {x_} = 1.0/screenWidthInPixels
-    // {_y} = 1.0/screenHeightInPixels
-    FxaaFloat2 fxaaQualityRcpFrame,
-    //
-    // Only used on FXAA Console.
-    // This must be from a constant/uniform.
-    // This effects sub-pixel AA quality and inversely sharpness.
-    //   Where N ranges between,
-    //     N = 0.50 (default)
-    //     N = 0.33 (sharper)
-    // {x__} = -N/screenWidthInPixels
-    // {_y_} = -N/screenHeightInPixels
-    // {_z_} =  N/screenWidthInPixels
-    // {__w} =  N/screenHeightInPixels
-    FxaaFloat4 fxaaConsoleRcpFrameOpt,
-    //
-    // Only used on FXAA Console.
-    // Not used on 360, but used on PS3 and PC.
-    // This must be from a constant/uniform.
-    // {x__} = -2.0/screenWidthInPixels
-    // {_y_} = -2.0/screenHeightInPixels
-    // {_z_} =  2.0/screenWidthInPixels
-    // {__w} =  2.0/screenHeightInPixels
-    FxaaFloat4 fxaaConsoleRcpFrameOpt2,
-    //
-    // Only used on FXAA Console.
-    // Only used on 360 in place of fxaaConsoleRcpFrameOpt2.
-    // This must be from a constant/uniform.
-    // {x__} =  8.0/screenWidthInPixels
-    // {_y_} =  8.0/screenHeightInPixels
-    // {_z_} = -4.0/screenWidthInPixels
-    // {__w} = -4.0/screenHeightInPixels
-    FxaaFloat4 fxaaConsole360RcpFrameOpt2,
-    //
-    // Only used on FXAA Quality.
-    // This used to be the FXAA_QUALITY_SUBPIX define.
-    // It is here now to allow easier tuning.
-    // Choose the amount of sub-pixel aliasing removal.
-    // This can effect sharpness.
-    //   1.00 - upper limit (softer)
-    //   0.75 - default amount of filtering
-    //   0.50 - lower limit (sharper, less sub-pixel aliasing removal)
-    //   0.25 - almost off
-    //   0.00 - completely off
-    FxaaFloat fxaaQualitySubpix,
-    //
-    // Only used on FXAA Quality.
-    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD define.
-    // It is here now to allow easier tuning.
-    // The minimum amount of local contrast required to apply algorithm.
-    //   0.333 - too little (faster)
-    //   0.250 - low quality
-    //   0.166 - default
-    //   0.125 - high quality
-    //   0.063 - overkill (slower)
-    FxaaFloat fxaaQualityEdgeThreshold,
-    //
-    // Only used on FXAA Quality.
-    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD_MIN define.
-    // It is here now to allow easier tuning.
-    // Trims the algorithm from processing darks.
-    //   0.0833 - upper limit (default, the start of visible unfiltered edges)
-    //   0.0625 - high quality (faster)
-    //   0.0312 - visible limit (slower)
-    // Special notes when using FXAA_GREEN_AS_LUMA,
-    //   Likely want to set this to zero.
-    //   As colors that are mostly not-green
-    //   will appear very dark in the green channel!
-    //   Tune by looking at mostly non-green content,
-    //   then start at zero and increase until aliasing is a problem.
-    FxaaFloat fxaaQualityEdgeThresholdMin,
-    //
-    // Only used on FXAA Console.
-    // This used to be the FXAA_CONSOLE_EDGE_SHARPNESS define.
-    // It is here now to allow easier tuning.
-    // This does not effect PS3, as this needs to be compiled in.
-    //   Use FXAA_CONSOLE_PS3_EDGE_SHARPNESS for PS3.
-    //   Due to the PS3 being ALU bound,
-    //   there are only three safe values here: 2 and 4 and 8.
-    //   These options use the shaders ability to a free *|/ by 2|4|8.
-    // For all other platforms can be a non-power of two.
-    //   8.0 is sharper (default!!!)
-    //   4.0 is softer
-    //   2.0 is really soft (good only for vector graphics inputs)
-    FxaaFloat fxaaConsoleEdgeSharpness,
-    //
-    // Only used on FXAA Console.
-    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD define.
-    // It is here now to allow easier tuning.
-    // This does not effect PS3, as this needs to be compiled in.
-    //   Use FXAA_CONSOLE_PS3_EDGE_THRESHOLD for PS3.
-    //   Due to the PS3 being ALU bound,
-    //   there are only two safe values here: 1/4 and 1/8.
-    //   These options use the shaders ability to a free *|/ by 2|4|8.
-    // The console setting has a different mapping than the quality setting.
-    // Other platforms can use other values.
-    //   0.125 leaves less aliasing, but is softer (default!!!)
-    //   0.25 leaves more aliasing, and is sharper
-    FxaaFloat fxaaConsoleEdgeThreshold,
-    //
-    // Only used on FXAA Console.
-    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD_MIN define.
-    // It is here now to allow easier tuning.
-    // Trims the algorithm from processing darks.
-    // The console setting has a different mapping than the quality setting.
-    // This only applies when FXAA_EARLY_EXIT is 1.
-    // This does not apply to PS3,
-    // PS3 was simplified to avoid more shader instructions.
-    //   0.06 - faster but more aliasing in darks
-    //   0.05 - default
-    //   0.04 - slower and less aliasing in darks
-    // Special notes when using FXAA_GREEN_AS_LUMA,
-    //   Likely want to set this to zero.
-    //   As colors that are mostly not-green
-    //   will appear very dark in the green channel!
-    //   Tune by looking at mostly non-green content,
-    //   then start at zero and increase until aliasing is a problem.
-    FxaaFloat fxaaConsoleEdgeThresholdMin,
-    //
-    // Extra constants for 360 FXAA Console only.
-    // Use zeros or anything else for other platforms.
-    // These must be in physical constant registers and NOT immediates.
-    // Immediates will result in compiler un-optimizing.
-    // {xyzw} = float4(1.0, -1.0, 0.25, -0.25)
-    FxaaFloat4 fxaaConsole360ConstDir
-) {
-/*--------------------------------------------------------------------------*/
-    FxaaFloat2 posM;
-    posM.x = pos.x;
-    posM.y = pos.y;
-    #if (FXAA_GATHER4_ALPHA == 1)
-        #if (FXAA_DISCARD == 0)
-            FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
-            #if (FXAA_GREEN_AS_LUMA == 0)
-                #define lumaM rgbyM.w
-            #else
-                #define lumaM rgbyM.y
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_PC_CONSOLE
+            //
+            // The console algorithm for PC is included
+            // for developers targeting really low spec machines.
+            // Likely better to just run FXAA_PC, and use a really low preset.
+            //
+            #define FXAA_PC_CONSOLE 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_GLSL_120
+            #define FXAA_GLSL_120 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_GLSL_130
+            #define FXAA_GLSL_130 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_HLSL_3
+            #define FXAA_HLSL_3 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_HLSL_4
+            #define FXAA_HLSL_4 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_HLSL_5
+            #define FXAA_HLSL_5 0
+        #endif
+        /*==========================================================================*/
+        #ifndef FXAA_GREEN_AS_LUMA
+            //
+            // For those using non-linear color,
+            // and either not able to get luma in alpha, or not wanting to,
+            // this enables FXAA to run using green as a proxy for luma.
+            // So with this enabled, no need to pack luma in alpha.
+            //
+            // This will turn off AA on anything which lacks some amount of green.
+            // Pure red and blue or combination of only R and B, will get no AA.
+            //
+            // Might want to lower the settings for both,
+            //    fxaaConsoleEdgeThresholdMin
+            //    fxaaQualityEdgeThresholdMin
+            // In order to insure AA does not get turned off on colors
+            // which contain a minor amount of green.
+            //
+            // 1 = On.
+            // 0 = Off.
+            //
+            #define FXAA_GREEN_AS_LUMA 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_EARLY_EXIT
+            //
+            // Controls algorithm's early exit path.
+            // On PS3 turning this ON adds 2 cycles to the shader.
+            // On 360 turning this OFF adds 10ths of a millisecond to the shader.
+            // Turning this off on console will result in a more blurry image.
+            // So this defaults to on.
+            //
+            // 1 = On.
+            // 0 = Off.
+            //
+            #define FXAA_EARLY_EXIT 1
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_DISCARD
+            //
+            // Only valid for PC OpenGL currently.
+            // Probably will not work when FXAA_GREEN_AS_LUMA = 1.
+            //
+            // 1 = Use discard on pixels which don't need AA.
+            //     For APIs which enable concurrent TEX+ROP from same surface.
+            // 0 = Return unchanged color on pixels which don't need AA.
+            //
+            #define FXAA_DISCARD 0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_FAST_PIXEL_OFFSET
+            //
+            // Used for GLSL 120 only.
+            //
+            // 1 = GL API supports fast pixel offsets
+            // 0 = do not use fast pixel offsets
+            //
+            #ifdef GL_EXT_gpu_shader4
+                #define FXAA_FAST_PIXEL_OFFSET 1
+            #endif
+            #ifdef GL_NV_gpu_shader5
+                #define FXAA_FAST_PIXEL_OFFSET 1
+            #endif
+            #ifdef GL_ARB_gpu_shader5
+                #define FXAA_FAST_PIXEL_OFFSET 1
+            #endif
+            #ifndef FXAA_FAST_PIXEL_OFFSET
+                #define FXAA_FAST_PIXEL_OFFSET 0
             #endif
         #endif
-        #if (FXAA_GREEN_AS_LUMA == 0)
-            FxaaFloat4 luma4A = FxaaTexAlpha4(tex, posM);
-            FxaaFloat4 luma4B = FxaaTexOffAlpha4(tex, posM, FxaaInt2(-1, -1));
+        /*--------------------------------------------------------------------------*/
+        #ifndef FXAA_GATHER4_ALPHA
+            //
+            // 1 = API supports gather4 on alpha channel.
+            // 0 = API does not support gather4 on alpha channel.
+            //
+            #if (FXAA_HLSL_5 == 1)
+                #define FXAA_GATHER4_ALPHA 1
+            #endif
+            #ifdef GL_ARB_gpu_shader5
+                #define FXAA_GATHER4_ALPHA 1
+            #endif
+            #ifdef GL_NV_gpu_shader5
+                #define FXAA_GATHER4_ALPHA 1
+            #endif
+            #ifndef FXAA_GATHER4_ALPHA
+                #define FXAA_GATHER4_ALPHA 0
+            #endif
+        #endif
+
+
+        /*============================================================================
+                                FXAA QUALITY - TUNING KNOBS
+        ------------------------------------------------------------------------------
+        NOTE the other tuning knobs are now in the shader function inputs!
+        ============================================================================*/
+        #ifndef FXAA_QUALITY_PRESET
+            //
+            // Choose the quality preset.
+            // This needs to be compiled into the shader as it effects code.
+            // Best option to include multiple presets is to
+            // in each shader define the preset, then include this file.
+            //
+            // OPTIONS
+            // -----------------------------------------------------------------------
+            // 10 to 15 - default medium dither (10=fastest, 15=highest quality)
+            // 20 to 29 - less dither, more expensive (20=fastest, 29=highest quality)
+            // 39       - no dither, very expensive
+            //
+            // NOTES
+            // -----------------------------------------------------------------------
+            // 12 = slightly faster then FXAA 3.9 and higher edge quality (default)
+            // 13 = about same speed as FXAA 3.9 and better than 12
+            // 23 = closest to FXAA 3.9 visually and performance wise
+            //  _ = the lowest digit is directly related to performance
+            // _  = the highest digit is directly related to style
+            //
+            #define FXAA_QUALITY_PRESET 12
+        #endif
+
+
+        /*============================================================================
+
+                                FXAA QUALITY - PRESETS
+
+        ============================================================================*/
+
+        /*============================================================================
+                            FXAA QUALITY - MEDIUM DITHER PRESETS
+        ============================================================================*/
+        #if (FXAA_QUALITY_PRESET == 10)
+            #define FXAA_QUALITY_PS 3
+            #define FXAA_QUALITY_P0 1.5
+            #define FXAA_QUALITY_P1 3.0
+            #define FXAA_QUALITY_P2 12.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 11)
+            #define FXAA_QUALITY_PS 4
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 3.0
+            #define FXAA_QUALITY_P3 12.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 12)
+            #define FXAA_QUALITY_PS 5
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 4.0
+            #define FXAA_QUALITY_P4 12.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 13)
+            #define FXAA_QUALITY_PS 6
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 4.0
+            #define FXAA_QUALITY_P5 12.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 14)
+            #define FXAA_QUALITY_PS 7
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 4.0
+            #define FXAA_QUALITY_P6 12.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 15)
+            #define FXAA_QUALITY_PS 8
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 4.0
+            #define FXAA_QUALITY_P7 12.0
+        #endif
+
+        /*============================================================================
+                            FXAA QUALITY - LOW DITHER PRESETS
+        ============================================================================*/
+        #if (FXAA_QUALITY_PRESET == 20)
+            #define FXAA_QUALITY_PS 3
+            #define FXAA_QUALITY_P0 1.5
+            #define FXAA_QUALITY_P1 2.0
+            #define FXAA_QUALITY_P2 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 21)
+            #define FXAA_QUALITY_PS 4
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 22)
+            #define FXAA_QUALITY_PS 5
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 23)
+            #define FXAA_QUALITY_PS 6
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 24)
+            #define FXAA_QUALITY_PS 7
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 3.0
+            #define FXAA_QUALITY_P6 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 25)
+            #define FXAA_QUALITY_PS 8
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 4.0
+            #define FXAA_QUALITY_P7 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 26)
+            #define FXAA_QUALITY_PS 9
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 2.0
+            #define FXAA_QUALITY_P7 4.0
+            #define FXAA_QUALITY_P8 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 27)
+            #define FXAA_QUALITY_PS 10
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 2.0
+            #define FXAA_QUALITY_P7 2.0
+            #define FXAA_QUALITY_P8 4.0
+            #define FXAA_QUALITY_P9 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 28)
+            #define FXAA_QUALITY_PS 11
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 2.0
+            #define FXAA_QUALITY_P7 2.0
+            #define FXAA_QUALITY_P8 2.0
+            #define FXAA_QUALITY_P9 4.0
+            #define FXAA_QUALITY_P10 8.0
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PRESET == 29)
+            #define FXAA_QUALITY_PS 12
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.5
+            #define FXAA_QUALITY_P2 2.0
+            #define FXAA_QUALITY_P3 2.0
+            #define FXAA_QUALITY_P4 2.0
+            #define FXAA_QUALITY_P5 2.0
+            #define FXAA_QUALITY_P6 2.0
+            #define FXAA_QUALITY_P7 2.0
+            #define FXAA_QUALITY_P8 2.0
+            #define FXAA_QUALITY_P9 2.0
+            #define FXAA_QUALITY_P10 4.0
+            #define FXAA_QUALITY_P11 8.0
+        #endif
+
+        /*============================================================================
+                            FXAA QUALITY - EXTREME QUALITY
+        ============================================================================*/
+        #if (FXAA_QUALITY_PRESET == 39)
+            #define FXAA_QUALITY_PS 12
+            #define FXAA_QUALITY_P0 1.0
+            #define FXAA_QUALITY_P1 1.0
+            #define FXAA_QUALITY_P2 1.0
+            #define FXAA_QUALITY_P3 1.0
+            #define FXAA_QUALITY_P4 1.0
+            #define FXAA_QUALITY_P5 1.5
+            #define FXAA_QUALITY_P6 2.0
+            #define FXAA_QUALITY_P7 2.0
+            #define FXAA_QUALITY_P8 2.0
+            #define FXAA_QUALITY_P9 2.0
+            #define FXAA_QUALITY_P10 4.0
+            #define FXAA_QUALITY_P11 8.0
+        #endif
+
+
+
+        /*============================================================================
+
+                                        API PORTING
+
+        ============================================================================*/
+        #if (FXAA_GLSL_100 == 1) || (FXAA_GLSL_120 == 1) || (FXAA_GLSL_130 == 1)
+            #define FxaaBool bool
+            #define FxaaDiscard discard
+            #define FxaaFloat float
+            #define FxaaFloat2 vec2
+            #define FxaaFloat3 vec3
+            #define FxaaFloat4 vec4
+            #define FxaaHalf float
+            #define FxaaHalf2 vec2
+            #define FxaaHalf3 vec3
+            #define FxaaHalf4 vec4
+            #define FxaaInt2 ivec2
+            #define FxaaSat(x) clamp(x, 0.0, 1.0)
+            #define FxaaTex sampler2D
         #else
-            FxaaFloat4 luma4A = FxaaTexGreen4(tex, posM);
-            FxaaFloat4 luma4B = FxaaTexOffGreen4(tex, posM, FxaaInt2(-1, -1));
+            #define FxaaBool bool
+            #define FxaaDiscard clip(-1)
+            #define FxaaFloat float
+            #define FxaaFloat2 float2
+            #define FxaaFloat3 float3
+            #define FxaaFloat4 float4
+            #define FxaaHalf half
+            #define FxaaHalf2 half2
+            #define FxaaHalf3 half3
+            #define FxaaHalf4 half4
+            #define FxaaSat(x) saturate(x)
         #endif
-        #if (FXAA_DISCARD == 1)
-            #define lumaM luma4A.w
-        #endif
-        #define lumaE luma4A.z
-        #define lumaS luma4A.x
-        #define lumaSE luma4A.y
-        #define lumaNW luma4B.w
-        #define lumaN luma4B.z
-        #define lumaW luma4B.x
-    #else
-        FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
-        #if (FXAA_GREEN_AS_LUMA == 0)
-            #define lumaM rgbyM.w
-        #else
-            #define lumaM rgbyM.y
-        #endif
+        /*--------------------------------------------------------------------------*/
         #if (FXAA_GLSL_100 == 1)
-          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0, 1.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 0.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0,-1.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 0.0), fxaaQualityRcpFrame.xy));
-        #else
-          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0, 1), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0,-1), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 0), fxaaQualityRcpFrame.xy));
+        #define FxaaTexTop(t, p) texture2D(t, p, 0.0)
+        #define FxaaTexOff(t, p, o, r) texture2D(t, p + (o * r), 0.0)
         #endif
-    #endif
-/*--------------------------------------------------------------------------*/
-    FxaaFloat maxSM = max(lumaS, lumaM);
-    FxaaFloat minSM = min(lumaS, lumaM);
-    FxaaFloat maxESM = max(lumaE, maxSM);
-    FxaaFloat minESM = min(lumaE, minSM);
-    FxaaFloat maxWN = max(lumaN, lumaW);
-    FxaaFloat minWN = min(lumaN, lumaW);
-    FxaaFloat rangeMax = max(maxWN, maxESM);
-    FxaaFloat rangeMin = min(minWN, minESM);
-    FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;
-    FxaaFloat range = rangeMax - rangeMin;
-    FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);
-    FxaaBool earlyExit = range < rangeMaxClamped;
-/*--------------------------------------------------------------------------*/
-    if(earlyExit)
-        #if (FXAA_DISCARD == 1)
-            FxaaDiscard;
-        #else
-            return rgbyM;
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_GLSL_120 == 1)
+            // Requires,
+            //  #version 120
+            // And at least,
+            //  #extension GL_EXT_gpu_shader4 : enable
+            //  (or set FXAA_FAST_PIXEL_OFFSET 1 to work like DX9)
+            #define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)
+            #if (FXAA_FAST_PIXEL_OFFSET == 1)
+                #define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)
+            #else
+                #define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)
+            #endif
+            #if (FXAA_GATHER4_ALPHA == 1)
+                // use #extension GL_ARB_gpu_shader5 : enable
+                #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+                #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+                #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+                #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+            #endif
         #endif
-/*--------------------------------------------------------------------------*/
-    #if (FXAA_GATHER4_ALPHA == 0)
-        #if (FXAA_GLSL_100 == 1)
-          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0,-1.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 1.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0,-1.0), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 1.0), fxaaQualityRcpFrame.xy));
-        #else
-          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1,-1), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 1), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1,-1), fxaaQualityRcpFrame.xy));
-          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_GLSL_130 == 1)
+            // Requires "#version 130" or better
+            #define FxaaTexTop(t, p) textureLod(t, p, 0.0)
+            #define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
+            #if (FXAA_GATHER4_ALPHA == 1)
+                // use #extension GL_ARB_gpu_shader5 : enable
+                #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+                #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+                #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+                #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+            #endif
         #endif
-    #else
-        FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy));
-        FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
-    #endif
-/*--------------------------------------------------------------------------*/
-    FxaaFloat lumaNS = lumaN + lumaS;
-    FxaaFloat lumaWE = lumaW + lumaE;
-    FxaaFloat subpixRcpRange = 1.0/range;
-    FxaaFloat subpixNSWE = lumaNS + lumaWE;
-    FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;
-    FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat lumaNESE = lumaNE + lumaSE;
-    FxaaFloat lumaNWNE = lumaNW + lumaNE;
-    FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;
-    FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat lumaNWSW = lumaNW + lumaSW;
-    FxaaFloat lumaSWSE = lumaSW + lumaSE;
-    FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);
-    FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);
-    FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;
-    FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;
-    FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;
-    FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;
-    FxaaFloat lengthSign = fxaaQualityRcpFrame.x;
-    FxaaBool horzSpan = edgeHorz >= edgeVert;
-    FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;
-/*--------------------------------------------------------------------------*/
-    if(!horzSpan) lumaN = lumaW;
-    if(!horzSpan) lumaS = lumaE;
-    if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;
-    FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat gradientN = lumaN - lumaM;
-    FxaaFloat gradientS = lumaS - lumaM;
-    FxaaFloat lumaNN = lumaN + lumaM;
-    FxaaFloat lumaSS = lumaS + lumaM;
-    FxaaBool pairN = abs(gradientN) >= abs(gradientS);
-    FxaaFloat gradient = max(abs(gradientN), abs(gradientS));
-    if(pairN) lengthSign = -lengthSign;
-    FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);
-/*--------------------------------------------------------------------------*/
-    FxaaFloat2 posB;
-    posB.x = posM.x;
-    posB.y = posM.y;
-    FxaaFloat2 offNP;
-    offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;
-    offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;
-    if(!horzSpan) posB.x += lengthSign * 0.5;
-    if( horzSpan) posB.y += lengthSign * 0.5;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat2 posN;
-    posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;
-    posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;
-    FxaaFloat2 posP;
-    posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;
-    posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;
-    FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;
-    FxaaFloat lumaEndN = FxaaLuma(FxaaTexTop(tex, posN));
-    FxaaFloat subpixE = subpixC * subpixC;
-    FxaaFloat lumaEndP = FxaaLuma(FxaaTexTop(tex, posP));
-/*--------------------------------------------------------------------------*/
-    if(!pairN) lumaNN = lumaSS;
-    FxaaFloat gradientScaled = gradient * 1.0/4.0;
-    FxaaFloat lumaMM = lumaM - lumaNN * 0.5;
-    FxaaFloat subpixF = subpixD * subpixE;
-    FxaaBool lumaMLTZero = lumaMM < 0.0;
-/*--------------------------------------------------------------------------*/
-    lumaEndN -= lumaNN * 0.5;
-    lumaEndP -= lumaNN * 0.5;
-    FxaaBool doneN = abs(lumaEndN) >= gradientScaled;
-    FxaaBool doneP = abs(lumaEndP) >= gradientScaled;
-    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;
-    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;
-    FxaaBool doneNP = (!doneN) || (!doneP);
-    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;
-    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;
-/*--------------------------------------------------------------------------*/
-    if(doneNP) {
-        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
-        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
-        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
-        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
-        doneN = abs(lumaEndN) >= gradientScaled;
-        doneP = abs(lumaEndP) >= gradientScaled;
-        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;
-        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;
-        doneNP = (!doneN) || (!doneP);
-        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;
-        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;
-/*--------------------------------------------------------------------------*/
-        #if (FXAA_QUALITY_PS > 3)
-        if(doneNP) {
-            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
-            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
-            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
-            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
-            doneN = abs(lumaEndN) >= gradientScaled;
-            doneP = abs(lumaEndP) >= gradientScaled;
-            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;
-            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;
-            doneNP = (!doneN) || (!doneP);
-            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;
-            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;
-/*--------------------------------------------------------------------------*/
-            #if (FXAA_QUALITY_PS > 4)
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_HLSL_3 == 1)
+            #define FxaaInt2 float2
+            #define FxaaTex sampler2D
+            #define FxaaTexTop(t, p) tex2Dlod(t, float4(p, 0.0, 0.0))
+            #define FxaaTexOff(t, p, o, r) tex2Dlod(t, float4(p + (o * r), 0, 0))
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_HLSL_4 == 1)
+            #define FxaaInt2 int2
+            struct FxaaTex { SamplerState smpl; Texture2D tex; };
+            #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
+            #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
+        #endif
+        /*--------------------------------------------------------------------------*/
+        #if (FXAA_HLSL_5 == 1)
+            #define FxaaInt2 int2
+            struct FxaaTex { SamplerState smpl; Texture2D tex; };
+            #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
+            #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
+            #define FxaaTexAlpha4(t, p) t.tex.GatherAlpha(t.smpl, p)
+            #define FxaaTexOffAlpha4(t, p, o) t.tex.GatherAlpha(t.smpl, p, o)
+            #define FxaaTexGreen4(t, p) t.tex.GatherGreen(t.smpl, p)
+            #define FxaaTexOffGreen4(t, p, o) t.tex.GatherGreen(t.smpl, p, o)
+        #endif
+
+
+        /*============================================================================
+                        GREEN AS LUMA OPTION SUPPORT FUNCTION
+        ============================================================================*/
+        #if (FXAA_GREEN_AS_LUMA == 0)
+            FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.w; }
+        #else
+            FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.y; }
+        #endif
+
+
+
+
+        /*============================================================================
+
+                                    FXAA3 QUALITY - PC
+
+        ============================================================================*/
+        #if (FXAA_PC == 1)
+        /*--------------------------------------------------------------------------*/
+        FxaaFloat4 FxaaPixelShader(
+            //
+            // Use noperspective interpolation here (turn off perspective interpolation).
+            // {xy} = center of pixel
+            FxaaFloat2 pos,
+            //
+            // Used only for FXAA Console, and not used on the 360 version.
+            // Use noperspective interpolation here (turn off perspective interpolation).
+            // {xy_} = upper left of pixel
+            // {_zw} = lower right of pixel
+            FxaaFloat4 fxaaConsolePosPos,
+            //
+            // Input color texture.
+            // {rgb_} = color in linear or perceptual color space
+            // if (FXAA_GREEN_AS_LUMA == 0)
+            //     {__a} = luma in perceptual color space (not linear)
+            FxaaTex tex,
+            //
+            // Only used on the optimized 360 version of FXAA Console.
+            // For everything but 360, just use the same input here as for "tex".
+            // For 360, same texture, just alias with a 2nd sampler.
+            // This sampler needs to have an exponent bias of -1.
+            FxaaTex fxaaConsole360TexExpBiasNegOne,
+            //
+            // Only used on the optimized 360 version of FXAA Console.
+            // For everything but 360, just use the same input here as for "tex".
+            // For 360, same texture, just alias with a 3nd sampler.
+            // This sampler needs to have an exponent bias of -2.
+            FxaaTex fxaaConsole360TexExpBiasNegTwo,
+            //
+            // Only used on FXAA Quality.
+            // This must be from a constant/uniform.
+            // {x_} = 1.0/screenWidthInPixels
+            // {_y} = 1.0/screenHeightInPixels
+            FxaaFloat2 fxaaQualityRcpFrame,
+            //
+            // Only used on FXAA Console.
+            // This must be from a constant/uniform.
+            // This effects sub-pixel AA quality and inversely sharpness.
+            //   Where N ranges between,
+            //     N = 0.50 (default)
+            //     N = 0.33 (sharper)
+            // {x__} = -N/screenWidthInPixels
+            // {_y_} = -N/screenHeightInPixels
+            // {_z_} =  N/screenWidthInPixels
+            // {__w} =  N/screenHeightInPixels
+            FxaaFloat4 fxaaConsoleRcpFrameOpt,
+            //
+            // Only used on FXAA Console.
+            // Not used on 360, but used on PS3 and PC.
+            // This must be from a constant/uniform.
+            // {x__} = -2.0/screenWidthInPixels
+            // {_y_} = -2.0/screenHeightInPixels
+            // {_z_} =  2.0/screenWidthInPixels
+            // {__w} =  2.0/screenHeightInPixels
+            FxaaFloat4 fxaaConsoleRcpFrameOpt2,
+            //
+            // Only used on FXAA Console.
+            // Only used on 360 in place of fxaaConsoleRcpFrameOpt2.
+            // This must be from a constant/uniform.
+            // {x__} =  8.0/screenWidthInPixels
+            // {_y_} =  8.0/screenHeightInPixels
+            // {_z_} = -4.0/screenWidthInPixels
+            // {__w} = -4.0/screenHeightInPixels
+            FxaaFloat4 fxaaConsole360RcpFrameOpt2,
+            //
+            // Only used on FXAA Quality.
+            // This used to be the FXAA_QUALITY_SUBPIX define.
+            // It is here now to allow easier tuning.
+            // Choose the amount of sub-pixel aliasing removal.
+            // This can effect sharpness.
+            //   1.00 - upper limit (softer)
+            //   0.75 - default amount of filtering
+            //   0.50 - lower limit (sharper, less sub-pixel aliasing removal)
+            //   0.25 - almost off
+            //   0.00 - completely off
+            FxaaFloat fxaaQualitySubpix,
+            //
+            // Only used on FXAA Quality.
+            // This used to be the FXAA_QUALITY_EDGE_THRESHOLD define.
+            // It is here now to allow easier tuning.
+            // The minimum amount of local contrast required to apply algorithm.
+            //   0.333 - too little (faster)
+            //   0.250 - low quality
+            //   0.166 - default
+            //   0.125 - high quality
+            //   0.063 - overkill (slower)
+            FxaaFloat fxaaQualityEdgeThreshold,
+            //
+            // Only used on FXAA Quality.
+            // This used to be the FXAA_QUALITY_EDGE_THRESHOLD_MIN define.
+            // It is here now to allow easier tuning.
+            // Trims the algorithm from processing darks.
+            //   0.0833 - upper limit (default, the start of visible unfiltered edges)
+            //   0.0625 - high quality (faster)
+            //   0.0312 - visible limit (slower)
+            // Special notes when using FXAA_GREEN_AS_LUMA,
+            //   Likely want to set this to zero.
+            //   As colors that are mostly not-green
+            //   will appear very dark in the green channel!
+            //   Tune by looking at mostly non-green content,
+            //   then start at zero and increase until aliasing is a problem.
+            FxaaFloat fxaaQualityEdgeThresholdMin,
+            //
+            // Only used on FXAA Console.
+            // This used to be the FXAA_CONSOLE_EDGE_SHARPNESS define.
+            // It is here now to allow easier tuning.
+            // This does not effect PS3, as this needs to be compiled in.
+            //   Use FXAA_CONSOLE_PS3_EDGE_SHARPNESS for PS3.
+            //   Due to the PS3 being ALU bound,
+            //   there are only three safe values here: 2 and 4 and 8.
+            //   These options use the shaders ability to a free *|/ by 2|4|8.
+            // For all other platforms can be a non-power of two.
+            //   8.0 is sharper (default!!!)
+            //   4.0 is softer
+            //   2.0 is really soft (good only for vector graphics inputs)
+            FxaaFloat fxaaConsoleEdgeSharpness,
+            //
+            // Only used on FXAA Console.
+            // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD define.
+            // It is here now to allow easier tuning.
+            // This does not effect PS3, as this needs to be compiled in.
+            //   Use FXAA_CONSOLE_PS3_EDGE_THRESHOLD for PS3.
+            //   Due to the PS3 being ALU bound,
+            //   there are only two safe values here: 1/4 and 1/8.
+            //   These options use the shaders ability to a free *|/ by 2|4|8.
+            // The console setting has a different mapping than the quality setting.
+            // Other platforms can use other values.
+            //   0.125 leaves less aliasing, but is softer (default!!!)
+            //   0.25 leaves more aliasing, and is sharper
+            FxaaFloat fxaaConsoleEdgeThreshold,
+            //
+            // Only used on FXAA Console.
+            // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD_MIN define.
+            // It is here now to allow easier tuning.
+            // Trims the algorithm from processing darks.
+            // The console setting has a different mapping than the quality setting.
+            // This only applies when FXAA_EARLY_EXIT is 1.
+            // This does not apply to PS3,
+            // PS3 was simplified to avoid more shader instructions.
+            //   0.06 - faster but more aliasing in darks
+            //   0.05 - default
+            //   0.04 - slower and less aliasing in darks
+            // Special notes when using FXAA_GREEN_AS_LUMA,
+            //   Likely want to set this to zero.
+            //   As colors that are mostly not-green
+            //   will appear very dark in the green channel!
+            //   Tune by looking at mostly non-green content,
+            //   then start at zero and increase until aliasing is a problem.
+            FxaaFloat fxaaConsoleEdgeThresholdMin,
+            //
+            // Extra constants for 360 FXAA Console only.
+            // Use zeros or anything else for other platforms.
+            // These must be in physical constant registers and NOT immediates.
+            // Immediates will result in compiler un-optimizing.
+            // {xyzw} = float4(1.0, -1.0, 0.25, -0.25)
+            FxaaFloat4 fxaaConsole360ConstDir
+        ) {
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat2 posM;
+            posM.x = pos.x;
+            posM.y = pos.y;
+            #if (FXAA_GATHER4_ALPHA == 1)
+                #if (FXAA_DISCARD == 0)
+                    FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+                    #if (FXAA_GREEN_AS_LUMA == 0)
+                        #define lumaM rgbyM.w
+                    #else
+                        #define lumaM rgbyM.y
+                    #endif
+                #endif
+                #if (FXAA_GREEN_AS_LUMA == 0)
+                    FxaaFloat4 luma4A = FxaaTexAlpha4(tex, posM);
+                    FxaaFloat4 luma4B = FxaaTexOffAlpha4(tex, posM, FxaaInt2(-1, -1));
+                #else
+                    FxaaFloat4 luma4A = FxaaTexGreen4(tex, posM);
+                    FxaaFloat4 luma4B = FxaaTexOffGreen4(tex, posM, FxaaInt2(-1, -1));
+                #endif
+                #if (FXAA_DISCARD == 1)
+                    #define lumaM luma4A.w
+                #endif
+                #define lumaE luma4A.z
+                #define lumaS luma4A.x
+                #define lumaSE luma4A.y
+                #define lumaNW luma4B.w
+                #define lumaN luma4B.z
+                #define lumaW luma4B.x
+            #else
+                FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+                #if (FXAA_GREEN_AS_LUMA == 0)
+                    #define lumaM rgbyM.w
+                #else
+                    #define lumaM rgbyM.y
+                #endif
+                #if (FXAA_GLSL_100 == 1)
+                FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0, 1.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 0.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0,-1.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 0.0), fxaaQualityRcpFrame.xy));
+                #else
+                FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0, 1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0,-1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 0), fxaaQualityRcpFrame.xy));
+                #endif
+            #endif
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat maxSM = max(lumaS, lumaM);
+            FxaaFloat minSM = min(lumaS, lumaM);
+            FxaaFloat maxESM = max(lumaE, maxSM);
+            FxaaFloat minESM = min(lumaE, minSM);
+            FxaaFloat maxWN = max(lumaN, lumaW);
+            FxaaFloat minWN = min(lumaN, lumaW);
+            FxaaFloat rangeMax = max(maxWN, maxESM);
+            FxaaFloat rangeMin = min(minWN, minESM);
+            FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;
+            FxaaFloat range = rangeMax - rangeMin;
+            FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);
+            FxaaBool earlyExit = range < rangeMaxClamped;
+        /*--------------------------------------------------------------------------*/
+            if(earlyExit)
+                #if (FXAA_DISCARD == 1)
+                    FxaaDiscard;
+                #else
+                    return rgbyM;
+                #endif
+        /*--------------------------------------------------------------------------*/
+            #if (FXAA_GATHER4_ALPHA == 0)
+                #if (FXAA_GLSL_100 == 1)
+                FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0,-1.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 1.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0,-1.0), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 1.0), fxaaQualityRcpFrame.xy));
+                #else
+                FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1,-1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1,-1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+                #endif
+            #else
+                FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy));
+                FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+            #endif
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat lumaNS = lumaN + lumaS;
+            FxaaFloat lumaWE = lumaW + lumaE;
+            FxaaFloat subpixRcpRange = 1.0/range;
+            FxaaFloat subpixNSWE = lumaNS + lumaWE;
+            FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;
+            FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat lumaNESE = lumaNE + lumaSE;
+            FxaaFloat lumaNWNE = lumaNW + lumaNE;
+            FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;
+            FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat lumaNWSW = lumaNW + lumaSW;
+            FxaaFloat lumaSWSE = lumaSW + lumaSE;
+            FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);
+            FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);
+            FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;
+            FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;
+            FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;
+            FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;
+            FxaaFloat lengthSign = fxaaQualityRcpFrame.x;
+            FxaaBool horzSpan = edgeHorz >= edgeVert;
+            FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;
+        /*--------------------------------------------------------------------------*/
+            if(!horzSpan) lumaN = lumaW;
+            if(!horzSpan) lumaS = lumaE;
+            if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;
+            FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat gradientN = lumaN - lumaM;
+            FxaaFloat gradientS = lumaS - lumaM;
+            FxaaFloat lumaNN = lumaN + lumaM;
+            FxaaFloat lumaSS = lumaS + lumaM;
+            FxaaBool pairN = abs(gradientN) >= abs(gradientS);
+            FxaaFloat gradient = max(abs(gradientN), abs(gradientS));
+            if(pairN) lengthSign = -lengthSign;
+            FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat2 posB;
+            posB.x = posM.x;
+            posB.y = posM.y;
+            FxaaFloat2 offNP;
+            offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;
+            offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;
+            if(!horzSpan) posB.x += lengthSign * 0.5;
+            if( horzSpan) posB.y += lengthSign * 0.5;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat2 posN;
+            posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;
+            posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;
+            FxaaFloat2 posP;
+            posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;
+            posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;
+            FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;
+            FxaaFloat lumaEndN = FxaaLuma(FxaaTexTop(tex, posN));
+            FxaaFloat subpixE = subpixC * subpixC;
+            FxaaFloat lumaEndP = FxaaLuma(FxaaTexTop(tex, posP));
+        /*--------------------------------------------------------------------------*/
+            if(!pairN) lumaNN = lumaSS;
+            FxaaFloat gradientScaled = gradient * 1.0/4.0;
+            FxaaFloat lumaMM = lumaM - lumaNN * 0.5;
+            FxaaFloat subpixF = subpixD * subpixE;
+            FxaaBool lumaMLTZero = lumaMM < 0.0;
+        /*--------------------------------------------------------------------------*/
+            lumaEndN -= lumaNN * 0.5;
+            lumaEndP -= lumaNN * 0.5;
+            FxaaBool doneN = abs(lumaEndN) >= gradientScaled;
+            FxaaBool doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;
+            FxaaBool doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;
+        /*--------------------------------------------------------------------------*/
             if(doneNP) {
                 if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                 if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -905,13 +877,13 @@ FxaaFloat4 FxaaPixelShader(
                 if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                 doneN = abs(lumaEndN) >= gradientScaled;
                 doneP = abs(lumaEndP) >= gradientScaled;
-                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;
-                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;
                 doneNP = (!doneN) || (!doneP);
-                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;
-                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;
-/*--------------------------------------------------------------------------*/
-                #if (FXAA_QUALITY_PS > 5)
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;
+        /*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 3)
                 if(doneNP) {
                     if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                     if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -919,13 +891,13 @@ FxaaFloat4 FxaaPixelShader(
                     if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                     doneN = abs(lumaEndN) >= gradientScaled;
                     doneP = abs(lumaEndP) >= gradientScaled;
-                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;
-                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;
                     doneNP = (!doneN) || (!doneP);
-                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;
-                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;
-/*--------------------------------------------------------------------------*/
-                    #if (FXAA_QUALITY_PS > 6)
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;
+        /*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 4)
                     if(doneNP) {
                         if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                         if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -933,13 +905,13 @@ FxaaFloat4 FxaaPixelShader(
                         if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                         doneN = abs(lumaEndN) >= gradientScaled;
                         doneP = abs(lumaEndP) >= gradientScaled;
-                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;
-                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;
                         doneNP = (!doneN) || (!doneP);
-                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;
-                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;
-/*--------------------------------------------------------------------------*/
-                        #if (FXAA_QUALITY_PS > 7)
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;
+        /*--------------------------------------------------------------------------*/
+                        #if (FXAA_QUALITY_PS > 5)
                         if(doneNP) {
                             if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                             if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -947,41 +919,41 @@ FxaaFloat4 FxaaPixelShader(
                             if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                             doneN = abs(lumaEndN) >= gradientScaled;
                             doneP = abs(lumaEndP) >= gradientScaled;
-                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;
-                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;
+                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;
+                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;
                             doneNP = (!doneN) || (!doneP);
-                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;
-                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;
-/*--------------------------------------------------------------------------*/
-    #if (FXAA_QUALITY_PS > 8)
-    if(doneNP) {
-        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
-        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
-        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
-        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
-        doneN = abs(lumaEndN) >= gradientScaled;
-        doneP = abs(lumaEndP) >= gradientScaled;
-        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;
-        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;
-        doneNP = (!doneN) || (!doneP);
-        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;
-        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;
-/*--------------------------------------------------------------------------*/
-        #if (FXAA_QUALITY_PS > 9)
-        if(doneNP) {
-            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
-            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
-            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
-            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
-            doneN = abs(lumaEndN) >= gradientScaled;
-            doneP = abs(lumaEndP) >= gradientScaled;
-            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;
-            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;
-            doneNP = (!doneN) || (!doneP);
-            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;
-            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;
-/*--------------------------------------------------------------------------*/
-            #if (FXAA_QUALITY_PS > 10)
+                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;
+                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;
+        /*--------------------------------------------------------------------------*/
+                            #if (FXAA_QUALITY_PS > 6)
+                            if(doneNP) {
+                                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                                doneN = abs(lumaEndN) >= gradientScaled;
+                                doneP = abs(lumaEndP) >= gradientScaled;
+                                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;
+                                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;
+                                doneNP = (!doneN) || (!doneP);
+                                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;
+                                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;
+        /*--------------------------------------------------------------------------*/
+                                #if (FXAA_QUALITY_PS > 7)
+                                if(doneNP) {
+                                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                                    doneN = abs(lumaEndN) >= gradientScaled;
+                                    doneP = abs(lumaEndP) >= gradientScaled;
+                                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;
+                                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;
+                                    doneNP = (!doneN) || (!doneP);
+                                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;
+                                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;
+        /*--------------------------------------------------------------------------*/
+            #if (FXAA_QUALITY_PS > 8)
             if(doneNP) {
                 if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                 if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -989,13 +961,13 @@ FxaaFloat4 FxaaPixelShader(
                 if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                 doneN = abs(lumaEndN) >= gradientScaled;
                 doneP = abs(lumaEndP) >= gradientScaled;
-                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;
-                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;
                 doneNP = (!doneN) || (!doneP);
-                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;
-                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;
-/*--------------------------------------------------------------------------*/
-                #if (FXAA_QUALITY_PS > 11)
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;
+        /*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 9)
                 if(doneNP) {
                     if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                     if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -1003,13 +975,13 @@ FxaaFloat4 FxaaPixelShader(
                     if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                     doneN = abs(lumaEndN) >= gradientScaled;
                     doneP = abs(lumaEndP) >= gradientScaled;
-                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;
-                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;
                     doneNP = (!doneN) || (!doneP);
-                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;
-                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;
-/*--------------------------------------------------------------------------*/
-                    #if (FXAA_QUALITY_PS > 12)
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;
+        /*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 10)
                     if(doneNP) {
                         if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
                         if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
@@ -1017,97 +989,124 @@ FxaaFloat4 FxaaPixelShader(
                         if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
                         doneN = abs(lumaEndN) >= gradientScaled;
                         doneP = abs(lumaEndP) >= gradientScaled;
-                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;
-                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;
                         doneNP = (!doneN) || (!doneP);
-                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;
-                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;
-/*--------------------------------------------------------------------------*/
-                    }
-                    #endif
-/*--------------------------------------------------------------------------*/
-                }
-                #endif
-/*--------------------------------------------------------------------------*/
-            }
-            #endif
-/*--------------------------------------------------------------------------*/
-        }
-        #endif
-/*--------------------------------------------------------------------------*/
-    }
-    #endif
-/*--------------------------------------------------------------------------*/
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;
+        /*--------------------------------------------------------------------------*/
+                        #if (FXAA_QUALITY_PS > 11)
+                        if(doneNP) {
+                            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                            doneN = abs(lumaEndN) >= gradientScaled;
+                            doneP = abs(lumaEndP) >= gradientScaled;
+                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;
+                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;
+                            doneNP = (!doneN) || (!doneP);
+                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;
+                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;
+        /*--------------------------------------------------------------------------*/
+                            #if (FXAA_QUALITY_PS > 12)
+                            if(doneNP) {
+                                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                                doneN = abs(lumaEndN) >= gradientScaled;
+                                doneP = abs(lumaEndP) >= gradientScaled;
+                                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;
+                                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;
+                                doneNP = (!doneN) || (!doneP);
+                                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;
+                                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;
+        /*--------------------------------------------------------------------------*/
+                            }
+                            #endif
+        /*--------------------------------------------------------------------------*/
                         }
                         #endif
-/*--------------------------------------------------------------------------*/
+        /*--------------------------------------------------------------------------*/
                     }
                     #endif
-/*--------------------------------------------------------------------------*/
+        /*--------------------------------------------------------------------------*/
                 }
                 #endif
-/*--------------------------------------------------------------------------*/
+        /*--------------------------------------------------------------------------*/
             }
             #endif
-/*--------------------------------------------------------------------------*/
+        /*--------------------------------------------------------------------------*/
+                                }
+                                #endif
+        /*--------------------------------------------------------------------------*/
+                            }
+                            #endif
+        /*--------------------------------------------------------------------------*/
+                        }
+                        #endif
+        /*--------------------------------------------------------------------------*/
+                    }
+                    #endif
+        /*--------------------------------------------------------------------------*/
+                }
+                #endif
+        /*--------------------------------------------------------------------------*/
+            }
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat dstN = posM.x - posN.x;
+            FxaaFloat dstP = posP.x - posM.x;
+            if(!horzSpan) dstN = posM.y - posN.y;
+            if(!horzSpan) dstP = posP.y - posM.y;
+        /*--------------------------------------------------------------------------*/
+            FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;
+            FxaaFloat spanLength = (dstP + dstN);
+            FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;
+            FxaaFloat spanLengthRcp = 1.0/spanLength;
+        /*--------------------------------------------------------------------------*/
+            FxaaBool directionN = dstN < dstP;
+            FxaaFloat dst = min(dstN, dstP);
+            FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;
+            FxaaFloat subpixG = subpixF * subpixF;
+            FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;
+            FxaaFloat subpixH = subpixG * fxaaQualitySubpix;
+        /*--------------------------------------------------------------------------*/
+            FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
+            FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
+            if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;
+            if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;
+            #if (FXAA_DISCARD == 1)
+                return FxaaTexTop(tex, posM);
+            #else
+                return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);
+            #endif
         }
+        /*==========================================================================*/
         #endif
-/*--------------------------------------------------------------------------*/
-    }
-/*--------------------------------------------------------------------------*/
-    FxaaFloat dstN = posM.x - posN.x;
-    FxaaFloat dstP = posP.x - posM.x;
-    if(!horzSpan) dstN = posM.y - posN.y;
-    if(!horzSpan) dstP = posP.y - posM.y;
-/*--------------------------------------------------------------------------*/
-    FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;
-    FxaaFloat spanLength = (dstP + dstN);
-    FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;
-    FxaaFloat spanLengthRcp = 1.0/spanLength;
-/*--------------------------------------------------------------------------*/
-    FxaaBool directionN = dstN < dstP;
-    FxaaFloat dst = min(dstN, dstP);
-    FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;
-    FxaaFloat subpixG = subpixF * subpixF;
-    FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;
-    FxaaFloat subpixH = subpixG * fxaaQualitySubpix;
-/*--------------------------------------------------------------------------*/
-    FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
-    FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
-    if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;
-    if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;
-    #if (FXAA_DISCARD == 1)
-        return FxaaTexTop(tex, posM);
-    #else
-        return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);
-    #endif
-}
-/*==========================================================================*/
-#endif
 
-void main() {
-  gl_FragColor = FxaaPixelShader(
-    vUv,
-    vec4(0.0),
-    tDiffuse,
-    tDiffuse,
-    tDiffuse,
-    resolution,
-    vec4(0.0),
-    vec4(0.0),
-    vec4(0.0),
-    0.75,
-    0.166,
-    0.0833,
-    0.0,
-    0.0,
-    0.0,
-    vec4(0.0)
-  );
+        void main() {
+        gl_FragColor = FxaaPixelShader(
+            vUv,
+            vec4(0.0),
+            tDiffuse,
+            tDiffuse,
+            tDiffuse,
+            resolution,
+            vec4(0.0),
+            vec4(0.0),
+            vec4(0.0),
+            0.75,
+            0.166,
+            0.0833,
+            0.0,
+            0.0,
+            0.0,
+            vec4(0.0)
+        );
 
-  // TODO avoid querying texture twice for same texel
-  gl_FragColor.a = texture2D(tDiffuse, vUv).a;
-}
-`
-
+        // TODO avoid querying texture twice for same texel
+        gl_FragColor.a = texture2D(tDiffuse, vUv).a;
+        }
+    `
 };

--- a/examples/js/shaders/FXAAShader.js
+++ b/examples/js/shaders/FXAAShader.js
@@ -17,1099 +17,1097 @@ THREE.FXAAShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+precision highp float;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
-		"precision highp float;",
-		"",
-		"uniform sampler2D tDiffuse;",
-		"",
-		"uniform vec2 resolution;",
-		"",
-		"varying vec2 vUv;",
-		"",
-		"// FXAA 3.11 implementation by NVIDIA, ported to WebGL by Agost Biro (biro@archilogic.com)",
-		"",
-		"//----------------------------------------------------------------------------------",
-		"// File:        es3-kepler\FXAA\assets\shaders/FXAA_DefaultES.frag",
-		"// SDK Version: v3.00",
-		"// Email:       gameworks@nvidia.com",
-		"// Site:        http://developer.nvidia.com/",
-		"//",
-		"// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.",
-		"//",
-		"// Redistribution and use in source and binary forms, with or without",
-		"// modification, are permitted provided that the following conditions",
-		"// are met:",
-		"//  * Redistributions of source code must retain the above copyright",
-		"//    notice, this list of conditions and the following disclaimer.",
-		"//  * Redistributions in binary form must reproduce the above copyright",
-		"//    notice, this list of conditions and the following disclaimer in the",
-		"//    documentation and/or other materials provided with the distribution.",
-		"//  * Neither the name of NVIDIA CORPORATION nor the names of its",
-		"//    contributors may be used to endorse or promote products derived",
-		"//    from this software without specific prior written permission.",
-		"//",
-		"// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY",
-		"// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE",
-		"// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR",
-		"// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR",
-		"// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,",
-		"// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,",
-		"// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR",
-		"// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY",
-		"// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT",
-		"// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE",
-		"// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
-		"//",
-		"//----------------------------------------------------------------------------------",
-		"",
-		"#define FXAA_PC 1",
-		"#define FXAA_GLSL_100 1",
-		"#define FXAA_QUALITY_PRESET 12",
-		"",
-		"#define FXAA_GREEN_AS_LUMA 1",
-		"",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_PC_CONSOLE",
-		"    //",
-		"    // The console algorithm for PC is included",
-		"    // for developers targeting really low spec machines.",
-		"    // Likely better to just run FXAA_PC, and use a really low preset.",
-		"    //",
-		"    #define FXAA_PC_CONSOLE 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_GLSL_120",
-		"    #define FXAA_GLSL_120 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_GLSL_130",
-		"    #define FXAA_GLSL_130 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_HLSL_3",
-		"    #define FXAA_HLSL_3 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_HLSL_4",
-		"    #define FXAA_HLSL_4 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_HLSL_5",
-		"    #define FXAA_HLSL_5 0",
-		"#endif",
-		"/*==========================================================================*/",
-		"#ifndef FXAA_GREEN_AS_LUMA",
-		"    //",
-		"    // For those using non-linear color,",
-		"    // and either not able to get luma in alpha, or not wanting to,",
-		"    // this enables FXAA to run using green as a proxy for luma.",
-		"    // So with this enabled, no need to pack luma in alpha.",
-		"    //",
-		"    // This will turn off AA on anything which lacks some amount of green.",
-		"    // Pure red and blue or combination of only R and B, will get no AA.",
-		"    //",
-		"    // Might want to lower the settings for both,",
-		"    //    fxaaConsoleEdgeThresholdMin",
-		"    //    fxaaQualityEdgeThresholdMin",
-		"    // In order to insure AA does not get turned off on colors",
-		"    // which contain a minor amount of green.",
-		"    //",
-		"    // 1 = On.",
-		"    // 0 = Off.",
-		"    //",
-		"    #define FXAA_GREEN_AS_LUMA 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_EARLY_EXIT",
-		"    //",
-		"    // Controls algorithm's early exit path.",
-		"    // On PS3 turning this ON adds 2 cycles to the shader.",
-		"    // On 360 turning this OFF adds 10ths of a millisecond to the shader.",
-		"    // Turning this off on console will result in a more blurry image.",
-		"    // So this defaults to on.",
-		"    //",
-		"    // 1 = On.",
-		"    // 0 = Off.",
-		"    //",
-		"    #define FXAA_EARLY_EXIT 1",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_DISCARD",
-		"    //",
-		"    // Only valid for PC OpenGL currently.",
-		"    // Probably will not work when FXAA_GREEN_AS_LUMA = 1.",
-		"    //",
-		"    // 1 = Use discard on pixels which don't need AA.",
-		"    //     For APIs which enable concurrent TEX+ROP from same surface.",
-		"    // 0 = Return unchanged color on pixels which don't need AA.",
-		"    //",
-		"    #define FXAA_DISCARD 0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_FAST_PIXEL_OFFSET",
-		"    //",
-		"    // Used for GLSL 120 only.",
-		"    //",
-		"    // 1 = GL API supports fast pixel offsets",
-		"    // 0 = do not use fast pixel offsets",
-		"    //",
-		"    #ifdef GL_EXT_gpu_shader4",
-		"        #define FXAA_FAST_PIXEL_OFFSET 1",
-		"    #endif",
-		"    #ifdef GL_NV_gpu_shader5",
-		"        #define FXAA_FAST_PIXEL_OFFSET 1",
-		"    #endif",
-		"    #ifdef GL_ARB_gpu_shader5",
-		"        #define FXAA_FAST_PIXEL_OFFSET 1",
-		"    #endif",
-		"    #ifndef FXAA_FAST_PIXEL_OFFSET",
-		"        #define FXAA_FAST_PIXEL_OFFSET 0",
-		"    #endif",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#ifndef FXAA_GATHER4_ALPHA",
-		"    //",
-		"    // 1 = API supports gather4 on alpha channel.",
-		"    // 0 = API does not support gather4 on alpha channel.",
-		"    //",
-		"    #if (FXAA_HLSL_5 == 1)",
-		"        #define FXAA_GATHER4_ALPHA 1",
-		"    #endif",
-		"    #ifdef GL_ARB_gpu_shader5",
-		"        #define FXAA_GATHER4_ALPHA 1",
-		"    #endif",
-		"    #ifdef GL_NV_gpu_shader5",
-		"        #define FXAA_GATHER4_ALPHA 1",
-		"    #endif",
-		"    #ifndef FXAA_GATHER4_ALPHA",
-		"        #define FXAA_GATHER4_ALPHA 0",
-		"    #endif",
-		"#endif",
-		"",
-		"",
-		"/*============================================================================",
-		"                        FXAA QUALITY - TUNING KNOBS",
-		"------------------------------------------------------------------------------",
-		"NOTE the other tuning knobs are now in the shader function inputs!",
-		"============================================================================*/",
-		"#ifndef FXAA_QUALITY_PRESET",
-		"    //",
-		"    // Choose the quality preset.",
-		"    // This needs to be compiled into the shader as it effects code.",
-		"    // Best option to include multiple presets is to",
-		"    // in each shader define the preset, then include this file.",
-		"    //",
-		"    // OPTIONS",
-		"    // -----------------------------------------------------------------------",
-		"    // 10 to 15 - default medium dither (10=fastest, 15=highest quality)",
-		"    // 20 to 29 - less dither, more expensive (20=fastest, 29=highest quality)",
-		"    // 39       - no dither, very expensive",
-		"    //",
-		"    // NOTES",
-		"    // -----------------------------------------------------------------------",
-		"    // 12 = slightly faster then FXAA 3.9 and higher edge quality (default)",
-		"    // 13 = about same speed as FXAA 3.9 and better than 12",
-		"    // 23 = closest to FXAA 3.9 visually and performance wise",
-		"    //  _ = the lowest digit is directly related to performance",
-		"    // _  = the highest digit is directly related to style",
-		"    //",
-		"    #define FXAA_QUALITY_PRESET 12",
-		"#endif",
-		"",
-		"",
-		"/*============================================================================",
-		"",
-		"                           FXAA QUALITY - PRESETS",
-		"",
-		"============================================================================*/",
-		"",
-		"/*============================================================================",
-		"                     FXAA QUALITY - MEDIUM DITHER PRESETS",
-		"============================================================================*/",
-		"#if (FXAA_QUALITY_PRESET == 10)",
-		"    #define FXAA_QUALITY_PS 3",
-		"    #define FXAA_QUALITY_P0 1.5",
-		"    #define FXAA_QUALITY_P1 3.0",
-		"    #define FXAA_QUALITY_P2 12.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 11)",
-		"    #define FXAA_QUALITY_PS 4",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 3.0",
-		"    #define FXAA_QUALITY_P3 12.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 12)",
-		"    #define FXAA_QUALITY_PS 5",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 4.0",
-		"    #define FXAA_QUALITY_P4 12.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 13)",
-		"    #define FXAA_QUALITY_PS 6",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 4.0",
-		"    #define FXAA_QUALITY_P5 12.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 14)",
-		"    #define FXAA_QUALITY_PS 7",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 4.0",
-		"    #define FXAA_QUALITY_P6 12.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 15)",
-		"    #define FXAA_QUALITY_PS 8",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 4.0",
-		"    #define FXAA_QUALITY_P7 12.0",
-		"#endif",
-		"",
-		"/*============================================================================",
-		"                     FXAA QUALITY - LOW DITHER PRESETS",
-		"============================================================================*/",
-		"#if (FXAA_QUALITY_PRESET == 20)",
-		"    #define FXAA_QUALITY_PS 3",
-		"    #define FXAA_QUALITY_P0 1.5",
-		"    #define FXAA_QUALITY_P1 2.0",
-		"    #define FXAA_QUALITY_P2 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 21)",
-		"    #define FXAA_QUALITY_PS 4",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 22)",
-		"    #define FXAA_QUALITY_PS 5",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 23)",
-		"    #define FXAA_QUALITY_PS 6",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 24)",
-		"    #define FXAA_QUALITY_PS 7",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 3.0",
-		"    #define FXAA_QUALITY_P6 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 25)",
-		"    #define FXAA_QUALITY_PS 8",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 4.0",
-		"    #define FXAA_QUALITY_P7 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 26)",
-		"    #define FXAA_QUALITY_PS 9",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 2.0",
-		"    #define FXAA_QUALITY_P7 4.0",
-		"    #define FXAA_QUALITY_P8 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 27)",
-		"    #define FXAA_QUALITY_PS 10",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 2.0",
-		"    #define FXAA_QUALITY_P7 2.0",
-		"    #define FXAA_QUALITY_P8 4.0",
-		"    #define FXAA_QUALITY_P9 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 28)",
-		"    #define FXAA_QUALITY_PS 11",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 2.0",
-		"    #define FXAA_QUALITY_P7 2.0",
-		"    #define FXAA_QUALITY_P8 2.0",
-		"    #define FXAA_QUALITY_P9 4.0",
-		"    #define FXAA_QUALITY_P10 8.0",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_QUALITY_PRESET == 29)",
-		"    #define FXAA_QUALITY_PS 12",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.5",
-		"    #define FXAA_QUALITY_P2 2.0",
-		"    #define FXAA_QUALITY_P3 2.0",
-		"    #define FXAA_QUALITY_P4 2.0",
-		"    #define FXAA_QUALITY_P5 2.0",
-		"    #define FXAA_QUALITY_P6 2.0",
-		"    #define FXAA_QUALITY_P7 2.0",
-		"    #define FXAA_QUALITY_P8 2.0",
-		"    #define FXAA_QUALITY_P9 2.0",
-		"    #define FXAA_QUALITY_P10 4.0",
-		"    #define FXAA_QUALITY_P11 8.0",
-		"#endif",
-		"",
-		"/*============================================================================",
-		"                     FXAA QUALITY - EXTREME QUALITY",
-		"============================================================================*/",
-		"#if (FXAA_QUALITY_PRESET == 39)",
-		"    #define FXAA_QUALITY_PS 12",
-		"    #define FXAA_QUALITY_P0 1.0",
-		"    #define FXAA_QUALITY_P1 1.0",
-		"    #define FXAA_QUALITY_P2 1.0",
-		"    #define FXAA_QUALITY_P3 1.0",
-		"    #define FXAA_QUALITY_P4 1.0",
-		"    #define FXAA_QUALITY_P5 1.5",
-		"    #define FXAA_QUALITY_P6 2.0",
-		"    #define FXAA_QUALITY_P7 2.0",
-		"    #define FXAA_QUALITY_P8 2.0",
-		"    #define FXAA_QUALITY_P9 2.0",
-		"    #define FXAA_QUALITY_P10 4.0",
-		"    #define FXAA_QUALITY_P11 8.0",
-		"#endif",
-		"",
-		"",
-		"",
-		"/*============================================================================",
-		"",
-		"                                API PORTING",
-		"",
-		"============================================================================*/",
-		"#if (FXAA_GLSL_100 == 1) || (FXAA_GLSL_120 == 1) || (FXAA_GLSL_130 == 1)",
-		"    #define FxaaBool bool",
-		"    #define FxaaDiscard discard",
-		"    #define FxaaFloat float",
-		"    #define FxaaFloat2 vec2",
-		"    #define FxaaFloat3 vec3",
-		"    #define FxaaFloat4 vec4",
-		"    #define FxaaHalf float",
-		"    #define FxaaHalf2 vec2",
-		"    #define FxaaHalf3 vec3",
-		"    #define FxaaHalf4 vec4",
-		"    #define FxaaInt2 ivec2",
-		"    #define FxaaSat(x) clamp(x, 0.0, 1.0)",
-		"    #define FxaaTex sampler2D",
-		"#else",
-		"    #define FxaaBool bool",
-		"    #define FxaaDiscard clip(-1)",
-		"    #define FxaaFloat float",
-		"    #define FxaaFloat2 float2",
-		"    #define FxaaFloat3 float3",
-		"    #define FxaaFloat4 float4",
-		"    #define FxaaHalf half",
-		"    #define FxaaHalf2 half2",
-		"    #define FxaaHalf3 half3",
-		"    #define FxaaHalf4 half4",
-		"    #define FxaaSat(x) saturate(x)",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_GLSL_100 == 1)",
-		"  #define FxaaTexTop(t, p) texture2D(t, p, 0.0)",
-		"  #define FxaaTexOff(t, p, o, r) texture2D(t, p + (o * r), 0.0)",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_GLSL_120 == 1)",
-		"    // Requires,",
-		"    //  #version 120",
-		"    // And at least,",
-		"    //  #extension GL_EXT_gpu_shader4 : enable",
-		"    //  (or set FXAA_FAST_PIXEL_OFFSET 1 to work like DX9)",
-		"    #define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)",
-		"    #if (FXAA_FAST_PIXEL_OFFSET == 1)",
-		"        #define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)",
-		"    #else",
-		"        #define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)",
-		"    #endif",
-		"    #if (FXAA_GATHER4_ALPHA == 1)",
-		"        // use #extension GL_ARB_gpu_shader5 : enable",
-		"        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)",
-		"        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)",
-		"        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)",
-		"        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)",
-		"    #endif",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_GLSL_130 == 1)",
-		"    // Requires \"#version 130\" or better",
-		"    #define FxaaTexTop(t, p) textureLod(t, p, 0.0)",
-		"    #define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)",
-		"    #if (FXAA_GATHER4_ALPHA == 1)",
-		"        // use #extension GL_ARB_gpu_shader5 : enable",
-		"        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)",
-		"        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)",
-		"        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)",
-		"        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)",
-		"    #endif",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_HLSL_3 == 1)",
-		"    #define FxaaInt2 float2",
-		"    #define FxaaTex sampler2D",
-		"    #define FxaaTexTop(t, p) tex2Dlod(t, float4(p, 0.0, 0.0))",
-		"    #define FxaaTexOff(t, p, o, r) tex2Dlod(t, float4(p + (o * r), 0, 0))",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_HLSL_4 == 1)",
-		"    #define FxaaInt2 int2",
-		"    struct FxaaTex { SamplerState smpl; Texture2D tex; };",
-		"    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)",
-		"    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)",
-		"#endif",
-		"/*--------------------------------------------------------------------------*/",
-		"#if (FXAA_HLSL_5 == 1)",
-		"    #define FxaaInt2 int2",
-		"    struct FxaaTex { SamplerState smpl; Texture2D tex; };",
-		"    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)",
-		"    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)",
-		"    #define FxaaTexAlpha4(t, p) t.tex.GatherAlpha(t.smpl, p)",
-		"    #define FxaaTexOffAlpha4(t, p, o) t.tex.GatherAlpha(t.smpl, p, o)",
-		"    #define FxaaTexGreen4(t, p) t.tex.GatherGreen(t.smpl, p)",
-		"    #define FxaaTexOffGreen4(t, p, o) t.tex.GatherGreen(t.smpl, p, o)",
-		"#endif",
-		"",
-		"",
-		"/*============================================================================",
-		"                   GREEN AS LUMA OPTION SUPPORT FUNCTION",
-		"============================================================================*/",
-		"#if (FXAA_GREEN_AS_LUMA == 0)",
-		"    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.w; }",
-		"#else",
-		"    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.y; }",
-		"#endif",
-		"",
-		"",
-		"",
-		"",
-		"/*============================================================================",
-		"",
-		"                             FXAA3 QUALITY - PC",
-		"",
-		"============================================================================*/",
-		"#if (FXAA_PC == 1)",
-		"/*--------------------------------------------------------------------------*/",
-		"FxaaFloat4 FxaaPixelShader(",
-		"    //",
-		"    // Use noperspective interpolation here (turn off perspective interpolation).",
-		"    // {xy} = center of pixel",
-		"    FxaaFloat2 pos,",
-		"    //",
-		"    // Used only for FXAA Console, and not used on the 360 version.",
-		"    // Use noperspective interpolation here (turn off perspective interpolation).",
-		"    // {xy_} = upper left of pixel",
-		"    // {_zw} = lower right of pixel",
-		"    FxaaFloat4 fxaaConsolePosPos,",
-		"    //",
-		"    // Input color texture.",
-		"    // {rgb_} = color in linear or perceptual color space",
-		"    // if (FXAA_GREEN_AS_LUMA == 0)",
-		"    //     {__a} = luma in perceptual color space (not linear)",
-		"    FxaaTex tex,",
-		"    //",
-		"    // Only used on the optimized 360 version of FXAA Console.",
-		"    // For everything but 360, just use the same input here as for \"tex\".",
-		"    // For 360, same texture, just alias with a 2nd sampler.",
-		"    // This sampler needs to have an exponent bias of -1.",
-		"    FxaaTex fxaaConsole360TexExpBiasNegOne,",
-		"    //",
-		"    // Only used on the optimized 360 version of FXAA Console.",
-		"    // For everything but 360, just use the same input here as for \"tex\".",
-		"    // For 360, same texture, just alias with a 3nd sampler.",
-		"    // This sampler needs to have an exponent bias of -2.",
-		"    FxaaTex fxaaConsole360TexExpBiasNegTwo,",
-		"    //",
-		"    // Only used on FXAA Quality.",
-		"    // This must be from a constant/uniform.",
-		"    // {x_} = 1.0/screenWidthInPixels",
-		"    // {_y} = 1.0/screenHeightInPixels",
-		"    FxaaFloat2 fxaaQualityRcpFrame,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // This must be from a constant/uniform.",
-		"    // This effects sub-pixel AA quality and inversely sharpness.",
-		"    //   Where N ranges between,",
-		"    //     N = 0.50 (default)",
-		"    //     N = 0.33 (sharper)",
-		"    // {x__} = -N/screenWidthInPixels",
-		"    // {_y_} = -N/screenHeightInPixels",
-		"    // {_z_} =  N/screenWidthInPixels",
-		"    // {__w} =  N/screenHeightInPixels",
-		"    FxaaFloat4 fxaaConsoleRcpFrameOpt,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // Not used on 360, but used on PS3 and PC.",
-		"    // This must be from a constant/uniform.",
-		"    // {x__} = -2.0/screenWidthInPixels",
-		"    // {_y_} = -2.0/screenHeightInPixels",
-		"    // {_z_} =  2.0/screenWidthInPixels",
-		"    // {__w} =  2.0/screenHeightInPixels",
-		"    FxaaFloat4 fxaaConsoleRcpFrameOpt2,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // Only used on 360 in place of fxaaConsoleRcpFrameOpt2.",
-		"    // This must be from a constant/uniform.",
-		"    // {x__} =  8.0/screenWidthInPixels",
-		"    // {_y_} =  8.0/screenHeightInPixels",
-		"    // {_z_} = -4.0/screenWidthInPixels",
-		"    // {__w} = -4.0/screenHeightInPixels",
-		"    FxaaFloat4 fxaaConsole360RcpFrameOpt2,",
-		"    //",
-		"    // Only used on FXAA Quality.",
-		"    // This used to be the FXAA_QUALITY_SUBPIX define.",
-		"    // It is here now to allow easier tuning.",
-		"    // Choose the amount of sub-pixel aliasing removal.",
-		"    // This can effect sharpness.",
-		"    //   1.00 - upper limit (softer)",
-		"    //   0.75 - default amount of filtering",
-		"    //   0.50 - lower limit (sharper, less sub-pixel aliasing removal)",
-		"    //   0.25 - almost off",
-		"    //   0.00 - completely off",
-		"    FxaaFloat fxaaQualitySubpix,",
-		"    //",
-		"    // Only used on FXAA Quality.",
-		"    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD define.",
-		"    // It is here now to allow easier tuning.",
-		"    // The minimum amount of local contrast required to apply algorithm.",
-		"    //   0.333 - too little (faster)",
-		"    //   0.250 - low quality",
-		"    //   0.166 - default",
-		"    //   0.125 - high quality",
-		"    //   0.063 - overkill (slower)",
-		"    FxaaFloat fxaaQualityEdgeThreshold,",
-		"    //",
-		"    // Only used on FXAA Quality.",
-		"    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD_MIN define.",
-		"    // It is here now to allow easier tuning.",
-		"    // Trims the algorithm from processing darks.",
-		"    //   0.0833 - upper limit (default, the start of visible unfiltered edges)",
-		"    //   0.0625 - high quality (faster)",
-		"    //   0.0312 - visible limit (slower)",
-		"    // Special notes when using FXAA_GREEN_AS_LUMA,",
-		"    //   Likely want to set this to zero.",
-		"    //   As colors that are mostly not-green",
-		"    //   will appear very dark in the green channel!",
-		"    //   Tune by looking at mostly non-green content,",
-		"    //   then start at zero and increase until aliasing is a problem.",
-		"    FxaaFloat fxaaQualityEdgeThresholdMin,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // This used to be the FXAA_CONSOLE_EDGE_SHARPNESS define.",
-		"    // It is here now to allow easier tuning.",
-		"    // This does not effect PS3, as this needs to be compiled in.",
-		"    //   Use FXAA_CONSOLE_PS3_EDGE_SHARPNESS for PS3.",
-		"    //   Due to the PS3 being ALU bound,",
-		"    //   there are only three safe values here: 2 and 4 and 8.",
-		"    //   These options use the shaders ability to a free *|/ by 2|4|8.",
-		"    // For all other platforms can be a non-power of two.",
-		"    //   8.0 is sharper (default!!!)",
-		"    //   4.0 is softer",
-		"    //   2.0 is really soft (good only for vector graphics inputs)",
-		"    FxaaFloat fxaaConsoleEdgeSharpness,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD define.",
-		"    // It is here now to allow easier tuning.",
-		"    // This does not effect PS3, as this needs to be compiled in.",
-		"    //   Use FXAA_CONSOLE_PS3_EDGE_THRESHOLD for PS3.",
-		"    //   Due to the PS3 being ALU bound,",
-		"    //   there are only two safe values here: 1/4 and 1/8.",
-		"    //   These options use the shaders ability to a free *|/ by 2|4|8.",
-		"    // The console setting has a different mapping than the quality setting.",
-		"    // Other platforms can use other values.",
-		"    //   0.125 leaves less aliasing, but is softer (default!!!)",
-		"    //   0.25 leaves more aliasing, and is sharper",
-		"    FxaaFloat fxaaConsoleEdgeThreshold,",
-		"    //",
-		"    // Only used on FXAA Console.",
-		"    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD_MIN define.",
-		"    // It is here now to allow easier tuning.",
-		"    // Trims the algorithm from processing darks.",
-		"    // The console setting has a different mapping than the quality setting.",
-		"    // This only applies when FXAA_EARLY_EXIT is 1.",
-		"    // This does not apply to PS3,",
-		"    // PS3 was simplified to avoid more shader instructions.",
-		"    //   0.06 - faster but more aliasing in darks",
-		"    //   0.05 - default",
-		"    //   0.04 - slower and less aliasing in darks",
-		"    // Special notes when using FXAA_GREEN_AS_LUMA,",
-		"    //   Likely want to set this to zero.",
-		"    //   As colors that are mostly not-green",
-		"    //   will appear very dark in the green channel!",
-		"    //   Tune by looking at mostly non-green content,",
-		"    //   then start at zero and increase until aliasing is a problem.",
-		"    FxaaFloat fxaaConsoleEdgeThresholdMin,",
-		"    //",
-		"    // Extra constants for 360 FXAA Console only.",
-		"    // Use zeros or anything else for other platforms.",
-		"    // These must be in physical constant registers and NOT immediates.",
-		"    // Immediates will result in compiler un-optimizing.",
-		"    // {xyzw} = float4(1.0, -1.0, 0.25, -0.25)",
-		"    FxaaFloat4 fxaaConsole360ConstDir",
-		") {",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat2 posM;",
-		"    posM.x = pos.x;",
-		"    posM.y = pos.y;",
-		"    #if (FXAA_GATHER4_ALPHA == 1)",
-		"        #if (FXAA_DISCARD == 0)",
-		"            FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);",
-		"            #if (FXAA_GREEN_AS_LUMA == 0)",
-		"                #define lumaM rgbyM.w",
-		"            #else",
-		"                #define lumaM rgbyM.y",
-		"            #endif",
-		"        #endif",
-		"        #if (FXAA_GREEN_AS_LUMA == 0)",
-		"            FxaaFloat4 luma4A = FxaaTexAlpha4(tex, posM);",
-		"            FxaaFloat4 luma4B = FxaaTexOffAlpha4(tex, posM, FxaaInt2(-1, -1));",
-		"        #else",
-		"            FxaaFloat4 luma4A = FxaaTexGreen4(tex, posM);",
-		"            FxaaFloat4 luma4B = FxaaTexOffGreen4(tex, posM, FxaaInt2(-1, -1));",
-		"        #endif",
-		"        #if (FXAA_DISCARD == 1)",
-		"            #define lumaM luma4A.w",
-		"        #endif",
-		"        #define lumaE luma4A.z",
-		"        #define lumaS luma4A.x",
-		"        #define lumaSE luma4A.y",
-		"        #define lumaNW luma4B.w",
-		"        #define lumaN luma4B.z",
-		"        #define lumaW luma4B.x",
-		"    #else",
-		"        FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);",
-		"        #if (FXAA_GREEN_AS_LUMA == 0)",
-		"            #define lumaM rgbyM.w",
-		"        #else",
-		"            #define lumaM rgbyM.y",
-		"        #endif",
-		"        #if (FXAA_GLSL_100 == 1)",
-		"          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0, 1.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 0.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0,-1.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 0.0), fxaaQualityRcpFrame.xy));",
-		"        #else",
-		"          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0, 1), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0,-1), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 0), fxaaQualityRcpFrame.xy));",
-		"        #endif",
-		"    #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat maxSM = max(lumaS, lumaM);",
-		"    FxaaFloat minSM = min(lumaS, lumaM);",
-		"    FxaaFloat maxESM = max(lumaE, maxSM);",
-		"    FxaaFloat minESM = min(lumaE, minSM);",
-		"    FxaaFloat maxWN = max(lumaN, lumaW);",
-		"    FxaaFloat minWN = min(lumaN, lumaW);",
-		"    FxaaFloat rangeMax = max(maxWN, maxESM);",
-		"    FxaaFloat rangeMin = min(minWN, minESM);",
-		"    FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;",
-		"    FxaaFloat range = rangeMax - rangeMin;",
-		"    FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);",
-		"    FxaaBool earlyExit = range < rangeMaxClamped;",
-		"/*--------------------------------------------------------------------------*/",
-		"    if(earlyExit)",
-		"        #if (FXAA_DISCARD == 1)",
-		"            FxaaDiscard;",
-		"        #else",
-		"            return rgbyM;",
-		"        #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"    #if (FXAA_GATHER4_ALPHA == 0)",
-		"        #if (FXAA_GLSL_100 == 1)",
-		"          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0,-1.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 1.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0,-1.0), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 1.0), fxaaQualityRcpFrame.xy));",
-		"        #else",
-		"          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1,-1), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 1), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1,-1), fxaaQualityRcpFrame.xy));",
-		"          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));",
-		"        #endif",
-		"    #else",
-		"        FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy));",
-		"        FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));",
-		"    #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat lumaNS = lumaN + lumaS;",
-		"    FxaaFloat lumaWE = lumaW + lumaE;",
-		"    FxaaFloat subpixRcpRange = 1.0/range;",
-		"    FxaaFloat subpixNSWE = lumaNS + lumaWE;",
-		"    FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;",
-		"    FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat lumaNESE = lumaNE + lumaSE;",
-		"    FxaaFloat lumaNWNE = lumaNW + lumaNE;",
-		"    FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;",
-		"    FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat lumaNWSW = lumaNW + lumaSW;",
-		"    FxaaFloat lumaSWSE = lumaSW + lumaSE;",
-		"    FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);",
-		"    FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);",
-		"    FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;",
-		"    FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;",
-		"    FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;",
-		"    FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;",
-		"    FxaaFloat lengthSign = fxaaQualityRcpFrame.x;",
-		"    FxaaBool horzSpan = edgeHorz >= edgeVert;",
-		"    FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;",
-		"/*--------------------------------------------------------------------------*/",
-		"    if(!horzSpan) lumaN = lumaW;",
-		"    if(!horzSpan) lumaS = lumaE;",
-		"    if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;",
-		"    FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat gradientN = lumaN - lumaM;",
-		"    FxaaFloat gradientS = lumaS - lumaM;",
-		"    FxaaFloat lumaNN = lumaN + lumaM;",
-		"    FxaaFloat lumaSS = lumaS + lumaM;",
-		"    FxaaBool pairN = abs(gradientN) >= abs(gradientS);",
-		"    FxaaFloat gradient = max(abs(gradientN), abs(gradientS));",
-		"    if(pairN) lengthSign = -lengthSign;",
-		"    FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat2 posB;",
-		"    posB.x = posM.x;",
-		"    posB.y = posM.y;",
-		"    FxaaFloat2 offNP;",
-		"    offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;",
-		"    offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;",
-		"    if(!horzSpan) posB.x += lengthSign * 0.5;",
-		"    if( horzSpan) posB.y += lengthSign * 0.5;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat2 posN;",
-		"    posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;",
-		"    posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;",
-		"    FxaaFloat2 posP;",
-		"    posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;",
-		"    posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;",
-		"    FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;",
-		"    FxaaFloat lumaEndN = FxaaLuma(FxaaTexTop(tex, posN));",
-		"    FxaaFloat subpixE = subpixC * subpixC;",
-		"    FxaaFloat lumaEndP = FxaaLuma(FxaaTexTop(tex, posP));",
-		"/*--------------------------------------------------------------------------*/",
-		"    if(!pairN) lumaNN = lumaSS;",
-		"    FxaaFloat gradientScaled = gradient * 1.0/4.0;",
-		"    FxaaFloat lumaMM = lumaM - lumaNN * 0.5;",
-		"    FxaaFloat subpixF = subpixD * subpixE;",
-		"    FxaaBool lumaMLTZero = lumaMM < 0.0;",
-		"/*--------------------------------------------------------------------------*/",
-		"    lumaEndN -= lumaNN * 0.5;",
-		"    lumaEndP -= lumaNN * 0.5;",
-		"    FxaaBool doneN = abs(lumaEndN) >= gradientScaled;",
-		"    FxaaBool doneP = abs(lumaEndP) >= gradientScaled;",
-		"    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;",
-		"    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;",
-		"    FxaaBool doneNP = (!doneN) || (!doneP);",
-		"    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;",
-		"    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;",
-		"/*--------------------------------------------------------------------------*/",
-		"    if(doneNP) {",
-		"        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"        doneN = abs(lumaEndN) >= gradientScaled;",
-		"        doneP = abs(lumaEndP) >= gradientScaled;",
-		"        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;",
-		"        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;",
-		"        doneNP = (!doneN) || (!doneP);",
-		"        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;",
-		"        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;",
-		"/*--------------------------------------------------------------------------*/",
-		"        #if (FXAA_QUALITY_PS > 3)",
-		"        if(doneNP) {",
-		"            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"            doneN = abs(lumaEndN) >= gradientScaled;",
-		"            doneP = abs(lumaEndP) >= gradientScaled;",
-		"            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;",
-		"            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;",
-		"            doneNP = (!doneN) || (!doneP);",
-		"            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;",
-		"            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;",
-		"/*--------------------------------------------------------------------------*/",
-		"            #if (FXAA_QUALITY_PS > 4)",
-		"            if(doneNP) {",
-		"                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                doneN = abs(lumaEndN) >= gradientScaled;",
-		"                doneP = abs(lumaEndP) >= gradientScaled;",
-		"                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;",
-		"                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;",
-		"                doneNP = (!doneN) || (!doneP);",
-		"                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;",
-		"                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;",
-		"/*--------------------------------------------------------------------------*/",
-		"                #if (FXAA_QUALITY_PS > 5)",
-		"                if(doneNP) {",
-		"                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                    doneN = abs(lumaEndN) >= gradientScaled;",
-		"                    doneP = abs(lumaEndP) >= gradientScaled;",
-		"                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;",
-		"                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;",
-		"                    doneNP = (!doneN) || (!doneP);",
-		"                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;",
-		"                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;",
-		"/*--------------------------------------------------------------------------*/",
-		"                    #if (FXAA_QUALITY_PS > 6)",
-		"                    if(doneNP) {",
-		"                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                        doneN = abs(lumaEndN) >= gradientScaled;",
-		"                        doneP = abs(lumaEndP) >= gradientScaled;",
-		"                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;",
-		"                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;",
-		"                        doneNP = (!doneN) || (!doneP);",
-		"                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;",
-		"                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;",
-		"/*--------------------------------------------------------------------------*/",
-		"                        #if (FXAA_QUALITY_PS > 7)",
-		"                        if(doneNP) {",
-		"                            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                            doneN = abs(lumaEndN) >= gradientScaled;",
-		"                            doneP = abs(lumaEndP) >= gradientScaled;",
-		"                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;",
-		"                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;",
-		"                            doneNP = (!doneN) || (!doneP);",
-		"                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;",
-		"                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;",
-		"/*--------------------------------------------------------------------------*/",
-		"    #if (FXAA_QUALITY_PS > 8)",
-		"    if(doneNP) {",
-		"        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"        doneN = abs(lumaEndN) >= gradientScaled;",
-		"        doneP = abs(lumaEndP) >= gradientScaled;",
-		"        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;",
-		"        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;",
-		"        doneNP = (!doneN) || (!doneP);",
-		"        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;",
-		"        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;",
-		"/*--------------------------------------------------------------------------*/",
-		"        #if (FXAA_QUALITY_PS > 9)",
-		"        if(doneNP) {",
-		"            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"            doneN = abs(lumaEndN) >= gradientScaled;",
-		"            doneP = abs(lumaEndP) >= gradientScaled;",
-		"            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;",
-		"            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;",
-		"            doneNP = (!doneN) || (!doneP);",
-		"            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;",
-		"            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;",
-		"/*--------------------------------------------------------------------------*/",
-		"            #if (FXAA_QUALITY_PS > 10)",
-		"            if(doneNP) {",
-		"                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                doneN = abs(lumaEndN) >= gradientScaled;",
-		"                doneP = abs(lumaEndP) >= gradientScaled;",
-		"                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;",
-		"                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;",
-		"                doneNP = (!doneN) || (!doneP);",
-		"                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;",
-		"                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;",
-		"/*--------------------------------------------------------------------------*/",
-		"                #if (FXAA_QUALITY_PS > 11)",
-		"                if(doneNP) {",
-		"                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                    doneN = abs(lumaEndN) >= gradientScaled;",
-		"                    doneP = abs(lumaEndP) >= gradientScaled;",
-		"                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;",
-		"                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;",
-		"                    doneNP = (!doneN) || (!doneP);",
-		"                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;",
-		"                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;",
-		"/*--------------------------------------------------------------------------*/",
-		"                    #if (FXAA_QUALITY_PS > 12)",
-		"                    if(doneNP) {",
-		"                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));",
-		"                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));",
-		"                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;",
-		"                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;",
-		"                        doneN = abs(lumaEndN) >= gradientScaled;",
-		"                        doneP = abs(lumaEndP) >= gradientScaled;",
-		"                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;",
-		"                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;",
-		"                        doneNP = (!doneN) || (!doneP);",
-		"                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;",
-		"                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;",
-		"/*--------------------------------------------------------------------------*/",
-		"                    }",
-		"                    #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"                }",
-		"                #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"            }",
-		"            #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"        }",
-		"        #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"    }",
-		"    #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"                        }",
-		"                        #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"                    }",
-		"                    #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"                }",
-		"                #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"            }",
-		"            #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"        }",
-		"        #endif",
-		"/*--------------------------------------------------------------------------*/",
-		"    }",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat dstN = posM.x - posN.x;",
-		"    FxaaFloat dstP = posP.x - posM.x;",
-		"    if(!horzSpan) dstN = posM.y - posN.y;",
-		"    if(!horzSpan) dstP = posP.y - posM.y;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;",
-		"    FxaaFloat spanLength = (dstP + dstN);",
-		"    FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;",
-		"    FxaaFloat spanLengthRcp = 1.0/spanLength;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaBool directionN = dstN < dstP;",
-		"    FxaaFloat dst = min(dstN, dstP);",
-		"    FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;",
-		"    FxaaFloat subpixG = subpixF * subpixF;",
-		"    FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;",
-		"    FxaaFloat subpixH = subpixG * fxaaQualitySubpix;",
-		"/*--------------------------------------------------------------------------*/",
-		"    FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;",
-		"    FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);",
-		"    if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;",
-		"    if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;",
-		"    #if (FXAA_DISCARD == 1)",
-		"        return FxaaTexTop(tex, posM);",
-		"    #else",
-		"        return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);",
-		"    #endif",
-		"}",
-		"/*==========================================================================*/",
-		"#endif",
-		"",
-		"void main() {",
-		"  gl_FragColor = FxaaPixelShader(",
-		"    vUv,",
-		"    vec4(0.0),",
-		"    tDiffuse,",
-		"    tDiffuse,",
-		"    tDiffuse,",
-		"    resolution,",
-		"    vec4(0.0),",
-		"    vec4(0.0),",
-		"    vec4(0.0),",
-		"    0.75,",
-		"    0.166,",
-		"    0.0833,",
-		"    0.0,",
-		"    0.0,",
-		"    0.0,",
-		"    vec4(0.0)",
-		"  );",
-		"",
-		"  // TODO avoid querying texture twice for same texel",
-		"  gl_FragColor.a = texture2D(tDiffuse, vUv).a;",
-		"}"
-	].join( "\n" )
+uniform vec2 resolution;
+
+varying vec2 vUv;
+
+// FXAA 3.11 implementation by NVIDIA, ported to WebGL by Agost Biro (biro@archilogic.com)
+
+//----------------------------------------------------------------------------------
+// File:        es3-keplerFXAAassetsshaders/FXAA_DefaultES.frag
+// SDK Version: v3.00
+// Email:       gameworks@nvidia.com
+// Site:        http://developer.nvidia.com/
+//
+// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//----------------------------------------------------------------------------------
+
+#define FXAA_PC 1
+#define FXAA_GLSL_100 1
+#define FXAA_QUALITY_PRESET 12
+
+#define FXAA_GREEN_AS_LUMA 1
+
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_PC_CONSOLE
+    //
+    // The console algorithm for PC is included
+    // for developers targeting really low spec machines.
+    // Likely better to just run FXAA_PC, and use a really low preset.
+    //
+    #define FXAA_PC_CONSOLE 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GLSL_120
+    #define FXAA_GLSL_120 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GLSL_130
+    #define FXAA_GLSL_130 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_HLSL_3
+    #define FXAA_HLSL_3 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_HLSL_4
+    #define FXAA_HLSL_4 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_HLSL_5
+    #define FXAA_HLSL_5 0
+#endif
+/*==========================================================================*/
+#ifndef FXAA_GREEN_AS_LUMA
+    //
+    // For those using non-linear color,
+    // and either not able to get luma in alpha, or not wanting to,
+    // this enables FXAA to run using green as a proxy for luma.
+    // So with this enabled, no need to pack luma in alpha.
+    //
+    // This will turn off AA on anything which lacks some amount of green.
+    // Pure red and blue or combination of only R and B, will get no AA.
+    //
+    // Might want to lower the settings for both,
+    //    fxaaConsoleEdgeThresholdMin
+    //    fxaaQualityEdgeThresholdMin
+    // In order to insure AA does not get turned off on colors
+    // which contain a minor amount of green.
+    //
+    // 1 = On.
+    // 0 = Off.
+    //
+    #define FXAA_GREEN_AS_LUMA 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_EARLY_EXIT
+    //
+    // Controls algorithm's early exit path.
+    // On PS3 turning this ON adds 2 cycles to the shader.
+    // On 360 turning this OFF adds 10ths of a millisecond to the shader.
+    // Turning this off on console will result in a more blurry image.
+    // So this defaults to on.
+    //
+    // 1 = On.
+    // 0 = Off.
+    //
+    #define FXAA_EARLY_EXIT 1
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_DISCARD
+    //
+    // Only valid for PC OpenGL currently.
+    // Probably will not work when FXAA_GREEN_AS_LUMA = 1.
+    //
+    // 1 = Use discard on pixels which don't need AA.
+    //     For APIs which enable concurrent TEX+ROP from same surface.
+    // 0 = Return unchanged color on pixels which don't need AA.
+    //
+    #define FXAA_DISCARD 0
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_FAST_PIXEL_OFFSET
+    //
+    // Used for GLSL 120 only.
+    //
+    // 1 = GL API supports fast pixel offsets
+    // 0 = do not use fast pixel offsets
+    //
+    #ifdef GL_EXT_gpu_shader4
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifdef GL_NV_gpu_shader5
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifdef GL_ARB_gpu_shader5
+        #define FXAA_FAST_PIXEL_OFFSET 1
+    #endif
+    #ifndef FXAA_FAST_PIXEL_OFFSET
+        #define FXAA_FAST_PIXEL_OFFSET 0
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+#ifndef FXAA_GATHER4_ALPHA
+    //
+    // 1 = API supports gather4 on alpha channel.
+    // 0 = API does not support gather4 on alpha channel.
+    //
+    #if (FXAA_HLSL_5 == 1)
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifdef GL_ARB_gpu_shader5
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifdef GL_NV_gpu_shader5
+        #define FXAA_GATHER4_ALPHA 1
+    #endif
+    #ifndef FXAA_GATHER4_ALPHA
+        #define FXAA_GATHER4_ALPHA 0
+    #endif
+#endif
+
+
+/*============================================================================
+                        FXAA QUALITY - TUNING KNOBS
+------------------------------------------------------------------------------
+NOTE the other tuning knobs are now in the shader function inputs!
+============================================================================*/
+#ifndef FXAA_QUALITY_PRESET
+    //
+    // Choose the quality preset.
+    // This needs to be compiled into the shader as it effects code.
+    // Best option to include multiple presets is to
+    // in each shader define the preset, then include this file.
+    //
+    // OPTIONS
+    // -----------------------------------------------------------------------
+    // 10 to 15 - default medium dither (10=fastest, 15=highest quality)
+    // 20 to 29 - less dither, more expensive (20=fastest, 29=highest quality)
+    // 39       - no dither, very expensive
+    //
+    // NOTES
+    // -----------------------------------------------------------------------
+    // 12 = slightly faster then FXAA 3.9 and higher edge quality (default)
+    // 13 = about same speed as FXAA 3.9 and better than 12
+    // 23 = closest to FXAA 3.9 visually and performance wise
+    //  _ = the lowest digit is directly related to performance
+    // _  = the highest digit is directly related to style
+    //
+    #define FXAA_QUALITY_PRESET 12
+#endif
+
+
+/*============================================================================
+
+                           FXAA QUALITY - PRESETS
+
+============================================================================*/
+
+/*============================================================================
+                     FXAA QUALITY - MEDIUM DITHER PRESETS
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 10)
+    #define FXAA_QUALITY_PS 3
+    #define FXAA_QUALITY_P0 1.5
+    #define FXAA_QUALITY_P1 3.0
+    #define FXAA_QUALITY_P2 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 11)
+    #define FXAA_QUALITY_PS 4
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 3.0
+    #define FXAA_QUALITY_P3 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 12)
+    #define FXAA_QUALITY_PS 5
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 4.0
+    #define FXAA_QUALITY_P4 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 13)
+    #define FXAA_QUALITY_PS 6
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 4.0
+    #define FXAA_QUALITY_P5 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 14)
+    #define FXAA_QUALITY_PS 7
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 4.0
+    #define FXAA_QUALITY_P6 12.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 15)
+    #define FXAA_QUALITY_PS 8
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 4.0
+    #define FXAA_QUALITY_P7 12.0
+#endif
+
+/*============================================================================
+                     FXAA QUALITY - LOW DITHER PRESETS
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 20)
+    #define FXAA_QUALITY_PS 3
+    #define FXAA_QUALITY_P0 1.5
+    #define FXAA_QUALITY_P1 2.0
+    #define FXAA_QUALITY_P2 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 21)
+    #define FXAA_QUALITY_PS 4
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 22)
+    #define FXAA_QUALITY_PS 5
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 23)
+    #define FXAA_QUALITY_PS 6
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 24)
+    #define FXAA_QUALITY_PS 7
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 3.0
+    #define FXAA_QUALITY_P6 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 25)
+    #define FXAA_QUALITY_PS 8
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 4.0
+    #define FXAA_QUALITY_P7 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 26)
+    #define FXAA_QUALITY_PS 9
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 4.0
+    #define FXAA_QUALITY_P8 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 27)
+    #define FXAA_QUALITY_PS 10
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 4.0
+    #define FXAA_QUALITY_P9 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 28)
+    #define FXAA_QUALITY_PS 11
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 4.0
+    #define FXAA_QUALITY_P10 8.0
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_QUALITY_PRESET == 29)
+    #define FXAA_QUALITY_PS 12
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.5
+    #define FXAA_QUALITY_P2 2.0
+    #define FXAA_QUALITY_P3 2.0
+    #define FXAA_QUALITY_P4 2.0
+    #define FXAA_QUALITY_P5 2.0
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 2.0
+    #define FXAA_QUALITY_P10 4.0
+    #define FXAA_QUALITY_P11 8.0
+#endif
+
+/*============================================================================
+                     FXAA QUALITY - EXTREME QUALITY
+============================================================================*/
+#if (FXAA_QUALITY_PRESET == 39)
+    #define FXAA_QUALITY_PS 12
+    #define FXAA_QUALITY_P0 1.0
+    #define FXAA_QUALITY_P1 1.0
+    #define FXAA_QUALITY_P2 1.0
+    #define FXAA_QUALITY_P3 1.0
+    #define FXAA_QUALITY_P4 1.0
+    #define FXAA_QUALITY_P5 1.5
+    #define FXAA_QUALITY_P6 2.0
+    #define FXAA_QUALITY_P7 2.0
+    #define FXAA_QUALITY_P8 2.0
+    #define FXAA_QUALITY_P9 2.0
+    #define FXAA_QUALITY_P10 4.0
+    #define FXAA_QUALITY_P11 8.0
+#endif
+
+
+
+/*============================================================================
+
+                                API PORTING
+
+============================================================================*/
+#if (FXAA_GLSL_100 == 1) || (FXAA_GLSL_120 == 1) || (FXAA_GLSL_130 == 1)
+    #define FxaaBool bool
+    #define FxaaDiscard discard
+    #define FxaaFloat float
+    #define FxaaFloat2 vec2
+    #define FxaaFloat3 vec3
+    #define FxaaFloat4 vec4
+    #define FxaaHalf float
+    #define FxaaHalf2 vec2
+    #define FxaaHalf3 vec3
+    #define FxaaHalf4 vec4
+    #define FxaaInt2 ivec2
+    #define FxaaSat(x) clamp(x, 0.0, 1.0)
+    #define FxaaTex sampler2D
+#else
+    #define FxaaBool bool
+    #define FxaaDiscard clip(-1)
+    #define FxaaFloat float
+    #define FxaaFloat2 float2
+    #define FxaaFloat3 float3
+    #define FxaaFloat4 float4
+    #define FxaaHalf half
+    #define FxaaHalf2 half2
+    #define FxaaHalf3 half3
+    #define FxaaHalf4 half4
+    #define FxaaSat(x) saturate(x)
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_GLSL_100 == 1)
+  #define FxaaTexTop(t, p) texture2D(t, p, 0.0)
+  #define FxaaTexOff(t, p, o, r) texture2D(t, p + (o * r), 0.0)
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_GLSL_120 == 1)
+    // Requires,
+    //  #version 120
+    // And at least,
+    //  #extension GL_EXT_gpu_shader4 : enable
+    //  (or set FXAA_FAST_PIXEL_OFFSET 1 to work like DX9)
+    #define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)
+    #if (FXAA_FAST_PIXEL_OFFSET == 1)
+        #define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)
+    #else
+        #define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)
+    #endif
+    #if (FXAA_GATHER4_ALPHA == 1)
+        // use #extension GL_ARB_gpu_shader5 : enable
+        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_GLSL_130 == 1)
+    // Requires "#version 130" or better
+    #define FxaaTexTop(t, p) textureLod(t, p, 0.0)
+    #define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
+    #if (FXAA_GATHER4_ALPHA == 1)
+        // use #extension GL_ARB_gpu_shader5 : enable
+        #define FxaaTexAlpha4(t, p) textureGather(t, p, 3)
+        #define FxaaTexOffAlpha4(t, p, o) textureGatherOffset(t, p, o, 3)
+        #define FxaaTexGreen4(t, p) textureGather(t, p, 1)
+        #define FxaaTexOffGreen4(t, p, o) textureGatherOffset(t, p, o, 1)
+    #endif
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_HLSL_3 == 1)
+    #define FxaaInt2 float2
+    #define FxaaTex sampler2D
+    #define FxaaTexTop(t, p) tex2Dlod(t, float4(p, 0.0, 0.0))
+    #define FxaaTexOff(t, p, o, r) tex2Dlod(t, float4(p + (o * r), 0, 0))
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_HLSL_4 == 1)
+    #define FxaaInt2 int2
+    struct FxaaTex { SamplerState smpl; Texture2D tex; };
+    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
+    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
+#endif
+/*--------------------------------------------------------------------------*/
+#if (FXAA_HLSL_5 == 1)
+    #define FxaaInt2 int2
+    struct FxaaTex { SamplerState smpl; Texture2D tex; };
+    #define FxaaTexTop(t, p) t.tex.SampleLevel(t.smpl, p, 0.0)
+    #define FxaaTexOff(t, p, o, r) t.tex.SampleLevel(t.smpl, p, 0.0, o)
+    #define FxaaTexAlpha4(t, p) t.tex.GatherAlpha(t.smpl, p)
+    #define FxaaTexOffAlpha4(t, p, o) t.tex.GatherAlpha(t.smpl, p, o)
+    #define FxaaTexGreen4(t, p) t.tex.GatherGreen(t.smpl, p)
+    #define FxaaTexOffGreen4(t, p, o) t.tex.GatherGreen(t.smpl, p, o)
+#endif
+
+
+/*============================================================================
+                   GREEN AS LUMA OPTION SUPPORT FUNCTION
+============================================================================*/
+#if (FXAA_GREEN_AS_LUMA == 0)
+    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.w; }
+#else
+    FxaaFloat FxaaLuma(FxaaFloat4 rgba) { return rgba.y; }
+#endif
+
+
+
+
+/*============================================================================
+
+                             FXAA3 QUALITY - PC
+
+============================================================================*/
+#if (FXAA_PC == 1)
+/*--------------------------------------------------------------------------*/
+FxaaFloat4 FxaaPixelShader(
+    //
+    // Use noperspective interpolation here (turn off perspective interpolation).
+    // {xy} = center of pixel
+    FxaaFloat2 pos,
+    //
+    // Used only for FXAA Console, and not used on the 360 version.
+    // Use noperspective interpolation here (turn off perspective interpolation).
+    // {xy_} = upper left of pixel
+    // {_zw} = lower right of pixel
+    FxaaFloat4 fxaaConsolePosPos,
+    //
+    // Input color texture.
+    // {rgb_} = color in linear or perceptual color space
+    // if (FXAA_GREEN_AS_LUMA == 0)
+    //     {__a} = luma in perceptual color space (not linear)
+    FxaaTex tex,
+    //
+    // Only used on the optimized 360 version of FXAA Console.
+    // For everything but 360, just use the same input here as for "tex".
+    // For 360, same texture, just alias with a 2nd sampler.
+    // This sampler needs to have an exponent bias of -1.
+    FxaaTex fxaaConsole360TexExpBiasNegOne,
+    //
+    // Only used on the optimized 360 version of FXAA Console.
+    // For everything but 360, just use the same input here as for "tex".
+    // For 360, same texture, just alias with a 3nd sampler.
+    // This sampler needs to have an exponent bias of -2.
+    FxaaTex fxaaConsole360TexExpBiasNegTwo,
+    //
+    // Only used on FXAA Quality.
+    // This must be from a constant/uniform.
+    // {x_} = 1.0/screenWidthInPixels
+    // {_y} = 1.0/screenHeightInPixels
+    FxaaFloat2 fxaaQualityRcpFrame,
+    //
+    // Only used on FXAA Console.
+    // This must be from a constant/uniform.
+    // This effects sub-pixel AA quality and inversely sharpness.
+    //   Where N ranges between,
+    //     N = 0.50 (default)
+    //     N = 0.33 (sharper)
+    // {x__} = -N/screenWidthInPixels
+    // {_y_} = -N/screenHeightInPixels
+    // {_z_} =  N/screenWidthInPixels
+    // {__w} =  N/screenHeightInPixels
+    FxaaFloat4 fxaaConsoleRcpFrameOpt,
+    //
+    // Only used on FXAA Console.
+    // Not used on 360, but used on PS3 and PC.
+    // This must be from a constant/uniform.
+    // {x__} = -2.0/screenWidthInPixels
+    // {_y_} = -2.0/screenHeightInPixels
+    // {_z_} =  2.0/screenWidthInPixels
+    // {__w} =  2.0/screenHeightInPixels
+    FxaaFloat4 fxaaConsoleRcpFrameOpt2,
+    //
+    // Only used on FXAA Console.
+    // Only used on 360 in place of fxaaConsoleRcpFrameOpt2.
+    // This must be from a constant/uniform.
+    // {x__} =  8.0/screenWidthInPixels
+    // {_y_} =  8.0/screenHeightInPixels
+    // {_z_} = -4.0/screenWidthInPixels
+    // {__w} = -4.0/screenHeightInPixels
+    FxaaFloat4 fxaaConsole360RcpFrameOpt2,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_SUBPIX define.
+    // It is here now to allow easier tuning.
+    // Choose the amount of sub-pixel aliasing removal.
+    // This can effect sharpness.
+    //   1.00 - upper limit (softer)
+    //   0.75 - default amount of filtering
+    //   0.50 - lower limit (sharper, less sub-pixel aliasing removal)
+    //   0.25 - almost off
+    //   0.00 - completely off
+    FxaaFloat fxaaQualitySubpix,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD define.
+    // It is here now to allow easier tuning.
+    // The minimum amount of local contrast required to apply algorithm.
+    //   0.333 - too little (faster)
+    //   0.250 - low quality
+    //   0.166 - default
+    //   0.125 - high quality
+    //   0.063 - overkill (slower)
+    FxaaFloat fxaaQualityEdgeThreshold,
+    //
+    // Only used on FXAA Quality.
+    // This used to be the FXAA_QUALITY_EDGE_THRESHOLD_MIN define.
+    // It is here now to allow easier tuning.
+    // Trims the algorithm from processing darks.
+    //   0.0833 - upper limit (default, the start of visible unfiltered edges)
+    //   0.0625 - high quality (faster)
+    //   0.0312 - visible limit (slower)
+    // Special notes when using FXAA_GREEN_AS_LUMA,
+    //   Likely want to set this to zero.
+    //   As colors that are mostly not-green
+    //   will appear very dark in the green channel!
+    //   Tune by looking at mostly non-green content,
+    //   then start at zero and increase until aliasing is a problem.
+    FxaaFloat fxaaQualityEdgeThresholdMin,
+    //
+    // Only used on FXAA Console.
+    // This used to be the FXAA_CONSOLE_EDGE_SHARPNESS define.
+    // It is here now to allow easier tuning.
+    // This does not effect PS3, as this needs to be compiled in.
+    //   Use FXAA_CONSOLE_PS3_EDGE_SHARPNESS for PS3.
+    //   Due to the PS3 being ALU bound,
+    //   there are only three safe values here: 2 and 4 and 8.
+    //   These options use the shaders ability to a free *|/ by 2|4|8.
+    // For all other platforms can be a non-power of two.
+    //   8.0 is sharper (default!!!)
+    //   4.0 is softer
+    //   2.0 is really soft (good only for vector graphics inputs)
+    FxaaFloat fxaaConsoleEdgeSharpness,
+    //
+    // Only used on FXAA Console.
+    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD define.
+    // It is here now to allow easier tuning.
+    // This does not effect PS3, as this needs to be compiled in.
+    //   Use FXAA_CONSOLE_PS3_EDGE_THRESHOLD for PS3.
+    //   Due to the PS3 being ALU bound,
+    //   there are only two safe values here: 1/4 and 1/8.
+    //   These options use the shaders ability to a free *|/ by 2|4|8.
+    // The console setting has a different mapping than the quality setting.
+    // Other platforms can use other values.
+    //   0.125 leaves less aliasing, but is softer (default!!!)
+    //   0.25 leaves more aliasing, and is sharper
+    FxaaFloat fxaaConsoleEdgeThreshold,
+    //
+    // Only used on FXAA Console.
+    // This used to be the FXAA_CONSOLE_EDGE_THRESHOLD_MIN define.
+    // It is here now to allow easier tuning.
+    // Trims the algorithm from processing darks.
+    // The console setting has a different mapping than the quality setting.
+    // This only applies when FXAA_EARLY_EXIT is 1.
+    // This does not apply to PS3,
+    // PS3 was simplified to avoid more shader instructions.
+    //   0.06 - faster but more aliasing in darks
+    //   0.05 - default
+    //   0.04 - slower and less aliasing in darks
+    // Special notes when using FXAA_GREEN_AS_LUMA,
+    //   Likely want to set this to zero.
+    //   As colors that are mostly not-green
+    //   will appear very dark in the green channel!
+    //   Tune by looking at mostly non-green content,
+    //   then start at zero and increase until aliasing is a problem.
+    FxaaFloat fxaaConsoleEdgeThresholdMin,
+    //
+    // Extra constants for 360 FXAA Console only.
+    // Use zeros or anything else for other platforms.
+    // These must be in physical constant registers and NOT immediates.
+    // Immediates will result in compiler un-optimizing.
+    // {xyzw} = float4(1.0, -1.0, 0.25, -0.25)
+    FxaaFloat4 fxaaConsole360ConstDir
+) {
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posM;
+    posM.x = pos.x;
+    posM.y = pos.y;
+    #if (FXAA_GATHER4_ALPHA == 1)
+        #if (FXAA_DISCARD == 0)
+            FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+            #if (FXAA_GREEN_AS_LUMA == 0)
+                #define lumaM rgbyM.w
+            #else
+                #define lumaM rgbyM.y
+            #endif
+        #endif
+        #if (FXAA_GREEN_AS_LUMA == 0)
+            FxaaFloat4 luma4A = FxaaTexAlpha4(tex, posM);
+            FxaaFloat4 luma4B = FxaaTexOffAlpha4(tex, posM, FxaaInt2(-1, -1));
+        #else
+            FxaaFloat4 luma4A = FxaaTexGreen4(tex, posM);
+            FxaaFloat4 luma4B = FxaaTexOffGreen4(tex, posM, FxaaInt2(-1, -1));
+        #endif
+        #if (FXAA_DISCARD == 1)
+            #define lumaM luma4A.w
+        #endif
+        #define lumaE luma4A.z
+        #define lumaS luma4A.x
+        #define lumaSE luma4A.y
+        #define lumaNW luma4B.w
+        #define lumaN luma4B.z
+        #define lumaW luma4B.x
+    #else
+        FxaaFloat4 rgbyM = FxaaTexTop(tex, posM);
+        #if (FXAA_GREEN_AS_LUMA == 0)
+            #define lumaM rgbyM.w
+        #else
+            #define lumaM rgbyM.y
+        #endif
+        #if (FXAA_GLSL_100 == 1)
+          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0, 1.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 0.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 0.0,-1.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 0.0), fxaaQualityRcpFrame.xy));
+        #else
+          FxaaFloat lumaS = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0, 1), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaN = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 0,-1), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 0), fxaaQualityRcpFrame.xy));
+        #endif
+    #endif
+/*--------------------------------------------------------------------------*/
+    FxaaFloat maxSM = max(lumaS, lumaM);
+    FxaaFloat minSM = min(lumaS, lumaM);
+    FxaaFloat maxESM = max(lumaE, maxSM);
+    FxaaFloat minESM = min(lumaE, minSM);
+    FxaaFloat maxWN = max(lumaN, lumaW);
+    FxaaFloat minWN = min(lumaN, lumaW);
+    FxaaFloat rangeMax = max(maxWN, maxESM);
+    FxaaFloat rangeMin = min(minWN, minESM);
+    FxaaFloat rangeMaxScaled = rangeMax * fxaaQualityEdgeThreshold;
+    FxaaFloat range = rangeMax - rangeMin;
+    FxaaFloat rangeMaxClamped = max(fxaaQualityEdgeThresholdMin, rangeMaxScaled);
+    FxaaBool earlyExit = range < rangeMaxClamped;
+/*--------------------------------------------------------------------------*/
+    if(earlyExit)
+        #if (FXAA_DISCARD == 1)
+            FxaaDiscard;
+        #else
+            return rgbyM;
+        #endif
+/*--------------------------------------------------------------------------*/
+    #if (FXAA_GATHER4_ALPHA == 0)
+        #if (FXAA_GLSL_100 == 1)
+          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0,-1.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0, 1.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2( 1.0,-1.0), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaFloat2(-1.0, 1.0), fxaaQualityRcpFrame.xy));
+        #else
+          FxaaFloat lumaNW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1,-1), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaSE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1, 1), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2( 1,-1), fxaaQualityRcpFrame.xy));
+          FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+        #endif
+    #else
+        FxaaFloat lumaNE = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(1, -1), fxaaQualityRcpFrame.xy));
+        FxaaFloat lumaSW = FxaaLuma(FxaaTexOff(tex, posM, FxaaInt2(-1, 1), fxaaQualityRcpFrame.xy));
+    #endif
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNS = lumaN + lumaS;
+    FxaaFloat lumaWE = lumaW + lumaE;
+    FxaaFloat subpixRcpRange = 1.0/range;
+    FxaaFloat subpixNSWE = lumaNS + lumaWE;
+    FxaaFloat edgeHorz1 = (-2.0 * lumaM) + lumaNS;
+    FxaaFloat edgeVert1 = (-2.0 * lumaM) + lumaWE;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNESE = lumaNE + lumaSE;
+    FxaaFloat lumaNWNE = lumaNW + lumaNE;
+    FxaaFloat edgeHorz2 = (-2.0 * lumaE) + lumaNESE;
+    FxaaFloat edgeVert2 = (-2.0 * lumaN) + lumaNWNE;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat lumaNWSW = lumaNW + lumaSW;
+    FxaaFloat lumaSWSE = lumaSW + lumaSE;
+    FxaaFloat edgeHorz4 = (abs(edgeHorz1) * 2.0) + abs(edgeHorz2);
+    FxaaFloat edgeVert4 = (abs(edgeVert1) * 2.0) + abs(edgeVert2);
+    FxaaFloat edgeHorz3 = (-2.0 * lumaW) + lumaNWSW;
+    FxaaFloat edgeVert3 = (-2.0 * lumaS) + lumaSWSE;
+    FxaaFloat edgeHorz = abs(edgeHorz3) + edgeHorz4;
+    FxaaFloat edgeVert = abs(edgeVert3) + edgeVert4;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat subpixNWSWNESE = lumaNWSW + lumaNESE;
+    FxaaFloat lengthSign = fxaaQualityRcpFrame.x;
+    FxaaBool horzSpan = edgeHorz >= edgeVert;
+    FxaaFloat subpixA = subpixNSWE * 2.0 + subpixNWSWNESE;
+/*--------------------------------------------------------------------------*/
+    if(!horzSpan) lumaN = lumaW;
+    if(!horzSpan) lumaS = lumaE;
+    if(horzSpan) lengthSign = fxaaQualityRcpFrame.y;
+    FxaaFloat subpixB = (subpixA * (1.0/12.0)) - lumaM;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat gradientN = lumaN - lumaM;
+    FxaaFloat gradientS = lumaS - lumaM;
+    FxaaFloat lumaNN = lumaN + lumaM;
+    FxaaFloat lumaSS = lumaS + lumaM;
+    FxaaBool pairN = abs(gradientN) >= abs(gradientS);
+    FxaaFloat gradient = max(abs(gradientN), abs(gradientS));
+    if(pairN) lengthSign = -lengthSign;
+    FxaaFloat subpixC = FxaaSat(abs(subpixB) * subpixRcpRange);
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posB;
+    posB.x = posM.x;
+    posB.y = posM.y;
+    FxaaFloat2 offNP;
+    offNP.x = (!horzSpan) ? 0.0 : fxaaQualityRcpFrame.x;
+    offNP.y = ( horzSpan) ? 0.0 : fxaaQualityRcpFrame.y;
+    if(!horzSpan) posB.x += lengthSign * 0.5;
+    if( horzSpan) posB.y += lengthSign * 0.5;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat2 posN;
+    posN.x = posB.x - offNP.x * FXAA_QUALITY_P0;
+    posN.y = posB.y - offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat2 posP;
+    posP.x = posB.x + offNP.x * FXAA_QUALITY_P0;
+    posP.y = posB.y + offNP.y * FXAA_QUALITY_P0;
+    FxaaFloat subpixD = ((-2.0)*subpixC) + 3.0;
+    FxaaFloat lumaEndN = FxaaLuma(FxaaTexTop(tex, posN));
+    FxaaFloat subpixE = subpixC * subpixC;
+    FxaaFloat lumaEndP = FxaaLuma(FxaaTexTop(tex, posP));
+/*--------------------------------------------------------------------------*/
+    if(!pairN) lumaNN = lumaSS;
+    FxaaFloat gradientScaled = gradient * 1.0/4.0;
+    FxaaFloat lumaMM = lumaM - lumaNN * 0.5;
+    FxaaFloat subpixF = subpixD * subpixE;
+    FxaaBool lumaMLTZero = lumaMM < 0.0;
+/*--------------------------------------------------------------------------*/
+    lumaEndN -= lumaNN * 0.5;
+    lumaEndP -= lumaNN * 0.5;
+    FxaaBool doneN = abs(lumaEndN) >= gradientScaled;
+    FxaaBool doneP = abs(lumaEndP) >= gradientScaled;
+    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P1;
+    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P1;
+    FxaaBool doneNP = (!doneN) || (!doneP);
+    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P1;
+    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P1;
+/*--------------------------------------------------------------------------*/
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P2;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P2;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P2;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P2;
+/*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PS > 3)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P3;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P3;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P3;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P3;
+/*--------------------------------------------------------------------------*/
+            #if (FXAA_QUALITY_PS > 4)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P4;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P4;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P4;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P4;
+/*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 5)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P5;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P5;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P5;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P5;
+/*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 6)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P6;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P6;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P6;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P6;
+/*--------------------------------------------------------------------------*/
+                        #if (FXAA_QUALITY_PS > 7)
+                        if(doneNP) {
+                            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                            doneN = abs(lumaEndN) >= gradientScaled;
+                            doneP = abs(lumaEndP) >= gradientScaled;
+                            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P7;
+                            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P7;
+                            doneNP = (!doneN) || (!doneP);
+                            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P7;
+                            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P7;
+/*--------------------------------------------------------------------------*/
+    #if (FXAA_QUALITY_PS > 8)
+    if(doneNP) {
+        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+        doneN = abs(lumaEndN) >= gradientScaled;
+        doneP = abs(lumaEndP) >= gradientScaled;
+        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P8;
+        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P8;
+        doneNP = (!doneN) || (!doneP);
+        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P8;
+        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P8;
+/*--------------------------------------------------------------------------*/
+        #if (FXAA_QUALITY_PS > 9)
+        if(doneNP) {
+            if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+            if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+            if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+            if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+            doneN = abs(lumaEndN) >= gradientScaled;
+            doneP = abs(lumaEndP) >= gradientScaled;
+            if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P9;
+            if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P9;
+            doneNP = (!doneN) || (!doneP);
+            if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P9;
+            if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P9;
+/*--------------------------------------------------------------------------*/
+            #if (FXAA_QUALITY_PS > 10)
+            if(doneNP) {
+                if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                doneN = abs(lumaEndN) >= gradientScaled;
+                doneP = abs(lumaEndP) >= gradientScaled;
+                if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P10;
+                if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P10;
+                doneNP = (!doneN) || (!doneP);
+                if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P10;
+                if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P10;
+/*--------------------------------------------------------------------------*/
+                #if (FXAA_QUALITY_PS > 11)
+                if(doneNP) {
+                    if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                    if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                    if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                    if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                    doneN = abs(lumaEndN) >= gradientScaled;
+                    doneP = abs(lumaEndP) >= gradientScaled;
+                    if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P11;
+                    if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P11;
+                    doneNP = (!doneN) || (!doneP);
+                    if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P11;
+                    if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P11;
+/*--------------------------------------------------------------------------*/
+                    #if (FXAA_QUALITY_PS > 12)
+                    if(doneNP) {
+                        if(!doneN) lumaEndN = FxaaLuma(FxaaTexTop(tex, posN.xy));
+                        if(!doneP) lumaEndP = FxaaLuma(FxaaTexTop(tex, posP.xy));
+                        if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
+                        if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
+                        doneN = abs(lumaEndN) >= gradientScaled;
+                        doneP = abs(lumaEndP) >= gradientScaled;
+                        if(!doneN) posN.x -= offNP.x * FXAA_QUALITY_P12;
+                        if(!doneN) posN.y -= offNP.y * FXAA_QUALITY_P12;
+                        doneNP = (!doneN) || (!doneP);
+                        if(!doneP) posP.x += offNP.x * FXAA_QUALITY_P12;
+                        if(!doneP) posP.y += offNP.y * FXAA_QUALITY_P12;
+/*--------------------------------------------------------------------------*/
+                    }
+                    #endif
+/*--------------------------------------------------------------------------*/
+                }
+                #endif
+/*--------------------------------------------------------------------------*/
+            }
+            #endif
+/*--------------------------------------------------------------------------*/
+        }
+        #endif
+/*--------------------------------------------------------------------------*/
+    }
+    #endif
+/*--------------------------------------------------------------------------*/
+                        }
+                        #endif
+/*--------------------------------------------------------------------------*/
+                    }
+                    #endif
+/*--------------------------------------------------------------------------*/
+                }
+                #endif
+/*--------------------------------------------------------------------------*/
+            }
+            #endif
+/*--------------------------------------------------------------------------*/
+        }
+        #endif
+/*--------------------------------------------------------------------------*/
+    }
+/*--------------------------------------------------------------------------*/
+    FxaaFloat dstN = posM.x - posN.x;
+    FxaaFloat dstP = posP.x - posM.x;
+    if(!horzSpan) dstN = posM.y - posN.y;
+    if(!horzSpan) dstP = posP.y - posM.y;
+/*--------------------------------------------------------------------------*/
+    FxaaBool goodSpanN = (lumaEndN < 0.0) != lumaMLTZero;
+    FxaaFloat spanLength = (dstP + dstN);
+    FxaaBool goodSpanP = (lumaEndP < 0.0) != lumaMLTZero;
+    FxaaFloat spanLengthRcp = 1.0/spanLength;
+/*--------------------------------------------------------------------------*/
+    FxaaBool directionN = dstN < dstP;
+    FxaaFloat dst = min(dstN, dstP);
+    FxaaBool goodSpan = directionN ? goodSpanN : goodSpanP;
+    FxaaFloat subpixG = subpixF * subpixF;
+    FxaaFloat pixelOffset = (dst * (-spanLengthRcp)) + 0.5;
+    FxaaFloat subpixH = subpixG * fxaaQualitySubpix;
+/*--------------------------------------------------------------------------*/
+    FxaaFloat pixelOffsetGood = goodSpan ? pixelOffset : 0.0;
+    FxaaFloat pixelOffsetSubpix = max(pixelOffsetGood, subpixH);
+    if(!horzSpan) posM.x += pixelOffsetSubpix * lengthSign;
+    if( horzSpan) posM.y += pixelOffsetSubpix * lengthSign;
+    #if (FXAA_DISCARD == 1)
+        return FxaaTexTop(tex, posM);
+    #else
+        return FxaaFloat4(FxaaTexTop(tex, posM).xyz, lumaM);
+    #endif
+}
+/*==========================================================================*/
+#endif
+
+void main() {
+  gl_FragColor = FxaaPixelShader(
+    vUv,
+    vec4(0.0),
+    tDiffuse,
+    tDiffuse,
+    tDiffuse,
+    resolution,
+    vec4(0.0),
+    vec4(0.0),
+    vec4(0.0),
+    0.75,
+    0.166,
+    0.0833,
+    0.0,
+    0.0,
+    0.0,
+    vec4(0.0)
+  );
+
+  // TODO avoid querying texture twice for same texel
+  gl_FragColor.a = texture2D(tDiffuse, vUv).a;
+}
+`
 
 };

--- a/examples/js/shaders/FilmShader.js
+++ b/examples/js/shaders/FilmShader.js
@@ -34,67 +34,66 @@ THREE.FilmShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-// control parameter
-uniform float time;
+		// control parameter
+		uniform float time;
 
-uniform bool grayscale;
+		uniform bool grayscale;
 
-// noise effect intensity value (0 = no effect, 1 = full effect)
-uniform float nIntensity;
+		// noise effect intensity value (0 = no effect, 1 = full effect)
+		uniform float nIntensity;
 
-// scanlines effect intensity value (0 = no effect, 1 = full effect)
-uniform float sIntensity;
+		// scanlines effect intensity value (0 = no effect, 1 = full effect)
+		uniform float sIntensity;
 
-// scanlines effect count value (0 = no effect, 4096 = full effect)
-uniform float sCount;
+		// scanlines effect count value (0 = no effect, 4096 = full effect)
+		uniform float sCount;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	// sample the source
-	vec4 cTextureScreen = texture2D( tDiffuse, vUv );
+			// sample the source
+			vec4 cTextureScreen = texture2D( tDiffuse, vUv );
 
-	// make some noise
-	float dx = rand( vUv + time );
+			// make some noise
+			float dx = rand( vUv + time );
 
-	// add noise
-	vec3 cResult = cTextureScreen.rgb + cTextureScreen.rgb * clamp( 0.1 + dx, 0.0, 1.0 );
+			// add noise
+			vec3 cResult = cTextureScreen.rgb + cTextureScreen.rgb * clamp( 0.1 + dx, 0.0, 1.0 );
 
-	// get us a sine and cosine
-	vec2 sc = vec2( sin( vUv.y * sCount ), cos( vUv.y * sCount ) );
+			// get us a sine and cosine
+			vec2 sc = vec2( sin( vUv.y * sCount ), cos( vUv.y * sCount ) );
 
-	// add scanlines
-	cResult += cTextureScreen.rgb * vec3( sc.x, sc.y, sc.x ) * sIntensity;
+			// add scanlines
+			cResult += cTextureScreen.rgb * vec3( sc.x, sc.y, sc.x ) * sIntensity;
 
-	// interpolate between source and result by intensity
-	cResult = cTextureScreen.rgb + clamp( nIntensity, 0.0,1.0 ) * ( cResult - cTextureScreen.rgb );
+			// interpolate between source and result by intensity
+			cResult = cTextureScreen.rgb + clamp( nIntensity, 0.0,1.0 ) * ( cResult - cTextureScreen.rgb );
 
-	// convert to grayscale if desired
-	if( grayscale ) {
+			// convert to grayscale if desired
+			if( grayscale ) {
 
-		cResult = vec3( cResult.r * 0.3 + cResult.g * 0.59 + cResult.b * 0.11 );
+				cResult = vec3( cResult.r * 0.3 + cResult.g * 0.59 + cResult.b * 0.11 );
 
-	}
+			}
 
-	gl_FragColor =  vec4( cResult, cTextureScreen.a );
+			gl_FragColor =  vec4( cResult, cTextureScreen.a );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/FocusShader.js
+++ b/examples/js/shaders/FocusShader.js
@@ -19,68 +19,68 @@ THREE.FocusShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float screenWidth;
-uniform float screenHeight;
-uniform float sampleDistance;
-uniform float waveFactor;
+		uniform float screenWidth;
+		uniform float screenHeight;
+		uniform float sampleDistance;
+		uniform float waveFactor;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 color, org, tmp, add;
-	float sample_dist, f;
-	vec2 vin;
-	vec2 uv = vUv;
+			vec4 color, org, tmp, add;
+			float sample_dist, f;
+			vec2 vin;
+			vec2 uv = vUv;
 
-	add = color = org = texture2D( tDiffuse, uv );
+			add = color = org = texture2D( tDiffuse, uv );
 
-	vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );
-	sample_dist = dot( vin, vin ) * 2.0;
+			vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );
+			sample_dist = dot( vin, vin ) * 2.0;
 
-	f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;
+			f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;
 
-	vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );
+			vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );
-	if( tmp.b < color.b ) color = tmp;
+			add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );
+			if( tmp.b < color.b ) color = tmp;
 
-	color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );
-	color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );
+			color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );
+			color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );
 
-	gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );
+			gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );
 
-}
-`
+		}
+	`
 };

--- a/examples/js/shaders/FocusShader.js
+++ b/examples/js/shaders/FocusShader.js
@@ -18,74 +18,69 @@ THREE.FocusShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float screenWidth;
+uniform float screenHeight;
+uniform float sampleDistance;
+uniform float waveFactor;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float screenWidth;",
-		"uniform float screenHeight;",
-		"uniform float sampleDistance;",
-		"uniform float waveFactor;",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 color, org, tmp, add;
+	float sample_dist, f;
+	vec2 vin;
+	vec2 uv = vUv;
 
-		"varying vec2 vUv;",
+	add = color = org = texture2D( tDiffuse, uv );
 
-		"void main() {",
+	vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );
+	sample_dist = dot( vin, vin ) * 2.0;
 
-		"	vec4 color, org, tmp, add;",
-		"	float sample_dist, f;",
-		"	vec2 vin;",
-		"	vec2 uv = vUv;",
+	f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;
 
-		"	add = color = org = texture2D( tDiffuse, uv );",
+	vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );
 
-		"	vin = ( uv - vec2( 0.5 ) ) * vec2( 1.4 );",
-		"	sample_dist = dot( vin, vin ) * 2.0;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	f = ( waveFactor * 100.0 + sample_dist ) * sampleDistance * 4.0;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	vec2 sampleSize = vec2(  1.0 / screenWidth, 1.0 / screenHeight ) * vec2( f );",
+	add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( 0.111964, 0.993712 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( 0.846724, 0.532032 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( 0.943883, -0.330279 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( 0.330279, -0.943883 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );
+	if( tmp.b < color.b ) color = tmp;
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( -0.532032, -0.846724 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );
+	color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( -0.993712, -0.111964 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
+	gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );
 
-		"	add += tmp = texture2D( tDiffuse, uv + vec2( -0.707107, 0.707107 ) * sampleSize );",
-		"	if( tmp.b < color.b ) color = tmp;",
-
-		"	color = color * vec4( 2.0 ) - ( add / vec4( 8.0 ) );",
-		"	color = color + ( add / vec4( 8.0 ) - color ) * ( vec4( 1.0 ) - vec4( sample_dist * 0.5 ) );",
-
-		"	gl_FragColor = vec4( color.rgb * color.rgb * vec3( 0.95 ) + color.rgb, 1.0 );",
-
-		"}"
-
-
-	].join( "\n" )
+}
+`
 };

--- a/examples/js/shaders/FreiChenShader.js
+++ b/examples/js/shaders/FreiChenShader.js
@@ -16,74 +16,74 @@ THREE.FreiChenShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-varying vec2 vUv;
+		uniform sampler2D tDiffuse;
+		varying vec2 vUv;
 
-uniform vec2 aspect;
+		uniform vec2 aspect;
 
-vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);
+		vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);
 
 
-mat3 G[9];
+		mat3 G[9];
 
-// hard coded matrix values!!!! as suggested in https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/EdgePass.cpp#L45
+		// hard coded matrix values!!!! as suggested in https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/EdgePass.cpp#L45
 
-const mat3 g0 = mat3( 0.3535533845424652, 0, -0.3535533845424652, 0.5, 0, -0.5, 0.3535533845424652, 0, -0.3535533845424652 );
-const mat3 g1 = mat3( 0.3535533845424652, 0.5, 0.3535533845424652, 0, 0, 0, -0.3535533845424652, -0.5, -0.3535533845424652 );
-const mat3 g2 = mat3( 0, 0.3535533845424652, -0.5, -0.3535533845424652, 0, 0.3535533845424652, 0.5, -0.3535533845424652, 0 );
-const mat3 g3 = mat3( 0.5, -0.3535533845424652, 0, -0.3535533845424652, 0, 0.3535533845424652, 0, 0.3535533845424652, -0.5 );
-const mat3 g4 = mat3( 0, -0.5, 0, 0.5, 0, 0.5, 0, -0.5, 0 );
-const mat3 g5 = mat3( -0.5, 0, 0.5, 0, 0, 0, 0.5, 0, -0.5 );
-const mat3 g6 = mat3( 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.6666666865348816, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204 );
-const mat3 g7 = mat3( -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, 0.6666666865348816, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408 );
-const mat3 g8 = mat3( 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408 );
+		const mat3 g0 = mat3( 0.3535533845424652, 0, -0.3535533845424652, 0.5, 0, -0.5, 0.3535533845424652, 0, -0.3535533845424652 );
+		const mat3 g1 = mat3( 0.3535533845424652, 0.5, 0.3535533845424652, 0, 0, 0, -0.3535533845424652, -0.5, -0.3535533845424652 );
+		const mat3 g2 = mat3( 0, 0.3535533845424652, -0.5, -0.3535533845424652, 0, 0.3535533845424652, 0.5, -0.3535533845424652, 0 );
+		const mat3 g3 = mat3( 0.5, -0.3535533845424652, 0, -0.3535533845424652, 0, 0.3535533845424652, 0, 0.3535533845424652, -0.5 );
+		const mat3 g4 = mat3( 0, -0.5, 0, 0.5, 0, 0.5, 0, -0.5, 0 );
+		const mat3 g5 = mat3( -0.5, 0, 0.5, 0, 0, 0, 0.5, 0, -0.5 );
+		const mat3 g6 = mat3( 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.6666666865348816, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204 );
+		const mat3 g7 = mat3( -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, 0.6666666865348816, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408 );
+		const mat3 g8 = mat3( 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408 );
 
-void main(void)
-{
+		void main(void)
+		{
 
-	G[0] = g0,
-	G[1] = g1,
-	G[2] = g2,
-	G[3] = g3,
-	G[4] = g4,
-	G[5] = g5,
-	G[6] = g6,
-	G[7] = g7,
-	G[8] = g8;
+			G[0] = g0,
+			G[1] = g1,
+			G[2] = g2,
+			G[3] = g3,
+			G[4] = g4,
+			G[5] = g5,
+			G[6] = g6,
+			G[7] = g7,
+			G[8] = g8;
 
-	mat3 I;
-	float cnv[9];
-	vec3 sample;
+			mat3 I;
+			float cnv[9];
+			vec3 sample;
 
-	/* fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
-	for (float i=0.0; i<3.0; i++) {
-		for (float j=0.0; j<3.0; j++) {
-			sample = texture2D(tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;
-			I[int(i)][int(j)] = length(sample);
+			/* fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
+			for (float i=0.0; i<3.0; i++) {
+				for (float j=0.0; j<3.0; j++) {
+					sample = texture2D(tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;
+					I[int(i)][int(j)] = length(sample);
+				}
+			}
+
+			/* calculate the convolution values for all the masks */
+			for (int i=0; i<9; i++) {
+				float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);
+				cnv[i] = dp3 * dp3;
+			}
+
+			float M = (cnv[0] + cnv[1]) + (cnv[2] + cnv[3]);
+			float S = (cnv[4] + cnv[5]) + (cnv[6] + cnv[7]) + (cnv[8] + M);
+
+			gl_FragColor = vec4(vec3(sqrt(M/S)), 1.0);
 		}
-	}
-
-	/* calculate the convolution values for all the masks */
-	for (int i=0; i<9; i++) {
-		float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);
-		cnv[i] = dp3 * dp3;
-	}
-
-	float M = (cnv[0] + cnv[1]) + (cnv[2] + cnv[3]);
-	float S = (cnv[4] + cnv[5]) + (cnv[6] + cnv[7]) + (cnv[8] + M);
-
-	gl_FragColor = vec4(vec3(sqrt(M/S)), 1.0);
-}
-`
+	`
 };

--- a/examples/js/shaders/FreiChenShader.js
+++ b/examples/js/shaders/FreiChenShader.js
@@ -15,79 +15,75 @@ THREE.FreiChenShader = {
 		"aspect": { value: new THREE.Vector2( 512, 512 ) }
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+varying vec2 vUv;
 
-	].join( "\n" ),
+uniform vec2 aspect;
 
-	fragmentShader: [
-
-		"uniform sampler2D tDiffuse;",
-		"varying vec2 vUv;",
-
-		"uniform vec2 aspect;",
-
-		"vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);",
+vec2 texel = vec2(1.0 / aspect.x, 1.0 / aspect.y);
 
 
-		"mat3 G[9];",
+mat3 G[9];
 
-		// hard coded matrix values!!!! as suggested in https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/EdgePass.cpp#L45
+// hard coded matrix values!!!! as suggested in https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/EdgePass.cpp#L45
 
-		"const mat3 g0 = mat3( 0.3535533845424652, 0, -0.3535533845424652, 0.5, 0, -0.5, 0.3535533845424652, 0, -0.3535533845424652 );",
-		"const mat3 g1 = mat3( 0.3535533845424652, 0.5, 0.3535533845424652, 0, 0, 0, -0.3535533845424652, -0.5, -0.3535533845424652 );",
-		"const mat3 g2 = mat3( 0, 0.3535533845424652, -0.5, -0.3535533845424652, 0, 0.3535533845424652, 0.5, -0.3535533845424652, 0 );",
-		"const mat3 g3 = mat3( 0.5, -0.3535533845424652, 0, -0.3535533845424652, 0, 0.3535533845424652, 0, 0.3535533845424652, -0.5 );",
-		"const mat3 g4 = mat3( 0, -0.5, 0, 0.5, 0, 0.5, 0, -0.5, 0 );",
-		"const mat3 g5 = mat3( -0.5, 0, 0.5, 0, 0, 0, 0.5, 0, -0.5 );",
-		"const mat3 g6 = mat3( 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.6666666865348816, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204 );",
-		"const mat3 g7 = mat3( -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, 0.6666666865348816, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408 );",
-		"const mat3 g8 = mat3( 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408 );",
+const mat3 g0 = mat3( 0.3535533845424652, 0, -0.3535533845424652, 0.5, 0, -0.5, 0.3535533845424652, 0, -0.3535533845424652 );
+const mat3 g1 = mat3( 0.3535533845424652, 0.5, 0.3535533845424652, 0, 0, 0, -0.3535533845424652, -0.5, -0.3535533845424652 );
+const mat3 g2 = mat3( 0, 0.3535533845424652, -0.5, -0.3535533845424652, 0, 0.3535533845424652, 0.5, -0.3535533845424652, 0 );
+const mat3 g3 = mat3( 0.5, -0.3535533845424652, 0, -0.3535533845424652, 0, 0.3535533845424652, 0, 0.3535533845424652, -0.5 );
+const mat3 g4 = mat3( 0, -0.5, 0, 0.5, 0, 0.5, 0, -0.5, 0 );
+const mat3 g5 = mat3( -0.5, 0, 0.5, 0, 0, 0, 0.5, 0, -0.5 );
+const mat3 g6 = mat3( 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.6666666865348816, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204 );
+const mat3 g7 = mat3( -0.3333333432674408, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, 0.6666666865348816, 0.1666666716337204, -0.3333333432674408, 0.1666666716337204, -0.3333333432674408 );
+const mat3 g8 = mat3( 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408, 0.3333333432674408 );
 
-		"void main(void)",
-		"{",
+void main(void)
+{
 
-		"	G[0] = g0,",
-		"	G[1] = g1,",
-		"	G[2] = g2,",
-		"	G[3] = g3,",
-		"	G[4] = g4,",
-		"	G[5] = g5,",
-		"	G[6] = g6,",
-		"	G[7] = g7,",
-		"	G[8] = g8;",
+	G[0] = g0,
+	G[1] = g1,
+	G[2] = g2,
+	G[3] = g3,
+	G[4] = g4,
+	G[5] = g5,
+	G[6] = g6,
+	G[7] = g7,
+	G[8] = g8;
 
-		"	mat3 I;",
-		"	float cnv[9];",
-		"	vec3 sample;",
+	mat3 I;
+	float cnv[9];
+	vec3 sample;
 
-		/* fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
-		"	for (float i=0.0; i<3.0; i++) {",
-		"		for (float j=0.0; j<3.0; j++) {",
-		"			sample = texture2D(tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;",
-		"			I[int(i)][int(j)] = length(sample);",
-		"		}",
-		"	}",
+	/* fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
+	for (float i=0.0; i<3.0; i++) {
+		for (float j=0.0; j<3.0; j++) {
+			sample = texture2D(tDiffuse, vUv + texel * vec2(i-1.0,j-1.0) ).rgb;
+			I[int(i)][int(j)] = length(sample);
+		}
+	}
 
-		/* calculate the convolution values for all the masks */
-		"	for (int i=0; i<9; i++) {",
-		"		float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);",
-		"		cnv[i] = dp3 * dp3;",
-		"	}",
+	/* calculate the convolution values for all the masks */
+	for (int i=0; i<9; i++) {
+		float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);
+		cnv[i] = dp3 * dp3;
+	}
 
-		"	float M = (cnv[0] + cnv[1]) + (cnv[2] + cnv[3]);",
-		"	float S = (cnv[4] + cnv[5]) + (cnv[6] + cnv[7]) + (cnv[8] + M);",
+	float M = (cnv[0] + cnv[1]) + (cnv[2] + cnv[3]);
+	float S = (cnv[4] + cnv[5]) + (cnv[6] + cnv[7]) + (cnv[8] + M);
 
-		"	gl_FragColor = vec4(vec3(sqrt(M/S)), 1.0);",
-		"}"
-
-	].join( "\n" )
+	gl_FragColor = vec4(vec3(sqrt(M/S)), 1.0);
+}
+`
 };

--- a/examples/js/shaders/FresnelShader.js
+++ b/examples/js/shaders/FresnelShader.js
@@ -17,54 +17,53 @@ THREE.FresnelShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform float mRefractionRatio;
-uniform float mFresnelBias;
-uniform float mFresnelScale;
-uniform float mFresnelPower;
+		uniform float mRefractionRatio;
+		uniform float mFresnelBias;
+		uniform float mFresnelScale;
+		uniform float mFresnelPower;
 
-varying vec3 vReflect;
-varying vec3 vRefract[3];
-varying float vReflectionFactor;
+		varying vec3 vReflect;
+		varying vec3 vRefract[3];
+		varying float vReflectionFactor;
 
-void main() {
+		void main() {
 
-	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
 
-	vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
+			vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
 
-	vec3 I = worldPosition.xyz - cameraPosition;
+			vec3 I = worldPosition.xyz - cameraPosition;
 
-	vReflect = reflect( I, worldNormal );
-	vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );
-	vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );
-	vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );
-	vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );
+			vReflect = reflect( I, worldNormal );
+			vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );
+			vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );
+			vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );
+			vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );
 
-	gl_Position = projectionMatrix * mvPosition;
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform samplerCube tCube;
+		uniform samplerCube tCube;
 
-varying vec3 vReflect;
-varying vec3 vRefract[3];
-varying float vReflectionFactor;
+		varying vec3 vReflect;
+		varying vec3 vRefract[3];
+		varying float vReflectionFactor;
 
-void main() {
+		void main() {
 
-	vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );
-	vec4 refractedColor = vec4( 1.0 );
+			vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );
+			vec4 refractedColor = vec4( 1.0 );
 
-	refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;
-	refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;
-	refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;
+			refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;
+			refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;
+			refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;
 
-	gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );
+			gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/FresnelShader.js
+++ b/examples/js/shaders/FresnelShader.js
@@ -16,59 +16,55 @@ THREE.FresnelShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform float mRefractionRatio;
+uniform float mFresnelBias;
+uniform float mFresnelScale;
+uniform float mFresnelPower;
 
-		"uniform float mRefractionRatio;",
-		"uniform float mFresnelBias;",
-		"uniform float mFresnelScale;",
-		"uniform float mFresnelPower;",
+varying vec3 vReflect;
+varying vec3 vRefract[3];
+varying float vReflectionFactor;
 
-		"varying vec3 vReflect;",
-		"varying vec3 vRefract[3];",
-		"varying float vReflectionFactor;",
+void main() {
 
-		"void main() {",
+	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
 
-		"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-		"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
+	vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
 
-		"	vec3 worldNormal = normalize( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );",
+	vec3 I = worldPosition.xyz - cameraPosition;
 
-		"	vec3 I = worldPosition.xyz - cameraPosition;",
+	vReflect = reflect( I, worldNormal );
+	vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );
+	vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );
+	vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );
+	vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );
 
-		"	vReflect = reflect( I, worldNormal );",
-		"	vRefract[0] = refract( normalize( I ), worldNormal, mRefractionRatio );",
-		"	vRefract[1] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.99 );",
-		"	vRefract[2] = refract( normalize( I ), worldNormal, mRefractionRatio * 0.98 );",
-		"	vReflectionFactor = mFresnelBias + mFresnelScale * pow( 1.0 + dot( normalize( I ), worldNormal ), mFresnelPower );",
+	gl_Position = projectionMatrix * mvPosition;
 
-		"	gl_Position = projectionMatrix * mvPosition;",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform samplerCube tCube;
 
-	].join( "\n" ),
+varying vec3 vReflect;
+varying vec3 vRefract[3];
+varying float vReflectionFactor;
 
-	fragmentShader: [
+void main() {
 
-		"uniform samplerCube tCube;",
+	vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );
+	vec4 refractedColor = vec4( 1.0 );
 
-		"varying vec3 vReflect;",
-		"varying vec3 vRefract[3];",
-		"varying float vReflectionFactor;",
+	refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;
+	refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;
+	refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;
 
-		"void main() {",
+	gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );
 
-		"	vec4 reflectedColor = textureCube( tCube, vec3( -vReflect.x, vReflect.yz ) );",
-		"	vec4 refractedColor = vec4( 1.0 );",
-
-		"	refractedColor.r = textureCube( tCube, vec3( -vRefract[0].x, vRefract[0].yz ) ).r;",
-		"	refractedColor.g = textureCube( tCube, vec3( -vRefract[1].x, vRefract[1].yz ) ).g;",
-		"	refractedColor.b = textureCube( tCube, vec3( -vRefract[2].x, vRefract[2].yz ) ).b;",
-
-		"	gl_FragColor = mix( refractedColor, reflectedColor, clamp( vReflectionFactor, 0.0, 1.0 ) );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/GammaCorrectionShader.js
+++ b/examples/js/shaders/GammaCorrectionShader.js
@@ -14,28 +14,27 @@ THREE.GammaCorrectionShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
+			vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
 
-	gl_FragColor = LinearTosRGB( tex ); // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
+			gl_FragColor = LinearTosRGB( tex ); // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/GammaCorrectionShader.js
+++ b/examples/js/shaders/GammaCorrectionShader.js
@@ -13,33 +13,29 @@ THREE.GammaCorrectionShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
 
-		"varying vec2 vUv;",
+	gl_FragColor = LinearTosRGB( tex ); // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
 
-		"void main() {",
-
-		"	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
-
-		"	gl_FragColor = LinearTosRGB( tex );", // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/GodRaysShader.js
+++ b/examples/js/shaders/GodRaysShader.js
@@ -29,29 +29,28 @@ THREE.GodRaysDepthMaskShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
- vUv = uv;
- gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		vUv = uv;
+		gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform sampler2D tInput;
+		uniform sampler2D tInput;
 
-void main() {
+		void main() {
 
-	gl_FragColor = vec4( 1.0 ) - texture2D( tInput, vUv );
+			gl_FragColor = vec4( 1.0 ) - texture2D( tInput, vUv );
 
 
-}
-`
-
+		}
+	`
 };
 
 
@@ -87,100 +86,99 @@ THREE.GodRaysGenerateShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
- vUv = uv;
- gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		vUv = uv;
+		gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#define TAPS_PER_PASS 6.0
+		#define TAPS_PER_PASS 6.0
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform sampler2D tInput;
+		uniform sampler2D tInput;
 
-uniform vec2 vSunPositionScreenSpace;
-uniform float fStepSize; // filter step size
+		uniform vec2 vSunPositionScreenSpace;
+		uniform float fStepSize; // filter step size
 
-void main() {
+		void main() {
 
-	// delta from current pixel to "sun" position
+			// delta from current pixel to "sun" position
 
-	vec2 delta = vSunPositionScreenSpace - vUv;
-	float dist = length( delta );
+			vec2 delta = vSunPositionScreenSpace - vUv;
+			float dist = length( delta );
 
-	// Step vector (uv space)
+			// Step vector (uv space)
 
-	vec2 stepv = fStepSize * delta / dist;
+			vec2 stepv = fStepSize * delta / dist;
 
-	// Number of iterations between pixel and sun
+			// Number of iterations between pixel and sun
 
-	float iters = dist/fStepSize;
+			float iters = dist/fStepSize;
 
-	vec2 uv = vUv.xy;
-	float col = 0.0;
+			vec2 uv = vUv.xy;
+			float col = 0.0;
 
-	// This breaks ANGLE in Chrome 22
-	//	- see http://code.google.com/p/chromium/issues/detail?id=153105
+			// This breaks ANGLE in Chrome 22
+			//	- see http://code.google.com/p/chromium/issues/detail?id=153105
 
-	/*
-		// Unrolling didnt do much on my hardware (ATI Mobility Radeon 3450),
-		// so i've just left the loop
+			/*
+				// Unrolling didnt do much on my hardware (ATI Mobility Radeon 3450),
+				// so i've just left the loop
 
-		"for ( float i = 0.0; i < TAPS_PER_PASS; i += 1.0 ) {",
+				"for ( float i = 0.0; i < TAPS_PER_PASS; i += 1.0 ) {",
 
-		// Accumulate samples, making sure we dont walk past the light source.
+				// Accumulate samples, making sure we dont walk past the light source.
 
-		// The check for uv.y < 1 would not be necessary with "border" UV wrap
-		// mode, with a black border color. I don't think this is currently
-		// exposed by three.js. As a result there might be artifacts when the
-		// sun is to the left, right or bottom of screen as these cases are
-		// not specifically handled.
+				// The check for uv.y < 1 would not be necessary with "border" UV wrap
+				// mode, with a black border color. I don't think this is currently
+				// exposed by three.js. As a result there might be artifacts when the
+				// sun is to the left, right or bottom of screen as these cases are
+				// not specifically handled.
 
-		"	col += ( i <= iters && uv.y < 1.0 ? texture2D( tInput, uv ).r : 0.0 );",
-		"	uv += stepv;",
+				"	col += ( i <= iters && uv.y < 1.0 ? texture2D( tInput, uv ).r : 0.0 );",
+				"	uv += stepv;",
 
-		"}",
-		*/
+				"}",
+				*/
 
-	// Unrolling loop manually makes it work in ANGLE
+			// Unrolling loop manually makes it work in ANGLE
 
-	if ( 0.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 0.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	if ( 1.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 1.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	if ( 2.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 2.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	if ( 3.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 3.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	if ( 4.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 4.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	if ( 5.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
-	uv += stepv;
+			if ( 5.0 <= iters && uv.y < 1.0 ) col += texture2D( tInput, uv ).r;
+			uv += stepv;
 
-	// Should technically be dividing by 'iters', but 'TAPS_PER_PASS' smooths out
-	// objectionable artifacts, in particular near the sun position. The side
-	// effect is that the result is darker than it should be around the sun, as
-	// TAPS_PER_PASS is greater than the number of samples actually accumulated.
-	// When the result is inverted (in the shader 'godrays_combine', this produces
-	// a slight bright spot at the position of the sun, even when it is occluded.
+			// Should technically be dividing by 'iters', but 'TAPS_PER_PASS' smooths out
+			// objectionable artifacts, in particular near the sun position. The side
+			// effect is that the result is darker than it should be around the sun, as
+			// TAPS_PER_PASS is greater than the number of samples actually accumulated.
+			// When the result is inverted (in the shader 'godrays_combine', this produces
+			// a slight bright spot at the position of the sun, even when it is occluded.
 
-	gl_FragColor = vec4( col/TAPS_PER_PASS );
-	gl_FragColor.a = 1.0;
+			gl_FragColor = vec4( col/TAPS_PER_PASS );
+			gl_FragColor.a = 1.0;
 
-}
-`
-
+		}
+	`
 };
 
 /**
@@ -211,37 +209,36 @@ THREE.GodRaysCombineShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform sampler2D tColors;
-uniform sampler2D tGodRays;
+		uniform sampler2D tColors;
+		uniform sampler2D tGodRays;
 
-uniform vec2 vSunPositionScreenSpace;
-uniform float fGodRayIntensity;
+		uniform vec2 vSunPositionScreenSpace;
+		uniform float fGodRayIntensity;
 
-void main() {
+		void main() {
 
-	// Since THREE.MeshDepthMaterial renders foreground objects white and background
-	// objects black, the god-rays will be white streaks. Therefore value is inverted
-	// before being combined with tColors
+			// Since THREE.MeshDepthMaterial renders foreground objects white and background
+			// objects black, the god-rays will be white streaks. Therefore value is inverted
+			// before being combined with tColors
 
-	gl_FragColor = texture2D( tColors, vUv ) + fGodRayIntensity * vec4( 1.0 - texture2D( tGodRays, vUv ).r );
-	gl_FragColor.a = 1.0;
+			gl_FragColor = texture2D( tColors, vUv ) + fGodRayIntensity * vec4( 1.0 - texture2D( tGodRays, vUv ).r );
+			gl_FragColor.a = 1.0;
 
-}
-`
-
+		}
+	`
 };
 
 
@@ -273,40 +270,39 @@ THREE.GodRaysFakeSunShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform vec2 vSunPositionScreenSpace;
-uniform float fAspect;
+		uniform vec2 vSunPositionScreenSpace;
+		uniform float fAspect;
 
-uniform vec3 sunColor;
-uniform vec3 bgColor;
+		uniform vec3 sunColor;
+		uniform vec3 bgColor;
 
-void main() {
+		void main() {
 
-	vec2 diff = vUv - vSunPositionScreenSpace;
+			vec2 diff = vUv - vSunPositionScreenSpace;
 
-	// Correct for aspect ratio
+			// Correct for aspect ratio
 
-	diff.x *= fAspect;
+			diff.x *= fAspect;
 
-	float prop = clamp( length( diff ) / 0.5, 0.0, 1.0 );
-	prop = 0.35 * pow( 1.0 - prop, 3.0 );
+			float prop = clamp( length( diff ) / 0.5, 0.0, 1.0 );
+			prop = 0.35 * pow( 1.0 - prop, 3.0 );
 
-	gl_FragColor.xyz = mix( sunColor, bgColor, 1.0 - prop );
-	gl_FragColor.w = 1.0;
+			gl_FragColor.xyz = mix( sunColor, bgColor, 1.0 - prop );
+			gl_FragColor.w = 1.0;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/HalftoneShader.js
+++ b/examples/js/shaders/HalftoneShader.js
@@ -25,290 +25,286 @@ THREE.HalftoneShader = {
 		"disable": { value: false }
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUV;
 
-		"varying vec2 vUV;",
+void main() {
 
-		"void main() {",
+	vUV = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 
-		"	vUV = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#define SQRT2_MINUS_ONE 0.41421356
+#define SQRT2_HALF_MINUS_ONE 0.20710678
+#define PI2 6.28318531
+#define SHAPE_DOT 1
+#define SHAPE_ELLIPSE 2
+#define SHAPE_LINE 3
+#define SHAPE_SQUARE 4
+#define BLENDING_LINEAR 1
+#define BLENDING_MULTIPLY 2
+#define BLENDING_ADD 3
+#define BLENDING_LIGHTER 4
+#define BLENDING_DARKER 5
+uniform sampler2D tDiffuse;
+uniform float radius;
+uniform float rotateR;
+uniform float rotateG;
+uniform float rotateB;
+uniform float scatter;
+uniform float width;
+uniform float height;
+uniform int shape;
+uniform bool disable;
+uniform float blending;
+uniform int blendingMode;
+varying vec2 vUV;
+uniform bool greyscale;
+const int samples = 8;
 
-	].join( "\n" ),
+float blend( float a, float b, float t ) {
 
-	fragmentShader: [
+	// linear blend
+	return a * ( 1.0 - t ) + b * t;
 
-		"#define SQRT2_MINUS_ONE 0.41421356",
-		"#define SQRT2_HALF_MINUS_ONE 0.20710678",
-		"#define PI2 6.28318531",
-		"#define SHAPE_DOT 1",
-		"#define SHAPE_ELLIPSE 2",
-		"#define SHAPE_LINE 3",
-		"#define SHAPE_SQUARE 4",
-		"#define BLENDING_LINEAR 1",
-		"#define BLENDING_MULTIPLY 2",
-		"#define BLENDING_ADD 3",
-		"#define BLENDING_LIGHTER 4",
-		"#define BLENDING_DARKER 5",
-		"uniform sampler2D tDiffuse;",
-		"uniform float radius;",
-		"uniform float rotateR;",
-		"uniform float rotateG;",
-		"uniform float rotateB;",
-		"uniform float scatter;",
-		"uniform float width;",
-		"uniform float height;",
-		"uniform int shape;",
-		"uniform bool disable;",
-		"uniform float blending;",
-		"uniform int blendingMode;",
-		"varying vec2 vUV;",
-		"uniform bool greyscale;",
-		"const int samples = 8;",
+}
 
-		"float blend( float a, float b, float t ) {",
+float hypot( float x, float y ) {
 
-		// linear blend
-		"	return a * ( 1.0 - t ) + b * t;",
+	// vector magnitude
+	return sqrt( x * x + y * y );
 
-		"}",
+}
 
-		"float hypot( float x, float y ) {",
+float rand( vec2 seed ){
 
-		// vector magnitude
-		"	return sqrt( x * x + y * y );",
+// get pseudo-random number
+return fract( sin( dot( seed.xy, vec2( 12.9898, 78.233 ) ) ) * 43758.5453 );
 
-		"}",
+}
 
-		"float rand( vec2 seed ){",
+float distanceToDotRadius( float channel, vec2 coord, vec2 normal, vec2 p, float angle, float rad_max ) {
 
-		// get pseudo-random number
-	    "return fract( sin( dot( seed.xy, vec2( 12.9898, 78.233 ) ) ) * 43758.5453 );",
+	// apply shape-specific transforms
+	float dist = hypot( coord.x - p.x, coord.y - p.y );
+	float rad = channel;
 
-		"}",
+	if ( shape == SHAPE_DOT ) {
 
-		"float distanceToDotRadius( float channel, vec2 coord, vec2 normal, vec2 p, float angle, float rad_max ) {",
+		rad = pow( abs( rad ), 1.125 ) * rad_max;
 
-		// apply shape-specific transforms
-		"	float dist = hypot( coord.x - p.x, coord.y - p.y );",
-		"	float rad = channel;",
+	} else if ( shape == SHAPE_ELLIPSE ) {
 
-		"	if ( shape == SHAPE_DOT ) {",
+		rad = pow( abs( rad ), 1.125 ) * rad_max;
 
-		"		rad = pow( abs( rad ), 1.125 ) * rad_max;",
+		if ( dist != 0.0 ) {
+			float dot_p = abs( ( p.x - coord.x ) / dist * normal.x + ( p.y - coord.y ) / dist * normal.y );
+			dist = ( dist * ( 1.0 - SQRT2_HALF_MINUS_ONE ) ) + dot_p * dist * SQRT2_MINUS_ONE;
+		}
 
-		"	} else if ( shape == SHAPE_ELLIPSE ) {",
+	} else if ( shape == SHAPE_LINE ) {
 
-		"		rad = pow( abs( rad ), 1.125 ) * rad_max;",
+		rad = pow( abs( rad ), 1.5) * rad_max;
+		float dot_p = ( p.x - coord.x ) * normal.x + ( p.y - coord.y ) * normal.y;
+		dist = hypot( normal.x * dot_p, normal.y * dot_p );
 
-		"		if ( dist != 0.0 ) {",
-		"			float dot_p = abs( ( p.x - coord.x ) / dist * normal.x + ( p.y - coord.y ) / dist * normal.y );",
-		"			dist = ( dist * ( 1.0 - SQRT2_HALF_MINUS_ONE ) ) + dot_p * dist * SQRT2_MINUS_ONE;",
-		"		}",
+	} else if ( shape == SHAPE_SQUARE ) {
 
-		"	} else if ( shape == SHAPE_LINE ) {",
+		float theta = atan( p.y - coord.y, p.x - coord.x ) - angle;
+		float sin_t = abs( sin( theta ) );
+		float cos_t = abs( cos( theta ) );
+		rad = pow( abs( rad ), 1.4 );
+		rad = rad_max * ( rad + ( ( sin_t > cos_t ) ? rad - sin_t * rad : rad - cos_t * rad ) );
 
-		"		rad = pow( abs( rad ), 1.5) * rad_max;",
-		"		float dot_p = ( p.x - coord.x ) * normal.x + ( p.y - coord.y ) * normal.y;",
-		"		dist = hypot( normal.x * dot_p, normal.y * dot_p );",
+	}
 
-		"	} else if ( shape == SHAPE_SQUARE ) {",
+	return rad - dist;
 
-		"		float theta = atan( p.y - coord.y, p.x - coord.x ) - angle;",
-		"		float sin_t = abs( sin( theta ) );",
-		"		float cos_t = abs( cos( theta ) );",
-		"		rad = pow( abs( rad ), 1.4 );",
-		"		rad = rad_max * ( rad + ( ( sin_t > cos_t ) ? rad - sin_t * rad : rad - cos_t * rad ) );",
+}
 
-		"	}",
+struct Cell {
 
-		"	return rad - dist;",
+	// grid sample positions
+	vec2 normal;
+	vec2 p1;
+	vec2 p2;
+	vec2 p3;
+	vec2 p4;
+	float samp2;
+	float samp1;
+	float samp3;
+	float samp4;
 
-		"}",
+};
 
-		"struct Cell {",
+vec4 getSample( vec2 point ) {
 
-		// grid sample positions
-		"	vec2 normal;",
-		"	vec2 p1;",
-		"	vec2 p2;",
-		"	vec2 p3;",
-		"	vec2 p4;",
-		"	float samp2;",
-		"	float samp1;",
-		"	float samp3;",
-		"	float samp4;",
+	// multi-sampled point
+	vec4 tex = texture2D( tDiffuse, vec2( point.x / width, point.y / height ) );
+	float base = rand( vec2( floor( point.x ), floor( point.y ) ) ) * PI2;
+	float step = PI2 / float( samples );
+	float dist = radius * 0.66;
+
+	for ( int i = 0; i < samples; ++i ) {
 
-		"};",
+		float r = base + step * float( i );
+		vec2 coord = point + vec2( cos( r ) * dist, sin( r ) * dist );
+		tex += texture2D( tDiffuse, vec2( coord.x / width, coord.y / height ) );
 
-		"vec4 getSample( vec2 point ) {",
+	}
 
-		// multi-sampled point
-		"	vec4 tex = texture2D( tDiffuse, vec2( point.x / width, point.y / height ) );",
-		"	float base = rand( vec2( floor( point.x ), floor( point.y ) ) ) * PI2;",
-		"	float step = PI2 / float( samples );",
-		"	float dist = radius * 0.66;",
-
-		"	for ( int i = 0; i < samples; ++i ) {",
-
-		"		float r = base + step * float( i );",
-		"		vec2 coord = point + vec2( cos( r ) * dist, sin( r ) * dist );",
-		"		tex += texture2D( tDiffuse, vec2( coord.x / width, coord.y / height ) );",
-
-		"	}",
-
-		"	tex /= float( samples ) + 1.0;",
-		"	return tex;",
-
-		"}",
-
-		"float getDotColour( Cell c, vec2 p, int channel, float angle, float aa ) {",
-
-		// get colour for given point
-		"	float dist_c_1, dist_c_2, dist_c_3, dist_c_4, res;",
-
-		"	if ( channel == 0 ) {",
-
-		"		c.samp1 = getSample( c.p1 ).r;",
-		"		c.samp2 = getSample( c.p2 ).r;",
-		"		c.samp3 = getSample( c.p3 ).r;",
-		"		c.samp4 = getSample( c.p4 ).r;",
-
-		"	} else if (channel == 1) {",
-
-		"		c.samp1 = getSample( c.p1 ).g;",
-		"		c.samp2 = getSample( c.p2 ).g;",
-		"		c.samp3 = getSample( c.p3 ).g;",
-		"		c.samp4 = getSample( c.p4 ).g;",
-
-		"	} else {",
-
-		"		c.samp1 = getSample( c.p1 ).b;",
-		"		c.samp3 = getSample( c.p3 ).b;",
-		"		c.samp2 = getSample( c.p2 ).b;",
-		"		c.samp4 = getSample( c.p4 ).b;",
-
-		"	}",
-
-		"	dist_c_1 = distanceToDotRadius( c.samp1, c.p1, c.normal, p, angle, radius );",
-		"	dist_c_2 = distanceToDotRadius( c.samp2, c.p2, c.normal, p, angle, radius );",
-		"	dist_c_3 = distanceToDotRadius( c.samp3, c.p3, c.normal, p, angle, radius );",
-		"	dist_c_4 = distanceToDotRadius( c.samp4, c.p4, c.normal, p, angle, radius );",
-		"	res = ( dist_c_1 > 0.0 ) ? clamp( dist_c_1 / aa, 0.0, 1.0 ) : 0.0;",
-		"	res += ( dist_c_2 > 0.0 ) ? clamp( dist_c_2 / aa, 0.0, 1.0 ) : 0.0;",
-		"	res += ( dist_c_3 > 0.0 ) ? clamp( dist_c_3 / aa, 0.0, 1.0 ) : 0.0;",
-		"	res += ( dist_c_4 > 0.0 ) ? clamp( dist_c_4 / aa, 0.0, 1.0 ) : 0.0;",
-		"	res = clamp( res, 0.0, 1.0 );",
-
-		"	return res;",
-
-		"}",
-
-		"Cell getReferenceCell( vec2 p, vec2 origin, float grid_angle, float step ) {",
-
-		// get containing cell
-		"	Cell c;",
-
-		// calc grid
-		"	vec2 n = vec2( cos( grid_angle ), sin( grid_angle ) );",
-		"	float threshold = step * 0.5;",
-		"	float dot_normal = n.x * ( p.x - origin.x ) + n.y * ( p.y - origin.y );",
-		"	float dot_line = -n.y * ( p.x - origin.x ) + n.x * ( p.y - origin.y );",
-		"	vec2 offset = vec2( n.x * dot_normal, n.y * dot_normal );",
-		"	float offset_normal = mod( hypot( offset.x, offset.y ), step );",
-		"	float normal_dir = ( dot_normal < 0.0 ) ? 1.0 : -1.0;",
-		"	float normal_scale = ( ( offset_normal < threshold ) ? -offset_normal : step - offset_normal ) * normal_dir;",
-		"	float offset_line = mod( hypot( ( p.x - offset.x ) - origin.x, ( p.y - offset.y ) - origin.y ), step );",
-		"	float line_dir = ( dot_line < 0.0 ) ? 1.0 : -1.0;",
-		"	float line_scale = ( ( offset_line < threshold ) ? -offset_line : step - offset_line ) * line_dir;",
-
-		// get closest corner
-		"	c.normal = n;",
-		"	c.p1.x = p.x - n.x * normal_scale + n.y * line_scale;",
-		"	c.p1.y = p.y - n.y * normal_scale - n.x * line_scale;",
-
-		// scatter
-		"	if ( scatter != 0.0 ) {",
-
-		"		float off_mag = scatter * threshold * 0.5;",
-		"		float off_angle = rand( vec2( floor( c.p1.x ), floor( c.p1.y ) ) ) * PI2;",
-		"		c.p1.x += cos( off_angle ) * off_mag;",
-		"		c.p1.y += sin( off_angle ) * off_mag;",
-
-		"	}",
-
-		// find corners
-		"	float normal_step = normal_dir * ( ( offset_normal < threshold ) ? step : -step );",
-		"	float line_step = line_dir * ( ( offset_line < threshold ) ? step : -step );",
-		"	c.p2.x = c.p1.x - n.x * normal_step;",
-		"	c.p2.y = c.p1.y - n.y * normal_step;",
-		"	c.p3.x = c.p1.x + n.y * line_step;",
-		"	c.p3.y = c.p1.y - n.x * line_step;",
-		"	c.p4.x = c.p1.x - n.x * normal_step + n.y * line_step;",
-		"	c.p4.y = c.p1.y - n.y * normal_step - n.x * line_step;",
-
-		"	return c;",
-
-		"}",
-
-		"float blendColour( float a, float b, float t ) {",
-
-		// blend colours
-		"	if ( blendingMode == BLENDING_LINEAR ) {",
-		"		return blend( a, b, 1.0 - t );",
-		"	} else if ( blendingMode == BLENDING_ADD ) {",
-		"		return blend( a, min( 1.0, a + b ), t );",
-		"	} else if ( blendingMode == BLENDING_MULTIPLY ) {",
-		"		return blend( a, max( 0.0, a * b ), t );",
-		"	} else if ( blendingMode == BLENDING_LIGHTER ) {",
-		"		return blend( a, max( a, b ), t );",
-		"	} else if ( blendingMode == BLENDING_DARKER ) {",
-		"		return blend( a, min( a, b ), t );",
-		"	} else {",
-		"		return blend( a, b, 1.0 - t );",
-		"	}",
-
-		"}",
-
-		"void main() {",
-
-		"	if ( ! disable ) {",
+	tex /= float( samples ) + 1.0;
+	return tex;
+
+}
+
+float getDotColour( Cell c, vec2 p, int channel, float angle, float aa ) {
+
+	// get colour for given point
+	float dist_c_1, dist_c_2, dist_c_3, dist_c_4, res;
+
+	if ( channel == 0 ) {
+
+		c.samp1 = getSample( c.p1 ).r;
+		c.samp2 = getSample( c.p2 ).r;
+		c.samp3 = getSample( c.p3 ).r;
+		c.samp4 = getSample( c.p4 ).r;
+
+	} else if (channel == 1) {
+
+		c.samp1 = getSample( c.p1 ).g;
+		c.samp2 = getSample( c.p2 ).g;
+		c.samp3 = getSample( c.p3 ).g;
+		c.samp4 = getSample( c.p4 ).g;
+
+	} else {
+
+		c.samp1 = getSample( c.p1 ).b;
+		c.samp3 = getSample( c.p3 ).b;
+		c.samp2 = getSample( c.p2 ).b;
+		c.samp4 = getSample( c.p4 ).b;
+
+	}
+
+	dist_c_1 = distanceToDotRadius( c.samp1, c.p1, c.normal, p, angle, radius );
+	dist_c_2 = distanceToDotRadius( c.samp2, c.p2, c.normal, p, angle, radius );
+	dist_c_3 = distanceToDotRadius( c.samp3, c.p3, c.normal, p, angle, radius );
+	dist_c_4 = distanceToDotRadius( c.samp4, c.p4, c.normal, p, angle, radius );
+	res = ( dist_c_1 > 0.0 ) ? clamp( dist_c_1 / aa, 0.0, 1.0 ) : 0.0;
+	res += ( dist_c_2 > 0.0 ) ? clamp( dist_c_2 / aa, 0.0, 1.0 ) : 0.0;
+	res += ( dist_c_3 > 0.0 ) ? clamp( dist_c_3 / aa, 0.0, 1.0 ) : 0.0;
+	res += ( dist_c_4 > 0.0 ) ? clamp( dist_c_4 / aa, 0.0, 1.0 ) : 0.0;
+	res = clamp( res, 0.0, 1.0 );
+
+	return res;
+
+}
+
+Cell getReferenceCell( vec2 p, vec2 origin, float grid_angle, float step ) {
+
+	// get containing cell
+	Cell c;
+
+	// calc grid
+	vec2 n = vec2( cos( grid_angle ), sin( grid_angle ) );
+	float threshold = step * 0.5;
+	float dot_normal = n.x * ( p.x - origin.x ) + n.y * ( p.y - origin.y );
+	float dot_line = -n.y * ( p.x - origin.x ) + n.x * ( p.y - origin.y );
+	vec2 offset = vec2( n.x * dot_normal, n.y * dot_normal );
+	float offset_normal = mod( hypot( offset.x, offset.y ), step );
+	float normal_dir = ( dot_normal < 0.0 ) ? 1.0 : -1.0;
+	float normal_scale = ( ( offset_normal < threshold ) ? -offset_normal : step - offset_normal ) * normal_dir;
+	float offset_line = mod( hypot( ( p.x - offset.x ) - origin.x, ( p.y - offset.y ) - origin.y ), step );
+	float line_dir = ( dot_line < 0.0 ) ? 1.0 : -1.0;
+	float line_scale = ( ( offset_line < threshold ) ? -offset_line : step - offset_line ) * line_dir;
+
+	// get closest corner
+	c.normal = n;
+	c.p1.x = p.x - n.x * normal_scale + n.y * line_scale;
+	c.p1.y = p.y - n.y * normal_scale - n.x * line_scale;
+
+	// scatter
+	if ( scatter != 0.0 ) {
+
+		float off_mag = scatter * threshold * 0.5;
+		float off_angle = rand( vec2( floor( c.p1.x ), floor( c.p1.y ) ) ) * PI2;
+		c.p1.x += cos( off_angle ) * off_mag;
+		c.p1.y += sin( off_angle ) * off_mag;
+
+	}
+
+	// find corners
+	float normal_step = normal_dir * ( ( offset_normal < threshold ) ? step : -step );
+	float line_step = line_dir * ( ( offset_line < threshold ) ? step : -step );
+	c.p2.x = c.p1.x - n.x * normal_step;
+	c.p2.y = c.p1.y - n.y * normal_step;
+	c.p3.x = c.p1.x + n.y * line_step;
+	c.p3.y = c.p1.y - n.x * line_step;
+	c.p4.x = c.p1.x - n.x * normal_step + n.y * line_step;
+	c.p4.y = c.p1.y - n.y * normal_step - n.x * line_step;
+
+	return c;
+
+}
+
+float blendColour( float a, float b, float t ) {
+
+	// blend colours
+	if ( blendingMode == BLENDING_LINEAR ) {
+		return blend( a, b, 1.0 - t );
+	} else if ( blendingMode == BLENDING_ADD ) {
+		return blend( a, min( 1.0, a + b ), t );
+	} else if ( blendingMode == BLENDING_MULTIPLY ) {
+		return blend( a, max( 0.0, a * b ), t );
+	} else if ( blendingMode == BLENDING_LIGHTER ) {
+		return blend( a, max( a, b ), t );
+	} else if ( blendingMode == BLENDING_DARKER ) {
+		return blend( a, min( a, b ), t );
+	} else {
+		return blend( a, b, 1.0 - t );
+	}
+
+}
+
+void main() {
+
+	if ( ! disable ) {
 
 		// setup
-		"		vec2 p = vec2( vUV.x * width, vUV.y * height );",
-		"		vec2 origin = vec2( 0, 0 );",
-		"		float aa = ( radius < 2.5 ) ? radius * 0.5 : 1.25;",
+		vec2 p = vec2( vUV.x * width, vUV.y * height );
+		vec2 origin = vec2( 0, 0 );
+		float aa = ( radius < 2.5 ) ? radius * 0.5 : 1.25;
 
 		// get channel samples
-		"		Cell cell_r = getReferenceCell( p, origin, rotateR, radius );",
-		"		Cell cell_g = getReferenceCell( p, origin, rotateG, radius );",
-		"		Cell cell_b = getReferenceCell( p, origin, rotateB, radius );",
-		"		float r = getDotColour( cell_r, p, 0, rotateR, aa );",
-		"		float g = getDotColour( cell_g, p, 1, rotateG, aa );",
-		"		float b = getDotColour( cell_b, p, 2, rotateB, aa );",
+		Cell cell_r = getReferenceCell( p, origin, rotateR, radius );
+		Cell cell_g = getReferenceCell( p, origin, rotateG, radius );
+		Cell cell_b = getReferenceCell( p, origin, rotateB, radius );
+		float r = getDotColour( cell_r, p, 0, rotateR, aa );
+		float g = getDotColour( cell_g, p, 1, rotateG, aa );
+		float b = getDotColour( cell_b, p, 2, rotateB, aa );
 
 		// blend with original
-		"		vec4 colour = texture2D( tDiffuse, vUV );",
-		"		r = blendColour( r, colour.r, blending );",
-		"		g = blendColour( g, colour.g, blending );",
-		"		b = blendColour( b, colour.b, blending );",
+		vec4 colour = texture2D( tDiffuse, vUV );
+		r = blendColour( r, colour.r, blending );
+		g = blendColour( g, colour.g, blending );
+		b = blendColour( b, colour.b, blending );
 
-		"		if ( greyscale ) {",
-		"			r = g = b = (r + b + g) / 3.0;",
-		"		}",
+		if ( greyscale ) {
+			r = g = b = (r + b + g) / 3.0;
+		}
 
-		"		gl_FragColor = vec4( r, g, b, 1.0 );",
+		gl_FragColor = vec4( r, g, b, 1.0 );
 
-		"	} else {",
+	} else {
 
-		"		gl_FragColor = texture2D( tDiffuse, vUV );",
+		gl_FragColor = texture2D( tDiffuse, vUV );
 
-		"	}",
+	}
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/HalftoneShader.js
+++ b/examples/js/shaders/HalftoneShader.js
@@ -26,285 +26,284 @@ THREE.HalftoneShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUV;
+		varying vec2 vUV;
 
-void main() {
+		void main() {
 
-	vUV = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+			vUV = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#define SQRT2_MINUS_ONE 0.41421356
-#define SQRT2_HALF_MINUS_ONE 0.20710678
-#define PI2 6.28318531
-#define SHAPE_DOT 1
-#define SHAPE_ELLIPSE 2
-#define SHAPE_LINE 3
-#define SHAPE_SQUARE 4
-#define BLENDING_LINEAR 1
-#define BLENDING_MULTIPLY 2
-#define BLENDING_ADD 3
-#define BLENDING_LIGHTER 4
-#define BLENDING_DARKER 5
-uniform sampler2D tDiffuse;
-uniform float radius;
-uniform float rotateR;
-uniform float rotateG;
-uniform float rotateB;
-uniform float scatter;
-uniform float width;
-uniform float height;
-uniform int shape;
-uniform bool disable;
-uniform float blending;
-uniform int blendingMode;
-varying vec2 vUV;
-uniform bool greyscale;
-const int samples = 8;
+		#define SQRT2_MINUS_ONE 0.41421356
+		#define SQRT2_HALF_MINUS_ONE 0.20710678
+		#define PI2 6.28318531
+		#define SHAPE_DOT 1
+		#define SHAPE_ELLIPSE 2
+		#define SHAPE_LINE 3
+		#define SHAPE_SQUARE 4
+		#define BLENDING_LINEAR 1
+		#define BLENDING_MULTIPLY 2
+		#define BLENDING_ADD 3
+		#define BLENDING_LIGHTER 4
+		#define BLENDING_DARKER 5
+		uniform sampler2D tDiffuse;
+		uniform float radius;
+		uniform float rotateR;
+		uniform float rotateG;
+		uniform float rotateB;
+		uniform float scatter;
+		uniform float width;
+		uniform float height;
+		uniform int shape;
+		uniform bool disable;
+		uniform float blending;
+		uniform int blendingMode;
+		varying vec2 vUV;
+		uniform bool greyscale;
+		const int samples = 8;
 
-float blend( float a, float b, float t ) {
+		float blend( float a, float b, float t ) {
 
-	// linear blend
-	return a * ( 1.0 - t ) + b * t;
+			// linear blend
+			return a * ( 1.0 - t ) + b * t;
 
-}
-
-float hypot( float x, float y ) {
-
-	// vector magnitude
-	return sqrt( x * x + y * y );
-
-}
-
-float rand( vec2 seed ){
-
-// get pseudo-random number
-return fract( sin( dot( seed.xy, vec2( 12.9898, 78.233 ) ) ) * 43758.5453 );
-
-}
-
-float distanceToDotRadius( float channel, vec2 coord, vec2 normal, vec2 p, float angle, float rad_max ) {
-
-	// apply shape-specific transforms
-	float dist = hypot( coord.x - p.x, coord.y - p.y );
-	float rad = channel;
-
-	if ( shape == SHAPE_DOT ) {
-
-		rad = pow( abs( rad ), 1.125 ) * rad_max;
-
-	} else if ( shape == SHAPE_ELLIPSE ) {
-
-		rad = pow( abs( rad ), 1.125 ) * rad_max;
-
-		if ( dist != 0.0 ) {
-			float dot_p = abs( ( p.x - coord.x ) / dist * normal.x + ( p.y - coord.y ) / dist * normal.y );
-			dist = ( dist * ( 1.0 - SQRT2_HALF_MINUS_ONE ) ) + dot_p * dist * SQRT2_MINUS_ONE;
 		}
 
-	} else if ( shape == SHAPE_LINE ) {
+		float hypot( float x, float y ) {
 
-		rad = pow( abs( rad ), 1.5) * rad_max;
-		float dot_p = ( p.x - coord.x ) * normal.x + ( p.y - coord.y ) * normal.y;
-		dist = hypot( normal.x * dot_p, normal.y * dot_p );
+			// vector magnitude
+			return sqrt( x * x + y * y );
 
-	} else if ( shape == SHAPE_SQUARE ) {
-
-		float theta = atan( p.y - coord.y, p.x - coord.x ) - angle;
-		float sin_t = abs( sin( theta ) );
-		float cos_t = abs( cos( theta ) );
-		rad = pow( abs( rad ), 1.4 );
-		rad = rad_max * ( rad + ( ( sin_t > cos_t ) ? rad - sin_t * rad : rad - cos_t * rad ) );
-
-	}
-
-	return rad - dist;
-
-}
-
-struct Cell {
-
-	// grid sample positions
-	vec2 normal;
-	vec2 p1;
-	vec2 p2;
-	vec2 p3;
-	vec2 p4;
-	float samp2;
-	float samp1;
-	float samp3;
-	float samp4;
-
-};
-
-vec4 getSample( vec2 point ) {
-
-	// multi-sampled point
-	vec4 tex = texture2D( tDiffuse, vec2( point.x / width, point.y / height ) );
-	float base = rand( vec2( floor( point.x ), floor( point.y ) ) ) * PI2;
-	float step = PI2 / float( samples );
-	float dist = radius * 0.66;
-
-	for ( int i = 0; i < samples; ++i ) {
-
-		float r = base + step * float( i );
-		vec2 coord = point + vec2( cos( r ) * dist, sin( r ) * dist );
-		tex += texture2D( tDiffuse, vec2( coord.x / width, coord.y / height ) );
-
-	}
-
-	tex /= float( samples ) + 1.0;
-	return tex;
-
-}
-
-float getDotColour( Cell c, vec2 p, int channel, float angle, float aa ) {
-
-	// get colour for given point
-	float dist_c_1, dist_c_2, dist_c_3, dist_c_4, res;
-
-	if ( channel == 0 ) {
-
-		c.samp1 = getSample( c.p1 ).r;
-		c.samp2 = getSample( c.p2 ).r;
-		c.samp3 = getSample( c.p3 ).r;
-		c.samp4 = getSample( c.p4 ).r;
-
-	} else if (channel == 1) {
-
-		c.samp1 = getSample( c.p1 ).g;
-		c.samp2 = getSample( c.p2 ).g;
-		c.samp3 = getSample( c.p3 ).g;
-		c.samp4 = getSample( c.p4 ).g;
-
-	} else {
-
-		c.samp1 = getSample( c.p1 ).b;
-		c.samp3 = getSample( c.p3 ).b;
-		c.samp2 = getSample( c.p2 ).b;
-		c.samp4 = getSample( c.p4 ).b;
-
-	}
-
-	dist_c_1 = distanceToDotRadius( c.samp1, c.p1, c.normal, p, angle, radius );
-	dist_c_2 = distanceToDotRadius( c.samp2, c.p2, c.normal, p, angle, radius );
-	dist_c_3 = distanceToDotRadius( c.samp3, c.p3, c.normal, p, angle, radius );
-	dist_c_4 = distanceToDotRadius( c.samp4, c.p4, c.normal, p, angle, radius );
-	res = ( dist_c_1 > 0.0 ) ? clamp( dist_c_1 / aa, 0.0, 1.0 ) : 0.0;
-	res += ( dist_c_2 > 0.0 ) ? clamp( dist_c_2 / aa, 0.0, 1.0 ) : 0.0;
-	res += ( dist_c_3 > 0.0 ) ? clamp( dist_c_3 / aa, 0.0, 1.0 ) : 0.0;
-	res += ( dist_c_4 > 0.0 ) ? clamp( dist_c_4 / aa, 0.0, 1.0 ) : 0.0;
-	res = clamp( res, 0.0, 1.0 );
-
-	return res;
-
-}
-
-Cell getReferenceCell( vec2 p, vec2 origin, float grid_angle, float step ) {
-
-	// get containing cell
-	Cell c;
-
-	// calc grid
-	vec2 n = vec2( cos( grid_angle ), sin( grid_angle ) );
-	float threshold = step * 0.5;
-	float dot_normal = n.x * ( p.x - origin.x ) + n.y * ( p.y - origin.y );
-	float dot_line = -n.y * ( p.x - origin.x ) + n.x * ( p.y - origin.y );
-	vec2 offset = vec2( n.x * dot_normal, n.y * dot_normal );
-	float offset_normal = mod( hypot( offset.x, offset.y ), step );
-	float normal_dir = ( dot_normal < 0.0 ) ? 1.0 : -1.0;
-	float normal_scale = ( ( offset_normal < threshold ) ? -offset_normal : step - offset_normal ) * normal_dir;
-	float offset_line = mod( hypot( ( p.x - offset.x ) - origin.x, ( p.y - offset.y ) - origin.y ), step );
-	float line_dir = ( dot_line < 0.0 ) ? 1.0 : -1.0;
-	float line_scale = ( ( offset_line < threshold ) ? -offset_line : step - offset_line ) * line_dir;
-
-	// get closest corner
-	c.normal = n;
-	c.p1.x = p.x - n.x * normal_scale + n.y * line_scale;
-	c.p1.y = p.y - n.y * normal_scale - n.x * line_scale;
-
-	// scatter
-	if ( scatter != 0.0 ) {
-
-		float off_mag = scatter * threshold * 0.5;
-		float off_angle = rand( vec2( floor( c.p1.x ), floor( c.p1.y ) ) ) * PI2;
-		c.p1.x += cos( off_angle ) * off_mag;
-		c.p1.y += sin( off_angle ) * off_mag;
-
-	}
-
-	// find corners
-	float normal_step = normal_dir * ( ( offset_normal < threshold ) ? step : -step );
-	float line_step = line_dir * ( ( offset_line < threshold ) ? step : -step );
-	c.p2.x = c.p1.x - n.x * normal_step;
-	c.p2.y = c.p1.y - n.y * normal_step;
-	c.p3.x = c.p1.x + n.y * line_step;
-	c.p3.y = c.p1.y - n.x * line_step;
-	c.p4.x = c.p1.x - n.x * normal_step + n.y * line_step;
-	c.p4.y = c.p1.y - n.y * normal_step - n.x * line_step;
-
-	return c;
-
-}
-
-float blendColour( float a, float b, float t ) {
-
-	// blend colours
-	if ( blendingMode == BLENDING_LINEAR ) {
-		return blend( a, b, 1.0 - t );
-	} else if ( blendingMode == BLENDING_ADD ) {
-		return blend( a, min( 1.0, a + b ), t );
-	} else if ( blendingMode == BLENDING_MULTIPLY ) {
-		return blend( a, max( 0.0, a * b ), t );
-	} else if ( blendingMode == BLENDING_LIGHTER ) {
-		return blend( a, max( a, b ), t );
-	} else if ( blendingMode == BLENDING_DARKER ) {
-		return blend( a, min( a, b ), t );
-	} else {
-		return blend( a, b, 1.0 - t );
-	}
-
-}
-
-void main() {
-
-	if ( ! disable ) {
-
-		// setup
-		vec2 p = vec2( vUV.x * width, vUV.y * height );
-		vec2 origin = vec2( 0, 0 );
-		float aa = ( radius < 2.5 ) ? radius * 0.5 : 1.25;
-
-		// get channel samples
-		Cell cell_r = getReferenceCell( p, origin, rotateR, radius );
-		Cell cell_g = getReferenceCell( p, origin, rotateG, radius );
-		Cell cell_b = getReferenceCell( p, origin, rotateB, radius );
-		float r = getDotColour( cell_r, p, 0, rotateR, aa );
-		float g = getDotColour( cell_g, p, 1, rotateG, aa );
-		float b = getDotColour( cell_b, p, 2, rotateB, aa );
-
-		// blend with original
-		vec4 colour = texture2D( tDiffuse, vUV );
-		r = blendColour( r, colour.r, blending );
-		g = blendColour( g, colour.g, blending );
-		b = blendColour( b, colour.b, blending );
-
-		if ( greyscale ) {
-			r = g = b = (r + b + g) / 3.0;
 		}
 
-		gl_FragColor = vec4( r, g, b, 1.0 );
+		float rand( vec2 seed ){
 
-	} else {
+		// get pseudo-random number
+		return fract( sin( dot( seed.xy, vec2( 12.9898, 78.233 ) ) ) * 43758.5453 );
 
-		gl_FragColor = texture2D( tDiffuse, vUV );
+		}
 
-	}
+		float distanceToDotRadius( float channel, vec2 coord, vec2 normal, vec2 p, float angle, float rad_max ) {
 
-}
-`
+			// apply shape-specific transforms
+			float dist = hypot( coord.x - p.x, coord.y - p.y );
+			float rad = channel;
 
+			if ( shape == SHAPE_DOT ) {
+
+				rad = pow( abs( rad ), 1.125 ) * rad_max;
+
+			} else if ( shape == SHAPE_ELLIPSE ) {
+
+				rad = pow( abs( rad ), 1.125 ) * rad_max;
+
+				if ( dist != 0.0 ) {
+					float dot_p = abs( ( p.x - coord.x ) / dist * normal.x + ( p.y - coord.y ) / dist * normal.y );
+					dist = ( dist * ( 1.0 - SQRT2_HALF_MINUS_ONE ) ) + dot_p * dist * SQRT2_MINUS_ONE;
+				}
+
+			} else if ( shape == SHAPE_LINE ) {
+
+				rad = pow( abs( rad ), 1.5) * rad_max;
+				float dot_p = ( p.x - coord.x ) * normal.x + ( p.y - coord.y ) * normal.y;
+				dist = hypot( normal.x * dot_p, normal.y * dot_p );
+
+			} else if ( shape == SHAPE_SQUARE ) {
+
+				float theta = atan( p.y - coord.y, p.x - coord.x ) - angle;
+				float sin_t = abs( sin( theta ) );
+				float cos_t = abs( cos( theta ) );
+				rad = pow( abs( rad ), 1.4 );
+				rad = rad_max * ( rad + ( ( sin_t > cos_t ) ? rad - sin_t * rad : rad - cos_t * rad ) );
+
+			}
+
+			return rad - dist;
+
+		}
+
+		struct Cell {
+
+			// grid sample positions
+			vec2 normal;
+			vec2 p1;
+			vec2 p2;
+			vec2 p3;
+			vec2 p4;
+			float samp2;
+			float samp1;
+			float samp3;
+			float samp4;
+
+		};
+
+		vec4 getSample( vec2 point ) {
+
+			// multi-sampled point
+			vec4 tex = texture2D( tDiffuse, vec2( point.x / width, point.y / height ) );
+			float base = rand( vec2( floor( point.x ), floor( point.y ) ) ) * PI2;
+			float step = PI2 / float( samples );
+			float dist = radius * 0.66;
+
+			for ( int i = 0; i < samples; ++i ) {
+
+				float r = base + step * float( i );
+				vec2 coord = point + vec2( cos( r ) * dist, sin( r ) * dist );
+				tex += texture2D( tDiffuse, vec2( coord.x / width, coord.y / height ) );
+
+			}
+
+			tex /= float( samples ) + 1.0;
+			return tex;
+
+		}
+
+		float getDotColour( Cell c, vec2 p, int channel, float angle, float aa ) {
+
+			// get colour for given point
+			float dist_c_1, dist_c_2, dist_c_3, dist_c_4, res;
+
+			if ( channel == 0 ) {
+
+				c.samp1 = getSample( c.p1 ).r;
+				c.samp2 = getSample( c.p2 ).r;
+				c.samp3 = getSample( c.p3 ).r;
+				c.samp4 = getSample( c.p4 ).r;
+
+			} else if (channel == 1) {
+
+				c.samp1 = getSample( c.p1 ).g;
+				c.samp2 = getSample( c.p2 ).g;
+				c.samp3 = getSample( c.p3 ).g;
+				c.samp4 = getSample( c.p4 ).g;
+
+			} else {
+
+				c.samp1 = getSample( c.p1 ).b;
+				c.samp3 = getSample( c.p3 ).b;
+				c.samp2 = getSample( c.p2 ).b;
+				c.samp4 = getSample( c.p4 ).b;
+
+			}
+
+			dist_c_1 = distanceToDotRadius( c.samp1, c.p1, c.normal, p, angle, radius );
+			dist_c_2 = distanceToDotRadius( c.samp2, c.p2, c.normal, p, angle, radius );
+			dist_c_3 = distanceToDotRadius( c.samp3, c.p3, c.normal, p, angle, radius );
+			dist_c_4 = distanceToDotRadius( c.samp4, c.p4, c.normal, p, angle, radius );
+			res = ( dist_c_1 > 0.0 ) ? clamp( dist_c_1 / aa, 0.0, 1.0 ) : 0.0;
+			res += ( dist_c_2 > 0.0 ) ? clamp( dist_c_2 / aa, 0.0, 1.0 ) : 0.0;
+			res += ( dist_c_3 > 0.0 ) ? clamp( dist_c_3 / aa, 0.0, 1.0 ) : 0.0;
+			res += ( dist_c_4 > 0.0 ) ? clamp( dist_c_4 / aa, 0.0, 1.0 ) : 0.0;
+			res = clamp( res, 0.0, 1.0 );
+
+			return res;
+
+		}
+
+		Cell getReferenceCell( vec2 p, vec2 origin, float grid_angle, float step ) {
+
+			// get containing cell
+			Cell c;
+
+			// calc grid
+			vec2 n = vec2( cos( grid_angle ), sin( grid_angle ) );
+			float threshold = step * 0.5;
+			float dot_normal = n.x * ( p.x - origin.x ) + n.y * ( p.y - origin.y );
+			float dot_line = -n.y * ( p.x - origin.x ) + n.x * ( p.y - origin.y );
+			vec2 offset = vec2( n.x * dot_normal, n.y * dot_normal );
+			float offset_normal = mod( hypot( offset.x, offset.y ), step );
+			float normal_dir = ( dot_normal < 0.0 ) ? 1.0 : -1.0;
+			float normal_scale = ( ( offset_normal < threshold ) ? -offset_normal : step - offset_normal ) * normal_dir;
+			float offset_line = mod( hypot( ( p.x - offset.x ) - origin.x, ( p.y - offset.y ) - origin.y ), step );
+			float line_dir = ( dot_line < 0.0 ) ? 1.0 : -1.0;
+			float line_scale = ( ( offset_line < threshold ) ? -offset_line : step - offset_line ) * line_dir;
+
+			// get closest corner
+			c.normal = n;
+			c.p1.x = p.x - n.x * normal_scale + n.y * line_scale;
+			c.p1.y = p.y - n.y * normal_scale - n.x * line_scale;
+
+			// scatter
+			if ( scatter != 0.0 ) {
+
+				float off_mag = scatter * threshold * 0.5;
+				float off_angle = rand( vec2( floor( c.p1.x ), floor( c.p1.y ) ) ) * PI2;
+				c.p1.x += cos( off_angle ) * off_mag;
+				c.p1.y += sin( off_angle ) * off_mag;
+
+			}
+
+			// find corners
+			float normal_step = normal_dir * ( ( offset_normal < threshold ) ? step : -step );
+			float line_step = line_dir * ( ( offset_line < threshold ) ? step : -step );
+			c.p2.x = c.p1.x - n.x * normal_step;
+			c.p2.y = c.p1.y - n.y * normal_step;
+			c.p3.x = c.p1.x + n.y * line_step;
+			c.p3.y = c.p1.y - n.x * line_step;
+			c.p4.x = c.p1.x - n.x * normal_step + n.y * line_step;
+			c.p4.y = c.p1.y - n.y * normal_step - n.x * line_step;
+
+			return c;
+
+		}
+
+		float blendColour( float a, float b, float t ) {
+
+			// blend colours
+			if ( blendingMode == BLENDING_LINEAR ) {
+				return blend( a, b, 1.0 - t );
+			} else if ( blendingMode == BLENDING_ADD ) {
+				return blend( a, min( 1.0, a + b ), t );
+			} else if ( blendingMode == BLENDING_MULTIPLY ) {
+				return blend( a, max( 0.0, a * b ), t );
+			} else if ( blendingMode == BLENDING_LIGHTER ) {
+				return blend( a, max( a, b ), t );
+			} else if ( blendingMode == BLENDING_DARKER ) {
+				return blend( a, min( a, b ), t );
+			} else {
+				return blend( a, b, 1.0 - t );
+			}
+
+		}
+
+		void main() {
+
+			if ( ! disable ) {
+
+				// setup
+				vec2 p = vec2( vUV.x * width, vUV.y * height );
+				vec2 origin = vec2( 0, 0 );
+				float aa = ( radius < 2.5 ) ? radius * 0.5 : 1.25;
+
+				// get channel samples
+				Cell cell_r = getReferenceCell( p, origin, rotateR, radius );
+				Cell cell_g = getReferenceCell( p, origin, rotateG, radius );
+				Cell cell_b = getReferenceCell( p, origin, rotateB, radius );
+				float r = getDotColour( cell_r, p, 0, rotateR, aa );
+				float g = getDotColour( cell_g, p, 1, rotateG, aa );
+				float b = getDotColour( cell_b, p, 2, rotateB, aa );
+
+				// blend with original
+				vec4 colour = texture2D( tDiffuse, vUV );
+				r = blendColour( r, colour.r, blending );
+				g = blendColour( g, colour.g, blending );
+				b = blendColour( b, colour.b, blending );
+
+				if ( greyscale ) {
+					r = g = b = (r + b + g) / 3.0;
+				}
+
+				gl_FragColor = vec4( r, g, b, 1.0 );
+
+			} else {
+
+				gl_FragColor = texture2D( tDiffuse, vUV );
+
+			}
+
+		}
+	`
 };

--- a/examples/js/shaders/HorizontalBlurShader.js
+++ b/examples/js/shaders/HorizontalBlurShader.js
@@ -19,44 +19,40 @@ THREE.HorizontalBlurShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float h;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float h;",
+	vec4 sum = vec4( 0.0 );
 
-		"varying vec2 vUv;",
+	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;
 
-		"void main() {",
+	gl_FragColor = sum;
 
-		"	vec4 sum = vec4( 0.0 );",
-
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;",
-
-		"	gl_FragColor = sum;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/HorizontalBlurShader.js
+++ b/examples/js/shaders/HorizontalBlurShader.js
@@ -20,39 +20,38 @@ THREE.HorizontalBlurShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float h;
+		uniform sampler2D tDiffuse;
+		uniform float h;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 sum = vec4( 0.0 );
+			vec4 sum = vec4( 0.0 );
 
-	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * h, vUv.y ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * h, vUv.y ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * h, vUv.y ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * h, vUv.y ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * h, vUv.y ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * h, vUv.y ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * h, vUv.y ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * h, vUv.y ) ) * 0.051;
 
-	gl_FragColor = sum;
+			gl_FragColor = sum;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/HorizontalTiltShiftShader.js
+++ b/examples/js/shaders/HorizontalTiltShiftShader.js
@@ -20,42 +20,41 @@ THREE.HorizontalTiltShiftShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float h;
-uniform float r;
+		uniform sampler2D tDiffuse;
+		uniform float h;
+		uniform float r;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 sum = vec4( 0.0 );
+			vec4 sum = vec4( 0.0 );
 
-	float hh = h * abs( r - vUv.y );
+			float hh = h * abs( r - vUv.y );
 
-	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;
 
-	gl_FragColor = sum;
+			gl_FragColor = sum;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/HorizontalTiltShiftShader.js
+++ b/examples/js/shaders/HorizontalTiltShiftShader.js
@@ -19,47 +19,43 @@ THREE.HorizontalTiltShiftShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float h;
+uniform float r;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float h;",
-		"uniform float r;",
+	vec4 sum = vec4( 0.0 );
 
-		"varying vec2 vUv;",
+	float hh = h * abs( r - vUv.y );
 
-		"void main() {",
+	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;
 
-		"	vec4 sum = vec4( 0.0 );",
+	gl_FragColor = sum;
 
-		"	float hh = h * abs( r - vUv.y );",
-
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 4.0 * hh, vUv.y ) ) * 0.051;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 3.0 * hh, vUv.y ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 2.0 * hh, vUv.y ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x - 1.0 * hh, vUv.y ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 1.0 * hh, vUv.y ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 2.0 * hh, vUv.y ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 3.0 * hh, vUv.y ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x + 4.0 * hh, vUv.y ) ) * 0.051;",
-
-		"	gl_FragColor = sum;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/HueSaturationShader.js
+++ b/examples/js/shaders/HueSaturationShader.js
@@ -18,48 +18,47 @@ THREE.HueSaturationShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float hue;
-uniform float saturation;
+		uniform sampler2D tDiffuse;
+		uniform float hue;
+		uniform float saturation;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	gl_FragColor = texture2D( tDiffuse, vUv );
+			gl_FragColor = texture2D( tDiffuse, vUv );
 
-	// hue
-	float angle = hue * 3.14159265;
-	float s = sin(angle), c = cos(angle);
-	vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;
-	float len = length(gl_FragColor.rgb);
-	gl_FragColor.rgb = vec3(
-		dot(gl_FragColor.rgb, weights.xyz),
-		dot(gl_FragColor.rgb, weights.zxy),
-		dot(gl_FragColor.rgb, weights.yzx)
-	);
+			// hue
+			float angle = hue * 3.14159265;
+			float s = sin(angle), c = cos(angle);
+			vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;
+			float len = length(gl_FragColor.rgb);
+			gl_FragColor.rgb = vec3(
+				dot(gl_FragColor.rgb, weights.xyz),
+				dot(gl_FragColor.rgb, weights.zxy),
+				dot(gl_FragColor.rgb, weights.yzx)
+			);
 
-	// saturation
-	float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;
-	if (saturation > 0.0) {
-		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));
-	} else {
-		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);
-	}
+			// saturation
+			float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;
+			if (saturation > 0.0) {
+				gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));
+			} else {
+				gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);
+			}
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/HueSaturationShader.js
+++ b/examples/js/shaders/HueSaturationShader.js
@@ -17,53 +17,49 @@ THREE.HueSaturationShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float hue;
+uniform float saturation;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float hue;",
-		"uniform float saturation;",
+	gl_FragColor = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	// hue
+	float angle = hue * 3.14159265;
+	float s = sin(angle), c = cos(angle);
+	vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;
+	float len = length(gl_FragColor.rgb);
+	gl_FragColor.rgb = vec3(
+		dot(gl_FragColor.rgb, weights.xyz),
+		dot(gl_FragColor.rgb, weights.zxy),
+		dot(gl_FragColor.rgb, weights.yzx)
+	);
 
-		"void main() {",
+	// saturation
+	float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;
+	if (saturation > 0.0) {
+		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));
+	} else {
+		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);
+	}
 
-		"	gl_FragColor = texture2D( tDiffuse, vUv );",
-
-		// hue
-		"	float angle = hue * 3.14159265;",
-		"	float s = sin(angle), c = cos(angle);",
-		"	vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;",
-		"	float len = length(gl_FragColor.rgb);",
-		"	gl_FragColor.rgb = vec3(",
-		"		dot(gl_FragColor.rgb, weights.xyz),",
-		"		dot(gl_FragColor.rgb, weights.zxy),",
-		"		dot(gl_FragColor.rgb, weights.yzx)",
-		"	);",
-
-		// saturation
-		"	float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;",
-		"	if (saturation > 0.0) {",
-		"		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - saturation));",
-		"	} else {",
-		"		gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-saturation);",
-		"	}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/KaleidoShader.js
+++ b/examples/js/shaders/KaleidoShader.js
@@ -21,36 +21,35 @@ THREE.KaleidoShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float sides;
-uniform float angle;
+		uniform sampler2D tDiffuse;
+		uniform float sides;
+		uniform float angle;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec2 p = vUv - 0.5;
-	float r = length(p);
-	float a = atan(p.y, p.x) + angle;
-	float tau = 2. * 3.1416 ;
-	a = mod(a, tau/sides);
-	a = abs(a - tau/sides/2.) ;
-	p = r * vec2(cos(a), sin(a));
-	vec4 color = texture2D(tDiffuse, p + 0.5);
-	gl_FragColor = color;
+			vec2 p = vUv - 0.5;
+			float r = length(p);
+			float a = atan(p.y, p.x) + angle;
+			float tau = 2. * 3.1416 ;
+			a = mod(a, tau/sides);
+			a = abs(a - tau/sides/2.) ;
+			p = r * vec2(cos(a), sin(a));
+			vec4 color = texture2D(tDiffuse, p + 0.5);
+			gl_FragColor = color;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/KaleidoShader.js
+++ b/examples/js/shaders/KaleidoShader.js
@@ -20,41 +20,37 @@ THREE.KaleidoShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float sides;
+uniform float angle;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float sides;",
-		"uniform float angle;",
+	vec2 p = vUv - 0.5;
+	float r = length(p);
+	float a = atan(p.y, p.x) + angle;
+	float tau = 2. * 3.1416 ;
+	a = mod(a, tau/sides);
+	a = abs(a - tau/sides/2.) ;
+	p = r * vec2(cos(a), sin(a));
+	vec4 color = texture2D(tDiffuse, p + 0.5);
+	gl_FragColor = color;
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	vec2 p = vUv - 0.5;",
-		"	float r = length(p);",
-		"	float a = atan(p.y, p.x) + angle;",
-		"	float tau = 2. * 3.1416 ;",
-		"	a = mod(a, tau/sides);",
-		"	a = abs(a - tau/sides/2.) ;",
-		"	p = r * vec2(cos(a), sin(a));",
-		"	vec4 color = texture2D(tDiffuse, p + 0.5);",
-		"	gl_FragColor = color;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/LuminosityHighPassShader.js
+++ b/examples/js/shaders/LuminosityHighPassShader.js
@@ -20,41 +20,40 @@ THREE.LuminosityHighPassShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform vec3 defaultColor;
-uniform float defaultOpacity;
-uniform float luminosityThreshold;
-uniform float smoothWidth;
+		uniform sampler2D tDiffuse;
+		uniform vec3 defaultColor;
+		uniform float defaultOpacity;
+		uniform float luminosityThreshold;
+		uniform float smoothWidth;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 texel = texture2D( tDiffuse, vUv );
+			vec4 texel = texture2D( tDiffuse, vUv );
 
-	vec3 luma = vec3( 0.299, 0.587, 0.114 );
+			vec3 luma = vec3( 0.299, 0.587, 0.114 );
 
-	float v = dot( texel.xyz, luma );
+			float v = dot( texel.xyz, luma );
 
-	vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );
+			vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );
 
-	float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );
+			float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );
 
-	gl_FragColor = mix( outputColor, texel, alpha );
+			gl_FragColor = mix( outputColor, texel, alpha );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/LuminosityHighPassShader.js
+++ b/examples/js/shaders/LuminosityHighPassShader.js
@@ -19,46 +19,42 @@ THREE.LuminosityHighPassShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform vec3 defaultColor;
+uniform float defaultOpacity;
+uniform float luminosityThreshold;
+uniform float smoothWidth;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec3 defaultColor;",
-		"uniform float defaultOpacity;",
-		"uniform float luminosityThreshold;",
-		"uniform float smoothWidth;",
+	vec4 texel = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	vec3 luma = vec3( 0.299, 0.587, 0.114 );
 
-		"void main() {",
+	float v = dot( texel.xyz, luma );
 
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
+	vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );
 
-		"	vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+	float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );
 
-		"	float v = dot( texel.xyz, luma );",
+	gl_FragColor = mix( outputColor, texel, alpha );
 
-		"	vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );",
-
-		"	float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );",
-
-		"	gl_FragColor = mix( outputColor, texel, alpha );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/LuminosityShader.js
+++ b/examples/js/shaders/LuminosityShader.js
@@ -14,33 +14,32 @@ THREE.LuminosityShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 texel = texture2D( tDiffuse, vUv );
+			vec4 texel = texture2D( tDiffuse, vUv );
 
-	float l = linearToRelativeLuminance( texel.rgb );
+			float l = linearToRelativeLuminance( texel.rgb );
 
-	gl_FragColor = vec4( l, l, l, texel.w );
+			gl_FragColor = vec4( l, l, l, texel.w );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/LuminosityShader.js
+++ b/examples/js/shaders/LuminosityShader.js
@@ -13,38 +13,34 @@ THREE.LuminosityShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"#include <common>",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 texel = texture2D( tDiffuse, vUv );
 
-		"varying vec2 vUv;",
+	float l = linearToRelativeLuminance( texel.rgb );
 
-		"void main() {",
+	gl_FragColor = vec4( l, l, l, texel.w );
 
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
-
-		"	float l = linearToRelativeLuminance( texel.rgb );",
-
-		"	gl_FragColor = vec4( l, l, l, texel.w );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/MirrorShader.js
+++ b/examples/js/shaders/MirrorShader.js
@@ -16,43 +16,39 @@ THREE.MirrorShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform int side;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform int side;",
+	vec2 p = vUv;
+	if (side == 0){
+		if (p.x > 0.5) p.x = 1.0 - p.x;
+	}else if (side == 1){
+		if (p.x < 0.5) p.x = 1.0 - p.x;
+	}else if (side == 2){
+		if (p.y < 0.5) p.y = 1.0 - p.y;
+	}else if (side == 3){
+		if (p.y > 0.5) p.y = 1.0 - p.y;
+	}
+	vec4 color = texture2D(tDiffuse, p);
+	gl_FragColor = color;
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	vec2 p = vUv;",
-		"	if (side == 0){",
-		"		if (p.x > 0.5) p.x = 1.0 - p.x;",
-		"	}else if (side == 1){",
-		"		if (p.x < 0.5) p.x = 1.0 - p.x;",
-		"	}else if (side == 2){",
-		"		if (p.y < 0.5) p.y = 1.0 - p.y;",
-		"	}else if (side == 3){",
-		"		if (p.y > 0.5) p.y = 1.0 - p.y;",
-		"	} ",
-		"	vec4 color = texture2D(tDiffuse, p);",
-		"	gl_FragColor = color;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/MirrorShader.js
+++ b/examples/js/shaders/MirrorShader.js
@@ -17,38 +17,37 @@ THREE.MirrorShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform int side;
+		uniform sampler2D tDiffuse;
+		uniform int side;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec2 p = vUv;
-	if (side == 0){
-		if (p.x > 0.5) p.x = 1.0 - p.x;
-	}else if (side == 1){
-		if (p.x < 0.5) p.x = 1.0 - p.x;
-	}else if (side == 2){
-		if (p.y < 0.5) p.y = 1.0 - p.y;
-	}else if (side == 3){
-		if (p.y > 0.5) p.y = 1.0 - p.y;
-	}
-	vec4 color = texture2D(tDiffuse, p);
-	gl_FragColor = color;
+			vec2 p = vUv;
+			if (side == 0){
+				if (p.x > 0.5) p.x = 1.0 - p.x;
+			}else if (side == 1){
+				if (p.x < 0.5) p.x = 1.0 - p.x;
+			}else if (side == 2){
+				if (p.y < 0.5) p.y = 1.0 - p.y;
+			}else if (side == 3){
+				if (p.y > 0.5) p.y = 1.0 - p.y;
+			}
+			vec4 color = texture2D(tDiffuse, p);
+			gl_FragColor = color;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/NormalMapShader.js
+++ b/examples/js/shaders/NormalMapShader.js
@@ -17,33 +17,32 @@ THREE.NormalMapShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float height;
-uniform vec2 resolution;
-uniform sampler2D heightMap;
+		uniform float height;
+		uniform vec2 resolution;
+		uniform sampler2D heightMap;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	float val = texture2D( heightMap, vUv ).x;
+			float val = texture2D( heightMap, vUv ).x;
 
-	float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;
-	float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;
+			float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;
+			float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;
 
-	gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );
+			gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/NormalMapShader.js
+++ b/examples/js/shaders/NormalMapShader.js
@@ -16,38 +16,34 @@ THREE.NormalMapShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float height;
+uniform vec2 resolution;
+uniform sampler2D heightMap;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform float height;",
-		"uniform vec2 resolution;",
-		"uniform sampler2D heightMap;",
+	float val = texture2D( heightMap, vUv ).x;
 
-		"varying vec2 vUv;",
+	float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;
+	float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;
 
-		"void main() {",
+	gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );
 
-		"	float val = texture2D( heightMap, vUv ).x;",
-
-		"	float valU = texture2D( heightMap, vUv + vec2( 1.0 / resolution.x, 0.0 ) ).x;",
-		"	float valV = texture2D( heightMap, vUv + vec2( 0.0, 1.0 / resolution.y ) ).x;",
-
-		"	gl_FragColor = vec4( ( 0.5 * normalize( vec3( val - valU, val - valV, height  ) ) + 0.5 ), 1.0 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/OceanShaders.js
+++ b/examples/js/shaders/OceanShaders.js
@@ -24,14 +24,14 @@
 
 THREE.OceanShaders = {};
 THREE.OceanShaders[ "ocean_sim_vertex" ] = {
-	vertexShader: [
-		"varying vec2 vUV;",
+	vertexShader: /* glsl */`
+varying vec2 vUV;
 
-		"void main (void) {",
-		"	vUV = position.xy * 0.5 + 0.5;",
-		"	gl_Position = vec4(position, 1.0 );",
-		"}"
-	].join( "\n" )
+void main (void) {
+	vUV = position.xy * 0.5 + 0.5;
+	gl_Position = vec4(position, 1.0 );
+}
+`
 };
 THREE.OceanShaders[ "ocean_subtransform" ] = {
 	uniforms: {
@@ -39,49 +39,49 @@ THREE.OceanShaders[ "ocean_subtransform" ] = {
 		"u_transformSize": { value: 512.0 },
 		"u_subtransformSize": { value: 250.0 }
 	},
-	fragmentShader: [
-		//GPU FFT using a Stockham formulation
+	fragmentShader: /* glsl */`
+//GPU FFT using a Stockham formulation
 
-		"precision highp float;",
-		"#include <common>",
+precision highp float;
+#include <common>
 
-		"uniform sampler2D u_input;",
-		"uniform float u_transformSize;",
-		"uniform float u_subtransformSize;",
+uniform sampler2D u_input;
+uniform float u_transformSize;
+uniform float u_subtransformSize;
 
-		"varying vec2 vUV;",
+varying vec2 vUV;
 
-		"vec2 multiplyComplex (vec2 a, vec2 b) {",
-		"	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);",
-		"}",
+vec2 multiplyComplex (vec2 a, vec2 b) {
+	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
+}
 
-		"void main (void) {",
-		"	#ifdef HORIZONTAL",
-		"	float index = vUV.x * u_transformSize - 0.5;",
-		"	#else",
-		"	float index = vUV.y * u_transformSize - 0.5;",
-		"	#endif",
+void main (void) {
+	#ifdef HORIZONTAL
+	float index = vUV.x * u_transformSize - 0.5;
+	#else
+	float index = vUV.y * u_transformSize - 0.5;
+	#endif
 
-		"	float evenIndex = floor(index / u_subtransformSize) * (u_subtransformSize * 0.5) + mod(index, u_subtransformSize * 0.5);",
+	float evenIndex = floor(index / u_subtransformSize) * (u_subtransformSize * 0.5) + mod(index, u_subtransformSize * 0.5);
 
-		//transform two complex sequences simultaneously
-		"	#ifdef HORIZONTAL",
-		"	vec4 even = texture2D(u_input, vec2(evenIndex + 0.5, gl_FragCoord.y) / u_transformSize).rgba;",
-		"	vec4 odd = texture2D(u_input, vec2(evenIndex + u_transformSize * 0.5 + 0.5, gl_FragCoord.y) / u_transformSize).rgba;",
-		"	#else",
-		"	vec4 even = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + 0.5) / u_transformSize).rgba;",
-		"	vec4 odd = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + u_transformSize * 0.5 + 0.5) / u_transformSize).rgba;",
-		"	#endif",
+	//transform two complex sequences simultaneously
+	#ifdef HORIZONTAL
+	vec4 even = texture2D(u_input, vec2(evenIndex + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
+	vec4 odd = texture2D(u_input, vec2(evenIndex + u_transformSize * 0.5 + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
+	#else
+	vec4 even = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + 0.5) / u_transformSize).rgba;
+	vec4 odd = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + u_transformSize * 0.5 + 0.5) / u_transformSize).rgba;
+	#endif
 
-		"	float twiddleArgument = -2.0 * PI * (index / u_subtransformSize);",
-		"	vec2 twiddle = vec2(cos(twiddleArgument), sin(twiddleArgument));",
+	float twiddleArgument = -2.0 * PI * (index / u_subtransformSize);
+	vec2 twiddle = vec2(cos(twiddleArgument), sin(twiddleArgument));
 
-		"	vec2 outputA = even.xy + multiplyComplex(twiddle, odd.xy);",
-		"	vec2 outputB = even.zw + multiplyComplex(twiddle, odd.zw);",
+	vec2 outputA = even.xy + multiplyComplex(twiddle, odd.xy);
+	vec2 outputB = even.zw + multiplyComplex(twiddle, odd.zw);
 
-		"	gl_FragColor = vec4(outputA, outputB);",
-		"}"
-	].join( "\n" )
+	gl_FragColor = vec4(outputA, outputB);
+}
+`
 };
 THREE.OceanShaders[ "ocean_initial_spectrum" ] = {
 	uniforms: {
@@ -89,82 +89,82 @@ THREE.OceanShaders[ "ocean_initial_spectrum" ] = {
 		"u_resolution": { value: 512.0 },
 		"u_size": { value: 250.0 }
 	},
-	vertexShader: [
-		"void main (void) {",
-		"	gl_Position = vec4(position, 1.0);",
-		"}"
-	].join( "\n" ),
-	fragmentShader: [
-		"precision highp float;",
-		"#include <common>",
+	vertexShader: /* glsl */`
+void main (void) {
+	gl_Position = vec4(position, 1.0);
+}
+`,
+	fragmentShader: /* glsl */`
+precision highp float;
+#include <common>
 
-		"const float G = 9.81;",
-		"const float KM = 370.0;",
-		"const float CM = 0.23;",
+const float G = 9.81;
+const float KM = 370.0;
+const float CM = 0.23;
 
-		"uniform vec2 u_wind;",
-		"uniform float u_resolution;",
-		"uniform float u_size;",
+uniform vec2 u_wind;
+uniform float u_resolution;
+uniform float u_size;
 
-		"float omega (float k) {",
-		"	return sqrt(G * k * (1.0 + pow2(k / KM)));",
-		"}",
+float omega (float k) {
+	return sqrt(G * k * (1.0 + pow2(k / KM)));
+}
 
-		"#if __VERSION__ == 100",
-		"float tanh (float x) {",
-		"	return (1.0 - exp(-2.0 * x)) / (1.0 + exp(-2.0 * x));",
-		"}",
-		"#endif",
+#if __VERSION__ == 100
+float tanh (float x) {
+	return (1.0 - exp(-2.0 * x)) / (1.0 + exp(-2.0 * x));
+}
+#endif
 
-		"void main (void) {",
-		"	vec2 coordinates = gl_FragCoord.xy - 0.5;",
+void main (void) {
+	vec2 coordinates = gl_FragCoord.xy - 0.5;
 
-		"	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;",
-		"	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;",
+	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
 
-		"	vec2 K = (2.0 * PI * vec2(n, m)) / u_size;",
-		"	float k = length(K);",
+	vec2 K = (2.0 * PI * vec2(n, m)) / u_size;
+	float k = length(K);
 
-		"	float l_wind = length(u_wind);",
+	float l_wind = length(u_wind);
 
-		"	float Omega = 0.84;",
-		"	float kp = G * pow2(Omega / l_wind);",
+	float Omega = 0.84;
+	float kp = G * pow2(Omega / l_wind);
 
-		"	float c = omega(k) / k;",
-		"	float cp = omega(kp) / kp;",
+	float c = omega(k) / k;
+	float cp = omega(kp) / kp;
 
-		"	float Lpm = exp(-1.25 * pow2(kp / k));",
-		"	float gamma = 1.7;",
-		"	float sigma = 0.08 * (1.0 + 4.0 * pow(Omega, -3.0));",
-		"	float Gamma = exp(-pow2(sqrt(k / kp) - 1.0) / 2.0 * pow2(sigma));",
-		"	float Jp = pow(gamma, Gamma);",
-		"	float Fp = Lpm * Jp * exp(-Omega / sqrt(10.0) * (sqrt(k / kp) - 1.0));",
-		"	float alphap = 0.006 * sqrt(Omega);",
-		"	float Bl = 0.5 * alphap * cp / c * Fp;",
+	float Lpm = exp(-1.25 * pow2(kp / k));
+	float gamma = 1.7;
+	float sigma = 0.08 * (1.0 + 4.0 * pow(Omega, -3.0));
+	float Gamma = exp(-pow2(sqrt(k / kp) - 1.0) / 2.0 * pow2(sigma));
+	float Jp = pow(gamma, Gamma);
+	float Fp = Lpm * Jp * exp(-Omega / sqrt(10.0) * (sqrt(k / kp) - 1.0));
+	float alphap = 0.006 * sqrt(Omega);
+	float Bl = 0.5 * alphap * cp / c * Fp;
 
-		"	float z0 = 0.000037 * pow2(l_wind) / G * pow(l_wind / cp, 0.9);",
-		"	float uStar = 0.41 * l_wind / log(10.0 / z0);",
-		"	float alpham = 0.01 * ((uStar < CM) ? (1.0 + log(uStar / CM)) : (1.0 + 3.0 * log(uStar / CM)));",
-		"	float Fm = exp(-0.25 * pow2(k / KM - 1.0));",
-		"	float Bh = 0.5 * alpham * CM / c * Fm * Lpm;",
+	float z0 = 0.000037 * pow2(l_wind) / G * pow(l_wind / cp, 0.9);
+	float uStar = 0.41 * l_wind / log(10.0 / z0);
+	float alpham = 0.01 * ((uStar < CM) ? (1.0 + log(uStar / CM)) : (1.0 + 3.0 * log(uStar / CM)));
+	float Fm = exp(-0.25 * pow2(k / KM - 1.0));
+	float Bh = 0.5 * alpham * CM / c * Fm * Lpm;
 
-		"	float a0 = log(2.0) / 4.0;",
-		"	float am = 0.13 * uStar / CM;",
-		"	float Delta = tanh(a0 + 4.0 * pow(c / cp, 2.5) + am * pow(CM / c, 2.5));",
+	float a0 = log(2.0) / 4.0;
+	float am = 0.13 * uStar / CM;
+	float Delta = tanh(a0 + 4.0 * pow(c / cp, 2.5) + am * pow(CM / c, 2.5));
 
-		"	float cosPhi = dot(normalize(u_wind), normalize(K));",
+	float cosPhi = dot(normalize(u_wind), normalize(K));
 
-		"	float S = (1.0 / (2.0 * PI)) * pow(k, -4.0) * (Bl + Bh) * (1.0 + Delta * (2.0 * cosPhi * cosPhi - 1.0));",
+	float S = (1.0 / (2.0 * PI)) * pow(k, -4.0) * (Bl + Bh) * (1.0 + Delta * (2.0 * cosPhi * cosPhi - 1.0));
 
-		"	float dk = 2.0 * PI / u_size;",
-		"	float h = sqrt(S / 2.0) * dk;",
+	float dk = 2.0 * PI / u_size;
+	float h = sqrt(S / 2.0) * dk;
 
-		"	if (K.x == 0.0 && K.y == 0.0) {",
-		"		h = 0.0;", //no DC term
-		"	}",
-		"	gl_FragColor = vec4(h, 0.0, 0.0, 0.0);",
-		"}"
-	].join( "\n" )
+	if (K.x == 0.0 && K.y == 0.0) {
+		h = 0.0; //no DC term
+	}
+	gl_FragColor = vec4(h, 0.0, 0.0, 0.0);
+}
+`
 };
 THREE.OceanShaders[ "ocean_phase" ] = {
 	uniforms: {
@@ -173,38 +173,38 @@ THREE.OceanShaders[ "ocean_phase" ] = {
 		"u_resolution": { value: null },
 		"u_size": { value: null }
 	},
-	fragmentShader: [
-		"precision highp float;",
-		"#include <common>",
+	fragmentShader: /* glsl */`
+precision highp float;
+#include <common>
 
-		"const float G = 9.81;",
-		"const float KM = 370.0;",
+const float G = 9.81;
+const float KM = 370.0;
 
-		"varying vec2 vUV;",
+varying vec2 vUV;
 
-		"uniform sampler2D u_phases;",
-		"uniform float u_deltaTime;",
-		"uniform float u_resolution;",
-		"uniform float u_size;",
+uniform sampler2D u_phases;
+uniform float u_deltaTime;
+uniform float u_resolution;
+uniform float u_size;
 
-		"float omega (float k) {",
-		"	return sqrt(G * k * (1.0 + k * k / KM * KM));",
-		"}",
+float omega (float k) {
+	return sqrt(G * k * (1.0 + k * k / KM * KM));
+}
 
-		"void main (void) {",
-		"	float deltaTime = 1.0 / 60.0;",
-		"	vec2 coordinates = gl_FragCoord.xy - 0.5;",
-		"	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;",
-		"	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;",
-		"	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;",
+void main (void) {
+	float deltaTime = 1.0 / 60.0;
+	vec2 coordinates = gl_FragCoord.xy - 0.5;
+	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
+	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
 
-		"	float phase = texture2D(u_phases, vUV).r;",
-		"	float deltaPhase = omega(length(waveVector)) * u_deltaTime;",
-		"	phase = mod(phase + deltaPhase, 2.0 * PI);",
+	float phase = texture2D(u_phases, vUV).r;
+	float deltaPhase = omega(length(waveVector)) * u_deltaTime;
+	phase = mod(phase + deltaPhase, 2.0 * PI);
 
-		"	gl_FragColor = vec4(phase, 0.0, 0.0, 0.0);",
-		"}"
-	].join( "\n" )
+	gl_FragColor = vec4(phase, 0.0, 0.0, 0.0);
+}
+`
 };
 THREE.OceanShaders[ "ocean_spectrum" ] = {
 	uniforms: {
@@ -214,61 +214,61 @@ THREE.OceanShaders[ "ocean_spectrum" ] = {
 		"u_phases": { value: null },
 		"u_initialSpectrum": { value: null }
 	},
-	fragmentShader: [
-		"precision highp float;",
-		"#include <common>",
+	fragmentShader: /* glsl */`
+precision highp float;
+#include <common>
 
-		"const float G = 9.81;",
-		"const float KM = 370.0;",
+const float G = 9.81;
+const float KM = 370.0;
 
-		"varying vec2 vUV;",
+varying vec2 vUV;
 
-		"uniform float u_size;",
-		"uniform float u_resolution;",
-		"uniform float u_choppiness;",
-		"uniform sampler2D u_phases;",
-		"uniform sampler2D u_initialSpectrum;",
+uniform float u_size;
+uniform float u_resolution;
+uniform float u_choppiness;
+uniform sampler2D u_phases;
+uniform sampler2D u_initialSpectrum;
 
-		"vec2 multiplyComplex (vec2 a, vec2 b) {",
-		"	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);",
-		"}",
+vec2 multiplyComplex (vec2 a, vec2 b) {
+	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
+}
 
-		"vec2 multiplyByI (vec2 z) {",
-		"	return vec2(-z[1], z[0]);",
-		"}",
+vec2 multiplyByI (vec2 z) {
+	return vec2(-z[1], z[0]);
+}
 
-		"float omega (float k) {",
-		"	return sqrt(G * k * (1.0 + k * k / KM * KM));",
-		"}",
+float omega (float k) {
+	return sqrt(G * k * (1.0 + k * k / KM * KM));
+}
 
-		"void main (void) {",
-		"	vec2 coordinates = gl_FragCoord.xy - 0.5;",
-		"	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;",
-		"	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;",
-		"	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;",
+void main (void) {
+	vec2 coordinates = gl_FragCoord.xy - 0.5;
+	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
+	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
 
-		"	float phase = texture2D(u_phases, vUV).r;",
-		"	vec2 phaseVector = vec2(cos(phase), sin(phase));",
+	float phase = texture2D(u_phases, vUV).r;
+	vec2 phaseVector = vec2(cos(phase), sin(phase));
 
-		"	vec2 h0 = texture2D(u_initialSpectrum, vUV).rg;",
-		"	vec2 h0Star = texture2D(u_initialSpectrum, vec2(1.0 - vUV + 1.0 / u_resolution)).rg;",
-		"	h0Star.y *= -1.0;",
+	vec2 h0 = texture2D(u_initialSpectrum, vUV).rg;
+	vec2 h0Star = texture2D(u_initialSpectrum, vec2(1.0 - vUV + 1.0 / u_resolution)).rg;
+	h0Star.y *= -1.0;
 
-		"	vec2 h = multiplyComplex(h0, phaseVector) + multiplyComplex(h0Star, vec2(phaseVector.x, -phaseVector.y));",
+	vec2 h = multiplyComplex(h0, phaseVector) + multiplyComplex(h0Star, vec2(phaseVector.x, -phaseVector.y));
 
-		"	vec2 hX = -multiplyByI(h * (waveVector.x / length(waveVector))) * u_choppiness;",
-		"	vec2 hZ = -multiplyByI(h * (waveVector.y / length(waveVector))) * u_choppiness;",
+	vec2 hX = -multiplyByI(h * (waveVector.x / length(waveVector))) * u_choppiness;
+	vec2 hZ = -multiplyByI(h * (waveVector.y / length(waveVector))) * u_choppiness;
 
-		//no DC term
-		"	if (waveVector.x == 0.0 && waveVector.y == 0.0) {",
-		"		h = vec2(0.0);",
-		"		hX = vec2(0.0);",
-		"		hZ = vec2(0.0);",
-		"	}",
+	//no DC term
+	if (waveVector.x == 0.0 && waveVector.y == 0.0) {
+		h = vec2(0.0);
+		hX = vec2(0.0);
+		hZ = vec2(0.0);
+	}
 
-		"	gl_FragColor = vec4(hX + multiplyByI(h), hZ);",
-		"}"
-	].join( "\n" )
+	gl_FragColor = vec4(hX + multiplyByI(h), hZ);
+}
+`
 };
 THREE.OceanShaders[ "ocean_normals" ] = {
 	uniforms: {
@@ -276,33 +276,33 @@ THREE.OceanShaders[ "ocean_normals" ] = {
 		"u_resolution": { value: null },
 		"u_size": { value: null }
 	},
-	fragmentShader: [
-		"precision highp float;",
+	fragmentShader: /* glsl */`
+precision highp float;
 
-		"varying vec2 vUV;",
+varying vec2 vUV;
 
-		"uniform sampler2D u_displacementMap;",
-		"uniform float u_resolution;",
-		"uniform float u_size;",
+uniform sampler2D u_displacementMap;
+uniform float u_resolution;
+uniform float u_size;
 
-		"void main (void) {",
-		"	float texel = 1.0 / u_resolution;",
-		"	float texelSize = u_size / u_resolution;",
+void main (void) {
+	float texel = 1.0 / u_resolution;
+	float texelSize = u_size / u_resolution;
 
-		"	vec3 center = texture2D(u_displacementMap, vUV).rgb;",
-		"	vec3 right = vec3(texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(texel, 0.0)).rgb - center;",
-		"	vec3 left = vec3(-texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(-texel, 0.0)).rgb - center;",
-		"	vec3 top = vec3(0.0, 0.0, -texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, -texel)).rgb - center;",
-		"	vec3 bottom = vec3(0.0, 0.0, texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, texel)).rgb - center;",
+	vec3 center = texture2D(u_displacementMap, vUV).rgb;
+	vec3 right = vec3(texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(texel, 0.0)).rgb - center;
+	vec3 left = vec3(-texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(-texel, 0.0)).rgb - center;
+	vec3 top = vec3(0.0, 0.0, -texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, -texel)).rgb - center;
+	vec3 bottom = vec3(0.0, 0.0, texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, texel)).rgb - center;
 
-		"	vec3 topRight = cross(right, top);",
-		"	vec3 topLeft = cross(top, left);",
-		"	vec3 bottomLeft = cross(left, bottom);",
-		"	vec3 bottomRight = cross(bottom, right);",
+	vec3 topRight = cross(right, top);
+	vec3 topLeft = cross(top, left);
+	vec3 bottomLeft = cross(left, bottom);
+	vec3 bottomRight = cross(bottom, right);
 
-		"	gl_FragColor = vec4(normalize(topRight + topLeft + bottomLeft + bottomRight), 1.0);",
-		"}"
-	].join( "\n" )
+	gl_FragColor = vec4(normalize(topRight + topLeft + bottomLeft + bottomRight), 1.0);
+}
+`
 };
 THREE.OceanShaders[ "ocean_main" ] = {
 	uniforms: {
@@ -318,56 +318,56 @@ THREE.OceanShaders[ "ocean_main" ] = {
 		"u_sunDirection": { value: null },
 		"u_exposure": { value: null }
 	},
-	vertexShader: [
-		"precision highp float;",
+	vertexShader: /* glsl */`
+precision highp float;
 
-		"varying vec3 vPos;",
-		"varying vec2 vUV;",
+varying vec3 vPos;
+varying vec2 vUV;
 
-		"uniform mat4 u_projectionMatrix;",
-		"uniform mat4 u_viewMatrix;",
-		"uniform float u_size;",
-		"uniform float u_geometrySize;",
-		"uniform sampler2D u_displacementMap;",
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_viewMatrix;
+uniform float u_size;
+uniform float u_geometrySize;
+uniform sampler2D u_displacementMap;
 
-		"void main (void) {",
-		"	vec3 newPos = position + texture2D(u_displacementMap, uv).rgb * (u_geometrySize / u_size);",
-		"	vPos = newPos;",
-		"	vUV = uv;",
-		"	gl_Position = u_projectionMatrix * u_viewMatrix * vec4(newPos, 1.0);",
-		"}"
-	].join( "\n" ),
-	fragmentShader: [
-		"precision highp float;",
+void main (void) {
+	vec3 newPos = position + texture2D(u_displacementMap, uv).rgb * (u_geometrySize / u_size);
+	vPos = newPos;
+	vUV = uv;
+	gl_Position = u_projectionMatrix * u_viewMatrix * vec4(newPos, 1.0);
+}
+`,
+	fragmentShader: /* glsl */`
+precision highp float;
 
-		"varying vec3 vPos;",
-		"varying vec2 vUV;",
+varying vec3 vPos;
+varying vec2 vUV;
 
-		"uniform sampler2D u_displacementMap;",
-		"uniform sampler2D u_normalMap;",
-		"uniform vec3 u_cameraPosition;",
-		"uniform vec3 u_oceanColor;",
-		"uniform vec3 u_skyColor;",
-		"uniform vec3 u_sunDirection;",
-		"uniform float u_exposure;",
+uniform sampler2D u_displacementMap;
+uniform sampler2D u_normalMap;
+uniform vec3 u_cameraPosition;
+uniform vec3 u_oceanColor;
+uniform vec3 u_skyColor;
+uniform vec3 u_sunDirection;
+uniform float u_exposure;
 
-		"vec3 hdr (vec3 color, float exposure) {",
-		"	return 1.0 - exp(-color * exposure);",
-		"}",
+vec3 hdr (vec3 color, float exposure) {
+	return 1.0 - exp(-color * exposure);
+}
 
-		"void main (void) {",
-		"	vec3 normal = texture2D(u_normalMap, vUV).rgb;",
+void main (void) {
+	vec3 normal = texture2D(u_normalMap, vUV).rgb;
 
-		"	vec3 view = normalize(u_cameraPosition - vPos);",
-		"	float fresnel = 0.02 + 0.98 * pow(1.0 - dot(normal, view), 5.0);",
-		"	vec3 sky = fresnel * u_skyColor;",
+	vec3 view = normalize(u_cameraPosition - vPos);
+	float fresnel = 0.02 + 0.98 * pow(1.0 - dot(normal, view), 5.0);
+	vec3 sky = fresnel * u_skyColor;
 
-		"	float diffuse = clamp(dot(normal, normalize(u_sunDirection)), 0.0, 1.0);",
-		"	vec3 water = (1.0 - fresnel) * u_oceanColor * u_skyColor * diffuse;",
+	float diffuse = clamp(dot(normal, normalize(u_sunDirection)), 0.0, 1.0);
+	vec3 water = (1.0 - fresnel) * u_oceanColor * u_skyColor * diffuse;
 
-		"	vec3 color = sky + water;",
+	vec3 color = sky + water;
 
-		"	gl_FragColor = vec4(hdr(color, u_exposure), 1.0);",
-		"}"
-	].join( "\n" )
+	gl_FragColor = vec4(hdr(color, u_exposure), 1.0);
+}
+`
 };

--- a/examples/js/shaders/OceanShaders.js
+++ b/examples/js/shaders/OceanShaders.js
@@ -25,13 +25,13 @@
 THREE.OceanShaders = {};
 THREE.OceanShaders[ "ocean_sim_vertex" ] = {
 	vertexShader: /* glsl */`
-varying vec2 vUV;
+		varying vec2 vUV;
 
-void main (void) {
-	vUV = position.xy * 0.5 + 0.5;
-	gl_Position = vec4(position, 1.0 );
-}
-`
+		void main (void) {
+			vUV = position.xy * 0.5 + 0.5;
+			gl_Position = vec4(position, 1.0 );
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_subtransform" ] = {
 	uniforms: {
@@ -40,48 +40,48 @@ THREE.OceanShaders[ "ocean_subtransform" ] = {
 		"u_subtransformSize": { value: 250.0 }
 	},
 	fragmentShader: /* glsl */`
-//GPU FFT using a Stockham formulation
+		//GPU FFT using a Stockham formulation
 
-precision highp float;
-#include <common>
+		precision highp float;
+		#include <common>
 
-uniform sampler2D u_input;
-uniform float u_transformSize;
-uniform float u_subtransformSize;
+		uniform sampler2D u_input;
+		uniform float u_transformSize;
+		uniform float u_subtransformSize;
 
-varying vec2 vUV;
+		varying vec2 vUV;
 
-vec2 multiplyComplex (vec2 a, vec2 b) {
-	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
-}
+		vec2 multiplyComplex (vec2 a, vec2 b) {
+			return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
+		}
 
-void main (void) {
-	#ifdef HORIZONTAL
-	float index = vUV.x * u_transformSize - 0.5;
-	#else
-	float index = vUV.y * u_transformSize - 0.5;
-	#endif
+		void main (void) {
+			#ifdef HORIZONTAL
+			float index = vUV.x * u_transformSize - 0.5;
+			#else
+			float index = vUV.y * u_transformSize - 0.5;
+			#endif
 
-	float evenIndex = floor(index / u_subtransformSize) * (u_subtransformSize * 0.5) + mod(index, u_subtransformSize * 0.5);
+			float evenIndex = floor(index / u_subtransformSize) * (u_subtransformSize * 0.5) + mod(index, u_subtransformSize * 0.5);
 
-	//transform two complex sequences simultaneously
-	#ifdef HORIZONTAL
-	vec4 even = texture2D(u_input, vec2(evenIndex + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
-	vec4 odd = texture2D(u_input, vec2(evenIndex + u_transformSize * 0.5 + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
-	#else
-	vec4 even = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + 0.5) / u_transformSize).rgba;
-	vec4 odd = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + u_transformSize * 0.5 + 0.5) / u_transformSize).rgba;
-	#endif
+			//transform two complex sequences simultaneously
+			#ifdef HORIZONTAL
+			vec4 even = texture2D(u_input, vec2(evenIndex + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
+			vec4 odd = texture2D(u_input, vec2(evenIndex + u_transformSize * 0.5 + 0.5, gl_FragCoord.y) / u_transformSize).rgba;
+			#else
+			vec4 even = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + 0.5) / u_transformSize).rgba;
+			vec4 odd = texture2D(u_input, vec2(gl_FragCoord.x, evenIndex + u_transformSize * 0.5 + 0.5) / u_transformSize).rgba;
+			#endif
 
-	float twiddleArgument = -2.0 * PI * (index / u_subtransformSize);
-	vec2 twiddle = vec2(cos(twiddleArgument), sin(twiddleArgument));
+			float twiddleArgument = -2.0 * PI * (index / u_subtransformSize);
+			vec2 twiddle = vec2(cos(twiddleArgument), sin(twiddleArgument));
 
-	vec2 outputA = even.xy + multiplyComplex(twiddle, odd.xy);
-	vec2 outputB = even.zw + multiplyComplex(twiddle, odd.zw);
+			vec2 outputA = even.xy + multiplyComplex(twiddle, odd.xy);
+			vec2 outputB = even.zw + multiplyComplex(twiddle, odd.zw);
 
-	gl_FragColor = vec4(outputA, outputB);
-}
-`
+			gl_FragColor = vec4(outputA, outputB);
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_initial_spectrum" ] = {
 	uniforms: {
@@ -90,81 +90,81 @@ THREE.OceanShaders[ "ocean_initial_spectrum" ] = {
 		"u_size": { value: 250.0 }
 	},
 	vertexShader: /* glsl */`
-void main (void) {
-	gl_Position = vec4(position, 1.0);
-}
-`,
+		void main (void) {
+			gl_Position = vec4(position, 1.0);
+		}
+	`,
 	fragmentShader: /* glsl */`
-precision highp float;
-#include <common>
+		precision highp float;
+		#include <common>
 
-const float G = 9.81;
-const float KM = 370.0;
-const float CM = 0.23;
+		const float G = 9.81;
+		const float KM = 370.0;
+		const float CM = 0.23;
 
-uniform vec2 u_wind;
-uniform float u_resolution;
-uniform float u_size;
+		uniform vec2 u_wind;
+		uniform float u_resolution;
+		uniform float u_size;
 
-float omega (float k) {
-	return sqrt(G * k * (1.0 + pow2(k / KM)));
-}
+		float omega (float k) {
+			return sqrt(G * k * (1.0 + pow2(k / KM)));
+		}
 
-#if __VERSION__ == 100
-float tanh (float x) {
-	return (1.0 - exp(-2.0 * x)) / (1.0 + exp(-2.0 * x));
-}
-#endif
+		#if __VERSION__ == 100
+		float tanh (float x) {
+			return (1.0 - exp(-2.0 * x)) / (1.0 + exp(-2.0 * x));
+		}
+		#endif
 
-void main (void) {
-	vec2 coordinates = gl_FragCoord.xy - 0.5;
+		void main (void) {
+			vec2 coordinates = gl_FragCoord.xy - 0.5;
 
-	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
-	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
+			float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+			float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
 
-	vec2 K = (2.0 * PI * vec2(n, m)) / u_size;
-	float k = length(K);
+			vec2 K = (2.0 * PI * vec2(n, m)) / u_size;
+			float k = length(K);
 
-	float l_wind = length(u_wind);
+			float l_wind = length(u_wind);
 
-	float Omega = 0.84;
-	float kp = G * pow2(Omega / l_wind);
+			float Omega = 0.84;
+			float kp = G * pow2(Omega / l_wind);
 
-	float c = omega(k) / k;
-	float cp = omega(kp) / kp;
+			float c = omega(k) / k;
+			float cp = omega(kp) / kp;
 
-	float Lpm = exp(-1.25 * pow2(kp / k));
-	float gamma = 1.7;
-	float sigma = 0.08 * (1.0 + 4.0 * pow(Omega, -3.0));
-	float Gamma = exp(-pow2(sqrt(k / kp) - 1.0) / 2.0 * pow2(sigma));
-	float Jp = pow(gamma, Gamma);
-	float Fp = Lpm * Jp * exp(-Omega / sqrt(10.0) * (sqrt(k / kp) - 1.0));
-	float alphap = 0.006 * sqrt(Omega);
-	float Bl = 0.5 * alphap * cp / c * Fp;
+			float Lpm = exp(-1.25 * pow2(kp / k));
+			float gamma = 1.7;
+			float sigma = 0.08 * (1.0 + 4.0 * pow(Omega, -3.0));
+			float Gamma = exp(-pow2(sqrt(k / kp) - 1.0) / 2.0 * pow2(sigma));
+			float Jp = pow(gamma, Gamma);
+			float Fp = Lpm * Jp * exp(-Omega / sqrt(10.0) * (sqrt(k / kp) - 1.0));
+			float alphap = 0.006 * sqrt(Omega);
+			float Bl = 0.5 * alphap * cp / c * Fp;
 
-	float z0 = 0.000037 * pow2(l_wind) / G * pow(l_wind / cp, 0.9);
-	float uStar = 0.41 * l_wind / log(10.0 / z0);
-	float alpham = 0.01 * ((uStar < CM) ? (1.0 + log(uStar / CM)) : (1.0 + 3.0 * log(uStar / CM)));
-	float Fm = exp(-0.25 * pow2(k / KM - 1.0));
-	float Bh = 0.5 * alpham * CM / c * Fm * Lpm;
+			float z0 = 0.000037 * pow2(l_wind) / G * pow(l_wind / cp, 0.9);
+			float uStar = 0.41 * l_wind / log(10.0 / z0);
+			float alpham = 0.01 * ((uStar < CM) ? (1.0 + log(uStar / CM)) : (1.0 + 3.0 * log(uStar / CM)));
+			float Fm = exp(-0.25 * pow2(k / KM - 1.0));
+			float Bh = 0.5 * alpham * CM / c * Fm * Lpm;
 
-	float a0 = log(2.0) / 4.0;
-	float am = 0.13 * uStar / CM;
-	float Delta = tanh(a0 + 4.0 * pow(c / cp, 2.5) + am * pow(CM / c, 2.5));
+			float a0 = log(2.0) / 4.0;
+			float am = 0.13 * uStar / CM;
+			float Delta = tanh(a0 + 4.0 * pow(c / cp, 2.5) + am * pow(CM / c, 2.5));
 
-	float cosPhi = dot(normalize(u_wind), normalize(K));
+			float cosPhi = dot(normalize(u_wind), normalize(K));
 
-	float S = (1.0 / (2.0 * PI)) * pow(k, -4.0) * (Bl + Bh) * (1.0 + Delta * (2.0 * cosPhi * cosPhi - 1.0));
+			float S = (1.0 / (2.0 * PI)) * pow(k, -4.0) * (Bl + Bh) * (1.0 + Delta * (2.0 * cosPhi * cosPhi - 1.0));
 
-	float dk = 2.0 * PI / u_size;
-	float h = sqrt(S / 2.0) * dk;
+			float dk = 2.0 * PI / u_size;
+			float h = sqrt(S / 2.0) * dk;
 
-	if (K.x == 0.0 && K.y == 0.0) {
-		h = 0.0; //no DC term
-	}
-	gl_FragColor = vec4(h, 0.0, 0.0, 0.0);
-}
-`
+			if (K.x == 0.0 && K.y == 0.0) {
+				h = 0.0; //no DC term
+			}
+			gl_FragColor = vec4(h, 0.0, 0.0, 0.0);
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_phase" ] = {
 	uniforms: {
@@ -174,37 +174,37 @@ THREE.OceanShaders[ "ocean_phase" ] = {
 		"u_size": { value: null }
 	},
 	fragmentShader: /* glsl */`
-precision highp float;
-#include <common>
+		precision highp float;
+		#include <common>
 
-const float G = 9.81;
-const float KM = 370.0;
+		const float G = 9.81;
+		const float KM = 370.0;
 
-varying vec2 vUV;
+		varying vec2 vUV;
 
-uniform sampler2D u_phases;
-uniform float u_deltaTime;
-uniform float u_resolution;
-uniform float u_size;
+		uniform sampler2D u_phases;
+		uniform float u_deltaTime;
+		uniform float u_resolution;
+		uniform float u_size;
 
-float omega (float k) {
-	return sqrt(G * k * (1.0 + k * k / KM * KM));
-}
+		float omega (float k) {
+			return sqrt(G * k * (1.0 + k * k / KM * KM));
+		}
 
-void main (void) {
-	float deltaTime = 1.0 / 60.0;
-	vec2 coordinates = gl_FragCoord.xy - 0.5;
-	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
-	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
-	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
+		void main (void) {
+			float deltaTime = 1.0 / 60.0;
+			vec2 coordinates = gl_FragCoord.xy - 0.5;
+			float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+			float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
+			vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
 
-	float phase = texture2D(u_phases, vUV).r;
-	float deltaPhase = omega(length(waveVector)) * u_deltaTime;
-	phase = mod(phase + deltaPhase, 2.0 * PI);
+			float phase = texture2D(u_phases, vUV).r;
+			float deltaPhase = omega(length(waveVector)) * u_deltaTime;
+			phase = mod(phase + deltaPhase, 2.0 * PI);
 
-	gl_FragColor = vec4(phase, 0.0, 0.0, 0.0);
-}
-`
+			gl_FragColor = vec4(phase, 0.0, 0.0, 0.0);
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_spectrum" ] = {
 	uniforms: {
@@ -215,60 +215,60 @@ THREE.OceanShaders[ "ocean_spectrum" ] = {
 		"u_initialSpectrum": { value: null }
 	},
 	fragmentShader: /* glsl */`
-precision highp float;
-#include <common>
+		precision highp float;
+		#include <common>
 
-const float G = 9.81;
-const float KM = 370.0;
+		const float G = 9.81;
+		const float KM = 370.0;
 
-varying vec2 vUV;
+		varying vec2 vUV;
 
-uniform float u_size;
-uniform float u_resolution;
-uniform float u_choppiness;
-uniform sampler2D u_phases;
-uniform sampler2D u_initialSpectrum;
+		uniform float u_size;
+		uniform float u_resolution;
+		uniform float u_choppiness;
+		uniform sampler2D u_phases;
+		uniform sampler2D u_initialSpectrum;
 
-vec2 multiplyComplex (vec2 a, vec2 b) {
-	return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
-}
+		vec2 multiplyComplex (vec2 a, vec2 b) {
+			return vec2(a[0] * b[0] - a[1] * b[1], a[1] * b[0] + a[0] * b[1]);
+		}
 
-vec2 multiplyByI (vec2 z) {
-	return vec2(-z[1], z[0]);
-}
+		vec2 multiplyByI (vec2 z) {
+			return vec2(-z[1], z[0]);
+		}
 
-float omega (float k) {
-	return sqrt(G * k * (1.0 + k * k / KM * KM));
-}
+		float omega (float k) {
+			return sqrt(G * k * (1.0 + k * k / KM * KM));
+		}
 
-void main (void) {
-	vec2 coordinates = gl_FragCoord.xy - 0.5;
-	float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
-	float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
-	vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
+		void main (void) {
+			vec2 coordinates = gl_FragCoord.xy - 0.5;
+			float n = (coordinates.x < u_resolution * 0.5) ? coordinates.x : coordinates.x - u_resolution;
+			float m = (coordinates.y < u_resolution * 0.5) ? coordinates.y : coordinates.y - u_resolution;
+			vec2 waveVector = (2.0 * PI * vec2(n, m)) / u_size;
 
-	float phase = texture2D(u_phases, vUV).r;
-	vec2 phaseVector = vec2(cos(phase), sin(phase));
+			float phase = texture2D(u_phases, vUV).r;
+			vec2 phaseVector = vec2(cos(phase), sin(phase));
 
-	vec2 h0 = texture2D(u_initialSpectrum, vUV).rg;
-	vec2 h0Star = texture2D(u_initialSpectrum, vec2(1.0 - vUV + 1.0 / u_resolution)).rg;
-	h0Star.y *= -1.0;
+			vec2 h0 = texture2D(u_initialSpectrum, vUV).rg;
+			vec2 h0Star = texture2D(u_initialSpectrum, vec2(1.0 - vUV + 1.0 / u_resolution)).rg;
+			h0Star.y *= -1.0;
 
-	vec2 h = multiplyComplex(h0, phaseVector) + multiplyComplex(h0Star, vec2(phaseVector.x, -phaseVector.y));
+			vec2 h = multiplyComplex(h0, phaseVector) + multiplyComplex(h0Star, vec2(phaseVector.x, -phaseVector.y));
 
-	vec2 hX = -multiplyByI(h * (waveVector.x / length(waveVector))) * u_choppiness;
-	vec2 hZ = -multiplyByI(h * (waveVector.y / length(waveVector))) * u_choppiness;
+			vec2 hX = -multiplyByI(h * (waveVector.x / length(waveVector))) * u_choppiness;
+			vec2 hZ = -multiplyByI(h * (waveVector.y / length(waveVector))) * u_choppiness;
 
-	//no DC term
-	if (waveVector.x == 0.0 && waveVector.y == 0.0) {
-		h = vec2(0.0);
-		hX = vec2(0.0);
-		hZ = vec2(0.0);
-	}
+			//no DC term
+			if (waveVector.x == 0.0 && waveVector.y == 0.0) {
+				h = vec2(0.0);
+				hX = vec2(0.0);
+				hZ = vec2(0.0);
+			}
 
-	gl_FragColor = vec4(hX + multiplyByI(h), hZ);
-}
-`
+			gl_FragColor = vec4(hX + multiplyByI(h), hZ);
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_normals" ] = {
 	uniforms: {
@@ -277,32 +277,32 @@ THREE.OceanShaders[ "ocean_normals" ] = {
 		"u_size": { value: null }
 	},
 	fragmentShader: /* glsl */`
-precision highp float;
+		precision highp float;
 
-varying vec2 vUV;
+		varying vec2 vUV;
 
-uniform sampler2D u_displacementMap;
-uniform float u_resolution;
-uniform float u_size;
+		uniform sampler2D u_displacementMap;
+		uniform float u_resolution;
+		uniform float u_size;
 
-void main (void) {
-	float texel = 1.0 / u_resolution;
-	float texelSize = u_size / u_resolution;
+		void main (void) {
+			float texel = 1.0 / u_resolution;
+			float texelSize = u_size / u_resolution;
 
-	vec3 center = texture2D(u_displacementMap, vUV).rgb;
-	vec3 right = vec3(texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(texel, 0.0)).rgb - center;
-	vec3 left = vec3(-texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(-texel, 0.0)).rgb - center;
-	vec3 top = vec3(0.0, 0.0, -texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, -texel)).rgb - center;
-	vec3 bottom = vec3(0.0, 0.0, texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, texel)).rgb - center;
+			vec3 center = texture2D(u_displacementMap, vUV).rgb;
+			vec3 right = vec3(texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(texel, 0.0)).rgb - center;
+			vec3 left = vec3(-texelSize, 0.0, 0.0) + texture2D(u_displacementMap, vUV + vec2(-texel, 0.0)).rgb - center;
+			vec3 top = vec3(0.0, 0.0, -texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, -texel)).rgb - center;
+			vec3 bottom = vec3(0.0, 0.0, texelSize) + texture2D(u_displacementMap, vUV + vec2(0.0, texel)).rgb - center;
 
-	vec3 topRight = cross(right, top);
-	vec3 topLeft = cross(top, left);
-	vec3 bottomLeft = cross(left, bottom);
-	vec3 bottomRight = cross(bottom, right);
+			vec3 topRight = cross(right, top);
+			vec3 topLeft = cross(top, left);
+			vec3 bottomLeft = cross(left, bottom);
+			vec3 bottomRight = cross(bottom, right);
 
-	gl_FragColor = vec4(normalize(topRight + topLeft + bottomLeft + bottomRight), 1.0);
-}
-`
+			gl_FragColor = vec4(normalize(topRight + topLeft + bottomLeft + bottomRight), 1.0);
+		}
+	`
 };
 THREE.OceanShaders[ "ocean_main" ] = {
 	uniforms: {
@@ -319,55 +319,55 @@ THREE.OceanShaders[ "ocean_main" ] = {
 		"u_exposure": { value: null }
 	},
 	vertexShader: /* glsl */`
-precision highp float;
+		precision highp float;
 
-varying vec3 vPos;
-varying vec2 vUV;
+		varying vec3 vPos;
+		varying vec2 vUV;
 
-uniform mat4 u_projectionMatrix;
-uniform mat4 u_viewMatrix;
-uniform float u_size;
-uniform float u_geometrySize;
-uniform sampler2D u_displacementMap;
+		uniform mat4 u_projectionMatrix;
+		uniform mat4 u_viewMatrix;
+		uniform float u_size;
+		uniform float u_geometrySize;
+		uniform sampler2D u_displacementMap;
 
-void main (void) {
-	vec3 newPos = position + texture2D(u_displacementMap, uv).rgb * (u_geometrySize / u_size);
-	vPos = newPos;
-	vUV = uv;
-	gl_Position = u_projectionMatrix * u_viewMatrix * vec4(newPos, 1.0);
-}
-`,
+		void main (void) {
+			vec3 newPos = position + texture2D(u_displacementMap, uv).rgb * (u_geometrySize / u_size);
+			vPos = newPos;
+			vUV = uv;
+			gl_Position = u_projectionMatrix * u_viewMatrix * vec4(newPos, 1.0);
+		}
+	`,
 	fragmentShader: /* glsl */`
-precision highp float;
+		precision highp float;
 
-varying vec3 vPos;
-varying vec2 vUV;
+		varying vec3 vPos;
+		varying vec2 vUV;
 
-uniform sampler2D u_displacementMap;
-uniform sampler2D u_normalMap;
-uniform vec3 u_cameraPosition;
-uniform vec3 u_oceanColor;
-uniform vec3 u_skyColor;
-uniform vec3 u_sunDirection;
-uniform float u_exposure;
+		uniform sampler2D u_displacementMap;
+		uniform sampler2D u_normalMap;
+		uniform vec3 u_cameraPosition;
+		uniform vec3 u_oceanColor;
+		uniform vec3 u_skyColor;
+		uniform vec3 u_sunDirection;
+		uniform float u_exposure;
 
-vec3 hdr (vec3 color, float exposure) {
-	return 1.0 - exp(-color * exposure);
-}
+		vec3 hdr (vec3 color, float exposure) {
+			return 1.0 - exp(-color * exposure);
+		}
 
-void main (void) {
-	vec3 normal = texture2D(u_normalMap, vUV).rgb;
+		void main (void) {
+			vec3 normal = texture2D(u_normalMap, vUV).rgb;
 
-	vec3 view = normalize(u_cameraPosition - vPos);
-	float fresnel = 0.02 + 0.98 * pow(1.0 - dot(normal, view), 5.0);
-	vec3 sky = fresnel * u_skyColor;
+			vec3 view = normalize(u_cameraPosition - vPos);
+			float fresnel = 0.02 + 0.98 * pow(1.0 - dot(normal, view), 5.0);
+			vec3 sky = fresnel * u_skyColor;
 
-	float diffuse = clamp(dot(normal, normalize(u_sunDirection)), 0.0, 1.0);
-	vec3 water = (1.0 - fresnel) * u_oceanColor * u_skyColor * diffuse;
+			float diffuse = clamp(dot(normal, normalize(u_sunDirection)), 0.0, 1.0);
+			vec3 water = (1.0 - fresnel) * u_oceanColor * u_skyColor * diffuse;
 
-	vec3 color = sky + water;
+			vec3 color = sky + water;
 
-	gl_FragColor = vec4(hdr(color, u_exposure), 1.0);
-}
-`
+			gl_FragColor = vec4(hdr(color, u_exposure), 1.0);
+		}
+	`
 };

--- a/examples/js/shaders/ParallaxShader.js
+++ b/examples/js/shaders/ParallaxShader.js
@@ -21,164 +21,162 @@ THREE.ParallaxShader = {
 		"parallaxMaxLayers": { value: null }
 	},
 
-	vertexShader: [
-		"varying vec2 vUv;",
-		"varying vec3 vViewPosition;",
-		"varying vec3 vNormal;",
+	vertexShader: /* glsl */`
+varying vec2 vUv;
+varying vec3 vViewPosition;
+varying vec3 vNormal;
 
-		"void main() {",
+void main() {
 
-		"	vUv = uv;",
-		"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-		"	vViewPosition = -mvPosition.xyz;",
-		"	vNormal = normalize( normalMatrix * normal );",
-		"	gl_Position = projectionMatrix * mvPosition;",
+	vUv = uv;
+	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+	vViewPosition = -mvPosition.xyz;
+	vNormal = normalize( normalMatrix * normal );
+	gl_Position = projectionMatrix * mvPosition;
 
-		"}"
+}
+`,
 
-	].join( "\n" ),
+	fragmentShader: /* glsl */`
+uniform sampler2D bumpMap;
+uniform sampler2D map;
 
-	fragmentShader: [
-		"uniform sampler2D bumpMap;",
-		"uniform sampler2D map;",
+uniform float parallaxScale;
+uniform float parallaxMinLayers;
+uniform float parallaxMaxLayers;
 
-		"uniform float parallaxScale;",
-		"uniform float parallaxMinLayers;",
-		"uniform float parallaxMaxLayers;",
+varying vec2 vUv;
+varying vec3 vViewPosition;
+varying vec3 vNormal;
 
-		"varying vec2 vUv;",
-		"varying vec3 vViewPosition;",
-		"varying vec3 vNormal;",
+#ifdef USE_BASIC_PARALLAX
 
-		"#ifdef USE_BASIC_PARALLAX",
+	vec2 parallaxMap( in vec3 V ) {
 
-		"	vec2 parallaxMap( in vec3 V ) {",
-
-		"		float initialHeight = texture2D( bumpMap, vUv ).r;",
+		float initialHeight = texture2D( bumpMap, vUv ).r;
 
 		// No Offset Limitting: messy, floating output at grazing angles.
 		//"vec2 texCoordOffset = parallaxScale * V.xy / V.z * initialHeight;",
 
 		// Offset Limiting
-		"		vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;",
-		"		return vUv - texCoordOffset;",
+		vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;
+		return vUv - texCoordOffset;
 
-		"	}",
+	}
 
-		"#else",
+#else
 
-		"	vec2 parallaxMap( in vec3 V ) {",
+	vec2 parallaxMap( in vec3 V ) {
 
 		// Determine number of layers from angle between V and N
-		"		float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );",
+		float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );
 
-		"		float layerHeight = 1.0 / numLayers;",
-		"		float currentLayerHeight = 0.0;",
+		float layerHeight = 1.0 / numLayers;
+		float currentLayerHeight = 0.0;
 		// Shift of texture coordinates for each iteration
-		"		vec2 dtex = parallaxScale * V.xy / V.z / numLayers;",
+		vec2 dtex = parallaxScale * V.xy / V.z / numLayers;
 
-		"		vec2 currentTextureCoords = vUv;",
+		vec2 currentTextureCoords = vUv;
 
-		"		float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
+		float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
 
 		// while ( heightFromTexture > currentLayerHeight )
 		// Infinite loops are not well supported. Do a "large" finite
 		// loop, but not too large, as it slows down some compilers.
-		"		for ( int i = 0; i < 30; i += 1 ) {",
-		"			if ( heightFromTexture <= currentLayerHeight ) {",
-		"				break;",
-		"			}",
-		"			currentLayerHeight += layerHeight;",
-		// Shift texture coordinates along vector V
-		"			currentTextureCoords -= dtex;",
-		"			heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
-		"		}",
+		for ( int i = 0; i < 30; i += 1 ) {
+			if ( heightFromTexture <= currentLayerHeight ) {
+				break;
+			}
+			currentLayerHeight += layerHeight;
+			// Shift texture coordinates along vector V
+			currentTextureCoords -= dtex;
+			heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
+		}
 
-		"		#ifdef USE_STEEP_PARALLAX",
+		#ifdef USE_STEEP_PARALLAX
 
-		"			return currentTextureCoords;",
+			return currentTextureCoords;
 
-		"		#elif defined( USE_RELIEF_PARALLAX )",
+		#elif defined( USE_RELIEF_PARALLAX )
 
-		"			vec2 deltaTexCoord = dtex / 2.0;",
-		"			float deltaHeight = layerHeight / 2.0;",
+			vec2 deltaTexCoord = dtex / 2.0;
+			float deltaHeight = layerHeight / 2.0;
 
-		// Return to the mid point of previous layer
-		"			currentTextureCoords += deltaTexCoord;",
-		"			currentLayerHeight -= deltaHeight;",
+			// Return to the mid point of previous layer
+			currentTextureCoords += deltaTexCoord;
+			currentLayerHeight -= deltaHeight;
 
-		// Binary search to increase precision of Steep Parallax Mapping
-		"			const int numSearches = 5;",
-		"			for ( int i = 0; i < numSearches; i += 1 ) {",
+			// Binary search to increase precision of Steep Parallax Mapping
+			const int numSearches = 5;
+			for ( int i = 0; i < numSearches; i += 1 ) {
 
-		"				deltaTexCoord /= 2.0;",
-		"				deltaHeight /= 2.0;",
-		"				heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;",
-		// Shift along or against vector V
-		"				if( heightFromTexture > currentLayerHeight ) {", // Below the surface
+				deltaTexCoord /= 2.0;
+				deltaHeight /= 2.0;
+				heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
+				// Shift along or against vector V
+				if( heightFromTexture > currentLayerHeight ) { // Below the surface
 
-		"					currentTextureCoords -= deltaTexCoord;",
-		"					currentLayerHeight += deltaHeight;",
+					currentTextureCoords -= deltaTexCoord;
+					currentLayerHeight += deltaHeight;
 
-		"				} else {", // above the surface
+				} else { // above the surface
 
-		"					currentTextureCoords += deltaTexCoord;",
-		"					currentLayerHeight -= deltaHeight;",
+					currentTextureCoords += deltaTexCoord;
+					currentLayerHeight -= deltaHeight;
 
-		"				}",
+				}
 
-		"			}",
-		"			return currentTextureCoords;",
+			}
+			return currentTextureCoords;
 
-		"		#elif defined( USE_OCLUSION_PARALLAX )",
+		#elif defined( USE_OCLUSION_PARALLAX )
 
-		"			vec2 prevTCoords = currentTextureCoords + dtex;",
+			vec2 prevTCoords = currentTextureCoords + dtex;
 
-		// Heights for linear interpolation
-		"			float nextH = heightFromTexture - currentLayerHeight;",
-		"			float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;",
+			// Heights for linear interpolation
+			float nextH = heightFromTexture - currentLayerHeight;
+			float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;
 
-		// Proportions for linear interpolation
-		"			float weight = nextH / ( nextH - prevH );",
+			// Proportions for linear interpolation
+			float weight = nextH / ( nextH - prevH );
 
-		// Interpolation of texture coordinates
-		"			return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );",
+			// Interpolation of texture coordinates
+			return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );
 
-		"		#else", // NO_PARALLAX
+		#else // NO_PARALLAX
 
-		"			return vUv;",
+			return vUv;
 
-		"		#endif",
+		#endif
 
-		"	}",
-		"#endif",
+	}
+#endif
 
-		"vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {",
+vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {
 
- 		"	vec2 texDx = dFdx( vUv );",
-		"	vec2 texDy = dFdy( vUv );",
+	vec2 texDx = dFdx( vUv );
+	vec2 texDy = dFdy( vUv );
 
-		"	vec3 vSigmaX = dFdx( surfPosition );",
-		"	vec3 vSigmaY = dFdy( surfPosition );",
-		"	vec3 vR1 = cross( vSigmaY, surfNormal );",
-		"	vec3 vR2 = cross( surfNormal, vSigmaX );",
-		"	float fDet = dot( vSigmaX, vR1 );",
+	vec3 vSigmaX = dFdx( surfPosition );
+	vec3 vSigmaY = dFdy( surfPosition );
+	vec3 vR1 = cross( vSigmaY, surfNormal );
+	vec3 vR2 = cross( surfNormal, vSigmaX );
+	float fDet = dot( vSigmaX, vR1 );
 
-		"	vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );",
-		"	vec3 vProjVtex;",
-		"	vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;",
-		"	vProjVtex.z = dot( surfNormal, viewPosition );",
+	vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );
+	vec3 vProjVtex;
+	vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;
+	vProjVtex.z = dot( surfNormal, viewPosition );
 
-		"	return parallaxMap( vProjVtex );",
-		"}",
+	return parallaxMap( vProjVtex );
+}
 
-		"void main() {",
+void main() {
 
-		"	vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );",
-		"	gl_FragColor = texture2D( map, mapUv );",
+	vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );
+	gl_FragColor = texture2D( map, mapUv );
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/ParallaxShader.js
+++ b/examples/js/shaders/ParallaxShader.js
@@ -22,161 +22,160 @@ THREE.ParallaxShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
-varying vec3 vViewPosition;
-varying vec3 vNormal;
+		varying vec2 vUv;
+		varying vec3 vViewPosition;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-	vViewPosition = -mvPosition.xyz;
-	vNormal = normalize( normalMatrix * normal );
-	gl_Position = projectionMatrix * mvPosition;
+			vUv = uv;
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			vViewPosition = -mvPosition.xyz;
+			vNormal = normalize( normalMatrix * normal );
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D bumpMap;
-uniform sampler2D map;
+		uniform sampler2D bumpMap;
+		uniform sampler2D map;
 
-uniform float parallaxScale;
-uniform float parallaxMinLayers;
-uniform float parallaxMaxLayers;
+		uniform float parallaxScale;
+		uniform float parallaxMinLayers;
+		uniform float parallaxMaxLayers;
 
-varying vec2 vUv;
-varying vec3 vViewPosition;
-varying vec3 vNormal;
+		varying vec2 vUv;
+		varying vec3 vViewPosition;
+		varying vec3 vNormal;
 
-#ifdef USE_BASIC_PARALLAX
+		#ifdef USE_BASIC_PARALLAX
 
-	vec2 parallaxMap( in vec3 V ) {
+			vec2 parallaxMap( in vec3 V ) {
 
-		float initialHeight = texture2D( bumpMap, vUv ).r;
+				float initialHeight = texture2D( bumpMap, vUv ).r;
 
-		// No Offset Limitting: messy, floating output at grazing angles.
-		//"vec2 texCoordOffset = parallaxScale * V.xy / V.z * initialHeight;",
+				// No Offset Limitting: messy, floating output at grazing angles.
+				//"vec2 texCoordOffset = parallaxScale * V.xy / V.z * initialHeight;",
 
-		// Offset Limiting
-		vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;
-		return vUv - texCoordOffset;
+				// Offset Limiting
+				vec2 texCoordOffset = parallaxScale * V.xy * initialHeight;
+				return vUv - texCoordOffset;
 
-	}
-
-#else
-
-	vec2 parallaxMap( in vec3 V ) {
-
-		// Determine number of layers from angle between V and N
-		float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );
-
-		float layerHeight = 1.0 / numLayers;
-		float currentLayerHeight = 0.0;
-		// Shift of texture coordinates for each iteration
-		vec2 dtex = parallaxScale * V.xy / V.z / numLayers;
-
-		vec2 currentTextureCoords = vUv;
-
-		float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
-
-		// while ( heightFromTexture > currentLayerHeight )
-		// Infinite loops are not well supported. Do a "large" finite
-		// loop, but not too large, as it slows down some compilers.
-		for ( int i = 0; i < 30; i += 1 ) {
-			if ( heightFromTexture <= currentLayerHeight ) {
-				break;
 			}
-			currentLayerHeight += layerHeight;
-			// Shift texture coordinates along vector V
-			currentTextureCoords -= dtex;
-			heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
-		}
 
-		#ifdef USE_STEEP_PARALLAX
+		#else
 
-			return currentTextureCoords;
+			vec2 parallaxMap( in vec3 V ) {
 
-		#elif defined( USE_RELIEF_PARALLAX )
+				// Determine number of layers from angle between V and N
+				float numLayers = mix( parallaxMaxLayers, parallaxMinLayers, abs( dot( vec3( 0.0, 0.0, 1.0 ), V ) ) );
 
-			vec2 deltaTexCoord = dtex / 2.0;
-			float deltaHeight = layerHeight / 2.0;
+				float layerHeight = 1.0 / numLayers;
+				float currentLayerHeight = 0.0;
+				// Shift of texture coordinates for each iteration
+				vec2 dtex = parallaxScale * V.xy / V.z / numLayers;
 
-			// Return to the mid point of previous layer
-			currentTextureCoords += deltaTexCoord;
-			currentLayerHeight -= deltaHeight;
+				vec2 currentTextureCoords = vUv;
 
-			// Binary search to increase precision of Steep Parallax Mapping
-			const int numSearches = 5;
-			for ( int i = 0; i < numSearches; i += 1 ) {
+				float heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
 
-				deltaTexCoord /= 2.0;
-				deltaHeight /= 2.0;
-				heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
-				// Shift along or against vector V
-				if( heightFromTexture > currentLayerHeight ) { // Below the surface
+				// while ( heightFromTexture > currentLayerHeight )
+				// Infinite loops are not well supported. Do a "large" finite
+				// loop, but not too large, as it slows down some compilers.
+				for ( int i = 0; i < 30; i += 1 ) {
+					if ( heightFromTexture <= currentLayerHeight ) {
+						break;
+					}
+					currentLayerHeight += layerHeight;
+					// Shift texture coordinates along vector V
+					currentTextureCoords -= dtex;
+					heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
+				}
 
-					currentTextureCoords -= deltaTexCoord;
-					currentLayerHeight += deltaHeight;
+				#ifdef USE_STEEP_PARALLAX
 
-				} else { // above the surface
+					return currentTextureCoords;
 
+				#elif defined( USE_RELIEF_PARALLAX )
+
+					vec2 deltaTexCoord = dtex / 2.0;
+					float deltaHeight = layerHeight / 2.0;
+
+					// Return to the mid point of previous layer
 					currentTextureCoords += deltaTexCoord;
 					currentLayerHeight -= deltaHeight;
 
-				}
+					// Binary search to increase precision of Steep Parallax Mapping
+					const int numSearches = 5;
+					for ( int i = 0; i < numSearches; i += 1 ) {
+
+						deltaTexCoord /= 2.0;
+						deltaHeight /= 2.0;
+						heightFromTexture = texture2D( bumpMap, currentTextureCoords ).r;
+						// Shift along or against vector V
+						if( heightFromTexture > currentLayerHeight ) { // Below the surface
+
+							currentTextureCoords -= deltaTexCoord;
+							currentLayerHeight += deltaHeight;
+
+						} else { // above the surface
+
+							currentTextureCoords += deltaTexCoord;
+							currentLayerHeight -= deltaHeight;
+
+						}
+
+					}
+					return currentTextureCoords;
+
+				#elif defined( USE_OCLUSION_PARALLAX )
+
+					vec2 prevTCoords = currentTextureCoords + dtex;
+
+					// Heights for linear interpolation
+					float nextH = heightFromTexture - currentLayerHeight;
+					float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;
+
+					// Proportions for linear interpolation
+					float weight = nextH / ( nextH - prevH );
+
+					// Interpolation of texture coordinates
+					return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );
+
+				#else // NO_PARALLAX
+
+					return vUv;
+
+				#endif
 
 			}
-			return currentTextureCoords;
-
-		#elif defined( USE_OCLUSION_PARALLAX )
-
-			vec2 prevTCoords = currentTextureCoords + dtex;
-
-			// Heights for linear interpolation
-			float nextH = heightFromTexture - currentLayerHeight;
-			float prevH = texture2D( bumpMap, prevTCoords ).r - currentLayerHeight + layerHeight;
-
-			// Proportions for linear interpolation
-			float weight = nextH / ( nextH - prevH );
-
-			// Interpolation of texture coordinates
-			return prevTCoords * weight + currentTextureCoords * ( 1.0 - weight );
-
-		#else // NO_PARALLAX
-
-			return vUv;
-
 		#endif
 
-	}
-#endif
+		vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {
 
-vec2 perturbUv( vec3 surfPosition, vec3 surfNormal, vec3 viewPosition ) {
+			vec2 texDx = dFdx( vUv );
+			vec2 texDy = dFdy( vUv );
 
-	vec2 texDx = dFdx( vUv );
-	vec2 texDy = dFdy( vUv );
+			vec3 vSigmaX = dFdx( surfPosition );
+			vec3 vSigmaY = dFdy( surfPosition );
+			vec3 vR1 = cross( vSigmaY, surfNormal );
+			vec3 vR2 = cross( surfNormal, vSigmaX );
+			float fDet = dot( vSigmaX, vR1 );
 
-	vec3 vSigmaX = dFdx( surfPosition );
-	vec3 vSigmaY = dFdy( surfPosition );
-	vec3 vR1 = cross( vSigmaY, surfNormal );
-	vec3 vR2 = cross( surfNormal, vSigmaX );
-	float fDet = dot( vSigmaX, vR1 );
+			vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );
+			vec3 vProjVtex;
+			vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;
+			vProjVtex.z = dot( surfNormal, viewPosition );
 
-	vec2 vProjVscr = ( 1.0 / fDet ) * vec2( dot( vR1, viewPosition ), dot( vR2, viewPosition ) );
-	vec3 vProjVtex;
-	vProjVtex.xy = texDx * vProjVscr.x + texDy * vProjVscr.y;
-	vProjVtex.z = dot( surfNormal, viewPosition );
+			return parallaxMap( vProjVtex );
+		}
 
-	return parallaxMap( vProjVtex );
-}
+		void main() {
 
-void main() {
+			vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );
+			gl_FragColor = texture2D( map, mapUv );
 
-	vec2 mapUv = perturbUv( -vViewPosition, normalize( vNormal ), normalize( vViewPosition ) );
-	gl_FragColor = texture2D( map, mapUv );
-
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/PixelShader.js
+++ b/examples/js/shaders/PixelShader.js
@@ -15,29 +15,25 @@ THREE.PixelShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying highp vec2 vUv;
+		varying highp vec2 vUv;
 
-void main() {
-
-vUv = uv;
-gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-}
-`,
+		void main() {
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float pixelSize;
-uniform vec2 resolution;
+		uniform sampler2D tDiffuse;
+		uniform float pixelSize;
+		uniform vec2 resolution;
 
-varying highp vec2 vUv;
+		varying highp vec2 vUv;
 
-void main(){
-
-vec2 dxy = pixelSize / resolution;
-vec2 coord = dxy * floor( vUv / dxy );
-gl_FragColor = texture2D(tDiffuse, coord);
-
-}
-`
+		void main(){
+			vec2 dxy = pixelSize / resolution;
+			vec2 coord = dxy * floor( vUv / dxy );
+			gl_FragColor = texture2D(tDiffuse, coord);
+		}
+	`
 };

--- a/examples/js/shaders/PixelShader.js
+++ b/examples/js/shaders/PixelShader.js
@@ -14,34 +14,30 @@ THREE.PixelShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying highp vec2 vUv;
 
-		"varying highp vec2 vUv;",
+void main() {
 
-		"void main() {",
+vUv = uv;
+gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"vUv = uv;",
-		"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float pixelSize;
+uniform vec2 resolution;
 
-	].join( "\n" ),
+varying highp vec2 vUv;
 
-	fragmentShader: [
+void main(){
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float pixelSize;",
-		"uniform vec2 resolution;",
+vec2 dxy = pixelSize / resolution;
+vec2 coord = dxy * floor( vUv / dxy );
+gl_FragColor = texture2D(tDiffuse, coord);
 
-		"varying highp vec2 vUv;",
-
-		"void main(){",
-
-		"vec2 dxy = pixelSize / resolution;",
-		"vec2 coord = dxy * floor( vUv / dxy );",
-		"gl_FragColor = texture2D(tDiffuse, coord);",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 };

--- a/examples/js/shaders/RGBShiftShader.js
+++ b/examples/js/shaders/RGBShiftShader.js
@@ -20,37 +20,33 @@ THREE.RGBShiftShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float amount;
+uniform float angle;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float amount;",
-		"uniform float angle;",
+	vec2 offset = amount * vec2( cos(angle), sin(angle));
+	vec4 cr = texture2D(tDiffuse, vUv + offset);
+	vec4 cga = texture2D(tDiffuse, vUv);
+	vec4 cb = texture2D(tDiffuse, vUv - offset);
+	gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
 
-		"varying vec2 vUv;",
-
-		"void main() {",
-
-		"	vec2 offset = amount * vec2( cos(angle), sin(angle));",
-		"	vec4 cr = texture2D(tDiffuse, vUv + offset);",
-		"	vec4 cga = texture2D(tDiffuse, vUv);",
-		"	vec4 cb = texture2D(tDiffuse, vUv - offset);",
-		"	gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/RGBShiftShader.js
+++ b/examples/js/shaders/RGBShiftShader.js
@@ -21,32 +21,31 @@ THREE.RGBShiftShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float amount;
-uniform float angle;
+		uniform sampler2D tDiffuse;
+		uniform float amount;
+		uniform float angle;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec2 offset = amount * vec2( cos(angle), sin(angle));
-	vec4 cr = texture2D(tDiffuse, vUv + offset);
-	vec4 cga = texture2D(tDiffuse, vUv);
-	vec4 cb = texture2D(tDiffuse, vUv - offset);
-	gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
+			vec2 offset = amount * vec2( cos(angle), sin(angle));
+			vec4 cr = texture2D(tDiffuse, vUv + offset);
+			vec4 cga = texture2D(tDiffuse, vUv);
+			vec4 cb = texture2D(tDiffuse, vUv - offset);
+			gl_FragColor = vec4(cr.r, cga.g, cb.b, cga.a);
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/SAOShader.js
+++ b/examples/js/shaders/SAOShader.js
@@ -31,151 +31,150 @@ THREE.SAOShader = {
 		"kernelRadius": { value: 100.0 },
 		"randomSeed": { value: 0.0 }
 	},
-	vertexShader: [
-		"varying vec2 vUv;",
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"void main() {",
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"}"
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`,
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
-	fragmentShader: [
-		"#include <common>",
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+#if DIFFUSE_TEXTURE == 1
+uniform sampler2D tDiffuse;
+#endif
 
-		"#if DIFFUSE_TEXTURE == 1",
-		"uniform sampler2D tDiffuse;",
-		"#endif",
+uniform sampler2D tDepth;
 
-		"uniform sampler2D tDepth;",
+#if NORMAL_TEXTURE == 1
+uniform sampler2D tNormal;
+#endif
 
-		"#if NORMAL_TEXTURE == 1",
-		"uniform sampler2D tNormal;",
-		"#endif",
+uniform float cameraNear;
+uniform float cameraFar;
+uniform mat4 cameraProjectionMatrix;
+uniform mat4 cameraInverseProjectionMatrix;
 
-		"uniform float cameraNear;",
-		"uniform float cameraFar;",
-		"uniform mat4 cameraProjectionMatrix;",
-		"uniform mat4 cameraInverseProjectionMatrix;",
+uniform float scale;
+uniform float intensity;
+uniform float bias;
+uniform float kernelRadius;
+uniform float minResolution;
+uniform vec2 size;
+uniform float randomSeed;
 
-		"uniform float scale;",
-		"uniform float intensity;",
-		"uniform float bias;",
-		"uniform float kernelRadius;",
-		"uniform float minResolution;",
-		"uniform vec2 size;",
-		"uniform float randomSeed;",
+// RGBA depth
 
-		"// RGBA depth",
+#include <packing>
 
-		"#include <packing>",
+vec4 getDefaultColor( const in vec2 screenPosition ) {
+	#if DIFFUSE_TEXTURE == 1
+	return texture2D( tDiffuse, vUv );
+	#else
+	return vec4( 1.0 );
+	#endif
+}
 
-		"vec4 getDefaultColor( const in vec2 screenPosition ) {",
-		"	#if DIFFUSE_TEXTURE == 1",
-		"	return texture2D( tDiffuse, vUv );",
-		"	#else",
-		"	return vec4( 1.0 );",
-		"	#endif",
-		"}",
+float getDepth( const in vec2 screenPosition ) {
+	#if DEPTH_PACKING == 1
+	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+	#else
+	return texture2D( tDepth, screenPosition ).x;
+	#endif
+}
 
-		"float getDepth( const in vec2 screenPosition ) {",
-		"	#if DEPTH_PACKING == 1",
-		"	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );",
-		"	#else",
-		"	return texture2D( tDepth, screenPosition ).x;",
-		"	#endif",
-		"}",
+float getViewZ( const in float depth ) {
+	#if PERSPECTIVE_CAMERA == 1
+	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
+	#else
+	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
+	#endif
+}
 
-		"float getViewZ( const in float depth ) {",
-		"	#if PERSPECTIVE_CAMERA == 1",
-		"	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );",
-		"	#else",
-		"	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );",
-		"	#endif",
-		"}",
+vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
+	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
+	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
+	clipPosition *= clipW; // unprojection.
 
-		"vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {",
-		"	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];",
-		"	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );",
-		"	clipPosition *= clipW; // unprojection.",
+	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
+}
 
-		"	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;",
-		"}",
+vec3 getViewNormal( const in vec3 viewPosition, const in vec2 screenPosition ) {
+	#if NORMAL_TEXTURE == 1
+	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
+	#else
+	return normalize( cross( dFdx( viewPosition ), dFdy( viewPosition ) ) );
+	#endif
+}
 
-		"vec3 getViewNormal( const in vec3 viewPosition, const in vec2 screenPosition ) {",
-		"	#if NORMAL_TEXTURE == 1",
-		"	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );",
-		"	#else",
-		"	return normalize( cross( dFdx( viewPosition ), dFdy( viewPosition ) ) );",
-		"	#endif",
-		"}",
+float scaleDividedByCameraFar;
+float minResolutionMultipliedByCameraFar;
 
-		"float scaleDividedByCameraFar;",
-		"float minResolutionMultipliedByCameraFar;",
+float getOcclusion( const in vec3 centerViewPosition, const in vec3 centerViewNormal, const in vec3 sampleViewPosition ) {
+	vec3 viewDelta = sampleViewPosition - centerViewPosition;
+	float viewDistance = length( viewDelta );
+	float scaledScreenDistance = scaleDividedByCameraFar * viewDistance;
 
-		"float getOcclusion( const in vec3 centerViewPosition, const in vec3 centerViewNormal, const in vec3 sampleViewPosition ) {",
-		"	vec3 viewDelta = sampleViewPosition - centerViewPosition;",
-		"	float viewDistance = length( viewDelta );",
-		"	float scaledScreenDistance = scaleDividedByCameraFar * viewDistance;",
+	return max(0.0, (dot(centerViewNormal, viewDelta) - minResolutionMultipliedByCameraFar) / scaledScreenDistance - bias) / (1.0 + pow2( scaledScreenDistance ) );
+}
 
-		"	return max(0.0, (dot(centerViewNormal, viewDelta) - minResolutionMultipliedByCameraFar) / scaledScreenDistance - bias) / (1.0 + pow2( scaledScreenDistance ) );",
-		"}",
+// moving costly divides into consts
+const float ANGLE_STEP = PI2 * float( NUM_RINGS ) / float( NUM_SAMPLES );
+const float INV_NUM_SAMPLES = 1.0 / float( NUM_SAMPLES );
 
-		"// moving costly divides into consts",
-		"const float ANGLE_STEP = PI2 * float( NUM_RINGS ) / float( NUM_SAMPLES );",
-		"const float INV_NUM_SAMPLES = 1.0 / float( NUM_SAMPLES );",
+float getAmbientOcclusion( const in vec3 centerViewPosition ) {
+	// precompute some variables require in getOcclusion.
+	scaleDividedByCameraFar = scale / cameraFar;
+	minResolutionMultipliedByCameraFar = minResolution * cameraFar;
+	vec3 centerViewNormal = getViewNormal( centerViewPosition, vUv );
 
-		"float getAmbientOcclusion( const in vec3 centerViewPosition ) {",
-		"	// precompute some variables require in getOcclusion.",
-		"	scaleDividedByCameraFar = scale / cameraFar;",
-		"	minResolutionMultipliedByCameraFar = minResolution * cameraFar;",
-		"	vec3 centerViewNormal = getViewNormal( centerViewPosition, vUv );",
+	// jsfiddle that shows sample pattern: https://jsfiddle.net/a16ff1p7/
+	float angle = rand( vUv + randomSeed ) * PI2;
+	vec2 radius = vec2( kernelRadius * INV_NUM_SAMPLES ) / size;
+	vec2 radiusStep = radius;
 
-		"	// jsfiddle that shows sample pattern: https://jsfiddle.net/a16ff1p7/",
-		"	float angle = rand( vUv + randomSeed ) * PI2;",
-		"	vec2 radius = vec2( kernelRadius * INV_NUM_SAMPLES ) / size;",
-		"	vec2 radiusStep = radius;",
+	float occlusionSum = 0.0;
+	float weightSum = 0.0;
 
-		"	float occlusionSum = 0.0;",
-		"	float weightSum = 0.0;",
+	for( int i = 0; i < NUM_SAMPLES; i ++ ) {
+		vec2 sampleUv = vUv + vec2( cos( angle ), sin( angle ) ) * radius;
+		radius += radiusStep;
+		angle += ANGLE_STEP;
 
-		"	for( int i = 0; i < NUM_SAMPLES; i ++ ) {",
-		"		vec2 sampleUv = vUv + vec2( cos( angle ), sin( angle ) ) * radius;",
-		"		radius += radiusStep;",
-		"		angle += ANGLE_STEP;",
+		float sampleDepth = getDepth( sampleUv );
+		if( sampleDepth >= ( 1.0 - EPSILON ) ) {
+			continue;
+		}
 
-		"		float sampleDepth = getDepth( sampleUv );",
-		"		if( sampleDepth >= ( 1.0 - EPSILON ) ) {",
-		"			continue;",
-		"		}",
+		float sampleViewZ = getViewZ( sampleDepth );
+		vec3 sampleViewPosition = getViewPosition( sampleUv, sampleDepth, sampleViewZ );
+		occlusionSum += getOcclusion( centerViewPosition, centerViewNormal, sampleViewPosition );
+		weightSum += 1.0;
+	}
 
-		"		float sampleViewZ = getViewZ( sampleDepth );",
-		"		vec3 sampleViewPosition = getViewPosition( sampleUv, sampleDepth, sampleViewZ );",
-		"		occlusionSum += getOcclusion( centerViewPosition, centerViewNormal, sampleViewPosition );",
-		"		weightSum += 1.0;",
-		"	}",
+	if( weightSum == 0.0 ) discard;
 
-		"	if( weightSum == 0.0 ) discard;",
-
-		"	return occlusionSum * ( intensity / weightSum );",
-		"}",
+	return occlusionSum * ( intensity / weightSum );
+}
 
 
-		"void main() {",
-		"	float centerDepth = getDepth( vUv );",
-		"	if( centerDepth >= ( 1.0 - EPSILON ) ) {",
-		"		discard;",
-		"	}",
+void main() {
+	float centerDepth = getDepth( vUv );
+	if( centerDepth >= ( 1.0 - EPSILON ) ) {
+		discard;
+	}
 
-		"	float centerViewZ = getViewZ( centerDepth );",
-		"	vec3 viewPosition = getViewPosition( vUv, centerDepth, centerViewZ );",
+	float centerViewZ = getViewZ( centerDepth );
+	vec3 viewPosition = getViewPosition( vUv, centerDepth, centerViewZ );
 
-		"	float ambientOcclusion = getAmbientOcclusion( viewPosition );",
+	float ambientOcclusion = getAmbientOcclusion( viewPosition );
 
-		"	gl_FragColor = getDefaultColor( vUv );",
-		"	gl_FragColor.xyz *=  1.0 - ambientOcclusion;",
-		"}"
-	].join( "\n" )
+	gl_FragColor = getDefaultColor( vUv );
+	gl_FragColor.xyz *=  1.0 - ambientOcclusion;
+}
+`
 };

--- a/examples/js/shaders/SAOShader.js
+++ b/examples/js/shaders/SAOShader.js
@@ -32,149 +32,149 @@ THREE.SAOShader = {
 		"randomSeed": { value: 0.0 }
 	},
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-}
-`,
+		void main() {
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+		}
+	`,
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-#if DIFFUSE_TEXTURE == 1
-uniform sampler2D tDiffuse;
-#endif
+		#if DIFFUSE_TEXTURE == 1
+		uniform sampler2D tDiffuse;
+		#endif
 
-uniform sampler2D tDepth;
+		uniform sampler2D tDepth;
 
-#if NORMAL_TEXTURE == 1
-uniform sampler2D tNormal;
-#endif
+		#if NORMAL_TEXTURE == 1
+		uniform sampler2D tNormal;
+		#endif
 
-uniform float cameraNear;
-uniform float cameraFar;
-uniform mat4 cameraProjectionMatrix;
-uniform mat4 cameraInverseProjectionMatrix;
+		uniform float cameraNear;
+		uniform float cameraFar;
+		uniform mat4 cameraProjectionMatrix;
+		uniform mat4 cameraInverseProjectionMatrix;
 
-uniform float scale;
-uniform float intensity;
-uniform float bias;
-uniform float kernelRadius;
-uniform float minResolution;
-uniform vec2 size;
-uniform float randomSeed;
+		uniform float scale;
+		uniform float intensity;
+		uniform float bias;
+		uniform float kernelRadius;
+		uniform float minResolution;
+		uniform vec2 size;
+		uniform float randomSeed;
 
-// RGBA depth
+		// RGBA depth
 
-#include <packing>
+		#include <packing>
 
-vec4 getDefaultColor( const in vec2 screenPosition ) {
-	#if DIFFUSE_TEXTURE == 1
-	return texture2D( tDiffuse, vUv );
-	#else
-	return vec4( 1.0 );
-	#endif
-}
-
-float getDepth( const in vec2 screenPosition ) {
-	#if DEPTH_PACKING == 1
-	return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
-	#else
-	return texture2D( tDepth, screenPosition ).x;
-	#endif
-}
-
-float getViewZ( const in float depth ) {
-	#if PERSPECTIVE_CAMERA == 1
-	return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
-	#else
-	return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
-	#endif
-}
-
-vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
-	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
-	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
-	clipPosition *= clipW; // unprojection.
-
-	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
-}
-
-vec3 getViewNormal( const in vec3 viewPosition, const in vec2 screenPosition ) {
-	#if NORMAL_TEXTURE == 1
-	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
-	#else
-	return normalize( cross( dFdx( viewPosition ), dFdy( viewPosition ) ) );
-	#endif
-}
-
-float scaleDividedByCameraFar;
-float minResolutionMultipliedByCameraFar;
-
-float getOcclusion( const in vec3 centerViewPosition, const in vec3 centerViewNormal, const in vec3 sampleViewPosition ) {
-	vec3 viewDelta = sampleViewPosition - centerViewPosition;
-	float viewDistance = length( viewDelta );
-	float scaledScreenDistance = scaleDividedByCameraFar * viewDistance;
-
-	return max(0.0, (dot(centerViewNormal, viewDelta) - minResolutionMultipliedByCameraFar) / scaledScreenDistance - bias) / (1.0 + pow2( scaledScreenDistance ) );
-}
-
-// moving costly divides into consts
-const float ANGLE_STEP = PI2 * float( NUM_RINGS ) / float( NUM_SAMPLES );
-const float INV_NUM_SAMPLES = 1.0 / float( NUM_SAMPLES );
-
-float getAmbientOcclusion( const in vec3 centerViewPosition ) {
-	// precompute some variables require in getOcclusion.
-	scaleDividedByCameraFar = scale / cameraFar;
-	minResolutionMultipliedByCameraFar = minResolution * cameraFar;
-	vec3 centerViewNormal = getViewNormal( centerViewPosition, vUv );
-
-	// jsfiddle that shows sample pattern: https://jsfiddle.net/a16ff1p7/
-	float angle = rand( vUv + randomSeed ) * PI2;
-	vec2 radius = vec2( kernelRadius * INV_NUM_SAMPLES ) / size;
-	vec2 radiusStep = radius;
-
-	float occlusionSum = 0.0;
-	float weightSum = 0.0;
-
-	for( int i = 0; i < NUM_SAMPLES; i ++ ) {
-		vec2 sampleUv = vUv + vec2( cos( angle ), sin( angle ) ) * radius;
-		radius += radiusStep;
-		angle += ANGLE_STEP;
-
-		float sampleDepth = getDepth( sampleUv );
-		if( sampleDepth >= ( 1.0 - EPSILON ) ) {
-			continue;
+		vec4 getDefaultColor( const in vec2 screenPosition ) {
+			#if DIFFUSE_TEXTURE == 1
+			return texture2D( tDiffuse, vUv );
+			#else
+			return vec4( 1.0 );
+			#endif
 		}
 
-		float sampleViewZ = getViewZ( sampleDepth );
-		vec3 sampleViewPosition = getViewPosition( sampleUv, sampleDepth, sampleViewZ );
-		occlusionSum += getOcclusion( centerViewPosition, centerViewNormal, sampleViewPosition );
-		weightSum += 1.0;
-	}
+		float getDepth( const in vec2 screenPosition ) {
+			#if DEPTH_PACKING == 1
+			return unpackRGBAToDepth( texture2D( tDepth, screenPosition ) );
+			#else
+			return texture2D( tDepth, screenPosition ).x;
+			#endif
+		}
 
-	if( weightSum == 0.0 ) discard;
+		float getViewZ( const in float depth ) {
+			#if PERSPECTIVE_CAMERA == 1
+			return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
+			#else
+			return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
+			#endif
+		}
 
-	return occlusionSum * ( intensity / weightSum );
-}
+		vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
+			float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
+			vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
+			clipPosition *= clipW; // unprojection.
+
+			return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
+		}
+
+		vec3 getViewNormal( const in vec3 viewPosition, const in vec2 screenPosition ) {
+			#if NORMAL_TEXTURE == 1
+			return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
+			#else
+			return normalize( cross( dFdx( viewPosition ), dFdy( viewPosition ) ) );
+			#endif
+		}
+
+		float scaleDividedByCameraFar;
+		float minResolutionMultipliedByCameraFar;
+
+		float getOcclusion( const in vec3 centerViewPosition, const in vec3 centerViewNormal, const in vec3 sampleViewPosition ) {
+			vec3 viewDelta = sampleViewPosition - centerViewPosition;
+			float viewDistance = length( viewDelta );
+			float scaledScreenDistance = scaleDividedByCameraFar * viewDistance;
+
+			return max(0.0, (dot(centerViewNormal, viewDelta) - minResolutionMultipliedByCameraFar) / scaledScreenDistance - bias) / (1.0 + pow2( scaledScreenDistance ) );
+		}
+
+		// moving costly divides into consts
+		const float ANGLE_STEP = PI2 * float( NUM_RINGS ) / float( NUM_SAMPLES );
+		const float INV_NUM_SAMPLES = 1.0 / float( NUM_SAMPLES );
+
+		float getAmbientOcclusion( const in vec3 centerViewPosition ) {
+			// precompute some variables require in getOcclusion.
+			scaleDividedByCameraFar = scale / cameraFar;
+			minResolutionMultipliedByCameraFar = minResolution * cameraFar;
+			vec3 centerViewNormal = getViewNormal( centerViewPosition, vUv );
+
+			// jsfiddle that shows sample pattern: https://jsfiddle.net/a16ff1p7/
+			float angle = rand( vUv + randomSeed ) * PI2;
+			vec2 radius = vec2( kernelRadius * INV_NUM_SAMPLES ) / size;
+			vec2 radiusStep = radius;
+
+			float occlusionSum = 0.0;
+			float weightSum = 0.0;
+
+			for( int i = 0; i < NUM_SAMPLES; i ++ ) {
+				vec2 sampleUv = vUv + vec2( cos( angle ), sin( angle ) ) * radius;
+				radius += radiusStep;
+				angle += ANGLE_STEP;
+
+				float sampleDepth = getDepth( sampleUv );
+				if( sampleDepth >= ( 1.0 - EPSILON ) ) {
+					continue;
+				}
+
+				float sampleViewZ = getViewZ( sampleDepth );
+				vec3 sampleViewPosition = getViewPosition( sampleUv, sampleDepth, sampleViewZ );
+				occlusionSum += getOcclusion( centerViewPosition, centerViewNormal, sampleViewPosition );
+				weightSum += 1.0;
+			}
+
+			if( weightSum == 0.0 ) discard;
+
+			return occlusionSum * ( intensity / weightSum );
+		}
 
 
-void main() {
-	float centerDepth = getDepth( vUv );
-	if( centerDepth >= ( 1.0 - EPSILON ) ) {
-		discard;
-	}
+		void main() {
+			float centerDepth = getDepth( vUv );
+			if( centerDepth >= ( 1.0 - EPSILON ) ) {
+				discard;
+			}
 
-	float centerViewZ = getViewZ( centerDepth );
-	vec3 viewPosition = getViewPosition( vUv, centerDepth, centerViewZ );
+			float centerViewZ = getViewZ( centerDepth );
+			vec3 viewPosition = getViewPosition( vUv, centerDepth, centerViewZ );
 
-	float ambientOcclusion = getAmbientOcclusion( viewPosition );
+			float ambientOcclusion = getAmbientOcclusion( viewPosition );
 
-	gl_FragColor = getDefaultColor( vUv );
-	gl_FragColor.xyz *=  1.0 - ambientOcclusion;
-}
-`
+			gl_FragColor = getDefaultColor( vUv );
+			gl_FragColor.xyz *=  1.0 - ambientOcclusion;
+		}
+	`
 };

--- a/examples/js/shaders/SMAAShader.js
+++ b/examples/js/shaders/SMAAShader.js
@@ -22,93 +22,92 @@ THREE.SMAAEdgesShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform vec2 resolution;
+		uniform vec2 resolution;
 
-varying vec2 vUv;
-varying vec4 vOffset[ 3 ];
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
 
-void SMAAEdgeDetectionVS( vec2 texcoord ) {
-	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0,  1.0 ); // WebGL port note: Changed sign in W component
-	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4(  1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
-	vOffset[ 2 ] = texcoord.xyxy + resolution.xyxy * vec4( -2.0, 0.0, 0.0,  2.0 ); // WebGL port note: Changed sign in W component
-}
+		void SMAAEdgeDetectionVS( vec2 texcoord ) {
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0,  1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4(  1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 2 ] = texcoord.xyxy + resolution.xyxy * vec4( -2.0, 0.0, 0.0,  2.0 ); // WebGL port note: Changed sign in W component
+		}
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	SMAAEdgeDetectionVS( vUv );
+			SMAAEdgeDetectionVS( vUv );
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
-varying vec4 vOffset[ 3 ];
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
 
-vec4 SMAAColorEdgeDetectionPS( vec2 texcoord, vec4 offset[3], sampler2D colorTex ) {
-	vec2 threshold = vec2( SMAA_THRESHOLD, SMAA_THRESHOLD );
+		vec4 SMAAColorEdgeDetectionPS( vec2 texcoord, vec4 offset[3], sampler2D colorTex ) {
+			vec2 threshold = vec2( SMAA_THRESHOLD, SMAA_THRESHOLD );
 
-	// Calculate color deltas:
-	vec4 delta;
-	vec3 C = texture2D( colorTex, texcoord ).rgb;
+			// Calculate color deltas:
+			vec4 delta;
+			vec3 C = texture2D( colorTex, texcoord ).rgb;
 
-	vec3 Cleft = texture2D( colorTex, offset[0].xy ).rgb;
-	vec3 t = abs( C - Cleft );
-	delta.x = max( max( t.r, t.g ), t.b );
+			vec3 Cleft = texture2D( colorTex, offset[0].xy ).rgb;
+			vec3 t = abs( C - Cleft );
+			delta.x = max( max( t.r, t.g ), t.b );
 
-	vec3 Ctop = texture2D( colorTex, offset[0].zw ).rgb;
-	t = abs( C - Ctop );
-	delta.y = max( max( t.r, t.g ), t.b );
+			vec3 Ctop = texture2D( colorTex, offset[0].zw ).rgb;
+			t = abs( C - Ctop );
+			delta.y = max( max( t.r, t.g ), t.b );
 
-	// We do the usual threshold:
-	vec2 edges = step( threshold, delta.xy );
+			// We do the usual threshold:
+			vec2 edges = step( threshold, delta.xy );
 
-	// Then discard if there is no edge:
-	if ( dot( edges, vec2( 1.0, 1.0 ) ) == 0.0 )
-		discard;
+			// Then discard if there is no edge:
+			if ( dot( edges, vec2( 1.0, 1.0 ) ) == 0.0 )
+				discard;
 
-	// Calculate right and bottom deltas:
-	vec3 Cright = texture2D( colorTex, offset[1].xy ).rgb;
-	t = abs( C - Cright );
-	delta.z = max( max( t.r, t.g ), t.b );
+			// Calculate right and bottom deltas:
+			vec3 Cright = texture2D( colorTex, offset[1].xy ).rgb;
+			t = abs( C - Cright );
+			delta.z = max( max( t.r, t.g ), t.b );
 
-	vec3 Cbottom  = texture2D( colorTex, offset[1].zw ).rgb;
-	t = abs( C - Cbottom );
-	delta.w = max( max( t.r, t.g ), t.b );
+			vec3 Cbottom  = texture2D( colorTex, offset[1].zw ).rgb;
+			t = abs( C - Cbottom );
+			delta.w = max( max( t.r, t.g ), t.b );
 
-	// Calculate the maximum delta in the direct neighborhood:
-	float maxDelta = max( max( max( delta.x, delta.y ), delta.z ), delta.w );
+			// Calculate the maximum delta in the direct neighborhood:
+			float maxDelta = max( max( max( delta.x, delta.y ), delta.z ), delta.w );
 
-	// Calculate left-left and top-top deltas:
-	vec3 Cleftleft  = texture2D( colorTex, offset[2].xy ).rgb;
-	t = abs( C - Cleftleft );
-	delta.z = max( max( t.r, t.g ), t.b );
+			// Calculate left-left and top-top deltas:
+			vec3 Cleftleft  = texture2D( colorTex, offset[2].xy ).rgb;
+			t = abs( C - Cleftleft );
+			delta.z = max( max( t.r, t.g ), t.b );
 
-	vec3 Ctoptop = texture2D( colorTex, offset[2].zw ).rgb;
-	t = abs( C - Ctoptop );
-	delta.w = max( max( t.r, t.g ), t.b );
+			vec3 Ctoptop = texture2D( colorTex, offset[2].zw ).rgb;
+			t = abs( C - Ctoptop );
+			delta.w = max( max( t.r, t.g ), t.b );
 
-	// Calculate the final maximum delta:
-	maxDelta = max( max( maxDelta, delta.z ), delta.w );
+			// Calculate the final maximum delta:
+			maxDelta = max( max( maxDelta, delta.z ), delta.w );
 
-	// Local contrast adaptation in action:
-	edges.xy *= step( 0.5 * maxDelta, delta.xy );
+			// Local contrast adaptation in action:
+			edges.xy *= step( 0.5 * maxDelta, delta.xy );
 
-	return vec4( edges, 0.0, 0.0 );
-}
+			return vec4( edges, 0.0, 0.0 );
+		}
 
-void main() {
+		void main() {
 
-	gl_FragColor = SMAAColorEdgeDetectionPS( vUv, vOffset, tDiffuse );
+			gl_FragColor = SMAAColorEdgeDetectionPS( vUv, vOffset, tDiffuse );
 
-}
-`
-
+		}
+	`
 };
 
 THREE.SMAAWeightsShader = {
@@ -132,237 +131,236 @@ THREE.SMAAWeightsShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform vec2 resolution;
+		uniform vec2 resolution;
 
-varying vec2 vUv;
-varying vec4 vOffset[ 3 ];
-varying vec2 vPixcoord;
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
+		varying vec2 vPixcoord;
 
-void SMAABlendingWeightCalculationVS( vec2 texcoord ) {
-	vPixcoord = texcoord / resolution;
+		void SMAABlendingWeightCalculationVS( vec2 texcoord ) {
+			vPixcoord = texcoord / resolution;
 
-	// We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
-	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.25, 0.125, 1.25, 0.125 ); // WebGL port note: Changed sign in Y and W components
-	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.125, 0.25, -0.125, -1.25 ); // WebGL port note: Changed sign in Y and W components
+			// We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.25, 0.125, 1.25, 0.125 ); // WebGL port note: Changed sign in Y and W components
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.125, 0.25, -0.125, -1.25 ); // WebGL port note: Changed sign in Y and W components
 
-	// And these for the searches, they indicate the ends of the loops:
-	vOffset[ 2 ] = vec4( vOffset[ 0 ].xz, vOffset[ 1 ].yw ) + vec4( -2.0, 2.0, -2.0, 2.0 ) * resolution.xxyy * float( SMAA_MAX_SEARCH_STEPS );
+			// And these for the searches, they indicate the ends of the loops:
+			vOffset[ 2 ] = vec4( vOffset[ 0 ].xz, vOffset[ 1 ].yw ) + vec4( -2.0, 2.0, -2.0, 2.0 ) * resolution.xxyy * float( SMAA_MAX_SEARCH_STEPS );
 
-}
+		}
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	SMAABlendingWeightCalculationVS( vUv );
+			SMAABlendingWeightCalculationVS( vUv );
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#define SMAASampleLevelZeroOffset( tex, coord, offset ) texture2D( tex, coord + float( offset ) * resolution, 0.0 )
+		#define SMAASampleLevelZeroOffset( tex, coord, offset ) texture2D( tex, coord + float( offset ) * resolution, 0.0 )
 
-uniform sampler2D tDiffuse;
-uniform sampler2D tArea;
-uniform sampler2D tSearch;
-uniform vec2 resolution;
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tArea;
+		uniform sampler2D tSearch;
+		uniform vec2 resolution;
 
-varying vec2 vUv;
-varying vec4 vOffset[3];
-varying vec2 vPixcoord;
+		varying vec2 vUv;
+		varying vec4 vOffset[3];
+		varying vec2 vPixcoord;
 
-#if __VERSION__ == 100
-vec2 round( vec2 x ) {
-	return sign( x ) * floor( abs( x ) + 0.5 );
-}
-#endif
+		#if __VERSION__ == 100
+		vec2 round( vec2 x ) {
+			return sign( x ) * floor( abs( x ) + 0.5 );
+		}
+		#endif
 
-float SMAASearchLength( sampler2D searchTex, vec2 e, float bias, float scale ) {
-	// Not required if searchTex accesses are set to point:
-	// float2 SEARCH_TEX_PIXEL_SIZE = 1.0 / float2(66.0, 33.0);
-	// e = float2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE +
-	//     e * float2(scale, 1.0) * float2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
-	e.r = bias + e.r * scale;
-	return 255.0 * texture2D( searchTex, e, 0.0 ).r;
-}
+		float SMAASearchLength( sampler2D searchTex, vec2 e, float bias, float scale ) {
+			// Not required if searchTex accesses are set to point:
+			// float2 SEARCH_TEX_PIXEL_SIZE = 1.0 / float2(66.0, 33.0);
+			// e = float2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE +
+			//     e * float2(scale, 1.0) * float2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
+			e.r = bias + e.r * scale;
+			return 255.0 * texture2D( searchTex, e, 0.0 ).r;
+		}
 
-float SMAASearchXLeft( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
-	/**
-			* @PSEUDO_GATHER4
-			* This texcoord has been offset by (-0.25, -0.125) in the vertex shader to
-			* sample between edge, thus fetching four edges in a row.
-			* Sampling with different offsets in each direction allows to disambiguate
-			* which edges are active from the four fetched ones.
-			*/
-	vec2 e = vec2( 0.0, 1.0 );
+		float SMAASearchXLeft( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			/**
+			 * @PSEUDO_GATHER4
+			 * This texcoord has been offset by (-0.25, -0.125) in the vertex shader to
+			 * sample between edge, thus fetching four edges in a row.
+			 * Sampling with different offsets in each direction allows to disambiguate
+			 * which edges are active from the four fetched ones.
+			 */
+			vec2 e = vec2( 0.0, 1.0 );
 
-	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
-		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
-		texcoord -= vec2( 2.0, 0.0 ) * resolution;
-		if ( ! ( texcoord.x > end && e.g > 0.8281 && e.r == 0.0 ) ) break;
-	}
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord -= vec2( 2.0, 0.0 ) * resolution;
+				if ( ! ( texcoord.x > end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+			}
 
-	// We correct the previous (-0.25, -0.125) offset we applied:
-	texcoord.x += 0.25 * resolution.x;
+			// We correct the previous (-0.25, -0.125) offset we applied:
+			texcoord.x += 0.25 * resolution.x;
 
-	// The searches are bias by 1, so adjust the coords accordingly:
-	texcoord.x += resolution.x;
+			// The searches are bias by 1, so adjust the coords accordingly:
+			texcoord.x += resolution.x;
 
-	// Disambiguate the length added by the last step:
-	texcoord.x += 2.0 * resolution.x; // Undo last step
-	texcoord.x -= resolution.x * SMAASearchLength(searchTex, e, 0.0, 0.5);
+			// Disambiguate the length added by the last step:
+			texcoord.x += 2.0 * resolution.x; // Undo last step
+			texcoord.x -= resolution.x * SMAASearchLength(searchTex, e, 0.0, 0.5);
 
-	return texcoord.x;
-}
+			return texcoord.x;
+		}
 
-float SMAASearchXRight( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
-	vec2 e = vec2( 0.0, 1.0 );
+		float SMAASearchXRight( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 0.0, 1.0 );
 
-	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
-		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
-		texcoord += vec2( 2.0, 0.0 ) * resolution;
-		if ( ! ( texcoord.x < end && e.g > 0.8281 && e.r == 0.0 ) ) break;
-	}
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord += vec2( 2.0, 0.0 ) * resolution;
+				if ( ! ( texcoord.x < end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+			}
 
-	texcoord.x -= 0.25 * resolution.x;
-	texcoord.x -= resolution.x;
-	texcoord.x -= 2.0 * resolution.x;
-	texcoord.x += resolution.x * SMAASearchLength( searchTex, e, 0.5, 0.5 );
+			texcoord.x -= 0.25 * resolution.x;
+			texcoord.x -= resolution.x;
+			texcoord.x -= 2.0 * resolution.x;
+			texcoord.x += resolution.x * SMAASearchLength( searchTex, e, 0.5, 0.5 );
 
-	return texcoord.x;
-}
+			return texcoord.x;
+		}
 
-float SMAASearchYUp( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
-	vec2 e = vec2( 1.0, 0.0 );
+		float SMAASearchYUp( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 1.0, 0.0 );
 
-	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
-		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
-		texcoord += vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
-		if ( ! ( texcoord.y > end && e.r > 0.8281 && e.g == 0.0 ) ) break;
-	}
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord += vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+				if ( ! ( texcoord.y > end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+			}
 
-	texcoord.y -= 0.25 * resolution.y; // WebGL port note: Changed sign
-	texcoord.y -= resolution.y; // WebGL port note: Changed sign
-	texcoord.y -= 2.0 * resolution.y; // WebGL port note: Changed sign
-	texcoord.y += resolution.y * SMAASearchLength( searchTex, e.gr, 0.0, 0.5 ); // WebGL port note: Changed sign
+			texcoord.y -= 0.25 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= 2.0 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y += resolution.y * SMAASearchLength( searchTex, e.gr, 0.0, 0.5 ); // WebGL port note: Changed sign
 
-	return texcoord.y;
-}
+			return texcoord.y;
+		}
 
-float SMAASearchYDown( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
-	vec2 e = vec2( 1.0, 0.0 );
+		float SMAASearchYDown( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 1.0, 0.0 );
 
-	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
-		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
-		texcoord -= vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
-		if ( ! ( texcoord.y < end && e.r > 0.8281 && e.g == 0.0 ) ) break;
-	}
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord -= vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+				if ( ! ( texcoord.y < end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+			}
 
-	texcoord.y += 0.25 * resolution.y; // WebGL port note: Changed sign
-	texcoord.y += resolution.y; // WebGL port note: Changed sign
-	texcoord.y += 2.0 * resolution.y; // WebGL port note: Changed sign
-	texcoord.y -= resolution.y * SMAASearchLength( searchTex, e.gr, 0.5, 0.5 ); // WebGL port note: Changed sign
+			texcoord.y += 0.25 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y += resolution.y; // WebGL port note: Changed sign
+			texcoord.y += 2.0 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= resolution.y * SMAASearchLength( searchTex, e.gr, 0.5, 0.5 ); // WebGL port note: Changed sign
 
-	return texcoord.y;
-}
+			return texcoord.y;
+		}
 
-vec2 SMAAArea( sampler2D areaTex, vec2 dist, float e1, float e2, float offset ) {
-	// Rounding prevents precision errors of bilinear filtering:
-	vec2 texcoord = float( SMAA_AREATEX_MAX_DISTANCE ) * round( 4.0 * vec2( e1, e2 ) ) + dist;
+		vec2 SMAAArea( sampler2D areaTex, vec2 dist, float e1, float e2, float offset ) {
+			// Rounding prevents precision errors of bilinear filtering:
+			vec2 texcoord = float( SMAA_AREATEX_MAX_DISTANCE ) * round( 4.0 * vec2( e1, e2 ) ) + dist;
 
-	// We do a scale and bias for mapping to texel space:
-	texcoord = SMAA_AREATEX_PIXEL_SIZE * texcoord + ( 0.5 * SMAA_AREATEX_PIXEL_SIZE );
+			// We do a scale and bias for mapping to texel space:
+			texcoord = SMAA_AREATEX_PIXEL_SIZE * texcoord + ( 0.5 * SMAA_AREATEX_PIXEL_SIZE );
 
-	// Move to proper place, according to the subpixel offset:
-	texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;
+			// Move to proper place, according to the subpixel offset:
+			texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;
 
-	return texture2D( areaTex, texcoord, 0.0 ).rg;
-}
+			return texture2D( areaTex, texcoord, 0.0 ).rg;
+		}
 
-vec4 SMAABlendingWeightCalculationPS( vec2 texcoord, vec2 pixcoord, vec4 offset[ 3 ], sampler2D edgesTex, sampler2D areaTex, sampler2D searchTex, ivec4 subsampleIndices ) {
-	vec4 weights = vec4( 0.0, 0.0, 0.0, 0.0 );
+		vec4 SMAABlendingWeightCalculationPS( vec2 texcoord, vec2 pixcoord, vec4 offset[ 3 ], sampler2D edgesTex, sampler2D areaTex, sampler2D searchTex, ivec4 subsampleIndices ) {
+			vec4 weights = vec4( 0.0, 0.0, 0.0, 0.0 );
 
-	vec2 e = texture2D( edgesTex, texcoord ).rg;
+			vec2 e = texture2D( edgesTex, texcoord ).rg;
 
-	if ( e.g > 0.0 ) { // Edge at north
-		vec2 d;
+			if ( e.g > 0.0 ) { // Edge at north
+				vec2 d;
 
-		// Find the distance to the left:
-		vec2 coords;
-		coords.x = SMAASearchXLeft( edgesTex, searchTex, offset[ 0 ].xy, offset[ 2 ].x );
-		coords.y = offset[ 1 ].y; // offset[1].y = texcoord.y - 0.25 * resolution.y (@CROSSING_OFFSET)
-		d.x = coords.x;
+				// Find the distance to the left:
+				vec2 coords;
+				coords.x = SMAASearchXLeft( edgesTex, searchTex, offset[ 0 ].xy, offset[ 2 ].x );
+				coords.y = offset[ 1 ].y; // offset[1].y = texcoord.y - 0.25 * resolution.y (@CROSSING_OFFSET)
+				d.x = coords.x;
 
-		// Now fetch the left crossing edges, two at a time using bilinear
-		// filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to
-		// discern what value each edge has:
-		float e1 = texture2D( edgesTex, coords, 0.0 ).r;
+				// Now fetch the left crossing edges, two at a time using bilinear
+				// filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to
+				// discern what value each edge has:
+				float e1 = texture2D( edgesTex, coords, 0.0 ).r;
 
-		// Find the distance to the right:
-		coords.x = SMAASearchXRight( edgesTex, searchTex, offset[ 0 ].zw, offset[ 2 ].y );
-		d.y = coords.x;
+				// Find the distance to the right:
+				coords.x = SMAASearchXRight( edgesTex, searchTex, offset[ 0 ].zw, offset[ 2 ].y );
+				d.y = coords.x;
 
-		// We want the distances to be in pixel units (doing this here allow to
-		// better interleave arithmetic and memory accesses):
-		d = d / resolution.x - pixcoord.x;
+				// We want the distances to be in pixel units (doing this here allow to
+				// better interleave arithmetic and memory accesses):
+				d = d / resolution.x - pixcoord.x;
 
-		// SMAAArea below needs a sqrt, as the areas texture is compressed
-		// quadratically:
-		vec2 sqrt_d = sqrt( abs( d ) );
+				// SMAAArea below needs a sqrt, as the areas texture is compressed
+				// quadratically:
+				vec2 sqrt_d = sqrt( abs( d ) );
 
-		// Fetch the right crossing edges:
-		coords.y -= 1.0 * resolution.y; // WebGL port note: Added
-		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 1, 0 ) ).r;
+				// Fetch the right crossing edges:
+				coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+				float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 1, 0 ) ).r;
 
-		// Ok, we know how this pattern looks like, now it is time for getting
-		// the actual area:
-		weights.rg = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.y ) );
-	}
+				// Ok, we know how this pattern looks like, now it is time for getting
+				// the actual area:
+				weights.rg = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.y ) );
+			}
 
-	if ( e.r > 0.0 ) { // Edge at west
-		vec2 d;
+			if ( e.r > 0.0 ) { // Edge at west
+				vec2 d;
 
-		// Find the distance to the top:
-		vec2 coords;
+				// Find the distance to the top:
+				vec2 coords;
 
-		coords.y = SMAASearchYUp( edgesTex, searchTex, offset[ 1 ].xy, offset[ 2 ].z );
-		coords.x = offset[ 0 ].x; // offset[1].x = texcoord.x - 0.25 * resolution.x;
-		d.x = coords.y;
+				coords.y = SMAASearchYUp( edgesTex, searchTex, offset[ 1 ].xy, offset[ 2 ].z );
+				coords.x = offset[ 0 ].x; // offset[1].x = texcoord.x - 0.25 * resolution.x;
+				d.x = coords.y;
 
-		// Fetch the top crossing edges:
-		float e1 = texture2D( edgesTex, coords, 0.0 ).g;
+				// Fetch the top crossing edges:
+				float e1 = texture2D( edgesTex, coords, 0.0 ).g;
 
-		// Find the distance to the bottom:
-		coords.y = SMAASearchYDown( edgesTex, searchTex, offset[ 1 ].zw, offset[ 2 ].w );
-		d.y = coords.y;
+				// Find the distance to the bottom:
+				coords.y = SMAASearchYDown( edgesTex, searchTex, offset[ 1 ].zw, offset[ 2 ].w );
+				d.y = coords.y;
 
-		// We want the distances to be in pixel units:
-		d = d / resolution.y - pixcoord.y;
+				// We want the distances to be in pixel units:
+				d = d / resolution.y - pixcoord.y;
 
-		// SMAAArea below needs a sqrt, as the areas texture is compressed
-		// quadratically:
-		vec2 sqrt_d = sqrt( abs( d ) );
+				// SMAAArea below needs a sqrt, as the areas texture is compressed
+				// quadratically:
+				vec2 sqrt_d = sqrt( abs( d ) );
 
-		// Fetch the bottom crossing edges:
-		coords.y -= 1.0 * resolution.y; // WebGL port note: Added
-		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 0, 1 ) ).g;
+				// Fetch the bottom crossing edges:
+				coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+				float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 0, 1 ) ).g;
 
-		// Get the area for this direction:
-		weights.ba = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.x ) );
-	}
+				// Get the area for this direction:
+				weights.ba = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.x ) );
+			}
 
-	return weights;
-}
+			return weights;
+		}
 
-void main() {
+		void main() {
 
-	gl_FragColor = SMAABlendingWeightCalculationPS( vUv, vPixcoord, vOffset, tDiffuse, tArea, tSearch, ivec4( 0.0 ) );
+			gl_FragColor = SMAABlendingWeightCalculationPS( vUv, vPixcoord, vOffset, tDiffuse, tArea, tSearch, ivec4( 0.0 ) );
 
-}
-`
-
+		}
+	`
 };
 
 THREE.SMAABlendShader = {
@@ -376,81 +374,80 @@ THREE.SMAABlendShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform vec2 resolution;
+		uniform vec2 resolution;
 
-varying vec2 vUv;
-varying vec4 vOffset[ 2 ];
+		varying vec2 vUv;
+		varying vec4 vOffset[ 2 ];
 
-void SMAANeighborhoodBlendingVS( vec2 texcoord ) {
-	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0, 1.0 ); // WebGL port note: Changed sign in W component
-	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( 1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
-}
-
-void main() {
-
-	vUv = uv;
-
-	SMAANeighborhoodBlendingVS( vUv );
-
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-}
-`,
-
-	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform sampler2D tColor;
-uniform vec2 resolution;
-
-varying vec2 vUv;
-varying vec4 vOffset[ 2 ];
-
-vec4 SMAANeighborhoodBlendingPS( vec2 texcoord, vec4 offset[ 2 ], sampler2D colorTex, sampler2D blendTex ) {
-	// Fetch the blending weights for current pixel:
-	vec4 a;
-	a.xz = texture2D( blendTex, texcoord ).xz;
-	a.y = texture2D( blendTex, offset[ 1 ].zw ).g;
-	a.w = texture2D( blendTex, offset[ 1 ].xy ).a;
-
-	// Is there any blending weight with a value greater than 0.0?
-	if ( dot(a, vec4( 1.0, 1.0, 1.0, 1.0 )) < 1e-5 ) {
-		return texture2D( colorTex, texcoord, 0.0 );
-	} else {
-		// Up to 4 lines can be crossing a pixel (one through each edge). We
-		// favor blending by choosing the line with the maximum weight for each
-		// direction:
-		vec2 offset;
-		offset.x = a.a > a.b ? a.a : -a.b; // left vs. right
-		offset.y = a.g > a.r ? -a.g : a.r; // top vs. bottom // WebGL port note: Changed signs
-
-		// Then we go in the direction that has the maximum weight:
-		if ( abs( offset.x ) > abs( offset.y )) { // horizontal vs. vertical
-			offset.y = 0.0;
-		} else {
-			offset.x = 0.0;
+		void SMAANeighborhoodBlendingVS( vec2 texcoord ) {
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0, 1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( 1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
 		}
 
-		// Fetch the opposite color and lerp by hand:
-		vec4 C = texture2D( colorTex, texcoord, 0.0 );
-		texcoord += sign( offset ) * resolution;
-		vec4 Cop = texture2D( colorTex, texcoord, 0.0 );
-		float s = abs( offset.x ) > abs( offset.y ) ? abs( offset.x ) : abs( offset.y );
+		void main() {
 
-		// WebGL port note: Added gamma correction
-		C.xyz = pow(C.xyz, vec3(2.2));
-		Cop.xyz = pow(Cop.xyz, vec3(2.2));
-		vec4 mixed = mix(C, Cop, s);
-		mixed.xyz = pow(mixed.xyz, vec3(1.0 / 2.2));
+			vUv = uv;
 
-		return mixed;
-	}
-}
+			SMAANeighborhoodBlendingVS( vUv );
 
-void main() {
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-	gl_FragColor = SMAANeighborhoodBlendingPS( vUv, vOffset, tColor, tDiffuse );
+		}
+	`,
 
-}
-`
+	fragmentShader: /* glsl */`
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tColor;
+		uniform vec2 resolution;
 
+		varying vec2 vUv;
+		varying vec4 vOffset[ 2 ];
+
+		vec4 SMAANeighborhoodBlendingPS( vec2 texcoord, vec4 offset[ 2 ], sampler2D colorTex, sampler2D blendTex ) {
+			// Fetch the blending weights for current pixel:
+			vec4 a;
+			a.xz = texture2D( blendTex, texcoord ).xz;
+			a.y = texture2D( blendTex, offset[ 1 ].zw ).g;
+			a.w = texture2D( blendTex, offset[ 1 ].xy ).a;
+
+			// Is there any blending weight with a value greater than 0.0?
+			if ( dot(a, vec4( 1.0, 1.0, 1.0, 1.0 )) < 1e-5 ) {
+				return texture2D( colorTex, texcoord, 0.0 );
+			} else {
+				// Up to 4 lines can be crossing a pixel (one through each edge). We
+				// favor blending by choosing the line with the maximum weight for each
+				// direction:
+				vec2 offset;
+				offset.x = a.a > a.b ? a.a : -a.b; // left vs. right
+				offset.y = a.g > a.r ? -a.g : a.r; // top vs. bottom // WebGL port note: Changed signs
+
+				// Then we go in the direction that has the maximum weight:
+				if ( abs( offset.x ) > abs( offset.y )) { // horizontal vs. vertical
+					offset.y = 0.0;
+				} else {
+					offset.x = 0.0;
+				}
+
+				// Fetch the opposite color and lerp by hand:
+				vec4 C = texture2D( colorTex, texcoord, 0.0 );
+				texcoord += sign( offset ) * resolution;
+				vec4 Cop = texture2D( colorTex, texcoord, 0.0 );
+				float s = abs( offset.x ) > abs( offset.y ) ? abs( offset.x ) : abs( offset.y );
+
+				// WebGL port note: Added gamma correction
+				C.xyz = pow(C.xyz, vec3(2.2));
+				Cop.xyz = pow(Cop.xyz, vec3(2.2));
+				vec4 mixed = mix(C, Cop, s);
+				mixed.xyz = pow(mixed.xyz, vec3(1.0 / 2.2));
+
+				return mixed;
+			}
+		}
+
+		void main() {
+
+			gl_FragColor = SMAANeighborhoodBlendingPS( vUv, vOffset, tColor, tDiffuse );
+
+		}
+	`
 };

--- a/examples/js/shaders/SMAAShader.js
+++ b/examples/js/shaders/SMAAShader.js
@@ -21,97 +21,93 @@ THREE.SMAAEdgesShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform vec2 resolution;
 
-		"uniform vec2 resolution;",
+varying vec2 vUv;
+varying vec4 vOffset[ 3 ];
 
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[ 3 ];",
+void SMAAEdgeDetectionVS( vec2 texcoord ) {
+	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0,  1.0 ); // WebGL port note: Changed sign in W component
+	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4(  1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
+	vOffset[ 2 ] = texcoord.xyxy + resolution.xyxy * vec4( -2.0, 0.0, 0.0,  2.0 ); // WebGL port note: Changed sign in W component
+}
 
-		"void SMAAEdgeDetectionVS( vec2 texcoord ) {",
-		"	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0,  1.0 );", // WebGL port note: Changed sign in W component
-		"	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4(  1.0, 0.0, 0.0, -1.0 );", // WebGL port note: Changed sign in W component
-		"	vOffset[ 2 ] = texcoord.xyxy + resolution.xyxy * vec4( -2.0, 0.0, 0.0,  2.0 );", // WebGL port note: Changed sign in W component
-		"}",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	SMAAEdgeDetectionVS( vUv );
 
-		"	SMAAEdgeDetectionVS( vUv );",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
 
-	].join( "\n" ),
+varying vec2 vUv;
+varying vec4 vOffset[ 3 ];
 
-	fragmentShader: [
+vec4 SMAAColorEdgeDetectionPS( vec2 texcoord, vec4 offset[3], sampler2D colorTex ) {
+	vec2 threshold = vec2( SMAA_THRESHOLD, SMAA_THRESHOLD );
 
-		"uniform sampler2D tDiffuse;",
+	// Calculate color deltas:
+	vec4 delta;
+	vec3 C = texture2D( colorTex, texcoord ).rgb;
 
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[ 3 ];",
+	vec3 Cleft = texture2D( colorTex, offset[0].xy ).rgb;
+	vec3 t = abs( C - Cleft );
+	delta.x = max( max( t.r, t.g ), t.b );
 
-		"vec4 SMAAColorEdgeDetectionPS( vec2 texcoord, vec4 offset[3], sampler2D colorTex ) {",
-		"	vec2 threshold = vec2( SMAA_THRESHOLD, SMAA_THRESHOLD );",
+	vec3 Ctop = texture2D( colorTex, offset[0].zw ).rgb;
+	t = abs( C - Ctop );
+	delta.y = max( max( t.r, t.g ), t.b );
 
-		// Calculate color deltas:
-		"	vec4 delta;",
-		"	vec3 C = texture2D( colorTex, texcoord ).rgb;",
+	// We do the usual threshold:
+	vec2 edges = step( threshold, delta.xy );
 
-		"	vec3 Cleft = texture2D( colorTex, offset[0].xy ).rgb;",
-		"	vec3 t = abs( C - Cleft );",
-		"	delta.x = max( max( t.r, t.g ), t.b );",
+	// Then discard if there is no edge:
+	if ( dot( edges, vec2( 1.0, 1.0 ) ) == 0.0 )
+		discard;
 
-		"	vec3 Ctop = texture2D( colorTex, offset[0].zw ).rgb;",
-		"	t = abs( C - Ctop );",
-		"	delta.y = max( max( t.r, t.g ), t.b );",
+	// Calculate right and bottom deltas:
+	vec3 Cright = texture2D( colorTex, offset[1].xy ).rgb;
+	t = abs( C - Cright );
+	delta.z = max( max( t.r, t.g ), t.b );
 
-		// We do the usual threshold:
-		"	vec2 edges = step( threshold, delta.xy );",
+	vec3 Cbottom  = texture2D( colorTex, offset[1].zw ).rgb;
+	t = abs( C - Cbottom );
+	delta.w = max( max( t.r, t.g ), t.b );
 
-		// Then discard if there is no edge:
-		"	if ( dot( edges, vec2( 1.0, 1.0 ) ) == 0.0 )",
-		"		discard;",
+	// Calculate the maximum delta in the direct neighborhood:
+	float maxDelta = max( max( max( delta.x, delta.y ), delta.z ), delta.w );
 
-		// Calculate right and bottom deltas:
-		"	vec3 Cright = texture2D( colorTex, offset[1].xy ).rgb;",
-		"	t = abs( C - Cright );",
-		"	delta.z = max( max( t.r, t.g ), t.b );",
+	// Calculate left-left and top-top deltas:
+	vec3 Cleftleft  = texture2D( colorTex, offset[2].xy ).rgb;
+	t = abs( C - Cleftleft );
+	delta.z = max( max( t.r, t.g ), t.b );
 
-		"	vec3 Cbottom  = texture2D( colorTex, offset[1].zw ).rgb;",
-		"	t = abs( C - Cbottom );",
-		"	delta.w = max( max( t.r, t.g ), t.b );",
+	vec3 Ctoptop = texture2D( colorTex, offset[2].zw ).rgb;
+	t = abs( C - Ctoptop );
+	delta.w = max( max( t.r, t.g ), t.b );
 
-		// Calculate the maximum delta in the direct neighborhood:
-		"	float maxDelta = max( max( max( delta.x, delta.y ), delta.z ), delta.w );",
+	// Calculate the final maximum delta:
+	maxDelta = max( max( maxDelta, delta.z ), delta.w );
 
-		// Calculate left-left and top-top deltas:
-		"	vec3 Cleftleft  = texture2D( colorTex, offset[2].xy ).rgb;",
-		"	t = abs( C - Cleftleft );",
-		"	delta.z = max( max( t.r, t.g ), t.b );",
+	// Local contrast adaptation in action:
+	edges.xy *= step( 0.5 * maxDelta, delta.xy );
 
-		"	vec3 Ctoptop = texture2D( colorTex, offset[2].zw ).rgb;",
-		"	t = abs( C - Ctoptop );",
-		"	delta.w = max( max( t.r, t.g ), t.b );",
+	return vec4( edges, 0.0, 0.0 );
+}
 
-		// Calculate the final maximum delta:
-		"	maxDelta = max( max( maxDelta, delta.z ), delta.w );",
+void main() {
 
-		// Local contrast adaptation in action:
-		"	edges.xy *= step( 0.5 * maxDelta, delta.xy );",
+	gl_FragColor = SMAAColorEdgeDetectionPS( vUv, vOffset, tDiffuse );
 
-		"	return vec4( edges, 0.0, 0.0 );",
-		"}",
-
-		"void main() {",
-
-		"	gl_FragColor = SMAAColorEdgeDetectionPS( vUv, vOffset, tDiffuse );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -135,241 +131,237 @@ THREE.SMAAWeightsShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform vec2 resolution;
 
-		"uniform vec2 resolution;",
+varying vec2 vUv;
+varying vec4 vOffset[ 3 ];
+varying vec2 vPixcoord;
 
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[ 3 ];",
-		"varying vec2 vPixcoord;",
+void SMAABlendingWeightCalculationVS( vec2 texcoord ) {
+	vPixcoord = texcoord / resolution;
 
-		"void SMAABlendingWeightCalculationVS( vec2 texcoord ) {",
-		"	vPixcoord = texcoord / resolution;",
+	// We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
+	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.25, 0.125, 1.25, 0.125 ); // WebGL port note: Changed sign in Y and W components
+	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.125, 0.25, -0.125, -1.25 ); // WebGL port note: Changed sign in Y and W components
 
-		// We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
-		"	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.25, 0.125, 1.25, 0.125 );", // WebGL port note: Changed sign in Y and W components
-		"	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.125, 0.25, -0.125, -1.25 );", // WebGL port note: Changed sign in Y and W components
+	// And these for the searches, they indicate the ends of the loops:
+	vOffset[ 2 ] = vec4( vOffset[ 0 ].xz, vOffset[ 1 ].yw ) + vec4( -2.0, 2.0, -2.0, 2.0 ) * resolution.xxyy * float( SMAA_MAX_SEARCH_STEPS );
 
-		// And these for the searches, they indicate the ends of the loops:
-		"	vOffset[ 2 ] = vec4( vOffset[ 0 ].xz, vOffset[ 1 ].yw ) + vec4( -2.0, 2.0, -2.0, 2.0 ) * resolution.xxyy * float( SMAA_MAX_SEARCH_STEPS );",
+}
 
-		"}",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	SMAABlendingWeightCalculationVS( vUv );
 
-		"	SMAABlendingWeightCalculationVS( vUv );",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#define SMAASampleLevelZeroOffset( tex, coord, offset ) texture2D( tex, coord + float( offset ) * resolution, 0.0 )
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
+uniform sampler2D tArea;
+uniform sampler2D tSearch;
+uniform vec2 resolution;
 
-	fragmentShader: [
+varying vec2 vUv;
+varying vec4 vOffset[3];
+varying vec2 vPixcoord;
 
-		"#define SMAASampleLevelZeroOffset( tex, coord, offset ) texture2D( tex, coord + float( offset ) * resolution, 0.0 )",
+#if __VERSION__ == 100
+vec2 round( vec2 x ) {
+	return sign( x ) * floor( abs( x ) + 0.5 );
+}
+#endif
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tArea;",
-		"uniform sampler2D tSearch;",
-		"uniform vec2 resolution;",
+float SMAASearchLength( sampler2D searchTex, vec2 e, float bias, float scale ) {
+	// Not required if searchTex accesses are set to point:
+	// float2 SEARCH_TEX_PIXEL_SIZE = 1.0 / float2(66.0, 33.0);
+	// e = float2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE +
+	//     e * float2(scale, 1.0) * float2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
+	e.r = bias + e.r * scale;
+	return 255.0 * texture2D( searchTex, e, 0.0 ).r;
+}
 
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[3];",
-		"varying vec2 vPixcoord;",
-
-		"#if __VERSION__ == 100",
-		"vec2 round( vec2 x ) {",
-		"	return sign( x ) * floor( abs( x ) + 0.5 );",
-		"}",
-		"#endif",
-
-		"float SMAASearchLength( sampler2D searchTex, vec2 e, float bias, float scale ) {",
-		// Not required if searchTex accesses are set to point:
-		// float2 SEARCH_TEX_PIXEL_SIZE = 1.0 / float2(66.0, 33.0);
-		// e = float2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE +
-		//     e * float2(scale, 1.0) * float2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
-		"	e.r = bias + e.r * scale;",
-		"	return 255.0 * texture2D( searchTex, e, 0.0 ).r;",
-		"}",
-
-		"float SMAASearchXLeft( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {",
-		/**
+float SMAASearchXLeft( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+	/**
 			* @PSEUDO_GATHER4
 			* This texcoord has been offset by (-0.25, -0.125) in the vertex shader to
 			* sample between edge, thus fetching four edges in a row.
 			* Sampling with different offsets in each direction allows to disambiguate
 			* which edges are active from the four fetched ones.
 			*/
-		"	vec2 e = vec2( 0.0, 1.0 );",
+	vec2 e = vec2( 0.0, 1.0 );
 
-		"	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) {", // WebGL port note: Changed while to for
-		"		e = texture2D( edgesTex, texcoord, 0.0 ).rg;",
-		"		texcoord -= vec2( 2.0, 0.0 ) * resolution;",
-		"		if ( ! ( texcoord.x > end && e.g > 0.8281 && e.r == 0.0 ) ) break;",
-		"	}",
+	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+		texcoord -= vec2( 2.0, 0.0 ) * resolution;
+		if ( ! ( texcoord.x > end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+	}
 
-		// We correct the previous (-0.25, -0.125) offset we applied:
-		"	texcoord.x += 0.25 * resolution.x;",
+	// We correct the previous (-0.25, -0.125) offset we applied:
+	texcoord.x += 0.25 * resolution.x;
 
-		// The searches are bias by 1, so adjust the coords accordingly:
-		"	texcoord.x += resolution.x;",
+	// The searches are bias by 1, so adjust the coords accordingly:
+	texcoord.x += resolution.x;
 
-		// Disambiguate the length added by the last step:
-		"	texcoord.x += 2.0 * resolution.x;", // Undo last step
-		"	texcoord.x -= resolution.x * SMAASearchLength(searchTex, e, 0.0, 0.5);",
+	// Disambiguate the length added by the last step:
+	texcoord.x += 2.0 * resolution.x; // Undo last step
+	texcoord.x -= resolution.x * SMAASearchLength(searchTex, e, 0.0, 0.5);
 
-		"	return texcoord.x;",
-		"}",
+	return texcoord.x;
+}
 
-		"float SMAASearchXRight( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {",
-		"	vec2 e = vec2( 0.0, 1.0 );",
+float SMAASearchXRight( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+	vec2 e = vec2( 0.0, 1.0 );
 
-		"	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) {", // WebGL port note: Changed while to for
-		"		e = texture2D( edgesTex, texcoord, 0.0 ).rg;",
-		"		texcoord += vec2( 2.0, 0.0 ) * resolution;",
-		"		if ( ! ( texcoord.x < end && e.g > 0.8281 && e.r == 0.0 ) ) break;",
-		"	}",
+	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+		texcoord += vec2( 2.0, 0.0 ) * resolution;
+		if ( ! ( texcoord.x < end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+	}
 
-		"	texcoord.x -= 0.25 * resolution.x;",
-		"	texcoord.x -= resolution.x;",
-		"	texcoord.x -= 2.0 * resolution.x;",
-		"	texcoord.x += resolution.x * SMAASearchLength( searchTex, e, 0.5, 0.5 );",
+	texcoord.x -= 0.25 * resolution.x;
+	texcoord.x -= resolution.x;
+	texcoord.x -= 2.0 * resolution.x;
+	texcoord.x += resolution.x * SMAASearchLength( searchTex, e, 0.5, 0.5 );
 
-		"	return texcoord.x;",
-		"}",
+	return texcoord.x;
+}
 
-		"float SMAASearchYUp( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {",
-		"	vec2 e = vec2( 1.0, 0.0 );",
+float SMAASearchYUp( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+	vec2 e = vec2( 1.0, 0.0 );
 
-		"	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) {", // WebGL port note: Changed while to for
-		"		e = texture2D( edgesTex, texcoord, 0.0 ).rg;",
-		"		texcoord += vec2( 0.0, 2.0 ) * resolution;", // WebGL port note: Changed sign
-		"		if ( ! ( texcoord.y > end && e.r > 0.8281 && e.g == 0.0 ) ) break;",
-		"	}",
+	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+		texcoord += vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+		if ( ! ( texcoord.y > end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+	}
 
-		"	texcoord.y -= 0.25 * resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y -= resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y -= 2.0 * resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y += resolution.y * SMAASearchLength( searchTex, e.gr, 0.0, 0.5 );", // WebGL port note: Changed sign
+	texcoord.y -= 0.25 * resolution.y; // WebGL port note: Changed sign
+	texcoord.y -= resolution.y; // WebGL port note: Changed sign
+	texcoord.y -= 2.0 * resolution.y; // WebGL port note: Changed sign
+	texcoord.y += resolution.y * SMAASearchLength( searchTex, e.gr, 0.0, 0.5 ); // WebGL port note: Changed sign
 
-		"	return texcoord.y;",
-		"}",
+	return texcoord.y;
+}
 
-		"float SMAASearchYDown( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {",
-		"	vec2 e = vec2( 1.0, 0.0 );",
+float SMAASearchYDown( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+	vec2 e = vec2( 1.0, 0.0 );
 
-		"	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) {", // WebGL port note: Changed while to for
-		"		e = texture2D( edgesTex, texcoord, 0.0 ).rg;",
-		"		texcoord -= vec2( 0.0, 2.0 ) * resolution;", // WebGL port note: Changed sign
-		"		if ( ! ( texcoord.y < end && e.r > 0.8281 && e.g == 0.0 ) ) break;",
-		"	}",
+	for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+		e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+		texcoord -= vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+		if ( ! ( texcoord.y < end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+	}
 
-		"	texcoord.y += 0.25 * resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y += resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y += 2.0 * resolution.y;", // WebGL port note: Changed sign
-		"	texcoord.y -= resolution.y * SMAASearchLength( searchTex, e.gr, 0.5, 0.5 );", // WebGL port note: Changed sign
+	texcoord.y += 0.25 * resolution.y; // WebGL port note: Changed sign
+	texcoord.y += resolution.y; // WebGL port note: Changed sign
+	texcoord.y += 2.0 * resolution.y; // WebGL port note: Changed sign
+	texcoord.y -= resolution.y * SMAASearchLength( searchTex, e.gr, 0.5, 0.5 ); // WebGL port note: Changed sign
 
-		"	return texcoord.y;",
-		"}",
+	return texcoord.y;
+}
 
-		"vec2 SMAAArea( sampler2D areaTex, vec2 dist, float e1, float e2, float offset ) {",
-		// Rounding prevents precision errors of bilinear filtering:
-		"	vec2 texcoord = float( SMAA_AREATEX_MAX_DISTANCE ) * round( 4.0 * vec2( e1, e2 ) ) + dist;",
+vec2 SMAAArea( sampler2D areaTex, vec2 dist, float e1, float e2, float offset ) {
+	// Rounding prevents precision errors of bilinear filtering:
+	vec2 texcoord = float( SMAA_AREATEX_MAX_DISTANCE ) * round( 4.0 * vec2( e1, e2 ) ) + dist;
 
-		// We do a scale and bias for mapping to texel space:
-		"	texcoord = SMAA_AREATEX_PIXEL_SIZE * texcoord + ( 0.5 * SMAA_AREATEX_PIXEL_SIZE );",
+	// We do a scale and bias for mapping to texel space:
+	texcoord = SMAA_AREATEX_PIXEL_SIZE * texcoord + ( 0.5 * SMAA_AREATEX_PIXEL_SIZE );
 
-		// Move to proper place, according to the subpixel offset:
-		"	texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;",
+	// Move to proper place, according to the subpixel offset:
+	texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;
 
-		"	return texture2D( areaTex, texcoord, 0.0 ).rg;",
-		"}",
+	return texture2D( areaTex, texcoord, 0.0 ).rg;
+}
 
-		"vec4 SMAABlendingWeightCalculationPS( vec2 texcoord, vec2 pixcoord, vec4 offset[ 3 ], sampler2D edgesTex, sampler2D areaTex, sampler2D searchTex, ivec4 subsampleIndices ) {",
-		"	vec4 weights = vec4( 0.0, 0.0, 0.0, 0.0 );",
+vec4 SMAABlendingWeightCalculationPS( vec2 texcoord, vec2 pixcoord, vec4 offset[ 3 ], sampler2D edgesTex, sampler2D areaTex, sampler2D searchTex, ivec4 subsampleIndices ) {
+	vec4 weights = vec4( 0.0, 0.0, 0.0, 0.0 );
 
-		"	vec2 e = texture2D( edgesTex, texcoord ).rg;",
+	vec2 e = texture2D( edgesTex, texcoord ).rg;
 
-		"	if ( e.g > 0.0 ) {", // Edge at north
-		"		vec2 d;",
+	if ( e.g > 0.0 ) { // Edge at north
+		vec2 d;
 
 		// Find the distance to the left:
-		"		vec2 coords;",
-		"		coords.x = SMAASearchXLeft( edgesTex, searchTex, offset[ 0 ].xy, offset[ 2 ].x );",
-		"		coords.y = offset[ 1 ].y;", // offset[1].y = texcoord.y - 0.25 * resolution.y (@CROSSING_OFFSET)
-		"		d.x = coords.x;",
+		vec2 coords;
+		coords.x = SMAASearchXLeft( edgesTex, searchTex, offset[ 0 ].xy, offset[ 2 ].x );
+		coords.y = offset[ 1 ].y; // offset[1].y = texcoord.y - 0.25 * resolution.y (@CROSSING_OFFSET)
+		d.x = coords.x;
 
 		// Now fetch the left crossing edges, two at a time using bilinear
 		// filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to
 		// discern what value each edge has:
-		"		float e1 = texture2D( edgesTex, coords, 0.0 ).r;",
+		float e1 = texture2D( edgesTex, coords, 0.0 ).r;
 
 		// Find the distance to the right:
-		"		coords.x = SMAASearchXRight( edgesTex, searchTex, offset[ 0 ].zw, offset[ 2 ].y );",
-		"		d.y = coords.x;",
+		coords.x = SMAASearchXRight( edgesTex, searchTex, offset[ 0 ].zw, offset[ 2 ].y );
+		d.y = coords.x;
 
 		// We want the distances to be in pixel units (doing this here allow to
 		// better interleave arithmetic and memory accesses):
-		"		d = d / resolution.x - pixcoord.x;",
+		d = d / resolution.x - pixcoord.x;
 
 		// SMAAArea below needs a sqrt, as the areas texture is compressed
 		// quadratically:
-		"		vec2 sqrt_d = sqrt( abs( d ) );",
+		vec2 sqrt_d = sqrt( abs( d ) );
 
 		// Fetch the right crossing edges:
-		"		coords.y -= 1.0 * resolution.y;", // WebGL port note: Added
-		"		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 1, 0 ) ).r;",
+		coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 1, 0 ) ).r;
 
 		// Ok, we know how this pattern looks like, now it is time for getting
 		// the actual area:
-		"		weights.rg = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.y ) );",
-		"	}",
+		weights.rg = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.y ) );
+	}
 
-		"	if ( e.r > 0.0 ) {", // Edge at west
-		"		vec2 d;",
+	if ( e.r > 0.0 ) { // Edge at west
+		vec2 d;
 
 		// Find the distance to the top:
-		"		vec2 coords;",
+		vec2 coords;
 
-		"		coords.y = SMAASearchYUp( edgesTex, searchTex, offset[ 1 ].xy, offset[ 2 ].z );",
-		"		coords.x = offset[ 0 ].x;", // offset[1].x = texcoord.x - 0.25 * resolution.x;
-		"		d.x = coords.y;",
+		coords.y = SMAASearchYUp( edgesTex, searchTex, offset[ 1 ].xy, offset[ 2 ].z );
+		coords.x = offset[ 0 ].x; // offset[1].x = texcoord.x - 0.25 * resolution.x;
+		d.x = coords.y;
 
 		// Fetch the top crossing edges:
-		"		float e1 = texture2D( edgesTex, coords, 0.0 ).g;",
+		float e1 = texture2D( edgesTex, coords, 0.0 ).g;
 
 		// Find the distance to the bottom:
-		"		coords.y = SMAASearchYDown( edgesTex, searchTex, offset[ 1 ].zw, offset[ 2 ].w );",
-		"		d.y = coords.y;",
+		coords.y = SMAASearchYDown( edgesTex, searchTex, offset[ 1 ].zw, offset[ 2 ].w );
+		d.y = coords.y;
 
 		// We want the distances to be in pixel units:
-		"		d = d / resolution.y - pixcoord.y;",
+		d = d / resolution.y - pixcoord.y;
 
 		// SMAAArea below needs a sqrt, as the areas texture is compressed
 		// quadratically:
-		"		vec2 sqrt_d = sqrt( abs( d ) );",
+		vec2 sqrt_d = sqrt( abs( d ) );
 
 		// Fetch the bottom crossing edges:
-		"		coords.y -= 1.0 * resolution.y;", // WebGL port note: Added
-		"		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 0, 1 ) ).g;",
+		coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+		float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 0, 1 ) ).g;
 
 		// Get the area for this direction:
-		"		weights.ba = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.x ) );",
-		"	}",
+		weights.ba = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.x ) );
+	}
 
-		"	return weights;",
-		"}",
+	return weights;
+}
 
-		"void main() {",
+void main() {
 
-		"	gl_FragColor = SMAABlendingWeightCalculationPS( vUv, vPixcoord, vOffset, tDiffuse, tArea, tSearch, ivec4( 0.0 ) );",
+	gl_FragColor = SMAABlendingWeightCalculationPS( vUv, vPixcoord, vOffset, tDiffuse, tArea, tSearch, ivec4( 0.0 ) );
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -383,86 +375,82 @@ THREE.SMAABlendShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform vec2 resolution;
 
-		"uniform vec2 resolution;",
+varying vec2 vUv;
+varying vec4 vOffset[ 2 ];
 
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[ 2 ];",
+void SMAANeighborhoodBlendingVS( vec2 texcoord ) {
+	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0, 1.0 ); // WebGL port note: Changed sign in W component
+	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( 1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
+}
 
-		"void SMAANeighborhoodBlendingVS( vec2 texcoord ) {",
-		"	vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0, 1.0 );", // WebGL port note: Changed sign in W component
-		"	vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( 1.0, 0.0, 0.0, -1.0 );", // WebGL port note: Changed sign in W component
-		"}",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	SMAANeighborhoodBlendingVS( vUv );
 
-		"	SMAANeighborhoodBlendingVS( vUv );",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform sampler2D tColor;
+uniform vec2 resolution;
 
-	].join( "\n" ),
+varying vec2 vUv;
+varying vec4 vOffset[ 2 ];
 
-	fragmentShader: [
+vec4 SMAANeighborhoodBlendingPS( vec2 texcoord, vec4 offset[ 2 ], sampler2D colorTex, sampler2D blendTex ) {
+	// Fetch the blending weights for current pixel:
+	vec4 a;
+	a.xz = texture2D( blendTex, texcoord ).xz;
+	a.y = texture2D( blendTex, offset[ 1 ].zw ).g;
+	a.w = texture2D( blendTex, offset[ 1 ].xy ).a;
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tColor;",
-		"uniform vec2 resolution;",
-
-		"varying vec2 vUv;",
-		"varying vec4 vOffset[ 2 ];",
-
-		"vec4 SMAANeighborhoodBlendingPS( vec2 texcoord, vec4 offset[ 2 ], sampler2D colorTex, sampler2D blendTex ) {",
-		// Fetch the blending weights for current pixel:
-		"	vec4 a;",
-		"	a.xz = texture2D( blendTex, texcoord ).xz;",
-		"	a.y = texture2D( blendTex, offset[ 1 ].zw ).g;",
-		"	a.w = texture2D( blendTex, offset[ 1 ].xy ).a;",
-
-		// Is there any blending weight with a value greater than 0.0?
-		"	if ( dot(a, vec4( 1.0, 1.0, 1.0, 1.0 )) < 1e-5 ) {",
-		"		return texture2D( colorTex, texcoord, 0.0 );",
-		"	} else {",
+	// Is there any blending weight with a value greater than 0.0?
+	if ( dot(a, vec4( 1.0, 1.0, 1.0, 1.0 )) < 1e-5 ) {
+		return texture2D( colorTex, texcoord, 0.0 );
+	} else {
 		// Up to 4 lines can be crossing a pixel (one through each edge). We
 		// favor blending by choosing the line with the maximum weight for each
 		// direction:
-		"		vec2 offset;",
-		"		offset.x = a.a > a.b ? a.a : -a.b;", // left vs. right
-		"		offset.y = a.g > a.r ? -a.g : a.r;", // top vs. bottom // WebGL port note: Changed signs
+		vec2 offset;
+		offset.x = a.a > a.b ? a.a : -a.b; // left vs. right
+		offset.y = a.g > a.r ? -a.g : a.r; // top vs. bottom // WebGL port note: Changed signs
 
 		// Then we go in the direction that has the maximum weight:
-		"		if ( abs( offset.x ) > abs( offset.y )) {", // horizontal vs. vertical
-		"			offset.y = 0.0;",
-		"		} else {",
-		"			offset.x = 0.0;",
-		"		}",
+		if ( abs( offset.x ) > abs( offset.y )) { // horizontal vs. vertical
+			offset.y = 0.0;
+		} else {
+			offset.x = 0.0;
+		}
 
 		// Fetch the opposite color and lerp by hand:
-		"		vec4 C = texture2D( colorTex, texcoord, 0.0 );",
-		"		texcoord += sign( offset ) * resolution;",
-		"		vec4 Cop = texture2D( colorTex, texcoord, 0.0 );",
-		"		float s = abs( offset.x ) > abs( offset.y ) ? abs( offset.x ) : abs( offset.y );",
+		vec4 C = texture2D( colorTex, texcoord, 0.0 );
+		texcoord += sign( offset ) * resolution;
+		vec4 Cop = texture2D( colorTex, texcoord, 0.0 );
+		float s = abs( offset.x ) > abs( offset.y ) ? abs( offset.x ) : abs( offset.y );
 
 		// WebGL port note: Added gamma correction
-		"		C.xyz = pow(C.xyz, vec3(2.2));",
-		"		Cop.xyz = pow(Cop.xyz, vec3(2.2));",
-		"		vec4 mixed = mix(C, Cop, s);",
-		"		mixed.xyz = pow(mixed.xyz, vec3(1.0 / 2.2));",
+		C.xyz = pow(C.xyz, vec3(2.2));
+		Cop.xyz = pow(Cop.xyz, vec3(2.2));
+		vec4 mixed = mix(C, Cop, s);
+		mixed.xyz = pow(mixed.xyz, vec3(1.0 / 2.2));
 
-		"		return mixed;",
-		"	}",
-		"}",
+		return mixed;
+	}
+}
 
-		"void main() {",
+void main() {
 
-		"	gl_FragColor = SMAANeighborhoodBlendingPS( vUv, vOffset, tColor, tDiffuse );",
+	gl_FragColor = SMAANeighborhoodBlendingPS( vUv, vOffset, tColor, tDiffuse );
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -32,146 +32,142 @@ THREE.SSAOShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform sampler2D tNormal;
+uniform sampler2D tDepth;
+uniform sampler2D tNoise;
 
-	].join( "\n" ),
+uniform vec3 kernel[ KERNEL_SIZE ];
 
-	fragmentShader: [
+uniform vec2 resolution;
 
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tNormal;",
-		"uniform sampler2D tDepth;",
-		"uniform sampler2D tNoise;",
+uniform float cameraNear;
+uniform float cameraFar;
+uniform mat4 cameraProjectionMatrix;
+uniform mat4 cameraInverseProjectionMatrix;
 
-		"uniform vec3 kernel[ KERNEL_SIZE ];",
+uniform float kernelRadius;
+uniform float minDistance; // avoid artifacts caused by neighbour fragments with minimal depth difference
+uniform float maxDistance; // avoid the influence of fragments which are too far away
 
-		"uniform vec2 resolution;",
+varying vec2 vUv;
 
-		"uniform float cameraNear;",
-		"uniform float cameraFar;",
-		"uniform mat4 cameraProjectionMatrix;",
-		"uniform mat4 cameraInverseProjectionMatrix;",
+#include <packing>
 
-		"uniform float kernelRadius;",
-		"uniform float minDistance;", // avoid artifacts caused by neighbour fragments with minimal depth difference
-		"uniform float maxDistance;", // avoid the influence of fragments which are too far away
+float getDepth( const in vec2 screenPosition ) {
 
-		"varying vec2 vUv;",
+	return texture2D( tDepth, screenPosition ).x;
 
-		"#include <packing>",
+}
 
-		"float getDepth( const in vec2 screenPosition ) {",
+float getLinearDepth( const in vec2 screenPosition ) {
 
-		"	return texture2D( tDepth, screenPosition ).x;",
+	#if PERSPECTIVE_CAMERA == 1
 
-		"}",
+		float fragCoordZ = texture2D( tDepth, screenPosition ).x;
+		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
 
-		"float getLinearDepth( const in vec2 screenPosition ) {",
+	#else
 
-		"	#if PERSPECTIVE_CAMERA == 1",
+		return texture2D( depthSampler, coord ).x;
 
-		"		float fragCoordZ = texture2D( tDepth, screenPosition ).x;",
-		"		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );",
-		"		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );",
+	#endif
 
-		"	#else",
+}
 
-		"		return texture2D( depthSampler, coord ).x;",
+float getViewZ( const in float depth ) {
 
-		"	#endif",
+	#if PERSPECTIVE_CAMERA == 1
 
-		"}",
+		return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
 
-		"float getViewZ( const in float depth ) {",
+	#else
 
-		"	#if PERSPECTIVE_CAMERA == 1",
+		return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
 
-		"		return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );",
+	#endif
 
-		"	#else",
+}
 
-		"		return orthographicDepthToViewZ( depth, cameraNear, cameraFar );",
+vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
 
-		"	#endif",
+	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
 
-		"}",
+	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
 
-		"vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {",
+	clipPosition *= clipW; // unprojection.
 
-		"	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];",
+	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
 
-		"	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );",
+}
 
-		"	clipPosition *= clipW; // unprojection.",
+vec3 getViewNormal( const in vec2 screenPosition ) {
 
-		"	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;",
+	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
 
-		"}",
+}
 
-		"vec3 getViewNormal( const in vec2 screenPosition ) {",
+void main() {
 
-		"	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );",
+	float depth = getDepth( vUv );
+	float viewZ = getViewZ( depth );
 
-		"}",
+	vec3 viewPosition = getViewPosition( vUv, depth, viewZ );
+	vec3 viewNormal = getViewNormal( vUv );
 
-		"void main() {",
+ vec2 noiseScale = vec2( resolution.x / 4.0, resolution.y / 4.0 );
+	vec3 random = texture2D( tNoise, vUv * noiseScale ).xyz;
 
-		"	float depth = getDepth( vUv );",
-		"	float viewZ = getViewZ( depth );",
+	// compute matrix used to reorient a kernel vector
 
-		"	vec3 viewPosition = getViewPosition( vUv, depth, viewZ );",
-		"	vec3 viewNormal = getViewNormal( vUv );",
+	vec3 tangent = normalize( random - viewNormal * dot( random, viewNormal ) );
+	vec3 bitangent = cross( viewNormal, tangent );
+	mat3 kernelMatrix = mat3( tangent, bitangent, viewNormal );
 
-		" vec2 noiseScale = vec2( resolution.x / 4.0, resolution.y / 4.0 );",
-		"	vec3 random = texture2D( tNoise, vUv * noiseScale ).xyz;",
+ float occlusion = 0.0;
 
-		// compute matrix used to reorient a kernel vector
+ for ( int i = 0; i < KERNEL_SIZE; i ++ ) {
 
-		"	vec3 tangent = normalize( random - viewNormal * dot( random, viewNormal ) );",
-		"	vec3 bitangent = cross( viewNormal, tangent );",
-		"	mat3 kernelMatrix = mat3( tangent, bitangent, viewNormal );",
+		vec3 sampleVector = kernelMatrix * kernel[ i ]; // reorient sample vector in view space
+		vec3 samplePoint = viewPosition + ( sampleVector * kernelRadius ); // calculate sample point
 
-		" float occlusion = 0.0;",
+		vec4 samplePointNDC = cameraProjectionMatrix * vec4( samplePoint, 1.0 ); // project point and calculate NDC
+		samplePointNDC /= samplePointNDC.w;
 
-		" for ( int i = 0; i < KERNEL_SIZE; i ++ ) {",
+		vec2 samplePointUv = samplePointNDC.xy * 0.5 + 0.5; // compute uv coordinates
 
-		"		vec3 sampleVector = kernelMatrix * kernel[ i ];", // reorient sample vector in view space
-		"		vec3 samplePoint = viewPosition + ( sampleVector * kernelRadius );", // calculate sample point
+		float realDepth = getLinearDepth( samplePointUv ); // get linear depth from depth texture
+		float sampleDepth = viewZToOrthographicDepth( samplePoint.z, cameraNear, cameraFar ); // compute linear depth of the sample view Z value
+		float delta = sampleDepth - realDepth;
 
-		"		vec4 samplePointNDC = cameraProjectionMatrix * vec4( samplePoint, 1.0 );", // project point and calculate NDC
-		"		samplePointNDC /= samplePointNDC.w;",
+		if ( delta > minDistance && delta < maxDistance ) { // if fragment is before sample point, increase occlusion
 
-		"		vec2 samplePointUv = samplePointNDC.xy * 0.5 + 0.5;", // compute uv coordinates
+			occlusion += 1.0;
 
-		"		float realDepth = getLinearDepth( samplePointUv );", // get linear depth from depth texture
-		"		float sampleDepth = viewZToOrthographicDepth( samplePoint.z, cameraNear, cameraFar );", // compute linear depth of the sample view Z value
-		"		float delta = sampleDepth - realDepth;",
+		}
 
-		"		if ( delta > minDistance && delta < maxDistance ) {", // if fragment is before sample point, increase occlusion
+	}
 
-		"			occlusion += 1.0;",
+	occlusion = clamp( occlusion / float( KERNEL_SIZE ), 0.0, 1.0 );
 
-		"		}",
+	gl_FragColor = vec4( vec3( 1.0 - occlusion ), 1.0 );
 
-		"	}",
-
-		"	occlusion = clamp( occlusion / float( KERNEL_SIZE ), 0.0, 1.0 );",
-
-		"	gl_FragColor = vec4( vec3( 1.0 - occlusion ), 1.0 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -189,54 +185,50 @@ THREE.SSAODepthShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDepth;
 
-	].join( "\n" ),
+uniform float cameraNear;
+uniform float cameraFar;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform sampler2D tDepth;",
+#include <packing>
 
-		"uniform float cameraNear;",
-		"uniform float cameraFar;",
+float getLinearDepth( const in vec2 screenPosition ) {
 
-		"varying vec2 vUv;",
+	#if PERSPECTIVE_CAMERA == 1
 
-		"#include <packing>",
+		float fragCoordZ = texture2D( tDepth, screenPosition ).x;
+		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
 
-		"float getLinearDepth( const in vec2 screenPosition ) {",
+	#else
 
-		"	#if PERSPECTIVE_CAMERA == 1",
+		return texture2D( depthSampler, coord ).x;
 
-		"		float fragCoordZ = texture2D( tDepth, screenPosition ).x;",
-		"		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );",
-		"		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );",
+	#endif
 
-		"	#else",
+}
 
-		"		return texture2D( depthSampler, coord ).x;",
+void main() {
 
-		"	#endif",
+	float depth = getLinearDepth( vUv );
+	gl_FragColor = vec4( vec3( 1.0 - depth ), 1.0 );
 
-		"}",
-
-		"void main() {",
-
-		"	float depth = getLinearDepth( vUv );",
-		"	gl_FragColor = vec4( vec3( 1.0 - depth ), 1.0 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -249,47 +241,43 @@ THREE.SSAOBlurShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
 
-	].join( "\n" ),
+uniform vec2 resolution;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform sampler2D tDiffuse;",
+void main() {
 
-		"uniform vec2 resolution;",
+	vec2 texelSize = ( 1.0 / resolution );
+	float result = 0.0;
 
-		"varying vec2 vUv;",
+	for ( int i = - 2; i <= 2; i ++ ) {
 
-		"void main() {",
+		for ( int j = - 2; j <= 2; j ++ ) {
 
-		"	vec2 texelSize = ( 1.0 / resolution );",
-		"	float result = 0.0;",
+			vec2 offset = ( vec2( float( i ), float( j ) ) ) * texelSize;
+			result += texture2D( tDiffuse, vUv + offset ).r;
 
-		"	for ( int i = - 2; i <= 2; i ++ ) {",
+		}
 
-		"		for ( int j = - 2; j <= 2; j ++ ) {",
+	}
 
-		"			vec2 offset = ( vec2( float( i ), float( j ) ) ) * texelSize;",
-		"			result += texture2D( tDiffuse, vUv + offset ).r;",
+	gl_FragColor = vec4( vec3( result / ( 5.0 * 5.0 ) ), 1.0 );
 
-		"		}",
-
-		"	}",
-
-		"	gl_FragColor = vec4( vec3( result / ( 5.0 * 5.0 ) ), 1.0 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -33,142 +33,141 @@ THREE.SSAOShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform sampler2D tNormal;
-uniform sampler2D tDepth;
-uniform sampler2D tNoise;
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tNormal;
+		uniform sampler2D tDepth;
+		uniform sampler2D tNoise;
 
-uniform vec3 kernel[ KERNEL_SIZE ];
+		uniform vec3 kernel[ KERNEL_SIZE ];
 
-uniform vec2 resolution;
+		uniform vec2 resolution;
 
-uniform float cameraNear;
-uniform float cameraFar;
-uniform mat4 cameraProjectionMatrix;
-uniform mat4 cameraInverseProjectionMatrix;
+		uniform float cameraNear;
+		uniform float cameraFar;
+		uniform mat4 cameraProjectionMatrix;
+		uniform mat4 cameraInverseProjectionMatrix;
 
-uniform float kernelRadius;
-uniform float minDistance; // avoid artifacts caused by neighbour fragments with minimal depth difference
-uniform float maxDistance; // avoid the influence of fragments which are too far away
+		uniform float kernelRadius;
+		uniform float minDistance; // avoid artifacts caused by neighbour fragments with minimal depth difference
+		uniform float maxDistance; // avoid the influence of fragments which are too far away
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-#include <packing>
+		#include <packing>
 
-float getDepth( const in vec2 screenPosition ) {
+		float getDepth( const in vec2 screenPosition ) {
 
-	return texture2D( tDepth, screenPosition ).x;
-
-}
-
-float getLinearDepth( const in vec2 screenPosition ) {
-
-	#if PERSPECTIVE_CAMERA == 1
-
-		float fragCoordZ = texture2D( tDepth, screenPosition ).x;
-		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
-		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
-
-	#else
-
-		return texture2D( depthSampler, coord ).x;
-
-	#endif
-
-}
-
-float getViewZ( const in float depth ) {
-
-	#if PERSPECTIVE_CAMERA == 1
-
-		return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
-
-	#else
-
-		return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
-
-	#endif
-
-}
-
-vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
-
-	float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
-
-	vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
-
-	clipPosition *= clipW; // unprojection.
-
-	return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
-
-}
-
-vec3 getViewNormal( const in vec2 screenPosition ) {
-
-	return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
-
-}
-
-void main() {
-
-	float depth = getDepth( vUv );
-	float viewZ = getViewZ( depth );
-
-	vec3 viewPosition = getViewPosition( vUv, depth, viewZ );
-	vec3 viewNormal = getViewNormal( vUv );
-
- vec2 noiseScale = vec2( resolution.x / 4.0, resolution.y / 4.0 );
-	vec3 random = texture2D( tNoise, vUv * noiseScale ).xyz;
-
-	// compute matrix used to reorient a kernel vector
-
-	vec3 tangent = normalize( random - viewNormal * dot( random, viewNormal ) );
-	vec3 bitangent = cross( viewNormal, tangent );
-	mat3 kernelMatrix = mat3( tangent, bitangent, viewNormal );
-
- float occlusion = 0.0;
-
- for ( int i = 0; i < KERNEL_SIZE; i ++ ) {
-
-		vec3 sampleVector = kernelMatrix * kernel[ i ]; // reorient sample vector in view space
-		vec3 samplePoint = viewPosition + ( sampleVector * kernelRadius ); // calculate sample point
-
-		vec4 samplePointNDC = cameraProjectionMatrix * vec4( samplePoint, 1.0 ); // project point and calculate NDC
-		samplePointNDC /= samplePointNDC.w;
-
-		vec2 samplePointUv = samplePointNDC.xy * 0.5 + 0.5; // compute uv coordinates
-
-		float realDepth = getLinearDepth( samplePointUv ); // get linear depth from depth texture
-		float sampleDepth = viewZToOrthographicDepth( samplePoint.z, cameraNear, cameraFar ); // compute linear depth of the sample view Z value
-		float delta = sampleDepth - realDepth;
-
-		if ( delta > minDistance && delta < maxDistance ) { // if fragment is before sample point, increase occlusion
-
-			occlusion += 1.0;
+			return texture2D( tDepth, screenPosition ).x;
 
 		}
 
-	}
+		float getLinearDepth( const in vec2 screenPosition ) {
 
-	occlusion = clamp( occlusion / float( KERNEL_SIZE ), 0.0, 1.0 );
+			#if PERSPECTIVE_CAMERA == 1
 
-	gl_FragColor = vec4( vec3( 1.0 - occlusion ), 1.0 );
+				float fragCoordZ = texture2D( tDepth, screenPosition ).x;
+				float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+				return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
 
-}
-`
+			#else
 
+				return texture2D( depthSampler, coord ).x;
+
+			#endif
+
+		}
+
+		float getViewZ( const in float depth ) {
+
+			#if PERSPECTIVE_CAMERA == 1
+
+				return perspectiveDepthToViewZ( depth, cameraNear, cameraFar );
+
+			#else
+
+				return orthographicDepthToViewZ( depth, cameraNear, cameraFar );
+
+			#endif
+
+		}
+
+		vec3 getViewPosition( const in vec2 screenPosition, const in float depth, const in float viewZ ) {
+
+			float clipW = cameraProjectionMatrix[2][3] * viewZ + cameraProjectionMatrix[3][3];
+
+			vec4 clipPosition = vec4( ( vec3( screenPosition, depth ) - 0.5 ) * 2.0, 1.0 );
+
+			clipPosition *= clipW; // unprojection.
+
+			return ( cameraInverseProjectionMatrix * clipPosition ).xyz;
+
+		}
+
+		vec3 getViewNormal( const in vec2 screenPosition ) {
+
+			return unpackRGBToNormal( texture2D( tNormal, screenPosition ).xyz );
+
+		}
+
+		void main() {
+
+			float depth = getDepth( vUv );
+			float viewZ = getViewZ( depth );
+
+			vec3 viewPosition = getViewPosition( vUv, depth, viewZ );
+			vec3 viewNormal = getViewNormal( vUv );
+
+			vec2 noiseScale = vec2( resolution.x / 4.0, resolution.y / 4.0 );
+			vec3 random = texture2D( tNoise, vUv * noiseScale ).xyz;
+
+			// compute matrix used to reorient a kernel vector
+
+			vec3 tangent = normalize( random - viewNormal * dot( random, viewNormal ) );
+			vec3 bitangent = cross( viewNormal, tangent );
+			mat3 kernelMatrix = mat3( tangent, bitangent, viewNormal );
+
+			float occlusion = 0.0;
+
+			for ( int i = 0; i < KERNEL_SIZE; i ++ ) {
+
+					vec3 sampleVector = kernelMatrix * kernel[ i ]; // reorient sample vector in view space
+					vec3 samplePoint = viewPosition + ( sampleVector * kernelRadius ); // calculate sample point
+
+					vec4 samplePointNDC = cameraProjectionMatrix * vec4( samplePoint, 1.0 ); // project point and calculate NDC
+					samplePointNDC /= samplePointNDC.w;
+
+					vec2 samplePointUv = samplePointNDC.xy * 0.5 + 0.5; // compute uv coordinates
+
+					float realDepth = getLinearDepth( samplePointUv ); // get linear depth from depth texture
+					float sampleDepth = viewZToOrthographicDepth( samplePoint.z, cameraNear, cameraFar ); // compute linear depth of the sample view Z value
+					float delta = sampleDepth - realDepth;
+
+					if ( delta > minDistance && delta < maxDistance ) { // if fragment is before sample point, increase occlusion
+
+						occlusion += 1.0;
+
+					}
+
+				}
+
+				occlusion = clamp( occlusion / float( KERNEL_SIZE ), 0.0, 1.0 );
+
+				gl_FragColor = vec4( vec3( 1.0 - occlusion ), 1.0 );
+
+		}
+	`
 };
 
 THREE.SSAODepthShader = {
@@ -186,50 +185,49 @@ THREE.SSAODepthShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDepth;
+		uniform sampler2D tDepth;
 
-uniform float cameraNear;
-uniform float cameraFar;
+		uniform float cameraNear;
+		uniform float cameraFar;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-#include <packing>
+		#include <packing>
 
-float getLinearDepth( const in vec2 screenPosition ) {
+		float getLinearDepth( const in vec2 screenPosition ) {
 
-	#if PERSPECTIVE_CAMERA == 1
+			#if PERSPECTIVE_CAMERA == 1
 
-		float fragCoordZ = texture2D( tDepth, screenPosition ).x;
-		float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
-		return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
+				float fragCoordZ = texture2D( tDepth, screenPosition ).x;
+				float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+				return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
 
-	#else
+			#else
 
-		return texture2D( depthSampler, coord ).x;
+				return texture2D( depthSampler, coord ).x;
 
-	#endif
+			#endif
 
-}
+		}
 
-void main() {
+		void main() {
 
-	float depth = getLinearDepth( vUv );
-	gl_FragColor = vec4( vec3( 1.0 - depth ), 1.0 );
+			float depth = getLinearDepth( vUv );
+			gl_FragColor = vec4( vec3( 1.0 - depth ), 1.0 );
 
-}
-`
-
+		}
+	`
 };
 
 THREE.SSAOBlurShader = {
@@ -242,42 +240,41 @@ THREE.SSAOBlurShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-}
-`,
-
-	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-
-uniform vec2 resolution;
-
-varying vec2 vUv;
-
-void main() {
-
-	vec2 texelSize = ( 1.0 / resolution );
-	float result = 0.0;
-
-	for ( int i = - 2; i <= 2; i ++ ) {
-
-		for ( int j = - 2; j <= 2; j ++ ) {
-
-			vec2 offset = ( vec2( float( i ), float( j ) ) ) * texelSize;
-			result += texture2D( tDiffuse, vUv + offset ).r;
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
 		}
+	`,
 
-	}
+	fragmentShader: /* glsl */`
+		uniform sampler2D tDiffuse;
 
-	gl_FragColor = vec4( vec3( result / ( 5.0 * 5.0 ) ), 1.0 );
+		uniform vec2 resolution;
 
-}
-`
+		varying vec2 vUv;
 
+		void main() {
+
+			vec2 texelSize = ( 1.0 / resolution );
+			float result = 0.0;
+
+			for ( int i = - 2; i <= 2; i ++ ) {
+
+				for ( int j = - 2; j <= 2; j ++ ) {
+
+					vec2 offset = ( vec2( float( i ), float( j ) ) ) * texelSize;
+					result += texture2D( tDiffuse, vUv + offset ).r;
+
+				}
+
+			}
+
+			gl_FragColor = vec4( vec3( result / ( 5.0 * 5.0 ) ), 1.0 );
+
+		}
+	`
 };

--- a/examples/js/shaders/SepiaShader.js
+++ b/examples/js/shaders/SepiaShader.js
@@ -16,35 +16,34 @@ THREE.SepiaShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float amount;
+		uniform float amount;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 color = texture2D( tDiffuse, vUv );
-	vec3 c = color.rgb;
+			vec4 color = texture2D( tDiffuse, vUv );
+			vec3 c = color.rgb;
 
-	color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );
-	color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );
-	color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );
+			color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );
+			color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );
+			color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );
 
-	gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );
+			gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/SepiaShader.js
+++ b/examples/js/shaders/SepiaShader.js
@@ -15,40 +15,36 @@ THREE.SepiaShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float amount;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float amount;",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	vec4 color = texture2D( tDiffuse, vUv );
+	vec3 c = color.rgb;
 
-		"varying vec2 vUv;",
+	color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );
+	color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );
+	color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );
 
-		"void main() {",
+	gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );
 
-		"	vec4 color = texture2D( tDiffuse, vUv );",
-		"	vec3 c = color.rgb;",
-
-		"	color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );",
-		"	color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );",
-		"	color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );",
-
-		"	gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/SobelOperatorShader.js
+++ b/examples/js/shaders/SobelOperatorShader.js
@@ -17,70 +17,69 @@ THREE.SobelOperatorShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform vec2 resolution;
-varying vec2 vUv;
+		uniform sampler2D tDiffuse;
+		uniform vec2 resolution;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec2 texel = vec2( 1.0 / resolution.x, 1.0 / resolution.y );
+			vec2 texel = vec2( 1.0 / resolution.x, 1.0 / resolution.y );
 
-	// kernel definition (in glsl matrices are filled in column-major order)
+			// kernel definition (in glsl matrices are filled in column-major order)
 
-	const mat3 Gx = mat3( -1, -2, -1, 0, 0, 0, 1, 2, 1 ); // x direction kernel
-	const mat3 Gy = mat3( -1, 0, 1, -2, 0, 2, -1, 0, 1 ); // y direction kernel
+			const mat3 Gx = mat3( -1, -2, -1, 0, 0, 0, 1, 2, 1 ); // x direction kernel
+			const mat3 Gy = mat3( -1, 0, 1, -2, 0, 2, -1, 0, 1 ); // y direction kernel
 
-	// fetch the 3x3 neighbourhood of a fragment
+			// fetch the 3x3 neighbourhood of a fragment
 
-	// first column
+			// first column
 
-	float tx0y0 = texture2D( tDiffuse, vUv + texel * vec2( -1, -1 ) ).r;
-	float tx0y1 = texture2D( tDiffuse, vUv + texel * vec2( -1,  0 ) ).r;
-	float tx0y2 = texture2D( tDiffuse, vUv + texel * vec2( -1,  1 ) ).r;
+			float tx0y0 = texture2D( tDiffuse, vUv + texel * vec2( -1, -1 ) ).r;
+			float tx0y1 = texture2D( tDiffuse, vUv + texel * vec2( -1,  0 ) ).r;
+			float tx0y2 = texture2D( tDiffuse, vUv + texel * vec2( -1,  1 ) ).r;
 
-	// second column
+			// second column
 
-	float tx1y0 = texture2D( tDiffuse, vUv + texel * vec2(  0, -1 ) ).r;
-	float tx1y1 = texture2D( tDiffuse, vUv + texel * vec2(  0,  0 ) ).r;
-	float tx1y2 = texture2D( tDiffuse, vUv + texel * vec2(  0,  1 ) ).r;
+			float tx1y0 = texture2D( tDiffuse, vUv + texel * vec2(  0, -1 ) ).r;
+			float tx1y1 = texture2D( tDiffuse, vUv + texel * vec2(  0,  0 ) ).r;
+			float tx1y2 = texture2D( tDiffuse, vUv + texel * vec2(  0,  1 ) ).r;
 
-	// third column
+			// third column
 
-	float tx2y0 = texture2D( tDiffuse, vUv + texel * vec2(  1, -1 ) ).r;
-	float tx2y1 = texture2D( tDiffuse, vUv + texel * vec2(  1,  0 ) ).r;
-	float tx2y2 = texture2D( tDiffuse, vUv + texel * vec2(  1,  1 ) ).r;
+			float tx2y0 = texture2D( tDiffuse, vUv + texel * vec2(  1, -1 ) ).r;
+			float tx2y1 = texture2D( tDiffuse, vUv + texel * vec2(  1,  0 ) ).r;
+			float tx2y2 = texture2D( tDiffuse, vUv + texel * vec2(  1,  1 ) ).r;
 
-	// gradient value in x direction
+			// gradient value in x direction
 
-	float valueGx = Gx[0][0] * tx0y0 + Gx[1][0] * tx1y0 + Gx[2][0] * tx2y0 +
-		Gx[0][1] * tx0y1 + Gx[1][1] * tx1y1 + Gx[2][1] * tx2y1 +
-		Gx[0][2] * tx0y2 + Gx[1][2] * tx1y2 + Gx[2][2] * tx2y2;
+			float valueGx = Gx[0][0] * tx0y0 + Gx[1][0] * tx1y0 + Gx[2][0] * tx2y0 +
+				Gx[0][1] * tx0y1 + Gx[1][1] * tx1y1 + Gx[2][1] * tx2y1 +
+				Gx[0][2] * tx0y2 + Gx[1][2] * tx1y2 + Gx[2][2] * tx2y2;
 
-	// gradient value in y direction
+			// gradient value in y direction
 
-	float valueGy = Gy[0][0] * tx0y0 + Gy[1][0] * tx1y0 + Gy[2][0] * tx2y0 +
-		Gy[0][1] * tx0y1 + Gy[1][1] * tx1y1 + Gy[2][1] * tx2y1 +
-		Gy[0][2] * tx0y2 + Gy[1][2] * tx1y2 + Gy[2][2] * tx2y2;
+			float valueGy = Gy[0][0] * tx0y0 + Gy[1][0] * tx1y0 + Gy[2][0] * tx2y0 +
+				Gy[0][1] * tx0y1 + Gy[1][1] * tx1y1 + Gy[2][1] * tx2y1 +
+				Gy[0][2] * tx0y2 + Gy[1][2] * tx1y2 + Gy[2][2] * tx2y2;
 
-	// magnitute of the total gradient
+			// magnitute of the total gradient
 
-	float G = sqrt( ( valueGx * valueGx ) + ( valueGy * valueGy ) );
+			float G = sqrt( ( valueGx * valueGx ) + ( valueGy * valueGy ) );
 
-	gl_FragColor = vec4( vec3( G ), 1 );
+			gl_FragColor = vec4( vec3( G ), 1 );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/SobelOperatorShader.js
+++ b/examples/js/shaders/SobelOperatorShader.js
@@ -16,75 +16,71 @@ THREE.SobelOperatorShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform vec2 resolution;
+varying vec2 vUv;
 
-	].join( "\n" ),
+void main() {
 
-	fragmentShader: [
+	vec2 texel = vec2( 1.0 / resolution.x, 1.0 / resolution.y );
 
-		"uniform sampler2D tDiffuse;",
-		"uniform vec2 resolution;",
-		"varying vec2 vUv;",
+	// kernel definition (in glsl matrices are filled in column-major order)
 
-		"void main() {",
+	const mat3 Gx = mat3( -1, -2, -1, 0, 0, 0, 1, 2, 1 ); // x direction kernel
+	const mat3 Gy = mat3( -1, 0, 1, -2, 0, 2, -1, 0, 1 ); // y direction kernel
 
-		"	vec2 texel = vec2( 1.0 / resolution.x, 1.0 / resolution.y );",
+	// fetch the 3x3 neighbourhood of a fragment
 
-		// kernel definition (in glsl matrices are filled in column-major order)
+	// first column
 
-		"	const mat3 Gx = mat3( -1, -2, -1, 0, 0, 0, 1, 2, 1 );", // x direction kernel
-		"	const mat3 Gy = mat3( -1, 0, 1, -2, 0, 2, -1, 0, 1 );", // y direction kernel
+	float tx0y0 = texture2D( tDiffuse, vUv + texel * vec2( -1, -1 ) ).r;
+	float tx0y1 = texture2D( tDiffuse, vUv + texel * vec2( -1,  0 ) ).r;
+	float tx0y2 = texture2D( tDiffuse, vUv + texel * vec2( -1,  1 ) ).r;
 
-		// fetch the 3x3 neighbourhood of a fragment
+	// second column
 
-		// first column
+	float tx1y0 = texture2D( tDiffuse, vUv + texel * vec2(  0, -1 ) ).r;
+	float tx1y1 = texture2D( tDiffuse, vUv + texel * vec2(  0,  0 ) ).r;
+	float tx1y2 = texture2D( tDiffuse, vUv + texel * vec2(  0,  1 ) ).r;
 
-		"	float tx0y0 = texture2D( tDiffuse, vUv + texel * vec2( -1, -1 ) ).r;",
-		"	float tx0y1 = texture2D( tDiffuse, vUv + texel * vec2( -1,  0 ) ).r;",
-		"	float tx0y2 = texture2D( tDiffuse, vUv + texel * vec2( -1,  1 ) ).r;",
+	// third column
 
-		// second column
+	float tx2y0 = texture2D( tDiffuse, vUv + texel * vec2(  1, -1 ) ).r;
+	float tx2y1 = texture2D( tDiffuse, vUv + texel * vec2(  1,  0 ) ).r;
+	float tx2y2 = texture2D( tDiffuse, vUv + texel * vec2(  1,  1 ) ).r;
 
-		"	float tx1y0 = texture2D( tDiffuse, vUv + texel * vec2(  0, -1 ) ).r;",
-		"	float tx1y1 = texture2D( tDiffuse, vUv + texel * vec2(  0,  0 ) ).r;",
-		"	float tx1y2 = texture2D( tDiffuse, vUv + texel * vec2(  0,  1 ) ).r;",
+	// gradient value in x direction
 
-		// third column
+	float valueGx = Gx[0][0] * tx0y0 + Gx[1][0] * tx1y0 + Gx[2][0] * tx2y0 +
+		Gx[0][1] * tx0y1 + Gx[1][1] * tx1y1 + Gx[2][1] * tx2y1 +
+		Gx[0][2] * tx0y2 + Gx[1][2] * tx1y2 + Gx[2][2] * tx2y2;
 
-		"	float tx2y0 = texture2D( tDiffuse, vUv + texel * vec2(  1, -1 ) ).r;",
-		"	float tx2y1 = texture2D( tDiffuse, vUv + texel * vec2(  1,  0 ) ).r;",
-		"	float tx2y2 = texture2D( tDiffuse, vUv + texel * vec2(  1,  1 ) ).r;",
+	// gradient value in y direction
 
-		// gradient value in x direction
+	float valueGy = Gy[0][0] * tx0y0 + Gy[1][0] * tx1y0 + Gy[2][0] * tx2y0 +
+		Gy[0][1] * tx0y1 + Gy[1][1] * tx1y1 + Gy[2][1] * tx2y1 +
+		Gy[0][2] * tx0y2 + Gy[1][2] * tx1y2 + Gy[2][2] * tx2y2;
 
-		"	float valueGx = Gx[0][0] * tx0y0 + Gx[1][0] * tx1y0 + Gx[2][0] * tx2y0 + ",
-		"		Gx[0][1] * tx0y1 + Gx[1][1] * tx1y1 + Gx[2][1] * tx2y1 + ",
-		"		Gx[0][2] * tx0y2 + Gx[1][2] * tx1y2 + Gx[2][2] * tx2y2; ",
+	// magnitute of the total gradient
 
-		// gradient value in y direction
+	float G = sqrt( ( valueGx * valueGx ) + ( valueGy * valueGy ) );
 
-		"	float valueGy = Gy[0][0] * tx0y0 + Gy[1][0] * tx1y0 + Gy[2][0] * tx2y0 + ",
-		"		Gy[0][1] * tx0y1 + Gy[1][1] * tx1y1 + Gy[2][1] * tx2y1 + ",
-		"		Gy[0][2] * tx0y2 + Gy[1][2] * tx1y2 + Gy[2][2] * tx2y2; ",
+	gl_FragColor = vec4( vec3( G ), 1 );
 
-		// magnitute of the total gradient
-
-		"	float G = sqrt( ( valueGx * valueGx ) + ( valueGy * valueGy ) );",
-
-		"	gl_FragColor = vec4( vec3( G ), 1 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/TechnicolorShader.js
+++ b/examples/js/shaders/TechnicolorShader.js
@@ -16,28 +16,27 @@ THREE.TechnicolorShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-varying vec2 vUv;
+		uniform sampler2D tDiffuse;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
-	vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);
+			vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
+			vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);
 
-	gl_FragColor = newTex;
+			gl_FragColor = newTex;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/TechnicolorShader.js
+++ b/examples/js/shaders/TechnicolorShader.js
@@ -15,33 +15,29 @@ THREE.TechnicolorShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+varying vec2 vUv;
 
-	].join( "\n" ),
+void main() {
 
-	fragmentShader: [
+	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );
+	vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);
 
-		"uniform sampler2D tDiffuse;",
-		"varying vec2 vUv;",
+	gl_FragColor = newTex;
 
-		"void main() {",
-
-		"	vec4 tex = texture2D( tDiffuse, vec2( vUv.x, vUv.y ) );",
-		"	vec4 newTex = vec4(tex.r, (tex.g + tex.b) * .5, (tex.g + tex.b) * .5, 1.0);",
-
-		"	gl_FragColor = newTex;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/ToneMapShader.js
+++ b/examples/js/shaders/ToneMapShader.js
@@ -16,62 +16,58 @@ THREE.ToneMapShader = {
 		"middleGrey": { value: 0.6 }
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"#include <common>",
+uniform float middleGrey;
+uniform float minLuminance;
+uniform float maxLuminance;
+#ifdef ADAPTED_LUMINANCE
+	uniform sampler2D luminanceMap;
+#else
+	uniform float averageLuminance;
+#endif
 
-		"uniform sampler2D tDiffuse;",
-
-		"varying vec2 vUv;",
-
-		"uniform float middleGrey;",
-		"uniform float minLuminance;",
-		"uniform float maxLuminance;",
-		"#ifdef ADAPTED_LUMINANCE",
-		"	uniform sampler2D luminanceMap;",
-		"#else",
-		"	uniform float averageLuminance;",
-		"#endif",
-
-		"vec3 ToneMap( vec3 vColor ) {",
-		"	#ifdef ADAPTED_LUMINANCE",
+vec3 ToneMap( vec3 vColor ) {
+	#ifdef ADAPTED_LUMINANCE
 		// Get the calculated average luminance
-		"		float fLumAvg = texture2D(luminanceMap, vec2(0.5, 0.5)).r;",
-		"	#else",
-		"		float fLumAvg = averageLuminance;",
-		"	#endif",
+		float fLumAvg = texture2D(luminanceMap, vec2(0.5, 0.5)).r;
+	#else
+		float fLumAvg = averageLuminance;
+	#endif
 
-		// Calculate the luminance of the current pixel
-		"	float fLumPixel = linearToRelativeLuminance( vColor );",
+	// Calculate the luminance of the current pixel
+	float fLumPixel = linearToRelativeLuminance( vColor );
 
-		// Apply the modified operator (Eq. 4)
-		"	float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );",
+	// Apply the modified operator (Eq. 4)
+	float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );
 
-		"	float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (maxLuminance * maxLuminance)))) / (1.0 + fLumScaled);",
-		"	return fLumCompressed * vColor;",
-		"}",
+	float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (maxLuminance * maxLuminance)))) / (1.0 + fLumScaled);
+	return fLumCompressed * vColor;
+}
 
-		"void main() {",
+void main() {
 
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
+	vec4 texel = texture2D( tDiffuse, vUv );
 
-		"	gl_FragColor = vec4( ToneMap( texel.xyz ), texel.w );",
+	gl_FragColor = vec4( ToneMap( texel.xyz ), texel.w );
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/ToneMapShader.js
+++ b/examples/js/shaders/ToneMapShader.js
@@ -17,57 +17,56 @@ THREE.ToneMapShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-uniform float middleGrey;
-uniform float minLuminance;
-uniform float maxLuminance;
-#ifdef ADAPTED_LUMINANCE
-	uniform sampler2D luminanceMap;
-#else
-	uniform float averageLuminance;
-#endif
+		uniform float middleGrey;
+		uniform float minLuminance;
+		uniform float maxLuminance;
+		#ifdef ADAPTED_LUMINANCE
+			uniform sampler2D luminanceMap;
+		#else
+			uniform float averageLuminance;
+		#endif
 
-vec3 ToneMap( vec3 vColor ) {
-	#ifdef ADAPTED_LUMINANCE
-		// Get the calculated average luminance
-		float fLumAvg = texture2D(luminanceMap, vec2(0.5, 0.5)).r;
-	#else
-		float fLumAvg = averageLuminance;
-	#endif
+		vec3 ToneMap( vec3 vColor ) {
+			#ifdef ADAPTED_LUMINANCE
+				// Get the calculated average luminance
+				float fLumAvg = texture2D(luminanceMap, vec2(0.5, 0.5)).r;
+			#else
+				float fLumAvg = averageLuminance;
+			#endif
 
-	// Calculate the luminance of the current pixel
-	float fLumPixel = linearToRelativeLuminance( vColor );
+			// Calculate the luminance of the current pixel
+			float fLumPixel = linearToRelativeLuminance( vColor );
 
-	// Apply the modified operator (Eq. 4)
-	float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );
+			// Apply the modified operator (Eq. 4)
+			float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );
 
-	float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (maxLuminance * maxLuminance)))) / (1.0 + fLumScaled);
-	return fLumCompressed * vColor;
-}
+			float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (maxLuminance * maxLuminance)))) / (1.0 + fLumScaled);
+			return fLumCompressed * vColor;
+		}
 
-void main() {
+		void main() {
 
-	vec4 texel = texture2D( tDiffuse, vUv );
+			vec4 texel = texture2D( tDiffuse, vUv );
 
-	gl_FragColor = vec4( ToneMap( texel.xyz ), texel.w );
+			gl_FragColor = vec4( ToneMap( texel.xyz ), texel.w );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/ToonShader.js
+++ b/examples/js/shaders/ToonShader.js
@@ -24,61 +24,61 @@ THREE.ToonShader1 = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec3 vNormal;
-varying vec3 vRefract;
+		varying vec3 vNormal;
+		varying vec3 vRefract;
 
-void main() {
+		void main() {
 
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
-	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-	vec3 worldNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
+			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			vec3 worldNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
 
-	vNormal = normalize( normalMatrix * normal );
+			vNormal = normalize( normalMatrix * normal );
 
-	vec3 I = worldPosition.xyz - cameraPosition;
-	vRefract = refract( normalize( I ), worldNormal, 1.02 );
+			vec3 I = worldPosition.xyz - cameraPosition;
+			vRefract = refract( normalize( I ), worldNormal, 1.02 );
 
-	gl_Position = projectionMatrix * mvPosition;
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 uBaseColor;
+		uniform vec3 uBaseColor;
 
-uniform vec3 uDirLightPos;
-uniform vec3 uDirLightColor;
+		uniform vec3 uDirLightPos;
+		uniform vec3 uDirLightColor;
 
-uniform vec3 uAmbientLightColor;
+		uniform vec3 uAmbientLightColor;
 
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-varying vec3 vRefract;
+		varying vec3 vRefract;
 
-void main() {
+		void main() {
 
-	float directionalLightWeighting = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
-	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
+			float directionalLightWeighting = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
+			vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-	float intensity = smoothstep( - 0.5, 1.0, pow( length(lightWeighting), 20.0 ) );
-	intensity += length(lightWeighting) * 0.2;
+			float intensity = smoothstep( - 0.5, 1.0, pow( length(lightWeighting), 20.0 ) );
+			intensity += length(lightWeighting) * 0.2;
 
-	float cameraWeighting = dot( normalize( vNormal ), vRefract );
-	intensity += pow( 1.0 - length( cameraWeighting ), 6.0 );
-	intensity = intensity * 0.2 + 0.3;
+			float cameraWeighting = dot( normalize( vNormal ), vRefract );
+			intensity += pow( 1.0 - length( cameraWeighting ), 6.0 );
+			intensity = intensity * 0.2 + 0.3;
 
-	if ( intensity < 0.50 ) {
+			if ( intensity < 0.50 ) {
 
-		gl_FragColor = vec4( 2.0 * intensity * uBaseColor, 1.0 );
+				gl_FragColor = vec4( 2.0 * intensity * uBaseColor, 1.0 );
 
-	} else {
+			} else {
 
-		gl_FragColor = vec4( 1.0 - 2.0 * ( 1.0 - intensity ) * ( 1.0 - uBaseColor ), 1.0 );
+				gl_FragColor = vec4( 1.0 - 2.0 * ( 1.0 - intensity ) * ( 1.0 - uBaseColor ), 1.0 );
 
-}
+			}
 
-}
-`
+		}
+	`
 
 };
 
@@ -100,52 +100,51 @@ THREE.ToonShader2 = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-	vNormal = normalize( normalMatrix * normal );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vNormal = normalize( normalMatrix * normal );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 uBaseColor;
-uniform vec3 uLineColor1;
-uniform vec3 uLineColor2;
-uniform vec3 uLineColor3;
-uniform vec3 uLineColor4;
+		uniform vec3 uBaseColor;
+		uniform vec3 uLineColor1;
+		uniform vec3 uLineColor2;
+		uniform vec3 uLineColor3;
+		uniform vec3 uLineColor4;
 
-uniform vec3 uDirLightPos;
-uniform vec3 uDirLightColor;
+		uniform vec3 uDirLightPos;
+		uniform vec3 uDirLightColor;
 
-uniform vec3 uAmbientLightColor;
+		uniform vec3 uAmbientLightColor;
 
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	float camera = max( dot( normalize( vNormal ), vec3( 0.0, 0.0, 1.0 ) ), 0.4);
-	float light = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
+			float camera = max( dot( normalize( vNormal ), vec3( 0.0, 0.0, 1.0 ) ), 0.4);
+			float light = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
 
-	gl_FragColor = vec4( uBaseColor, 1.0 );
+			gl_FragColor = vec4( uBaseColor, 1.0 );
 
-	if ( length(uAmbientLightColor + uDirLightColor * light) < 1.00 ) {
+			if ( length(uAmbientLightColor + uDirLightColor * light) < 1.00 ) {
 
-		gl_FragColor *= vec4( uLineColor1, 1.0 );
+				gl_FragColor *= vec4( uLineColor1, 1.0 );
 
-	}
+			}
 
-	if ( length(uAmbientLightColor + uDirLightColor * camera) < 0.50 ) {
+			if ( length(uAmbientLightColor + uDirLightColor * camera) < 0.50 ) {
 
-		gl_FragColor *= vec4( uLineColor2, 1.0 );
+				gl_FragColor *= vec4( uLineColor2, 1.0 );
 
-	}
+			}
 
-}
-`
-
+		}
+	`
 };
 
 THREE.ToonShaderHatching = {
@@ -166,80 +165,79 @@ THREE.ToonShaderHatching = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-	vNormal = normalize( normalMatrix * normal );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vNormal = normalize( normalMatrix * normal );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 uBaseColor;
-uniform vec3 uLineColor1;
-uniform vec3 uLineColor2;
-uniform vec3 uLineColor3;
-uniform vec3 uLineColor4;
+		uniform vec3 uBaseColor;
+		uniform vec3 uLineColor1;
+		uniform vec3 uLineColor2;
+		uniform vec3 uLineColor3;
+		uniform vec3 uLineColor4;
 
-uniform vec3 uDirLightPos;
-uniform vec3 uDirLightColor;
+		uniform vec3 uDirLightPos;
+		uniform vec3 uDirLightColor;
 
-uniform vec3 uAmbientLightColor;
+		uniform vec3 uAmbientLightColor;
 
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
-	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
+			float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
+			vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-	gl_FragColor = vec4( uBaseColor, 1.0 );
+			gl_FragColor = vec4( uBaseColor, 1.0 );
 
-	if ( length(lightWeighting) < 1.00 ) {
+			if ( length(lightWeighting) < 1.00 ) {
 
-		if ( mod(gl_FragCoord.x + gl_FragCoord.y, 10.0) == 0.0) {
+				if ( mod(gl_FragCoord.x + gl_FragCoord.y, 10.0) == 0.0) {
 
-			gl_FragColor = vec4( uLineColor1, 1.0 );
+					gl_FragColor = vec4( uLineColor1, 1.0 );
+
+				}
+
+			}
+
+			if ( length(lightWeighting) < 0.75 ) {
+
+				if (mod(gl_FragCoord.x - gl_FragCoord.y, 10.0) == 0.0) {
+
+					gl_FragColor = vec4( uLineColor2, 1.0 );
+
+				}
+
+			}
+
+			if ( length(lightWeighting) < 0.50 ) {
+
+				if (mod(gl_FragCoord.x + gl_FragCoord.y - 5.0, 10.0) == 0.0) {
+
+					gl_FragColor = vec4( uLineColor3, 1.0 );
+
+				}
+
+			}
+
+			if ( length(lightWeighting) < 0.3465 ) {
+
+				if (mod(gl_FragCoord.x - gl_FragCoord.y - 5.0, 10.0) == 0.0) {
+
+					gl_FragColor = vec4( uLineColor4, 1.0 );
+
+				}
+
+			}
 
 		}
-
-	}
-
-	if ( length(lightWeighting) < 0.75 ) {
-
-		if (mod(gl_FragCoord.x - gl_FragCoord.y, 10.0) == 0.0) {
-
-			gl_FragColor = vec4( uLineColor2, 1.0 );
-
-		}
-
-	}
-
-	if ( length(lightWeighting) < 0.50 ) {
-
-		if (mod(gl_FragCoord.x + gl_FragCoord.y - 5.0, 10.0) == 0.0) {
-
-			gl_FragColor = vec4( uLineColor3, 1.0 );
-
-		}
-
-	}
-
-	if ( length(lightWeighting) < 0.3465 ) {
-
-		if (mod(gl_FragCoord.x - gl_FragCoord.y - 5.0, 10.0) == 0.0) {
-
-			gl_FragColor = vec4( uLineColor4, 1.0 );
-
-	}
-
-	}
-
-}
-`
-
+	`
 };
 
 THREE.ToonShaderDotted = {
@@ -257,58 +255,57 @@ THREE.ToonShaderDotted = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-	vNormal = normalize( normalMatrix * normal );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vNormal = normalize( normalMatrix * normal );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 uBaseColor;
-uniform vec3 uLineColor1;
-uniform vec3 uLineColor2;
-uniform vec3 uLineColor3;
-uniform vec3 uLineColor4;
+		uniform vec3 uBaseColor;
+		uniform vec3 uLineColor1;
+		uniform vec3 uLineColor2;
+		uniform vec3 uLineColor3;
+		uniform vec3 uLineColor4;
 
-uniform vec3 uDirLightPos;
-uniform vec3 uDirLightColor;
+		uniform vec3 uDirLightPos;
+		uniform vec3 uDirLightColor;
 
-uniform vec3 uAmbientLightColor;
+		uniform vec3 uAmbientLightColor;
 
-varying vec3 vNormal;
+		varying vec3 vNormal;
 
-void main() {
+		void main() {
 
-float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
-vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
+			float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
+			vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-gl_FragColor = vec4( uBaseColor, 1.0 );
+			gl_FragColor = vec4( uBaseColor, 1.0 );
 
-if ( length(lightWeighting) < 1.00 ) {
+			if ( length(lightWeighting) < 1.00 ) {
 
-		if ( ( mod(gl_FragCoord.x, 4.001) + mod(gl_FragCoord.y, 4.0) ) > 6.00 ) {
+				if ( ( mod(gl_FragCoord.x, 4.001) + mod(gl_FragCoord.y, 4.0) ) > 6.00 ) {
 
-			gl_FragColor = vec4( uLineColor1, 1.0 );
+					gl_FragColor = vec4( uLineColor1, 1.0 );
+
+				}
+
+			}
+
+			if ( length(lightWeighting) < 0.50 ) {
+
+				if ( ( mod(gl_FragCoord.x + 2.0, 4.001) + mod(gl_FragCoord.y + 2.0, 4.0) ) > 6.00 ) {
+
+					gl_FragColor = vec4( uLineColor1, 1.0 );
+
+				}
+
+			}
 
 		}
-
-	}
-
-	if ( length(lightWeighting) < 0.50 ) {
-
-		if ( ( mod(gl_FragCoord.x + 2.0, 4.001) + mod(gl_FragCoord.y + 2.0, 4.0) ) > 6.00 ) {
-
-			gl_FragColor = vec4( uLineColor1, 1.0 );
-
-		}
-
-	}
-
-}
-`
-
+	`
 };

--- a/examples/js/shaders/ToonShader.js
+++ b/examples/js/shaders/ToonShader.js
@@ -23,66 +23,62 @@ THREE.ToonShader1 = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec3 vNormal;
+varying vec3 vRefract;
 
-		"varying vec3 vNormal;",
-		"varying vec3 vRefract;",
+void main() {
 
-		"void main() {",
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+	vec3 worldNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
 
-		"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-		"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-		"	vec3 worldNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );",
+	vNormal = normalize( normalMatrix * normal );
 
-		"	vNormal = normalize( normalMatrix * normal );",
+	vec3 I = worldPosition.xyz - cameraPosition;
+	vRefract = refract( normalize( I ), worldNormal, 1.02 );
 
-		"	vec3 I = worldPosition.xyz - cameraPosition;",
-		"	vRefract = refract( normalize( I ), worldNormal, 1.02 );",
+	gl_Position = projectionMatrix * mvPosition;
 
-		"	gl_Position = projectionMatrix * mvPosition;",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 uBaseColor;
 
-	].join( "\n" ),
+uniform vec3 uDirLightPos;
+uniform vec3 uDirLightColor;
 
-	fragmentShader: [
+uniform vec3 uAmbientLightColor;
 
-		"uniform vec3 uBaseColor;",
+varying vec3 vNormal;
 
-		"uniform vec3 uDirLightPos;",
-		"uniform vec3 uDirLightColor;",
+varying vec3 vRefract;
 
-		"uniform vec3 uAmbientLightColor;",
+void main() {
 
-		"varying vec3 vNormal;",
+	float directionalLightWeighting = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
+	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-		"varying vec3 vRefract;",
+	float intensity = smoothstep( - 0.5, 1.0, pow( length(lightWeighting), 20.0 ) );
+	intensity += length(lightWeighting) * 0.2;
 
-		"void main() {",
+	float cameraWeighting = dot( normalize( vNormal ), vRefract );
+	intensity += pow( 1.0 - length( cameraWeighting ), 6.0 );
+	intensity = intensity * 0.2 + 0.3;
 
-		"	float directionalLightWeighting = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);",
-		"	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;",
+	if ( intensity < 0.50 ) {
 
-		"	float intensity = smoothstep( - 0.5, 1.0, pow( length(lightWeighting), 20.0 ) );",
-		"	intensity += length(lightWeighting) * 0.2;",
+		gl_FragColor = vec4( 2.0 * intensity * uBaseColor, 1.0 );
 
-		"	float cameraWeighting = dot( normalize( vNormal ), vRefract );",
-		"	intensity += pow( 1.0 - length( cameraWeighting ), 6.0 );",
-		"	intensity = intensity * 0.2 + 0.3;",
+	} else {
 
-		"	if ( intensity < 0.50 ) {",
+		gl_FragColor = vec4( 1.0 - 2.0 * ( 1.0 - intensity ) * ( 1.0 - uBaseColor ), 1.0 );
 
-		"		gl_FragColor = vec4( 2.0 * intensity * uBaseColor, 1.0 );",
+}
 
-		"	} else {",
-
-		"		gl_FragColor = vec4( 1.0 - 2.0 * ( 1.0 - intensity ) * ( 1.0 - uBaseColor ), 1.0 );",
-
-		"}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -103,56 +99,52 @@ THREE.ToonShader2 = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec3 vNormal;
 
-		"varying vec3 vNormal;",
+void main() {
 
-		"void main() {",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+	vNormal = normalize( normalMatrix * normal );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"	vNormal = normalize( normalMatrix * normal );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 uBaseColor;
+uniform vec3 uLineColor1;
+uniform vec3 uLineColor2;
+uniform vec3 uLineColor3;
+uniform vec3 uLineColor4;
 
-	].join( "\n" ),
+uniform vec3 uDirLightPos;
+uniform vec3 uDirLightColor;
 
-	fragmentShader: [
+uniform vec3 uAmbientLightColor;
 
-		"uniform vec3 uBaseColor;",
-		"uniform vec3 uLineColor1;",
-		"uniform vec3 uLineColor2;",
-		"uniform vec3 uLineColor3;",
-		"uniform vec3 uLineColor4;",
+varying vec3 vNormal;
 
-		"uniform vec3 uDirLightPos;",
-		"uniform vec3 uDirLightColor;",
+void main() {
 
-		"uniform vec3 uAmbientLightColor;",
+	float camera = max( dot( normalize( vNormal ), vec3( 0.0, 0.0, 1.0 ) ), 0.4);
+	float light = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);
 
-		"varying vec3 vNormal;",
+	gl_FragColor = vec4( uBaseColor, 1.0 );
 
-		"void main() {",
+	if ( length(uAmbientLightColor + uDirLightColor * light) < 1.00 ) {
 
-		"	float camera = max( dot( normalize( vNormal ), vec3( 0.0, 0.0, 1.0 ) ), 0.4);",
-		"	float light = max( dot( normalize( vNormal ), uDirLightPos ), 0.0);",
+		gl_FragColor *= vec4( uLineColor1, 1.0 );
 
-		"	gl_FragColor = vec4( uBaseColor, 1.0 );",
+	}
 
-		"	if ( length(uAmbientLightColor + uDirLightColor * light) < 1.00 ) {",
+	if ( length(uAmbientLightColor + uDirLightColor * camera) < 0.50 ) {
 
-		"		gl_FragColor *= vec4( uLineColor1, 1.0 );",
+		gl_FragColor *= vec4( uLineColor2, 1.0 );
 
-		"	}",
+	}
 
-		"	if ( length(uAmbientLightColor + uDirLightColor * camera) < 0.50 ) {",
-
-		"		gl_FragColor *= vec4( uLineColor2, 1.0 );",
-
-		"	}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -173,84 +165,80 @@ THREE.ToonShaderHatching = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec3 vNormal;
 
-		"varying vec3 vNormal;",
+void main() {
 
-		"void main() {",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+	vNormal = normalize( normalMatrix * normal );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"	vNormal = normalize( normalMatrix * normal );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 uBaseColor;
+uniform vec3 uLineColor1;
+uniform vec3 uLineColor2;
+uniform vec3 uLineColor3;
+uniform vec3 uLineColor4;
 
-	].join( "\n" ),
+uniform vec3 uDirLightPos;
+uniform vec3 uDirLightColor;
 
-	fragmentShader: [
+uniform vec3 uAmbientLightColor;
 
-		"uniform vec3 uBaseColor;",
-		"uniform vec3 uLineColor1;",
-		"uniform vec3 uLineColor2;",
-		"uniform vec3 uLineColor3;",
-		"uniform vec3 uLineColor4;",
+varying vec3 vNormal;
 
-		"uniform vec3 uDirLightPos;",
-		"uniform vec3 uDirLightColor;",
+void main() {
 
-		"uniform vec3 uAmbientLightColor;",
+	float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
+	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-		"varying vec3 vNormal;",
+	gl_FragColor = vec4( uBaseColor, 1.0 );
 
-		"void main() {",
+	if ( length(lightWeighting) < 1.00 ) {
 
-		"	float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);",
-		"	vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;",
+		if ( mod(gl_FragCoord.x + gl_FragCoord.y, 10.0) == 0.0) {
 
-		"	gl_FragColor = vec4( uBaseColor, 1.0 );",
+			gl_FragColor = vec4( uLineColor1, 1.0 );
 
-		"	if ( length(lightWeighting) < 1.00 ) {",
+		}
 
-		"		if ( mod(gl_FragCoord.x + gl_FragCoord.y, 10.0) == 0.0) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor1, 1.0 );",
+	if ( length(lightWeighting) < 0.75 ) {
 
-		"		}",
+		if (mod(gl_FragCoord.x - gl_FragCoord.y, 10.0) == 0.0) {
 
-		"	}",
+			gl_FragColor = vec4( uLineColor2, 1.0 );
 
-		"	if ( length(lightWeighting) < 0.75 ) {",
+		}
 
-		"		if (mod(gl_FragCoord.x - gl_FragCoord.y, 10.0) == 0.0) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor2, 1.0 );",
+	if ( length(lightWeighting) < 0.50 ) {
 
-		"		}",
+		if (mod(gl_FragCoord.x + gl_FragCoord.y - 5.0, 10.0) == 0.0) {
 
-		"	}",
+			gl_FragColor = vec4( uLineColor3, 1.0 );
 
-		"	if ( length(lightWeighting) < 0.50 ) {",
+		}
 
-		"		if (mod(gl_FragCoord.x + gl_FragCoord.y - 5.0, 10.0) == 0.0) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor3, 1.0 );",
+	if ( length(lightWeighting) < 0.3465 ) {
 
-		"		}",
+		if (mod(gl_FragCoord.x - gl_FragCoord.y - 5.0, 10.0) == 0.0) {
 
-		"	}",
+			gl_FragColor = vec4( uLineColor4, 1.0 );
 
-		"	if ( length(lightWeighting) < 0.3465 ) {",
+	}
 
-		"		if (mod(gl_FragCoord.x - gl_FragCoord.y - 5.0, 10.0) == 0.0) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor4, 1.0 );",
-
-		"	}",
-
-		"	}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };
 
@@ -268,63 +256,59 @@ THREE.ToonShaderDotted = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec3 vNormal;
 
-		"varying vec3 vNormal;",
+void main() {
 
-		"void main() {",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+	vNormal = normalize( normalMatrix * normal );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-		"	vNormal = normalize( normalMatrix * normal );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 uBaseColor;
+uniform vec3 uLineColor1;
+uniform vec3 uLineColor2;
+uniform vec3 uLineColor3;
+uniform vec3 uLineColor4;
 
-	].join( "\n" ),
+uniform vec3 uDirLightPos;
+uniform vec3 uDirLightColor;
 
-	fragmentShader: [
+uniform vec3 uAmbientLightColor;
 
-		"uniform vec3 uBaseColor;",
-		"uniform vec3 uLineColor1;",
-		"uniform vec3 uLineColor2;",
-		"uniform vec3 uLineColor3;",
-		"uniform vec3 uLineColor4;",
+varying vec3 vNormal;
 
-		"uniform vec3 uDirLightPos;",
-		"uniform vec3 uDirLightColor;",
+void main() {
 
-		"uniform vec3 uAmbientLightColor;",
+float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);
+vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;
 
-		"varying vec3 vNormal;",
+gl_FragColor = vec4( uBaseColor, 1.0 );
 
-		"void main() {",
+if ( length(lightWeighting) < 1.00 ) {
 
-		"float directionalLightWeighting = max( dot( normalize(vNormal), uDirLightPos ), 0.0);",
-		"vec3 lightWeighting = uAmbientLightColor + uDirLightColor * directionalLightWeighting;",
+		if ( ( mod(gl_FragCoord.x, 4.001) + mod(gl_FragCoord.y, 4.0) ) > 6.00 ) {
 
-		"gl_FragColor = vec4( uBaseColor, 1.0 );",
+			gl_FragColor = vec4( uLineColor1, 1.0 );
 
-		"if ( length(lightWeighting) < 1.00 ) {",
+		}
 
-		"		if ( ( mod(gl_FragCoord.x, 4.001) + mod(gl_FragCoord.y, 4.0) ) > 6.00 ) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor1, 1.0 );",
+	if ( length(lightWeighting) < 0.50 ) {
 
-		"		}",
+		if ( ( mod(gl_FragCoord.x + 2.0, 4.001) + mod(gl_FragCoord.y + 2.0, 4.0) ) > 6.00 ) {
 
-		"	}",
+			gl_FragColor = vec4( uLineColor1, 1.0 );
 
-		"	if ( length(lightWeighting) < 0.50 ) {",
+		}
 
-		"		if ( ( mod(gl_FragCoord.x + 2.0, 4.001) + mod(gl_FragCoord.y + 2.0, 4.0) ) > 6.00 ) {",
+	}
 
-		"			gl_FragColor = vec4( uLineColor1, 1.0 );",
-
-		"		}",
-
-		"	}",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/TranslucentShader.js
+++ b/examples/js/shaders/TranslucentShader.js
@@ -34,168 +34,167 @@ THREE.TranslucentShader = {
 	] ),
 
 	vertexShader: /* glsl */`
-varying vec3 vNormal;
-varying vec2 vUv;
+		varying vec3 vNormal;
+		varying vec2 vUv;
 
-varying vec3 vViewPosition;
+		varying vec3 vViewPosition;
 
-#include <common>
+		#include <common>
 
-void main() {
+		void main() {
 
-	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
 
-	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
 
-	vViewPosition = -mvPosition.xyz;
+			vViewPosition = -mvPosition.xyz;
 
-	vNormal = normalize( normalMatrix * normal );
+			vNormal = normalize( normalMatrix * normal );
 
-	vUv = uv;
+			vUv = uv;
 
-	gl_Position = projectionMatrix * mvPosition;
+			gl_Position = projectionMatrix * mvPosition;
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#define USE_UV
-#define USE_MAP
-#define PHONG
-#define TRANSLUCENT
-#include <common>
-#include <bsdfs>
-#include <uv_pars_fragment>
-#include <map_pars_fragment>
-#include <lights_phong_pars_fragment>
+		#define USE_UV
+		#define USE_MAP
+		#define PHONG
+		#define TRANSLUCENT
+		#include <common>
+		#include <bsdfs>
+		#include <uv_pars_fragment>
+		#include <map_pars_fragment>
+		#include <lights_phong_pars_fragment>
 
-varying vec3 vColor;
+		varying vec3 vColor;
 
-uniform vec3 diffuse;
-uniform vec3 specular;
-uniform vec3 emissive;
-uniform float opacity;
-uniform float shininess;
+		uniform vec3 diffuse;
+		uniform vec3 specular;
+		uniform vec3 emissive;
+		uniform float opacity;
+		uniform float shininess;
 
-// Translucency
-uniform sampler2D thicknessMap;
-uniform float thicknessPower;
-uniform float thicknessScale;
-uniform float thicknessDistortion;
-uniform float thicknessAmbient;
-uniform float thicknessAttenuation;
-uniform vec3 thicknessColor;
+		// Translucency
+		uniform sampler2D thicknessMap;
+		uniform float thicknessPower;
+		uniform float thicknessScale;
+		uniform float thicknessDistortion;
+		uniform float thicknessAmbient;
+		uniform float thicknessAttenuation;
+		uniform vec3 thicknessColor;
 
-#include <lights_pars_begin>
+		#include <lights_pars_begin>
 
-void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {
-	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;
-	vec3 scatteringHalf = normalize(directLight.direction + (geometry.normal * thicknessDistortion));
-	float scatteringDot = pow(saturate(dot(geometry.viewDir, -scatteringHalf)), thicknessPower) * thicknessScale;
-	vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;
-	reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;
-}
-
-void main() {
-
-	vec3 normal = normalize( vNormal );
-
-	vec3 viewerDirection = normalize( vViewPosition );
-
-	vec4 diffuseColor = vec4( diffuse, opacity );
-	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-
-	#include <map_fragment>
-	#include <color_fragment>
-	#include <specularmap_fragment>
-
-	vec3 totalEmissiveRadiance = emissive;
-
-	#include <lights_phong_fragment>
-
-	// Doing lights fragment begin.
-	GeometricContext geometry;
-	geometry.position = - vViewPosition;
-	geometry.normal = normal;
-	geometry.viewDir = normalize( vViewPosition );
-
-	IncidentLight directLight;
-
-	#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )
-
-		PointLight pointLight;
-
-		#pragma unroll_loop
-		for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
-			pointLight = pointLights[ i ];
-			getPointDirectLightIrradiance( pointLight, geometry, directLight );
-
-			#ifdef USE_SHADOWMAP
-			directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
-			#endif
-
-			RE_Direct( directLight, geometry, material, reflectedLight );
-
-			#if defined( TRANSLUCENT ) && defined( USE_UV )
-			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
-			#endif
+		void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {
+			vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;
+			vec3 scatteringHalf = normalize(directLight.direction + (geometry.normal * thicknessDistortion));
+			float scatteringDot = pow(saturate(dot(geometry.viewDir, -scatteringHalf)), thicknessPower) * thicknessScale;
+			vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;
+			reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;
 		}
 
-		#endif
+		void main() {
 
-	#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )
+			vec3 normal = normalize( vNormal );
 
-		DirectionalLight directionalLight;
+			vec3 viewerDirection = normalize( vViewPosition );
 
-		#pragma unroll_loop
-		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
-			directionalLight = directionalLights[ i ];
-			getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
+			vec4 diffuseColor = vec4( diffuse, opacity );
+			ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 
-			#ifdef USE_SHADOWMAP
-			directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#include <map_fragment>
+			#include <color_fragment>
+			#include <specularmap_fragment>
+
+			vec3 totalEmissiveRadiance = emissive;
+
+			#include <lights_phong_fragment>
+
+			// Doing lights fragment begin.
+			GeometricContext geometry;
+			geometry.position = - vViewPosition;
+			geometry.normal = normal;
+			geometry.viewDir = normalize( vViewPosition );
+
+			IncidentLight directLight;
+
+			#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )
+
+				PointLight pointLight;
+
+				#pragma unroll_loop
+				for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
+					pointLight = pointLights[ i ];
+					getPointDirectLightIrradiance( pointLight, geometry, directLight );
+
+					#ifdef USE_SHADOWMAP
+					directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
+					#endif
+
+					RE_Direct( directLight, geometry, material, reflectedLight );
+
+					#if defined( TRANSLUCENT ) && defined( USE_UV )
+					RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
+					#endif
+				}
+
+				#endif
+
+			#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )
+
+				DirectionalLight directionalLight;
+
+				#pragma unroll_loop
+				for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
+					directionalLight = directionalLights[ i ];
+					getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
+
+					#ifdef USE_SHADOWMAP
+					directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+					#endif
+
+					RE_Direct( directLight, geometry, material, reflectedLight );
+
+					#if defined( TRANSLUCENT ) && defined( USE_UV )
+					RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
+					#endif
+				}
+
 			#endif
 
-			RE_Direct( directLight, geometry, material, reflectedLight );
+			#if defined( RE_IndirectDiffuse )
 
-			#if defined( TRANSLUCENT ) && defined( USE_UV )
-			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
+				vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
+
+				#if ( NUM_HEMI_LIGHTS > 0 )
+
+					#pragma unroll_loop
+					for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
+
+						irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+
+					}
+
+				#endif
+
 			#endif
+
+			#if defined( RE_IndirectSpecular )
+
+				vec3 radiance = vec3( 0.0 );
+				vec3 clearcoatRadiance = vec3( 0.0 );
+
+			#endif
+			#include <lights_fragment_end>
+
+			vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
+			gl_FragColor = vec4( outgoingLight, diffuseColor.a );	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
+
+			#include <encodings_fragment>
+
 		}
-
-	#endif
-
-	#if defined( RE_IndirectDiffuse )
-
-		vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
-
-		#if ( NUM_HEMI_LIGHTS > 0 )
-
-			#pragma unroll_loop
-			for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
-
-				irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
-
-			}
-
-		#endif
-
-	#endif
-
-	#if defined( RE_IndirectSpecular )
-
-		vec3 radiance = vec3( 0.0 );
-		vec3 clearcoatRadiance = vec3( 0.0 );
-
-	#endif
-	#include <lights_fragment_end>
-
-	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
-
-	#include <encodings_fragment>
-
-}
-`,
-
+	`,
 };

--- a/examples/js/shaders/TranslucentShader.js
+++ b/examples/js/shaders/TranslucentShader.js
@@ -40,7 +40,7 @@ THREE.TranslucentShader = {
 
 		"varying vec3 vViewPosition;",
 
-		THREE.ShaderChunk[ "common" ],
+		"#include <common>",
 
 		"void main() {",
 
@@ -88,7 +88,7 @@ THREE.TranslucentShader = {
 		"uniform float thicknessAttenuation;",
 		"uniform vec3 thicknessColor;",
 
-		THREE.ShaderChunk[ "lights_pars_begin" ],
+		"#include <lights_pars_begin>",
 
 		"void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {",
 		"	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;",
@@ -107,13 +107,13 @@ THREE.TranslucentShader = {
 		"	vec4 diffuseColor = vec4( diffuse, opacity );",
 		"	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
 
-		THREE.ShaderChunk[ "map_fragment" ],
-		THREE.ShaderChunk[ "color_fragment" ],
-		THREE.ShaderChunk[ "specularmap_fragment" ],
+		"	#include <map_fragment>",
+		"	#include <color_fragment>",
+		"	#include <specularmap_fragment>",
 
 		"	vec3 totalEmissiveRadiance = emissive;",
 
-		THREE.ShaderChunk[ "lights_phong_fragment" ],
+		"	#include <lights_phong_fragment>",
 
 		// Doing lights fragment begin.
 		"	GeometricContext geometry;",
@@ -190,12 +190,12 @@ THREE.TranslucentShader = {
 		"		vec3 clearcoatRadiance = vec3( 0.0 );",
 
 		"	#endif",
-		THREE.ShaderChunk[ "lights_fragment_end" ],
+		"	#include <lights_fragment_end>",
 
 		"	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
 		"	gl_FragColor = vec4( outgoingLight, diffuseColor.a );",	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
 
-		THREE.ShaderChunk[ "encodings_fragment" ],
+		"	#include <encodings_fragment>",
 
 		"}"
 

--- a/examples/js/shaders/TranslucentShader.js
+++ b/examples/js/shaders/TranslucentShader.js
@@ -33,172 +33,169 @@ THREE.TranslucentShader = {
 
 	] ),
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec3 vNormal;
+varying vec2 vUv;
 
-		"varying vec3 vNormal;",
-		"varying vec2 vUv;",
+varying vec3 vViewPosition;
 
-		"varying vec3 vViewPosition;",
+#include <common>
 
-		"#include <common>",
+void main() {
 
-		"void main() {",
+	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
 
-		"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
+	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
 
-		"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
+	vViewPosition = -mvPosition.xyz;
 
-		"	vViewPosition = -mvPosition.xyz;",
+	vNormal = normalize( normalMatrix * normal );
 
-		"	vNormal = normalize( normalMatrix * normal );",
+	vUv = uv;
 
-		"	vUv = uv;",
+	gl_Position = projectionMatrix * mvPosition;
 
-		"	gl_Position = projectionMatrix * mvPosition;",
+}
+`,
 
-		"}",
+	fragmentShader: /* glsl */`
+#define USE_UV
+#define USE_MAP
+#define PHONG
+#define TRANSLUCENT
+#include <common>
+#include <bsdfs>
+#include <uv_pars_fragment>
+#include <map_pars_fragment>
+#include <lights_phong_pars_fragment>
 
-	].join( "\n" ),
+varying vec3 vColor;
 
-	fragmentShader: [
-		"#define USE_UV",
-		"#define USE_MAP",
-		"#define PHONG",
-		"#define TRANSLUCENT",
-		"#include <common>",
-		"#include <bsdfs>",
-		"#include <uv_pars_fragment>",
-		"#include <map_pars_fragment>",
-		"#include <lights_phong_pars_fragment>",
+uniform vec3 diffuse;
+uniform vec3 specular;
+uniform vec3 emissive;
+uniform float opacity;
+uniform float shininess;
 
-		"varying vec3 vColor;",
+// Translucency
+uniform sampler2D thicknessMap;
+uniform float thicknessPower;
+uniform float thicknessScale;
+uniform float thicknessDistortion;
+uniform float thicknessAmbient;
+uniform float thicknessAttenuation;
+uniform vec3 thicknessColor;
 
-		"uniform vec3 diffuse;",
-		"uniform vec3 specular;",
-		"uniform vec3 emissive;",
-		"uniform float opacity;",
-		"uniform float shininess;",
+#include <lights_pars_begin>
 
-		// Translucency
-		"uniform sampler2D thicknessMap;",
-		"uniform float thicknessPower;",
-		"uniform float thicknessScale;",
-		"uniform float thicknessDistortion;",
-		"uniform float thicknessAmbient;",
-		"uniform float thicknessAttenuation;",
-		"uniform vec3 thicknessColor;",
+void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {
+	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;
+	vec3 scatteringHalf = normalize(directLight.direction + (geometry.normal * thicknessDistortion));
+	float scatteringDot = pow(saturate(dot(geometry.viewDir, -scatteringHalf)), thicknessPower) * thicknessScale;
+	vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;
+	reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;
+}
 
-		"#include <lights_pars_begin>",
+void main() {
 
-		"void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {",
-		"	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;",
-		"	vec3 scatteringHalf = normalize(directLight.direction + (geometry.normal * thicknessDistortion));",
-		"	float scatteringDot = pow(saturate(dot(geometry.viewDir, -scatteringHalf)), thicknessPower) * thicknessScale;",
-		"	vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;",
-		"	reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;",
-		"}",
+	vec3 normal = normalize( vNormal );
 
-		"void main() {",
+	vec3 viewerDirection = normalize( vViewPosition );
 
-		"	vec3 normal = normalize( vNormal );",
+	vec4 diffuseColor = vec4( diffuse, opacity );
+	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 
-		"	vec3 viewerDirection = normalize( vViewPosition );",
+	#include <map_fragment>
+	#include <color_fragment>
+	#include <specularmap_fragment>
 
-		"	vec4 diffuseColor = vec4( diffuse, opacity );",
-		"	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
+	vec3 totalEmissiveRadiance = emissive;
 
-		"	#include <map_fragment>",
-		"	#include <color_fragment>",
-		"	#include <specularmap_fragment>",
+	#include <lights_phong_fragment>
 
-		"	vec3 totalEmissiveRadiance = emissive;",
+	// Doing lights fragment begin.
+	GeometricContext geometry;
+	geometry.position = - vViewPosition;
+	geometry.normal = normal;
+	geometry.viewDir = normalize( vViewPosition );
 
-		"	#include <lights_phong_fragment>",
+	IncidentLight directLight;
 
-		// Doing lights fragment begin.
-		"	GeometricContext geometry;",
-		"	geometry.position = - vViewPosition;",
-		"	geometry.normal = normal;",
-		"	geometry.viewDir = normalize( vViewPosition );",
+	#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )
 
-		"	IncidentLight directLight;",
+		PointLight pointLight;
 
-		"	#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )",
+		#pragma unroll_loop
+		for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
+			pointLight = pointLights[ i ];
+			getPointDirectLightIrradiance( pointLight, geometry, directLight );
 
-		"		PointLight pointLight;",
+			#ifdef USE_SHADOWMAP
+			directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;
+			#endif
 
-		"		#pragma unroll_loop",
-		"		for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {",
-		"		 	pointLight = pointLights[ i ];",
-		"		 	getPointDirectLightIrradiance( pointLight, geometry, directLight );",
+			RE_Direct( directLight, geometry, material, reflectedLight );
 
-		"			#ifdef USE_SHADOWMAP",
-		"			directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;",
-		"			#endif",
+			#if defined( TRANSLUCENT ) && defined( USE_UV )
+			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
+			#endif
+		}
 
-		"			RE_Direct( directLight, geometry, material, reflectedLight );",
+		#endif
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
-		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
-		"			#endif",
-		"		}",
+	#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )
 
-		"		#endif",
+		DirectionalLight directionalLight;
 
-		"	#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )",
+		#pragma unroll_loop
+		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
+			directionalLight = directionalLights[ i ];
+			getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
-		"		DirectionalLight directionalLight;",
+			#ifdef USE_SHADOWMAP
+			directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#endif
 
-		"		#pragma unroll_loop",
-		"		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {",
-		"			directionalLight = directionalLights[ i ];",
-		"			getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );",
+			RE_Direct( directLight, geometry, material, reflectedLight );
 
-		"			#ifdef USE_SHADOWMAP",
-		"			directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;",
-		"			#endif",
+			#if defined( TRANSLUCENT ) && defined( USE_UV )
+			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);
+			#endif
+		}
 
-		"			RE_Direct( directLight, geometry, material, reflectedLight );",
+	#endif
 
-		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
-		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
-		"			#endif",
-		"		}",
+	#if defined( RE_IndirectDiffuse )
 
-		"	#endif",
+		vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
-		"	#if defined( RE_IndirectDiffuse )",
+		#if ( NUM_HEMI_LIGHTS > 0 )
 
-		"		vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );",
+			#pragma unroll_loop
+			for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-		"		#if ( NUM_HEMI_LIGHTS > 0 )",
+				irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
 
-		"			#pragma unroll_loop",
-		"			for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {",
+			}
 
-		"				irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );",
+		#endif
 
-		"			}",
+	#endif
 
-		"		#endif",
+	#if defined( RE_IndirectSpecular )
 
-		"	#endif",
+		vec3 radiance = vec3( 0.0 );
+		vec3 clearcoatRadiance = vec3( 0.0 );
 
-		"	#if defined( RE_IndirectSpecular )",
+	#endif
+	#include <lights_fragment_end>
 
-		"		vec3 radiance = vec3( 0.0 );",
-		"		vec3 clearcoatRadiance = vec3( 0.0 );",
+	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
+	gl_FragColor = vec4( outgoingLight, diffuseColor.a );	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
 
-		"	#endif",
-		"	#include <lights_fragment_end>",
+	#include <encodings_fragment>
 
-		"	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
-		"	gl_FragColor = vec4( outgoingLight, diffuseColor.a );",	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
-
-		"	#include <encodings_fragment>",
-
-		"}"
-
-	].join( "\n" ),
+}
+`,
 
 };

--- a/examples/js/shaders/TriangleBlurShader.js
+++ b/examples/js/shaders/TriangleBlurShader.js
@@ -20,49 +20,48 @@ THREE.TriangleBlurShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-#include <common>
+		#include <common>
 
-#define ITERATIONS 10.0
+		#define ITERATIONS 10.0
 
-uniform sampler2D texture;
-uniform vec2 delta;
+		uniform sampler2D texture;
+		uniform vec2 delta;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 color = vec4( 0.0 );
+			vec4 color = vec4( 0.0 );
 
-	float total = 0.0;
+			float total = 0.0;
 
-	// randomize the lookup values to hide the fixed number of samples
+			// randomize the lookup values to hide the fixed number of samples
 
-	float offset = rand( vUv );
+			float offset = rand( vUv );
 
-	for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {
+			for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {
 
-		float percent = ( t + offset - 0.5 ) / ITERATIONS;
-		float weight = 1.0 - abs( percent );
+				float percent = ( t + offset - 0.5 ) / ITERATIONS;
+				float weight = 1.0 - abs( percent );
 
-		color += texture2D( texture, vUv + delta * percent ) * weight;
-		total += weight;
+				color += texture2D( texture, vUv + delta * percent ) * weight;
+				total += weight;
 
-	}
+			}
 
-	gl_FragColor = color / total;
+			gl_FragColor = color / total;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/TriangleBlurShader.js
+++ b/examples/js/shaders/TriangleBlurShader.js
@@ -19,54 +19,50 @@ THREE.TriangleBlurShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+#include <common>
 
-	].join( "\n" ),
+#define ITERATIONS 10.0
 
-	fragmentShader: [
+uniform sampler2D texture;
+uniform vec2 delta;
 
-		"#include <common>",
+varying vec2 vUv;
 
-		"#define ITERATIONS 10.0",
+void main() {
 
-		"uniform sampler2D texture;",
-		"uniform vec2 delta;",
+	vec4 color = vec4( 0.0 );
 
-		"varying vec2 vUv;",
+	float total = 0.0;
 
-		"void main() {",
+	// randomize the lookup values to hide the fixed number of samples
 
-		"	vec4 color = vec4( 0.0 );",
+	float offset = rand( vUv );
 
-		"	float total = 0.0;",
+	for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {
 
-		// randomize the lookup values to hide the fixed number of samples
+		float percent = ( t + offset - 0.5 ) / ITERATIONS;
+		float weight = 1.0 - abs( percent );
 
-		"	float offset = rand( vUv );",
+		color += texture2D( texture, vUv + delta * percent ) * weight;
+		total += weight;
 
-		"	for ( float t = -ITERATIONS; t <= ITERATIONS; t ++ ) {",
+	}
 
-		"		float percent = ( t + offset - 0.5 ) / ITERATIONS;",
-		"		float weight = 1.0 - abs( percent );",
+	gl_FragColor = color / total;
 
-		"		color += texture2D( texture, vUv + delta * percent ) * weight;",
-		"		total += weight;",
-
-		"	}",
-
-		"	gl_FragColor = color / total;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/UnpackDepthRGBAShader.js
+++ b/examples/js/shaders/UnpackDepthRGBAShader.js
@@ -14,36 +14,32 @@ THREE.UnpackDepthRGBAShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float opacity;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float opacity;",
+#include <packing>
 
-		"uniform sampler2D tDiffuse;",
+void main() {
 
-		"varying vec2 vUv;",
+	float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );
+	gl_FragColor = vec4( vec3( depth ), opacity );
 
-		"#include <packing>",
-
-		"void main() {",
-
-		"	float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );",
-		"	gl_FragColor = vec4( vec3( depth ), opacity );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/UnpackDepthRGBAShader.js
+++ b/examples/js/shaders/UnpackDepthRGBAShader.js
@@ -15,31 +15,30 @@ THREE.UnpackDepthRGBAShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float opacity;
+		uniform float opacity;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-#include <packing>
+		#include <packing>
 
-void main() {
+		void main() {
 
-	float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );
-	gl_FragColor = vec4( vec3( depth ), opacity );
+			float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );
+			gl_FragColor = vec4( vec3( depth ), opacity );
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/VerticalBlurShader.js
+++ b/examples/js/shaders/VerticalBlurShader.js
@@ -20,39 +20,38 @@ THREE.VerticalBlurShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float v;
+		uniform sampler2D tDiffuse;
+		uniform float v;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 sum = vec4( 0.0 );
+			vec4 sum = vec4( 0.0 );
 
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;
 
-	gl_FragColor = sum;
+			gl_FragColor = sum;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/VerticalBlurShader.js
+++ b/examples/js/shaders/VerticalBlurShader.js
@@ -19,44 +19,40 @@ THREE.VerticalBlurShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float v;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float v;",
+	vec4 sum = vec4( 0.0 );
 
-		"varying vec2 vUv;",
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;
 
-		"void main() {",
+	gl_FragColor = sum;
 
-		"	vec4 sum = vec4( 0.0 );",
-
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * v ) ) * 0.051;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * v ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * v ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * v ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * v ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * v ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * v ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * v ) ) * 0.051;",
-
-		"	gl_FragColor = sum;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/VerticalTiltShiftShader.js
+++ b/examples/js/shaders/VerticalTiltShiftShader.js
@@ -20,42 +20,41 @@ THREE.VerticalTiltShiftShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform sampler2D tDiffuse;
-uniform float v;
-uniform float r;
+		uniform sampler2D tDiffuse;
+		uniform float v;
+		uniform float r;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vec4 sum = vec4( 0.0 );
+			vec4 sum = vec4( 0.0 );
 
-	float vv = v * abs( r - vUv.y );
+			float vv = v * abs( r - vUv.y );
 
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;
-	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;
+			sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;
 
-	gl_FragColor = sum;
+			gl_FragColor = sum;
 
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/VerticalTiltShiftShader.js
+++ b/examples/js/shaders/VerticalTiltShiftShader.js
@@ -19,47 +19,43 @@ THREE.VerticalTiltShiftShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform sampler2D tDiffuse;
+uniform float v;
+uniform float r;
 
-	].join( "\n" ),
+varying vec2 vUv;
 
-	fragmentShader: [
+void main() {
 
-		"uniform sampler2D tDiffuse;",
-		"uniform float v;",
-		"uniform float r;",
+	vec4 sum = vec4( 0.0 );
 
-		"varying vec2 vUv;",
+	float vv = v * abs( r - vUv.y );
 
-		"void main() {",
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;
+	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;
 
-		"	vec4 sum = vec4( 0.0 );",
+	gl_FragColor = sum;
 
-		"	float vv = v * abs( r - vUv.y );",
-
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 4.0 * vv ) ) * 0.051;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 3.0 * vv ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 2.0 * vv ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y - 1.0 * vv ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y ) ) * 0.1633;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 1.0 * vv ) ) * 0.1531;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 2.0 * vv ) ) * 0.12245;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 3.0 * vv ) ) * 0.0918;",
-		"	sum += texture2D( tDiffuse, vec2( vUv.x, vUv.y + 4.0 * vv ) ) * 0.051;",
-
-		"	gl_FragColor = sum;",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/VignetteShader.js
+++ b/examples/js/shaders/VignetteShader.js
@@ -16,37 +16,34 @@ THREE.VignetteShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+varying vec2 vUv;
 
-		"varying vec2 vUv;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	vUv = uv;",
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform float offset;
+uniform float darkness;
 
-	].join( "\n" ),
+uniform sampler2D tDiffuse;
 
-	fragmentShader: [
+varying vec2 vUv;
 
-		"uniform float offset;",
-		"uniform float darkness;",
+void main() {
 
-		"uniform sampler2D tDiffuse;",
+	// Eskil's vignette
 
-		"varying vec2 vUv;",
+	vec4 texel = texture2D( tDiffuse, vUv );
+	vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );
+	gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );
 
-		"void main() {",
-
-		// Eskil's vignette
-
-		"	vec4 texel = texture2D( tDiffuse, vUv );",
-		"	vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );",
-		"	gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );",
-
-		/*
+	/*
 		// alternative version from glfx.js
 		// this one makes more "dusty" look (as opposed to "burned")
 
@@ -56,8 +53,7 @@ THREE.VignetteShader = {
 		"	gl_FragColor = color;",
 		*/
 
-		"}"
-
-	].join( "\n" )
+}
+`
 
 };

--- a/examples/js/shaders/VignetteShader.js
+++ b/examples/js/shaders/VignetteShader.js
@@ -17,43 +17,41 @@ THREE.VignetteShader = {
 	},
 
 	vertexShader: /* glsl */`
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	vUv = uv;
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform float offset;
-uniform float darkness;
+		uniform float offset;
+		uniform float darkness;
 
-uniform sampler2D tDiffuse;
+		uniform sampler2D tDiffuse;
 
-varying vec2 vUv;
+		varying vec2 vUv;
 
-void main() {
+		void main() {
 
-	// Eskil's vignette
+			// Eskil's vignette
 
-	vec4 texel = texture2D( tDiffuse, vUv );
-	vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );
-	gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );
+			vec4 texel = texture2D( tDiffuse, vUv );
+			vec2 uv = ( vUv - vec2( 0.5 ) ) * vec2( offset );
+			gl_FragColor = vec4( mix( texel.rgb, vec3( 1.0 - darkness ), dot( uv, uv ) ), texel.a );
 
-	/*
-		// alternative version from glfx.js
-		// this one makes more "dusty" look (as opposed to "burned")
+			/* alternative version from glfx.js
+			 * this one makes more "dusty" look (as opposed to "burned")
+			 *
+			 * 	vec4 color = texture2D( tDiffuse, vUv );
+			 * 	float dist = distance( vUv, vec2( 0.5 ) );
+			 * 	color.rgb *= smoothstep( 0.8, offset * 0.799, dist *( darkness + offset ) );
+			 * 	gl_FragColor = color;
+			 */
 
-		"	vec4 color = texture2D( tDiffuse, vUv );",
-		"	float dist = distance( vUv, vec2( 0.5 ) );",
-		"	color.rgb *= smoothstep( 0.8, offset * 0.799, dist *( darkness + offset ) );",
-		"	gl_FragColor = color;",
-		*/
-
-}
-`
-
+		}
+	`
 };

--- a/examples/js/shaders/VolumeShader.js
+++ b/examples/js/shaders/VolumeShader.js
@@ -15,310 +15,310 @@ THREE.VolumeRenderShader1 = {
 		"u_data": { value: null },
 		"u_cmdata": { value: null }
 	},
-	vertexShader: [
-		"		varying vec4 v_nearpos;",
-		"		varying vec4 v_farpos;",
-		"		varying vec3 v_position;",
+	vertexShader: /* glsl */`
+		varying vec4 v_nearpos;
+		varying vec4 v_farpos;
+		varying vec3 v_position;
 
-		"		mat4 inversemat(mat4 m) {",
-		// Taken from https://github.com/stackgl/glsl-inverse/blob/master/index.glsl
-		// This function is licenced by the MIT license to Mikola Lysenko
-		"				float",
-		"				a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],",
-		"				a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],",
-		"				a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],",
-		"				a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],",
+		mat4 inversemat(mat4 m) {
+				// Taken from https://github.com/stackgl/glsl-inverse/blob/master/index.glsl
+				// This function is licenced by the MIT license to Mikola Lysenko
+				float
+				a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],
+				a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],
+				a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],
+				a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],
 
-		"				b00 = a00 * a11 - a01 * a10,",
-		"				b01 = a00 * a12 - a02 * a10,",
-		"				b02 = a00 * a13 - a03 * a10,",
-		"				b03 = a01 * a12 - a02 * a11,",
-		"				b04 = a01 * a13 - a03 * a11,",
-		"				b05 = a02 * a13 - a03 * a12,",
-		"				b06 = a20 * a31 - a21 * a30,",
-		"				b07 = a20 * a32 - a22 * a30,",
-		"				b08 = a20 * a33 - a23 * a30,",
-		"				b09 = a21 * a32 - a22 * a31,",
-		"				b10 = a21 * a33 - a23 * a31,",
-		"				b11 = a22 * a33 - a23 * a32,",
+				b00 = a00 * a11 - a01 * a10,
+				b01 = a00 * a12 - a02 * a10,
+				b02 = a00 * a13 - a03 * a10,
+				b03 = a01 * a12 - a02 * a11,
+				b04 = a01 * a13 - a03 * a11,
+				b05 = a02 * a13 - a03 * a12,
+				b06 = a20 * a31 - a21 * a30,
+				b07 = a20 * a32 - a22 * a30,
+				b08 = a20 * a33 - a23 * a30,
+				b09 = a21 * a32 - a22 * a31,
+				b10 = a21 * a33 - a23 * a31,
+				b11 = a22 * a33 - a23 * a32,
 
-		"				det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;",
+				det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
 
-		"		return mat4(",
-		"				a11 * b11 - a12 * b10 + a13 * b09,",
-		"				a02 * b10 - a01 * b11 - a03 * b09,",
-		"				a31 * b05 - a32 * b04 + a33 * b03,",
-		"				a22 * b04 - a21 * b05 - a23 * b03,",
-		"				a12 * b08 - a10 * b11 - a13 * b07,",
-		"				a00 * b11 - a02 * b08 + a03 * b07,",
-		"				a32 * b02 - a30 * b05 - a33 * b01,",
-		"				a20 * b05 - a22 * b02 + a23 * b01,",
-		"				a10 * b10 - a11 * b08 + a13 * b06,",
-		"				a01 * b08 - a00 * b10 - a03 * b06,",
-		"				a30 * b04 - a31 * b02 + a33 * b00,",
-		"				a21 * b02 - a20 * b04 - a23 * b00,",
-		"				a11 * b07 - a10 * b09 - a12 * b06,",
-		"				a00 * b09 - a01 * b07 + a02 * b06,",
-		"				a31 * b01 - a30 * b03 - a32 * b00,",
-		"				a20 * b03 - a21 * b01 + a22 * b00) / det;",
-		"		}",
+		return mat4(
+				a11 * b11 - a12 * b10 + a13 * b09,
+				a02 * b10 - a01 * b11 - a03 * b09,
+				a31 * b05 - a32 * b04 + a33 * b03,
+				a22 * b04 - a21 * b05 - a23 * b03,
+				a12 * b08 - a10 * b11 - a13 * b07,
+				a00 * b11 - a02 * b08 + a03 * b07,
+				a32 * b02 - a30 * b05 - a33 * b01,
+				a20 * b05 - a22 * b02 + a23 * b01,
+				a10 * b10 - a11 * b08 + a13 * b06,
+				a01 * b08 - a00 * b10 - a03 * b06,
+				a30 * b04 - a31 * b02 + a33 * b00,
+				a21 * b02 - a20 * b04 - a23 * b00,
+				a11 * b07 - a10 * b09 - a12 * b06,
+				a00 * b09 - a01 * b07 + a02 * b06,
+				a31 * b01 - a30 * b03 - a32 * b00,
+				a20 * b03 - a21 * b01 + a22 * b00) / det;
+		}
 
 
-		"		void main() {",
-		// Prepare transforms to map to "camera view". See also:
-		// https://threejs.org/docs/#api/renderers/webgl/WebGLProgram
-		"				mat4 viewtransformf = modelViewMatrix;",
-		"				mat4 viewtransformi = inversemat(modelViewMatrix);",
+		void main() {
+				// Prepare transforms to map to "camera view". See also:
+				// https://threejs.org/docs/#api/renderers/webgl/WebGLProgram
+				mat4 viewtransformf = modelViewMatrix;
+				mat4 viewtransformi = inversemat(modelViewMatrix);
 
-		// Project local vertex coordinate to camera position. Then do a step
-		// backward (in cam coords) to the near clipping plane, and project back. Do
-		// the same for the far clipping plane. This gives us all the information we
-		// need to calculate the ray and truncate it to the viewing cone.
-		"				vec4 position4 = vec4(position, 1.0);",
-		"				vec4 pos_in_cam = viewtransformf * position4;",
+				// Project local vertex coordinate to camera position. Then do a step
+				// backward (in cam coords) to the near clipping plane, and project back. Do
+				// the same for the far clipping plane. This gives us all the information we
+				// need to calculate the ray and truncate it to the viewing cone.
+				vec4 position4 = vec4(position, 1.0);
+				vec4 pos_in_cam = viewtransformf * position4;
 
-		// Intersection of ray and near clipping plane (z = -1 in clip coords)
-		"				pos_in_cam.z = -pos_in_cam.w;",
-		"				v_nearpos = viewtransformi * pos_in_cam;",
+				// Intersection of ray and near clipping plane (z = -1 in clip coords)
+				pos_in_cam.z = -pos_in_cam.w;
+				v_nearpos = viewtransformi * pos_in_cam;
 
-		// Intersection of ray and far clipping plane (z = +1 in clip coords)
-		"				pos_in_cam.z = pos_in_cam.w;",
-		"				v_farpos = viewtransformi * pos_in_cam;",
+				// Intersection of ray and far clipping plane (z = +1 in clip coords)
+				pos_in_cam.z = pos_in_cam.w;
+				v_farpos = viewtransformi * pos_in_cam;
 
-		// Set varyings and output pos
-		"				v_position = position;",
-		"				gl_Position = projectionMatrix * viewMatrix * modelMatrix * position4;",
-		"		}",
-	].join( "\n" ),
-	fragmentShader: [
-		"		precision highp float;",
-		"		precision mediump sampler3D;",
+				// Set varyings and output pos
+				v_position = position;
+				gl_Position = projectionMatrix * viewMatrix * modelMatrix * position4;
+		}
+`,
+	fragmentShader: /* glsl */`
+		precision highp float;
+		precision mediump sampler3D;
 
-		"		uniform vec3 u_size;",
-		"		uniform int u_renderstyle;",
-		"		uniform float u_renderthreshold;",
-		"		uniform vec2 u_clim;",
+		uniform vec3 u_size;
+		uniform int u_renderstyle;
+		uniform float u_renderthreshold;
+		uniform vec2 u_clim;
 
-		"		uniform sampler3D u_data;",
-		"		uniform sampler2D u_cmdata;",
+		uniform sampler3D u_data;
+		uniform sampler2D u_cmdata;
 
-		"		varying vec3 v_position;",
-		"		varying vec4 v_nearpos;",
-		"		varying vec4 v_farpos;",
+		varying vec3 v_position;
+		varying vec4 v_nearpos;
+		varying vec4 v_farpos;
 
 		// The maximum distance through our rendering volume is sqrt(3).
-		"		const int MAX_STEPS = 887;	// 887 for 512^3, 1774 for 1024^3",
-		"		const int REFINEMENT_STEPS = 4;",
-		"		const float relative_step_size = 1.0;",
-		"		const vec4 ambient_color = vec4(0.2, 0.4, 0.2, 1.0);",
-		"		const vec4 diffuse_color = vec4(0.8, 0.2, 0.2, 1.0);",
-		"		const vec4 specular_color = vec4(1.0, 1.0, 1.0, 1.0);",
-		"		const float shininess = 40.0;",
+		const int MAX_STEPS = 887;	// 887 for 512^3, 1774 for 1024^3
+		const int REFINEMENT_STEPS = 4;
+		const float relative_step_size = 1.0;
+		const vec4 ambient_color = vec4(0.2, 0.4, 0.2, 1.0);
+		const vec4 diffuse_color = vec4(0.8, 0.2, 0.2, 1.0);
+		const vec4 specular_color = vec4(1.0, 1.0, 1.0, 1.0);
+		const float shininess = 40.0;
 
-		"		void cast_mip(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray);",
-		"		void cast_iso(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray);",
+		void cast_mip(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray);
+		void cast_iso(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray);
 
-		"		float sample1(vec3 texcoords);",
-		"		vec4 apply_colormap(float val);",
-		"		vec4 add_lighting(float val, vec3 loc, vec3 step, vec3 view_ray);",
-
-
-		"		void main() {",
-		// Normalize clipping plane info
-		"				vec3 farpos = v_farpos.xyz / v_farpos.w;",
-		"				vec3 nearpos = v_nearpos.xyz / v_nearpos.w;",
-
-		// Calculate unit vector pointing in the view direction through this fragment.
-		"				vec3 view_ray = normalize(nearpos.xyz - farpos.xyz);",
-
-		// Compute the (negative) distance to the front surface or near clipping plane.
-		// v_position is the back face of the cuboid, so the initial distance calculated in the dot
-		// product below is the distance from near clip plane to the back of the cuboid
-		"				float distance = dot(nearpos - v_position, view_ray);",
-		"				distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,",
-		"																		(u_size.x - 0.5 - v_position.x) / view_ray.x));",
-		"				distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,",
-		"																		(u_size.y - 0.5 - v_position.y) / view_ray.y));",
-		"				distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,",
-		"																		(u_size.z - 0.5 - v_position.z) / view_ray.z));",
-
-		// Now we have the starting position on the front surface
-		"				vec3 front = v_position + view_ray * distance;",
-
-		// Decide how many steps to take
-		"				int nsteps = int(-distance / relative_step_size + 0.5);",
-		"				if ( nsteps < 1 )",
-		"						discard;",
-
-		// Get starting location and step vector in texture coordinates
-		"				vec3 step = ((v_position - front) / u_size) / float(nsteps);",
-		"				vec3 start_loc = front / u_size;",
-
-		// For testing: show the number of steps. This helps to establish
-		// whether the rays are correctly oriented
-		//'gl_FragColor = vec4(0.0, float(nsteps) / 1.0 / u_size.x, 1.0, 1.0);',
-		//'return;',
-
-		"				if (u_renderstyle == 0)",
-		"						cast_mip(start_loc, step, nsteps, view_ray);",
-		"				else if (u_renderstyle == 1)",
-		"						cast_iso(start_loc, step, nsteps, view_ray);",
-
-		"				if (gl_FragColor.a < 0.05)",
-		"						discard;",
-		"		}",
+		float sample1(vec3 texcoords);
+		vec4 apply_colormap(float val);
+		vec4 add_lighting(float val, vec3 loc, vec3 step, vec3 view_ray);
 
 
-		"		float sample1(vec3 texcoords) {",
-		"				/* Sample float value from a 3D texture. Assumes intensity data. */",
-		"				return texture(u_data, texcoords.xyz).r;",
-		"		}",
+		void main() {
+				// Normalize clipping plane info
+				vec3 farpos = v_farpos.xyz / v_farpos.w;
+				vec3 nearpos = v_nearpos.xyz / v_nearpos.w;
+
+				// Calculate unit vector pointing in the view direction through this fragment.
+				vec3 view_ray = normalize(nearpos.xyz - farpos.xyz);
+
+				// Compute the (negative) distance to the front surface or near clipping plane.
+				// v_position is the back face of the cuboid, so the initial distance calculated in the dot
+				// product below is the distance from near clip plane to the back of the cuboid
+				float distance = dot(nearpos - v_position, view_ray);
+				distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,
+																		(u_size.x - 0.5 - v_position.x) / view_ray.x));
+				distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,
+																		(u_size.y - 0.5 - v_position.y) / view_ray.y));
+				distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
+																		(u_size.z - 0.5 - v_position.z) / view_ray.z));
+
+				// Now we have the starting position on the front surface
+				vec3 front = v_position + view_ray * distance;
+
+				// Decide how many steps to take
+				int nsteps = int(-distance / relative_step_size + 0.5);
+				if ( nsteps < 1 )
+						discard;
+
+				// Get starting location and step vector in texture coordinates
+				vec3 step = ((v_position - front) / u_size) / float(nsteps);
+				vec3 start_loc = front / u_size;
+
+				// For testing: show the number of steps. This helps to establish
+				// whether the rays are correctly oriented
+				//'gl_FragColor = vec4(0.0, float(nsteps) / 1.0 / u_size.x, 1.0, 1.0);',
+				//'return;',
+
+				if (u_renderstyle == 0)
+						cast_mip(start_loc, step, nsteps, view_ray);
+				else if (u_renderstyle == 1)
+						cast_iso(start_loc, step, nsteps, view_ray);
+
+				if (gl_FragColor.a < 0.05)
+						discard;
+		}
 
 
-		"		vec4 apply_colormap(float val) {",
-		"				val = (val - u_clim[0]) / (u_clim[1] - u_clim[0]);",
-		"				return texture2D(u_cmdata, vec2(val, 0.5));",
-		"		}",
+		float sample1(vec3 texcoords) {
+				/* Sample float value from a 3D texture. Assumes intensity data. */
+				return texture(u_data, texcoords.xyz).r;
+		}
 
 
-		"		void cast_mip(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray) {",
-
-		"				float max_val = -1e6;",
-		"				int max_i = 100;",
-		"				vec3 loc = start_loc;",
-
-		// Enter the raycasting loop. In WebGL 1 the loop index cannot be compared with
-		// non-constant expression. So we use a hard-coded max, and an additional condition
-		// inside the loop.
-		"				for (int iter=0; iter<MAX_STEPS; iter++) {",
-		"						if (iter >= nsteps)",
-		"								break;",
-		// Sample from the 3D texture
-		"						float val = sample1(loc);",
-		// Apply MIP operation
-		"						if (val > max_val) {",
-		"								max_val = val;",
-		"								max_i = iter;",
-		"						}",
-		// Advance location deeper into the volume
-		"						loc += step;",
-		"				}",
-
-		// Refine location, gives crispier images
-		"				vec3 iloc = start_loc + step * (float(max_i) - 0.5);",
-		"				vec3 istep = step / float(REFINEMENT_STEPS);",
-		"				for (int i=0; i<REFINEMENT_STEPS; i++) {",
-		"						max_val = max(max_val, sample1(iloc));",
-		"						iloc += istep;",
-		"				}",
-
-		// Resolve final color
-		"				gl_FragColor = apply_colormap(max_val);",
-		"		}",
+		vec4 apply_colormap(float val) {
+				val = (val - u_clim[0]) / (u_clim[1] - u_clim[0]);
+				return texture2D(u_cmdata, vec2(val, 0.5));
+		}
 
 
-		"		void cast_iso(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray) {",
+		void cast_mip(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray) {
 
-		"				gl_FragColor = vec4(0.0);	// init transparent",
-		"				vec4 color3 = vec4(0.0);	// final color",
-		"				vec3 dstep = 1.5 / u_size;	// step to sample derivative",
-		"				vec3 loc = start_loc;",
+				float max_val = -1e6;
+				int max_i = 100;
+				vec3 loc = start_loc;
 
-		"				float low_threshold = u_renderthreshold - 0.02 * (u_clim[1] - u_clim[0]);",
+				// Enter the raycasting loop. In WebGL 1 the loop index cannot be compared with
+				// non-constant expression. So we use a hard-coded max, and an additional condition
+				// inside the loop.
+				for (int iter=0; iter<MAX_STEPS; iter++) {
+						if (iter >= nsteps)
+								break;
+						// Sample from the 3D texture
+						float val = sample1(loc);
+						// Apply MIP operation
+						if (val > max_val) {
+								max_val = val;
+								max_i = iter;
+						}
+						// Advance location deeper into the volume
+						loc += step;
+				}
 
-		// Enter the raycasting loop. In WebGL 1 the loop index cannot be compared with
-		// non-constant expression. So we use a hard-coded max, and an additional condition
-		// inside the loop.
-		"				for (int iter=0; iter<MAX_STEPS; iter++) {",
-		"						if (iter >= nsteps)",
-		"								break;",
+				// Refine location, gives crispier images
+				vec3 iloc = start_loc + step * (float(max_i) - 0.5);
+				vec3 istep = step / float(REFINEMENT_STEPS);
+				for (int i=0; i<REFINEMENT_STEPS; i++) {
+						max_val = max(max_val, sample1(iloc));
+						iloc += istep;
+				}
 
-		// Sample from the 3D texture
-		"						float val = sample1(loc);",
-
-		"						if (val > low_threshold) {",
-		// Take the last interval in smaller steps
-		"								vec3 iloc = loc - 0.5 * step;",
-		"								vec3 istep = step / float(REFINEMENT_STEPS);",
-		"								for (int i=0; i<REFINEMENT_STEPS; i++) {",
-		"										val = sample1(iloc);",
-		"										if (val > u_renderthreshold) {",
-		"												gl_FragColor = add_lighting(val, iloc, dstep, view_ray);",
-		"												return;",
-		"										}",
-		"										iloc += istep;",
-		"								}",
-		"						}",
-
-		// Advance location deeper into the volume
-		"						loc += step;",
-		"				}",
-		"		}",
+				// Resolve final color
+				gl_FragColor = apply_colormap(max_val);
+		}
 
 
-		"		vec4 add_lighting(float val, vec3 loc, vec3 step, vec3 view_ray)",
-		"		{",
-		// Calculate color by incorporating lighting
+		void cast_iso(vec3 start_loc, vec3 step, int nsteps, vec3 view_ray) {
 
-		// View direction
-		"				vec3 V = normalize(view_ray);",
+				gl_FragColor = vec4(0.0);	// init transparent
+				vec4 color3 = vec4(0.0);	// final color
+				vec3 dstep = 1.5 / u_size;	// step to sample derivative
+				vec3 loc = start_loc;
 
-		// calculate normal vector from gradient
-		"				vec3 N;",
-		"				float val1, val2;",
-		"				val1 = sample1(loc + vec3(-step[0], 0.0, 0.0));",
-		"				val2 = sample1(loc + vec3(+step[0], 0.0, 0.0));",
-		"				N[0] = val1 - val2;",
-		"				val = max(max(val1, val2), val);",
-		"				val1 = sample1(loc + vec3(0.0, -step[1], 0.0));",
-		"				val2 = sample1(loc + vec3(0.0, +step[1], 0.0));",
-		"				N[1] = val1 - val2;",
-		"				val = max(max(val1, val2), val);",
-		"				val1 = sample1(loc + vec3(0.0, 0.0, -step[2]));",
-		"				val2 = sample1(loc + vec3(0.0, 0.0, +step[2]));",
-		"				N[2] = val1 - val2;",
-		"				val = max(max(val1, val2), val);",
+				float low_threshold = u_renderthreshold - 0.02 * (u_clim[1] - u_clim[0]);
 
-		"				float gm = length(N); // gradient magnitude",
-		"				N = normalize(N);",
+				// Enter the raycasting loop. In WebGL 1 the loop index cannot be compared with
+				// non-constant expression. So we use a hard-coded max, and an additional condition
+				// inside the loop.
+				for (int iter=0; iter<MAX_STEPS; iter++) {
+						if (iter >= nsteps)
+								break;
 
-		// Flip normal so it points towards viewer
-		"				float Nselect = float(dot(N, V) > 0.0);",
-		"				N = (2.0 * Nselect - 1.0) * N;	// ==	Nselect * N - (1.0-Nselect)*N;",
+						// Sample from the 3D texture
+						float val = sample1(loc);
 
-		// Init colors
-		"				vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);",
-		"				vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);",
-		"				vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);",
+						if (val > low_threshold) {
+								// Take the last interval in smaller steps
+								vec3 iloc = loc - 0.5 * step;
+								vec3 istep = step / float(REFINEMENT_STEPS);
+								for (int i=0; i<REFINEMENT_STEPS; i++) {
+										val = sample1(iloc);
+										if (val > u_renderthreshold) {
+												gl_FragColor = add_lighting(val, iloc, dstep, view_ray);
+												return;
+										}
+										iloc += istep;
+								}
+						}
 
-		// note: could allow multiple lights
-		"				for (int i=0; i<1; i++)",
-		"				{",
-								 // Get light direction (make sure to prevent zero devision)
-		"						vec3 L = normalize(view_ray);	//lightDirs[i];",
-		"						float lightEnabled = float( length(L) > 0.0 );",
-		"						L = normalize(L + (1.0 - lightEnabled));",
+						// Advance location deeper into the volume
+						loc += step;
+				}
+		}
 
-		// Calculate lighting properties
-		"						float lambertTerm = clamp(dot(N, L), 0.0, 1.0);",
-		"						vec3 H = normalize(L+V); // Halfway vector",
-		"						float specularTerm = pow(max(dot(H, N), 0.0), shininess);",
 
-		// Calculate mask
-		"						float mask1 = lightEnabled;",
+		vec4 add_lighting(float val, vec3 loc, vec3 step, vec3 view_ray)
+		{
+				// Calculate color by incorporating lighting
 
-		// Calculate colors
-		"						ambient_color +=	mask1 * ambient_color;	// * gl_LightSource[i].ambient;",
-		"						diffuse_color +=	mask1 * lambertTerm;",
-		"						specular_color += mask1 * specularTerm * specular_color;",
-		"				}",
+				// View direction
+				vec3 V = normalize(view_ray);
 
-		// Calculate final color by componing different components
-		"				vec4 final_color;",
-		"				vec4 color = apply_colormap(val);",
-		"				final_color = color * (ambient_color + diffuse_color) + specular_color;",
-		"				final_color.a = color.a;",
-		"				return final_color;",
-		"		}",
-	].join( "\n" )
+				// calculate normal vector from gradient
+				vec3 N;
+				float val1, val2;
+				val1 = sample1(loc + vec3(-step[0], 0.0, 0.0));
+				val2 = sample1(loc + vec3(+step[0], 0.0, 0.0));
+				N[0] = val1 - val2;
+				val = max(max(val1, val2), val);
+				val1 = sample1(loc + vec3(0.0, -step[1], 0.0));
+				val2 = sample1(loc + vec3(0.0, +step[1], 0.0));
+				N[1] = val1 - val2;
+				val = max(max(val1, val2), val);
+				val1 = sample1(loc + vec3(0.0, 0.0, -step[2]));
+				val2 = sample1(loc + vec3(0.0, 0.0, +step[2]));
+				N[2] = val1 - val2;
+				val = max(max(val1, val2), val);
+
+				float gm = length(N); // gradient magnitude
+				N = normalize(N);
+
+				// Flip normal so it points towards viewer
+				float Nselect = float(dot(N, V) > 0.0);
+				N = (2.0 * Nselect - 1.0) * N;	// ==	Nselect * N - (1.0-Nselect)*N;
+
+				// Init colors
+				vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
+				vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
+				vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
+
+				// note: could allow multiple lights
+				for (int i=0; i<1; i++)
+				{
+						// Get light direction (make sure to prevent zero devision)
+						vec3 L = normalize(view_ray);	//lightDirs[i];
+						float lightEnabled = float( length(L) > 0.0 );
+						L = normalize(L + (1.0 - lightEnabled));
+
+						// Calculate lighting properties
+						float lambertTerm = clamp(dot(N, L), 0.0, 1.0);
+						vec3 H = normalize(L+V); // Halfway vector
+						float specularTerm = pow(max(dot(H, N), 0.0), shininess);
+
+						// Calculate mask
+						float mask1 = lightEnabled;
+
+						// Calculate colors
+						ambient_color +=	mask1 * ambient_color;	// * gl_LightSource[i].ambient;
+						diffuse_color +=	mask1 * lambertTerm;
+						specular_color += mask1 * specularTerm * specular_color;
+				}
+
+				// Calculate final color by componing different components
+				vec4 final_color;
+				vec4 color = apply_colormap(val);
+				final_color = color * (ambient_color + diffuse_color) + specular_color;
+				final_color.a = color.a;
+				return final_color;
+		}
+`
 };

--- a/examples/js/shaders/VolumeShader.js
+++ b/examples/js/shaders/VolumeShader.js
@@ -89,7 +89,7 @@ THREE.VolumeRenderShader1 = {
 				v_position = position;
 				gl_Position = projectionMatrix * viewMatrix * modelMatrix * position4;
 		}
-`,
+	`,
 	fragmentShader: /* glsl */`
 		precision highp float;
 		precision mediump sampler3D;
@@ -320,5 +320,5 @@ THREE.VolumeRenderShader1 = {
 				final_color.a = color.a;
 				return final_color;
 		}
-`
+	`
 };

--- a/examples/js/shaders/WaterRefractionShader.js
+++ b/examples/js/shaders/WaterRefractionShader.js
@@ -72,8 +72,8 @@ THREE.WaterRefractionShader = {
 
 		"void main() {",
 
-		" float waveStrength = 0.1;",
-		" float waveSpeed = 0.03;",
+		"	float waveStrength = 0.1;",
+		"	float waveSpeed = 0.03;",
 
 		// simple distortion (ripple) via dudv map (see https://www.youtube.com/watch?v=6B7IF6GOu7s)
 
@@ -83,8 +83,8 @@ THREE.WaterRefractionShader = {
 
 		// new uv coords
 
-		" vec4 uv = vec4( vUvRefraction );",
-		" uv.xy += distortion;",
+		"	vec4 uv = vec4( vUvRefraction );",
+		"	uv.xy += distortion;",
 
 		"	vec4 base = texture2DProj( tDiffuse, uv );",
 

--- a/examples/js/shaders/WaterRefractionShader.js
+++ b/examples/js/shaders/WaterRefractionShader.js
@@ -30,63 +30,63 @@ THREE.WaterRefractionShader = {
 	},
 
 	vertexShader: /* glsl */`
-uniform mat4 textureMatrix;
+		uniform mat4 textureMatrix;
 
-varying vec2 vUv;
-varying vec4 vUvRefraction;
+		varying vec2 vUv;
+		varying vec4 vUvRefraction;
 
-void main() {
+		void main() {
 
-	vUv = uv;
+			vUv = uv;
 
-	vUvRefraction = textureMatrix * vec4( position, 1.0 );
+			vUvRefraction = textureMatrix * vec4( position, 1.0 );
 
-	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-}
-`,
+		}
+	`,
 
 	fragmentShader: /* glsl */`
-uniform vec3 color;
-uniform float time;
-uniform sampler2D tDiffuse;
-uniform sampler2D tDudv;
+		uniform vec3 color;
+		uniform float time;
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tDudv;
 
-varying vec2 vUv;
-varying vec4 vUvRefraction;
+		varying vec2 vUv;
+		varying vec4 vUvRefraction;
 
-float blendOverlay( float base, float blend ) {
+		float blendOverlay( float base, float blend ) {
 
-	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
+			return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-}
+		}
 
-vec3 blendOverlay( vec3 base, vec3 blend ) {
+		vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ),blendOverlay( base.b, blend.b ) );
+			return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ),blendOverlay( base.b, blend.b ) );
 
-}
+		}
 
-void main() {
+		void main() {
 
-	float waveStrength = 0.1;
-	float waveSpeed = 0.03;
+			float waveStrength = 0.1;
+			float waveSpeed = 0.03;
 
-	// simple distortion (ripple) via dudv map (see https://www.youtube.com/watch?v=6B7IF6GOu7s)
+			// simple distortion (ripple) via dudv map (see https://www.youtube.com/watch?v=6B7IF6GOu7s)
 
-	vec2 distortedUv = texture2D( tDudv, vec2( vUv.x + time * waveSpeed, vUv.y ) ).rg * waveStrength;
-	distortedUv = vUv.xy + vec2( distortedUv.x, distortedUv.y + time * waveSpeed );
-	vec2 distortion = ( texture2D( tDudv, distortedUv ).rg * 2.0 - 1.0 ) * waveStrength;
+			vec2 distortedUv = texture2D( tDudv, vec2( vUv.x + time * waveSpeed, vUv.y ) ).rg * waveStrength;
+			distortedUv = vUv.xy + vec2( distortedUv.x, distortedUv.y + time * waveSpeed );
+			vec2 distortion = ( texture2D( tDudv, distortedUv ).rg * 2.0 - 1.0 ) * waveStrength;
 
-	// new uv coords
+			// new uv coords
 
-	vec4 uv = vec4( vUvRefraction );
-	uv.xy += distortion;
+			vec4 uv = vec4( vUvRefraction );
+			uv.xy += distortion;
 
-	vec4 base = texture2DProj( tDiffuse, uv );
+			vec4 base = texture2DProj( tDiffuse, uv );
 
-	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
+			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-}
-`
+		}
+	`
 };

--- a/examples/js/shaders/WaterRefractionShader.js
+++ b/examples/js/shaders/WaterRefractionShader.js
@@ -29,68 +29,64 @@ THREE.WaterRefractionShader = {
 
 	},
 
-	vertexShader: [
+	vertexShader: /* glsl */`
+uniform mat4 textureMatrix;
 
-		"uniform mat4 textureMatrix;",
+varying vec2 vUv;
+varying vec4 vUvRefraction;
 
-		"varying vec2 vUv;",
-		"varying vec4 vUvRefraction;",
+void main() {
 
-		"void main() {",
+	vUv = uv;
 
-		"	vUv = uv;",
+	vUvRefraction = textureMatrix * vec4( position, 1.0 );
 
-		"	vUvRefraction = textureMatrix * vec4( position, 1.0 );",
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-		"	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+}
+`,
 
-		"}"
+	fragmentShader: /* glsl */`
+uniform vec3 color;
+uniform float time;
+uniform sampler2D tDiffuse;
+uniform sampler2D tDudv;
 
-	].join( "\n" ),
+varying vec2 vUv;
+varying vec4 vUvRefraction;
 
-	fragmentShader: [
+float blendOverlay( float base, float blend ) {
 
-		"uniform vec3 color;",
-		"uniform float time;",
-		"uniform sampler2D tDiffuse;",
-		"uniform sampler2D tDudv;",
+	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );
 
-		"varying vec2 vUv;",
-		"varying vec4 vUvRefraction;",
+}
 
-		"float blendOverlay( float base, float blend ) {",
+vec3 blendOverlay( vec3 base, vec3 blend ) {
 
-		"	return( base < 0.5 ? ( 2.0 * base * blend ) : ( 1.0 - 2.0 * ( 1.0 - base ) * ( 1.0 - blend ) ) );",
+	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ),blendOverlay( base.b, blend.b ) );
 
-		"}",
+}
 
-		"vec3 blendOverlay( vec3 base, vec3 blend ) {",
+void main() {
 
-		"	return vec3( blendOverlay( base.r, blend.r ), blendOverlay( base.g, blend.g ),blendOverlay( base.b, blend.b ) );",
+	float waveStrength = 0.1;
+	float waveSpeed = 0.03;
 
-		"}",
+	// simple distortion (ripple) via dudv map (see https://www.youtube.com/watch?v=6B7IF6GOu7s)
 
-		"void main() {",
+	vec2 distortedUv = texture2D( tDudv, vec2( vUv.x + time * waveSpeed, vUv.y ) ).rg * waveStrength;
+	distortedUv = vUv.xy + vec2( distortedUv.x, distortedUv.y + time * waveSpeed );
+	vec2 distortion = ( texture2D( tDudv, distortedUv ).rg * 2.0 - 1.0 ) * waveStrength;
 
-		"	float waveStrength = 0.1;",
-		"	float waveSpeed = 0.03;",
+	// new uv coords
 
-		// simple distortion (ripple) via dudv map (see https://www.youtube.com/watch?v=6B7IF6GOu7s)
+	vec4 uv = vec4( vUvRefraction );
+	uv.xy += distortion;
 
-		"	vec2 distortedUv = texture2D( tDudv, vec2( vUv.x + time * waveSpeed, vUv.y ) ).rg * waveStrength;",
-		"	distortedUv = vUv.xy + vec2( distortedUv.x, distortedUv.y + time * waveSpeed );",
-		"	vec2 distortion = ( texture2D( tDudv, distortedUv ).rg * 2.0 - 1.0 ) * waveStrength;",
+	vec4 base = texture2DProj( tDiffuse, uv );
 
-		// new uv coords
+	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
-		"	vec4 uv = vec4( vUvRefraction );",
-		"	uv.xy += distortion;",
-
-		"	vec4 base = texture2DProj( tDiffuse, uv );",
-
-		"	gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );",
-
-		"}"
-
-	].join( "\n" )
+}
+`
 };

--- a/examples/jsm/nodes/core/FunctionNode.js
+++ b/examples/jsm/nodes/core/FunctionNode.js
@@ -6,7 +6,7 @@
 import { TempNode } from './TempNode.js';
 import { NodeLib } from './NodeLib.js';
 
-var declarationRegexp = /^([a-z_0-9]+)\s([a-z_0-9]+)\s*\((.*?)\)/i,
+var declarationRegexp = /^(?:(?:\s*\/\/.*?\n)*)\s*([a-z_0-9]+)\s([a-z_0-9]+)\s*\((.*?)\)/i,
 	propertiesRegexp = /[a-z_0-9]+/ig;
 
 function FunctionNode( src, includes, extensions, keywords, type ) {

--- a/examples/webgl_instancing_modified.html
+++ b/examples/webgl_instancing_modified.html
@@ -72,25 +72,25 @@
 
 						var material = new THREE.MeshMatcapMaterial( { color: 0xaaaaff, matcap: texture } );
 
-						var colorParsChunk = [
-							'attribute vec3 instanceColor;',
-							'varying vec3 vInstanceColor;',
-							'#include <common>'
-						].join( '\n' );
+						var colorParsChunk = /* glsl */`
+							attribute vec3 instanceColor;
+							varying vec3 vInstanceColor;
+							#include <common>
+						`;
 
-						var instanceColorChunk = [
-							'#include <begin_vertex>',
-							'\tvInstanceColor = instanceColor;'
-						].join( '\n' );
+						var instanceColorChunk = /* glsl */`
+							#include <begin_vertex>
+							vInstanceColor = instanceColor;
+						`;
 
-						var fragmentParsChunk = [
-							'varying vec3 vInstanceColor;',
-							'#include <common>'
-						].join( '\n' );
+						var fragmentParsChunk = /* glsl */`
+							varying vec3 vInstanceColor;
+							#include <common>
+						`;
 
-						var colorChunk = [
-							'vec4 diffuseColor = vec4( diffuse * vInstanceColor, opacity );'
-						].join( '\n' );
+						var colorChunk = /* glsl */`
+							vec4 diffuseColor = vec4( diffuse * vInstanceColor, opacity );
+						`;
 
 						material.onBeforeCompile = function ( shader ) {
 

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -44,14 +44,14 @@
 					shader.vertexShader = 'uniform float time;\n' + shader.vertexShader;
 					shader.vertexShader = shader.vertexShader.replace(
 						'#include <begin_vertex>',
-						[
-							'float theta = sin( time + position.y ) / 2.0;',
-							'float c = cos( theta );',
-							'float s = sin( theta );',
-							'mat3 m = mat3( c, 0, s, 0, 1, 0, -s, 0, c );',
-							'vec3 transformed = vec3( position ) * m;',
-							'vNormal = vNormal * m;'
-						].join( '\n' )
+						/* glsl */`
+							float theta = sin( time + position.y ) / 2.0;
+							float c = cos( theta );
+							float s = sin( theta );
+							mat3 m = mat3( c, 0, s, 0, 1, 0, -s, 0, c );
+							vec3 transformed = vec3( position ) * m;
+							vNormal = vNormal * m;
+						`
 					);
 
 					materialShader = shader;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -1382,13 +1382,13 @@
 						var tex = new Nodes.TextureNode( getTexture( "brick" ) );
 						var sat = new Nodes.FloatNode( 0 );
 
-						var satrgb = new Nodes.FunctionNode( [
-							"vec3 satrgb( vec3 rgb, float adjustment ) {",
-							// include luminance function from LuminanceNode
-							"	vec3 intensity = vec3( luminance( rgb ) );",
-							"	return mix( intensity, rgb, adjustment );",
-							"}"
-						].join( "\n" ), [ Nodes.LuminanceNode.Nodes.luminance ] );
+						var satrgb = new Nodes.FunctionNode( /* glsl */`
+							vec3 satrgb( vec3 rgb, float adjustment ) {
+								// include luminance function from LuminanceNode
+								vec3 intensity = vec3( luminance( rgb ) );
+								return mix( intensity, rgb, adjustment );
+							}
+						`, [ Nodes.LuminanceNode.Nodes.luminance ] );
 
 						var saturation = new Nodes.FunctionCallNode( satrgb );
 						saturation.inputs.rgb = tex;
@@ -1869,49 +1869,49 @@
 
 						mtl = new Nodes.StandardNodeMaterial();
 
-						var hash2 = new Nodes.FunctionNode( [
-							"vec2 hash2(vec2 p) {",
-							"	return fract(sin(vec2(dot(p, vec2(123.4, 748.6)), dot(p, vec2(547.3, 659.3))))*5232.85324);",
-							"}"
-						].join( "\n" ) );
+						var hash2 = new Nodes.FunctionNode( /* glsl */`
+							vec2 hash2(vec2 p) {
+								return fract(sin(vec2(dot(p, vec2(123.4, 748.6)), dot(p, vec2(547.3, 659.3))))*5232.85324);
+							}
+						` );
 
-						var voronoi = new Nodes.FunctionNode( [
+						var voronoi = new Nodes.FunctionNode( /* glsl */`
 							// Based off of iq's described here: http://www.iquilezles.org/www/articles/voronoili
-							"float voronoi(vec2 p, in float time) {",
-							"	vec2 n = floor(p);",
-							"	vec2 f = fract(p);",
-							"	float md = 5.0;",
-							"	vec2 m = vec2(0.0);",
-							"	for (int i = -1; i <= 1; i++) {",
-							"		for (int j = -1; j <= 1; j++) {",
-							"			vec2 g = vec2(i, j);",
-							"			vec2 o = hash2(n + g);",
-							"			o = 0.5 + 0.5 * sin(time + 5.038 * o);",
-							"			vec2 r = g + o - f;",
-							"			float d = dot(r, r);",
-							"			if (d < md) {",
-							"				md = d;",
-							"				m = n+g+o;",
-							"			}",
-							"		}",
-							"	}",
-							"	return md;",
-							"}"
-						].join( "\n" ), [ hash2 ] ); // define hash2 as dependencies
+							float voronoi(vec2 p, in float time) {
+								vec2 n = floor(p);
+								vec2 f = fract(p);
+								float md = 5.0;
+								vec2 m = vec2(0.0);
+								for (int i = -1; i <= 1; i++) {
+									for (int j = -1; j <= 1; j++) {
+										vec2 g = vec2(i, j);
+										vec2 o = hash2(n + g);
+										o = 0.5 + 0.5 * sin(time + 5.038 * o);
+										vec2 r = g + o - f;
+										float d = dot(r, r);
+										if (d < md) {
+											md = d;
+											m = n+g+o;
+										}
+									}
+								}
+								return md;
+							}
+						`, [ hash2 ] ); // define hash2 as dependencies
 
-						var voronoiLayers = new Nodes.FunctionNode( [
+						var voronoiLayers = new Nodes.FunctionNode( /* glsl */`
 							// based on https://www.shadertoy.com/view/4tXSDf
-							"float voronoiLayers(vec2 p, in float time) {",
-							"	float v = 0.0;",
-							"	float a = 0.4;",
-							"	for (int i = 0; i < 3; i++) {",
-							"		v += voronoi(p, time) * a;",
-							"		p *= 2.0;",
-							"		a *= 0.5;",
-							"	}",
-							"	return v;",
-							"}"
-						].join( "\n" ), [ voronoi ] ); // define voronoi as dependencies
+							float voronoiLayers(vec2 p, in float time) {
+								float v = 0.0;
+								float a = 0.4;
+								for (int i = 0; i < 3; i++) {
+									v += voronoi(p, time) * a;
+									p *= 2.0;
+									a *= 0.5;
+								}
+								return v;
+							}
+						`, [ voronoi ] ); // define voronoi as dependencies
 
 						var time = new Nodes.TimerNode();
 						var timeScale = new Nodes.FloatNode( 2 );
@@ -2453,12 +2453,12 @@
 
 						mtl = new Nodes.PhongNodeMaterial();
 
-						var keywordsexample = new Nodes.FunctionNode( [
+						var keywordsexample = new Nodes.FunctionNode( /* glsl */`
 							// use "uv" reserved keyword
-							"vec4 keywordsexample( sampler2D texture ) {",
-							"	return texture2D( texture, myUV ) + vec4( position * myAlpha, 0.0 );",
-							"}"
-						].join( "\n" ) );
+							vec4 keywordsexample( sampler2D texture ) {
+								return texture2D( texture, myUV ) + vec( position * myAlpha, 0.0 );
+							}
+						` );
 
 						// add local keyword ( const only )
 						keywordsexample.keywords[ "myAlpha" ] = new Nodes.ConstNode( "float myAlpha .05" );
@@ -2667,14 +2667,14 @@
 
 						// VERTEX
 
-						var setMyVar = new Nodes.FunctionNode( [
-							"void setMyVar( vec3 pos ) {",
-							// set "myVar" in vertex shader in this example,
-							// can be used in fragment shader too or in rest of the current shader
-							"	myVar = pos;",
+						var setMyVar = new Nodes.FunctionNode( /* glsl */`
+							void setMyVar( vec3 pos ) {
+								// set "myVar" in vertex shader in this example,
+								// can be used in fragment shader too or in rest of the current shader
+								myVar = pos;
 
-							"}"
-						].join( "\n" ) );
+							}
+						` );
 
 						// add keyword
 						setMyVar.keywords[ "myVar" ] = varying;
@@ -2688,13 +2688,13 @@
 
 						// FRAGMENT
 
-						var clipFromPos = new Nodes.FunctionNode( [
-							"void clipFromPos( vec3 pos ) {",
+						var clipFromPos = new Nodes.FunctionNode( /* glsl */`
+							void clipFromPos( vec3 pos ) {
 
-							"	if ( pos.y < .0 ) discard;",
+								if ( pos.y < .0 ) discard;
 
-							"}"
-						].join( "\n" ) );
+							}
+						` );
 
 						var clipFromPosCall = new Nodes.FunctionCallNode( clipFromPos, {
 							pos: varying
@@ -2915,22 +2915,22 @@
 						var delta = new Nodes.Vector2Node( .5, .25 );
 						var alpha = new Nodes.FloatNode( 1 );
 
-						var blurtexture = new Nodes.FunctionNode( [
+						var blurtexture = new Nodes.FunctionNode( /* glsl */`
 							// Reference: TriangleBlurShader.js
-							"vec4 blurtexture(sampler2D texture, vec2 uv, vec2 delta) {",
-							"	vec4 color = vec4( 0.0 );",
-							"	float total = 0.0;",
-							// randomize the lookup values to hide the fixed number of samples
-							"	float offset = rand( uv );",
-							"	for ( float t = -BLUR_ITERATIONS; t <= BLUR_ITERATIONS; t ++ ) {",
-							"		float percent = ( t + offset - 0.5 ) / BLUR_ITERATIONS;",
-							"		float weight = 1.0 - abs( percent );",
-							"		color += texture2D( texture, uv + delta * percent ) * weight;",
-							"		total += weight;",
-							"	}",
-							"	return color / total;",
-							"}"
-						].join( "\n" ), [ new Nodes.ConstNode( "float BLUR_ITERATIONS 10.0" ) ] );
+							vec4 blurtexture(sampler2D texture, vec2 uv, vec2 delta) {
+								vec4 color = vec4( 0.0 );
+								float total = 0.0;
+								// randomize the lookup values to hide the fixed number of samples
+								float offset = rand( uv );
+								for ( float t = -BLUR_ITERATIONS; t <= BLUR_ITERATIONS; t ++ ) {
+									float percent = ( t + offset - 0.5 ) / BLUR_ITERATIONS;
+									float weight = 1.0 - abs( percent );
+									color += texture2D( texture, uv + delta * percent ) * weight;
+									total += weight;
+								}
+								return color / total;
+							}
+						`, [ new Nodes.ConstNode( "float BLUR_ITERATIONS 10.0" ) ] );
 
 						var blurredTexture = new Nodes.FunctionCallNode( blurtexture, {
 							texture: new Nodes.TextureNode( getTexture( "brick" ) ),
@@ -2977,28 +2977,28 @@
 
 						var scale = new Nodes.FloatNode( .02 );
 
-						var triplanarMapping = new Nodes.FunctionNode( [
+						var triplanarMapping = new Nodes.FunctionNode( /* glsl */`
 							// Reference: https://github.com/keijiro/StandardTriplanar
-							"vec4 triplanar_mapping( sampler2D texture, vec3 normal, vec3 position, float scale ) {",
+							vec4 triplanar_mapping( sampler2D texture, vec3 normal, vec3 position, float scale ) {
 
-							// Blending factor of triplanar mapping
-							"	vec3 bf = normalize( abs( normal ) );",
-							"	bf /= dot( bf, vec3( 1.0 ) );",
+								// Blending factor of triplanar mapping
+								vec3 bf = normalize( abs( normal ) );
+								bf /= dot( bf, vec3( 1.0 ) );
 
-							// Triplanar mapping
-							"	vec2 tx = position.yz * scale;",
-							"	vec2 ty = position.zx * scale;",
-							"	vec2 tz = position.xy * scale;",
+								// Triplanar mapping
+								vec2 tx = position.yz * scale;
+								vec2 ty = position.zx * scale;
+								vec2 tz = position.xy * scale;
 
-							// Base color
-							"	vec4 cx = texture2D(texture, tx) * bf.x;",
-							"	vec4 cy = texture2D(texture, ty) * bf.y;",
-							"	vec4 cz = texture2D(texture, tz) * bf.z;",
+								// Base color
+								vec4 cx = texture2D(texture, tx) * bf.x;
+								vec4 cy = texture2D(texture, ty) * bf.y;
+								vec4 cz = texture2D(texture, tz) * bf.z;
 
-							"	return cx + cy + cz;",
+								return cx + cy + cz;
 
-							"}"
-						].join( "\n" ) );
+							}
+						` );
 
 						var triplanarMappingTexture = new Nodes.FunctionCallNode( triplanarMapping, {
 							texture: new Nodes.TextureNode( getTexture( "brick" ) ),

--- a/examples/webgl_postprocessing_crossfade.html
+++ b/examples/webgl_postprocessing_crossfade.html
@@ -266,54 +266,49 @@
 							value: this.textures[ 0 ]
 						}
 					},
-					vertexShader: [
+					vertexShader: /* glsl */`
+						varying vec2 vUv;
 
-						"varying vec2 vUv;",
+						void main() {
 
-						"void main() {",
+							vUv = vec2( uv.x, uv.y );
+							gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-						"vUv = vec2( uv.x, uv.y );",
-						"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+						}
+					`,
+					fragmentShader: /* glsl */`
+						uniform float mixRatio;
 
-						"}"
+						uniform sampler2D tDiffuse1;
+						uniform sampler2D tDiffuse2;
+						uniform sampler2D tMixTexture;
 
-					].join( "\n" ),
-					fragmentShader: [
+						uniform int useTexture;
+						uniform float threshold;
 
-						"uniform float mixRatio;",
+						varying vec2 vUv;
 
-						"uniform sampler2D tDiffuse1;",
-						"uniform sampler2D tDiffuse2;",
-						"uniform sampler2D tMixTexture;",
+						void main() {
 
-						"uniform int useTexture;",
-						"uniform float threshold;",
+							vec4 texel1 = texture2D( tDiffuse1, vUv );
+							vec4 texel2 = texture2D( tDiffuse2, vUv );
 
-						"varying vec2 vUv;",
+							if (useTexture==1) {
 
-						"void main() {",
+								vec4 transitionTexel = texture2D( tMixTexture, vUv );
+								float r = mixRatio * (1.0 + threshold * 2.0) - threshold;
+								float mixf=clamp((transitionTexel.r - r)*(1.0/threshold), 0.0, 1.0);
 
-						"	vec4 texel1 = texture2D( tDiffuse1, vUv );",
-						"	vec4 texel2 = texture2D( tDiffuse2, vUv );",
+								gl_FragColor = mix( texel1, texel2, mixf );
 
-						"	if (useTexture==1) {",
+							} else {
 
-						"		vec4 transitionTexel = texture2D( tMixTexture, vUv );",
-						"		float r = mixRatio * (1.0 + threshold * 2.0) - threshold;",
-						"		float mixf=clamp((transitionTexel.r - r)*(1.0/threshold), 0.0, 1.0);",
+								gl_FragColor = mix( texel2, texel1, mixRatio );
 
-						"		gl_FragColor = mix( texel1, texel2, mixf );",
+							}
 
-						"	} else {",
-
-						"		gl_FragColor = mix( texel2, texel1, mixRatio );",
-
-						"	}",
-
-						"}"
-
-					].join( "\n" )
-
+						}
+					`
 				} );
 
 				var quadgeometry = new THREE.PlaneBufferGeometry( window.innerWidth, window.innerHeight );

--- a/examples/webgl_postprocessing_nodes.html
+++ b/examples/webgl_postprocessing_nodes.html
@@ -260,13 +260,13 @@
 						var screen = new Nodes.ScreenNode();
 						var sat = new Nodes.FloatNode( 0 );
 
-						var satrgb = new Nodes.FunctionNode( [
-							"vec3 satrgb( vec3 rgb, float adjustment ) {",
-							// include luminance function from LuminanceNode
-							"	vec3 intensity = vec3( luminance( rgb ) );",
-							"	return mix( intensity, rgb, adjustment );",
-							"}"
-						].join( "\n" ), [ Nodes.LuminanceNode.Nodes.luminance ] );
+						var satrgb = new Nodes.FunctionNode( /* glsl */`
+							vec3 satrgb( vec3 rgb, float adjustment ) {
+								// include luminance function from LuminanceNode
+								vec3 intensity = vec3( luminance( rgb ) );
+								return mix( intensity, rgb, adjustment );
+							}
+						`, [ Nodes.LuminanceNode.Nodes.luminance ] );
 
 						var saturation = new Nodes.FunctionCallNode( satrgb );
 						saturation.inputs.rgb = screen;

--- a/examples/webgl_postprocessing_nodes_pass.html
+++ b/examples/webgl_postprocessing_nodes_pass.html
@@ -260,13 +260,13 @@
 						var screen = new Nodes.ScreenNode();
 						var sat = new Nodes.FloatNode( 0 );
 
-						var satrgb = new Nodes.FunctionNode( [
-							"vec3 satrgb( vec3 rgb, float adjustment ) {",
-							// include luminance function from LuminanceNode
-							"	vec3 intensity = vec3( luminance( rgb ) );",
-							"	return mix( intensity, rgb, adjustment );",
-							"}"
-						].join( "\n" ), [ Nodes.LuminanceNode.Nodes.luminance ] );
+						var satrgb = new Nodes.FunctionNode( /* glsl */`
+							vec3 satrgb( vec3 rgb, float adjustment ) {
+								// include luminance function from LuminanceNode
+								vec3 intensity = vec3( luminance( rgb ) );
+								return mix( intensity, rgb, adjustment );
+							}
+						`, [ Nodes.LuminanceNode.Nodes.luminance ] );
 
 						var saturation = new Nodes.FunctionCallNode( satrgb );
 						saturation.inputs.rgb = screen;

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -65,30 +65,30 @@
 
 				uniforms: {},
 
-				vertexShader: [
-					"varying vec2 vUV;",
-					"varying vec3 vNormal;",
+				vertexShader: /* glsl */`
+					varying vec2 vUV;
+					varying vec3 vNormal;
 
-					"void main() {",
+					void main() {
 
-					"vUV = uv;",
-					"vNormal = vec3( normal );",
-					"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+						vUV = uv;
+						vNormal = vec3( normal );
+						gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-					"}"
-				].join( "\n" ),
+					}
+				`,
 
-				fragmentShader: [
-					"varying vec2 vUV;",
-					"varying vec3 vNormal;",
+				fragmentShader: /* glsl */`
+					varying vec2 vUV;
+					varying vec3 vNormal;
 
-					"void main() {",
+					void main() {
 
-					"vec4 c = vec4( abs( vNormal ) + vec3( vUV, 0.0 ), 0.0 );",
-					"gl_FragColor = c;",
+						vec4 c = vec4( abs( vNormal ) + vec3( vUV, 0.0 ), 0.0 );
+						gl_FragColor = c;
 
-					"}"
-				].join( "\n" )
+					}
+				`
 			} );
 
 			for ( var i = 0; i < 50; ++ i ) {

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -129,56 +129,53 @@
 						THREE.UniformsLib[ "lights" ]
 
 					] ),
-					vertexShader: [
-						"varying vec3 vViewPosition;",
-						"varying vec3 vNormal;",
-						"void main() {",
-						THREE.ShaderChunk[ "beginnormal_vertex" ],
-						THREE.ShaderChunk[ "defaultnormal_vertex" ],
+					vertexShader: /* glsl */`
+						varying vec3 vViewPosition;
+						varying vec3 vNormal;
+						void main() {
+							#include <beginnormal_vertex>
+							#include <defaultnormal_vertex>
 
-						"	vNormal = normalize( transformedNormal );",
-						"vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-						"vViewPosition = -mvPosition.xyz;",
-						"gl_Position = projectionMatrix * mvPosition;",
-						"}"
+							vNormal = normalize( transformedNormal );
+							vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+							vViewPosition = -mvPosition.xyz;
+							gl_Position = projectionMatrix * mvPosition;
+						}
+					`,
 
-					].join( "\n" ),
+					fragmentShader: /* glsl */`
+						#include <common>
+						#include <bsdfs>
+						#include <lights_pars_begin>
+						#include <lights_phong_pars_fragment>
 
-					fragmentShader: [
+						void main() {
+							vec3 normal = normalize( -vNormal );
+							vec3 viewPosition = normalize( vViewPosition );
+							#if NUM_DIR_LIGHTS > 0
 
-						THREE.ShaderChunk[ "common" ],
-						THREE.ShaderChunk[ "bsdfs" ],
-						THREE.ShaderChunk[ "lights_pars_begin" ],
-						THREE.ShaderChunk[ "lights_phong_pars_fragment" ],
+								vec3 dirDiffuse = vec3( 0.0 );
 
-						"void main() {",
-						"vec3 normal = normalize( -vNormal );",
-						"vec3 viewPosition = normalize( vViewPosition );",
-						"#if NUM_DIR_LIGHTS > 0",
+								for( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
-						"vec3 dirDiffuse = vec3( 0.0 );",
+									vec4 lDirection = viewMatrix * vec4( directionalLights[i].direction, 0.0 );
+									vec3 dirVector = normalize( lDirection.xyz );
+									float dotProduct = dot( viewPosition, dirVector );
+									dotProduct = 1.0 * max( dotProduct, 0.0 ) + (1.0 - max( -dot( normal, dirVector ), 0.0 ));
+									dotProduct *= dotProduct;
+									dirDiffuse += max( 0.5 * dotProduct, 0.0 ) * directionalLights[i].color;
+								}
+							#endif
 
-						"for( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {",
+							//Fade out atmosphere at edge
+							float viewDot = abs(dot( normal, viewPosition ));
+							viewDot = clamp( pow( viewDot + 0.6, 10.0 ), 0.0, 1.0);
 
-						"vec4 lDirection = viewMatrix * vec4( directionalLights[i].direction, 0.0 );",
-						"vec3 dirVector = normalize( lDirection.xyz );",
-						"float dotProduct = dot( viewPosition, dirVector );",
-						"dotProduct = 1.0 * max( dotProduct, 0.0 ) + (1.0 - max( -dot( normal, dirVector ), 0.0 ));",
-						"dotProduct *= dotProduct;",
-						"dirDiffuse += max( 0.5 * dotProduct, 0.0 ) * directionalLights[i].color;",
-						"}",
-						"#endif",
+							vec3 color = vec3( 0.05, 0.09, 0.13 ) * dirDiffuse;
+							gl_FragColor = vec4( color, viewDot );
 
-						//Fade out atmosphere at edge
-						"float viewDot = abs(dot( normal, viewPosition ));",
-						"viewDot = clamp( pow( viewDot + 0.6, 10.0 ), 0.0, 1.0);",
-
-						"vec3 color = vec3( 0.05, 0.09, 0.13 ) * dirDiffuse;",
-						"gl_FragColor = vec4( color, viewDot );",
-
-						"}"
-
-					].join( "\n" )
+						}
+						`
 				};
 
 				var earthAtmoMat = new THREE.ShaderMaterial( atmoShader );
@@ -248,31 +245,28 @@
 				sphereAtmoMesh.scale.set( 1.05, 1.05, 1.05 );
 				scene.add( sphereAtmoMesh );
 
-				var vBGShader = [
-					// "attribute vec2 uv;",
-					"varying vec2 vUv;",
-					"void main() {",
-					"vUv = uv;",
-					"gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
-					"}"
+				var vBGShader = /* glsl */`
+					// attribute vec2 uv;
+					varying vec2 vUv;
+					void main() {
+						vUv = uv;
+						gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+					}
+				`;
 
-				].join( "\n" );
+				var pBGShader = /* glsl */`
+					uniform sampler2D map;
+					varying vec2 vUv;
 
-				var pBGShader = [
+					void main() {
 
-					"uniform sampler2D map;",
-					"varying vec2 vUv;",
+						vec2 sampleUV = vUv;
+						vec4 color = texture2D( map, sampleUV, 0.0 );
 
-					"void main() {",
+						gl_FragColor = vec4( color.xyz, 1.0 );
 
-					"vec2 sampleUV = vUv;",
-					"vec4 color = texture2D( map, sampleUV, 0.0 );",
-
-					"gl_FragColor = vec4( color.xyz, 1.0 );",
-
-					"}"
-
-				].join( "\n" );
+					}
+				`;
 
 				// Skybox
 				adaptiveLuminanceMat = new THREE.ShaderMaterial( {

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -149,15 +149,15 @@
 					OperatorNode.ADD
 				);
 
-				var sineWaveFunction = new FunctionNode( [
+				var sineWaveFunction = new FunctionNode( /* glsl */`
 					// https://stackoverflow.com/questions/36174431/how-to-make-a-wave-warp-effect-in-shader
-					"vec2 sineWave(vec2 uv, vec2 phase) {",
-					// wave distortion
-					"	float x = sin( 25.0*uv.y + 30.0*uv.x + 6.28*phase.x) * 0.01;",
-					"	float y = sin( 25.0*uv.y + 30.0*uv.x + 6.28*phase.y) * 0.03;",
-					"	return vec2(uv.x+x, uv.y+y);",
-					"}"
-				].join( "\n" ) );
+					vec2 sineWave(vec2 uv, vec2 phase) {
+						// wave distortion
+						float x = sin( 25.0*uv.y + 30.0*uv.x + 6.28*phase.x) * 0.01;
+						float y = sin( 25.0*uv.y + 30.0*uv.x + 6.28*phase.y) * 0.03;
+						return vec2(uv.x+x, uv.y+y);
+					}
+				`);
 
 				scene.add( sprite3 = new THREE.Sprite( new SpriteNodeMaterial() ) );
 				sprite3.position.x = - 30;

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -28,43 +28,41 @@
 
 			var RADIUS = 75;
 
-			THREE.ShaderChunk[ 'lights_pars_begin' ] += [
-				'',
-				'#if defined TILED_FORWARD',
-				'uniform vec4 tileData;',
-				'uniform sampler2D tileTexture;',
-				'uniform sampler2D lightTexture;',
-				'#endif'
-			].join( '\n' );
+			THREE.ShaderChunk[ 'lights_pars_begin' ] += /* glsl */`
+				#if defined TILED_FORWARD
+					uniform vec4 tileData;
+					uniform sampler2D tileTexture;
+					uniform sampler2D lightTexture;
+				#endif
+			`;
 
-			THREE.ShaderChunk[ 'lights_fragment_end' ] += [
-				'',
-				'#if defined TILED_FORWARD',
-				'vec2 tUv = floor(gl_FragCoord.xy / tileData.xy * 32.) / 32. + tileData.zw;',
-				'vec4 tile = texture2D(tileTexture, tUv);',
-				'for (int i=0; i < 4; i++) {',
-				'	float tileVal = tile.x * 255.;',
-				'  	tile.xyzw = tile.yzwx;',
-				'	if(tileVal == 0.){ continue; }',
-				'  	float tileDiv = 128.;',
-				'	for (int j=0; j < 8; j++) {',
-				'  		if (tileVal < tileDiv) {  tileDiv *= 0.5; continue; }',
-				'		tileVal -= tileDiv;',
-				'		tileDiv *= 0.5;',
-				'  		PointLight pointlight;',
-				'		float uvx = (float(8 * i + j) + 0.5) / 32.;',
-				'  		vec4 lightData = texture2D(lightTexture, vec2(uvx, 0.));',
-				'  		vec4 lightColor = texture2D(lightTexture, vec2(uvx, 1.));',
-				'  		pointlight.position = lightData.xyz;',
-				'  		pointlight.distance = lightData.w;',
-				'  		pointlight.color = lightColor.rgb;',
-				'  		pointlight.decay = lightColor.a;',
-				'  		getPointDirectLightIrradiance( pointlight, geometry, directLight );',
-				'		RE_Direct( directLight, geometry, material, reflectedLight );',
-				'	}',
-				'}',
-				'#endif'
-			].join( '\n' );
+			THREE.ShaderChunk[ 'lights_fragment_end' ] += /* glsl */`
+				#if defined TILED_FORWARD
+					vec2 tUv = floor(gl_FragCoord.xy / tileData.xy * 32.) / 32. + tileData.zw;
+					vec4 tile = texture2D(tileTexture, tUv);
+					for (int i=0; i < 4; i++) {
+						float tileVal = tile.x * 255.;
+						tile.xyzw = tile.yzwx;
+						if(tileVal == 0.){ continue; }
+						float tileDiv = 128.;
+						for (int j=0; j < 8; j++) {
+							if (tileVal < tileDiv) {  tileDiv *= 0.5; continue; }
+							tileVal -= tileDiv;
+							tileDiv *= 0.5;
+							PointLight pointlight;
+							float uvx = (float(8 * i + j) + 0.5) / 32.;
+							vec4 lightData = texture2D(lightTexture, vec2(uvx, 0.));
+							vec4 lightColor = texture2D(lightTexture, vec2(uvx, 1.));
+							pointlight.position = lightData.xyz;
+							pointlight.distance = lightData.w;
+							pointlight.color = lightColor.rgb;
+							pointlight.decay = lightColor.a;
+							getPointDirectLightIrradiance( pointlight, geometry, directLight );
+							RE_Direct( directLight, geometry, material, reflectedLight );
+						}
+					}
+				#endif
+			`;
 
 			var lights = [];
 


### PR DESCRIPTION
Code is converted using [yushijinhun/convert-shader](https://github.com/yushijinhun/convert-shader) with some manual fixes.

* `/* glsl */` prefix is added, which should enable syntax highlighting (see #15473).
* Comments outside string literals are moved into the string template. For example:
    ```js
    [
        // this is comment
        "    this is code"
    ].join( "\n" )
    ```
    now becomes
    ```js
    /* glsl */`
        // this is comment
        this is code
    `
    ```
