### PR TITLE
LOD: Add ability to get current level

### DIFF
--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -60,6 +60,11 @@ scene.add( lod );
 		Default is true.
 		</p>
 
+		<h3>[property:integer currentLevel]</h3>
+		<p>
+		The currently active LOD level. As index of the levels array.
+		</p>
+
 		<h3>[property:array levels]</h3>
 		<p>
 		An array of [page:object level] objects<br /><br />

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -60,7 +60,7 @@ scene.add( lod );
 		Default is true.
 		</p>
 
-                <h3>[property:array levels]</h3>
+		<h3>[property:array levels]</h3>
 		<p>
 		An array of [page:object level] objects<br /><br />
 

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -59,7 +59,7 @@ scene.add( lod );
 		If set to false, you have to call [page:LOD.update]() in the render loop by yourself.
 		Default is true.
 		</p>
-			
+
                 <h3>[property:array levels]</h3>
 		<p>
 		An array of [page:object level] objects<br /><br />

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -59,13 +59,8 @@ scene.add( lod );
 		If set to false, you have to call [page:LOD.update]() in the render loop by yourself.
 		Default is true.
 		</p>
-
-		<h3>[property:integer currentLevel]</h3>
-		<p>
-		The currently active LOD level. As index of the levels array.
-		</p>
-
-		<h3>[property:array levels]</h3>
+			
+                <h3>[property:array levels]</h3>
 		<p>
 		An array of [page:object level] objects<br /><br />
 
@@ -91,6 +86,13 @@ scene.add( lod );
 		Returns a clone of this LOD object and its associated distance specific objects.
 		</p>
 
+
+		<h3>[method:integer getCurrentLevel]()</h3>
+		<p>
+		Get the currently active LOD level. As index of the levels array.
+		</p>
+
+		
 
 		<h3>[method:Object3D getObjectForDistance]( [param:Float distance] )</h3>
 		<p>

--- a/src/objects/LOD.d.ts
+++ b/src/objects/LOD.d.ts
@@ -12,7 +12,6 @@ export class LOD extends Object3D {
 	levels: { distance: number; object: Object3D }[];
 	autoUpdate: boolean;
 	readonly isLOD: true;
-	readonly _currentLevel: 0;
 
 	addLevel( object: Object3D, distance?: number ): this;
 	getCurrentLevel(): number;

--- a/src/objects/LOD.d.ts
+++ b/src/objects/LOD.d.ts
@@ -12,8 +12,10 @@ export class LOD extends Object3D {
 	levels: { distance: number; object: Object3D }[];
 	autoUpdate: boolean;
 	readonly isLOD: true;
+	readonly _currentLevel: 0;
 
 	addLevel( object: Object3D, distance?: number ): this;
+	getCurrentLevel(): number;
 	getObjectForDistance( distance: number ): Object3D | null;
 	raycast( raycaster: Raycaster, intersects: Intersection[] ): void;
 	update( camera: Camera ): void;

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -33,7 +33,7 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	constructor: LOD,
 
 	isLOD: true,
-	
+
 	copy: function ( source ) {
 
 		Object3D.prototype.copy.call( this, source, false );

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -7,13 +7,14 @@ import { Object3D } from '../core/Object3D.js';
  * @author mrdoob / http://mrdoob.com/
  */
 
-var _currentLevel = 0;
 var _v1 = new Vector3();
 var _v2 = new Vector3();
 
 function LOD() {
 
 	Object3D.call( this );
+
+	this.currentLevel = 0;
 
 	this.type = 'LOD';
 
@@ -77,12 +78,6 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		this.add( object );
 
 		return this;
-
-	},
-	
-	getCurrentLevel: function () {
-
-		return _currentLevel;
 
 	},
 
@@ -154,7 +149,7 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			}
 
-			_currentLevel = i - 1;
+			this.currentLevel = i - 1;
 
 			for ( ; i < l; i ++ ) {
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -81,9 +81,9 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	},
 
-        getCurrentLevel: function () {
+	getCurrentLevel: function () {
 
-                 return this._currentLevel;
+		return this._currentLevel;
 
 	},
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -32,6 +32,8 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	constructor: LOD,
 
 	isLOD: true,
+	
+	currentLevel: 0,
 
 	copy: function ( source ) {
 
@@ -146,6 +148,8 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 				}
 
 			}
+			
+			this.currentLevel = i - 1;
 
 			for ( ; i < l; i ++ ) {
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -14,8 +14,6 @@ function LOD() {
 
 	Object3D.call( this );
 
-	this.currentLevel = 0;
-
 	this.type = 'LOD';
 
 	Object.defineProperties( this, {
@@ -34,6 +32,8 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	constructor: LOD,
 
 	isLOD: true,
+
+	currentLevel: 0,
 
 	copy: function ( source ) {
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -14,6 +14,8 @@ function LOD() {
 
 	Object3D.call( this );
 
+	this._currentLevel = 0;
+
 	this.type = 'LOD';
 
 	Object.defineProperties( this, {
@@ -32,8 +34,6 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 	constructor: LOD,
 
 	isLOD: true,
-
-	currentLevel: 0,
 
 	copy: function ( source ) {
 
@@ -78,6 +78,12 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		this.add( object );
 
 		return this;
+
+	},
+
+        getCurrentLevel: function () {
+
+                 return this._currentLevel;
 
 	},
 
@@ -149,7 +155,7 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			}
 
-			this.currentLevel = i - 1;
+			this._currentLevel = i - 1;
 
 			for ( ; i < l; i ++ ) {
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -7,6 +7,7 @@ import { Object3D } from '../core/Object3D.js';
  * @author mrdoob / http://mrdoob.com/
  */
 
+var _currentLevel = 0;
 var _v1 = new Vector3();
 var _v2 = new Vector3();
 
@@ -33,8 +34,6 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	isLOD: true,
 	
-	currentLevel: 0,
-
 	copy: function ( source ) {
 
 		Object3D.prototype.copy.call( this, source, false );
@@ -78,6 +77,12 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 		this.add( object );
 
 		return this;
+
+	},
+	
+	getCurrentLevel: function () {
+
+		return _currentLevel;
 
 	},
 
@@ -148,8 +153,8 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 				}
 
 			}
-			
-			this.currentLevel = i - 1;
+
+			_currentLevel = i - 1;
 
 			for ( ; i < l; i ++ ) {
 


### PR DESCRIPTION
Sometimes it's useful to have the current LOD level. This is awkward to do outside of LOD as it involves duplicating the logic inside of LOD.

One use case is the loading of progressively larger textures when the LOD activates a certain level.