### PR TITLE
Editor: Fix call of SkeletonHelper.update().

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -79,9 +79,11 @@ var Viewport = function ( editor ) {
 
 			selectionBox.setFromObject( object );
 
-			if ( editor.helpers[ object.id ] !== undefined ) {
+			var helper = editor.helpers[ object.id ];
 
-				editor.helpers[ object.id ].update();
+			if ( helper !== undefined && helper.isSkeletonHelper !== true ) {
+
+				helper.update();
 
 			}
 

--- a/src/helpers/SkeletonHelper.d.ts
+++ b/src/helpers/SkeletonHelper.d.ts
@@ -9,6 +9,8 @@ export class SkeletonHelper extends LineSegments {
 	bones: Bone[];
 	root: Object3D;
 
+	readonly isSkeletonHelper: true;
+
 	getBoneList( object: Object3D ): Bone[];
 	update(): void;
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -85,6 +85,8 @@ function SkeletonHelper( object ) {
 SkeletonHelper.prototype = Object.create( LineSegments.prototype );
 SkeletonHelper.prototype.constructor = SkeletonHelper;
 
+SkeletonHelper.prototype.isSkeletonHelper = true;
+
 SkeletonHelper.prototype.updateMatrixWorld = function ( force ) {
 
 	var bones = this.bones;


### PR DESCRIPTION
`SkeletonHelper.update()` should not be called anymore. However, the `Viewport` class of the editor still uses it and thus produces unnecessary console errors.

The PR fixed this by introducing `SkeletonHelper.isSkeletonHelper`. It is used for a check in `Viewport`.