### PR TITLE
PropertyBinding: Remove check for "root" node name in findNode().

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -198,7 +198,7 @@ Object.assign( PropertyBinding, {
 
 	findNode: function ( root, nodeName ) {
 
-		if ( ! nodeName || nodeName === "" || nodeName === "root" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
+		if ( ! nodeName || nodeName === "" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
 
 			return root;
 


### PR DESCRIPTION
Fix #18526
Fix #16693

This PR removes a check in `PropertyBinding.findNode()` which  broke models where non-root nodes where names as `root`.