### PR TITLE
Editor: Fix black textures when loading JSON scenes.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -644,16 +644,6 @@ Editor.prototype = {
 	fromJSON: function ( json ) {
 
 		var loader = new THREE.ObjectLoader();
-
-		// backwards
-
-		if ( json.scene === undefined ) {
-
-			this.setScene( loader.parse( json ) );
-			return;
-
-		}
-
 		var camera = loader.parse( json.camera );
 
 		this.camera.copy( camera );
@@ -663,7 +653,11 @@ Editor.prototype = {
 		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
-		this.setScene( loader.parse( json.scene ) );
+		loader.parse( json.scene, ( scene ) => {
+
+			this.setScene( scene );
+
+		} );
 
 	},
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -540,17 +540,19 @@ var Loader = function ( editor ) {
 				var loader = new THREE.ObjectLoader();
 				loader.setResourcePath( scope.texturePath );
 
-				var result = loader.parse( data );
+				loader.parse( data, function ( result ) {
 
-				if ( result.isScene ) {
+					if ( result.isScene ) {
 
-					editor.execute( new SetSceneCommand( editor, result ) );
+						editor.execute( new SetSceneCommand( editor, result ) );
 
-				} else {
+					} else {
 
-					editor.execute( new AddObjectCommand( editor, result ) );
+						editor.execute( new AddObjectCommand( editor, result ) );
 
-				}
+					}
+
+				} );
 
 				break;
 


### PR DESCRIPTION
Fixed #15180.

Ensures the editor only sets a scene/object if textures are actually loaded. This done by moving the related logic in the `onLoad()` callback of `ObjectLoader.parse()`. The editor already use this approach when loading `glTF` assets.