### PR TITLE
FunctionNode: Allow leading whitespace in declaration regexp.

### DIFF
--- a/examples/jsm/nodes/core/FunctionNode.js
+++ b/examples/jsm/nodes/core/FunctionNode.js
@@ -6,7 +6,7 @@
 import { TempNode } from './TempNode.js';
 import { NodeLib } from './NodeLib.js';
 
-var declarationRegexp = /^([a-z_0-9]+)\s([a-z_0-9]+)\s*\((.*?)\)/i,
+var declarationRegexp = /^\s*([a-z_0-9]+)\s([a-z_0-9]+)\s*\((.*?)\)/i,
 	propertiesRegexp = /[a-z_0-9]+/ig;
 
 function FunctionNode( src, includes, extensions, keywords, type ) {


### PR DESCRIPTION
leading whitespace is common in copy-paste situations or when using multi-line template literals; this change allows (and ignores) leading whitespace when looking for glsl function declarations