### PR TITLE
LOD: Honor camera zoom

### DIFF
--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -128,9 +128,7 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 			_v1.setFromMatrixPosition( camera.matrixWorld );
 			_v2.setFromMatrixPosition( this.matrixWorld );
 
-			var distance = _v1.distanceTo( _v2 );
-
-			distance /= camera.zoom;
+			var distance = _v1.distanceTo( _v2 ) / camera.zoom;
 
 			levels[ 0 ].object.visible = true;
 

--- a/src/objects/LOD.js
+++ b/src/objects/LOD.js
@@ -130,6 +130,8 @@ LOD.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			var distance = _v1.distanceTo( _v2 );
 
+			distance /= camera.zoom;
+
 			levels[ 0 ].object.visible = true;
 
 			for ( var i = 1, l = levels.length; i < l; i ++ ) {


### PR DESCRIPTION
The use of camera.zoom creates an unintended effect that, even though the distanceToCamera may be far away, a close-up view is generated of a low-poly geometry

This pull request compensates for camera zoom, so that a higher level of detail is shown, based on distance and zoom.