### PR TITLE
Editor: Fix drag&drop in UIOutliner.

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -522,8 +522,23 @@ UIOutliner.prototype.setOptions = function ( options ) {
 
 		} else if ( area > 0.75 ) {
 
-			var nextObject = scene.getObjectById( this.nextSibling.value );
-			moveObject( object, nextObject.parent, nextObject );
+			var nextObject, parent;
+
+			if ( this.nextSibling !== null ) {
+
+				nextObject = scene.getObjectById( this.nextSibling.value );
+				parent = nextObject.parent;
+
+			} else {
+
+				// end of list (no next object)
+
+				nextObject = null;
+				parent = scene.getObjectById( this.value ).parent;
+
+			}
+
+			moveObject( object, parent, nextObject );
 
 		} else {
 


### PR DESCRIPTION
You can currently produce a runtime error (`Uncaught TypeError: Cannot read property 'value' of null`) if you try to drag&drop a 3D object to the bottom of a list. E.g. moving the box under the directional light is not possible.

![image](https://user-images.githubusercontent.com/12612165/73942164-e3d49e80-48ee-11ea-99fc-a231fbbbf285.png)

The PR fixes this by checking if the end of the list is reached and then adjusting the arguments for `moveObject()`. Fortunately, `MoveObjectCommand` can already handle the situation when `nextObject` is `undefined`.