### PR TITLE
Editor: Only rebuild geometry sidebar if type has changed.

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -61,6 +61,8 @@ var SidebarGeometry = function ( editor ) {
 	container.setDisplay( 'none' );
 	container.setPaddingTop( '20px' );
 
+	var currentGeometryType = null;
+
 	// Actions
 
 	/*
@@ -215,15 +217,21 @@ var SidebarGeometry = function ( editor ) {
 
 			//
 
-			parameters.clear();
+			if ( currentGeometryType !== geometry.type ) {
 
-			if ( geometry.type === 'BufferGeometry' || geometry.type === 'Geometry' ) {
+				parameters.clear();
 
-				parameters.add( new SidebarGeometryModifiers( editor, object ) );
+				if ( geometry.type === 'BufferGeometry' || geometry.type === 'Geometry' ) {
 
-			} else if ( geometryUIClasses[ geometry.type ] !== undefined ) {
+					parameters.add( new SidebarGeometryModifiers( editor, object ) );
 
-				parameters.add( new geometryUIClasses[ geometry.type ]( editor, object ) );
+				} else if ( geometryUIClasses[ geometry.type ] !== undefined ) {
+
+					parameters.add( new geometryUIClasses[ geometry.type ]( editor, object ) );
+
+				}
+
+				currentGeometryType = geometry.type;
 
 			}
 


### PR DESCRIPTION
AFAICS, it's only necessary to rebuild the UI if the geometry type has changed. This PR should save some unnecessary object creation/DOM manipulation. 