### PR TITLE
EventDispatcher: remove unwanted references in event objects.

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -76,6 +76,8 @@ Object.assign( EventDispatcher.prototype, {
 
 			}
 
+			event.target = null;
+
 		}
 
 	}


### PR DESCRIPTION
Use of EventDispatcher with long lasting event objects can create unwanted references to objects.

For example: the pre allocated  _removedEvent in Object3D at https://github.com/mrdoob/three.js/blob/9c9d05a2b91b2a76dd1e5b7409af39ed5205f49d/src/core/Object3D.js#L26 can will gain a 'target' reference to a removed Object3D if the object has any event listeners.

drop the reference after use to prevent this.