### PR TITLE
Editor: Ensure material browser shows correct material name.

### DIFF
--- a/editor/js/Sidebar.Project.js
+++ b/editor/js/Sidebar.Project.js
@@ -287,6 +287,7 @@ var SidebarProject = function ( editor ) {
 	} );
 
 	signals.materialAdded.add( refreshMaterialBrowserUI );
+	signals.materialChanged.add( refreshMaterialBrowserUI );
 	signals.materialRemoved.add( refreshMaterialBrowserUI );
 
 	function refreshMaterialBrowserUI() {


### PR DESCRIPTION
Another minor fix for the material browser. If the listbox is not refreshed when the material changes, the entries do not correctly show the current name of the material. Only when a new material is added or an existing is removed.