### PR TITLE
Fix typo in WebGLPrograms from frawbuffers to fragDepth

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -280,7 +280,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			index0AttributeName: material.index0AttributeName,
 
 			extensionDerivatives: material.extensions && material.extensions.derivatives,
-			extensionFragDepth: material.extensions && material.extensions.frawbuffers,
+			extensionFragDepth: material.extensions && material.extensions.fragDepth,
 			extensionDrawbuffers: material.extensions && material.extensions.drawbuffers,
 			extensionShaderTextureLOD: material.extensions && material.extensions.shaderTextureLOD,
 


### PR DESCRIPTION
Otherwise, it is no longer possible to enable the fragDepth extension.

Fixes #18576