### PR TITLE
Editor: Make "Minify Shaders" option more robust.

### DIFF
--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -158,7 +158,7 @@ var MenubarEdit = function ( editor ) {
 
 			var material = object.material;
 
-			if ( material.isShaderMaterial ) {
+			if ( material !== undefined && material.isShaderMaterial ) {
 
 				try {
 

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -118,10 +118,11 @@ var MenubarEdit = function ( editor ) {
 
 		var object = editor.selected;
 
-		var parent = object.parent;
-		if ( parent === undefined ) return; // avoid deleting the camera or scene
+		if ( object !== null && object.parent !== null ) {
 
-		editor.execute( new RemoveObjectCommand( editor, object ) );
+			editor.execute( new RemoveObjectCommand( editor, object ) );
+
+		}
 
 	} );
 	options.add( option );


### PR DESCRIPTION
Fixed #18553.

This PR should fix the last runtime error mentioned in the above issue. It happens when you select a 3D object without a material and then hit `Minify Shaders`.