### PR TITLE
Typo fix in WebGLRenderTarget.html doc page

### DIFF
--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -38,7 +38,7 @@
 		[page:Constant minFilter] - default is [page:Textures LinearFilter]. <br />
 		[page:Constant format] - default is [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
-		[page:Number anisotropy] - default is *1*. See [page:Texture.anistropy]<br />
+		[page:Number anisotropy] - default is *1*. See [page:Texture.anisotropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
 		[page:Boolean depthBuffer] - default is *true*. Set this to false if you don't need it. <br />
 		[page:Boolean stencilBuffer] - default is *true*. Set this to false if you don't need it.<br /><br />


### PR DESCRIPTION
From 'anistropy' to 'anisotropy'