### PR TITLE
Fix empty name problem in GLTFLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1826,7 +1826,7 @@ THREE.GLTFLoader = ( function () {
 
 			texture.flipY = false;
 
-			if ( textureDef.name !== undefined ) texture.name = textureDef.name;
+			if ( textureDef.name ) texture.name = textureDef.name;
 
 			// Ignore unknown mime types, like DDS files.
 			if ( source.mimeType in MIME_TYPE_FORMATS ) {
@@ -2163,7 +2163,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			if ( materialDef.name !== undefined ) material.name = materialDef.name;
+			if ( materialDef.name ) material.name = materialDef.name;
 
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = THREE.sRGBEncoding;
@@ -2654,7 +2654,7 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
-		if ( cameraDef.name !== undefined ) camera.name = cameraDef.name;
+		if ( cameraDef.name ) camera.name = cameraDef.name;
 
 		assignExtrasToUserData( camera, cameraDef );
 
@@ -2875,7 +2875,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			var name = animationDef.name !== undefined ? animationDef.name : 'animation_' + animationIndex;
+			var name = animationDef.name ? animationDef.name : 'animation_' + animationIndex;
 
 			return new THREE.AnimationClip( name, undefined, tracks );
 
@@ -2994,7 +2994,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			if ( nodeDef.name !== undefined ) {
+			if ( nodeDef.name ) {
 
 				node.userData.name = nodeDef.name;
 				node.name = THREE.PropertyBinding.sanitizeNodeName( nodeDef.name );
@@ -3152,7 +3152,7 @@ THREE.GLTFLoader = ( function () {
 			var parser = this;
 
 			var scene = new THREE.Scene();
-			if ( sceneDef.name !== undefined ) scene.name = sceneDef.name;
+			if ( sceneDef.name ) scene.name = sceneDef.name;
 
 			assignExtrasToUserData( scene, sceneDef );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1891,7 +1891,7 @@ var GLTFLoader = ( function () {
 
 			texture.flipY = false;
 
-			if ( textureDef.name !== undefined ) texture.name = textureDef.name;
+			if ( textureDef.name ) texture.name = textureDef.name;
 
 			// Ignore unknown mime types, like DDS files.
 			if ( source.mimeType in MIME_TYPE_FORMATS ) {
@@ -2228,7 +2228,7 @@ var GLTFLoader = ( function () {
 
 			}
 
-			if ( materialDef.name !== undefined ) material.name = materialDef.name;
+			if ( materialDef.name ) material.name = materialDef.name;
 
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;
@@ -2719,7 +2719,7 @@ var GLTFLoader = ( function () {
 
 		}
 
-		if ( cameraDef.name !== undefined ) camera.name = cameraDef.name;
+		if ( cameraDef.name ) camera.name = cameraDef.name;
 
 		assignExtrasToUserData( camera, cameraDef );
 
@@ -2940,7 +2940,7 @@ var GLTFLoader = ( function () {
 
 			}
 
-			var name = animationDef.name !== undefined ? animationDef.name : 'animation_' + animationIndex;
+			var name = animationDef.name ? animationDef.name : 'animation_' + animationIndex;
 
 			return new AnimationClip( name, undefined, tracks );
 
@@ -3059,7 +3059,7 @@ var GLTFLoader = ( function () {
 
 			}
 
-			if ( nodeDef.name !== undefined ) {
+			if ( nodeDef.name ) {
 
 				node.userData.name = nodeDef.name;
 				node.name = PropertyBinding.sanitizeNodeName( nodeDef.name );
@@ -3217,7 +3217,7 @@ var GLTFLoader = ( function () {
 			var parser = this;
 
 			var scene = new Scene();
-			if ( sceneDef.name !== undefined ) scene.name = sceneDef.name;
+			if ( sceneDef.name ) scene.name = sceneDef.name;
 
 			assignExtrasToUserData( scene, sceneDef );
 


### PR DESCRIPTION
References: 

https://github.com/mrdoob/three.js/issues/18530#issuecomment-583831617

https://spectrum.chat/react-three-fiber/general/help-required-unable-to-load-a-gltf-model~d77788d6-35ff-4e5d-b3e9-23682c661699

GLTF's can be exported with empty names, or missing names. GLTFLoader seems to have problems with the former. For instance, this is the nodes array of the following model: https://sketchfab.com/3d-models/red-city-356c773c4b9a45d8b9d4aa04c60ecb27

```jsx
  ...
  { mesh: 0, name: '' },
  { mesh: 1, name: '' },
  { mesh: 2, name: '' },
  { mesh: 3, name: '' }
```

GLTFLoader will auto generate names, like mesh_0, mesh_1 and so on, this happens in loadMesh:

```jsx
mesh.name = meshDef.name || ( 'mesh_' + meshIndex );
if ( geometries.length > 1 ) mesh.name += '_' + i;
```

Notice how it checks the string itself. So, by now the mesh has an actual name, but a small bug wipes it out again afterwards in the LoadNode function:

```jsx
if ( nodeDef.name !== undefined ) {
  node.userData.name = nodeDef.name;
  node.name = THREE.PropertyBinding.sanitizeNodeName( nodeDef.name );
}
```

Here it checks against undefined, so despite the def name being empty and the auto-generated name being present, it goes in there and overwrites the name with an empty string.

I have fixed all the other places that had this problem.