### PR TITLE
Docs: Update Quaternion.html

### DIFF
--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -12,9 +12,8 @@
 
 		<p class="desc">
 			Implementation of a [link:http://en.wikipedia.org/wiki/Quaternion quaternion].
-			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation rotating things]
-			without encountering the dreaded
-			[link:http://en.wikipedia.org/wiki/Gimbal_lock gimbal lock] issue, amongst other
+			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation describing rotations]
+			more concisely compared to 3x3 matrices, amongst other
 			advantages.
 		</p>
 

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -12,9 +12,7 @@
 
 		<p class="desc">
 			Implementation of a [link:http://en.wikipedia.org/wiki/Quaternion quaternion].
-			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation describing rotations]
-			more concisely compared to 3x3 matrices, amongst other
-			advantages.
+			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation rotating things].
 		</p>
 
 

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -12,9 +12,8 @@
 
 		<p class="desc">
 			Implementation of a [link:http://en.wikipedia.org/wiki/Quaternion quaternion].
-			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation rotating things]
-			without encountering the dreaded
-			[link:http://en.wikipedia.org/wiki/Gimbal_lock gimbal lock] issue, amongst other
+			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation describing rotations]
+			more concisely compared to 3x3 matrices, amongst other
 			advantages.
 		</p>
 

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -12,9 +12,7 @@
 
 		<p class="desc">
 			Implementation of a [link:http://en.wikipedia.org/wiki/Quaternion quaternion].
-			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation describing rotations]
-			more concisely compared to 3x3 matrices, amongst other
-			advantages.
+			This is used for [link:https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation rotating things].
 		</p>
 
 


### PR DESCRIPTION
### Summary

The [documentation page for quaternions](https://threejs.org/docs/#api/en/math/Quaternion) states that one of the reasons quaternions are used is to avoid gimbal lock. This is a common misconception. Gimbal lock will happen when describing rotations with Euler angles, regardless of whether these angles are composed together as 3 matrices, or 3 quaternions, or something else.

Gimbal lock is resolved when using an axis-angle system and composing rotations by multiplying into a stored quaternion (or matrix).

This PR fixes the doc by instead highlighting one of the reasons quaternions are typically used (less numbers required for storage), which is good because composing rotations requires less operations and is thus computationally faster.

### Why this matters

Quaternions are already somewhat intimidating due to requiring more mathematical background than you might usually need to understand how and why they work. I believe keeping this misconception in the doc further adds to any confusion the user may have, and at best obscures the real reasons why engines use quaternions (faster to compose, easier to interpolate).

This misconception may cause users to re-implement their systems to use quaternions when encountering gimbal lock, only to discover that that was not necessary to fix it nor sufficient, and that an axis-angle system with matrices may be perfectly fine and would have saved them a lot of time (this is exactly what happened to me a few years ago and hence why I'm here).

### Details

I want to start off by saying I'm not here to make any claims about the merits of quaternions and whether to encourage or dissuade people from using them. I simply want to be clear about (1) what exactly is it that quaternions do that you can't do with other systems of describing rotations and (2) what exactly causes gimbal lock and how to fix it.

Most of what I wanted to say here has been eloquently stated 20 years ago in the [gamdev.net discussion](https://www.gamedev.net/articles/programming/math-and-physics/do-we-really-need-quaternions-r1199) linked to in the doc here:

https://threejs.org/docs/index.html#api/en/math/Matrix4.makeRotationAxis

_Note that this doc states that constructing axis angles from matrices is a mathematically sound alternative to rotating with quaternions, which supports my point that gimbal lock is not uniquely solved by using quaternions._

The discussion above explains how you can use rotation matrices to get identical results to a system using quaternions (including creating a system that does not suffer from gimbal lock). The conclusion from that post is that we don't need quaternions. I believe there are valid reasons to use quaternions over matrices:

* Eric Haines explains [in this video](https://www.youtube.com/watch?v=Ocoibc7MoKg) that interpolating rotations correctly with axis-angle is much easier than with Euler angles, that this is simple to do with quaternions and that this simplicity is why many engines use quaternions. 
* Eric Lengyel's _Fundamentals of Game Engine Design_ volume 1 page 89 explains that even though rotating a vector by a quaternion actually takes more operations than rotating by a 3x3 matrix, composing quaternions together only takes 16 multiplies and 12 adds, compared to 27 multiplies and 18 adds required to compute the product of 3x3 matrices, so that gives you a computational speed up).

These are two good reasons to choose quaternions for your rotation system. Resolving gimbal lock is not one of them. In fact, a rotation system that uses quaternions is no more and no less susceptible to the issue of gimbal lock than one that uses matrices. It doesn't matter what method you're using to describe, store and compose your rotations. It matters whether you're using a system of 3 fixed angles (Euler) or a system that lets you accumulate rotations of arbitrary axis-angles.

If you're not convinced by the linked gamedev.net discussion, I put together this demo as a way to clearly show how a system with quaternions can gimbal lock:

https://gimbal-lock-quaternions.glitch.me/

Controls:

* Rotate the cubes with W,A,S,D and Q,E.
* Reset with R

_(doesn't really work on mobile, sorry)._ 

The easiest way to get the cubes to gimbal lock here is to hold D until you see the **-X** side head on. The top two scenes are now in a locked state. Notice that **W/S** and **Q/E** are now both rotating the cube in the same way. You can no longer rotate around the Z axis with Q/E (pointing perpendicular from the screen) as shown by the bottom two scenes which do not experience gimbal lock.

You can inspect the code for this here:

https://glitch.com/edit/#!/gimbal-lock-quaternions?path=index.html:1:0

Click on **index.html** on the left. Each of the 4 rotation systems is documented here. Towards the end is the rotation system that uses quaternions but still has gimbal lock. This essentially creates 3 quaternions, each has a set angle that is controlled by the keyboard, and those 3 quaternions are composed in a specific order before being set to the cube's rotation.

You might say this is "using quaternions wrong", but why do we not say that about matrices when used in that same way? The answer is that the choice to use quaternions vs matrices tells you nothing about whether a system will gimbal lock. It depends on how they're composed. It is therefore incorrect for the doc to state that quaternions are used to avoid gimbal lock.

### In Conclusion

I am happy to hear from the experts in this community about whether you agree that this is indeed a misconception that would be helpful to remove. I appreciate your time on this very lengthy PR for what is a single line doc change.

I hope the linked demo and code help untangle the ideas of quaternions vs matrices vs euler angles vs axis angles, if anyone has struggled with this as I have.