### PR TITLE
InstancedMesh: Improve normal matrix calculation

### DIFF
--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -3,7 +3,14 @@ vec3 transformedNormal = objectNormal;
 
 #ifdef USE_INSTANCING
 
-	transformedNormal = mat3( instanceMatrix ) * transformedNormal;
+	// this is in lieu of a per-instance normal-matrix
+	// shear transforms in the instance matrix are not supported
+
+	mat3 m = mat3( instanceMatrix );
+
+	transformedNormal /= vec3( dot( m[ 0 ], m[ 0 ] ), dot( m[ 1 ], m[ 1 ] ), dot( m[ 2 ], m[ 2 ] ) );
+
+	transformedNormal = m * transformedNormal;
 
 #endif
 


### PR DESCRIPTION
Fixes #18497

Implemented a work-around suggested by @zeux in #18497.

Non-uniform scale in the instance matrix is supported, but shear transforms, for example, are not.