### PR TITLE
Fix tests: wrong parameters

### DIFF
--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -546,7 +546,7 @@ export default QUnit.module( 'Maths', () => {
 			var b = new Vector3( 2, 3, 4 );
 			var c = new Matrix4().set( 1, 0, 0, 2, 0, 1, 0, 3, 0, 0, 1, 4, 0, 0, 0, 1 );
 
-			a.makeTranslation( b );
+			a.makeTranslation( b.x, b.y, b.z );
 			assert.ok( matrixEquals4( a, c ), "Passed!" );
 
 		} );

--- a/test/unit/src/math/Plane.tests.js
+++ b/test/unit/src/math/Plane.tests.js
@@ -126,7 +126,7 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "clone", ( assert ) => {
 
-			var a = new Plane( 2.0, 0.5, 0.25 );
+			var a = new Plane( new Vector3( 2.0, 0.5, 0.25 ) );
 			var b = a.clone();
 
 			assert.ok( a.equals( b ), "clones are equal" );


### PR DESCRIPTION
Two tests were using wrong parameters (individual numbers  instead of an object and the other way around)