### PR TITLE
Docs: Clean up page of ShadowMaterial and LightShadow classes.

### DIFF
--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -22,7 +22,7 @@
 		<p>
 		[page:Camera camera] - the light's view of the world.<br /><br />
 
-		Create a new [name]. This is not intended to be called directly - it is used as a base class by 
+		Create a new [name]. This is not intended to be called directly - it is used as a base class by
 		other light shadows.
 		</p>
 
@@ -48,7 +48,7 @@
 
 		<h3>[property:WebGLRenderTarget mapPass]</h3>
 		<p>
-			The distribution map generated using the internal camera; an occlusion is calculated based 
+			The distribution map generated using the internal camera; an occlusion is calculated based
 			on the distribution of depths. Computed internally during rendering.
 		</p>
 
@@ -74,7 +74,7 @@
 
 			High values will cause unwanted banding effects in the shadows - a greater [page:.mapSize mapSize]
 			will allow for a higher value to be used here before these effects become visible.<br />
-			If [page:WebGLRenderer.shadowMap.type] is set to [page:Renderer PCFSoftShadowMap], radius has 
+			If [page:WebGLRenderer.shadowMap.type] is set to [page:Renderer PCFSoftShadowMap], radius has
 			no effect and it is recommended to increase softness by decreasing [page:.mapSize mapSize] instead.<br /><br />
 
 			Note that this has no effect if the [page:WebGLRenderer.shadowMap.type] is set to [page:Renderer BasicShadowMap].
@@ -123,6 +123,8 @@
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		</p>
 	</body>
 </html>

--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -70,17 +70,17 @@ scene.add( helper );
 		</p>
 
 		<h2>Methods</h2>
-		
+
+		<p>
+			See the base [page:LightShadow LightShadow] class for common methods.
+		</p>
+
 		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 
 		light -- the light for which the shadow is being rendered.<br />
 		viewportIndex -- calculates the matrix for this viewport
-		</p>
-
-		<p>
-			See the base [page:LightShadow LightShadow] class for common methods.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/lights/shadows/SpotLightShadow.html
+++ b/docs/api/en/lights/shadows/SpotLightShadow.html
@@ -59,10 +59,10 @@ scene.add( helper );
 
 		<h2>Constructor</h2>
 
-		The constructor creates a [param:PerspectiveCamera PerspectiveCamera] to manage the shadow's view of the world.
+		<p>The constructor creates a [param:PerspectiveCamera PerspectiveCamera] to manage the shadow's view of the world.</p>
 
 		<h2>Properties</h2>
-		See the base [page:LightShadow LightShadow] class for common properties.
+		<p>See the base [page:LightShadow LightShadow] class for common properties.</p>
 
 
 	 <h3>[property:Camera camera]</h3>
@@ -80,7 +80,7 @@ scene.add( helper );
 	 </p>
 
 		<h2>Methods</h2>
-		See the base [page:LightShadow LightShadow] class for common methods.
+		<p>See the base [page:LightShadow LightShadow] class for common methods.</p>
 
 		<h3>[method:SpotLightShadow update]( [param:SpotLight light] )</h3>
 		<p>

--- a/docs/api/en/materials/ShadowMaterial.html
+++ b/docs/api/en/materials/ShadowMaterial.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Material] &rarr; [page:ShaderMaterial] &rarr;
+		[page:Material] &rarr;
 
 		<h1>[name]</h1>
 
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-var planeGeometry = new THREE.PlaneGeometry( 2000, 2000 );
+var planeGeometry = new THREE.PlaneBufferGeometry( 2000, 2000 );
 planeGeometry.rotateX( - Math.PI / 2 );
 
 var planeMaterial = new THREE.ShadowMaterial();
@@ -40,18 +40,18 @@ scene.add( plane );
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
-			Any property of the material (including any property inherited from [page:Material] and [page:ShaderMaterial]) can be passed in here.<br /><br />
+			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 		</p>
 
 
 		<h2>Properties</h2>
-		<p>See the base [page:Material] and [page:ShaderMaterial] classes for common properties.</p>
+		<p>See the base [page:Material] classes for common properties.</p>
 
 		<h3>[property:Boolean transparent]</h3>
 		<p>Defines whether this material is transparent. Default is *true*.</p>
 
 		<h2>Methods</h2>
-		<p>See the base [page:Material] and [page:ShaderMaterial] classes for common methods.</p>
+		<p>See the base [page:Material] classes for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/zh/lights/shadows/DirectionalLightShadow.html
+++ b/docs/api/zh/lights/shadows/DirectionalLightShadow.html
@@ -76,14 +76,15 @@ scene.add( helper );
 			在光的世界里。这用于生成场景的深度图;从光的角度来看，其他物体背后的物体将处于阴影中。<br /><br />
 		</p>
 
-
 		<h2>方法</h2>
 		<p>
-			有关常用方法，请参阅基础[page：LightShadow LightShadow]类。
+			有关常用方法，请参阅基础[page:LightShadow LightShadow]类。
 		</p>
 
 		<h2>源码</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		</p>
 	</body>
 </html>

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -70,16 +70,16 @@ scene.add( helper );
 
 		<h2>方法</h2>
 
+		<p>
+			共有方法请参见其基类[page:LightShadow LightShadow]。
+		</p>
+
 		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 
 		light -- the light for which the shadow is being rendered.<br />
 		viewportIndex -- calculates the matrix for this viewport
-		</p>
-		
-		<p>
-			共有方法请参见其基类[page:LightShadow LightShadow]。
 		</p>
 
 		<h2>源代码</h2>

--- a/docs/api/zh/lights/shadows/SpotLightShadow.html
+++ b/docs/api/zh/lights/shadows/SpotLightShadow.html
@@ -58,19 +58,21 @@ scene.add( helper );
 
 
 		<h2>构造函数</h2>
-		构造函数创建一个 [param:PerspectiveCamera PerspectiveCamera] 来管理阴影的世界视图
+		<p>构造函数创建一个 [param:PerspectiveCamera PerspectiveCamera] 来管理阴影的世界视图</p>
+
 		<h2>属性</h2>
-		有关常用属性，请参阅基础LightShadow类。
+		<p>有关常用属性，请参阅基础LightShadow类。</p>
+
 	 <h3>[property:Camera camera]</h3>
 	 <p>
 		 在光的世界里。这用于生成场景的深度图;从光的角度来看，其他物体背后的物体将处于阴影中。<br /><br />
 
 		 默认值为PerspectiveCamera，近剪裁平面为0.5。 fov将通过更新方法跟踪拥有SpotLight的角度属性。同样，aspect属性将跟踪mapSize的方面。如果设置了灯光的距离属性，则远剪裁平面将跟踪该值，否则默认为500。
-
 	 </p>
 
 		<h2>方法</h2>
-		有关常用方法，请参阅基础LightShadow类。
+		<p>有关常用方法，请参阅基础LightShadow类。</p>
+
 		<h3>[method:SpotLightShadow update]( [param:SpotLight light] )</h3>
 		<p>
 			根据传入的[page:SpotLight light]更新内部透视[page:.camera camera]。
@@ -78,6 +80,8 @@ scene.add( helper );
 
 		<h2>Source</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/src/lights/[name].js src/lights/[name].js]
+		</p>
 	</body>
 </html>

--- a/docs/api/zh/materials/ShadowMaterial.html
+++ b/docs/api/zh/materials/ShadowMaterial.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Material] &rarr; [page:ShaderMaterial] &rarr;
+		[page:Material] &rarr;
 
 		<h1>阴影材质([name])</h1>
 
@@ -17,13 +17,13 @@
 		</p>
 
 		<h3>例子(Example)</h3>
-	
+
 		<p>
 			[example:webgl_geometry_spline_editor geometry / spline / editor]
 		</p>
 
 		<code>
-var planeGeometry = new THREE.PlaneGeometry( 2000, 2000 );
+var planeGeometry = new THREE.PlaneBufferGeometry( 2000, 2000 );
 planeGeometry.rotateX( - Math.PI / 2 );
 
 var planeMaterial = new THREE.ShadowMaterial();
@@ -39,18 +39,18 @@ scene.add( plane );
 
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p> [page:Object parameters] - (可选)用于定义材质外观的对象，具有一个或多个属性。
-			材质的任何属性都可以从此处传入(包括从[page:Material] 和 [page:ShaderMaterial]继承的任何属性)。<br /><br />
+			材质的任何属性都可以从此处传入(包括从[page:Material]]继承的任何属性)。<br /><br />
 		</p>
 
 
 		<h2>属性(Properties)</h2>
-		<p>共有属性请参见其基类[page:Material]和[page:ShaderMaterial]。</p>
+		<p>共有属性请参见其基类[page:Material]。</p>
 
 		<h3>[property:Boolean transparent]</h3>
 		<p>定义此材质是否透明。默认值为 *true*。</p>
 
 		<h2>方法(Methods)</h2>
-		<p>共有方法请参见其基类[page:Material]和[page:ShaderMaterial]。</p>
+		<p>共有方法请参见其基类[page:Material]。</p>
 
 		<h2>源码(Source)</h2>
 


### PR DESCRIPTION
`ShadowMaterial` does not inherit from `ShaderMaterial`. Also some style improvements for `LightShadow` classes.