### PR TITLE
WebXRManager: Check if controller is defined in animation loop

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -468,7 +468,7 @@ function WebXRManager( renderer, gl ) {
 			var inputPose = null;
 			var gripPose = null;
 
-			if ( inputSource ) {
+			if ( controller && inputSource ) {
 
 				if ( controller.targetRay ) {
 
@@ -498,13 +498,13 @@ function WebXRManager( renderer, gl ) {
 
 			}
 
-			if ( controller.targetRay ) {
+			if ( controller && controller.targetRay ) {
 
 				controller.targetRay.visible = inputPose !== null;
 
 			}
 
-			if ( controller.grip ) {
+			if ( controller && controller.grip ) {
 
 				controller.grip.visible = gripPose !== null;
 


### PR DESCRIPTION
Using r113 in Oculus browser 8 on a Quest, trying to access the second controller inside the animation loop with `renderer.xr.controller(1)` leads an uncaught `TypeError` and crash. The same happens dropping back to r112. It is fixed by explicitly checking for the controller.

The entries in the `controllers` array appear not to be well defined at all times. If this is considered a browser bug I can file a report with Oculus, but this simple check avoids the issue.