### PR TITLE
BokehShader: Fix wrong format of render target.

### DIFF
--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -19,14 +19,12 @@ THREE.BokehPass = function ( scene, camera, params ) {
 	var width = params.width || window.innerWidth || 1;
 	var height = params.height || window.innerHeight || 1;
 
-	this.renderTargetColor = new THREE.WebGLRenderTarget( width, height, {
-		minFilter: THREE.LinearFilter,
-		magFilter: THREE.LinearFilter,
-		format: THREE.RGBFormat
+	this.renderTargetDepth = new THREE.WebGLRenderTarget( width, height, {
+		minFilter: THREE.NearestFilter,
+		magFilter: THREE.NearestFilter,
+		stencilBuffer: false
 	} );
-	this.renderTargetColor.texture.name = "BokehPass.color";
 
-	this.renderTargetDepth = this.renderTargetColor.clone();
 	this.renderTargetDepth.texture.name = "BokehPass.depth";
 
 	// depth material

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -4,11 +4,10 @@
 
 import {
 	Color,
-	LinearFilter,
 	MeshDepthMaterial,
+	NearestFilter,
 	NoBlending,
 	RGBADepthPacking,
-	RGBFormat,
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
@@ -33,14 +32,12 @@ var BokehPass = function ( scene, camera, params ) {
 	var width = params.width || window.innerWidth || 1;
 	var height = params.height || window.innerHeight || 1;
 
-	this.renderTargetColor = new WebGLRenderTarget( width, height, {
-		minFilter: LinearFilter,
-		magFilter: LinearFilter,
-		format: RGBFormat
+	this.renderTargetDepth = new WebGLRenderTarget( width, height, {
+		minFilter: NearestFilter,
+		magFilter: NearestFilter,
+		stencilBuffer: false
 	} );
-	this.renderTargetColor.texture.name = "BokehPass.color";
 
-	this.renderTargetDepth = this.renderTargetColor.clone();
 	this.renderTargetDepth.texture.name = "BokehPass.depth";
 
 	// depth material


### PR DESCRIPTION
Fixed #18607.

When using RGBA depth packing, you also need a render target with `RGBA` format 😉.