### PR TITLE
Material: Move vertexTangents to MeshStandardMaterial.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -298,13 +298,6 @@
 		Defines whether vertex coloring is used. Default is *false*.
 		</p>
 
-		<h3>[property:Boolean vertexTangents]</h3>
-		<p>
-		Defines whether precomputed vertex tangents, which must be provided in a vec4 "tangent" attribute,
-		are used. When disabled, tangents are derived automatically. Using precomputed tangents will give
-		more accurate normal map details in some cases, such as with mirrored UVs. Default is false.
-		</p>
-
 		<h3>[property:Boolean visible]</h3>
 		<p>
 		Defines whether this material is visible. Default is *true*.

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -250,6 +250,13 @@
 		<h3>[property:Boolean skinning]</h3>
 		<p>Define whether the material uses skinning. Default is false.</p>
 
+		<h3>[property:Boolean vertexTangents]</h3>
+		<p>
+		Defines whether precomputed vertex tangents, which must be provided in a vec4 "tangent" attribute,
+		are used. When disabled, tangents are derived automatically. Using precomputed tangents will give
+		more accurate normal map details in some cases, such as with mirrored UVs. Default is false.
+		</p>
+
 		<h3>[property:Boolean wireframe]</h3>
 		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
 

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -258,12 +258,6 @@ This starts at *0* and counts how many times [property:Boolean needsUpdate] is s
 Defines whether vertex coloring is used. Default is *false*.
 </p>
 
-<h3>[property:Boolean vertexTangents]</h3>
-<p>	Defines whether precomputed vertex tangents, which must be provided in a vec4 "tangent" attribute,
-	are used. When disabled, tangents are derived automatically. Using precomputed tangents will give
-	more accurate normal map details in some cases, such as with mirrored UVs. Default is false.
-</p>
-
 <h3>[property:Boolean visible]</h3>
 <p> 此材质是否可见。默认为*true*。
 </p>

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -201,6 +201,12 @@
 		<h3>[property:Boolean skinning]</h3>
 		<p>材质是否使用蒙皮。默认值为false。</p>
 
+		<h3>[property:Boolean vertexTangents]</h3>
+		<p>	Defines whether precomputed vertex tangents, which must be provided in a vec4 "tangent" attribute,
+			are used. When disabled, tangents are derived automatically. Using precomputed tangents will give
+			more accurate normal map details in some cases, such as with mirrored UVs. Default is false.
+		</p>
+
 		<h3>[property:Boolean wireframe]</h3>
 		<p>将几何体渲染为线框。默认值为*false*（即渲染为平面多边形）。</p>
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -109,6 +109,8 @@ MaterialLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		if ( json.morphNormals !== undefined ) material.morphNormals = json.morphNormals;
 		if ( json.dithering !== undefined ) material.dithering = json.dithering;
 
+		if ( json.vertexTangents !== undefined ) material.vertexTangents = json.vertexTangents;
+
 		if ( json.visible !== undefined ) material.visible = json.visible;
 
 		if ( json.toneMapped !== undefined ) material.toneMapped = json.toneMapped;

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -48,7 +48,6 @@ export interface MaterialParameters {
 	toneMapped?: boolean;
 	transparent?: boolean;
 	vertexColors?: boolean;
-	vertexTangents?: boolean;
 	visible?: boolean;
 	stencilWrite?: boolean;
 	stencilFunc?: StencilFunc;
@@ -289,11 +288,6 @@ export class Material extends EventDispatcher {
 	 * Defines whether vertex coloring is used. Default is false.
 	 */
 	vertexColors: boolean;
-
-	/**
-	 * Defines whether precomputed vertex tangents are used. Default is false.
-	 */
-	vertexTangents: boolean;
 
 	/**
 	 * Defines whether this material is visible. Default is true.

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -23,7 +23,6 @@ function Material() {
 	this.blending = NormalBlending;
 	this.side = FrontSide;
 	this.flatShading = false;
-	this.vertexTangents = false;
 	this.vertexColors = false;
 
 	this.opacity = 1;
@@ -346,7 +345,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.blending = source.blending;
 		this.side = source.side;
 		this.flatShading = source.flatShading;
-		this.vertexTangents = source.vertexTangents;
 		this.vertexColors = source.vertexColors;
 
 		this.opacity = source.opacity;

--- a/src/materials/MeshStandardMaterial.d.ts
+++ b/src/materials/MeshStandardMaterial.d.ts
@@ -33,6 +33,7 @@ export interface MeshStandardMaterialParameters extends MaterialParameters {
 	wireframe?: boolean;
 	wireframeLinewidth?: number;
 	skinning?: boolean;
+	vertexTangents?: boolean;
 	morphTargets?: boolean;
 	morphNormals?: boolean;
 }
@@ -69,6 +70,7 @@ export class MeshStandardMaterial extends Material {
 	wireframe: boolean;
 	wireframeLinewidth: number;
 	skinning: boolean;
+	vertexTangents: boolean;
 	morphTargets: boolean;
 	morphNormals: boolean;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -110,6 +110,8 @@ function MeshStandardMaterial( parameters ) {
 	this.morphTargets = false;
 	this.morphNormals = false;
 
+	this.vertexTangents = false;
+
 	this.setValues( parameters );
 
 }
@@ -171,6 +173,8 @@ MeshStandardMaterial.prototype.copy = function ( source ) {
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
+
+	this.vertexTangents = source.vertexTangents;
 
 	return this;
 


### PR DESCRIPTION
Fixed #18610.

Moving `vertexTangents` to `MeshStandardMaterial` should even more robust than just improving the docs.