### PR TITLE
TS: Add optionalTarget in CatmullRomCurve3.getPoint()

### DIFF
--- a/src/extras/curves/CatmullRomCurve3.d.ts
+++ b/src/extras/curves/CatmullRomCurve3.d.ts
@@ -43,6 +43,6 @@ export class CatmullRomCurve3 extends Curve<Vector3> {
 
 	points: Vector3[];
 
-	getPoint( t: number ): Vector3;
+	getPoint( t: number, optionalTarget?: Vector3 ): Vector3;
 
 }


### PR DESCRIPTION
CatmullRomCurve3.getPoint() should accept an [optional Vector3 target](https://github.com/mrdoob/three.js/blob/master/src/extras/curves/CatmullRomCurve3.js#L104) argument. It's missing in the TypeScript declaration file, which leads to compiler errors if users try to use this option.