### PR TITLE
TS: Remove 4 redundant definitions inherited from Curve

### DIFF
--- a/src/extras/curves/CatmullRomCurve3.d.ts
+++ b/src/extras/curves/CatmullRomCurve3.d.ts
@@ -43,6 +43,4 @@ export class CatmullRomCurve3 extends Curve<Vector3> {
 
 	points: Vector3[];
 
-	getPoint( t: number, optionalTarget?: Vector3 ): Vector3;
-
 }

--- a/src/extras/curves/CatmullRomCurve3.d.ts
+++ b/src/extras/curves/CatmullRomCurve3.d.ts
@@ -43,6 +43,6 @@ export class CatmullRomCurve3 extends Curve<Vector3> {
 
 	points: Vector3[];
 
-	getPoint( t: number ): Vector3;
+	getPoint( t: number, optionalTarget?: Vector3 ): Vector3;
 
 }

--- a/src/extras/curves/CubicBezierCurve3.d.ts
+++ b/src/extras/curves/CubicBezierCurve3.d.ts
@@ -10,6 +10,4 @@ export class CubicBezierCurve3 extends Curve<Vector3> {
 	v2: Vector3;
 	v3: Vector3;
 
-	getPoint( t: number ): Vector3;
-
 }

--- a/src/extras/curves/LineCurve3.d.ts
+++ b/src/extras/curves/LineCurve3.d.ts
@@ -8,6 +8,4 @@ export class LineCurve3 extends Curve<Vector3> {
 	v1: Vector3;
 	v2: Vector3;
 
-	getPoint( t: number ): Vector3;
-
 }

--- a/src/extras/curves/QuadraticBezierCurve3.d.ts
+++ b/src/extras/curves/QuadraticBezierCurve3.d.ts
@@ -9,6 +9,4 @@ export class QuadraticBezierCurve3 extends Curve<Vector3> {
 	v1: Vector3;
 	v2: Vector3;
 
-	getPoint( t: number ): Vector3;
-
 }


### PR DESCRIPTION
CatmullRomCurve3.getPoint() should accept an [optional Vector3 target](https://github.com/mrdoob/three.js/blob/master/src/extras/curves/CatmullRomCurve3.js#L104) argument. It's missing in the TypeScript declaration file, which leads to compiler errors if users try to use this option.