### PR TITLE
DragControls: Add support for dragging a group object.

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -91,6 +91,12 @@ controls.addEventListener( 'dragend', function ( event ) {
 			Whether or not the controls are enabled.
 		</p>
 
+		<h3>[property:Boolean transformGroup]</h3>
+		<p>
+			This option only works if the [page:DragControls.objects] array contains a single draggable group object. 
+			If set to *true*, [name] does not transform individual objects but the entire group. Default is *false*.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>
@@ -108,6 +114,11 @@ controls.addEventListener( 'dragend', function ( event ) {
 		<h3>[method:null dispose] ()</h3>
 		<p>
 			Should be called if the controls is no longer required.
+		</p>
+
+		<h3>[method:Array getObjects] ()</h3>
+		<p>
+			Returns the array of draggable objects.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -91,6 +91,12 @@ controls.addEventListener( 'dragend', function ( event ) {
 			Whether or not the controls are enabled.
 		</p>
 
+		<h3>[property:Boolean transformGroup]</h3>
+		<p>
+			This option only works if the [page:DragControls.objects] array contains a single draggable group object.
+			If set to *true*, [name] does not transform individual objects but the entire group. Default is *false*.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>
@@ -108,6 +114,11 @@ controls.addEventListener( 'dragend', function ( event ) {
 		<h3>[method:null dispose] ()</h3>
 		<p>
 			Should be called if the controls is no longer required.
+		</p>
+
+		<h3>[method:Array getObjects] ()</h3>
+		<p>
+			Returns the array of draggable objects.
 		</p>
 
 		<h2>Source</h2>

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -52,6 +52,12 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 	}
 
+	function getObjects() {
+
+		return _objects;
+
+	}
+
 	function onDocumentMouseMove( event ) {
 
 		event.preventDefault();
@@ -123,7 +129,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _intersections.length > 0 ) {
 
-			_selected = _intersections[ 0 ].object;
+			_selected = ( scope.transformGroup === true ) ? _objects[ 0 ] : _intersections[ 0 ].object;
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
@@ -202,7 +208,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _intersections.length > 0 ) {
 
-			_selected = _intersections[ 0 ].object;
+			_selected = ( scope.transformGroup === true ) ? _objects[ 0 ] : _intersections[ 0 ].object;
 
 			_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
@@ -243,10 +249,12 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 	// API
 
 	this.enabled = true;
+	this.transformGroup = false;
 
 	this.activate = activate;
 	this.deactivate = deactivate;
 	this.dispose = dispose;
+	this.getObjects = getObjects;
 
 };
 

--- a/examples/jsm/controls/DragControls.d.ts
+++ b/examples/jsm/controls/DragControls.d.ts
@@ -13,9 +13,11 @@ export class DragControls extends EventDispatcher {
 	// API
 
 	enabled: boolean;
+	transformGroup: boolean;
 
 	activate(): void;
 	deactivate(): void;
 	dispose(): void;
+	getObjects(): Object3D[];
 
 }

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -61,6 +61,12 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 	}
 
+	function getObjects() {
+
+		return _objects;
+
+	}
+
 	function onDocumentMouseMove( event ) {
 
 		event.preventDefault();
@@ -132,7 +138,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _intersections.length > 0 ) {
 
-			_selected = _intersections[ 0 ].object;
+			_selected = ( scope.transformGroup === true ) ? _objects[ 0 ] : _intersections[ 0 ].object;
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
@@ -211,7 +217,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _intersections.length > 0 ) {
 
-			_selected = _intersections[ 0 ].object;
+			_selected = ( scope.transformGroup === true ) ? _objects[ 0 ] : _intersections[ 0 ].object;
 
 			_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
@@ -252,10 +258,12 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 	// API
 
 	this.enabled = true;
+	this.transformGroup = false;
 
 	this.activate = activate;
 	this.deactivate = deactivate;
 	this.dispose = dispose;
+	this.getObjects = getObjects;
 
 };
 

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -18,23 +18,25 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
+			Use "Shift+Click" to add/remove objects to a group. This mode enables group dragging.
 		</div>
 
 		<script type="module">
 
 			import * as THREE from '../build/three.module.js';
 
-			import Stats from './jsm/libs/stats.module.js';
-
 			import { DragControls } from './jsm/controls/DragControls.js';
 
-			var container, stats;
+			var container;
 			var camera, scene, renderer;
+			var controls, group;
 			var objects = [];
+			var enableSelection = false;
+
+			var mouse = new THREE.Vector2(), raycaster = new THREE.Raycaster();
 
 			init();
-			animate();
 
 			function init() {
 
@@ -60,6 +62,9 @@
 				light.shadow.mapSize.height = 1024;
 
 				scene.add( light );
+
+				group = new THREE.Group();
+				scene.add( group );
 
 				var geometry = new THREE.BoxBufferGeometry( 40, 40, 40 );
 
@@ -97,26 +102,18 @@
 
 				container.appendChild( renderer.domElement );
 
-				var controls = new DragControls( objects, camera, renderer.domElement );
-
-				controls.addEventListener( 'dragstart', function ( event ) {
-
-					event.object.material.emissive.set( 0xaaaaaa );
-
-				} );
-
-				controls.addEventListener( 'dragend', function ( event ) {
-
-					event.object.material.emissive.set( 0x000000 );
-
-				} );
-
-				stats = new Stats();
-				container.appendChild( stats.dom );
+				controls = new DragControls( [ ... objects ], camera, renderer.domElement );
+				controls.addEventListener( 'drag', render );
 
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
+
+				document.addEventListener( 'click', onClick, false );
+				window.addEventListener( 'keydown', onKeyDown, false );
+				window.addEventListener( 'keyup', onKeyUp, false );
+
+				render();
 
 			}
 
@@ -127,16 +124,65 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
-			//
+			function onKeyDown( event ) {
 
-			function animate() {
+				enableSelection = ( event.keyCode === 16 ) ? true : false;
 
-				requestAnimationFrame( animate );
+			}
+
+			function onKeyUp() {
+
+				enableSelection = false;
+
+			}
+
+			function onClick( event ) {
+
+				event.preventDefault();
+
+				if ( enableSelection === true ) {
+
+					var draggableObjects = controls.getObjects();
+					draggableObjects.length = 0;
+
+					mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+					mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+
+					raycaster.setFromCamera( mouse, camera );
+
+					var intersections = raycaster.intersectObjects( objects, true );
+
+					if ( intersections.length > 0 ) {
+
+						var object = intersections[ 0 ].object;
+						object.material.emissive.set( 0xaaaaaa );
+						group.attach( object );
+
+						controls.transformGroup = true;
+						draggableObjects.push( group );
+
+					} else {
+
+						for ( var i = group.children.length - 1; i >= 0; i -- ) {
+
+							var object = group.children[ i ];
+							object.material.emissive.set( 0x000000 );
+							scene.attach( object );
+
+						}
+
+						controls.transformGroup = false;
+						draggableObjects.push( ...objects );
+
+					}
+
+				}
 
 				render();
-				stats.update();
 
 			}
 

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -19,7 +19,8 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
-			Use "Shift+Click" to add objects to a group. This mode enables group dragging.
+			Use "Shift+Click" to add/remove objects to/from a group.<br />
+			Grouped objects can be transformed as a union.
 		</div>
 
 		<script type="module">
@@ -159,21 +160,25 @@
 					if ( intersections.length > 0 ) {
 
 						var object = intersections[ 0 ].object;
-						object.material.emissive.set( 0xaaaaaa );
-						group.attach( object );
+
+						if ( group.children.includes( object ) === true ) {
+
+							object.material.emissive.set( 0x000000 );
+							scene.attach( object );
+
+						} else {
+
+							object.material.emissive.set( 0xaaaaaa );
+							group.attach( object );
+
+						}
 
 						controls.transformGroup = true;
 						draggableObjects.push( group );
 
-					} else {
+					}
 
-						for ( var i = group.children.length - 1; i >= 0; i -- ) {
-
-							var object = group.children[ i ];
-							object.material.emissive.set( 0x000000 );
-							scene.attach( object );
-
-						}
+					if ( group.children.length === 0 ) {
 
 						controls.transformGroup = false;
 						draggableObjects.push( ...objects );

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -19,7 +19,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
-			Use "Shift+Click" to add/remove objects to a group. This mode enables group dragging.
+			Use "Shift+Click" to add objects to a group. This mode enables group dragging.
 		</div>
 
 		<script type="module">


### PR DESCRIPTION
This PR adds a small enhancement to `DragControls`. It allows users to drag a group instead of the individual 3D objects. I've seen this feature request multiple times in the past and I thought it's a good addition to the controls (e.g. https://discourse.threejs.org/t/dragcontrol-for-a-group-object/12645). 

The idea is to expose the array of draggable objects and introduce a new boolean property that enables the new behavior. I've enhanced `webgl_loader_3mf_materials` to shows this new feature. It's now possible to drag the entire truck and not its individual parts.

