### PR TITLE
WebGLRenderer: Support nested render() calls in Scene.onBeforeRender().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1168,7 +1168,7 @@ function WebGLRenderer( parameters ) {
 
 		currentRenderState = renderStates.get( scene, camera );
 		currentRenderState.init();
-		
+
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
 		_frustum.setFromProjectionMatrix( _projScreenMatrix );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1164,12 +1164,11 @@ function WebGLRenderer( parameters ) {
 		}
 
 		//
+		scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
 
 		currentRenderState = renderStates.get( scene, camera );
 		currentRenderState.init();
-
-		scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
-
+		
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
 		_frustum.setFromProjectionMatrix( _projScreenMatrix );
 


### PR DESCRIPTION
Attempting to call WebGLRenderer.render() inside scene.onBeforeRender() results in currentRenderState being null and crashes the renderer. Fixed with a slight change of ordering. 