### PR TITLE
KeyframeTrack: Clarify if-clause in .trim().

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -254,7 +254,12 @@ Object.assign( KeyframeTrack.prototype, {
 		if ( from !== 0 || to !== nKeys ) {
 
 			// empty tracks are forbidden, so keep at least one keyframe
-			if ( from >= to ) to = Math.max( to, 1 ), from = to - 1;
+			if ( from >= to ) {
+
+				to = Math.max( to, 1 );
+				from = to - 1;
+
+			}
 
 			var stride = this.getValueSize();
 			this.times = AnimationUtils.arraySlice( times, from, to );


### PR DESCRIPTION
Fixed #18616