### PR TITLE
WebGLRenderer: Ignore map alpha in opaque materials

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2093,27 +2093,15 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
-		var alphaMode = materialDef.alphaMode || ALPHA_MODES.OPAQUE;
+		var alphaMode = materialDef.alphaMode;
 
 		if ( alphaMode === ALPHA_MODES.BLEND ) {
 
 			materialParams.transparent = true;
 
-		} else {
+		} else if ( alphaMode === ALPHA_MODES.MASK ) {
 
-			materialParams.transparent = false;
-
-			if ( alphaMode === ALPHA_MODES.MASK ) {
-
-				materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;
-
-			} else {
-
-				// for ALPHA_MODES.OPAQUE, we use a negative alphaTest value to enable alphaTesting,
-				// causing the test to always be passed, but also replacing any alpha value with 1.0.
-				materialParams.alphaTest = - 0.5;
-
-			}
+			materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;
 
 		}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2156,27 +2156,15 @@ var GLTFLoader = ( function () {
 
 		}
 
-		var alphaMode = materialDef.alphaMode || ALPHA_MODES.OPAQUE;
+		var alphaMode = materialDef.alphaMode;
 
 		if ( alphaMode === ALPHA_MODES.BLEND ) {
 
 			materialParams.transparent = true;
 
-		} else {
+		} else if ( alphaMode === ALPHA_MODES.MASK ) {
 
-			materialParams.transparent = false;
-
-			if ( alphaMode === ALPHA_MODES.MASK ) {
-
-				materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;
-
-			} else {
-
-				// for ALPHA_MODES.OPAQUE, we use a negative alphaTest value to enable alphaTesting,
-				// causing the test to always be passed, but also replacing any alpha value with 1.0.
-				materialParams.alphaTest = - 0.5;
-
-			}
+			materialParams.alphaTest = materialDef.alphaCutoff !== undefined ? materialDef.alphaCutoff : 0.5;
 
 		}
 

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -5,6 +5,11 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
+		<style>
+			body {
+				background-color: white;
+			}
+		</style>
 	</head>
 
 	<body>
@@ -14,7 +19,7 @@
 			<div id="description"></div>
 		</div>
 
-		<div id="container" style="background-color: white;"></div>
+		<div id="container"></div>
 
 		<script type="module">
 

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -84,6 +84,7 @@ import skinning_vertex from './ShaderChunk/skinning_vertex.glsl.js';
 import skinnormal_vertex from './ShaderChunk/skinnormal_vertex.glsl.js';
 import specularmap_fragment from './ShaderChunk/specularmap_fragment.glsl.js';
 import specularmap_pars_fragment from './ShaderChunk/specularmap_pars_fragment.glsl.js';
+import transparent_fragment from './ShaderChunk/transparent_fragment.glsl.js';
 import tonemapping_fragment from './ShaderChunk/tonemapping_fragment.glsl.js';
 import tonemapping_pars_fragment from './ShaderChunk/tonemapping_pars_fragment.glsl.js';
 import uv_pars_fragment from './ShaderChunk/uv_pars_fragment.glsl.js';
@@ -214,6 +215,7 @@ export var ShaderChunk = {
 	skinnormal_vertex: skinnormal_vertex,
 	specularmap_fragment: specularmap_fragment,
 	specularmap_pars_fragment: specularmap_pars_fragment,
+	transparent_fragment: transparent_fragment,
 	tonemapping_fragment: tonemapping_fragment,
 	tonemapping_pars_fragment: tonemapping_pars_fragment,
 	uv_pars_fragment: uv_pars_fragment,

--- a/src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/alphatest_fragment.glsl.js
@@ -2,7 +2,6 @@ export default /* glsl */`
 #ifdef ALPHATEST
 
 	if ( diffuseColor.a < ALPHATEST ) discard;
-	diffuseColor.a = 1.0;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/transparent_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transparent_fragment.glsl.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+#ifndef TRANSPARENT
+
+	diffuseColor.a = 1.0;
+
+#endif
+`;

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -35,13 +35,14 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <specularmap_fragment>
 
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 
 	// accumulation (baked indirect lighting only)
 	#ifdef USE_LIGHTMAP
-	
+
 		vec4 lightMapTexel= texture2D( lightMap, vUv2 );
 		reflectedLight.indirectDiffuse += lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;
 

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -48,6 +48,7 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <specularmap_fragment>
 	#include <emissivemap_fragment>
 

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -34,6 +34,7 @@ void main() {
 	#include <map_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <normal_fragment_begin>
 	#include <normal_fragment_maps>
 

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -45,6 +45,7 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <specularmap_fragment>
 	#include <normal_fragment_begin>
 	#include <normal_fragment_maps>

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -85,6 +85,7 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <roughnessmap_fragment>
 	#include <metalnessmap_fragment>
 	#include <normal_fragment_begin>

--- a/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
@@ -43,6 +43,7 @@ void main() {
 	#include <color_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 	#include <specularmap_fragment>
 	#include <normal_fragment_begin>
 	#include <normal_fragment_maps>

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl.js
@@ -20,6 +20,7 @@ void main() {
 	#include <map_particle_fragment>
 	#include <color_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 
 	outgoingLight = diffuseColor.rgb;
 

--- a/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
@@ -21,6 +21,7 @@ void main() {
 	#include <map_fragment>
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
+	#include <transparent_fragment>
 
 	outgoingLight = diffuseColor.rgb;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -625,6 +625,7 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
+			parameters.transparent ? '#define TRANSPARENT' : '',
 
 			( parameters.outputEncoding || parameters.mapEncoding || parameters.matcapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding || parameters.lightMapEncoding ) ?
 				ShaderChunk[ 'encodings_pars_fragment' ] : '', // this code is required here because it is used by the various encoding/decoding function defined below

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -49,7 +49,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 		"numDirLightShadows", "numPointLightShadows", "numSpotLightShadows",
 		"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
 		"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering",
-		"sheen"
+		"sheen", "transparent"
 	];
 
 	function getShaderObject( material, shaderID ) {
@@ -262,6 +262,7 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			numClipIntersection: nClipIntersection,
 
 			dithering: material.dithering,
+			transparent: material.transparent,
 
 			shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,


### PR DESCRIPTION
Fixes #15483

/ping @donmccurdy @elalish @FMS-Cat 