### PR TITLE
TS: Fixes passing PositionalAudio to AudioAnalyser

### DIFF
--- a/src/audio/Audio.d.ts
+++ b/src/audio/Audio.d.ts
@@ -58,3 +58,9 @@ export class Audio extends Object3D {
 	load( file: string ): Audio;
 
 }
+
+export class AudioWeaken extends Audio {
+
+	getOutput(): any;
+
+}

--- a/src/audio/Audio.d.ts
+++ b/src/audio/Audio.d.ts
@@ -4,7 +4,7 @@ import { AudioContext } from './AudioContext';
 
 // Extras / Audio /////////////////////////////////////////////////////////////////////
 
-export class Audio extends Object3D {
+export class Audio<NodeType extends AudioNode = GainNode> extends Object3D {
 
 	constructor( listener: AudioListener );
 	type: 'Audio';
@@ -27,7 +27,7 @@ export class Audio extends Object3D {
 	source: AudioBufferSourceNode;
 	filters: any[];
 
-	getOutput(): GainNode;
+	getOutput(): NodeType;
 	setNodeSource( audioNode: AudioBufferSourceNode ): this;
 	setMediaElementSource( mediaElement: HTMLMediaElement ): this;
 	setMediaStreamSource( mediaStream: MediaStream ): this;
@@ -56,11 +56,5 @@ export class Audio extends Object3D {
 	 * @deprecated Use {@link AudioLoader} instead.
 	 */
 	load( file: string ): Audio;
-
-}
-
-export class AudioWeaken extends Audio {
-
-	getOutput(): any;
 
 }

--- a/src/audio/AudioAnalyser.d.ts
+++ b/src/audio/AudioAnalyser.d.ts
@@ -1,8 +1,8 @@
-import { AudioWeaken } from './Audio';
+import { Audio } from './Audio';
 
 export class AudioAnalyser {
 
-	constructor( audio: AudioWeaken, fftSize: number );
+	constructor( audio: Audio<AudioNode>, fftSize: number );
 
 	analyser: AnalyserNode;
 	data: Uint8Array;

--- a/src/audio/AudioAnalyser.d.ts
+++ b/src/audio/AudioAnalyser.d.ts
@@ -1,8 +1,8 @@
-import { Audio } from './Audio';
+import { AudioWeaken } from './Audio';
 
 export class AudioAnalyser {
 
-	constructor( audio: Audio, fftSize: number );
+	constructor( audio: AudioWeaken, fftSize: number );
 
 	analyser: AnalyserNode;
 	data: Uint8Array;

--- a/src/audio/PositionalAudio.d.ts
+++ b/src/audio/PositionalAudio.d.ts
@@ -1,11 +1,5 @@
 import { AudioListener } from './AudioListener';
-import { Audio } from './Audio';
-
-export class AudioWeaken extends Audio {
-
-	getOutput(): any;
-
-}
+import { AudioWeaken } from './Audio';
 
 export class PositionalAudio extends AudioWeaken {
 

--- a/src/audio/PositionalAudio.d.ts
+++ b/src/audio/PositionalAudio.d.ts
@@ -1,7 +1,7 @@
 import { AudioListener } from './AudioListener';
-import { AudioWeaken } from './Audio';
+import { Audio } from './Audio';
 
-export class PositionalAudio extends AudioWeaken {
+export class PositionalAudio extends Audio<PannerNode> {
 
 	constructor( listener: AudioListener );
 


### PR DESCRIPTION
Fixies getting a Typescript compile error on this:
`
new THREE.AudioAnalyser(new THREE.PositionalAudio(audioListener), 32);
`
Error:
```
error TS2345: Argument of type 'PositionalAudio' is not assignable to parameter of type 'Audio'.
  The types returned by 'getOutput()' are incompatible between these types.
    Property 'gain' is missing in type 'PannerNode' but required in type 'GainNode'.
```
Error was introduced with pull #18022

This is a weaksauce fix I'm afraid.  Might be better to factor out a GainNode free Interface for Audio and PositionalAudio to extend.
