### PR TITLE
Do not require a camera for DeviceOrientationControls

### DIFF
--- a/docs/examples/en/controls/DeviceOrientationControls.html
+++ b/docs/examples/en/controls/DeviceOrientationControls.html
@@ -12,7 +12,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			Can be used to orient the camera based on the mobile device's orientation.
+			Can be used to orient an object based on the mobile device's orientation.
 		</p>
 
 		<h2>Example</h2>
@@ -21,10 +21,10 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:Camera object] )</h3>
+		<h3>[name]( [param:Object3D object] )</h3>
 		<p>
 			<p>
-				[page:Camera object]: The camera to be controlled.
+				[page:Object3D object]: The object to be controlled.
 			</p>
 			<p>
 				Creates a new instance of [name].
@@ -48,9 +48,9 @@
 			Whether or not the controls are enabled.
 		</p>
 
-		<h3>[property:Camera object]</h3>
+		<h3>[property:Object3D object]</h3>
 		<p>
-			The camera to be controlled.
+			The object to be controlled.
 		</p>
 
 		<h3>[property:Number screenOrientation]</h3>

--- a/examples/jsm/controls/DeviceOrientationControls.d.ts
+++ b/examples/jsm/controls/DeviceOrientationControls.d.ts
@@ -1,12 +1,12 @@
 import {
-	Camera
+	Object3D
 } from '../../../src/Three';
 
 export class DeviceOrientationControls {
 
-	constructor( object: Camera );
+	constructor( object: Object3D );
 
-	object: Camera;
+	object: Object3D;
 
 	// API
 


### PR DESCRIPTION
Based on a quick look at the source code of DeviceOrientationControls.js, a camera is not needed for the controls to work, since the controls do not use any methods or properties that are only available on cameras.

Case in point: for the [jsdoom](https://github.com/pineapplemachine/jsdoom) inspector [3D view](https://github.com/pineapplemachine/jsdoom/blob/master/web/lumpTypeView.ts#L392), I am using the DeviceOrientationControls to change the orientation of a "view head" object, which has some cameras as its children.