### PR TITLE
TS: Fix Inconsistent types on SSAOPass params

### DIFF
--- a/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -21,7 +21,7 @@ export class SSAOPass extends Pass {
 	width: number;
 	height: boolean;
 	clear: boolean;
-	kernelRadius: boolean;
+	kernelRadius: number;
 	kernelSize: boolean;
 	kernel: Vector3[];
 	noiseTexture: DataTexture;

--- a/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -22,7 +22,7 @@ export class SSAOPass extends Pass {
 	height: boolean;
 	clear: boolean;
 	kernelRadius: number;
-	kernelSize: boolean;
+	kernelSize: number;
 	kernel: Vector3[];
 	noiseTexture: DataTexture;
 	output: number;


### PR DESCRIPTION
TypeScript throws a type error if you pass a `number` to the
 `kernelRadius` or `kernelSize` because it expects a [boolean](https://github.com/mrdoob/three.js/blob/cceffcbec987ba640b98285503e1267336626f22/examples/jsm/postprocessing/SSAOPass.d.ts#L24).

However the plain js version [SSAOPass.js](https://github.com/mrdoob/three.js/blob/cceffcbec987ba640b98285503e1267336626f22/examples/jsm/postprocessing/SSAOPass.js#L47) 
initializes it as a number and looking at the example
[here](https://github.com/mrdoob/three.js/blob/c23b245814ac71999d8303c07434fcfd244288dd/examples/webgl_postprocessing_ssao.html#L100), it's passed a number too.

The same holds for `kernelSize`.

Looking at the closely matching types for the `saoKernelRadius`
in [SAOPass.d.ts ](https://github.com/mrdoob/three.js/blob/cceffcbec987ba640b98285503e1267336626f22/examples/jsm/postprocessing/SAOPass.d.ts#L21), it's typed as a number.

I might be biased and wish for my code to work,
I hope am not missing something. :)
