### PR TITLE
GLTFExporter: Fix mesh cache key

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1131,10 +1131,25 @@ THREE.GLTFExporter.prototype = {
 		 */
 		function processMesh( mesh ) {
 
-			var cacheKey = mesh.geometry.uuid + ':' + mesh.material.uuid;
-			if ( cachedData.meshes.has( cacheKey ) ) {
+			var meshCacheKeyParts = [ mesh.geometry.uuid ];
+			if ( Array.isArray( mesh.material ) ) {
 
-				return cachedData.meshes.get( cacheKey );
+				for ( var i = 0, l = mesh.material.length; i < l; i++ ) {
+
+					meshCacheKeyParts.push( mesh.material[ i ].uuid	);
+
+				}
+
+			} else {
+
+				meshCacheKeyParts.push( mesh.material.uuid );
+
+			}
+
+			var meshCacheKey = meshCacheKeyParts.join( ':' );
+			if ( cachedData.meshes.has( meshCacheKey ) ) {
+
+				return cachedData.meshes.get( meshCacheKey );
 
 			}
 
@@ -1459,7 +1474,7 @@ THREE.GLTFExporter.prototype = {
 			outputJSON.meshes.push( gltfMesh );
 
 			var index = outputJSON.meshes.length - 1;
-			cachedData.meshes.set( cacheKey, index );
+			cachedData.meshes.set( meshCacheKey, index );
 
 			return index;
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1153,10 +1153,25 @@ GLTFExporter.prototype = {
 		 */
 		function processMesh( mesh ) {
 
-			var cacheKey = mesh.geometry.uuid + ':' + mesh.material.uuid;
-			if ( cachedData.meshes.has( cacheKey ) ) {
+			var meshCacheKeyParts = [ mesh.geometry.uuid ];
+			if ( Array.isArray( mesh.material ) ) {
 
-				return cachedData.meshes.get( cacheKey );
+				for ( var i = 0, l = mesh.material.length; i < l; i++ ) {
+
+					meshCacheKeyParts.push( mesh.material[ i ].uuid	);
+
+				}
+
+			} else {
+
+				meshCacheKeyParts.push( mesh.material.uuid );
+
+			}
+
+			var meshCacheKey = meshCacheKeyParts.join( ':' );
+			if ( cachedData.meshes.has( meshCacheKey ) ) {
+
+				return cachedData.meshes.get( meshCacheKey );
 
 			}
 
@@ -1481,7 +1496,7 @@ GLTFExporter.prototype = {
 			outputJSON.meshes.push( gltfMesh );
 
 			var index = outputJSON.meshes.length - 1;
-			cachedData.meshes.set( cacheKey, index );
+			cachedData.meshes.set( meshCacheKey, index );
 
 			return index;
 


### PR DESCRIPTION
Hello!

1. Function `processMesh` has 2 `cacheKey` variables: one for mesh and one for attribute. Because of that meshes are cached with invalid keys. This PR renames first `cacheKey` to `meshCacheKey`
1. Fix multimaterial mesh caching by joining uuids

Thank you for your great work!