### PR TITLE
Examples: Remove unnecessary texture parameters.

### DIFF
--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -52,7 +52,6 @@
 			var reflectionCube = new THREE.CubeTextureLoader()
 				.setPath( 'textures/cube/SwedishRoyalCastle/' )
 				.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-			reflectionCube.format = THREE.RGBFormat;
 
 			scene = new THREE.Scene();
 			scene.background = new THREE.Color( 0xa0a0a0 );

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -415,7 +415,6 @@
 							 r + "posz.jpg", r + "negz.jpg" ];
 
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.format = THREE.RGBFormat;
 				textureCube.mapping = THREE.CubeReflectionMapping;
 				textureCube.encoding = THREE.sRGBEncoding;
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -54,7 +54,6 @@
 				var texture = textureLoader.load( "textures/disturb.jpg" );
 				texture.repeat.set( 20, 10 );
 				texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
-				texture.format = THREE.RGBFormat;
 				texture.encoding = THREE.sRGBEncoding;
 
 				// MATERIALS

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -198,7 +198,6 @@
 									r + "posy.jpg", r + "negy.jpg",
 									r + "posz.jpg", r + "negz.jpg" ];
 								textureCube = new THREE.CubeTextureLoader().load( urls );
-								textureCube.format = THREE.RGBFormat;
 								textureCube.mapping = THREE.CubeReflectionMapping;
 
 							}

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -50,11 +50,8 @@
 				];
 
 				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
-				reflectionCube.format = THREE.RGBFormat;
-
 				var refractionCube = new THREE.CubeTextureLoader().load( urls );
 				refractionCube.mapping = THREE.CubeRefractionMapping;
-				refractionCube.format = THREE.RGBFormat;
 
 				scene = new THREE.Scene();
 				scene.background = reflectionCube;

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -56,16 +56,12 @@
 							 r + "posz.jpg", r + "negz.jpg" ];
 
 				textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.format = THREE.RGBFormat;
-				textureCube.mapping = THREE.CubeReflectionMapping;
 				textureCube.encoding = THREE.sRGBEncoding;
 
 				var textureLoader = new THREE.TextureLoader();
 
 				textureEquirec = textureLoader.load( "textures/2294472375_24a3b8ef46_o.jpg" );
 				textureEquirec.mapping = THREE.EquirectangularReflectionMapping;
-				textureEquirec.magFilter = THREE.LinearFilter;
-				textureEquirec.minFilter = THREE.LinearMipmapLinearFilter;
 				textureEquirec.encoding = THREE.sRGBEncoding;
 
 				textureSphere = textureLoader.load( "textures/metal.jpg" );

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -103,7 +103,6 @@
 				];
 
 				var textureCube = new THREE.CubeTextureLoader().load( urls, updatePREM );
-				textureCube.format = THREE.RGBFormat;
 
 				library[ textureCube.uuid ] = textureCube;
 

--- a/examples/webgl_materials_shaders_fresnel.html
+++ b/examples/webgl_materials_shaders_fresnel.html
@@ -54,7 +54,6 @@
 				];
 
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.format = THREE.RGBFormat;
 
 				scene = new THREE.Scene();
 				scene.background = textureCube;

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -45,7 +45,6 @@
 				var reflectionCube = new THREE.CubeTextureLoader()
 					.setPath( 'textures/cube/SwedishRoyalCastle/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				reflectionCube.format = THREE.RGBFormat;
 				reflectionCube.encoding = THREE.sRGBEncoding;
 
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -45,7 +45,6 @@
 				var reflectionCube = new THREE.CubeTextureLoader()
 					.setPath( 'textures/cube/SwedishRoyalCastle/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				reflectionCube.format = THREE.RGBFormat;
 				reflectionCube.encoding = THREE.sRGBEncoding;
 
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -45,7 +45,6 @@
 				var reflectionCube = new THREE.CubeTextureLoader()
 					.setPath( 'textures/cube/SwedishRoyalCastle/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				reflectionCube.format = THREE.RGBFormat;
 				reflectionCube.encoding = THREE.sRGBEncoding;
 
 				scene = new THREE.Scene();

--- a/examples/webgl_panorama_dualfisheye.html
+++ b/examples/webgl_panorama_dualfisheye.html
@@ -88,7 +88,6 @@
 
 				var texture = new THREE.TextureLoader().load( 'textures/ricoh_theta_s.jpg' );
 				texture.minFilter = THREE.LinearFilter;
-				texture.format = THREE.RGBFormat;
 
 				var material = new THREE.MeshBasicMaterial( { map: texture } );
 

--- a/examples/webgl_performance_doublesided.html
+++ b/examples/webgl_performance_doublesided.html
@@ -64,7 +64,6 @@
 				];
 
 				var reflectionCube = new THREE.CubeTextureLoader().load( urls );
-				reflectionCube.format = THREE.RGBFormat;
 				reflectionCube.encoding = THREE.sRGBEncoding;
 
 				var material = new THREE.MeshPhongMaterial( { specular: 0x101010, shininess: 100, envMap: reflectionCube, combine: THREE.MixOperation, reflectivity: 0.1, side: THREE.DoubleSide } );

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -83,7 +83,6 @@
 							 r + 'posz.jpg', r + 'negz.jpg' ];
 
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.format = THREE.RGBFormat;
 
 				scene.background = textureCube;
 

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -315,7 +315,6 @@
 							 r + "dark-s_pz.jpg", r + "dark-s_nz.jpg" ];
 
 				var textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.format = THREE.RGBFormat;
 				textureCube.encoding = THREE.sRGBEncoding;
 
 				sceneCube.background = textureCube;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -76,19 +76,16 @@
 				textureSquares.repeat.set( 50, 50 );
 				textureSquares.wrapS = textureSquares.wrapT = THREE.RepeatWrapping;
 				textureSquares.magFilter = THREE.NearestFilter;
-				textureSquares.format = THREE.RGBFormat;
 				textureSquares.encoding = THREE.sRGBEncoding;
 
 				var textureNoiseColor = textureLoader.load( "textures/disturb.jpg" );
 				textureNoiseColor.repeat.set( 1, 1 );
 				textureNoiseColor.wrapS = textureNoiseColor.wrapT = THREE.RepeatWrapping;
-				textureNoiseColor.format = THREE.RGBFormat;
 				textureNoiseColor.encoding = THREE.sRGBEncoding;
 
 				var textureLava = textureLoader.load( "textures/lava/lavatile.jpg" );
 				textureLava.repeat.set( 6, 2 );
 				textureLava.wrapS = textureLava.wrapT = THREE.RepeatWrapping;
-				textureLava.format = THREE.RGBFormat;
 				textureLava.encoding = THREE.sRGBEncoding;
 
 				// GROUND

--- a/examples/webxr_vr_panorama_depth.html
+++ b/examples/webxr_vr_panorama_depth.html
@@ -60,7 +60,6 @@
 				loader.load( './textures/kandao3.jpg', function ( texture ) {
 
 					texture.minFilter = THREE.NearestFilter;
-					texture.format = THREE.RGBFormat;
 					texture.generateMipmaps = false;
 					sphere.material.map = texture;
 
@@ -69,7 +68,6 @@
 				loader.load( './textures/kandao3_depthmap.jpg', function ( depth ) {
 
 					depth.minFilter = THREE.NearestFilter;
-					depth.format = THREE.RGBFormat;
 					depth.generateMipmaps = false;
 					sphere.material.displacementMap = depth;
 

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -30,7 +30,6 @@
 				var background = new THREE.CubeTextureLoader()
 					.setPath( 'textures/cube/MilkyWay/' )
 					.load( [ 'dark-s_px.jpg', 'dark-s_nx.jpg', 'dark-s_py.jpg', 'dark-s_ny.jpg', 'dark-s_pz.jpg', 'dark-s_nz.jpg' ] );
-				background.format = THREE.RGBFormat;
 
 				scene = new THREE.Scene();
 				scene.background = background;


### PR DESCRIPTION
Because of #15757, a lot of texture parameter settings in the examples are not necessary anymore.