### PR TITLE
TransformControls: Better error handling and docs.

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -14,7 +14,9 @@
 
 		<p class="desc">
 			This class can be used to transform objects in 3D space by adapting a similar interaction model of DCC tools like Blender.
-			Unlike other controls, it is not intended to transform the scene's camera.
+			Unlike other controls, it is not intended to transform the scene's camera.<br /><br />
+
+			[name] expects that its attached 3D object is part of the scene graph.
 		</p>
 
 		<h2>Example</h2>

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -14,7 +14,9 @@
 
 		<p class="desc">
 			This class can be used to transform objects in 3D space by adapting a similar interaction model of DCC tools like Blender.
-			Unlike other controls, it is not intended to transform the scene's camera.
+			Unlike other controls, it is not intended to transform the scene's camera.<br /><br />
+
+			[name] expects that its attached 3D object is part of the scene graph.
 		</p>
 
 		<h2>Example</h2>

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -206,7 +206,17 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( this.object !== undefined ) {
 
 			this.object.updateMatrixWorld();
-			this.object.parent.matrixWorld.decompose( parentPosition, parentQuaternion, parentScale );
+
+			if ( this.object.parent === null ) {
+
+				console.error( 'TransformControls: The attached 3D object must be a part of the scene graph.' );
+
+			} else {
+
+				this.object.parent.matrixWorld.decompose( parentPosition, parentQuaternion, parentScale );
+
+			}
+
 			this.object.matrixWorld.decompose( worldPosition, worldQuaternion, worldScale );
 
 			parentQuaternionInv.copy( parentQuaternion ).inverse();

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -229,7 +229,17 @@ var TransformControls = function ( camera, domElement ) {
 		if ( this.object !== undefined ) {
 
 			this.object.updateMatrixWorld();
-			this.object.parent.matrixWorld.decompose( parentPosition, parentQuaternion, parentScale );
+
+			if ( this.object.parent === null ) {
+
+				console.error( 'TransformControls: The attached 3D object must be a part of the scene graph.' );
+
+			} else {
+
+				this.object.parent.matrixWorld.decompose( parentPosition, parentQuaternion, parentScale );
+
+			}
+
 			this.object.matrixWorld.decompose( worldPosition, worldQuaternion, worldScale );
 
 			parentQuaternionInv.copy( parentQuaternion ).inverse();


### PR DESCRIPTION
`TransformControls` can only be used if its attached 3D object is part of the scene graph. This was not obvious for all users. The PR improves the docs and the error handling so affected users hopefully easier understand the cause of certain runtime errors.

https://discourse.threejs.org/t/how-to-handle-controls-after-removing-all-object-from-scene/8839/10?u=mugen87