### PR TITLE
SSAOPass: Improve depth precision with WebGL 2.

### DIFF
--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -1,5 +1,7 @@
 /**
  * @author Mugen87 / https://github.com/Mugen87
+ *
+ * For best results it's recommended to use SSAOPass with a WebGL 2 rendering context.
  */
 
 THREE.SSAOPass = function ( scene, camera, width, height ) {
@@ -31,7 +33,6 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 	// beauty render target with depth buffer
 
 	var depthTexture = new THREE.DepthTexture();
-	depthTexture.type = THREE.UnsignedShortType;
 	depthTexture.minFilter = THREE.NearestFilter;
 	depthTexture.maxFilter = THREE.NearestFilter;
 
@@ -40,7 +41,8 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 		magFilter: THREE.LinearFilter,
 		format: THREE.RGBAFormat,
 		depthTexture: depthTexture,
-		depthBuffer: true
+		depthBuffer: true,
+		stencilBuffer: false
 	} );
 
 	// normal render target
@@ -48,7 +50,8 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 	this.normalRenderTarget = new THREE.WebGLRenderTarget( this.width, this.height, {
 		minFilter: THREE.NearestFilter,
 		magFilter: THREE.NearestFilter,
-		format: THREE.RGBAFormat
+		format: THREE.RGBAFormat,
+		stencilBuffer: false
 	} );
 
 	// ssao render target
@@ -56,7 +59,8 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 	this.ssaoRenderTarget = new THREE.WebGLRenderTarget( this.width, this.height, {
 		minFilter: THREE.LinearFilter,
 		magFilter: THREE.LinearFilter,
-		format: THREE.RGBAFormat
+		format: THREE.RGBAFormat,
+		stencilBuffer: false
 	} );
 
 	this.blurRenderTarget = this.ssaoRenderTarget.clone();
@@ -167,6 +171,10 @@ THREE.SSAOPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ),
 	},
 
 	render: function ( renderer, writeBuffer /*, readBuffer, deltaTime, maskActive */ ) {
+
+		// configure depthTexture
+
+		this.beautyRenderTarget.depthTexture.type = ( renderer.capabilities.isWebGL2 ) ? THREE.FloatType : THREE.UnsignedShortType;
 
 		// render beauty and depth
 

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -1,5 +1,7 @@
 /**
  * @author Mugen87 / https://github.com/Mugen87
+ *
+ * For best results it's recommended to use SSAOPass with a WebGL 2 rendering context.
  */
 
 import {
@@ -61,7 +63,6 @@ var SSAOPass = function ( scene, camera, width, height ) {
 	// beauty render target with depth buffer
 
 	var depthTexture = new DepthTexture();
-	depthTexture.type = UnsignedShortType;
 	depthTexture.minFilter = NearestFilter;
 	depthTexture.maxFilter = NearestFilter;
 
@@ -70,7 +71,8 @@ var SSAOPass = function ( scene, camera, width, height ) {
 		magFilter: LinearFilter,
 		format: RGBAFormat,
 		depthTexture: depthTexture,
-		depthBuffer: true
+		depthBuffer: true,
+		stencilBuffer: false
 	} );
 
 	// normal render target
@@ -78,7 +80,8 @@ var SSAOPass = function ( scene, camera, width, height ) {
 	this.normalRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 		minFilter: NearestFilter,
 		magFilter: NearestFilter,
-		format: RGBAFormat
+		format: RGBAFormat,
+		stencilBuffer: false
 	} );
 
 	// ssao render target
@@ -86,7 +89,8 @@ var SSAOPass = function ( scene, camera, width, height ) {
 	this.ssaoRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 		minFilter: LinearFilter,
 		magFilter: LinearFilter,
-		format: RGBAFormat
+		format: RGBAFormat,
+		stencilBuffer: false
 	} );
 
 	this.blurRenderTarget = this.ssaoRenderTarget.clone();
@@ -197,6 +201,10 @@ SSAOPass.prototype = Object.assign( Object.create( Pass.prototype ), {
 	},
 
 	render: function ( renderer, writeBuffer /*, readBuffer, deltaTime, maskActive */ ) {
+
+		// configure depthTexture
+
+		this.beautyRenderTarget.depthTexture.type = ( renderer.capabilities.isWebGL2 ) ? FloatType : UnsignedShortType;
 
 		// render beauty and depth
 


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/issues/17865#issuecomment-588235524

`SSAOPass` relies on `WEBGL_depth_texture` extension. This PR makes the usage of WebGL2 mandatory and then use `THREE.FloatType` for `DepthTexture.type` to enable 32 bit depth precision (instead of 16 bit). This noticeably improves the usability of `SSAOPass`. Check out how the view frustum can be enlarged without introducing artifacts.