### PR TITLE
Added initCubeTexture to WebGLRenderer.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -403,6 +403,9 @@
 		<h3>[method:null initTexture]( [param:Texture texture] )</h3>
 		<p> Initializes the given texture. Useful for preloading a texture rather than waiting until first render (which can cause noticeable lags due to decode and GPU upload overhead).</p>
 
+		<h3>[method:null initCubeTexture]( [param:CubeTexture texture] )</h3>
+		<p> Initializes the given cube texture. Can be used to preload a cubemap rather than waiting until first render (which can cause noticeable lags due to decode and GPU upload overhead).</p>
+
 		<h3>[method:null resetGLState]( )</h3>
 		<p>Reset the GL state to default. Called internally if the WebGL context is lost.</p>
 

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -20,6 +20,7 @@ import { RenderTarget } from './webgl/WebGLRenderLists';
 import { Geometry } from './../core/Geometry';
 import { BufferGeometry } from './../core/BufferGeometry';
 import { Texture } from '../textures/Texture';
+import { CubeTexture } from '../textures/CubeTexture';
 
 export interface Renderer {
 	domElement: HTMLCanvasElement;
@@ -429,6 +430,13 @@ export class WebGLRenderer implements Renderer {
 	 * @param texture The texture to Initialize.
 	 */
 	initTexture( texture: Texture ): void;
+
+	/**
+	 * Initializes the given cube texture. Can be used to preload a cubemap rather than waiting until first render (which can cause noticeable lags due to decode and GPU upload overhead).
+	 *
+	 * @param texture The cube texture to Initialize.
+	 */
+	initCubeTexture( texture: CubeTexture ): void;
 
 	/**
 	 * @deprecated

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2832,6 +2832,14 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.initCubeTexture = function ( texture ) {
+
+		textures.setTextureCube( texture, 0 );
+
+		state.unbindTexture();
+
+	};
+
 	if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
 
 		__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'observe', { detail: this } ) ); // eslint-disable-line no-undef


### PR DESCRIPTION
Just as ``WebGLRenderer.initTexture`` is useful to upload loaded maps to the GPU without having to wait for first use, I propose ``WebGLRenderer.initCubeTexture`` to upload cubemaps to the GPU without the need to use them first (i.e. assigning them to ``Scene.background``).