### PR TITLE
WebGLClipping: Set numIntersection to 0 in projectPlanes().

### DIFF
--- a/src/renderers/webgl/WebGLClipping.js
+++ b/src/renderers/webgl/WebGLClipping.js
@@ -153,6 +153,7 @@ function WebGLClipping() {
 		}
 
 		scope.numPlanes = nPlanes;
+		scope.numIntersection = 0;
 
 		return dstArray;
 


### PR DESCRIPTION
Fixed #18675.

When `setState()` gets called with a material that has no clipping planes and shadows are enabled, it will enter this line https://github.com/mrdoob/three.js/blob/f7dd2f0e487094bb3297c2f2b3a7f4e1b5b8b569/src/renderers/webgl/WebGLClipping.js#L69

Which resets the `numPlanes` but not the `numIntersection` which was dirty with old values from previous materials with clipping planes.