### PR TITLE
CSM: Remove redundant "toRad" function

### DIFF
--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -1,6 +1,5 @@
 import * as THREE from '../../../build/three.module.js';
 import FrustumVertex from './FrustumVertex.js';
-import { toRad } from './Utils.js';
 
 export default class Frustum {
 
@@ -22,10 +21,10 @@ export default class Frustum {
 
 	getViewSpaceVertices() {
 
-		this.nearPlaneY = this.near * Math.tan( toRad( this.fov / 2 ) );
+		this.nearPlaneY = this.near * Math.tan( THREE.MathUtils.degToRad( this.fov / 2 ) );
 		this.nearPlaneX = this.aspect * this.nearPlaneY;
 
-		this.farPlaneY = this.far * Math.tan( toRad( this.fov / 2 ) );
+		this.farPlaneY = this.far * Math.tan( THREE.MathUtils.degToRad( this.fov / 2 ) );
 		this.farPlaneX = this.aspect * this.farPlaneY;
 
 		// 3 --- 0  vertices.near/far order

--- a/examples/jsm/csm/Utils.js
+++ b/examples/jsm/csm/Utils.js
@@ -1,5 +1,0 @@
-export function toRad( degrees ) {
-
-	return degrees * Math.PI / 180;
-
-}


### PR DESCRIPTION
Removes the `toRad` functions and replaces it with `MathUtils.degToRad`.

I'm looking into making some other changes to the CSM example coming up including:
- Using named imports to be consistent with the other examples.
- Adding support for orthographic cameras for convenience
- Adding fade between cascades

@vHawk Let me know what you think!