### PR TITLE
CSM: Use named imports and add author attribution

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -1,4 +1,15 @@
-import * as THREE from '../../../build/three.module.js';
+import {
+	Vector2,
+	Vector3,
+	DirectionalLight,
+	MathUtils,
+	ShaderChunk,
+	LineBasicMaterial,
+	Object3D,
+	BufferGeometry,
+	BufferAttribute,
+	Line
+} from '../../../build/three.module.js';
 import Frustum from './Frustum.js';
 import FrustumBoundingBox from './FrustumBoundingBox.js';
 import Shader from './Shader.js';
@@ -19,7 +30,7 @@ export default class CSM {
 		this.mode = data.mode || 'practical';
 		this.shadowMapSize = data.shadowMapSize || 2048;
 		this.shadowBias = data.shadowBias || 0.000001;
-		this.lightDirection = data.lightDirection || new THREE.Vector3( 1, - 1, 1 ).normalize();
+		this.lightDirection = data.lightDirection || new Vector3( 1, - 1, 1 ).normalize();
 		this.lightIntensity = data.lightIntensity || 1;
 		this.lightNear = data.lightNear || 1;
 		this.lightFar = data.lightFar || 2000;
@@ -41,7 +52,7 @@ export default class CSM {
 
 		for ( let i = 0; i < this.cascades; i ++ ) {
 
-			const light = new THREE.DirectionalLight( 0xffffff, this.lightIntensity );
+			const light = new DirectionalLight( 0xffffff, this.lightIntensity );
 			light.castShadow = true;
 			light.shadow.mapSize.width = this.shadowMapSize;
 			light.shadow.mapSize.height = this.shadowMapSize;
@@ -133,7 +144,7 @@ export default class CSM {
 
 			for ( let i = 1; i < amount; i ++ ) {
 
-				r.push( THREE.MathUtils.lerp( uni[ i - 1 ], log[ i - 1 ], lambda ) );
+				r.push( MathUtils.lerp( uni[ i - 1 ], log[ i - 1 ], lambda ) );
 
 			}
 
@@ -160,7 +171,7 @@ export default class CSM {
 
 			const squaredBBWidth = Math.max( bbox.size.x, bbox.size.y );
 
-			let center = new THREE.Vector3( bbox.center.x, bbox.center.y, bbox.center.z );
+			let center = new Vector3( bbox.center.x, bbox.center.y, bbox.center.z );
 			center.applyMatrix4( light.shadow.camera.matrixWorld );
 
 			light.shadow.camera.left = - squaredBBWidth / 2;
@@ -184,8 +195,8 @@ export default class CSM {
 
 	injectInclude() {
 
-		THREE.ShaderChunk.lights_fragment_begin = Shader.lights_fragment_begin;
-		THREE.ShaderChunk.lights_pars_begin = Shader.lights_pars_begin;
+		ShaderChunk.lights_fragment_begin = Shader.lights_fragment_begin;
+		ShaderChunk.lights_pars_begin = Shader.lights_pars_begin;
 
 	}
 
@@ -201,7 +212,7 @@ export default class CSM {
 
 			let amount = this.breaks[ i ];
 			let prev = this.breaks[ i - 1 ] || 0;
-			breaksVec2.push( new THREE.Vector2( prev, amount ) );
+			breaksVec2.push( new Vector2( prev, amount ) );
 
 		}
 
@@ -239,7 +250,7 @@ export default class CSM {
 
 			let amount = this.breaks[ i ];
 			let prev = this.breaks[ i - 1 ] || 0;
-			breaksVec2.push( new THREE.Vector2( prev, amount ) );
+			breaksVec2.push( new Vector2( prev, amount ) );
 
 		}
 
@@ -266,16 +277,16 @@ export default class CSM {
 
 		let frustum;
 		let geometry, vertices;
-		const material = new THREE.LineBasicMaterial( { color: 0xffffff } );
-		const object = new THREE.Object3D();
+		const material = new LineBasicMaterial( { color: 0xffffff } );
+		const object = new Object3D();
 
 		for ( let i = 0; i < this.frustums.length; i ++ ) {
 
 			frustum = this.frustums[ i ].toSpace( cameraMatrix );
 
-			geometry = new THREE.BufferGeometry();
+			geometry = new BufferGeometry();
 			vertices = [];
-			
+
 
 			for ( let i = 0; i < 5; i ++ ) {
 
@@ -283,12 +294,12 @@ export default class CSM {
 				vertices.push( point.x, point.y, point.z );
 
 			}
-			
-			geometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
 
-			object.add( new THREE.Line( geometry, material ) );
+			geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
 
-			geometry = new THREE.BufferGeometry();
+			object.add( new Line( geometry, material ) );
+
+			geometry = new BufferGeometry();
 			vertices = [];
 
 			for ( let i = 0; i < 5; i ++ ) {
@@ -297,14 +308,14 @@ export default class CSM {
 				vertices.push( point.x, point.y, point.z );
 
 			}
-			
-			geometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
 
-			object.add( new THREE.Line( geometry, material ) );
+			geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
+
+			object.add( new Line( geometry, material ) );
 
 			for ( let i = 0; i < 4; i ++ ) {
 
-				geometry = new THREE.BufferGeometry();
+				geometry = new BufferGeometry();
 				vertices = [];
 
 				const near = frustum.vertices.near[ i ];
@@ -312,10 +323,10 @@ export default class CSM {
 
 				vertices.push( near.x, near.y, near.z );
 				vertices.push( far.x, far.y, far.z );
-				
-				geometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( vertices ), 3 ) );
 
-				object.add( new THREE.Line( geometry, material ) );
+				geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
+
+				object.add( new Line( geometry, material ) );
 
 			}
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -1,3 +1,7 @@
+/**
+ * @author vHawk / https://github.com/vHawk/
+ */
+
 import {
 	Vector2,
 	Vector3,

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../../build/three.module.js';
+import { MathUtils, Vector3 } from '../../../build/three.module.js';
 import FrustumVertex from './FrustumVertex.js';
 
 export default class Frustum {
@@ -21,10 +21,10 @@ export default class Frustum {
 
 	getViewSpaceVertices() {
 
-		this.nearPlaneY = this.near * Math.tan( THREE.MathUtils.degToRad( this.fov / 2 ) );
+		this.nearPlaneY = this.near * Math.tan( MathUtils.degToRad( this.fov / 2 ) );
 		this.nearPlaneX = this.aspect * this.nearPlaneY;
 
-		this.farPlaneY = this.far * Math.tan( THREE.MathUtils.degToRad( this.fov / 2 ) );
+		this.farPlaneY = this.far * Math.tan( MathUtils.degToRad( this.fov / 2 ) );
 		this.farPlaneX = this.aspect * this.farPlaneY;
 
 		// 3 --- 0  vertices.near/far order
@@ -96,7 +96,7 @@ export default class Frustum {
 	toSpace( cameraMatrix ) {
 
 		const result = new Frustum();
-		const point = new THREE.Vector3();
+		const point = new Vector3();
 
 		for ( var i = 0; i < 4; i ++ ) {
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -1,3 +1,7 @@
+/**
+ * @author vHawk / https://github.com/vHawk/
+ */
+
 import { MathUtils, Vector3 } from '../../../build/three.module.js';
 import FrustumVertex from './FrustumVertex.js';
 

--- a/examples/jsm/csm/FrustumBoundingBox.js
+++ b/examples/jsm/csm/FrustumBoundingBox.js
@@ -1,3 +1,7 @@
+/**
+ * @author vHawk / https://github.com/vHawk/
+ */
+
 export default class FrustumBoundingBox {
 
 	constructor() {

--- a/examples/jsm/csm/FrustumVertex.js
+++ b/examples/jsm/csm/FrustumVertex.js
@@ -1,3 +1,7 @@
+/**
+ * @author vHawk / https://github.com/vHawk/
+ */
+
 export default class FrustumVertex {
 
 	constructor( x, y, z ) {

--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -1,3 +1,7 @@
+/**
+ * @author vHawk / https://github.com/vHawk/
+ */
+
 import { ShaderChunk } from '../../../build/three.module.js';
 
 export default {

--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../../build/three.module.js';
+import { ShaderChunk } from '../../../build/three.module.js';
 
 export default {
 	lights_fragment_begin: /* glsl */`
@@ -168,5 +168,5 @@ uniform vec2 CSM_cascades[CSM_CASCADES];
 uniform float cameraNear;
 uniform float shadowFar;
 #endif
-	` + THREE.ShaderChunk.lights_pars_begin
+	` + ShaderChunk.lights_pars_begin
 };


### PR DESCRIPTION
Switch the CSM example files to use named imports and add author attribution for @vHawk to be consistent with other examples.