### PR TITLE
New version of index_thumbs.html that displays a list of examples and thumbnails

### DIFF
--- a/examples/index_thumbs.html
+++ b/examples/index_thumbs.html
@@ -1,0 +1,154 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>three.js examples (Visual)</title>
+<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+<link rel="shortcut icon" href="../files/favicon.ico" />
+<link rel="stylesheet" type="text/css" href="../files/index_thumbs.css">
+<script src="files.js"></script>
+</head>
+<body>
+<script>
+function createLink(file) {
+    var link = document.createElement('a');
+    link.href = file + '.html';
+    link.setAttribute('target', 'new');
+    var fig = document.createElement('figure');
+    link.appendChild(fig);
+
+    var img = document.createElement('img');
+    img.setAttribute('src', 'screenshots/' + file + '.png');
+    img.setAttribute('id', 'figimg');
+    img.setAttribute('width', 320);
+    img.setAttribute('height', 200);
+    img.setAttribute('alt', link.textContent);
+    fig.appendChild(img);
+
+    var caption = document.createElement('figcaption');
+    fig.appendChild(caption);
+
+    var txt = document.createElement('p');
+    txt.style = 'display:inline'
+    txt.innerHTML = getName(file);
+    caption.appendChild(txt);
+
+    var src_link = createSourceLink(file);
+    caption.appendChild(src_link);
+
+    return link;
+}
+
+function createSourceLink(file) {
+    var link = document.createElement('a');
+    link.href = 'https://github.com/mrdoob/three.js/blob/master/examples/' + file + '.html';
+    link.setAttribute('target', 'new');
+
+    var img = document.createElement('img');
+    img.style = 'position: relative; left: 4px; top: 2px;'
+    img.setAttribute('src', '../files/ic_github_black_24dp.svg');
+    img.setAttribute('width', 20);
+    img.setAttribute('height', 20);
+    img.setAttribute('alt', 'View the source code on GitHub');
+    link.appendChild(img);
+
+    return link;
+}
+
+function updateFilter() {
+    var v = filter.value;
+    var exp = new RegExp(v, 'gi');
+    for (var key in files) {
+        var section = files[key];
+        for (var i = 0; i < section.length; i++) {
+            filterExample(section[i], exp);
+        }
+    }
+    layoutList();
+}
+
+function filterExample(file, exp) {
+    var link = links[file];
+    var name = getName(file);
+    var res = file.match(exp);
+    var text;
+    if (res && res.length > 0) {
+        link.classList.remove('hidden');
+        for (var i = 0; i < res.length; i++) {
+            text = name.replace(res[i], '<b>' + res[i] + '</b>');
+        }
+    } else {
+        link.classList.add('hidden');
+    }
+}
+
+function layoutList() {
+    for (var key in files) {
+        var collapsed = true;
+        var section = files[key];
+        for (var i = 0; i < section.length; i++) {
+            var file = section[i];
+            if (links[file].classList.contains('hidden') === false) {
+                collapsed = false;
+                break;
+            }
+        }
+        var element = document.querySelector('h1[data-category="' + key + '"]');
+        if (collapsed) {
+            element.classList.add('hidden');
+        } else {
+            element.classList.remove('hidden');
+        }
+    }
+}
+
+function getName(file) {
+    var name = file.split('_');
+    name.shift();
+    return name.join(' / ');
+}
+
+var links = {};
+var container = document.createElement('div');
+container.setAttribute('id', 'container');
+document.body.appendChild(container);
+
+var header = document.createElement('div');
+header.setAttribute('id', 'header');
+container.appendChild(header);
+
+var filter = document.createElement('input');
+filter.setAttribute('autofocus', 'true');
+filter.setAttribute('placeholder', '');
+filter.setAttribute('type', 'search');
+filter.setAttribute('id', 'filter');
+filter.setAttribute('autocorrect', 'off');
+filter.setAttribute('autocapitalize', 'off');
+filter.setAttribute('spellcheck', 'off');
+filter.addEventListener('input', function() {
+    updateFilter();
+});
+header.appendChild(filter);
+
+var content = document.createElement('div');
+content.setAttribute('id', 'content');
+container.appendChild(content);
+
+for (var key in files) {
+    var section = files[key];
+    var section_title = document.createElement('h1');
+    section_title.textContent = key;
+    section_title.setAttribute('data-category', key);
+    content.appendChild(section_title);
+    var grid = document.createElement('div');
+    grid.setAttribute('id', 'grid');
+    content.appendChild(grid);
+    for (var i = 0; i < section.length; i++) {
+        var file = section[i];
+        var link = createLink(file);
+        grid.appendChild(link);
+        links[file] = link;
+    }
+}
+</script>
+</body>
+</html>

--- a/files/index_thumbs.css
+++ b/files/index_thumbs.css
@@ -1,0 +1,123 @@
+:root {
+    --color-blue: #049EF4;
+    --text-color: #444;
+    --secondary-text-color: #9e9e9e;
+    --font-size: 16px;
+    --line-height: 22px;
+    --border-style: 1px solid #E8E8E8;
+    --header-height: 40px;
+    --panel-width: 300px;
+    --panel-padding: 16px;
+    --icon-size: 20px;
+}
+
+@font-face {
+    font-family: 'Roboto Mono';
+    src: local('Roboto Mono'), local('RobotoMono-Regular'), url('../files/RobotoMono-Regular.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 400;
+}
+
+html,
+body {
+    height: 100%;
+}
+
+html {
+    font-size: calc(var(--font-size) - 1px);
+    line-height: calc(var(--line-height) - 1px);
+}
+
+body {
+    font-family: 'Roboto Mono', monospace;
+    margin: 0px;
+    color: var(--text-color);
+    background-color: #ffffff;
+}
+
+a {
+    display: inline-block;
+    margin-bottom: 8px;
+    width: calc(50% - 4px);
+    text-decoration: none;
+    color: black;
+}
+
+@media screen and (min-width: 50em) {
+    a {
+        width: calc(10% - 6px);
+    }
+}
+
+.hidden {
+    display: none !important;
+}
+
+a:hover img {
+    transform: scale(1.01);
+}
+
+figure {
+    margin: 0;
+    overflow: hidden;
+}
+
+figcaption {
+    margin-top: 4px;
+    margin-bottom: 12px;
+}
+
+#figimg {
+    border: solid #ccc 1px;
+    max-width: 100%;
+    height: auto;
+    display: block;
+    background: #ccc;
+    border-radius: 8px 8px;
+}
+
+#container {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #fff;
+}
+
+#header {
+    position: absolute;
+    left: 16px;
+    top: 8px;
+    right: 16px;
+    height: var(--header-height);
+    background-color: #fff;
+}
+
+#filter {
+    border: 1px solid var(--color-blue);
+    color: var(--color-blue);
+    border-radius: 4px;
+    line-height: 32px;
+    padding: 0px 8px;
+    margin-left: 0;
+    font-size: 1.2rem;
+    width: 320px;
+}
+
+#content {
+    position: absolute;
+    left: 16px;
+    top: 44px;
+    right: 16px;
+    bottom: 0px;
+    background-color: #fff;
+}
+
+#grid {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    background-color: #fff;
+}

--- a/utils/examples/README.md
+++ b/utils/examples/README.md
@@ -1,0 +1,36 @@
+# Alternative three.js examples page with thumbnails #
+
+### Purpose ###
+
+Generates an alternative examples page that has an automatically generated thumbnail of each example as a visual reference. Google Puppeteer is used to capture a screen shot of each example. 
+
+After installing Node and the relevant npm packages (see below), run `node generate_thumbnails.js` and a new set of thumbnail images will be created in the `<three.js repo>/examples/thumbs` folder. 
+
+Visit `<three.js repo>/examples/thumbs/index_thumbs.html` to see the page.
+
+### Comprised of 2 parts: ###
+
+1/ The example page itself
+  * Visually easy to find examples by name or thumbnail
+  * Input allows selection filtering by name
+
+2/ A node.js script to generate thumbnails for all the examples
+* Found in `./utils/examples/generate_thumbanils.js`
+* Developed using:
+  * Node 10.16
+  * npm 6.13
+  * Google Puppeteer 2.0.0 (npm)
+  * Sharp 0.23.2 (npm)
+  * Capture a thumbnail from `files.js` (created as part of the three.js build)
+  * Specify tweaks for individual experiments
+    * Needed to generate a thumbnail that wasn't representative (E.G. loader takes too longer to render and captured thumbnail is blank)
+    * In the latter case, you can apply "Tweaks" to help get a good capture. Current tweaks are:
+        * `delay: <n>` add a delay before capture in ms
+        * `click: <selector>` inject a "click" event in the given HTML selector once it loads (E.G. useful for the webaudio examples that need interaction before they start)
+        * more to come (consider inject JavaScript to control an experiment more accurately)
+  * Can add a `--dev` command line parameter and this will force generation of examples in the tweaked_examples_dev array instead of the master list - see code for details
+
+### Future enhancements ###
+* Consider a way to allow new or updated examples to be selected.
+* Consider other ways to improve the 'fidelity' of the captured thumbnails. Given browser/network/rendering differences, what you end up with is still pretty random.  Perhaps consider a "screen shot" mode in each example, triggered by a JavaScript "tweak" that forces display of a representative visual?
+* Consider a way to combined the default examples view with a thumbnail option.  Seems bad to have two versions.

--- a/utils/examples/generate_thumbnails.js
+++ b/utils/examples/generate_thumbnails.js
@@ -1,0 +1,276 @@
+/*
+    @author callumprentice - https://callum.com (2019-11)
+
+    Generates images for an alternative version of the 
+    three.js examples page with thumbnail previews
+
+    Requirements:
+        node 10.16
+        npm 6.13
+        Google Puppeteer 2.0.0 (npm)
+        Sharp 0.23.2 (npm)
+*/
+
+const puppeteer = require('puppeteer');
+const sharp = require('sharp');
+const vm = require('vm');
+const fs = require('fs');
+
+const screenshot_width = 1024;
+const screenshot_height = 768;
+const thumbnail_width = 320;
+const thumbnail_height = parseInt((thumbnail_width / screenshot_width) * screenshot_height);
+const default_delay_ms = 2500;
+var dev_mode = false;
+
+// This is a list of examples whose capture parameters need to be tweaked. Currently, the
+// valid tweaks are 'delay' which changes the number of ms to wait before capture
+// (some examples take a longer time to load and initialize) and 'click' which inserts
+// a click event into the named selector (some examples - e.g. webaudio - need a click to
+// start because of browser restrictions)
+// Note: As examples change names or get deleted, the tweaks here might need to be updated.
+var tweaked_examples = [];
+tweaked_examples.push({name: 'webaudio_orientation', tweak: {click: 'button', delay: 2500}});
+tweaked_examples.push({name: 'webaudio_visualizer', tweak: {click: 'button', delay: 2500}});
+tweaked_examples.push({name: 'webaudio_timing', tweak: {click: 'button', delay: 2500}});
+tweaked_examples.push({name: 'webaudio_sandbox', tweak: {click: 'button', delay: 2500}});
+tweaked_examples.push({name: 'webgl_materials_video', tweak: {click: 'button', delay: 2500}});
+tweaked_examples.push({name: 'webgl2_materials_texture2darray', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_animation_multiple', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_3mf_materials', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_collada_kinematics', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_collada_skinning', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_animation_multiple', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_draco', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_fbx', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_gltf', tweak: {delay: 7000}});
+tweaked_examples.push({name: 'webgl_loader_gltf_extensions', tweak: {delay: 7000}});
+tweaked_examples.push({name: 'webgl_loader_imagebitmap', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_lwo', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_mmd', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_loader_mmd_audio', tweak: {delay: 7000}});
+tweaked_examples.push({name: 'webgl_loader_vrm', tweak: {delay: 7000}});
+tweaked_examples.push({name: 'webgl_loader_x', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_materials_car', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_materials_envmaps_parallax', tweak: {delay: 5000}});
+tweaked_examples.push({name: 'webgl_materials_translucency', tweak: {delay: 7000}});
+tweaked_examples.push({name: 'webxr_vr_cubes', tweak: {delay: 5000}});
+
+// This list of tweaked examples is to allow for testing individual (or more) example captures
+// and useful when you are experimenting with a tweak - changing the delay or figuring out
+// which selector to send a click to.
+var tweaked_examples_dev = [];
+tweaked_examples_dev.push({name: 'webaudio_orientation', tweak: {click: 'button', delay: 2500}});
+
+function build_example_list() {
+    // Read the JavaScript file that contains the primary list of example names
+    const js_filename = '../../examples/files.js';
+    var data = fs.readFileSync(js_filename);
+    const script = new vm.Script(data);
+    script.runInThisContext();
+
+    // Create an array of example names and empty tweaks using the
+    // entries we read from the JavaScript file we just loaded
+    var file_js_examples = [];
+    for (var key in files) {
+        for (var i = 0; i < files[key].length; ++i) {
+            const example_name = files[key][i];
+            file_js_examples.push({
+                name: example_name,
+                tweak: {}
+            });
+        }
+    }
+
+    // This will be populated with a list of example names from the list
+    // of tweaks that do not appear in the canonical list - usually this
+    // happens because an example has been removed or renamed
+    const invalid_example_names = [];
+
+    // Step through list of tweaked examples and for each, either merge it into
+    // the main list along with its tweak or add it to a list of invalid names
+    // that no longer appear in the canonical list
+    tweaked_examples.forEach(({name, tweak}) => {
+        let index = file_js_examples.findIndex(x => x.name === name);
+
+        index !== -1
+            ? (file_js_examples[index] = {
+                  name,
+                  tweak
+              })
+            : invalid_example_names.push({
+                  name,
+                  tweak
+              });
+    });
+
+    // Return both the merged canonical list as well the list of invalid names
+    // so we can inform the user that there are some entries in the tweak list which
+    // need their attention
+    return {
+        list: file_js_examples,
+        invalid: invalid_example_names
+    };
+}
+
+async function grab_shot(filename_base, thumb_dir, tweak, force_overwrite) {
+    // The path to the 'thumbs' folder and filename where the
+    // thumbnail will be saved - if it exists, we don't overwrite.
+    // Exception to this is if force_overwrite flag is true, the thumbnail
+    // will always be overwritten
+    const thumb_path = thumb_dir + '/' + filename_base + '.jpg';
+    if (!force_overwrite) {
+        if (fs.existsSync(thumb_path)) {
+            console.warn("Thumb already exists - won't overwrite: ", thumb_path);
+            return;
+        }
+    }
+
+    const browser = await puppeteer.launch({
+        defaultViewport: {
+            width: screenshot_width,
+            height: screenshot_height
+        }
+    });
+
+    // need a URL vs file:/// to open in Puppeteer - problem is, some of the
+    // new examples are only in dev and not yet present on the web site so
+    // will 404 - not sure yet how to deal with this without a 2 stage approach
+    const url = 'https://threejs.org/examples/' + filename_base + '.html';
+
+    const page = await browser.newPage();
+
+    console.log('Navigating to URL:', url);
+    await page.goto(url);
+    console.log('    Navigation complete');
+
+    let delay_ms = default_delay_ms;
+
+    if (tweak.delay != undefined) {
+        console.log('Tweak: delay set to', tweak.delay, 'ms');
+        delay_ms = tweak.delay;
+    }
+
+    if (tweak.click != undefined) {
+        console.log('Tweak: injecting a click to selector', tweak.click);
+        page.waitForSelector(tweak.click);
+        page.click(tweak.click);
+    }
+
+    // delay for N milliseconds - I think there is a better way to
+    // do this in node but this seems to work
+    console.log('Pausing for', delay_ms, 'ms');
+    await new Promise((resolve, reject) => {
+        setTimeout(() => resolve(), delay_ms);
+    });
+    console.log('    Pause complete');
+
+    console.log('Taking screenshot');
+    const shot_path = './' + filename_base + '_shot.png';
+    await page.screenshot({
+        path: shot_path
+    });
+    console.log('    Screenshot taken');
+
+    // use Sharp to resize the image and convert to a JPG (from PNG)
+    console.log('Creating thumbnail size', thumbnail_width, 'x', thumbnail_height, 'in', thumb_dir);
+    await sharp(shot_path)
+        .resize(thumbnail_width, thumbnail_height)
+        .toFile(thumb_path)
+        .then(info => {
+            console.log(info);
+        })
+        .catch(err => {
+            console.error(err);
+        });
+    console.log('    Thumbnail created');
+
+    console.log('Waiting for browser to close');
+    await browser.close();
+    console.log('    Browser is closed');
+
+    // the initial full-size shot is saved in the same folder as the script and once
+    // we have created the thumbnail, we no longer need it so it can be removed.
+    console.log('Removing initial shot:', shot_path);
+    fs.unlink(shot_path, err => {
+        if (err) {
+            console.error(err);
+            return;
+        }
+    });
+    console.log('    Initial shot removed');
+}
+
+// async aware version of array.forEach along with some
+// helpful log display
+async function asyncForEach(array, callback) {
+    for (let index = 0; index < array.length; index++) {
+        var log_line =
+            '\n' +
+            '(' +
+            (index + 1).toString() +
+            '/' +
+            array.length.toString() +
+            ') Grabbing shot of ' +
+            array[index].name +
+            ' with tweak ' +
+            JSON.stringify(array[index].tweak);
+        console.log(log_line);
+
+        await callback(array[index], index, array);
+    }
+}
+
+function grab_all_examples() {
+    // create a master list of example names/tweaks to capture based off
+    // the list in files.js and the tweaks listed at the top of this file
+    var result = build_example_list();
+
+    // sometimes there are 'orphans' - tweaks to examples that have been
+    // renamed or removed - highlight these - they won't be captured.
+    if (result.invalid.length) {
+        console.error("There are tweaks with names not found in main list - these won't be used");
+        console.table(result.invalid);
+    }
+
+    // make the folder to store the thumbnails in
+    const thumb_dir = '../../examples/thumbs/';
+    if (!fs.existsSync(thumb_dir)) {
+        fs.mkdirSync(thumb_dir);
+    }
+
+    const grab_all_shots = async () => {
+        await asyncForEach(result.list, async example => {
+            const force_overwrite = false;
+            await grab_shot(example.name, thumb_dir, example.tweak, force_overwrite);
+        });
+    };
+
+    // only grab all the shots if we are NOT in dev mode
+    if (!dev_mode) {
+        grab_all_shots();
+    }
+
+    const grab_all_shots_dev = async () => {
+        await asyncForEach(tweaked_examples_dev, async example => {
+            const force_overwrite = true;
+            await grab_shot(example.name, thumb_dir, example.tweak, force_overwrite);
+        });
+    };
+
+    // only grab all the dev shots if we ARE in dev mode
+    if (dev_mode) {
+        grab_all_shots_dev();
+    }
+}
+
+// Set 'dev' mode if '--dev' flag appears in command line args
+// Main effect currently is to NOT grab main list, grab shots listed
+// in tweaked_examples_dev[] and overwrite existing thumbnails.
+for (let j = 0; j < process.argv.length; j++) {
+    if (process.argv[j] == '--dev') {
+        dev_mode = true;
+    }
+}
+
+grab_all_examples();


### PR DESCRIPTION
Re-added the code and made a new pull request after something bad happened to original repository. 

This change re-adds the index_thumbs.html and associated CSS file -this page displays the list of examples dynamically and now references the official screenshots folder for thumbnails.

Also re-added the node.js script I wrote to capture thumbnails for all examples.