### PR TITLE
Editor: Fix geometry sidebar.

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -247,7 +247,14 @@ var SidebarGeometry = function ( editor ) {
 
 	}
 
-	signals.objectSelected.add( build );
+	signals.objectSelected.add( function () {
+
+		currentGeometryType = null;
+
+		build();
+
+	} );
+
 	signals.geometryChanged.add( build );
 
 	return container;


### PR DESCRIPTION
Fixed a bug introduced by #18561.

When an object is selected, it's necessary to reset `currentGeometryType`. Otherwise the UI will not be updated correctly if objects share the same type of geometry.