### PR TITLE
TS: Add generic types for Geometry and Material definitions

### DIFF
--- a/src/objects/InstancedMesh.d.ts
+++ b/src/objects/InstancedMesh.d.ts
@@ -1,17 +1,16 @@
-import { Geometry } from './../core/Geometry';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Material } from './../materials/Material';
+import { MeshBasicMaterial } from './../materials/MeshBasicMaterial';
 import { BufferAttribute } from './../core/BufferAttribute';
 import { Mesh } from './Mesh';
 import { Matrix4 } from './../math/Matrix4';
 
-export class InstancedMesh extends Mesh {
+export class InstancedMesh<
+	TGeometry extends BufferGeometry,
+	TMaterial extends Material = MeshBasicMaterial
+> extends Mesh<TGeometry, TMaterial> {
 
-	constructor(
-		geometry: Geometry | BufferGeometry,
-		material: Material | Material[],
-		count: number
-	);
+	constructor( geometry: TGeometry, material: TMaterial, count: number );
 
 	count: number;
 	instanceMatrix: BufferAttribute;

--- a/src/objects/Line.d.ts
+++ b/src/objects/Line.d.ts
@@ -1,20 +1,20 @@
 import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
+import { LineBasicMaterial } from './../materials/LineBasicMaterial';
 import { Raycaster } from './../core/Raycaster';
 import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Line extends Object3D {
+export class Line<
+	TGeometry extends Geometry | BufferGeometry = BufferGeometry,
+	TMaterial extends Material = LineBasicMaterial
+> extends Object3D {
 
-	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
-		mode?: number
-	);
+	constructor( geometry?: TGeometry, material?: TMaterial, mode?: number );
 
-	geometry: Geometry | BufferGeometry;
-	material: Material | Material[];
+	geometry: TGeometry;
+	material: TMaterial;
 
 	type: 'Line' | 'LineLoop' | 'LineSegments';
 	readonly isLine: true;

--- a/src/objects/LineLoop.d.ts
+++ b/src/objects/LineLoop.d.ts
@@ -1,14 +1,14 @@
 import { Line } from './Line';
 import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
-import { BufferGeometry } from '../core/BufferGeometry';
+import { LineBasicMaterial } from '../materials/LineBasicMaterial';
 
-export class LineLoop extends Line {
+export class LineLoop<
+	TGeometry extends Geometry,
+	TMaterial extends Material = LineBasicMaterial
+> extends Line<TGeometry, TMaterial> {
 
-	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
-	);
+	constructor( geometry?: TGeometry, material?: TMaterial );
 
 	type: 'LineLoop';
 	readonly isLineLoop: true;

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -1,7 +1,7 @@
 import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
 import { Line } from './Line';
-import { BufferGeometry } from '../core/BufferGeometry';
+import { LineBasicMaterial } from '../materials/LineBasicMaterial';
 
 /**
  * @deprecated
@@ -12,13 +12,12 @@ export const LineStrip: number;
  */
 export const LinePieces: number;
 
-export class LineSegments extends Line {
+export class LineSegments<
+	TGeometry extends Geometry = Geometry,
+	TMaterial extends Material = LineBasicMaterial
+> extends Line<TGeometry, TMaterial> {
 
-	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
-		mode?: number
-	);
+	constructor( geometry?: TGeometry, material?: TMaterial, mode?: number );
 
 	type: 'LineSegments';
 	readonly isLineSegments: true;

--- a/src/objects/Mesh.d.ts
+++ b/src/objects/Mesh.d.ts
@@ -1,19 +1,20 @@
 import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
+import { MeshBasicMaterial } from './../materials/MeshBasicMaterial';
 import { Raycaster } from './../core/Raycaster';
 import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Mesh extends Object3D {
+export class Mesh<
+	TGeometry extends Geometry | BufferGeometry = BufferGeometry,
+	TMaterial extends Material | Material[] = MeshBasicMaterial
+> extends Object3D {
 
-	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
-	);
+	constructor( geometry?: TGeometry, material?: TMaterial );
 
-	geometry: Geometry | BufferGeometry;
-	material: Material | Material[];
+	geometry: TGeometry;
+	material: TMaterial;
 	morphTargetInfluences?: number[];
 	morphTargetDictionary?: { [key: string]: number };
 	readonly isMesh: true;

--- a/src/objects/Points.d.ts
+++ b/src/objects/Points.d.ts
@@ -1,5 +1,6 @@
 import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
+import { PointsMaterial } from './../materials/PointsMaterial';
 import { Raycaster } from './../core/Raycaster';
 import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
@@ -10,16 +11,16 @@ import { Intersection } from '../core/Raycaster';
  *
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/objects/ParticleSystem.js">src/objects/ParticleSystem.js</a>
  */
-export class Points extends Object3D {
+export class Points<
+	TGeometry extends Geometry | BufferGeometry = BufferGeometry,
+	TMaterial extends Material = PointsMaterial
+> extends Object3D {
 
 	/**
 	 * @param geometry An instance of Geometry or BufferGeometry.
 	 * @param material An instance of Material (optional).
 	 */
-	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
-	);
+	constructor( geometry?: TGeometry, material?: TMaterial );
 
 	type: 'Points';
 	morphTargetInfluences?: number[];
@@ -29,12 +30,12 @@ export class Points extends Object3D {
 	/**
 	 * An instance of Geometry or BufferGeometry, where each vertex designates the position of a particle in the system.
 	 */
-	geometry: Geometry | BufferGeometry;
+	geometry: TGeometry;
 
 	/**
 	 * An instance of Material, defining the object's appearance. Default is a PointsMaterial with randomised colour.
 	 */
-	material: Material | Material[];
+	material: TMaterial;
 
 	raycast( raycaster: Raycaster, intersects: Intersection[] ): void;
 	updateMorphTargets(): void;

--- a/src/objects/SkinnedMesh.d.ts
+++ b/src/objects/SkinnedMesh.d.ts
@@ -1,15 +1,19 @@
-import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
+import { MeshBasicMaterial } from './../materials/MeshBasicMaterial';
+
 import { Matrix4 } from './../math/Matrix4';
 import { Skeleton } from './Skeleton';
 import { Mesh } from './Mesh';
 import { BufferGeometry } from '../core/BufferGeometry';
 
-export class SkinnedMesh extends Mesh {
+export class SkinnedMesh<
+	TGeometry extends BufferGeometry,
+	TMaterial extends Material = MeshBasicMaterial
+> extends Mesh<TGeometry, TMaterial> {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
+		geometry?: TGeometry,
+		material?: TMaterial,
 		useVertexTexture?: boolean
 	);
 


### PR DESCRIPTION
This allows for inferences like .getAttribute() on a THREE.Points .geometry instance, which is nice. I also ran eslint --fix, which for some reason changed all the imports from `'` to `"`.

