### PR TITLE
CSM: Use cache objects in initCascades

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -37,6 +37,8 @@ export default class CSM {
 		this.lightFar = data.lightFar || 2000;
 		this.lightMargin = data.lightMargin || 200;
 		this.customSplitsCallback = data.customSplitsCallback;
+		this.mainFrustum = new Frustum();
+		this.frustums = [];
 
 		this.lights = [];
 		this.materials = [];
@@ -74,16 +76,8 @@ export default class CSM {
 
 		const camera = this.camera;
 		camera.updateProjectionMatrix();
-		this.mainFrustum = new Frustum( {
-
-			maxFar: this.maxFar,
-			projectionMatrix: camera.projectionMatrix
-
-		} );
-
-		this.mainFrustum.getViewSpaceVertices();
-
-		this.frustums = this.mainFrustum.split( this.breaks );
+		this.mainFrustum.setFromProjectionMatrix( camera.projectionMatrix, this.maxFar );
+		this.mainFrustum.split( this.breaks, this.frustums );
 
 	}
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -45,20 +45,20 @@ export default class Frustum {
 		// 2 --- 1
 		// clip space spans from [-1, 1]
 
-		this.vertices.near[ 0 ] = new Vector3( 1, 1, - 1 );
-		this.vertices.near[ 1 ] = new Vector3( 1, - 1, - 1 );
-		this.vertices.near[ 2 ] = new Vector3( - 1, - 1, - 1 );
-		this.vertices.near[ 3 ] = new Vector3( - 1, 1, - 1 );
+		this.vertices.near[ 0 ].set( 1, 1, - 1 );
+		this.vertices.near[ 1 ].set( 1, - 1, - 1 );
+		this.vertices.near[ 2 ].set( - 1, - 1, - 1 );
+		this.vertices.near[ 3 ].set( - 1, 1, - 1 );
 		this.vertices.near.forEach( function( v ) {
 
 			v.applyMatrix4( inverseProjectionMatrix );
 
 		} );
 
-		this.vertices.far[ 0 ] = new Vector3( 1, 1, 1 );
-		this.vertices.far[ 1 ] = new Vector3( 1, - 1, 1 );
-		this.vertices.far[ 2 ] = new Vector3( - 1, - 1, 1 );
-		this.vertices.far[ 3 ] = new Vector3( - 1, 1, 1 );
+		this.vertices.far[ 0 ].set( 1, 1, 1 );
+		this.vertices.far[ 1 ].set( 1, - 1, 1 );
+		this.vertices.far[ 2 ].set( - 1, - 1, 1 );
+		this.vertices.far[ 3 ].set( - 1, 1, 1 );
 		this.vertices.far.forEach( function( v ) {
 
 			v.applyMatrix4( inverseProjectionMatrix );
@@ -92,7 +92,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.near[ j ] = this.vertices.near[ j ].clone();
+					cascade.vertices.near[ j ].copy( this.vertices.near[ j ] );
 
 				}
 
@@ -100,7 +100,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.near[ j ] = new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i - 1 ] );
+					cascade.vertices.near[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i - 1 ] );
 
 				}
 
@@ -110,7 +110,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.far[ j ] = this.vertices.far[ j ].clone();
+					cascade.vertices.far[ j ].copy( this.vertices.far[ j ] );
 
 				}
 
@@ -118,7 +118,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.far[ j ] = new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i ] );
+					cascade.vertices.far[ j ].lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i ] );
 
 				}
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -12,9 +12,6 @@ export default class Frustum {
 
 		data = data || {};
 
-		this.projectionMatrix = data.projectionMatrix;
-		this.maxFar = data.maxFar || 10000;
-
 		this.vertices = {
 			near: [
 				new Vector3(),
@@ -30,15 +27,19 @@ export default class Frustum {
 			]
 		};
 
+		if ( data.projectionMatrix !== undefined ) {
+
+			this.setFromProjectionMatrix( data.projectionMatrix, data.maxFar || 10000 );
+
+		}
+
 	}
 
-	getViewSpaceVertices() {
+	setFromProjectionMatrix( projectionMatrix, maxFar ) {
 
-		const maxFar = this.maxFar;
-		const projectionMatrix = this.projectionMatrix;
 		const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-		inverseProjectionMatrix.getInverse( this.projectionMatrix );
+		inverseProjectionMatrix.getInverse( projectionMatrix );
 
 		// 3 --- 0  vertices.near/far order
 		// |     |
@@ -80,13 +81,18 @@ export default class Frustum {
 
 	}
 
-	split( breaks ) {
+	split( breaks, target ) {
 
-		const result = [];
+		while ( breaks.length > target.length ) {
+
+			target.push( new Frustum() );
+
+		}
+		target.length = breaks.length;
 
 		for ( let i = 0; i < breaks.length; i ++ ) {
 
-			const cascade = new Frustum();
+			const cascade = target[ i ];
 
 			if ( i === 0 ) {
 
@@ -124,11 +130,7 @@ export default class Frustum {
 
 			}
 
-			result.push( cascade );
-
 		}
-
-		return result;
 
 	}
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -16,8 +16,18 @@ export default class Frustum {
 		this.maxFar = data.maxFar || 10000;
 
 		this.vertices = {
-			near: [],
-			far: []
+			near: [
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3()
+			],
+			far: [
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3()
+			]
 		};
 
 	}
@@ -35,24 +45,20 @@ export default class Frustum {
 		// 2 --- 1
 		// clip space spans from [-1, 1]
 
-		this.vertices.near.push(
-			new Vector3( 1, 1, - 1 ),
-			new Vector3( 1, - 1, - 1 ),
-			new Vector3( - 1, - 1, - 1 ),
-			new Vector3( - 1, 1, - 1 )
-		);
+		this.vertices.near[ 0 ] = new Vector3( 1, 1, - 1 );
+		this.vertices.near[ 1 ] = new Vector3( 1, - 1, - 1 );
+		this.vertices.near[ 2 ] = new Vector3( - 1, - 1, - 1 );
+		this.vertices.near[ 3 ] = new Vector3( - 1, 1, - 1 );
 		this.vertices.near.forEach( function( v ) {
 
 			v.applyMatrix4( inverseProjectionMatrix );
 
 		} );
 
-		this.vertices.far.push(
-			new Vector3( 1, 1, 1 ),
-			new Vector3( 1, - 1, 1 ),
-			new Vector3( - 1, - 1, 1 ),
-			new Vector3( - 1, 1, 1 )
-		)
+		this.vertices.far[ 0 ] = new Vector3( 1, 1, 1 );
+		this.vertices.far[ 1 ] = new Vector3( 1, - 1, 1 );
+		this.vertices.far[ 2 ] = new Vector3( - 1, - 1, 1 );
+		this.vertices.far[ 3 ] = new Vector3( - 1, 1, 1 );
 		this.vertices.far.forEach( function( v ) {
 
 			v.applyMatrix4( inverseProjectionMatrix );
@@ -94,7 +100,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.near.push( new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i - 1 ] ) );
+					cascade.vertices.near[ j ] = new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i - 1 ] );
 
 				}
 
@@ -112,7 +118,7 @@ export default class Frustum {
 
 				for ( let j = 0; j < 4; j ++ ) {
 
-					cascade.vertices.far.push( new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i ] ) );
+					cascade.vertices.far[ j ] = new Vector3().lerpVectors( this.vertices.near[ j ], this.vertices.far[ j ], breaks[ i ] );
 
 				}
 
@@ -135,11 +141,11 @@ export default class Frustum {
 
 			point.set( this.vertices.near[ i ].x, this.vertices.near[ i ].y, this.vertices.near[ i ].z );
 			point.applyMatrix4( cameraMatrix );
-			result.vertices.near.push( point.clone() );
+			result.vertices.near[ i ] = point.clone();
 
 			point.set( this.vertices.far[ i ].x, this.vertices.far[ i ].y, this.vertices.far[ i ].z );
 			point.applyMatrix4( cameraMatrix );
-			result.vertices.far.push( point.clone() );
+			result.vertices.far[ i ] = point.clone();
 
 		}
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -84,7 +84,11 @@ export default class Frustum {
 
 			if ( i === 0 ) {
 
-				cascade.vertices.near = this.vertices.near;
+				for ( let j = 0; j < 4; j ++ ) {
+
+					cascade.vertices.near[ j ] = this.vertices.near[ j ].clone();
+
+				}
 
 			} else {
 
@@ -98,7 +102,11 @@ export default class Frustum {
 
 			if ( i === breaks - 1 ) {
 
-				cascade.vertices.far = this.vertices.far;
+				for ( let j = 0; j < 4; j ++ ) {
+
+					cascade.vertices.far[ j ] = this.vertices.far[ j ].clone();
+
+				}
 
 			} else {
 


### PR DESCRIPTION
The `initCascades` function must be called whenever `fov`, `near`, `far`, or `aspect` fields are changed on a camera so it can be a hot function especially when resizing a window or animating a transition between camera types. I've modified it here to reuse `Frustum` instances rather than create new ones whenever it's called to save on object allocation.

I'll be doing the same thing for `.update` next.

Temporary live link:

https://raw.githack.com/gkjohnson/three.js/csm-cache-objects/examples/webgl_shadowmap_csm.html

@vHawk 

_Edit: Looks like the failure is a diff issue from `css3d_youtube`:_

> ERROR! Diff wrong in 0.079 of pixels in file: css3d_youtube