### PR TITLE
CSM: Use cached objects in .update

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -21,6 +21,7 @@ import Shader from './Shader.js';
 
 const _cameraToLightMatrix = new Matrix4();
 const _lightSpaceFrustum = new Frustum();
+const _frustum = new Frustum();
 const _center = new Vector3();
 const _bbox = new FrustumBoundingBox();
 
@@ -276,14 +277,13 @@ export default class CSM {
 
 	helper( cameraMatrix ) {
 
-		let frustum;
 		let geometry, vertices;
 		const material = new LineBasicMaterial( { color: 0xffffff } );
 		const object = new Object3D();
 
 		for ( let i = 0; i < this.frustums.length; i ++ ) {
 
-			frustum = this.frustums[ i ].toSpace( cameraMatrix );
+			this.frustums[ i ].toSpace( cameraMatrix, _frustum );
 
 			geometry = new BufferGeometry();
 			vertices = [];
@@ -291,7 +291,7 @@ export default class CSM {
 
 			for ( let i = 0; i < 5; i ++ ) {
 
-				const point = frustum.vertices.near[ i === 4 ? 0 : i ];
+				const point = _frustum.vertices.near[ i === 4 ? 0 : i ];
 				vertices.push( point.x, point.y, point.z );
 
 			}
@@ -305,7 +305,7 @@ export default class CSM {
 
 			for ( let i = 0; i < 5; i ++ ) {
 
-				const point = frustum.vertices.far[ i === 4 ? 0 : i ];
+				const point = _frustum.vertices.far[ i === 4 ? 0 : i ];
 				vertices.push( point.x, point.y, point.z );
 
 			}
@@ -319,8 +319,8 @@ export default class CSM {
 				geometry = new BufferGeometry();
 				vertices = [];
 
-				const near = frustum.vertices.near[ i ];
-				const far = frustum.vertices.far[ i ];
+				const near = _frustum.vertices.near[ i ];
+				const far = _frustum.vertices.far[ i ];
 
 				vertices.push( near.x, near.y, near.z );
 				vertices.push( far.x, far.y, far.z );

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -20,7 +20,7 @@ import FrustumBoundingBox from './FrustumBoundingBox.js';
 import Shader from './Shader.js';
 
 const _cameraToLightMatrix = new Matrix4();
-const _frustum = new Frustum();
+const _lightSpaceFrustum = new Frustum();
 const _center = new Vector3();
 const _bbox = new FrustumBoundingBox();
 
@@ -166,11 +166,11 @@ export default class CSM {
 
 			const light = this.lights[ i ];
 			_cameraToLightMatrix.multiplyMatrices( light.shadow.camera.matrixWorldInverse, cameraMatrix );
-			this.frustums[ i ].toSpace( _cameraToLightMatrix, _frustum );
+			this.frustums[ i ].toSpace( _cameraToLightMatrix, _lightSpaceFrustum );
 
 			light.shadow.camera.updateMatrixWorld( true );
 
-			_bbox.fromFrustum( _frustum );
+			_bbox.fromFrustum( _lightSpaceFrustum );
 			_bbox.getSize();
 			_bbox.getCenter( this.lightMargin );
 

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -134,24 +134,19 @@ export default class Frustum {
 
 	}
 
-	toSpace( cameraMatrix ) {
-
-		const result = new Frustum();
-		const point = new Vector3();
+	toSpace( cameraMatrix, target ) {
 
 		for ( var i = 0; i < 4; i ++ ) {
 
-			point.set( this.vertices.near[ i ].x, this.vertices.near[ i ].y, this.vertices.near[ i ].z );
-			point.applyMatrix4( cameraMatrix );
-			result.vertices.near[ i ] = point.clone();
+			target.vertices.near[ i ]
+				.copy( this.vertices.near[ i ] )
+				.applyMatrix4( cameraMatrix );
 
-			point.set( this.vertices.far[ i ].x, this.vertices.far[ i ].y, this.vertices.far[ i ].z );
-			point.applyMatrix4( cameraMatrix );
-			result.vertices.far[ i ] = point.clone();
+			target.vertices.far[ i ]
+				.copy( this.vertices.far[ i ] )
+				.applyMatrix4( cameraMatrix );
 
 		}
-
-		return result;
 
 	}
 

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -214,7 +214,7 @@
 
 				requestAnimationFrame( animate );
 
-				csm.update( camera.matrix );
+				csm.update( camera.matrixWorld );
 				controls.update();
 
 				if ( params.orthographic ) {

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -214,6 +214,7 @@
 
 				requestAnimationFrame( animate );
 
+				camera.updateMatrixWorld();
 				csm.update( camera.matrixWorld );
 				controls.update();
 


### PR DESCRIPTION
Follow up to #18723

The `update` function gets fired every frame so I've removed any instantiation of new objects in that loop. I also updated the example page to pass the camera world matrix rather than the local matrix when calculating the shadow camera volumes.

Both `getExtendedBreaks` and `getBreaks` can get called frequently, as well, and create new arrays every call, so I'll address those next.

Temporary live link:
https://raw.githack.com/gkjohnson/three.js/csm-update-cache-objects/examples/webgl_shadowmap_csm.html

@vHawk 