### PR TITLE
Utils: Move converters to modules.

### DIFF
--- a/utils/converters/README.md
+++ b/utils/converters/README.md
@@ -1,11 +1,12 @@
 Utilities for converting model files to the Three.js JSON format.
+It's necessary to install the [esm](https://www.npmjs.com/package/esm) npm package before you can use the converters.
 
 ## obj2three.js
 
 Usage:
 
 ```
-node obj2three.js model.obj
+node -r esm obj2three.js model.obj
 ```
 
 ## fbx2three.js
@@ -13,5 +14,5 @@ node obj2three.js model.obj
 Usage:
 
 ```
-node fbx2three.js model.fbx
+node -r esm fbx2three.js model.fbx
 ```

--- a/utils/converters/fbx2three.js
+++ b/utils/converters/fbx2three.js
@@ -1,5 +1,8 @@
-var fs = require( 'fs' );
-var path = require( 'path' );
+import fs from 'fs';
+import path from 'path';
+
+import { FBXLoader } from '../../examples/jsm/loaders/FBXLoader.js';
+import { ImageLoader, ImageUtils, LoaderUtils } from '../../build/three.module.js';
 
 if ( process.argv.length <= 2 ) {
 
@@ -10,19 +13,13 @@ if ( process.argv.length <= 2 ) {
 
 //
 
-var PRECISION = 6;
+const PRECISION = 6;
 
 function parseNumber( key, value ) {
 
 	return typeof value === 'number' ? parseFloat( value.toFixed( PRECISION ) ) : value;
 
 }
-
-THREE = require( '../../build/three.js' );
-require( '../../examples/js/curves/NURBSCurve.js' );
-require( '../../examples/js/curves/NURBSUtils.js' );
-require( '../../examples/js/loaders/FBXLoader.js' );
-global.Zlib = require( '../../examples/js/libs/inflate.min.js' ).Zlib;
 
 global.window = {
 	innerWidth: 1024,
@@ -39,7 +36,7 @@ global.window = {
 };
 
 // HTML Images are not available, so use a Buffer instead.
-THREE.ImageLoader.prototype.load = function ( url, onLoad ) {
+ImageLoader.prototype.load = function ( url, onLoad ) {
 
 	if ( this.path !== undefined ) url = this.path + url;
 
@@ -56,7 +53,7 @@ THREE.ImageLoader.prototype.load = function ( url, onLoad ) {
 };
 
 // Convert image buffer to data URL.
-THREE.ImageUtils.getDataURL = function ( image ) {
+ImageUtils.getDataURL = function ( image ) {
 
 	if ( ! ( image instanceof Buffer ) ) {
 
@@ -64,7 +61,7 @@ THREE.ImageUtils.getDataURL = function ( image ) {
 
 	}
 
-	var dataURL = 'data:';
+	let dataURL = 'data:';
 	dataURL += this.format === THREE.RGBAFormat ? 'image/png' : 'image/jpeg';
 	dataURL += ';base64,';
 	dataURL += image.toString( 'base64' );
@@ -74,11 +71,11 @@ THREE.ImageUtils.getDataURL = function ( image ) {
 
 //
 
-var file = process.argv[ 2 ];
-var resourceDirectory = THREE.LoaderUtils.extractUrlBase( file );
-var loader = new THREE.FBXLoader();
+const file = process.argv[ 2 ];
+const resourceDirectory = LoaderUtils.extractUrlBase( file );
+const loader = new FBXLoader();
 
-var arraybuffer = fs.readFileSync( file ).buffer;
-var object = loader.parse( arraybuffer, resourceDirectory );
-var content = JSON.stringify( object.toJSON(), parseNumber );
+const arraybuffer = fs.readFileSync( file ).buffer;
+const object = loader.parse( arraybuffer, resourceDirectory );
+const content = JSON.stringify( object.toJSON(), parseNumber );
 fs.writeFileSync( path.basename( file, '.fbx' ) + '.json', content, 'utf8' );

--- a/utils/converters/obj2three.js
+++ b/utils/converters/obj2three.js
@@ -1,5 +1,7 @@
-var fs = require( 'fs' );
-var path = require( 'path' );
+import fs from 'fs';
+import path from 'path';
+
+import { OBJLoader } from '../../examples/jsm/loaders/OBJLoader.js';
 
 if ( process.argv.length <= 2 ) {
 
@@ -10,7 +12,7 @@ if ( process.argv.length <= 2 ) {
 
 //
 
-var PRECISION = 6;
+const PRECISION = 6;
 
 function parseNumber( key, value ) {
 
@@ -18,13 +20,10 @@ function parseNumber( key, value ) {
 
 }
 
-THREE = require( '../../build/three.js' );
-require( '../../examples/js/loaders/OBJLoader.js' );
+const file = process.argv[ 2 ];
+const loader = new OBJLoader();
 
-var file = process.argv[ 2 ];
-var loader = new THREE.OBJLoader();
+const text = fs.readFileSync( file, 'utf8' );
 
-var text = fs.readFileSync( file, 'utf8' );
-
-var content = JSON.stringify( loader.parse( text ).toJSON(), parseNumber );
+const content = JSON.stringify( loader.parse( text ).toJSON(), parseNumber );
 fs.writeFileSync( path.basename( file, '.obj' ) + '.json', content, 'utf8' );


### PR DESCRIPTION
`fbx2three.js` and `obj2three.js` are still using examples files from the `js` directory. This PR ensures that both scripts use modules. Since the ES6 module support in context of node is complicated, the scripts now require the usage of [esm](https://www.npmjs.com/package/esm).

Tested the change with `Samba Dancing.fbx`, `stanford-bunny.fbx` and `emerald.obj`.

Sidenote: I also like to suggest to remove both scripts and refer to the editor instead. The project only provides for two 3D formats such converters which is somewhat inconsistent. Besides, even the current implementation of `fbx2three.js` does not cover all features compared to the browser version and requires some ugly monkey-patching so textures can be handled. Not a proper solution, IMO.