### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -2,19 +2,19 @@
  * @author arya-s / https://github.com/arya-s
  *
  * This is a helper for visualising a given light's shadow map.
- * It works for shadow casting lights: THREE.DirectionalLight and THREE.SpotLight.
+ * It works for shadow casting lights: DirectionalLight and SpotLight.
  * It renders out the shadow map and displays it on a HUD.
  *
  * Example usage:
- *	1) Include <script src='examples/js/utils/ShadowMapViewer.js'><script> in your html file
+ *	1) Import ShadowMapViewer into your app.
  *
  *	2) Create a shadow casting light and name it optionally:
- *		var light = new THREE.DirectionalLight( 0xffffff, 1 );
+ *		var light = new DirectionalLight( 0xffffff, 1 );
  *		light.castShadow = true;
  *		light.name = 'Sun';
  *
  *	3) Create a shadow map viewer for that light and set its size and position optionally:
- *		var shadowMapViewer = new THREE.ShadowMapViewer( light );
+ *		var shadowMapViewer = new ShadowMapViewer( light );
  *		shadowMapViewer.size.set( 128, 128 );	//width, height  default: 256, 256
  *		shadowMapViewer.position.set( 10, 10 );	//x, y in pixel	 default: 0, 0 (top left corner)
  *

--- a/examples/jsm/utils/ShadowMapViewer.js
+++ b/examples/jsm/utils/ShadowMapViewer.js
@@ -2,14 +2,14 @@
  * @author arya-s / https://github.com/arya-s
  *
  * This is a helper for visualising a given light's shadow map.
- * It works for shadow casting lights: THREE.DirectionalLight and THREE.SpotLight.
+ * It works for shadow casting lights: DirectionalLight and SpotLight.
  * It renders out the shadow map and displays it on a HUD.
  *
  * Example usage:
- *	1) Include <script src='examples/js/utils/ShadowMapViewer.js'><script> in your html file
+ *	1) Import ShadowMapViewer into your app.
  *
  *	2) Create a shadow casting light and name it optionally:
- *		var light = new THREE.DirectionalLight( 0xffffff, 1 );
+ *		var light = new DirectionalLight( 0xffffff, 1 );
  *		light.castShadow = true;
  *		light.name = 'Sun';
  *

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -226,7 +226,7 @@ var files = [
 	{ path: 'utils/BufferGeometryUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/GeometryUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/SceneUtils.js', dependencies: [], ignoreList: [] },
-	{ path: 'utils/ShadowMapViewer.js', dependencies: [ { name: 'UnpackDepthRGBAShader', path: 'shaders/UnpackDepthRGBAShader.js' } ], ignoreList: [ 'DirectionalLight', 'SpotLight' ] },
+	{ path: 'utils/ShadowMapViewer.js', dependencies: [ { name: 'UnpackDepthRGBAShader', path: 'shaders/UnpackDepthRGBAShader.js' } ], ignoreList: [] },
 	{ path: 'utils/SkeletonUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/TypedArrayUtils.js', dependencies: [], ignoreList: [] },
 	{ path: 'utils/UVsDebug.js', dependencies: [], ignoreList: [ 'SphereBufferGeometry' ] },


### PR DESCRIPTION
Remove references to `examples/js/` in `ShadowMapViewer` and refer to modules instead. 