### PR TITLE
Global: Remove references to examples/js.

### DIFF
--- a/docs/api/en/animation/KeyframeTrack.html
+++ b/docs/api/en/animation/KeyframeTrack.html
@@ -58,7 +58,7 @@
 
 		<p>
 			Some examples of how to manually create [page:AnimationClip AnimationClips] with different sorts
-			of KeyframeTracks can be found in the [link:https://threejs.org/examples/js/animation/AnimationClipCreator.js AnimationClipCreator]
+			of KeyframeTracks can be found in the [link:https://threejs.org/examples/jsm/animation/AnimationClipCreator.js AnimationClipCreator]
 			file.
 		</p>
 

--- a/docs/api/en/cameras/StereoCamera.html
+++ b/docs/api/en/cameras/StereoCamera.html
@@ -25,9 +25,9 @@
 
 		<p>
 		This class is used internally in the files<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/AnaglyphEffect.js examples/js/effects/AnaglyphEffect.js]<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/ParallaxBarrierEffect.js examples/js/effects/ParallaxBarrierEffect.js]<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/StereoEffect.js examples/js/effects/StereoEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/AnaglyphEffect.js examples/jsm/effects/AnaglyphEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/ParallaxBarrierEffect.js examples/jsm/effects/ParallaxBarrierEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/StereoEffect.js examples/jsm/effects/StereoEffect.js]<br /><br />
 		used in the above examples.
 		</p>
 

--- a/docs/api/en/deprecated/DeprecatedList.html
+++ b/docs/api/en/deprecated/DeprecatedList.html
@@ -473,7 +473,7 @@
 
 		<h3>[page:LensFlare]</h3>
 		<p>
-			LensFlare has been moved to [link:https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Lensflare.js /examples/js/objects/Lensflare.js].
+			LensFlare has been moved to [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/objects/Lensflare.js /examples/jsm/objects/Lensflare.js].
 		</p>
 
 
@@ -509,7 +509,7 @@
 		<h3>[page:Projector]</h3>
 		<p>
 			Projector has been moved to
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/Projector.js 	/examples/js/renderers/Projector.js].<br /><br />
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/Projector.js 	/examples/jsm/renderers/Projector.js].<br /><br />
 
 			Projector.projectVector() is now [page:Vector.project]().<br /><br />
 

--- a/docs/api/en/lights/RectAreaLight.html
+++ b/docs/api/en/lights/RectAreaLight.html
@@ -20,7 +20,7 @@
 			<ul>
 				<li>There is no shadow support.</li>
 				<li>Only [page:MeshStandardMaterial MeshStandardMaterial] and [page:MeshPhysicalMaterial MeshPhysicalMaterial] are supported.</li>
-				<li>You have to include [link:https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] into your scene and call *init()*.</li>
+				<li>You have to include [link:https://threejs.org/examples/jsm/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] into your scene and call *init()*.</li>
 			</ul>
 		</p>
 

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -20,8 +20,8 @@
 		<h2>Examples</h2>
 
 		<p>
-			See the [link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/DDSLoader.js DDSLoader]
-			and [link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PVRLoader.js PVRLoader]
+			See the [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/DDSLoader.js DDSLoader]
+			and [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PVRLoader.js PVRLoader]
 			for examples of derived classes.
 		</p>
 

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -21,7 +21,7 @@
 		<h2>Examples</h2>
 
 		<p>
-			See the [link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/RGBELoader.js RGBELoader]
+			See the [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/RGBELoader.js RGBELoader]
 			for an example of a derived class.
 		</p>
 

--- a/docs/api/zh/animation/KeyframeTrack.html
+++ b/docs/api/zh/animation/KeyframeTrack.html
@@ -49,7 +49,7 @@
 		</ul>
 
 		<p>
-			可以在[link:https://threejs.org/examples/js/animation/AnimationClipCreator.js AnimationClipCreator]文件中找到用不同类型的关键帧轨道创建动画剪辑([page:AnimationClip AnimationClips])的示例。
+			可以在[link:https://threejs.org/examples/jsm/animation/AnimationClipCreator.js AnimationClipCreator]文件中找到用不同类型的关键帧轨道创建动画剪辑([page:AnimationClip AnimationClips])的示例。
 		</p>
 
 		<p>

--- a/docs/api/zh/cameras/StereoCamera.html
+++ b/docs/api/zh/cameras/StereoCamera.html
@@ -25,9 +25,9 @@
 
 		<p>
 			这些类在以上示例中的文件内部使用：<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/AnaglyphEffect.js examples/js/effects/AnaglyphEffect.js]<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/ParallaxBarrierEffect.js examples/js/effects/ParallaxBarrierEffect.js]<br /><br />
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/effects/StereoEffect.js examples/js/effects/StereoEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/AnaglyphEffect.js examples/jsm/effects/AnaglyphEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/ParallaxBarrierEffect.js examples/jsm/effects/ParallaxBarrierEffect.js]<br /><br />
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/effects/StereoEffect.js examples/jsm/effects/StereoEffect.js]<br /><br />
 		</p>
 
 

--- a/docs/api/zh/deprecated/DeprecatedList.html
+++ b/docs/api/zh/deprecated/DeprecatedList.html
@@ -454,7 +454,7 @@
 
 		<h3>[page:LensFlare]</h3>
 		<p>
-			LensFlare 已被移动到了 [link:https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Lensflare.js /examples/js/objects/Lensflare.js].
+			LensFlare 已被移动到了 [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/objects/Lensflare.js /examples/jsm/objects/Lensflare.js].
 		</p>
 
 
@@ -484,13 +484,13 @@
 
 		<h3>[page:Projector]</h3>
 		<p>
-			CanvasRenderer 已被移动到了 [link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/CanvasRenderer.js /examples/js/renderers/CanvasRenderer.js].
+			CanvasRenderer has been removed.
 		</p>
 
 		<h3>[page:Projector]</h3>
 		<p>
 			Projector 已被移动到了
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/Projector.js 	/examples/js/renderers/Projector.js]。<br /><br />
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/Projector.js 	/examples/jsm/renderers/Projector.js]。<br /><br />
 
 			Projector.projectVector() 现在是 [page:Vector.project]()。<br /><br />
 

--- a/docs/api/zh/lights/RectAreaLight.html
+++ b/docs/api/zh/lights/RectAreaLight.html
@@ -19,7 +19,7 @@
 			<ul>
 				<li>不支持阴影。</li>
 				<li>只支持 [page:MeshStandardMaterial MeshStandardMaterial] 和 [page:MeshPhysicalMaterial MeshPhysicalMaterial] 两种材质。</li>
-				<li>你必须在你的场景中加入 [link:https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] ，并调用*init()*。</li>
+				<li>你必须在你的场景中加入 [link:https://threejs.org/examples/jsm/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] ，并调用*init()*。</li>
 			</ul>
 		</p>
 

--- a/docs/api/zh/loaders/CompressedTextureLoader.html
+++ b/docs/api/zh/loaders/CompressedTextureLoader.html
@@ -20,8 +20,8 @@
 		<h2>例子</h2>
 
 		<p>
-			请参考[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/DDSLoader.js DDSLoader]
-			和[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PVRLoader.js PVRLoader]
+			请参考[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/DDSLoader.js DDSLoader]
+			和[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PVRLoader.js PVRLoader]
 			子类的例子
 		</p>
 

--- a/docs/api/zh/loaders/DataTextureLoader.html
+++ b/docs/api/zh/loaders/DataTextureLoader.html
@@ -21,7 +21,7 @@
 		<h2>例子</h2>
 
 		<p>
-			请参考[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/RGBELoader.js RGBELoader]
+			请参考[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/RGBELoader.js RGBELoader]
 			这个子类的例子。
 		</p>
 

--- a/docs/examples/en/animations/CCDIKSolver.html
+++ b/docs/examples/en/animations/CCDIKSolver.html
@@ -21,7 +21,7 @@
 		var ikSolver;
 
 		// Load MMD resources and instantiate CCDIKSolver
-		new THREE.MMDLoader().load(
+		new MMDLoader().load(
 			'models/mmd/miku.pmd',
 			function ( mesh ) {
 
@@ -98,7 +98,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/CCDIKSolver.js examples/js/animation/CCDIKSolver.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/CCDIKSolver.js examples/jsm/animation/CCDIKSolver.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/animations/MMDAnimationHelper.html
+++ b/docs/examples/en/animations/MMDAnimationHelper.html
@@ -19,10 +19,10 @@
 
 		<code>
 		// Instantiate a helper
-		var helper = new THREE.MMDAnimationHelper();
+		var helper = new MMDAnimationHelper();
 
 		// Load MMD resources and add to helper
-		new THREE.MMDLoader().loadWithAnimation(
+		new MMDLoader().loadWithAnimation(
 			'models/mmd/miku.pmd',
 			'models/mmd/dance.vmd',
 			function ( mmd ) {
@@ -165,7 +165,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/MMDAnimationHelper.js examples/js/animation/MMDAnimationHelper.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/MMDAnimationHelper.js examples/jsm/animation/MMDAnimationHelper.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/animations/MMDPhysics.html
+++ b/docs/examples/en/animations/MMDPhysics.html
@@ -20,11 +20,11 @@
 		var physics;
 
 		// Load MMD resources and instantiate MMDPhysics
-		new THREE.MMDLoader().load(
+		new MMDLoader().load(
 			'models/mmd/miku.pmd',
 			function ( mesh ) {
 
-				physics = new THREE.MMDPhysics( mesh )
+				physics = new MMDPhysics( mesh )
 				scene.add( mesh );
 
 			}
@@ -108,7 +108,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/MMDPhysics.js examples/js/animation/MMDPhysics.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/MMDPhysics.js examples/jsm/animation/MMDPhysics.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/DeviceOrientationControls.html
+++ b/docs/examples/en/controls/DeviceOrientationControls.html
@@ -83,7 +83,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/DeviceOrientationControls.js examples/js/controls/DeviceOrientationControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/DeviceOrientationControls.js examples/jsm/controls/DeviceOrientationControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -21,7 +21,7 @@
 		<p>[example:misc_controls_drag misc / controls / drag ]</p>
 
 		<code>
-var controls = new THREE.DragControls( objects, camera, renderer.domElement );
+var controls = new DragControls( objects, camera, renderer.domElement );
 
 // add event listener to highlight dragged objects
 
@@ -93,7 +93,7 @@ controls.addEventListener( 'dragend', function ( event ) {
 
 		<h3>[property:Boolean transformGroup]</h3>
 		<p>
-			This option only works if the [page:DragControls.objects] array contains a single draggable group object. 
+			This option only works if the [page:DragControls.objects] array contains a single draggable group object.
 			If set to *true*, [name] does not transform individual objects but the entire group. Default is *false*.
 		</p>
 
@@ -124,7 +124,7 @@ controls.addEventListener( 'dragend', function ( event ) {
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/DragControls.js examples/js/controls/DragControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/DragControls.js examples/jsm/controls/DragControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/FirstPersonControls.html
+++ b/docs/examples/en/controls/FirstPersonControls.html
@@ -159,7 +159,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/FirstPersonControls.js examples/js/controls/FirstPersonControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/FirstPersonControls.js examples/jsm/controls/FirstPersonControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/FlyControls.html
+++ b/docs/examples/en/controls/FlyControls.html
@@ -88,7 +88,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/FlyControls.js examples/js/controls/FlyControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/FlyControls.js examples/jsm/controls/FlyControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -32,7 +32,7 @@ var scene = new THREE.Scene();
 
 var camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
-var controls = new THREE.OrbitControls( camera, renderer.domElement );
+var controls = new OrbitControls( camera, renderer.domElement );
 
 //controls.update() must be called after any manual changes to the camera's transform
 camera.position.set( 0, 20, 100 );
@@ -292,7 +292,7 @@ controls.touches = {
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrbitControls.js examples/js/controls/OrbitControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/OrbitControls.js examples/jsm/controls/OrbitControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/PointerLockControls.html
+++ b/docs/examples/en/controls/PointerLockControls.html
@@ -143,7 +143,7 @@ controls.addEventListener( 'unlock', function () {
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/PointerLockControls.js examples/js/controls/PointerLockControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/PointerLockControls.js examples/jsm/controls/PointerLockControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -201,7 +201,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/TrackballControls.js examples/js/controls/TrackballControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TrackballControls.js examples/jsm/controls/TrackballControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -220,7 +220,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/TransformControls.js examples/js/controls/TransformControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TransformControls.js examples/jsm/controls/TransformControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/exporters/ColladaExporter.html
+++ b/docs/examples/en/exporters/ColladaExporter.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// Instantiate an exporter
-		var exporter = new THREE.ColladaExporter();
+		var exporter = new ColladaExporter();
 
 		// Parse the input and generate the ply output
 		var data = exporter.parse( scene, null, options );
@@ -77,7 +77,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/ColladaExporter.js examples/js/exporters/ColladaExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/ColladaExporter.js examples/jsm/exporters/ColladaExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -38,7 +38,7 @@
 
 		<code>
 		// Instantiate a exporter
-		var exporter = new THREE.GLTFExporter();
+		var exporter = new GLTFExporter();
 
 		// Parse the input and generate the glTF output
 		exporter.parse( scene, function ( gltf ) {
@@ -108,7 +108,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/GLTFExporter.js examples/js/exporters/GLTFExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/GLTFExporter.js examples/jsm/exporters/GLTFExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/exporters/PLYExporter.html
+++ b/docs/examples/en/exporters/PLYExporter.html
@@ -23,7 +23,7 @@
 
 		<code>
 		// Instantiate an exporter
-		var exporter = new THREE.PLYExporter();
+		var exporter = new PLYExporter();
 
 		// Parse the input and generate the ply output
 		var data = exporter.parse( scene, options );
@@ -60,7 +60,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/PLYExporter.js examples/js/exporters/PLYExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/PLYExporter.js examples/jsm/exporters/PLYExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/en/geometries/ConvexBufferGeometry.html
@@ -36,7 +36,7 @@
 
 		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
-		<code>var geometry = new THREE.ConvexBufferGeometry( points );
+		<code>var geometry = new ConvexBufferGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -53,7 +53,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/ConvexGeometry.js examples/js/geometries/ConvexGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/ConvexGeometry.js examples/jsm/geometries/ConvexGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/geometries/ConvexGeometry.html
+++ b/docs/examples/en/geometries/ConvexGeometry.html
@@ -35,7 +35,7 @@
 
 		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
-		<code>var geometry = new THREE.ConvexGeometry( points );
+		<code>var geometry = new ConvexGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -52,7 +52,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/ConvexGeometry.js examples/js/geometries/ConvexGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/ConvexGeometry.js examples/jsm/geometries/ConvexGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/geometries/DecalGeometry.html
+++ b/docs/examples/en/geometries/DecalGeometry.html
@@ -34,7 +34,7 @@
 
 		<p>[example:webgl_decals WebGL / decals]</p>
 
-		<code>var geometry =  new THREE.DecalGeometry( mesh, position, orientation, size );
+		<code>var geometry =  new DecalGeometry( mesh, position, orientation, size );
 		var material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -53,7 +53,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/DecalGeometry.js examples/js/geometries/DecalGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/DecalGeometry.js examples/jsm/geometries/DecalGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/helpers/FaceNormalsHelper.html
+++ b/docs/examples/en/helpers/FaceNormalsHelper.html
@@ -31,7 +31,7 @@
 		material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );
 		box = new THREE.Mesh( geometry, material );
 
-		helper = new THREE.FaceNormalsHelper( box, 2, 0x00ff00, 1 );
+		helper = new FaceNormalsHelper( box, 2, 0x00ff00, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/en/helpers/RectAreaLightHelper.html
+++ b/docs/examples/en/helpers/RectAreaLightHelper.html
@@ -21,7 +21,7 @@
 		<code>
 var light = new THREE.RectAreaLight( 0xffffbb, 1.0, 5, 5 );
 
-var helper = new THREE.RectAreaLightHelper( light );
+var helper = new RectAreaLightHelper( light );
 
 light.add( helper ); // helper must be added as a child of the light
 		</code>

--- a/docs/examples/en/helpers/VertexNormalsHelper.html
+++ b/docs/examples/en/helpers/VertexNormalsHelper.html
@@ -30,7 +30,7 @@
 		var material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );
 		var box = new THREE.Mesh( geometry, material );
 
-		var helper = new THREE.VertexNormalsHelper( box, 2, 0x00ff00, 1 );
+		var helper = new VertexNormalsHelper( box, 2, 0x00ff00, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/en/helpers/VertexTangentsHelper.html
+++ b/docs/examples/en/helpers/VertexTangentsHelper.html
@@ -30,7 +30,7 @@
 		var material = new THREE.MeshNormalMaterial();
 		var box = new THREE.Mesh( geometry, material );
 
-		var helper = new THREE.VertexTangentsHelper( box, 1, 0x00ffff, 1 );
+		var helper = new VertexTangentsHelper( box, 1, 0x00ffff, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/en/loaders/BasisTextureLoader.html
+++ b/docs/examples/en/loaders/BasisTextureLoader.html
@@ -25,15 +25,15 @@
 			This loader parallelizes the transcoding process across a configurable number
 			of web workers, before transferring the transcoded compressed texture back
 			to the main thread. The required WASM transcoder and JS wrapper are available from the
-			[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
+			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
 			directory.
 		</p>
 
 		<h2>Example</h2>
 
 		<code>
-		var basisLoader = new THREE.BasisTextureLoader();
-		basisLoader.setTranscoderPath( 'examples/js/libs/basis/' );
+		var basisLoader = new BasisTextureLoader();
+		basisLoader.setTranscoderPath( 'examples/jsm/libs/basis/' );
 		basisLoader.detectSupport( renderer );
 		basisLoader.load( 'diffuse.basis', function ( texture ) {
 
@@ -114,7 +114,7 @@
 		</p>
 		<p>
 		The WASM transcoder and JS wrapper are available from the
-		[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
+		[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
 		directory.
 		</p>
 
@@ -134,7 +134,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/BasisTextureLoader.js examples/js/loaders/BasisTextureLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/BasisTextureLoader.js examples/jsm/loaders/BasisTextureLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -31,10 +31,10 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.DRACOLoader();
+		var loader = new DRACOLoader();
 
 		// Specify path to a folder containing WASM/JS decoding libraries.
-		loader.setDecoderPath( '/examples/js/libs/draco/' );
+		loader.setDecoderPath( '/examples/jsm/libs/draco/' );
 
 		// Optional: Pre-fetch Draco WASM/JS module.
 		loader.preload();
@@ -145,7 +145,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/DRACOLoader.js examples/js/loaders/DRACOLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/DRACOLoader.js examples/jsm/loaders/DRACOLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -55,11 +55,11 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.GLTFLoader();
+		var loader = new GLTFLoader();
 
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
-		var dracoLoader = new THREE.DRACOLoader();
-		dracoLoader.setDecoderPath( '/examples/js/libs/draco/' );
+		var dracoLoader = new DRACOLoader();
+		dracoLoader.setDecoderPath( '/examples/jsm/libs/draco/' );
 		loader.setDRACOLoader( dracoLoader );
 
 		// Load a glTF resource
@@ -183,7 +183,7 @@
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
 		</p>
 		<p>
-		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
+		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme] for the details of Draco and its decoder.
 		</p>
 
 		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>
@@ -205,7 +205,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js examples/js/loaders/GLTFLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/GLTFLoader.js examples/jsm/loaders/GLTFLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.MMDLoader();
+		var loader = new MMDLoader();
 
 		// Load a MMD model
 		loader.load(
@@ -118,7 +118,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/MMDLoader.js examples/js/loaders/MMDLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/MMDLoader.js examples/jsm/loaders/MMDLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/MTLLoader.html
+++ b/docs/examples/en/loaders/MTLLoader.html
@@ -73,7 +73,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/[name].js examples/js/loaders/[name].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/[name].js examples/jsm/loaders/[name].js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -24,7 +24,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.OBJLoader();
+		var loader = new OBJLoader();
 
 		// load a resource
 		loader.load(
@@ -102,7 +102,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader.js examples/js/loaders/OBJLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/OBJLoader.js examples/jsm/loaders/OBJLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/OBJLoader2.html
+++ b/docs/examples/en/loaders/OBJLoader2.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// instantiate the loader
-		let loader = new THREE.OBJLoader2();
+		let loader = new OBJLoader2();
 
 		// function called on successful load
 		function callbackOnLoad ( object3d ) {

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -22,7 +22,7 @@
 		<code>
 
 		// instantiate a loader
-		var loader = new THREE.PCDLoader();
+		var loader = new PCDLoader();
 
 		// load a resource
 		loader.load(
@@ -99,7 +99,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PCDLoader.js examples/js/loaders/PCDLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PCDLoader.js examples/jsm/loaders/PCDLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.PDBLoader();
+		var loader = new PDBLoader();
 
 		// load a PDB resource
 		loader.load(
@@ -92,7 +92,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PDBLoader.js examples/js/loaders/PDBLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PDBLoader.js examples/jsm/loaders/PDBLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/PRWMLoader.html
+++ b/docs/examples/en/loaders/PRWMLoader.html
@@ -24,7 +24,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.PRWMLoader();
+		var loader = new PRWMLoader();
 
 		// load a resource
 		loader.load(
@@ -99,7 +99,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PRWMLoader.js examples/js/loaders/PRWMLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PRWMLoader.js examples/jsm/loaders/PRWMLoader.js]
 		</p>
 
 	</body>

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.SVGLoader();
+		var loader = new SVGLoader();
 
 		// load a SVG resource
 		loader.load(
@@ -105,7 +105,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/SVGLoader.js examples/js/loaders/SVGLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/SVGLoader.js examples/jsm/loaders/SVGLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.TGALoader();
+		var loader = new TGALoader();
 
 		// load a resource
 		var texture = loader.load(
@@ -84,7 +84,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/TGALoader.js examples/js/loaders/TGALoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/TGALoader.js examples/jsm/loaders/TGALoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -18,7 +18,7 @@
 		<h2>Example</h2>
 
 		<code>
-		var lut = new THREE.Lut( 'rainbow', 512 );
+		var lut = new Lut( 'rainbow', 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
@@ -140,7 +140,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/[path].js examples/js/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -18,7 +18,7 @@
 
 		<code>
 		// Create a sampler for a Mesh surface.
-		var sampler = new THREE.MeshSurfaceSampler( surfaceMesh )
+		var sampler = new MeshSurfaceSampler( surfaceMesh )
 			.setWeightAttribute( 'color' )
 			.build();
 
@@ -80,7 +80,7 @@
 		<h2>Source</h2>
 
 		<p>
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/MeshSurfaceSampler.js examples/js/math/MeshSurfaceSampler.js]
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/MeshSurfaceSampler.js examples/jsm/math/MeshSurfaceSampler.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -187,7 +187,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/convexhull/Face.html
+++ b/docs/examples/en/math/convexhull/Face.html
@@ -85,7 +85,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/convexhull/HalfEdge.html
+++ b/docs/examples/en/math/convexhull/HalfEdge.html
@@ -75,7 +75,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/math/convexhull/VertexList.html
+++ b/docs/examples/en/math/convexhull/VertexList.html
@@ -87,7 +87,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		<p>
 	</body>
 </html>

--- a/docs/examples/en/math/convexhull/VertexNode.html
+++ b/docs/examples/en/math/convexhull/VertexNode.html
@@ -48,7 +48,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		<p>
 	</body>
 </html>

--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -31,11 +31,11 @@ var textureFlare0 = textureLoader.load( "textures/lensflare/lensflare0.png" );
 var textureFlare1 = textureLoader.load( "textures/lensflare/lensflare2.png" );
 var textureFlare2 = textureLoader.load( "textures/lensflare/lensflare3.png" );
 
-var lensflare = new THREE.Lensflare();
+var lensflare = new Lensflare();
 
-lensflare.addElement( new THREE.LensflareElement( textureFlare0, 512, 0 ) );
-lensflare.addElement( new THREE.LensflareElement( textureFlare1, 512, 0 ) );
-lensflare.addElement( new THREE.LensflareElement( textureFlare2, 60, 0.6 ) );
+lensflare.addElement( new LensflareElement( textureFlare0, 512, 0 ) );
+lensflare.addElement( new LensflareElement( textureFlare1, 512, 0 ) );
+lensflare.addElement( new LensflareElement( textureFlare2, 60, 0.6 ) );
 
 light.add( lensflare );
 		</code>
@@ -58,7 +58,7 @@ light.add( lensflare );
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Lensflare.js examples/js/objects/Lensflare.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/objects/Lensflare.js examples/jsm/objects/Lensflare.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/postprocessing/EffectComposer.html
+++ b/docs/examples/en/postprocessing/EffectComposer.html
@@ -151,7 +151,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/postprocessing/EffectComposer.js examples/js/postprocessing/EffectComposer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/postprocessing/EffectComposer.js examples/jsm/postprocessing/EffectComposer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/renderers/CSS2DRenderer.html
+++ b/docs/examples/en/renderers/CSS2DRenderer.html
@@ -61,7 +61,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/CSS2DRenderer.js examples/js/renderers/CSS2DRenderer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/CSS2DRenderer.js examples/jsm/renderers/CSS2DRenderer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/renderers/CSS3DRenderer.html
+++ b/docs/examples/en/renderers/CSS3DRenderer.html
@@ -73,7 +73,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/CSS3DRenderer.js examples/js/renderers/CSS3DRenderer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/CSS3DRenderer.js examples/jsm/renderers/CSS3DRenderer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -103,7 +103,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/SVGRenderer.js examples/js/renderers/SVGRenderer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/SVGRenderer.js examples/jsm/renderers/SVGRenderer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -86,7 +86,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/BufferGeometryUtils.js examples/js/utils/BufferGeometryUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/BufferGeometryUtils.js examples/jsm/utils/BufferGeometryUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/utils/SceneUtils.html
+++ b/docs/examples/en/utils/SceneUtils.html
@@ -36,7 +36,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/SceneUtils.js examples/js/utils/SceneUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/SceneUtils.js examples/jsm/utils/SceneUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/en/utils/SkeletonUtils.html
+++ b/docs/examples/en/utils/SkeletonUtils.html
@@ -56,7 +56,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/SkeletonUtils.js examples/js/utils/SkeletonUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/SkeletonUtils.js examples/jsm/utils/SkeletonUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/animations/CCDIKSolver.html
+++ b/docs/examples/zh/animations/CCDIKSolver.html
@@ -21,7 +21,7 @@
 		var ikSolver;
 
 		// Load MMD resources and instantiate CCDIKSolver
-		new THREE.MMDLoader().load(
+		new MMDLoader().load(
 			'models/mmd/miku.pmd',
 			function ( mesh ) {
 
@@ -98,7 +98,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/CCDIKSolver.js examples/js/animation/CCDIKSolver.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/CCDIKSolver.js examples/jsm/animation/CCDIKSolver.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/animations/MMDAnimationHelper.html
+++ b/docs/examples/zh/animations/MMDAnimationHelper.html
@@ -19,10 +19,10 @@
 
 		<code>
 		// Instantiate a helper
-		var helper = new THREE.MMDAnimationHelper();
+		var helper = new MMDAnimationHelper();
 
 		// Load MMD resources and add to helper
-		new THREE.MMDLoader().loadWithAnimation(
+		new MMDLoader().loadWithAnimation(
 			'models/mmd/miku.pmd',
 			'models/mmd/dance.vmd',
 			function ( mmd ) {
@@ -165,7 +165,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/MMDAnimationHelper.js examples/js/animation/MMDAnimationHelper.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/MMDAnimationHelper.js examples/jsm/animation/MMDAnimationHelper.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/animations/MMDPhysics.html
+++ b/docs/examples/zh/animations/MMDPhysics.html
@@ -20,11 +20,11 @@
 		var physics;
 
 		// Load MMD resources and instantiate MMDPhysics
-		new THREE.MMDLoader().load(
+		new MMDLoader().load(
 			'models/mmd/miku.pmd',
 			function ( mesh ) {
 
-				physics = new THREE.MMDPhysics( mesh )
+				physics = new MMDPhysics( mesh )
 				scene.add( mesh );
 
 			}
@@ -108,7 +108,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/animation/MMDPhysics.js examples/js/animation/MMDPhysics.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/animation/MMDPhysics.js examples/jsm/animation/MMDPhysics.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/DeviceOrientationControls.html
+++ b/docs/examples/zh/controls/DeviceOrientationControls.html
@@ -83,7 +83,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/DeviceOrientationControls.js examples/js/controls/DeviceOrientationControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/DeviceOrientationControls.js examples/jsm/controls/DeviceOrientationControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -21,7 +21,7 @@
 		<p>[example:misc_controls_drag misc / controls / drag ]</p>
 
 		<code>
-var controls = new THREE.DragControls( objects, camera, renderer.domElement );
+var controls = new DragControls( objects, camera, renderer.domElement );
 
 // add event listener to highlight dragged objects
 
@@ -124,7 +124,7 @@ controls.addEventListener( 'dragend', function ( event ) {
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/DragControls.js examples/js/controls/DragControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/DragControls.js examples/jsm/controls/DragControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/FirstPersonControls.html
+++ b/docs/examples/zh/controls/FirstPersonControls.html
@@ -159,7 +159,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/FirstPersonControls.js examples/js/controls/FirstPersonControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/FirstPersonControls.js examples/jsm/controls/FirstPersonControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/FlyControls.html
+++ b/docs/examples/zh/controls/FlyControls.html
@@ -88,7 +88,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/FlyControls.js examples/js/controls/FlyControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/FlyControls.js examples/jsm/controls/FlyControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -32,7 +32,7 @@ var scene = new THREE.Scene();
 
 var camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
-var controls = new THREE.OrbitControls( camera, renderer.domElement );
+var controls = new OrbitControls( camera, renderer.domElement );
 
 //controls.update() must be called after any manual changes to the camera's transform
 camera.position.set( 0, 20, 100 );
@@ -291,7 +291,7 @@ controls.touches = {
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrbitControls.js examples/js/controls/OrbitControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/OrbitControls.js examples/jsm/controls/OrbitControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/PointerLockControls.html
+++ b/docs/examples/zh/controls/PointerLockControls.html
@@ -143,7 +143,7 @@ controls.addEventListener( 'unlock', function () {
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/PointerLockControls.js examples/js/controls/PointerLockControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/PointerLockControls.js examples/jsm/controls/PointerLockControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/TrackballControls.html
+++ b/docs/examples/zh/controls/TrackballControls.html
@@ -201,7 +201,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/TrackballControls.js examples/js/controls/TrackballControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TrackballControls.js examples/jsm/controls/TrackballControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -220,7 +220,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/controls/TransformControls.js examples/js/controls/TransformControls.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TransformControls.js examples/jsm/controls/TransformControls.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/exporters/ColladaExporter.html
+++ b/docs/examples/zh/exporters/ColladaExporter.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// Instantiate an exporter
-		var exporter = new THREE.ColladaExporter();
+		var exporter = new ColladaExporter();
 
 		// Parse the input and generate the ply output
 		var data = exporter.parse( scene, null, options );
@@ -77,7 +77,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/ColladaExporter.js examples/js/exporters/ColladaExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/ColladaExporter.js examples/jsm/exporters/ColladaExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/exporters/GLTFExporter.html
+++ b/docs/examples/zh/exporters/GLTFExporter.html
@@ -38,7 +38,7 @@
 
 		<code>
 		// Instantiate a exporter
-		var exporter = new THREE.GLTFExporter();
+		var exporter = new GLTFExporter();
 
 		// Parse the input and generate the glTF output
 		exporter.parse( scene, function ( gltf ) {
@@ -108,7 +108,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/GLTFExporter.js examples/js/exporters/GLTFExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/GLTFExporter.js examples/jsm/exporters/GLTFExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/exporters/PLYExporter.html
+++ b/docs/examples/zh/exporters/PLYExporter.html
@@ -23,7 +23,7 @@
 
 		<code>
 		// Instantiate an exporter
-		var exporter = new THREE.PLYExporter();
+		var exporter = new PLYExporter();
 
 		// Parse the input and generate the ply output
 		var data = exporter.parse( scene, options );
@@ -60,7 +60,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/PLYExporter.js examples/js/exporters/PLYExporter.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/PLYExporter.js examples/jsm/exporters/PLYExporter.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/zh/geometries/ConvexBufferGeometry.html
@@ -36,7 +36,7 @@
 
 		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
-		<code>var geometry = new THREE.ConvexBufferGeometry( points );
+		<code>var geometry = new ConvexBufferGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -53,7 +53,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/ConvexGeometry.js examples/js/geometries/ConvexGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/ConvexGeometry.js examples/jsm/geometries/ConvexGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/geometries/ConvexGeometry.html
+++ b/docs/examples/zh/geometries/ConvexGeometry.html
@@ -35,7 +35,7 @@
 
 		<p>[example:webgl_geometry_convex geometry / convex ]</p>
 
-		<code>var geometry = new THREE.ConvexGeometry( points );
+		<code>var geometry = new ConvexGeometry( points );
 		var material = new THREE.MeshBasicMaterial( {color: 0x00ff00} );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -52,7 +52,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/ConvexGeometry.js examples/js/geometries/ConvexGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/ConvexGeometry.js examples/jsm/geometries/ConvexGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/geometries/DecalGeometry.html
+++ b/docs/examples/zh/geometries/DecalGeometry.html
@@ -34,7 +34,7 @@
 
 		<p>[example:webgl_decals WebGL / decals]</p>
 
-		<code>var geometry =  new THREE.DecalGeometry( mesh, position, orientation, size );
+		<code>var geometry =  new DecalGeometry( mesh, position, orientation, size );
 		var material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
 		var mesh = new THREE.Mesh( geometry, material );
 		scene.add( mesh );
@@ -53,7 +53,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/geometries/DecalGeometry.js examples/js/geometries/DecalGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/DecalGeometry.js examples/jsm/geometries/DecalGeometry.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/helpers/FaceNormalsHelper.html
+++ b/docs/examples/zh/helpers/FaceNormalsHelper.html
@@ -31,7 +31,7 @@
 		material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );
 		box = new THREE.Mesh( geometry, material );
 
-		helper = new THREE.FaceNormalsHelper( box, 2, 0x00ff00, 1 );
+		helper = new FaceNormalsHelper( box, 2, 0x00ff00, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/zh/helpers/RectAreaLightHelper.html
+++ b/docs/examples/zh/helpers/RectAreaLightHelper.html
@@ -21,7 +21,7 @@
 		<code>
 var light = new THREE.RectAreaLight( 0xffffbb, 1.0, 5, 5 );
 
-var helper = new THREE.RectAreaLightHelper( light );
+var helper = new RectAreaLightHelper( light );
 
 scene.add( helper );
 		</code>

--- a/docs/examples/zh/helpers/VertexNormalsHelper.html
+++ b/docs/examples/zh/helpers/VertexNormalsHelper.html
@@ -30,7 +30,7 @@
 		var material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );
 		var box = new THREE.Mesh( geometry, material );
 
-		var helper = new THREE.VertexNormalsHelper( box, 2, 0x00ff00, 1 );
+		var helper = new VertexNormalsHelper( box, 2, 0x00ff00, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/zh/helpers/VertexTangentsHelper.html
+++ b/docs/examples/zh/helpers/VertexTangentsHelper.html
@@ -30,7 +30,7 @@
 		var material = new THREE.MeshNormalMaterial();
 		var box = new THREE.Mesh( geometry, material );
 
-		var helper = new THREE.VertexTangentsHelper( box, 1, 0x00ffff, 1 );
+		var helper = new VertexTangentsHelper( box, 1, 0x00ffff, 1 );
 
 		scene.add( box );
 		scene.add( helper );

--- a/docs/examples/zh/loaders/BasisTextureLoader.html
+++ b/docs/examples/zh/loaders/BasisTextureLoader.html
@@ -25,15 +25,15 @@
 			This loader parallelizes the transcoding process across a configurable number
 			of web workers, before transferring the transcoded compressed texture back
 			to the main thread. The required WASM transcoder and JS wrapper are available from the
-			[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
+			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
 			directory.
 		</p>
 
 		<h2>Example</h2>
 
 		<code>
-		var basisLoader = new THREE.BasisTextureLoader();
-		basisLoader.setTranscoderPath( 'examples/js/libs/basis/' );
+		var basisLoader = new BasisTextureLoader();
+		basisLoader.setTranscoderPath( 'examples/jsm/libs/basis/' );
 		basisLoader.detectSupport( renderer );
 		basisLoader.load( 'diffuse.basis', function ( texture ) {
 
@@ -114,7 +114,7 @@
 		</p>
 		<p>
 		The WASM transcoder and JS wrapper are available from the
-		[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
+		[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
 		directory.
 		</p>
 
@@ -134,7 +134,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/BasisTextureLoader.js examples/js/loaders/BasisTextureLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/BasisTextureLoader.js examples/jsm/loaders/BasisTextureLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -31,10 +31,10 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.DRACOLoader();
+		var loader = new DRACOLoader();
 
 		// Specify path to a folder containing WASM/JS decoding libraries.
-		loader.setDecoderPath( '/examples/js/libs/draco/' );
+		loader.setDecoderPath( '/examples/jsm/libs/draco/' );
 
 		// Optional: Pre-fetch Draco WASM/JS module.
 		loader.preload();
@@ -145,7 +145,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/DRACOLoader.js examples/js/loaders/DRACOLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/DRACOLoader.js examples/jsm/loaders/DRACOLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -54,11 +54,11 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.GLTFLoader();
+		var loader = new GLTFLoader();
 
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
-		var dracoLoader = new THREE.DRACOLoader();
-		dracoLoader.setDecoderPath( '/examples/js/libs/draco/' );
+		var dracoLoader = new DRACOLoader();
+		dracoLoader.setDecoderPath( '/examples/jsm/libs/draco/' );
 		loader.setDRACOLoader( dracoLoader );
 
 		// Load a glTF resource
@@ -178,7 +178,7 @@
 		[page:DRACOLoader dracoLoader] — THREE.DRACOLoader的实例，用于解码使用KHR_draco_mesh_compression扩展压缩过的文件。
 		</p>
 		<p>
-		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme]来了解Draco及其解码器的详细信息。
+		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme]来了解Draco及其解码器的详细信息。
 		</p>
 
 		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>
@@ -200,7 +200,7 @@
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js examples/js/loaders/GLTFLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/GLTFLoader.js examples/jsm/loaders/GLTFLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/MMDLoader.html
+++ b/docs/examples/zh/loaders/MMDLoader.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// Instantiate a loader
-		var loader = new THREE.MMDLoader();
+		var loader = new MMDLoader();
 
 		// Load a MMD model
 		loader.load(
@@ -118,7 +118,7 @@
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/MMDLoader.js examples/js/loaders/MMDLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/MMDLoader.js examples/jsm/loaders/MMDLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/MTLLoader.html
+++ b/docs/examples/zh/loaders/MTLLoader.html
@@ -73,7 +73,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/[name].js examples/js/loaders/[name].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/[name].js examples/jsm/loaders/[name].js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/OBJLoader.html
+++ b/docs/examples/zh/loaders/OBJLoader.html
@@ -24,7 +24,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.OBJLoader();
+		var loader = new OBJLoader();
 
 		// load a resource
 		loader.load(
@@ -102,7 +102,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/OBJLoader.js examples/js/loaders/OBJLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/OBJLoader.js examples/jsm/loaders/OBJLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/OBJLoader2.html
+++ b/docs/examples/zh/loaders/OBJLoader2.html
@@ -22,7 +22,7 @@
 
 		<code>
 		// instantiate the loader
-		let loader = new THREE.OBJLoader2();
+		let loader = new OBJLoader2();
 
 		// function called on successful load
 		function callbackOnLoad ( object3d ) {

--- a/docs/examples/zh/loaders/PCDLoader.html
+++ b/docs/examples/zh/loaders/PCDLoader.html
@@ -22,7 +22,7 @@
 		<code>
 
 		// instantiate a loader
-		var loader = new THREE.PCDLoader();
+		var loader = new PCDLoader();
 
 		// load a resource
 		loader.load(
@@ -99,7 +99,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PCDLoader.js examples/js/loaders/PCDLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PCDLoader.js examples/jsm/loaders/PCDLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/PDBLoader.html
+++ b/docs/examples/zh/loaders/PDBLoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.PDBLoader();
+		var loader = new PDBLoader();
 
 		// load a PDB resource
 		loader.load(
@@ -92,7 +92,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PDBLoader.js examples/js/loaders/PDBLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PDBLoader.js examples/jsm/loaders/PDBLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/PRWMLoader.html
+++ b/docs/examples/zh/loaders/PRWMLoader.html
@@ -24,7 +24,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.PRWMLoader();
+		var loader = new PRWMLoader();
 
 		// load a resource
 		loader.load(
@@ -99,7 +99,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/PRWMLoader.js examples/js/loaders/PRWMLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PRWMLoader.js examples/jsm/loaders/PRWMLoader.js]
 		</p>
 
 	</body>

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.SVGLoader();
+		var loader = new SVGLoader();
 
 		// load a SVG resource
 		loader.load(
@@ -105,7 +105,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/SVGLoader.js examples/js/loaders/SVGLoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/SVGLoader.js examples/jsm/loaders/SVGLoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -20,7 +20,7 @@
 
 		<code>
 		// instantiate a loader
-		var loader = new THREE.TGALoader();
+		var loader = new TGALoader();
 
 		// load a resource
 		var texture = loader.load(
@@ -84,7 +84,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/TGALoader.js examples/js/loaders/TGALoader.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/TGALoader.js examples/jsm/loaders/TGALoader.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/Lut.html
+++ b/docs/examples/zh/math/Lut.html
@@ -17,7 +17,7 @@
 
 		<h2>Example</h2>
 		<code>
-		var lut = new THREE.Lut( 'rainbow', 512 );
+		var lut = new Lut( 'rainbow', 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
@@ -139,7 +139,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/[path].js examples/js/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -18,7 +18,7 @@
 
 		<code>
 		// Create a sampler for a BufferGeometry surface.
-		var sampler = new THREE.MeshSurfaceSampler( surfaceMesh )
+		var sampler = new MeshSurfaceSampler( surfaceMesh )
 			.setWeightAttribute( 'color' )
 			.build();
 
@@ -80,7 +80,7 @@
 		<h2>Source</h2>
 
 		<p>
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/MeshSurfaceSampler.js examples/js/math/MeshSurfaceSampler.js]
+		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/MeshSurfaceSampler.js examples/jsm/math/MeshSurfaceSampler.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/ConvexHull.html
+++ b/docs/examples/zh/math/convexhull/ConvexHull.html
@@ -187,7 +187,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/Face.html
+++ b/docs/examples/zh/math/convexhull/Face.html
@@ -85,7 +85,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/HalfEdge.html
+++ b/docs/examples/zh/math/convexhull/HalfEdge.html
@@ -75,7 +75,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/VertexList.html
+++ b/docs/examples/zh/math/convexhull/VertexList.html
@@ -87,7 +87,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		<p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/VertexNode.html
+++ b/docs/examples/zh/math/convexhull/VertexNode.html
@@ -48,7 +48,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/math/ConvexHull.js examples/js/math/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		<p>
 	</body>
 </html>

--- a/docs/examples/zh/objects/Lensflare.html
+++ b/docs/examples/zh/objects/Lensflare.html
@@ -31,11 +31,11 @@ var textureFlare0 = textureLoader.load( "textures/lensflare/lensflare0.png" );
 var textureFlare1 = textureLoader.load( "textures/lensflare/lensflare2.png" );
 var textureFlare2 = textureLoader.load( "textures/lensflare/lensflare3.png" );
 
-var lensflare = new THREE.Lensflare();
+var lensflare = new Lensflare();
 
-lensflare.addElement( new THREE.LensflareElement( textureFlare0, 512, 0 ) );
-lensflare.addElement( new THREE.LensflareElement( textureFlare1, 512, 0 ) );
-lensflare.addElement( new THREE.LensflareElement( textureFlare2, 60, 0.6 ) );
+lensflare.addElement( new LensflareElement( textureFlare0, 512, 0 ) );
+lensflare.addElement( new LensflareElement( textureFlare1, 512, 0 ) );
+lensflare.addElement( new LensflareElement( textureFlare2, 60, 0.6 ) );
 
 light.add( lensflare );
 		</code>
@@ -58,7 +58,7 @@ light.add( lensflare );
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Lensflare.js examples/js/objects/Lensflare.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/objects/Lensflare.js examples/jsm/objects/Lensflare.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/postprocessing/EffectComposer.html
+++ b/docs/examples/zh/postprocessing/EffectComposer.html
@@ -152,7 +152,7 @@
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/postprocessing/EffectComposer.js examples/js/postprocessing/EffectComposer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/postprocessing/EffectComposer.js examples/jsm/postprocessing/EffectComposer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/renderers/CSS2DRenderer.html
+++ b/docs/examples/zh/renderers/CSS2DRenderer.html
@@ -61,7 +61,7 @@
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/CSS2DRenderer.js examples/js/renderers/CSS2DRenderer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/CSS2DRenderer.js examples/jsm/renderers/CSS2DRenderer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/renderers/CSS3DRenderer.html
+++ b/docs/examples/zh/renderers/CSS3DRenderer.html
@@ -74,7 +74,7 @@
 		<h2>源代码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/renderers/CSS3DRenderer.js examples/js/renderers/CSS3DRenderer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/CSS3DRenderer.js examples/jsm/renderers/CSS3DRenderer.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/renderers/SVGRenderer.html
+++ b/docs/examples/zh/renderers/SVGRenderer.html
@@ -95,6 +95,8 @@
 
 		<h2>源代码</h2>
 
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/js/[path].js examples/js/[path].js]
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/SVGRenderer.js examples/jsm/renderers/SVGRenderer.js]
+		</p>
 	</body>
 </html>

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -86,7 +86,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/BufferGeometryUtils.js examples/js/utils/BufferGeometryUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/BufferGeometryUtils.js examples/jsm/utils/BufferGeometryUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/utils/SceneUtils.html
+++ b/docs/examples/zh/utils/SceneUtils.html
@@ -29,7 +29,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/SceneUtils.js examples/js/utils/SceneUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/SceneUtils.js examples/jsm/utils/SceneUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/utils/SkeletonUtils.html
+++ b/docs/examples/zh/utils/SkeletonUtils.html
@@ -56,7 +56,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/js/utils/SkeletonUtils.js examples/js/utils/SkeletonUtils.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/SkeletonUtils.js examples/jsm/utils/SkeletonUtils.js]
 		</p>
 	</body>
 </html>

--- a/docs/manual/en/introduction/Browser-support.html
+++ b/docs/manual/en/introduction/Browser-support.html
@@ -13,7 +13,7 @@
 	<h2>Overview</h2>
 	<div>
 		<p>
-			Three.js can use WebGL to render your scenes on all modern browsers. For older browsers, especially Internet Explorer 10 and below, you may have to fallback to one of the other [link:https://github.com/mrdoob/three.js/tree/master/examples/js/renderers renderers] (CSS2DRenderer, CSS3DRenderer, SVGRenderer). Additionally, you may have to include some polyfills, especially if you are using files from the [link:https://github.com/mrdoob/three.js/tree/master/examples /examples] folder.
+			Three.js can use WebGL to render your scenes on all modern browsers. For older browsers, especially Internet Explorer 10 and below, you may have to fallback to one of the other [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm/renderers renderers] (CSS2DRenderer, CSS3DRenderer, SVGRenderer). Additionally, you may have to include some polyfills, especially if you are using files from the [link:https://github.com/mrdoob/three.js/tree/master/examples /examples] folder.
 		</p>
 		<p>
 			Note: if you don't need to support these old browsers, then it is not recommended to use the other renderers as they are slower and support less features than the WebGLRenderer.

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -15,7 +15,7 @@
 	<p>
 		3D models are available in hundreds of file formats, each with different
 		purposes, assorted features, and varying complexity. Although
-		<a href="https://github.com/mrdoob/three.js/tree/dev/examples/js/loaders" target="_blank" rel="noopener">
+		<a href="https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders" target="_blank" rel="noopener">
 		three.js provides many loaders</a>, choosing the right format and
 		workflow will save time and frustration later on. Some formats are
 		difficult to work with, inefficient for realtime experiences, or simply not

--- a/docs/manual/zh/introduction/Browser-support.html
+++ b/docs/manual/zh/introduction/Browser-support.html
@@ -13,7 +13,7 @@
 	<h2>总览</h2>
 	<div>
 		<p>
-            在所有现代浏览器中，Three.js可以使用WebGL来渲染场景。对于较旧的浏览器，特别是Internet Explorer 10或者更低版本浏览器，你将需要回落到其它[link:https://github.com/mrdoob/three.js/tree/master/examples/js/renderers renderers]（CSS2DRenderer、CSS3DRenderer、SVGRenderer）。此外，你或许不得不包含一些额外的“填充物”来解决兼容性问题，特别是当你使用[link:https://github.com/mrdoob/three.js/tree/master/examples /examples]目录中的文件时。
+            在所有现代浏览器中，Three.js可以使用WebGL来渲染场景。对于较旧的浏览器，特别是Internet Explorer 10或者更低版本浏览器，你将需要回落到其它[link:https://github.com/mrdoob/three.js/tree/master/examples/jsm/renderers renderers]（CSS2DRenderer、CSS3DRenderer、SVGRenderer）。此外，你或许不得不包含一些额外的“填充物”来解决兼容性问题，特别是当你使用[link:https://github.com/mrdoob/three.js/tree/master/examples /examples]目录中的文件时。
 		</p>
 		<p>
             注意：如果你并不需要支持较旧的浏览器，那就不推荐使用其他渲染器来进行渲染，因为与WebGLRenderer相比，其它渲染器渲染较慢，并且不支持WebGL的诸多特性。

--- a/docs/manual/zh/introduction/Loading-3D-models.html
+++ b/docs/manual/zh/introduction/Loading-3D-models.html
@@ -14,7 +14,7 @@
 
 	<p>
 	目前，3D模型的格式有成千上万种可供选择，但每一种格式都具有不同的目的、用途以及复杂性。
-		虽然<a href="https://github.com/mrdoob/three.js/tree/dev/examples/js/loaders" target="_blank" rel="noopener">
+		虽然<a href="https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders" target="_blank" rel="noopener">
 	three.js已经提供了多种导入工具</a>，
 	但是选择正确的文件格式以及工作流程将可以节省很多时间，以及避免遭受很多挫折。某些格式难以使用，或者实时体验效率低下，或者目前尚未得到完全支持。
 	</p>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -2139,19 +2139,19 @@ export var SceneUtils = {
 
 	createMultiMaterialObject: function ( /* geometry, materials */ ) {
 
-		console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+		console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 	},
 
 	detach: function ( /* child, parent, scene */ ) {
 
-		console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+		console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 	},
 
 	attach: function ( /* child, scene, parent */ ) {
 
-		console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+		console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 	}
 
@@ -2161,6 +2161,6 @@ export var SceneUtils = {
 
 export function LensFlare() {
 
-	console.error( 'THREE.LensFlare has been moved to /examples/js/objects/Lensflare.js' );
+	console.error( 'THREE.LensFlare has been moved to /examples/jsm/objects/Lensflare.js' );
 
 }

--- a/src/core/InstancedBufferAttribute.d.ts
+++ b/src/core/InstancedBufferAttribute.d.ts
@@ -2,7 +2,7 @@ import { BufferGeometry } from './BufferGeometry';
 import { BufferAttribute } from './BufferAttribute';
 
 /**
- * @see <a href="https://github.com/mrdoob/three.js/blob/master/examples/js/BufferGeometryUtils.js">examples/js/BufferGeometryUtils.js</a>
+ * @see <a href="https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/BufferGeometryUtils.js">examples/jsm/utils/BufferGeometryUtils.js</a>
  */
 export namespace BufferGeometryUtils {
 	export function mergeBufferGeometries(


### PR DESCRIPTION
This PR removes references to `examples/js` from the code base and docs. Besides, the code examples now assume that example files were imported via modules and thus are not in the `THREE` namespace anymore.

This PR is a preparation to deprecate `examples/js`. 