### PR TITLE
Examples: Deprecate examples/js.

### DIFF
--- a/docs/manual/en/introduction/Import-via-modules.html
+++ b/docs/manual/en/introduction/Import-via-modules.html
@@ -66,8 +66,8 @@
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other components like loaders or controls are part of the
 			examples directory. three.js ensures that these files are kept in sync with the core but users have to import them separately if they are required
-			for a project. You can find in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory an ES6
-			module version for almost all example files. If you install three.js via npm, you can import them like so:
+			for a project. You can find them in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory. If you install three.js
+			via npm, import example files like so:
 		</p>
 		<code>
 		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -81,19 +81,10 @@
 
 	<p>
 		Only a few loaders (e.g. [page:ObjectLoader]) are included by default with
-		three.js — others should be added to your page individually. Depending on your
-		preference and comfort with build tools, choose one of the following:
+		three.js — others should be added to your app individually.
 	</p>
 
 	<code>
-		// global script
-		&lt;script src="GLTFLoader.js"&gt;&lt;/script&gt;
-
-		// commonjs
-		var THREE = window.THREE = require('three');
-		require('three/examples/js/loaders/GLTFLoader');
-
-		// ES modules
 		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 	</code>
 

--- a/docs/manual/zh/introduction/Import-via-modules.html
+++ b/docs/manual/zh/introduction/Import-via-modules.html
@@ -64,10 +64,10 @@
 
 		<h2>可引入的示例</h2>
 		<p>
-			three.js的核心专注于实现3D引擎中最为重要的组件。其他诸如加载器和控制器等组件，是示例文件夹中的一部分。
-			three.js确保这些文件能够与核心保持同步，但如果在一个项目中这些组件是必要的，用户将必须分别地引入它们。
-			你可以在[link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm]文件夹中找到所有示例文件的ES6版本。
-			如果你是通过npm来安装three.js的，那么你可以使用类似下面的代码来引入它们：
+			The core of three.js is focused on the most important components of a 3D engine. Many other components like loaders or controls are part of the
+			examples directory. three.js ensures that these files are kept in sync with the core but users have to import them separately if they are required
+			for a project. You can find them in the [link:https://github.com/mrdoob/three.js/tree/master/examples/jsm examples/jsm] directory. If you install three.js
+			via npm, import example files like so:
 		</p>
 		<code>
 		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';

--- a/docs/manual/zh/introduction/Loading-3D-models.html
+++ b/docs/manual/zh/introduction/Loading-3D-models.html
@@ -70,19 +70,11 @@
 	<h2>加载</h2>
 
 	<p>
-		three.js中默认仅包含了几个加载器（例如：[page:ObjectLoader]）——其它加载器需要你分别地添加到页面中。
-		取决于你对构建工具的偏好，选择以下任意一种方式：
+		Only a few loaders (e.g. [page:ObjectLoader]) are included by default with
+		three.js — others should be added to your app individually.
 	</p>
 
 	<code>
-		// global script
-		&lt;script src="GLTFLoader.js"&gt;&lt;/script&gt;
-
-		// commonjs
-		var THREE = window.THREE = require('three');
-		require('three/examples/js/loaders/GLTFLoader');
-
-		// ES modules
 		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 	</code>
 

--- a/examples/js/WebGL.js
+++ b/examples/js/WebGL.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.WebGL: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/animation/AnimationClipCreator.js
+++ b/examples/js/animation/AnimationClipCreator.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AnimationClipCreator: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  *
  * Creator of typical test AnimationClips / KeyframeTracks

--- a/examples/js/animation/CCDIKSolver.js
+++ b/examples/js/animation/CCDIKSolver.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CCDIKSolver: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahiro / https://github.com/takahirox
  *

--- a/examples/js/animation/MMDAnimationHelper.js
+++ b/examples/js/animation/MMDAnimationHelper.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MMDAnimationHelper: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahiro / https://github.com/takahirox
  *

--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MMDPhysics: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahiro / https://github.com/takahirox
  *

--- a/examples/js/animation/TimelinerController.js
+++ b/examples/js/animation/TimelinerController.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TimelinerController: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Controller class for the Timeliner GUI.
  *

--- a/examples/js/cameras/CinematicCamera.js
+++ b/examples/js/cameras/CinematicCamera.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CinematicCamera: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author greggman / http://games.greggman.com/

--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DeviceOrientationControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author richt / http://richt.me
  * @author WestLangley / http://github.com/WestLangley

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DragControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / https://github.com/zz85
  * @author mrdoob / http://mrdoob.com

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FirstPersonControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FlyControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author James Baicoianu / http://www.baicoianu.com/
  */

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OrbitControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author qiao / https://github.com/qiao
  * @author mrdoob / http://mrdoob.com

--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PointerLockControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TrackballControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Eberhard Graether / http://egraether.com/
  * @author Mark Lundin 	/ http://mark-lundin.com

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TransformControls: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author arodic / https://github.com/arodic
  */

--- a/examples/js/curves/CurveExtras.js
+++ b/examples/js/curves/CurveExtras.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CurveExtras: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * A bunch of parametric curves
  * @author zz85

--- a/examples/js/curves/NURBSCurve.js
+++ b/examples/js/curves/NURBSCurve.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.NURBSCurve: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author renej
  * NURBS curve object

--- a/examples/js/curves/NURBSSurface.js
+++ b/examples/js/curves/NURBSSurface.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.NURBSSurface: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author renej
  * NURBS surface object

--- a/examples/js/curves/NURBSUtils.js
+++ b/examples/js/curves/NURBSUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.NURBSUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author renej
  * NURBS utils

--- a/examples/js/effects/AnaglyphEffect.js
+++ b/examples/js/effects/AnaglyphEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AnaglyphEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author marklundin / http://mark-lundin.com/

--- a/examples/js/effects/AsciiEffect.js
+++ b/examples/js/effects/AsciiEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AsciiEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / https://github.com/zz85
  *

--- a/examples/js/effects/OutlineEffect.js
+++ b/examples/js/effects/OutlineEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OutlineEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahirox / http://github.com/takahirox/
  *

--- a/examples/js/effects/ParallaxBarrierEffect.js
+++ b/examples/js/effects/ParallaxBarrierEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ParallaxBarrierEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author marklundin / http://mark-lundin.com/

--- a/examples/js/effects/PeppersGhostEffect.js
+++ b/examples/js/effects/PeppersGhostEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PeppersGhostEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Created by tpowellmeto on 29/10/2015.
  *

--- a/examples/js/effects/StereoEffect.js
+++ b/examples/js/effects/StereoEffect.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.StereoEffect: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  * @authod mrdoob / http://mrdoob.com/

--- a/examples/js/exporters/ColladaExporter.js
+++ b/examples/js/exporters/ColladaExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ColladaExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Garrett Johnson / http://gkjohnson.github.io/
  * https://github.com/gkjohnson/collada-exporter-js

--- a/examples/js/exporters/DRACOExporter.js
+++ b/examples/js/exporters/DRACOExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DRACOExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Export draco compressed files from threejs geometry objects.
  *

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GLTFExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author fernandojsg / http://fernandojsg.com
  * @author Don McCurdy / https://www.donmccurdy.com

--- a/examples/js/exporters/MMDExporter.js
+++ b/examples/js/exporters/MMDExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MMDExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahiro / http://github.com/takahirox
  *

--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OBJExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/exporters/PLYExporter.js
+++ b/examples/js/exporters/PLYExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PLYExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Garrett Johnson / http://gkjohnson.github.io/
  * https://github.com/gkjohnson/ply-exporter-js

--- a/examples/js/exporters/STLExporter.js
+++ b/examples/js/exporters/STLExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.STLExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author kovacsv / http://kovacsv.hu/
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/exporters/TypedGeometryExporter.js
+++ b/examples/js/exporters/TypedGeometryExporter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TypedGeometryExporter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/geometries/BoxLineGeometry.js
+++ b/examples/js/geometries/BoxLineGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BoxLineGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/geometries/ConvexGeometry.js
+++ b/examples/js/geometries/ConvexGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ConvexGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  */

--- a/examples/js/geometries/DecalGeometry.js
+++ b/examples/js/geometries/DecalGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DecalGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  * @author spite / https://github.com/spite

--- a/examples/js/geometries/LightningStrike.js
+++ b/examples/js/geometries/LightningStrike.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LightningStrike: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author yomboprime https://github.com/yomboprime
  *

--- a/examples/js/geometries/ParametricGeometries.js
+++ b/examples/js/geometries/ParametricGeometries.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ParametricGeometries: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85
  *

--- a/examples/js/geometries/TeapotBufferGeometry.js
+++ b/examples/js/geometries/TeapotBufferGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TeapotBufferGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Eric Haines / http://erichaines.com/
  *

--- a/examples/js/interactive/SelectionBox.js
+++ b/examples/js/interactive/SelectionBox.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SelectionBox: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author HypnosNova / https://www.threejs.org.cn/gallery
  * This is a class to check whether objects are in a selection area in 3D space

--- a/examples/js/interactive/SelectionHelper.js
+++ b/examples/js/interactive/SelectionHelper.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SelectionHelper: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author HypnosNova / https://www.threejs.org.cn/gallery
  */

--- a/examples/js/lights/LightProbeGenerator.js
+++ b/examples/js/lights/LightProbeGenerator.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LightProbeGenerator: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  */

--- a/examples/js/lights/RectAreaLightUniformsLib.js
+++ b/examples/js/lights/RectAreaLightUniformsLib.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.RectAreaLightUniformsLib: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Uniforms library for RectAreaLight shared webgl shaders
  * @author abelnation

--- a/examples/js/lines/Line2.js
+++ b/examples/js/lines/Line2.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Line2: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/LineGeometry.js
+++ b/examples/js/lines/LineGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LineGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LineMaterial: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LineSegments2: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LineSegmentsGeometry: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/Wireframe.js
+++ b/examples/js/lines/Wireframe.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Wireframe: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/lines/WireframeGeometry2.js
+++ b/examples/js/lines/WireframeGeometry2.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.WireframeGeometry2: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.3MFLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author technohippy / https://github.com/technohippy
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AMFLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author tamarintech / https://tamarintech.com
  *

--- a/examples/js/loaders/AssimpLoader.js
+++ b/examples/js/loaders/AssimpLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AssimpLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Virtulous / https://virtulo.us/
  */

--- a/examples/js/loaders/BVHLoader.js
+++ b/examples/js/loaders/BVHLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BVHLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author herzig / http://github.com/herzig
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BasisTextureLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Don McCurdy / https://www.donmccurdy.com
  * @author Austin Eng / https://github.com/austinEng

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ColladaLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/loaders/DDSLoader.js
+++ b/examples/js/loaders/DDSLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DDSLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DRACOLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Don McCurdy / https://www.donmccurdy.com
  */

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.EXRLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Richard M. / https://github.com/richardmonette
  * @author ScieCode / http://github.com/sciecode

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FBXLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Kyle-Larson https://github.com/Kyle-Larson
  * @author Takahiro https://github.com/takahirox

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GCodeLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * THREE.GCodeLoader is used to load gcode files usually used for 3D printing or CNC applications.
  *

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GLTFLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Rich Tibbett / https://github.com/richtr
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HDRCubeTextureLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
 * @author Prashant Sharma / spidersharma03
 * @author Ben Houston / http://clara.io / bhouston

--- a/examples/js/loaders/KMZLoader.js
+++ b/examples/js/loaders/KMZLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.KMZLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/loaders/KTXLoader.js
+++ b/examples/js/loaders/KTXLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.KTXLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author amakaseev / https://github.com/amakaseev
  *

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LDrawLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author yomboprime / https://github.com/yomboprime/

--- a/examples/js/loaders/MD2Loader.js
+++ b/examples/js/loaders/MD2Loader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MD2Loader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MMDLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author takahiro / https://github.com/takahirox
  *

--- a/examples/js/loaders/MTLLoader.js
+++ b/examples/js/loaders/MTLLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MTLLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Loads a Wavefront .mtl file specifying materials
  *

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.NRRDLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /*
  *  three.js NRRD file loader
  */

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OBJLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PCDLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Filipe Caixeta / http://filipecaixeta.com.br
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/loaders/PDBLoader.js
+++ b/examples/js/loaders/PDBLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PDBLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author Mugen87 / https://github.com/Mugen87

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PLYLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Wei Meng / http://about.me/menway
  *

--- a/examples/js/loaders/PRWMLoader.js
+++ b/examples/js/loaders/PRWMLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PRWMLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Kevin Chapelier / https://github.com/kchapelier
  * See https://github.com/kchapelier/PRWM for more informations about this file format

--- a/examples/js/loaders/PVRLoader.js
+++ b/examples/js/loaders/PVRLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PVRLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /*
  *	 PVRLoader
  *   Author: pierre lepers

--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.RGBELoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Nikos M. / https://github.com/foo123/
  */

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.STLLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author aleeper / http://adamleeper.com/
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SVGLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author zz85 / http://joshuakoo.com/

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TDSLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Autodesk 3DS three.js file loader, based on lib3ds.
  *

--- a/examples/js/loaders/TGALoader.js
+++ b/examples/js/loaders/TGALoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TGALoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Daosheng Mu / https://github.com/DaoshengMu/
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TTFLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author gero3 / https://github.com/gero3
  * @author tentone / https://github.com/tentone

--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VRMLLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  */

--- a/examples/js/loaders/VRMLoader.js
+++ b/examples/js/loaders/VRMLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VRMLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Takahiro / https://github.com/takahirox
  */

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VTKLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author Alex Pletzer

--- a/examples/js/loaders/XLoader.js
+++ b/examples/js/loaders/XLoader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.XLoader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author adrs2002 / https://github.com/adrs2002
  */

--- a/examples/js/math/ColorConverter.js
+++ b/examples/js/math/ColorConverter.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ColorConverter: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author bhouston / http://exocortex.com/
  * @author zz85 / http://github.com/zz85

--- a/examples/js/math/ConvexHull.js
+++ b/examples/js/math/ConvexHull.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ConvexHull: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/math/ImprovedNoise.js
+++ b/examples/js/math/ImprovedNoise.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ImprovedNoise: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 // http://mrl.nyu.edu/~perlin/noise/
 
 THREE.ImprovedNoise = function () {

--- a/examples/js/math/Lut.js
+++ b/examples/js/math/Lut.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Lut: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author daron1337 / http://daron1337.github.io/
  */

--- a/examples/js/math/SimplexNoise.js
+++ b/examples/js/math/SimplexNoise.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SimplexNoise: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 // Ported from Stefan Gustavson's java implementation
 // http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf
 // Read Stefan's excellent paper for details on how this code works.

--- a/examples/js/misc/ConvexObjectBreaker.js
+++ b/examples/js/misc/ConvexObjectBreaker.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ConvexObjectBreaker: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author yomboprime https://github.com/yomboprime
  *

--- a/examples/js/misc/GPUComputationRenderer.js
+++ b/examples/js/misc/GPUComputationRenderer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GPUComputationRenderer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author yomboprime https://github.com/yomboprime
  *

--- a/examples/js/misc/Gyroscope.js
+++ b/examples/js/misc/Gyroscope.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Gyroscope: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/misc/MD2Character.js
+++ b/examples/js/misc/MD2Character.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MD2Character: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/misc/MD2CharacterComplex.js
+++ b/examples/js/misc/MD2CharacterComplex.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MD2CharacterComplex: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/misc/MorphAnimMesh.js
+++ b/examples/js/misc/MorphAnimMesh.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MorphAnimMesh: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/misc/MorphBlendMesh.js
+++ b/examples/js/misc/MorphBlendMesh.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MorphBlendMesh: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/misc/Ocean.js
+++ b/examples/js/misc/Ocean.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Ocean: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /*
 	three.js Ocean
 */

--- a/examples/js/misc/RollerCoaster.js
+++ b/examples/js/misc/RollerCoaster.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.RollerCoaster: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/misc/Volume.js
+++ b/examples/js/misc/Volume.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Volume: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * This class had been written to handle the output of the NRRD loader.
  * It contains a volume of data and informations about it.

--- a/examples/js/misc/VolumeSlice.js
+++ b/examples/js/misc/VolumeSlice.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VolumeSlice: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * This class has been made to hold a slice of a volume data
  * @class

--- a/examples/js/modifiers/ExplodeModifier.js
+++ b/examples/js/modifiers/ExplodeModifier.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ExplodeModifier: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Make all faces use unique vertices
  * so that each face can be separated from others

--- a/examples/js/modifiers/SimplifyModifier.js
+++ b/examples/js/modifiers/SimplifyModifier.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SimplifyModifier: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *

--- a/examples/js/modifiers/SubdivisionModifier.js
+++ b/examples/js/modifiers/SubdivisionModifier.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SubdivisionModifier: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  *	@author zz85 / http://twitter.com/blurspline / http://www.lab4games.net/zz85/blog
  *	@author centerionware / http://www.centerionware.com

--- a/examples/js/modifiers/TessellateModifier.js
+++ b/examples/js/modifiers/TessellateModifier.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TessellateModifier: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Break faces with edges longer than maxEdgeLength
  * - not recursive

--- a/examples/js/objects/Fire.js
+++ b/examples/js/objects/Fire.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Fire: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mike Piecuch / https://github.com/mikepiecuch
  *

--- a/examples/js/objects/Lensflare.js
+++ b/examples/js/objects/Lensflare.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Lensflare: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/objects/LightningStorm.js
+++ b/examples/js/objects/LightningStorm.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LightningStorm: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author yomboprime https://github.com/yomboprime
  *

--- a/examples/js/objects/MarchingCubes.js
+++ b/examples/js/objects/MarchingCubes.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MarchingCubes: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author mrdoob / http://mrdoob.com

--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Reflector: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Slayvin / http://slayvin.net
  */

--- a/examples/js/objects/ReflectorRTT.js
+++ b/examples/js/objects/ReflectorRTT.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ReflectorRTT: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * RTT version
  */

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Refractor: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/objects/ShadowMesh.js
+++ b/examples/js/objects/ShadowMesh.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ShadowMesh: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author erichlof /  http://github.com/erichlof
  *

--- a/examples/js/objects/Sky.js
+++ b/examples/js/objects/Sky.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Sky: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / https://github.com/zz85
  *

--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Water: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author jbouny / https://github.com/jbouny
  *

--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Water2: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/js/postprocessing/AdaptiveToneMappingPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AdaptiveToneMappingPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author miibond
  * Generate a texture that represents the luminosity of the current scene, adapted over time

--- a/examples/js/postprocessing/AfterimagePass.js
+++ b/examples/js/postprocessing/AfterimagePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AfterimagePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author HypnosNova / https://www.threejs.org.cn/gallery/
  */

--- a/examples/js/postprocessing/BloomPass.js
+++ b/examples/js/postprocessing/BloomPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BloomPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/BokehPass.js
+++ b/examples/js/postprocessing/BokehPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BokehPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Depth-of-field post-process with bokeh shader
  */

--- a/examples/js/postprocessing/ClearPass.js
+++ b/examples/js/postprocessing/ClearPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ClearPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/postprocessing/CubeTexturePass.js
+++ b/examples/js/postprocessing/CubeTexturePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CubeTexturePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author bhouston / http://clara.io/
  */

--- a/examples/js/postprocessing/DotScreenPass.js
+++ b/examples/js/postprocessing/DotScreenPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DotScreenPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.EffectComposer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/FilmPass.js
+++ b/examples/js/postprocessing/FilmPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FilmPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/GlitchPass.js
+++ b/examples/js/postprocessing/GlitchPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GlitchPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/HalftonePass.js
+++ b/examples/js/postprocessing/HalftonePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HalftonePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author meatbags / xavierburrow.com, github/meatbags
  *

--- a/examples/js/postprocessing/MaskPass.js
+++ b/examples/js/postprocessing/MaskPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MaskPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OutlinePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author spidersharma / http://eduperiment.com/
  */

--- a/examples/js/postprocessing/RenderPass.js
+++ b/examples/js/postprocessing/RenderPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.RenderPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/SAOPass.js
+++ b/examples/js/postprocessing/SAOPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SAOPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author ludobaka / ludobaka.github.io
  * SAO implementation inspired from bhouston previous SAO work

--- a/examples/js/postprocessing/SMAAPass.js
+++ b/examples/js/postprocessing/SMAAPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SMAAPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mpk / http://polko.me/
  */

--- a/examples/js/postprocessing/SSAARenderPass.js
+++ b/examples/js/postprocessing/SSAARenderPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SSAARenderPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
 *
 * Supersample Anti-Aliasing Render Pass

--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SSAOPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  */

--- a/examples/js/postprocessing/SavePass.js
+++ b/examples/js/postprocessing/SavePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SavePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/ShaderPass.js
+++ b/examples/js/postprocessing/ShaderPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ShaderPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/TAARenderPass.js
+++ b/examples/js/postprocessing/TAARenderPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TAARenderPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  *
  * Temporal Anti-Aliasing Render Pass

--- a/examples/js/postprocessing/TexturePass.js
+++ b/examples/js/postprocessing/TexturePass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TexturePass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/postprocessing/UnrealBloomPass.js
+++ b/examples/js/postprocessing/UnrealBloomPass.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.UnrealBloomPass: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author spidersharma / http://eduperiment.com/
  */

--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CSS2DRenderer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CSS3DRenderer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * Based on http://www.emagix.net/academic/mscs-project/item/camera-sync-with-css3-and-webgl-threejs
  * @author mrdoob / http://mrdoob.com/

--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.Projector: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author supereggbert / http://www.paulbrunt.co.uk/

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SVGRenderer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/js/shaders/ACESFilmicToneMappingShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ACESFilmicToneMappingShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/shaders/AfterimageShader.js
+++ b/examples/js/shaders/AfterimageShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.AfterimageShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author HypnosNova / https://www.threejs.org.cn/gallery/
  *

--- a/examples/js/shaders/BasicShader.js
+++ b/examples/js/shaders/BasicShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BasicShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://www.mrdoob.com
  *

--- a/examples/js/shaders/BleachBypassShader.js
+++ b/examples/js/shaders/BleachBypassShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BleachBypassShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/BlendShader.js
+++ b/examples/js/shaders/BlendShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BlendShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/BokehShader.js
+++ b/examples/js/shaders/BokehShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BokehShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/BokehShader2.js
+++ b/examples/js/shaders/BokehShader2.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BokehShader2: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / https://github.com/zz85 | twitter.com/blurspline
  *

--- a/examples/js/shaders/BrightnessContrastShader.js
+++ b/examples/js/shaders/BrightnessContrastShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BrightnessContrastShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author tapio / http://tapio.github.com/
  *

--- a/examples/js/shaders/ColorCorrectionShader.js
+++ b/examples/js/shaders/ColorCorrectionShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ColorCorrectionShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/ColorifyShader.js
+++ b/examples/js/shaders/ColorifyShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ColorifyShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/ConvolutionShader.js
+++ b/examples/js/shaders/ConvolutionShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ConvolutionShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/CopyShader.js
+++ b/examples/js/shaders/CopyShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.CopyShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/DOFMipMapShader.js
+++ b/examples/js/shaders/DOFMipMapShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DOFMipMapShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/DepthLimitedBlurShader.js
+++ b/examples/js/shaders/DepthLimitedBlurShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DepthLimitedBlurShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * TODO
  */

--- a/examples/js/shaders/DigitalGlitch.js
+++ b/examples/js/shaders/DigitalGlitch.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DigitalGlitch: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author felixturner / http://airtight.cc/
  *

--- a/examples/js/shaders/DotScreenShader.js
+++ b/examples/js/shaders/DotScreenShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.DotScreenShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/FXAAShader.js
+++ b/examples/js/shaders/FXAAShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FXAAShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  * @author davidedc / http://www.sketchpatch.net/

--- a/examples/js/shaders/FilmShader.js
+++ b/examples/js/shaders/FilmShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FilmShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/FocusShader.js
+++ b/examples/js/shaders/FocusShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FocusShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/FreiChenShader.js
+++ b/examples/js/shaders/FreiChenShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FreiChenShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / https://github.com/zz85 | https://www.lab4games.net/zz85/blog
  *

--- a/examples/js/shaders/FresnelShader.js
+++ b/examples/js/shaders/FresnelShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.FresnelShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/GammaCorrectionShader.js
+++ b/examples/js/shaders/GammaCorrectionShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GammaCorrectionShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author WestLangley / http://github.com/WestLangley
  *

--- a/examples/js/shaders/GodRaysShader.js
+++ b/examples/js/shaders/GodRaysShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GodRaysShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author huwb / http://huwbowles.com/
  *

--- a/examples/js/shaders/HalftoneShader.js
+++ b/examples/js/shaders/HalftoneShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HalftoneShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author meatbags / xavierburrow.com, github/meatbags
  *

--- a/examples/js/shaders/HorizontalBlurShader.js
+++ b/examples/js/shaders/HorizontalBlurShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HorizontalBlurShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / http://www.lab4games.net/zz85/blog
  *

--- a/examples/js/shaders/HorizontalTiltShiftShader.js
+++ b/examples/js/shaders/HorizontalTiltShiftShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HorizontalTiltShiftShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/HueSaturationShader.js
+++ b/examples/js/shaders/HueSaturationShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.HueSaturationShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author tapio / http://tapio.github.com/
  *

--- a/examples/js/shaders/KaleidoShader.js
+++ b/examples/js/shaders/KaleidoShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.KaleidoShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author felixturner / http://airtight.cc/
  *

--- a/examples/js/shaders/LuminosityHighPassShader.js
+++ b/examples/js/shaders/LuminosityHighPassShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LuminosityHighPassShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author bhouston / http://clara.io/
  *

--- a/examples/js/shaders/LuminosityShader.js
+++ b/examples/js/shaders/LuminosityShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.LuminosityShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/MirrorShader.js
+++ b/examples/js/shaders/MirrorShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.MirrorShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author felixturner / http://airtight.cc/
  *

--- a/examples/js/shaders/NormalMapShader.js
+++ b/examples/js/shaders/NormalMapShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.NormalMapShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/OceanShaders.js
+++ b/examples/js/shaders/OceanShaders.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.OceanShaders: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /* Author: Aleksandr Albert
 // Website: www.routter.co.tt
 

--- a/examples/js/shaders/ParallaxShader.js
+++ b/examples/js/shaders/ParallaxShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ParallaxShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 // Parallax Occlusion shaders from
 //    http://sunandblackcat.com/tipFullView.php?topicid=28
 // No tangent-space transforms logic based on

--- a/examples/js/shaders/PixelShader.js
+++ b/examples/js/shaders/PixelShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.PixelShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author wongbryan / http://wongbryan.github.io
  *

--- a/examples/js/shaders/RGBShiftShader.js
+++ b/examples/js/shaders/RGBShiftShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.RGBShiftShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author felixturner / http://airtight.cc/
  *

--- a/examples/js/shaders/SAOShader.js
+++ b/examples/js/shaders/SAOShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SAOShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * TODO
  */

--- a/examples/js/shaders/SMAAShader.js
+++ b/examples/js/shaders/SMAAShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SMAAShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mpk / http://polko.me/
  *

--- a/examples/js/shaders/SSAOShader.js
+++ b/examples/js/shaders/SSAOShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SSAOShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/shaders/SepiaShader.js
+++ b/examples/js/shaders/SepiaShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SepiaShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/SobelOperatorShader.js
+++ b/examples/js/shaders/SobelOperatorShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SobelOperatorShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/shaders/SubsurfaceScatteringShader.js
+++ b/examples/js/shaders/SubsurfaceScatteringShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SubsurfaceScatteringShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author daoshengmu / http://dsmu.me/
  *

--- a/examples/js/shaders/TechnicolorShader.js
+++ b/examples/js/shaders/TechnicolorShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TechnicolorShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author flimshaw / http://charliehoey.com
  *

--- a/examples/js/shaders/ToneMapShader.js
+++ b/examples/js/shaders/ToneMapShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ToneMapShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author miibond
  *

--- a/examples/js/shaders/ToonShader.js
+++ b/examples/js/shaders/ToonShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ToonShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/

--- a/examples/js/shaders/TriangleBlurShader.js
+++ b/examples/js/shaders/TriangleBlurShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TriangleBlurShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / http://www.lab4games.net/zz85/blog
  *

--- a/examples/js/shaders/UnpackDepthRGBAShader.js
+++ b/examples/js/shaders/UnpackDepthRGBAShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.UnpackDepthRGBAShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/VerticalBlurShader.js
+++ b/examples/js/shaders/VerticalBlurShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VerticalBlurShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / http://www.lab4games.net/zz85/blog
  *

--- a/examples/js/shaders/VerticalTiltShiftShader.js
+++ b/examples/js/shaders/VerticalTiltShiftShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VerticalTiltShiftShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/VignetteShader.js
+++ b/examples/js/shaders/VignetteShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VignetteShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  *

--- a/examples/js/shaders/VolumeShader.js
+++ b/examples/js/shaders/VolumeShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.VolumeShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Almar Klein / http://almarklein.org
  *

--- a/examples/js/shaders/WaterRefractionShader.js
+++ b/examples/js/shaders/WaterRefractionShader.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.WaterRefractionShader: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author Mugen87 / https://github.com/Mugen87
  *

--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.BufferGeometryUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  */

--- a/examples/js/utils/GeometryUtils.js
+++ b/examples/js/utils/GeometryUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.GeometryUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author alteredq / http://alteredqualia.com/

--- a/examples/js/utils/SceneUtils.js
+++ b/examples/js/utils/SceneUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SceneUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author alteredq / http://alteredqualia.com/
  */

--- a/examples/js/utils/ShadowMapViewer.js
+++ b/examples/js/utils/ShadowMapViewer.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.ShadowMapViewer: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author arya-s / https://github.com/arya-s
  *

--- a/examples/js/utils/SkeletonUtils.js
+++ b/examples/js/utils/SkeletonUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.SkeletonUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author sunag / http://www.sunag.com.br
  */

--- a/examples/js/utils/TypedArrayUtils.js
+++ b/examples/js/utils/TypedArrayUtils.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.TypedArrayUtils: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 
 THREE.TypedArrayUtils = {};
 

--- a/examples/js/utils/UVsDebug.js
+++ b/examples/js/utils/UVsDebug.js
@@ -1,3 +1,4 @@
+console.warn( "THREE.UVsDebug: As part of the transition to ES6 Modules, the files in 'examples/js' have been deprecated in r117 (May 2020) and will be deleted in r124 (December 2020). You can find more information about developing using ES6 Modules in https://threejs.org/docs/index.html#manual/en/introduction/Import-via-modules." );
 /**
  * @author zz85 / http://github.com/zz85
  * @author WestLangley / http://github.com/WestLangley


### PR DESCRIPTION
This PR will deprecate all files in the `examples/js` directory except for all external libraries. A console message will warn the user about the removal of those files in one of the upcoming releases. Right now, I've added `R117`. The exact date is of course open for discussion. Same for the warning's text.

The PR replaces #17544.