### PR TITLE
Examples: set .depthWrite to false for transparent materials

### DIFF
--- a/examples/webgl_materials_physical_transparency.html
+++ b/examples/webgl_materials_physical_transparency.html
@@ -95,7 +95,8 @@
 					alphaTest: 0.5,
 					envMap: hdrCubeRenderTarget.texture,
 					envMapIntensity: params.envMapIntensity,
-					depthTest: false,
+					depthWrite: false,
+					opacity: 1, // set to 1 when transparency is non-zero
 					transparency: params.transparency,
 					transparent: true
 				} );

--- a/examples/webgl_materials_physical_transparency.html
+++ b/examples/webgl_materials_physical_transparency.html
@@ -96,8 +96,8 @@
 					envMap: hdrCubeRenderTarget.texture,
 					envMapIntensity: params.envMapIntensity,
 					depthWrite: false,
-					opacity: 1, // set to 1 when transparency is non-zero
-					transparency: params.transparency,
+					transparency: params.transparency, // use material.transparency for glass materials
+					opacity: 1,                        // set material.opacity to 1 when material.transparency is non-zero
 					transparent: true
 				} );
 


### PR DESCRIPTION
Use the coding pattern we are currently recommending for this use case.