### PR TITLE
Suggestion: Make unroll_loop robust to nested blocks

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -221,7 +221,7 @@ function includeReplacer( match, include ) {
 
 // Unroll Loops
 
-var loopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
+var loopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+)$/g;
 
 function unrollLoops( string ) {
 
@@ -229,9 +229,33 @@ function unrollLoops( string ) {
 
 }
 
-function loopReplacer( match, start, end, snippet ) {
+function loopReplacer( match, start, end, remainingFile ) {
 
 	var string = '';
+	var snippet = '';
+	var remaining = '';
+	var braceCount = 1;
+	for ( var i = 0, l = remainingFile.length; i < l; i ++ ) {
+
+		if ( remainingFile[ i ] === '{' ) {
+
+			braceCount ++;
+
+		} else if ( remainingFile[ i ] === '}' ) {
+
+			braceCount --;
+
+		}
+
+		if ( braceCount === 0 ) {
+
+			snippet = remainingFile.substring( 0, i );
+			remaining = remainingFile.substring( i + 1 );
+			break;
+
+		}
+
+	}
 
 	for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
@@ -240,6 +264,8 @@ function loopReplacer( match, start, end, snippet ) {
 			.replace( /UNROLLED_LOOP_INDEX/g, i );
 
 	}
+
+	string += unrollLoops( remaining );
 
 	return string;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -235,22 +235,44 @@ function loopReplacer( match, start, end, remainingFile ) {
 	var snippet = '';
 	var remaining = '';
 	var braceCount = 1;
-	for ( var i = 0, l = remainingFile.length; i < l; i ++ ) {
+	var i = 0;
 
-		if ( remainingFile[ i ] === '{' ) {
+	while ( true ) {
+
+		var nextOpen = remainingFile.indexOf( '{', i );
+		var nextClosed = remainingFile.indexOf( '}', i );
+
+		if ( nextOpen === - 1 && nextClosed === - 1 ) {
+
+			snippet = remainingFile;
+			break;
+
+		} else if ( nextClosed === - 1 ) {
 
 			braceCount ++;
+			i = nextOpen + 1;
 
-		} else if ( remainingFile[ i ] === '}' ) {
+		} else if ( nextOpen === - 1 ) {
 
 			braceCount --;
+			i = nextClosed + 1;
+
+		} else if ( nextOpen < nextClosed ) {
+
+			braceCount ++;
+			i = nextOpen + 1;
+
+		} else {
+
+			braceCount --;
+			i = nextClosed + 1;
 
 		}
 
 		if ( braceCount === 0 ) {
 
-			snippet = remainingFile.substring( 0, i );
-			remaining = remainingFile.substring( i + 1 );
+			snippet = remainingFile.substring( 0, i - 1 );
+			remaining = remainingFile.substring( i );
 			break;
 
 		}


### PR DESCRIPTION
Here's a modest attempt at addressing #18751. We find the snippet by finding the appropriate `}` brace and then unrolling the rest of the string.

I ran some quick metrics in Chrome using the following snippet inserted before [this line](https://github.com/mrdoob/three.js/blob/d5c0ef10799e4a8a42f21d256f9d8de267458bfe/src/renderers/webgl/WebGLProgram.js#L653).

```js
	var startTime = window.performance.now();
	for ( let i = 0; i < 10000; i ++ ) {

		unrollLoops( vertexShader );
		unrollLoops( fragmentShader );

	}
	console.log( ( window.performance.now() - startTime ) / 1000, 'ms' );
```

It looks like it takes ~1.5 times as long to unroll the loops with the new method, so maybe we really can't have it all :( Here are the numbers I got:

**In Dev**
```
webgl_shadowmap_csm:
0.05951 ms
0.45431 ms

webgl_lights_pointlights:
0.06783 ms
0.31878 ms
```

**This Branch**
```
webgl_shadowmap_csm:
0.06506 ms
0.78221 ms

lights / pointslights:
0.12640 ms
0.58718 ms
```

Maybe some other people have other thoughts on how to address this or speed it up.