### PR TITLE
Docs: Added section on extracting position, rotation and scale from a Matrix4.

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -77,6 +77,24 @@ m.elements = [ 11, 21, 31, 41,
 		code, you'll have to take the [link:https://en.wikipedia.org/wiki/Transpose transpose] of any matrices outlined here to make sense of the calculations.
 		</p>
 
+		<h2>Extracting position, rotation and scale</h2>
+		<p>
+			There are several options available for extracting position, rotation and scale from a Matrix4.
+			<ul>
+				<li>
+					[page:Vector3.setFromMatrixPosition]: can be used to extract the translation component.
+				</li>
+				<li>
+					[page:Vector3.setFromMatrixScale]: can be used to extract the scale component.
+				</li>
+				<li>
+					[page:Quaternion.setFromRotationMatrix], [page:Euler.setFromRotationMatrix] or [page:.extractRotation extractRotation] can be used to extract the rotation component.
+				</li>
+				<li>
+					[page:.decompose decompose] can be used to extract position, rotation and scale all at once.
+				</li>
+			</ul>
+		</p>
 
 		<h2>Constructor</h2>
 

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -71,6 +71,24 @@ m.elements = [ 11, 21, 31, 41,
 		请记住，如果您正在阅读源代码，您必须对这里列出的任何矩阵进行转置[link:https://en.wikipedia.org/wiki/Transpose transpose]，以理解计算。
 		</p>
 
+		<h2>Extracting position, rotation and scale</h2>
+		<p>
+			There are several options available for extracting position, rotation and scale from a Matrix4.
+			<ul>
+				<li>
+					[page:Vector3.setFromMatrixPosition]: can be used to extract the translation component.
+				</li>
+				<li>
+					[page:Vector3.setFromMatrixScale]: can be used to extract the scale component.
+				</li>
+				<li>
+					[page:Quaternion.setFromRotationMatrix], [page:Euler.setFromRotationMatrix] or [page:.extractRotation extractRotation] can be used to extract the rotation component.
+				</li>
+				<li>
+					[page:.decompose decompose] can be used to extract position, rotation and scale all at once.
+				</li>
+			</ul>
+		</p>
 
 		<h2>构造器（Constructor）</h2>
 


### PR DESCRIPTION
This seemed like the easiest approach to make the reader aware of the options available to them for extracting transform components from a matrix.
I considered adding a note on each of the functions themselves, but that would lead to quite a lot of duplicated information.