### PR TITLE
CSM: Miscellaneous Fixes

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -386,4 +386,26 @@ export default class CSM {
 
 	}
 
+	dispose() {
+
+		const shaders = this.shaders;
+		shaders.forEach( function ( shader, material ) {
+
+			delete material.onBeforeCompile;
+			delete material.defines.USE_CSM;
+			delete material.defines.CSM_CASCADES;
+			delete material.defines.CSM_FADE;
+
+			delete shader.uniforms.CSM_cascades;
+			delete shader.uniforms.cameraNear;
+			delete shader.uniforms.shadowFar;
+
+
+			material.needsUpdate = true;
+
+		} );
+		shaders.clear();
+
+	}
+
 }

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -235,16 +235,16 @@ export default class CSM {
 		}
 
 		const breaksVec2 = [];
-		this.getExtendedBreaks( breaksVec2 );
-
-		const far = Math.min( this.camera.far, this.maxFar );
+		const self = this;
 		const shaders = this.shaders;
-		const camera = this.camera;
 
 		material.onBeforeCompile = function ( shader ) {
 
+			const far = Math.min( self.camera.far, self.maxFar );
+			self.getExtendedBreaks( breaksVec2 );
+
 			shader.uniforms.CSM_cascades = { value: breaksVec2 };
-			shader.uniforms.cameraNear = { value: camera.near };
+			shader.uniforms.cameraNear = { value: self.camera.near };
 			shader.uniforms.shadowFar = { value: far };
 
 			shaders.set( material, shader );

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -53,8 +53,7 @@ export default class CSM {
 		this.breaks = [];
 
 		this.lights = [];
-		this.shaders = [];
-		this.materials = [];
+		this.shaders = new Map();
 		this.createLights();
 
 		this.getBreaks();
@@ -238,39 +237,39 @@ export default class CSM {
 		const breaksVec2 = [];
 		this.getExtendedBreaks( breaksVec2 );
 
-		const self = this;
 		const far = Math.min( this.camera.far, this.maxFar );
+		const shaders = this.shaders;
+		const camera = this.camera;
 
 		material.onBeforeCompile = function ( shader ) {
 
 			shader.uniforms.CSM_cascades = { value: breaksVec2 };
-			shader.uniforms.cameraNear = { value: self.camera.near };
+			shader.uniforms.cameraNear = { value: camera.near };
 			shader.uniforms.shadowFar = { value: far };
 
-			self.shaders.push( shader );
+			shaders.set( material, shader );
 
 		};
-		this.materials.push( material );
+		shaders.set( material, null );
 
 	}
 
 	updateUniforms() {
 
 		const far = Math.min( this.camera.far, this.maxFar );
+		const shaders = this.shaders;
 
-		for ( let i = 0; i < this.shaders.length; i ++ ) {
+		shaders.forEach( function ( shader, material ) {
 
-			const shader = this.shaders[ i ];
-			const uniforms = shader.uniforms;
-			this.getExtendedBreaks( uniforms.CSM_cascades.value );
-			uniforms.cameraNear.value = this.camera.near;
-			uniforms.shadowFar.value = far;
+			if ( shader !== null ) {
 
-		}
+				const uniforms = shader.uniforms;
+				this.getExtendedBreaks( uniforms.CSM_cascades.value );
+				uniforms.cameraNear.value = this.camera.near;
+				uniforms.shadowFar.value = far;
 
-		for ( let i = 0; i < this.materials.length; i ++ ) {
+			}
 
-			const material = this.materials[ i ];
 			if ( ! this.fade && 'CSM_FADE' in material.defines ) {
 
 				delete material.defines.CSM_FADE;
@@ -283,7 +282,7 @@ export default class CSM {
 
 			}
 
-		}
+		}, this );
 
 	}
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -400,7 +400,6 @@ export default class CSM {
 			delete shader.uniforms.cameraNear;
 			delete shader.uniforms.shadowFar;
 
-
 			material.needsUpdate = true;
 
 		} );

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -140,7 +140,7 @@
 				gui.add( params, 'fade' ).onChange( function ( value ) { 
 
 					csm.fade = value;
-					csm.updateUniforms();
+					csm.updateFrustums();
 
 				} );
 


### PR DESCRIPTION
A quick follow up to #18761.

- Adds a `dispose` function to remove CSM from materials.
- Fixes issue which was causing new shaders to be added to the `shaders` array every time a material was recompiled resulting.
- Fix issue mentioned in https://github.com/mrdoob/three.js/pull/18761#issuecomment-592138879 which was caused by stale values being used in `onBeforeCompile`.

I'm still working on the issue I found (https://github.com/mrdoob/three.js/pull/18761#issuecomment-592162657) but the solution wasn't immediately obvious.

Temporary live link:
https://raw.githack.com/gkjohnson/three.js/csm-fixes/examples/webgl_shadowmap_csm.html

@vHawk 