### PR TITLE
CSM: change fade margin computation

### DIFF
--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -102,7 +102,7 @@ IncidentLight directLight;
 				directionalLightShadow = directionalLightShadows[ i ];
 				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 
-				bool shouldFadeLastCascade = i == CSM_CASCADES - 1 && linearDepth > ( csmx + csmy ) / 2.0;
+				bool shouldFadeLastCascade = i == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
 				directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
 
 			}
@@ -110,7 +110,7 @@ IncidentLight directLight;
 			ReflectedLight prevLight = reflectedLight;
 			RE_Direct( directLight, geometry, material, reflectedLight );
 
-			bool shouldBlend = i != CSM_CASCADES - 1 || i == CSM_CASCADES - 1 && linearDepth < ( csmx + csmy ) / 2.0;
+			bool shouldBlend = i != CSM_CASCADES - 1 || i == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
 			float blendRatio = shouldBlend ? ratio : 1.0;
 
 			reflectedLight.directDiffuse = mix( prevLight.directDiffuse, reflectedLight.directDiffuse, blendRatio );

--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -78,7 +78,7 @@ IncidentLight directLight;
 	DirectionalLightShadow directionalLightShadow;
 	#endif
 
-	#if defined( CSM_FADE )
+	#if defined( USE_SHADOWMAP ) && defined( CSM_FADE )
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];

--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -84,10 +84,15 @@ IncidentLight directLight;
 		directionalLight = directionalLights[ i ];
 		getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
-		float margin = 0.25 * pow( linearDepth, 2.0 );
-		float csmx = CSM_cascades[ i ].x - margin / 2.0;
-		float csmy = CSM_cascades[ i ].y + margin / 2.0;
-		if( i < NUM_DIR_LIGHT_SHADOWS && linearDepth >= csmx && ( linearDepth < csmy ||  i == CSM_CASCADES - 1 ) ) {
+		// NOTE: Depth gets larger away from the camera.
+		// cascade.x is closer, cascade.y is further
+		vec2 cascade = CSM_cascades[ i ];
+		float cascadeCenter = ( cascade.x + cascade.y ) / 2.0;
+		float closestEdge = linearDepth < cascadeCenter ? cascade.x : cascade.y;
+		float margin = 0.25 * pow( closestEdge, 2.0 );
+		float csmx = cascade.x - margin / 2.0;
+		float csmy = cascade.y + margin / 2.0;
+		if( i < NUM_DIR_LIGHT_SHADOWS && linearDepth >= csmx && ( linearDepth < csmy || i == CSM_CASCADES - 1 ) ) {
 
 			float dist = min( linearDepth - csmx, csmy - linearDepth );
 			float ratio = clamp( dist / margin, 0.0, 1.0 );

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -212,6 +212,7 @@
 					camera.updateProjectionMatrix();
 
 					updateOrthoCamera();
+					csm.updateFrustums();
 
 					renderer.setSize( window.innerWidth, window.innerHeight );
 


### PR DESCRIPTION
Addresses issue mentioned here: https://github.com/mrdoob/three.js/pull/18761#issuecomment-592162657. The issue was that the fade margin was being calculated solely off of the fragments depth which means it was getting massive near the camera far plane to a point where every cascade was seeing that it was supposed to contribute to the light at far distances.

- Add `USE_SHADOWMAP` guard for the `CSM_FADE` case in the shader.
- Fix far distance background glow when shadow distance was small.
- Fix the csm frustum not updating correctly when resizing the window.

Temporary live link:
https://raw.githack.com/gkjohnson/three.js/csm-change-fade-computation/examples/webgl_shadowmap_csm.html

@vHawk 