### PR TITLE
CSM: Remove pixel swimming in shadows

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -170,6 +170,10 @@ export default class CSM {
 			_cameraToLightMatrix.multiplyMatrices( light.shadow.camera.matrixWorldInverse, cameraMatrix );
 			frustums[ i ].toSpace( _cameraToLightMatrix, _lightSpaceFrustum );
 
+			const farTopRight = _lightSpaceFrustum.vertices.far[ 0 ];
+            const nearBotLeft = _lightSpaceFrustum.vertices.near[ 2 ];
+            let squaredBBWidth = farTopRight.distanceTo( nearBotLeft );
+
 			_bbox.makeEmpty();
 			for ( let j = 0; j < 4; j ++ ) {
 
@@ -178,11 +182,6 @@ export default class CSM {
 
 			}
 
-			_bbox.getSize( _size );
-			_bbox.getCenter( _center );
-			_center.z = _bbox.max.z + this.lightMargin;
-
-			let squaredBBWidth = _lightSpaceFrustum.vertices.far[ 0 ].distanceTo( _lightSpaceFrustum.vertices.near[ 2 ] );
 			if ( this.fade ) {
 
 				// expand the shadow extents by the fade margin if fade is enabled.
@@ -196,6 +195,8 @@ export default class CSM {
 			}
 
 			const texelSize = squaredBBWidth / this.shadowMapSize;
+			_bbox.getCenter( _center );
+			_center.z = _bbox.max.z + this.lightMargin;
 			_center.x = Math.floor( _center.x / texelSize ) * texelSize;
 			_center.y = Math.floor( _center.y / texelSize ) * texelSize;
 			_center.applyMatrix4( light.shadow.camera.matrixWorld );

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -187,7 +187,7 @@ export default class CSM {
 
 			}
 
-            let squaredBBWidth = point1.distanceTo( point2 );
+			let squaredBBWidth = point1.distanceTo( point2 );
 			_bbox.makeEmpty();
 			for ( let j = 0; j < 4; j ++ ) {
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -170,15 +170,29 @@ export default class CSM {
 			_cameraToLightMatrix.multiplyMatrices( light.shadow.camera.matrixWorldInverse, cameraMatrix );
 			frustums[ i ].toSpace( _cameraToLightMatrix, _lightSpaceFrustum );
 
-			const farTopRight = _lightSpaceFrustum.vertices.far[ 0 ];
-            const nearBotLeft = _lightSpaceFrustum.vertices.near[ 2 ];
-            let squaredBBWidth = farTopRight.distanceTo( nearBotLeft );
+			// Get the two points that represent that furthest points on the frustum assuming
+			// that's either the diagonal across the far plane or the diagonal across the whole
+			// frustum itself.
+			const nearVerts = _lightSpaceFrustum.vertices.near;
+			const farVerts = _lightSpaceFrustum.vertices.far;
+			const point1 = farVerts[ 0 ];
+			let point2;
+			if ( point1.distanceTo( farVerts[ 2 ] ) > point1.distanceTo( nearVerts[ 2 ] ) ) {
 
+				point2 = farVerts[ 2 ];
+
+			} else {
+
+				point2 = nearVerts[ 2 ];
+
+			}
+
+            let squaredBBWidth = point1.distanceTo( point2 );
 			_bbox.makeEmpty();
 			for ( let j = 0; j < 4; j ++ ) {
 
-				_bbox.expandByPoint( _lightSpaceFrustum.vertices.near[ j ] );
-				_bbox.expandByPoint( _lightSpaceFrustum.vertices.far[ j ] );
+				_bbox.expandByPoint( nearVerts[ j ] );
+				_bbox.expandByPoint( farVerts[ j ] );
 
 			}
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -181,9 +181,8 @@ export default class CSM {
 			_bbox.getSize( _size );
 			_bbox.getCenter( _center );
 			_center.z = _bbox.max.z + this.lightMargin;
-			_center.applyMatrix4( light.shadow.camera.matrixWorld );
 
-			let squaredBBWidth = Math.max( _size.x, _size.y );
+			let squaredBBWidth = _lightSpaceFrustum.vertices.far[ 0 ].distanceTo( _lightSpaceFrustum.vertices.far[ 2 ] );
 			if ( this.fade ) {
 
 				// expand the shadow extents by the fade margin if fade is enabled.
@@ -195,6 +194,12 @@ export default class CSM {
 				squaredBBWidth += margin;
 
 			}
+
+			const texelSize = squaredBBWidth / this.shadowMapSize;
+			_center.x = Math.floor( _center.x / texelSize ) * texelSize;
+			_center.y = Math.floor( _center.y / texelSize ) * texelSize;
+			_center.z = Math.floor( _center.z / texelSize ) * texelSize;
+			_center.applyMatrix4( light.shadow.camera.matrixWorld );
 
 			light.shadow.camera.left = - squaredBBWidth / 2;
 			light.shadow.camera.right = squaredBBWidth / 2;

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -182,7 +182,7 @@ export default class CSM {
 			_bbox.getCenter( _center );
 			_center.z = _bbox.max.z + this.lightMargin;
 
-			let squaredBBWidth = _lightSpaceFrustum.vertices.far[ 0 ].distanceTo( _lightSpaceFrustum.vertices.far[ 2 ] );
+			let squaredBBWidth = _lightSpaceFrustum.vertices.far[ 0 ].distanceTo( _lightSpaceFrustum.vertices.near[ 2 ] );
 			if ( this.fade ) {
 
 				// expand the shadow extents by the fade margin if fade is enabled.
@@ -198,7 +198,6 @@ export default class CSM {
 			const texelSize = squaredBBWidth / this.shadowMapSize;
 			_center.x = Math.floor( _center.x / texelSize ) * texelSize;
 			_center.y = Math.floor( _center.y / texelSize ) * texelSize;
-			_center.z = Math.floor( _center.z / texelSize ) * texelSize;
 			_center.applyMatrix4( light.shadow.camera.matrixWorld );
 
 			light.shadow.camera.left = - squaredBBWidth / 2;


### PR DESCRIPTION
Removes pixel swimming in CSM shadows by always making the XY shadow bounds big enough to cover the largest extent of the contained frustum and positioning the bounds at a discrete number of shadow texels in world space.

Temporary Live Links:
[Before](https://raw.githack.com/mrdoob/three.js/dev/examples/webgl_shadowmap_csm.html) vs [After](https://raw.githack.com/gkjohnson/three.js/csm-prevent-pixel-swimming/examples/webgl_shadowmap_csm.html)

Because this PR forces the shadow bounds to cover the largest extents of the contained frustum vs tightly containing it given the current rotation the shadow maps will look a little blurrier. This is because they have been stretched but I think it's a fine trade off to get rid of the distraction of dancing shadows. This should also mean we can calculate the shadow bounds once when the frustums are updated and just reposition them every camera move to hopefully make the updates simpler and little faster at some point.

@vHawk 