### PR TITLE
Examples: Make examples searchable by tags.

### DIFF
--- a/examples/files.js
+++ b/examples/files.js
@@ -390,6 +390,12 @@ var files = {
 };
 
 var tags = {
+    "webgl_clipping_intersection": [ "csg", "solid" ],
+    "webgl_fire": [ "smoke" ],
+    "webgl_materials_translucency": [ "subsurface", "scattering" ],
     "webgl_postprocessing_unreal_bloom": [ "glow" ],
-    "webgl_postprocessing_unreal_bloom_selective": [ "glow" ]
+    "webgl_postprocessing_unreal_bloom_selective": [ "glow" ],
+    "webgl_shadowmap_csm": [ "cascade" ],
+    "webgl_shadowmap_pcss": [ "soft" ],
+    "webgl_simple_gi": [ "global", "illumination" ]
 };

--- a/examples/files.js
+++ b/examples/files.js
@@ -388,3 +388,8 @@ var files = {
 		"misc_uv_tests"
 	]
 };
+
+var tags = {
+    "webgl_postprocessing_unreal_bloom": [ "glow" ],
+    "webgl_postprocessing_unreal_bloom_selective": [ "glow" ]
+};

--- a/examples/index.html
+++ b/examples/index.html
@@ -246,7 +246,9 @@
 
 			var link = links[ file ];
 			var name = getName( file );
-			var res = file.match( exp );
+			var matchCandidates = ( tags[ file ] || [] ).slice();
+			matchCandidates.push( file );
+			var res = matchCandidates.join( ' ' ).match( exp );
 			var text;
 
 			if ( res && res.length > 0 ) {


### PR DESCRIPTION
Basically what commit says - as per https://github.com/mrdoob/three.js/issues/18700#issuecomment-591612307

@munrocket I thought about adding the tags from #18773 here, but a bunch of entries like 
```
		"webxr_ar_paint",
		{ 'file': 'webxr_ar_paint', 'tags': 'Tiled forward lightingCreated by wizgrav.' },
		"webxr_vr_ballshooter",
		{ 'file': 'webxr_vr_ballshooter', 'tags': 'Tiled forward lightingCreated by wizgrav.' },
		"webxr_vr_cubes",
		{ 'file': 'webxr_vr_cubes', 'tags': 'Tiled forward lightingCreated by wizgrav.' },
		"webxr_vr_dragging",
		{ 'file': 'webxr_vr_dragging', 'tags': 'Tiled forward lightingCreated by wizgrav.' },
```
make me think your autogeneration script needs some finetuning, no?