### PR TITLE
A couple of lgtm regexp fixes

### DIFF
--- a/editor/js/libs/codemirror/codemirror.js
+++ b/editor/js/libs/codemirror/codemirror.js
@@ -6752,7 +6752,7 @@
       var prop = lineClass[1] ? "bgClass" : "textClass";
       if (output[prop] == null)
         output[prop] = lineClass[2];
-      else if (!(new RegExp("(?:^|\s)" + lineClass[2] + "(?:$|\s)")).test(output[prop]))
+      else if (!(new RegExp("(?:^|\\s)" + lineClass[2] + "(?:$|\\s)")).test(output[prop]))
         output[prop] += " " + lineClass[2];
     }
     return type;

--- a/editor/js/libs/ternjs/doc_comment.js
+++ b/editor/js/libs/ternjs/doc_comment.js
@@ -325,7 +325,7 @@
 
     for (var i = 0; i < comments.length; ++i) {
       var comment = comments[i];
-      var decl = /(?:\n|$|\*)\s*@(type|param|arg(?:ument)?|returns?|this)\s+(.*)/g, m;
+      var decl = /(?:\n|\$|\*)\s*@(type|param|arg(?:ument)?|returns?|this)\s+(.*)/g, m;
       while (m = decl.exec(comment)) {
         if (m[1] == "this" && (parsed = parseType(scope, m[2], 0))) {
           self = parsed;

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1284,7 +1284,7 @@ THREE.MMDLoader = ( function () {
 
 				try {
 
-					index = parseInt( filePath.match( 'toon([0-9]{2})\.bmp$' )[ 1 ] );
+					index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
 
 				} catch ( e ) {
 

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -1320,7 +1320,7 @@ var MMDLoader = ( function () {
 
 				try {
 
-					index = parseInt( filePath.match( 'toon([0-9]{2})\.bmp$' )[ 1 ] );
+					index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
 
 				} catch ( e ) {
 


### PR DESCRIPTION
I just clicked that `lgtm` button to see what those 200+ issues were and, seeing some of them were not addressed in 5 years, I figured noone is going to, so have a PR.

![Screen Shot 2020-03-01 at 1 45 04 ](https://user-images.githubusercontent.com/242577/75617484-22612000-5b60-11ea-8367-d5d3ca87436b.png)
 
On the other hand, some of the problems it detects are invalid, for example:

![Screen Shot 2020-03-01 at 1 48 00 ](https://user-images.githubusercontent.com/242577/75617494-3d339480-5b60-11ea-917a-2b1c511997e5.png)

so merge at your own risk :)