### PR TITLE
CSM: Add CSMHelper class with more visualizations 

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -333,68 +333,6 @@ export default class CSM {
 
 	}
 
-	helper( cameraMatrix ) {
-
-		let geometry, vertices;
-		const material = new LineBasicMaterial( { color: 0xffffff } );
-		const object = new Object3D();
-
-		for ( let i = 0; i < this.frustums.length; i ++ ) {
-
-			this.frustums[ i ].toSpace( cameraMatrix, _frustum );
-
-			geometry = new BufferGeometry();
-			vertices = [];
-
-
-			for ( let i = 0; i < 5; i ++ ) {
-
-				const point = _frustum.vertices.near[ i === 4 ? 0 : i ];
-				vertices.push( point.x, point.y, point.z );
-
-			}
-
-			geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
-
-			object.add( new Line( geometry, material ) );
-
-			geometry = new BufferGeometry();
-			vertices = [];
-
-			for ( let i = 0; i < 5; i ++ ) {
-
-				const point = _frustum.vertices.far[ i === 4 ? 0 : i ];
-				vertices.push( point.x, point.y, point.z );
-
-			}
-
-			geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
-
-			object.add( new Line( geometry, material ) );
-
-			for ( let i = 0; i < 4; i ++ ) {
-
-				geometry = new BufferGeometry();
-				vertices = [];
-
-				const near = _frustum.vertices.near[ i ];
-				const far = _frustum.vertices.far[ i ];
-
-				vertices.push( near.x, near.y, near.z );
-				vertices.push( far.x, far.y, far.z );
-
-				geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
-
-				object.add( new Line( geometry, material ) );
-
-			}
-
-		}
-
-		return object;
-
-	}
-
 	remove() {
 
 		for ( let i = 0; i < this.lights.length; i ++ ) {

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -21,7 +21,7 @@ const _bbox = new Box3();
 const _uniformArray = [];
 const _logArray = [];
 
-export default class CSM {
+export class CSM {
 
 	constructor( data ) {
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -8,11 +8,6 @@ import {
 	DirectionalLight,
 	MathUtils,
 	ShaderChunk,
-	LineBasicMaterial,
-	Object3D,
-	BufferGeometry,
-	BufferAttribute,
-	Line,
 	Matrix4,
 	Box3
 } from '../../../build/three.module.js';
@@ -21,9 +16,7 @@ import Shader from './Shader.js';
 
 const _cameraToLightMatrix = new Matrix4();
 const _lightSpaceFrustum = new Frustum();
-const _frustum = new Frustum();
 const _center = new Vector3();
-const _size = new Vector3();
 const _bbox = new Box3();
 const _uniformArray = [];
 const _logArray = [];

--- a/examples/jsm/csm/CSMHelper.js
+++ b/examples/jsm/csm/CSMHelper.js
@@ -1,0 +1,110 @@
+import { Group, Mesh, LineSegments, BufferGeometry, LineBasicMaterial, Box3Helper, Box3, PlaneBufferGeometry, MeshBasicMaterial } from '../../../build/three.module.js';
+
+class CSMHelper extends Group {
+
+	constructor( csm ) {
+
+		super();
+		this.csm = csm;
+
+		const indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
+		const positions = new Float32Array( 24 );
+		const frustumGeometry = new BufferGeometry();
+		frustumGeometry.setIndex( new BufferAttribute( indices, 1 ) );
+		frustumGeometry.setAttribute( 'position', new BufferAttribute( positions, 3, false ) );
+		this.add( frustumGeometry );
+
+		this.frustumLines = new LineSegments( frustumGeometry, new LineBasicMaterial() );
+		this.cascadeLines = [];
+		this.cascadePlanes = [];
+		this.shadowLines = [];
+
+	}
+
+	update() {
+
+		const csm = this.csm;
+		const cascades = csm.cascades;
+		const mainFrustum = csm.mainFrustum;
+		const mainFrustumPositions = mainFrustum.geometry.positions;
+		const frustums = csm.frustums;
+		const lights = csm.lights;
+
+		const frustumLines = this.frustumLines;
+		const cascadeLines = this.cascadeLines;
+		const cascadePlanes = this.cascadePlanes;
+		const shadowLines = this.shadowLines;
+
+		while( cascadeLines.length > cascades ) {
+
+			this.remove( cascadeLines.pop() );
+			this.remove( cascadePlanes.pop() );
+			this.remove( shadowLines.pop() );
+
+		}
+
+		while( cascadeLines.length < cascades ) {
+
+			const cascadeLine = new Box3Helper( new Box3(), 0xffffff );
+			const cascadePlane = new Mesh( new PlaneBufferGeometry(), new MeshBasicMaterial( { transparent: true, opacity: 0.1 } ) );
+			const shadowLineGroup = new Group();
+			const shadowLine = new Box3Helper( new Box3(), 0xffff00 );
+			shadowLineGroup.add( shadowLine );
+
+			this.add( cascadeLine );
+			this.add( cascadePlane );
+			this.add( shadowLine );
+
+			cascadeLines.push( cascadeLine );
+			cascadePlanes.push( cascadePlane );
+			shadowLines.push( shadowLineGroup );
+
+		}
+
+		for ( let i = 0; i < cascades; i ++ ) {
+
+			const frustum = frustums[ i ];
+			const light = lights[ i ];
+			const shadowCam = light.shadow.camera;
+			const farVerts = frustum.vertices.far;
+
+			const cascadeLine = cascadeLines[ i ];
+			const cascadePlane = cascadePlanes[ i ];
+			const shadowLineGroup = shadowLines[ i ];
+			const shadowLine = shadowLineGroup.children[ 0 ];
+
+			cascadeLine.box.min.copy( farVerts[ 2 ] );
+			cascadeLine.box.max.copy( farVerts[ 0 ] );
+
+			cascadePlane.position.addVectors( farVerts[ 0 ], farVerts[ 2 ] );
+			cascadePlane.position.multiplyScalar( 0.5 );
+			cascadePlane.scale.subVectors( farVerts[ 0 ], farVerts[ 2 ] );
+
+			this.remove( shadowLineGroup );
+			shadowCam.matrixWorld.decompose( shadowLineGroup.position, shadowLineGroup.quaternion, shadowLineGroup.scale );
+			this.attach( shadowLineGroup );
+
+			shadowLine.box.min.set( shadowCam.bottom, shadowCam.left, shadowCam.near );
+			shadowLine.box.max.set( shadowCam.top, shadowCam.right, shadowCam.far );
+
+			cascadeLine.update();
+			shadowLine.update();
+
+		}
+
+		mainFrustumPositions.setXYZ( 0, farVerts[ 0 ] );
+		mainFrustumPositions.setXYZ( 1, farVerts[ 3 ] );
+		mainFrustumPositions.setXYZ( 2, farVerts[ 2 ] );
+		mainFrustumPositions.setXYZ( 3, farVerts[ 1 ] );
+
+		mainFrustumPositions.setXYZ( 4, nearVerts[ 0 ] );
+		mainFrustumPositions.setXYZ( 5, nearVerts[ 3 ] );
+		mainFrustumPositions.setXYZ( 6, nearVerts[ 2 ] );
+		mainFrustumPositions.setXYZ( 7, nearVerts[ 1 ] );
+		mainFrustumPositions.needsUpdate = true;
+
+	}
+
+}
+
+export { CSMHelper };

--- a/examples/jsm/csm/CSMHelper.js
+++ b/examples/jsm/csm/CSMHelper.js
@@ -1,4 +1,16 @@
-import { Group, Mesh, LineSegments, BufferGeometry, LineBasicMaterial, Box3Helper, Box3, PlaneBufferGeometry, MeshBasicMaterial, BufferAttribute, DoubleSide } from '../../../build/three.module.js';
+import {
+	Group,
+	Mesh,
+	LineSegments,
+	BufferGeometry,
+	LineBasicMaterial,
+	Box3Helper,
+	Box3,
+	PlaneBufferGeometry,
+	MeshBasicMaterial,
+	BufferAttribute,
+	DoubleSide
+} from '../../../build/three.module.js';
 
 class CSMHelper extends Group {
 
@@ -6,6 +18,9 @@ class CSMHelper extends Group {
 
 		super();
 		this.csm = csm;
+		this.displayFrustum = true;
+		this.displayPlanes = true;
+		this.displayShadowBounds = true;
 
 		const indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
 		const positions = new Float32Array( 24 );
@@ -19,6 +34,32 @@ class CSMHelper extends Group {
 		this.cascadeLines = [];
 		this.cascadePlanes = [];
 		this.shadowLines = [];
+
+	}
+
+	updateVisibility() {
+
+		const displayFrustum = this.displayFrustum;
+		const displayPlanes = this.displayPlanes;
+		const displayShadowBounds = this.displayShadowBounds;
+
+		const frustumLines = this.frustumLines;
+		const cascadeLines = this.cascadeLines;
+		const cascadePlanes = this.cascadePlanes;
+		const shadowLines = this.shadowLines;
+		for ( let i = 0, l = cascadeLines.length; i < l; i ++ ) {
+
+			const cascadeLine = cascadeLines[ i ];
+			const cascadePlane = cascadePlanes[ i ];
+			const shadowLineGroup = shadowLines[ i ];
+
+			cascadeLine.visible = displayFrustum;
+			cascadePlane.visible = displayFrustum && displayPlanes;
+			shadowLineGroup.visible = displayShadowBounds;
+
+		}
+
+		frustumLines.visible = displayFrustum;
 
 	}
 

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -21,8 +21,9 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 			import * as CSM from './jsm/csm/CSM.js';
+			import { CSMHelper } from './jsm/csm/CSMHelper.js';
 
-			var renderer, scene, camera, orthoCamera, controls, csm;
+			var renderer, scene, camera, orthoCamera, controls, csm, csmHelper;
 
 			var params = {
 				orthographic: false,
@@ -35,10 +36,10 @@
 				margin: 100,
 				lightFar: 5000,
 				lightNear: 1,
-				helper: function () {
+				autoUpdateHelper: true,
+				updateHelper: function () {
 
-					var helper = csm.helper( camera.matrix );
-					scene.add( helper );
+					csmHelper.update();
 
 				}
 			};
@@ -92,6 +93,9 @@
 					lightDirection: new THREE.Vector3( params.lightX, params.lightY, params.lightZ ).normalize(),
 					camera: camera
 				} );
+
+				csmHelper = new CSMHelper( csm );
+				scene.add( csmHelper );
 
 				var floorMaterial = new THREE.MeshPhongMaterial( { color: '#252a34' } );
 				csm.setupMaterial( floorMaterial );
@@ -204,8 +208,32 @@
 
 				} );
 
-				gui.add( params, 'helper' ).name( 'add frustum helper' );
+				const helperFolder = gui.addFolder( 'helper' );
+				
+				helperFolder.add( csmHelper, 'visible' );
 
+				helperFolder.add( csmHelper, 'displayFrustum' ).onChange( function () { 
+
+					csmHelper.updateVisibility();
+
+				} );
+
+				helperFolder.add( csmHelper, 'displayPlanes' ).onChange( function () { 
+
+					csmHelper.updateVisibility();
+
+				} );
+
+				helperFolder.add( csmHelper, 'displayShadowBounds' ).onChange( function () { 
+
+					csmHelper.updateVisibility();
+
+				} );
+
+				helperFolder.add( params, 'autoUpdateHelper' ).name( 'auto update' );
+
+				helperFolder.add( params, 'updateHelper' ).name( 'update' );
+				
 				window.addEventListener( 'resize', function () {
 
 					camera.aspect = window.innerWidth / window.innerHeight;
@@ -231,10 +259,20 @@
 
 					updateOrthoCamera();
 					csm.updateFrustums();
+					if ( params.autoUpdateHelper ) {
+						
+						csmHelper.update();
+					
+					}
 					renderer.render( scene, orthoCamera );
 
 				} else {
 	
+					if ( params.autoUpdateHelper ) {
+						
+						csmHelper.update();
+					
+					}
 					renderer.render( scene, camera );
 
 				}

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -20,7 +20,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';
-			import * as CSM from './jsm/csm/CSM.js';
+			import { CSM } from './jsm/csm/CSM.js';
 			import { CSMHelper } from './jsm/csm/CSMHelper.js';
 
 			var renderer, scene, camera, orthoCamera, controls, csm, csmHelper;
@@ -84,7 +84,7 @@
 				var ambientLight = new THREE.AmbientLight( 0xffffff, 0.5 );
 				scene.add( ambientLight );
 
-				csm = new CSM.default({
+				csm = new CSM({
 					maxFar: params.far,
 					cascades: 4,
 					mode: params.mode,
@@ -95,6 +95,7 @@
 				} );
 
 				csmHelper = new CSMHelper( csm );
+				csmHelper.visible = false;
 				scene.add( csmHelper );
 
 				var floorMaterial = new THREE.MeshPhongMaterial( { color: '#252a34' } );

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -235,6 +235,8 @@
 
 				helperFolder.add( params, 'updateHelper' ).name( 'update' );
 				
+				helperFolder.open();
+
 				window.addEventListener( 'resize', function () {
 
 					camera.aspect = window.innerWidth / window.innerHeight;


### PR DESCRIPTION
Adds a `CSMHelper` based in part on the `CSM.helper` result and removes the `CSM.helper` function. The new `CSMHelper` object includes the following features:

- Updateable so a single instance can be reused.
- Add partially transparent planes to cascade boundaries so you can see where the cascade boundaries sit in first person.
- Add box helpers to display shadow bounds for each light.
- Ability to toggle the frustum, shadow bounds boxes, and cascade planes independently.

Temporary Live Link:

https://raw.githack.com/gkjohnson/three.js/csm-helper/examples/webgl_shadowmap_csm.html

![image](https://user-images.githubusercontent.com/734200/75634932-cf6e8380-5bc6-11ea-882c-c694abaa3c1e.png)

![image](https://user-images.githubusercontent.com/734200/75634955-152b4c00-5bc7-11ea-86fc-c23073026044.png)

@vHawk 