### PR TITLE
Raycaster: Stop traversing children when layers test false

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -46,11 +46,9 @@ function ascSort( a, b ) {
 
 function intersectObject( object, raycaster, intersects, recursive ) {
 
-	if ( object.layers.test( raycaster.layers ) ) {
+	if ( object.layers.test( raycaster.layers ) === false ) return;
 
-		object.raycast( raycaster, intersects );
-
-	}
+	object.raycast( raycaster, intersects );
 
 	if ( recursive === true ) {
 


### PR DESCRIPTION
#18694 introduced testing on layers instead of the visibility of the object. However, with that change it also changed the behaviour where it wouldn't stop traversing children if the object would test false. I am using `Group`s and setting the layer/visibility on the group. The renderer picks this up correctly: if the `Group`'s visibility is `false` or if the `Group`'s layer is testing `false`, the children are also not rendered. I would like to see `Raycaster` to match this behaviour.

I am not sure if this was intentional or not, so I am happy to discuss this if the change was intentional.