### PR TITLE
Examples: Fix webgl_buffergeometry_instancing_lambert.

### DIFF
--- a/examples/webgl_buffergeometry_instancing_lambert.html
+++ b/examples/webgl_buffergeometry_instancing_lambert.html
@@ -49,6 +49,8 @@
 			#include <logdepthbuf_pars_vertex>
 			#include <clipping_planes_pars_vertex>
 
+			varying vec2 vHighPrecisionZW;
+
 			void main() {
 
 				#include <uv_vertex>
@@ -75,6 +77,8 @@
 				#include <project_vertex>
 				#include <logdepthbuf_vertex>
 				#include <clipping_planes_vertex>
+
+				vHighPrecisionZW = gl_Position.zw;
 
 			}
 			`;


### PR DESCRIPTION
Fixed #18801.