### PR TITLE
ARButton.d.ts: `ARButton.createButton` must have sessionInit as 2nd argument

### DIFF
--- a/examples/jsm/webxr/ARButton.d.ts
+++ b/examples/jsm/webxr/ARButton.d.ts
@@ -3,5 +3,5 @@ import {
 } from '../../../src/Three';
 
 export namespace ARButton {
-	export function createButton( renderer: WebGLRenderer ): HTMLElement;
+	export function createButton( renderer: WebGLRenderer, sessionInit?: any ): HTMLElement;
 }


### PR DESCRIPTION
See: https://github.com/mrdoob/three.js/blob/dev/examples/jsm/webxr/ARButton.js#L8