### PR TITLE
Release hit test source when session ends

### DIFF
--- a/examples/webxr_ar_hittest.html
+++ b/examples/webxr_ar_hittest.html
@@ -23,7 +23,7 @@
 
 			var reticle;
 
-			var hitTestSource;
+			var hitTestSource = null;
 			var hitTestSourceRequested = false;
 
 			init();
@@ -123,6 +123,13 @@
 								hitTestSource = source;
 
 							} );
+
+						} );
+
+						session.addEventListener( 'end', function () {
+
+							hitTestSourceRequested = false;
+							hitTestSource = null;
 
 						} );
 


### PR DESCRIPTION
**Problem this PR fixes**

In [WebXR AR hit test example](https://threejs.org/examples/#webxr_ar_hittest), hit test doesn't work if you leave AR mode and enter again.

How to reproduce
1. Enter AR mode and you see reticle, which means hit test works
2. Leave AR mode
3. Enter AR mode again and you don't see reticle, which means hit test doesn't work

**Root issue**

According to [WebXR AR hit test API spec](https://immersive-web.github.io/hit-test/) `XRHitTestSource` is bound to `XRSession` which creates the hit test source. If I understand correctly, `XRHitTestSource` no longer works if `XRSession` ends to which the source is bound.

**Solution**

If you leave AR mode, AR session ends. And if you enter AR mode again, new AR session is created. Then we need to release hit test source when an old session ends and we need to create a new hit test source when a new session starts.

I confirmed this solution works with [WebXR Emulator Extension](WebXR-emulator-extension).