### PR TITLE
Update types of nullable bounding boxes and spheres

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -42,8 +42,8 @@ export class BufferGeometry extends EventDispatcher {
 	};
 	morphTargetsRelative: boolean;
 	groups: { start: number; count: number; materialIndex?: number }[];
-	boundingBox: Box3;
-	boundingSphere: Sphere;
+	boundingBox: Box3 | null;
+	boundingSphere: Sphere | null;
 	drawRange: { start: number; count: number };
 	userData: {[key: string]: any};
 	readonly isBufferGeometry: true;

--- a/src/core/DirectGeometry.d.ts
+++ b/src/core/DirectGeometry.d.ts
@@ -27,8 +27,8 @@ export class DirectGeometry {
 	morphTargets: MorphTarget[];
 	skinWeights: Vector4[];
 	skinIndices: Vector4[];
-	boundingBox: Box3;
-	boundingSphere: Sphere;
+	boundingBox: Box3 | null;
+	boundingSphere: Sphere | null;
 	verticesNeedUpdate: boolean;
 	normalsNeedUpdate: boolean;
 	colorsNeedUpdate: boolean;

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -121,12 +121,12 @@ export class Geometry extends EventDispatcher {
 	/**
 	 * Bounding box.
 	 */
-	boundingBox: Box3;
+	boundingBox: Box3 | null;
 
 	/**
 	 * Bounding sphere.
 	 */
-	boundingSphere: Sphere;
+	boundingSphere: Sphere | null;
 
 	/**
 	 * Set to true if the vertices array has been updated.


### PR DESCRIPTION
Bounding boxes and spheres can be computed on geometry.
These bounding boxes are not computed by default and are instead set to null.
They only become non-null when they are explicitly being computed.

This change reflects that by changing the types of bounding boxes and spheres to be nullable. Otherwise typescript assumes that these values cannot be null.