### PR TITLE
Docs: Fix markup.

### DIFF
--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -57,28 +58,35 @@
 		<h2>Methods</h2>
 
 		<h3>[method:HalfEdge addAdjoiningFace]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
-		[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br />
+			[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
 
-		<p>Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
-			All the half edges are created in CCW order thus the face is always pointing outside the hull</p>
+			Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
+			All the half edges are created in CCW order thus the face is always pointing outside the hull
+		</p>
 
 		<h3>[method:ConvexHull addNewFaces]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
-		[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br />
+			[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
 
-		<p>Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.</p>
+			Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.
+		</p>
 
 		<h3>[method:ConvexHull addVertexToFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
-		[page:VertexNodeNode vertex] - The vertex to add.<br /><br />
-		[page:Face face] - The target face.<br /><br />
+		<p>
+			[page:VertexNodeNode vertex] - The vertex to add.<br />
+			[page:Face face] - The target face.<br /><br />
 
-		<p>Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.</p>
+			Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.
+		</p>
 
 		<h3>[method:ConvexHull addVertexToHull]( [param:VertexNode eyeVertex] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 
-		<p>Adds a vertex to the hull with the following algorithm
+			Adds a vertex to the hull with the following algorithm
 			<ul>
 				<li>Compute the 'horizon' which is a chain of half edges. For an edge to belong to this group it must be the edge connecting a face that can see 'eyeVertex' and a face which cannot see 'eyeVertex'.</li>
 				<li>All the faces that can see 'eyeVertex' have its visible vertices removed from the assigned vertex list.</li>
@@ -100,27 +108,32 @@
 		<p>Computes the extremes values (min/max vectors) which will be used to compute the inital hull.</p>
 
 		<h3>[method:ConvexHull computeHorizon]( [param:Vector3 eyePoint], [param:HalfEdge crossEdge], [param:Face face], [param:Array horizon]	)</h3>
-		[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br /><br />
-		[page:HalfEdge crossEdge] - The edge used to jump to the current face.<br /><br />
-		[page:Face face] - The current face being tested.<br /><br />
-		[page:Array horizon] - The edges that form part of the horizon in CCW order.<br /><br />
+		<p>
+			[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br />
+			[page:HalfEdge crossEdge] - The edge used to jump to the current face.<br />
+			[page:Face face] - The current face being tested.<br />
+			[page:Array horizon] - The edges that form part of the horizon in CCW order.<br /><br />
 
-		<p>Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.</p>
+			Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.
+		</p>
 
 		<h3>[method:ConvexHull computeInitialHull]()</h3>
 
 		<p>Computes the initial simplex assigning to its faces all the points that are candidates to form part of the hull.</p>
 
 		<h3>[method:ConvexHull containsPoint]( [param:Vector3 point] )</h3>
-		[page:Vector3 point] - A point in 3D space.<br /><br />
+		<p>
+			[page:Vector3 point] - A point in 3D space.<br /><br />
 
-		<p>Returns *true* if the given point is inside this convex hull.</p>
+			Returns *true* if the given point is inside this convex hull.
+		</p>
 
 		<h3>[method:ConvexHull deleteFaceVertices]( [param:Face face], [param:Face absorbingFace]	)</h3>
-		[page:Face face] - The given face.<br /><br />
-		[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
+		<p>
+			[page:Face face] - The given face.<br />
+			[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
 
-		<p>Removes all the visible vertices that 'face' is able to see.
+			Removes all the visible vertices that 'face' is able to see.
 			<ul>
 				<li>If 'absorbingFace' doesn't exist, then all the removed vertices will be added to the 'unassigned' vertex list.</li>
 				<li>If 'absorbingFace' exists, then this method will assign all the vertices of 'face' that can see 'absorbingFace'.</li>
@@ -129,15 +142,19 @@
 		</p>
 
 		<h3>[method:Vector3 intersectRay]( [param:Ray ray], [param:Vector3 target] )</h3>
-		[page:Ray ray] - The given ray.<br /><br />
-		[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
+		<p>
+			[page:Ray ray] - The given ray.<br />
+			[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
 
-		<p>Performs a ray intersection test with this convext hull. If no intersection is found, *null* is returned.</p>
+			Performs a ray intersection test with this convext hull. If no intersection is found, *null* is returned.
+		</p>
 
 		<h3>[method:Boolean intersectsRay]( [param:Ray ray] )</h3>
-		[page:Ray ray] - The given ray.<br /><br />
+		<p>
+			[page:Ray ray] - The given ray.<br /><br />
 
-		<p>Returns *true* if the given ray intersects with this convex hull.</p>
+			Returns *true* if the given ray intersects with this convex hull.
+		</p>
 
 		<h3>[method:ConvexHull makeEmpty]()</h3>
 
@@ -158,31 +175,40 @@
 		<p>Removes inactive (e.g. deleted) faces from the internal face list.</p>
 
 		<h3>[method:VertexNode removeAllVerticesFromFace]( [param:Face face]	)</h3>
-		[page:Face face] - The given face.<br /><br />
+		<p>
+			[page:Face face] - The given face.<br /><br />
 
-		<p>Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.</p>
+			Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.
+		</p>
 
 		<h3>[method:ConvexHull removeVertexFromFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
-		[page:VertexNode vertex] - The vertex to remove.<br /><br />
-		[page:Face face] - The target face.<br /><br />
+		<p>
+			[page:VertexNode vertex] - The vertex to remove.<br />
+			[page:Face face] - The target face.<br /><br />
 
-		<p>Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.</p>
+			Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.
+		</p>
 
 		<h3>[method:ConvexHull resolveUnassignedPoints]( [param:Array newFaces]	)</h3>
-		[page:Face newFaces] - An array of new faces.<br /><br />
+		<p>
+			[page:Face newFaces] - An array of new faces.<br /><br />
 
-		<p>Reassigns as many vertices as possible from the unassigned list to the new faces.</p>
+			Reassigns as many vertices as possible from the unassigned list to the new faces.
+		</p>
 
 		<h3>[method:ConvexHull setFromObject]( [param:Object3D object] )</h3>
-		[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
+		<p>
+			[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
 
-		<p>Computes the convex hull of an [page:Object3D] (including its children),
-		accounting for the world transforms of both the object and its childrens.</p>
+			Computes the convex hull of an [page:Object3D] (including its children),accounting for the world transforms of both the object and its childrens.
+		</p>
 
 		<h3>[method:ConvexHull setFromPoints]( [param:Array points] )</h3>
-		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
+		<p>
+			[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
 
-		<p>Computes to convex hull for the given array of points.</p>
+			Computes to convex hull for the given array of points.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/en/math/convexhull/Face.html
+++ b/docs/examples/en/math/convexhull/Face.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -62,25 +63,31 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Face create]( [param:VertexNode a], [param:VertexNode b], [param:VertexNode c] )</h3>
-		[page:VertexNode a] - First vertex of the face.<br /><br />
-		[page:VertexNode b] - Second vertex of the face.<br /><br />
-		[page:VertexNode c] - Third vertex of the face.<br /><br />
+		<p>
+			[page:VertexNode a] - First vertex of the face.<br />
+			[page:VertexNode b] - Second vertex of the face.<br />
+			[page:VertexNode c] - Third vertex of the face.<br /><br />
 
-		<p>Creates a face.</p>
+			Creates a face.
+		</p>
 
 		<h3>[method:HalfEdge getEdge]( [param:Integer i] )</h3>
-		[page:Integer i] - The index of the edge.<br /><br />
+		<p>
+			[page:Integer i] - The index of the edge.<br /><br />
 
-		<p>Returns an edge by the given index.</p>
+			Returns an edge by the given index.
+		</p>
 
 		<h3>[method:Face compute] ()</h3>
 
 		<p>Computes all properties of the face.</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		[page:Vector3 point] - Any point in 3D space.<br /><br />
+		<p>
+			[page:Vector3 point] - Any point in 3D space.<br /><br />
 
-		<p>Returns the signed distance from a given point to the plane representation of this face.</p>
+			Returns the signed distance from a given point to the plane representation of this face.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/en/math/convexhull/HalfEdge.html
+++ b/docs/examples/en/math/convexhull/HalfEdge.html
@@ -20,8 +20,10 @@
 
 		<h3>[name]( [param:VertexNode vertex], [param:Face face] )</h3>
 		<p>
-		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br /><br />
-		[page:Face face] - [page:Face] A reference to its face.<br />
+		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br />
+		[page:Face face] - [page:Face] A reference to its face.<br /><br />
+
+		Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -68,9 +70,11 @@
 		(straight-line length) of the edge.</p>
 
 		<h3>[method:HalfEdge setTwin]( [param:HalfEdge edge] )</h3>
-		[page:HalfEdge edge] - Any half-edge.<br /><br />
+		<p>
+			[page:HalfEdge edge] - Any half-edge.<br /><br />
 
-		<p>Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.</p>
+			Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/en/math/convexhull/VertexList.html
+++ b/docs/examples/en/math/convexhull/VertexList.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -47,38 +48,48 @@
 
 		<h3>[method:VertexList insertBefore]( [param:Vertex target], [param:Vertex vertex] )</h3>
 		<p>
-		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
-		[page:Vertex vertex] - The vertex to insert.<br /><br />
+			[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br />
+			[page:Vertex vertex] - The vertex to insert.<br /><br />
+
+			Inserts a vertex <strong>before</strong> a target vertex.
 		</p>
 
-		<p>Inserts a vertex <strong>before</strong> a target vertex.</p>
-
 		<h3>[method:VertexList insertAfter]( [param:Vertex target], [param:Vertex vertex] )</h3>
-		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
-		[page:Vertex vertex] - The vertex to insert.<br /><br />
+		<p>
+			[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br />
+			[page:Vertex vertex] - The vertex to insert.<br /><br />
 
-		<p>Inserts a vertex <strong>after</strong> a target vertex.</p>
+			Inserts a vertex <strong>after</strong> a target vertex.
+		</p>
 
 		<h3>[method:VertexList append]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The vertex to append.<br /><br />
+		<p>
+			[page:Vertex vertex] - The vertex to append.<br /><br />
 
-		<p>Appends a vertex to the end of the linked list.</p>
+			Appends a vertex to the end of the linked list.
+		</p>
 
 		<h3>[method:VertexList appendChain]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
+		<p>
+			[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
 
-		<p>Appends a chain of vertices where the given vertex is the head.</p>
+			Appends a chain of vertices where the given vertex is the head.
+		</p>
 
 		<h3>[method:VertexList remove]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The vertex to remove.<br /><br />
+		<p>
+			[page:Vertex vertex] - The vertex to remove.<br /><br />
 
-		<p>Removes a vertex from the linked list.</p>
+			Removes a vertex from the linked list.
+		</p>
 
 		<h3>[method:VertexList removeSubList]( [param:Vertex a], [param:Vertex b] )</h3>
-		[page:Vertex a] - The head of the sublist.<br /><br />
-		[page:Vertex b] - The tail of the sublist.<br /><br />
+		<p>
+			[page:Vertex a] - The head of the sublist.<br />
+			[page:Vertex b] - The tail of the sublist.<br /><br />
 
-		<p>Removes a sublist of vertices from the linked list.</p>
+			Removes a sublist of vertices from the linked list.
+		</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
 

--- a/docs/examples/en/math/convexhull/VertexNode.html
+++ b/docs/examples/en/math/convexhull/VertexNode.html
@@ -21,6 +21,8 @@
 		<h3>[name]( [param:Vector3 point] )</h3>
 		<p>
 		[page:Vector3 point] - [page:Vector3] A point (x, y, z) in 3D space.<br /><br />
+
+		Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/examples/zh/math/convexhull/ConvexHull.html
+++ b/docs/examples/zh/math/convexhull/ConvexHull.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -57,28 +58,35 @@
 		<h2>Methods</h2>
 
 		<h3>[method:HalfEdge addAdjoiningFace]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
-		[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br />
+			[page:HalfEdge horizonEdge] - A single edge of the horizon.<br /><br />
 
-		<p>Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
-			All the half edges are created in CCW order thus the face is always pointing outside the hull</p>
+			Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order.
+			All the half edges are created in CCW order thus the face is always pointing outside the hull
+		</p>
 
 		<h3>[method:ConvexHull addNewFaces]( [param:VertexNode eyeVertex], [param:HalfEdge horizonEdge] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
-		[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br />
+			[page:HalfEdge horizon] - An array of half-edges that form the horizon.<br /><br />
 
-		<p>Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.</p>
+			Adds 'horizon.length' faces to the hull, each face will be linked with the horizon opposite face and the face on the left/right.
+		</p>
 
 		<h3>[method:ConvexHull addVertexToFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
-		[page:VertexNodeNode vertex] - The vertex to add.<br /><br />
-		[page:Face face] - The target face.<br /><br />
+		<p>
+			[page:VertexNodeNode vertex] - The vertex to add.<br />
+			[page:Face face] - The target face.<br /><br />
 
-		<p>Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.</p>
+			Adds a vertex to the 'assigned' list of vertices and assigns it to the given face.
+		</p>
 
 		<h3>[method:ConvexHull addVertexToHull]( [param:VertexNode eyeVertex] )</h3>
-		[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
+		<p>
+			[page:VertexNode eyeVertex] - The vertex that is added to the hull.<br /><br />
 
-		<p>Adds a vertex to the hull with the following algorithm
+			Adds a vertex to the hull with the following algorithm
 			<ul>
 				<li>Compute the 'horizon' which is a chain of half edges. For an edge to belong to this group it must be the edge connecting a face that can see 'eyeVertex' and a face which cannot see 'eyeVertex'.</li>
 				<li>All the faces that can see 'eyeVertex' have its visible vertices removed from the assigned vertex list.</li>
@@ -100,27 +108,32 @@
 		<p>Computes the extremes values (min/max vectors) which will be used to compute the inital hull.</p>
 
 		<h3>[method:ConvexHull computeHorizon]( [param:Vector3 eyePoint], [param:HalfEdge crossEdge], [param:Face face], [param:Array horizon]	)</h3>
-		[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br /><br />
-		[page:HalfEdge crossEdge] - The edge used to jump to the current face.<br /><br />
-		[page:Face face] - The current face being tested.<br /><br />
-		[page:Array horizon] - The edges that form part of the horizon in CCW order.<br /><br />
+		<p>
+			[page:Vector3 eyePoint] - The 3D-coordinates of a point.<br />
+			[page:HalfEdge crossEdge] - The edge used to jump to the current face.<br />
+			[page:Face face] - The current face being tested.<br />
+			[page:Array horizon] - The edges that form part of the horizon in CCW order.<br /><br />
 
-		<p>Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.</p>
+			Computes a chain of half edges in CCW order called the 'horizon'. For an edge to be part of the horizon it must join a face that can see 'eyePoint' and a face that cannot see 'eyePoint'.
+		</p>
 
 		<h3>[method:ConvexHull computeInitialHull]()</h3>
 
 		<p>Computes the initial simplex assigning to its faces all the points that are candidates to form part of the hull.</p>
 
 		<h3>[method:ConvexHull containsPoint]( [param:Vector3 point] )</h3>
-		[page:Vector3 point] - A point in 3D space.<br /><br />
+		<p>
+			[page:Vector3 point] - A point in 3D space.<br /><br />
 
-		<p>Returns *true* if the given point is inside this convex hull.</p>
+			Returns *true* if the given point is inside this convex hull.
+		</p>
 
 		<h3>[method:ConvexHull deleteFaceVertices]( [param:Face face], [param:Face absorbingFace]	)</h3>
-		[page:Face face] - The given face.<br /><br />
-		[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
+		<p>
+			[page:Face face] - The given face.<br />
+			[page:Face absorbingFace] - An optional face that tries to absorb the vertices of the first face.<br /><br />
 
-		<p>Removes all the visible vertices that 'face' is able to see.
+			Removes all the visible vertices that 'face' is able to see.
 			<ul>
 				<li>If 'absorbingFace' doesn't exist, then all the removed vertices will be added to the 'unassigned' vertex list.</li>
 				<li>If 'absorbingFace' exists, then this method will assign all the vertices of 'face' that can see 'absorbingFace'.</li>
@@ -129,15 +142,19 @@
 		</p>
 
 		<h3>[method:Vector3 intersectRay]( [param:Ray ray], [param:Vector3 target] )</h3>
-		[page:Ray ray] - The given ray.<br /><br />
-		[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
+		<p>
+			[page:Ray ray] - The given ray.<br />
+			[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
 
-		<p>Performs a ray intersection test with this convext hull. If no intersection is found, *null* is returned.</p>
+			Performs a ray intersection test with this convext hull. If no intersection is found, *null* is returned.
+		</p>
 
 		<h3>[method:Boolean intersectsRay]( [param:Ray ray] )</h3>
-		[page:Ray ray] - The given ray.<br /><br />
+		<p>
+			[page:Ray ray] - The given ray.<br /><br />
 
-		<p>Returns *true* if the given ray intersects with this convex hull.</p>
+			Returns *true* if the given ray intersects with this convex hull.
+		</p>
 
 		<h3>[method:ConvexHull makeEmpty]()</h3>
 
@@ -158,31 +175,40 @@
 		<p>Removes inactive (e.g. deleted) faces from the internal face list.</p>
 
 		<h3>[method:VertexNode removeAllVerticesFromFace]( [param:Face face]	)</h3>
-		[page:Face face] - The given face.<br /><br />
+		<p>
+			[page:Face face] - The given face.<br /><br />
 
-		<p>Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.</p>
+			Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list.
+		</p>
 
 		<h3>[method:ConvexHull removeVertexFromFace]( [param:VertexNode vertex], [param:Face face]	)</h3>
-		[page:VertexNode vertex] - The vertex to remove.<br /><br />
-		[page:Face face] - The target face.<br /><br />
+		<p>
+			[page:VertexNode vertex] - The vertex to remove.<br />
+			[page:Face face] - The target face.<br /><br />
 
-		<p>Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.</p>
+			Removes a vertex from the 'assigned' list of vertices and from the given face. It also makes sure that the link from 'face' to the first vertex it sees in 'assigned' is linked correctly after the removal.
+		</p>
 
 		<h3>[method:ConvexHull resolveUnassignedPoints]( [param:Array newFaces]	)</h3>
-		[page:Face newFaces] - An array of new faces.<br /><br />
+		<p>
+			[page:Face newFaces] - An array of new faces.<br /><br />
 
-		<p>Reassigns as many vertices as possible from the unassigned list to the new faces.</p>
+			Reassigns as many vertices as possible from the unassigned list to the new faces.
+		</p>
 
 		<h3>[method:ConvexHull setFromObject]( [param:Object3D object] )</h3>
-		[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
+		<p>
+			[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
 
-		<p>Computes the convex hull of an [page:Object3D] (including its children),
-		accounting for the world transforms of both the object and its childrens.</p>
+			Computes the convex hull of an [page:Object3D] (including its children),accounting for the world transforms of both the object and its childrens.
+		</p>
 
 		<h3>[method:ConvexHull setFromPoints]( [param:Array points] )</h3>
-		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
+		<p>
+			[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting convex hull will contain.<br /><br />
 
-		<p>Computes to convex hull for the given array of points.</p>
+			Computes to convex hull for the given array of points.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/zh/math/convexhull/Face.html
+++ b/docs/examples/zh/math/convexhull/Face.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -62,25 +63,31 @@
 		<h2>Methods</h2>
 
 		<h3>[method:Face create]( [param:VertexNode a], [param:VertexNode b], [param:VertexNode c] )</h3>
-		[page:VertexNode a] - First vertex of the face.<br /><br />
-		[page:VertexNode b] - Second vertex of the face.<br /><br />
-		[page:VertexNode c] - Third vertex of the face.<br /><br />
+		<p>
+			[page:VertexNode a] - First vertex of the face.<br />
+			[page:VertexNode b] - Second vertex of the face.<br />
+			[page:VertexNode c] - Third vertex of the face.<br /><br />
 
-		<p>Creates a face.</p>
+			Creates a face.
+		</p>
 
 		<h3>[method:HalfEdge getEdge]( [param:Integer i] )</h3>
-		[page:Integer i] - The index of the edge.<br /><br />
+		<p>
+			[page:Integer i] - The index of the edge.<br /><br />
 
-		<p>Returns an edge by the given index.</p>
+			Returns an edge by the given index.
+		</p>
 
 		<h3>[method:Face compute] ()</h3>
 
 		<p>Computes all properties of the face.</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
-		[page:Vector3 point] - Any point in 3D space.<br /><br />
+		<p>
+			[page:Vector3 point] - Any point in 3D space.<br /><br />
 
-		<p>Returns the signed distance from a given point to the plane representation of this face.</p>
+			Returns the signed distance from a given point to the plane representation of this face.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/zh/math/convexhull/HalfEdge.html
+++ b/docs/examples/zh/math/convexhull/HalfEdge.html
@@ -20,10 +20,11 @@
 
 		<h3>[name]( [param:VertexNode vertex], [param:Face face] )</h3>
 		<p>
-		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br /><br />
-		[page:Face face] - [page:Face] A reference to its face.<br />
-		</p>
+		[page:VertexNode vertex] - [page:VertexNode] A reference to its destination vertex.<br />
+		[page:Face face] - [page:Face] A reference to its face.<br /><br />
 
+		Creates a new instance of [name].
+		</p>
 		<h2>Properties</h2>
 
 		<h3>[property:VertexNode vertex]</h3>
@@ -68,9 +69,11 @@
 		(straight-line length) of the edge.</p>
 
 		<h3>[method:HalfEdge setTwin]( [param:HalfEdge edge] )</h3>
-		[page:HalfEdge edge] - Any half-edge.<br /><br />
+		<p>
+			[page:HalfEdge edge] - Any half-edge.<br /><br />
 
-		<p>Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.</p>
+			Sets the twin edge of this half-edge. It also ensures that the twin reference of the given half-edge is correctly set.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/zh/math/convexhull/VertexList.html
+++ b/docs/examples/zh/math/convexhull/VertexList.html
@@ -20,6 +20,7 @@
 
 		<h3>[name]()</h3>
 		<p>
+			Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>
@@ -47,38 +48,48 @@
 
 		<h3>[method:VertexList insertBefore]( [param:Vertex target], [param:Vertex vertex] )</h3>
 		<p>
-		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
-		[page:Vertex vertex] - The vertex to insert.<br /><br />
+			[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br />
+			[page:Vertex vertex] - The vertex to insert.<br /><br />
+
+			Inserts a vertex <strong>before</strong> a target vertex.
 		</p>
 
-		<p>Inserts a vertex <strong>before</strong> a target vertex.</p>
-
 		<h3>[method:VertexList insertAfter]( [param:Vertex target], [param:Vertex vertex] )</h3>
-		[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br /><br />
-		[page:Vertex vertex] - The vertex to insert.<br /><br />
+		<p>
+			[page:Vertex target] - The target vertex. It's assumed that this vertex belongs to the linked list.<br />
+			[page:Vertex vertex] - The vertex to insert.<br /><br />
 
-		<p>Inserts a vertex <strong>after</strong> a target vertex.</p>
+			Inserts a vertex <strong>after</strong> a target vertex.
+		</p>
 
 		<h3>[method:VertexList append]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The vertex to append.<br /><br />
+		<p>
+			[page:Vertex vertex] - The vertex to append.<br /><br />
 
-		<p>Appends a vertex to the end of the linked list.</p>
+			Appends a vertex to the end of the linked list.
+		</p>
 
 		<h3>[method:VertexList appendChain]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
+		<p>
+			[page:Vertex vertex] - The head vertex of a chain of vertices.<br /><br />
 
-		<p>Appends a chain of vertices where the given vertex is the head.</p>
+			Appends a chain of vertices where the given vertex is the head.
+		</p>
 
 		<h3>[method:VertexList remove]( [param:Vertex vertex] )</h3>
-		[page:Vertex vertex] - The vertex to remove.<br /><br />
+		<p>
+			[page:Vertex vertex] - The vertex to remove.<br /><br />
 
-		<p>Removes a vertex from the linked list.</p>
+			Removes a vertex from the linked list.
+		</p>
 
 		<h3>[method:VertexList removeSubList]( [param:Vertex a], [param:Vertex b] )</h3>
-		[page:Vertex a] - The head of the sublist.<br /><br />
-		[page:Vertex b] - The tail of the sublist.<br /><br />
+		<p>
+			[page:Vertex a] - The head of the sublist.<br />
+			[page:Vertex b] - The tail of the sublist.<br /><br />
 
-		<p>Removes a sublist of vertices from the linked list.</p>
+			Removes a sublist of vertices from the linked list.
+		</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
 

--- a/docs/examples/zh/math/convexhull/VertexNode.html
+++ b/docs/examples/zh/math/convexhull/VertexNode.html
@@ -21,6 +21,8 @@
 		<h3>[name]( [param:Vector3 point] )</h3>
 		<p>
 		[page:Vector3 point] - [page:Vector3] A point (x, y, z) in 3D space.<br /><br />
+
+		Creates a new instance of [name].
 		</p>
 
 		<h2>Properties</h2>


### PR DESCRIPTION
Implements the markup of certain example pages according to the rest of the docs.

Related: #16619