### PR TITLE
Fix for buffergeometry.d.ts ts definition

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -99,7 +99,7 @@ export class BufferGeometry extends EventDispatcher {
 	 */
 	computeVertexNormals(): void;
 
-	merge( geometry: BufferGeometry, offset: number ): BufferGeometry;
+	merge( geometry: BufferGeometry, offset?: number ): BufferGeometry;
 	normalizeNormals(): void;
 
 	toNonIndexed(): BufferGeometry;


### PR DESCRIPTION
Based on the documentation and the source, the "offset" parameter is optional in "merge". Now it's fixed in d.ts