### PR TITLE
Fix docs for renderBufferImmediate

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -427,9 +427,9 @@
 		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Fog fog], [param:Geometry geometry], [param:Material material], [param:Object3D object], [param:Object group] )</h3>
 		<p>Render a buffer geometry group using the camera and with the specified material.</p>
 
-		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program] )</h3>
+		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:WebGLProgram program] )</h3>
 		<p>object - an instance of [page:Object3D]<br />
-		program - an instance of shaderProgram<br />
+		program - an instance of [page:WebGLProgram]<br />
 
 		Renders an instance of [page:ImmediateRenderObject]. Gets called by renderObjectImmediate().
 		</p>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -427,12 +427,11 @@
 		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Fog fog], [param:Geometry geometry], [param:Material material], [param:Object3D object], [param:Object group] )</h3>
 		<p>Render a buffer geometry group using the camera and with the specified material.</p>
 
-		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program], [param:Material shading] )</h3>
+		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program] )</h3>
 		<p>object - an instance of [page:Object3D]<br />
 		program - an instance of shaderProgram<br />
-		shading - an instance of Material<br /><br />
 
-		Render an immediate buffer. Gets called by renderImmediateObject.
+		Render an immediate buffer. Gets called by renderObjectImmediate.
 		</p>
 
 		<h3>[method:null setAnimationLoop]( [param:Function callback] )</h3>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -431,7 +431,7 @@
 		<p>object - an instance of [page:Object3D]<br />
 		program - an instance of shaderProgram<br />
 
-		Render an immediate buffer. Gets called by renderObjectImmediate.
+		Renders an instance of [page:ImmediateRenderObject]. Gets called by renderObjectImmediate().
 		</p>
 
 		<h3>[method:null setAnimationLoop]( [param:Function callback] )</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -384,12 +384,11 @@
 		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Fog fog], [param:Geometry geometry], [param:Material material], [param:Object3D object], [param:Object group] )</h3>
 		<p>使用相机和指定材质渲染缓冲几何组。</p>
 
-		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program], [param:Material shading] )</h3>
+		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program] )</h3>
 		<p>object - 一个[page:Object3D]实例<br />
 		program - 一个shaderProgram实例<br />
-		shading - 一个Material实例<br /><br />
 
-		渲染即使缓冲，由enderImmediateObject对象调用
+		渲染即使缓冲，由renderObjectImmediate对象调用
 		</p>
 
 		<h3>[method:null setAnimationLoop]( [param:Function callback] )</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -384,9 +384,9 @@
 		<h3>[method:null renderBufferDirect]( [param:Camera camera], [param:Fog fog], [param:Geometry geometry], [param:Material material], [param:Object3D object], [param:Object group] )</h3>
 		<p>使用相机和指定材质渲染缓冲几何组。</p>
 
-		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:shaderprogram program] )</h3>
+		<h3>[method:null renderBufferImmediate]( [param:Object3D object], [param:WebGLProgram program] )</h3>
 		<p>object - 一个[page:Object3D]实例<br />
-		program - 一个shaderProgram实例<br />
+		program - 一个[page:WebGLProgram]实例<br />
 
 		渲染即使缓冲，由renderObjectImmediate对象调用
 		</p>


### PR DESCRIPTION
Looking at the code I saw that it actually does not take a Material as input. I suppose it's a leftover from an old implementation? Also, I guess there was typo: `renderImmediateObject` -> `renderObjectImmediate`

See https://github.com/mrdoob/three.js/blob/9cd486bd4fc2f19d2817ed5f93ac0cf736dfe43c/src/renderers/WebGLRenderer.js#L657