### PR TITLE
TS: Clean up PointsMaterial.

### DIFF
--- a/src/Three.Legacy.d.ts
+++ b/src/Three.Legacy.d.ts
@@ -13,6 +13,21 @@ export namespace SceneUtils {
 }
 
 /**
+ * @deprecated Use an Array instead.
+ */
+export class MultiMaterial extends Material {
+
+	constructor( materials?: Material[] );
+
+	readonly isMultiMaterial: true;
+
+	materials: Material[];
+
+	toJSON( meta: any ): any;
+
+}
+
+/**
  * @deprecated Material.vertexColors is now a boolean.
  */
 export enum Colors {}

--- a/src/materials/PointsMaterial.d.ts
+++ b/src/materials/PointsMaterial.d.ts
@@ -2,33 +2,13 @@ import { Material, MaterialParameters } from './Material';
 import { Color } from './../math/Color';
 import { Texture } from './../textures/Texture';
 
-// MultiMaterial does not inherit the Material class in the original code. However, it should treat as Material class.
-// See tests/canvas/canvas_materials.ts.
-/**
- * @deprecated Use an Array instead.
- */
-export class MultiMaterial extends Material {
-
-	constructor( materials?: Material[] );
-
-	readonly isMultiMaterial: true;
-
-	materials: Material[];
-
-	toJSON( meta: any ): any;
-
-}
-
-/**
- * @deprecated Use {@link MultiMaterial} instead.
- */
-
 export interface PointsMaterialParameters extends MaterialParameters {
 	color?: Color | string | number;
 	map?: Texture | null;
 	alphaMap?: Texture | null;
 	size?: number;
 	sizeAttenuation?: boolean;
+	morphTargets?: boolean;
 }
 
 export class PointsMaterial extends Material {
@@ -40,6 +20,7 @@ export class PointsMaterial extends Material {
 	alphaMap: Texture | null;
 	size: number;
 	sizeAttenuation: boolean;
+	morphTargets: boolean;
 
 	setValues( parameters: PointsMaterialParameters ): void;
 


### PR DESCRIPTION
Adds `morphTargets` as a property and moves `MultiMaterial` declaration to `Three.Legacy.d.ts`.