### PR TITLE
LineDashedMaterial: Improve docs and TS file.

### DIFF
--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Material] &rarr;
+		[page:Material] &rarr; [page:LineBasicMaterial] &rarr;
 
 		<h1>[name]</h1>
 
@@ -38,18 +38,12 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 		[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
-		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
-
-		The exception is the property [page:Hexadecimal color], which can be passed i	as a hexadecimal
-		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+		Any property of the material (including any property inherited from [page:LineBasicMaterial]) can be passed in here.
 		</p>
 
 
 		<h2>Properties</h2>
-		<p>See the base [page:Material] class for common properties.</p>
-
-		<h3>[property:Color color]</h3>
-		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
+		<p>See the base [page:LineBasicMaterial] class for common properties.</p>
 
 		<h3>[property:number dashSize]</h3>
 		<p>The size of the dash. This is both the gap with the stroke. Default is *3*.</p>
@@ -57,22 +51,12 @@
 		<h3>[property:number gapSize]</h3>
 		<p>The size of the gap. Default is *1*.</p>
 
-		<h3>[property:Float linewidth]</h3>
-		<p>
-			Controls line thickness. Default is *1*.<br /><br />
-
-			Due to limitations of the [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			with the [page:WebGLRenderer WebGL] renderer on most platforms linewidth will
-			always be 1 regardless of the set value.
-		</p>
 
 		<h3>[property:number scale]</h3>
 		<p>The scale of the dashed part of a line. Default is *1*.</p>
 
 		<h2>Methods</h2>
-		<p>See the base [page:Material] class for common methods.</p>
-
-
+		<p>See the base [page:LineBasicMaterial] class for common methods.</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/zh/materials/LineDashedMaterial.html
+++ b/docs/api/zh/materials/LineDashedMaterial.html
@@ -8,7 +8,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Material] &rarr;
+		[page:Material] &rarr; [page:LineBasicMaterial] &rarr;
 
 		<h1>虚线材质([name])</h1>
 
@@ -37,16 +37,11 @@
 
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
-		[page:Object parameters] - (可选)用于定义材质外观的对象，具有一个或多个属性。材质的任何属性都可以从此处传入(包括从[page:Material]继承的任何属性)。<br /><br />
-		属性[page:Hexadecimal color]例外，其可以作为十六进制字符串传递，默认情况下为 *0xffffff*（白色），内部调用[page:Color.set](color)。
+		[page:Object parameters] - (可选)用于定义材质外观的对象，具有一个或多个属性。材质的任何属性都可以从此处传入(包括从[page:LineBasicMaterial]继承的任何属性)。
 		</p>
 
-
 		<h2>属性(Properties)</h2>
-		<p>共有属性请参见其基类[page:Material]。</p>
-
-		<h3>[property:Color color]</h3>
-		<p>材质的颜色([page:Color])，默认值为白色 (0xffffff)。</p>
+		<p>共有属性请参见其基类[page:LineBasicMaterial]。</p>
 
 		<h3>[property:number dashSize]</h3>
 		<p>虚线的大小，是指破折号和间隙之和。默认值为 *3*。</p>
@@ -54,21 +49,11 @@
 		<h3>[property:number gapSize]</h3>
 		<p>间隙的大小，默认值为 *1*。</p>
 
-		<h3>[property:Float linewidth]</h3>
-		<p>
-			控制线宽。默认值为 *1*。<br /><br />
-
-			由于[link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]与
-			大多数平台上[page:WebGLRenderer WebGL]渲染器的限制，无论如何设置该值，线宽始终为1。
-		</p>
-
 		<h3>[property:number scale]</h3>
 		<p>线条中虚线部分的占比。默认值为 *1*。</p>
 
 		<h2>方法(Methods)</h2>
-		<p>共有方法请参见其基类[page:Material]。</p>
-
-
+		<p>共有方法请参见其基类[page:LineBasicMaterial]。</p>
 
 		<h2>源码(Source)</h2>
 

--- a/src/materials/LineDashedMaterial.d.ts
+++ b/src/materials/LineDashedMaterial.d.ts
@@ -1,10 +1,7 @@
 import { Color } from './../math/Color';
-import { MaterialParameters } from './Material';
-import { LineBasicMaterial } from './LineBasicMaterial';
+import { LineBasicMaterial, LineBasicMaterialParameters } from './LineBasicMaterial';
 
-export interface LineDashedMaterialParameters extends MaterialParameters {
-	color?: Color | string | number;
-	linewidth?: number;
+export interface LineDashedMaterialParameters extends LineBasicMaterialParameters {
 	scale?: number;
 	dashSize?: number;
 	gapSize?: number;


### PR DESCRIPTION
`LineDashedMaterial` is derived from `LineBasicMaterial` which was not correctly documented so far. Besides, the TS file should also make use of the existing `LineBasicMaterialParameters` interface.