### PR TITLE
Examples: Clean up ParametricGeometries.

### DIFF
--- a/examples/js/geometries/ParametricGeometries.js
+++ b/examples/js/geometries/ParametricGeometries.js
@@ -96,14 +96,13 @@ THREE.ParametricGeometries = {
  *
  *********************************************/
 
-THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsRadius, closed, debug ) {
+THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsRadius, closed ) {
 
 	this.path = path;
 	this.segments = segments || 64;
 	this.radius = radius || 1;
 	this.segmentsRadius = segmentsRadius || 8;
 	this.closed = closed || false;
-	if ( debug ) this.debug = new THREE.Object3D();
 
 	var scope = this, numpoints = this.segments + 1;
 
@@ -118,6 +117,8 @@ THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, seg
 	this.normals = normals;
 	this.binormals = binormals;
 
+	var position = new THREE.Vector3();
+
 	var ParametricTube = function ( u, v, target ) {
 
 		v *= 2 * Math.PI;
@@ -125,28 +126,19 @@ THREE.ParametricGeometries.TubeGeometry = function ( path, segments, radius, seg
 		var i = u * ( numpoints - 1 );
 		i = Math.floor( i );
 
-		var pos = path.getPointAt( u );
+		path.getPointAt( u, position );
 
-		var tangent = tangents[ i ];
 		var normal = normals[ i ];
 		var binormal = binormals[ i ];
-
-		if ( scope.debug ) {
-
-			scope.debug.add( new THREE.ArrowHelper( tangent, pos, radius, 0x0000ff ) );
-			scope.debug.add( new THREE.ArrowHelper( normal, pos, radius, 0xff0000 ) );
-			scope.debug.add( new THREE.ArrowHelper( binormal, pos, radius, 0x00ff00 ) );
-
-		}
 
 		var cx = - scope.radius * Math.cos( v ); // TODO: Hack: Negating it so it faces outside.
 		var cy = scope.radius * Math.sin( v );
 
-		pos.x += cx * normal.x + cy * binormal.x;
-		pos.y += cx * normal.y + cy * binormal.y;
-		pos.z += cx * normal.z + cy * binormal.z;
+		position.x += cx * normal.x + cy * binormal.x;
+		position.y += cx * normal.y + cy * binormal.y;
+		position.z += cx * normal.z + cy * binormal.z;
 
-		target.copy( pos );
+		target.copy( position );
 
 	};
 

--- a/examples/jsm/geometries/ParametricGeometries.d.ts
+++ b/examples/jsm/geometries/ParametricGeometries.d.ts
@@ -11,7 +11,7 @@ export namespace ParametricGeometries {
 
 	export class TubeGeometry {
 
-  	constructor( path: Curve<Vector3>, segments?: number, radius?: number, segmentsRadius?: number, closed?: boolean, debug?: boolean );
+  	constructor( path: Curve<Vector3>, segments?: number, radius?: number, segmentsRadius?: number, closed?: boolean );
 
 	}
 

--- a/examples/jsm/geometries/ParametricGeometries.js
+++ b/examples/jsm/geometries/ParametricGeometries.js
@@ -6,10 +6,8 @@
  */
 
 import {
-	ArrowHelper,
 	Curve,
 	Geometry,
-	Object3D,
 	ParametricGeometry,
 	Vector3
 } from "../../../build/three.module.js";
@@ -105,14 +103,13 @@ var ParametricGeometries = {
  *
  *********************************************/
 
-ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsRadius, closed, debug ) {
+ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsRadius, closed ) {
 
 	this.path = path;
 	this.segments = segments || 64;
 	this.radius = radius || 1;
 	this.segmentsRadius = segmentsRadius || 8;
 	this.closed = closed || false;
-	if ( debug ) this.debug = new Object3D();
 
 	var scope = this, numpoints = this.segments + 1;
 
@@ -127,6 +124,8 @@ ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsR
 	this.normals = normals;
 	this.binormals = binormals;
 
+	var position = new Vector3();
+
 	var ParametricTube = function ( u, v, target ) {
 
 		v *= 2 * Math.PI;
@@ -134,28 +133,19 @@ ParametricGeometries.TubeGeometry = function ( path, segments, radius, segmentsR
 		var i = u * ( numpoints - 1 );
 		i = Math.floor( i );
 
-		var pos = path.getPointAt( u );
+		path.getPointAt( u, position );
 
-		var tangent = tangents[ i ];
 		var normal = normals[ i ];
 		var binormal = binormals[ i ];
-
-		if ( scope.debug ) {
-
-			scope.debug.add( new ArrowHelper( tangent, pos, radius, 0x0000ff ) );
-			scope.debug.add( new ArrowHelper( normal, pos, radius, 0xff0000 ) );
-			scope.debug.add( new ArrowHelper( binormal, pos, radius, 0x00ff00 ) );
-
-		}
 
 		var cx = - scope.radius * Math.cos( v ); // TODO: Hack: Negating it so it faces outside.
 		var cy = scope.radius * Math.sin( v );
 
-		pos.x += cx * normal.x + cy * binormal.x;
-		pos.y += cx * normal.y + cy * binormal.y;
-		pos.z += cx * normal.z + cy * binormal.z;
+		position.x += cx * normal.x + cy * binormal.x;
+		position.y += cx * normal.y + cy * binormal.y;
+		position.z += cx * normal.z + cy * binormal.z;
 
-		target.copy( pos );
+		target.copy( position );
 
 	};
 

--- a/examples/webgl_geometries_parametric.html
+++ b/examples/webgl_geometries_parametric.html
@@ -79,7 +79,7 @@
 
 				var torus = new ParametricGeometries.TorusKnotGeometry( 50, 10, 50, 20, 2, 3 );
 				var sphere = new ParametricGeometries.SphereGeometry( 50, 20, 10 );
-				var tube = new ParametricGeometries.TubeGeometry( GrannyKnot, 100, 3, 8, true, false );
+				var tube = new ParametricGeometries.TubeGeometry( GrannyKnot, 100, 3, 8, true );
 
 				torus = new THREE.BufferGeometry().fromGeometry( torus );
 				sphere = new THREE.BufferGeometry().fromGeometry( sphere );

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -39,6 +39,8 @@
 
 			var binormal = new THREE.Vector3();
 			var normal = new THREE.Vector3();
+			var position = new THREE.Vector3();
+			var lookAt = new THREE.Vector3();
 
 			var pipeSpline = new THREE.CatmullRomCurve3( [
 				new THREE.Vector3( 0, 10, - 10 ), new THREE.Vector3( 10, 0, - 10 ),
@@ -290,8 +292,8 @@
 				var looptime = 20 * 1000;
 				var t = ( time % looptime ) / looptime;
 
-				var pos = tubeGeometry.parameters.path.getPointAt( t );
-				pos.multiplyScalar( params.scale );
+				tubeGeometry.parameters.path.getPointAt( t, position );
+				position.multiplyScalar( params.scale );
 
 				// interpolation
 
@@ -310,18 +312,19 @@
 
 				// we move on a offset on its binormal
 
-				pos.add( normal.clone().multiplyScalar( offset ) );
+				position.add( normal.clone().multiplyScalar( offset ) );
 
-				splineCamera.position.copy( pos );
-				cameraEye.position.copy( pos );
+				splineCamera.position.copy( position );
+				cameraEye.position.copy( position );
 
 				// using arclength for stablization in look ahead
 
-				var lookAt = tubeGeometry.parameters.path.getPointAt( ( t + 30 / tubeGeometry.parameters.path.getLength() ) % 1 ).multiplyScalar( params.scale );
+				tubeGeometry.parameters.path.getPointAt( ( t + 30 / tubeGeometry.parameters.path.getLength() ) % 1, lookAt );
+				lookAt.multiplyScalar( params.scale );
 
 				// camera orientation 2 - up orientation via normal
 
-				if ( ! params.lookAhead ) lookAt.copy( pos ).add( dir );
+				if ( ! params.lookAhead ) lookAt.copy( position ).add( dir );
 				splineCamera.matrix.lookAt( splineCamera.position, lookAt, normal );
 				splineCamera.quaternion.setFromRotationMatrix( splineCamera.matrix );
 


### PR DESCRIPTION
Minor clean up and performance improvement (by using the optional target of `Curve.getPointAt()`).