### PR TITLE
WebGLTextures: WebGL2 framebuffer RGBformat fallback

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -985,9 +985,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		// Handles WebGL2 RGBFormat fallback - #18858
 
-		if ( isWebGL2 &&
-			renderTarget.texture.format === RGBFormat &&
-			( renderTarget.texture.type === FloatType || renderTarget.texture.type === HalfFloatType ) ) {
+		if ( isWebGL2 && renderTarget.texture.format === RGBFormat && ( renderTarget.texture.type === FloatType || renderTarget.texture.type === HalfFloatType ) ) {
 
 			renderTarget.texture.format = RGBAFormat;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -180,10 +180,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			extensions.get( 'EXT_color_buffer_float' );
 
-		} else if ( internalFormat === _gl.RGB16F || internalFormat === _gl.RGB32F ) {
-
-			console.warn( 'THREE.WebGLRenderer: Floating point textures with RGB format not supported. Please use RGBA instead.' );
-
 		}
 
 		return internalFormat;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -987,6 +987,18 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		var isMultisample = ( renderTarget.isWebGLMultisampleRenderTarget === true );
 		var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
 
+		// Handles WebGL2 RGBFormat fallback - #18858
+
+		if ( isWebGL2 &&
+			renderTarget.texture.format === RGBFormat &&
+			( renderTarget.texture.type === FloatType || renderTarget.texture.type === HalfFloatType ) ) {
+
+			renderTarget.texture.format = RGBAFormat;
+
+			console.warn( 'THREE.WebGLRenderer: Rendering to textures with RGB format is not supported. Using RGBA format instead.' );
+
+		}
+
 		// Setup framebuffer
 
 		if ( isCube ) {


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/18858

Aside from the case explicited by the issue, there was also the need for fallback when using `RenderBufferStorage` ( multisampled rendertarget ).

Thoroughly tested the behavior in both WebGL1 and WebGL2, everything should be working correctly.

_requires build update_