### PR TITLE
Math: move to es6 classes

### DIFF
--- a/examples/js/math/ColorConverter.js
+++ b/examples/js/math/ColorConverter.js
@@ -3,15 +3,17 @@
  * @author zz85 / http://github.com/zz85
  */
 
-THREE.ColorConverter = {
+import { MathUtils } from "../../../build/three.js";
+
+var ColorConverter = {
 
 	setHSV: function ( color, h, s, v ) {
 
 		// https://gist.github.com/xpansive/1337890#file-index-js
 
-		h = THREE.MathUtils.euclideanModulo( h, 1 );
-		s = THREE.MathUtils.clamp( s, 0, 1 );
-		v = THREE.MathUtils.clamp( v, 0, 1 );
+		h = MathUtils.euclideanModulo( h, 1 );
+		s = MathUtils.clamp( s, 0, 1 );
+		v = MathUtils.clamp( v, 0, 1 );
 
 		return color.setHSL( h, ( s * v ) / ( ( h = ( 2 - s ) * v ) < 1 ? h : ( 2 - h ) ), h * 0.5 );
 
@@ -84,5 +86,6 @@ THREE.ColorConverter = {
 
 	}
 
-
 };
+
+export { ColorConverter };

--- a/examples/js/math/ConvexHull.js
+++ b/examples/js/math/ConvexHull.js
@@ -5,20 +5,20 @@
  *
  */
 
-THREE.ConvexHull = ( function () {
+import { Vector3 } from "../../../build/three.module.js";
 
-	var Visible = 0;
-	var Deleted = 1;
+var Visible = 0;
+var Deleted = 1;
 
-	var v1 = new THREE.Vector3();
+var v1 = new Vector3();
 
-	function ConvexHull() {
+class ConvexHull {
+
+	constructor() {
 
 		this.tolerance = - 1;
-
 		this.faces = []; // the generated faces of the convex hull
 		this.newFaces = []; // this array holds the faces that are generated within a single iteration
-
 		// the vertex lists work as follows:
 		//
 		// let 'a' and 'b' be 'Face' instances
@@ -31,389 +31,327 @@ THREE.ConvexHull = ( function () {
 		//
 		this.assigned = new VertexList();
 		this.unassigned = new VertexList();
-
-		this.vertices = []; 	// vertices of the hull (internal representation of given geometry data)
+		this.vertices = []; // vertices of the hull (internal representation of given geometry data)
 
 	}
 
-	Object.assign( ConvexHull.prototype, {
+	setFromPoints( points ) {
 
-		setFromPoints: function ( points ) {
+		if ( Array.isArray( points ) !== true ) {
 
-			if ( Array.isArray( points ) !== true ) {
+			console.error( 'THREE.ConvexHull: Points parameter is not an array.' );
 
-				console.error( 'THREE.ConvexHull: Points parameter is not an array.' );
+		}
 
-			}
+		if ( points.length < 4 ) {
 
-			if ( points.length < 4 ) {
+			console.error( 'THREE.ConvexHull: The algorithm needs at least four points.' );
 
-				console.error( 'THREE.ConvexHull: The algorithm needs at least four points.' );
+		}
 
-			}
+		this.makeEmpty();
 
-			this.makeEmpty();
+		for ( var i = 0, l = points.length; i < l; i ++ ) {
 
-			for ( var i = 0, l = points.length; i < l; i ++ ) {
+			this.vertices.push( new VertexNode( points[ i ] ) );
 
-				this.vertices.push( new VertexNode( points[ i ] ) );
+		}
 
-			}
+		this.compute();
 
-			this.compute();
+		return this;
 
-			return this;
+	}
 
-		},
+	setFromObject( object ) {
 
-		setFromObject: function ( object ) {
+		var points = [];
 
-			var points = [];
+		object.updateMatrixWorld( true );
 
-			object.updateMatrixWorld( true );
+		object.traverse( function ( node ) {
 
-			object.traverse( function ( node ) {
+			var i, l, point;
 
-				var i, l, point;
+			var geometry = node.geometry;
 
-				var geometry = node.geometry;
+			if ( geometry !== undefined ) {
 
-				if ( geometry !== undefined ) {
+				if ( geometry.isGeometry ) {
 
-					if ( geometry.isGeometry ) {
+					var vertices = geometry.vertices;
 
-						var vertices = geometry.vertices;
+					for ( i = 0, l = vertices.length; i < l; i ++ ) {
 
-						for ( i = 0, l = vertices.length; i < l; i ++ ) {
+						point = vertices[ i ].clone();
+						point.applyMatrix4( node.matrixWorld );
 
-							point = vertices[ i ].clone();
-							point.applyMatrix4( node.matrixWorld );
+						points.push( point );
+
+					}
+
+				} else if ( geometry.isBufferGeometry ) {
+
+					var attribute = geometry.attributes.position;
+
+					if ( attribute !== undefined ) {
+
+						for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+							point = new THREE.Vector3();
+
+							point.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
 
 							points.push( point );
 
 						}
 
-					} else if ( geometry.isBufferGeometry ) {
-
-						var attribute = geometry.attributes.position;
-
-						if ( attribute !== undefined ) {
-
-							for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-								point = new THREE.Vector3();
-
-								point.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-
-								points.push( point );
-
-							}
-
-						}
-
 					}
 
 				}
 
-			} );
-
-			return this.setFromPoints( points );
-
-		},
-
-		containsPoint: function ( point ) {
-
-			var faces = this.faces;
-
-			for ( var i = 0, l = faces.length; i < l; i ++ ) {
-
-				var face = faces[ i ];
-
-				// compute signed distance and check on what half space the point lies
-
-				if ( face.distanceToPoint( point ) > this.tolerance ) return false;
-
 			}
 
-			return true;
+		} );
 
-		},
+		return this.setFromPoints( points );
 
-		intersectRay: function ( ray, target ) {
+	}
 
-			// based on "Fast Ray-Convex Polyhedron Intersection"  by Eric Haines, GRAPHICS GEMS II
+	containsPoint( point ) {
 
-			var faces = this.faces;
+		var faces = this.faces;
 
-			var tNear = - Infinity;
-			var tFar = Infinity;
+		for ( var i = 0, l = faces.length; i < l; i ++ ) {
 
-			for ( var i = 0, l = faces.length; i < l; i ++ ) {
+			var face = faces[ i ];
 
-				var face = faces[ i ];
+			// compute signed distance and check on what half space the point lies
 
-				// interpret faces as planes for the further computation
+			if ( face.distanceToPoint( point ) > this.tolerance ) return false;
 
-				var vN = face.distanceToPoint( ray.origin );
-				var vD = face.normal.dot( ray.direction );
+		}
 
-				// if the origin is on the positive side of a plane (so the plane can "see" the origin) and
-				// the ray is turned away or parallel to the plane, there is no intersection
+		return true;
 
-				if ( vN > 0 && vD >= 0 ) return null;
+	}
 
-				// compute the distance from the ray’s origin to the intersection with the plane
+	intersectRay( ray, target ) {
 
-				var t = ( vD !== 0 ) ? ( - vN / vD ) : 0;
+		// based on "Fast Ray-Convex Polyhedron Intersection"  by Eric Haines, GRAPHICS GEMS II
 
-				// only proceed if the distance is positive. a negative distance means the intersection point
-				// lies "behind" the origin
+		var faces = this.faces;
 
-				if ( t <= 0 ) continue;
+		var tNear = - Infinity;
+		var tFar = Infinity;
 
-				// now categorized plane as front-facing or back-facing
+		for ( var i = 0, l = faces.length; i < l; i ++ ) {
 
-				if ( vD > 0 ) {
+			var face = faces[ i ];
 
-					//  plane faces away from the ray, so this plane is a back-face
+			// interpret faces as planes for the further computation
 
-					tFar = Math.min( t, tFar );
+			var vN = face.distanceToPoint( ray.origin );
+			var vD = face.normal.dot( ray.direction );
 
-				} else {
+			// if the origin is on the positive side of a plane (so the plane can "see" the origin) and
+			// the ray is turned away or parallel to the plane, there is no intersection
 
-					// front-face
+			if ( vN > 0 && vD >= 0 ) return null;
 
-					tNear = Math.max( t, tNear );
+			// compute the distance from the ray’s origin to the intersection with the plane
 
-				}
+			var t = ( vD !== 0 ) ? ( - vN / vD ) : 0;
 
-				if ( tNear > tFar ) {
+			// only proceed if the distance is positive. a negative distance means the intersection point
+			// lies "behind" the origin
 
-					// if tNear ever is greater than tFar, the ray must miss the convex hull
+			if ( t <= 0 ) continue;
 
-					return null;
+			// now categorized plane as front-facing or back-facing
 
-				}
+			if ( vD > 0 ) {
 
-			}
+				//  plane faces away from the ray, so this plane is a back-face
 
-			// evaluate intersection point
-
-			// always try tNear first since its the closer intersection point
-
-			if ( tNear !== - Infinity ) {
-
-				ray.at( tNear, target );
+				tFar = Math.min( t, tFar );
 
 			} else {
 
-				ray.at( tFar, target );
+				// front-face
+
+				tNear = Math.max( t, tNear );
 
 			}
 
-			return target;
+			if ( tNear > tFar ) {
 
-		},
+				// if tNear ever is greater than tFar, the ray must miss the convex hull
 
-		intersectsRay: function ( ray ) {
+				return null;
 
-			return this.intersectRay( ray, v1 ) !== null;
+			}
 
-		},
+		}
 
-		makeEmpty: function () {
+		// evaluate intersection point
 
-			this.faces = [];
-			this.vertices = [];
+		// always try tNear first since its the closer intersection point
 
-			return this;
+		if ( tNear !== - Infinity ) {
 
-		},
+			ray.at( tNear, target );
 
-		// Adds a vertex to the 'assigned' list of vertices and assigns it to the given face
+		} else {
 
-		addVertexToFace: function ( vertex, face ) {
+			ray.at( tFar, target );
 
-			vertex.face = face;
+		}
 
-			if ( face.outside === null ) {
+		return target;
 
-				this.assigned.append( vertex );
+	}
+
+	intersectsRay( ray ) {
+
+		return this.intersectRay( ray, v1 ) !== null;
+
+	}
+
+	makeEmpty() {
+
+		this.faces = [];
+		this.vertices = [];
+
+		return this;
+
+	}
+
+	// Adds a vertex to the 'assigned' list of vertices and assigns it to the given face
+
+	addVertexToFace( vertex, face ) {
+
+		vertex.face = face;
+
+		if ( face.outside === null ) {
+
+			this.assigned.append( vertex );
+
+		} else {
+
+			this.assigned.insertBefore( face.outside, vertex );
+
+		}
+
+		face.outside = vertex;
+
+		return this;
+
+	}
+
+	// Removes a vertex from the 'assigned' list of vertices and from the given face
+
+	removeVertexFromFace( vertex, face ) {
+
+		if ( vertex === face.outside ) {
+
+			// fix face.outside link
+
+			if ( vertex.next !== null && vertex.next.face === face ) {
+
+				// face has at least 2 outside vertices, move the 'outside' reference
+
+				face.outside = vertex.next;
 
 			} else {
 
-				this.assigned.insertBefore( face.outside, vertex );
+				// vertex was the only outside vertex that face had
 
-			}
-
-			face.outside = vertex;
-
-			return this;
-
-		},
-
-		// Removes a vertex from the 'assigned' list of vertices and from the given face
-
-		removeVertexFromFace: function ( vertex, face ) {
-
-			if ( vertex === face.outside ) {
-
-				// fix face.outside link
-
-				if ( vertex.next !== null && vertex.next.face === face ) {
-
-					// face has at least 2 outside vertices, move the 'outside' reference
-
-					face.outside = vertex.next;
-
-				} else {
-
-					// vertex was the only outside vertex that face had
-
-					face.outside = null;
-
-				}
-
-			}
-
-			this.assigned.remove( vertex );
-
-			return this;
-
-		},
-
-		// Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list
-
-		removeAllVerticesFromFace: function ( face ) {
-
-			if ( face.outside !== null ) {
-
-				// reference to the first and last vertex of this face
-
-				var start = face.outside;
-				var end = face.outside;
-
-				while ( end.next !== null && end.next.face === face ) {
-
-					end = end.next;
-
-				}
-
-				this.assigned.removeSubList( start, end );
-
-				// fix references
-
-				start.prev = end.next = null;
 				face.outside = null;
 
-				return start;
+			}
+
+		}
+
+		this.assigned.remove( vertex );
+
+		return this;
+
+	}
+
+	// Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list
+
+	removeAllVerticesFromFace( face ) {
+
+		if ( face.outside !== null ) {
+
+			// reference to the first and last vertex of this face
+
+			var start = face.outside;
+			var end = face.outside;
+
+			while ( end.next !== null && end.next.face === face ) {
+
+				end = end.next;
 
 			}
 
-		},
+			this.assigned.removeSubList( start, end );
 
-		// Removes all the visible vertices that 'face' is able to see
+			// fix references
 
-		deleteFaceVertices: function ( face, absorbingFace ) {
+			start.prev = end.next = null;
+			face.outside = null;
 
-			var faceVertices = this.removeAllVerticesFromFace( face );
+			return start;
 
-			if ( faceVertices !== undefined ) {
+		}
 
-				if ( absorbingFace === undefined ) {
+	}
 
-					// mark the vertices to be reassigned to some other face
+	// Removes all the visible vertices that 'face' is able to see
 
-					this.unassigned.appendChain( faceVertices );
+	deleteFaceVertices( face, absorbingFace ) {
+
+		var faceVertices = this.removeAllVerticesFromFace( face );
+
+		if ( faceVertices !== undefined ) {
+
+			if ( absorbingFace === undefined ) {
+
+				// mark the vertices to be reassigned to some other face
+
+				this.unassigned.appendChain( faceVertices );
 
 
-				} else {
+			} else {
 
-					// if there's an absorbing face try to assign as many vertices as possible to it
+				// if there's an absorbing face try to assign as many vertices as possible to it
 
-					var vertex = faceVertices;
-
-					do {
-
-						// we need to buffer the subsequent vertex at this point because the 'vertex.next' reference
-						// will be changed by upcoming method calls
-
-						var nextVertex = vertex.next;
-
-						var distance = absorbingFace.distanceToPoint( vertex.point );
-
-						// check if 'vertex' is able to see 'absorbingFace'
-
-						if ( distance > this.tolerance ) {
-
-							this.addVertexToFace( vertex, absorbingFace );
-
-						} else {
-
-							this.unassigned.append( vertex );
-
-						}
-
-						// now assign next vertex
-
-						vertex = nextVertex;
-
-					} while ( vertex !== null );
-
-				}
-
-			}
-
-			return this;
-
-		},
-
-		// Reassigns as many vertices as possible from the unassigned list to the new faces
-
-		resolveUnassignedPoints: function ( newFaces ) {
-
-			if ( this.unassigned.isEmpty() === false ) {
-
-				var vertex = this.unassigned.first();
+				var vertex = faceVertices;
 
 				do {
 
-					// buffer 'next' reference, see .deleteFaceVertices()
+					// we need to buffer the subsequent vertex at this point because the 'vertex.next' reference
+					// will be changed by upcoming method calls
 
 					var nextVertex = vertex.next;
 
-					var maxDistance = this.tolerance;
+					var distance = absorbingFace.distanceToPoint( vertex.point );
 
-					var maxFace = null;
+					// check if 'vertex' is able to see 'absorbingFace'
 
-					for ( var i = 0; i < newFaces.length; i ++ ) {
+					if ( distance > this.tolerance ) {
 
-						var face = newFaces[ i ];
+						this.addVertexToFace( vertex, absorbingFace );
 
-						if ( face.mark === Visible ) {
+					} else {
 
-							var distance = face.distanceToPoint( vertex.point );
-
-							if ( distance > maxDistance ) {
-
-								maxDistance = distance;
-								maxFace = face;
-
-							}
-
-							if ( maxDistance > 1000 * this.tolerance ) break;
-
-						}
+						this.unassigned.append( vertex );
 
 					}
 
-					// 'maxFace' can be null e.g. if there are identical vertices
-
-					if ( maxFace !== null ) {
-
-						this.addVertexToFace( vertex, maxFace );
-
-					}
+					// now assign next vertex
 
 					vertex = nextVertex;
 
@@ -421,533 +359,591 @@ THREE.ConvexHull = ( function () {
 
 			}
 
-			return this;
+		}
 
-		},
+		return this;
 
-		// Computes the extremes of a simplex which will be the initial hull
+	}
 
-		computeExtremes: function () {
+	// Reassigns as many vertices as possible from the unassigned list to the new faces
 
-			var min = new THREE.Vector3();
-			var max = new THREE.Vector3();
+	resolveUnassignedPoints( newFaces ) {
 
-			var minVertices = [];
-			var maxVertices = [];
+		if ( this.unassigned.isEmpty() === false ) {
 
-			var i, l, j;
-
-			// initially assume that the first vertex is the min/max
-
-			for ( i = 0; i < 3; i ++ ) {
-
-				minVertices[ i ] = maxVertices[ i ] = this.vertices[ 0 ];
-
-			}
-
-			min.copy( this.vertices[ 0 ].point );
-			max.copy( this.vertices[ 0 ].point );
-
-			// compute the min/max vertex on all six directions
-
-			for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
-
-				var vertex = this.vertices[ i ];
-				var point = vertex.point;
-
-				// update the min coordinates
-
-				for ( j = 0; j < 3; j ++ ) {
-
-					if ( point.getComponent( j ) < min.getComponent( j ) ) {
-
-						min.setComponent( j, point.getComponent( j ) );
-						minVertices[ j ] = vertex;
-
-					}
-
-				}
-
-				// update the max coordinates
-
-				for ( j = 0; j < 3; j ++ ) {
-
-					if ( point.getComponent( j ) > max.getComponent( j ) ) {
-
-						max.setComponent( j, point.getComponent( j ) );
-						maxVertices[ j ] = vertex;
-
-					}
-
-				}
-
-			}
-
-			// use min/max vectors to compute an optimal epsilon
-
-			this.tolerance = 3 * Number.EPSILON * (
-				Math.max( Math.abs( min.x ), Math.abs( max.x ) ) +
-				Math.max( Math.abs( min.y ), Math.abs( max.y ) ) +
-				Math.max( Math.abs( min.z ), Math.abs( max.z ) )
-			);
-
-			return { min: minVertices, max: maxVertices };
-
-		},
-
-		// Computes the initial simplex assigning to its faces all the points
-		// that are candidates to form part of the hull
-
-		computeInitialHull: function () {
-
-			var line3, plane, closestPoint;
-
-			return function computeInitialHull() {
-
-				if ( line3 === undefined ) {
-
-					line3 = new THREE.Line3();
-					plane = new THREE.Plane();
-					closestPoint = new THREE.Vector3();
-
-				}
-
-				var vertex, vertices = this.vertices;
-				var extremes = this.computeExtremes();
-				var min = extremes.min;
-				var max = extremes.max;
-
-				var v0, v1, v2, v3;
-				var i, l, j;
-
-				// 1. Find the two vertices 'v0' and 'v1' with the greatest 1d separation
-				// (max.x - min.x)
-				// (max.y - min.y)
-				// (max.z - min.z)
-
-				var distance, maxDistance = 0;
-				var index = 0;
-
-				for ( i = 0; i < 3; i ++ ) {
-
-					distance = max[ i ].point.getComponent( i ) - min[ i ].point.getComponent( i );
-
-					if ( distance > maxDistance ) {
-
-						maxDistance = distance;
-						index = i;
-
-					}
-
-				}
-
-				v0 = min[ index ];
-				v1 = max[ index ];
-
-				// 2. The next vertex 'v2' is the one farthest to the line formed by 'v0' and 'v1'
-
-				maxDistance = 0;
-				line3.set( v0.point, v1.point );
-
-				for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
-
-					vertex = vertices[ i ];
-
-					if ( vertex !== v0 && vertex !== v1 ) {
-
-						line3.closestPointToPoint( vertex.point, true, closestPoint );
-
-						distance = closestPoint.distanceToSquared( vertex.point );
-
-						if ( distance > maxDistance ) {
-
-							maxDistance = distance;
-							v2 = vertex;
-
-						}
-
-					}
-
-				}
-
-				// 3. The next vertex 'v3' is the one farthest to the plane 'v0', 'v1', 'v2'
-
-				maxDistance = - 1;
-				plane.setFromCoplanarPoints( v0.point, v1.point, v2.point );
-
-				for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
-
-					vertex = vertices[ i ];
-
-					if ( vertex !== v0 && vertex !== v1 && vertex !== v2 ) {
-
-						distance = Math.abs( plane.distanceToPoint( vertex.point ) );
-
-						if ( distance > maxDistance ) {
-
-							maxDistance = distance;
-							v3 = vertex;
-
-						}
-
-					}
-
-				}
-
-				var faces = [];
-
-				if ( plane.distanceToPoint( v3.point ) < 0 ) {
-
-					// the face is not able to see the point so 'plane.normal' is pointing outside the tetrahedron
-
-					faces.push(
-						Face.create( v0, v1, v2 ),
-						Face.create( v3, v1, v0 ),
-						Face.create( v3, v2, v1 ),
-						Face.create( v3, v0, v2 )
-					);
-
-					// set the twin edge
-
-					for ( i = 0; i < 3; i ++ ) {
-
-						j = ( i + 1 ) % 3;
-
-						// join face[ i ] i > 0, with the first face
-
-						faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( j ) );
-
-						// join face[ i ] with face[ i + 1 ], 1 <= i <= 3
-
-						faces[ i + 1 ].getEdge( 1 ).setTwin( faces[ j + 1 ].getEdge( 0 ) );
-
-					}
-
-				} else {
-
-					// the face is able to see the point so 'plane.normal' is pointing inside the tetrahedron
-
-					faces.push(
-						Face.create( v0, v2, v1 ),
-						Face.create( v3, v0, v1 ),
-						Face.create( v3, v1, v2 ),
-						Face.create( v3, v2, v0 )
-					);
-
-					// set the twin edge
-
-					for ( i = 0; i < 3; i ++ ) {
-
-						j = ( i + 1 ) % 3;
-
-						// join face[ i ] i > 0, with the first face
-
-						faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( ( 3 - i ) % 3 ) );
-
-						// join face[ i ] with face[ i + 1 ]
-
-						faces[ i + 1 ].getEdge( 0 ).setTwin( faces[ j + 1 ].getEdge( 1 ) );
-
-					}
-
-				}
-
-				// the initial hull is the tetrahedron
-
-				for ( i = 0; i < 4; i ++ ) {
-
-					this.faces.push( faces[ i ] );
-
-				}
-
-				// initial assignment of vertices to the faces of the tetrahedron
-
-				for ( i = 0, l = vertices.length; i < l; i ++ ) {
-
-					vertex = vertices[ i ];
-
-					if ( vertex !== v0 && vertex !== v1 && vertex !== v2 && vertex !== v3 ) {
-
-						maxDistance = this.tolerance;
-						var maxFace = null;
-
-						for ( j = 0; j < 4; j ++ ) {
-
-							distance = this.faces[ j ].distanceToPoint( vertex.point );
-
-							if ( distance > maxDistance ) {
-
-								maxDistance = distance;
-								maxFace = this.faces[ j ];
-
-							}
-
-						}
-
-						if ( maxFace !== null ) {
-
-							this.addVertexToFace( vertex, maxFace );
-
-						}
-
-					}
-
-				}
-
-				return this;
-
-			};
-
-		}(),
-
-		// Removes inactive faces
-
-		reindexFaces: function () {
-
-			var activeFaces = [];
-
-			for ( var i = 0; i < this.faces.length; i ++ ) {
-
-				var face = this.faces[ i ];
-
-				if ( face.mark === Visible ) {
-
-					activeFaces.push( face );
-
-				}
-
-			}
-
-			this.faces = activeFaces;
-
-			return this;
-
-		},
-
-		// Finds the next vertex to create faces with the current hull
-
-		nextVertexToAdd: function () {
-
-			// if the 'assigned' list of vertices is empty, no vertices are left. return with 'undefined'
-
-			if ( this.assigned.isEmpty() === false ) {
-
-				var eyeVertex, maxDistance = 0;
-
-				// grap the first available face and start with the first visible vertex of that face
-
-				var eyeFace = this.assigned.first().face;
-				var vertex = eyeFace.outside;
-
-				// now calculate the farthest vertex that face can see
-
-				do {
-
-					var distance = eyeFace.distanceToPoint( vertex.point );
-
-					if ( distance > maxDistance ) {
-
-						maxDistance = distance;
-						eyeVertex = vertex;
-
-					}
-
-					vertex = vertex.next;
-
-				} while ( vertex !== null && vertex.face === eyeFace );
-
-				return eyeVertex;
-
-			}
-
-		},
-
-		// Computes a chain of half edges in CCW order called the 'horizon'.
-		// For an edge to be part of the horizon it must join a face that can see
-		// 'eyePoint' and a face that cannot see 'eyePoint'.
-
-		computeHorizon: function ( eyePoint, crossEdge, face, horizon ) {
-
-			// moves face's vertices to the 'unassigned' vertex list
-
-			this.deleteFaceVertices( face );
-
-			face.mark = Deleted;
-
-			var edge;
-
-			if ( crossEdge === null ) {
-
-				edge = crossEdge = face.getEdge( 0 );
-
-			} else {
-
-				// start from the next edge since 'crossEdge' was already analyzed
-				// (actually 'crossEdge.twin' was the edge who called this method recursively)
-
-				edge = crossEdge.next;
-
-			}
+			var vertex = this.unassigned.first();
 
 			do {
 
-				var twinEdge = edge.twin;
-				var oppositeFace = twinEdge.face;
+				// buffer 'next' reference, see .deleteFaceVertices()
 
-				if ( oppositeFace.mark === Visible ) {
+				var nextVertex = vertex.next;
 
-					if ( oppositeFace.distanceToPoint( eyePoint ) > this.tolerance ) {
+				var maxDistance = this.tolerance;
 
-						// the opposite face can see the vertex, so proceed with next edge
+				var maxFace = null;
 
-						this.computeHorizon( eyePoint, twinEdge, oppositeFace, horizon );
+				for ( var i = 0; i < newFaces.length; i ++ ) {
 
-					} else {
+					var face = newFaces[ i ];
 
-						// the opposite face can't see the vertex, so this edge is part of the horizon
+					if ( face.mark === Visible ) {
 
-						horizon.push( edge );
+						var distance = face.distanceToPoint( vertex.point );
+
+						if ( distance > maxDistance ) {
+
+							maxDistance = distance;
+							maxFace = face;
+
+						}
+
+						if ( maxDistance > 1000 * this.tolerance ) break;
 
 					}
 
 				}
 
-				edge = edge.next;
+				// 'maxFace' can be null e.g. if there are identical vertices
 
-			} while ( edge !== crossEdge );
+				if ( maxFace !== null ) {
 
-			return this;
-
-		},
-
-		// Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order
-
-		addAdjoiningFace: function ( eyeVertex, horizonEdge ) {
-
-			// all the half edges are created in ccw order thus the face is always pointing outside the hull
-
-			var face = Face.create( eyeVertex, horizonEdge.tail(), horizonEdge.head() );
-
-			this.faces.push( face );
-
-			// join face.getEdge( - 1 ) with the horizon's opposite edge face.getEdge( - 1 ) = face.getEdge( 2 )
-
-			face.getEdge( - 1 ).setTwin( horizonEdge.twin );
-
-			return face.getEdge( 0 ); // the half edge whose vertex is the eyeVertex
-
-
-		},
-
-		//  Adds 'horizon.length' faces to the hull, each face will be linked with the
-		//  horizon opposite face and the face on the left/right
-
-		addNewFaces: function ( eyeVertex, horizon ) {
-
-			this.newFaces = [];
-
-			var firstSideEdge = null;
-			var previousSideEdge = null;
-
-			for ( var i = 0; i < horizon.length; i ++ ) {
-
-				var horizonEdge = horizon[ i ];
-
-				// returns the right side edge
-
-				var sideEdge = this.addAdjoiningFace( eyeVertex, horizonEdge );
-
-				if ( firstSideEdge === null ) {
-
-					firstSideEdge = sideEdge;
-
-				} else {
-
-					// joins face.getEdge( 1 ) with previousFace.getEdge( 0 )
-
-					sideEdge.next.setTwin( previousSideEdge );
+					this.addVertexToFace( vertex, maxFace );
 
 				}
 
-				this.newFaces.push( sideEdge.face );
-				previousSideEdge = sideEdge;
+				vertex = nextVertex;
 
-			}
-
-			// perform final join of new faces
-
-			firstSideEdge.next.setTwin( previousSideEdge );
-
-			return this;
-
-		},
-
-		// Adds a vertex to the hull
-
-		addVertexToHull: function ( eyeVertex ) {
-
-			var horizon = [];
-
-			this.unassigned.clear();
-
-			// remove 'eyeVertex' from 'eyeVertex.face' so that it can't be added to the 'unassigned' vertex list
-
-			this.removeVertexFromFace( eyeVertex, eyeVertex.face );
-
-			this.computeHorizon( eyeVertex.point, null, eyeVertex.face, horizon );
-
-			this.addNewFaces( eyeVertex, horizon );
-
-			// reassign 'unassigned' vertices to the new faces
-
-			this.resolveUnassignedPoints( this.newFaces );
-
-			return	this;
-
-		},
-
-		cleanup: function () {
-
-			this.assigned.clear();
-			this.unassigned.clear();
-			this.newFaces = [];
-
-			return this;
-
-		},
-
-		compute: function () {
-
-			var vertex;
-
-			this.computeInitialHull();
-
-			// add all available vertices gradually to the hull
-
-			while ( ( vertex = this.nextVertexToAdd() ) !== undefined ) {
-
-				this.addVertexToHull( vertex );
-
-			}
-
-			this.reindexFaces();
-
-			this.cleanup();
-
-			return this;
+			} while ( vertex !== null );
 
 		}
 
-	} );
+		return this;
 
-	//
+	}
 
-	function Face() {
+	// Computes the extremes of a simplex which will be the initial hull
+
+	computeExtremes() {
+
+		var min = new THREE.Vector3();
+		var max = new THREE.Vector3();
+
+		var minVertices = [];
+		var maxVertices = [];
+
+		var i, l, j;
+
+		// initially assume that the first vertex is the min/max
+
+		for ( i = 0; i < 3; i ++ ) {
+
+			minVertices[ i ] = maxVertices[ i ] = this.vertices[ 0 ];
+
+		}
+
+		min.copy( this.vertices[ 0 ].point );
+		max.copy( this.vertices[ 0 ].point );
+
+		// compute the min/max vertex on all six directions
+
+		for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+			var vertex = this.vertices[ i ];
+			var point = vertex.point;
+
+			// update the min coordinates
+
+			for ( j = 0; j < 3; j ++ ) {
+
+				if ( point.getComponent( j ) < min.getComponent( j ) ) {
+
+					min.setComponent( j, point.getComponent( j ) );
+					minVertices[ j ] = vertex;
+
+				}
+
+			}
+
+			// update the max coordinates
+
+			for ( j = 0; j < 3; j ++ ) {
+
+				if ( point.getComponent( j ) > max.getComponent( j ) ) {
+
+					max.setComponent( j, point.getComponent( j ) );
+					maxVertices[ j ] = vertex;
+
+				}
+
+			}
+
+		}
+
+		// use min/max vectors to compute an optimal epsilon
+
+		this.tolerance = 3 * Number.EPSILON * (
+			Math.max( Math.abs( min.x ), Math.abs( max.x ) ) +
+      Math.max( Math.abs( min.y ), Math.abs( max.y ) ) +
+      Math.max( Math.abs( min.z ), Math.abs( max.z ) )
+		);
+
+		return { min: minVertices, max: maxVertices };
+
+	}
+
+	// Computes the initial simplex assigning to its faces all the points
+	// that are candidates to form part of the hull
+
+	computeInitialHull() {
+
+		var line3, plane, closestPoint;
+
+		return function computeInitialHull() {
+
+			if ( line3 === undefined ) {
+
+				line3 = new THREE.Line3();
+				plane = new THREE.Plane();
+				closestPoint = new THREE.Vector3();
+
+			}
+
+			var vertex, vertices = this.vertices;
+			var extremes = this.computeExtremes();
+			var min = extremes.min;
+			var max = extremes.max;
+
+			var v0, v1, v2, v3;
+			var i, l, j;
+
+			// 1. Find the two vertices 'v0' and 'v1' with the greatest 1d separation
+			// (max.x - min.x)
+			// (max.y - min.y)
+			// (max.z - min.z)
+
+			var distance, maxDistance = 0;
+			var index = 0;
+
+			for ( i = 0; i < 3; i ++ ) {
+
+				distance = max[ i ].point.getComponent( i ) - min[ i ].point.getComponent( i );
+
+				if ( distance > maxDistance ) {
+
+					maxDistance = distance;
+					index = i;
+
+				}
+
+			}
+
+			v0 = min[ index ];
+			v1 = max[ index ];
+
+			// 2. The next vertex 'v2' is the one farthest to the line formed by 'v0' and 'v1'
+
+			maxDistance = 0;
+			line3.set( v0.point, v1.point );
+
+			for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+				vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 ) {
+
+					line3.closestPointToPoint( vertex.point, true, closestPoint );
+
+					distance = closestPoint.distanceToSquared( vertex.point );
+
+					if ( distance > maxDistance ) {
+
+						maxDistance = distance;
+						v2 = vertex;
+
+					}
+
+				}
+
+			}
+
+			// 3. The next vertex 'v3' is the one farthest to the plane 'v0', 'v1', 'v2'
+
+			maxDistance = - 1;
+			plane.setFromCoplanarPoints( v0.point, v1.point, v2.point );
+
+			for ( i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+				vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 && vertex !== v2 ) {
+
+					distance = Math.abs( plane.distanceToPoint( vertex.point ) );
+
+					if ( distance > maxDistance ) {
+
+						maxDistance = distance;
+						v3 = vertex;
+
+					}
+
+				}
+
+			}
+
+			var faces = [];
+
+			if ( plane.distanceToPoint( v3.point ) < 0 ) {
+
+				// the face is not able to see the point so 'plane.normal' is pointing outside the tetrahedron
+
+				faces.push(
+					Face.create( v0, v1, v2 ),
+					Face.create( v3, v1, v0 ),
+					Face.create( v3, v2, v1 ),
+					Face.create( v3, v0, v2 )
+				);
+
+				// set the twin edge
+
+				for ( i = 0; i < 3; i ++ ) {
+
+					j = ( i + 1 ) % 3;
+
+					// join face[ i ] i > 0, with the first face
+
+					faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( j ) );
+
+					// join face[ i ] with face[ i + 1 ], 1 <= i <= 3
+
+					faces[ i + 1 ].getEdge( 1 ).setTwin( faces[ j + 1 ].getEdge( 0 ) );
+
+				}
+
+			} else {
+
+				// the face is able to see the point so 'plane.normal' is pointing inside the tetrahedron
+
+				faces.push(
+					Face.create( v0, v2, v1 ),
+					Face.create( v3, v0, v1 ),
+					Face.create( v3, v1, v2 ),
+					Face.create( v3, v2, v0 )
+				);
+
+				// set the twin edge
+
+				for ( i = 0; i < 3; i ++ ) {
+
+					j = ( i + 1 ) % 3;
+
+					// join face[ i ] i > 0, with the first face
+
+					faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( ( 3 - i ) % 3 ) );
+
+					// join face[ i ] with face[ i + 1 ]
+
+					faces[ i + 1 ].getEdge( 0 ).setTwin( faces[ j + 1 ].getEdge( 1 ) );
+
+				}
+
+			}
+
+			// the initial hull is the tetrahedron
+
+			for ( i = 0; i < 4; i ++ ) {
+
+				this.faces.push( faces[ i ] );
+
+			}
+
+			// initial assignment of vertices to the faces of the tetrahedron
+
+			for ( i = 0, l = vertices.length; i < l; i ++ ) {
+
+				vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 && vertex !== v2 && vertex !== v3 ) {
+
+					maxDistance = this.tolerance;
+					var maxFace = null;
+
+					for ( j = 0; j < 4; j ++ ) {
+
+						distance = this.faces[ j ].distanceToPoint( vertex.point );
+
+						if ( distance > maxDistance ) {
+
+							maxDistance = distance;
+							maxFace = this.faces[ j ];
+
+						}
+
+					}
+
+					if ( maxFace !== null ) {
+
+						this.addVertexToFace( vertex, maxFace );
+
+					}
+
+				}
+
+			}
+
+			return this;
+
+		};
+
+	}
+
+	// Removes inactive faces
+
+	reindexFaces() {
+
+		var activeFaces = [];
+
+		for ( var i = 0; i < this.faces.length; i ++ ) {
+
+			var face = this.faces[ i ];
+
+			if ( face.mark === Visible ) {
+
+				activeFaces.push( face );
+
+			}
+
+		}
+
+		this.faces = activeFaces;
+
+		return this;
+
+	}
+
+	// Finds the next vertex to create faces with the current hull
+
+	nextVertexToAdd() {
+
+		// if the 'assigned' list of vertices is empty, no vertices are left. return with 'undefined'
+
+		if ( this.assigned.isEmpty() === false ) {
+
+			var eyeVertex, maxDistance = 0;
+
+			// grap the first available face and start with the first visible vertex of that face
+
+			var eyeFace = this.assigned.first().face;
+			var vertex = eyeFace.outside;
+
+			// now calculate the farthest vertex that face can see
+
+			do {
+
+				var distance = eyeFace.distanceToPoint( vertex.point );
+
+				if ( distance > maxDistance ) {
+
+					maxDistance = distance;
+					eyeVertex = vertex;
+
+				}
+
+				vertex = vertex.next;
+
+			} while ( vertex !== null && vertex.face === eyeFace );
+
+			return eyeVertex;
+
+		}
+
+	}
+
+	// Computes a chain of half edges in CCW order called the 'horizon'.
+	// For an edge to be part of the horizon it must join a face that can see
+	// 'eyePoint' and a face that cannot see 'eyePoint'.
+
+	computeHorizon( eyePoint, crossEdge, face, horizon ) {
+
+		// moves face's vertices to the 'unassigned' vertex list
+
+		this.deleteFaceVertices( face );
+
+		face.mark = Deleted;
+
+		var edge;
+
+		if ( crossEdge === null ) {
+
+			edge = crossEdge = face.getEdge( 0 );
+
+		} else {
+
+			// start from the next edge since 'crossEdge' was already analyzed
+			// (actually 'crossEdge.twin' was the edge who called this method recursively)
+
+			edge = crossEdge.next;
+
+		}
+
+		do {
+
+			var twinEdge = edge.twin;
+			var oppositeFace = twinEdge.face;
+
+			if ( oppositeFace.mark === Visible ) {
+
+				if ( oppositeFace.distanceToPoint( eyePoint ) > this.tolerance ) {
+
+					// the opposite face can see the vertex, so proceed with next edge
+
+					this.computeHorizon( eyePoint, twinEdge, oppositeFace, horizon );
+
+				} else {
+
+					// the opposite face can't see the vertex, so this edge is part of the horizon
+
+					horizon.push( edge );
+
+				}
+
+			}
+
+			edge = edge.next;
+
+		} while ( edge !== crossEdge );
+
+		return this;
+
+	}
+
+	// Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order
+
+	addAdjoiningFace( eyeVertex, horizonEdge ) {
+
+		// all the half edges are created in ccw order thus the face is always pointing outside the hull
+
+		var face = Face.create( eyeVertex, horizonEdge.tail(), horizonEdge.head() );
+
+		this.faces.push( face );
+
+		// join face.getEdge( - 1 ) with the horizon's opposite edge face.getEdge( - 1 ) = face.getEdge( 2 )
+
+		face.getEdge( - 1 ).setTwin( horizonEdge.twin );
+
+		return face.getEdge( 0 ); // the half edge whose vertex is the eyeVertex
+
+
+	}
+
+	//  Adds 'horizon.length' faces to the hull, each face will be linked with the
+	//  horizon opposite face and the face on the left/right
+
+	addNewFaces( eyeVertex, horizon ) {
+
+		this.newFaces = [];
+
+		var firstSideEdge = null;
+		var previousSideEdge = null;
+
+		for ( var i = 0; i < horizon.length; i ++ ) {
+
+			var horizonEdge = horizon[ i ];
+
+			// returns the right side edge
+
+			var sideEdge = this.addAdjoiningFace( eyeVertex, horizonEdge );
+
+			if ( firstSideEdge === null ) {
+
+				firstSideEdge = sideEdge;
+
+			} else {
+
+				// joins face.getEdge( 1 ) with previousFace.getEdge( 0 )
+
+				sideEdge.next.setTwin( previousSideEdge );
+
+			}
+
+			this.newFaces.push( sideEdge.face );
+			previousSideEdge = sideEdge;
+
+		}
+
+		// perform final join of new faces
+
+		firstSideEdge.next.setTwin( previousSideEdge );
+
+		return this;
+
+	}
+
+	// Adds a vertex to the hull
+
+	addVertexToHull( eyeVertex ) {
+
+		var horizon = [];
+
+		this.unassigned.clear();
+
+		// remove 'eyeVertex' from 'eyeVertex.face' so that it can't be added to the 'unassigned' vertex list
+
+		this.removeVertexFromFace( eyeVertex, eyeVertex.face );
+
+		this.computeHorizon( eyeVertex.point, null, eyeVertex.face, horizon );
+
+		this.addNewFaces( eyeVertex, horizon );
+
+		// reassign 'unassigned' vertices to the new faces
+
+		this.resolveUnassignedPoints( this.newFaces );
+
+		return	this;
+
+	}
+
+	cleanup() {
+
+		this.assigned.clear();
+		this.unassigned.clear();
+		this.newFaces = [];
+
+		return this;
+
+	}
+
+	compute() {
+
+		var vertex;
+
+		this.computeInitialHull();
+
+		// add all available vertices gradually to the hull
+
+		while ( ( vertex = this.nextVertexToAdd() ) !== undefined ) {
+
+			this.addVertexToHull( vertex );
+
+		}
+
+		this.reindexFaces();
+
+		this.cleanup();
+
+		return this;
+
+	}
+
+}
+
+class Face {
+
+	constructor() {
 
 		this.normal = new THREE.Vector3();
 		this.midpoint = new THREE.Vector3();
 		this.area = 0;
-
 		this.constant = 0; // signed distance from face to the origin
 		this.outside = null; // reference to a vertex in a vertex list this face can see
 		this.mark = Visible;
@@ -955,93 +951,88 @@ THREE.ConvexHull = ( function () {
 
 	}
 
-	Object.assign( Face, {
+	create( a, b, c ) {
 
-		create: function ( a, b, c ) {
+		var face = new Face();
 
-			var face = new Face();
+		var e0 = new HalfEdge( a, face );
+		var e1 = new HalfEdge( b, face );
+		var e2 = new HalfEdge( c, face );
 
-			var e0 = new HalfEdge( a, face );
-			var e1 = new HalfEdge( b, face );
-			var e2 = new HalfEdge( c, face );
+		// join edges
 
-			// join edges
+		e0.next = e2.prev = e1;
+		e1.next = e0.prev = e2;
+		e2.next = e1.prev = e0;
 
-			e0.next = e2.prev = e1;
-			e1.next = e0.prev = e2;
-			e2.next = e1.prev = e0;
+		// main half edge reference
 
-			// main half edge reference
+		face.edge = e0;
 
-			face.edge = e0;
+		return face.compute();
 
-			return face.compute();
+	}
 
-		}
+	getEdge( i ) {
 
-	} );
+		var edge = this.edge;
 
-	Object.assign( Face.prototype, {
+		while ( i > 0 ) {
 
-		getEdge: function ( i ) {
-
-			var edge = this.edge;
-
-			while ( i > 0 ) {
-
-				edge = edge.next;
-				i --;
-
-			}
-
-			while ( i < 0 ) {
-
-				edge = edge.prev;
-				i ++;
-
-			}
-
-			return edge;
-
-		},
-
-		compute: function () {
-
-			var triangle;
-
-			return function compute() {
-
-				if ( triangle === undefined ) triangle = new THREE.Triangle();
-
-				var a = this.edge.tail();
-				var b = this.edge.head();
-				var c = this.edge.next.head();
-
-				triangle.set( a.point, b.point, c.point );
-
-				triangle.getNormal( this.normal );
-				triangle.getMidpoint( this.midpoint );
-				this.area = triangle.getArea();
-
-				this.constant = this.normal.dot( this.midpoint );
-
-				return this;
-
-			};
-
-		}(),
-
-		distanceToPoint: function ( point ) {
-
-			return this.normal.dot( point ) - this.constant;
+			edge = edge.next;
+			i --;
 
 		}
 
-	} );
+		while ( i < 0 ) {
 
-	// Entity for a Doubly-Connected Edge List (DCEL).
+			edge = edge.prev;
+			i ++;
 
-	function HalfEdge( vertex, face ) {
+		}
+
+		return edge;
+
+	}
+
+	compute() {
+
+		var triangle;
+
+		return function compute() {
+
+			if ( triangle === undefined ) triangle = new THREE.Triangle();
+
+			var a = this.edge.tail();
+			var b = this.edge.head();
+			var c = this.edge.next.head();
+
+			triangle.set( a.point, b.point, c.point );
+
+			triangle.getNormal( this.normal );
+			triangle.getMidpoint( this.midpoint );
+			this.area = triangle.getArea();
+
+			this.constant = this.normal.dot( this.midpoint );
+
+			return this;
+
+		};
+
+	}
+
+	distanceToPoint( point ) {
+
+		return this.normal.dot( point ) - this.constant;
+
+	}
+
+}
+
+// Entity for a Doubly-Connected Edge List (DCEL).
+class HalfEdge {
+
+	constructor( vertex, face ) {
 
 		this.vertex = vertex;
 		this.prev = null;
@@ -1051,64 +1042,62 @@ THREE.ConvexHull = ( function () {
 
 	}
 
-	Object.assign( HalfEdge.prototype, {
+	head() {
 
-		head: function () {
+		return this.vertex;
 
-			return this.vertex;
+	}
 
-		},
+	tail() {
 
-		tail: function () {
+		return this.prev ? this.prev.vertex : null;
 
-			return this.prev ? this.prev.vertex : null;
+	}
 
-		},
+	length() {
 
-		length: function () {
+		var head = this.head();
+		var tail = this.tail();
 
-			var head = this.head();
-			var tail = this.tail();
+		if ( tail !== null ) {
 
-			if ( tail !== null ) {
-
-				return tail.point.distanceTo( head.point );
-
-			}
-
-			return - 1;
-
-		},
-
-		lengthSquared: function () {
-
-			var head = this.head();
-			var tail = this.tail();
-
-			if ( tail !== null ) {
-
-				return tail.point.distanceToSquared( head.point );
-
-			}
-
-			return - 1;
-
-		},
-
-		setTwin: function ( edge ) {
-
-			this.twin = edge;
-			edge.twin = this;
-
-			return this;
+			return tail.point.distanceTo( head.point );
 
 		}
 
-	} );
+		return - 1;
 
-	// A vertex as a double linked list node.
+	}
 
-	function VertexNode( point ) {
+	lengthSquared() {
+
+		var head = this.head();
+		var tail = this.tail();
+
+		if ( tail !== null ) {
+
+			return tail.point.distanceToSquared( head.point );
+
+		}
+
+		return - 1;
+
+	}
+
+	setTwin( edge ) {
+
+		this.twin = edge;
+		edge.twin = this;
+
+		return this;
+
+	}
+
+}
+// A vertex as a double linked list node.
+class VertexNode {
+
+	constructor( point ) {
 
 		this.point = point;
 		this.prev = null;
@@ -1117,200 +1106,200 @@ THREE.ConvexHull = ( function () {
 
 	}
 
-	// A double linked list that contains vertex nodes.
+}
 
-	function VertexList() {
+// A double linked list that contains vertex nodes.
+class VertexList {
+
+	constructor() {
 
 		this.head = null;
 		this.tail = null;
 
 	}
 
-	Object.assign( VertexList.prototype, {
+	first() {
 
-		first: function () {
+		return this.head;
 
-			return this.head;
+	}
 
-		},
+	last() {
 
-		last: function () {
+		return this.tail;
 
-			return this.tail;
+	}
 
-		},
+	clear() {
 
-		clear: function () {
+		this.head = this.tail = null;
 
-			this.head = this.tail = null;
+		return this;
 
-			return this;
+	}
 
-		},
+	// Inserts a vertex before the target vertex
 
-		// Inserts a vertex before the target vertex
+	insertBefore( target, vertex ) {
 
-		insertBefore: function ( target, vertex ) {
+		vertex.prev = target.prev;
+		vertex.next = target;
 
-			vertex.prev = target.prev;
-			vertex.next = target;
+		if ( vertex.prev === null ) {
 
-			if ( vertex.prev === null ) {
+			this.head = vertex;
 
-				this.head = vertex;
+		} else {
 
-			} else {
-
-				vertex.prev.next = vertex;
-
-			}
-
-			target.prev = vertex;
-
-			return this;
-
-		},
-
-		// Inserts a vertex after the target vertex
-
-		insertAfter: function ( target, vertex ) {
-
-			vertex.prev = target;
-			vertex.next = target.next;
-
-			if ( vertex.next === null ) {
-
-				this.tail = vertex;
-
-			} else {
-
-				vertex.next.prev = vertex;
-
-			}
-
-			target.next = vertex;
-
-			return this;
-
-		},
-
-		// Appends a vertex to the end of the linked list
-
-		append: function ( vertex ) {
-
-			if ( this.head === null ) {
-
-				this.head = vertex;
-
-			} else {
-
-				this.tail.next = vertex;
-
-			}
-
-			vertex.prev = this.tail;
-			vertex.next = null; // the tail has no subsequent vertex
-
-			this.tail = vertex;
-
-			return this;
-
-		},
-
-		// Appends a chain of vertices where 'vertex' is the head.
-
-		appendChain: function ( vertex ) {
-
-			if ( this.head === null ) {
-
-				this.head = vertex;
-
-			} else {
-
-				this.tail.next = vertex;
-
-			}
-
-			vertex.prev = this.tail;
-
-			// ensure that the 'tail' reference points to the last vertex of the chain
-
-			while ( vertex.next !== null ) {
-
-				vertex = vertex.next;
-
-			}
-
-			this.tail = vertex;
-
-			return this;
-
-		},
-
-		// Removes a vertex from the linked list
-
-		remove: function ( vertex ) {
-
-			if ( vertex.prev === null ) {
-
-				this.head = vertex.next;
-
-			} else {
-
-				vertex.prev.next = vertex.next;
-
-			}
-
-			if ( vertex.next === null ) {
-
-				this.tail = vertex.prev;
-
-			} else {
-
-				vertex.next.prev = vertex.prev;
-
-			}
-
-			return this;
-
-		},
-
-		// Removes a list of vertices whose 'head' is 'a' and whose 'tail' is b
-
-		removeSubList: function ( a, b ) {
-
-			if ( a.prev === null ) {
-
-				this.head = b.next;
-
-			} else {
-
-				a.prev.next = b.next;
-
-			}
-
-			if ( b.next === null ) {
-
-				this.tail = a.prev;
-
-			} else {
-
-				b.next.prev = a.prev;
-
-			}
-
-			return this;
-
-		},
-
-		isEmpty: function () {
-
-			return this.head === null;
+			vertex.prev.next = vertex;
 
 		}
 
-	} );
+		target.prev = vertex;
 
-	return ConvexHull;
+		return this;
 
-} )();
+	}
+
+	// Inserts a vertex after the target vertex
+
+	insertAfter( target, vertex ) {
+
+		vertex.prev = target;
+		vertex.next = target.next;
+
+		if ( vertex.next === null ) {
+
+			this.tail = vertex;
+
+		} else {
+
+			vertex.next.prev = vertex;
+
+		}
+
+		target.next = vertex;
+
+		return this;
+
+	}
+
+	// Appends a vertex to the end of the linked list
+
+	append( vertex ) {
+
+		if ( this.head === null ) {
+
+			this.head = vertex;
+
+		} else {
+
+			this.tail.next = vertex;
+
+		}
+
+		vertex.prev = this.tail;
+		vertex.next = null; // the tail has no subsequent vertex
+
+		this.tail = vertex;
+
+		return this;
+
+	}
+
+	// Appends a chain of vertices where 'vertex' is the head.
+
+	appendChain( vertex ) {
+
+		if ( this.head === null ) {
+
+			this.head = vertex;
+
+		} else {
+
+			this.tail.next = vertex;
+
+		}
+
+		vertex.prev = this.tail;
+
+		// ensure that the 'tail' reference points to the last vertex of the chain
+
+		while ( vertex.next !== null ) {
+
+			vertex = vertex.next;
+
+		}
+
+		this.tail = vertex;
+
+		return this;
+
+	}
+
+	// Removes a vertex from the linked list
+
+	remove( vertex ) {
+
+		if ( vertex.prev === null ) {
+
+			this.head = vertex.next;
+
+		} else {
+
+			vertex.prev.next = vertex.next;
+
+		}
+
+		if ( vertex.next === null ) {
+
+			this.tail = vertex.prev;
+
+		} else {
+
+			vertex.next.prev = vertex.prev;
+
+		}
+
+		return this;
+
+	}
+
+	// Removes a list of vertices whose 'head' is 'a' and whose 'tail' is b
+
+	removeSubList( a, b ) {
+
+		if ( a.prev === null ) {
+
+			this.head = b.next;
+
+		} else {
+
+			a.prev.next = b.next;
+
+		}
+
+		if ( b.next === null ) {
+
+			this.tail = a.prev;
+
+		} else {
+
+			b.next.prev = a.prev;
+
+		}
+
+		return this;
+
+	}
+
+	isEmpty() {
+
+		return this.head === null;
+
+	}
+
+}
+
+
+export { ConvexHull };

--- a/examples/js/math/ImprovedNoise.js
+++ b/examples/js/math/ImprovedNoise.js
@@ -1,6 +1,6 @@
 // http://mrl.nyu.edu/~perlin/noise/
 
-THREE.ImprovedNoise = function () {
+var ImprovedNoise = function () {
 
 	var p = [ 151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10,
 		 23, 190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33, 88, 237, 149, 56, 87,
@@ -70,3 +70,5 @@ THREE.ImprovedNoise = function () {
 	};
 
 };
+
+export { ImprovedNoise };

--- a/examples/js/math/Lut.js
+++ b/examples/js/math/Lut.js
@@ -1,24 +1,33 @@
 /**
  * @author daron1337 / http://daron1337.github.io/
  */
+import { Color } from "../../../build/three.module.js";
 
-THREE.Lut = function ( colormap, numberofcolors ) {
+var ColorMapKeywords = {
 
-	this.lut = [];
-	this.setColorMap( colormap, numberofcolors );
-	return this;
+	"rainbow": [[ 0.0, 0x0000FF ], [ 0.2, 0x00FFFF ], [ 0.5, 0x00FF00 ], [ 0.8, 0xFFFF00 ], [ 1.0, 0xFF0000 ]],
+	"cooltowarm": [[ 0.0, 0x3C4EC2 ], [ 0.2, 0x9BBCFF ], [ 0.5, 0xDCDCDC ], [ 0.8, 0xF6A385 ], [ 1.0, 0xB40426 ]],
+	"blackbody": [[ 0.0, 0x000000 ], [ 0.2, 0x780000 ], [ 0.5, 0xE63200 ], [ 0.8, 0xFFFF00 ], [ 1.0, 0xFFFFFF ]],
+	"grayscale": [[ 0.0, 0x000000 ], [ 0.2, 0x404040 ], [ 0.5, 0x7F7F80 ], [ 0.8, 0xBFBFBF ], [ 1.0, 0xFFFFFF ]]
 
 };
 
-THREE.Lut.prototype = {
+class Lut {
 
-	constructor: THREE.Lut,
+	constructor( colormap, numberofcolors ) {
 
-	lut: [], map: [], n: 256, minV: 0, maxV: 1,
+		this.lut = [];
+		this.map;
+		this.n = 256;
+		this.minV = 0;
+		this.maxV = 1;
+		this.setColorMap( colormap, numberofcolors );
 
-	set: function ( value ) {
+	}
 
-		if ( value instanceof THREE.Lut ) {
+	set( value ) {
+
+		if ( value instanceof Lut ) {
 
 			this.copy( value );
 
@@ -26,27 +35,27 @@ THREE.Lut.prototype = {
 
 		return this;
 
-	},
+	}
 
-	setMin: function ( min ) {
+	setMin( min ) {
 
 		this.minV = min;
 
 		return this;
 
-	},
+	}
 
-	setMax: function ( max ) {
+	setMax( max ) {
 
 		this.maxV = max;
 
 		return this;
 
-	},
+	}
 
-	setColorMap: function ( colormap, numberofcolors ) {
+	setColorMap( colormap, numberofcolors ) {
 
-		this.map = THREE.ColorMapKeywords[ colormap ] || THREE.ColorMapKeywords.rainbow;
+		this.map = ColorMapKeywords[ colormap ] || ColorMapKeywords.rainbow;
 		this.n = numberofcolors || 32;
 
 		var step = 1.0 / this.n;
@@ -61,8 +70,8 @@ THREE.Lut.prototype = {
 					var min = this.map[ j ][ 0 ];
 					var max = this.map[ j + 1 ][ 0 ];
 
-					var minColor = new THREE.Color( this.map[ j ][ 1 ] );
-					var maxColor = new THREE.Color( this.map[ j + 1 ][ 1 ] );
+					var minColor = new Color( this.map[ j ][ 1 ] );
+					var maxColor = new Color( this.map[ j + 1 ][ 1 ] );
 
 					var color = minColor.lerp( maxColor, ( i - min ) / ( max - min ) );
 
@@ -76,9 +85,9 @@ THREE.Lut.prototype = {
 
 		return this;
 
-	},
+	}
 
-	copy: function ( lut ) {
+	copy( lut ) {
 
 		this.lut = lut.lut;
 		this.map = lut.map;
@@ -88,9 +97,9 @@ THREE.Lut.prototype = {
 
 		return this;
 
-	},
+	}
 
-	getColor: function ( alpha ) {
+	getColor( alpha ) {
 
 		if ( alpha <= this.minV ) {
 
@@ -109,15 +118,15 @@ THREE.Lut.prototype = {
 
 		return this.lut[ colorPosition ];
 
-	},
+	}
 
-	addColorMap: function ( colormapName, arrayOfColors ) {
+	addColorMap( colormapName, arrayOfColors ) {
 
-		THREE.ColorMapKeywords[ colormapName ] = arrayOfColors;
+		ColorMapKeywords[ colormapName ] = arrayOfColors;
 
-	},
+	}
 
-	createCanvas: function () {
+	createCanvas() {
 
 		var canvas = document.createElement( 'canvas' );
 		canvas.width = 1;
@@ -127,9 +136,9 @@ THREE.Lut.prototype = {
 
 		return canvas;
 
-	},
+	}
 
-	updateCanvas: function ( canvas ) {
+	updateCanvas( canvas ) {
 
 		var ctx = canvas.getContext( '2d', { alpha: false } );
 
@@ -150,8 +159,8 @@ THREE.Lut.prototype = {
 					var min = this.map[ j - 1 ][ 0 ];
 					var max = this.map[ j ][ 0 ];
 
-					var minColor = new THREE.Color( this.map[ j - 1 ][ 1 ] );
-					var maxColor = new THREE.Color( this.map[ j ][ 1 ] );
+					var minColor = new Color( this.map[ j - 1 ][ 1 ] );
+					var maxColor = new Color( this.map[ j ][ 1 ] );
 
 					var color = minColor.lerp( maxColor, ( i - min ) / ( max - min ) );
 
@@ -173,13 +182,7 @@ THREE.Lut.prototype = {
 		return canvas;
 
 	}
-};
 
-THREE.ColorMapKeywords = {
+}
 
-	"rainbow": [[ 0.0, 0x0000FF ], [ 0.2, 0x00FFFF ], [ 0.5, 0x00FF00 ], [ 0.8, 0xFFFF00 ], [ 1.0, 0xFF0000 ]],
-	"cooltowarm": [[ 0.0, 0x3C4EC2 ], [ 0.2, 0x9BBCFF ], [ 0.5, 0xDCDCDC ], [ 0.8, 0xF6A385 ], [ 1.0, 0xB40426 ]],
-	"blackbody": [[ 0.0, 0x000000 ], [ 0.2, 0x780000 ], [ 0.5, 0xE63200 ], [ 0.8, 0xFFFF00 ], [ 1.0, 0xFFFFFF ]],
-	"grayscale": [[ 0.0, 0x000000 ], [ 0.2, 0x404040 ], [ 0.5, 0x7F7F80 ], [ 0.8, 0xBFBFBF ], [ 1.0, 0xFFFFFF ]]
-
-};
+export { Lut, ColorMapKeywords };

--- a/examples/js/math/SimplexNoise.js
+++ b/examples/js/math/SimplexNoise.js
@@ -11,395 +11,401 @@
  * You can pass in a random number generator object if you like.
  * It is assumed to have a random() method.
  */
-THREE.SimplexNoise = function ( r ) {
+class SimplexNoise {
 
-	if ( r == undefined ) r = Math;
-	this.grad3 = [[ 1, 1, 0 ], [ - 1, 1, 0 ], [ 1, - 1, 0 ], [ - 1, - 1, 0 ],
-		[ 1, 0, 1 ], [ - 1, 0, 1 ], [ 1, 0, - 1 ], [ - 1, 0, - 1 ],
-		[ 0, 1, 1 ], [ 0, - 1, 1 ], [ 0, 1, - 1 ], [ 0, - 1, - 1 ]];
+	constructor( r ) {
 
-	this.grad4 = [[ 0, 1, 1, 1 ], [ 0, 1, 1, - 1 ], [ 0, 1, - 1, 1 ], [ 0, 1, - 1, - 1 ],
-	     [ 0, - 1, 1, 1 ], [ 0, - 1, 1, - 1 ], [ 0, - 1, - 1, 1 ], [ 0, - 1, - 1, - 1 ],
-	     [ 1, 0, 1, 1 ], [ 1, 0, 1, - 1 ], [ 1, 0, - 1, 1 ], [ 1, 0, - 1, - 1 ],
-	     [ - 1, 0, 1, 1 ], [ - 1, 0, 1, - 1 ], [ - 1, 0, - 1, 1 ], [ - 1, 0, - 1, - 1 ],
-	     [ 1, 1, 0, 1 ], [ 1, 1, 0, - 1 ], [ 1, - 1, 0, 1 ], [ 1, - 1, 0, - 1 ],
-	     [ - 1, 1, 0, 1 ], [ - 1, 1, 0, - 1 ], [ - 1, - 1, 0, 1 ], [ - 1, - 1, 0, - 1 ],
-	     [ 1, 1, 1, 0 ], [ 1, 1, - 1, 0 ], [ 1, - 1, 1, 0 ], [ 1, - 1, - 1, 0 ],
-	     [ - 1, 1, 1, 0 ], [ - 1, 1, - 1, 0 ], [ - 1, - 1, 1, 0 ], [ - 1, - 1, - 1, 0 ]];
+		if ( r == undefined ) r = Math;
+		this.grad3 = [[ 1, 1, 0 ], [ - 1, 1, 0 ], [ 1, - 1, 0 ], [ - 1, - 1, 0 ],
+			[ 1, 0, 1 ], [ - 1, 0, 1 ], [ 1, 0, - 1 ], [ - 1, 0, - 1 ],
+			[ 0, 1, 1 ], [ 0, - 1, 1 ], [ 0, 1, - 1 ], [ 0, - 1, - 1 ]];
 
-	this.p = [];
-	for ( var i = 0; i < 256; i ++ ) {
+		this.grad4 = [[ 0, 1, 1, 1 ], [ 0, 1, 1, - 1 ], [ 0, 1, - 1, 1 ], [ 0, 1, - 1, - 1 ],
+			[ 0, - 1, 1, 1 ], [ 0, - 1, 1, - 1 ], [ 0, - 1, - 1, 1 ], [ 0, - 1, - 1, - 1 ],
+			[ 1, 0, 1, 1 ], [ 1, 0, 1, - 1 ], [ 1, 0, - 1, 1 ], [ 1, 0, - 1, - 1 ],
+			[ - 1, 0, 1, 1 ], [ - 1, 0, 1, - 1 ], [ - 1, 0, - 1, 1 ], [ - 1, 0, - 1, - 1 ],
+			[ 1, 1, 0, 1 ], [ 1, 1, 0, - 1 ], [ 1, - 1, 0, 1 ], [ 1, - 1, 0, - 1 ],
+			[ - 1, 1, 0, 1 ], [ - 1, 1, 0, - 1 ], [ - 1, - 1, 0, 1 ], [ - 1, - 1, 0, - 1 ],
+			[ 1, 1, 1, 0 ], [ 1, 1, - 1, 0 ], [ 1, - 1, 1, 0 ], [ 1, - 1, - 1, 0 ],
+			[ - 1, 1, 1, 0 ], [ - 1, 1, - 1, 0 ], [ - 1, - 1, 1, 0 ], [ - 1, - 1, - 1, 0 ]];
 
-		this.p[ i ] = Math.floor( r.random() * 256 );
+		this.p = [];
+		for ( var i = 0; i < 256; i ++ ) {
 
-	}
-	// To remove the need for index wrapping, double the permutation table length
-	this.perm = [];
-	for ( var i = 0; i < 512; i ++ ) {
+			this.p[ i ] = Math.floor( r.random() * 256 );
 
-		this.perm[ i ] = this.p[ i & 255 ];
+		}
+		// To remove the need for index wrapping, double the permutation table length
+		this.perm = [];
+		for ( var i = 0; i < 512; i ++ ) {
 
-	}
+			this.perm[ i ] = this.p[ i & 255 ];
 
-	// A lookup table to traverse the simplex around a given point in 4D.
-	// Details can be found where this table is used, in the 4D noise method.
-	this.simplex = [
-		[ 0, 1, 2, 3 ], [ 0, 1, 3, 2 ], [ 0, 0, 0, 0 ], [ 0, 2, 3, 1 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 1, 2, 3, 0 ],
-		[ 0, 2, 1, 3 ], [ 0, 0, 0, 0 ], [ 0, 3, 1, 2 ], [ 0, 3, 2, 1 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 1, 3, 2, 0 ],
-		[ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ],
-		[ 1, 2, 0, 3 ], [ 0, 0, 0, 0 ], [ 1, 3, 0, 2 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 2, 3, 0, 1 ], [ 2, 3, 1, 0 ],
-		[ 1, 0, 2, 3 ], [ 1, 0, 3, 2 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 2, 0, 3, 1 ], [ 0, 0, 0, 0 ], [ 2, 1, 3, 0 ],
-		[ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ],
-		[ 2, 0, 1, 3 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 3, 0, 1, 2 ], [ 3, 0, 2, 1 ], [ 0, 0, 0, 0 ], [ 3, 1, 2, 0 ],
-		[ 2, 1, 0, 3 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 3, 1, 0, 2 ], [ 0, 0, 0, 0 ], [ 3, 2, 0, 1 ], [ 3, 2, 1, 0 ]];
+		}
 
-};
-
-THREE.SimplexNoise.prototype.dot = function ( g, x, y ) {
-
-	return g[ 0 ] * x + g[ 1 ] * y;
-
-};
-
-THREE.SimplexNoise.prototype.dot3 = function ( g, x, y, z ) {
-
-	return g[ 0 ] * x + g[ 1 ] * y + g[ 2 ] * z;
-
-};
-
-THREE.SimplexNoise.prototype.dot4 = function ( g, x, y, z, w ) {
-
-	return g[ 0 ] * x + g[ 1 ] * y + g[ 2 ] * z + g[ 3 ] * w;
-
-};
-
-THREE.SimplexNoise.prototype.noise = function ( xin, yin ) {
-
-	var n0, n1, n2; // Noise contributions from the three corners
-	// Skew the input space to determine which simplex cell we're in
-	var F2 = 0.5 * ( Math.sqrt( 3.0 ) - 1.0 );
-	var s = ( xin + yin ) * F2; // Hairy factor for 2D
-	var i = Math.floor( xin + s );
-	var j = Math.floor( yin + s );
-	var G2 = ( 3.0 - Math.sqrt( 3.0 ) ) / 6.0;
-	var t = ( i + j ) * G2;
-	var X0 = i - t; // Unskew the cell origin back to (x,y) space
-	var Y0 = j - t;
-	var x0 = xin - X0; // The x,y distances from the cell origin
-	var y0 = yin - Y0;
-	// For the 2D case, the simplex shape is an equilateral triangle.
-	// Determine which simplex we are in.
-	var i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
-	if ( x0 > y0 ) {
-
-		i1 = 1; j1 = 0;
-
-		// lower triangle, XY order: (0,0)->(1,0)->(1,1)
-
-	}	else {
-
-		i1 = 0; j1 = 1;
-
-	} // upper triangle, YX order: (0,0)->(0,1)->(1,1)
-	// A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
-	// a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
-	// c = (3-sqrt(3))/6
-	var x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords
-	var y1 = y0 - j1 + G2;
-	var x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y) unskewed coords
-	var y2 = y0 - 1.0 + 2.0 * G2;
-	// Work out the hashed gradient indices of the three simplex corners
-	var ii = i & 255;
-	var jj = j & 255;
-	var gi0 = this.perm[ ii + this.perm[ jj ] ] % 12;
-	var gi1 = this.perm[ ii + i1 + this.perm[ jj + j1 ] ] % 12;
-	var gi2 = this.perm[ ii + 1 + this.perm[ jj + 1 ] ] % 12;
-	// Calculate the contribution from the three corners
-	var t0 = 0.5 - x0 * x0 - y0 * y0;
-	if ( t0 < 0 ) n0 = 0.0;
-	else {
-
-		t0 *= t0;
-		n0 = t0 * t0 * this.dot( this.grad3[ gi0 ], x0, y0 ); // (x,y) of grad3 used for 2D gradient
+		// A lookup table to traverse the simplex around a given point in 4D.
+		// Details can be found where this table is used, in the 4D noise method.
+		this.simplex = [
+			[ 0, 1, 2, 3 ], [ 0, 1, 3, 2 ], [ 0, 0, 0, 0 ], [ 0, 2, 3, 1 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 1, 2, 3, 0 ],
+			[ 0, 2, 1, 3 ], [ 0, 0, 0, 0 ], [ 0, 3, 1, 2 ], [ 0, 3, 2, 1 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 1, 3, 2, 0 ],
+			[ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ],
+			[ 1, 2, 0, 3 ], [ 0, 0, 0, 0 ], [ 1, 3, 0, 2 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 2, 3, 0, 1 ], [ 2, 3, 1, 0 ],
+			[ 1, 0, 2, 3 ], [ 1, 0, 3, 2 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 2, 0, 3, 1 ], [ 0, 0, 0, 0 ], [ 2, 1, 3, 0 ],
+			[ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ],
+			[ 2, 0, 1, 3 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 3, 0, 1, 2 ], [ 3, 0, 2, 1 ], [ 0, 0, 0, 0 ], [ 3, 1, 2, 0 ],
+			[ 2, 1, 0, 3 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 3, 1, 0, 2 ], [ 0, 0, 0, 0 ], [ 3, 2, 0, 1 ], [ 3, 2, 1, 0 ]];
 
 	}
-	var t1 = 0.5 - x1 * x1 - y1 * y1;
-	if ( t1 < 0 ) n1 = 0.0;
-	else {
 
-		t1 *= t1;
-		n1 = t1 * t1 * this.dot( this.grad3[ gi1 ], x1, y1 );
+	dot( g, x, y ) {
+
+		return g[ 0 ] * x + g[ 1 ] * y;
 
 	}
-	var t2 = 0.5 - x2 * x2 - y2 * y2;
-	if ( t2 < 0 ) n2 = 0.0;
-	else {
 
-		t2 *= t2;
-		n2 = t2 * t2 * this.dot( this.grad3[ gi2 ], x2, y2 );
+	dot3( g, x, y, z ) {
+
+		return g[ 0 ] * x + g[ 1 ] * y + g[ 2 ] * z;
 
 	}
-	// Add contributions from each corner to get the final noise value.
-	// The result is scaled to return values in the interval [-1,1].
-	return 70.0 * ( n0 + n1 + n2 );
 
-};
+	dot4( g, x, y, z, w ) {
 
-// 3D simplex noise
-THREE.SimplexNoise.prototype.noise3d = function ( xin, yin, zin ) {
-
-	var n0, n1, n2, n3; // Noise contributions from the four corners
-	// Skew the input space to determine which simplex cell we're in
-	var F3 = 1.0 / 3.0;
-	var s = ( xin + yin + zin ) * F3; // Very nice and simple skew factor for 3D
-	var i = Math.floor( xin + s );
-	var j = Math.floor( yin + s );
-	var k = Math.floor( zin + s );
-	var G3 = 1.0 / 6.0; // Very nice and simple unskew factor, too
-	var t = ( i + j + k ) * G3;
-	var X0 = i - t; // Unskew the cell origin back to (x,y,z) space
-	var Y0 = j - t;
-	var Z0 = k - t;
-	var x0 = xin - X0; // The x,y,z distances from the cell origin
-	var y0 = yin - Y0;
-	var z0 = zin - Z0;
-	// For the 3D case, the simplex shape is a slightly irregular tetrahedron.
-	// Determine which simplex we are in.
-	var i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords
-	var i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
-	if ( x0 >= y0 ) {
-
-		if ( y0 >= z0 ) {
-
-			i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 1; k2 = 0;
-
-			// X Y Z order
-
-		} else if ( x0 >= z0 ) {
-
-			i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 0; k2 = 1;
-
-			// X Z Y order
-
-		} else {
-
-			i1 = 0; j1 = 0; k1 = 1; i2 = 1; j2 = 0; k2 = 1;
-
-		} // Z X Y order
-
-	} else { // x0<y0
-
-		if ( y0 < z0 ) {
-
-			i1 = 0; j1 = 0; k1 = 1; i2 = 0; j2 = 1; k2 = 1;
-
-			// Z Y X order
-
-		} else if ( x0 < z0 ) {
-
-			i1 = 0; j1 = 1; k1 = 0; i2 = 0; j2 = 1; k2 = 1;
-
-			// Y Z X order
-
-		} else {
-
-			i1 = 0; j1 = 1; k1 = 0; i2 = 1; j2 = 1; k2 = 0;
-
-		} // Y X Z order
+		return g[ 0 ] * x + g[ 1 ] * y + g[ 2 ] * z + g[ 3 ] * w;
 
 	}
-	// A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
-	// a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and
-	// a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z), where
-	// c = 1/6.
-	var x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords
-	var y1 = y0 - j1 + G3;
-	var z1 = z0 - k1 + G3;
-	var x2 = x0 - i2 + 2.0 * G3; // Offsets for third corner in (x,y,z) coords
-	var y2 = y0 - j2 + 2.0 * G3;
-	var z2 = z0 - k2 + 2.0 * G3;
-	var x3 = x0 - 1.0 + 3.0 * G3; // Offsets for last corner in (x,y,z) coords
-	var y3 = y0 - 1.0 + 3.0 * G3;
-	var z3 = z0 - 1.0 + 3.0 * G3;
-	// Work out the hashed gradient indices of the four simplex corners
-	var ii = i & 255;
-	var jj = j & 255;
-	var kk = k & 255;
-	var gi0 = this.perm[ ii + this.perm[ jj + this.perm[ kk ] ] ] % 12;
-	var gi1 = this.perm[ ii + i1 + this.perm[ jj + j1 + this.perm[ kk + k1 ] ] ] % 12;
-	var gi2 = this.perm[ ii + i2 + this.perm[ jj + j2 + this.perm[ kk + k2 ] ] ] % 12;
-	var gi3 = this.perm[ ii + 1 + this.perm[ jj + 1 + this.perm[ kk + 1 ] ] ] % 12;
-	// Calculate the contribution from the four corners
-	var t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
-	if ( t0 < 0 ) n0 = 0.0;
-	else {
 
-		t0 *= t0;
-		n0 = t0 * t0 * this.dot3( this.grad3[ gi0 ], x0, y0, z0 );
+	noise( xin, yin ) {
 
-	}
-	var t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
-	if ( t1 < 0 ) n1 = 0.0;
-	else {
+		var n0, n1, n2; // Noise contributions from the three corners
+		// Skew the input space to determine which simplex cell we're in
+		var F2 = 0.5 * ( Math.sqrt( 3.0 ) - 1.0 );
+		var s = ( xin + yin ) * F2; // Hairy factor for 2D
+		var i = Math.floor( xin + s );
+		var j = Math.floor( yin + s );
+		var G2 = ( 3.0 - Math.sqrt( 3.0 ) ) / 6.0;
+		var t = ( i + j ) * G2;
+		var X0 = i - t; // Unskew the cell origin back to (x,y) space
+		var Y0 = j - t;
+		var x0 = xin - X0; // The x,y distances from the cell origin
+		var y0 = yin - Y0;
+		// For the 2D case, the simplex shape is an equilateral triangle.
+		// Determine which simplex we are in.
+		var i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
+		if ( x0 > y0 ) {
 
-		t1 *= t1;
-		n1 = t1 * t1 * this.dot3( this.grad3[ gi1 ], x1, y1, z1 );
+			i1 = 1; j1 = 0;
 
-	}
-	var t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
-	if ( t2 < 0 ) n2 = 0.0;
-	else {
+			// lower triangle, XY order: (0,0)->(1,0)->(1,1)
 
-		t2 *= t2;
-		n2 = t2 * t2 * this.dot3( this.grad3[ gi2 ], x2, y2, z2 );
+		}	else {
 
-	}
-	var t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
-	if ( t3 < 0 ) n3 = 0.0;
-	else {
+			i1 = 0; j1 = 1;
 
-		t3 *= t3;
-		n3 = t3 * t3 * this.dot3( this.grad3[ gi3 ], x3, y3, z3 );
+		} // upper triangle, YX order: (0,0)->(0,1)->(1,1)
+		// A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
+		// a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
+		// c = (3-sqrt(3))/6
+		var x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords
+		var y1 = y0 - j1 + G2;
+		var x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y) unskewed coords
+		var y2 = y0 - 1.0 + 2.0 * G2;
+		// Work out the hashed gradient indices of the three simplex corners
+		var ii = i & 255;
+		var jj = j & 255;
+		var gi0 = this.perm[ ii + this.perm[ jj ] ] % 12;
+		var gi1 = this.perm[ ii + i1 + this.perm[ jj + j1 ] ] % 12;
+		var gi2 = this.perm[ ii + 1 + this.perm[ jj + 1 ] ] % 12;
+		// Calculate the contribution from the three corners
+		var t0 = 0.5 - x0 * x0 - y0 * y0;
+		if ( t0 < 0 ) n0 = 0.0;
+		else {
 
-	}
-	// Add contributions from each corner to get the final noise value.
-	// The result is scaled to stay just inside [-1,1]
-	return 32.0 * ( n0 + n1 + n2 + n3 );
+			t0 *= t0;
+			n0 = t0 * t0 * this.dot( this.grad3[ gi0 ], x0, y0 ); // (x,y) of grad3 used for 2D gradient
 
-};
+		}
+		var t1 = 0.5 - x1 * x1 - y1 * y1;
+		if ( t1 < 0 ) n1 = 0.0;
+		else {
 
-// 4D simplex noise
-THREE.SimplexNoise.prototype.noise4d = function ( x, y, z, w ) {
+			t1 *= t1;
+			n1 = t1 * t1 * this.dot( this.grad3[ gi1 ], x1, y1 );
 
-	// For faster and easier lookups
-	var grad4 = this.grad4;
-	var simplex = this.simplex;
-	var perm = this.perm;
+		}
+		var t2 = 0.5 - x2 * x2 - y2 * y2;
+		if ( t2 < 0 ) n2 = 0.0;
+		else {
 
-	// The skewing and unskewing factors are hairy again for the 4D case
-	var F4 = ( Math.sqrt( 5.0 ) - 1.0 ) / 4.0;
-	var G4 = ( 5.0 - Math.sqrt( 5.0 ) ) / 20.0;
-	var n0, n1, n2, n3, n4; // Noise contributions from the five corners
-	// Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in
-	var s = ( x + y + z + w ) * F4; // Factor for 4D skewing
-	var i = Math.floor( x + s );
-	var j = Math.floor( y + s );
-	var k = Math.floor( z + s );
-	var l = Math.floor( w + s );
-	var t = ( i + j + k + l ) * G4; // Factor for 4D unskewing
-	var X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
-	var Y0 = j - t;
-	var Z0 = k - t;
-	var W0 = l - t;
-	var x0 = x - X0; // The x,y,z,w distances from the cell origin
-	var y0 = y - Y0;
-	var z0 = z - Z0;
-	var w0 = w - W0;
+			t2 *= t2;
+			n2 = t2 * t2 * this.dot( this.grad3[ gi2 ], x2, y2 );
 
-	// For the 4D case, the simplex is a 4D shape I won't even try to describe.
-	// To find out which of the 24 possible simplices we're in, we need to
-	// determine the magnitude ordering of x0, y0, z0 and w0.
-	// The method below is a good way of finding the ordering of x,y,z,w and
-	// then find the correct traversal order for the simplex we’re in.
-	// First, six pair-wise comparisons are performed between each possible pair
-	// of the four coordinates, and the results are used to add up binary bits
-	// for an integer index.
-	var c1 = ( x0 > y0 ) ? 32 : 0;
-	var c2 = ( x0 > z0 ) ? 16 : 0;
-	var c3 = ( y0 > z0 ) ? 8 : 0;
-	var c4 = ( x0 > w0 ) ? 4 : 0;
-	var c5 = ( y0 > w0 ) ? 2 : 0;
-	var c6 = ( z0 > w0 ) ? 1 : 0;
-	var c = c1 + c2 + c3 + c4 + c5 + c6;
-	var i1, j1, k1, l1; // The integer offsets for the second simplex corner
-	var i2, j2, k2, l2; // The integer offsets for the third simplex corner
-	var i3, j3, k3, l3; // The integer offsets for the fourth simplex corner
-	// simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some order.
-	// Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w and x<w
-	// impossible. Only the 24 indices which have non-zero entries make any sense.
-	// We use a thresholding to set the coordinates in turn from the largest magnitude.
-	// The number 3 in the "simplex" array is at the position of the largest coordinate.
-	i1 = simplex[ c ][ 0 ] >= 3 ? 1 : 0;
-	j1 = simplex[ c ][ 1 ] >= 3 ? 1 : 0;
-	k1 = simplex[ c ][ 2 ] >= 3 ? 1 : 0;
-	l1 = simplex[ c ][ 3 ] >= 3 ? 1 : 0;
-	// The number 2 in the "simplex" array is at the second largest coordinate.
-	i2 = simplex[ c ][ 0 ] >= 2 ? 1 : 0;
-	j2 = simplex[ c ][ 1 ] >= 2 ? 1 : 0; k2 = simplex[ c ][ 2 ] >= 2 ? 1 : 0;
-	l2 = simplex[ c ][ 3 ] >= 2 ? 1 : 0;
-	// The number 1 in the "simplex" array is at the second smallest coordinate.
-	i3 = simplex[ c ][ 0 ] >= 1 ? 1 : 0;
-	j3 = simplex[ c ][ 1 ] >= 1 ? 1 : 0;
-	k3 = simplex[ c ][ 2 ] >= 1 ? 1 : 0;
-	l3 = simplex[ c ][ 3 ] >= 1 ? 1 : 0;
-	// The fifth corner has all coordinate offsets = 1, so no need to look that up.
-	var x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coords
-	var y1 = y0 - j1 + G4;
-	var z1 = z0 - k1 + G4;
-	var w1 = w0 - l1 + G4;
-	var x2 = x0 - i2 + 2.0 * G4; // Offsets for third corner in (x,y,z,w) coords
-	var y2 = y0 - j2 + 2.0 * G4;
-	var z2 = z0 - k2 + 2.0 * G4;
-	var w2 = w0 - l2 + 2.0 * G4;
-	var x3 = x0 - i3 + 3.0 * G4; // Offsets for fourth corner in (x,y,z,w) coords
-	var y3 = y0 - j3 + 3.0 * G4;
-	var z3 = z0 - k3 + 3.0 * G4;
-	var w3 = w0 - l3 + 3.0 * G4;
-	var x4 = x0 - 1.0 + 4.0 * G4; // Offsets for last corner in (x,y,z,w) coords
-	var y4 = y0 - 1.0 + 4.0 * G4;
-	var z4 = z0 - 1.0 + 4.0 * G4;
-	var w4 = w0 - 1.0 + 4.0 * G4;
-	// Work out the hashed gradient indices of the five simplex corners
-	var ii = i & 255;
-	var jj = j & 255;
-	var kk = k & 255;
-	var ll = l & 255;
-	var gi0 = perm[ ii + perm[ jj + perm[ kk + perm[ ll ] ] ] ] % 32;
-	var gi1 = perm[ ii + i1 + perm[ jj + j1 + perm[ kk + k1 + perm[ ll + l1 ] ] ] ] % 32;
-	var gi2 = perm[ ii + i2 + perm[ jj + j2 + perm[ kk + k2 + perm[ ll + l2 ] ] ] ] % 32;
-	var gi3 = perm[ ii + i3 + perm[ jj + j3 + perm[ kk + k3 + perm[ ll + l3 ] ] ] ] % 32;
-	var gi4 = perm[ ii + 1 + perm[ jj + 1 + perm[ kk + 1 + perm[ ll + 1 ] ] ] ] % 32;
-	// Calculate the contribution from the five corners
-	var t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;
-	if ( t0 < 0 ) n0 = 0.0;
-	else {
-
-		t0 *= t0;
-		n0 = t0 * t0 * this.dot4( grad4[ gi0 ], x0, y0, z0, w0 );
+		}
+		// Add contributions from each corner to get the final noise value.
+		// The result is scaled to return values in the interval [-1,1].
+		return 70.0 * ( n0 + n1 + n2 );
 
 	}
-	var t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;
-	if ( t1 < 0 ) n1 = 0.0;
-	else {
 
-		t1 *= t1;
-		n1 = t1 * t1 * this.dot4( grad4[ gi1 ], x1, y1, z1, w1 );
+	// 3D simplex noise
+	noise3d( xin, yin, zin ) {
+
+		var n0, n1, n2, n3; // Noise contributions from the four corners
+		// Skew the input space to determine which simplex cell we're in
+		var F3 = 1.0 / 3.0;
+		var s = ( xin + yin + zin ) * F3; // Very nice and simple skew factor for 3D
+		var i = Math.floor( xin + s );
+		var j = Math.floor( yin + s );
+		var k = Math.floor( zin + s );
+		var G3 = 1.0 / 6.0; // Very nice and simple unskew factor, too
+		var t = ( i + j + k ) * G3;
+		var X0 = i - t; // Unskew the cell origin back to (x,y,z) space
+		var Y0 = j - t;
+		var Z0 = k - t;
+		var x0 = xin - X0; // The x,y,z distances from the cell origin
+		var y0 = yin - Y0;
+		var z0 = zin - Z0;
+		// For the 3D case, the simplex shape is a slightly irregular tetrahedron.
+		// Determine which simplex we are in.
+		var i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords
+		var i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
+		if ( x0 >= y0 ) {
+
+			if ( y0 >= z0 ) {
+
+				i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 1; k2 = 0;
+
+				// X Y Z order
+
+			} else if ( x0 >= z0 ) {
+
+				i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 0; k2 = 1;
+
+				// X Z Y order
+
+			} else {
+
+				i1 = 0; j1 = 0; k1 = 1; i2 = 1; j2 = 0; k2 = 1;
+
+			} // Z X Y order
+
+		} else { // x0<y0
+
+			if ( y0 < z0 ) {
+
+				i1 = 0; j1 = 0; k1 = 1; i2 = 0; j2 = 1; k2 = 1;
+
+				// Z Y X order
+
+			} else if ( x0 < z0 ) {
+
+				i1 = 0; j1 = 1; k1 = 0; i2 = 0; j2 = 1; k2 = 1;
+
+				// Y Z X order
+
+			} else {
+
+				i1 = 0; j1 = 1; k1 = 0; i2 = 1; j2 = 1; k2 = 0;
+
+			} // Y X Z order
+
+		}
+		// A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
+		// a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and
+		// a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z), where
+		// c = 1/6.
+		var x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords
+		var y1 = y0 - j1 + G3;
+		var z1 = z0 - k1 + G3;
+		var x2 = x0 - i2 + 2.0 * G3; // Offsets for third corner in (x,y,z) coords
+		var y2 = y0 - j2 + 2.0 * G3;
+		var z2 = z0 - k2 + 2.0 * G3;
+		var x3 = x0 - 1.0 + 3.0 * G3; // Offsets for last corner in (x,y,z) coords
+		var y3 = y0 - 1.0 + 3.0 * G3;
+		var z3 = z0 - 1.0 + 3.0 * G3;
+		// Work out the hashed gradient indices of the four simplex corners
+		var ii = i & 255;
+		var jj = j & 255;
+		var kk = k & 255;
+		var gi0 = this.perm[ ii + this.perm[ jj + this.perm[ kk ] ] ] % 12;
+		var gi1 = this.perm[ ii + i1 + this.perm[ jj + j1 + this.perm[ kk + k1 ] ] ] % 12;
+		var gi2 = this.perm[ ii + i2 + this.perm[ jj + j2 + this.perm[ kk + k2 ] ] ] % 12;
+		var gi3 = this.perm[ ii + 1 + this.perm[ jj + 1 + this.perm[ kk + 1 ] ] ] % 12;
+		// Calculate the contribution from the four corners
+		var t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
+		if ( t0 < 0 ) n0 = 0.0;
+		else {
+
+			t0 *= t0;
+			n0 = t0 * t0 * this.dot3( this.grad3[ gi0 ], x0, y0, z0 );
+
+		}
+		var t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
+		if ( t1 < 0 ) n1 = 0.0;
+		else {
+
+			t1 *= t1;
+			n1 = t1 * t1 * this.dot3( this.grad3[ gi1 ], x1, y1, z1 );
+
+		}
+		var t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
+		if ( t2 < 0 ) n2 = 0.0;
+		else {
+
+			t2 *= t2;
+			n2 = t2 * t2 * this.dot3( this.grad3[ gi2 ], x2, y2, z2 );
+
+		}
+		var t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
+		if ( t3 < 0 ) n3 = 0.0;
+		else {
+
+			t3 *= t3;
+			n3 = t3 * t3 * this.dot3( this.grad3[ gi3 ], x3, y3, z3 );
+
+		}
+		// Add contributions from each corner to get the final noise value.
+		// The result is scaled to stay just inside [-1,1]
+		return 32.0 * ( n0 + n1 + n2 + n3 );
 
 	}
-	var t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;
-	if ( t2 < 0 ) n2 = 0.0;
-	else {
 
-		t2 *= t2;
-		n2 = t2 * t2 * this.dot4( grad4[ gi2 ], x2, y2, z2, w2 );
+	// 4D simplex noise
+	noise4d( x, y, z, w ) {
 
-	} var t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;
-	if ( t3 < 0 ) n3 = 0.0;
-	else {
+		// For faster and easier lookups
+		var grad4 = this.grad4;
+		var simplex = this.simplex;
+		var perm = this.perm;
 
-		t3 *= t3;
-		n3 = t3 * t3 * this.dot4( grad4[ gi3 ], x3, y3, z3, w3 );
+		// The skewing and unskewing factors are hairy again for the 4D case
+		var F4 = ( Math.sqrt( 5.0 ) - 1.0 ) / 4.0;
+		var G4 = ( 5.0 - Math.sqrt( 5.0 ) ) / 20.0;
+		var n0, n1, n2, n3, n4; // Noise contributions from the five corners
+		// Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in
+		var s = ( x + y + z + w ) * F4; // Factor for 4D skewing
+		var i = Math.floor( x + s );
+		var j = Math.floor( y + s );
+		var k = Math.floor( z + s );
+		var l = Math.floor( w + s );
+		var t = ( i + j + k + l ) * G4; // Factor for 4D unskewing
+		var X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
+		var Y0 = j - t;
+		var Z0 = k - t;
+		var W0 = l - t;
+		var x0 = x - X0; // The x,y,z,w distances from the cell origin
+		var y0 = y - Y0;
+		var z0 = z - Z0;
+		var w0 = w - W0;
+
+		// For the 4D case, the simplex is a 4D shape I won't even try to describe.
+		// To find out which of the 24 possible simplices we're in, we need to
+		// determine the magnitude ordering of x0, y0, z0 and w0.
+		// The method below is a good way of finding the ordering of x,y,z,w and
+		// then find the correct traversal order for the simplex we’re in.
+		// First, six pair-wise comparisons are performed between each possible pair
+		// of the four coordinates, and the results are used to add up binary bits
+		// for an integer index.
+		var c1 = ( x0 > y0 ) ? 32 : 0;
+		var c2 = ( x0 > z0 ) ? 16 : 0;
+		var c3 = ( y0 > z0 ) ? 8 : 0;
+		var c4 = ( x0 > w0 ) ? 4 : 0;
+		var c5 = ( y0 > w0 ) ? 2 : 0;
+		var c6 = ( z0 > w0 ) ? 1 : 0;
+		var c = c1 + c2 + c3 + c4 + c5 + c6;
+		var i1, j1, k1, l1; // The integer offsets for the second simplex corner
+		var i2, j2, k2, l2; // The integer offsets for the third simplex corner
+		var i3, j3, k3, l3; // The integer offsets for the fourth simplex corner
+		// simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some order.
+		// Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w and x<w
+		// impossible. Only the 24 indices which have non-zero entries make any sense.
+		// We use a thresholding to set the coordinates in turn from the largest magnitude.
+		// The number 3 in the "simplex" array is at the position of the largest coordinate.
+		i1 = simplex[ c ][ 0 ] >= 3 ? 1 : 0;
+		j1 = simplex[ c ][ 1 ] >= 3 ? 1 : 0;
+		k1 = simplex[ c ][ 2 ] >= 3 ? 1 : 0;
+		l1 = simplex[ c ][ 3 ] >= 3 ? 1 : 0;
+		// The number 2 in the "simplex" array is at the second largest coordinate.
+		i2 = simplex[ c ][ 0 ] >= 2 ? 1 : 0;
+		j2 = simplex[ c ][ 1 ] >= 2 ? 1 : 0; k2 = simplex[ c ][ 2 ] >= 2 ? 1 : 0;
+		l2 = simplex[ c ][ 3 ] >= 2 ? 1 : 0;
+		// The number 1 in the "simplex" array is at the second smallest coordinate.
+		i3 = simplex[ c ][ 0 ] >= 1 ? 1 : 0;
+		j3 = simplex[ c ][ 1 ] >= 1 ? 1 : 0;
+		k3 = simplex[ c ][ 2 ] >= 1 ? 1 : 0;
+		l3 = simplex[ c ][ 3 ] >= 1 ? 1 : 0;
+		// The fifth corner has all coordinate offsets = 1, so no need to look that up.
+		var x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coords
+		var y1 = y0 - j1 + G4;
+		var z1 = z0 - k1 + G4;
+		var w1 = w0 - l1 + G4;
+		var x2 = x0 - i2 + 2.0 * G4; // Offsets for third corner in (x,y,z,w) coords
+		var y2 = y0 - j2 + 2.0 * G4;
+		var z2 = z0 - k2 + 2.0 * G4;
+		var w2 = w0 - l2 + 2.0 * G4;
+		var x3 = x0 - i3 + 3.0 * G4; // Offsets for fourth corner in (x,y,z,w) coords
+		var y3 = y0 - j3 + 3.0 * G4;
+		var z3 = z0 - k3 + 3.0 * G4;
+		var w3 = w0 - l3 + 3.0 * G4;
+		var x4 = x0 - 1.0 + 4.0 * G4; // Offsets for last corner in (x,y,z,w) coords
+		var y4 = y0 - 1.0 + 4.0 * G4;
+		var z4 = z0 - 1.0 + 4.0 * G4;
+		var w4 = w0 - 1.0 + 4.0 * G4;
+		// Work out the hashed gradient indices of the five simplex corners
+		var ii = i & 255;
+		var jj = j & 255;
+		var kk = k & 255;
+		var ll = l & 255;
+		var gi0 = perm[ ii + perm[ jj + perm[ kk + perm[ ll ] ] ] ] % 32;
+		var gi1 = perm[ ii + i1 + perm[ jj + j1 + perm[ kk + k1 + perm[ ll + l1 ] ] ] ] % 32;
+		var gi2 = perm[ ii + i2 + perm[ jj + j2 + perm[ kk + k2 + perm[ ll + l2 ] ] ] ] % 32;
+		var gi3 = perm[ ii + i3 + perm[ jj + j3 + perm[ kk + k3 + perm[ ll + l3 ] ] ] ] % 32;
+		var gi4 = perm[ ii + 1 + perm[ jj + 1 + perm[ kk + 1 + perm[ ll + 1 ] ] ] ] % 32;
+		// Calculate the contribution from the five corners
+		var t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;
+		if ( t0 < 0 ) n0 = 0.0;
+		else {
+
+			t0 *= t0;
+			n0 = t0 * t0 * this.dot4( grad4[ gi0 ], x0, y0, z0, w0 );
+
+		}
+		var t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;
+		if ( t1 < 0 ) n1 = 0.0;
+		else {
+
+			t1 *= t1;
+			n1 = t1 * t1 * this.dot4( grad4[ gi1 ], x1, y1, z1, w1 );
+
+		}
+		var t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;
+		if ( t2 < 0 ) n2 = 0.0;
+		else {
+
+			t2 *= t2;
+			n2 = t2 * t2 * this.dot4( grad4[ gi2 ], x2, y2, z2, w2 );
+
+		} var t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;
+		if ( t3 < 0 ) n3 = 0.0;
+		else {
+
+			t3 *= t3;
+			n3 = t3 * t3 * this.dot4( grad4[ gi3 ], x3, y3, z3, w3 );
+
+		}
+		var t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;
+		if ( t4 < 0 ) n4 = 0.0;
+		else {
+
+			t4 *= t4;
+			n4 = t4 * t4 * this.dot4( grad4[ gi4 ], x4, y4, z4, w4 );
+
+		}
+		// Sum up and scale the result to cover the range [-1,1]
+		return 27.0 * ( n0 + n1 + n2 + n3 + n4 );
 
 	}
-	var t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;
-	if ( t4 < 0 ) n4 = 0.0;
-	else {
 
-		t4 *= t4;
-		n4 = t4 * t4 * this.dot4( grad4[ gi4 ], x4, y4, z4, w4 );
+}
 
-	}
-	// Sum up and scale the result to cover the range [-1,1]
-	return 27.0 * ( n0 + n1 + n2 + n3 + n4 );
-
-};
+export { SimplexNoise };

--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -6,25 +6,25 @@ import { Vector2 } from './Vector2.js';
 
 var _vector = new Vector2();
 
-function Box2( min, max ) {
+class Box2 {
 
-	this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
-	this.max = ( max !== undefined ) ? max : new Vector2( - Infinity, - Infinity );
+	constructor( min, max ) {
 
-}
+		this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
+		this.max = ( max !== undefined ) ? max : new Vector2( - Infinity, - Infinity );
 
-Object.assign( Box2.prototype, {
+	}
 
-	set: function ( min, max ) {
+	set( min, max ) {
 
 		this.min.copy( min );
 		this.max.copy( max );
 
 		return this;
 
-	},
+	}
 
-	setFromPoints: function ( points ) {
+	setFromPoints( points ) {
 
 		this.makeEmpty();
 
@@ -36,9 +36,9 @@ Object.assign( Box2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromCenterAndSize: function ( center, size ) {
+	setFromCenterAndSize( center, size ) {
 
 		var halfSize = _vector.copy( size ).multiplyScalar( 0.5 );
 		this.min.copy( center ).sub( halfSize );
@@ -46,41 +46,41 @@ Object.assign( Box2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Box2( this.min, this.max );
 
-	},
+	}
 
-	copy: function ( box ) {
+	copy( box ) {
 
 		this.min.copy( box.min );
 		this.max.copy( box.max );
 
 		return this;
 
-	},
+	}
 
-	makeEmpty: function () {
+	makeEmpty() {
 
 		this.min.x = this.min.y = + Infinity;
 		this.max.x = this.max.y = - Infinity;
 
 		return this;
 
-	},
+	}
 
-	isEmpty: function () {
+	isEmpty() {
 
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
 
 		return ( this.max.x < this.min.x ) || ( this.max.y < this.min.y );
 
-	},
+	}
 
-	getCenter: function ( target ) {
+	getCenter( target ) {
 
 		if ( target === undefined ) {
 
@@ -91,9 +91,9 @@ Object.assign( Box2.prototype, {
 
 		return this.isEmpty() ? target.set( 0, 0 ) : target.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
 
-	},
+	}
 
-	getSize: function ( target ) {
+	getSize( target ) {
 
 		if ( target === undefined ) {
 
@@ -104,50 +104,50 @@ Object.assign( Box2.prototype, {
 
 		return this.isEmpty() ? target.set( 0, 0 ) : target.subVectors( this.max, this.min );
 
-	},
+	}
 
-	expandByPoint: function ( point ) {
+	expandByPoint( point ) {
 
 		this.min.min( point );
 		this.max.max( point );
 
 		return this;
 
-	},
+	}
 
-	expandByVector: function ( vector ) {
+	expandByVector( vector ) {
 
 		this.min.sub( vector );
 		this.max.add( vector );
 
 		return this;
 
-	},
+	}
 
-	expandByScalar: function ( scalar ) {
+	expandByScalar( scalar ) {
 
 		this.min.addScalar( - scalar );
 		this.max.addScalar( scalar );
 
 		return this;
 
-	},
+	}
 
-	containsPoint: function ( point ) {
+	containsPoint( point ) {
 
 		return point.x < this.min.x || point.x > this.max.x ||
 			point.y < this.min.y || point.y > this.max.y ? false : true;
 
-	},
+	}
 
-	containsBox: function ( box ) {
+	containsBox( box ) {
 
 		return this.min.x <= box.min.x && box.max.x <= this.max.x &&
 			this.min.y <= box.min.y && box.max.y <= this.max.y;
 
-	},
+	}
 
-	getParameter: function ( point, target ) {
+	getParameter( point, target ) {
 
 		// This can potentially have a divide by zero if the box
 		// has a size dimension of 0.
@@ -164,18 +164,18 @@ Object.assign( Box2.prototype, {
 			( point.y - this.min.y ) / ( this.max.y - this.min.y )
 		);
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		// using 4 splitting planes to rule out intersections
 
 		return box.max.x < this.min.x || box.min.x > this.max.x ||
 			box.max.y < this.min.y || box.min.y > this.max.y ? false : true;
 
-	},
+	}
 
-	clampPoint: function ( point, target ) {
+	clampPoint( point, target ) {
 
 		if ( target === undefined ) {
 
@@ -186,49 +186,48 @@ Object.assign( Box2.prototype, {
 
 		return target.copy( point ).clamp( this.min, this.max );
 
-	},
+	}
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint( point ) {
 
 		var clampedPoint = _vector.copy( point ).clamp( this.min, this.max );
 		return clampedPoint.sub( point ).length();
 
-	},
+	}
 
-	intersect: function ( box ) {
+	intersect( box ) {
 
 		this.min.max( box.min );
 		this.max.min( box.max );
 
 		return this;
 
-	},
+	}
 
-	union: function ( box ) {
+	union( box ) {
 
 		this.min.min( box.min );
 		this.max.max( box.max );
 
 		return this;
 
-	},
+	}
 
-	translate: function ( offset ) {
+	translate( offset ) {
 
 		this.min.add( offset );
 		this.max.add( offset );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( box ) {
+	equals( box ) {
 
 		return box.min.equals( this.min ) && box.max.equals( this.max );
 
 	}
 
-} );
-
+}
 
 export { Box2 };

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -1,64 +1,29 @@
 import { Vector3 } from './Vector3.js';
 
-var _points = [
-	new Vector3(),
-	new Vector3(),
-	new Vector3(),
-	new Vector3(),
-	new Vector3(),
-	new Vector3(),
-	new Vector3(),
-	new Vector3()
-];
-
-var _vector = new Vector3();
-
-var _box = new Box3();
-
-// triangle centered vertices
-
-var _v0 = new Vector3();
-var _v1 = new Vector3();
-var _v2 = new Vector3();
-
-// triangle edge vectors
-
-var _f0 = new Vector3();
-var _f1 = new Vector3();
-var _f2 = new Vector3();
-
-var _center = new Vector3();
-var _extents = new Vector3();
-var _triangleNormal = new Vector3();
-var _testAxis = new Vector3();
-
 /**
  * @author bhouston / http://clara.io
  * @author WestLangley / http://github.com/WestLangley
  */
+class Box3 {
 
-function Box3( min, max ) {
+	constructor( min, max ) {
 
-	this.min = ( min !== undefined ) ? min : new Vector3( + Infinity, + Infinity, + Infinity );
-	this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
+		this.isBox3 = true;
+		this.min = ( min !== undefined ) ? min : new Vector3( + Infinity, + Infinity, + Infinity );
+		this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
 
-}
+	}
 
-
-Object.assign( Box3.prototype, {
-
-	isBox3: true,
-
-	set: function ( min, max ) {
+	set( min, max ) {
 
 		this.min.copy( min );
 		this.max.copy( max );
 
 		return this;
 
-	},
+	}
 
-	setFromArray: function ( array ) {
+	setFromArray( array ) {
 
 		var minX = + Infinity;
 		var minY = + Infinity;
@@ -89,9 +54,9 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromBufferAttribute: function ( attribute ) {
+	setFromBufferAttribute( attribute ) {
 
 		var minX = + Infinity;
 		var minY = + Infinity;
@@ -122,9 +87,9 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromPoints: function ( points ) {
+	setFromPoints( points ) {
 
 		this.makeEmpty();
 
@@ -136,9 +101,9 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromCenterAndSize: function ( center, size ) {
+	setFromCenterAndSize( center, size ) {
 
 		var halfSize = _vector.copy( size ).multiplyScalar( 0.5 );
 
@@ -147,49 +112,49 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromObject: function ( object ) {
+	setFromObject( object ) {
 
 		this.makeEmpty();
 
 		return this.expandByObject( object );
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Box3( this.min, this.max );
 
-	},
+	}
 
-	copy: function ( box ) {
+	copy( box ) {
 
 		this.min.copy( box.min );
 		this.max.copy( box.max );
 
 		return this;
 
-	},
+	}
 
-	makeEmpty: function () {
+	makeEmpty() {
 
 		this.min.x = this.min.y = this.min.z = + Infinity;
 		this.max.x = this.max.y = this.max.z = - Infinity;
 
 		return this;
 
-	},
+	}
 
-	isEmpty: function () {
+	isEmpty() {
 
 		// this is a more robust check for empty than ( volume <= 0 ) because volume can get positive with two negative axes
 
 		return ( this.max.x < this.min.x ) || ( this.max.y < this.min.y ) || ( this.max.z < this.min.z );
 
-	},
+	}
 
-	getCenter: function ( target ) {
+	getCenter( target ) {
 
 		if ( target === undefined ) {
 
@@ -200,9 +165,9 @@ Object.assign( Box3.prototype, {
 
 		return this.isEmpty() ? target.set( 0, 0, 0 ) : target.addVectors( this.min, this.max ).multiplyScalar( 0.5 );
 
-	},
+	}
 
-	getSize: function ( target ) {
+	getSize( target ) {
 
 		if ( target === undefined ) {
 
@@ -213,36 +178,36 @@ Object.assign( Box3.prototype, {
 
 		return this.isEmpty() ? target.set( 0, 0, 0 ) : target.subVectors( this.max, this.min );
 
-	},
+	}
 
-	expandByPoint: function ( point ) {
+	expandByPoint( point ) {
 
 		this.min.min( point );
 		this.max.max( point );
 
 		return this;
 
-	},
+	}
 
-	expandByVector: function ( vector ) {
+	expandByVector( vector ) {
 
 		this.min.sub( vector );
 		this.max.add( vector );
 
 		return this;
 
-	},
+	}
 
-	expandByScalar: function ( scalar ) {
+	expandByScalar( scalar ) {
 
 		this.min.addScalar( - scalar );
 		this.max.addScalar( scalar );
 
 		return this;
 
-	},
+	}
 
-	expandByObject: function ( object ) {
+	expandByObject( object ) {
 
 		// Computes the world-axis-aligned bounding box of an object (including its children),
 		// accounting for both the object's, and children's, world transforms
@@ -276,25 +241,25 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	containsPoint: function ( point ) {
+	containsPoint( point ) {
 
 		return point.x < this.min.x || point.x > this.max.x ||
 			point.y < this.min.y || point.y > this.max.y ||
 			point.z < this.min.z || point.z > this.max.z ? false : true;
 
-	},
+	}
 
-	containsBox: function ( box ) {
+	containsBox( box ) {
 
 		return this.min.x <= box.min.x && box.max.x <= this.max.x &&
 			this.min.y <= box.min.y && box.max.y <= this.max.y &&
 			this.min.z <= box.min.z && box.max.z <= this.max.z;
 
-	},
+	}
 
-	getParameter: function ( point, target ) {
+	getParameter( point, target ) {
 
 		// This can potentially have a divide by zero if the box
 		// has a size dimension of 0.
@@ -312,18 +277,18 @@ Object.assign( Box3.prototype, {
 			( point.z - this.min.z ) / ( this.max.z - this.min.z )
 		);
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		// using 6 splitting planes to rule out intersections.
 		return box.max.x < this.min.x || box.min.x > this.max.x ||
 			box.max.y < this.min.y || box.min.y > this.max.y ||
 			box.max.z < this.min.z || box.min.z > this.max.z ? false : true;
 
-	},
+	}
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere( sphere ) {
 
 		// Find the point on the AABB closest to the sphere center.
 		this.clampPoint( sphere.center, _vector );
@@ -331,9 +296,9 @@ Object.assign( Box3.prototype, {
 		// If that point is inside the sphere, the AABB and sphere intersect.
 		return _vector.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius );
 
-	},
+	}
 
-	intersectsPlane: function ( plane ) {
+	intersectsPlane( plane ) {
 
 		// We compute the minimum and maximum dot product values. If those values
 		// are on the same side (back or front) of the plane, then there is no intersection.
@@ -378,9 +343,9 @@ Object.assign( Box3.prototype, {
 
 		return ( min <= - plane.constant && max >= - plane.constant );
 
-	},
+	}
 
-	intersectsTriangle: function ( triangle ) {
+	intersectsTriangle( triangle ) {
 
 		if ( this.isEmpty() ) {
 
@@ -431,9 +396,9 @@ Object.assign( Box3.prototype, {
 
 		return satForAxes( axes, _v0, _v1, _v2, _extents );
 
-	},
+	}
 
-	clampPoint: function ( point, target ) {
+	clampPoint( point, target ) {
 
 		if ( target === undefined ) {
 
@@ -444,17 +409,17 @@ Object.assign( Box3.prototype, {
 
 		return target.copy( point ).clamp( this.min, this.max );
 
-	},
+	}
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint( point ) {
 
 		var clampedPoint = _vector.copy( point ).clamp( this.min, this.max );
 
 		return clampedPoint.sub( point ).length();
 
-	},
+	}
 
-	getBoundingSphere: function ( target ) {
+	getBoundingSphere( target ) {
 
 		if ( target === undefined ) {
 
@@ -469,9 +434,9 @@ Object.assign( Box3.prototype, {
 
 		return target;
 
-	},
+	}
 
-	intersect: function ( box ) {
+	intersect( box ) {
 
 		this.min.max( box.min );
 		this.max.min( box.max );
@@ -481,18 +446,18 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	union: function ( box ) {
+	union( box ) {
 
 		this.min.min( box.min );
 		this.max.max( box.max );
 
 		return this;
 
-	},
+	}
 
-	applyMatrix4: function ( matrix ) {
+	applyMatrix4( matrix ) {
 
 		// transform of empty box is an empty box.
 		if ( this.isEmpty() ) return this;
@@ -511,24 +476,24 @@ Object.assign( Box3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	translate: function ( offset ) {
+	translate( offset ) {
 
 		this.min.add( offset );
 		this.max.add( offset );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( box ) {
+	equals( box ) {
 
 		return box.min.equals( this.min ) && box.max.equals( this.max );
 
 	}
 
-} );
+}
 
 function satForAxes( axes, v0, v1, v2, extents ) {
 
@@ -557,5 +522,38 @@ function satForAxes( axes, v0, v1, v2, extents ) {
 	return true;
 
 }
+
+
+var _points = [
+	new Vector3(),
+	new Vector3(),
+	new Vector3(),
+	new Vector3(),
+	new Vector3(),
+	new Vector3(),
+	new Vector3(),
+	new Vector3()
+];
+
+var _vector = new Vector3();
+
+var _box = new Box3();
+
+// triangle centered vertices
+
+var _v0 = new Vector3();
+var _v1 = new Vector3();
+var _v2 = new Vector3();
+
+// triangle edge vectors
+
+var _f0 = new Vector3();
+var _f1 = new Vector3();
+var _f2 = new Vector3();
+
+var _center = new Vector3();
+var _extents = new Vector3();
+var _triangleNormal = new Vector3();
+var _testAxis = new Vector3();
 
 export { Box3 };

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -32,49 +32,26 @@ var _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 
 var _hslA = { h: 0, s: 0, l: 0 };
 var _hslB = { h: 0, s: 0, l: 0 };
 
-function Color( r, g, b ) {
+class Color {
 
-	if ( g === undefined && b === undefined ) {
+	constructor( r, g, b ) {
 
-		// r is THREE.Color, hex or string
-		return this.set( r );
+		this.isColor = true;
+		this.r = r;
+		this.g = g;
+		this.b = b;
+	  if ( g === undefined && b === undefined ) {
+
+			// r is THREE.Color, hex or string
+			return this.set( r );
+
+	  }
+
+	  return this.setRGB( r, g, b );
 
 	}
 
-	return this.setRGB( r, g, b );
-
-}
-
-function hue2rgb( p, q, t ) {
-
-	if ( t < 0 ) t += 1;
-	if ( t > 1 ) t -= 1;
-	if ( t < 1 / 6 ) return p + ( q - p ) * 6 * t;
-	if ( t < 1 / 2 ) return q;
-	if ( t < 2 / 3 ) return p + ( q - p ) * 6 * ( 2 / 3 - t );
-	return p;
-
-}
-
-function SRGBToLinear( c ) {
-
-	return ( c < 0.04045 ) ? c * 0.0773993808 : Math.pow( c * 0.9478672986 + 0.0521327014, 2.4 );
-
-}
-
-function LinearToSRGB( c ) {
-
-	return ( c < 0.0031308 ) ? c * 12.92 : 1.055 * ( Math.pow( c, 0.41666 ) ) - 0.055;
-
-}
-
-Object.assign( Color.prototype, {
-
-	isColor: true,
-
-	r: 1, g: 1, b: 1,
-
-	set: function ( value ) {
+	set( value ) {
 
 		if ( value && value.isColor ) {
 
@@ -92,9 +69,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setScalar: function ( scalar ) {
+	setScalar( scalar ) {
 
 		this.r = scalar;
 		this.g = scalar;
@@ -102,9 +79,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setHex: function ( hex ) {
+	setHex( hex ) {
 
 		hex = Math.floor( hex );
 
@@ -114,9 +91,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setRGB: function ( r, g, b ) {
+	setRGB( r, g, b ) {
 
 		this.r = r;
 		this.g = g;
@@ -124,9 +101,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setHSL: function ( h, s, l ) {
+	setHSL( h, s, l ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 		h = MathUtils.euclideanModulo( h, 1 );
@@ -150,9 +127,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setStyle: function ( style ) {
+	setStyle( style ) {
 
 		function handleAlpha( string ) {
 
@@ -267,9 +244,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setColorName: function ( style ) {
+	setColorName( style ) {
 
 		// color keywords
 		var hex = _colorKeywords[ style ];
@@ -288,15 +265,15 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this.r, this.g, this.b );
+		return new Color( this.r, this.g, this.b );
 
-	},
+	}
 
-	copy: function ( color ) {
+	copy( color ) {
 
 		this.r = color.r;
 		this.g = color.g;
@@ -304,9 +281,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyGammaToLinear: function ( color, gammaFactor ) {
+	copyGammaToLinear( color, gammaFactor ) {
 
 		if ( gammaFactor === undefined ) gammaFactor = 2.0;
 
@@ -316,9 +293,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyLinearToGamma: function ( color, gammaFactor ) {
+	copyLinearToGamma( color, gammaFactor ) {
 
 		if ( gammaFactor === undefined ) gammaFactor = 2.0;
 
@@ -330,25 +307,25 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	convertGammaToLinear: function ( gammaFactor ) {
+	convertGammaToLinear( gammaFactor ) {
 
 		this.copyGammaToLinear( this, gammaFactor );
 
 		return this;
 
-	},
+	}
 
-	convertLinearToGamma: function ( gammaFactor ) {
+	convertLinearToGamma( gammaFactor ) {
 
 		this.copyLinearToGamma( this, gammaFactor );
 
 		return this;
 
-	},
+	}
 
-	copySRGBToLinear: function ( color ) {
+	copySRGBToLinear( color ) {
 
 		this.r = SRGBToLinear( color.r );
 		this.g = SRGBToLinear( color.g );
@@ -356,9 +333,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyLinearToSRGB: function ( color ) {
+	copyLinearToSRGB( color ) {
 
 		this.r = LinearToSRGB( color.r );
 		this.g = LinearToSRGB( color.g );
@@ -366,37 +343,37 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	convertSRGBToLinear: function () {
+	convertSRGBToLinear() {
 
 		this.copySRGBToLinear( this );
 
 		return this;
 
-	},
+	}
 
-	convertLinearToSRGB: function () {
+	convertLinearToSRGB() {
 
 		this.copyLinearToSRGB( this );
 
 		return this;
 
-	},
+	}
 
-	getHex: function () {
+	getHex() {
 
 		return ( this.r * 255 ) << 16 ^ ( this.g * 255 ) << 8 ^ ( this.b * 255 ) << 0;
 
-	},
+	}
 
-	getHexString: function () {
+	getHexString() {
 
 		return ( '000000' + this.getHex().toString( 16 ) ).slice( - 6 );
 
-	},
+	}
 
-	getHSL: function ( target ) {
+	getHSL( target ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 
@@ -444,15 +421,15 @@ Object.assign( Color.prototype, {
 
 		return target;
 
-	},
+	}
 
-	getStyle: function () {
+	getStyle() {
 
 		return 'rgb(' + ( ( this.r * 255 ) | 0 ) + ',' + ( ( this.g * 255 ) | 0 ) + ',' + ( ( this.b * 255 ) | 0 ) + ')';
 
-	},
+	}
 
-	offsetHSL: function ( h, s, l ) {
+	offsetHSL( h, s, l ) {
 
 		this.getHSL( _hslA );
 
@@ -462,9 +439,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	add: function ( color ) {
+	add( color ) {
 
 		this.r += color.r;
 		this.g += color.g;
@@ -472,9 +449,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addColors: function ( color1, color2 ) {
+	addColors( color1, color2 ) {
 
 		this.r = color1.r + color2.r;
 		this.g = color1.g + color2.g;
@@ -482,9 +459,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScalar: function ( s ) {
+	addScalar( s ) {
 
 		this.r += s;
 		this.g += s;
@@ -492,9 +469,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	sub: function ( color ) {
+	sub( color ) {
 
 		this.r = Math.max( 0, this.r - color.r );
 		this.g = Math.max( 0, this.g - color.g );
@@ -502,9 +479,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( color ) {
+	multiply( color ) {
 
 		this.r *= color.r;
 		this.g *= color.g;
@@ -512,9 +489,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( s ) {
+	multiplyScalar( s ) {
 
 		this.r *= s;
 		this.g *= s;
@@ -522,9 +499,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerp: function ( color, alpha ) {
+	lerp( color, alpha ) {
 
 		this.r += ( color.r - this.r ) * alpha;
 		this.g += ( color.g - this.g ) * alpha;
@@ -532,9 +509,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerpHSL: function ( color, alpha ) {
+	lerpHSL( color, alpha ) {
 
 		this.getHSL( _hslA );
 		color.getHSL( _hslB );
@@ -547,15 +524,15 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( c ) {
+	equals( c ) {
 
 		return ( c.r === this.r ) && ( c.g === this.g ) && ( c.b === this.b );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -565,9 +542,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -578,15 +555,38 @@ Object.assign( Color.prototype, {
 
 		return array;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
 		return this.getHex();
 
 	}
 
-} );
+}
+
+function hue2rgb( p, q, t ) {
+
+	if ( t < 0 ) t += 1;
+	if ( t > 1 ) t -= 1;
+	if ( t < 1 / 6 ) return p + ( q - p ) * 6 * t;
+	if ( t < 1 / 2 ) return q;
+	if ( t < 2 / 3 ) return p + ( q - p ) * 6 * ( 2 / 3 - t );
+	return p;
+
+}
+
+function SRGBToLinear( c ) {
+
+	return ( c < 0.04045 ) ? c * 0.0773993808 : Math.pow( c * 0.9478672986 + 0.0521327014, 2.4 );
+
+}
+
+function LinearToSRGB( c ) {
+
+	return ( c < 0.0031308 ) ? c * 12.92 : 1.055 * ( Math.pow( c, 0.41666 ) ) - 0.055;
+
+}
 
 Color.NAMES = _colorKeywords;
 

--- a/src/math/Cylindrical.js
+++ b/src/math/Cylindrical.js
@@ -4,20 +4,18 @@
  * Ref: https://en.wikipedia.org/wiki/Cylindrical_coordinate_system
  *
  */
+class Cylindrical {
 
-function Cylindrical( radius, theta, y ) {
+	constructor( radius, theta, y ) {
 
-	this.radius = ( radius !== undefined ) ? radius : 1.0; // distance from the origin to a point in the x-z plane
-	this.theta = ( theta !== undefined ) ? theta : 0; // counterclockwise angle in the x-z plane measured in radians from the positive z-axis
-	this.y = ( y !== undefined ) ? y : 0; // height above the x-z plane
+		this.radius = ( radius !== undefined ) ? radius : 1.0; // distance from the origin to a point in the x-z plane
+		this.theta = ( theta !== undefined ) ? theta : 0; // counterclockwise angle in the x-z plane measured in radians from the positive z-axis
+		this.y = ( y !== undefined ) ? y : 0; // height above the x-z plane
+		return this;
 
-	return this;
+	}
 
-}
-
-Object.assign( Cylindrical.prototype, {
-
-	set: function ( radius, theta, y ) {
+	set( radius, theta, y ) {
 
 		this.radius = radius;
 		this.theta = theta;
@@ -25,15 +23,15 @@ Object.assign( Cylindrical.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
 		return new this.constructor().copy( this );
 
-	},
+	}
 
-	copy: function ( other ) {
+	copy( other ) {
 
 		this.radius = other.radius;
 		this.theta = other.theta;
@@ -41,15 +39,15 @@ Object.assign( Cylindrical.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromVector3: function ( v ) {
+	setFromVector3( v ) {
 
 		return this.setFromCartesianCoords( v.x, v.y, v.z );
 
-	},
+	}
 
-	setFromCartesianCoords: function ( x, y, z ) {
+	setFromCartesianCoords( x, y, z ) {
 
 		this.radius = Math.sqrt( x * x + z * z );
 		this.theta = Math.atan2( x, z );
@@ -59,7 +57,6 @@ Object.assign( Cylindrical.prototype, {
 
 	}
 
-} );
-
+}
 
 export { Cylindrical };

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -12,96 +12,71 @@ import { MathUtils } from './MathUtils.js';
 var _matrix = new Matrix4();
 var _quaternion = new Quaternion();
 
-function Euler( x, y, z, order ) {
+class Euler {
 
-	this._x = x || 0;
-	this._y = y || 0;
-	this._z = z || 0;
-	this._order = order || Euler.DefaultOrder;
+	constructor( x, y, z, order ) {
 
-}
-
-Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
-
-Euler.DefaultOrder = 'XYZ';
-
-Object.defineProperties( Euler.prototype, {
-
-	x: {
-
-		get: function () {
-
-			return this._x;
-
-		},
-
-		set: function ( value ) {
-
-			this._x = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	y: {
-
-		get: function () {
-
-			return this._y;
-
-		},
-
-		set: function ( value ) {
-
-			this._y = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	z: {
-
-		get: function () {
-
-			return this._z;
-
-		},
-
-		set: function ( value ) {
-
-			this._z = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	order: {
-
-		get: function () {
-
-			return this._order;
-
-		},
-
-		set: function ( value ) {
-
-			this._order = value;
-			this._onChangeCallback();
-
-		}
+		this.isEuler = true;
+		this._x = x || 0;
+		this._y = y || 0;
+		this._z = z || 0;
+		this._order = order || Euler.DefaultOrder;
 
 	}
 
-} );
+	get x() {
 
-Object.assign( Euler.prototype, {
+		return this._x;
 
-	isEuler: true,
+	}
 
-	set: function ( x, y, z, order ) {
+	set x( value ) {
+
+		this._x = value;
+		this._onChangeCallback();
+
+	}
+
+	get y() {
+
+		return this._y;
+
+	}
+
+	set y( value ) {
+
+		this._y = value;
+		this._onChangeCallback();
+
+	}
+
+	get z() {
+
+		return this._z;
+
+	}
+
+	set z( value ) {
+
+		this._z = value;
+		this._onChangeCallback();
+
+	}
+
+	get order() {
+
+		return this._order;
+
+	}
+
+	set order( value ) {
+
+		this._order = value;
+		this._onChangeCallback();
+
+	}
+
+	set( x, y, z, order ) {
 
 		this._x = x;
 		this._y = y;
@@ -112,15 +87,15 @@ Object.assign( Euler.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this._x, this._y, this._z, this._order );
+		return new Euler( this._x, this._y, this._z, this._order );
 
-	},
+	}
 
-	copy: function ( euler ) {
+	copy( euler ) {
 
 		this._x = euler._x;
 		this._y = euler._y;
@@ -131,9 +106,9 @@ Object.assign( Euler.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromRotationMatrix: function ( m, order, update ) {
+	setFromRotationMatrix( m, order, update ) {
 
 		var clamp = MathUtils.clamp;
 
@@ -254,23 +229,23 @@ Object.assign( Euler.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromQuaternion: function ( q, order, update ) {
+	setFromQuaternion( q, order, update ) {
 
 		_matrix.makeRotationFromQuaternion( q );
 
 		return this.setFromRotationMatrix( _matrix, order, update );
 
-	},
+	}
 
-	setFromVector3: function ( v, order ) {
+	setFromVector3( v, order ) {
 
 		return this.set( v.x, v.y, v.z, order || this._order );
 
-	},
+	}
 
-	reorder: function ( newOrder ) {
+	reorder( newOrder ) {
 
 		// WARNING: this discards revolution information -bhouston
 
@@ -278,15 +253,15 @@ Object.assign( Euler.prototype, {
 
 		return this.setFromQuaternion( _quaternion, newOrder );
 
-	},
+	}
 
-	equals: function ( euler ) {
+	equals( euler ) {
 
 		return ( euler._x === this._x ) && ( euler._y === this._y ) && ( euler._z === this._z ) && ( euler._order === this._order );
 
-	},
+	}
 
-	fromArray: function ( array ) {
+	fromArray( array ) {
 
 		this._x = array[ 0 ];
 		this._y = array[ 1 ];
@@ -297,9 +272,9 @@ Object.assign( Euler.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -311,9 +286,9 @@ Object.assign( Euler.prototype, {
 
 		return array;
 
-	},
+	}
 
-	toVector3: function ( optionalResult ) {
+	toVector3( optionalResult ) {
 
 		if ( optionalResult ) {
 
@@ -325,19 +300,22 @@ Object.assign( Euler.prototype, {
 
 		}
 
-	},
+	}
 
-	_onChange: function ( callback ) {
+	_onChange( callback ) {
 
 		this._onChangeCallback = callback;
 
 		return this;
 
-	},
+	}
 
-	_onChangeCallback: function () {}
+	_onChangeCallback() {}
 
-} );
+}
 
+Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
+
+Euler.DefaultOrder = 'XYZ';
 
 export { Euler };

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -11,24 +11,22 @@ import { Plane } from './Plane.js';
 var _sphere = new Sphere();
 var _vector = new Vector3();
 
-function Frustum( p0, p1, p2, p3, p4, p5 ) {
+class Frustum {
 
-	this.planes = [
+	constructor( p0, p1, p2, p3, p4, p5 ) {
 
-		( p0 !== undefined ) ? p0 : new Plane(),
-		( p1 !== undefined ) ? p1 : new Plane(),
-		( p2 !== undefined ) ? p2 : new Plane(),
-		( p3 !== undefined ) ? p3 : new Plane(),
-		( p4 !== undefined ) ? p4 : new Plane(),
-		( p5 !== undefined ) ? p5 : new Plane()
+		this.planes = [
+			( p0 !== undefined ) ? p0 : new Plane(),
+			( p1 !== undefined ) ? p1 : new Plane(),
+			( p2 !== undefined ) ? p2 : new Plane(),
+			( p3 !== undefined ) ? p3 : new Plane(),
+			( p4 !== undefined ) ? p4 : new Plane(),
+			( p5 !== undefined ) ? p5 : new Plane()
+		];
 
-	];
+	}
 
-}
-
-Object.assign( Frustum.prototype, {
-
-	set: function ( p0, p1, p2, p3, p4, p5 ) {
+	set( p0, p1, p2, p3, p4, p5 ) {
 
 		var planes = this.planes;
 
@@ -41,15 +39,15 @@ Object.assign( Frustum.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Frustum().copy( this );
 
-	},
+	}
 
-	copy: function ( frustum ) {
+	copy( frustum ) {
 
 		var planes = this.planes;
 
@@ -61,9 +59,9 @@ Object.assign( Frustum.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromProjectionMatrix: function ( m ) {
+	setFromProjectionMatrix( m ) {
 
 		var planes = this.planes;
 		var me = m.elements;
@@ -81,9 +79,9 @@ Object.assign( Frustum.prototype, {
 
 		return this;
 
-	},
+	}
 
-	intersectsObject: function ( object ) {
+	intersectsObject( object ) {
 
 		var geometry = object.geometry;
 
@@ -93,9 +91,9 @@ Object.assign( Frustum.prototype, {
 
 		return this.intersectsSphere( _sphere );
 
-	},
+	}
 
-	intersectsSprite: function ( sprite ) {
+	intersectsSprite( sprite ) {
 
 		_sphere.center.set( 0, 0, 0 );
 		_sphere.radius = 0.7071067811865476;
@@ -103,9 +101,9 @@ Object.assign( Frustum.prototype, {
 
 		return this.intersectsSphere( _sphere );
 
-	},
+	}
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere( sphere ) {
 
 		var planes = this.planes;
 		var center = sphere.center;
@@ -125,9 +123,9 @@ Object.assign( Frustum.prototype, {
 
 		return true;
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		var planes = this.planes;
 
@@ -151,9 +149,9 @@ Object.assign( Frustum.prototype, {
 
 		return true;
 
-	},
+	}
 
-	containsPoint: function ( point ) {
+	containsPoint( point ) {
 
 		var planes = this.planes;
 
@@ -171,7 +169,7 @@ Object.assign( Frustum.prototype, {
 
 	}
 
-} );
+}
 
 
 export { Frustum };

--- a/src/math/Interpolant.js
+++ b/src/math/Interpolant.js
@@ -19,22 +19,25 @@
  *
  * @author tschw
  */
+class Interpolant {
 
-function Interpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-	this.parameterPositions = parameterPositions;
-	this._cachedIndex = 0;
+		this.parameterPositions = parameterPositions;
+		this._cachedIndex = 0;
+		this.resultBuffer = resultBuffer !== undefined ?
+			resultBuffer : new sampleValues( sampleSize );
+		this.sampleValues = sampleValues;
+		this.valueSize = sampleSize;
+		//( 0, t, t0 ), returns this.resultBuffer
+		this.beforeStart_ = this.copySampleValue_;
 
-	this.resultBuffer = resultBuffer !== undefined ?
-		resultBuffer : new sampleValues.constructor( sampleSize );
-	this.sampleValues = sampleValues;
-	this.valueSize = sampleSize;
+		//( N-1, tN-1, t ), returns this.resultBuffer
+		this.afterEnd_ = this.copySampleValue_;
 
-}
+	}
 
-Object.assign( Interpolant.prototype, {
-
-	evaluate: function ( t ) {
+	evaluate( t ) {
 
 		var pp = this.parameterPositions,
 			i1 = this._cachedIndex,
@@ -193,22 +196,9 @@ Object.assign( Interpolant.prototype, {
 
 		return this.interpolate_( i1, t0, t, t1 );
 
-	},
+	}
 
-	settings: null, // optional, subclass-specific settings structure
-	// Note: The indirection allows central control of many interpolants.
-
-	// --- Protected interface
-
-	DefaultSettings_: {},
-
-	getSettings_: function () {
-
-		return this.settings || this.DefaultSettings_;
-
-	},
-
-	copySampleValue_: function ( index ) {
+	copySampleValue_( index ) {
 
 		// copies a sample value to the result buffer
 
@@ -225,35 +215,23 @@ Object.assign( Interpolant.prototype, {
 
 		return result;
 
-	},
+	}
 
 	// Template methods for derived classes:
 
-	interpolate_: function ( /* i1, t0, t, t1 */ ) {
+	interpolate_( /* i1, t0, t, t1 */ ) {
 
 		throw new Error( 'call to abstract method' );
 		// implementations shall return this.resultBuffer
 
-	},
+	}
 
-	intervalChanged_: function ( /* i1, t0, t1 */ ) {
+	intervalChanged_( /* i1, t0, t1 */ ) {
 
 		// empty
 
 	}
 
-} );
-
-//!\ DECLARE ALIAS AFTER assign prototype !
-Object.assign( Interpolant.prototype, {
-
-	//( 0, t, t0 ), returns this.resultBuffer
-	beforeStart_: Interpolant.prototype.copySampleValue_,
-
-	//( N-1, tN-1, t ), returns this.resultBuffer
-	afterEnd_: Interpolant.prototype.copySampleValue_,
-
-} );
-
+}
 
 export { Interpolant };

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -8,40 +8,40 @@ import { MathUtils } from './MathUtils.js';
 var _startP = new Vector3();
 var _startEnd = new Vector3();
 
-function Line3( start, end ) {
+class Line3 {
 
-	this.start = ( start !== undefined ) ? start : new Vector3();
-	this.end = ( end !== undefined ) ? end : new Vector3();
+	constructor( start, end ) {
 
-}
+		this.start = ( start !== undefined ) ? start : new Vector3();
+		this.end = ( end !== undefined ) ? end : new Vector3();
 
-Object.assign( Line3.prototype, {
+	}
 
-	set: function ( start, end ) {
+	set( start, end ) {
 
 		this.start.copy( start );
 		this.end.copy( end );
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Line3( this.start, this.end );
 
-	},
+	}
 
-	copy: function ( line ) {
+	copy( line ) {
 
 		this.start.copy( line.start );
 		this.end.copy( line.end );
 
 		return this;
 
-	},
+	}
 
-	getCenter: function ( target ) {
+	getCenter( target ) {
 
 		if ( target === undefined ) {
 
@@ -52,9 +52,9 @@ Object.assign( Line3.prototype, {
 
 		return target.addVectors( this.start, this.end ).multiplyScalar( 0.5 );
 
-	},
+	}
 
-	delta: function ( target ) {
+	delta( target ) {
 
 		if ( target === undefined ) {
 
@@ -65,21 +65,21 @@ Object.assign( Line3.prototype, {
 
 		return target.subVectors( this.end, this.start );
 
-	},
+	}
 
-	distanceSq: function () {
+	distanceSq() {
 
 		return this.start.distanceToSquared( this.end );
 
-	},
+	}
 
-	distance: function () {
+	distance() {
 
 		return this.start.distanceTo( this.end );
 
-	},
+	}
 
-	at: function ( t, target ) {
+	at( t, target ) {
 
 		if ( target === undefined ) {
 
@@ -90,9 +90,9 @@ Object.assign( Line3.prototype, {
 
 		return this.delta( target ).multiplyScalar( t ).add( this.start );
 
-	},
+	}
 
-	closestPointToPointParameter: function ( point, clampToLine ) {
+	closestPointToPointParameter( point, clampToLine ) {
 
 		_startP.subVectors( point, this.start );
 		_startEnd.subVectors( this.end, this.start );
@@ -110,9 +110,9 @@ Object.assign( Line3.prototype, {
 
 		return t;
 
-	},
+	}
 
-	closestPointToPoint: function ( point, clampToLine, target ) {
+	closestPointToPoint( point, clampToLine, target ) {
 
 		var t = this.closestPointToPointParameter( point, clampToLine );
 
@@ -125,24 +125,23 @@ Object.assign( Line3.prototype, {
 
 		return this.delta( target ).multiplyScalar( t ).add( this.start );
 
-	},
+	}
 
-	applyMatrix4: function ( matrix ) {
+	applyMatrix4( matrix ) {
 
 		this.start.applyMatrix4( matrix );
 		this.end.applyMatrix4( matrix );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( line ) {
+	equals( line ) {
 
 		return line.start.equals( this.start ) && line.end.equals( this.end );
 
 	}
 
-} );
-
+}
 
 export { Line3 };

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -4,30 +4,25 @@
  * @author bhouston / http://clara.io
  * @author tschw
  */
+class Matrix3 {
 
-function Matrix3() {
+	constructor() {
 
-	this.elements = [
+		this.isMatrix3 = true;
+		this.elements = [
+			1, 0, 0,
+			0, 1, 0,
+			0, 0, 1
+		];
+		if ( arguments.length > 0 ) {
 
-		1, 0, 0,
-		0, 1, 0,
-		0, 0, 1
+			console.error( 'THREE.Matrix3: the constructor no longer reads arguments. use .set() instead.' );
 
-	];
-
-	if ( arguments.length > 0 ) {
-
-		console.error( 'THREE.Matrix3: the constructor no longer reads arguments. use .set() instead.' );
+		}
 
 	}
 
-}
-
-Object.assign( Matrix3.prototype, {
-
-	isMatrix3: true,
-
-	set: function ( n11, n12, n13, n21, n22, n23, n31, n32, n33 ) {
+	set( n11, n12, n13, n21, n22, n23, n31, n32, n33 ) {
 
 		var te = this.elements;
 
@@ -37,9 +32,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	identity: function () {
+	identity() {
 
 		this.set(
 
@@ -51,15 +46,15 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
 		return new this.constructor().fromArray( this.elements );
 
-	},
+	}
 
-	copy: function ( m ) {
+	copy( m ) {
 
 		var te = this.elements;
 		var me = m.elements;
@@ -70,9 +65,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	extractBasis: function ( xAxis, yAxis, zAxis ) {
+	extractBasis( xAxis, yAxis, zAxis ) {
 
 		xAxis.setFromMatrix3Column( this, 0 );
 		yAxis.setFromMatrix3Column( this, 1 );
@@ -80,9 +75,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromMatrix4: function ( m ) {
+	setFromMatrix4( m ) {
 
 		var me = m.elements;
 
@@ -96,21 +91,21 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( m ) {
+	multiply( m ) {
 
 		return this.multiplyMatrices( this, m );
 
-	},
+	}
 
-	premultiply: function ( m ) {
+	premultiply( m ) {
 
 		return this.multiplyMatrices( m, this );
 
-	},
+	}
 
-	multiplyMatrices: function ( a, b ) {
+	multiplyMatrices( a, b ) {
 
 		var ae = a.elements;
 		var be = b.elements;
@@ -138,9 +133,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( s ) {
+	multiplyScalar( s ) {
 
 		var te = this.elements;
 
@@ -150,9 +145,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	determinant: function () {
+	determinant() {
 
 		var te = this.elements;
 
@@ -162,9 +157,9 @@ Object.assign( Matrix3.prototype, {
 
 		return a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g;
 
-	},
+	}
 
-	getInverse: function ( matrix, throwOnDegenerate ) {
+	getInverse( matrix, throwOnDegenerate ) {
 
 		if ( matrix && matrix.isMatrix4 ) {
 
@@ -219,9 +214,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	transpose: function () {
+	transpose() {
 
 		var tmp, m = this.elements;
 
@@ -231,15 +226,15 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getNormalMatrix: function ( matrix4 ) {
+	getNormalMatrix( matrix4 ) {
 
 		return this.setFromMatrix4( matrix4 ).getInverse( this ).transpose();
 
-	},
+	}
 
-	transposeIntoArray: function ( r ) {
+	transposeIntoArray( r ) {
 
 		var m = this.elements;
 
@@ -255,9 +250,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setUvTransform: function ( tx, ty, sx, sy, rotation, cx, cy ) {
+	setUvTransform( tx, ty, sx, sy, rotation, cx, cy ) {
 
 		var c = Math.cos( rotation );
 		var s = Math.sin( rotation );
@@ -268,9 +263,9 @@ Object.assign( Matrix3.prototype, {
 			0, 0, 1
 		);
 
-	},
+	}
 
-	scale: function ( sx, sy ) {
+	scale( sx, sy ) {
 
 		var te = this.elements;
 
@@ -279,9 +274,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	rotate: function ( theta ) {
+	rotate( theta ) {
 
 		var c = Math.cos( theta );
 		var s = Math.sin( theta );
@@ -301,9 +296,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	translate: function ( tx, ty ) {
+	translate( tx, ty ) {
 
 		var te = this.elements;
 
@@ -312,9 +307,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( matrix ) {
+	equals( matrix ) {
 
 		var te = this.elements;
 		var me = matrix.elements;
@@ -327,9 +322,9 @@ Object.assign( Matrix3.prototype, {
 
 		return true;
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -341,9 +336,9 @@ Object.assign( Matrix3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -366,7 +361,7 @@ Object.assign( Matrix3.prototype, {
 
 	}
 
-} );
+}
 
 
 export { Matrix3 };

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1,13 +1,5 @@
 import { Vector3 } from './Vector3.js';
 
-var _v1 = new Vector3();
-var _m1 = new Matrix4();
-var _zero = new Vector3( 0, 0, 0 );
-var _one = new Vector3( 1, 1, 1 );
-var _x = new Vector3();
-var _y = new Vector3();
-var _z = new Vector3();
-
 /**
  * @author mrdoob / http://mrdoob.com/
  * @author supereggbert / http://www.paulbrunt.co.uk/
@@ -20,31 +12,26 @@ var _z = new Vector3();
  * @author bhouston / http://clara.io
  * @author WestLangley / http://github.com/WestLangley
  */
+class Matrix4 {
 
-function Matrix4() {
+	constructor() {
 
-	this.elements = [
+		this.isMatrix4 = true;
+		this.elements = [
+			1, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 1, 0,
+			0, 0, 0, 1
+		];
+		if ( arguments.length > 0 ) {
 
-		1, 0, 0, 0,
-		0, 1, 0, 0,
-		0, 0, 1, 0,
-		0, 0, 0, 1
+			console.error( 'THREE.Matrix4: the constructor no longer reads arguments. use .set() instead.' );
 
-	];
-
-	if ( arguments.length > 0 ) {
-
-		console.error( 'THREE.Matrix4: the constructor no longer reads arguments. use .set() instead.' );
+		}
 
 	}
 
-}
-
-Object.assign( Matrix4.prototype, {
-
-	isMatrix4: true,
-
-	set: function ( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 ) {
+	set( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 ) {
 
 		var te = this.elements;
 
@@ -55,9 +42,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	identity: function () {
+	identity() {
 
 		this.set(
 
@@ -70,15 +57,15 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
 		return new Matrix4().fromArray( this.elements );
 
-	},
+	}
 
-	copy: function ( m ) {
+	copy( m ) {
 
 		var te = this.elements;
 		var me = m.elements;
@@ -90,9 +77,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyPosition: function ( m ) {
+	copyPosition( m ) {
 
 		var te = this.elements, me = m.elements;
 
@@ -102,9 +89,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	extractBasis: function ( xAxis, yAxis, zAxis ) {
+	extractBasis( xAxis, yAxis, zAxis ) {
 
 		xAxis.setFromMatrixColumn( this, 0 );
 		yAxis.setFromMatrixColumn( this, 1 );
@@ -112,9 +99,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeBasis: function ( xAxis, yAxis, zAxis ) {
+	makeBasis( xAxis, yAxis, zAxis ) {
 
 		this.set(
 			xAxis.x, yAxis.x, zAxis.x, 0,
@@ -125,9 +112,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	extractRotation: function ( m ) {
+	extractRotation( m ) {
 
 		// this method does not support reflection matrices
 
@@ -160,9 +147,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationFromEuler: function ( euler ) {
+	makeRotationFromEuler( euler ) {
 
 		if ( ! ( euler && euler.isEuler ) ) {
 
@@ -288,15 +275,15 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationFromQuaternion: function ( q ) {
+	makeRotationFromQuaternion( q ) {
 
 		return this.compose( _zero, q, _one );
 
-	},
+	}
 
-	lookAt: function ( eye, target, up ) {
+	lookAt( eye, target, up ) {
 
 		var te = this.elements;
 
@@ -341,9 +328,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( m, n ) {
+	multiply( m, n ) {
 
 		if ( n !== undefined ) {
 
@@ -354,15 +341,15 @@ Object.assign( Matrix4.prototype, {
 
 		return this.multiplyMatrices( this, m );
 
-	},
+	}
 
-	premultiply: function ( m ) {
+	premultiply( m ) {
 
 		return this.multiplyMatrices( m, this );
 
-	},
+	}
 
-	multiplyMatrices: function ( a, b ) {
+	multiplyMatrices( a, b ) {
 
 		var ae = a.elements;
 		var be = b.elements;
@@ -400,9 +387,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( s ) {
+	multiplyScalar( s ) {
 
 		var te = this.elements;
 
@@ -413,9 +400,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	determinant: function () {
+	determinant() {
 
 		var te = this.elements;
 
@@ -463,9 +450,9 @@ Object.assign( Matrix4.prototype, {
 
 		);
 
-	},
+	}
 
-	transpose: function () {
+	transpose() {
 
 		var te = this.elements;
 		var tmp;
@@ -480,9 +467,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setPosition: function ( x, y, z ) {
+	setPosition( x, y, z ) {
 
 		var te = this.elements;
 
@@ -502,9 +489,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getInverse: function ( m, throwOnDegenerate ) {
+	getInverse( m, throwOnDegenerate ) {
 
 		// based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 		var te = this.elements,
@@ -564,9 +551,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	scale: function ( v ) {
+	scale( v ) {
 
 		var te = this.elements;
 		var x = v.x, y = v.y, z = v.z;
@@ -578,9 +565,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getMaxScaleOnAxis: function () {
+	getMaxScaleOnAxis() {
 
 		var te = this.elements;
 
@@ -590,9 +577,9 @@ Object.assign( Matrix4.prototype, {
 
 		return Math.sqrt( Math.max( scaleXSq, scaleYSq, scaleZSq ) );
 
-	},
+	}
 
-	makeTranslation: function ( x, y, z ) {
+	makeTranslation( x, y, z ) {
 
 		this.set(
 
@@ -605,9 +592,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationX: function ( theta ) {
+	makeRotationX( theta ) {
 
 		var c = Math.cos( theta ), s = Math.sin( theta );
 
@@ -622,9 +609,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationY: function ( theta ) {
+	makeRotationY( theta ) {
 
 		var c = Math.cos( theta ), s = Math.sin( theta );
 
@@ -639,9 +626,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationZ: function ( theta ) {
+	makeRotationZ( theta ) {
 
 		var c = Math.cos( theta ), s = Math.sin( theta );
 
@@ -656,9 +643,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeRotationAxis: function ( axis, angle ) {
+	makeRotationAxis( axis, angle ) {
 
 		// Based on http://www.gamedev.net/reference/articles/article1199.asp
 
@@ -679,9 +666,9 @@ Object.assign( Matrix4.prototype, {
 
 		 return this;
 
-	},
+	}
 
-	makeScale: function ( x, y, z ) {
+	makeScale( x, y, z ) {
 
 		this.set(
 
@@ -694,9 +681,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeShear: function ( x, y, z ) {
+	makeShear( x, y, z ) {
 
 		this.set(
 
@@ -709,9 +696,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	compose: function ( position, quaternion, scale ) {
+	compose( position, quaternion, scale ) {
 
 		var te = this.elements;
 
@@ -745,9 +732,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	decompose: function ( position, quaternion, scale ) {
+	decompose( position, quaternion, scale ) {
 
 		var te = this.elements;
 
@@ -790,9 +777,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makePerspective: function ( left, right, top, bottom, near, far ) {
+	makePerspective( left, right, top, bottom, near, far ) {
 
 		if ( far === undefined ) {
 
@@ -816,9 +803,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	makeOrthographic: function ( left, right, top, bottom, near, far ) {
+	makeOrthographic( left, right, top, bottom, near, far ) {
 
 		var te = this.elements;
 		var w = 1.0 / ( right - left );
@@ -836,9 +823,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( matrix ) {
+	equals( matrix ) {
 
 		var te = this.elements;
 		var me = matrix.elements;
@@ -851,9 +838,9 @@ Object.assign( Matrix4.prototype, {
 
 		return true;
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -865,9 +852,9 @@ Object.assign( Matrix4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -898,7 +885,14 @@ Object.assign( Matrix4.prototype, {
 
 	}
 
-} );
+}
 
+var _v1 = new Vector3();
+var _m1 = new Matrix4();
+var _zero = new Vector3( 0, 0, 0 );
+var _one = new Vector3( 1, 1, 1 );
+var _x = new Vector3();
+var _y = new Vector3();
+var _z = new Vector3();
 
 export { Matrix4 };

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -9,47 +9,45 @@ var _vector1 = new Vector3();
 var _vector2 = new Vector3();
 var _normalMatrix = new Matrix3();
 
-function Plane( normal, constant ) {
+class Plane {
 
-	// normal is assumed to be normalized
+	constructor( normal, constant ) {
 
-	this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
-	this.constant = ( constant !== undefined ) ? constant : 0;
+		this.isPlane = true;
+		// normal is assumed to be normalized
+		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
+		this.constant = ( constant !== undefined ) ? constant : 0;
 
-}
+	}
 
-Object.assign( Plane.prototype, {
-
-	isPlane: true,
-
-	set: function ( normal, constant ) {
+	set( normal, constant ) {
 
 		this.normal.copy( normal );
 		this.constant = constant;
 
 		return this;
 
-	},
+	}
 
-	setComponents: function ( x, y, z, w ) {
+	setComponents( x, y, z, w ) {
 
 		this.normal.set( x, y, z );
 		this.constant = w;
 
 		return this;
 
-	},
+	}
 
-	setFromNormalAndCoplanarPoint: function ( normal, point ) {
+	setFromNormalAndCoplanarPoint( normal, point ) {
 
 		this.normal.copy( normal );
 		this.constant = - point.dot( this.normal );
 
 		return this;
 
-	},
+	}
 
-	setFromCoplanarPoints: function ( a, b, c ) {
+	setFromCoplanarPoints( a, b, c ) {
 
 		var normal = _vector1.subVectors( c, b ).cross( _vector2.subVectors( a, b ) ).normalize();
 
@@ -59,24 +57,24 @@ Object.assign( Plane.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Plane( this.normal, this.constant );
 
-	},
+	}
 
-	copy: function ( plane ) {
+	copy( plane ) {
 
 		this.normal.copy( plane.normal );
 		this.constant = plane.constant;
 
 		return this;
 
-	},
+	}
 
-	normalize: function () {
+	normalize() {
 
 		// Note: will lead to a divide by zero if the plane is invalid.
 
@@ -86,30 +84,30 @@ Object.assign( Plane.prototype, {
 
 		return this;
 
-	},
+	}
 
-	negate: function () {
+	negate() {
 
 		this.constant *= - 1;
 		this.normal.negate();
 
 		return this;
 
-	},
+	}
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint( point ) {
 
 		return this.normal.dot( point ) + this.constant;
 
-	},
+	}
 
-	distanceToSphere: function ( sphere ) {
+	distanceToSphere( sphere ) {
 
 		return this.distanceToPoint( sphere.center ) - sphere.radius;
 
-	},
+	}
 
-	projectPoint: function ( point, target ) {
+	projectPoint( point, target ) {
 
 		if ( target === undefined ) {
 
@@ -120,9 +118,9 @@ Object.assign( Plane.prototype, {
 
 		return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
 
-	},
+	}
 
-	intersectLine: function ( line, target ) {
+	intersectLine( line, target ) {
 
 		if ( target === undefined ) {
 
@@ -159,9 +157,9 @@ Object.assign( Plane.prototype, {
 
 		return target.copy( direction ).multiplyScalar( t ).add( line.start );
 
-	},
+	}
 
-	intersectsLine: function ( line ) {
+	intersectsLine( line ) {
 
 		// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
 
@@ -170,21 +168,21 @@ Object.assign( Plane.prototype, {
 
 		return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		return box.intersectsPlane( this );
 
-	},
+	}
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere( sphere ) {
 
 		return sphere.intersectsPlane( this );
 
-	},
+	}
 
-	coplanarPoint: function ( target ) {
+	coplanarPoint( target ) {
 
 		if ( target === undefined ) {
 
@@ -195,9 +193,9 @@ Object.assign( Plane.prototype, {
 
 		return target.copy( this.normal ).multiplyScalar( - this.constant );
 
-	},
+	}
 
-	applyMatrix4: function ( matrix, optionalNormalMatrix ) {
+	applyMatrix4( matrix, optionalNormalMatrix ) {
 
 		var normalMatrix = optionalNormalMatrix || _normalMatrix.getNormalMatrix( matrix );
 
@@ -209,23 +207,23 @@ Object.assign( Plane.prototype, {
 
 		return this;
 
-	},
+	}
 
-	translate: function ( offset ) {
+	translate( offset ) {
 
 		this.constant -= offset.dot( this.normal );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( plane ) {
+	equals( plane ) {
 
 		return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
 
 	}
 
-} );
+}
 
 
 export { Plane };

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -7,24 +7,77 @@
 
 import { MathUtils } from './MathUtils.js';
 
-function Quaternion( x, y, z, w ) {
+class Quaternion {
 
-	this._x = x || 0;
-	this._y = y || 0;
-	this._z = z || 0;
-	this._w = ( w !== undefined ) ? w : 1;
+	constructor( x, y, z, w ) {
 
-}
+		this.isQuaternion = true;
+		this._x = x || 0;
+		this._y = y || 0;
+		this._z = z || 0;
+		this._w = ( w !== undefined ) ? w : 1;
 
-Object.assign( Quaternion, {
+	}
 
-	slerp: function ( qa, qb, qm, t ) {
+	get x() {
+
+		return this._x;
+
+	}
+
+	set x( value ) {
+
+		this._x = value;
+		this._onChangeCallback();
+
+	}
+
+	get y() {
+
+		return this._y;
+
+	}
+
+	set y( value ) {
+
+		this._y = value;
+		this._onChangeCallback();
+
+	}
+
+	get z() {
+
+		return this._z;
+
+	}
+
+	set z( value ) {
+
+		this._z = value;
+		this._onChangeCallback();
+
+	}
+
+	get w() {
+
+		return this._w;
+
+	}
+
+	set w( value ) {
+
+		this._w = value;
+		this._onChangeCallback();
+
+	}
+
+	slerp( qa, qb, qm, t ) {
 
 		return qm.copy( qa ).slerp( qb, t );
 
-	},
+	}
 
-	slerpFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
+	static slerpFlat( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
 
 		// fuzz-free, array-based Quaternion SLERP operation
 
@@ -86,85 +139,7 @@ Object.assign( Quaternion, {
 
 	}
 
-} );
-
-Object.defineProperties( Quaternion.prototype, {
-
-	x: {
-
-		get: function () {
-
-			return this._x;
-
-		},
-
-		set: function ( value ) {
-
-			this._x = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	y: {
-
-		get: function () {
-
-			return this._y;
-
-		},
-
-		set: function ( value ) {
-
-			this._y = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	z: {
-
-		get: function () {
-
-			return this._z;
-
-		},
-
-		set: function ( value ) {
-
-			this._z = value;
-			this._onChangeCallback();
-
-		}
-
-	},
-
-	w: {
-
-		get: function () {
-
-			return this._w;
-
-		},
-
-		set: function ( value ) {
-
-			this._w = value;
-			this._onChangeCallback();
-
-		}
-
-	}
-
-} );
-
-Object.assign( Quaternion.prototype, {
-
-	isQuaternion: true,
-
-	set: function ( x, y, z, w ) {
+	set( x, y, z, w ) {
 
 		this._x = x;
 		this._y = y;
@@ -175,15 +150,15 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this._x, this._y, this._z, this._w );
+		return new Quaternion( this._x, this._y, this._z, this._w );
 
-	},
+	}
 
-	copy: function ( quaternion ) {
+	copy( quaternion ) {
 
 		this._x = quaternion.x;
 		this._y = quaternion.y;
@@ -194,9 +169,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromEuler: function ( euler, update ) {
+	setFromEuler( euler, update ) {
 
 		if ( ! ( euler && euler.isEuler ) ) {
 
@@ -269,9 +244,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromAxisAngle: function ( axis, angle ) {
+	setFromAxisAngle( axis, angle ) {
 
 		// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
 
@@ -288,9 +263,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromRotationMatrix: function ( m ) {
+	setFromRotationMatrix( m ) {
 
 		// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
 
@@ -347,9 +322,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromUnitVectors: function ( vFrom, vTo ) {
+	setFromUnitVectors( vFrom, vTo ) {
 
 		// assumes direction vectors vFrom and vTo are normalized
 
@@ -390,15 +365,15 @@ Object.assign( Quaternion.prototype, {
 
 		return this.normalize();
 
-	},
+	}
 
-	angleTo: function ( q ) {
+	angleTo( q ) {
 
 		return 2 * Math.acos( Math.abs( MathUtils.clamp( this.dot( q ), - 1, 1 ) ) );
 
-	},
+	}
 
-	rotateTowards: function ( q, step ) {
+	rotateTowards( q, step ) {
 
 		var angle = this.angleTo( q );
 
@@ -410,17 +385,17 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	inverse: function () {
+	inverse() {
 
 		// quaternion is assumed to have unit length
 
 		return this.conjugate();
 
-	},
+	}
 
-	conjugate: function () {
+	conjugate() {
 
 		this._x *= - 1;
 		this._y *= - 1;
@@ -430,27 +405,27 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	dot: function ( v ) {
+	dot( v ) {
 
 		return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
 
-	},
+	}
 
-	lengthSq: function () {
+	lengthSq() {
 
 		return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
 
-	},
+	}
 
-	length: function () {
+	length() {
 
 		return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
 
-	},
+	}
 
-	normalize: function () {
+	normalize() {
 
 		var l = this.length();
 
@@ -476,9 +451,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( q, p ) {
+	multiply( q, p ) {
 
 		if ( p !== undefined ) {
 
@@ -489,15 +464,15 @@ Object.assign( Quaternion.prototype, {
 
 		return this.multiplyQuaternions( this, q );
 
-	},
+	}
 
-	premultiply: function ( q ) {
+	premultiply( q ) {
 
 		return this.multiplyQuaternions( q, this );
 
-	},
+	}
 
-	multiplyQuaternions: function ( a, b ) {
+	multiplyQuaternions( a, b ) {
 
 		// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
 
@@ -513,9 +488,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	slerp: function ( qb, t ) {
+	slerp( qb, t ) {
 
 		if ( t === 0 ) return this;
 		if ( t === 1 ) return this.copy( qb );
@@ -583,15 +558,15 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( quaternion ) {
+	equals( quaternion ) {
 
 		return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -604,9 +579,9 @@ Object.assign( Quaternion.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -618,19 +593,19 @@ Object.assign( Quaternion.prototype, {
 
 		return array;
 
-	},
+	}
 
-	_onChange: function ( callback ) {
+	_onChange( callback ) {
 
 		this._onChangeCallback = callback;
 
 		return this;
 
-	},
+	}
 
-	_onChangeCallback: function () {}
+	_onChangeCallback() {}
 
-} );
+}
 
 
 export { Quaternion };

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -12,41 +12,40 @@ var _normal = new Vector3();
 /**
  * @author bhouston / http://clara.io
  */
+class Ray {
 
-function Ray( origin, direction ) {
+	constructor( origin, direction ) {
 
-	this.origin = ( origin !== undefined ) ? origin : new Vector3();
-	this.direction = ( direction !== undefined ) ? direction : new Vector3( 0, 0, - 1 );
+		this.origin = ( origin !== undefined ) ? origin : new Vector3();
+		this.direction = ( direction !== undefined ) ? direction : new Vector3( 0, 0, - 1 );
 
-}
+	}
 
-Object.assign( Ray.prototype, {
-
-	set: function ( origin, direction ) {
+	set( origin, direction ) {
 
 		this.origin.copy( origin );
 		this.direction.copy( direction );
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Ray( this.origin, this.direction );
 
-	},
+	}
 
-	copy: function ( ray ) {
+	copy( ray ) {
 
 		this.origin.copy( ray.origin );
 		this.direction.copy( ray.direction );
 
 		return this;
 
-	},
+	}
 
-	at: function ( t, target ) {
+	at( t, target ) {
 
 		if ( target === undefined ) {
 
@@ -57,25 +56,25 @@ Object.assign( Ray.prototype, {
 
 		return target.copy( this.direction ).multiplyScalar( t ).add( this.origin );
 
-	},
+	}
 
-	lookAt: function ( v ) {
+	lookAt( v ) {
 
 		this.direction.copy( v ).sub( this.origin ).normalize();
 
 		return this;
 
-	},
+	}
 
-	recast: function ( t ) {
+	recast( t ) {
 
 		this.origin.copy( this.at( t, _vector ) );
 
 		return this;
 
-	},
+	}
 
-	closestPointToPoint: function ( point, target ) {
+	closestPointToPoint( point, target ) {
 
 		if ( target === undefined ) {
 
@@ -96,15 +95,15 @@ Object.assign( Ray.prototype, {
 
 		return target.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
-	},
+	}
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint( point ) {
 
 		return Math.sqrt( this.distanceSqToPoint( point ) );
 
-	},
+	}
 
-	distanceSqToPoint: function ( point ) {
+	distanceSqToPoint( point ) {
 
 		var directionDistance = _vector.subVectors( point, this.origin ).dot( this.direction );
 
@@ -120,9 +119,9 @@ Object.assign( Ray.prototype, {
 
 		return _vector.distanceToSquared( point );
 
-	},
+	}
 
-	distanceSqToSegment: function ( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+	distanceSqToSegment( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
 
 		// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
 		// It returns the min distance between the ray and the segment
@@ -239,9 +238,9 @@ Object.assign( Ray.prototype, {
 
 		return sqrDist;
 
-	},
+	}
 
-	intersectSphere: function ( sphere, target ) {
+	intersectSphere( sphere, target ) {
 
 		_vector.subVectors( sphere.center, this.origin );
 		var tca = _vector.dot( this.direction );
@@ -269,15 +268,15 @@ Object.assign( Ray.prototype, {
 		// else t0 is in front of the ray, so return the first collision point scaled by t0
 		return this.at( t0, target );
 
-	},
+	}
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere( sphere ) {
 
 		return this.distanceSqToPoint( sphere.center ) <= ( sphere.radius * sphere.radius );
 
-	},
+	}
 
-	distanceToPlane: function ( plane ) {
+	distanceToPlane( plane ) {
 
 		var denominator = plane.normal.dot( this.direction );
 
@@ -302,9 +301,9 @@ Object.assign( Ray.prototype, {
 
 		return t >= 0 ? t : null;
 
-	},
+	}
 
-	intersectPlane: function ( plane, target ) {
+	intersectPlane( plane, target ) {
 
 		var t = this.distanceToPlane( plane );
 
@@ -316,9 +315,9 @@ Object.assign( Ray.prototype, {
 
 		return this.at( t, target );
 
-	},
+	}
 
-	intersectsPlane: function ( plane ) {
+	intersectsPlane( plane ) {
 
 		// check if the ray lies on the plane first
 
@@ -342,9 +341,9 @@ Object.assign( Ray.prototype, {
 
 		return false;
 
-	},
+	}
 
-	intersectBox: function ( box, target ) {
+	intersectBox( box, target ) {
 
 		var tmin, tmax, tymin, tymax, tzmin, tzmax;
 
@@ -411,15 +410,15 @@ Object.assign( Ray.prototype, {
 
 		return this.at( tmin >= 0 ? tmin : tmax, target );
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		return this.intersectBox( box, _vector ) !== null;
 
-	},
+	}
 
-	intersectTriangle: function ( a, b, c, backfaceCulling, target ) {
+	intersectTriangle( a, b, c, backfaceCulling, target ) {
 
 		// Compute the offset origin, edges, and normal.
 
@@ -492,24 +491,23 @@ Object.assign( Ray.prototype, {
 		// Ray intersects triangle.
 		return this.at( QdN / DdN, target );
 
-	},
+	}
 
-	applyMatrix4: function ( matrix4 ) {
+	applyMatrix4( matrix4 ) {
 
 		this.origin.applyMatrix4( matrix4 );
 		this.direction.transformDirection( matrix4 );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( ray ) {
+	equals( ray ) {
 
 		return ray.origin.equals( this.origin ) && ray.direction.equals( this.direction );
 
 	}
 
-} );
-
+}
 
 export { Ray };

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -7,26 +7,25 @@ var _box = new Box3();
  * @author bhouston / http://clara.io
  * @author mrdoob / http://mrdoob.com/
  */
+class Sphere {
 
-function Sphere( center, radius ) {
+	constructor( center, radius ) {
 
-	this.center = ( center !== undefined ) ? center : new Vector3();
-	this.radius = ( radius !== undefined ) ? radius : 0;
+		this.center = ( center !== undefined ) ? center : new Vector3();
+		this.radius = ( radius !== undefined ) ? radius : 0;
 
-}
+	}
 
-Object.assign( Sphere.prototype, {
-
-	set: function ( center, radius ) {
+	set( center, radius ) {
 
 		this.center.copy( center );
 		this.radius = radius;
 
 		return this;
 
-	},
+	}
 
-	setFromPoints: function ( points, optionalCenter ) {
+	setFromPoints( points, optionalCenter ) {
 
 		var center = this.center;
 
@@ -52,62 +51,62 @@ Object.assign( Sphere.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Sphere( this.center, this.radius );
 
-	},
+	}
 
-	copy: function ( sphere ) {
+	copy( sphere ) {
 
 		this.center.copy( sphere.center );
 		this.radius = sphere.radius;
 
 		return this;
 
-	},
+	}
 
-	empty: function () {
+	empty() {
 
 		return ( this.radius <= 0 );
 
-	},
+	}
 
-	containsPoint: function ( point ) {
+	containsPoint( point ) {
 
 		return ( point.distanceToSquared( this.center ) <= ( this.radius * this.radius ) );
 
-	},
+	}
 
-	distanceToPoint: function ( point ) {
+	distanceToPoint( point ) {
 
 		return ( point.distanceTo( this.center ) - this.radius );
 
-	},
+	}
 
-	intersectsSphere: function ( sphere ) {
+	intersectsSphere( sphere ) {
 
 		var radiusSum = this.radius + sphere.radius;
 
 		return sphere.center.distanceToSquared( this.center ) <= ( radiusSum * radiusSum );
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		return box.intersectsSphere( this );
 
-	},
+	}
 
-	intersectsPlane: function ( plane ) {
+	intersectsPlane( plane ) {
 
 		return Math.abs( plane.distanceToPoint( this.center ) ) <= this.radius;
 
-	},
+	}
 
-	clampPoint: function ( point, target ) {
+	clampPoint( point, target ) {
 
 		var deltaLengthSq = this.center.distanceToSquared( point );
 
@@ -129,9 +128,9 @@ Object.assign( Sphere.prototype, {
 
 		return target;
 
-	},
+	}
 
-	getBoundingBox: function ( target ) {
+	getBoundingBox( target ) {
 
 		if ( target === undefined ) {
 
@@ -145,32 +144,31 @@ Object.assign( Sphere.prototype, {
 
 		return target;
 
-	},
+	}
 
-	applyMatrix4: function ( matrix ) {
+	applyMatrix4( matrix ) {
 
 		this.center.applyMatrix4( matrix );
 		this.radius = this.radius * matrix.getMaxScaleOnAxis();
 
 		return this;
 
-	},
+	}
 
-	translate: function ( offset ) {
+	translate( offset ) {
 
 		this.center.add( offset );
 
 		return this;
 
-	},
+	}
 
-	equals: function ( sphere ) {
+	equals( sphere ) {
 
 		return sphere.center.equals( this.center ) && ( sphere.radius === this.radius );
 
 	}
 
-} );
-
+}
 
 export { Sphere };

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -9,20 +9,18 @@ import { MathUtils } from './MathUtils.js';
  * The polar angle (phi) is measured from the positive y-axis. The positive y-axis is up.
  * The azimuthal angle (theta) is measured from the positive z-axis.
  */
+class Spherical {
 
-function Spherical( radius, phi, theta ) {
+	constructor( radius, phi, theta ) {
 
-	this.radius = ( radius !== undefined ) ? radius : 1.0;
-	this.phi = ( phi !== undefined ) ? phi : 0; // polar angle
-	this.theta = ( theta !== undefined ) ? theta : 0; // azimuthal angle
+		this.radius = ( radius !== undefined ) ? radius : 1.0;
+		this.phi = ( phi !== undefined ) ? phi : 0; // polar angle
+		this.theta = ( theta !== undefined ) ? theta : 0; // azimuthal angle
+		return this;
 
-	return this;
+	}
 
-}
-
-Object.assign( Spherical.prototype, {
-
-	set: function ( radius, phi, theta ) {
+	set( radius, phi, theta ) {
 
 		this.radius = radius;
 		this.phi = phi;
@@ -30,15 +28,15 @@ Object.assign( Spherical.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Spherical( this.radius, this.phi, this.theta );
 
-	},
+	}
 
-	copy: function ( other ) {
+	copy( other ) {
 
 		this.radius = other.radius;
 		this.phi = other.phi;
@@ -46,25 +44,25 @@ Object.assign( Spherical.prototype, {
 
 		return this;
 
-	},
+	}
 
 	// restrict phi to be betwee EPS and PI-EPS
-	makeSafe: function () {
+	makeSafe() {
 
 		var EPS = 0.000001;
 		this.phi = Math.max( EPS, Math.min( Math.PI - EPS, this.phi ) );
 
 		return this;
 
-	},
+	}
 
-	setFromVector3: function ( v ) {
+	setFromVector3( v ) {
 
 		return this.setFromCartesianCoords( v.x, v.y, v.z );
 
-	},
+	}
 
-	setFromCartesianCoords: function ( x, y, z ) {
+	setFromCartesianCoords( x, y, z ) {
 
 		this.radius = Math.sqrt( x * x + y * y + z * z );
 
@@ -84,7 +82,6 @@ Object.assign( Spherical.prototype, {
 
 	}
 
-} );
-
+}
 
 export { Spherical };

--- a/src/math/SphericalHarmonics3.js
+++ b/src/math/SphericalHarmonics3.js
@@ -10,26 +10,22 @@ import { Vector3 } from './Vector3.js';
  * Secondary reference:
  *   https://www.ppsloan.org/publications/StupidSH36.pdf
  */
-
 // 3-band SH defined by 9 coefficients
+class SphericalHarmonics3 {
 
-function SphericalHarmonics3() {
+	constructor() {
 
-	this.coefficients = [];
+		this.isSphericalHarmonics3 = true;
+		this.coefficients = [];
+		for ( var i = 0; i < 9; i ++ ) {
 
-	for ( var i = 0; i < 9; i ++ ) {
+			this.coefficients.push( new Vector3() );
 
-		this.coefficients.push( new Vector3() );
+		}
 
 	}
 
-}
-
-Object.assign( SphericalHarmonics3.prototype, {
-
-	isSphericalHarmonics3: true,
-
-	set: function ( coefficients ) {
+	set( coefficients ) {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -39,9 +35,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	zero: function () {
+	zero() {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -51,11 +47,11 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
 	// get the radiance in the direction of the normal
 	// target is a Vector3
-	getAt: function ( normal, target ) {
+	getAt( normal, target ) {
 
 		// normal is assumed to be unit length
 
@@ -80,12 +76,12 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return target;
 
-	},
+	}
 
 	// get the irradiance (radiance convolved with cosine lobe) in the direction of the normal
 	// target is a Vector3
 	// https://graphics.stanford.edu/papers/envmap/envmap.pdf
-	getIrradianceAt: function ( normal, target ) {
+	getIrradianceAt( normal, target ) {
 
 		// normal is assumed to be unit length
 
@@ -110,9 +106,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return target;
 
-	},
+	}
 
-	add: function ( sh ) {
+	add( sh ) {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -122,10 +118,10 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
 
-	scale: function ( s ) {
+	scale( s ) {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -135,9 +131,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerp: function ( sh, alpha ) {
+	lerp( sh, alpha ) {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -147,9 +143,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( sh ) {
+	equals( sh ) {
 
 		for ( var i = 0; i < 9; i ++ ) {
 
@@ -163,21 +159,21 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return true;
 
-	},
+	}
 
-	copy: function ( sh ) {
+	copy( sh ) {
 
 		return this.set( sh.coefficients );
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new SphericalHarmonics3().copy( this );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -191,9 +187,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -210,13 +206,9 @@ Object.assign( SphericalHarmonics3.prototype, {
 
 	}
 
-} );
-
-Object.assign( SphericalHarmonics3, {
-
 	// evaluate the basis functions
 	// shBasis is an Array[ 9 ]
-	getBasisAt: function ( normal, shBasis ) {
+	getBasisAt( normal, shBasis ) {
 
 		// normal is assumed to be unit length
 
@@ -239,6 +231,6 @@ Object.assign( SphericalHarmonics3, {
 
 	}
 
-} );
+}
 
 export { SphericalHarmonics3 };

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -18,117 +18,17 @@ var _vap = new Vector3();
 var _vbp = new Vector3();
 var _vcp = new Vector3();
 
-function Triangle( a, b, c ) {
+class Triangle {
 
-	this.a = ( a !== undefined ) ? a : new Vector3();
-	this.b = ( b !== undefined ) ? b : new Vector3();
-	this.c = ( c !== undefined ) ? c : new Vector3();
+	constructor( a, b, c ) {
 
-}
-
-Object.assign( Triangle, {
-
-	getNormal: function ( a, b, c, target ) {
-
-		if ( target === undefined ) {
-
-			console.warn( 'THREE.Triangle: .getNormal() target is now required' );
-			target = new Vector3();
-
-		}
-
-		target.subVectors( c, b );
-		_v0.subVectors( a, b );
-		target.cross( _v0 );
-
-		var targetLengthSq = target.lengthSq();
-		if ( targetLengthSq > 0 ) {
-
-			return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
-
-		}
-
-		return target.set( 0, 0, 0 );
-
-	},
-
-	// static/instance method to calculate barycentric coordinates
-	// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-	getBarycoord: function ( point, a, b, c, target ) {
-
-		_v0.subVectors( c, a );
-		_v1.subVectors( b, a );
-		_v2.subVectors( point, a );
-
-		var dot00 = _v0.dot( _v0 );
-		var dot01 = _v0.dot( _v1 );
-		var dot02 = _v0.dot( _v2 );
-		var dot11 = _v1.dot( _v1 );
-		var dot12 = _v1.dot( _v2 );
-
-		var denom = ( dot00 * dot11 - dot01 * dot01 );
-
-		if ( target === undefined ) {
-
-			console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
-			target = new Vector3();
-
-		}
-
-		// collinear or singular triangle
-		if ( denom === 0 ) {
-
-			// arbitrary location outside of triangle?
-			// not sure if this is the best idea, maybe should be returning undefined
-			return target.set( - 2, - 1, - 1 );
-
-		}
-
-		var invDenom = 1 / denom;
-		var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
-		var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
-
-		// barycentric coordinates must always sum to 1
-		return target.set( 1 - u - v, v, u );
-
-	},
-
-	containsPoint: function ( point, a, b, c ) {
-
-		Triangle.getBarycoord( point, a, b, c, _v3 );
-
-		return ( _v3.x >= 0 ) && ( _v3.y >= 0 ) && ( ( _v3.x + _v3.y ) <= 1 );
-
-	},
-
-	getUV: function ( point, p1, p2, p3, uv1, uv2, uv3, target ) {
-
-		this.getBarycoord( point, p1, p2, p3, _v3 );
-
-		target.set( 0, 0 );
-		target.addScaledVector( uv1, _v3.x );
-		target.addScaledVector( uv2, _v3.y );
-		target.addScaledVector( uv3, _v3.z );
-
-		return target;
-
-	},
-
-	isFrontFacing: function ( a, b, c, direction ) {
-
-		_v0.subVectors( c, b );
-		_v1.subVectors( a, b );
-
-		// strictly front facing
-		return ( _v0.cross( _v1 ).dot( direction ) < 0 ) ? true : false;
+		this.a = ( a !== undefined ) ? a : new Vector3();
+		this.b = ( b !== undefined ) ? b : new Vector3();
+		this.c = ( c !== undefined ) ? c : new Vector3();
 
 	}
 
-} );
-
-Object.assign( Triangle.prototype, {
-
-	set: function ( a, b, c ) {
+	set( a, b, c ) {
 
 		this.a.copy( a );
 		this.b.copy( b );
@@ -136,9 +36,9 @@ Object.assign( Triangle.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromPointsAndIndices: function ( points, i0, i1, i2 ) {
+	setFromPointsAndIndices( points, i0, i1, i2 ) {
 
 		this.a.copy( points[ i0 ] );
 		this.b.copy( points[ i1 ] );
@@ -146,15 +46,15 @@ Object.assign( Triangle.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new Triangle( this.a, this.b, this.c );
 
-	},
+	}
 
-	copy: function ( triangle ) {
+	copy( triangle ) {
 
 		this.a.copy( triangle.a );
 		this.b.copy( triangle.b );
@@ -162,18 +62,18 @@ Object.assign( Triangle.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getArea: function () {
+	getArea() {
 
 		_v0.subVectors( this.c, this.b );
 		_v1.subVectors( this.a, this.b );
 
 		return _v0.cross( _v1 ).length() * 0.5;
 
-	},
+	}
 
-	getMidpoint: function ( target ) {
+	getMidpoint( target ) {
 
 		if ( target === undefined ) {
 
@@ -184,15 +84,15 @@ Object.assign( Triangle.prototype, {
 
 		return target.addVectors( this.a, this.b ).add( this.c ).multiplyScalar( 1 / 3 );
 
-	},
+	}
 
-	getNormal: function ( target ) {
+	getNormal( target ) {
 
 		return Triangle.getNormal( this.a, this.b, this.c, target );
 
-	},
+	}
 
-	getPlane: function ( target ) {
+	getPlane( target ) {
 
 		if ( target === undefined ) {
 
@@ -203,39 +103,39 @@ Object.assign( Triangle.prototype, {
 
 		return target.setFromCoplanarPoints( this.a, this.b, this.c );
 
-	},
+	}
 
-	getBarycoord: function ( point, target ) {
+	getBarycoord( point, target ) {
 
 		return Triangle.getBarycoord( point, this.a, this.b, this.c, target );
 
-	},
+	}
 
-	getUV: function ( point, uv1, uv2, uv3, target ) {
+	getUV( point, uv1, uv2, uv3, target ) {
 
 		return Triangle.getUV( point, this.a, this.b, this.c, uv1, uv2, uv3, target );
 
-	},
+	}
 
-	containsPoint: function ( point ) {
+	containsPoint( point ) {
 
 		return Triangle.containsPoint( point, this.a, this.b, this.c );
 
-	},
+	}
 
-	isFrontFacing: function ( direction ) {
+	isFrontFacing( direction ) {
 
 		return Triangle.isFrontFacing( this.a, this.b, this.c, direction );
 
-	},
+	}
 
-	intersectsBox: function ( box ) {
+	intersectsBox( box ) {
 
 		return box.intersectsTriangle( this );
 
-	},
+	}
 
-	closestPointToPoint: function ( p, target ) {
+	closestPointToPoint( p, target ) {
 
 		if ( target === undefined ) {
 
@@ -321,15 +221,110 @@ Object.assign( Triangle.prototype, {
 
 		return target.copy( a ).addScaledVector( _vab, v ).addScaledVector( _vac, w );
 
-	},
+	}
 
-	equals: function ( triangle ) {
+	equals( triangle ) {
 
 		return triangle.a.equals( this.a ) && triangle.b.equals( this.b ) && triangle.c.equals( this.c );
 
 	}
 
-} );
+	static getNormal( a, b, c, target ) {
 
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Triangle: .getNormal() target is now required' );
+			target = new Vector3();
+
+		}
+
+		target.subVectors( c, b );
+		_v0.subVectors( a, b );
+		target.cross( _v0 );
+
+		var targetLengthSq = target.lengthSq();
+		if ( targetLengthSq > 0 ) {
+
+			return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
+
+		}
+
+		return target.set( 0, 0, 0 );
+
+	}
+
+	// static/instance method to calculate barycentric coordinates
+	// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
+	static getBarycoord( point, a, b, c, target ) {
+
+		_v0.subVectors( c, a );
+		_v1.subVectors( b, a );
+		_v2.subVectors( point, a );
+
+		var dot00 = _v0.dot( _v0 );
+		var dot01 = _v0.dot( _v1 );
+		var dot02 = _v0.dot( _v2 );
+		var dot11 = _v1.dot( _v1 );
+		var dot12 = _v1.dot( _v2 );
+
+		var denom = ( dot00 * dot11 - dot01 * dot01 );
+
+		if ( target === undefined ) {
+
+			console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
+			target = new Vector3();
+
+		}
+
+		// collinear or singular triangle
+		if ( denom === 0 ) {
+
+			// arbitrary location outside of triangle?
+			// not sure if this is the best idea, maybe should be returning undefined
+			return target.set( - 2, - 1, - 1 );
+
+		}
+
+		var invDenom = 1 / denom;
+		var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
+		var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
+
+		// barycentric coordinates must always sum to 1
+		return target.set( 1 - u - v, v, u );
+
+	}
+
+	containsPoint( point, a, b, c ) {
+
+		Triangle.getBarycoord( point, a, b, c, _v3 );
+
+		return ( _v3.x >= 0 ) && ( _v3.y >= 0 ) && ( ( _v3.x + _v3.y ) <= 1 );
+
+	}
+
+	static getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
+
+		this.getBarycoord( point, p1, p2, p3, _v3 );
+
+		target.set( 0, 0 );
+		target.addScaledVector( uv1, _v3.x );
+		target.addScaledVector( uv2, _v3.y );
+		target.addScaledVector( uv3, _v3.z );
+
+		return target;
+
+	}
+
+	isFrontFacing( a, b, c, direction ) {
+
+		_v0.subVectors( c, b );
+		_v1.subVectors( a, b );
+
+		// strictly front facing
+		return ( _v0.cross( _v1 ).dot( direction ) < 0 ) ? true : false;
+
+	}
+
+}
 
 export { Triangle };

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -5,88 +5,76 @@
  * @author zz85 / http://www.lab4games.net/zz85/blog
  */
 
-function Vector2( x, y ) {
+class Vector2 {
 
-	this.x = x || 0;
-	this.y = y || 0;
+	constructor( x, y ) {
 
-}
-
-Object.defineProperties( Vector2.prototype, {
-
-	"width": {
-
-		get: function () {
-
-			return this.x;
-
-		},
-
-		set: function ( value ) {
-
-			this.x = value;
-
-		}
-
-	},
-
-	"height": {
-
-		get: function () {
-
-			return this.y;
-
-		},
-
-		set: function ( value ) {
-
-			this.y = value;
-
-		}
+		this.isVector2 = true;
+		this.x = x || 0;
+		this.y = y || 0;
 
 	}
 
-} );
+	get width() {
 
-Object.assign( Vector2.prototype, {
+		return this.x;
 
-	isVector2: true,
+	}
 
-	set: function ( x, y ) {
+	set width( value ) {
+
+		this.x = value;
+
+	}
+
+
+	get height() {
+
+		return this.y;
+
+	}
+
+	set height( value ) {
+
+		this.y = value;
+
+	}
+
+	set( x, y ) {
 
 		this.x = x;
 		this.y = y;
 
 		return this;
 
-	},
+	}
 
-	setScalar: function ( scalar ) {
+	setScalar( scalar ) {
 
 		this.x = scalar;
 		this.y = scalar;
 
 		return this;
 
-	},
+	}
 
-	setX: function ( x ) {
+	setX( x ) {
 
 		this.x = x;
 
 		return this;
 
-	},
+	}
 
-	setY: function ( y ) {
+	setY( y ) {
 
 		this.y = y;
 
 		return this;
 
-	},
+	}
 
-	setComponent: function ( index, value ) {
+	setComponent( index, value ) {
 
 		switch ( index ) {
 
@@ -98,9 +86,9 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getComponent: function ( index ) {
+	getComponent( index ) {
 
 		switch ( index ) {
 
@@ -110,24 +98,24 @@ Object.assign( Vector2.prototype, {
 
 		}
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this.x, this.y );
+		return new Vector2( this.x, this.y );
 
-	},
+	}
 
-	copy: function ( v ) {
+	copy( v ) {
 
 		this.x = v.x;
 		this.y = v.y;
 
 		return this;
 
-	},
+	}
 
-	add: function ( v, w ) {
+	add( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -141,36 +129,36 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScalar: function ( s ) {
+	addScalar( s ) {
 
 		this.x += s;
 		this.y += s;
 
 		return this;
 
-	},
+	}
 
-	addVectors: function ( a, b ) {
+	addVectors( a, b ) {
 
 		this.x = a.x + b.x;
 		this.y = a.y + b.y;
 
 		return this;
 
-	},
+	}
 
-	addScaledVector: function ( v, s ) {
+	addScaledVector( v, s ) {
 
 		this.x += v.x * s;
 		this.y += v.y * s;
 
 		return this;
 
-	},
+	}
 
-	sub: function ( v, w ) {
+	sub( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -184,60 +172,60 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	subScalar: function ( s ) {
+	subScalar( s ) {
 
 		this.x -= s;
 		this.y -= s;
 
 		return this;
 
-	},
+	}
 
-	subVectors: function ( a, b ) {
+	subVectors( a, b ) {
 
 		this.x = a.x - b.x;
 		this.y = a.y - b.y;
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( v ) {
+	multiply( v ) {
 
 		this.x *= v.x;
 		this.y *= v.y;
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( scalar ) {
+	multiplyScalar( scalar ) {
 
 		this.x *= scalar;
 		this.y *= scalar;
 
 		return this;
 
-	},
+	}
 
-	divide: function ( v ) {
+	divide( v ) {
 
 		this.x /= v.x;
 		this.y /= v.y;
 
 		return this;
 
-	},
+	}
 
-	divideScalar: function ( scalar ) {
+	divideScalar( scalar ) {
 
 		return this.multiplyScalar( 1 / scalar );
 
-	},
+	}
 
-	applyMatrix3: function ( m ) {
+	applyMatrix3( m ) {
 
 		var x = this.x, y = this.y;
 		var e = m.elements;
@@ -247,27 +235,27 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	min: function ( v ) {
+	min( v ) {
 
 		this.x = Math.min( this.x, v.x );
 		this.y = Math.min( this.y, v.y );
 
 		return this;
 
-	},
+	}
 
-	max: function ( v ) {
+	max( v ) {
 
 		this.x = Math.max( this.x, v.x );
 		this.y = Math.max( this.y, v.y );
 
 		return this;
 
-	},
+	}
 
-	clamp: function ( min, max ) {
+	clamp( min, max ) {
 
 		// assumes min < max, componentwise
 
@@ -276,107 +264,107 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clampScalar: function ( minVal, maxVal ) {
+	clampScalar( minVal, maxVal ) {
 
 		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
 		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
 
 		return this;
 
-	},
+	}
 
-	clampLength: function ( min, max ) {
+	clampLength( min, max ) {
 
 		var length = this.length();
 
 		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
 
-	},
+	}
 
-	floor: function () {
+	floor() {
 
 		this.x = Math.floor( this.x );
 		this.y = Math.floor( this.y );
 
 		return this;
 
-	},
+	}
 
-	ceil: function () {
+	ceil() {
 
 		this.x = Math.ceil( this.x );
 		this.y = Math.ceil( this.y );
 
 		return this;
 
-	},
+	}
 
-	round: function () {
+	round() {
 
 		this.x = Math.round( this.x );
 		this.y = Math.round( this.y );
 
 		return this;
 
-	},
+	}
 
-	roundToZero: function () {
+	roundToZero() {
 
 		this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
 		this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
 
 		return this;
 
-	},
+	}
 
-	negate: function () {
+	negate() {
 
 		this.x = - this.x;
 		this.y = - this.y;
 
 		return this;
 
-	},
+	}
 
-	dot: function ( v ) {
+	dot( v ) {
 
 		return this.x * v.x + this.y * v.y;
 
-	},
+	}
 
-	cross: function ( v ) {
+	cross( v ) {
 
 		return this.x * v.y - this.y * v.x;
 
-	},
+	}
 
-	lengthSq: function () {
+	lengthSq() {
 
 		return this.x * this.x + this.y * this.y;
 
-	},
+	}
 
-	length: function () {
+	length() {
 
 		return Math.sqrt( this.x * this.x + this.y * this.y );
 
-	},
+	}
 
-	manhattanLength: function () {
+	manhattanLength() {
 
 		return Math.abs( this.x ) + Math.abs( this.y );
 
-	},
+	}
 
-	normalize: function () {
+	normalize() {
 
 		return this.divideScalar( this.length() || 1 );
 
-	},
+	}
 
-	angle: function () {
+	angle() {
 
 		// computes the angle in radians with respect to the positive x-axis
 
@@ -384,55 +372,55 @@ Object.assign( Vector2.prototype, {
 
 		return angle;
 
-	},
+	}
 
-	distanceTo: function ( v ) {
+	distanceTo( v ) {
 
 		return Math.sqrt( this.distanceToSquared( v ) );
 
-	},
+	}
 
-	distanceToSquared: function ( v ) {
+	distanceToSquared( v ) {
 
 		var dx = this.x - v.x, dy = this.y - v.y;
 		return dx * dx + dy * dy;
 
-	},
+	}
 
-	manhattanDistanceTo: function ( v ) {
+	manhattanDistanceTo( v ) {
 
 		return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y );
 
-	},
+	}
 
-	setLength: function ( length ) {
+	setLength( length ) {
 
 		return this.normalize().multiplyScalar( length );
 
-	},
+	}
 
-	lerp: function ( v, alpha ) {
+	lerp( v, alpha ) {
 
 		this.x += ( v.x - this.x ) * alpha;
 		this.y += ( v.y - this.y ) * alpha;
 
 		return this;
 
-	},
+	}
 
-	lerpVectors: function ( v1, v2, alpha ) {
+	lerpVectors( v1, v2, alpha ) {
 
 		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
 
-	},
+	}
 
-	equals: function ( v ) {
+	equals( v ) {
 
 		return ( ( v.x === this.x ) && ( v.y === this.y ) );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -441,9 +429,9 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -453,9 +441,9 @@ Object.assign( Vector2.prototype, {
 
 		return array;
 
-	},
+	}
 
-	fromBufferAttribute: function ( attribute, index, offset ) {
+	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {
 
@@ -468,9 +456,9 @@ Object.assign( Vector2.prototype, {
 
 		return this;
 
-	},
+	}
 
-	rotateAround: function ( center, angle ) {
+	rotateAround( center, angle ) {
 
 		var c = Math.cos( angle ), s = Math.sin( angle );
 
@@ -484,7 +472,6 @@ Object.assign( Vector2.prototype, {
 
 	}
 
-} );
-
+}
 
 export { Vector2 };

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -9,23 +9,18 @@ import { Quaternion } from './Quaternion.js';
  * @author egraether / http://egraether.com/
  * @author WestLangley / http://github.com/WestLangley
  */
+class Vector3 {
 
-var _vector = new Vector3();
-var _quaternion = new Quaternion();
+	constructor( x, y, z ) {
 
-function Vector3( x, y, z ) {
+		this.isVector3 = true;
+		this.x = x || 0;
+		this.y = y || 0;
+		this.z = z || 0;
 
-	this.x = x || 0;
-	this.y = y || 0;
-	this.z = z || 0;
+	}
 
-}
-
-Object.assign( Vector3.prototype, {
-
-	isVector3: true,
-
-	set: function ( x, y, z ) {
+	set( x, y, z ) {
 
 		this.x = x;
 		this.y = y;
@@ -33,9 +28,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setScalar: function ( scalar ) {
+	setScalar( scalar ) {
 
 		this.x = scalar;
 		this.y = scalar;
@@ -43,33 +38,33 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setX: function ( x ) {
+	setX( x ) {
 
 		this.x = x;
 
 		return this;
 
-	},
+	}
 
-	setY: function ( y ) {
+	setY( y ) {
 
 		this.y = y;
 
 		return this;
 
-	},
+	}
 
-	setZ: function ( z ) {
+	setZ( z ) {
 
 		this.z = z;
 
 		return this;
 
-	},
+	}
 
-	setComponent: function ( index, value ) {
+	setComponent( index, value ) {
 
 		switch ( index ) {
 
@@ -82,9 +77,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getComponent: function ( index ) {
+	getComponent( index ) {
 
 		switch ( index ) {
 
@@ -95,15 +90,15 @@ Object.assign( Vector3.prototype, {
 
 		}
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this.x, this.y, this.z );
+		return new Vector3( this.x, this.y, this.z );
 
-	},
+	}
 
-	copy: function ( v ) {
+	copy( v ) {
 
 		this.x = v.x;
 		this.y = v.y;
@@ -111,9 +106,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	add: function ( v, w ) {
+	add( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -128,9 +123,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScalar: function ( s ) {
+	addScalar( s ) {
 
 		this.x += s;
 		this.y += s;
@@ -138,9 +133,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addVectors: function ( a, b ) {
+	addVectors( a, b ) {
 
 		this.x = a.x + b.x;
 		this.y = a.y + b.y;
@@ -148,9 +143,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScaledVector: function ( v, s ) {
+	addScaledVector( v, s ) {
 
 		this.x += v.x * s;
 		this.y += v.y * s;
@@ -158,9 +153,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	sub: function ( v, w ) {
+	sub( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -175,9 +170,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	subScalar: function ( s ) {
+	subScalar( s ) {
 
 		this.x -= s;
 		this.y -= s;
@@ -185,9 +180,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	subVectors: function ( a, b ) {
+	subVectors( a, b ) {
 
 		this.x = a.x - b.x;
 		this.y = a.y - b.y;
@@ -195,9 +190,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( v, w ) {
+	multiply( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -212,9 +207,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( scalar ) {
+	multiplyScalar( scalar ) {
 
 		this.x *= scalar;
 		this.y *= scalar;
@@ -222,9 +217,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyVectors: function ( a, b ) {
+	multiplyVectors( a, b ) {
 
 		this.x = a.x * b.x;
 		this.y = a.y * b.y;
@@ -232,9 +227,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	applyEuler: function ( euler ) {
+	applyEuler( euler ) {
 
 		if ( ! ( euler && euler.isEuler ) ) {
 
@@ -244,15 +239,15 @@ Object.assign( Vector3.prototype, {
 
 		return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
 
-	},
+	}
 
-	applyAxisAngle: function ( axis, angle ) {
+	applyAxisAngle( axis, angle ) {
 
 		return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
 
-	},
+	}
 
-	applyMatrix3: function ( m ) {
+	applyMatrix3( m ) {
 
 		var x = this.x, y = this.y, z = this.z;
 		var e = m.elements;
@@ -263,15 +258,15 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	applyNormalMatrix: function ( m ) {
+	applyNormalMatrix( m ) {
 
 		return this.applyMatrix3( m ).normalize();
 
-	},
+	}
 
-	applyMatrix4: function ( m ) {
+	applyMatrix4( m ) {
 
 		var x = this.x, y = this.y, z = this.z;
 		var e = m.elements;
@@ -284,9 +279,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	applyQuaternion: function ( q ) {
+	applyQuaternion( q ) {
 
 		var x = this.x, y = this.y, z = this.z;
 		var qx = q.x, qy = q.y, qz = q.z, qw = q.w;
@@ -306,21 +301,21 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	project: function ( camera ) {
+	project( camera ) {
 
 		return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
 
-	},
+	}
 
-	unproject: function ( camera ) {
+	unproject( camera ) {
 
 		return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
 
-	},
+	}
 
-	transformDirection: function ( m ) {
+	transformDirection( m ) {
 
 		// input: THREE.Matrix4 affine matrix
 		// vector interpreted as a direction
@@ -334,9 +329,9 @@ Object.assign( Vector3.prototype, {
 
 		return this.normalize();
 
-	},
+	}
 
-	divide: function ( v ) {
+	divide( v ) {
 
 		this.x /= v.x;
 		this.y /= v.y;
@@ -344,15 +339,15 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	divideScalar: function ( scalar ) {
+	divideScalar( scalar ) {
 
 		return this.multiplyScalar( 1 / scalar );
 
-	},
+	}
 
-	min: function ( v ) {
+	min( v ) {
 
 		this.x = Math.min( this.x, v.x );
 		this.y = Math.min( this.y, v.y );
@@ -360,9 +355,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	max: function ( v ) {
+	max( v ) {
 
 		this.x = Math.max( this.x, v.x );
 		this.y = Math.max( this.y, v.y );
@@ -370,9 +365,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clamp: function ( min, max ) {
+	clamp( min, max ) {
 
 		// assumes min < max, componentwise
 
@@ -382,9 +377,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clampScalar: function ( minVal, maxVal ) {
+	clampScalar( minVal, maxVal ) {
 
 		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
 		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
@@ -392,17 +387,17 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clampLength: function ( min, max ) {
+	clampLength( min, max ) {
 
 		var length = this.length();
 
 		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
 
-	},
+	}
 
-	floor: function () {
+	floor() {
 
 		this.x = Math.floor( this.x );
 		this.y = Math.floor( this.y );
@@ -410,9 +405,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	ceil: function () {
+	ceil() {
 
 		this.x = Math.ceil( this.x );
 		this.y = Math.ceil( this.y );
@@ -420,9 +415,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	round: function () {
+	round() {
 
 		this.x = Math.round( this.x );
 		this.y = Math.round( this.y );
@@ -430,9 +425,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	roundToZero: function () {
+	roundToZero() {
 
 		this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
 		this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
@@ -440,9 +435,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	negate: function () {
+	negate() {
 
 		this.x = - this.x;
 		this.y = - this.y;
@@ -450,47 +445,45 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	dot: function ( v ) {
+	dot( v ) {
 
 		return this.x * v.x + this.y * v.y + this.z * v.z;
 
-	},
+	}
 
-	// TODO lengthSquared?
-
-	lengthSq: function () {
+	lengthSq() {
 
 		return this.x * this.x + this.y * this.y + this.z * this.z;
 
-	},
+	}
 
-	length: function () {
+	length() {
 
 		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
 
-	},
+	}
 
-	manhattanLength: function () {
+	manhattanLength() {
 
 		return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
 
-	},
+	}
 
-	normalize: function () {
+	normalize() {
 
 		return this.divideScalar( this.length() || 1 );
 
-	},
+	}
 
-	setLength: function ( length ) {
+	setLength( length ) {
 
 		return this.normalize().multiplyScalar( length );
 
-	},
+	}
 
-	lerp: function ( v, alpha ) {
+	lerp( v, alpha ) {
 
 		this.x += ( v.x - this.x ) * alpha;
 		this.y += ( v.y - this.y ) * alpha;
@@ -498,15 +491,15 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerpVectors: function ( v1, v2, alpha ) {
+	lerpVectors( v1, v2, alpha ) {
 
 		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
 
-	},
+	}
 
-	cross: function ( v, w ) {
+	cross( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -517,9 +510,9 @@ Object.assign( Vector3.prototype, {
 
 		return this.crossVectors( this, v );
 
-	},
+	}
 
-	crossVectors: function ( a, b ) {
+	crossVectors( a, b ) {
 
 		var ax = a.x, ay = a.y, az = a.z;
 		var bx = b.x, by = b.y, bz = b.z;
@@ -530,9 +523,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	projectOnVector: function ( v ) {
+	projectOnVector( v ) {
 
 		var denominator = v.lengthSq();
 
@@ -542,26 +535,26 @@ Object.assign( Vector3.prototype, {
 
 		return this.copy( v ).multiplyScalar( scalar );
 
-	},
+	}
 
-	projectOnPlane: function ( planeNormal ) {
+	projectOnPlane( planeNormal ) {
 
 		_vector.copy( this ).projectOnVector( planeNormal );
 
 		return this.sub( _vector );
 
-	},
+	}
 
-	reflect: function ( normal ) {
+	reflect( normal ) {
 
 		// reflect incident vector off plane orthogonal to normal
 		// normal is assumed to have unit length
 
 		return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
 
-	},
+	}
 
-	angleTo: function ( v ) {
+	angleTo( v ) {
 
 		var denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
 
@@ -573,35 +566,35 @@ Object.assign( Vector3.prototype, {
 
 		return Math.acos( MathUtils.clamp( theta, - 1, 1 ) );
 
-	},
+	}
 
-	distanceTo: function ( v ) {
+	distanceTo( v ) {
 
 		return Math.sqrt( this.distanceToSquared( v ) );
 
-	},
+	}
 
-	distanceToSquared: function ( v ) {
+	distanceToSquared( v ) {
 
 		var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
 
 		return dx * dx + dy * dy + dz * dz;
 
-	},
+	}
 
-	manhattanDistanceTo: function ( v ) {
+	manhattanDistanceTo( v ) {
 
 		return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
 
-	},
+	}
 
-	setFromSpherical: function ( s ) {
+	setFromSpherical( s ) {
 
 		return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
 
-	},
+	}
 
-	setFromSphericalCoords: function ( radius, phi, theta ) {
+	setFromSphericalCoords( radius, phi, theta ) {
 
 		var sinPhiRadius = Math.sin( phi ) * radius;
 
@@ -611,15 +604,15 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromCylindrical: function ( c ) {
+	setFromCylindrical( c ) {
 
 		return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
 
-	},
+	}
 
-	setFromCylindricalCoords: function ( radius, theta, y ) {
+	setFromCylindricalCoords( radius, theta, y ) {
 
 		this.x = radius * Math.sin( theta );
 		this.y = y;
@@ -627,9 +620,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromMatrixPosition: function ( m ) {
+	setFromMatrixPosition( m ) {
 
 		var e = m.elements;
 
@@ -639,9 +632,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromMatrixScale: function ( m ) {
+	setFromMatrixScale( m ) {
 
 		var sx = this.setFromMatrixColumn( m, 0 ).length();
 		var sy = this.setFromMatrixColumn( m, 1 ).length();
@@ -653,27 +646,27 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setFromMatrixColumn: function ( m, index ) {
+	setFromMatrixColumn( m, index ) {
 
 		return this.fromArray( m.elements, index * 4 );
 
-	},
+	}
 
-	setFromMatrix3Column: function ( m, index ) {
+	setFromMatrix3Column( m, index ) {
 
 		return this.fromArray( m.elements, index * 3 );
 
-	},
+	}
 
-	equals: function ( v ) {
+	equals( v ) {
 
 		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -683,9 +676,9 @@ Object.assign( Vector3.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -696,9 +689,9 @@ Object.assign( Vector3.prototype, {
 
 		return array;
 
-	},
+	}
 
-	fromBufferAttribute: function ( attribute, index, offset ) {
+	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {
 
@@ -714,7 +707,9 @@ Object.assign( Vector3.prototype, {
 
 	}
 
-} );
+}
 
+var _vector = new Vector3();
+var _quaternion = new Quaternion();
 
 export { Vector3 };

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -6,56 +6,43 @@
  * @author WestLangley / http://github.com/WestLangley
  */
 
-function Vector4( x, y, z, w ) {
+class Vector4 {
 
-	this.x = x || 0;
-	this.y = y || 0;
-	this.z = z || 0;
-	this.w = ( w !== undefined ) ? w : 1;
+	constructor( x, y, z, w ) {
 
-}
-
-Object.defineProperties( Vector4.prototype, {
-
-	"width": {
-
-		get: function () {
-
-			return this.z;
-
-		},
-
-		set: function ( value ) {
-
-			this.z = value;
-
-		}
-
-	},
-
-	"height": {
-
-		get: function () {
-
-			return this.w;
-
-		},
-
-		set: function ( value ) {
-
-			this.w = value;
-
-		}
+		this.isVector4 = true;
+		this.x = x || 0;
+		this.y = y || 0;
+		this.z = z || 0;
+		this.w = ( w !== undefined ) ? w : 1;
 
 	}
 
-} );
+	get width() {
 
-Object.assign( Vector4.prototype, {
+		return this.z;
 
-	isVector4: true,
+	}
 
-	set: function ( x, y, z, w ) {
+	set width( value ) {
+
+		this.z = value;
+
+	}
+
+	get height() {
+
+		return this.w;
+
+	}
+
+	set height( value ) {
+
+		this.w = value;
+
+	}
+
+	set( x, y, z, w ) {
 
 		this.x = x;
 		this.y = y;
@@ -64,9 +51,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setScalar: function ( scalar ) {
+	setScalar( scalar ) {
 
 		this.x = scalar;
 		this.y = scalar;
@@ -75,41 +62,41 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setX: function ( x ) {
+	setX( x ) {
 
 		this.x = x;
 
 		return this;
 
-	},
+	}
 
-	setY: function ( y ) {
+	setY( y ) {
 
 		this.y = y;
 
 		return this;
 
-	},
+	}
 
-	setZ: function ( z ) {
+	setZ( z ) {
 
 		this.z = z;
 
 		return this;
 
-	},
+	}
 
-	setW: function ( w ) {
+	setW( w ) {
 
 		this.w = w;
 
 		return this;
 
-	},
+	}
 
-	setComponent: function ( index, value ) {
+	setComponent( index, value ) {
 
 		switch ( index ) {
 
@@ -123,9 +110,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	getComponent: function ( index ) {
+	getComponent( index ) {
 
 		switch ( index ) {
 
@@ -137,15 +124,15 @@ Object.assign( Vector4.prototype, {
 
 		}
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor( this.x, this.y, this.z, this.w );
+		return new Vector4( this.x, this.y, this.z, this.w );
 
-	},
+	}
 
-	copy: function ( v ) {
+	copy( v ) {
 
 		this.x = v.x;
 		this.y = v.y;
@@ -154,9 +141,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	add: function ( v, w ) {
+	add( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -172,9 +159,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScalar: function ( s ) {
+	addScalar( s ) {
 
 		this.x += s;
 		this.y += s;
@@ -183,9 +170,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addVectors: function ( a, b ) {
+	addVectors( a, b ) {
 
 		this.x = a.x + b.x;
 		this.y = a.y + b.y;
@@ -194,9 +181,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScaledVector: function ( v, s ) {
+	addScaledVector( v, s ) {
 
 		this.x += v.x * s;
 		this.y += v.y * s;
@@ -205,9 +192,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	sub: function ( v, w ) {
+	sub( v, w ) {
 
 		if ( w !== undefined ) {
 
@@ -223,9 +210,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	subScalar: function ( s ) {
+	subScalar( s ) {
 
 		this.x -= s;
 		this.y -= s;
@@ -234,9 +221,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	subVectors: function ( a, b ) {
+	subVectors( a, b ) {
 
 		this.x = a.x - b.x;
 		this.y = a.y - b.y;
@@ -245,9 +232,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( scalar ) {
+	multiplyScalar( scalar ) {
 
 		this.x *= scalar;
 		this.y *= scalar;
@@ -256,9 +243,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	applyMatrix4: function ( m ) {
+	applyMatrix4( m ) {
 
 		var x = this.x, y = this.y, z = this.z, w = this.w;
 		var e = m.elements;
@@ -270,15 +257,15 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	divideScalar: function ( scalar ) {
+	divideScalar( scalar ) {
 
 		return this.multiplyScalar( 1 / scalar );
 
-	},
+	}
 
-	setAxisAngleFromQuaternion: function ( q ) {
+	setAxisAngleFromQuaternion( q ) {
 
 		// http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/index.htm
 
@@ -304,9 +291,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setAxisAngleFromRotationMatrix: function ( m ) {
+	setAxisAngleFromRotationMatrix( m ) {
 
 		// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm
 
@@ -434,9 +421,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	min: function ( v ) {
+	min( v ) {
 
 		this.x = Math.min( this.x, v.x );
 		this.y = Math.min( this.y, v.y );
@@ -445,9 +432,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	max: function ( v ) {
+	max( v ) {
 
 		this.x = Math.max( this.x, v.x );
 		this.y = Math.max( this.y, v.y );
@@ -456,9 +443,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clamp: function ( min, max ) {
+	clamp( min, max ) {
 
 		// assumes min < max, componentwise
 
@@ -469,9 +456,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clampScalar: function ( minVal, maxVal ) {
+	clampScalar( minVal, maxVal ) {
 
 		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
 		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
@@ -480,17 +467,17 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clampLength: function ( min, max ) {
+	clampLength( min, max ) {
 
 		var length = this.length();
 
 		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
 
-	},
+	}
 
-	floor: function () {
+	floor() {
 
 		this.x = Math.floor( this.x );
 		this.y = Math.floor( this.y );
@@ -499,9 +486,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	ceil: function () {
+	ceil() {
 
 		this.x = Math.ceil( this.x );
 		this.y = Math.ceil( this.y );
@@ -510,9 +497,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	round: function () {
+	round() {
 
 		this.x = Math.round( this.x );
 		this.y = Math.round( this.y );
@@ -521,9 +508,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	roundToZero: function () {
+	roundToZero() {
 
 		this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
 		this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
@@ -532,9 +519,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	negate: function () {
+	negate() {
 
 		this.x = - this.x;
 		this.y = - this.y;
@@ -543,45 +530,45 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	dot: function ( v ) {
+	dot( v ) {
 
 		return this.x * v.x + this.y * v.y + this.z * v.z + this.w * v.w;
 
-	},
+	}
 
-	lengthSq: function () {
+	lengthSq() {
 
 		return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
 
-	},
+	}
 
-	length: function () {
+	length() {
 
 		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w );
 
-	},
+	}
 
-	manhattanLength: function () {
+	manhattanLength() {
 
 		return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z ) + Math.abs( this.w );
 
-	},
+	}
 
-	normalize: function () {
+	normalize() {
 
 		return this.divideScalar( this.length() || 1 );
 
-	},
+	}
 
-	setLength: function ( length ) {
+	setLength( length ) {
 
 		return this.normalize().multiplyScalar( length );
 
-	},
+	}
 
-	lerp: function ( v, alpha ) {
+	lerp( v, alpha ) {
 
 		this.x += ( v.x - this.x ) * alpha;
 		this.y += ( v.y - this.y ) * alpha;
@@ -590,21 +577,21 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerpVectors: function ( v1, v2, alpha ) {
+	lerpVectors( v1, v2, alpha ) {
 
 		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
 
-	},
+	}
 
-	equals: function ( v ) {
+	equals( v ) {
 
 		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) && ( v.w === this.w ) );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -615,9 +602,9 @@ Object.assign( Vector4.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -629,9 +616,9 @@ Object.assign( Vector4.prototype, {
 
 		return array;
 
-	},
+	}
 
-	fromBufferAttribute: function ( attribute, index, offset ) {
+	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {
 
@@ -648,7 +635,6 @@ Object.assign( Vector4.prototype, {
 
 	}
 
-} );
-
+}
 
 export { Vector4 };

--- a/src/math/interpolants/CubicInterpolant.js
+++ b/src/math/interpolants/CubicInterpolant.js
@@ -1,6 +1,5 @@
-import { ZeroCurvatureEnding } from '../../constants.js';
+import { ZeroCurvatureEnding, WrapAroundEnding, ZeroSlopeEnding } from '../../constants.js';
 import { Interpolant } from '../Interpolant.js';
-import { WrapAroundEnding, ZeroSlopeEnding } from '../../constants.js';
 
 /**
  * Fast and simple cubic spline interpolant.
@@ -12,29 +11,21 @@ import { WrapAroundEnding, ZeroSlopeEnding } from '../../constants.js';
  * @author tschw
  */
 
-function CubicInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class CubicInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-	this._weightPrev = - 0;
-	this._offsetPrev = - 0;
-	this._weightNext = - 0;
-	this._offsetNext = - 0;
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
+		this._weightPrev = - 0;
+		this._offsetPrev = - 0;
+		this._weightNext = - 0;
+		this._offsetNext = - 0;
+		this.endingStart = ZeroCurvatureEnding;
+	  this.endingEnd = ZeroCurvatureEnding;
 
-}
+	}
 
-CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
-
-	constructor: CubicInterpolant,
-
-	DefaultSettings_: {
-
-		endingStart: ZeroCurvatureEnding,
-		endingEnd: ZeroCurvatureEnding
-
-	},
-
-	intervalChanged_: function ( i1, t0, t1 ) {
+	intervalChanged_( i1, t0, t1 ) {
 
 		var pp = this.parameterPositions,
 			iPrev = i1 - 2,
@@ -45,7 +36,7 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 
 		if ( tPrev === undefined ) {
 
-			switch ( this.getSettings_().endingStart ) {
+			switch ( this.endingStart ) {
 
 				case ZeroSlopeEnding:
 
@@ -75,7 +66,7 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 
 		if ( tNext === undefined ) {
 
-			switch ( this.getSettings_().endingEnd ) {
+			switch ( this.endingEnd ) {
 
 				case ZeroSlopeEnding:
 
@@ -111,9 +102,9 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 		this._offsetPrev = iPrev * stride;
 		this._offsetNext = iNext * stride;
 
-	},
+	}
 
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		var result = this.resultBuffer,
 			values = this.sampleValues,
@@ -150,7 +141,6 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 
 	}
 
-} );
-
+}
 
 export { CubicInterpolant };

--- a/src/math/interpolants/DiscreteInterpolant.js
+++ b/src/math/interpolants/DiscreteInterpolant.js
@@ -8,23 +8,20 @@ import { Interpolant } from '../Interpolant.js';
  * @author tschw
  */
 
-function DiscreteInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class DiscreteInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-DiscreteInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: DiscreteInterpolant,
-
-	interpolate_: function ( i1 /*, t0, t, t1 */ ) {
+	interpolate_( i1 /*, t0, t, t1 */ ) {
 
 		return this.copySampleValue_( i1 - 1 );
 
 	}
 
-} );
-
+}
 
 export { DiscreteInterpolant };

--- a/src/math/interpolants/LinearInterpolant.js
+++ b/src/math/interpolants/LinearInterpolant.js
@@ -4,17 +4,15 @@ import { Interpolant } from '../Interpolant.js';
  * @author tschw
  */
 
-function LinearInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class LinearInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-LinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: LinearInterpolant,
-
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		var result = this.resultBuffer,
 			values = this.sampleValues,
@@ -38,7 +36,7 @@ LinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototyp
 
 	}
 
-} );
+}
 
 
 export { LinearInterpolant };

--- a/src/math/interpolants/QuaternionLinearInterpolant.js
+++ b/src/math/interpolants/QuaternionLinearInterpolant.js
@@ -7,17 +7,15 @@ import { Quaternion } from '../Quaternion.js';
  * @author tschw
  */
 
-function QuaternionLinearInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class QuaternionLinearInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-QuaternionLinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: QuaternionLinearInterpolant,
-
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		var result = this.resultBuffer,
 			values = this.sampleValues,
@@ -37,7 +35,6 @@ QuaternionLinearInterpolant.prototype = Object.assign( Object.create( Interpolan
 
 	}
 
-} );
-
+}
 
 export { QuaternionLinearInterpolant };


### PR DESCRIPTION
Hi all.
This pull relates to #11552 #17425

I've been working on sorting the maths scripts into ES6 classes. It's close but needs some help.
My local dev website runs all of the code just fine however:

- "geometry / terrain /raycast" example has had a noticeable performance hit
- "camera / array" example fails silently...
- various WebGLProgram warnings (i.e. fakepath() ... pow(f, e) ... negative f values)

I also tried to work my way through some of the unit tests but le brain died at that point.

Going to have a look at the other folders as there may be some easier candidates for ES6 transformation.

update:
[mrdoob's comment on let/const](https://github.com/mrdoob/three.js/pull/17276#issuecomment-527687857)
[Blocking dependencies](https://github.com/mrdoob/three.js/issues/6419#issuecomment-599160231)
