### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/examples/en/loaders/BasisTextureLoader.html
+++ b/docs/examples/en/loaders/BasisTextureLoader.html
@@ -25,7 +25,7 @@
 			This loader parallelizes the transcoding process across a configurable number
 			of web workers, before transferring the transcoded compressed texture back
 			to the main thread. The required WASM transcoder and JS wrapper are available from the
-			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
+			[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
 			directory.
 		</p>
 
@@ -33,7 +33,7 @@
 
 		<code>
 		var basisLoader = new BasisTextureLoader();
-		basisLoader.setTranscoderPath( 'examples/jsm/libs/basis/' );
+		basisLoader.setTranscoderPath( 'examples/js/libs/basis/' );
 		basisLoader.detectSupport( renderer );
 		basisLoader.load( 'diffuse.basis', function ( texture ) {
 
@@ -118,7 +118,7 @@
 		</p>
 		<p>
 		The WASM transcoder and JS wrapper are available from the
-		[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
+		[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
 		directory.
 		</p>
 

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -34,7 +34,7 @@
 		var loader = new DRACOLoader();
 
 		// Specify path to a folder containing WASM/JS decoding libraries.
-		loader.setDecoderPath( '/examples/jsm/libs/draco/' );
+		loader.setDecoderPath( '/examples/js/libs/draco/' );
 
 		// Optional: Pre-fetch Draco WASM/JS module.
 		loader.preload();

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -59,7 +59,7 @@
 
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
 		var dracoLoader = new DRACOLoader();
-		dracoLoader.setDecoderPath( '/examples/jsm/libs/draco/' );
+		dracoLoader.setDecoderPath( '/examples/js/libs/draco/' );
 		loader.setDRACOLoader( dracoLoader );
 
 		// Load a glTF resource
@@ -187,7 +187,7 @@
 		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
 		</p>
 		<p>
-		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme] for the details of Draco and its decoder.
+		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme] for the details of Draco and its decoder.
 		</p>
 
 		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>

--- a/docs/examples/zh/loaders/BasisTextureLoader.html
+++ b/docs/examples/zh/loaders/BasisTextureLoader.html
@@ -25,7 +25,7 @@
 			This loader parallelizes the transcoding process across a configurable number
 			of web workers, before transferring the transcoded compressed texture back
 			to the main thread. The required WASM transcoder and JS wrapper are available from the
-			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
+			[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
 			directory.
 		</p>
 
@@ -33,7 +33,7 @@
 
 		<code>
 		var basisLoader = new BasisTextureLoader();
-		basisLoader.setTranscoderPath( 'examples/jsm/libs/basis/' );
+		basisLoader.setTranscoderPath( 'examples/js/libs/basis/' );
 		basisLoader.detectSupport( renderer );
 		basisLoader.load( 'diffuse.basis', function ( texture ) {
 
@@ -118,7 +118,7 @@
 		</p>
 		<p>
 		The WASM transcoder and JS wrapper are available from the
-		[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
+		[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/basis examples/js/libs/basis]
 		directory.
 		</p>
 

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -34,7 +34,7 @@
 		var loader = new DRACOLoader();
 
 		// Specify path to a folder containing WASM/JS decoding libraries.
-		loader.setDecoderPath( '/examples/jsm/libs/draco/' );
+		loader.setDecoderPath( '/examples/js/libs/draco/' );
 
 		// Optional: Pre-fetch Draco WASM/JS module.
 		loader.preload();

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -58,7 +58,7 @@
 
 		// Optional: Provide a DRACOLoader instance to decode compressed mesh data
 		var dracoLoader = new DRACOLoader();
-		dracoLoader.setDecoderPath( '/examples/jsm/libs/draco/' );
+		dracoLoader.setDecoderPath( '/examples/js/libs/draco/' );
 		loader.setDRACOLoader( dracoLoader );
 
 		// Load a glTF resource
@@ -182,7 +182,7 @@
 		[page:DRACOLoader dracoLoader] — THREE.DRACOLoader的实例，用于解码使用KHR_draco_mesh_compression扩展压缩过的文件。
 		</p>
 		<p>
-		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme]来了解Draco及其解码器的详细信息。
+		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme]来了解Draco及其解码器的详细信息。
 		</p>
 
 		<h3>[method:null setDDSLoader]( [param:DDSLoader ddsLoader] )</h3>


### PR DESCRIPTION
Follow up of #18743. Fixed a few links that should still point to `examples/js/libs`.