### PR TITLE
Rendering fix for degenerate UVs

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */ `
+export default /* glsl */`
 #ifdef USE_NORMALMAP
 
 	uniform sampler2D normalMap;
@@ -29,9 +29,9 @@ export default /* glsl */ `
 		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
 
 		// This avoids NaNs with degenerate UV coordinates
-        if ( scale == 0.0 ) {
+		if ( scale == 0.0 ) {
 
-            return normalize( surf_norm );
+			return normalize( surf_norm );
 
 		}
 		

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* glsl */ `
 #ifdef USE_NORMALMAP
 
 	uniform sampler2D normalMap;
@@ -28,6 +28,13 @@ export default /* glsl */`
 
 		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
 
+		// This avoids NaNs with degenerate UV coordinates
+        if ( scale == 0.0 ) {
+
+            return normalize( surf_norm );
+
+		}
+		
 		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
 		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
 		vec3 N = normalize( surf_norm );


### PR DESCRIPTION
Upstreaming a bugfix from model-viewer: https://github.com/google/model-viewer/pull/1078

Unfortunately the models I have that display it are not for public consumption, but it's not hard to create a repro. If you have a non-degenerate triangle with duplicate UV coordinates (which happens a lot with DRACO compression), you get NaNs in the normal which can come out as a variety of different artifacts depending on the GPU driver (I've seen all-black triangles on my macbook pro and random black noise on triangles on my Linux desktop). 

I've only repro'd this with glTF models without supplied tangents.