### PR TITLE
KeyframeTrack.d.ts: fix a method's name in d.ts file

### DIFF
--- a/src/animation/KeyframeTrack.d.ts
+++ b/src/animation/KeyframeTrack.d.ts
@@ -29,7 +29,7 @@ export class KeyframeTrack {
 	setInterpolation( interpolation: InterpolationModes ): KeyframeTrack;
 	getInterpolation(): InterpolationModes;
 
-	getValuesize(): number;
+	getValueSize(): number;
 
 	shift( timeOffset: number ): KeyframeTrack;
 	scale( timeScale: number ): KeyframeTrack;


### PR DESCRIPTION
It should be `getValueSize` in type description file

https://github.com/mrdoob/three.js/blob/bef4ad17e104806a3419f92834b64d9884d5fc71/src/animation/KeyframeTrack.js#L187
