### PR TITLE
Shaders: assign the clipping shader chunk its own varying

### DIFF
--- a/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_fragment.glsl.js
@@ -7,7 +7,7 @@ export default /* glsl */`
 	for ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {
 
 		plane = clippingPlanes[ i ];
-		if ( dot( vViewPosition, plane.xyz ) > plane.w ) discard;
+		if ( dot( vClipPosition, plane.xyz ) > plane.w ) discard;
 
 	}
 	#pragma unroll_loop_end
@@ -20,7 +20,7 @@ export default /* glsl */`
 		for ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {
 
 			plane = clippingPlanes[ i ];
-			clipped = ( dot( vViewPosition, plane.xyz ) > plane.w ) && clipped;
+			clipped = ( dot( vClipPosition, plane.xyz ) > plane.w ) && clipped;
 
 		}
 		#pragma unroll_loop_end

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_fragment.glsl.js
@@ -1,9 +1,7 @@
 export default /* glsl */`
 #if NUM_CLIPPING_PLANES > 0
 
-	#if ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP ) && ! defined( TOON )
-		varying vec3 vViewPosition;
-	#endif
+	varying vec3 vClipPosition;
 
 	uniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];
 

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_pars_vertex.glsl.js
@@ -1,5 +1,7 @@
 export default /* glsl */`
-#if NUM_CLIPPING_PLANES > 0 && ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP ) && ! defined( TOON )
-	varying vec3 vViewPosition;
+#if NUM_CLIPPING_PLANES > 0
+
+	varying vec3 vClipPosition;
+
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clipping_planes_vertex.glsl.js
@@ -1,5 +1,7 @@
 export default /* glsl */`
-#if NUM_CLIPPING_PLANES > 0 && ! defined( STANDARD ) && ! defined( PHONG ) && ! defined( MATCAP ) && ! defined( TOON )
-	vViewPosition = - mvPosition.xyz;
+#if NUM_CLIPPING_PLANES > 0
+
+	vClipPosition = - mvPosition.xyz;
+
 #endif
 `;


### PR DESCRIPTION
Fixes #17192.

Trying to prevent declaration conflicts with the Normal shader was difficult because the conditions in that case were more complex for that material.

Instead, we can just assign the clipping chunk its own varying and eliminate the conditionals.

