### PR TITLE
Update jsfiddle with working cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ function animate() {
 }
 ```
 
-If everything went well you should see [this](https://jsfiddle.net/f2Lommf5/).
+If everything went well you should see [this](https://jsfiddle.net/3hkq1L4s/).
 
 ### Change log ###
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ function animate() {
 }
 ```
 
-If everything went well you should see [this](https://jsfiddle.net/3hkq1L4s/).
+If everything went well you should see [this](https://jsfiddle.net/972m5cdx/).
 
 ### Change log ###
 


### PR DESCRIPTION
RawGit has shut down, and because of this the link in our readme no longer works. This PR migrates the jsfiddle example to use jsDelivr instead.