### PR TITLE
GLTFLoader: Use a smaller bounding box for morph targets

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2225,6 +2225,7 @@ THREE.GLTFLoader = ( function () {
 
 		if ( targets !== undefined ) {
 
+			var maxDisplacement = new THREE.Vector3();
 			var vector = new THREE.Vector3();
 
 			for ( var i = 0, il = targets.length; i < il; i ++ ) {
@@ -2246,7 +2247,11 @@ THREE.GLTFLoader = ( function () {
 						vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
 						vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
 
-						box.expandByVector( vector );
+						// Note: this assumes that the sum of all weights is at most 1. This isn't quite correct - it's more conservative
+						// to assume that each target can have a max weight of 1. However, for some use cases - notably, when morph targets
+						// are used to implement key-frame animations and as such only two are active at a time - this results in very large
+						// boxes. So for now we make a box that's sometimes a touch too small but is hopefully mostly of reasonable size.
+						maxDisplacement.max( vector );
 
 					} else {
 
@@ -2257,6 +2262,9 @@ THREE.GLTFLoader = ( function () {
 				}
 
 			}
+
+			// As per comment above this box isn't conservative, but has a reasonable size for a very large number of morph targets.
+			box.expandByVector( maxDisplacement );
 
 		}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2288,6 +2288,7 @@ var GLTFLoader = ( function () {
 
 		if ( targets !== undefined ) {
 
+			var maxDisplacement = new Vector3();
 			var vector = new Vector3();
 
 			for ( var i = 0, il = targets.length; i < il; i ++ ) {
@@ -2309,7 +2310,11 @@ var GLTFLoader = ( function () {
 						vector.setY( Math.max( Math.abs( min[ 1 ] ), Math.abs( max[ 1 ] ) ) );
 						vector.setZ( Math.max( Math.abs( min[ 2 ] ), Math.abs( max[ 2 ] ) ) );
 
-						box.expandByVector( vector );
+						// Note: this assumes that the sum of all weights is at most 1. This isn't quite correct - it's more conservative
+						// to assume that each target can have a max weight of 1. However, for some use cases - notably, when morph targets
+						// are used to implement key-frame animations and as such only two are active at a time - this results in very large
+						// boxes. So for now we make a box that's sometimes a touch too small but is hopefully mostly of reasonable size.
+						maxDisplacement.max( vector );
 
 					} else {
 
@@ -2320,6 +2325,9 @@ var GLTFLoader = ( function () {
 				}
 
 			}
+
+			// As per comment above this box isn't conservative, but has a reasonable size for a very large number of morph targets.
+			box.expandByVector( maxDisplacement );
 
 		}
 


### PR DESCRIPTION
Instead of assuming a worst case when the weight of each target is +-1,
assume that the sum of the weights is +-1 instead.

This isn't quite correct and may result in a bounding box that's too
small, but in at least one case - when morph targets are used for
keyframe animations and only two are active at a time - this results in
a much smaller bounding box.

In some other more realistic cases this may also reduce the bounding box
without a real impact on it being conservative, e.g. it's common to have
50 blend shapes for facial animations but only a few are active at a
time, and extreme deformations are typically contained within a box
that's computed with the new algorithm as well.

Fixes #18809.