### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -59,13 +59,6 @@
 			Returns a vector for a given position on the curve path.
 		</p>
 
-		<h3>[method:Vector getPointAt]( [param:Float u] )</h3>
-		<p>
-			[page:Float u] - A position on the curve according to the arc length. Must be in the range [ 0, 1 ]. <br><br />
-
-			Returns a vector for a given position on the curve path according to the arc length.
-		</p>
-
 		<h3>[method:Array getPoints]( [param:Integer divisions] )</h3>
 		<p>
 			divisions -- number of pieces to divide the curve into. Default is *12*.<br /><br />

--- a/docs/api/zh/extras/core/CurvePath.html
+++ b/docs/api/zh/extras/core/CurvePath.html
@@ -59,13 +59,6 @@
 			Returns a vector for a given position on the curve path.
 		</p>
 
-		<h3>[method:Vector getPointAt]( [param:Float u] )</h3>
-		<p>
-			[page:Float u] - A position on the curve according to the arc length. Must be in the range [ 0, 1 ]. <br><br />
-
-			Returns a vector for a given position on the curve path according to the arc length.
-		</p>
-
 		<h3>[method:Array getPoints]( [param:Integer divisions] )</h3>
 		<p>
 			divisions -- 曲线分段数量。默认值为*12*。<br /><br />

--- a/src/extras/core/CurvePath.d.ts
+++ b/src/extras/core/CurvePath.d.ts
@@ -13,7 +13,6 @@ export class CurvePath<T extends Vector> extends Curve<T> {
 	checkConnection(): boolean;
 	closePath(): void;
 	getPoint( t: number ): T;
-	getPointAt( t: number ): T;
 	getLength(): number;
 	updateArcLengths(): void;
 	getCurveLengths(): number[];


### PR DESCRIPTION
Follow-up of #18921.

The description of the OP actually confused me. He was talking about `getPointAt()` although this method is not overwritten by `CurvePath`.