### PR TITLE
GLTFExporter: Better handle point and line geometries.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1176,17 +1176,14 @@ THREE.GLTFExporter.prototype = {
 
 			} else {
 
-				if ( ! geometry.isBufferGeometry ) {
-
-					console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use THREE.BufferGeometry instead.' );
-
-					var geometryTemp = new THREE.BufferGeometry();
-					geometryTemp.fromGeometry( geometry );
-					geometry = geometryTemp;
-
-				}
-
 				mode = mesh.material.wireframe ? WEBGL_CONSTANTS.LINES : WEBGL_CONSTANTS.TRIANGLES;
+
+			}
+
+			if ( ! geometry.isBufferGeometry ) {
+
+				console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use THREE.BufferGeometry instead.' );
+				geometry = new THREE.BufferGeometry().setFromObject( mesh );
 
 			}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1198,17 +1198,14 @@ GLTFExporter.prototype = {
 
 			} else {
 
-				if ( ! geometry.isBufferGeometry ) {
-
-					console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use BufferGeometry instead.' );
-
-					var geometryTemp = new BufferGeometry();
-					geometryTemp.fromGeometry( geometry );
-					geometry = geometryTemp;
-
-				}
-
 				mode = mesh.material.wireframe ? WEBGL_CONSTANTS.LINES : WEBGL_CONSTANTS.TRIANGLES;
+
+			}
+
+			if ( ! geometry.isBufferGeometry ) {
+
+				console.warn( 'GLTFExporter: Exporting THREE.Geometry will increase file size. Use BufferGeometry instead.' );
+				geometry = new BufferGeometry().setFromObject( mesh );
 
 			}
 


### PR DESCRIPTION
Fixed #15864.

`BufferGeometry.fromGeometry()` can only handle mesh geometries. However, `BufferGeometry.setFromObject()` also supports points and lines.