### PR TITLE
Editor: Ensure to correctly configure GLTFLoader with DRACOLoader.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -219,7 +219,11 @@ var Loader = function ( editor ) {
 
 					} else {
 
+						var dracoLoader = new DRACOLoader();
+						dracoLoader.setDecoderPath( '../examples/js/libs/draco/gltf/' );
+
 						loader = new GLTFLoader( manager );
+						loader.setDRACOLoader( dracoLoader );
 
 					}
 


### PR DESCRIPTION
Fixed #18930.

It already worked for `glb` files. But for `gltf` files, `DRACOLoader` was not applied to `GLTFLoader`.