### PR TITLE
Water: Added support for logarithmic depth buffer.

### DIFF
--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -90,8 +90,10 @@ THREE.Water = function ( geometry, options ) {
 			'varying vec4 mirrorCoord;',
 			'varying vec4 worldPosition;',
 
-			THREE.ShaderChunk[ 'fog_pars_vertex' ],
-			THREE.ShaderChunk[ 'shadowmap_pars_vertex' ],
+		 	'#include <common>',
+		 	'#include <fog_pars_vertex>',
+			'#include <shadowmap_pars_vertex>',
+			'#include <logdepthbuf_pars_vertex>',
 
 			'void main() {',
 			'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
@@ -100,9 +102,9 @@ THREE.Water = function ( geometry, options ) {
 			'	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
 			'	gl_Position = projectionMatrix * mvPosition;',
 
-			THREE.ShaderChunk[ 'fog_vertex' ],
-			THREE.ShaderChunk[ 'shadowmap_vertex' ],
-
+			'#include <logdepthbuf_vertex>',
+			'#include <fog_vertex>',
+			'#include <shadowmap_vertex>',
 			'}'
 		].join( '\n' ),
 
@@ -140,15 +142,18 @@ THREE.Water = function ( geometry, options ) {
 			'	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;',
 			'}',
 
-			THREE.ShaderChunk[ 'common' ],
-			THREE.ShaderChunk[ 'packing' ],
-			THREE.ShaderChunk[ 'bsdfs' ],
-			THREE.ShaderChunk[ 'fog_pars_fragment' ],
-			THREE.ShaderChunk[ 'lights_pars_begin' ],
-			THREE.ShaderChunk[ 'shadowmap_pars_fragment' ],
-			THREE.ShaderChunk[ 'shadowmask_pars_fragment' ],
+			'#include <common>',
+			'#include <packing>',
+			'#include <bsdfs>',
+			'#include <fog_pars_fragment>',
+			'#include <logdepthbuf_pars_fragment>',
+			'#include <lights_pars_begin>',
+			'#include <shadowmap_pars_fragment>',
+			'#include <shadowmask_pars_fragment>',
 
 			'void main() {',
+
+			'#include <logdepthbuf_fragment>',
 			'	vec4 noise = getNoise( worldPosition.xz * size );',
 			'	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );',
 
@@ -172,9 +177,8 @@ THREE.Water = function ( geometry, options ) {
 			'	vec3 outgoingLight = albedo;',
 			'	gl_FragColor = vec4( outgoingLight, alpha );',
 
-			THREE.ShaderChunk[ 'tonemapping_fragment' ],
-			THREE.ShaderChunk[ 'fog_fragment' ],
-
+			'#include <tonemapping_fragment>',
+			'#include <fog_fragment>',
 			'}'
 		].join( '\n' )
 

--- a/examples/js/objects/Water2.js
+++ b/examples/js/objects/Water2.js
@@ -239,6 +239,7 @@ THREE.Water.WaterShader = {
 
 	vertexShader: [
 
+		'#include <common>',
 		'#include <fog_pars_vertex>',
 		'#include <logdepthbuf_pars_vertex>',
 

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -17,7 +17,6 @@ import {
 	PerspectiveCamera,
 	Plane,
 	RGBFormat,
-	ShaderChunk,
 	ShaderMaterial,
 	UniformsLib,
 	UniformsUtils,
@@ -109,8 +108,10 @@ var Water = function ( geometry, options ) {
 			'varying vec4 mirrorCoord;',
 			'varying vec4 worldPosition;',
 
-			ShaderChunk[ 'fog_pars_vertex' ],
-			ShaderChunk[ 'shadowmap_pars_vertex' ],
+		 	'#include <common>',
+		 	'#include <fog_pars_vertex>',
+			'#include <shadowmap_pars_vertex>',
+			'#include <logdepthbuf_pars_vertex>',
 
 			'void main() {',
 			'	mirrorCoord = modelMatrix * vec4( position, 1.0 );',
@@ -119,9 +120,9 @@ var Water = function ( geometry, options ) {
 			'	vec4 mvPosition =  modelViewMatrix * vec4( position, 1.0 );',
 			'	gl_Position = projectionMatrix * mvPosition;',
 
-			ShaderChunk[ 'fog_vertex' ],
-			ShaderChunk[ 'shadowmap_vertex' ],
-
+			'#include <logdepthbuf_vertex>',
+			'#include <fog_vertex>',
+			'#include <shadowmap_vertex>',
 			'}'
 		].join( '\n' ),
 
@@ -159,15 +160,18 @@ var Water = function ( geometry, options ) {
 			'	diffuseColor += max( dot( sunDirection, surfaceNormal ), 0.0 ) * sunColor * diffuse;',
 			'}',
 
-			ShaderChunk[ 'common' ],
-			ShaderChunk[ 'packing' ],
-			ShaderChunk[ 'bsdfs' ],
-			ShaderChunk[ 'fog_pars_fragment' ],
-			ShaderChunk[ 'lights_pars_begin' ],
-			ShaderChunk[ 'shadowmap_pars_fragment' ],
-			ShaderChunk[ 'shadowmask_pars_fragment' ],
+			'#include <common>',
+			'#include <packing>',
+			'#include <bsdfs>',
+			'#include <fog_pars_fragment>',
+			'#include <logdepthbuf_pars_fragment>',
+			'#include <lights_pars_begin>',
+			'#include <shadowmap_pars_fragment>',
+			'#include <shadowmask_pars_fragment>',
 
 			'void main() {',
+
+			'#include <logdepthbuf_fragment>',
 			'	vec4 noise = getNoise( worldPosition.xz * size );',
 			'	vec3 surfaceNormal = normalize( noise.xzy * vec3( 1.5, 1.0, 1.5 ) );',
 
@@ -191,9 +195,8 @@ var Water = function ( geometry, options ) {
 			'	vec3 outgoingLight = albedo;',
 			'	gl_FragColor = vec4( outgoingLight, alpha );',
 
-			ShaderChunk[ 'tonemapping_fragment' ],
-			ShaderChunk[ 'fog_fragment' ],
-
+			'#include <tonemapping_fragment>',
+			'#include <fog_fragment>',
 			'}'
 		].join( '\n' )
 

--- a/examples/jsm/objects/Water2.js
+++ b/examples/jsm/objects/Water2.js
@@ -256,6 +256,7 @@ Water.WaterShader = {
 
 	vertexShader: [
 
+		'#include <common>',
 		'#include <fog_pars_vertex>',
 		'#include <logdepthbuf_pars_vertex>',
 


### PR DESCRIPTION
Fixed #13963.

Also fixed the broken logarithmic depth buffer support for `Water2`. Since 8d00c49c4d32c323839da05012f9a126180b9535, the logarithmic depth buffer shader chunks rely on `common` in both vertex and fragment shader.