### PR TITLE
GLTFLoader: Use self instead of window

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1758,7 +1758,7 @@ THREE.GLTFLoader = ( function () {
 		var options = this.options;
 		var textureLoader = this.textureLoader;
 
-		var URL = window.URL || window.webkitURL;
+		var URL = self.URL || self.webkitURL;
 
 		var textureDef = json.textures[ textureIndex ];
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1821,7 +1821,7 @@ var GLTFLoader = ( function () {
 		var options = this.options;
 		var textureLoader = this.textureLoader;
 
-		var URL = window.URL || window.webkitURL;
+		var URL = self.URL || self.webkitURL;
 
 		var textureDef = json.textures[ textureIndex ];
 


### PR DESCRIPTION
Replacing `window` with `self` has no negative effects and GLTFLoader then works in web workers.

`window.URL` --> `self.URL`

[URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) is available in Web Workers.

Window API: [self](https://developer.mozilla.org/en-US/docs/Web/API/Window/self)

(to use` GLTFLoader` in worker, also using `manager.addHandler` to add an edited `TextureLoader` that uses `ImageBitmapLoader` instead of `ImageLoader`)