### PR TITLE
GLTFExporter: Ensure no empty material arrays.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -896,16 +896,16 @@ THREE.GLTFExporter.prototype = {
 
 			}
 
-			if ( ! outputJSON.materials ) {
-
-				outputJSON.materials = [];
-
-			}
-
-			if ( material.isShaderMaterial && ! material.isGLTFSpecularGlossinessMaterial ) {
+			if ( material.isShaderMaterial ) {
 
 				console.warn( 'GLTFExporter: THREE.ShaderMaterial not supported.' );
 				return null;
+
+			}
+
+			if ( ! outputJSON.materials ) {
+
+				outputJSON.materials = [];
 
 			}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -918,16 +918,16 @@ GLTFExporter.prototype = {
 
 			}
 
-			if ( ! outputJSON.materials ) {
-
-				outputJSON.materials = [];
-
-			}
-
-			if ( material.isShaderMaterial && ! material.isGLTFSpecularGlossinessMaterial ) {
+			if ( material.isShaderMaterial ) {
 
 				console.warn( 'GLTFExporter: THREE.ShaderMaterial not supported.' );
 				return null;
+
+			}
+
+			if ( ! outputJSON.materials ) {
+
+				outputJSON.materials = [];
 
 			}
 


### PR DESCRIPTION
This PR should fix #15860. At least I'm not aware of any scene graph configurations that could still produce empty arrays.