### PR TITLE
Fix TessellateModifier ts definition

### DIFF
--- a/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -2,7 +2,7 @@ import {
 	Geometry
 } from '../../../src/Three';
 
-export class SubdivisionModifier {
+export class TessellateModifier {
 
 	constructor( maxEdgeLength: number );
 	maxEdgeLength: number;


### PR DESCRIPTION
Hi, I think there is a kind of copy/paste issue in the typescript definition of `TessellateModifier`.
It causes import issues when using typescript.