### PR TITLE
Helpers: move to class syntax

### DIFF
--- a/src/helpers/AxesHelper.js
+++ b/src/helpers/AxesHelper.js
@@ -8,34 +8,30 @@ import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 
-function AxesHelper( size ) {
 
-	size = size || 1;
+class AxesHelper extends LineSegments {
 
-	var vertices = [
-		0, 0, 0,	size, 0, 0,
-		0, 0, 0,	0, size, 0,
-		0, 0, 0,	0, 0, size
-	];
+	constructor( size ) {
 
-	var colors = [
-		1, 0, 0,	1, 0.6, 0,
-		0, 1, 0,	0.6, 1, 0,
-		0, 0, 1,	0, 0.6, 1
-	];
+		size = size || 1;
+		var vertices = [
+			0, 0, 0, size, 0, 0,
+			0, 0, 0, 0, size, 0,
+			0, 0, 0, 0, 0, size
+		];
+		var colors = [
+			1, 0, 0, 1, 0.6, 0,
+			0, 1, 0, 0.6, 1, 0,
+			0, 0, 1, 0, 0.6, 1
+		];
+		var geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+		super( geometry, material );
 
-	var geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-	geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
-
-	var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
-
-	LineSegments.call( this, geometry, material );
+	}
 
 }
-
-AxesHelper.prototype = Object.create( LineSegments.prototype );
-AxesHelper.prototype.constructor = AxesHelper;
-
 
 export { AxesHelper };

--- a/src/helpers/Box3Helper.js
+++ b/src/helpers/Box3Helper.js
@@ -7,49 +7,37 @@ import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { BufferAttribute } from '../core/BufferAttribute.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
-import { Object3D } from '../core/Object3D.js';
 
-function Box3Helper( box, color ) {
 
-	this.type = 'Box3Helper';
+class Box3Helper extends LineSegments {
 
-	this.box = box;
+	constructor( box, color ) {
 
-	color = color || 0xffff00;
+		color = color || 0xffff00;
+		var indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
+		var positions = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 1, - 1, 1, - 1, - 1 ];
+		var geometry = new BufferGeometry();
+		geometry.setIndex( new BufferAttribute( indices, 1 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-	var indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
+		super( geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+		this.type = 'Box3Helper';
+		this.box = box;
+		this.geometry.computeBoundingSphere();
 
-	var positions = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 1, - 1, 1, - 1, - 1 ];
+	}
+	updateMatrixWorld( force ) {
 
-	var geometry = new BufferGeometry();
+		var box = this.box;
+		if ( box.isEmpty() )
+			return;
+		box.getCenter( this.position );
+		box.getSize( this.scale );
+		this.scale.multiplyScalar( 0.5 );
+		super.updateMatrixWorld( force );
 
-	geometry.setIndex( new BufferAttribute( indices, 1 ) );
-
-	geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-
-	LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
-
-	this.geometry.computeBoundingSphere();
+	}
 
 }
-
-Box3Helper.prototype = Object.create( LineSegments.prototype );
-Box3Helper.prototype.constructor = Box3Helper;
-
-Box3Helper.prototype.updateMatrixWorld = function ( force ) {
-
-	var box = this.box;
-
-	if ( box.isEmpty() ) return;
-
-	box.getCenter( this.position );
-
-	box.getSize( this.scale );
-
-	this.scale.multiplyScalar( 0.5 );
-
-	Object3D.prototype.updateMatrixWorld.call( this, force );
-
-};
 
 export { Box3Helper };

--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -11,107 +11,106 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
 
 var _box = new Box3();
 
-function BoxHelper( object, color ) {
+class BoxHelper extends LineSegments {
 
-	this.object = object;
+	constructor( object, color ) {
 
-	if ( color === undefined ) color = 0xffff00;
+		if ( color === undefined ) color = 0xffff00;
 
-	var indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
-	var positions = new Float32Array( 8 * 3 );
+		var indices = new Uint16Array( [ 0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7 ] );
+		var positions = new Float32Array( 8 * 3 );
+		var geometry = new BufferGeometry();
+		geometry.setIndex( new BufferAttribute( indices, 1 ) );
+		geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
-	var geometry = new BufferGeometry();
-	geometry.setIndex( new BufferAttribute( indices, 1 ) );
-	geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
+		super( geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+		this.object = object;
+		this.matrixAutoUpdate = false;
+		this.update();
 
-	LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+	}
+	update( object ) {
 
-	this.matrixAutoUpdate = false;
+		if ( object !== undefined ) {
 
-	this.update();
+			console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
+
+		}
+		if ( this.object !== undefined ) {
+
+			_box.setFromObject( this.object );
+
+		}
+		if ( _box.isEmpty() ) return;
+
+		var min = _box.min;
+		var max = _box.max;
+		/*
+			5____4
+		1/___0/|
+		| 6__|_7
+		2/___3/
+
+		0: max.x, max.y, max.z
+		1: min.x, max.y, max.z
+		2: min.x, min.y, max.z
+		3: max.x, min.y, max.z
+		4: max.x, max.y, min.z
+		5: min.x, max.y, min.z
+		6: min.x, min.y, min.z
+		7: max.x, min.y, min.z
+		*/
+		var position = this.geometry.attributes.position;
+		var array = position.array;
+		array[ 0 ] = max.x;
+		array[ 1 ] = max.y;
+		array[ 2 ] = max.z;
+		array[ 3 ] = min.x;
+		array[ 4 ] = max.y;
+		array[ 5 ] = max.z;
+		array[ 6 ] = min.x;
+		array[ 7 ] = min.y;
+		array[ 8 ] = max.z;
+		array[ 9 ] = max.x;
+		array[ 10 ] = min.y;
+		array[ 11 ] = max.z;
+		array[ 12 ] = max.x;
+		array[ 13 ] = max.y;
+		array[ 14 ] = min.z;
+		array[ 15 ] = min.x;
+		array[ 16 ] = max.y;
+		array[ 17 ] = min.z;
+		array[ 18 ] = min.x;
+		array[ 19 ] = min.y;
+		array[ 20 ] = min.z;
+		array[ 21 ] = max.x;
+		array[ 22 ] = min.y;
+		array[ 23 ] = min.z;
+		position.needsUpdate = true;
+		this.geometry.computeBoundingSphere();
+
+	}
+	setFromObject( object ) {
+
+		this.object = object;
+		this.update();
+		return this;
+
+	}
+	copy( source ) {
+
+		super.copy( source );
+		this.object = source.object;
+		return this;
+
+	}
+	clone() {
+
+		return new BoxHelper( this.object, this.color );
+
+	}
 
 }
 
-BoxHelper.prototype = Object.create( LineSegments.prototype );
-BoxHelper.prototype.constructor = BoxHelper;
-
-BoxHelper.prototype.update = function ( object ) {
-
-	if ( object !== undefined ) {
-
-		console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
-
-	}
-
-	if ( this.object !== undefined ) {
-
-		_box.setFromObject( this.object );
-
-	}
-
-	if ( _box.isEmpty() ) return;
-
-	var min = _box.min;
-	var max = _box.max;
-
-	/*
-	  5____4
-	1/___0/|
-	| 6__|_7
-	2/___3/
-
-	0: max.x, max.y, max.z
-	1: min.x, max.y, max.z
-	2: min.x, min.y, max.z
-	3: max.x, min.y, max.z
-	4: max.x, max.y, min.z
-	5: min.x, max.y, min.z
-	6: min.x, min.y, min.z
-	7: max.x, min.y, min.z
-	*/
-
-	var position = this.geometry.attributes.position;
-	var array = position.array;
-
-	array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;
-	array[ 3 ] = min.x; array[ 4 ] = max.y; array[ 5 ] = max.z;
-	array[ 6 ] = min.x; array[ 7 ] = min.y; array[ 8 ] = max.z;
-	array[ 9 ] = max.x; array[ 10 ] = min.y; array[ 11 ] = max.z;
-	array[ 12 ] = max.x; array[ 13 ] = max.y; array[ 14 ] = min.z;
-	array[ 15 ] = min.x; array[ 16 ] = max.y; array[ 17 ] = min.z;
-	array[ 18 ] = min.x; array[ 19 ] = min.y; array[ 20 ] = min.z;
-	array[ 21 ] = max.x; array[ 22 ] = min.y; array[ 23 ] = min.z;
-
-	position.needsUpdate = true;
-
-	this.geometry.computeBoundingSphere();
-
-
-};
-
-BoxHelper.prototype.setFromObject = function ( object ) {
-
-	this.object = object;
-	this.update();
-
-	return this;
-
-};
-
-BoxHelper.prototype.copy = function ( source ) {
-
-	LineSegments.prototype.copy.call( this, source );
-
-	this.object = source.object;
-
-	return this;
-
-};
-
-BoxHelper.prototype.clone = function () {
-
-	return new this.constructor().copy( this );
-
-};
 
 export { BoxHelper };

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -19,165 +19,133 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 var _vector = new Vector3();
 var _camera = new Camera();
 
-function CameraHelper( camera ) {
+class CameraHelper extends LineSegments {
 
-	var geometry = new BufferGeometry();
-	var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: true, toneMapped: false } );
+	constructor( camera ) {
 
-	var vertices = [];
-	var colors = [];
+		function addPoint( id, color ) {
 
-	var pointMap = {};
+			vertices.push( 0, 0, 0 );
+			colors.push( color.r, color.g, color.b );
+			if ( pointMap[ id ] === undefined ) {
 
-	// colors
+				pointMap[ id ] = [];
 
-	var colorFrustum = new Color( 0xffaa00 );
-	var colorCone = new Color( 0xff0000 );
-	var colorUp = new Color( 0x00aaff );
-	var colorTarget = new Color( 0xffffff );
-	var colorCross = new Color( 0x333333 );
-
-	// near
-
-	addLine( 'n1', 'n2', colorFrustum );
-	addLine( 'n2', 'n4', colorFrustum );
-	addLine( 'n4', 'n3', colorFrustum );
-	addLine( 'n3', 'n1', colorFrustum );
-
-	// far
-
-	addLine( 'f1', 'f2', colorFrustum );
-	addLine( 'f2', 'f4', colorFrustum );
-	addLine( 'f4', 'f3', colorFrustum );
-	addLine( 'f3', 'f1', colorFrustum );
-
-	// sides
-
-	addLine( 'n1', 'f1', colorFrustum );
-	addLine( 'n2', 'f2', colorFrustum );
-	addLine( 'n3', 'f3', colorFrustum );
-	addLine( 'n4', 'f4', colorFrustum );
-
-	// cone
-
-	addLine( 'p', 'n1', colorCone );
-	addLine( 'p', 'n2', colorCone );
-	addLine( 'p', 'n3', colorCone );
-	addLine( 'p', 'n4', colorCone );
-
-	// up
-
-	addLine( 'u1', 'u2', colorUp );
-	addLine( 'u2', 'u3', colorUp );
-	addLine( 'u3', 'u1', colorUp );
-
-	// target
-
-	addLine( 'c', 't', colorTarget );
-	addLine( 'p', 'c', colorCross );
-
-	// cross
-
-	addLine( 'cn1', 'cn2', colorCross );
-	addLine( 'cn3', 'cn4', colorCross );
-
-	addLine( 'cf1', 'cf2', colorCross );
-	addLine( 'cf3', 'cf4', colorCross );
-
-	function addLine( a, b, color ) {
-
-		addPoint( a, color );
-		addPoint( b, color );
-
-	}
-
-	function addPoint( id, color ) {
-
-		vertices.push( 0, 0, 0 );
-		colors.push( color.r, color.g, color.b );
-
-		if ( pointMap[ id ] === undefined ) {
-
-			pointMap[ id ] = [];
+			}
+			pointMap[ id ].push( ( vertices.length / 3 ) - 1 );
 
 		}
 
-		pointMap[ id ].push( ( vertices.length / 3 ) - 1 );
+		function addLine( a, b, color ) {
+
+			addPoint( a, color );
+			addPoint( b, color );
+
+		}
+
+		var geometry = new BufferGeometry();
+		var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: true, toneMapped: false } );
+		var vertices = [];
+		var colors = [];
+		var pointMap = {};
+
+		// colors
+		var colorFrustum = new Color( 0xffaa00 );
+		var colorCone = new Color( 0xff0000 );
+		var colorUp = new Color( 0x00aaff );
+		var colorTarget = new Color( 0xffffff );
+		var colorCross = new Color( 0x333333 );
+
+		// near
+		addLine( 'n1', 'n2', colorFrustum );
+		addLine( 'n2', 'n4', colorFrustum );
+		addLine( 'n4', 'n3', colorFrustum );
+		addLine( 'n3', 'n1', colorFrustum );
+
+		// far
+		addLine( 'f1', 'f2', colorFrustum );
+		addLine( 'f2', 'f4', colorFrustum );
+		addLine( 'f4', 'f3', colorFrustum );
+		addLine( 'f3', 'f1', colorFrustum );
+
+		// sides
+		addLine( 'n1', 'f1', colorFrustum );
+		addLine( 'n2', 'f2', colorFrustum );
+		addLine( 'n3', 'f3', colorFrustum );
+		addLine( 'n4', 'f4', colorFrustum );
+
+		// cone
+		addLine( 'p', 'n1', colorCone );
+		addLine( 'p', 'n2', colorCone );
+		addLine( 'p', 'n3', colorCone );
+		addLine( 'p', 'n4', colorCone );
+
+		// up
+		addLine( 'u1', 'u2', colorUp );
+		addLine( 'u2', 'u3', colorUp );
+		addLine( 'u3', 'u1', colorUp );
+
+		// target
+		addLine( 'c', 't', colorTarget );
+		addLine( 'p', 'c', colorCross );
+
+		// cross
+		addLine( 'cn1', 'cn2', colorCross );
+		addLine( 'cn3', 'cn4', colorCross );
+		addLine( 'cf1', 'cf2', colorCross );
+		addLine( 'cf3', 'cf4', colorCross );
+
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+
+		super( geometry, material );
+		this.camera = camera;
+		if ( this.camera.updateProjectionMatrix ) this.camera.updateProjectionMatrix();
+		this.matrix = camera.matrixWorld;
+		this.matrixAutoUpdate = false;
+		this.pointMap = pointMap;
+		this.update();
+
+	}
+	update() {
+
+		var geometry = this.geometry;
+		var pointMap = this.pointMap;
+		var w = 1, h = 1;
+		// we need just camera projection matrix inverse
+		// world matrix must be identity
+		_camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
+		// center / target
+		setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
+		setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
+		// near
+		setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
+		setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
+		setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
+		setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
+		// far
+		setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
+		setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
+		setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
+		setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
+		// up
+		setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
+		setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
+		setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
+		// cross
+		setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
+		setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
+		setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
+		setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
+		setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
+		setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
+		setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
+		setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
+		geometry.getAttribute( 'position' ).needsUpdate = true;
 
 	}
 
-	geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-	geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
-
-	LineSegments.call( this, geometry, material );
-
-	this.camera = camera;
-	if ( this.camera.updateProjectionMatrix ) this.camera.updateProjectionMatrix();
-
-	this.matrix = camera.matrixWorld;
-	this.matrixAutoUpdate = false;
-
-	this.pointMap = pointMap;
-
-	this.update();
-
 }
-
-CameraHelper.prototype = Object.create( LineSegments.prototype );
-CameraHelper.prototype.constructor = CameraHelper;
-
-CameraHelper.prototype.update = function () {
-
-	var geometry = this.geometry;
-	var pointMap = this.pointMap;
-
-	var w = 1, h = 1;
-
-	// we need just camera projection matrix inverse
-	// world matrix must be identity
-
-	_camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
-
-	// center / target
-
-	setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
-	setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
-
-	// near
-
-	setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
-	setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
-	setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
-	setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
-
-	// far
-
-	setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
-	setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
-	setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
-	setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
-
-	// up
-
-	setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
-	setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
-	setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
-
-	// cross
-
-	setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
-	setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
-	setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
-	setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
-
-	setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
-	setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
-	setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
-	setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
-
-	geometry.getAttribute( 'position' ).needsUpdate = true;
-
-};
 
 function setPoint( point, pointMap, geometry, camera, x, y, z ) {
 

--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -15,80 +15,71 @@ var _v1 = new Vector3();
 var _v2 = new Vector3();
 var _v3 = new Vector3();
 
-function DirectionalLightHelper( light, size, color ) {
+class DirectionalLightHelper extends Object3D {
 
-	Object3D.call( this );
+	constructor( light, size, color ) {
 
-	this.light = light;
-	this.light.updateMatrixWorld();
+		super();
+		this.light = light;
+		this.light.updateMatrixWorld();
+		this.matrix = light.matrixWorld;
+		this.matrixAutoUpdate = false;
+		this.color = color;
 
-	this.matrix = light.matrixWorld;
-	this.matrixAutoUpdate = false;
+		if ( size === undefined ) size = 1;
 
-	this.color = color;
+		var geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( [
+			- size, size, 0,
+			size, size, 0,
+			size, - size, 0,
+			- size, - size, 0,
+			- size, size, 0
+		], 3 ) );
+		var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
 
-	if ( size === undefined ) size = 1;
+		this.lightPlane = new Line( geometry, material );
+		this.add( this.lightPlane );
 
-	var geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( [
-		- size, size, 0,
-		size, size, 0,
-		size, - size, 0,
-		- size, - size, 0,
-		- size, size, 0
-	], 3 ) );
+		geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
+		this.targetLine = new Line( geometry, material );
 
-	var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
+		this.add( this.targetLine );
+		this.update();
 
-	this.lightPlane = new Line( geometry, material );
-	this.add( this.lightPlane );
+	}
+	dispose() {
 
-	geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
+		this.lightPlane.geometry.dispose();
+		this.lightPlane.material.dispose();
+		this.targetLine.geometry.dispose();
+		this.targetLine.material.dispose();
 
-	this.targetLine = new Line( geometry, material );
-	this.add( this.targetLine );
+	}
+	update() {
 
-	this.update();
+		_v1.setFromMatrixPosition( this.light.matrixWorld );
+		_v2.setFromMatrixPosition( this.light.target.matrixWorld );
+		_v3.subVectors( _v2, _v1 );
+		this.lightPlane.lookAt( _v2 );
+		if ( this.color !== undefined ) {
 
-}
+			this.lightPlane.material.color.set( this.color );
+			this.targetLine.material.color.set( this.color );
 
-DirectionalLightHelper.prototype = Object.create( Object3D.prototype );
-DirectionalLightHelper.prototype.constructor = DirectionalLightHelper;
+		} else {
 
-DirectionalLightHelper.prototype.dispose = function () {
+			this.lightPlane.material.color.copy( this.light.color );
+			this.targetLine.material.color.copy( this.light.color );
 
-	this.lightPlane.geometry.dispose();
-	this.lightPlane.material.dispose();
-	this.targetLine.geometry.dispose();
-	this.targetLine.material.dispose();
-
-};
-
-DirectionalLightHelper.prototype.update = function () {
-
-	_v1.setFromMatrixPosition( this.light.matrixWorld );
-	_v2.setFromMatrixPosition( this.light.target.matrixWorld );
-	_v3.subVectors( _v2, _v1 );
-
-	this.lightPlane.lookAt( _v2 );
-
-	if ( this.color !== undefined ) {
-
-		this.lightPlane.material.color.set( this.color );
-		this.targetLine.material.color.set( this.color );
-
-	} else {
-
-		this.lightPlane.material.color.copy( this.light.color );
-		this.targetLine.material.color.copy( this.light.color );
+		}
+		this.targetLine.lookAt( _v2 );
+		this.targetLine.scale.z = _v3.length();
 
 	}
 
-	this.targetLine.lookAt( _v2 );
-	this.targetLine.scale.z = _v3.length();
-
-};
+}
 
 
 export { DirectionalLightHelper };

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -8,64 +8,68 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Color } from '../math/Color.js';
 
-function GridHelper( size, divisions, color1, color2 ) {
 
-	size = size || 10;
-	divisions = divisions || 10;
-	color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
-	color2 = new Color( color2 !== undefined ? color2 : 0x888888 );
+class GridHelper extends LineSegments {
 
-	var center = divisions / 2;
-	var step = size / divisions;
-	var halfSize = size / 2;
+	constructor( size, divisions, color1, color2 ) {
 
-	var vertices = [], colors = [];
+		size = size || 10;
+		divisions = divisions || 10;
+		color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
+		color2 = new Color( color2 !== undefined ? color2 : 0x888888 );
 
-	for ( var i = 0, j = 0, k = - halfSize; i <= divisions; i ++, k += step ) {
+		var center = divisions / 2;
+		var step = size / divisions;
+		var halfSize = size / 2;
 
-		vertices.push( - halfSize, 0, k, halfSize, 0, k );
-		vertices.push( k, 0, - halfSize, k, 0, halfSize );
+		var vertices = [], colors = [];
 
-		var color = i === center ? color1 : color2;
+		for ( var i = 0, j = 0, k = - halfSize; i <= divisions; i ++, k += step ) {
 
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
-		color.toArray( colors, j ); j += 3;
+			vertices.push( - halfSize, 0, k, halfSize, 0, k );
+			vertices.push( k, 0, - halfSize, k, 0, halfSize );
+
+			var color = i === center ? color1 : color2;
+
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+			color.toArray( colors, j ); j += 3;
+
+		}
+
+		var geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+
+		super( geometry, material );
+		this.size = size;
+		this.divisions = divisions;
+		this.color1 = color1;
+		this.color2 = color2;
 
 	}
 
-	var geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-	geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+	copy( source ) {
 
-	var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
-
-	LineSegments.call( this, geometry, material );
-
-}
-
-GridHelper.prototype = Object.assign( Object.create( LineSegments.prototype ), {
-
-	constructor: GridHelper,
-
-	copy: function ( source ) {
-
-		LineSegments.prototype.copy.call( this, source );
+		super.copy( source );
 
 		this.geometry.copy( source.geometry );
 		this.material.copy( source.material );
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
-		return new this.constructor().copy( this );
+		return new GridHelper( this.size, this.divisions, this.color1, this.color2 );
 
 	}
 
-} );
+}
+
 
 export { GridHelper };

--- a/src/helpers/PlaneHelper.js
+++ b/src/helpers/PlaneHelper.js
@@ -8,56 +8,46 @@ import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { MeshBasicMaterial } from '../materials/MeshBasicMaterial.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
-import { Object3D } from '../core/Object3D.js';
 import { FrontSide, BackSide } from '../constants.js';
 
-function PlaneHelper( plane, size, hex ) {
 
-	this.type = 'PlaneHelper';
+class PlaneHelper extends Line {
 
-	this.plane = plane;
+	constructor( plane, size, hex ) {
 
-	this.size = ( size === undefined ) ? 1 : size;
+		var color = ( hex !== undefined ) ? hex : 0xffff00;
+		var positions = [ 1, - 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0 ];
 
-	var color = ( hex !== undefined ) ? hex : 0xffff00;
+		var geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.computeBoundingSphere();
 
-	var positions = [ 1, - 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0 ];
+		super( geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+		this.type = 'PlaneHelper';
+		this.plane = plane;
+		this.size = ( size === undefined ) ? 1 : size;
 
-	var geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-	geometry.computeBoundingSphere();
+		var positions2 = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, - 1, 1, 1, - 1, 1 ];
+		var geometry2 = new BufferGeometry();
+		geometry2.setAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
+		geometry2.computeBoundingSphere();
+		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false, toneMapped: false } ) ) );
 
-	Line.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+	}
+	updateMatrixWorld( force ) {
 
-	//
+		var scale = - this.plane.constant;
+		if ( Math.abs( scale ) < 1e-8 ) scale = 1e-8; // sign does not matter
+		this.scale.set( 0.5 * this.size, 0.5 * this.size, scale );
+		this.children[ 0 ].material.side = ( scale < 0 ) ? BackSide : FrontSide; // renderer flips side when determinant < 0; flipping not wanted here
+		this.lookAt( this.plane.normal );
+		this.updateMatrixWorld( force );
+		// TODO: delete comment vvv
+		//Object3D.prototype.updateMatrixWorld(force);
 
-	var positions2 = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, - 1, 1, 1, - 1, 1 ];
-
-	var geometry2 = new BufferGeometry();
-	geometry2.setAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
-	geometry2.computeBoundingSphere();
-
-	this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false, toneMapped: false } ) ) );
+	}
 
 }
 
-PlaneHelper.prototype = Object.create( Line.prototype );
-PlaneHelper.prototype.constructor = PlaneHelper;
-
-PlaneHelper.prototype.updateMatrixWorld = function ( force ) {
-
-	var scale = - this.plane.constant;
-
-	if ( Math.abs( scale ) < 1e-8 ) scale = 1e-8; // sign does not matter
-
-	this.scale.set( 0.5 * this.size, 0.5 * this.size, scale );
-
-	this.children[ 0 ].material.side = ( scale < 0 ) ? BackSide : FrontSide; // renderer flips side when determinant < 0; flipping not wanted here
-
-	this.lookAt( this.plane.normal );
-
-	Object3D.prototype.updateMatrixWorld.call( this, force );
-
-};
 
 export { PlaneHelper };

--- a/src/helpers/PointLightHelper.js
+++ b/src/helpers/PointLightHelper.js
@@ -7,86 +7,79 @@ import { Mesh } from '../objects/Mesh.js';
 import { MeshBasicMaterial } from '../materials/MeshBasicMaterial.js';
 import { SphereBufferGeometry } from '../geometries/SphereGeometry.js';
 
-function PointLightHelper( light, sphereSize, color ) {
 
-	this.light = light;
-	this.light.updateMatrixWorld();
+class PointLightHelper extends Mesh {
 
-	this.color = color;
+	constructor( light, sphereSize, color ) {
 
-	var geometry = new SphereBufferGeometry( sphereSize, 4, 2 );
-	var material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
+		var geometry = new SphereBufferGeometry( sphereSize, 4, 2 );
+		var material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
+		super( geometry, material );
 
-	Mesh.call( this, geometry, material );
+		this.light = light;
+		this.light.updateMatrixWorld();
+		this.color = color;
+		this.matrix = this.light.matrixWorld;
+		this.matrixAutoUpdate = false;
+		this.update();
+		/*
+		var distanceGeometry = new THREE.IcosahedronBufferGeometry( 1, 2 );
+		var distanceMaterial = new THREE.MeshBasicMaterial( { color: hexColor, fog: false, wireframe: true, opacity: 0.1, transparent: true } );
 
-	this.matrix = this.light.matrixWorld;
-	this.matrixAutoUpdate = false;
+		this.lightSphere = new THREE.Mesh( bulbGeometry, bulbMaterial );
+		this.lightDistance = new THREE.Mesh( distanceGeometry, distanceMaterial );
 
-	this.update();
+		var d = light.distance;
 
+		if ( d === 0.0 ) {
 
-	/*
-	var distanceGeometry = new THREE.IcosahedronBufferGeometry( 1, 2 );
-	var distanceMaterial = new THREE.MeshBasicMaterial( { color: hexColor, fog: false, wireframe: true, opacity: 0.1, transparent: true } );
+				this.lightDistance.visible = false;
 
-	this.lightSphere = new THREE.Mesh( bulbGeometry, bulbMaterial );
-	this.lightDistance = new THREE.Mesh( distanceGeometry, distanceMaterial );
+		} else {
 
-	var d = light.distance;
+				this.lightDistance.scale.set( d, d, d );
 
-	if ( d === 0.0 ) {
+		}
 
-		this.lightDistance.visible = false;
-
-	} else {
-
-		this.lightDistance.scale.set( d, d, d );
+		this.add( this.lightDistance );
+		*/
 
 	}
+	dispose() {
 
-	this.add( this.lightDistance );
-	*/
+		this.geometry.dispose();
+		this.material.dispose();
+
+	}
+	update() {
+
+		if ( this.color !== undefined ) {
+
+			this.material.color.set( this.color );
+
+		} else {
+
+			this.material.color.copy( this.light.color );
+
+		}
+		/*
+		var d = this.light.distance;
+
+		if ( d === 0.0 ) {
+
+				this.lightDistance.visible = false;
+
+		} else {
+
+				this.lightDistance.visible = true;
+				this.lightDistance.scale.set( d, d, d );
+
+		}
+		*/
+
+	}
 
 }
-
-PointLightHelper.prototype = Object.create( Mesh.prototype );
-PointLightHelper.prototype.constructor = PointLightHelper;
-
-PointLightHelper.prototype.dispose = function () {
-
-	this.geometry.dispose();
-	this.material.dispose();
-
-};
-
-PointLightHelper.prototype.update = function () {
-
-	if ( this.color !== undefined ) {
-
-		this.material.color.set( this.color );
-
-	} else {
-
-		this.material.color.copy( this.light.color );
-
-	}
-
-	/*
-	var d = this.light.distance;
-
-	if ( d === 0.0 ) {
-
-		this.lightDistance.visible = false;
-
-	} else {
-
-		this.lightDistance.visible = true;
-		this.lightDistance.scale.set( d, d, d );
-
-	}
-	*/
-
-};
 
 
 export { PointLightHelper };

--- a/src/helpers/PolarGridHelper.js
+++ b/src/helpers/PolarGridHelper.js
@@ -10,85 +10,86 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Color } from '../math/Color.js';
 
-function PolarGridHelper( radius, radials, circles, divisions, color1, color2 ) {
+class PolarGridHelper extends LineSegments {
 
-	radius = radius || 10;
-	radials = radials || 16;
-	circles = circles || 8;
-	divisions = divisions || 64;
-	color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
-	color2 = new Color( color2 !== undefined ? color2 : 0x888888 );
+	constructor( radius, radials, circles, divisions, color1, color2 ) {
 
-	var vertices = [];
-	var colors = [];
+		radius = radius || 10;
+		radials = radials || 16;
+		circles = circles || 8;
+		divisions = divisions || 64;
+		color1 = new Color( color1 !== undefined ? color1 : 0x444444 );
+		color2 = new Color( color2 !== undefined ? color2 : 0x888888 );
 
-	var x, z;
-	var v, i, j, r, color;
+		var vertices = [];
+		var colors = [];
 
-	// create the radials
+		var x, z;
+		var v, i, j, r, color;
 
-	for ( i = 0; i <= radials; i ++ ) {
+		// create the radials
 
-		v = ( i / radials ) * ( Math.PI * 2 );
+		for ( i = 0; i <= radials; i ++ ) {
 
-		x = Math.sin( v ) * radius;
-		z = Math.cos( v ) * radius;
+			v = ( i / radials ) * ( Math.PI * 2 );
 
-		vertices.push( 0, 0, 0 );
-		vertices.push( x, 0, z );
+			x = Math.sin( v ) * radius;
+			z = Math.cos( v ) * radius;
 
-		color = ( i & 1 ) ? color1 : color2;
-
-		colors.push( color.r, color.g, color.b );
-		colors.push( color.r, color.g, color.b );
-
-	}
-
-	// create the circles
-
-	for ( i = 0; i <= circles; i ++ ) {
-
-		color = ( i & 1 ) ? color1 : color2;
-
-		r = radius - ( radius / circles * i );
-
-		for ( j = 0; j < divisions; j ++ ) {
-
-			// first vertex
-
-			v = ( j / divisions ) * ( Math.PI * 2 );
-
-			x = Math.sin( v ) * r;
-			z = Math.cos( v ) * r;
-
+			vertices.push( 0, 0, 0 );
 			vertices.push( x, 0, z );
+
+			color = ( i & 1 ) ? color1 : color2;
+
 			colors.push( color.r, color.g, color.b );
-
-			// second vertex
-
-			v = ( ( j + 1 ) / divisions ) * ( Math.PI * 2 );
-
-			x = Math.sin( v ) * r;
-			z = Math.cos( v ) * r;
-
-			vertices.push( x, 0, z );
 			colors.push( color.r, color.g, color.b );
 
 		}
 
+		// create the circles
+
+		for ( i = 0; i <= circles; i ++ ) {
+
+			color = ( i & 1 ) ? color1 : color2;
+
+			r = radius - ( radius / circles * i );
+
+			for ( j = 0; j < divisions; j ++ ) {
+
+				// first vertex
+
+				v = ( j / divisions ) * ( Math.PI * 2 );
+
+				x = Math.sin( v ) * r;
+				z = Math.cos( v ) * r;
+
+				vertices.push( x, 0, z );
+				colors.push( color.r, color.g, color.b );
+
+				// second vertex
+
+				v = ( ( j + 1 ) / divisions ) * ( Math.PI * 2 );
+
+				x = Math.sin( v ) * r;
+				z = Math.cos( v ) * r;
+
+				vertices.push( x, 0, z );
+				colors.push( color.r, color.g, color.b );
+
+			}
+
+		}
+
+		var geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+
+		super( geometry, material );
+
 	}
-
-	var geometry = new BufferGeometry();
-	geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-	geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
-
-	var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
-
-	LineSegments.call( this, geometry, material );
 
 }
 
-PolarGridHelper.prototype = Object.create( LineSegments.prototype );
-PolarGridHelper.prototype.constructor = PolarGridHelper;
 
 export { PolarGridHelper };


### PR DESCRIPTION
Relates to: #18863

Helpers that were left out of the update
SkeletonHelper.js
ArrowHelper.js
because they are both used within the examples/js folder