### PR TITLE
call onUpload in WebGLAttributes.updateBuffer()

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -73,7 +73,7 @@ function WebGLAttributes( gl, capabilities ) {
 		gl.bindBuffer( bufferType, buffer );
 
 		attribute.onUploadCallback();
-		
+
 		if ( updateRange.count === - 1 ) {
 
 			// Not using update ranges

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -72,6 +72,8 @@ function WebGLAttributes( gl, capabilities ) {
 
 		gl.bindBuffer( bufferType, buffer );
 
+		attribute.onUploadCallback();
+		
 		if ( updateRange.count === - 1 ) {
 
 			// Not using update ranges


### PR DESCRIPTION
call onuploadcallback function in WebGLAttributes.updateBuffer() after gl.bindbuffer so that the application chould dispose the arraybuffer not only the init create function but also update. It is useful when users want release memory after they changed the attribute. 