### PR TITLE
Allow TrackballControls to work in a static scene

### DIFF
--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -16,10 +16,12 @@
 			<p>
 				[name] is similar to [page:OrbitControls]. However, it does not maintain a constant camera [page:Object3D.up up] vector.
 				That means if the camera orbits over the “north” and “south” poles, it does not flip to stay "right side up".
+
+				If using [name] in a static scene, make sure to disable the damping effect by setting [page:.staticMoving staticMoving] to *true*.
 			</p>
 		</p>
 
-		<h2>Examples</h2>
+		<h2>Example</h2>
 
 		<p>[example:misc_controls_trackball misc / controls / trackball ]</p>
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -516,6 +516,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		}
 
+		if (_this.staticMoving === true) _this.update();
+
 	}
 
 	function mouseup( event ) {

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -524,6 +524,8 @@ var TrackballControls = function ( object, domElement ) {
 
 		}
 
+		if (_this.staticMoving === true) _this.update();
+
 	}
 
 	function mouseup( event ) {


### PR DESCRIPTION
The `staticMoving` flag suggests that you can use the trackball control without an animation loop, which is not the case. This change allows people to use trackball control without an animation loop, by calling `update` directly after a mouseMove event.

I'm aware that it will cause two calls to update if you set `staticMoving` to true, and use an animation loop that updates the control. Let me know if there is a better way to do it

