### PR TITLE
Examples: Only call .clear() if necessary.

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -162,7 +162,7 @@ THREE.Reflector = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 
 		renderer.xr.enabled = currentXrEnabled;

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -198,7 +198,7 @@ THREE.Refractor = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 
 		renderer.xr.enabled = currentXrEnabled;

--- a/examples/js/objects/Water.js
+++ b/examples/js/objects/Water.js
@@ -295,7 +295,7 @@ THREE.Water = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, mirrorCamera );
 
 		scope.visible = true;

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -179,7 +179,7 @@ var Reflector = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 
 		renderer.xr.enabled = currentXrEnabled;

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -216,7 +216,7 @@ var Refractor = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 
 		renderer.xr.enabled = currentXrEnabled;

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -313,7 +313,7 @@ var Water = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
-		renderer.clear();
+		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, mirrorCamera );
 
 		scope.visible = true;


### PR DESCRIPTION
`Reflector`, `Refractor` and `Water` currently call `WebGLRenderer.clear()` even when `WebGLRenderer.autoClear` is set to `true`.