### PR TITLE
Syntax fix in WebGLCubeRenderTarget docs.

### DIFF
--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -24,7 +24,7 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number size], param:Object options])</h3>
+		<h3>[name]([param:Number size], [param:Object options])</h3>
 		<p>
 		[page:Float size] - the size, in pixels. <br />
 		options - (optional) object that holds texture parameters for an auto-generated target


### PR DESCRIPTION
Was breaking formatting of https://threejs.org/docs/index.html#api/en/renderers/WebGLCubeRenderTarget