### PR TITLE
Reflector: Fix rendering bug when using Scene.background.

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -162,6 +162,9 @@ THREE.Reflector = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
+
+		renderer.state.buffers.depth.setMask( true ); // make sure the depth buffer is writable so it can be properly cleared, see #18897
+
 		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -179,6 +179,9 @@ var Reflector = function ( geometry, options ) {
 		renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
 		renderer.setRenderTarget( renderTarget );
+
+		renderer.state.buffers.depth.setMask( true ); // make sure the depth buffer is writable so it can be properly cleared, see #18897
+
 		if ( renderer.autoClear === false ) renderer.clear();
 		renderer.render( scene, virtualCamera );
 


### PR DESCRIPTION
Fixed #18897.

I have finally found out was causes the rendering issue when using `Scene.background` with a mirror. This was really hard to debug since the error only happened when the instance of `Reflector` was right after the background cube mesh in the render list.

When rendering a skybox with `Scene.background`, the respective shader material sets `depthWrite` to `false` which prevents writes to the depth buffer. However, this also prevents proper clearing. And this was the reason why the glitches appear. The render target could not be cleared properly because the depth buffer was not writable.

To avoid similar problems in `WebGLRenderer`, the following code section exists at the end of `render()`.

https://github.com/mrdoob/three.js/blob/7c1424c5819ab622a346dd630ee4e6431388021e/src/renderers/WebGLRenderer.js#L1257-L1261

Using a similar approach in `Reflector` solves the issue.

Broken fiddle: https://jsfiddle.net/4xqwveo2/
Fixed fiddle: https://jsfiddle.net/szuxL9q7/1/