### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/js/curves/NURBSCurve.js
+++ b/examples/js/curves/NURBSCurve.js
@@ -38,7 +38,9 @@ THREE.NURBSCurve.prototype = Object.create( THREE.Curve.prototype );
 THREE.NURBSCurve.prototype.constructor = THREE.NURBSCurve;
 
 
-THREE.NURBSCurve.prototype.getPoint = function ( t ) {
+THREE.NURBSCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new THREE.Vector3();
 
 	var u = this.knots[ this.startKnot ] + t * ( this.knots[ this.endKnot ] - this.knots[ this.startKnot ] ); // linear mapping t->u
 
@@ -52,7 +54,7 @@ THREE.NURBSCurve.prototype.getPoint = function ( t ) {
 
 	}
 
-	return new THREE.Vector3( hpoint.x, hpoint.y, hpoint.z );
+	return point.set( hpoint.x, hpoint.y, hpoint.z );
 
 };
 

--- a/examples/jsm/curves/NURBSCurve.js
+++ b/examples/jsm/curves/NURBSCurve.js
@@ -45,7 +45,9 @@ NURBSCurve.prototype = Object.create( Curve.prototype );
 NURBSCurve.prototype.constructor = NURBSCurve;
 
 
-NURBSCurve.prototype.getPoint = function ( t ) {
+NURBSCurve.prototype.getPoint = function ( t, optionalTarget ) {
+
+	var point = optionalTarget || new Vector3();
 
 	var u = this.knots[ this.startKnot ] + t * ( this.knots[ this.endKnot ] - this.knots[ this.startKnot ] ); // linear mapping t->u
 
@@ -59,7 +61,7 @@ NURBSCurve.prototype.getPoint = function ( t ) {
 
 	}
 
-	return new Vector3( hpoint.x, hpoint.y, hpoint.z );
+	return point.set( hpoint.x, hpoint.y, hpoint.z );
 
 };
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -69,14 +69,17 @@
 
 				var spline = new THREE.CatmullRomCurve3( points );
 				var divisions = Math.round( 12 * points.length );
+				var point = new THREE.Vector3();
 				var color = new THREE.Color();
 
 				for ( var i = 0, l = divisions; i < l; i ++ ) {
 
-					var point = spline.getPoint( i / l );
+					var t = i / l;
+
+					spline.getPoint( t, point );
 					positions.push( point.x, point.y, point.z );
 
-					color.setHSL( i / l, 1.0, 0.5 );
+					color.setHSL( t, 1.0, 0.5 );
 					colors.push( color.r, color.g, color.b );
 
 				}

--- a/examples/webgl_shaders_vector.html
+++ b/examples/webgl_shaders_vector.html
@@ -122,8 +122,8 @@
 
 					var wind;
 
-					pts.push( path[ 0 ].getPoint( 0 ) );
-					pts2.push( path[ 0 ].getPoint( 0 ) );
+					pts.push( path[ 0 ].getPoint( 0, new THREE.Vector2() ) );
+					pts2.push( path[ 0 ].getPoint( 0, new THREE.Vector2() ) );
 
 					for ( var i = 0; i < path.length; i ++ ) {
 


### PR DESCRIPTION
Ensure `Curve.getPoint()` is correctly overwritten and used.