### PR TITLE
Fix binary reading problem of PCD format

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -210,7 +210,7 @@ PCDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				} else {
 
 					PCDheader.offset[ PCDheader.fields[ i ] ] = sizeSum;
-					sizeSum += PCDheader.size[ i ];
+					sizeSum += PCDheader.size[ i ] * PCDheader.count[ i ];
 
 				}
 


### PR DESCRIPTION
PCD binary format could look like this:
```
# .PCD v0.7 - Point Cloud Data file format
VERSION 0.7
FIELDS x y z _ intensity ring _
SIZE 4 4 4 1 4 2 1
TYPE F F F U F U U
COUNT 1 1 1 4 1 1 10
WIDTH 22539
HEIGHT 1
VIEWPOINT 0 0 0 1 0 0 0
POINTS 22539
DATA binary
```
The correct field size is SIZE * COUNT.