### PR TITLE
TS: Clean up Curve type declarations.

### DIFF
--- a/src/extras/core/Curve.d.ts
+++ b/src/extras/core/Curve.d.ts
@@ -71,6 +71,11 @@ export class Curve<T extends Vector> {
 	 */
 	getTangentAt( u: number, optionalTarget?: T ): T;
 
+	clone(): Curve<T>;
+	copy( source: Curve<T> ): this;
+	toJSON(): object;
+	fromJSON( json: object ): this;
+
 	/**
 	 * @deprecated since r84.
 	 */

--- a/src/extras/core/CurvePath.d.ts
+++ b/src/extras/core/CurvePath.d.ts
@@ -10,14 +10,9 @@ export class CurvePath<T extends Vector> extends Curve<T> {
 	autoClose: boolean;
 
 	add( curve: Curve<T> ): void;
-	checkConnection(): boolean;
 	closePath(): void;
 	getPoint( t: number ): T;
-	getLength(): number;
-	updateArcLengths(): void;
 	getCurveLengths(): number[];
-	getSpacedPoints( divisions?: number ): T[];
-	getPoints( divisions?: number ): T[];
 
 	/**
 	 * @deprecated Use {@link Geometry#setFromPoints new THREE.Geometry().setFromPoints( points )} instead.

--- a/src/extras/core/Path.d.ts
+++ b/src/extras/core/Path.d.ts
@@ -1,21 +1,6 @@
 import { Vector2 } from './../../math/Vector2';
 import { CurvePath } from './CurvePath';
 
-export enum PathActions {
-	MOVE_TO,
-	LINE_TO,
-	QUADRATIC_CURVE_TO, // Bezier quadratic curve
-	BEZIER_CURVE_TO, // Bezier cubic curve
-	CSPLINE_THRU, // Catmull-rom spline
-	ARC, // Circle
-	ELLIPSE,
-}
-
-export interface PathAction {
-	action: PathActions;
-	args: any;
-}
-
 /**
  * a 2d path representation, comprising of points, lines, and cubes, similar to the html5 2d canvas api. It extends CurvePath.
  */


### PR DESCRIPTION
When working with the `Curve` classes, I've noticed a few things to improve.