### PR TITLE
MeshBasicMaterial: Add dithering

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -9,6 +9,7 @@ uniform float opacity;
 #endif
 
 #include <common>
+#include <dithering_pars_fragment>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <uv2_pars_fragment>
@@ -66,6 +67,7 @@ void main() {
 	#include <encodings_fragment>
 	#include <fog_fragment>
 	#include <premultiplied_alpha_fragment>
+	#include <dithering_fragment>
 
 }
 `;


### PR DESCRIPTION
See forum discussion for context:

https://discourse.threejs.org/t/srgb-texture-encoding-gives-color-banding-issue/13855/17

This PR adds dithering to MeshBasicMaterial which is useful when linear->gamma color conversion is causing banding due to a texture even though the material does not support lighting .