### PR TITLE
MeshMatcapMaterial: Support dithering

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -14,6 +14,7 @@ varying vec3 vViewPosition;
 #endif
 
 #include <common>
+#include <dithering_pars_fragment>
 #include <color_pars_fragment>
 #include <uv_pars_fragment>
 #include <map_pars_fragment>
@@ -63,6 +64,7 @@ void main() {
 	#include <encodings_fragment>
 	#include <fog_fragment>
 	#include <premultiplied_alpha_fragment>
+	#include <dithering_fragment>
 
 }
 `;


### PR DESCRIPTION
`MeshMatcapMaterial` does not support lights, but it does support a matcap texture, and hence gradients.

Consequently this seems reasonable to me.