### PR TITLE
Sphere: Add makeEmpty function.

### DIFF
--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -76,6 +76,9 @@
 		<h3>[method:Boolean empty]()</h3>
 		<p>Checks to see if the sphere is empty (the radius set to 0).</p>
 
+		<h3>[method:Sphere makeEmpty]()</h3>
+		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to 0.</p>
+
 		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
 		<p>
 		Checks to see if the two spheres' centers and radii are equal.

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -11,12 +11,13 @@
 		<h1>[name]</h1>
 
 		<p class="desc">A sphere defined by a center and radius.</p>
+		<p></p>
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Vector3 center], [param:Float radius] )</h3>
 		<p>
 		[page:Vector3 center] - center of the sphere. Default is a [page:Vector3] at (0, 0, 0). <br />
-		[page:Float radius] - radius of the sphere. Default is 0.<br /><br />
+		[page:Float radius] - radius of the sphere. Default is -1.<br /><br />
 
 		Creates a new [name].
 
@@ -73,11 +74,14 @@
 		the distance will be negative.
 		</p>
 
-		<h3>[method:Boolean empty]()</h3>
-		<p>Checks to see if the sphere is empty (the radius set to 0).</p>
+		<h3>[method:Boolean isEmpty]()</h3>
+		<p>
+		Checks to see if the sphere is empty (the radius set to a negative number).</br>
+		Spheres with a radius of 0 contain only their center point and are not considererd to be empty.
+		</p>
 
 		<h3>[method:Sphere makeEmpty]()</h3>
-		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to 0.</p>
+		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to -1.</p>
 
 		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
 		<p>

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -11,7 +11,6 @@
 		<h1>[name]</h1>
 
 		<p class="desc">A sphere defined by a center and radius.</p>
-		<p></p>
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Vector3 center], [param:Float radius] )</h3>
@@ -77,7 +76,7 @@
 		<h3>[method:Boolean isEmpty]()</h3>
 		<p>
 		Checks to see if the sphere is empty (the radius set to a negative number).</br>
-		Spheres with a radius of 0 contain only their center point and are not considererd to be empty.
+		Spheres with a radius of 0 contain only their center point and are not considered to be empty.
 		</p>
 
 		<h3>[method:Sphere makeEmpty]()</h3>

--- a/docs/api/zh/math/Sphere.html
+++ b/docs/api/zh/math/Sphere.html
@@ -71,10 +71,13 @@
 		</p>
 
 		<h3>[method:Boolean isEmpty]()</h3>
-		<p>检查球是否为空（the radius set to a negative number）.</p>
+		<p>
+		检查球是否为空（the radius set to a negative number）.
+		Spheres with a radius of 0 contain only their center point and are not considered to be empty.
+		</p>
 
 		<h3>[method:Sphere makeEmpty]()</h3>
-		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to 0.</p>
+		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to -1.</p>
 
 		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
 		<p>

--- a/docs/api/zh/math/Sphere.html
+++ b/docs/api/zh/math/Sphere.html
@@ -70,8 +70,8 @@
 		若这个点，则距离将为负值。
 		</p>
 
-		<h3>[method:Boolean empty]()</h3>
-		<p>检查球是否为空（其半径设为了0）.</p>
+		<h3>[method:Boolean isEmpty]()</h3>
+		<p>检查球是否为空（the radius set to a negative number）.</p>
 
 		<h3>[method:Sphere makeEmpty]()</h3>
 		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to 0.</p>

--- a/docs/api/zh/math/Sphere.html
+++ b/docs/api/zh/math/Sphere.html
@@ -73,6 +73,9 @@
 		<h3>[method:Boolean empty]()</h3>
 		<p>检查球是否为空（其半径设为了0）.</p>
 
+		<h3>[method:Sphere makeEmpty]()</h3>
+		<p>Makes the sphere empty by setting [page:.center center] to (0, 0, 0) and [page:.radius radius] to 0.</p>
+
 		<h3>[method:Boolean equals]( [param:Sphere sphere] )</h3>
 		<p>
 		检查这两个球的球心与半径是否相等。

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -62,6 +62,7 @@ import { PointsMaterial } from './materials/PointsMaterial.js';
 import { ShaderMaterial } from './materials/ShaderMaterial.js';
 import { Box2 } from './math/Box2.js';
 import { Box3 } from './math/Box3.js';
+import { Sphere } from './math/Sphere.js';
 import { Color } from './math/Color.js';
 import { Frustum } from './math/Frustum.js';
 import { Line3 } from './math/Line3.js';
@@ -544,7 +545,7 @@ Object.assign( Box3.prototype, {
 
 Object.assign( Sphere.prototype, {
 
-	empty: function() {
+	empty: function () {
 
 		console.warn( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
 		return this.isEmpty();

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -542,6 +542,17 @@ Object.assign( Box3.prototype, {
 	}
 } );
 
+Object.assign( Sphere.prototype, {
+
+	empty: function() {
+
+		console.warn( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
+		return this.isEmpty();
+
+	},
+
+} );
+
 Frustum.prototype.setFromMatrix = function ( m ) {
 
 	console.warn( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -325,6 +325,12 @@ Object.assign( Box3.prototype, {
 
 	intersectsSphere: function ( sphere ) {
 
+		if( sphere.isEmpty() ) {
+
+			return false;
+
+		}
+
 		// Find the point on the AABB closest to the sphere center.
 		this.clampPoint( sphere.center, _vector );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -325,12 +325,6 @@ Object.assign( Box3.prototype, {
 
 	intersectsSphere: function ( sphere ) {
 
-		if( sphere.isEmpty() ) {
-
-			return false;
-
-		}
-
 		// Find the point on the AABB closest to the sphere center.
 		this.clampPoint( sphere.center, _vector );
 

--- a/src/math/Sphere.d.ts
+++ b/src/math/Sphere.d.ts
@@ -15,6 +15,7 @@ export class Sphere {
 	clone(): this;
 	copy( sphere: Sphere ): this;
 	empty(): boolean;
+	makeEmpty(): this;
 	containsPoint( point: Vector3 ): boolean;
 	distanceToPoint( point: Vector3 ): number;
 	intersectsSphere( sphere: Sphere ): boolean;

--- a/src/math/Sphere.d.ts
+++ b/src/math/Sphere.d.ts
@@ -14,7 +14,7 @@ export class Sphere {
 	setFromPoints( points: Vector3[], optionalCenter?: Vector3 ): Sphere;
 	clone(): this;
 	copy( sphere: Sphere ): this;
-	empty(): boolean;
+	isEmpty(): boolean;
 	makeEmpty(): this;
 	containsPoint( point: Vector3 ): boolean;
 	distanceToPoint( point: Vector3 ): number;
@@ -26,5 +26,10 @@ export class Sphere {
 	applyMatrix4( matrix: Matrix4 ): Sphere;
 	translate( offset: Vector3 ): Sphere;
 	equals( sphere: Sphere ): boolean;
+
+	/**
+	 * @deprecated Use {@link Sphere#isEmpty .isEmpty()} instead.
+	 */
+	empty(): any;
 
 }

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -75,6 +75,15 @@ Object.assign( Sphere.prototype, {
 
 	},
 
+	makeEmpty: function () {
+
+		this.center.set( 0, 0, 0 );
+		this.radius = 0;
+
+		return this;
+
+	},
+
 	containsPoint: function ( point ) {
 
 		return ( point.distanceToSquared( this.center ) <= ( this.radius * this.radius ) );

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -11,7 +11,7 @@ var _box = new Box3();
 function Sphere( center, radius ) {
 
 	this.center = ( center !== undefined ) ? center : new Vector3();
-	this.radius = ( radius !== undefined ) ? radius : -1;
+	this.radius = ( radius !== undefined ) ? radius : - 1;
 
 }
 
@@ -78,19 +78,13 @@ Object.assign( Sphere.prototype, {
 	makeEmpty: function () {
 
 		this.center.set( 0, 0, 0 );
-		this.radius = -1;
+		this.radius = - 1;
 
 		return this;
 
 	},
 
 	containsPoint: function ( point ) {
-
-		if( this.isEmpty() ) {
-
-			return false;
-
-		}
 
 		return ( point.distanceToSquared( this.center ) <= ( this.radius * this.radius ) );
 
@@ -103,12 +97,6 @@ Object.assign( Sphere.prototype, {
 	},
 
 	intersectsSphere: function ( sphere ) {
-
-		if( this.isEmpty() ) {
-
-			return false;
-
-		}
 
 		var radiusSum = this.radius + sphere.radius;
 
@@ -161,8 +149,9 @@ Object.assign( Sphere.prototype, {
 
 		}
 
-		if( this.isEmpty() ) {
+		if ( this.isEmpty() ) {
 
+			// Empty sphere produces empty bounding box
 			target.makeEmpty();
 			return target;
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -11,7 +11,7 @@ var _box = new Box3();
 function Sphere( center, radius ) {
 
 	this.center = ( center !== undefined ) ? center : new Vector3();
-	this.radius = ( radius !== undefined ) ? radius : 0;
+	this.radius = ( radius !== undefined ) ? radius : -1;
 
 }
 
@@ -69,22 +69,28 @@ Object.assign( Sphere.prototype, {
 
 	},
 
-	empty: function () {
+	isEmpty: function () {
 
-		return ( this.radius <= 0 );
+		return ( this.radius < 0 );
 
 	},
 
 	makeEmpty: function () {
 
 		this.center.set( 0, 0, 0 );
-		this.radius = 0;
+		this.radius = -1;
 
 		return this;
 
 	},
 
 	containsPoint: function ( point ) {
+
+		if( this.isEmpty() ) {
+
+			return false;
+
+		}
 
 		return ( point.distanceToSquared( this.center ) <= ( this.radius * this.radius ) );
 
@@ -97,6 +103,12 @@ Object.assign( Sphere.prototype, {
 	},
 
 	intersectsSphere: function ( sphere ) {
+
+		if( this.isEmpty() ) {
+
+			return false;
+
+		}
 
 		var radiusSum = this.radius + sphere.radius;
 
@@ -146,6 +158,13 @@ Object.assign( Sphere.prototype, {
 
 			console.warn( 'THREE.Sphere: .getBoundingBox() target is now required' );
 			target = new Box3();
+
+		}
+
+		if( this.isEmpty() ) {
+
+			target.makeEmpty();
+			return target;
 
 		}
 

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -118,6 +118,16 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "makeEmpty", ( assert ) => {
+
+			var a = new Sphere( one3.clone(), 1 );
+
+			a.makeEmpty();
+			assert.ok( a.empty(), "Passed!" );
+			assert.ok( a.center.equals( zero3 ), "Passed!" );
+
+		} );
+
 		QUnit.test( "containsPoint", ( assert ) => {
 
 			var a = new Sphere( one3.clone(), 1 );

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -25,7 +25,7 @@ export default QUnit.module( 'Maths', () => {
 
 			var a = new Sphere();
 			assert.ok( a.center.equals( zero3 ), "Passed!" );
-			assert.ok( a.radius == 0, "Passed!" );
+			assert.ok( a.radius == - 1, "Passed!" );
 
 			var a = new Sphere( one3.clone(), 1 );
 			assert.ok( a.center.equals( one3 ), "Passed!" );
@@ -44,7 +44,7 @@ export default QUnit.module( 'Maths', () => {
 
 			var a = new Sphere();
 			assert.ok( a.center.equals( zero3 ), "Passed!" );
-			assert.ok( a.radius == 0, "Passed!" );
+			assert.ok( a.radius == - 1, "Passed!" );
 
 			a.set( one3, 1 );
 			assert.ok( a.center.equals( one3 ), "Passed!" );
@@ -148,9 +148,6 @@ export default QUnit.module( 'Maths', () => {
 			a.set( zero3, 0 );
 			assert.ok( a.containsPoint( a.center ), "Passed!" );
 
-			a.makeEmpty();
-			assert.ok( !a.containsPoint( a.center ), "Passed" );
-
 		} );
 
 		QUnit.test( "distanceToPoint", ( assert ) => {
@@ -171,9 +168,6 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.intersectsSphere( b ), "Passed!" );
 			assert.ok( ! a.intersectsSphere( c ), "Passed!" );
 
-			a.makeEmpty();
-			assert.ok( !a.intersectsSphere( a ), "Passed!" );
-
 		} );
 
 		QUnit.test( "intersectsBox", ( assert ) => {
@@ -184,9 +178,6 @@ export default QUnit.module( 'Maths', () => {
 
 			assert.strictEqual( a.intersectsBox( box ), true, "Check unit sphere" );
 			assert.strictEqual( b.intersectsBox( box ), false, "Check shifted sphere" );
-
-			a.makeEmpty();
-			assert.strictEqual( a.intersectsBox( box ), false , "Check empty sphere");
 
 		} );
 
@@ -200,9 +191,6 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.intersectsPlane( b ), "Passed!" );
 			assert.ok( ! a.intersectsPlane( c ), "Passed!" );
 			assert.ok( ! a.intersectsPlane( d ), "Passed!" );
-
-			a.makeEmpty();
-			assert.ok( ! a.intersectsPlane( b ), "Passed!" );
 
 		} );
 

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -108,13 +108,21 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "empty", ( assert ) => {
+		QUnit.test( "isEmpty", ( assert ) => {
 
 			var a = new Sphere();
-			assert.ok( a.empty(), "Passed!" );
+			assert.ok( a.isEmpty(), "Passed!" );
 
 			a.set( one3, 1 );
-			assert.ok( ! a.empty(), "Passed!" );
+			assert.ok( ! a.isEmpty(), "Passed!" );
+
+			// Negative radius contains no points
+			a.set( one3, -1 );
+			assert.ok( a.isEmpty(), "Passed!" );
+
+			// Zero radius contains only the center point
+			a.set( one3, 0 );
+			assert.ok( ! a.isEmpty(), "Passed!" );
 
 		} );
 
@@ -122,8 +130,10 @@ export default QUnit.module( 'Maths', () => {
 
 			var a = new Sphere( one3.clone(), 1 );
 
+			assert.ok( ! a.isEmpty(), "Passed!" );
+
 			a.makeEmpty();
-			assert.ok( a.empty(), "Passed!" );
+			assert.ok( a.isEmpty(), "Passed!" );
 			assert.ok( a.center.equals( zero3 ), "Passed!" );
 
 		} );
@@ -134,6 +144,12 @@ export default QUnit.module( 'Maths', () => {
 
 			assert.ok( ! a.containsPoint( zero3 ), "Passed!" );
 			assert.ok( a.containsPoint( one3 ), "Passed!" );
+
+			a.set( zero3, 0 );
+			assert.ok( a.containsPoint( a.center ), "Passed!" );
+
+			a.makeEmpty();
+			assert.ok( !a.containsPoint( a.center ), "Passed" );
 
 		} );
 
@@ -155,16 +171,22 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.intersectsSphere( b ), "Passed!" );
 			assert.ok( ! a.intersectsSphere( c ), "Passed!" );
 
+			a.makeEmpty();
+			assert.ok( !a.intersectsSphere( a ), "Passed!" );
+
 		} );
 
 		QUnit.test( "intersectsBox", ( assert ) => {
 
-			var a = new Sphere();
-			var b = new Sphere( new Vector3( - 5, - 5, - 5 ) );
+			var a = new Sphere( zero3, 1 );
+			var b = new Sphere( new Vector3( - 5, - 5, - 5 ), 1 );
 			var box = new Box3( zero3, one3 );
 
-			assert.strictEqual( a.intersectsBox( box ), true, "Check default sphere" );
+			assert.strictEqual( a.intersectsBox( box ), true, "Check unit sphere" );
 			assert.strictEqual( b.intersectsBox( box ), false, "Check shifted sphere" );
+
+			a.makeEmpty();
+			assert.strictEqual( a.intersectsBox( box ), false , "Check empty sphere");
 
 		} );
 
@@ -178,6 +200,9 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.intersectsPlane( b ), "Passed!" );
 			assert.ok( ! a.intersectsPlane( c ), "Passed!" );
 			assert.ok( ! a.intersectsPlane( d ), "Passed!" );
+
+			a.makeEmpty();
+			assert.ok( ! a.intersectsPlane( b ), "Passed!" );
 
 		} );
 
@@ -204,6 +229,11 @@ export default QUnit.module( 'Maths', () => {
 			a.set( zero3, 0 );
 			a.getBoundingBox( aabb );
 			assert.ok( aabb.equals( new Box3( zero3, zero3 ) ), "Passed!" );
+
+			// Empty sphere produces empty bounding box
+			a.makeEmpty();
+			a.getBoundingBox( aabb );
+			assert.ok( aabb.isEmpty(), "Passed!" );
 
 		} );
 


### PR DESCRIPTION
Adds a `makeEmpty()` function for `Sphere` to allow clearing of bounding volumes in the same way as `Box.makeEmpty()`.

Technically, setting the centre of the sphere to 0, 0, 0 is not required for `Sphere.empty()` to return true, but I felt as though fully re-initialising the sphere to its default state was the right way to go to keep it consistent with `Box3.makeEmpty()`