### PR TITLE
Make layers apply recursively

### DIFF
--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -42,6 +42,11 @@
 			A bit mask storing which of the 32 layers this layers object is currently a member of.
 		</p>
 
+		<h3>[property:Boolean recursive]</h3>
+		<p>
+			If true parent object layers will affect rendering and raycasting of children. Defaults to *false*.
+		</p>
+
 
 		<h2>Methods</h2>
 

--- a/src/core/Layers.d.ts
+++ b/src/core/Layers.d.ts
@@ -3,6 +3,7 @@ export class Layers {
 	constructor();
 
 	mask: number;
+	recursive: boolean;
 
 	set( channel: number ): void;
 	enable( channel: number ): void;

--- a/src/core/Layers.js
+++ b/src/core/Layers.js
@@ -5,6 +5,7 @@
 function Layers() {
 
 	this.mask = 1 | 0;
+	this.recursive = false;
 
 }
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -50,15 +50,15 @@ function intersectObject( object, raycaster, intersects, recursive ) {
 
 		object.raycast( raycaster, intersects );
 
-	}
+		if ( recursive === true ) {
 
-	if ( recursive === true ) {
+			var children = object.children;
 
-		var children = object.children;
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-		for ( var i = 0, l = children.length; i < l; i ++ ) {
+				intersectObject( children[ i ], raycaster, intersects, true );
 
-			intersectObject( children[ i ], raycaster, intersects, true );
+			}
 
 		}
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -46,11 +46,17 @@ function ascSort( a, b ) {
 
 function intersectObject( object, raycaster, intersects, recursive ) {
 
-	if ( object.layers.test( raycaster.layers ) ) {
+	var layerTest = object.layers.test( raycaster.layers );
+
+	if ( layerTest ) {
 
 		object.raycast( raycaster, intersects );
 
-		if ( recursive === true ) {
+	}
+
+	if ( recursive === true ) {
+
+		if ( ! object.layers.recursive || object.layers.recursive && layerTest ) {
 
 			var children = object.children;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1381,13 +1381,13 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-		}
+			var children = object.children;
 
-		var children = object.children;
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-		for ( var i = 0, l = children.length; i < l; i ++ ) {
+				projectObject( children[ i ], camera, groupOrder, sortObjects );
 
-			projectObject( children[ i ], camera, groupOrder, sortObjects );
+			}
 
 		}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1272,9 +1272,9 @@ function WebGLRenderer( parameters ) {
 
 		if ( object.visible === false ) return;
 
-		var visible = object.layers.test( camera.layers );
+		var layerTest = object.layers.test( camera.layers );
 
-		if ( visible ) {
+		if ( ! object.layers.recursive || layerTest && object.layers.recursive ) {
 
 			if ( object.isGroup ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1274,7 +1274,7 @@ function WebGLRenderer( parameters ) {
 
 		var layerTest = object.layers.test( camera.layers );
 
-		if ( ! object.layers.recursive || layerTest && object.layers.recursive ) {
+		if ( layerTest ) {
 
 			if ( object.isGroup ) {
 
@@ -1381,11 +1381,15 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-			var children = object.children;
+			if ( ! object.layers.recursive || object.layers.recursive && layerTest ) {
 
-			for ( var i = 0, l = children.length; i < l; i ++ ) {
+				var children = object.children;
 
-				projectObject( children[ i ], camera, groupOrder, sortObjects );
+				for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+					projectObject( children[ i ], camera, groupOrder, sortObjects );
+
+				}
 
 			}
 

--- a/test/unit/src/core/Raycaster.tests.js
+++ b/test/unit/src/core/Raycaster.tests.js
@@ -6,12 +6,13 @@
 import { Raycaster } from '../../../../src/core/Raycaster';
 import { Vector3 } from '../../../../src/math/Vector3';
 import { Mesh } from '../../../../src/objects/Mesh';
-import { SphereGeometry } from '../../../../src/geometries/SphereGeometry';
+import { SphereGeometry, SphereBufferGeometry } from '../../../../src/geometries/SphereGeometry';
 import { BufferGeometry } from '../../../../src/core/BufferGeometry';
 import { Line } from '../../../../src/objects/Line.js';
 import { Points } from '../../../../src/objects/Points.js';
 import { PerspectiveCamera } from '../../../../src/cameras/PerspectiveCamera';
 import { OrthographicCamera } from '../../../../src/cameras/OrthographicCamera';
+import { Group } from '../../../../src/objects/Group';
 
 function checkRayDirectionAgainstReferenceVector( rayDirection, refVector, assert ) {
 
@@ -227,6 +228,27 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( "Recursive layers", ( assert ) => {
+
+			var raycaster = getRaycaster();
+			var geometry = new SphereBufferGeometry();
+			var child = new Mesh( geometry );
+			var parent = new Group();
+
+			parent.add( child );
+
+			raycaster.ray.origin.set( 0, 0, - 2 );
+			raycaster.ray.direction.set( 0, 0, 1 );
+
+			parent.layers.disableAll();
+			assert.ok( raycaster.intersectObject( parent, true ).length === 1,
+				"successful intersection with child that matches layer mask" );
+
+			parent.layers.recursive = true;
+			assert.ok( raycaster.intersectObject( parent, true ).length === 0,
+				"no intersection with recursive layer checking" );
+
+		} );
 
 	} );
 

--- a/test/unit/src/core/Raycaster.tests.js
+++ b/test/unit/src/core/Raycaster.tests.js
@@ -240,6 +240,11 @@ export default QUnit.module( 'Core', () => {
 			raycaster.ray.origin.set( 0, 0, - 2 );
 			raycaster.ray.direction.set( 0, 0, 1 );
 
+			parent.layers.recursive = true;
+			assert.ok( raycaster.intersectObject( parent, true ).length === 1,
+				"successful intersection with parent and child that matches recursive layer mask" );
+
+			parent.layers.recursive = false;
 			parent.layers.disableAll();
 			assert.ok( raycaster.intersectObject( parent, true ).length === 1,
 				"successful intersection with child that matches layer mask" );


### PR DESCRIPTION
Fix #18937

This PR changes layers to apply recursively -- so if a parent object does not pass the layer test then raycasting and rendering traversal will stop. This will let users treat groups of objects as a whole and is more consistent with the way object visibility works.

Ping @finnbear to see if this addresses your usecase, too.
