### PR TITLE
WebGLRenderer: Fixed vertex attributes update with InstancedMesh.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -748,6 +748,12 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( object.isInstancedMesh === true ) {
+
+			updateBuffers = true;
+
+		}
+
 		//
 
 		var index = geometry.index;


### PR DESCRIPTION
Fixed https://discourse.threejs.org/t/reusing-instancedmesh-geometry-and-material/14008/.

When two or more `InstancedMesh` share the same geometry, it's still necessary to refresh the vertex attributes via `setupVertexAttributes()`. That is necessary since the vertex data not only depend on the used geometry and material but also on the 3D object (`instanceMatrix`).

Hence, it's safe to always call `setupVertexAttributes()` when an `InstancedMesh` is going to be rendered otherwise `instanceMatrix` might have a wrong buffer binding.