### PR TITLE
WebGLRenderer: Add support for integer attributes with WebGL2.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -942,7 +942,7 @@ function WebGLRenderer( parameters ) {
 						}
 
 						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+						state.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
 
 					} else {
 
@@ -963,7 +963,7 @@ function WebGLRenderer( parameters ) {
 						}
 
 						_gl.bindBuffer( _gl.ARRAY_BUFFER, buffer );
-						_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+						state.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
 
 					}
 

--- a/src/renderers/webgl/WebGLState.d.ts
+++ b/src/renderers/webgl/WebGLState.d.ts
@@ -56,6 +56,7 @@ export class WebGLState {
 	enableAttribute( attribute: number ): void;
 	enableAttributeAndDivisor( attribute: number, meshPerAttribute: number ): void;
 	disableUnusedAttributes(): void;
+	vertexAttribPointer( index: number, size: number, type: number, normalized: boolean, stride: number, offset: number ): void;
 	enable( id: number ): void;
 	disable( id: number ): void;
 	useProgram( program: any ): boolean;

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -462,6 +462,20 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
+	function vertexAttribPointer( index, size, type, normalized, stride, offset ) {
+
+		if ( isWebGL2 === true && ( type === gl.INT || type === gl.UNSIGNED_INT ) ) {
+
+			gl.vertexAttribIPointer( index, size, type, normalized, stride, offset );
+
+		} else {
+
+			gl.vertexAttribPointer( index, size, type, normalized, stride, offset );
+
+		}
+
+	}
+
 	function enable( id ) {
 
 		if ( enabledCapabilities[ id ] !== true ) {
@@ -980,6 +994,7 @@ function WebGLState( gl, extensions, capabilities ) {
 		enableAttribute: enableAttribute,
 		enableAttributeAndDivisor: enableAttributeAndDivisor,
 		disableUnusedAttributes: disableUnusedAttributes,
+		vertexAttribPointer: vertexAttribPointer,
 		enable: enable,
 		disable: disable,
 


### PR DESCRIPTION
WebGL 2 supports integer vertex attributes. However, it only works when `vertexAttribIPointer` is used. More details in the [WebGL 2 specification](https://www.khronos.org/registry/webgl/specs/latest/2.0/), 5.31 "VertexAttrib function must match shader attribute type" . Also see this [discussion](https://community.khronos.org/t/nv-problems-using-integer-attributes/63212/4).

To be clear: 

- `Int32BufferAttribute` is mapped to GLSL `int`.
- `Uint32BufferAttribute` is mapped to GLSL `uint`.

The actual feature request comes from the [forum](https://discourse.threejs.org/t/uint32-custom-vertex-attribute-rejected-as-invalid/14019).