### PR TITLE
Update materialProperties.environment even if program doesn't change

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1519,11 +1519,12 @@ function WebGLRenderer( parameters ) {
 
 			materialProperties.program = program;
 			materialProperties.uniforms = parameters.uniforms;
-			materialProperties.environment = material.isMeshStandardMaterial ? scene.environment : null;
 			materialProperties.outputEncoding = _this.outputEncoding;
 			material.program = program;
 
 		}
+
+		materialProperties.environment = material.isMeshStandardMaterial ? scene.environment : null;
 
 		var programAttributes = program.getAttributes();
 


### PR DESCRIPTION
The environment map can be switched to a different image while still using the exact same shader. It's important to update materialProperties.environment in this case so that unnecessary calls to initMaterial can be avoided. Prior to this fix FPS could be halved after changing scene.environment to a different texture of the same type.