### PR TITLE
[documentation] Add a DocSearch

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -379,7 +379,7 @@
 						hitsPerPage: 10, 'facetFilters': ["lang:" + languageSelect.value]
 					}
 				})
-				if ('URLSearchParams' in window) {
+				if (window.location.hash.includes('q=')) {
 					const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
 					const searchQuery = urlParams.get('q')
 					document.getElementById('filter').value = searchQuery

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,6 +382,7 @@
 				if (window.location.hash.includes('q=')) {
 					const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
 					const searchQuery = urlParams.get('q')
+					window.innerWidth < 640 && document.getElementById('expandButton').click();
 					document.getElementById('filter').value = searchQuery
 					document.getElementById('filter').focus()
 					docSearch.autocomplete.autocomplete.setVal(searchQuery)

--- a/docs/index.html
+++ b/docs/index.html
@@ -369,9 +369,7 @@
 					apiKey: 'ec69071880b355699ad27cb720becc23',
 					indexName: 'threejs',
 					inputSelector: '#filter',
-					algoliaOptions: {
-						hitsPerPage: 20, 'facetFilters': ["lang:" + languageSelect.value]
-					}
+					algoliaOptions: { 'facetFilters': ["lang:" + languageSelect.value] }
 				})
 			}
 		</script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="shortcut icon" href="../files/favicon.ico" />
 		<link rel="stylesheet" type="text/css" href="../files/main.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 		<!-- console sandbox -->
 		<script src="../build/three.min.js" async defer></script>
 	</head>
@@ -84,7 +85,6 @@
 				language = value;
 
 				createNavigation();
-				updateFilter();
 				autoChangeUrlLanguage( language );
 
 			}
@@ -139,14 +139,12 @@
 			exitSearchButton.onclick = function( event ) {
 
 				filterInput.value = '';
-				updateFilter();
 				panel.classList.remove('searchFocused');
 
 			}
 
 			filterInput.oninput = function ( event ) {
 
-				updateFilter();
 
 			};
 
@@ -282,117 +280,6 @@
 
 			}
 
-
-			// Filtering
-
-			function updateFilter() {
-
-				// (uncomment the following line and the "Query strings" section, if you want query strings):
-				// updateQueryString();
-
-				var regExp = new RegExp( filterInput.value, 'gi' );
-
-				for ( var pageName in pageProperties ) {
-
-					var linkElement = pageProperties[ pageName ].linkElement;
-					var categoryClassList = linkElement.parentElement.classList;
-					var filterResults = pageName.match( regExp );
-
-					if ( filterResults && filterResults.length > 0 ) {
-
-						// Accentuate matching characters
-
-						for ( var i = 0; i < filterResults.length; i++ ) {
-
-							var result = filterResults[ i ];
-
-							if ( result !== '' ) {
-								pageName = pageName.replace( result, '<b>' + result + '</b>' );
-							}
-
-						}
-
-						categoryClassList.remove( 'hidden' );
-						linkElement.innerHTML = pageName;
-
-					} else {
-
-						// Hide all non-matching page names
-
-						categoryClassList.add( 'hidden' );
-
-					}
-
-				}
-
-				displayFilteredPanel();
-
-			}
-
-			function displayFilteredPanel() {
-
-				// Show/hide categories depending on their content
-				// First check if at least one page in this category is not hidden
-
-				categoryElements.forEach( function ( category ) {
-
-					var pages = category.children;
-					var pagesLength = pages.length;
-					var sectionClassList = category.parentElement.classList;
-
-					var hideCategory = true;
-
-					for ( var i = 0; i < pagesLength; i ++ ) {
-
-						var pageClassList = pages[ i ].classList;
-
-						if ( ! pageClassList.contains( 'hidden' ) ) {
-
-							hideCategory = false;
-
-						}
-
-					}
-
-					// If and only if all page names are hidden, hide the whole category
-
-					if ( hideCategory ) {
-
-						sectionClassList.add( 'hidden' );
-
-					} else {
-
-						sectionClassList.remove( 'hidden' );
-
-					}
-
-				} );
-
-			}
-
-
-			// Routing
-
-			function setUrlFragment( pageName ) {
-
-				// Handle navigation from the subpages (iframes):
-				// First separate the memeber (if existing) from the page name,
-				// then identify the subpage's URL and set it as URL fragment (re-adding the member)
-
-				var splitPageName = decomposePageName( pageName, '.', '.' );
-
-				var currentProperties = pageProperties[ splitPageName[ 0 ] ];
-
-				if ( currentProperties ) {
-
-					window.location.hash = currentProperties.pageURL + splitPageName[ 1 ];
-
-					createNewIframe();
-
-				}
-
-			}
-
 			function createNewIframe() {
 
 				// Change the content displayed in the iframe
@@ -474,6 +361,20 @@
 
 
 		</script>
+		<script>
+			function addSearch() {
+				var languageSelect = document.getElementById('language');
+	
+				docsearch({
+					apiKey: 'ec69071880b355699ad27cb720becc23',
+					indexName: 'threejs',
+					inputSelector: '#filter',
+					algoliaOptions: { 'facetFilters': ["lang:" + languageSelect.value] }
+				})
+			}
+		</script>
+		<script type="text/javascript" onload="addSearch()" async defer
+			src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 
 	</body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -369,7 +369,9 @@
 					apiKey: 'ec69071880b355699ad27cb720becc23',
 					indexName: 'threejs',
 					inputSelector: '#filter',
-					algoliaOptions: { 'facetFilters': ["lang:" + languageSelect.value] }
+					algoliaOptions: {
+						hitsPerPage: 20, 'facetFilters': ["lang:" + languageSelect.value]
+					}
 				})
 			}
 		</script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,8 @@
 
 				filterInput.value = '';
 				panel.classList.remove('searchFocused');
-
+				const newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
+				window.history.pushState({ path: newUrl }, '', newUrl);
 			}
 
 			filterInput.oninput = function ( event ) {
@@ -363,13 +364,36 @@
 		</script>
 		<script>
 			function addSearch() {
-				var languageSelect = document.getElementById('language');
-	
-				docsearch({
+				const languageSelect = document.getElementById('language');
+				const docSearch = docsearch({
 					apiKey: 'ec69071880b355699ad27cb720becc23',
 					indexName: 'threejs',
 					inputSelector: '#filter',
-					algoliaOptions: { 'facetFilters': ["lang:" + languageSelect.value] }
+					queryHook: (q) => {
+						let hash = window.location.hash.replace(/(\?q=.*)/g, '')
+						hash = hash.replace(/(\.html)/g, '')
+						var newRelativePathQuery = window.location.pathname + hash + ".html" + '?q=' + q;
+						history.pushState(null, '', newRelativePathQuery);
+					},
+					algoliaOptions: {
+						hitsPerPage: 10, 'facetFilters': ["lang:" + languageSelect.value]
+					}
+				})
+				if ('URLSearchParams' in window) {
+					const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
+					const searchQuery = urlParams.get('q')
+					document.getElementById('filter').value = searchQuery
+					document.getElementById('filter').focus()
+					docSearch.autocomplete.autocomplete.setVal(searchQuery)
+					docSearch.autocomplete.autocomplete.open()
+				}
+				const input = document.querySelector('#filter')
+				input.addEventListener('input', evt => {
+					if (evt.target.value === "") {
+						const hash = window.location.hash.replace(/(\?q=.*)/g, '')
+						const newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + hash;
+						window.history.pushState({ path: newUrl }, '', newUrl);
+					}
 				})
 			}
 		</script>

--- a/files/main.css
+++ b/files/main.css
@@ -126,7 +126,7 @@ h1 a {
 	left: 0px;
 	width: var(--panel-width);
 	height: 100%;
-	overflow: auto;
+	overflow: visible;
 	border-right: var(--border-style);
 	display: flex;
 	flex-direction: column;
@@ -277,7 +277,7 @@ h1 a {
 
 	#contentWrapper {
 		flex: 1;
-		overflow: hidden;
+		overflow: visible;
 		display: flex;
 		flex-direction: column;
 		transform: translate3d(0,0,0);
@@ -285,7 +285,7 @@ h1 a {
 	#panel #content {
 		flex: 1;
 		overflow-y: auto;
-		overflow-x: hidden;
+		overflow-x: visible;
 		-webkit-overflow-scrolling: touch;
 		padding: 0 var(--panel-padding) var(--panel-padding) var(--panel-padding);
 	}
@@ -487,7 +487,7 @@ iframe {
 		width: 100%;
 		right: 0;
 		z-index: 1000;
-		overflow-x: hidden;
+		overflow: visible;
 		transition: 0s 0s height;
 		border: none;
 		height: var(--header-height);
@@ -526,7 +526,7 @@ iframe {
 		max-width: 360px;
 		z-index: 10000;
 		transition: .25s transform;
-		overflow-x: hidden;
+		overflow: visible;
 		margin-right: -380px;
 		line-height: 2rem;
 	}
@@ -543,4 +543,23 @@ iframe {
 	#viewer {
 		padding-left: 0;
 	}
+}
+
+/* DocSearch */
+
+body .algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-],
+body .algolia-autocomplete .algolia-docsearch-suggestion,
+body .algolia-autocomplete .algolia-docsearch-suggestion--category-header,
+body .algolia-autocomplete .ds-dropdown-menu:before {
+	background-color: var(--background-color);
+	color: var(--text-color);
+}
+
+body .algolia-autocomplete .algolia-docsearch-suggestion--title {
+	color: var(--text-color);
+}
+
+body .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+	color: white;
+	color: var(--color-blue);
 }

--- a/files/main.css
+++ b/files/main.css
@@ -564,7 +564,12 @@ body .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
 	color: var(--color-blue);
 }
 
-body .ds-dropdown-menu {
+body .algolia-autocomplete .ds-dropdown-menu {
 	max-height: 80vh;
-	overflow-y: scroll;
+	overflow: scroll;
+}
+
+body .algolia-autocomplete .ds-dropdown-menu,
+body .algolia-autocomplete .ds-dropdown-menu * {
+	max-width:80vw;
 }

--- a/files/main.css
+++ b/files/main.css
@@ -563,3 +563,8 @@ body .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
 	color: white;
 	color: var(--color-blue);
 }
+
+body .ds-dropdown-menu {
+	max-height: 80vh;
+	overflow-y: scroll;
+}

--- a/files/main.css
+++ b/files/main.css
@@ -277,15 +277,14 @@ h1 a {
 
 	#contentWrapper {
 		flex: 1;
-		overflow: visible;
 		display: flex;
 		flex-direction: column;
 		transform: translate3d(0,0,0);
+		max-height: 100%;
 	}
 	#panel #content {
 		flex: 1;
-		overflow-y: auto;
-		overflow-x: visible;
+		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
 		padding: 0 var(--panel-padding) var(--panel-padding) var(--panel-padding);
 	}


### PR DESCRIPTION
👋 team,

TL;DR: Add a learn-as-you-type search experience to the documentation

I'm working at Algolia on the a project called [DocSearch](https://community.algolia.com/docsearch/) which goal is to enhance documentation websites with exhaustive, fast and relevant search. You might have seen DocSearch live already on websites like [react](https://reactjs.org/), [Bootstrap](https://getbootstrap.com/), [Brew](https://brew.sh/) or [jQuery](https://jquery.com/).

I have created [a preview of this PR](https://threejs-docsearch.surge.sh/docs/) and what DocSearch on the threejs website could will look like here. Feel free to try it and let us know what you think. Please note the learn-as-you-type experience and the typo tolerance:

The way DocSearch works is by crawling your content, pushing the results into an Algolia index, and then requesting this index directly from the website front-end through JavaScript.

We'll take care of crawling your website and populating the Algolia index with the latest changes every 24h for you. You don't need to change anything to your deployment process. The only thing you need to add are the following CSS and JS snippets that will bind the dropdown to your searchbox.

We built DocSearch with the idea of giving back to the Open-Source community. This is why your [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/threejs.json) is available on GitHub if you want to change it. We also have our own [documentation](https://community.algolia.com/docsearch/documentation/) to help you tweak the dropdown to your needs. You'll also have access to *analytics on the most searched terms* or those with *no results*. All of this is of course *entirely free*.