### PR TITLE
Fix GLTFExport Bug with Complex MorphTarget Animations.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -2254,7 +2254,9 @@ THREE.GLTFExporter.Utils = {
 
 				}
 
-				mergedTrack.name = '.morphTargetInfluences';
+				// We need to take into consideration that the target node for a
+				// blendshape animation might not be the root node of the animation:
+				mergedTrack.name = sourceTrack.name;
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -2254,9 +2254,9 @@ THREE.GLTFExporter.Utils = {
 
 				}
 
-				// We need to take into consideration that the target node for a
-				// blendshape animation might not be the root node of the animation:
-				mergedTrack.name = sourceTrack.name;
+				// We need to take into consideration the intended target node
+				// of our original un-merged morphTarget animation.
+				mergedTrack.name = sourceTrackBinding.nodeName + '.morphTargetInfluences';
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2276,9 +2276,9 @@ GLTFExporter.Utils = {
 
 				}
 
-				// We need to take into consideration that the target node for a
-				// blendshape animation might not be the root node of the animation:
-				mergedTrack.name = sourceTrack.name
+				// We need to take into consideration the intended target node
+				// of our original un-merged morphTarget animation.
+				mergedTrack.name = sourceTrackBinding.nodeName + '.morphTargetInfluences';
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2276,7 +2276,9 @@ GLTFExporter.Utils = {
 
 				}
 
-				mergedTrack.name = '.morphTargetInfluences';
+				// We need to take into consideration that the target node for a
+				// blendshape animation might not be the root node of the animation:
+				mergedTrack.name = sourceTrack.name
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;


### PR DESCRIPTION
Addresses a bug where GLTF Exporter is unable to merge/export morphtarget animations that aren't targeting the root object3d being exported.

Github Issue: https://github.com/mrdoob/three.js/issues/17579