### PR TITLE
examples/LineMaterial: add opacity in the uniforms

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -18,7 +18,8 @@ THREE.UniformsLib.line = {
 	resolution: { value: new THREE.Vector2( 1, 1 ) },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
-	gapSize: { value: 1 } // todo FIX - maybe change to totalSize
+	gapSize: { value: 1 }, // todo FIX - maybe change to totalSize
+	opacity: { value: 1 }
 
 };
 
@@ -341,6 +342,24 @@ THREE.LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.gapSize.value = value;
+
+			}
+
+		},
+
+		opacity: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.opacity.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.opacity.value = value;
 
 			}
 

--- a/examples/jsm/lines/LineMaterial.d.ts
+++ b/examples/jsm/lines/LineMaterial.d.ts
@@ -11,6 +11,7 @@ export interface LineMaterialParameters extends MaterialParameters {
 	dashScale?: number;
 	dashSize?: number;
 	gapSize?: number;
+	opacity?: boolean;
 	linewidth?: number;
 	resolution?: Vector2;
 }
@@ -23,6 +24,7 @@ export class LineMaterial extends ShaderMaterial {
 	dashScale: number;
 	dashSize: number;
 	gapSize: number;
+	opacity: boolean;
 	readonly isLineMaterial: true;
 	linewidth: number;
 	resolution: Vector2;

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -26,7 +26,8 @@ UniformsLib.line = {
 	resolution: { value: new Vector2( 1, 1 ) },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
-	gapSize: { value: 1 } // todo FIX - maybe change to totalSize
+	gapSize: { value: 1 }, // todo FIX - maybe change to totalSize
+	opacity: { value: 1 }
 
 };
 
@@ -349,6 +350,24 @@ var LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.gapSize.value = value;
+
+			}
+
+		},
+
+		opacity: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.opacity.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.opacity.value = value;
 
 			}
 


### PR DESCRIPTION
This PR adds the opacity to the list of uniforms for `examples/lines/LineMaterial`. `opacity` is already supported by the `fragmentShader` but cannot be modified when using the material.