### PR TITLE
modularize.js class support

### DIFF
--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -258,6 +258,18 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	} );
 
+	// classes
+
+	contents = contents.replace( /\nTHREE.(\w+) = class (\w+)/g, function ( match, p1, p2 ) {
+
+		classNames.push( p1 );
+
+		console.log( p1 );
+
+		return `\nclass ${p1}`;
+
+	} );
+
 	// class name
 
 	contents = contents.replace( /THREE\.([a-zA-Z0-9]+) = /g, function ( match, p1 ) {
@@ -276,18 +288,6 @@ function convert( path, exampleDependencies, ignoreList ) {
 		if ( classNames.includes( p2 ) ) return `${p2}${p3}`;
 
 		return match;
-
-	} );
-
-	// classes
-
-	contents = contents.replace( /\nTHREE.(\w+) = class (\w+)/g, function ( match, p1, p2 ) {
-
-		classNames.push( p1 );
-
-		console.log( p1 );
-
-		return `\nclass ${p1}`;
 
 	} );
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -281,13 +281,13 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	// classes
 
-	contents = contents.replace( /\nclass (\w+)/g, function ( match, p1 ) {
+	contents = contents.replace( /\nTHREE.(\w+) = class (\w+)/g, function ( match, p1, p2 ) {
 
 		classNames.push( p1 );
 
 		console.log( p1 );
 
-		return match;
+		return `\nclass ${p1}`;
 
 	} );
 

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -279,6 +279,18 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	} );
 
+	// classes
+
+	contents = contents.replace( /\nclass (\w+)/g, function ( match, p1 ) {
+
+		classNames.push( p1 );
+
+		console.log( p1 );
+
+		return match;
+
+	} );
+
 	// methods
 
 	contents = contents.replace( /new THREE\.([a-zA-Z0-9]+)\(/g, function ( match, p1 ) {


### PR DESCRIPTION
relates to #11552

Initial regex proposal.
I wasn't sure why `([a-zA-Z0-9]+)` was being used instead of `(\w+)`. [mdn link about character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes) Happy to change that around later.