### PR TITLE
Volume: Refactor slice access.

### DIFF
--- a/examples/js/misc/Volume.js
+++ b/examples/js/misc/Volume.js
@@ -357,15 +357,24 @@ THREE.Volume.prototype = {
 			return Math.abs( x.dot( base[ 2 ] ) ) > 0.9;
 
 		} );
-		var argumentsWithInversion = [ 'volume.xLength-1-', 'volume.yLength-1-', 'volume.zLength-1-' ];
-		var argArray = [ iDirection, jDirection, kDirection ].map( function ( direction, n ) {
 
-			return ( direction.dot( base[ n ] ) > 0 ? '' : argumentsWithInversion[ n ] ) + ( direction === axisInIJK ? 'IJKIndex' : direction.argVar );
+		sliceAccess = function ( i, j ) {
 
-		} );
-		var argString = argArray.join( ',' );
-		sliceAccess = eval( '(function sliceAccess (i,j) {return volume.access( ' + argString + ');})' );
+			var accessI, accessJ, accessK;
 
+			var si = ( iDirection === axisInIJK ) ? IJKIndex : ( iDirection.argVar === 'i' ? i : j );
+			var sj = ( jDirection === axisInIJK ) ? IJKIndex : ( jDirection.argVar === 'i' ? i : j );
+			var sk = ( kDirection === axisInIJK ) ? IJKIndex : ( kDirection.argVar === 'i' ? i : j );
+
+			// invert indices if necessary
+
+			var accessI = ( iDirection.dot( base[ 0 ] ) > 0 ) ? si : ( volume.xLength - 1 ) - si;
+			var accessJ = ( jDirection.dot( base[ 1 ] ) > 0 ) ? sj : ( volume.yLength - 1 ) - sj;
+			var accessK = ( kDirection.dot( base[ 2 ] ) > 0 ) ? sk : ( volume.zLength - 1 ) - sk;
+
+			return volume.access( accessI, accessJ, accessK );
+
+		};
 
 		return {
 			iLength: iLength,

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -364,15 +364,24 @@ Volume.prototype = {
 			return Math.abs( x.dot( base[ 2 ] ) ) > 0.9;
 
 		} );
-		var argumentsWithInversion = [ 'volume.xLength-1-', 'volume.yLength-1-', 'volume.zLength-1-' ];
-		var argArray = [ iDirection, jDirection, kDirection ].map( function ( direction, n ) {
 
-			return ( direction.dot( base[ n ] ) > 0 ? '' : argumentsWithInversion[ n ] ) + ( direction === axisInIJK ? 'IJKIndex' : direction.argVar );
+		sliceAccess = function ( i, j ) {
 
-		} );
-		var argString = argArray.join( ',' );
-		sliceAccess = eval( '(function sliceAccess (i,j) {return volume.access( ' + argString + ');})' );
+			var accessI, accessJ, accessK;
 
+			var si = ( iDirection === axisInIJK ) ? IJKIndex : ( iDirection.argVar === 'i' ? i : j );
+			var sj = ( jDirection === axisInIJK ) ? IJKIndex : ( jDirection.argVar === 'i' ? i : j );
+			var sk = ( kDirection === axisInIJK ) ? IJKIndex : ( kDirection.argVar === 'i' ? i : j );
+
+			// invert indices if necessary
+
+			var accessI = ( iDirection.dot( base[ 0 ] ) > 0 ) ? si : ( volume.xLength - 1 ) - si;
+			var accessJ = ( jDirection.dot( base[ 1 ] ) > 0 ) ? sj : ( volume.yLength - 1 ) - sj;
+			var accessK = ( kDirection.dot( base[ 2 ] ) > 0 ) ? sk : ( volume.zLength - 1 ) - sk;
+
+			return volume.access( accessI, accessJ, accessK );
+
+		};
 
 		return {
 			iLength: iLength,


### PR DESCRIPTION
see #19057

This changes avoid the usage of `eval()` as pointed out here: https://github.com/mrdoob/three.js/pull/8364#discussion_r403685974.