### PR TITLE
Examples: Make event handling more robust in scene comparison demo.

### DIFF
--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -163,7 +163,7 @@
 
 					sliderMoved = true;
 
-					sliderPos = e.pageX || e.touches[ 0 ].pageX;
+					sliderPos = e.pageX;
 
 					//prevent the slider from being positioned outside the window bounds
 					if ( sliderPos < 0 ) sliderPos = 0;

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -163,7 +163,7 @@
 
 					sliderMoved = true;
 
-					sliderPos = e.pageX;
+					sliderPos = ( e.pageX === undefined ) ? e.touches[ 0 ].pageX : e.pageX;
 
 					//prevent the slider from being positioned outside the window bounds
 					if ( sliderPos < 0 ) sliderPos = 0;


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/19066

Deleted a param that is likely to cause an error in the specific situation.