### PR TITLE
Matrix4.d.ts: Parameters of decompose is not optional

### DIFF
--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -171,13 +171,12 @@ export class Matrix4 implements Matrix {
 	compose( translation: Vector3, rotation: Quaternion, scale: Vector3 ): Matrix4;
 
 	/**
-	 * Decomposes this matrix into the translation, rotation and scale components.
-	 * If parameters are not passed, new instances will be created.
+	 * Decomposes this matrix into it's position, quaternion and scale components.
 	 */
 	decompose(
-		translation?: Vector3,
-		rotation?: Quaternion,
-		scale?: Vector3
+		translation: Vector3,
+		rotation: Quaternion,
+		scale: Vector3
 	): Matrix4;
 
 	/**


### PR DESCRIPTION
Not passing these parameters apparently throws an error.

https://github.com/mrdoob/three.js/blob/656e131cb02e8288c8ca68677d97af599715876d/src/math/Matrix4.js#L740-L754

See: https://threejs.org/docs/#api/en/math/Matrix4.decompose

I'm not sure these used to be optional in previous or not.
