### PR TITLE
Examples /misc/controls/transform: Change wrong keyup (Ctrl, 17) to Shift(16)

### DIFF
--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -133,7 +133,7 @@
 
 					switch ( event.keyCode ) {
 
-						case 17: // Ctrl
+						case 16: // Shift
 							control.setTranslationSnap( null );
 							control.setRotationSnap( null );
 							control.setScaleSnap( null );


### PR DESCRIPTION
Should snap to grid while pressing Shift, therefore Shift keyup should disable snapping.