### PR TITLE
Examples-Loaders: move to es6 class syntax

### DIFF
--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -18,35 +18,31 @@
  * - Metallic Display Properties (PBR)
  */
 
-THREE.ThreeMFLoader = function ( manager ) {
 
-	THREE.Loader.call( this, manager );
+THREE.ThreeMFLoader = class ThreeMFLoader extends THREE.Loader {
 
-	this.availableExtensions = [];
+	constructor( manager ) {
 
-};
+		super( manager );
+		this.availableExtensions = [];
 
-THREE.ThreeMFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.ThreeMFLoader,
+	load( url, onLoad, onProgress, onError ) {
 
-	load: function ( url, onLoad, onProgress, onError ) {
-
-		var scope = this;
-		var loader = new THREE.FileLoader( scope.manager );
-		loader.setPath( scope.path );
+		var loader = new THREE.FileLoader( this.manager );
+		loader.setPath( this.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( buffer ) {
 
-			onLoad( scope.parse( buffer ) );
+			onLoad( this.parse( buffer ) );
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
-		var scope = this;
 		var textureLoader = new THREE.TextureLoader( this.manager );
 
 		function loadDocument( data ) {
@@ -1178,9 +1174,9 @@ THREE.ThreeMFLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 				var ns = keys[ i ];
 
-				for ( var j = 0; j < scope.availableExtensions.length; j ++ ) {
+				for ( var j = 0; j < this.availableExtensions.length; j ++ ) {
 
-					var extension = scope.availableExtensions[ j ];
+					var extension = this.availableExtensions[ j ];
 
 					if ( extension.ns === ns ) {
 
@@ -1403,12 +1399,12 @@ THREE.ThreeMFLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 		return build( objects, data3mf );
 
-	},
+	}
 
-	addExtension: function ( extension ) {
+	addExtension( extension ) {
 
 		this.availableExtensions.push( extension );
 
 	}
 
-} );
+};

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -18,22 +18,20 @@
  *
  */
 
-THREE.AMFLoader = function ( manager ) {
+THREE.AMFLoader = class AMFLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.AMFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.AMFLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
-		var loader = new THREE.FileLoader( scope.manager );
-		loader.setPath( scope.path );
+		var loader = new THREE.FileLoader( this.manager );
+		loader.setPath( this.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.load( url, function ( text ) {
 
@@ -41,9 +39,9 @@ THREE.AMFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function loadDocument( data ) {
 
@@ -485,4 +483,4 @@ THREE.AMFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/AssimpLoader.js
+++ b/examples/js/loaders/AssimpLoader.js
@@ -2,17 +2,15 @@
  * @author Virtulous / https://virtulo.us/
  */
 
-THREE.AssimpLoader = function ( manager ) {
+THREE.AssimpLoader = class AssimpLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.AssimpLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.AssimpLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -28,9 +26,9 @@ THREE.AssimpLoader.prototype = Object.assign( Object.create( THREE.Loader.protot
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( buffer, path ) {
+	parse( buffer, path ) {
 
 		var textureLoader = new THREE.TextureLoader( this.manager );
 		textureLoader.setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
@@ -2251,4 +2249,4 @@ THREE.AssimpLoader.prototype = Object.assign( Object.create( THREE.Loader.protot
 
 	}
 
-} );
+};

--- a/examples/js/loaders/BVHLoader.js
+++ b/examples/js/loaders/BVHLoader.js
@@ -8,20 +8,17 @@
  *
  */
 
-THREE.BVHLoader = function ( manager ) {
+THREE.BVHLoader = class BVHLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.animateBonePositions = true;
-	this.animateBoneRotations = true;
+		super( manager );
+		this.animateBonePositions = true;
+		this.animateBoneRotations = true;
 
-};
+	}
 
-THREE.BVHLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-
-	constructor: THREE.BVHLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -33,9 +30,9 @@ THREE.BVHLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( text ) {
+	parse( text ) {
 
 		/*
 			reads a string array (lines) from a BVH file
@@ -404,4 +401,4 @@ THREE.BVHLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -16,50 +16,48 @@
  * of web workers, before transferring the transcoded compressed texture back
  * to the main thread.
  */
-THREE.BasisTextureLoader = function ( manager ) {
+THREE.BasisTextureLoader = class BasisTextureLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.transcoderPath = '';
-	this.transcoderBinary = null;
-	this.transcoderPending = null;
+		super( manager );
 
-	this.workerLimit = 4;
-	this.workerPool = [];
-	this.workerNextTaskID = 1;
-	this.workerSourceURL = '';
-	this.workerConfig = {
-		format: null,
-		astcSupported: false,
-		bptcSupported: false,
-		etcSupported: false,
-		dxtSupported: false,
-		pvrtcSupported: false,
-	};
+		this.transcoderPath = '';
+		this.transcoderBinary = null;
+		this.transcoderPending = null;
 
-};
+		this.workerLimit = 4;
+		this.workerPool = [];
+		this.workerNextTaskID = 1;
+		this.workerSourceURL = '';
+		this.workerConfig = {
+			format: null,
+			astcSupported: false,
+			bptcSupported: false,
+			etcSupported: false,
+			dxtSupported: false,
+			pvrtcSupported: false,
+		};
 
-THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.BasisTextureLoader,
-
-	setTranscoderPath: function ( path ) {
+	setTranscoderPath( path ) {
 
 		this.transcoderPath = path;
 
 		return this;
 
-	},
+	}
 
-	setWorkerLimit: function ( workerLimit ) {
+	setWorkerLimit( workerLimit ) {
 
 		this.workerLimit = workerLimit;
 
 		return this;
 
-	},
+	}
 
-	detectSupport: function ( renderer ) {
+	detectSupport( renderer ) {
 
 		var config = this.workerConfig;
 
@@ -98,9 +96,9 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		return this;
 
-	},
+	}
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var loader = new THREE.FileLoader( this.manager );
 
@@ -114,13 +112,13 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		}, onProgress, onError );
 
-	},
+	}
 
 	/**
 	 * @param  {ArrayBuffer} buffer
 	 * @return {Promise<THREE.CompressedTexture>}
 	 */
-	_createTexture: function ( buffer ) {
+	_createTexture( buffer ) {
 
 		var worker;
 		var taskID;
@@ -199,9 +197,9 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		return texturePending;
 
-	},
+	}
 
-	_initTranscoder: function () {
+	_initTranscoder() {
 
 		if ( ! this.transcoderPending ) {
 
@@ -245,9 +243,9 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		return this.transcoderPending;
 
-	},
+	}
 
-	_allocateWorker: function ( taskCost ) {
+	_allocateWorker( taskCost ) {
 
 		return this._initTranscoder().then( () => {
 
@@ -305,9 +303,9 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		} );
 
-	},
+	}
 
-	dispose: function () {
+	dispose() {
 
 		for ( var i = 0; i < this.workerPool.length; i ++ ) {
 
@@ -321,7 +319,7 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 	}
 
-} );
+};
 
 /* CONSTANTS */
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3,17 +3,24 @@
  * @author Mugen87 / https://github.com/Mugen87
  */
 
-THREE.ColladaLoader = function ( manager ) {
+THREE.ColladaLoader = class ColladaLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
+		this.options = {
 
-THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+			set convertUpAxis( value ) {
 
-	constructor: THREE.ColladaLoader,
+				console.warn( 'THREE.ColladaLoader: options.convertUpAxis() has been removed. Up axis is converted automatically.' );
 
-	load: function ( url, onLoad, onProgress, onError ) {
+			}
+
+		};
+
+	}
+
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -27,19 +34,9 @@ THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	options: {
-
-		set convertUpAxis( value ) {
-
-			console.warn( 'THREE.ColladaLoader: options.convertUpAxis() has been removed. Up axis is converted automatically.' );
-
-		}
-
-	},
-
-	parse: function ( text, path ) {
+	parse( text, path ) {
 
 		function getElementsByTagName( xml, name ) {
 
@@ -3945,4 +3942,4 @@ THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 	}
 
-} );
+};

--- a/examples/js/loaders/DDSLoader.js
+++ b/examples/js/loaders/DDSLoader.js
@@ -2,17 +2,15 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.DDSLoader = function ( manager ) {
+THREE.DDSLoader = class DDSLoader extends THREE.CompressedTextureLoader {
 
-	THREE.CompressedTextureLoader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.DDSLoader.prototype = Object.assign( Object.create( THREE.CompressedTextureLoader.prototype ), {
+	}
 
-	constructor: THREE.DDSLoader,
-
-	parse: function ( buffer, loadMipmaps ) {
+	parse( buffer, loadMipmaps ) {
 
 		var dds = { mipmaps: [], width: 0, height: 0, format: null, mipmapCount: 1 };
 
@@ -270,4 +268,4 @@ THREE.DDSLoader.prototype = Object.assign( Object.create( THREE.CompressedTextur
 
 	}
 
-} );
+};

--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -2,85 +2,83 @@
  * @author Don McCurdy / https://www.donmccurdy.com
  */
 
-THREE.DRACOLoader = function ( manager ) {
+THREE.DRACOLoader = class DRACOLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.decoderPath = '';
-	this.decoderConfig = {};
-	this.decoderBinary = null;
-	this.decoderPending = null;
+		super( manager );
 
-	this.workerLimit = 4;
-	this.workerPool = [];
-	this.workerNextTaskID = 1;
-	this.workerSourceURL = '';
+		this.decoderPath = '';
+		this.decoderConfig = {};
+		this.decoderBinary = null;
+		this.decoderPending = null;
 
-	this.defaultAttributeIDs = {
-		position: 'POSITION',
-		normal: 'NORMAL',
-		color: 'COLOR',
-		uv: 'TEX_COORD'
-	};
-	this.defaultAttributeTypes = {
-		position: 'Float32Array',
-		normal: 'Float32Array',
-		color: 'Float32Array',
-		uv: 'Float32Array'
-	};
+		this.workerLimit = 4;
+		this.workerPool = [];
+		this.workerNextTaskID = 1;
+		this.workerSourceURL = '';
 
-};
+		this.defaultAttributeIDs = {
+			position: 'POSITION',
+			normal: 'NORMAL',
+			color: 'COLOR',
+			uv: 'TEX_COORD'
+		};
+		this.defaultAttributeTypes = {
+			position: 'Float32Array',
+			normal: 'Float32Array',
+			color: 'Float32Array',
+			uv: 'Float32Array'
+		};
 
-THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.DRACOLoader,
-
-	setDecoderPath: function ( path ) {
+	setDecoderPath( path ) {
 
 		this.decoderPath = path;
 
 		return this;
 
-	},
+	}
 
-	setDecoderConfig: function ( config ) {
+	setDecoderConfig( config ) {
 
 		this.decoderConfig = config;
 
 		return this;
 
-	},
+	}
 
-	setWorkerLimit: function ( workerLimit ) {
+	setWorkerLimit( workerLimit ) {
 
 		this.workerLimit = workerLimit;
 
 		return this;
 
-	},
+	}
 
 	/** @deprecated */
-	setVerbosity: function () {
+	setVerbosity() {
 
 		console.warn( 'THREE.DRACOLoader: The .setVerbosity() method has been removed.' );
 
-	},
+	}
 
 	/** @deprecated */
-	setDrawMode: function () {
+	setDrawMode() {
 
 		console.warn( 'THREE.DRACOLoader: The .setDrawMode() method has been removed.' );
 
-	},
+	}
 
 	/** @deprecated */
-	setSkipDequantization: function () {
+	setSkipDequantization() {
 
 		console.warn( 'THREE.DRACOLoader: The .setSkipDequantization() method has been removed.' );
 
-	},
+	}
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var loader = new THREE.FileLoader( this.manager );
 
@@ -107,10 +105,10 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		}, onProgress, onError );
 
-	},
+	}
 
 	/** @deprecated Kept for backward-compatibility with previous DRACOLoader versions. */
-	decodeDracoFile: function ( buffer, callback, attributeIDs, attributeTypes ) {
+	decodeDracoFile( buffer, callback, attributeIDs, attributeTypes ) {
 
 		var taskConfig = {
 			attributeIDs: attributeIDs || this.defaultAttributeIDs,
@@ -120,9 +118,9 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		this.decodeGeometry( buffer, taskConfig ).then( callback );
 
-	},
+	}
 
-	decodeGeometry: function ( buffer, taskConfig ) {
+	decodeGeometry( buffer, taskConfig ) {
 
 		// TODO: For backward-compatibility, support 'attributeTypes' objects containing
 		// references (rather than names) to typed array constructors. These must be
@@ -220,9 +218,9 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		return geometryPending;
 
-	},
+	}
 
-	_createGeometry: function ( geometryData ) {
+	_createGeometry( geometryData ) {
 
 		var geometry = new THREE.BufferGeometry();
 
@@ -245,9 +243,9 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		return geometry;
 
-	},
+	}
 
-	_loadLibrary: function ( url, responseType ) {
+	_loadLibrary( url, responseType ) {
 
 		var loader = new THREE.FileLoader( this.manager );
 		loader.setPath( this.decoderPath );
@@ -259,17 +257,17 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		} );
 
-	},
+	}
 
-	preload: function () {
+	preload() {
 
 		this._initDecoder();
 
 		return this;
 
-	},
+	}
 
-	_initDecoder: function () {
+	_initDecoder() {
 
 		if ( this.decoderPending ) return this.decoderPending;
 
@@ -314,9 +312,9 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		return this.decoderPending;
 
-	},
+	}
 
-	_getWorker: function ( taskID, taskCost ) {
+	_getWorker( taskID, taskCost ) {
 
 		return this._initDecoder().then( () => {
 
@@ -370,23 +368,23 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		} );
 
-	},
+	}
 
-	_releaseTask: function ( worker, taskID ) {
+	_releaseTask( worker, taskID ) {
 
 		worker._taskLoad -= worker._taskCosts[ taskID ];
 		delete worker._callbacks[ taskID ];
 		delete worker._taskCosts[ taskID ];
 
-	},
+	}
 
-	debug: function () {
+	debug() {
 
 		console.log( 'Task load: ', this.workerPool.map( ( worker ) => worker._taskLoad ) );
 
-	},
+	}
 
-	dispose: function () {
+	dispose() {
 
 		for ( var i = 0; i < this.workerPool.length; ++ i ) {
 
@@ -400,7 +398,7 @@ THREE.DRACOLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	}
 
-} );
+};
 
 /* WEB WORKER */
 

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -74,19 +74,16 @@
 
 // // End of OpenEXR license -------------------------------------------------
 
-THREE.EXRLoader = function ( manager ) {
+THREE.EXRLoader = class EXRLoader extends THREE.DataTextureLoader {
 
-	THREE.DataTextureLoader.call( this, manager );
+	constructor( manager ) {
 
-	this.type = THREE.FloatType;
+		super( manager );
+		this.type = THREE.FloatType;
 
-};
+	}
 
-THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoader.prototype ), {
-
-	constructor: THREE.EXRLoader,
-
-	parse: function ( buffer ) {
+	parse( buffer ) {
 
 		const USHORT_RANGE = ( 1 << 16 );
 		const BITMAP_SIZE = ( USHORT_RANGE >> 3 );
@@ -2122,16 +2119,16 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			type: this.type
 		};
 
-	},
+	}
 
-	setDataType: function ( value ) {
+	setDataType( value ) {
 
 		this.type = value;
 		return this;
 
-	},
+	}
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		function onLoadCallback( texture, texData ) {
 
@@ -2165,4 +2162,4 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 	}
 
-} );
+};

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -9,19 +9,17 @@
  * @author joewalnes
  */
 
-THREE.GCodeLoader = function ( manager ) {
+THREE.GCodeLoader = class GCodeLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.splitLayer = false;
+		super( manager );
 
-};
+		this.splitLayer = false;
 
-THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.GCodeLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -33,9 +31,9 @@ THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		var state = { x: 0, y: 0, z: 0, e: 0, f: 0, extruding: false, relative: false };
 		var layers = [];
@@ -220,4 +218,4 @@ THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 	}
 
-} );
+};

--- a/examples/js/loaders/HDRCubeTextureLoader.js
+++ b/examples/js/loaders/HDRCubeTextureLoader.js
@@ -3,20 +3,18 @@
 * @author Ben Houston / http://clara.io / bhouston
 */
 
-THREE.HDRCubeTextureLoader = function ( manager ) {
+THREE.HDRCubeTextureLoader = class HDRCubeTextureLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.hdrLoader = new THREE.RGBELoader();
-	this.type = THREE.UnsignedByteType;
+		super( manager );
 
-};
+		this.hdrLoader = new THREE.RGBELoader();
+		this.type = THREE.UnsignedByteType;
 
-THREE.HDRCubeTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.HDRCubeTextureLoader,
-
-	load: function ( urls, onLoad, onProgress, onError ) {
+	load( urls, onLoad, onProgress, onError ) {
 
 		if ( ! Array.isArray( urls ) ) {
 
@@ -117,9 +115,9 @@ THREE.HDRCubeTextureLoader.prototype = Object.assign( Object.create( THREE.Loade
 
 		return texture;
 
-	},
+	}
 
-	setDataType: function ( value ) {
+	setDataType( value ) {
 
 		this.type = value;
 		this.hdrLoader.setDataType( value );
@@ -128,4 +126,4 @@ THREE.HDRCubeTextureLoader.prototype = Object.assign( Object.create( THREE.Loade
 
 	}
 
-} );
+};

--- a/examples/js/loaders/KMZLoader.js
+++ b/examples/js/loaders/KMZLoader.js
@@ -2,17 +2,15 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-THREE.KMZLoader = function ( manager ) {
+THREE.KMZLoader = class KMZLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.KMZLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.KMZLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -25,9 +23,9 @@ THREE.KMZLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function findFile( url ) {
 
@@ -102,4 +100,4 @@ THREE.KMZLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -2,17 +2,15 @@
  *  three.js NRRD file loader
  */
 
-THREE.NRRDLoader = function ( manager ) {
+THREE.NRRDLoader = class NRRDLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.NRRDLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -25,9 +23,9 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		// this parser is largely inspired from the XTK NRRD parser : https://github.com/xtk/X
 
@@ -400,9 +398,9 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 
 		return volume;
 
-	},
+	}
 
-	parseChars: function ( array, start, end ) {
+	parseChars( array, start, end ) {
 
 		// without borders, use the whole array
 		if ( start === undefined ) {
@@ -427,169 +425,169 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 
 		return output;
 
-	},
-
-	fieldFunctions: {
-
-		type: function ( data ) {
-
-			switch ( data ) {
-
-				case 'uchar':
-				case 'unsigned char':
-				case 'uint8':
-				case 'uint8_t':
-					this.__array = Uint8Array;
-					break;
-				case 'signed char':
-				case 'int8':
-				case 'int8_t':
-					this.__array = Int8Array;
-					break;
-				case 'short':
-				case 'short int':
-				case 'signed short':
-				case 'signed short int':
-				case 'int16':
-				case 'int16_t':
-					this.__array = Int16Array;
-					break;
-				case 'ushort':
-				case 'unsigned short':
-				case 'unsigned short int':
-				case 'uint16':
-				case 'uint16_t':
-					this.__array = Uint16Array;
-					break;
-				case 'int':
-				case 'signed int':
-				case 'int32':
-				case 'int32_t':
-					this.__array = Int32Array;
-					break;
-				case 'uint':
-				case 'unsigned int':
-				case 'uint32':
-				case 'uint32_t':
-					this.__array = Uint32Array;
-					break;
-				case 'float':
-					this.__array = Float32Array;
-					break;
-				case 'double':
-					this.__array = Float64Array;
-					break;
-				default:
-					throw new Error( 'Unsupported NRRD data type: ' + data );
-
-			}
-
-			return this.type = data;
-
-		},
-
-		endian: function ( data ) {
-
-			return this.endian = data;
-
-		},
-
-		encoding: function ( data ) {
-
-			return this.encoding = data;
-
-		},
-
-		dimension: function ( data ) {
-
-			return this.dim = parseInt( data, 10 );
-
-		},
-
-		sizes: function ( data ) {
-
-			var i;
-			return this.sizes = ( function () {
-
-				var _i, _len, _ref, _results;
-				_ref = data.split( /\s+/ );
-				_results = [];
-				for ( _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
-
-					i = _ref[ _i ];
-					_results.push( parseInt( i, 10 ) );
-
-				}
-				return _results;
-
-			} )();
-
-		},
-
-		space: function ( data ) {
-
-			return this.space = data;
-
-		},
-
-		'space origin': function ( data ) {
-
-			return this.space_origin = data.split( "(" )[ 1 ].split( ")" )[ 0 ].split( "," );
-
-		},
-
-		'space directions': function ( data ) {
-
-			var f, parts, v;
-			parts = data.match( /\(.*?\)/g );
-			return this.vectors = ( function () {
-
-				var _i, _len, _results;
-				_results = [];
-				for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
-
-					v = parts[ _i ];
-					_results.push( ( function () {
-
-						var _j, _len2, _ref, _results2;
-						_ref = v.slice( 1, - 1 ).split( /,/ );
-						_results2 = [];
-						for ( _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
-
-							f = _ref[ _j ];
-							_results2.push( parseFloat( f ) );
-
-						}
-						return _results2;
-
-					} )() );
-
-				}
-				return _results;
-
-			} )();
-
-		},
-
-		spacings: function ( data ) {
-
-			var f, parts;
-			parts = data.split( /\s+/ );
-			return this.spacings = ( function () {
-
-				var _i, _len, _results = [];
-
-				for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
-
-					f = parts[ _i ];
-					_results.push( parseFloat( f ) );
-
-				}
-				return _results;
-
-			} )();
-
-		}
 	}
 
-} );
+};
+
+THREE.NRRDLoader.prototype.fieldFunctions = {
+
+	type: function ( data ) {
+
+		switch ( data ) {
+
+			case 'uchar':
+			case 'unsigned char':
+			case 'uint8':
+			case 'uint8_t':
+				this.__array = Uint8Array;
+				break;
+			case 'signed char':
+			case 'int8':
+			case 'int8_t':
+				this.__array = Int8Array;
+				break;
+			case 'short':
+			case 'short int':
+			case 'signed short':
+			case 'signed short int':
+			case 'int16':
+			case 'int16_t':
+				this.__array = Int16Array;
+				break;
+			case 'ushort':
+			case 'unsigned short':
+			case 'unsigned short int':
+			case 'uint16':
+			case 'uint16_t':
+				this.__array = Uint16Array;
+				break;
+			case 'int':
+			case 'signed int':
+			case 'int32':
+			case 'int32_t':
+				this.__array = Int32Array;
+				break;
+			case 'uint':
+			case 'unsigned int':
+			case 'uint32':
+			case 'uint32_t':
+				this.__array = Uint32Array;
+				break;
+			case 'float':
+				this.__array = Float32Array;
+				break;
+			case 'double':
+				this.__array = Float64Array;
+				break;
+			default:
+				throw new Error( 'Unsupported NRRD data type: ' + data );
+
+		}
+
+		return this.type = data;
+
+	},
+
+	endian: function ( data ) {
+
+		return this.endian = data;
+
+	},
+
+	encoding: function ( data ) {
+
+		return this.encoding = data;
+
+	},
+
+	dimension: function ( data ) {
+
+		return this.dim = parseInt( data, 10 );
+
+	},
+
+	sizes: function ( data ) {
+
+		var i;
+		return this.sizes = ( function () {
+
+			var _i, _len, _ref, _results;
+			_ref = data.split( /\s+/ );
+			_results = [];
+			for ( _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
+
+				i = _ref[ _i ];
+				_results.push( parseInt( i, 10 ) );
+
+			}
+			return _results;
+
+		} )();
+
+	},
+
+	space: function ( data ) {
+
+		return this.space = data;
+
+	},
+
+	'space origin': function ( data ) {
+
+		return this.space_origin = data.split( "(" )[ 1 ].split( ")" )[ 0 ].split( "," );
+
+	},
+
+	'space directions': function ( data ) {
+
+		var f, parts, v;
+		parts = data.match( /\(.*?\)/g );
+		return this.vectors = ( function () {
+
+			var _i, _len, _results;
+			_results = [];
+			for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
+
+				v = parts[ _i ];
+				_results.push( ( function () {
+
+					var _j, _len2, _ref, _results2;
+					_ref = v.slice( 1, - 1 ).split( /,/ );
+					_results2 = [];
+					for ( _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
+
+						f = _ref[ _j ];
+						_results2.push( parseFloat( f ) );
+
+					}
+					return _results2;
+
+				} )() );
+
+			}
+			return _results;
+
+		} )();
+
+	},
+
+	spacings: function ( data ) {
+
+		var f, parts;
+		parts = data.split( /\s+/ );
+		return this.spacings = ( function () {
+
+			var _i, _len, _results = [];
+
+			for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
+
+				f = parts[ _i ];
+				_results.push( parseFloat( f ) );
+
+			}
+			return _results;
+
+		} )();
+
+	}
+};

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -5,20 +5,17 @@
  * Description: A THREE loader for PCD ascii and binary files.
  */
 
-THREE.PCDLoader = function ( manager ) {
+THREE.PCDLoader = class PCDLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.littleEndian = true;
+		super( manager );
 
-};
+		this.littleEndian = true;
 
+	}
 
-THREE.PCDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-
-	constructor: THREE.PCDLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -47,9 +44,9 @@ THREE.PCDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data, url ) {
+	parse( data, url ) {
 
 		// from https://gitlab.com/taketwo/three-pcd-loader/blob/master/decompress-lzf.js
 
@@ -389,4 +386,4 @@ THREE.PCDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/PDBLoader.js
+++ b/examples/js/loaders/PDBLoader.js
@@ -3,17 +3,15 @@
  * @author Mugen87 / https://github.com/Mugen87
  */
 
-THREE.PDBLoader = function ( manager ) {
+THREE.PDBLoader = class PDBLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.PDBLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.PDBLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -25,11 +23,11 @@ THREE.PDBLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
 	// Based on CanvasMol PDB parser
 
-	parse: function ( text ) {
+	parse( text ) {
 
 		function trim( text ) {
 
@@ -207,4 +205,4 @@ THREE.PDBLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -27,19 +27,17 @@
  */
 
 
-THREE.PLYLoader = function ( manager ) {
+THREE.PLYLoader = class PLYLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.propertyNameMapping = {};
+		super( manager );
 
-};
+		this.propertyNameMapping = {};
 
-THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.PLYLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -52,15 +50,15 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	setPropertyNameMapping: function ( mapping ) {
+	setPropertyNameMapping( mapping ) {
 
 		this.propertyNameMapping = mapping;
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function parseHeader( data ) {
 
@@ -495,4 +493,4 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/PVRLoader.js
+++ b/examples/js/loaders/PVRLoader.js
@@ -8,17 +8,15 @@
  *   TODO : implement loadMipmaps option
  */
 
-THREE.PVRLoader = function ( manager ) {
+THREE.PVRLoader = class PVRLoader extends THREE.CompressedTextureLoader {
 
-	THREE.CompressedTextureLoader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.PVRLoader.prototype = Object.assign( Object.create( THREE.CompressedTextureLoader.prototype ), {
+	}
 
-	constructor: THREE.PVRLoader,
-
-	parse: function ( buffer, loadMipmaps ) {
+	parse( buffer, loadMipmaps ) {
 
 		var headerLengthInt = 13;
 		var header = new Uint32Array( buffer, 0, headerLengthInt );
@@ -49,198 +47,197 @@ THREE.PVRLoader.prototype = Object.assign( Object.create( THREE.CompressedTextur
 
 	}
 
-} );
+	static _parseV3( pvrDatas ) {
 
-THREE.PVRLoader._parseV3 = function ( pvrDatas ) {
-
-	var header = pvrDatas.header;
-	var bpp, format;
+		var header = pvrDatas.header;
+		var bpp, format;
 
 
-	var metaLen = header[ 12 ],
-		pixelFormat = header[ 2 ],
-		height = header[ 6 ],
-		width = header[ 7 ],
-		// numSurfs = header[ 9 ],
-		numFaces = header[ 10 ],
-		numMipmaps = header[ 11 ];
+		var metaLen = header[ 12 ],
+			pixelFormat = header[ 2 ],
+			height = header[ 6 ],
+			width = header[ 7 ],
+			// numSurfs = header[ 9 ],
+			numFaces = header[ 10 ],
+			numMipmaps = header[ 11 ];
 
-	switch ( pixelFormat ) {
+		switch ( pixelFormat ) {
 
-		case 0 : // PVRTC 2bpp RGB
-			bpp = 2;
-			format = THREE.RGB_PVRTC_2BPPV1_Format;
-			break;
+			case 0 : // PVRTC 2bpp RGB
+				bpp = 2;
+				format = THREE.RGB_PVRTC_2BPPV1_Format;
+				break;
 
-		case 1 : // PVRTC 2bpp RGBA
-			bpp = 2;
-			format = THREE.RGBA_PVRTC_2BPPV1_Format;
-			break;
+			case 1 : // PVRTC 2bpp RGBA
+				bpp = 2;
+				format = THREE.RGBA_PVRTC_2BPPV1_Format;
+				break;
 
-		case 2 : // PVRTC 4bpp RGB
-			bpp = 4;
-			format = THREE.RGB_PVRTC_4BPPV1_Format;
-			break;
+			case 2 : // PVRTC 4bpp RGB
+				bpp = 4;
+				format = THREE.RGB_PVRTC_4BPPV1_Format;
+				break;
 
-		case 3 : // PVRTC 4bpp RGBA
-			bpp = 4;
-			format = THREE.RGBA_PVRTC_4BPPV1_Format;
-			break;
+			case 3 : // PVRTC 4bpp RGBA
+				bpp = 4;
+				format = THREE.RGBA_PVRTC_4BPPV1_Format;
+				break;
 
-		default :
-			console.error( 'THREE.PVRLoader: Unsupported PVR format:', pixelFormat );
-
-	}
-
-	pvrDatas.dataPtr = 52 + metaLen;
-	pvrDatas.bpp = bpp;
-	pvrDatas.format = format;
-	pvrDatas.width = width;
-	pvrDatas.height = height;
-	pvrDatas.numSurfaces = numFaces;
-	pvrDatas.numMipmaps = numMipmaps;
-	pvrDatas.isCubemap 	= ( numFaces === 6 );
-
-	return THREE.PVRLoader._extract( pvrDatas );
-
-};
-
-THREE.PVRLoader._parseV2 = function ( pvrDatas ) {
-
-	var header = pvrDatas.header;
-
-	var headerLength = header[ 0 ],
-		height = header[ 1 ],
-		width = header[ 2 ],
-		numMipmaps = header[ 3 ],
-		flags = header[ 4 ],
-		// dataLength = header[ 5 ],
-		// bpp =  header[ 6 ],
-		// bitmaskRed = header[ 7 ],
-		// bitmaskGreen = header[ 8 ],
-		// bitmaskBlue = header[ 9 ],
-		bitmaskAlpha = header[ 10 ],
-		// pvrTag = header[ 11 ],
-		numSurfs = header[ 12 ];
-
-
-	var TYPE_MASK = 0xff;
-	var PVRTC_2 = 24,
-		PVRTC_4 = 25;
-
-	var formatFlags = flags & TYPE_MASK;
-
-	var bpp, format;
-	var _hasAlpha = bitmaskAlpha > 0;
-
-	if ( formatFlags === PVRTC_4 ) {
-
-		format = _hasAlpha ? THREE.RGBA_PVRTC_4BPPV1_Format : THREE.RGB_PVRTC_4BPPV1_Format;
-		bpp = 4;
-
-	} else if ( formatFlags === PVRTC_2 ) {
-
-		format = _hasAlpha ? THREE.RGBA_PVRTC_2BPPV1_Format : THREE.RGB_PVRTC_2BPPV1_Format;
-		bpp = 2;
-
-	} else {
-
-		console.error( 'THREE.PVRLoader: Unknown PVR format:', formatFlags );
-
-	}
-
-	pvrDatas.dataPtr = headerLength;
-	pvrDatas.bpp = bpp;
-	pvrDatas.format = format;
-	pvrDatas.width = width;
-	pvrDatas.height = height;
-	pvrDatas.numSurfaces = numSurfs;
-	pvrDatas.numMipmaps = numMipmaps + 1;
-
-	// guess cubemap type seems tricky in v2
-	// it juste a pvr containing 6 surface (no explicit cubemap type)
-	pvrDatas.isCubemap 	= ( numSurfs === 6 );
-
-	return THREE.PVRLoader._extract( pvrDatas );
-
-};
-
-
-THREE.PVRLoader._extract = function ( pvrDatas ) {
-
-	var pvr = {
-		mipmaps: [],
-		width: pvrDatas.width,
-		height: pvrDatas.height,
-		format: pvrDatas.format,
-		mipmapCount: pvrDatas.numMipmaps,
-		isCubemap: pvrDatas.isCubemap
-	};
-
-	var buffer = pvrDatas.buffer;
-
-	var dataOffset = pvrDatas.dataPtr,
-		bpp = pvrDatas.bpp,
-		numSurfs = pvrDatas.numSurfaces,
-		dataSize = 0,
-		blockSize = 0,
-		blockWidth = 0,
-		blockHeight = 0,
-		widthBlocks = 0,
-		heightBlocks = 0;
-
-	if ( bpp === 2 ) {
-
-		blockWidth = 8;
-		blockHeight = 4;
-
-	} else {
-
-		blockWidth = 4;
-		blockHeight = 4;
-
-	}
-
-	blockSize = ( blockWidth * blockHeight ) * bpp / 8;
-
-	pvr.mipmaps.length = pvrDatas.numMipmaps * numSurfs;
-
-	var mipLevel = 0;
-
-	while ( mipLevel < pvrDatas.numMipmaps ) {
-
-		var sWidth = pvrDatas.width >> mipLevel,
-			sHeight = pvrDatas.height >> mipLevel;
-
-		widthBlocks = sWidth / blockWidth;
-		heightBlocks = sHeight / blockHeight;
-
-		// Clamp to minimum number of blocks
-		if ( widthBlocks < 2 ) widthBlocks = 2;
-		if ( heightBlocks < 2 ) heightBlocks = 2;
-
-		dataSize = widthBlocks * heightBlocks * blockSize;
-
-		for ( var surfIndex = 0; surfIndex < numSurfs; surfIndex ++ ) {
-
-			var byteArray = new Uint8Array( buffer, dataOffset, dataSize );
-
-			var mipmap = {
-				data: byteArray,
-				width: sWidth,
-				height: sHeight
-			};
-
-			pvr.mipmaps[ surfIndex * pvrDatas.numMipmaps + mipLevel ] = mipmap;
-
-			dataOffset += dataSize;
+			default :
+				console.error( 'THREE.PVRLoader: Unsupported PVR format:', pixelFormat );
 
 		}
 
-		mipLevel ++;
+		pvrDatas.dataPtr = 52 + metaLen;
+		pvrDatas.bpp = bpp;
+		pvrDatas.format = format;
+		pvrDatas.width = width;
+		pvrDatas.height = height;
+		pvrDatas.numSurfaces = numFaces;
+		pvrDatas.numMipmaps = numMipmaps;
+		pvrDatas.isCubemap 	= ( numFaces === 6 );
+
+		return THREE.PVRLoader._extract( pvrDatas );
 
 	}
 
-	return pvr;
+	static _parseV2( pvrDatas ) {
+
+		var header = pvrDatas.header;
+
+		var headerLength = header[ 0 ],
+			height = header[ 1 ],
+			width = header[ 2 ],
+			numMipmaps = header[ 3 ],
+			flags = header[ 4 ],
+			// dataLength = header[ 5 ],
+			// bpp =  header[ 6 ],
+			// bitmaskRed = header[ 7 ],
+			// bitmaskGreen = header[ 8 ],
+			// bitmaskBlue = header[ 9 ],
+			bitmaskAlpha = header[ 10 ],
+			// pvrTag = header[ 11 ],
+			numSurfs = header[ 12 ];
+
+
+		var TYPE_MASK = 0xff;
+		var PVRTC_2 = 24,
+			PVRTC_4 = 25;
+
+		var formatFlags = flags & TYPE_MASK;
+
+		var bpp, format;
+		var _hasAlpha = bitmaskAlpha > 0;
+
+		if ( formatFlags === PVRTC_4 ) {
+
+			format = _hasAlpha ? THREE.RGBA_PVRTC_4BPPV1_Format : THREE.RGB_PVRTC_4BPPV1_Format;
+			bpp = 4;
+
+		} else if ( formatFlags === PVRTC_2 ) {
+
+			format = _hasAlpha ? THREE.RGBA_PVRTC_2BPPV1_Format : THREE.RGB_PVRTC_2BPPV1_Format;
+			bpp = 2;
+
+		} else {
+
+			console.error( 'THREE.PVRLoader: Unknown PVR format:', formatFlags );
+
+		}
+
+		pvrDatas.dataPtr = headerLength;
+		pvrDatas.bpp = bpp;
+		pvrDatas.format = format;
+		pvrDatas.width = width;
+		pvrDatas.height = height;
+		pvrDatas.numSurfaces = numSurfs;
+		pvrDatas.numMipmaps = numMipmaps + 1;
+
+		// guess cubemap type seems tricky in v2
+		// it juste a pvr containing 6 surface (no explicit cubemap type)
+		pvrDatas.isCubemap 	= ( numSurfs === 6 );
+
+		return THREE.PVRLoader._extract( pvrDatas );
+
+	}
+
+	static _extract( pvrDatas ) {
+
+		var pvr = {
+			mipmaps: [],
+			width: pvrDatas.width,
+			height: pvrDatas.height,
+			format: pvrDatas.format,
+			mipmapCount: pvrDatas.numMipmaps,
+			isCubemap: pvrDatas.isCubemap
+		};
+
+		var buffer = pvrDatas.buffer;
+
+		var dataOffset = pvrDatas.dataPtr,
+			bpp = pvrDatas.bpp,
+			numSurfs = pvrDatas.numSurfaces,
+			dataSize = 0,
+			blockSize = 0,
+			blockWidth = 0,
+			blockHeight = 0,
+			widthBlocks = 0,
+			heightBlocks = 0;
+
+		if ( bpp === 2 ) {
+
+			blockWidth = 8;
+			blockHeight = 4;
+
+		} else {
+
+			blockWidth = 4;
+			blockHeight = 4;
+
+		}
+
+		blockSize = ( blockWidth * blockHeight ) * bpp / 8;
+
+		pvr.mipmaps.length = pvrDatas.numMipmaps * numSurfs;
+
+		var mipLevel = 0;
+
+		while ( mipLevel < pvrDatas.numMipmaps ) {
+
+			var sWidth = pvrDatas.width >> mipLevel,
+				sHeight = pvrDatas.height >> mipLevel;
+
+			widthBlocks = sWidth / blockWidth;
+			heightBlocks = sHeight / blockHeight;
+
+			// Clamp to minimum number of blocks
+			if ( widthBlocks < 2 ) widthBlocks = 2;
+			if ( heightBlocks < 2 ) heightBlocks = 2;
+
+			dataSize = widthBlocks * heightBlocks * blockSize;
+
+			for ( var surfIndex = 0; surfIndex < numSurfs; surfIndex ++ ) {
+
+				var byteArray = new Uint8Array( buffer, dataOffset, dataSize );
+
+				var mipmap = {
+					data: byteArray,
+					width: sWidth,
+					height: sHeight
+				};
+
+				pvr.mipmaps[ surfIndex * pvrDatas.numMipmaps + mipLevel ] = mipmap;
+
+				dataOffset += dataSize;
+
+			}
+
+			mipLevel ++;
+
+		}
+
+		return pvr;
+
+	}
 
 };

--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -4,22 +4,19 @@
 
 // https://github.com/mrdoob/three.js/issues/5552
 // http://en.wikipedia.org/wiki/RGBE_image_format
+// adapted from http://www.graphics.cornell.edu/~bjw/rgbe.html
 
-THREE.RGBELoader = function ( manager ) {
+THREE.RGBELoader = class RGBELoader extends THREE.DataTextureLoader {
 
-	THREE.DataTextureLoader.call( this, manager );
+	constructor( manager ) {
 
-	this.type = THREE.UnsignedByteType;
+		super( manager );
 
-};
+		this.type = THREE.UnsignedByteType;
 
-THREE.RGBELoader.prototype = Object.assign( Object.create( THREE.DataTextureLoader.prototype ), {
+	}
 
-	constructor: THREE.RGBELoader,
-
-	// adapted from http://www.graphics.cornell.edu/~bjw/rgbe.html
-
-	parse: function ( buffer ) {
+	parse( buffer ) {
 
 		var
 			/* return codes for rgbe routines */
@@ -471,16 +468,16 @@ THREE.RGBELoader.prototype = Object.assign( Object.create( THREE.DataTextureLoad
 
 		return null;
 
-	},
+	}
 
-	setDataType: function ( value ) {
+	setDataType( value ) {
 
 		this.type = value;
 		return this;
 
-	},
+	}
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		function onLoadCallback( texture, texData ) {
 
@@ -523,4 +520,4 @@ THREE.RGBELoader.prototype = Object.assign( Object.create( THREE.DataTextureLoad
 
 	}
 
-} );
+};

--- a/examples/js/loaders/STLLoader.js
+++ b/examples/js/loaders/STLLoader.js
@@ -56,17 +56,15 @@
  */
 
 
-THREE.STLLoader = function ( manager ) {
+THREE.STLLoader = class STLLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.STLLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.STLLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -91,9 +89,9 @@ THREE.STLLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function isBinary( data ) {
 
@@ -384,4 +382,4 @@ THREE.STLLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -4,23 +4,21 @@
  * @author yomboprime / https://yombo.org
  */
 
-THREE.SVGLoader = function ( manager ) {
+THREE.SVGLoader = class SVGLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	// Default dots per inch
-	this.defaultDPI = 90;
+		super( manager );
 
-	// Accepted units: 'mm', 'cm', 'in', 'pt', 'pc', 'px'
-	this.defaultUnit = "px";
+		// Default dots per inch
+		this.defaultDPI = 90;
 
-};
+		// Accepted units: 'mm', 'cm', 'in', 'pt', 'pc', 'px'
+		this.defaultUnit = "px";
 
-THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.SVGLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -32,9 +30,9 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( text ) {
+	parse( text ) {
 
 		var scope = this;
 
@@ -1264,7 +1262,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};
 
 THREE.SVGLoader.getStrokeStyle = function ( width, color, lineJoin, lineCap, miterLimit ) {
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -9,23 +9,21 @@
  * @constructor
  */
 
-THREE.TDSLoader = function ( manager ) {
+THREE.TDSLoader = class TDSLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.debug = false;
+		super( manager );
 
-	this.group = null;
-	this.position = 0;
+		this.debug = false;
 
-	this.materials = [];
-	this.meshes = [];
+		this.group = null;
+		this.position = 0;
 
-};
+		this.materials = [];
+		this.meshes = [];
 
-THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-
-	constructor: THREE.TDSLoader,
+	}
 
 	/**
 	 * Load 3ds file from url.
@@ -36,7 +34,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Function} onProgress onProgress callback.
 	 * @param {Function} onError onError callback.
 	 */
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -52,7 +50,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
 	/**
 	 * Parse arraybuffer data and load 3ds file.
@@ -62,7 +60,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {String} path Path for external resources.
 	 * @return {Group} Group loaded from 3ds file.
 	 */
-	parse: function ( arraybuffer, path ) {
+	parse( arraybuffer, path ) {
 
 		this.group = new THREE.Group();
 		this.position = 0;
@@ -79,7 +77,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return this.group;
 
-	},
+	}
 
 	/**
 	 * Decode file content to read 3ds data.
@@ -88,7 +86,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {ArrayBuffer} arraybuffer Arraybuffer data to be loaded.
 	 * @param {String} path Path for external resources.
 	 */
-	readFile: function ( arraybuffer, path ) {
+	readFile( arraybuffer, path ) {
 
 		var data = new DataView( arraybuffer );
 		var chunk = this.readChunk( data );
@@ -123,7 +121,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		this.debugMessage( 'Parsed ' + this.meshes.length + ' meshes' );
 
-	},
+	}
 
 	/**
 	 * Read mesh data chunk.
@@ -132,7 +130,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Dataview} data Dataview in use.
 	 * @param {String} path Path for external resources.
 	 */
-	readMeshData: function ( data, path ) {
+	readMeshData( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -172,7 +170,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}
 
-	},
+	}
 
 	/**
 	 * Read named object chunk.
@@ -180,7 +178,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @method readNamedObject
 	 * @param {Dataview} data Dataview in use.
 	 */
-	readNamedObject: function ( data ) {
+	readNamedObject( data ) {
 
 		var chunk = this.readChunk( data );
 		var name = this.readString( data, 64 );
@@ -208,7 +206,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		this.endChunk( chunk );
 
-	},
+	}
 
 	/**
 	 * Read material data chunk and add it to the material list.
@@ -217,7 +215,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Dataview} data Dataview in use.
 	 * @param {String} path Path for external resources.
 	 */
-	readMaterialEntry: function ( data, path ) {
+	readMaterialEntry( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -317,7 +315,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		this.materials[ material.name ] = material;
 
-	},
+	}
 
 	/**
 	 * Read mesh data chunk.
@@ -326,7 +324,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Dataview} data Dataview in use.
 	 * @return {Mesh} The parsed mesh.
 	 */
-	readMesh: function ( data ) {
+	readMesh( data ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -446,7 +444,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return mesh;
 
-	},
+	}
 
 	/**
 	 * Read face array data chunk.
@@ -455,7 +453,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Dataview} data Dataview in use.
 	 * @param {Mesh} mesh Mesh to be filled with the data read.
 	 */
-	readFaceArray: function ( data, mesh ) {
+	readFaceArray( data, mesh ) {
 
 		var chunk = this.readChunk( data );
 		var faces = this.readWord( data );
@@ -514,7 +512,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		this.endChunk( chunk );
 
-	},
+	}
 
 	/**
 	 * Read texture map data chunk.
@@ -524,7 +522,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {String} path Path for external resources.
 	 * @return {Texture} Texture read from this data chunk.
 	 */
-	readMap: function ( data, path ) {
+	readMap( data, path ) {
 
 		var chunk = this.readChunk( data );
 		var next = this.nextChunk( data, chunk );
@@ -576,7 +574,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return texture;
 
-	},
+	}
 
 	/**
 	 * Read material group data chunk.
@@ -585,7 +583,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Dataview} data Dataview in use.
 	 * @return {Object} Object with name and index of the object.
 	 */
-	readMaterialGroup: function ( data ) {
+	readMaterialGroup( data ) {
 
 		this.readChunk( data );
 		var name = this.readString( data, 64 );
@@ -603,7 +601,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return { name: name, index: index };
 
-	},
+	}
 
 	/**
 	 * Read a color value.
@@ -612,7 +610,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview.
 	 * @return {Color} Color value read..
 	 */
-	readColor: function ( data ) {
+	readColor( data ) {
 
 		var chunk = this.readChunk( data );
 		var color = new THREE.Color();
@@ -646,7 +644,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 		this.endChunk( chunk );
 		return color;
 
-	},
+	}
 
 	/**
 	 * Read next chunk of data.
@@ -655,7 +653,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview.
 	 * @return {Object} Chunk of data read.
 	 */
-	readChunk: function ( data ) {
+	readChunk( data ) {
 
 		var chunk = {};
 
@@ -667,7 +665,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return chunk;
 
-	},
+	}
 
 	/**
 	 * Set position to the end of the current chunk of data.
@@ -675,11 +673,11 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @method endChunk
 	 * @param {Object} chunk Data chunk.
 	 */
-	endChunk: function ( chunk ) {
+	endChunk( chunk ) {
 
 		this.position = chunk.end;
 
-	},
+	}
 
 	/**
 	 * Move to the next data chunk.
@@ -688,7 +686,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview.
 	 * @param {Object} chunk Data chunk.
 	 */
-	nextChunk: function ( data, chunk ) {
+	nextChunk( data, chunk ) {
 
 		if ( chunk.cur >= chunk.end ) {
 
@@ -711,18 +709,18 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}
 
-	},
+	}
 
 	/**
 	 * Reset dataview position.
 	 *
 	 * @method resetPosition
 	 */
-	resetPosition: function () {
+	resetPosition() {
 
 		this.position -= 6;
 
-	},
+	}
 
 	/**
 	 * Read byte value.
@@ -731,13 +729,13 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readByte: function ( data ) {
+	readByte( data ) {
 
 		var v = data.getUint8( this.position, true );
 		this.position += 1;
 		return v;
 
-	},
+	}
 
 	/**
 	 * Read 32 bit float value.
@@ -746,7 +744,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readFloat: function ( data ) {
+	readFloat( data ) {
 
 		try {
 
@@ -760,7 +758,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}
 
-	},
+	}
 
 	/**
 	 * Read 32 bit signed integer value.
@@ -769,13 +767,13 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readInt: function ( data ) {
+	readInt( data ) {
 
 		var v = data.getInt32( this.position, true );
 		this.position += 4;
 		return v;
 
-	},
+	}
 
 	/**
 	 * Read 16 bit signed integer value.
@@ -784,13 +782,13 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readShort: function ( data ) {
+	readShort( data ) {
 
 		var v = data.getInt16( this.position, true );
 		this.position += 2;
 		return v;
 
-	},
+	}
 
 	/**
 	 * Read 64 bit unsigned integer value.
@@ -799,13 +797,13 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readDWord: function ( data ) {
+	readDWord( data ) {
 
 		var v = data.getUint32( this.position, true );
 		this.position += 4;
 		return v;
 
-	},
+	}
 
 	/**
 	 * Read 32 bit unsigned integer value.
@@ -814,13 +812,13 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {DataView} data Dataview to read data from.
 	 * @return {Number} Data read from the dataview.
 	 */
-	readWord: function ( data ) {
+	readWord( data ) {
 
 		var v = data.getUint16( this.position, true );
 		this.position += 2;
 		return v;
 
-	},
+	}
 
 	/**
 	 * Read string value.
@@ -830,7 +828,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @param {Number} maxLength Max size of the string to be read.
 	 * @return {String} Data read from the dataview.
 	 */
-	readString: function ( data, maxLength ) {
+	readString( data, maxLength ) {
 
 		var s = '';
 
@@ -849,7 +847,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return s;
 
-	},
+	}
 
 	/**
 	 * Print debug message to the console.
@@ -859,7 +857,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 	 * @method debugMessage
 	 * @param {Object} message Debug message to print to the console.
 	 */
-	debugMessage: function ( message ) {
+	debugMessage( message ) {
 
 		if ( this.debug ) {
 
@@ -869,7 +867,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};
 
 // var NULL_CHUNK = 0x0000;
 var M3DMAGIC = 0x4D4D;

--- a/examples/js/loaders/TGALoader.js
+++ b/examples/js/loaders/TGALoader.js
@@ -4,17 +4,15 @@
  * @author takahirox / https://github.com/takahirox/
  */
 
-THREE.TGALoader = function ( manager ) {
+THREE.TGALoader = class TGALoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.TGALoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.TGALoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -39,9 +37,9 @@ THREE.TGALoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		return texture;
 
-	},
+	}
 
-	parse: function ( buffer ) {
+	parse( buffer ) {
 
 		// reference from vthibault, https://github.com/vthibault/roBrowser/blob/master/src/Loaders/Targa.js
 
@@ -540,4 +538,4 @@ THREE.TGALoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -8,20 +8,17 @@
  * to create THREE.Font objects.
  */
 
-THREE.TTFLoader = function ( manager ) {
+THREE.TTFLoader = class TTFLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.reversed = false;
+		super( manager );
 
-};
+		this.reversed = false;
 
+	}
 
-THREE.TTFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-
-	constructor: THREE.TTFLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -34,9 +31,9 @@ THREE.TTFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( arraybuffer ) {
+	parse( arraybuffer ) {
 
 		function convert( font, reversed ) {
 
@@ -197,4 +194,4 @@ THREE.TTFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -9,17 +9,15 @@
  * @author Sriram Somasundharam https://github.com/raamssundar
  */
 
-THREE.VTKLoader = function ( manager ) {
+THREE.VTKLoader = class VTKLoader extends THREE.Loader {
 
-	THREE.Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
+	}
 
-	constructor: THREE.VTKLoader,
-
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		var scope = this;
 
@@ -32,9 +30,9 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function parseASCII( data ) {
 
@@ -1175,4 +1173,4 @@ THREE.VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 	}
 
-} );
+};


### PR DESCRIPTION
related: #19061

This PR should not be pulled unless the related PR is merged first.

Various Loaders were not included in the init commit because of the following:
-global namespace pollution if anon functions unwrapped
-possible name collisions or issues (`KhronosTextureContainer`, `MaterialCreator`...)

The `webgl_loader_texture_rgbm` example did not use a loader.
