### PR TITLE
WebXRManager: Update camera's local matrix and transform properties.

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -413,6 +413,8 @@ function WebXRManager( renderer, gl ) {
 		// update camera and its children
 
 		camera.matrixWorld.copy( cameraVR.matrixWorld );
+		camera.matrix.copy( cameraVR.matrix );
+		camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 
 		var children = camera.children;
 


### PR DESCRIPTION
Fixed #18448.
Fixed #20920.

This would potentially overwrite user-defined values but since the world matrix is also set, I think this approach is more consistent and avoids side effects like in the above issue.