### PR TITLE
PMREMGenerator: set internal/output render targets as RGBE.

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -230,9 +230,9 @@ PMREMGenerator.prototype = {
 			magFilter: NearestFilter,
 			minFilter: NearestFilter,
 			generateMipmaps: false,
-			type: equirectangular ? equirectangular.type : UnsignedByteType,
-			format: equirectangular ? equirectangular.format : RGBEFormat,
-			encoding: equirectangular ? equirectangular.encoding : RGBEEncoding,
+			type: UnsignedByteType,
+			format: RGBEFormat,
+			encoding: _isLDR( equirectangular ) ? equirectangular.encoding : RGBEEncoding,
 			depthBuffer: false,
 			stencilBuffer: false
 		};
@@ -358,7 +358,7 @@ PMREMGenerator.prototype = {
 		}
 
 		uniforms[ 'inputEncoding' ].value = ENCODINGS[ texture.encoding ];
-		uniforms[ 'outputEncoding' ].value = ENCODINGS[ texture.encoding ];
+		uniforms[ 'outputEncoding' ].value = ENCODINGS[ cubeUVRenderTarget.texture.encoding ];
 
 		_setViewport( cubeUVRenderTarget, 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
 
@@ -504,6 +504,14 @@ PMREMGenerator.prototype = {
 	}
 
 };
+
+function _isLDR( texture ) {
+
+	if ( texture === undefined || texture.type !== UnsignedByteType ) return false;
+
+	return texture.encoding === LinearEncoding || texture.encoding === sRGBEncoding || texture.encoding === GammaEncoding;
+
+}
 
 function _createPlanes() {
 


### PR DESCRIPTION
Fixes #19053 

Based on https://github.com/mrdoob/three.js/issues/19053#issuecomment-610569210 and https://github.com/mrdoob/three.js/issues/19053#issuecomment-610969027

~This PR introduces the possibility for the output texture generated by PMREM to have different type than the inputted texture. This is important for mobile support, which often lacks the ability to render to floating point textures.~

See https://github.com/mrdoob/three.js/pull/19087#issuecomment-612161233 and https://github.com/mrdoob/three.js/pull/19087#issuecomment-612234820
