### PR TITLE
Bugfix at matrix calculation at FBX import

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -3986,43 +3986,49 @@ THREE.FBXLoader = ( function () {
 
 		// Global Shear*Scaling
 		var lParentTM = new THREE.Matrix4();
-		var lLSM;
-		var lParentGSM;
-		var lParentGRSM;
+		var lLSM = new Matrix4();
+		var lParentGSM = new Matrix4();
+		var lParentGRSM = new Matrix4();
+		
+		var lParentTM_inv = new Matrix4().getInverse( lParentTM );
 
 		lParentTM.copyPosition( lParentGX );
-		lParentGRSM = lParentTM.getInverse( lParentTM ).multiply( lParentGX );
-		lParentGSM = lParentGRM.getInverse( lParentGRM ).multiply( lParentGRSM );
+		lParentGRSM.multiply( lParentTM_inv ).multiply( lParentGX );
+		
+		var lParentGRM_inv = new Matrix4().getInverse( lParentGRM );
+		lParentGSM.multiply( lParentGRM_inv ).multiply( lParentGRSM );
 		lLSM = lScalingM;
 
-		var lGlobalRS;
+		var lGlobalRS = new Matrix4();
 		if ( inheritType === 0 ) {
 
-			lGlobalRS = lParentGRM.multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
 
 		} else if ( inheritType === 1 ) {
 
-			lGlobalRS = lParentGRM.multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
 
 		} else {
 
 			var lParentLSM = new THREE.Matrix4().copy( lScalingM );
 
-			var lParentGSM_noLocal = lParentGSM.multiply( lParentLSM.getInverse( lParentLSM ) );
+			var lParentLSM_inv = new Matrix4().getInverse( lParentLSM );
+			var lParentGSM_noLocal = new Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
-			lGlobalRS = lParentGRM.multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
 
 		}
 
 		// Calculate the local transform matrix
-		var lTransform = lTranslationM.multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM.getInverse( lRotationPivotM ) ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM.getInverse( lScalingPivotM ) );
+		var lTransform = new Matrix4();
+		lTransform.multiply( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
 
 		var lLocalTWithAllPivotAndOffsetInfo = new THREE.Matrix4().copyPosition( lTransform );
 
-		var lGlobalTranslation = lParentGX.multiply( lLocalTWithAllPivotAndOffsetInfo );
+		var lGlobalTranslation = new Matrix4().multiply(lParentGX).multiply( lLocalTWithAllPivotAndOffsetInfo );
 		lGlobalT.copyPosition( lGlobalTranslation );
 
-		lTransform = lGlobalT.multiply( lGlobalRS );
+		lTransform = new Matrix4().multiply(lGlobalT).multiply( lGlobalRS );
 
 		return lTransform;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4019,6 +4019,8 @@ THREE.FBXLoader = ( function () {
 
 		}
 
+		var lRotationPivotM_inv = new Matrix4().getInverse( lRotationPivotM );
+		var lScalingPivotM_inv = new Matrix4().getInverse( lScalingPivotM );
 		// Calculate the local transform matrix
 		var lTransform = new Matrix4();
 		lTransform.multiply( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -4066,6 +4066,8 @@ var FBXLoader = ( function () {
 
 		}
 
+		var lRotationPivotM_inv = new Matrix4().getInverse( lRotationPivotM );
+		var lScalingPivotM_inv = new Matrix4().getInverse( lScalingPivotM );
 		// Calculate the local transform matrix
 		var lTransform = new Matrix4();
 		lTransform.multiply( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -4004,6 +4004,7 @@ var FBXLoader = ( function () {
 			var array = transformData.rotation.map( MathUtils.degToRad );
 			array.push( transformData.eulerOrder );
 			lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+
 		}
 
 		if ( transformData.postRotation ) {
@@ -4026,7 +4027,7 @@ var FBXLoader = ( function () {
 		if ( transformData.parentMatrixWorld ) lParentGX = transformData.parentMatrixWorld;
 
 		// Global Rotation
-		var lLRM = new Matrix4().multiply(lPreRotationM).multiply(lRotationM).multiply(lPostRotationM);
+		var lLRM = lPreRotationM.multiply( lRotationM ).multiply( lPostRotationM );
 		var lParentGRM = new Matrix4();
 		lParentGX.extractRotation( lParentGRM );
 
@@ -4036,16 +4037,15 @@ var FBXLoader = ( function () {
 		var lParentGSM = new Matrix4();
 		var lParentGRSM = new Matrix4();
 		
-		var lParentTM_inv = new Matrix4().getInverse(lParentTM);
+		var lParentTM_inv = new Matrix4().getInverse( lParentTM );
 
 		lParentTM.copyPosition( lParentGX );
-		lParentGRSM.multiply(lParentTM_inv).multiply(lParentGX);
+		lParentGRSM.multiply( lParentTM_inv ).multiply( lParentGX );
 		
-		var lParentGRM_inv = new Matrix4().getInverse(lParentGRM);
-		lParentGSM.multiply(lParentGRM_inv).multiply(lParentGRSM);
+		var lParentGRM_inv = new Matrix4().getInverse( lParentGRM );
+		lParentGSM.multiply( lParentGRM_inv ).multiply( lParentGRSM );
 		lLSM = lScalingM;
-		
-	
+
 		var lGlobalRS = new Matrix4();
 		if ( inheritType === 0 ) {
 
@@ -4053,24 +4053,22 @@ var FBXLoader = ( function () {
 
 		} else if ( inheritType === 1 ) {
 
-			lGlobalRS.multiply(lParentGRM).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
 
 		} else {
 
 			var lParentLSM = new Matrix4().copy( lScalingM );
 
-			var lParentGSM_noLocal = new Matrix4().multiply(lParentGSM).multiply( lParentLSM.getInverse( lParentLSM ) );
+			var lParentLSM_inv = new Matrix4().getInverse( lParentLSM );
+			var lParentGSM_noLocal = new Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
-			lGlobalRS.multiply(lParentGRM).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
 
 		}
 
-		var lRotationPivotM_inv = new Matrix4().getInverse(lRotationPivotM);
-		var lScalingPivotM_inv = new Matrix4().getInverse(lScalingPivotM);
-
 		// Calculate the local transform matrix
-		var lTransform = new Matrix4;
-		lTransform.multiply(lTranslationM).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
+		var lTransform = new Matrix4();
+		lTransform.multiply( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
 
 		var lLocalTWithAllPivotAndOffsetInfo = new Matrix4().copyPosition( lTransform );
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -4005,7 +4005,6 @@ var FBXLoader = ( function () {
 			var array = transformData.rotation.map( MathUtils.degToRad );
 			array.push( transformData.eulerOrder );
 			lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-
 		}
 
 		if ( transformData.postRotation ) {
@@ -4028,49 +4027,58 @@ var FBXLoader = ( function () {
 		if ( transformData.parentMatrixWorld ) lParentGX = transformData.parentMatrixWorld;
 
 		// Global Rotation
-		var lLRM = lPreRotationM.multiply( lRotationM ).multiply( lPostRotationM );
+		var lLRM = new Matrix4().multiply(lPreRotationM).multiply(lRotationM).multiply(lPostRotationM);
 		var lParentGRM = new Matrix4();
 		lParentGX.extractRotation( lParentGRM );
 
 		// Global Shear*Scaling
 		var lParentTM = new Matrix4();
-		var lLSM;
-		var lParentGSM;
-		var lParentGRSM;
+		var lLSM = new Matrix4();
+		var lParentGSM = new Matrix4();
+		var lParentGRSM = new Matrix4();
+		
+		var lParentTM_inv = new Matrix4().getInverse(lParentTM);
 
 		lParentTM.copyPosition( lParentGX );
-		lParentGRSM = lParentTM.getInverse( lParentTM ).multiply( lParentGX );
-		lParentGSM = lParentGRM.getInverse( lParentGRM ).multiply( lParentGRSM );
+		lParentGRSM.multiply(lParentTM_inv).multiply(lParentGX);
+		
+		var lParentGRM_inv = new Matrix4().getInverse(lParentGRM);
+		lParentGSM.multiply(lParentGRM_inv).multiply(lParentGRSM);
 		lLSM = lScalingM;
-
-		var lGlobalRS;
+		
+	
+		var lGlobalRS = new Matrix4();
 		if ( inheritType === 0 ) {
 
-			lGlobalRS = lParentGRM.multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
+			lGlobalRS.multiply( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
 
 		} else if ( inheritType === 1 ) {
 
-			lGlobalRS = lParentGRM.multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
+			lGlobalRS.multiply(lParentGRM).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
 
 		} else {
 
 			var lParentLSM = new Matrix4().copy( lScalingM );
 
-			var lParentGSM_noLocal = lParentGSM.multiply( lParentLSM.getInverse( lParentLSM ) );
+			var lParentGSM_noLocal = new Matrix4().multiply(lParentGSM).multiply( lParentLSM.getInverse( lParentLSM ) );
 
-			lGlobalRS = lParentGRM.multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
+			lGlobalRS.multiply(lParentGRM).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
 
 		}
 
+		var lRotationPivotM_inv = new Matrix4().getInverse(lRotationPivotM);
+		var lScalingPivotM_inv = new Matrix4().getInverse(lScalingPivotM);
+
 		// Calculate the local transform matrix
-		var lTransform = lTranslationM.multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM.getInverse( lRotationPivotM ) ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM.getInverse( lScalingPivotM ) );
+		var lTransform = new Matrix4;
+		lTransform.multiply(lTranslationM).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
 
 		var lLocalTWithAllPivotAndOffsetInfo = new Matrix4().copyPosition( lTransform );
 
-		var lGlobalTranslation = lParentGX.multiply( lLocalTWithAllPivotAndOffsetInfo );
+		var lGlobalTranslation = new Matrix4().multiply(lParentGX).multiply( lLocalTWithAllPivotAndOffsetInfo );
 		lGlobalT.copyPosition( lGlobalTranslation );
 
-		lTransform = lGlobalT.multiply( lGlobalRS );
+		lTransform = new Matrix4().multiply(lGlobalT).multiply( lGlobalRS );
 
 		return lTransform;
 


### PR DESCRIPTION
During FBX import the transformation matrix calculation uses the Matrix4.multiply() - function wrong, which causes objects to have a wrong local rotation.

New Pull request, since #19092 was created from the wrong branch. 