### PR TITLE
docs: Fix simple typo, transfrom -> transform

### DIFF
--- a/examples/js/exporters/OBJExporter.js
+++ b/examples/js/exporters/OBJExporter.js
@@ -66,7 +66,7 @@ THREE.OBJExporter.prototype = {
 						vertex.y = vertices.getY( i );
 						vertex.z = vertices.getZ( i );
 
-						// transfrom the vertex to world space
+						// transform the vertex to world space
 						vertex.applyMatrix4( mesh.matrixWorld );
 
 						// transform the vertex to export format
@@ -104,7 +104,7 @@ THREE.OBJExporter.prototype = {
 						normal.y = normals.getY( i );
 						normal.z = normals.getZ( i );
 
-						// transfrom the normal to world space
+						// transform the normal to world space
 						normal.applyMatrix3( normalMatrixWorld ).normalize();
 
 						// transform the normal to export format
@@ -194,7 +194,7 @@ THREE.OBJExporter.prototype = {
 						vertex.y = vertices.getY( i );
 						vertex.z = vertices.getZ( i );
 
-						// transfrom the vertex to world space
+						// transform the vertex to world space
 						vertex.applyMatrix4( line.matrixWorld );
 
 						// transform the vertex to export format

--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -1275,7 +1275,7 @@ THREE.ThreeMFLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 				var object3D = build.clone();
 
-				// apply component transfrom
+				// apply component transform
 
 				var transform = component.transform;
 

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -2907,7 +2907,7 @@ THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 				if ( targetElement ) {
 
-					// get the parent of the transfrom element
+					// get the parent of the transform element
 
 					var parentVisualElement = targetElement.parentElement;
 

--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -76,7 +76,7 @@ OBJExporter.prototype = {
 						vertex.y = vertices.getY( i );
 						vertex.z = vertices.getZ( i );
 
-						// transfrom the vertex to world space
+						// transform the vertex to world space
 						vertex.applyMatrix4( mesh.matrixWorld );
 
 						// transform the vertex to export format
@@ -114,7 +114,7 @@ OBJExporter.prototype = {
 						normal.y = normals.getY( i );
 						normal.z = normals.getZ( i );
 
-						// transfrom the normal to world space
+						// transform the normal to world space
 						normal.applyMatrix3( normalMatrixWorld ).normalize();
 
 						// transform the normal to export format
@@ -204,7 +204,7 @@ OBJExporter.prototype = {
 						vertex.y = vertices.getY( i );
 						vertex.z = vertices.getZ( i );
 
-						// transfrom the vertex to world space
+						// transform the vertex to world space
 						vertex.applyMatrix4( line.matrixWorld );
 
 						// transform the vertex to export format

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1298,7 +1298,7 @@ ThreeMFLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				var object3D = build.clone();
 
-				// apply component transfrom
+				// apply component transform
 
 				var transform = component.transform;
 

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -2947,7 +2947,7 @@ ColladaLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				if ( targetElement ) {
 
-					// get the parent of the transfrom element
+					// get the parent of the transform element
 
 					var parentVisualElement = targetElement.parentElement;
 


### PR DESCRIPTION
There is a small typo in examples/js/exporters/OBJExporter.js, examples/js/loaders/3MFLoader.js, examples/js/loaders/ColladaLoader.js, examples/jsm/exporters/OBJExporter.js, examples/jsm/loaders/3MFLoader.js, examples/jsm/loaders/ColladaLoader.js.

Should read `transform` rather than `transfrom`.

