### PR TITLE
EXRLoader: Support additional attribute types

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1608,6 +1608,24 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 		}
 
+		function parseRational( dataView, offset ) {
+
+			var x = parseUint32( dataView, offset );
+			var y = parseUint32( dataView, offset );
+
+			return [ x, y ];
+
+		}
+
+		function parseTimecode( dataView, offset ) {
+
+			var x = parseUint32( dataView, offset );
+			var y = parseUint32( dataView, offset );
+
+			return [ x, y ];
+
+		}
+
 		function parseUint32( dataView, offset ) {
 
 			var Uint32 = dataView.getUint32( offset.value, true );
@@ -1882,6 +1900,14 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			} else if ( type === 'int' ) {
 
 				return parseUint32( dataView, offset );
+
+			} else if ( type === 'rational' ) {
+
+				return parseRational( dataView, offset );
+
+			} else if ( type === 'timecode' ) {
+
+				return parseTimecode( dataView, offset );
 
 			} else {
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1623,6 +1623,24 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 		}
 
+		function parseRational( dataView, offset ) {
+
+			var x = parseUint32( dataView, offset );
+			var y = parseUint32( dataView, offset );
+
+			return [ x, y ];
+
+		}
+
+		function parseTimecode( dataView, offset ) {
+
+			var x = parseUint32( dataView, offset );
+			var y = parseUint32( dataView, offset );
+
+			return [ x, y ];
+
+		}
+
 		function parseUint32( dataView, offset ) {
 
 			var Uint32 = dataView.getUint32( offset.value, true );
@@ -1897,6 +1915,14 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 			} else if ( type === 'int' ) {
 
 				return parseUint32( dataView, offset );
+
+			} else if ( type === 'rational' ) {
+
+				return parseRational( dataView, offset );
+
+			} else if ( type === 'timecode' ) {
+
+				return parseTimecode( dataView, offset );
 
 			} else {
 


### PR DESCRIPTION
Fixes #19105.

/ping @sciecode  I am concerned that `parseValue()` does not appear to differentiate between int and Uint. But I think this PR OK for now.