### PR TITLE
Editor: Support loading of 3MF files.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -4,6 +4,7 @@
 
 import * as THREE from '../../build/three.module.js';
 
+import { ThreeMFLoader } from '../../examples/jsm/loaders/3MFLoader.js';
 import { AMFLoader } from '../../examples/jsm/loaders/AMFLoader.js';
 import { ColladaLoader } from '../../examples/jsm/loaders/ColladaLoader.js';
 import { DRACOLoader } from '../../examples/jsm/loaders/DRACOLoader.js';
@@ -96,6 +97,20 @@ var Loader = function ( editor ) {
 				reader.addEventListener( 'load', function ( event ) {
 
 					var loader = new TDSLoader();
+					var object = loader.parse( event.target.result );
+
+					editor.execute( new AddObjectCommand( editor, object ) );
+
+				}, false );
+				reader.readAsArrayBuffer( file );
+
+				break;
+
+			case '3mf':
+
+				reader.addEventListener( 'load', function ( event ) {
+
+					var loader = new ThreeMFLoader();
 					var object = loader.parse( event.target.result );
 
 					editor.execute( new AddObjectCommand( editor, object ) );

--- a/editor/sw.js
+++ b/editor/sw.js
@@ -18,6 +18,7 @@ const assets = [
 	'../examples/js/libs/draco/draco_encoder.js',
 	'../examples/js/libs/draco/draco_wasm_wrapper.js',
 
+	'../examples/jsm/loaders/3MFLoader.js',
 	'../examples/jsm/loaders/AMFLoader.js',
 	'../examples/jsm/loaders/ColladaLoader.js',
 	'../examples/jsm/loaders/DRACOLoader.js',


### PR DESCRIPTION
`3MFLoader` has reached a certain maturity level so it's appropriate to integrate it into the editor. Especially since editor support makes it easier to debug 3MF assets and changes to the loader^^.