### PR TITLE
Fix TransformControl zoom for OrthographicCamera

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -1166,6 +1166,10 @@ THREE.TransformControlsGizmo = function () {
 			handle.position.copy( this.worldPosition );
 
 			var eyeDistance = this.worldPosition.distanceTo( this.cameraPosition );
+			// Orthographic camera zoom doesn't depend on eyeDistance, but on camera zoom factor.
+			if (this.camera.type == "OrthographicCamera") {
+				eyeDistance = 1000 / this.camera.zoom;
+			}
 			handle.scale.set( 1, 1, 1 ).multiplyScalar( eyeDistance * this.size / 7 );
 
 			// TODO: simplify helpers and consider decoupling from gizmo

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -1165,11 +1165,8 @@ THREE.TransformControlsGizmo = function () {
 			handle.rotation.set( 0, 0, 0 );
 			handle.position.copy( this.worldPosition );
 
-			var eyeDistance = this.worldPosition.distanceTo( this.cameraPosition );
-			// Orthographic camera zoom doesn't depend on eyeDistance, but on camera zoom factor.
-			if (this.camera.type == "OrthographicCamera") {
-				eyeDistance = 1000 / this.camera.zoom;
-			}
+			var eyeDistance = this.camera.isOrthographicCamera ? 1000 / this.camera.zoom : 
+				this.worldPosition.distanceTo( this.cameraPosition );			
 			handle.scale.set( 1, 1, 1 ).multiplyScalar( eyeDistance * this.size / 7 );
 
 			// TODO: simplify helpers and consider decoupling from gizmo

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1188,11 +1188,8 @@ var TransformControlsGizmo = function () {
 			handle.rotation.set( 0, 0, 0 );
 			handle.position.copy( this.worldPosition );
 
-			var eyeDistance = this.worldPosition.distanceTo( this.cameraPosition );
-			// Orthographic camera zoom doesn't depend on eyeDistance, but on camera zoom factor.
-			if (this.camera.type == "OrthographicCamera") {
-				eyeDistance = 1000 / this.camera.zoom;
-			}
+			var eyeDistance = this.camera.isOrthographicCamera ? 1000 / this.camera.zoom : 
+				this.worldPosition.distanceTo( this.cameraPosition );			
 			handle.scale.set( 1, 1, 1 ).multiplyScalar( eyeDistance * this.size / 7 );
 
 			// TODO: simplify helpers and consider decoupling from gizmo

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1189,6 +1189,10 @@ var TransformControlsGizmo = function () {
 			handle.position.copy( this.worldPosition );
 
 			var eyeDistance = this.worldPosition.distanceTo( this.cameraPosition );
+			// Orthographic camera zoom doesn't depend on eyeDistance, but on camera zoom factor.
+			if (this.camera.type == "OrthographicCamera") {
+				eyeDistance = 1000 / this.camera.zoom;
+			}
 			handle.scale.set( 1, 1, 1 ).multiplyScalar( eyeDistance * this.size / 7 );
 
 			// TODO: simplify helpers and consider decoupling from gizmo


### PR DESCRIPTION
When **OrthographcCamera** is used together with **OrbitControls** **TransformControls** graphical representation is not scaled correctly. This is because **TransformControls** was originally written for the **PerspectiveCamera**, where scaling is done by positioning camera further or closer to the object. 
For the orthographic projection this doesn't work, because camera position is always infinitely far away from the object, so zoom factor should be used instead.
The fix contains "magical number" _1000_. This was selected by experiment, but it can be changed, if there is a good reason. 
Current shape of the control with control size = 1:
![image](https://user-images.githubusercontent.com/6449956/79072562-8c312580-7cd9-11ea-8bde-9294b223cb26.png)
