### PR TITLE
remove VertexColor imports from MaterialHandler and TubePainter

### DIFF
--- a/examples/jsm/loaders/obj2/shared/MaterialHandler.js
+++ b/examples/jsm/loaders/obj2/shared/MaterialHandler.js
@@ -7,8 +7,7 @@ import {
 	LineBasicMaterial,
 	MaterialLoader,
 	MeshStandardMaterial,
-	PointsMaterial,
-	VertexColors
+	PointsMaterial
 } from "../../../../../build/three.module.js";
 
 
@@ -65,7 +64,7 @@ MaterialHandler.prototype = {
 
 		let defaultVertexColorMaterial = new MeshStandardMaterial( { color: 0xDCF1FF } );
 		defaultVertexColorMaterial.name = 'defaultVertexColorMaterial';
-		defaultVertexColorMaterial.vertexColors = VertexColors;
+		defaultVertexColorMaterial.vertexColors = true;
 
 		let defaultLineMaterial = new LineBasicMaterial();
 		defaultLineMaterial.name = 'defaultLineMaterial';

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -10,8 +10,7 @@ import {
 	Matrix4,
 	Mesh,
 	MeshStandardMaterial,
-	Vector3,
-	VertexColors
+	Vector3
 } from '../../../build/three.module.js';
 
 function TubePainter() {
@@ -34,7 +33,7 @@ function TubePainter() {
 	geometry.drawRange.count = 0;
 
 	let material = new MeshStandardMaterial( {
-		vertexColors: VertexColors
+		vertexColors: true
 	} );
 
 	let mesh = new Mesh( geometry, material );


### PR DESCRIPTION
Hello,

I've removed VertexColors imports in 2 of the examples, since it is not in src/constants anymore. It's probably harmless when using js, but that was preventing compilation with typescript.