### PR TITLE
WebGLRenderer: Save correct encoding after rendering to render target

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1516,7 +1516,7 @@ function WebGLRenderer( parameters ) {
 
 			materialProperties.program = program;
 			materialProperties.uniforms = parameters.uniforms;
-			materialProperties.outputEncoding = _this.outputEncoding;
+			materialProperties.outputEncoding = parameters.outputEncoding;
 			material.program = program;
 
 		}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1614,6 +1614,7 @@ function WebGLRenderer( parameters ) {
 
 		var fog = scene.fog;
 		var environment = material.isMeshStandardMaterial ? scene.environment : null;
+		var encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
 
 		var materialProperties = properties.get( material );
 		var lights = currentRenderState.state.lights;
@@ -1661,7 +1662,7 @@ function WebGLRenderer( parameters ) {
 
 				initMaterial( material, scene, object );
 
-			} else if ( materialProperties.outputEncoding !== _this.outputEncoding ) {
+			} else if ( materialProperties.outputEncoding !== encoding ) {
 
 				initMaterial( material, scene, object );
 


### PR DESCRIPTION
Fixes #18942

Based on https://github.com/mrdoob/three.js/issues/18942#issuecomment-613217437

This is a subtle, but very important problem to fix. It is not limited to the specific case of the issue and it affects every material.

When we compile any material to render on a `WebGLRenderTarget` that uses a different encoding from `renderer.outputEncoding`, the properties saved is incorrect. This causes the material to not get recompiled when rendering to the canvas again.

The inverse is also true.

[JSFiddle Reproduction](https://jsfiddle.net/m3h4ujt5/)