### PR TITLE
Add gamma correction pass to unreal bloom example

### DIFF
--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -34,7 +34,10 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
+
+			import { GammaCorrectionShader } from './jsm/shaders/GammaCorrectionShader.js';
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
+			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
 			import { UnrealBloomPass } from './jsm/postprocessing/UnrealBloomPass.js';
 
 			var scene, camera, controls, pointLight, stats;
@@ -82,9 +85,12 @@
 			bloomPass.strength = params.bloomStrength;
 			bloomPass.radius = params.bloomRadius;
 
+			var gammaCorrectionPass = new ShaderPass( GammaCorrectionShader );
+
 			composer = new EffectComposer( renderer );
 			composer.addPass( renderScene );
 			composer.addPass( bloomPass );
+			composer.addPass( gammaCorrectionPass );
 
 			new GLTFLoader().load( 'models/gltf/PrimaryIonDrive.glb', function ( gltf ) {
 


### PR DESCRIPTION
Fix for #14899

[Live link](https://raw.githack.com/mrdoob/three.js/bf4bf7222d972f2e0066338fc2e2131d8f54f858/examples/webgl_postprocessing_unreal_bloom.html). Note that there's some difference compared to the old version because of the gamma pass. I didn't make any adjustments to bloom parameters to compensate. 

For the unreal bloom pass to give correct results it needs to have a `GammaCorrectionPass`. 

Most likely, every post-processing example needs a `GammaCorrectionPass` somewhere in the mix to give correct results.

I've been looking into which passes need to be done in HDR, and which in LDR. It seems like bloom pass can be done in either HDR or LDR, but HDR gives better results (for lower performance). [Some discussion here](https://www.gamedev.net/forums/topic/673257-post-process-hdr-or-ldr-nowadays/). 

Some other passes, notably FXAA pass, [must be done in LDR](https://catlikecoding.com/unity/tutorials/advanced-rendering/fxaa/): 

> Providing LDR data is the responsibility of whoever provided the input for the FXAA pass

EDIT: Hmmm, actually the new example looks pretty bad now ☹️ I thought it looked better a few minutes ago. 