### PR TITLE
Minor correction to the FontLoader documentation 

### DIFF
--- a/docs/api/en/loaders/FontLoader.html
+++ b/docs/api/en/loaders/FontLoader.html
@@ -14,7 +14,7 @@
 
 		<p class="desc">
 		Class for loading a font in JSON format. Returns a [page:Font Font], which is an
-		array of [page:Shape Shape]s representing the font.
+		array of [page:Shape Shapes] representing the font.
 		This uses the [page:FileLoader] internally for loading files. <br /><br />
 
 		You can convert fonts online using [link:https://gero3.github.io/facetype.js/ facetype.js]


### PR DESCRIPTION
Although the page is called 'Shape' and not 'Shapes', it would be better if the whole word would act as a hyperlink. It's against good practices for designing hyperlinks and labels - and honestly looks kinda weird. 

References:
https://www.nngroup.com/articles/better-link-labels/
https://usabilitygeek.com/hyperlink-usability-guidelines-usable-links/