### PR TITLE
Examples: Fix winding order in instancing interleaved example

### DIFF
--- a/examples/webgl_buffergeometry_instancing_interleaved.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved.html
@@ -101,14 +101,14 @@
 			geometry.setAttribute( 'uv', uvs );
 
 			var indices = new Uint16Array( [
-				0, 1, 2,
-				2, 1, 3,
-				4, 5, 6,
-				6, 5, 7,
-				8, 9, 10,
-				10, 9, 11,
-				12, 13, 14,
-				14, 13, 15,
+				0, 2, 1,
+				2, 3, 1,
+				4, 6, 5,
+				6, 7, 5,
+				8, 10, 9,
+				10, 11, 9,
+				12, 14, 13,
+				14, 15, 13,
 				16, 17, 18,
 				18, 17, 19,
 				20, 21, 22,
@@ -121,7 +121,6 @@
 
 			var material = new THREE.MeshBasicMaterial();
 			material.map = new THREE.TextureLoader().load( 'textures/crate.gif' );
-			material.side = THREE.DoubleSide;
 
 			// per instance data
 


### PR DESCRIPTION
`DoubleSide` was previously required because the winding orders were incorrect.