### PR TITLE
Improve SVGLoader style support

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -107,8 +107,6 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 				}
 
-				path.opacity = style.opacity || 1.0;
-
 				transformPath( path, currentTransform );
 
 				paths.push( path );

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -884,6 +884,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 			addStyle( 'stroke-linejoin', 'strokeLineJoin' );
 			addStyle( 'stroke-linecap', 'strokeLineCap' );
 			addStyle( 'stroke-miterlimit', 'strokeMiterLimit', positive );
+			addStyle( 'visibility', 'visibility' );
 
 			return style;
 

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -51,6 +51,10 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 				case 'svg':
 					break;
 
+				case 'style':
+					parseCSSStylesheet( node );
+					break;
+
 				case 'g':
 					style = parseStyle( node, style );
 					break;
@@ -91,7 +95,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 					break;
 
 				default:
-					console.log( node );
+					// console.log( node );
 
 			}
 
@@ -102,6 +106,8 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 					path.color.setStyle( style.fill );
 
 				}
+
+				path.opacity = style.opacity || 1.0;
 
 				transformPath( path, currentTransform );
 
@@ -558,6 +564,34 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}
 
+		function parseCSSStylesheet( node ) {
+
+			if ( !node.sheet || !node.sheet.cssRules || !node.sheet.cssRules.length ) return;
+
+			for ( var i = 0; i < node.sheet.cssRules.length; i ++ ) {
+
+				var stylesheet = node.sheet.cssRules[ i ];
+
+				if ( stylesheet.type !== 1 ) continue;
+
+				var selectorList = stylesheet.selectorText
+					.split( /,/gm )
+					.filter( Boolean )
+					.map( i => i.trim() );
+
+				for ( var j = 0; j < selectorList.length; j ++ ) {
+
+					stylesheets[ selectorList[ j ] ] = Object.assign(
+						stylesheets[ selectorList[ j ] ] || {},
+						stylesheet.style
+					);
+
+				}
+				
+			}
+
+		}
+
 		/**
 		 * https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
 		 * https://mortoray.com/2017/02/16/rendering-an-svg-elliptical-arc-as-bezier-curves/ Appendix: Endpoint to center arc conversion
@@ -794,6 +828,29 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 			style = Object.assign( {}, style ); // clone style
 
+			var stylesheetStyles = {};
+
+			if ( node.hasAttribute( 'class' ) ) {
+
+				var classSelectors = node.getAttribute( 'class' )
+					.split( /\s/ )
+					.filter( Boolean )
+					.map( i => i.trim() );
+
+				for ( var i = 0; i < classSelectors.length; i ++ ) {
+
+					stylesheetStyles = Object.assign( stylesheetStyles, stylesheets[ '.' + classSelectors[ i ] ] );
+
+				}
+
+			}
+
+			if ( node.hasAttribute( 'id' ) ) {
+
+				stylesheetStyles = Object.assign( stylesheetStyles, stylesheets[ '#' + node.getAttribute( 'id' ) ] );
+
+			}
+
 			function addStyle( svgName, jsName, adjustFunction ) {
 
 				if ( adjustFunction === undefined ) adjustFunction = function copy( v ) {
@@ -803,6 +860,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 				};
 
 				if ( node.hasAttribute( svgName ) ) style[ jsName ] = adjustFunction( node.getAttribute( svgName ) );
+				if ( stylesheetStyles[ svgName ] ) style[ jsName ] = adjustFunction( stylesheetStyles[ svgName ] );
 				if ( node.style && node.style[ svgName ] !== '' ) style[ jsName ] = adjustFunction( node.style[ svgName ] );
 
 			}
@@ -821,6 +879,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 			addStyle( 'fill', 'fill' );
 			addStyle( 'fill-opacity', 'fillOpacity', clamp );
+			addStyle( 'opacity', 'opacity', clamp );
 			addStyle( 'stroke', 'stroke' );
 			addStyle( 'stroke-opacity', 'strokeOpacity', clamp );
 			addStyle( 'stroke-width', 'strokeWidth', positive );
@@ -1233,6 +1292,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 		//
 
 		var paths = [];
+		var stylesheets = {};
 
 		var transformStack = [];
 

--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -13,7 +13,6 @@ function ShapePath() {
 	this.type = 'ShapePath';
 
 	this.color = new Color();
-	this.opacity = 1.0;
 
 	this.subPaths = [];
 	this.currentPath = null;

--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -13,6 +13,7 @@ function ShapePath() {
 	this.type = 'ShapePath';
 
 	this.color = new Color();
+	this.opacity = 1.0;
 
 	this.subPaths = [];
 	this.currentPath = null;


### PR DESCRIPTION
## Changes
* Add support for `<style>` tag and `class / id` attributes in SVG files.
* Add global `opacity` support for Shapes.
* Silence `console.log` for unrecognised tags.

Currently SVGLoader does not work nicely with Adobe Illustrator exported SVGs, in some cases.
It is valid for SVGs to include DOM-like `<style>` definitions, linked via classes:

## Example

```svg
<?xml version="1.0" encoding="utf-8"?>
<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
]>
<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
  <style type="text/css">
    .st0{fill:#00ff00;opacity:0.2;}
  </style>
  <switch>
    <foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
      <i:pgfRef xlink:href="#adobe_illustrator_pgf"></i:pgfRef>
    </foreignObject>
    <g i:extraneous="self">
      <g>
        <polygon fill="#ff0000" class="st0" points="73.5,64.1 46.76,50.71 46.76,27.31 73.5,40.7"/>
      </g>
    </g>
  </switch>
</svg>
```

Current vs corrected preview:

![preview](https://user-images.githubusercontent.com/9549760/79416138-490fd480-7faf-11ea-856f-711988aa6f8d.jpg)

Corrected version reads additional styles from stylesheets using [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet). Also, silencing `console.log` for unrecognised tags does not clutter console with billions of exported third-party tags.

## Limitations / Not added in this PR

* Nested CSS selectors (ex. `container child { fill: #ff0000; }`)
* Support for all [CSS Interfaces](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants). Only type-1, direct stylesheet added, imports / keyframes / media queries not supported.

### Browser Support

Yes. [CSSRule](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Constants) , [CSSStyleSheet + .cssRules](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet)