### PR TITLE
CI: new exception to stop freezes

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -22,6 +22,7 @@ const exceptionList = [
 	'webaudio_visualizer', // audio can't be analyzed without proper audio hook
 	'webgl_loader_texture_pvrtc', // not supported in CI, useless
 	'webgl_materials_envmaps_parallax', // empty for some reason
+	'webgl_raymarching_reflect', // exception for Github Actions
 	'webgl_test_memory2', // gives fatal error in puppeteer
 	'webgl_tiled_forward', // exception for Github Actions
 	'webgl_worker_offscreencanvas', // in a worker, not robust


### PR DESCRIPTION
This is a monkey patch to stop freezes in Github Actions. Probably my fault with unhandled error.