### PR TITLE
Update typecast for getObjectByName

### DIFF
--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -14,6 +14,21 @@ import { Raycaster } from './Raycaster';
 import { EventDispatcher } from './EventDispatcher';
 import { BufferGeometry } from './BufferGeometry';
 import { Intersection } from './Raycaster';
+import { CubeCamera } from '../cameras/CubeCamera';
+import { Light } from '../lights/Light';
+import { Bone } from '../objects/Bone';
+import { LOD } from '../objects/LOD';
+import { Line } from '../objects/Line';
+import { Mesh } from '../objects/Mesh';
+import { Points } from '../objects/Points';
+import { Sprite } from '../objects/Sprite';
+import { Audio } from '../audio/Audio';
+import { ArrowHelper } from '../helpers/ArrowHelper';
+import { DirectionalLightHelper } from '../helpers/DirectionalLightHelper';
+import { HemisphereLightHelper } from '../helpers/HemisphereLightHelper';
+import { PointLightHelper } from '../helpers/PointLightHelper';
+import { SpotLightHelper } from '../helpers/SpotLightHelper';
+import { ImmediateRenderObject } from '../extras/objects/ImmediateRenderObject';
 
 export let Object3DIdCount: number;
 
@@ -297,7 +312,28 @@ export class Object3D extends EventDispatcher {
 	 * Searches through the object's children and returns the first with a matching id.
 	 * @param id	Unique number of the object instance
 	 */
-	getObjectById( id: number ): Object3D | undefined;
+	getObjectByName( name: string ):
+	Object3D |
+	Camera |
+	CubeCamera |
+	Light |
+	Bone |
+	Group |
+	LOD |
+	Line |
+	Mesh |
+	Points |
+	Sprite |
+	Scene |
+	Audio |
+	AudioListener |
+	ArrowHelper |
+	DirectionalLightHelper |
+	HemisphereLightHelper |
+	PointLightHelper |
+	SpotLightHelper |
+	ImmediateRenderObject |
+	undefined;
 
 	/**
 	 * Searches through the object's children and returns the first with a matching name.


### PR DESCRIPTION
### Typecast fails if `getObjectByName` method returns objects other than Object3D

Please refer the example mentioned below:

```
const scene = new THREE.scene()
const upperPlaneCloudMaterial = new THREE.PointsMaterial({
            vertexColors: THREE.VertexColors,
            size: 0.08,
            clippingPlanes: []
        })
const pointsObject = new THREE.Points(this.cloudGeometry, upperPlaneCloudMaterial)
const pointsObject.name = 'pointsObject'
scene.add(this.cloudField)
```

Now while getting cloud field by method `getObjectByName()` 
```
const pointsObject = scene.getObjectByName('pointsObject')
pointsObject.geometry.attributes.position.needsUpdate = true
pointsObject.geometry.attributes.position.setArray(attributesData.position)
pointsObject.geometry.computeBoundingSphere()
```
It gives type error as mentioned below:
`Property 'geometry' does not exist on type 'Object3D'`

**With the updated typecast pointsObject can be now accessed as mentioned below**
```
;(((cloudField as THREE.Points).geometry as BufferGeometry).attributes
                .position as BufferAttribute).needsUpdate = true
```