### PR TITLE
GLTFExporter: Added accessor.normalized support.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -702,6 +702,12 @@ THREE.GLTFExporter.prototype = {
 
 			};
 
+			if ( attribute.normalized === true ) {
+
+				gltfAccessor.normalized = true;
+				
+			}
+
 			if ( ! outputJSON.accessors ) {
 
 				outputJSON.accessors = [];

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -724,6 +724,12 @@ GLTFExporter.prototype = {
 
 			};
 
+			if ( attribute.normalized === true ) {
+
+				gltfAccessor.normalized = true;
+				
+			}
+
 			if ( ! outputJSON.accessors ) {
 
 				outputJSON.accessors = [];


### PR DESCRIPTION
As written in the title, I added the `gltf.json.accessor.normalized` property support in both exmples/js/exporters/GLTFExporter.js and examples/jsm/exporters/GLTFExporter.js. Happened to be using this property in my current project. Hope you accept it! 