### PR TITLE
Clean up Translucency.js

### DIFF
--- a/examples/jsm/shaders/TranslucentShader.js
+++ b/examples/jsm/shaders/TranslucentShader.js
@@ -3,7 +3,7 @@
  *
  * ------------------------------------------------------------------------------------------
  * Subsurface Scattering shader
- * Base on GDC 2011 – Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look
+ * Based on GDC 2011 – Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look
  * https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/
  *------------------------------------------------------------------------------------------
  */
@@ -11,24 +11,24 @@
 import {
 	Color,
 	ShaderChunk,
-	UniformsLib,
-	UniformsUtils
+	UniformsUtils,
+	ShaderLib
 } from "../../../build/three.module.js";
+
+function replaceAll( string, find, replace ) {
+
+	return string.split( find ).join( replace );
+
+}
+
+var meshphong_frag_head = ShaderChunk[ "meshphong_frag" ].slice( 0, ShaderChunk[ "meshphong_frag" ].indexOf( 'void main() {' ) );
+var meshphong_frag_body = ShaderChunk[ "meshphong_frag" ].slice( ShaderChunk[ "meshphong_frag" ].indexOf( 'void main() {' ) );
 
 var TranslucentShader = {
 
 	uniforms: UniformsUtils.merge( [
-
-		UniformsLib[ "common" ],
-		UniformsLib[ "lights" ],
+		ShaderLib[ "phong" ].uniforms,
 		{
-			"color": { value: new Color( 0xffffff ) },
-			"diffuse": { value: new Color( 0xffffff ) },
-			"specular": { value: new Color( 0xffffff ) },
-			"emissive": { value: new Color( 0x000000 ) },
-			"opacity": { value: 1 },
-			"shininess": { value: 1 },
-
 			"thicknessMap": { value: null },
 			"thicknessColor": { value: new Color( 0xffffff ) },
 			"thicknessDistortion": { value: 0.1 },
@@ -41,52 +41,16 @@ var TranslucentShader = {
 	] ),
 
 	vertexShader: [
-
-		"varying vec3 vNormal;",
-		"varying vec2 vUv;",
-
-		"varying vec3 vViewPosition;",
-
-		ShaderChunk[ "common" ],
-
-		"void main() {",
-
-		"	vec4 worldPosition = modelMatrix * vec4( position, 1.0 );",
-
-		"	vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );",
-
-		"	vViewPosition = -mvPosition.xyz;",
-
-		"	vNormal = normalize( normalMatrix * normal );",
-
-		"	vUv = uv;",
-
-		"	gl_Position = projectionMatrix * mvPosition;",
-
-		"}",
-
+		"#define USE_UV",
+		ShaderChunk[ "meshphong_vert" ],
 	].join( "\n" ),
 
 	fragmentShader: [
 		"#define USE_UV",
-		"#define USE_MAP",
-		"#define PHONG",
 		"#define TRANSLUCENT",
-		"#include <common>",
-		"#include <bsdfs>",
-		"#include <uv_pars_fragment>",
-		"#include <map_pars_fragment>",
-		"#include <lights_phong_pars_fragment>",
 
-		"varying vec3 vColor;",
+		meshphong_frag_head,
 
-		"uniform vec3 diffuse;",
-		"uniform vec3 specular;",
-		"uniform vec3 emissive;",
-		"uniform float opacity;",
-		"uniform float shininess;",
-
-		// Translucency
 		"uniform sampler2D thicknessMap;",
 		"uniform float thicknessPower;",
 		"uniform float thicknessScale;",
@@ -94,8 +58,6 @@ var TranslucentShader = {
 		"uniform float thicknessAmbient;",
 		"uniform float thicknessAttenuation;",
 		"uniform vec3 thicknessColor;",
-
-		ShaderChunk[ "lights_pars_begin" ],
 
 		"void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {",
 		"	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;",
@@ -105,109 +67,21 @@ var TranslucentShader = {
 		"	reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;",
 		"}",
 
-		"void main() {",
+		meshphong_frag_body.replace( "#include <lights_fragment_begin>",
 
-		"	vec3 normal = normalize( vNormal );",
+			replaceAll(
+				ShaderChunk[ 'lights_fragment_begin' ],
+				'RE_Direct( directLight, geometry, material, reflectedLight );',
+				[
+					"RE_Direct( directLight, geometry, material, reflectedLight );",
 
-		"	vec3 viewerDirection = normalize( vViewPosition );",
+					"#if defined( TRANSLUCENT ) && defined( USE_UV )",
+					" RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
+					"#endif",
+				].join( "\n" )
+			),
 
-		"	vec4 diffuseColor = vec4( diffuse, opacity );",
-		"	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
-
-		ShaderChunk[ "map_fragment" ],
-		ShaderChunk[ "color_fragment" ],
-		ShaderChunk[ "specularmap_fragment" ],
-
-		"	vec3 totalEmissiveRadiance = emissive;",
-
-		ShaderChunk[ "lights_phong_fragment" ],
-
-		// Doing lights fragment begin.
-		"	GeometricContext geometry;",
-		"	geometry.position = - vViewPosition;",
-		"	geometry.normal = normal;",
-		"	geometry.viewDir = normalize( vViewPosition );",
-
-		"	IncidentLight directLight;",
-
-		"	#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )",
-
-		"		PointLight pointLight;",
-
-		"		#pragma unroll_loop_start",
-		"		for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {",
-		"		 	pointLight = pointLights[ i ];",
-		"		 	getPointDirectLightIrradiance( pointLight, geometry, directLight );",
-
-		"			#ifdef USE_SHADOWMAP",
-		"			directLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;",
-		"			#endif",
-
-		"			RE_Direct( directLight, geometry, material, reflectedLight );",
-
-		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
-		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
-		"			#endif",
-		"		}",
-		"		#pragma unroll_loop_end",
-
-		"		#endif",
-
-		"	#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )",
-
-		"		DirectionalLight directionalLight;",
-
-		"		#pragma unroll_loop_start",
-		"		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {",
-		"			directionalLight = directionalLights[ i ];",
-		"			getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );",
-
-		"			#ifdef USE_SHADOWMAP",
-		"			directLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;",
-		"			#endif",
-
-		"			RE_Direct( directLight, geometry, material, reflectedLight );",
-
-		"			#if defined( TRANSLUCENT ) && defined( USE_UV )",
-		"			RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);",
-		"			#endif",
-		"		}",
-		"		#pragma unroll_loop_end",
-
-		"	#endif",
-
-		"	#if defined( RE_IndirectDiffuse )",
-
-		"		vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );",
-
-		"		#if ( NUM_HEMI_LIGHTS > 0 )",
-
-		"			#pragma unroll_loop_start",
-		"			for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {",
-
-		"				irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );",
-
-		"			}",
-		"			#pragma unroll_loop_end",
-
-		"		#endif",
-
-		"	#endif",
-
-		"	#if defined( RE_IndirectSpecular )",
-
-		"		vec3 radiance = vec3( 0.0 );",
-		"		vec3 clearcoatRadiance = vec3( 0.0 );",
-
-		"	#endif",
-		ShaderChunk[ "lights_fragment_end" ],
-
-		"	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;",
-		"	gl_FragColor = vec4( outgoingLight, diffuseColor.a );",	// TODO, this should be pre-multiplied to allow for bright highlights on very transparent objects
-
-		ShaderChunk[ "encodings_fragment" ],
-
-		"}"
+		),
 
 	].join( "\n" ),
 

--- a/examples/webgl_materials_translucency.html
+++ b/examples/webgl_materials_translucency.html
@@ -138,7 +138,7 @@
 
 			var ThicknessControls = function () {
 
-				this.distoration = uniforms[ 'thicknessDistortion' ].value;
+				this.distortion = uniforms[ 'thicknessDistortion' ].value;
 				this.ambient = uniforms[ 'thicknessAmbient' ].value;
 				this.attenuation = uniforms[ 'thicknessAttenuation' ].value;
 				this.power = uniforms[ 'thicknessPower' ].value;
@@ -149,9 +149,9 @@
 			var thicknessControls = new ThicknessControls();
 			var thicknessFolder = gui.addFolder( 'Thickness Control' );
 
-			thicknessFolder.add( thicknessControls, 'distoration' ).min( 0.01 ).max( 1 ).step( 0.01 ).onChange( function () {
+			thicknessFolder.add( thicknessControls, 'distortion' ).min( 0.01 ).max( 1 ).step( 0.01 ).onChange( function () {
 
-				uniforms[ 'thicknessDistortion' ].value = thicknessControls.distoration;
+				uniforms[ 'thicknessDistortion' ].value = thicknessControls.distortion;
 
 			} );
 


### PR DESCRIPTION
I was adapting the Translucency shader to work with MeshStandardMaterial, and I noticed that 90% of the code from the shader is from the Phong shader.

I cleaned it up and now it basically works like this:

```js
ShaderChunk[ "meshphong_frag" ].replace( 
  "RE_Direct( directLight, geometry, material, reflectedLight );",
  "..."
)
```

The Pros of this are:
- it's easier to understand and modify
- it's up to date with the Phong material

The Cons of this are:
- this also needs to be updated if ever the line `RE_Direct( directLight, geometry, material, reflectedLight );` will be changed. 

But I guess that's what CIs are for.

The updated example is the same of the current example since this is only a cleanup.
https://raw.githack.com/marcofugaro/three.js/translucency-update/examples/webgl_materials_translucency.html

----------------------

In this PR also:
- accidentally make the Translucency work also with Spotlights
- fix typo in webgl_materials_translucency.html

However there is a thing I wasn't able to do: make the shader work without a texture passed in `thicknessMap`.
In this line, if no texture, the sampled color is `0`, making the shader output color black. How do I remove it from the equation? With a uniform `useTexture`? Know of a better way?
https://github.com/mrdoob/three.js/blob/eb8639016466f0066714f7c1c0c67a59898979e0/examples/jsm/shaders/TranslucentShader.js#L101

------------------

Also, I have some suggestions:
- should we start using template literals in these shaders like we're doing in the ShaderChunks? Their browser support is the same as esmodules
- We should rename this to `SubsurfaceScatteringShader.js`, that's more clear and easier to find in my opinion (I was looking for subsurface scattering the Three.js and was puzzled to find nothing at first).