### PR TITLE
VRButton: Remove "options" parameter.

### DIFF
--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -68,6 +68,19 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
+		<h3>[method:void setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
+		<p>
+		[page:String referenceSpaceType] — The reference space type to set.<br /><br />
+
+		Can be used to configure a spatial relationship with the user's physical environment. Depending on how the user moves in 3D space, setting an
+		appropriate reference space can improve tracking. Default is *local-floor*.
+		Please check out the [link:https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType MDN] for possible values and their use cases.
+		</p>
+
+		<p>
+		Note: It is not possible to change the reference space type while presenting XR content.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/zh/renderers/webxr/WebXRManager.html
+++ b/docs/api/zh/renderers/webxr/WebXRManager.html
@@ -68,6 +68,19 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
+		<h3>[method:void setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
+		<p>
+		[page:String referenceSpaceType] — The reference space type to set.<br /><br />
+
+		Can be used to configure a spatial relationship with the user's physical environment. Depending on how the user moves in 3D space, setting an
+		appropriate reference space can improve tracking. Default is *local-floor*.
+		Please check out the [link:https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType MDN] for possible values and their use cases.
+		</p>
+
+		<p>
+		Note: It is not possible to change the reference space type while presenting XR content.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/examples/jsm/webxr/VRButton.d.ts
+++ b/examples/jsm/webxr/VRButton.d.ts
@@ -2,10 +2,6 @@ import {
 	WebGLRenderer
 } from '../../../src/Three';
 
-export interface WebXROptions {
-	referenceSpaceType: string;
-}
-
 export namespace VRButton {
-	export function createButton( renderer: WebGLRenderer, options?: WebXROptions ): HTMLElement;
+	export function createButton( renderer: WebGLRenderer ): HTMLElement;
 }

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -7,9 +7,9 @@ var VRButton = {
 
 	createButton: function ( renderer, options ) {
 
-		if ( options && options.referenceSpaceType ) {
+		if ( options ) {
 
-			renderer.xr.setReferenceSpaceType( options.referenceSpaceType );
+			console.error( 'THREE.VRButton: The "options" parameter has been removed. Please set the reference space type via renderer.xr.setReferenceSpaceType() instead.' );
 
 		}
 

--- a/examples/webxr_vr_panorama.html
+++ b/examples/webxr_vr_panorama.html
@@ -27,9 +27,10 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.xr.enabled = true;
+				renderer.xr.setReferenceSpaceType( 'local' );
 				document.body.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer, { referenceSpaceType: 'local' } ) );
+				document.body.appendChild( VRButton.createButton( renderer ) );
 
 				//
 

--- a/examples/webxr_vr_panorama_depth.html
+++ b/examples/webxr_vr_panorama_depth.html
@@ -84,9 +84,10 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.xr.enabled = true;
+				renderer.xr.setReferenceSpaceType( 'local' );
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer, { referenceSpaceType: 'local' } ) );
+				document.body.appendChild( VRButton.createButton( renderer ) );
 
 				//
 

--- a/examples/webxr_vr_rollercoaster.html
+++ b/examples/webxr_vr_rollercoaster.html
@@ -27,9 +27,10 @@
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.xr.enabled = true;
+			renderer.xr.setReferenceSpaceType( 'local' );
 			document.body.appendChild( renderer.domElement );
 
-			document.body.appendChild( VRButton.createButton( renderer, { referenceSpaceType: 'local' } ) );
+			document.body.appendChild( VRButton.createButton( renderer ) );
 
 			//
 

--- a/examples/webxr_vr_video.html
+++ b/examples/webxr_vr_video.html
@@ -115,9 +115,10 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.xr.enabled = true;
+				renderer.xr.setReferenceSpaceType( 'local' );
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer, { referenceSpaceType: 'local' } ) );
+				document.body.appendChild( VRButton.createButton( renderer ) );
 
 				//
 


### PR DESCRIPTION
Fixed  #18679.

This PR removes the `options` parameter from `VRButton`.

Similar to `.setFramebufferScaleFactor()`, `.referenceSpaceType()` is now used on the `renderer.xr` interface to configure the reference space type in the examples.

The new documentation highlights the usage of the method. Meaning similar to `.setFramebufferScaleFactor()`, it is not possible to change the value while presenting XR content.

