### PR TITLE
Docs: Clarify data space of Curve.computeFrenetFrames().

### DIFF
--- a/docs/api/en/extras/core/Curve.html
+++ b/docs/api/en/extras/core/Curve.html
@@ -102,7 +102,7 @@
 
 		<h3>[method:Object computeFrenetFrames]( [param:Integer segments], [param:Boolean closed] )</h3>
 		<p>
-		Generates the Frenet Frames. Used in geometries like [page:TubeGeometry] or [page:ExtrudeGeometry].
+		Generates the Frenet Frames. Requires a curve definition in 3D space. Used in geometries like [page:TubeGeometry] or [page:ExtrudeGeometry].
 		</p>
 
 		<h3>[method:Curve clone]()</h3>

--- a/docs/api/en/geometries/TubeBufferGeometry.html
+++ b/docs/api/en/geometries/TubeBufferGeometry.html
@@ -68,7 +68,7 @@
 
 		<h3>[name]([param:Curve path], [param:Integer tubularSegments], [param:Float radius], [param:Integer radialSegments], [param:Boolean closed])</h3>
 		<p>
-		path — [page:Curve] - A path that inherits from the [page:Curve] base class<br />
+		path — [page:Curve] - A 3D path that inherits from the [page:Curve] base class<br />
 		tubularSegments — [page:Integer] - The number of segments that make up the tube, default is 64<br />
 		radius — [page:Float] - The radius of the tube, default is 1<br />
 		radialSegments — [page:Integer] - The number of segments that make up the cross-section, default is 8 <br />

--- a/docs/api/en/geometries/TubeGeometry.html
+++ b/docs/api/en/geometries/TubeGeometry.html
@@ -68,7 +68,7 @@
 
 		<h3>[name]([param:Curve path], [param:Integer tubularSegments], [param:Float radius], [param:Integer radialSegments], [param:Boolean closed])</h3>
 		<p>
-		path — [page:Curve] - A path that inherits from the [page:Curve] base class<br />
+		path — [page:Curve] - A 3D path that inherits from the [page:Curve] base class<br />
 		tubularSegments — [page:Integer] - The number of segments that make up the tube, default is 64<br />
 		radius — [page:Float] - The radius of the tube, default is 1<br />
 		radialSegments — [page:Integer] - The number of segments that make up the cross-section, default is 8 <br />


### PR DESCRIPTION
See https://discourse.threejs.org/t/why-is-my-tube-geometry-faceless/14439/2?u=mugen87