### PR TITLE
TransformControls: Fix arguments of intersectObjectWithRay().

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -52,15 +52,15 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 	var raycaster = new THREE.Raycaster();
 
-	var intersectObjectWithRay = function( object, raycaster, includeInvisible ) {
+	var intersectObjectWithRay = function ( object, raycaster, includeInvisible ) {
 
 		var allIntersections = raycaster.intersectObject( object, true );
 
 		var intersection = false;
 
-		for ( var i = allIntersections.length; i--; ) {
+		for ( var i = allIntersections.length; i --; ) {
 
-			if (allIntersections[i].object.visible || includeInvisible) {
+			if ( allIntersections[ i ].object.visible || includeInvisible ) {
 
 				intersection = allIntersections[ i ];
 
@@ -72,7 +72,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		return intersection;
 
-	}
+	};
 
 	var _tempVector = new THREE.Vector3();
 	var _tempVector2 = new THREE.Vector3();
@@ -283,7 +283,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 			raycaster.setFromCamera( pointer, this.camera );
 
-			var planeIntersect = intersectObjectWithRay( [ _plane ], raycaster, true );
+			var planeIntersect = intersectObjectWithRay( _plane, raycaster, true );
 
 			if ( planeIntersect ) {
 
@@ -351,9 +351,9 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		raycaster.setFromCamera( pointer, this.camera );
 
-		var planeIntersect = intersectObjectWithRay( [ _plane ], raycaster, true );
+		var planeIntersect = intersectObjectWithRay( _plane, raycaster, true );
 
-		if ( !planeIntersect ) return;
+		if ( ! planeIntersect ) return;
 
 		pointEnd.copy( planeIntersect.point ).sub( worldPositionStart );
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -75,15 +75,15 @@ var TransformControls = function ( camera, domElement ) {
 
 	var raycaster = new Raycaster();
 
-	var intersectObjectWithRay = function( object, raycaster, includeInvisible ) {
+	var intersectObjectWithRay = function ( object, raycaster, includeInvisible ) {
 
 		var allIntersections = raycaster.intersectObject( object, true );
 
 		var intersection = false;
 
-		for ( var i =  allIntersections.length; i--; ) {
+		for ( var i = allIntersections.length; i --; ) {
 
-			if (allIntersections[i].object.visible || includeInvisible) {
+			if ( allIntersections[ i ].object.visible || includeInvisible ) {
 
 				intersection = allIntersections[ i ];
 
@@ -95,7 +95,7 @@ var TransformControls = function ( camera, domElement ) {
 
 		return intersection;
 
-	}
+	};
 
 	var _tempVector = new Vector3();
 	var _tempVector2 = new Vector3();
@@ -376,7 +376,7 @@ var TransformControls = function ( camera, domElement ) {
 
 		var planeIntersect = intersectObjectWithRay( _plane, raycaster, true );
 
-		if ( !planeIntersect ) return;
+		if ( ! planeIntersect ) return;
 
 		pointEnd.copy( planeIntersect.point ).sub( worldPositionStart );
 


### PR DESCRIPTION
`intersectObjectWithRay()`  was still called two times with an array as first parameter. But only in the `js` version of `TransformControls`. Seems something went out-of-sync.