### PR TITLE
SkinnedMesh: Apply skinning while raycasting

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -426,7 +426,7 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 	}
 
-	if ( object.boneTransform ) {
+	if ( object.isSkinnedMesh ) {
 
 		object.boneTransform( a, _vA );
 		object.boneTransform( b, _vB );

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -426,6 +426,14 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 	}
 
+	if ( object.boneTransform ) {
+
+		object.boneTransform( a, _vA );
+		object.boneTransform( b, _vB );
+		object.boneTransform( c, _vC );
+
+	}
+
 	var intersection = checkIntersection( object, material, raycaster, ray, _vA, _vB, _vC, _intersectionPoint );
 
 	if ( intersection ) {

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -115,7 +115,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 	},
 
-	boneTransform: ( function() {
+	boneTransform: ( function () {
 
 		var basePosition = new Vector3();
 
@@ -125,7 +125,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 		var vector = new Vector3();
 		var matrix = new Matrix4();
 
-		return function( index, target ) {
+		return function ( index, target ) {
 
 			var skeleton = this.skeleton;
 			var geometry = this.geometry;

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -6,6 +6,7 @@
 
 import { Mesh } from './Mesh.js';
 import { Matrix4 } from '../math/Matrix4.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
 
 function SkinnedMesh( geometry, material ) {
@@ -112,7 +113,51 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		return new this.constructor( this.geometry, this.material ).copy( this );
 
-	}
+	},
+
+	boneTransform: ( function() {
+
+		var basePosition = new Vector3();
+
+		var skinIndex = new Vector4();
+		var skinWeight = new Vector4();
+
+		var vector = new Vector3();
+		var matrix = new Matrix4();
+
+		return function( index, target ) {
+
+			var skeleton = this.skeleton;
+			var geometry = this.geometry;
+
+			skinIndex.fromBufferAttribute( geometry.attributes.skinIndex, index );
+			skinWeight.fromBufferAttribute( geometry.attributes.skinWeight, index );
+
+			basePosition.fromBufferAttribute( geometry.attributes.position, index ).applyMatrix4( this.bindMatrix );
+
+			target.set( 0, 0, 0 );
+
+			for ( var i = 0; i < 4; i ++ ) {
+
+				var weight = skinWeight.getComponent( i );
+
+				if ( weight !== 0 ) {
+
+					var boneIndex = skinIndex.getComponent( i );
+
+					matrix.multiplyMatrices( skeleton.bones[ boneIndex ].matrixWorld, skeleton.boneInverses[ boneIndex ] );
+
+					target.addScaledVector( vector.copy( basePosition ).applyMatrix4( matrix ), weight );
+
+				}
+
+			}
+
+			return target.applyMatrix4( this.bindMatrixInverse );
+
+		};
+
+	}() )
 
 } );
 


### PR DESCRIPTION
This PR just fixes the remaining feedback on https://github.com/mrdoob/three.js/pull/8953. Compared to the original PR from 2016:

- Support for all BufferAttribute and InterleavedBufferAtribute options
- No Geometry support (SkinnedMesh no longer supports Geometry)
- Zero object allocation during raycasting

As you might imagine, doing skinning while raycasting is slower than not doing skinning while raycasting. I think that is acceptable: there isn't much use for the latter. The object's bounding box is _not_ affected by skinning, but I believe that can be left as a future improvement. Being able to tell users "you need to scale your bounding box up a bit" is a much better answer than not supporting raycasting at all. 🙂