### PR TITLE
Fix copy/paste error in Loader.loadAsync doc

### DIFF
--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -59,7 +59,7 @@
 
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
+			[page:String url] — A string containing the path/URL of the file to be loaded.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -59,7 +59,7 @@
 
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
-			[page:String url] — A string containing the path/URL of the file to be loaded.<br />
+		[page:String url] — A string containing the path/URL of the file to be loaded.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		</p>
 		<p>

--- a/docs/api/zh/loaders/Loader.html
+++ b/docs/api/zh/loaders/Loader.html
@@ -59,7 +59,7 @@
 
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
+		[page:String url] — A string containing the path/URL of the file to be loaded.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		</p>
 		<p>


### PR DESCRIPTION
The docs were originally written for GLTFLoader. Accidently left in a reference to gltf files when I moved it to Loader. 