### PR TITLE
WebGLRenderer: default to NoToneMapping

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -12,7 +12,7 @@ import {
 	FloatType,
 	UnsignedByteType,
 	LinearEncoding,
-	LinearToneMapping,
+	NoToneMapping,
 	BackSide
 } from '../constants.js';
 import { MathUtils } from '../math/MathUtils.js';
@@ -107,7 +107,7 @@ function WebGLRenderer( parameters ) {
 
 	// tone mapping
 
-	this.toneMapping = LinearToneMapping;
+	this.toneMapping = NoToneMapping;
 	this.toneMappingExposure = 1.0;
 	this.toneMappingWhitePoint = 1.0;
 


### PR DESCRIPTION
`LinearToneMapping` with `.toneMappingExposure` set to 1 -- the current default --  is the same thing as `NoToneMapping`.

However, using linear tone mapping when applying tone mapping via post-processing, one runs the risk of applying exposure twice.

So, `NoToneMapping` is probably a better default.
