### PR TITLE
Instance mesh not show

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -750,7 +750,9 @@ function WebGLRenderer( parameters ) {
 			updateBuffers = true;
 
 		}
-
+		if (object.isInstancedMesh) {
+			updateBuffers = true;
+		}
 		//
 
 		var index = geometry.index;

--- a/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_fragment.glsl.js
@@ -40,7 +40,7 @@ export default /* glsl */`
 
 	#elif defined( ENVMAP_TYPE_CUBE_UV )
 
-		vec4 envColor = textureCubeUV( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ), 0.0 );
+		vec4 envColor = textureCubeUV( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ), bgRoughness );
 
 	#elif defined( ENVMAP_TYPE_EQUIREC )
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -239,7 +239,8 @@ var ShaderLib = {
 		uniforms: mergeUniforms( [
 			UniformsLib.envmap,
 			{
-				opacity: { value: 1.0 }
+				opacity: { value: 1.0 },
+				bgRoughness: { value: 0.0 }
 			}
 		] ),
 

--- a/src/renderers/shaders/ShaderLib/cube_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/cube_frag.glsl.js
@@ -2,7 +2,7 @@ export default /* glsl */`
 
 #include <envmap_common_pars_fragment>
 uniform float opacity;
-
+uniform float bgRoughness;
 varying vec3 vWorldDirection;
 
 #include <cube_uv_reflection_fragment>

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -102,7 +102,8 @@ function WebGLBackground( renderer, state, objects, premultipliedAlpha ) {
 
 			boxMesh.material.uniforms.envMap.value = texture;
 			boxMesh.material.uniforms.flipEnvMap.value = texture.isCubeTexture ? - 1 : 1;
-
+			boxMesh.material.uniforms.bgRoughness.value = scene.bgRoughness;
+			
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== texture.version ||
 				currentTonemapping !== renderer.toneMapping ) {

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -11,9 +11,10 @@ function Scene() {
 	this.type = 'Scene';
 
 	this.background = null;
+	this.bgRoughness = 0.0;
 	this.environment = null;
 	this.fog = null;
-
+	
 	this.overrideMaterial = null;
 
 	this.autoUpdate = true; // checked by the renderer


### PR DESCRIPTION
The same geometry is used by two instancemesh, and only one will be rendered。

```js
var geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
var boxMaterial = new THREE.MeshPhongMaterial( { color: 0xffb851 } );
var matWorld = new THREE.Matrix4();
matWorld.setPosition(1, 0, 0);
var mesh = new THREE.InstancedMesh( geometry, boxMaterial , 1 );
mesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage );
mesh.setMatrixAt( 0, matWorld);
scene.add(mesh);

var mesh2 = new THREE.InstancedMesh( geometry, boxMaterial , 1 );
mesh2.instanceMatrix.setUsage( THREE.DynamicDrawUsage );
var matWorld2 = new THREE.Matrix4();
matWorld2.setPosition(-1, 0, 0);
mesh2.setMatrixAt( 0, matWorld2);
scene.add(mesh2);
```
