### PR TITLE
Two InstancedMesh refer to the same Geometry, but only one is rendered

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -747,7 +747,9 @@ function WebGLRenderer( parameters ) {
 		}
 
 		if ( object.isInstancedMesh ) {
+
 			updateBuffers = true;
+
 		}
 
 		//

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -746,6 +746,10 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( object.isInstancedMesh ) {
+			updateBuffers = true;
+		}
+
 		//
 
 		var index = geometry.index;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4427058/80068233-d768f500-8571-11ea-83a0-4d09f154f2a5.png)

Test code snippet:

```js
			var geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
			var boxMaterial = new THREE.MeshPhongMaterial( { color: 0xffb851 } );
		
			var mesh = new THREE.InstancedMesh( geometry, boxMaterial, 1 );
			var matWorld = new THREE.Matrix4();
			matWorld.setPosition(1, 0, 0);
			mesh.setMatrixAt( 0, matWorld);
			
			scene.add(mesh);

			var mesh2 = new THREE.InstancedMesh( geometry, boxMaterial, 1 );
			var matWorld2 = new THREE.Matrix4();
			matWorld2.setPosition(-1, 0, 0);
			mesh2.setMatrixAt( 0, matWorld2);

			scene.add(mesh2);
```