### PR TITLE
Make elements on top that need click events possible

### DIFF
--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -128,6 +128,8 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 	}
 
 	function onDocumentMouseDown( event ) {
+		
+		if (event.target!=_domElement) return;
 
 		event.preventDefault();
 
@@ -201,6 +203,8 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 	}
 
 	function onDocumentTouchStart( event ) {
+		
+		if (event.target!=_domElement) return;
 
 		event.preventDefault();
 		event = event.changedTouches[ 0 ];


### PR DESCRIPTION
When developing a application with draggable objects that can have a toolbar element on top of it. It is not possible to capture the click event because it is captured by DragControls always. It should only be the case when the click event is comming from the _domElement. In my case I had a CSS2DObject on top of it. The proposed change solves this and is in my opinion always good to check no matter how it is used.