### PR TITLE
editor: make outliner resizable

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -455,6 +455,7 @@ select {
 	font-size: 12px;
 	cursor: default;
 	overflow: auto;
+	resize: vertical;
 	outline: none !important;
 }
 


### PR DESCRIPTION
This has been bothering me for way too long.
I always use the chrome inspector to make the outliner resizable and it seems to work fine. So I figured I might as well add it as a more permanent solution.
It doesn't seem to break anything major.
You can make the outliner bigger than the screen which might be a bit weird, but it's not really a problem.