### PR TITLE
Add InterleavedBufferAttribute serialization to BufferGeometry 

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -384,10 +384,13 @@ Object.assign( BufferAttribute.prototype, {
 	toJSON: function () {
 
 		return {
+			type: "BufferAttribute",
+			typedArray: {
+				type: this.array.constructor.name,
+				array: Array.prototype.slice.call(this.array),
+			}
 			itemSize: this.itemSize,
-			type: this.array.constructor.name,
-			array: Array.prototype.slice.call( this.array ),
-			normalized: this.normalized
+			normalized: this.normalized,
 		};
 
 	}

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -387,7 +387,7 @@ Object.assign( BufferAttribute.prototype, {
 			type: "BufferAttribute",
 			typedArray: {
 				type: this.array.constructor.name,
-				array: Array.prototype.slice.call(this.array)
+				array: Array.prototype.slice.call( this.array )
 			},
 			itemSize: this.itemSize,
 			normalized: this.normalized

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -387,10 +387,10 @@ Object.assign( BufferAttribute.prototype, {
 			type: "BufferAttribute",
 			typedArray: {
 				type: this.array.constructor.name,
-				array: Array.prototype.slice.call(this.array),
-			}
+				array: Array.prototype.slice.call(this.array)
+			},
 			itemSize: this.itemSize,
-			normalized: this.normalized,
+			normalized: this.normalized
 		};
 
 	}

--- a/src/core/InstancedBufferAttribute.js
+++ b/src/core/InstancedBufferAttribute.js
@@ -42,9 +42,8 @@ InstancedBufferAttribute.prototype = Object.assign( Object.create( BufferAttribu
 
 		var data = BufferAttribute.prototype.toJSON.call( this );
 
+		data.type = "InstancedBufferAttribute";
 		data.meshPerAttribute = this.meshPerAttribute;
-
-		data.isInstancedBufferAttribute = true;
 
 		return data;
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -91,7 +91,19 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	}
 
-} );
+	toJSON: function() {
 
+		return {
+			typedArray: {
+				type: this.array.constructor.name,
+				array: Array.prototype.slice.call(this.array)
+			},
+			stride: this.stride,
+			count: this.count,
+			usage: this.usage
+		};
+
+	}
+} );
 
 export { InterleavedBuffer };

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -91,12 +91,12 @@ Object.assign( InterleavedBuffer.prototype, {
 
 	},
 
-	toJSON: function() {
+	toJSON: function () {
 
 		return {
 			typedArray: {
 				type: this.array.constructor.name,
-				array: Array.prototype.slice.call(this.array)
+				array: Array.prototype.slice.call( this.array )
 			},
 			stride: this.stride,
 			count: this.count,

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -89,7 +89,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		return this;
 
-	}
+	},
 
 	toJSON: function() {
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -154,8 +154,7 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 
 	},
 
-	toJSON: function()
-	{
+	toJSON: function () {
 
 		return {
 			bufferType: "InterleavedBufferAttribute",

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -152,7 +152,21 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 
 		return this;
 
+	},
+
+	toJSON: function()
+	{
+
+		return {
+			bufferType: "InterleavedBufferAttribute",
+			data: this.data.toJSON(),
+			itemSize: this.itemSize,
+			offset: this.offset,
+			normalized: this.normalized
+		};
+
 	}
+
 
 } );
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -82,7 +82,7 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 
 		return bufferAttribute;
 
-	};
+	},
 
 	parse: function ( json ) {
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -37,17 +37,17 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 
 	},
 
-	parseBufferAttribute: function( json ) {
+	parseBufferAttribute: function ( json ) {
 
 		// Legacy format
 
-		if (json.array !== undefined) {
+		if ( json.array !== undefined ) {
 
-			var typedArray = new TYPED_ARRAYS[json.type](json.array);
+			var typedArray = new TYPED_ARRAYS[ json.type ]( json.array );
 			var contructor = json.isInstancedBufferAttribute ? InstancedBufferAttribute : BufferAttribute;
-			var bufferAttribute = new contructor(typedArray, json.itemSize, json.normalized);
+			var bufferAttribute = new contructor( typedArray, json.itemSize, json.normalized );
 
-			if (json.name !== undefined) bufferAttribute.name = json.name;
+			if ( json.name !== undefined ) bufferAttribute.name = json.name;
 
 			return bufferAttribute;
 
@@ -57,28 +57,28 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 
 		if ( json.type === "BufferAttribute" ) {
 
-			var typedArray = new TYPED_ARRAYS[json.typedArray.type](json.typedArray.array);
-			bufferAttribute = new BufferAttribute(typedArray, json.itemSize, json.normalized);
+			var typedArray = new TYPED_ARRAYS[ json.typedArray.type ]( json.typedArray.array );
+			bufferAttribute = new BufferAttribute( typedArray, json.itemSize, json.normalized );
 
 		} else if ( json.type === "InstancedBufferAttribute" ) {
 
-			var typedArray = new TYPED_ARRAYS[json.typedArray.type](json.typedArray.array);
-			bufferAttribute = new InstancedBufferAttribute(typedArray, json.itemSize, json.normalized, json.meshPerAttribute);
+			var typedArray = new TYPED_ARRAYS[ json.typedArray.type ]( json.typedArray.array );
+			bufferAttribute = new InstancedBufferAttribute( typedArray, json.itemSize, json.normalized, json.meshPerAttribute );
 
-		} else if ( json.type === "InterleavedBufferAttribute") {
+		} else if ( json.type === "InterleavedBufferAttribute" ) {
 
 			// InterleavedBuffer
 
-			var typedArray = new TYPED_ARRAYS[json.data.typedArray.type](json.data.typedArray.array);
-			var interleavedBuffer = new InterleavedBuffer(typedArray, json.data.stride);
-			interleavedBuffer.setUsage(json.data.usage);
+			var typedArray = new TYPED_ARRAYS[ json.data.typedArray.type ]( json.data.typedArray.array );
+			var interleavedBuffer = new InterleavedBuffer( typedArray, json.data.stride );
+			interleavedBuffer.setUsage( json.data.usage );
 			interleavedBuffer.count = json.data.count;
-			
-			bufferAttribute = new InterleavedBufferAttribute(interleavedBuffer, json.itemSize, json.offset, json.normalized);
+
+			bufferAttribute = new InterleavedBufferAttribute( interleavedBuffer, json.itemSize, json.offset, json.normalized );
 
 		}
 
-		if (json.name !== undefined) bufferAttribute.name = json.name;
+		if ( json.name !== undefined ) bufferAttribute.name = json.name;
 
 		return bufferAttribute;
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -831,8 +831,11 @@ export default QUnit.module( 'Core', () => {
 					"attributes": {
 						"attribute1": {
 							"itemSize": 1,
-							"type": "Uint16Array",
-							"array": [ 1, 3, 5, 7 ],
+							"type": "BufferAttribute",
+							"typedArray": {
+								"type": "Uint16Array",
+								"array": [ 1, 3, 5, 7 ],
+							},
 							"normalized": false,
 							"name": "attribute1"
 						}
@@ -864,8 +867,11 @@ export default QUnit.module( 'Core', () => {
 			gold.data.morphAttributes = {
 				"attribute1": [ {
 					"itemSize": 1,
-					"type": "Uint16Array",
-					"array": [ 1, 3, 5, 7 ],
+					"typedArray": {
+						"type": "Uint16Array",
+						"array": [ 1, 3, 5, 7 ]
+					},
+					"type": "BufferAttribute",
 					"normalized": false,
 					"name": "attribute1"
 				} ]


### PR DESCRIPTION
Hello

Added InterleavedBufferAttribute  and InterleavedBuffer JSON serialization method and applied them in the BufferGeometryLoader.

Since the type attribute was already being defined to make the code consistent with other serialization methods i used it to store the type of attribute and moved the typed array definition to a typedArray attribute. The typedArray attribute is checked to ensuse that the loader is still compatible with the older format.

```
{
	type: "BufferAttribute",
	itemSize: 3,
	normalized: false,
	typedArray: {
		type: "Float32Array",
		array: [...]
	}
}
```


Bellow there is a comparison of previous buffer serialization errors and the fixed version.

Thanks a lot.

![old](https://user-images.githubusercontent.com/9158354/80315412-5fa7fe00-87ef-11ea-8565-257c76063831.png)
![ok](https://user-images.githubusercontent.com/9158354/80315441-764e5500-87ef-11ea-93e1-8bac5f0bf4ed.png)

