### PR TITLE
PMREMGenerator: fix orientation, handedness and indexing order.

### DIFF
--- a/examples/jsm/nodes/misc/TextureCubeUVNode.js
+++ b/examples/jsm/nodes/misc/TextureCubeUVNode.js
@@ -64,21 +64,21 @@ TextureCubeUVNode.Nodes = ( function () {
 
 	var getUV = new FunctionNode(
 		`vec2 getUV(vec3 direction, float face) {
-				vec2 uv;
-				if (face == 0.0) {
-					uv = vec2(-direction.z, direction.y) / abs(direction.x);
-				} else if (face == 1.0) {
-					uv = vec2(direction.x, -direction.z) / abs(direction.y);
-				} else if (face == 2.0) {
-					uv = direction.xy / abs(direction.z);
-				} else if (face == 3.0) {
-					uv = vec2(direction.z, direction.y) / abs(direction.x);
-				} else if (face == 4.0) {
-					uv = direction.xz / abs(direction.y);
-				} else {
-					uv = vec2(-direction.x, direction.y) / abs(direction.z);
-				}
-				return 0.5 * (uv + 1.0);
+			vec2 uv;
+			if (face == 0.0) { // pos_x
+				uv = direction.zy / abs(direction.x);
+			} else if (face == 1.0) { // pos_y
+				uv = direction.xz / abs(direction.y);
+			} else if (face == 2.0) { // pos_z
+				uv = vec2(-direction.x, direction.y) / abs(direction.z);
+			} else if (face == 3.0) { // neg_x
+				uv = vec2(-direction.z, direction.y) / abs(direction.x);
+			} else if (face == 4.0) { // neg_y
+				uv = vec2(direction.x, -direction.z) / abs(direction.y);
+			} else { // neg_z
+				uv = direction.xy / abs(direction.z);
+			}
+			return 0.5 * (uv + 1.0);
 		}` );
 	getUV.useKeywords = false;
 
@@ -106,7 +106,7 @@ TextureCubeUVNode.Nodes = ( function () {
 			uv.y += filterInt * 2.0 * cubeUV_minTileSize;
 			uv.x += 3.0 * max(0.0, cubeUV_maxTileSize - 2.0 * faceSize);
 			uv *= texelSize;
- 
+
 			vec4 tl = texture2D(envMap, uv);
 			uv.x += texelSize;
 			vec4 tr = texture2D(envMap, uv);

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -258,7 +258,7 @@ PMREMGenerator.prototype = {
 		var aspect = 1;
 		var cubeCamera = new PerspectiveCamera( fov, aspect, near, far );
 		var upSign = [ 1, 1, 1, 1, - 1, 1 ];
-		var forwardSign = [ 1, 1, - 1, - 1, - 1, 1 ];
+		var forwardSign = [ 1, 1, 1, - 1, - 1, - 1 ];
 		var renderer = this._renderer;
 
 		var outputEncoding = renderer.outputEncoding;
@@ -270,7 +270,6 @@ PMREMGenerator.prototype = {
 		renderer.toneMapping = LinearToneMapping;
 		renderer.toneMappingExposure = 1.0;
 		renderer.outputEncoding = LinearEncoding;
-		scene.scale.z *= - 1;
 
 		var background = scene.background;
 		if ( background && background.isColor ) {
@@ -317,7 +316,6 @@ PMREMGenerator.prototype = {
 		renderer.toneMappingExposure = toneMappingExposure;
 		renderer.outputEncoding = outputEncoding;
 		renderer.setClearColor( clearColor, clearAlpha );
-		scene.scale.z *= - 1;
 
 	},
 
@@ -797,20 +795,20 @@ varying vec3 vOutputDirection;
 vec3 getDirection(vec2 uv, float face) {
 	uv = 2.0 * uv - 1.0;
 	vec3 direction = vec3(uv, 1.0);
-	if (face == 0.0) {
+	if (face == 0.0) { // pos_x
 		direction = direction.zyx;
-		direction.z *= -1.0;
-	} else if (face == 1.0) {
+	} else if (face == 1.0) { // pos_y
 		direction = direction.xzy;
-		direction.z *= -1.0;
-	} else if (face == 3.0) {
-		direction = direction.zyx;
+	} else if ( face == 2.0 ) { // pos_z
 		direction.x *= -1.0;
-	} else if (face == 4.0) {
-		direction = direction.xzy;
-		direction.y *= -1.0;
-	} else if (face == 5.0) {
+	} else if (face == 3.0) { // neg_x
+		direction = direction.zyx;
 		direction.xz *= -1.0;
+	} else if (face == 4.0) { // neg_y
+		direction = direction.xzy;
+		direction.yz *= -1.0;
+	} else if (face == 5.0) { // neg_z
+		direction.z *= -1.0;
 	}
 	return direction;
 }

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -257,8 +257,8 @@ PMREMGenerator.prototype = {
 		var fov = 90;
 		var aspect = 1;
 		var cubeCamera = new PerspectiveCamera( fov, aspect, near, far );
-		var upSign = [ 1, 1, 1, 1, - 1, 1 ];
-		var forwardSign = [ 1, 1, 1, - 1, - 1, - 1 ];
+		var upSign = [ 1, 1, 1, - 1, 1, 1 ];
+		var forwardSign = [ 1, - 1, 1, - 1, 1, - 1 ];
 		var renderer = this._renderer;
 
 		var outputEncoding = renderer.outputEncoding;
@@ -287,7 +287,7 @@ PMREMGenerator.prototype = {
 
 		for ( var i = 0; i < 6; i ++ ) {
 
-			var col = i % 3;
+			var col = Math.floor( i / 2 );
 			if ( col == 0 ) {
 
 				cubeCamera.up.set( 0, upSign[ i ], 0 );
@@ -306,7 +306,7 @@ PMREMGenerator.prototype = {
 			}
 
 			_setViewport( cubeUVRenderTarget,
-				col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
+				col * SIZE_MAX, ( i % 2 ) ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
 			renderer.setRenderTarget( cubeUVRenderTarget );
 			renderer.render( scene, cubeCamera );
 
@@ -554,8 +554,8 @@ function _createPlanes() {
 
 		for ( var face = 0; face < cubeFaces; face ++ ) {
 
-			var x = ( face % 3 ) * 2 / 3 - 1;
-			var y = face > 2 ? 0 : - 1;
+			var x = Math.floor( face / 2 ) * 2 / 3 - 1;
+			var y = face % 2 ? 0 : - 1;
 			var coordinates = [
 				x, y, 0,
 				x + 2 / 3, y, 0,
@@ -797,16 +797,16 @@ vec3 getDirection(vec2 uv, float face) {
 	vec3 direction = vec3(uv, 1.0);
 	if (face == 0.0) { // pos_x
 		direction = direction.zyx;
-	} else if (face == 1.0) { // pos_y
-		direction = direction.xzy;
-	} else if ( face == 2.0 ) { // pos_z
-		direction.x *= -1.0;
-	} else if (face == 3.0) { // neg_x
+	} else if (face == 1.0) { // neg_x
 		direction = direction.zyx;
 		direction.xz *= -1.0;
-	} else if (face == 4.0) { // neg_y
+	} else if ( face == 2.0 ) { // pos_y
+		direction = direction.xzy;
+	} else if (face == 3.0) { // neg_y
 		direction = direction.xzy;
 		direction.yz *= -1.0;
+	} else if (face == 4.0) { // pos_z
+		direction.x *= -1.0;
 	} else if (face == 5.0) { // neg_z
 		direction.z *= -1.0;
 	}

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -11,73 +11,73 @@ export default /* glsl */`
 // sampling a textureCube (not generally normalized).
 
 float getFace(vec3 direction) {
-    vec3 absDirection = abs(direction);
-    float face = -1.0;
-    if (absDirection.x > absDirection.z) {
-      if (absDirection.x > absDirection.y)
-        face = direction.x > 0.0 ? 0.0 : 3.0;
-      else
-        face = direction.y > 0.0 ? 1.0 : 4.0;
-    } else {
-      if (absDirection.z > absDirection.y)
-        face = direction.z > 0.0 ? 2.0 : 5.0;
-      else
-        face = direction.y > 0.0 ? 1.0 : 4.0;
-    }
-    return face;
+	vec3 absDirection = abs(direction);
+	float face = -1.0;
+	if (absDirection.x > absDirection.z) {
+		if (absDirection.x > absDirection.y)
+			face = direction.x > 0.0 ? 0.0 : 3.0;
+		else
+			face = direction.y > 0.0 ? 1.0 : 4.0;
+	} else {
+		if (absDirection.z > absDirection.y)
+			face = direction.z > 0.0 ? 2.0 : 5.0;
+		else
+			face = direction.y > 0.0 ? 1.0 : 4.0;
+	}
+	return face;
 }
 
 vec2 getUV(vec3 direction, float face) {
-    vec2 uv;
-    if (face == 0.0) {
-      uv = vec2(-direction.z, direction.y) / abs(direction.x);
-    } else if (face == 1.0) {
-      uv = vec2(direction.x, -direction.z) / abs(direction.y);
-    } else if (face == 2.0) {
-      uv = direction.xy / abs(direction.z);
-    } else if (face == 3.0) {
-      uv = vec2(direction.z, direction.y) / abs(direction.x);
-    } else if (face == 4.0) {
-      uv = direction.xz / abs(direction.y);
-    } else {
-      uv = vec2(-direction.x, direction.y) / abs(direction.z);
-    }
-    return 0.5 * (uv + 1.0);
+	vec2 uv;
+	if (face == 0.0) { // pos_x
+		uv = direction.zy / abs(direction.x);
+	} else if (face == 1.0) { // pos_y
+		uv = direction.xz / abs(direction.y);
+	} else if (face == 2.0) { // pos_z
+		uv = vec2(-direction.x, direction.y) / abs(direction.z);
+	} else if (face == 3.0) { // neg_x
+		uv = vec2(-direction.z, direction.y) / abs(direction.x);
+	} else if (face == 4.0) { // neg_y
+		uv = vec2(direction.x, -direction.z) / abs(direction.y);
+	} else { // neg_z
+		uv = direction.xy / abs(direction.z);
+	}
+	return 0.5 * (uv + 1.0);
 }
 
 vec3 bilinearCubeUV(sampler2D envMap, vec3 direction, float mipInt) {
-  float face = getFace(direction);
-  float filterInt = max(cubeUV_minMipLevel - mipInt, 0.0);
-  mipInt = max(mipInt, cubeUV_minMipLevel);
-  float faceSize = exp2(mipInt);
+	float face = getFace(direction);
+	float filterInt = max(cubeUV_minMipLevel - mipInt, 0.0);
+	mipInt = max(mipInt, cubeUV_minMipLevel);
+	float faceSize = exp2(mipInt);
 
-  float texelSize = 1.0 / (3.0 * cubeUV_maxTileSize);
+	float texelSize = 1.0 / (3.0 * cubeUV_maxTileSize);
 
-  vec2 uv = getUV(direction, face) * (faceSize - 1.0);
-  vec2 f = fract(uv);
-  uv += 0.5 - f;
-  if (face > 2.0) {
-    uv.y += faceSize;
-    face -= 3.0;
-  }
-  uv.x += face * faceSize;
-  if(mipInt < cubeUV_maxMipLevel){
-    uv.y += 2.0 * cubeUV_maxTileSize;
-  }
-  uv.y += filterInt * 2.0 * cubeUV_minTileSize;
-  uv.x += 3.0 * max(0.0, cubeUV_maxTileSize - 2.0 * faceSize);
-  uv *= texelSize;
+	vec2 uv = getUV(direction, face) * (faceSize - 1.0);
+	vec2 f = fract(uv);
+	uv += 0.5 - f;
+	if (face > 2.0) {
+		uv.y += faceSize;
+		face -= 3.0;
+	}
+	uv.x += face * faceSize;
+	if(mipInt < cubeUV_maxMipLevel){
+		uv.y += 2.0 * cubeUV_maxTileSize;
+	}
+	uv.y += filterInt * 2.0 * cubeUV_minTileSize;
+	uv.x += 3.0 * max(0.0, cubeUV_maxTileSize - 2.0 * faceSize);
+	uv *= texelSize;
 
-  vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-  uv.x += texelSize;
-  vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-  uv.y += texelSize;
-  vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-  uv.x -= texelSize;
-  vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-  vec3 tm = mix(tl, tr, f.x);
-  vec3 bm = mix(bl, br, f.x);
-  return mix(tm, bm, f.y);
+	vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.x += texelSize;
+	vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.y += texelSize;
+	vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.x -= texelSize;
+	vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	vec3 tm = mix(tl, tr, f.x);
+	vec3 bm = mix(bl, br, f.x);
+	return mix(tm, bm, f.y);
 }
 
 // These defines must match with PMREMGenerator
@@ -99,33 +99,33 @@ vec3 bilinearCubeUV(sampler2D envMap, vec3 direction, float mipInt) {
 #define m6 4.0
 
 float roughnessToMip(float roughness) {
-  float mip = 0.0;
-  if (roughness >= r1) {
-    mip = (r0 - roughness) * (m1 - m0) / (r0 - r1) + m0;
-  } else if (roughness >= r4) {
-    mip = (r1 - roughness) * (m4 - m1) / (r1 - r4) + m1;
-  } else if (roughness >= r5) {
-    mip = (r4 - roughness) * (m5 - m4) / (r4 - r5) + m4;
-  } else if (roughness >= r6) {
-    mip = (r5 - roughness) * (m6 - m5) / (r5 - r6) + m5;
-  } else {
-    mip = -2.0 * log2(1.16 * roughness);// 1.16 = 1.79^0.25
-  }
-  return mip;
+	float mip = 0.0;
+	if (roughness >= r1) {
+		mip = (r0 - roughness) * (m1 - m0) / (r0 - r1) + m0;
+	} else if (roughness >= r4) {
+		mip = (r1 - roughness) * (m4 - m1) / (r1 - r4) + m1;
+	} else if (roughness >= r5) {
+		mip = (r4 - roughness) * (m5 - m4) / (r4 - r5) + m4;
+	} else if (roughness >= r6) {
+		mip = (r5 - roughness) * (m6 - m5) / (r5 - r6) + m5;
+	} else {
+		mip = -2.0 * log2(1.16 * roughness);// 1.16 = 1.79^0.25
+	}
+	return mip;
 }
 
 vec4 textureCubeUV(sampler2D envMap, vec3 sampleDir, float roughness) {
-  float mip = clamp(roughnessToMip(roughness), m0, cubeUV_maxMipLevel);
-  float mipF = fract(mip);
-  float mipInt = floor(mip);
+	float mip = clamp(roughnessToMip(roughness), m0, cubeUV_maxMipLevel);
+	float mipF = fract(mip);
+	float mipInt = floor(mip);
 
-  vec3 color0 = bilinearCubeUV(envMap, sampleDir, mipInt);
-  if (mipF == 0.0) {
-    return vec4(color0, 1.0);
-  } else {
-    vec3 color1 = bilinearCubeUV(envMap, sampleDir, mipInt + 1.0);
-    return vec4(mix(color0, color1, mipF), 1.0);
-  }
+	vec3 color0 = bilinearCubeUV(envMap, sampleDir, mipInt);
+	if (mipF == 0.0) {
+		return vec4(color0, 1.0);
+	} else {
+		vec3 color1 = bilinearCubeUV(envMap, sampleDir, mipInt + 1.0);
+		return vec4(mix(color0, color1, mipF), 1.0);
+	}
 }
 #endif
 `;


### PR DESCRIPTION
Fixes #19159

#### Motive:

This PR intends to fix the need for "hacky" scene scaling when using `fromScene`, however it does other things that will improve how maintainable and easy to understand the code is. Namely:

#### Changes:

- It fixes the orientation, the same way @WestLangley suggested in #19235 ( those changes are indirectly contained in this PR ).

- It also normalizes the handedness utilized in the coordinate system of the CUBE_UV texture to the one used by Three.js world coordinates, this is what actually solves the problem with the hacky scaling.

- Finally, it modifies the face indexing order to match that of the WebGL/OpenGL-ES standard. Which is the same one used on CubeTexture and CubeMaps in general. 
`faces = [ pos_X, neg_X, pos_Y, neg_Y, pos_Z, neg_Z ]`

------

#### Discussion:

The only change that is not necessary, but highly encouraged, is the changes in the indexing order. If needed, I can easily revert the last commit, the first commit is self-sufficient and only includes the changes in handedness and orientation.

As an illustration as to how this PR modifies the output texture generated by PMREMGenerator, I've run a simple example that maps how each axis is oriented in the final image.

dev ( left )   -  PR ( right )
<img src="https://user-images.githubusercontent.com/3927951/80320826-1b1c6280-87ef-11ea-9024-9eadeddd7bee.png" width="256" />     <img src="https://user-images.githubusercontent.com/3927951/80320834-32f3e680-87ef-11ea-8a73-30952e6c3bff.png" width="256" />

------

#### Final considerations:

This PR has no impact on the final rendering, only in the cube_uv texture.

/ping @elalish @WestLangley suggestions and review are welcomed.

**requires build update**




