### PR TITLE
PropertyMixer: Fix buffer size for quaternion keyframe tracks.

### DIFF
--- a/src/animation/PropertyMixer.js
+++ b/src/animation/PropertyMixer.js
@@ -42,7 +42,7 @@ function PropertyMixer( binding, typeName, valueSize ) {
 			mixFunctionAdditive = this._slerpAdditive;
 			setIdentity = this._setAdditiveIdentityQuaternion;
 
-			this.buffer = new Float64Array( 24 );
+			this.buffer = new Float64Array( valueSize * 6 );
 			this._workIndex = 5;
 			break;
 


### PR DESCRIPTION
Fixed #19239.

Fixed quaternion array buffer size to account for glTF animations imported cubic spline interpolation