### PR TITLE
Examples: Clean up webgl_loader_mmd_audio.

### DIFF
--- a/examples/js/animation/MMDAnimationHelper.js
+++ b/examples/js/animation/MMDAnimationHelper.js
@@ -949,8 +949,6 @@ THREE.MMDAnimationHelper = ( function () {
 			// 'duration' can be bigger than 'audioDuration + delayTime' because of sync configuration
 			if ( ( this.currentTime - this.delayTime ) > this.audioDuration ) return false;
 
-			this.audio.startTime = this.currentTime - this.delayTime;
-
 			return true;
 
 		},

--- a/examples/jsm/animation/MMDAnimationHelper.js
+++ b/examples/jsm/animation/MMDAnimationHelper.js
@@ -958,8 +958,6 @@ var MMDAnimationHelper = ( function () {
 			// 'duration' can be bigger than 'audioDuration + delayTime' because of sync configuration
 			if ( ( this.currentTime - this.delayTime ) > this.audioDuration ) return false;
 
-			this.audio.startTime = this.currentTime - this.delayTime;
-
 			return true;
 
 		},

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -7,7 +7,6 @@
 		<link type="text/css" rel="stylesheet" href="main.css">
 		<style>
 			body {
-				background-color: #fff;
 				color: #444;
 			}
 			a {
@@ -17,6 +16,12 @@
 	</head>
 
 	<body>
+		<div id="overlay">
+			<div>
+				<button id="startButton">Click to Play</button>
+				<p>Audio playback requires user interaction.</p>
+			</div>
+		</div>
 		<div id="info">
 		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - MMDLoader test<br />
 		<a href="https://github.com/mrdoob/three.js/tree/master/examples/models/mmd#readme" target="_blank" rel="noopener">MMD Assets license</a><br />
@@ -46,16 +51,24 @@
 
 			var clock = new THREE.Clock();
 
-			Ammo().then( function ( AmmoLib ) {
+			var startButton = document.getElementById( 'startButton' );
+			startButton.addEventListener( 'click', function() {
 
-				Ammo = AmmoLib;
+				Ammo().then( function ( AmmoLib ) {
 
-				init();
-				animate();
+					Ammo = AmmoLib;
+
+					init();
+					animate();
+
+				} );
 
 			} );
 
 			function init() {
+
+				var overlay = document.getElementById( 'overlay' );
+				overlay.remove();
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -52,11 +52,9 @@
 			var clock = new THREE.Clock();
 
 			var startButton = document.getElementById( 'startButton' );
-			startButton.addEventListener( 'click', function() {
+			startButton.addEventListener( 'click', function () {
 
-				Ammo().then( function ( AmmoLib ) {
-
-					Ammo = AmmoLib;
+				Ammo().then( function () {
 
 					init();
 					animate();


### PR DESCRIPTION
Fixed #19258.

`webgl_loader_mmd_audio` needs the same approach like other WebAudio demos.

Besides, a deprecated line in `MMDAnimationHelper` was removed which had no effect anymore. `Audio.startTime` has been removed with `R110`. Even without the line, Miku seems to start singing at the right point^^.