### PR TITLE
OBJLoader: Fix parsing of vertex colors.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -253,9 +253,9 @@ THREE.OBJLoader = ( function () {
 				var src = this.colors;
 				var dst = this.object.geometry.colors;
 
-				dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
-				dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
-				dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
+				if ( src[ a ] !== undefined ) dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+				if ( src[ b ] !== undefined ) dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+				if ( src[ c ] !== undefined ) dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
 			},
 
@@ -288,12 +288,7 @@ THREE.OBJLoader = ( function () {
 				var ic = this.parseVertexIndex( c, vLen );
 
 				this.addVertex( ia, ib, ic );
-
-				if ( this.colors.length > 0 ) {
-
-					this.addColor( ia, ib, ic );
-
-				}
+				this.addColor( ia, ib, ic );
 
 				if ( ua !== undefined && ua !== '' ) {
 
@@ -460,6 +455,12 @@ THREE.OBJLoader = ( function () {
 									parseFloat( data[ 6 ] )
 
 								);
+
+							} else {
+
+								// if no colors are defined, add placeholders so color and vertex indices match
+
+								state.colors.push( undefined, undefined, undefined );
 
 							}
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -268,9 +268,9 @@ var OBJLoader = ( function () {
 				var src = this.colors;
 				var dst = this.object.geometry.colors;
 
-				dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
-				dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
-				dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
+				if ( src[ a ] !== undefined ) dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+				if ( src[ b ] !== undefined ) dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+				if ( src[ c ] !== undefined ) dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
 			},
 
@@ -303,12 +303,7 @@ var OBJLoader = ( function () {
 				var ic = this.parseVertexIndex( c, vLen );
 
 				this.addVertex( ia, ib, ic );
-
-				if ( this.colors.length > 0 ) {
-
-					this.addColor( ia, ib, ic );
-
-				}
+				this.addColor( ia, ib, ic );
 
 				if ( ua !== undefined && ua !== '' ) {
 
@@ -475,6 +470,12 @@ var OBJLoader = ( function () {
 									parseFloat( data[ 6 ] )
 
 								);
+
+							} else {
+
+								// if no colors are defined, add placeholders so color and vertex indices match
+
+								state.colors.push( undefined, undefined, undefined );
 
 							}
 


### PR DESCRIPTION
Fixed #19254.

For clarification: This PR will not add color attributes to objects which don' have vertex colors. It only ensures that the length of vertex and color arrays always match.