### PR TITLE
AnimationMixer: Fix import path.

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -4,7 +4,7 @@ import { LinearInterpolant } from '../math/interpolants/LinearInterpolant.js';
 import { PropertyBinding } from './PropertyBinding.js';
 import { PropertyMixer } from './PropertyMixer.js';
 import { AnimationClip } from './AnimationClip.js';
-import { NormalAnimationBlendMode } from '../constants';
+import { NormalAnimationBlendMode } from '../constants.js';
 
 /**
  *


### PR DESCRIPTION
AnimationMixer.js:7 GET http://localhost/lib/three.js_github/src/constants net::ERR_ABORTED 404 (Not Found)