### PR TITLE
Examples: Fix mmd_audio example for Safari.

### DIFF
--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -80,6 +80,10 @@
 
 				scene.add( new THREE.PolarGridHelper( 30, 10 ) );
 
+				var listener = new THREE.AudioListener();
+				camera.add( listener );
+				scene.add( camera );
+
 				var ambient = new THREE.AmbientLight( 0x666666 );
 				scene.add( ambient );
 
@@ -136,15 +140,9 @@
 
 						new THREE.AudioLoader().load( audioFile, function ( buffer ) {
 
-							var listener = new THREE.AudioListener();
 							var audio = new THREE.Audio( listener ).setBuffer( buffer );
 
-							listener.position.z = 1;
-
 							helper.add( audio, audioParams );
-
-							scene.add( audio );
-							scene.add( listener );
 							scene.add( mesh );
 
 							ready = true;


### PR DESCRIPTION
I'm not sure why but creating the audio listener before loading the audio seems to fix the issue on Safari 13.1, tested with macOS 10.15.4.

BTW: It's not necessary to add an instance of `THREE.Audio` to the scene graph. Besides, it's best practice to add the audio listener to the camera.