### PR TITLE
OrbitControls: allow for inverse Azimuthal range

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -170,7 +170,17 @@ THREE.OrbitControls = function ( object, domElement ) {
 			}
 
 			// restrict theta to be between desired limits
-			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+			if ( scope.minAzimuthAngle <= scope.maxAzimuthAngle ) {
+
+				spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+
+			} else {
+
+				spherical.theta = ( spherical.theta > ( scope.minAzimuthAngle + scope.maxAzimuthAngle ) / 2 ) ?
+					Math.max( scope.minAzimuthAngle, spherical.theta ) :
+					Math.min( scope.maxAzimuthAngle, spherical.theta );
+
+			}
 
 			// restrict phi to be between desired limits
 			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -180,7 +180,17 @@ var OrbitControls = function ( object, domElement ) {
 			}
 
 			// restrict theta to be between desired limits
-			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+			if ( scope.minAzimuthAngle <= scope.maxAzimuthAngle ) {
+
+				spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+
+			} else {
+
+				spherical.theta = ( spherical.theta > ( scope.minAzimuthAngle + scope.maxAzimuthAngle ) / 2 ) ?
+					Math.max( scope.minAzimuthAngle, spherical.theta ) :
+					Math.min( scope.maxAzimuthAngle, spherical.theta );
+
+			}
 
 			// restrict phi to be between desired limits
 			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );


### PR DESCRIPTION
**Motive**

Improve OrbitControls to allow any combination of min/max azimuth angle. So that camera doesn't need to be looking towards Z- to work correctly.

**Discussion**

In the current setup, we only allow for `minAzimuthAngle` to be less than `maxAzimuthAngle` . However this limits the way we can setup and adjust the camera view range. The following is how we currently have it setup.

<img src="https://user-images.githubusercontent.com/3927951/80763661-67301580-8b15-11ea-822f-fdbd93bf2ba6.png" width="256" />

However,  it doesn't allow for the inverse range:

<img src="https://user-images.githubusercontent.com/3927951/80763720-89c22e80-8b15-11ea-9b66-236c5f14d912.png" width="256" />

This is because, as soon as `MaxAzimuthAngle` becomes smaller than `MinAzimuthAngle`, the range test is no longer valid. AKA, If either min or max is crosses over PI and gets inverted - to + or + to -.

In other words, if min or max don't cross PI, we want the azimuthal angle to be within range [ min, max ]. However, once either one crosses PI, we want azimuthal angle to be within range [ - Infinity, max ]  or  range[ min, infinity ].

**Final thoughts**

We usually recommend that the user rotate the scene to be facing Z-, however if the scene has many cameras it might be impossible for all of the cameras to be within a valid configuration.

This doesn't alter previous behavior ( backwards compatible ), it just adds the correct behavior for the inversed range.


