### PR TITLE
WebGLProgram: reverse shader detach.

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -797,8 +797,9 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 
 	// clean up
 
-	gl.detachShader( program, glVertexShader );
-	gl.detachShader( program, glFragmentShader );
+	// spec fails on iOS 10 or lower - #18402
+	//gl.detachShader( program, glVertexShader );
+	//gl.detachShader( program, glFragmentShader );
 
 	gl.deleteShader( glVertexShader );
 	gl.deleteShader( glFragmentShader );


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/18402#issuecomment-622160914

Revert `gl.detachShaders`, iOS 10 and older doesn't conform with spec.

Fixed #19267.