### PR TITLE
TS: Fix mipmaps property type for cube textures

### DIFF
--- a/src/textures/Texture.d.ts
+++ b/src/textures/Texture.d.ts
@@ -33,7 +33,7 @@ export class Texture extends EventDispatcher {
 	name: string;
 	sourceFile: string;
 	image: any; // HTMLImageElement or ImageData or { width: number, height: number } in some children;
-	mipmaps: ImageData[];
+	mipmaps: any[]; // ImageData[] for 2D textures and CubeTexture[] for cube textures;
 	mapping: Mapping;
 	wrapS: Wrapping;
 	wrapT: Wrapping;


### PR DESCRIPTION
Fixes #19236.

Although I suggested to change the type to `ImageData[] | CubeTexture[]` in that issue, I noticed that that solution would have the following (potential) issues:
- a circular dependency (`Texture.d.ts` importing from `CubeTexture.d.ts` which is importing from `Texture.d.ts`)
- you would still have to cast when setting custom mipmaps when appending (which may be cumbersome for the most common cases):
```ts
(texture.mipmaps as ImageData[]).push(someImageData)
```

I know that the use of `any` has other issues. However, I saw that being used for the `image` property, so I figured using it in this case is probably acceptable as well.