### PR TITLE
CI: npm autopublish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - r*
+
+jobs:
+  publish:
+    name: 'Publish package'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - name: Restore cache
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-ci-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-ci-${{ env.cache-name }}-
+      - name: Install packages
+        run: npm ci
+
+      - name: === Publish package ===
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
This PR make an autopublish after adding tag and merging into master.

Owner of repository should add NPM tokens on github as described [here](https://sergiodxa.com/articles/github-actions-npm-publish/).
But nothing will happen if something will go wrong. 2FA in NPM is needed now.

Note that NPM was acquired by Microsoft and Github too. So we can just relax, it's the same company.
