### PR TITLE
Set pass size in EffectComposer.insertPass

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -82,6 +82,7 @@ Object.assign( THREE.EffectComposer.prototype, {
 	insertPass: function ( pass, index ) {
 
 		this.passes.splice( index, 0, pass );
+		pass.setSize( this._width * this._pixelRatio, this._height * this._pixelRatio );
 
 	},
 

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -97,6 +97,7 @@ Object.assign( EffectComposer.prototype, {
 	insertPass: function ( pass, index ) {
 
 		this.passes.splice( index, 0, pass );
+		pass.setSize( this._width * this._pixelRatio, this._height * this._pixelRatio );
 
 	},
 


### PR DESCRIPTION
`EffectComposer.addPass` calls `pass.setSize`, but `EffectComposer.insertPass` does not. I think it should.