### PR TITLE
Add MouseEvent to DragControls drag events

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -96,7 +96,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== object ) {
 
-				scope.dispatchEvent( { type: 'hoveron', object: object } );
+				scope.dispatchEvent( { type: 'hoveron', object: object, event: event } );
 
 				_domElement.style.cursor = 'pointer';
 				_hovered = object;
@@ -107,7 +107,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== null ) {
 
-				scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+				scope.dispatchEvent( { type: 'hoveroff', object: _hovered, event: event } );
 
 				_domElement.style.cursor = 'auto';
 				_hovered = null;

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -77,7 +77,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			}
 
-			scope.dispatchEvent( { type: 'drag', object: _selected } );
+			scope.dispatchEvent( { type: 'drag', object: _selected, event: event } );
 
 			return;
 
@@ -140,7 +140,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			_domElement.style.cursor = 'move';
 
-			scope.dispatchEvent( { type: 'dragstart', object: _selected } );
+			scope.dispatchEvent( { type: 'dragstart', object: _selected, event: event } );
 
 		}
 
@@ -153,7 +153,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _selected ) {
 
-			scope.dispatchEvent( { type: 'dragend', object: _selected } );
+			scope.dispatchEvent( { type: 'dragend', object: _selected, event: event } );
 
 			_selected = null;
 

--- a/examples/jsm/controls/DragControls.d.ts
+++ b/examples/jsm/controls/DragControls.d.ts
@@ -21,3 +21,10 @@ export class DragControls extends EventDispatcher {
 	getObjects(): Object3D[];
 
 }
+
+export interface DragEvent {
+	object: THREE.Object3D;
+	target: DragControls;
+	type: string;
+	event: MouseEvent;
+}

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -86,7 +86,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			}
 
-			scope.dispatchEvent( { type: 'drag', object: _selected } );
+			scope.dispatchEvent( { type: 'drag', object: _selected, event: event } );
 
 			return;
 
@@ -149,7 +149,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			_domElement.style.cursor = 'move';
 
-			scope.dispatchEvent( { type: 'dragstart', object: _selected } );
+			scope.dispatchEvent( { type: 'dragstart', object: _selected, event: event } );
 
 		}
 
@@ -162,7 +162,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 		if ( _selected ) {
 
-			scope.dispatchEvent( { type: 'dragend', object: _selected } );
+			scope.dispatchEvent( { type: 'dragend', object: _selected, event: event } );
 
 			_selected = null;
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -105,7 +105,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== object ) {
 
-				scope.dispatchEvent( { type: 'hoveron', object: object } );
+				scope.dispatchEvent( { type: 'hoveron', object: object, event: event } );
 
 				_domElement.style.cursor = 'pointer';
 				_hovered = object;
@@ -116,7 +116,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _hovered !== null ) {
 
-				scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+				scope.dispatchEvent( { type: 'hoveroff', object: _hovered, event: event } );
 
 				_domElement.style.cursor = 'auto';
 				_hovered = null;


### PR DESCRIPTION
Adding mouse event to the **DragControls** _drag_, _dragstart_ and _dragend_ events will help application to take different actions according to mouse buttons pressed and key modifiers used.

**DragEvent** interface for TypeScript added.

Also found it useful for _hoveron_, _hoveroff_ events.