### PR TITLE
TS: Change Geometric Object property types to generics

### DIFF
--- a/src/objects/InstancedMesh.d.ts
+++ b/src/objects/InstancedMesh.d.ts
@@ -5,11 +5,14 @@ import { BufferAttribute } from './../core/BufferAttribute';
 import { Mesh } from './Mesh';
 import { Matrix4 } from './../math/Matrix4';
 
-export class InstancedMesh extends Mesh {
+export class InstancedMesh <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material = Material
+> extends Mesh {
 
 	constructor(
-		geometry: Geometry | BufferGeometry,
-		material: Material | Material[],
+		geometry: TGeometry,
+		material: TMaterial,
 		count: number
 	);
 

--- a/src/objects/Line.d.ts
+++ b/src/objects/Line.d.ts
@@ -5,16 +5,19 @@ import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Line extends Object3D {
+export class Line <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Object3D {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
+		geometry?: TGeometry,
+		material?: TMaterial,
 		mode?: number
 	);
 
-	geometry: Geometry | BufferGeometry;
-	material: Material | Material[];
+	geometry: TGeometry;
+	material: TMaterial;
 
 	type: 'Line' | 'LineLoop' | 'LineSegments';
 	readonly isLine: true;

--- a/src/objects/LineLoop.d.ts
+++ b/src/objects/LineLoop.d.ts
@@ -3,11 +3,14 @@ import { Geometry } from './../core/Geometry';
 import { Material } from './../materials/Material';
 import { BufferGeometry } from '../core/BufferGeometry';
 
-export class LineLoop extends Line {
+export class LineLoop <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Line {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
+		geometry?: TGeometry,
+		material?: TMaterial
 	);
 
 	type: 'LineLoop';

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -12,11 +12,14 @@ export const LineStrip: number;
  */
 export const LinePieces: number;
 
-export class LineSegments extends Line {
+export class LineSegments <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Line {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
+		geometry?: TGeometry,
+		material?: TMaterial,
 		mode?: number
 	);
 

--- a/src/objects/Mesh.d.ts
+++ b/src/objects/Mesh.d.ts
@@ -5,15 +5,18 @@ import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Mesh extends Object3D {
+export class Mesh <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Object3D {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
+		geometry?: TGeometry,
+		material?: TMaterial
 	);
 
-	geometry: Geometry | BufferGeometry;
-	material: Material | Material[];
+	geometry: TGeometry;
+	material: TMaterial;
 	morphTargetInfluences?: number[];
 	morphTargetDictionary?: { [key: string]: number };
 	readonly isMesh: true;

--- a/src/objects/Points.d.ts
+++ b/src/objects/Points.d.ts
@@ -10,15 +10,18 @@ import { Intersection } from '../core/Raycaster';
  *
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/objects/ParticleSystem.js">src/objects/ParticleSystem.js</a>
  */
-export class Points extends Object3D {
+export class Points <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Object3D {
 
 	/**
 	 * @param geometry An instance of Geometry or BufferGeometry.
 	 * @param material An instance of Material (optional).
 	 */
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[]
+		geometry?: TGeometry,
+		material?: TMaterial
 	);
 
 	type: 'Points';
@@ -29,12 +32,12 @@ export class Points extends Object3D {
 	/**
 	 * An instance of Geometry or BufferGeometry, where each vertex designates the position of a particle in the system.
 	 */
-	geometry: Geometry | BufferGeometry;
+	geometry: TGeometry;
 
 	/**
 	 * An instance of Material, defining the object's appearance. Default is a PointsMaterial with randomised colour.
 	 */
-	material: Material | Material[];
+	material: TMaterial;
 
 	raycast( raycaster: Raycaster, intersects: Intersection[] ): void;
 	updateMorphTargets(): void;

--- a/src/objects/SkinnedMesh.d.ts
+++ b/src/objects/SkinnedMesh.d.ts
@@ -5,11 +5,14 @@ import { Skeleton } from './Skeleton';
 import { Mesh } from './Mesh';
 import { BufferGeometry } from '../core/BufferGeometry';
 
-export class SkinnedMesh extends Mesh {
+export class SkinnedMesh <
+	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
+	TMaterial extends Material | Material[] = Material | Material[]
+> extends Mesh {
 
 	constructor(
-		geometry?: Geometry | BufferGeometry,
-		material?: Material | Material[],
+		geometry?: TGeometry,
+		material?: TMaterial,
 		useVertexTexture?: boolean
 	);
 


### PR DESCRIPTION
This seems to resolve the issue, and when using the same syntax, you can get the expected type.

```
const myMesh = new Mesh( new Geometry(), new MeshBasicMaterial())

myMesh.material.map //error, map is not a property of Material | Material[]
```

With this, `myMesh.material` will be of type `MeshBasicMaterial`.

How to format this, ~and should there be an alias given to `Foo | Bar` or `Foo | Foo[]`?~ (no, because some classes use different signatures eg `InstancedMesh`)

Fixes #19072.
