### PR TITLE
Three.Legacy: Fire console warns only once.

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -94,9 +94,27 @@ import { CubeCamera } from './cameras/CubeCamera.js';
 export { BoxGeometry as CubeGeometry };
 export { MathUtils as Math };
 
+var warnOnce = ( function () {
+
+	var map = {};
+
+	return function ( message ) {
+
+		if ( ! map[ message ] ) {
+
+			console.warn( message );
+
+			map[ message ] = true;
+
+		}
+
+	};
+
+} )();
+
 export function Face4( a, b, c, d, normal, color, materialIndex ) {
 
-	console.warn( 'THREE.Face4 has been removed. A THREE.Face3 will be created instead.' );
+	warnOnce( 'THREE.Face4 has been removed. A THREE.Face3 will be created instead.' );
 	return new Face3( a, b, c, normal, color, materialIndex );
 
 }
@@ -109,7 +127,7 @@ export var VertexColors = 2;
 
 export function MeshFaceMaterial( materials ) {
 
-	console.warn( 'THREE.MeshFaceMaterial has been removed. Use an Array instead.' );
+	warnOnce( 'THREE.MeshFaceMaterial has been removed. Use an Array instead.' );
 	return materials;
 
 }
@@ -118,7 +136,7 @@ export function MultiMaterial( materials ) {
 
 	if ( materials === undefined ) materials = [];
 
-	console.warn( 'THREE.MultiMaterial has been removed. Use an Array instead.' );
+	warnOnce( 'THREE.MultiMaterial has been removed. Use an Array instead.' );
 	materials.isMultiMaterial = true;
 	materials.materials = materials;
 	materials.clone = function () {
@@ -133,49 +151,49 @@ export function MultiMaterial( materials ) {
 
 export function PointCloud( geometry, material ) {
 
-	console.warn( 'THREE.PointCloud has been renamed to THREE.Points.' );
+	warnOnce( 'THREE.PointCloud has been renamed to THREE.Points.' );
 	return new Points( geometry, material );
 
 }
 
 export function Particle( material ) {
 
-	console.warn( 'THREE.Particle has been renamed to THREE.Sprite.' );
+	warnOnce( 'THREE.Particle has been renamed to THREE.Sprite.' );
 	return new Sprite( material );
 
 }
 
 export function ParticleSystem( geometry, material ) {
 
-	console.warn( 'THREE.ParticleSystem has been renamed to THREE.Points.' );
+	warnOnce( 'THREE.ParticleSystem has been renamed to THREE.Points.' );
 	return new Points( geometry, material );
 
 }
 
 export function PointCloudMaterial( parameters ) {
 
-	console.warn( 'THREE.PointCloudMaterial has been renamed to THREE.PointsMaterial.' );
+	warnOnce( 'THREE.PointCloudMaterial has been renamed to THREE.PointsMaterial.' );
 	return new PointsMaterial( parameters );
 
 }
 
 export function ParticleBasicMaterial( parameters ) {
 
-	console.warn( 'THREE.ParticleBasicMaterial has been renamed to THREE.PointsMaterial.' );
+	warnOnce( 'THREE.ParticleBasicMaterial has been renamed to THREE.PointsMaterial.' );
 	return new PointsMaterial( parameters );
 
 }
 
 export function ParticleSystemMaterial( parameters ) {
 
-	console.warn( 'THREE.ParticleSystemMaterial has been renamed to THREE.PointsMaterial.' );
+	warnOnce( 'THREE.ParticleSystemMaterial has been renamed to THREE.PointsMaterial.' );
 	return new PointsMaterial( parameters );
 
 }
 
 export function Vertex( x, y, z ) {
 
-	console.warn( 'THREE.Vertex has been removed. Use THREE.Vector3 instead.' );
+	warnOnce( 'THREE.Vertex has been removed. Use THREE.Vector3 instead.' );
 	return new Vector3( x, y, z );
 
 }
@@ -184,70 +202,70 @@ export function Vertex( x, y, z ) {
 
 export function DynamicBufferAttribute( array, itemSize ) {
 
-	console.warn( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setUsage( THREE.DynamicDrawUsage ) instead.' );
+	warnOnce( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setUsage( THREE.DynamicDrawUsage ) instead.' );
 	return new BufferAttribute( array, itemSize ).setUsage( DynamicDrawUsage );
 
 }
 
 export function Int8Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.' );
+	warnOnce( 'THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.' );
 	return new Int8BufferAttribute( array, itemSize );
 
 }
 
 export function Uint8Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Uint8Attribute has been removed. Use new THREE.Uint8BufferAttribute() instead.' );
+	warnOnce( 'THREE.Uint8Attribute has been removed. Use new THREE.Uint8BufferAttribute() instead.' );
 	return new Uint8BufferAttribute( array, itemSize );
 
 }
 
 export function Uint8ClampedAttribute( array, itemSize ) {
 
-	console.warn( 'THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.' );
+	warnOnce( 'THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.' );
 	return new Uint8ClampedBufferAttribute( array, itemSize );
 
 }
 
 export function Int16Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Int16Attribute has been removed. Use new THREE.Int16BufferAttribute() instead.' );
+	warnOnce( 'THREE.Int16Attribute has been removed. Use new THREE.Int16BufferAttribute() instead.' );
 	return new Int16BufferAttribute( array, itemSize );
 
 }
 
 export function Uint16Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.' );
+	warnOnce( 'THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.' );
 	return new Uint16BufferAttribute( array, itemSize );
 
 }
 
 export function Int32Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Int32Attribute has been removed. Use new THREE.Int32BufferAttribute() instead.' );
+	warnOnce( 'THREE.Int32Attribute has been removed. Use new THREE.Int32BufferAttribute() instead.' );
 	return new Int32BufferAttribute( array, itemSize );
 
 }
 
 export function Uint32Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.' );
+	warnOnce( 'THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.' );
 	return new Uint32BufferAttribute( array, itemSize );
 
 }
 
 export function Float32Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Float32Attribute has been removed. Use new THREE.Float32BufferAttribute() instead.' );
+	warnOnce( 'THREE.Float32Attribute has been removed. Use new THREE.Float32BufferAttribute() instead.' );
 	return new Float32BufferAttribute( array, itemSize );
 
 }
 
 export function Float64Attribute( array, itemSize ) {
 
-	console.warn( 'THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.' );
+	warnOnce( 'THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.' );
 	return new Float64BufferAttribute( array, itemSize );
 
 }
@@ -272,7 +290,7 @@ Object.assign( CurvePath.prototype, {
 
 	createPointsGeometry: function ( divisions ) {
 
-		console.warn( 'THREE.CurvePath: .createPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
+		warnOnce( 'THREE.CurvePath: .createPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		// generate geometry from path points (for Line or Points objects)
 
@@ -283,7 +301,7 @@ Object.assign( CurvePath.prototype, {
 
 	createSpacedPointsGeometry: function ( divisions ) {
 
-		console.warn( 'THREE.CurvePath: .createSpacedPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
+		warnOnce( 'THREE.CurvePath: .createSpacedPointsGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		// generate geometry from equidistant sampling along the path
 
@@ -294,7 +312,7 @@ Object.assign( CurvePath.prototype, {
 
 	createGeometry: function ( points ) {
 
-		console.warn( 'THREE.CurvePath: .createGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
+		warnOnce( 'THREE.CurvePath: .createGeometry() has been removed. Use new THREE.Geometry().setFromPoints( points ) instead.' );
 
 		var geometry = new Geometry();
 
@@ -317,7 +335,7 @@ Object.assign( Path.prototype, {
 
 	fromPoints: function ( points ) {
 
-		console.warn( 'THREE.Path: .fromPoints() has been renamed to .setFromPoints().' );
+		warnOnce( 'THREE.Path: .fromPoints() has been renamed to .setFromPoints().' );
 		return this.setFromPoints( points );
 
 	}
@@ -328,7 +346,7 @@ Object.assign( Path.prototype, {
 
 export function ClosedSplineCurve3( points ) {
 
-	console.warn( 'THREE.ClosedSplineCurve3 has been deprecated. Use THREE.CatmullRomCurve3 instead.' );
+	warnOnce( 'THREE.ClosedSplineCurve3 has been deprecated. Use THREE.CatmullRomCurve3 instead.' );
 
 	CatmullRomCurve3.call( this, points );
 	this.type = 'catmullrom';
@@ -342,7 +360,7 @@ ClosedSplineCurve3.prototype = Object.create( CatmullRomCurve3.prototype );
 
 export function SplineCurve3( points ) {
 
-	console.warn( 'THREE.SplineCurve3 has been deprecated. Use THREE.CatmullRomCurve3 instead.' );
+	warnOnce( 'THREE.SplineCurve3 has been deprecated. Use THREE.CatmullRomCurve3 instead.' );
 
 	CatmullRomCurve3.call( this, points );
 	this.type = 'catmullrom';
@@ -355,7 +373,7 @@ SplineCurve3.prototype = Object.create( CatmullRomCurve3.prototype );
 
 export function Spline( points ) {
 
-	console.warn( 'THREE.Spline has been removed. Use THREE.CatmullRomCurve3 instead.' );
+	warnOnce( 'THREE.Spline has been removed. Use THREE.CatmullRomCurve3 instead.' );
 
 	CatmullRomCurve3.call( this, points );
 	this.type = 'catmullrom';
@@ -388,21 +406,21 @@ Object.assign( Spline.prototype, {
 
 export function AxisHelper( size ) {
 
-	console.warn( 'THREE.AxisHelper has been renamed to THREE.AxesHelper.' );
+	warnOnce( 'THREE.AxisHelper has been renamed to THREE.AxesHelper.' );
 	return new AxesHelper( size );
 
 }
 
 export function BoundingBoxHelper( object, color ) {
 
-	console.warn( 'THREE.BoundingBoxHelper has been deprecated. Creating a THREE.BoxHelper instead.' );
+	warnOnce( 'THREE.BoundingBoxHelper has been deprecated. Creating a THREE.BoxHelper instead.' );
 	return new BoxHelper( object, color );
 
 }
 
 export function EdgesHelper( object, hex ) {
 
-	console.warn( 'THREE.EdgesHelper has been removed. Use THREE.EdgesGeometry instead.' );
+	warnOnce( 'THREE.EdgesHelper has been removed. Use THREE.EdgesGeometry instead.' );
 	return new LineSegments( new EdgesGeometry( object.geometry ), new LineBasicMaterial( { color: hex !== undefined ? hex : 0xffffff } ) );
 
 }
@@ -421,7 +439,7 @@ SkeletonHelper.prototype.update = function () {
 
 export function WireframeHelper( object, hex ) {
 
-	console.warn( 'THREE.WireframeHelper has been removed. Use THREE.WireframeGeometry instead.' );
+	warnOnce( 'THREE.WireframeHelper has been removed. Use THREE.WireframeGeometry instead.' );
 	return new LineSegments( new WireframeGeometry( object.geometry ), new LineBasicMaterial( { color: hex !== undefined ? hex : 0xffffff } ) );
 
 }
@@ -432,7 +450,7 @@ Object.assign( Loader.prototype, {
 
 	extractUrlBase: function ( url ) {
 
-		console.warn( 'THREE.Loader: .extractUrlBase() has been deprecated. Use THREE.LoaderUtils.extractUrlBase() instead.' );
+		warnOnce( 'THREE.Loader: .extractUrlBase() has been deprecated. Use THREE.LoaderUtils.extractUrlBase() instead.' );
 		return LoaderUtils.extractUrlBase( url );
 
 	}
@@ -457,14 +475,14 @@ Loader.Handlers = {
 
 export function XHRLoader( manager ) {
 
-	console.warn( 'THREE.XHRLoader has been renamed to THREE.FileLoader.' );
+	warnOnce( 'THREE.XHRLoader has been renamed to THREE.FileLoader.' );
 	return new FileLoader( manager );
 
 }
 
 export function BinaryTextureLoader( manager ) {
 
-	console.warn( 'THREE.BinaryTextureLoader has been renamed to THREE.DataTextureLoader.' );
+	warnOnce( 'THREE.BinaryTextureLoader has been renamed to THREE.DataTextureLoader.' );
 	return new DataTextureLoader( manager );
 
 }
@@ -473,7 +491,7 @@ Object.assign( ObjectLoader.prototype, {
 
 	setTexturePath: function ( value ) {
 
-		console.warn( 'THREE.ObjectLoader: .setTexturePath() has been renamed to .setResourcePath().' );
+		warnOnce( 'THREE.ObjectLoader: .setTexturePath() has been renamed to .setResourcePath().' );
 		return this.setResourcePath( value );
 
 	}
@@ -486,25 +504,25 @@ Object.assign( Box2.prototype, {
 
 	center: function ( optionalTarget ) {
 
-		console.warn( 'THREE.Box2: .center() has been renamed to .getCenter().' );
+		warnOnce( 'THREE.Box2: .center() has been renamed to .getCenter().' );
 		return this.getCenter( optionalTarget );
 
 	},
 	empty: function () {
 
-		console.warn( 'THREE.Box2: .empty() has been renamed to .isEmpty().' );
+		warnOnce( 'THREE.Box2: .empty() has been renamed to .isEmpty().' );
 		return this.isEmpty();
 
 	},
 	isIntersectionBox: function ( box ) {
 
-		console.warn( 'THREE.Box2: .isIntersectionBox() has been renamed to .intersectsBox().' );
+		warnOnce( 'THREE.Box2: .isIntersectionBox() has been renamed to .intersectsBox().' );
 		return this.intersectsBox( box );
 
 	},
 	size: function ( optionalTarget ) {
 
-		console.warn( 'THREE.Box2: .size() has been renamed to .getSize().' );
+		warnOnce( 'THREE.Box2: .size() has been renamed to .getSize().' );
 		return this.getSize( optionalTarget );
 
 	}
@@ -514,31 +532,31 @@ Object.assign( Box3.prototype, {
 
 	center: function ( optionalTarget ) {
 
-		console.warn( 'THREE.Box3: .center() has been renamed to .getCenter().' );
+		warnOnce( 'THREE.Box3: .center() has been renamed to .getCenter().' );
 		return this.getCenter( optionalTarget );
 
 	},
 	empty: function () {
 
-		console.warn( 'THREE.Box3: .empty() has been renamed to .isEmpty().' );
+		warnOnce( 'THREE.Box3: .empty() has been renamed to .isEmpty().' );
 		return this.isEmpty();
 
 	},
 	isIntersectionBox: function ( box ) {
 
-		console.warn( 'THREE.Box3: .isIntersectionBox() has been renamed to .intersectsBox().' );
+		warnOnce( 'THREE.Box3: .isIntersectionBox() has been renamed to .intersectsBox().' );
 		return this.intersectsBox( box );
 
 	},
 	isIntersectionSphere: function ( sphere ) {
 
-		console.warn( 'THREE.Box3: .isIntersectionSphere() has been renamed to .intersectsSphere().' );
+		warnOnce( 'THREE.Box3: .isIntersectionSphere() has been renamed to .intersectsSphere().' );
 		return this.intersectsSphere( sphere );
 
 	},
 	size: function ( optionalTarget ) {
 
-		console.warn( 'THREE.Box3: .size() has been renamed to .getSize().' );
+		warnOnce( 'THREE.Box3: .size() has been renamed to .getSize().' );
 		return this.getSize( optionalTarget );
 
 	}
@@ -548,7 +566,7 @@ Object.assign( Sphere.prototype, {
 
 	empty: function () {
 
-		console.warn( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
+		warnOnce( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
 		return this.isEmpty();
 
 	},
@@ -557,14 +575,14 @@ Object.assign( Sphere.prototype, {
 
 Frustum.prototype.setFromMatrix = function ( m ) {
 
-	console.warn( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );
+	warnOnce( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );
 	return this.setFromProjectionMatrix( m );
 
 };
 
 Line3.prototype.center = function ( optionalTarget ) {
 
-	console.warn( 'THREE.Line3: .center() has been renamed to .getCenter().' );
+	warnOnce( 'THREE.Line3: .center() has been renamed to .getCenter().' );
 	return this.getCenter( optionalTarget );
 
 };
@@ -573,21 +591,21 @@ Object.assign( MathUtils, {
 
 	random16: function () {
 
-		console.warn( 'THREE.Math: .random16() has been deprecated. Use Math.random() instead.' );
+		warnOnce( 'THREE.Math: .random16() has been deprecated. Use Math.random() instead.' );
 		return Math.random();
 
 	},
 
 	nearestPowerOfTwo: function ( value ) {
 
-		console.warn( 'THREE.Math: .nearestPowerOfTwo() has been renamed to .floorPowerOfTwo().' );
+		warnOnce( 'THREE.Math: .nearestPowerOfTwo() has been renamed to .floorPowerOfTwo().' );
 		return MathUtils.floorPowerOfTwo( value );
 
 	},
 
 	nextPowerOfTwo: function ( value ) {
 
-		console.warn( 'THREE.Math: .nextPowerOfTwo() has been renamed to .ceilPowerOfTwo().' );
+		warnOnce( 'THREE.Math: .nextPowerOfTwo() has been renamed to .ceilPowerOfTwo().' );
 		return MathUtils.ceilPowerOfTwo( value );
 
 	}
@@ -598,13 +616,13 @@ Object.assign( Matrix3.prototype, {
 
 	flattenToArrayOffset: function ( array, offset ) {
 
-		console.warn( "THREE.Matrix3: .flattenToArrayOffset() has been deprecated. Use .toArray() instead." );
+		warnOnce( "THREE.Matrix3: .flattenToArrayOffset() has been deprecated. Use .toArray() instead." );
 		return this.toArray( array, offset );
 
 	},
 	multiplyVector3: function ( vector ) {
 
-		console.warn( 'THREE.Matrix3: .multiplyVector3() has been removed. Use vector.applyMatrix3( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix3: .multiplyVector3() has been removed. Use vector.applyMatrix3( matrix ) instead.' );
 		return vector.applyMatrix3( this );
 
 	},
@@ -615,7 +633,7 @@ Object.assign( Matrix3.prototype, {
 	},
 	applyToBufferAttribute: function ( attribute ) {
 
-		console.warn( 'THREE.Matrix3: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix3( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix3: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix3( matrix ) instead.' );
 		return attribute.applyMatrix3( this );
 
 	},
@@ -631,42 +649,42 @@ Object.assign( Matrix4.prototype, {
 
 	extractPosition: function ( m ) {
 
-		console.warn( 'THREE.Matrix4: .extractPosition() has been renamed to .copyPosition().' );
+		warnOnce( 'THREE.Matrix4: .extractPosition() has been renamed to .copyPosition().' );
 		return this.copyPosition( m );
 
 	},
 	flattenToArrayOffset: function ( array, offset ) {
 
-		console.warn( "THREE.Matrix4: .flattenToArrayOffset() has been deprecated. Use .toArray() instead." );
+		warnOnce( "THREE.Matrix4: .flattenToArrayOffset() has been deprecated. Use .toArray() instead." );
 		return this.toArray( array, offset );
 
 	},
 	getPosition: function () {
 
-		console.warn( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
 		return new Vector3().setFromMatrixColumn( this, 3 );
 
 	},
 	setRotationFromQuaternion: function ( q ) {
 
-		console.warn( 'THREE.Matrix4: .setRotationFromQuaternion() has been renamed to .makeRotationFromQuaternion().' );
+		warnOnce( 'THREE.Matrix4: .setRotationFromQuaternion() has been renamed to .makeRotationFromQuaternion().' );
 		return this.makeRotationFromQuaternion( q );
 
 	},
 	multiplyToArray: function () {
 
-		console.warn( 'THREE.Matrix4: .multiplyToArray() has been removed.' );
+		warnOnce( 'THREE.Matrix4: .multiplyToArray() has been removed.' );
 
 	},
 	multiplyVector3: function ( vector ) {
 
-		console.warn( 'THREE.Matrix4: .multiplyVector3() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .multiplyVector3() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
 		return vector.applyMatrix4( this );
 
 	},
 	multiplyVector4: function ( vector ) {
 
-		console.warn( 'THREE.Matrix4: .multiplyVector4() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .multiplyVector4() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
 		return vector.applyMatrix4( this );
 
 	},
@@ -677,13 +695,13 @@ Object.assign( Matrix4.prototype, {
 	},
 	rotateAxis: function ( v ) {
 
-		console.warn( 'THREE.Matrix4: .rotateAxis() has been removed. Use Vector3.transformDirection( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .rotateAxis() has been removed. Use Vector3.transformDirection( matrix ) instead.' );
 		v.transformDirection( this );
 
 	},
 	crossVector: function ( vector ) {
 
-		console.warn( 'THREE.Matrix4: .crossVector() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .crossVector() has been removed. Use vector.applyMatrix4( matrix ) instead.' );
 		return vector.applyMatrix4( this );
 
 	},
@@ -714,7 +732,7 @@ Object.assign( Matrix4.prototype, {
 	},
 	applyToBufferAttribute: function ( attribute ) {
 
-		console.warn( 'THREE.Matrix4: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix4( matrix ) instead.' );
+		warnOnce( 'THREE.Matrix4: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix4( matrix ) instead.' );
 		return attribute.applyMatrix4( this );
 
 	},
@@ -725,7 +743,7 @@ Object.assign( Matrix4.prototype, {
 	},
 	makeFrustum: function ( left, right, bottom, top, near, far ) {
 
-		console.warn( 'THREE.Matrix4: .makeFrustum() has been removed. Use .makePerspective( left, right, top, bottom, near, far ) instead.' );
+		warnOnce( 'THREE.Matrix4: .makeFrustum() has been removed. Use .makePerspective( left, right, top, bottom, near, far ) instead.' );
 		return this.makePerspective( left, right, top, bottom, near, far );
 
 	}
@@ -734,14 +752,14 @@ Object.assign( Matrix4.prototype, {
 
 Plane.prototype.isIntersectionLine = function ( line ) {
 
-	console.warn( 'THREE.Plane: .isIntersectionLine() has been renamed to .intersectsLine().' );
+	warnOnce( 'THREE.Plane: .isIntersectionLine() has been renamed to .intersectsLine().' );
 	return this.intersectsLine( line );
 
 };
 
 Quaternion.prototype.multiplyVector3 = function ( vector ) {
 
-	console.warn( 'THREE.Quaternion: .multiplyVector3() has been removed. Use is now vector.applyQuaternion( quaternion ) instead.' );
+	warnOnce( 'THREE.Quaternion: .multiplyVector3() has been removed. Use is now vector.applyQuaternion( quaternion ) instead.' );
 	return vector.applyQuaternion( this );
 
 };
@@ -750,19 +768,19 @@ Object.assign( Ray.prototype, {
 
 	isIntersectionBox: function ( box ) {
 
-		console.warn( 'THREE.Ray: .isIntersectionBox() has been renamed to .intersectsBox().' );
+		warnOnce( 'THREE.Ray: .isIntersectionBox() has been renamed to .intersectsBox().' );
 		return this.intersectsBox( box );
 
 	},
 	isIntersectionPlane: function ( plane ) {
 
-		console.warn( 'THREE.Ray: .isIntersectionPlane() has been renamed to .intersectsPlane().' );
+		warnOnce( 'THREE.Ray: .isIntersectionPlane() has been renamed to .intersectsPlane().' );
 		return this.intersectsPlane( plane );
 
 	},
 	isIntersectionSphere: function ( sphere ) {
 
-		console.warn( 'THREE.Ray: .isIntersectionSphere() has been renamed to .intersectsSphere().' );
+		warnOnce( 'THREE.Ray: .isIntersectionSphere() has been renamed to .intersectsSphere().' );
 		return this.intersectsSphere( sphere );
 
 	}
@@ -773,31 +791,31 @@ Object.assign( Triangle.prototype, {
 
 	area: function () {
 
-		console.warn( 'THREE.Triangle: .area() has been renamed to .getArea().' );
+		warnOnce( 'THREE.Triangle: .area() has been renamed to .getArea().' );
 		return this.getArea();
 
 	},
 	barycoordFromPoint: function ( point, target ) {
 
-		console.warn( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
+		warnOnce( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
 		return this.getBarycoord( point, target );
 
 	},
 	midpoint: function ( target ) {
 
-		console.warn( 'THREE.Triangle: .midpoint() has been renamed to .getMidpoint().' );
+		warnOnce( 'THREE.Triangle: .midpoint() has been renamed to .getMidpoint().' );
 		return this.getMidpoint( target );
 
 	},
 	normal: function ( target ) {
 
-		console.warn( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
+		warnOnce( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
 		return this.getNormal( target );
 
 	},
 	plane: function ( target ) {
 
-		console.warn( 'THREE.Triangle: .plane() has been renamed to .getPlane().' );
+		warnOnce( 'THREE.Triangle: .plane() has been renamed to .getPlane().' );
 		return this.getPlane( target );
 
 	}
@@ -808,13 +826,13 @@ Object.assign( Triangle, {
 
 	barycoordFromPoint: function ( point, a, b, c, target ) {
 
-		console.warn( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
+		warnOnce( 'THREE.Triangle: .barycoordFromPoint() has been renamed to .getBarycoord().' );
 		return Triangle.getBarycoord( point, a, b, c, target );
 
 	},
 	normal: function ( a, b, c, target ) {
 
-		console.warn( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
+		warnOnce( 'THREE.Triangle: .normal() has been renamed to .getNormal().' );
 		return Triangle.getNormal( a, b, c, target );
 
 	}
@@ -825,19 +843,19 @@ Object.assign( Shape.prototype, {
 
 	extractAllPoints: function ( divisions ) {
 
-		console.warn( 'THREE.Shape: .extractAllPoints() has been removed. Use .extractPoints() instead.' );
+		warnOnce( 'THREE.Shape: .extractAllPoints() has been removed. Use .extractPoints() instead.' );
 		return this.extractPoints( divisions );
 
 	},
 	extrude: function ( options ) {
 
-		console.warn( 'THREE.Shape: .extrude() has been removed. Use ExtrudeGeometry() instead.' );
+		warnOnce( 'THREE.Shape: .extrude() has been removed. Use ExtrudeGeometry() instead.' );
 		return new ExtrudeGeometry( this, options );
 
 	},
 	makeGeometry: function ( options ) {
 
-		console.warn( 'THREE.Shape: .makeGeometry() has been removed. Use ShapeGeometry() instead.' );
+		warnOnce( 'THREE.Shape: .makeGeometry() has been removed. Use ShapeGeometry() instead.' );
 		return new ShapeGeometry( this, options );
 
 	}
@@ -848,19 +866,19 @@ Object.assign( Vector2.prototype, {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-		console.warn( 'THREE.Vector2: .fromAttribute() has been renamed to .fromBufferAttribute().' );
+		warnOnce( 'THREE.Vector2: .fromAttribute() has been renamed to .fromBufferAttribute().' );
 		return this.fromBufferAttribute( attribute, index, offset );
 
 	},
 	distanceToManhattan: function ( v ) {
 
-		console.warn( 'THREE.Vector2: .distanceToManhattan() has been renamed to .manhattanDistanceTo().' );
+		warnOnce( 'THREE.Vector2: .distanceToManhattan() has been renamed to .manhattanDistanceTo().' );
 		return this.manhattanDistanceTo( v );
 
 	},
 	lengthManhattan: function () {
 
-		console.warn( 'THREE.Vector2: .lengthManhattan() has been renamed to .manhattanLength().' );
+		warnOnce( 'THREE.Vector2: .lengthManhattan() has been renamed to .manhattanLength().' );
 		return this.manhattanLength();
 
 	}
@@ -881,43 +899,43 @@ Object.assign( Vector3.prototype, {
 	},
 	getPositionFromMatrix: function ( m ) {
 
-		console.warn( 'THREE.Vector3: .getPositionFromMatrix() has been renamed to .setFromMatrixPosition().' );
+		warnOnce( 'THREE.Vector3: .getPositionFromMatrix() has been renamed to .setFromMatrixPosition().' );
 		return this.setFromMatrixPosition( m );
 
 	},
 	getScaleFromMatrix: function ( m ) {
 
-		console.warn( 'THREE.Vector3: .getScaleFromMatrix() has been renamed to .setFromMatrixScale().' );
+		warnOnce( 'THREE.Vector3: .getScaleFromMatrix() has been renamed to .setFromMatrixScale().' );
 		return this.setFromMatrixScale( m );
 
 	},
 	getColumnFromMatrix: function ( index, matrix ) {
 
-		console.warn( 'THREE.Vector3: .getColumnFromMatrix() has been renamed to .setFromMatrixColumn().' );
+		warnOnce( 'THREE.Vector3: .getColumnFromMatrix() has been renamed to .setFromMatrixColumn().' );
 		return this.setFromMatrixColumn( matrix, index );
 
 	},
 	applyProjection: function ( m ) {
 
-		console.warn( 'THREE.Vector3: .applyProjection() has been removed. Use .applyMatrix4( m ) instead.' );
+		warnOnce( 'THREE.Vector3: .applyProjection() has been removed. Use .applyMatrix4( m ) instead.' );
 		return this.applyMatrix4( m );
 
 	},
 	fromAttribute: function ( attribute, index, offset ) {
 
-		console.warn( 'THREE.Vector3: .fromAttribute() has been renamed to .fromBufferAttribute().' );
+		warnOnce( 'THREE.Vector3: .fromAttribute() has been renamed to .fromBufferAttribute().' );
 		return this.fromBufferAttribute( attribute, index, offset );
 
 	},
 	distanceToManhattan: function ( v ) {
 
-		console.warn( 'THREE.Vector3: .distanceToManhattan() has been renamed to .manhattanDistanceTo().' );
+		warnOnce( 'THREE.Vector3: .distanceToManhattan() has been renamed to .manhattanDistanceTo().' );
 		return this.manhattanDistanceTo( v );
 
 	},
 	lengthManhattan: function () {
 
-		console.warn( 'THREE.Vector3: .lengthManhattan() has been renamed to .manhattanLength().' );
+		warnOnce( 'THREE.Vector3: .lengthManhattan() has been renamed to .manhattanLength().' );
 		return this.manhattanLength();
 
 	}
@@ -928,13 +946,13 @@ Object.assign( Vector4.prototype, {
 
 	fromAttribute: function ( attribute, index, offset ) {
 
-		console.warn( 'THREE.Vector4: .fromAttribute() has been renamed to .fromBufferAttribute().' );
+		warnOnce( 'THREE.Vector4: .fromAttribute() has been renamed to .fromBufferAttribute().' );
 		return this.fromBufferAttribute( attribute, index, offset );
 
 	},
 	lengthManhattan: function () {
 
-		console.warn( 'THREE.Vector4: .lengthManhattan() has been renamed to .manhattanLength().' );
+		warnOnce( 'THREE.Vector4: .lengthManhattan() has been renamed to .manhattanLength().' );
 		return this.manhattanLength();
 
 	}
@@ -957,7 +975,7 @@ Object.assign( Geometry.prototype, {
 	},
 	applyMatrix: function ( matrix ) {
 
-		console.warn( 'THREE.Geometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+		warnOnce( 'THREE.Geometry: .applyMatrix() has been renamed to .applyMatrix4().' );
 		return this.applyMatrix4( matrix );
 
 	}
@@ -968,18 +986,18 @@ Object.assign( Object3D.prototype, {
 
 	getChildByName: function ( name ) {
 
-		console.warn( 'THREE.Object3D: .getChildByName() has been renamed to .getObjectByName().' );
+		warnOnce( 'THREE.Object3D: .getChildByName() has been renamed to .getObjectByName().' );
 		return this.getObjectByName( name );
 
 	},
 	renderDepth: function () {
 
-		console.warn( 'THREE.Object3D: .renderDepth has been removed. Use .renderOrder, instead.' );
+		warnOnce( 'THREE.Object3D: .renderDepth has been removed. Use .renderOrder, instead.' );
 
 	},
 	translate: function ( distance, axis ) {
 
-		console.warn( 'THREE.Object3D: .translate() has been removed. Use .translateOnAxis( axis, distance ) instead.' );
+		warnOnce( 'THREE.Object3D: .translate() has been removed. Use .translateOnAxis( axis, distance ) instead.' );
 		return this.translateOnAxis( axis, distance );
 
 	},
@@ -990,7 +1008,7 @@ Object.assign( Object3D.prototype, {
 	},
 	applyMatrix: function ( matrix ) {
 
-		console.warn( 'THREE.Object3D: .applyMatrix() has been renamed to .applyMatrix4().' );
+		warnOnce( 'THREE.Object3D: .applyMatrix() has been renamed to .applyMatrix4().' );
 		return this.applyMatrix4( matrix );
 
 	}
@@ -1002,13 +1020,13 @@ Object.defineProperties( Object3D.prototype, {
 	eulerOrder: {
 		get: function () {
 
-			console.warn( 'THREE.Object3D: .eulerOrder is now .rotation.order.' );
+			warnOnce( 'THREE.Object3D: .eulerOrder is now .rotation.order.' );
 			return this.rotation.order;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.Object3D: .eulerOrder is now .rotation.order.' );
+			warnOnce( 'THREE.Object3D: .eulerOrder is now .rotation.order.' );
 			this.rotation.order = value;
 
 		}
@@ -1016,12 +1034,12 @@ Object.defineProperties( Object3D.prototype, {
 	useQuaternion: {
 		get: function () {
 
-			console.warn( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
+			warnOnce( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
+			warnOnce( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
 
 		}
 	}
@@ -1061,7 +1079,7 @@ Object.defineProperties( LOD.prototype, {
 	objects: {
 		get: function () {
 
-			console.warn( 'THREE.LOD: .objects has been renamed to .levels.' );
+			warnOnce( 'THREE.LOD: .objects has been renamed to .levels.' );
 			return this.levels;
 
 		}
@@ -1073,12 +1091,12 @@ Object.defineProperty( Skeleton.prototype, 'useVertexTexture', {
 
 	get: function () {
 
-		console.warn( 'THREE.Skeleton: useVertexTexture has been removed.' );
+		warnOnce( 'THREE.Skeleton: useVertexTexture has been removed.' );
 
 	},
 	set: function () {
 
-		console.warn( 'THREE.Skeleton: useVertexTexture has been removed.' );
+		warnOnce( 'THREE.Skeleton: useVertexTexture has been removed.' );
 
 	}
 
@@ -1094,13 +1112,13 @@ Object.defineProperty( Curve.prototype, '__arcLengthDivisions', {
 
 	get: function () {
 
-		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
+		warnOnce( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
 		return this.arcLengthDivisions;
 
 	},
 	set: function ( value ) {
 
-		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
+		warnOnce( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
 		this.arcLengthDivisions = value;
 
 	}
@@ -1111,7 +1129,7 @@ Object.defineProperty( Curve.prototype, '__arcLengthDivisions', {
 
 PerspectiveCamera.prototype.setLens = function ( focalLength, filmGauge ) {
 
-	console.warn( "THREE.PerspectiveCamera.setLens is deprecated. " +
+	warnOnce( "THREE.PerspectiveCamera.setLens is deprecated. " +
 			"Use .setFocalLength and .filmGauge for a photographic setup." );
 
 	if ( filmGauge !== undefined ) this.filmGauge = filmGauge;
@@ -1125,14 +1143,14 @@ Object.defineProperties( Light.prototype, {
 	onlyShadow: {
 		set: function () {
 
-			console.warn( 'THREE.Light: .onlyShadow has been removed.' );
+			warnOnce( 'THREE.Light: .onlyShadow has been removed.' );
 
 		}
 	},
 	shadowCameraFov: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraFov is now .shadow.camera.fov.' );
+			warnOnce( 'THREE.Light: .shadowCameraFov is now .shadow.camera.fov.' );
 			this.shadow.camera.fov = value;
 
 		}
@@ -1140,7 +1158,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraLeft: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraLeft is now .shadow.camera.left.' );
+			warnOnce( 'THREE.Light: .shadowCameraLeft is now .shadow.camera.left.' );
 			this.shadow.camera.left = value;
 
 		}
@@ -1148,7 +1166,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraRight: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraRight is now .shadow.camera.right.' );
+			warnOnce( 'THREE.Light: .shadowCameraRight is now .shadow.camera.right.' );
 			this.shadow.camera.right = value;
 
 		}
@@ -1156,7 +1174,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraTop: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraTop is now .shadow.camera.top.' );
+			warnOnce( 'THREE.Light: .shadowCameraTop is now .shadow.camera.top.' );
 			this.shadow.camera.top = value;
 
 		}
@@ -1164,7 +1182,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraBottom: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraBottom is now .shadow.camera.bottom.' );
+			warnOnce( 'THREE.Light: .shadowCameraBottom is now .shadow.camera.bottom.' );
 			this.shadow.camera.bottom = value;
 
 		}
@@ -1172,7 +1190,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraNear: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraNear is now .shadow.camera.near.' );
+			warnOnce( 'THREE.Light: .shadowCameraNear is now .shadow.camera.near.' );
 			this.shadow.camera.near = value;
 
 		}
@@ -1180,7 +1198,7 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraFar: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowCameraFar is now .shadow.camera.far.' );
+			warnOnce( 'THREE.Light: .shadowCameraFar is now .shadow.camera.far.' );
 			this.shadow.camera.far = value;
 
 		}
@@ -1188,14 +1206,14 @@ Object.defineProperties( Light.prototype, {
 	shadowCameraVisible: {
 		set: function () {
 
-			console.warn( 'THREE.Light: .shadowCameraVisible has been removed. Use new THREE.CameraHelper( light.shadow.camera ) instead.' );
+			warnOnce( 'THREE.Light: .shadowCameraVisible has been removed. Use new THREE.CameraHelper( light.shadow.camera ) instead.' );
 
 		}
 	},
 	shadowBias: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowBias is now .shadow.bias.' );
+			warnOnce( 'THREE.Light: .shadowBias is now .shadow.bias.' );
 			this.shadow.bias = value;
 
 		}
@@ -1203,14 +1221,14 @@ Object.defineProperties( Light.prototype, {
 	shadowDarkness: {
 		set: function () {
 
-			console.warn( 'THREE.Light: .shadowDarkness has been removed.' );
+			warnOnce( 'THREE.Light: .shadowDarkness has been removed.' );
 
 		}
 	},
 	shadowMapWidth: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowMapWidth is now .shadow.mapSize.width.' );
+			warnOnce( 'THREE.Light: .shadowMapWidth is now .shadow.mapSize.width.' );
 			this.shadow.mapSize.width = value;
 
 		}
@@ -1218,7 +1236,7 @@ Object.defineProperties( Light.prototype, {
 	shadowMapHeight: {
 		set: function ( value ) {
 
-			console.warn( 'THREE.Light: .shadowMapHeight is now .shadow.mapSize.height.' );
+			warnOnce( 'THREE.Light: .shadowMapHeight is now .shadow.mapSize.height.' );
 			this.shadow.mapSize.height = value;
 
 		}
@@ -1232,7 +1250,7 @@ Object.defineProperties( BufferAttribute.prototype, {
 	length: {
 		get: function () {
 
-			console.warn( 'THREE.BufferAttribute: .length has been deprecated. Use .count instead.' );
+			warnOnce( 'THREE.BufferAttribute: .length has been deprecated. Use .count instead.' );
 			return this.array.length;
 
 		}
@@ -1240,13 +1258,13 @@ Object.defineProperties( BufferAttribute.prototype, {
 	dynamic: {
 		get: function () {
 
-			console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
+			warnOnce( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
 			return this.usage === DynamicDrawUsage;
 
 		},
 		set: function ( /* value */ ) {
 
-			console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
+			warnOnce( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
 			this.setUsage( DynamicDrawUsage );
 
 		}
@@ -1257,7 +1275,7 @@ Object.defineProperties( BufferAttribute.prototype, {
 Object.assign( BufferAttribute.prototype, {
 	setDynamic: function ( value ) {
 
-		console.warn( 'THREE.BufferAttribute: .setDynamic() has been deprecated. Use .setUsage() instead.' );
+		warnOnce( 'THREE.BufferAttribute: .setDynamic() has been deprecated. Use .setUsage() instead.' );
 		this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
 		return this;
 
@@ -1278,17 +1296,17 @@ Object.assign( BufferGeometry.prototype, {
 
 	addIndex: function ( index ) {
 
-		console.warn( 'THREE.BufferGeometry: .addIndex() has been renamed to .setIndex().' );
+		warnOnce( 'THREE.BufferGeometry: .addIndex() has been renamed to .setIndex().' );
 		this.setIndex( index );
 
 	},
 	addAttribute: function ( name, attribute ) {
 
-		console.warn( 'THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().' );
+		warnOnce( 'THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().' );
 
 		if ( ! ( attribute && attribute.isBufferAttribute ) && ! ( attribute && attribute.isInterleavedBufferAttribute ) ) {
 
-			console.warn( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
+			warnOnce( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
 
 			return this.setAttribute( name, new BufferAttribute( arguments[ 1 ], arguments[ 2 ] ) );
 
@@ -1296,7 +1314,7 @@ Object.assign( BufferGeometry.prototype, {
 
 		if ( name === 'index' ) {
 
-			console.warn( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
+			warnOnce( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
 			this.setIndex( attribute );
 
 			return this;
@@ -1310,40 +1328,40 @@ Object.assign( BufferGeometry.prototype, {
 
 		if ( indexOffset !== undefined ) {
 
-			console.warn( 'THREE.BufferGeometry: .addDrawCall() no longer supports indexOffset.' );
+			warnOnce( 'THREE.BufferGeometry: .addDrawCall() no longer supports indexOffset.' );
 
 		}
 
-		console.warn( 'THREE.BufferGeometry: .addDrawCall() is now .addGroup().' );
+		warnOnce( 'THREE.BufferGeometry: .addDrawCall() is now .addGroup().' );
 		this.addGroup( start, count );
 
 	},
 	clearDrawCalls: function () {
 
-		console.warn( 'THREE.BufferGeometry: .clearDrawCalls() is now .clearGroups().' );
+		warnOnce( 'THREE.BufferGeometry: .clearDrawCalls() is now .clearGroups().' );
 		this.clearGroups();
 
 	},
 	computeTangents: function () {
 
-		console.warn( 'THREE.BufferGeometry: .computeTangents() has been removed.' );
+		warnOnce( 'THREE.BufferGeometry: .computeTangents() has been removed.' );
 
 	},
 	computeOffsets: function () {
 
-		console.warn( 'THREE.BufferGeometry: .computeOffsets() has been removed.' );
+		warnOnce( 'THREE.BufferGeometry: .computeOffsets() has been removed.' );
 
 	},
 	removeAttribute: function ( name ) {
 
-		console.warn( 'THREE.BufferGeometry: .removeAttribute() has been renamed to .deleteAttribute().' );
+		warnOnce( 'THREE.BufferGeometry: .removeAttribute() has been renamed to .deleteAttribute().' );
 
 		return this.deleteAttribute( name );
 
 	},
 	applyMatrix: function ( matrix ) {
 
-		console.warn( 'THREE.BufferGeometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+		warnOnce( 'THREE.BufferGeometry: .applyMatrix() has been renamed to .applyMatrix4().' );
 		return this.applyMatrix4( matrix );
 
 	}
@@ -1363,7 +1381,7 @@ Object.defineProperties( BufferGeometry.prototype, {
 	offsets: {
 		get: function () {
 
-			console.warn( 'THREE.BufferGeometry: .offsets has been renamed to .groups.' );
+			warnOnce( 'THREE.BufferGeometry: .offsets has been renamed to .groups.' );
 			return this.groups;
 
 		}
@@ -1376,13 +1394,13 @@ Object.defineProperties( Raycaster.prototype, {
 	linePrecision: {
 		get: function () {
 
-			console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
+			warnOnce( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
 			return this.params.Line.threshold;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
+			warnOnce( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
 			this.params.Line.threshold = value;
 
 		}
@@ -1395,13 +1413,13 @@ Object.defineProperties( InterleavedBuffer.prototype, {
 	dynamic: {
 		get: function () {
 
-			console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
+			warnOnce( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
 			return this.usage === DynamicDrawUsage;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
+			warnOnce( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
 			this.setUsage( value );
 
 		}
@@ -1412,7 +1430,7 @@ Object.defineProperties( InterleavedBuffer.prototype, {
 Object.assign( InterleavedBuffer.prototype, {
 	setDynamic: function ( value ) {
 
-		console.warn( 'THREE.InterleavedBuffer: .setDynamic() has been deprecated. Use .setUsage() instead.' );
+		warnOnce( 'THREE.InterleavedBuffer: .setDynamic() has been deprecated. Use .setUsage() instead.' );
 		this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
 		return this;
 
@@ -1455,14 +1473,14 @@ Object.defineProperties( Uniform.prototype, {
 	dynamic: {
 		set: function () {
 
-			console.warn( 'THREE.Uniform: .dynamic has been removed. Use object.onBeforeRender() instead.' );
+			warnOnce( 'THREE.Uniform: .dynamic has been removed. Use object.onBeforeRender() instead.' );
 
 		}
 	},
 	onUpdate: {
 		value: function () {
 
-			console.warn( 'THREE.Uniform: .onUpdate() has been removed. Use object.onBeforeRender() instead.' );
+			warnOnce( 'THREE.Uniform: .onUpdate() has been removed. Use object.onBeforeRender() instead.' );
 			return this;
 
 		}
@@ -1477,12 +1495,12 @@ Object.defineProperties( Material.prototype, {
 	wrapAround: {
 		get: function () {
 
-			console.warn( 'THREE.Material: .wrapAround has been removed.' );
+			warnOnce( 'THREE.Material: .wrapAround has been removed.' );
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.Material: .wrapAround has been removed.' );
+			warnOnce( 'THREE.Material: .wrapAround has been removed.' );
 
 		}
 	},
@@ -1490,12 +1508,12 @@ Object.defineProperties( Material.prototype, {
 	overdraw: {
 		get: function () {
 
-			console.warn( 'THREE.Material: .overdraw has been removed.' );
+			warnOnce( 'THREE.Material: .overdraw has been removed.' );
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.Material: .overdraw has been removed.' );
+			warnOnce( 'THREE.Material: .overdraw has been removed.' );
 
 		}
 	},
@@ -1503,7 +1521,7 @@ Object.defineProperties( Material.prototype, {
 	wrapRGB: {
 		get: function () {
 
-			console.warn( 'THREE.Material: .wrapRGB has been removed.' );
+			warnOnce( 'THREE.Material: .wrapRGB has been removed.' );
 			return new Color();
 
 		}
@@ -1517,7 +1535,7 @@ Object.defineProperties( Material.prototype, {
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
+			warnOnce( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
 			this.flatShading = ( value === FlatShading );
 
 		}
@@ -1526,13 +1544,13 @@ Object.defineProperties( Material.prototype, {
 	stencilMask: {
 		get: function () {
 
-			console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+			warnOnce( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
 			return this.stencilFuncMask;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+			warnOnce( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
 			this.stencilFuncMask = value;
 
 		}
@@ -1545,13 +1563,13 @@ Object.defineProperties( MeshPhongMaterial.prototype, {
 	metal: {
 		get: function () {
 
-			console.warn( 'THREE.MeshPhongMaterial: .metal has been removed. Use THREE.MeshStandardMaterial instead.' );
+			warnOnce( 'THREE.MeshPhongMaterial: .metal has been removed. Use THREE.MeshStandardMaterial instead.' );
 			return false;
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.MeshPhongMaterial: .metal has been removed. Use THREE.MeshStandardMaterial instead' );
+			warnOnce( 'THREE.MeshPhongMaterial: .metal has been removed. Use THREE.MeshStandardMaterial instead' );
 
 		}
 	}
@@ -1563,13 +1581,13 @@ Object.defineProperties( ShaderMaterial.prototype, {
 	derivatives: {
 		get: function () {
 
-			console.warn( 'THREE.ShaderMaterial: .derivatives has been moved to .extensions.derivatives.' );
+			warnOnce( 'THREE.ShaderMaterial: .derivatives has been moved to .extensions.derivatives.' );
 			return this.extensions.derivatives;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE. ShaderMaterial: .derivatives has been moved to .extensions.derivatives.' );
+			warnOnce( 'THREE. ShaderMaterial: .derivatives has been moved to .extensions.derivatives.' );
 			this.extensions.derivatives = value;
 
 		}
@@ -1583,143 +1601,143 @@ Object.assign( WebGLRenderer.prototype, {
 
 	clearTarget: function ( renderTarget, color, depth, stencil ) {
 
-		console.warn( 'THREE.WebGLRenderer: .clearTarget() has been deprecated. Use .setRenderTarget() and .clear() instead.' );
+		warnOnce( 'THREE.WebGLRenderer: .clearTarget() has been deprecated. Use .setRenderTarget() and .clear() instead.' );
 		this.setRenderTarget( renderTarget );
 		this.clear( color, depth, stencil );
 
 	},
 	animate: function ( callback ) {
 
-		console.warn( 'THREE.WebGLRenderer: .animate() is now .setAnimationLoop().' );
+		warnOnce( 'THREE.WebGLRenderer: .animate() is now .setAnimationLoop().' );
 		this.setAnimationLoop( callback );
 
 	},
 	getCurrentRenderTarget: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .getCurrentRenderTarget() is now .getRenderTarget().' );
+		warnOnce( 'THREE.WebGLRenderer: .getCurrentRenderTarget() is now .getRenderTarget().' );
 		return this.getRenderTarget();
 
 	},
 	getMaxAnisotropy: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .getMaxAnisotropy() is now .capabilities.getMaxAnisotropy().' );
+		warnOnce( 'THREE.WebGLRenderer: .getMaxAnisotropy() is now .capabilities.getMaxAnisotropy().' );
 		return this.capabilities.getMaxAnisotropy();
 
 	},
 	getPrecision: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .getPrecision() is now .capabilities.precision.' );
+		warnOnce( 'THREE.WebGLRenderer: .getPrecision() is now .capabilities.precision.' );
 		return this.capabilities.precision;
 
 	},
 	resetGLState: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .resetGLState() is now .state.reset().' );
+		warnOnce( 'THREE.WebGLRenderer: .resetGLState() is now .state.reset().' );
 		return this.state.reset();
 
 	},
 	supportsFloatTextures: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsFloatTextures() is now .extensions.get( \'OES_texture_float\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsFloatTextures() is now .extensions.get( \'OES_texture_float\' ).' );
 		return this.extensions.get( 'OES_texture_float' );
 
 	},
 	supportsHalfFloatTextures: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsHalfFloatTextures() is now .extensions.get( \'OES_texture_half_float\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsHalfFloatTextures() is now .extensions.get( \'OES_texture_half_float\' ).' );
 		return this.extensions.get( 'OES_texture_half_float' );
 
 	},
 	supportsStandardDerivatives: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsStandardDerivatives() is now .extensions.get( \'OES_standard_derivatives\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsStandardDerivatives() is now .extensions.get( \'OES_standard_derivatives\' ).' );
 		return this.extensions.get( 'OES_standard_derivatives' );
 
 	},
 	supportsCompressedTextureS3TC: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsCompressedTextureS3TC() is now .extensions.get( \'WEBGL_compressed_texture_s3tc\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsCompressedTextureS3TC() is now .extensions.get( \'WEBGL_compressed_texture_s3tc\' ).' );
 		return this.extensions.get( 'WEBGL_compressed_texture_s3tc' );
 
 	},
 	supportsCompressedTexturePVRTC: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsCompressedTexturePVRTC() is now .extensions.get( \'WEBGL_compressed_texture_pvrtc\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsCompressedTexturePVRTC() is now .extensions.get( \'WEBGL_compressed_texture_pvrtc\' ).' );
 		return this.extensions.get( 'WEBGL_compressed_texture_pvrtc' );
 
 	},
 	supportsBlendMinMax: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsBlendMinMax() is now .extensions.get( \'EXT_blend_minmax\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsBlendMinMax() is now .extensions.get( \'EXT_blend_minmax\' ).' );
 		return this.extensions.get( 'EXT_blend_minmax' );
 
 	},
 	supportsVertexTextures: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsVertexTextures() is now .capabilities.vertexTextures.' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsVertexTextures() is now .capabilities.vertexTextures.' );
 		return this.capabilities.vertexTextures;
 
 	},
 	supportsInstancedArrays: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .supportsInstancedArrays() is now .extensions.get( \'ANGLE_instanced_arrays\' ).' );
+		warnOnce( 'THREE.WebGLRenderer: .supportsInstancedArrays() is now .extensions.get( \'ANGLE_instanced_arrays\' ).' );
 		return this.extensions.get( 'ANGLE_instanced_arrays' );
 
 	},
 	enableScissorTest: function ( boolean ) {
 
-		console.warn( 'THREE.WebGLRenderer: .enableScissorTest() is now .setScissorTest().' );
+		warnOnce( 'THREE.WebGLRenderer: .enableScissorTest() is now .setScissorTest().' );
 		this.setScissorTest( boolean );
 
 	},
 	initMaterial: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .initMaterial() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .initMaterial() has been removed.' );
 
 	},
 	addPrePlugin: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .addPrePlugin() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .addPrePlugin() has been removed.' );
 
 	},
 	addPostPlugin: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .addPostPlugin() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .addPostPlugin() has been removed.' );
 
 	},
 	updateShadowMap: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .updateShadowMap() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .updateShadowMap() has been removed.' );
 
 	},
 	setFaceCulling: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .setFaceCulling() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .setFaceCulling() has been removed.' );
 
 	},
 	allocTextureUnit: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .allocTextureUnit() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .allocTextureUnit() has been removed.' );
 
 	},
 	setTexture: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .setTexture() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .setTexture() has been removed.' );
 
 	},
 	setTexture2D: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .setTexture2D() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .setTexture2D() has been removed.' );
 
 	},
 	setTextureCube: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .setTextureCube() has been removed.' );
+		warnOnce( 'THREE.WebGLRenderer: .setTextureCube() has been removed.' );
 
 	},
 	getActiveMipMapLevel: function () {
 
-		console.warn( 'THREE.WebGLRenderer: .getActiveMipMapLevel() is now .getActiveMipmapLevel().' );
+		warnOnce( 'THREE.WebGLRenderer: .getActiveMipMapLevel() is now .getActiveMipmapLevel().' );
 		return this.getActiveMipmapLevel();
 
 	}
@@ -1736,7 +1754,7 @@ Object.defineProperties( WebGLRenderer.prototype, {
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMapEnabled is now .shadowMap.enabled.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMapEnabled is now .shadowMap.enabled.' );
 			this.shadowMap.enabled = value;
 
 		}
@@ -1749,7 +1767,7 @@ Object.defineProperties( WebGLRenderer.prototype, {
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMapType is now .shadowMap.type.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMapType is now .shadowMap.type.' );
 			this.shadowMap.type = value;
 
 		}
@@ -1757,20 +1775,20 @@ Object.defineProperties( WebGLRenderer.prototype, {
 	shadowMapCullFace: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMapCullFace has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMapCullFace has been removed. Set Material.shadowSide instead.' );
 			return undefined;
 
 		},
 		set: function ( /* value */ ) {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMapCullFace has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMapCullFace has been removed. Set Material.shadowSide instead.' );
 
 		}
 	},
 	context: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .context has been removed. Use .getContext() instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .context has been removed. Use .getContext() instead.' );
 			return this.getContext();
 
 		}
@@ -1778,7 +1796,7 @@ Object.defineProperties( WebGLRenderer.prototype, {
 	vr: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .vr has been renamed to .xr' );
+			warnOnce( 'THREE.WebGLRenderer: .vr has been renamed to .xr' );
 			return this.xr;
 
 		}
@@ -1786,26 +1804,26 @@ Object.defineProperties( WebGLRenderer.prototype, {
 	gammaInput: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
 			return false;
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
 
 		}
 	},
 	gammaOutput: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
 			return false;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
 			this.outputEncoding = ( value === true ) ? sRGBEncoding : LinearEncoding;
 
 		}
@@ -1818,39 +1836,39 @@ Object.defineProperties( WebGLShadowMap.prototype, {
 	cullFace: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.cullFace has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.cullFace has been removed. Set Material.shadowSide instead.' );
 			return undefined;
 
 		},
 		set: function ( /* cullFace */ ) {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.cullFace has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.cullFace has been removed. Set Material.shadowSide instead.' );
 
 		}
 	},
 	renderReverseSided: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.renderReverseSided has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.renderReverseSided has been removed. Set Material.shadowSide instead.' );
 			return undefined;
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.renderReverseSided has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.renderReverseSided has been removed. Set Material.shadowSide instead.' );
 
 		}
 	},
 	renderSingleSided: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.renderSingleSided has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.renderSingleSided has been removed. Set Material.shadowSide instead.' );
 			return undefined;
 
 		},
 		set: function () {
 
-			console.warn( 'THREE.WebGLRenderer: .shadowMap.renderSingleSided has been removed. Set Material.shadowSide instead.' );
+			warnOnce( 'THREE.WebGLRenderer: .shadowMap.renderSingleSided has been removed. Set Material.shadowSide instead.' );
 
 		}
 	}
@@ -1859,7 +1877,7 @@ Object.defineProperties( WebGLShadowMap.prototype, {
 
 export function WebGLRenderTargetCube( width, height, options ) {
 
-	console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( size, options ).' );
+	warnOnce( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( size, options ).' );
 	return new WebGLCubeRenderTarget( width, options );
 
 }
@@ -1871,13 +1889,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	wrapS: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .wrapS is now .texture.wrapS.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .wrapS is now .texture.wrapS.' );
 			return this.texture.wrapS;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .wrapS is now .texture.wrapS.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .wrapS is now .texture.wrapS.' );
 			this.texture.wrapS = value;
 
 		}
@@ -1885,13 +1903,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	wrapT: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .wrapT is now .texture.wrapT.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .wrapT is now .texture.wrapT.' );
 			return this.texture.wrapT;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .wrapT is now .texture.wrapT.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .wrapT is now .texture.wrapT.' );
 			this.texture.wrapT = value;
 
 		}
@@ -1899,13 +1917,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	magFilter: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .magFilter is now .texture.magFilter.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .magFilter is now .texture.magFilter.' );
 			return this.texture.magFilter;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .magFilter is now .texture.magFilter.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .magFilter is now .texture.magFilter.' );
 			this.texture.magFilter = value;
 
 		}
@@ -1913,13 +1931,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	minFilter: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .minFilter is now .texture.minFilter.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .minFilter is now .texture.minFilter.' );
 			return this.texture.minFilter;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .minFilter is now .texture.minFilter.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .minFilter is now .texture.minFilter.' );
 			this.texture.minFilter = value;
 
 		}
@@ -1927,13 +1945,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	anisotropy: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .anisotropy is now .texture.anisotropy.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .anisotropy is now .texture.anisotropy.' );
 			return this.texture.anisotropy;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .anisotropy is now .texture.anisotropy.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .anisotropy is now .texture.anisotropy.' );
 			this.texture.anisotropy = value;
 
 		}
@@ -1941,13 +1959,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	offset: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .offset is now .texture.offset.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .offset is now .texture.offset.' );
 			return this.texture.offset;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .offset is now .texture.offset.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .offset is now .texture.offset.' );
 			this.texture.offset = value;
 
 		}
@@ -1955,13 +1973,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	repeat: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .repeat is now .texture.repeat.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .repeat is now .texture.repeat.' );
 			return this.texture.repeat;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .repeat is now .texture.repeat.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .repeat is now .texture.repeat.' );
 			this.texture.repeat = value;
 
 		}
@@ -1969,13 +1987,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	format: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .format is now .texture.format.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .format is now .texture.format.' );
 			return this.texture.format;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .format is now .texture.format.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .format is now .texture.format.' );
 			this.texture.format = value;
 
 		}
@@ -1983,13 +2001,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	type: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .type is now .texture.type.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .type is now .texture.type.' );
 			return this.texture.type;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .type is now .texture.type.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .type is now .texture.type.' );
 			this.texture.type = value;
 
 		}
@@ -1997,13 +2015,13 @@ Object.defineProperties( WebGLRenderTarget.prototype, {
 	generateMipmaps: {
 		get: function () {
 
-			console.warn( 'THREE.WebGLRenderTarget: .generateMipmaps is now .texture.generateMipmaps.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .generateMipmaps is now .texture.generateMipmaps.' );
 			return this.texture.generateMipmaps;
 
 		},
 		set: function ( value ) {
 
-			console.warn( 'THREE.WebGLRenderTarget: .generateMipmaps is now .texture.generateMipmaps.' );
+			warnOnce( 'THREE.WebGLRenderTarget: .generateMipmaps is now .texture.generateMipmaps.' );
 			this.texture.generateMipmaps = value;
 
 		}
@@ -2018,7 +2036,7 @@ Object.defineProperties( Audio.prototype, {
 	load: {
 		value: function ( file ) {
 
-			console.warn( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
+			warnOnce( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
 			var scope = this;
 			var audioLoader = new AudioLoader();
 			audioLoader.load( file, function ( buffer ) {
@@ -2033,7 +2051,7 @@ Object.defineProperties( Audio.prototype, {
 	startTime: {
 		set: function () {
 
-			console.warn( 'THREE.Audio: .startTime is now .play( delay ).' );
+			warnOnce( 'THREE.Audio: .startTime is now .play( delay ).' );
 
 		}
 	}
@@ -2042,7 +2060,7 @@ Object.defineProperties( Audio.prototype, {
 
 AudioAnalyser.prototype.getData = function () {
 
-	console.warn( 'THREE.AudioAnalyser: .getData() is now .getFrequencyData().' );
+	warnOnce( 'THREE.AudioAnalyser: .getData() is now .getFrequencyData().' );
 	return this.getFrequencyData();
 
 };
@@ -2051,7 +2069,7 @@ AudioAnalyser.prototype.getData = function () {
 
 CubeCamera.prototype.updateCubeMap = function ( renderer, scene ) {
 
-	console.warn( 'THREE.CubeCamera: .updateCubeMap() is now .update().' );
+	warnOnce( 'THREE.CubeCamera: .updateCubeMap() is now .update().' );
 	return this.update( renderer, scene );
 
 };
@@ -2062,7 +2080,7 @@ export var GeometryUtils = {
 
 	merge: function ( geometry1, geometry2, materialIndexOffset ) {
 
-		console.warn( 'THREE.GeometryUtils: .merge() has been moved to Geometry. Use geometry.merge( geometry2, matrix, materialIndexOffset ) instead.' );
+		warnOnce( 'THREE.GeometryUtils: .merge() has been moved to Geometry. Use geometry.merge( geometry2, matrix, materialIndexOffset ) instead.' );
 		var matrix;
 
 		if ( geometry2.isMesh ) {
@@ -2080,7 +2098,7 @@ export var GeometryUtils = {
 
 	center: function ( geometry ) {
 
-		console.warn( 'THREE.GeometryUtils: .center() has been moved to Geometry. Use geometry.center() instead.' );
+		warnOnce( 'THREE.GeometryUtils: .center() has been moved to Geometry. Use geometry.center() instead.' );
 		return geometry.center();
 
 	}
@@ -2091,7 +2109,7 @@ ImageUtils.crossOrigin = undefined;
 
 ImageUtils.loadTexture = function ( url, mapping, onLoad, onError ) {
 
-	console.warn( 'THREE.ImageUtils.loadTexture has been deprecated. Use THREE.TextureLoader() instead.' );
+	warnOnce( 'THREE.ImageUtils.loadTexture has been deprecated. Use THREE.TextureLoader() instead.' );
 
 	var loader = new TextureLoader();
 	loader.setCrossOrigin( this.crossOrigin );
@@ -2106,7 +2124,7 @@ ImageUtils.loadTexture = function ( url, mapping, onLoad, onError ) {
 
 ImageUtils.loadTextureCube = function ( urls, mapping, onLoad, onError ) {
 
-	console.warn( 'THREE.ImageUtils.loadTextureCube has been deprecated. Use THREE.CubeTextureLoader() instead.' );
+	warnOnce( 'THREE.ImageUtils.loadTextureCube has been deprecated. Use THREE.CubeTextureLoader() instead.' );
 
 	var loader = new CubeTextureLoader();
 	loader.setCrossOrigin( this.crossOrigin );


### PR DESCRIPTION
When some method is deprecated, i tend to end up with a lot of warnings in the console. When it's something that fires a few times during init, i can live with it, when it's something in a loop i have to change it. 

This proposal aims to relieve some of that pressure to change from legacy right then and there when you see the warnings, since you most likely can't leave a warn printing in every frame. The user is notified of the deprecation, but the legacy method can proxy to the new method.

Something like this would also be easy to control with say `three.enableDeprecationWarnings =  true`. 

