### PR TITLE
TS: ShaderPass: Define uniforms type.

### DIFF
--- a/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -8,7 +8,7 @@ export class ShaderPass extends Pass {
 
 	constructor( shader: object, textureID?: string );
 	textureID: string;
-	uniforms: object;
+	uniforms: { [name: string]: { value: any } };
 	material: Material;
 	fsQuad: object;
 


### PR DESCRIPTION
Declaring `uniforms` as `object` is inconvenient, we can't access the properties inside it (`Property '...' does not exist on type 'object'.`). It's better to use an [indexable type](https://www.typescriptlang.org/docs/handbook/interfaces.html#indexable-types).