### PR TITLE
AnimationMixer: Restore original binding states in stopAllAction().

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -622,6 +622,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		for ( var i = 0; i !== nBindings; ++ i ) {
 
+			bindings[ i ].restoreOriginalState();
 			bindings[ i ].useCount = 0;
 
 		}

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -608,22 +608,10 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		var actions = this._actions,
 			nActions = this._nActiveActions,
-			bindings = this._bindings,
-			nBindings = this._nActiveBindings;
 
-		this._nActiveActions = 0;
-		this._nActiveBindings = 0;
+		for ( var i = nActions - 1; i >= 0; -- i ) {
 
-		for ( var i = 0; i !== nActions; ++ i ) {
-
-			actions[ i ].reset();
-
-		}
-
-		for ( var i = 0; i !== nBindings; ++ i ) {
-
-			bindings[ i ].restoreOriginalState();
-			bindings[ i ].useCount = 0;
+			actions[ i ].stop();
 
 		}
 

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -607,7 +607,7 @@ AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototy
 	stopAllAction: function () {
 
 		var actions = this._actions,
-			nActions = this._nActiveActions,
+			nActions = this._nActiveActions;
 
 		for ( var i = nActions - 1; i >= 0; -- i ) {
 


### PR DESCRIPTION
(Potential) fix to make behavior of AnimationAction.stop() and AnimationMixer.stopAllActions() consistent.

Fixed #19328.