### PR TITLE
CI: editorial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
-      - name: Restore cache
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-ci-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-ci-${{ env.cache-name }}-
+          node-version: 10
       - name: Install packages
         run: npm ci
 
@@ -47,15 +39,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
-      - name: Restore cache
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-ci-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-ci-${{ env.cache-name }}-
+          node-version: 10
       - name: Install packages
         run: npm ci && npm run build-test
 
@@ -77,15 +61,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
-      - name: Restore cache
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-ci-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-ci-${{ env.cache-name }}-
+          node-version: 10
       - name: Install packages
         run: npm ci && sudo apt-get install xvfb && npm run build
 
@@ -101,15 +77,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
-      - name: Restore cache
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-ci-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-ci-${{ env.cache-name }}-
+          node-version: 10
       - name: Install packages
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -52,14 +52,13 @@
     "build-examples": "rollup -c utils/build/rollup-examples.config.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"rollup -c test/rollup.unit.config.js -w -m inline\" \"http-server -p 8080\"",
-    "test": "npm run test-lint && npm run test-unit",
+    "lint-docs": "eslint docs --ext html",
+    "lint-examples": "eslint examples/jsm --ext js --ext ts --ignore-pattern libs && tsc -p utils/build/tsconfig-examples.lint.json",
     "test-lint": "eslint src --ext js --ext ts && tsc -p utils/build/tsconfig.lint.json",
-    "test-lint-docs": "eslint docs --ext html",
-    "test-lint-examples": "eslint examples/jsm --ext js --ext ts --ignore-pattern libs && tsc -p utils/build/tsconfig-examples.lint.json",
     "test-unit": "npm run build-test && qunit -r failonlyreporter test/unit/three.source.unit.js",
-    "test-e2e": "node --expose-gc test/e2e/puppeteer.js",
+    "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
-    "make-screenshot": "cross-env MAKE=true npm run test-e2e"
+    "make-screenshot": "cross-env MAKE=true node test/e2e/puppeteer.js"
   },
   "keywords": [
     "three",

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -123,8 +123,6 @@ const pup = puppeteer.launch( {
 			file = files[ id ];
 			attemptProgress = progressFunc( attemptId );
 			pageSize = 0;
-			global.gc();
-			global.gc();
 
 			try {
 


### PR DESCRIPTION
Package.json: editorial
* `test-lint-docs` -> `lint-docs` as suggested by Mugen
* remove `test` script as outdated, because Github Actions is support testing in forks
* remove `--expose-gc` flag as outdated, because Github Actions is robust
* remove cache from Github Actions because no need

 ̶F̶i̶x̶e̶s̶ ̶#̶1̶9̶3̶3̶2̶
̶*̶ ̶m̶o̶v̶e̶ ̶p̶u̶p̶p̶e̶t̶e̶e̶r̶ ̶i̶n̶t̶o̶ ̶/̶t̶e̶s̶t̶/̶ ̶f̶o̶l̶d̶e̶r̶
̶*̶ ̶s̶h̶o̶w̶ ̶i̶n̶s̶t̶a̶l̶l̶a̶t̶i̶o̶n̶ ̶s̶u̶g̶g̶e̶s̶t̶i̶o̶n̶ ̶i̶n̶ ̶c̶o̶n̶s̶o̶l̶e̶ ̶a̶f̶t̶e̶r̶ ̶`̶n̶p̶m̶ ̶r̶u̶n̶ ̶m̶a̶k̶e̶-̶s̶c̶r̶e̶e̶n̶s̶h̶o̶t̶`̶