### PR TITLE
Examples: force background color on ascii example.

### DIFF
--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -33,6 +33,7 @@
 				camera.position.z = 500;
 
 				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0, 0, 0 );
 
 				var light = new THREE.PointLight( 0xffffff );
 				light.position.set( 500, 500, 500 );


### PR DESCRIPTION
This is intended to fix a wrong behavior that happens on iOS.

If you don't set a background color, the background is assumed entirely white. Which leads to the wrong result. As followed:

<img src="https://user-images.githubusercontent.com/3927951/81830343-4f439300-9512-11ea-9c7b-cc00b0726287.png" height="256" />

The reason why this happens is a combination of iOS not handling `alpha: false` as expected and the following check inside `AsciiEffect`

https://github.com/mrdoob/three.js/blob/8791f00b3ee4919a89d33be7cab2fa9a355b94cc/examples/jsm/effects/AsciiEffect.js#L237-L243

@zz85 I know it's been a long time since you made this, but do you recall why that check is necessary? It's not immediately obvious to me. I would think that multiplying brightness by the alpha value would be correct here.

This follows @mrdoob recommendation of just filing the minimal friction fix for this, which doesn't change `AsciiEffect` directly.