### PR TITLE
Fix bug with geometry buffer attribute instances not being named correctly

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1344,6 +1344,24 @@ THREE.GLTFLoader = ( function () {
 
 					mesh.morphTargetDictionary[ targetNames[ i ] ] = i;
 
+					// Set the mesh's geometry's bufferAttribute instance names
+					// to match those used for the mesh's morphTargetDictionary
+					if ( mesh.geometry && mesh.geometry.morphAttributes ) {
+
+						if ( mesh.geometry.morphAttributes.normal && mesh.geometry.morphAttributes.normal.length === targetNames.length ) {
+
+							mesh.geometry.morphAttributes.normal[ i ].name = targetNames[ i ];
+
+						}
+
+						if ( mesh.geometry.morphAttributes.position && mesh.geometry.morphAttributes.position.length === targetNames.length ) {
+
+							mesh.geometry.morphAttributes.position[ i ].name = targetNames[ i ];
+
+						}
+
+					}
+
 				}
 
 			} else {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1408,6 +1408,24 @@ var GLTFLoader = ( function () {
 
 					mesh.morphTargetDictionary[ targetNames[ i ] ] = i;
 
+					// Set the mesh's geometry's bufferAttribute instance names
+					// to match those used for the mesh's morphTargetDictionary
+					if ( mesh.geometry && mesh.geometry.morphAttributes ) {
+
+						if ( mesh.geometry.morphAttributes.normal && mesh.geometry.morphAttributes.normal.length === targetNames.length ) {
+
+							mesh.geometry.morphAttributes.normal[ i ].name = targetNames[ i ];
+
+						}
+
+						if ( mesh.geometry.morphAttributes.position && mesh.geometry.morphAttributes.position.length === targetNames.length ) {
+
+							mesh.geometry.morphAttributes.position[ i ].name = targetNames[ i ];
+
+						}
+
+					}
+
 				}
 
 			} else {


### PR DESCRIPTION
This bug occurs when loading meshes with morph targets wherein members under the mesh's .geometry.morphAttributes property are incorrectly named. This breaks the user's ability to create morph target animations when targeting those meshes via a morph target name.

We can discuss the benefits/downsides of this approach to fixing the bug here and make changes if needed.

@donmccurdy I originally wanted to do the naming in the loadAccessor function. However it seemed like that isn't possible because the accessorIndex is not correlated to any meshIndex and there's no way to know the corresponding mesh at that point in the code.

Some of my `if` checking might be redundant here but it's not going to hurt anything. We may also want to consider adding warnings if any of those `if` checks fail.

Reference Github issue:
https://github.com/mrdoob/three.js/issues/19357