### PR TITLE
Track glTF associations for node, material and texture

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -3,7 +3,10 @@ import {
 	Camera,
 	Group,
 	Loader,
-	LoadingManager
+	LoadingManager,
+	Object3D,
+	Material,
+	Texture
 } from '../../../src/Three';
 
 import { DRACOLoader } from './DRACOLoader';
@@ -39,9 +42,16 @@ export class GLTFLoader extends Loader {
 
 }
 
+export interface GLTFReference {
+	type: 'materials'|'nodes'|'textures';
+	index: number;
+}
+
 export class GLTFParser {
 
 	json: any;
+
+	associations: Map<Object3D|Material|Texture, GLTFReference>;
 
 	getDependency: ( type: string, index: number ) => Promise<any>;
 	getDependencies: ( type: string ) => Promise<any[]>;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1468,6 +1468,9 @@ var GLTFLoader = ( function () {
 		// loader object cache
 		this.cache = new GLTFRegistry();
 
+		// associations between Three.js objects and glTF elements
+		this.associations = new Map();
+
 		// BufferGeometry caching
 		this.primitiveCache = {};
 
@@ -1977,6 +1980,11 @@ var GLTFLoader = ( function () {
 			texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || RepeatWrapping;
 			texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || RepeatWrapping;
 
+			parser.associations.set( texture, {
+				type: 'textures',
+				index: textureIndex
+			} );
+
 			return texture;
 
 		} );
@@ -2026,7 +2034,9 @@ var GLTFLoader = ( function () {
 
 				if ( transform ) {
 
+					var gltfReference = this.associations.get( texture );
 					texture = parser.extensions[ EXTENSIONS.KHR_TEXTURE_TRANSFORM ].extendTexture( texture, transform );
+					this.associations.set( texture, gltfReference );
 
 				}
 
@@ -2125,7 +2135,7 @@ var GLTFLoader = ( function () {
 				if ( useMorphNormals ) cachedMaterial.morphNormals = true;
 
 				this.cache.add( cacheKey, cachedMaterial );
-
+				this.associations.set( cachedMaterial, this.associations.get( material ) );
 			}
 
 			material = cachedMaterial;
@@ -2320,6 +2330,8 @@ var GLTFLoader = ( function () {
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;
 
 			assignExtrasToUserData( material, materialDef );
+
+			parser.associations.set( material, { type: 'materials', index: materialIndex } );
 
 			if ( materialDef.extensions ) addUnknownExtensionsToUserData( extensions, material, materialDef );
 
@@ -3160,6 +3172,8 @@ var GLTFLoader = ( function () {
 			}
 
 			assignExtrasToUserData( node, nodeDef );
+
+			parser.associations.set( node, { type: 'nodes', index: nodeIndex } );
 
 			if ( nodeDef.extensions ) addUnknownExtensionsToUserData( extensions, node, nodeDef );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3173,8 +3173,6 @@ var GLTFLoader = ( function () {
 
 			assignExtrasToUserData( node, nodeDef );
 
-			parser.associations.set( node, { type: 'nodes', index: nodeIndex } );
-
 			if ( nodeDef.extensions ) addUnknownExtensionsToUserData( extensions, node, nodeDef );
 
 			if ( nodeDef.matrix !== undefined ) {
@@ -3204,6 +3202,8 @@ var GLTFLoader = ( function () {
 				}
 
 			}
+
+			parser.associations.set( node, { type: 'nodes', index: nodeIndex } );
 
 			return node;
 


### PR DESCRIPTION
This change proposes keeping track of some associations between glTF dependencies and the Three.js instances that are created from them.

The use case addressed by this change is described in more detail in https://github.com/mrdoob/three.js/issues/19257. After discussion with @donmccurdy , it was agreed that we should start with nodes and materials. In pursuing this change, I realized that textures have the same ambiguity case as materials, so I also included textures in this change.

Thank you for considering this change!

Fixes https://github.com/mrdoob/three.js/issues/19257

