### PR TITLE
Fix CSM shadow clipped by to small shadow camera frustum

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -123,10 +123,10 @@ export class CSM {
 
 			}
 
-			shadowCam.left = - squaredBBWidth / 2;
-			shadowCam.right = squaredBBWidth / 2;
-			shadowCam.top = squaredBBWidth / 2;
-			shadowCam.bottom = - squaredBBWidth / 2;
+			shadowCam.left = - squaredBBWidth;
+			shadowCam.right = squaredBBWidth;
+			shadowCam.top = squaredBBWidth;
+			shadowCam.bottom = - squaredBBWidth;
 			shadowCam.updateProjectionMatrix();
 
 		}


### PR DESCRIPTION
Shadow frustrum is too small and shadow maps are clipped when getting close

![Capture](https://user-images.githubusercontent.com/19568990/82027718-f6e8ce80-9694-11ea-8d78-58c7b9240f98.PNG)

![Capture2](https://user-images.githubusercontent.com/19568990/82027737-fcdeaf80-9694-11ea-8c59-4802d73ab2eb.PNG)



