### PR TITLE
ShaderMaterial: Fix handling material extensions when cloning

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -109,7 +109,7 @@ ShaderMaterial.prototype.copy = function ( source ) {
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
 
-	this.extensions = source.extensions;
+	this.extensions = Object.assign( {}, source.extensions );
 
 	return this;
 


### PR DESCRIPTION
ShaderMaterial properties might be changed after cloning it, so it's important that a deep copy of extensions is created instead of just referencing the same extensions config object in the cloned material.