### PR TITLE
FBXLoader: Account for invalid parseAnimationLayers children IDs

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2491,6 +2491,11 @@ THREE.FBXLoader = ( function () {
 									if ( modelID !== undefined ) {
 
 										var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
+										
+										if (!rawModel) {
+											console.log("invalid rawModel", modelID, child);
+											return;
+										}
 
 										var node = {
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2491,9 +2491,8 @@ THREE.FBXLoader = ( function () {
 									if ( modelID !== undefined ) {
 
 										var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
-										
-										if (!rawModel) {
-											console.log("invalid rawModel", modelID, child);
+
+										if ( rawModel === undefined ) {
 											return;
 										}
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2538,9 +2538,8 @@ var FBXLoader = ( function () {
 									if ( modelID !== undefined ) {
 
 										var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
-										
-										if (!rawModel) {
-											console.log("invalid rawModel", modelID, child);
+
+										if ( rawModel === undefined ) {
 											return;
 										}
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2538,6 +2538,11 @@ var FBXLoader = ( function () {
 									if ( modelID !== undefined ) {
 
 										var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
+										
+										if (!rawModel) {
+											console.log("invalid rawModel", modelID, child);
+											return;
+										}
 
 										var node = {
 


### PR DESCRIPTION
For some of my FBX files, a few of the relationships point to objects without any relationship data. As a result, parseAnimationLayers crashes when accessing `fbxTree.Objects.Model[ modelID.toString() ]` and the FBX fails to parse.

Here are a few sample FBX that fail to parse as a result of the invalid data. The files were generated with [Unity's FBX Exporter plugin](https://docs.unity3d.com/Packages/com.unity.formats.fbx@2.0/manual/exporting.html), but are valid in every other FBX viewer or importer I have.

https://hypermesh-staging.accelerator.net/dev/performances/eeh5Y6?download=BNN-E021-A007.fbx (63MB)

<img width="557" alt="Screen Shot 2020-05-15 at 4 35 26 PM" src="https://user-images.githubusercontent.com/285917/82094032-472e5380-96ca-11ea-8879-e659d4a81f42.png">

https://hypermesh-staging.accelerator.net/dev/performances/XdhjOd?download=BNN-E021-A010.fbx (28MB)

<img width="553" alt="Screen Shot 2020-05-15 at 4 37 06 PM" src="https://user-images.githubusercontent.com/285917/82094064-54e3d900-96ca-11ea-8785-1557446691d8.png">

Let me know if I can be of any help testing, or providing more detail. This goes more low-level than I'm familiar with, so I'm not sure if the bug is better fixed on a helper level. I've also left debugging log in there, as I figured it helps highlight the problem.