### PR TITLE
Per-light Shadow Type Pt 1 : Move Spot / Directional Light Shadow Functions

### DIFF
--- a/examples/jsm/csm/Shader.js
+++ b/examples/jsm/csm/Shader.js
@@ -62,7 +62,17 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 		spotLightShadow = spotLightShadows[ i ];
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_VSM )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#else
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#endif
+
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );
@@ -110,7 +120,16 @@ IncidentLight directLight;
 
 				vec3 prevColor = directLight.color;
 				directionalLightShadow = directionalLightShadows[ i ];
-				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+
+				#if defined( SHADOWMAP_TYPE_PCF )
+				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+				#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+				#elif defined( SHADOWMAP_TYPE_VSM )
+				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+				#else
+				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+				#endif
 
 				bool shouldFadeLastCascade = UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
 				directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
@@ -143,7 +162,19 @@ IncidentLight directLight;
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 
 		directionalLightShadow = directionalLightShadows[ i ];
-		if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) {
+
+			#if defined( SHADOWMAP_TYPE_PCF )
+			directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+			directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#elif defined( SHADOWMAP_TYPE_VSM )
+			directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#else
+			directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+			#endif
+
+		}
 
 		#endif
 
@@ -173,7 +204,17 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 		directionalLightShadow = directionalLightShadows[ i ];
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_VSM )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#else
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#endif
+
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -75,7 +75,7 @@ IncidentLight directLight;
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
-		#elif defined(SHADOWMAP_TYPE_VSM )
+		#elif defined( SHADOWMAP_TYPE_VSM )
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#else
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
@@ -111,7 +111,7 @@ IncidentLight directLight;
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
-		#elif defined(SHADOWMAP_TYPE_VSM )
+		#elif defined( SHADOWMAP_TYPE_VSM )
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#else
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -72,9 +72,9 @@ IncidentLight directLight;
 		spotLightShadow = spotLightShadows[ i ];
 
 		#if defined( SHADOWMAP_TYPE_PCF )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_VSM )
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#else
@@ -108,9 +108,9 @@ IncidentLight directLight;
 		directionalLightShadow = directionalLightShadows[ i ];
 
 		#if defined( SHADOWMAP_TYPE_PCF )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_VSM )
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#else

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -70,7 +70,17 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 		spotLightShadow = spotLightShadows[ i ];
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined(SHADOWMAP_TYPE_VSM )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#else
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#endif
+
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );
@@ -96,7 +106,17 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 		directionalLightShadow = directionalLightShadows[ i ];
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined(SHADOWMAP_TYPE_VSM )
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#else
 		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#endif
+
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -74,11 +74,11 @@ IncidentLight directLight;
 		#if defined( SHADOWMAP_TYPE_PCF )
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#elif defined(SHADOWMAP_TYPE_VSM )
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#else
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
 		#endif
 
 		#endif
@@ -110,11 +110,11 @@ IncidentLight directLight;
 		#if defined( SHADOWMAP_TYPE_PCF )
         directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCF( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
-        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+        directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#elif defined(SHADOWMAP_TYPE_VSM )
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadowVSM( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#else
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#endif
 
 		#endif

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -119,7 +119,7 @@ export default /* glsl */`
 
 	}
 
-	float getShadowPCFSoft( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+	float getShadowPCFSoft( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, vec4 shadowCoord ) {
 
 		float shadow = 1.0;
 
@@ -178,7 +178,7 @@ export default /* glsl */`
 
 	}
 
-	float getShadowVSM( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+	float getShadowVSM( sampler2D shadowMap, float shadowBias, vec4 shadowCoord ) {
 
 		float shadow = 1.0;
 
@@ -205,7 +205,7 @@ export default /* glsl */`
 
 	}
 
-	float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+	float getShadow( sampler2D shadowMap, float shadowBias, vec4 shadowCoord ) {
 
 		float shadow = 1.0;
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -63,7 +63,7 @@ export default /* glsl */`
 
 	}
 
-	float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+	float getShadowPCF( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
 
 		float shadow = 1.0;
 
@@ -81,8 +81,6 @@ export default /* glsl */`
 		bool frustumTest = all( frustumTestVec );
 
 		if ( frustumTest ) {
-
-		#if defined( SHADOWMAP_TYPE_PCF )
 
 			vec2 texelSize = vec2( 1.0 ) / shadowMapSize;
 
@@ -115,7 +113,30 @@ export default /* glsl */`
 				texture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )
 			) * ( 1.0 / 17.0 );
 
-		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+		}
+
+		return shadow;
+
+	}
+
+	float getShadowPCFSoft( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+
+		float shadow = 1.0;
+
+		shadowCoord.xyz /= shadowCoord.w;
+		shadowCoord.z += shadowBias;
+
+		// if ( something && something ) breaks ATI OpenGL shader compiler
+		// if ( all( something, something ) ) using this instead
+
+		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
+		bool inFrustum = all( inFrustumVec );
+
+		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
+
+		bool frustumTest = all( frustumTestVec );
+
+		if ( frustumTest ) {
 
 			vec2 texelSize = vec2( 1.0 ) / shadowMapSize;
 			float dx = texelSize.x;
@@ -130,36 +151,81 @@ export default /* glsl */`
 				texture2DCompare( shadowMap, uv + vec2( dx, 0.0 ), shadowCoord.z ) +
 				texture2DCompare( shadowMap, uv + vec2( 0.0, dy ), shadowCoord.z ) +
 				texture2DCompare( shadowMap, uv + texelSize, shadowCoord.z ) +
-				mix( texture2DCompare( shadowMap, uv + vec2( -dx, 0.0 ), shadowCoord.z ), 
+				mix( texture2DCompare( shadowMap, uv + vec2( -dx, 0.0 ), shadowCoord.z ),
 					 texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 0.0 ), shadowCoord.z ),
 					 f.x ) +
-				mix( texture2DCompare( shadowMap, uv + vec2( -dx, dy ), shadowCoord.z ), 
+				mix( texture2DCompare( shadowMap, uv + vec2( -dx, dy ), shadowCoord.z ),
 					 texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, dy ), shadowCoord.z ),
 					 f.x ) +
-				mix( texture2DCompare( shadowMap, uv + vec2( 0.0, -dy ), shadowCoord.z ), 
+				mix( texture2DCompare( shadowMap, uv + vec2( 0.0, -dy ), shadowCoord.z ),
 					 texture2DCompare( shadowMap, uv + vec2( 0.0, 2.0 * dy ), shadowCoord.z ),
 					 f.y ) +
-				mix( texture2DCompare( shadowMap, uv + vec2( dx, -dy ), shadowCoord.z ), 
+				mix( texture2DCompare( shadowMap, uv + vec2( dx, -dy ), shadowCoord.z ),
 					 texture2DCompare( shadowMap, uv + vec2( dx, 2.0 * dy ), shadowCoord.z ),
 					 f.y ) +
-				mix( mix( texture2DCompare( shadowMap, uv + vec2( -dx, -dy ), shadowCoord.z ), 
+				mix( mix( texture2DCompare( shadowMap, uv + vec2( -dx, -dy ), shadowCoord.z ),
 						  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, -dy ), shadowCoord.z ),
 						  f.x ),
-					 mix( texture2DCompare( shadowMap, uv + vec2( -dx, 2.0 * dy ), shadowCoord.z ), 
+					 mix( texture2DCompare( shadowMap, uv + vec2( -dx, 2.0 * dy ), shadowCoord.z ),
 						  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 2.0 * dy ), shadowCoord.z ),
 						  f.x ),
 					 f.y )
 			) * ( 1.0 / 9.0 );
 
-		#elif defined( SHADOWMAP_TYPE_VSM )
+		}
+
+		return shadow;
+
+	}
+
+	float getShadowVSM( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+
+		float shadow = 1.0;
+
+		shadowCoord.xyz /= shadowCoord.w;
+		shadowCoord.z += shadowBias;
+
+		// if ( something && something ) breaks ATI OpenGL shader compiler
+		// if ( all( something, something ) ) using this instead
+
+		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
+		bool inFrustum = all( inFrustumVec );
+
+		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
+
+		bool frustumTest = all( frustumTestVec );
+
+		if ( frustumTest ) {
 
 			shadow = VSMShadow( shadowMap, shadowCoord.xy, shadowCoord.z );
 
-		#else // no percentage-closer filtering:
+		}
 
+		return shadow;
+
+	}
+
+	float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {
+
+		float shadow = 1.0;
+
+		shadowCoord.xyz /= shadowCoord.w;
+		shadowCoord.z += shadowBias;
+
+		// if ( something && something ) breaks ATI OpenGL shader compiler
+		// if ( all( something, something ) ) using this instead
+
+		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
+		bool inFrustum = all( inFrustumVec );
+
+		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
+
+		bool frustumTest = all( frustumTestVec );
+
+		if ( frustumTest ) {
+
+			// no percentage-closer filtering:
 			shadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );
-
-		#endif
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -42,6 +42,22 @@ export default /* glsl */`
 
 	}
 
+	bool isShadowCoordInFrustum( vec4 shadowCoord ) {
+
+		// if ( something && something ) breaks ATI OpenGL shader compiler
+		// if ( all( something, something ) ) using this instead
+
+		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
+		bool inFrustum = all( inFrustumVec );
+
+		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
+
+		bool frustumTest = all( frustumTestVec );
+
+		return frustumTest;
+
+	}
+
 	float VSMShadow (sampler2D shadow, vec2 uv, float compare ){
 
 		float occlusion = 1.0;
@@ -70,15 +86,7 @@ export default /* glsl */`
 		shadowCoord.xyz /= shadowCoord.w;
 		shadowCoord.z += shadowBias;
 
-		// if ( something && something ) breaks ATI OpenGL shader compiler
-		// if ( all( something, something ) ) using this instead
-
-		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
-		bool inFrustum = all( inFrustumVec );
-
-		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
-
-		bool frustumTest = all( frustumTestVec );
+		bool frustumTest = isShadowCoordInFrustum( shadowCoord );
 
 		if ( frustumTest ) {
 
@@ -126,15 +134,7 @@ export default /* glsl */`
 		shadowCoord.xyz /= shadowCoord.w;
 		shadowCoord.z += shadowBias;
 
-		// if ( something && something ) breaks ATI OpenGL shader compiler
-		// if ( all( something, something ) ) using this instead
-
-		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
-		bool inFrustum = all( inFrustumVec );
-
-		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
-
-		bool frustumTest = all( frustumTestVec );
+		bool frustumTest = isShadowCoordInFrustum( shadowCoord );
 
 		if ( frustumTest ) {
 
@@ -185,15 +185,7 @@ export default /* glsl */`
 		shadowCoord.xyz /= shadowCoord.w;
 		shadowCoord.z += shadowBias;
 
-		// if ( something && something ) breaks ATI OpenGL shader compiler
-		// if ( all( something, something ) ) using this instead
-
-		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
-		bool inFrustum = all( inFrustumVec );
-
-		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
-
-		bool frustumTest = all( frustumTestVec );
+		bool frustumTest = isShadowCoordInFrustum( shadowCoord );
 
 		if ( frustumTest ) {
 
@@ -212,15 +204,7 @@ export default /* glsl */`
 		shadowCoord.xyz /= shadowCoord.w;
 		shadowCoord.z += shadowBias;
 
-		// if ( something && something ) breaks ATI OpenGL shader compiler
-		// if ( all( something, something ) ) using this instead
-
-		bvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );
-		bool inFrustum = all( inFrustumVec );
-
-		bvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );
-
-		bool frustumTest = all( frustumTestVec );
+		bool frustumTest = isShadowCoordInFrustum( shadowCoord );
 
 		if ( frustumTest ) {
 

--- a/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmask_pars_fragment.glsl.js
@@ -13,7 +13,16 @@ float getShadowMask() {
 	for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
 
 		directionalLight = directionalLightShadows[ i ];
-		shadow *= receiveShadow ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+		shadow *= receiveShadow ? getShadowPCF( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+		shadow *= receiveShadow ? getShadowPCFSoft( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_VSM )
+		shadow *= receiveShadow ? getShadowVSM( directionalShadowMap[ i ], directionalLight.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#else
+		shadow *= receiveShadow ? getShadow( directionalShadowMap[ i ], directionalLight.shadowBias, vDirectionalShadowCoord[ i ] ) : 1.0;
+		#endif
 
 	}
 	#pragma unroll_loop_end
@@ -28,7 +37,16 @@ float getShadowMask() {
 	for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
 
 		spotLight = spotLightShadows[ i ];
-		shadow *= receiveShadow ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+
+		#if defined( SHADOWMAP_TYPE_PCF )
+		shadow *= receiveShadow ? getShadowPCF( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
+		shadow *= receiveShadow ? getShadowPCFSoft( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#elif defined( SHADOWMAP_TYPE_VSM )
+		shadow *= receiveShadow ? getShadowVSM( spotShadowMap[ i ], spotLight.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#else
+		shadow *= receiveShadow ? getShadow( spotShadowMap[ i ], spotLight.shadowBias, vSpotShadowCoord[ i ] ) : 1.0;
+		#endif
 
 	}
 	#pragma unroll_loop_end


### PR DESCRIPTION
This PR moves the shadow type check up to the lighting loop in `lights_fragment_begin.glsl.js` in a step towards enabling per-light shadow types, as discussed in #18934. This will allow both VSM and PCF shadows to be used in the same scene, for example.

The shadow logic for directional and spot lights has been separated into different functions so they can be individually called based on the shadow type define. In an upcoming PR the shadow code will be changed to something like so:

```glsl
#if DIR_LIGHT_SHADOW_TYPE_{{ UNROLLED_LOOP_INDEX }} == SHADOWMAP_TYPE_PCF

// ...

#endif
```

A couple things I'd like some ideas on as well as a general review:

- In separating out the shadow logic there is some redundancy in in the shadow functions -- any thoughts on how to best reuse it?
- I see that `shadowVSM` was separated out into another function previously. Was there a reason?Is it okay to move the logic into the new VSM function?

### Next PRs
- Update point light shadows similarly
- Fix CSM example
- Implement per-light shadow type defines

/ping @Oletus 