### PR TITLE
Add images to example page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -169,7 +169,7 @@
 				'<div class="card">',
 				'	<a href="' + file + '.html" target="viewer">',
 				'		<div class="cover">',
-				'			<img src="screenshots/' + file + '.png" />',
+				'			<img src="screenshots/' + file + '.png" loading="lazy" />',
 				'		</div>',
 				'		<div class="title">' + getName( file ) + '</div>',
 				'	</a>',

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,11 +6,6 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="shortcut icon" href="../files/favicon.ico" />
 		<link rel="stylesheet" type="text/css" href="../files/main.css">
-		<style>
-			#panel #content .link {
-				display: block;
-			}
-		</style>
 	</head>
 	<body>
 
@@ -110,13 +105,13 @@
 
 			// Events
 
-			filterInput.onfocus = function ( event ) {
+			filterInput.onfocus = function ( ) {
 
 				panel.classList.add( 'searchFocused' );
 
 			};
 
-			filterInput.onblur = function ( event ) {
+			filterInput.onblur = function ( ) {
 
 				if ( filterInput.value === '' ) {
 
@@ -126,7 +121,7 @@
 
 			};
 
-			exitSearchButton.onclick = function ( event ) {
+			exitSearchButton.onclick = function ( ) {
 
 				filterInput.value = '';
 				updateFilter();
@@ -169,12 +164,21 @@
 
 		function createLink( file ) {
 
-			var link = document.createElement( 'a' );
-			link.className = 'link';
-			link.href = file + '.html';
-			link.textContent = getName( file );
-			link.setAttribute( 'target', 'viewer' );
-			link.addEventListener( 'click', function ( event ) {
+
+			var template = [
+				'<div class="card">',
+				'	<a href="' + file + '.html" target="viewer">',
+				'		<div class="cover">',
+				'			<img src="screenshots/' + file + '.png" />',
+				'		</div>',
+				'		<div class="title">' + getName( file ) + '</div>',
+				'	</a>',
+				'</div>'
+			].join( "\n" );
+
+			var link = createElementFromHTML( template );
+
+			link.querySelector( 'a[target="viewer"]' ).addEventListener( 'click', function ( event ) {
 
 				if ( event.button !== 0 || event.ctrlKey || event.altKey || event.metaKey ) return;
 
@@ -263,12 +267,12 @@
 
 				}
 
-				link.innerHTML = text;
+				link.querySelector( '.title' ).innerHTML = text;
 
 			} else {
 
 				link.classList.add( 'hidden' );
-				link.innerHTML = name;
+				link.querySelector( '.title' ).innerHTML = name;
 
 			}
 
@@ -330,6 +334,15 @@
 			}
 
 			return '';
+
+		}
+
+
+		function createElementFromHTML( htmlString ) {
+
+			var div = document.createElement( 'div' );
+			div.innerHTML = htmlString.trim();
+			return div.firstChild;
 
 		}
 

--- a/files/main.css
+++ b/files/main.css
@@ -464,6 +464,39 @@ iframe {
 }
 
 
+.card {
+	border-radius: 3px;
+	overflow: hidden;
+	background-color: #f7f7f7;
+	padding-bottom: 6px;
+	margin-bottom: 16px;
+}
+
+.card.selected {
+	box-shadow: 0 0 0 3px var(--color-blue);
+	text-decoration: none !important;
+}
+
+.card .cover {
+	padding-bottom: 62.5%; /* 8:5 aspect ratio */
+	position: relative;
+	overflow: hidden;
+}
+
+.card .cover img {
+	position: absolute;
+	width: 100%;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+}
+
+.card .title {
+	padding: 8px 12px 8px;
+	font-size: 18px;
+	font-weight: 500;
+}
+
 /* mobile */
 
 @media all and ( max-width: 640px ) {

--- a/files/main.css
+++ b/files/main.css
@@ -478,7 +478,7 @@ iframe {
 }
 
 .card .cover {
-	padding-bottom: 62.5%; /* 8:5 aspect ratio */
+	padding-bottom: 56.25%; /* 16:9 aspect ratio */
 	position: relative;
 	overflow: hidden;
 }


### PR DESCRIPTION
Followup of discussion in #18839

Originally proposed by @looeee and @munrocket, this PR explores a way of adding images directly into the existing sidebar.

It includes a card layout for each link, which I found to be the perfect solution for its extensibility and simple interactivity. It also fits with the current threejs.org design.

Please share your views on this, any feedback is appreciated 🙌

This PR would close #17692

[<img width="1440" alt="Screenshot 2020-05-16 at 12 24 29" src="https://user-images.githubusercontent.com/7217420/82117462-55cf4600-9770-11ea-9fcd-7a08bdb9463c.png">](https://raw.githack.com/marcofugaro/three.js/example-page-images/examples/index.html)

### [Live demo](https://raw.githack.com/marcofugaro/three.js/example-page-images/examples/index.html)

# Possible future improvements
Improvements that might come in future PRs if we agree on it.

## Lazy loading

Downloads only the images currently visible in the viewport. Useful especially for mobile users.

It works with the native [loading="lazy"](https://addyosmani.com/blog/lazy-loading/) attribute, and it follows the Progressive Enhancement methodology, meaning that on unsupported browsers it defaults to the normal loading behaviour ([currently IE and Safari](https://caniuse.com/#feat=loading-lazy-attr)).

#### [Live demo](https://raw.githack.com/marcofugaro/three.js/example-page-lazy/examples/index.html)


## Tags

We could also show to the user the tags introduced in #18779 and #19245. On click of the tag, the search is populated with said tag and all of the examples with said tags are shown.

[<img width="1440" alt="Screenshot 2020-05-16 at 12 27 58" src="https://user-images.githubusercontent.com/7217420/82117644-a5fad800-9771-11ea-8325-a6209990bf61.png">](https://raw.githack.com/marcofugaro/three.js/example-page-tags/examples/index.html)

### [Live demo](https://raw.githack.com/marcofugaro/three.js/example-page-tags/examples/index.html)

## Sticky section titles

The section titles could stick to the top, making it clearer for the user to understand which section he is in.

This would be achieved with the Progressive Enhancement ideology as well, using `position: sticky;` for browsers that support it and automatically defaulting to the normal non-sticky behaviour for browsers that don't support it ([only IE](https://caniuse.com/#feat=css-sticky)).

[<img width="1438" alt="Screenshot 2020-05-16 at 12 33 14" src="https://user-images.githubusercontent.com/7217420/82117655-c0cd4c80-9771-11ea-86a0-0cab2019679f.png">](https://raw.githack.com/marcofugaro/three.js/example-page-sticky/examples/index.html)

### [Live demo (proof of concept)](https://raw.githack.com/marcofugaro/three.js/example-page-sticky/examples/index.html)

## Grid view
I also explored a grid arrangement for the cards. Having more cards visible makes it quicker for the user to scan through them.

This was also achieved in https://github.com/mrdoob/three.js/pull/18714#issuecomment-591676139, however I think splitting the view horizontally works better than splitting the view vertically, especially for smaller screens (I own a 13'' laptop). Since most examples have the main focus on the center, an horizontal split leaves them more available space (think of it like a square fitted into the view rectangle).

[<img width="1440" alt="Screenshot 2020-05-16 at 12 30 08" src="https://user-images.githubusercontent.com/7217420/82117648-b27f3080-9771-11ea-81fe-6601a4a51b8e.png">](https://raw.githack.com/marcofugaro/three.js/example-page-grid/examples/index.html)

### [Live demo (proof of concept)](https://raw.githack.com/marcofugaro/three.js/example-page-grid/examples/index.html)

## Better titles

Currently the titles are formatted like `animation / skinning / blending`, however only the last part is the effective title, `animation` and `skinning` are actually tags. If these are handled like the current tags, we could have a classically formatted title.

Ideally the titles could be more descriptive, containing more than one word.

We could achieve this with another object `var titles =` in the `examples/files.js`.

[<img width="1440" alt="Screenshot 2020-05-16 at 12 32 23" src="https://user-images.githubusercontent.com/7217420/82117649-b8751180-9771-11ea-862a-98b26ae4a12b.png">](https://raw.githack.com/marcofugaro/three.js/example-page-titles/examples/index.html)

### [Live demo (proof of concept)](https://raw.githack.com/marcofugaro/three.js/example-page-titles/examples/index.html)

