### PR TITLE
Docs: LightProbe clarification

### DIFF
--- a/docs/api/en/lights/LightProbe.html
+++ b/docs/api/en/lights/LightProbe.html
@@ -26,9 +26,8 @@
 		</p>
 
 		<p class="desc">
-			The current probe implementation in three.js only supports so called diffuse light probes. This type of light probe
-			is a different representation of an irradiance environment map. Other types of light probes like reflection probes
-			are not yet supported.
+			The current probe implementation in three.js supports so-called diffuse light probes. This type of light probe
+			is functionally equivalent to an irradiance environment map.
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/api/zh/lights/LightProbe.html
+++ b/docs/api/zh/lights/LightProbe.html
@@ -26,9 +26,8 @@
 		</p>
 
 		<p class="desc">
-			The current probe implementation in three.js only supports so called diffuse light probes. This type of light probe
-			is a different representation of an irradiance environment map. Other types of light probes like reflection probes
-			are not yet supported.
+			The current probe implementation in three.js supports so-called diffuse light probes. This type of light probe
+			is functionally equivalent to an irradiance environment map.
 		</p>
 
 		<h2>Examples</h2>


### PR DESCRIPTION
As discussed in https://github.com/mrdoob/three.js/pull/19372#discussion_r426177005.

It has not been decided if we will be removing `Material.envMap` in favor of implementing a `ReflectionProbe` class.

