### PR TITLE
OrbitControls: Method to check if rendering is needed

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -244,8 +244,8 @@ var OrbitControls = function ( object, domElement ) {
 
 	}();
 
-	// if damping is used, this method can be called to see if there is
-	// movement and re-render is needed (when not using infinite render loop)
+	// this method can be called to see if there is movement
+	// and re-render is needed (when not using infinite render loop)
 	// TODO: zoom change
 	this.needsUpdate = function () {
 		const treshold = 0.0001

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -244,6 +244,18 @@ var OrbitControls = function ( object, domElement ) {
 
 	}();
 
+	// if damping is used, this method can be called to see if there is
+	// movement and re-render is needed (when not using infinite render loop)
+	// TODO: zoom change
+	this.needsUpdate = function () {
+		const treshold = 0.0001
+		return [
+			Math.abs(sphericalDelta.phi),
+			Math.abs(sphericalDelta.theta),
+			panOffset.length()
+		].some((value) => value > treshold)
+	};
+
 	this.dispose = function () {
 
 		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );


### PR DESCRIPTION
Proposal for a public method that will allow you to check if rendering is needed due to camera movement. Useful for power management if you have a static scene. Also works with damping enabled.

Couldn't get zoom detection to work with either zoomChanged or scale. Any ideas?

    const animate = function () {
        if (controls.needsUpdate()) renderer.render(scene, camera)  
        requestAnimationFrame(animate)  
    }