### PR TITLE
Examples: Fix panning direction

### DIFF
--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -105,7 +105,7 @@
 				if ( isUserInteracting === true ) {
 
 					lon = ( onPointerDownPointerX - event.clientX ) * 0.1 + onPointerDownLon;
-					lat = ( event.clientY - onPointerDownPointerY ) * 0.1 + onPointerDownLat;
+					lat = ( onPointerDownPointerY - event.clientY ) * 0.1 + onPointerDownLat;
 
 				}
 


### PR DESCRIPTION
At least on my Mac, panning was backwards. I would expect the dragged point to remain roughly under the mouse.

Is this hardware/OS-specific?

These examples do not support touch.
