### PR TITLE
Optimized GCodeLoader

### DIFF
--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -204,8 +204,13 @@ THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 				var layer = layers[ i ];
 
- 	 	 	 	vertex.push( ...layer.vertex )
- 		 		pathVertex.push( ...layer.pathVertex )
+ 				for ( var j = 0; j < layer.vertex.length; j ++ ) {
+					vertex.push(layer.vertex[ j ])
+				}
+
+				for ( var j = 0; j < layer.pathVertex.length; j ++ ) {
+					pathVertex.push(layer.pathVertex[ j ])
+				}
 
 			}
 

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -204,8 +204,8 @@ THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 				var layer = layers[ i ];
 
- 	 	 	 	vertex.push(...layer.vertex)
- 		 		pathVertex.push(...layer.pathVertex)
+ 	 	 	 	vertex.push( ...layer.vertex )
+ 		 		pathVertex.push( ...layer.pathVertex )
 
 			}
 

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -204,8 +204,8 @@ THREE.GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototy
 
 				var layer = layers[ i ];
 
-				vertex = vertex.concat( layer.vertex );
-				pathVertex = pathVertex.concat( layer.pathVertex );
+ 	 	 	 	vertex.push(...layer.vertex)
+ 		 		pathVertex.push(...layer.pathVertex)
 
 			}
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -215,8 +215,13 @@ GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				var layer = layers[ i ];
 
- 	 	 	 	vertex.push( ...layer.vertex )
- 		 		pathVertex.push( ...layer.pathVertex )
+ 				for ( var j = 0; j < layer.vertex.length; j ++ ) {
+					vertex.push(layer.vertex[ j ])
+				}
+
+				for ( var j = 0; j < layer.pathVertex.length; j ++ ) {
+					pathVertex.push(layer.pathVertex[ j ])
+				}
 
 			}
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -215,8 +215,8 @@ GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				var layer = layers[ i ];
 
- 	 	 	 	vertex.push(...layer.vertex)
- 		 		pathVertex.push(...layer.pathVertex)
+ 	 	 	 	vertex.push( ...layer.vertex )
+ 		 		pathVertex.push( ...layer.pathVertex )
 
 			}
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -215,8 +215,8 @@ GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				var layer = layers[ i ];
 
-				vertex = vertex.concat( layer.vertex );
-				pathVertex = pathVertex.concat( layer.pathVertex );
+ 	 	 	 	vertex.push(...layer.vertex)
+ 		 		pathVertex.push(...layer.pathVertex)
 
 			}
 


### PR DESCRIPTION
When I try to load a large gcode file (68M)，chrome crashed.
Since concat always returns a new array, it is costly.
![potential_out_of_memory](https://user-images.githubusercontent.com/12627808/82281513-16009c80-99c4-11ea-979e-5d592b1c6c85.png)
