### PR TITLE
TS: Fix uniforms in ShaderMaterialParameters

### DIFF
--- a/src/materials/ShaderMaterial.d.ts
+++ b/src/materials/ShaderMaterial.d.ts
@@ -12,7 +12,7 @@ import { MaterialParameters, Material } from './Material';
  */
 
 export interface ShaderMaterialParameters extends MaterialParameters {
-	uniforms?: any;
+	uniforms?: { [uniform: string]: IUniform };
 	vertexShader?: string;
 	fragmentShader?: string;
 	linewidth?: number;


### PR DESCRIPTION
This is to ensure the "uniforms" property of ShaderMaterialParameters is used properly if it is given in the ShaderMaterial constructor.