### PR TITLE
TS: Prefer union arguments to overloads for simple cases

### DIFF
--- a/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/examples/jsm/postprocessing/SAOPass.d.ts
@@ -62,9 +62,7 @@ export class SAOPass extends Pass {
 	fsQuad: object;
 	params: SAOPassParams;
 
-	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color, clearAlpha?: number ): void;
-	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: number, clearAlpha?: number ): void;
-	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color, clearAlpha?: number ): void;
-	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: number, clearAlpha?: number ): void;
+	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;
+	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;
 
 }

--- a/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -52,9 +52,7 @@ export class SSAOPass extends Pass {
 	dipose(): void;
 	generateSampleKernel(): Vector3[];
 	generateRandomKernelRotations(): void;
-	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color, clearAlpha?: number ): void;
-	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: number, clearAlpha?: number ): void;
-	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color, clearAlpha?: number ): void;
-	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: number, clearAlpha?: number ): void;
+	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;
+	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;
 
 }

--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -38,9 +38,7 @@ export class Color {
 	 */
 	b: number;
 
-	set( color: Color ): Color;
-	set( color: number ): Color;
-	set( color: string ): Color;
+	set( color: Color | string | number ): Color;
 	setScalar( scalar: number ): Color;
 	setHex( hex: number ): Color;
 

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -274,9 +274,7 @@ export class WebGLRenderer implements Renderer {
 	/**
 	 * Sets the clear color, using color for the color and alpha for the opacity.
 	 */
-	setClearColor( color: Color, alpha?: number ): void;
-	setClearColor( color: string, alpha?: number ): void;
-	setClearColor( color: number, alpha?: number ): void;
+	setClearColor( color: Color | string | number, alpha?: number ): void;
 
 	/**
 	 * Returns a float with the current clear alpha. Ranges from 0 to 1.


### PR DESCRIPTION
This works around microsoft/TypeScript#14107

In my typescript project I accept config for colors as `color: string | number` but using that with threejs can be a fiddle in some cases:

```
  Overload 2 of 3, '(color: number): Color', gave the following error.
    Argument of type 'string | number' is not assignable to parameter of type 'number'.
      Type 'string' is not assignable to type 'number'.
  Overload 3 of 3, '(color: string): Color', gave the following error.
    Argument of type 'string | number' is not assignable to parameter of type 'string'.
```

I searched the codebase for overloads using `(	+)(\w+)\(.+\n\1\2\(` and it looks like `Color` is pretty much the only unnecessary use of overloads so have fixed all those which I found.

I cannot see any typescript tests besides lint so I have't tried to add any.