### PR TITLE
SelectionBox: fix corner cases

### DIFF
--- a/examples/js/interactive/SelectionBox.js
+++ b/examples/js/interactive/SelectionBox.js
@@ -65,7 +65,7 @@ THREE.SelectionBox = ( function () {
 			endPoint.x = Math.max( startPoint.x, endPoint.x );
 			endPoint.y = Math.min( startPoint.y, endPoint.y );
 
-			vecNear.copy( this.camera.position );
+			vecNear.setFromMatrixPosition( this.camera.matrixWorld );
 			vecTopLeft.copy( tmpPoint );
 			vecTopRight.set( endPoint.x, tmpPoint.y, 0 );
 			vecDownRight.copy( endPoint );

--- a/examples/js/interactive/SelectionBox.js
+++ b/examples/js/interactive/SelectionBox.js
@@ -54,6 +54,20 @@ THREE.SelectionBox = ( function () {
 		startPoint = startPoint || this.startPoint;
 		endPoint = endPoint || this.endPoint;
 
+		// Avoid invalid frustum
+
+		if ( startPoint.x === endPoint.x ) {
+
+			endPoint.x += Number.EPSILON;
+
+		}
+
+		if ( startPoint.y === endPoint.y ) {
+
+			endPoint.y += Number.EPSILON;
+
+		}
+
 		this.camera.updateProjectionMatrix();
 		this.camera.updateMatrixWorld();
 
@@ -101,8 +115,6 @@ THREE.SelectionBox = ( function () {
 			planes[ 5 ].normal.multiplyScalar( - 1 );
 
 		} else if ( this.camera.isOrthographicCamera ) {
-
-			if ( startPoint.equals( endPoint ) ) endPoint.addScalar( Number.EPSILON ); // avoid invalid frustum
 
 			var left = Math.min( startPoint.x, endPoint.x );
 			var top = Math.max( startPoint.y, endPoint.y );

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -59,6 +59,18 @@ var SelectionBox = ( function () {
 		startPoint = startPoint || this.startPoint;
 		endPoint = endPoint || this.endPoint;
 
+		if ( startPoint.x === endPoint.x ) {
+
+			endPoint.x += Number.EPSILON;
+
+		}
+
+		if ( startPoint.y === endPoint.y ) {
+
+			endPoint.y += Number.EPSILON;
+
+		}
+
 		this.camera.updateProjectionMatrix();
 		this.camera.updateMatrixWorld();
 
@@ -106,8 +118,6 @@ var SelectionBox = ( function () {
 			planes[ 5 ].normal.multiplyScalar( - 1 );
 
 		} else if ( this.camera.isOrthographicCamera ) {
-
-			if ( startPoint.equals( endPoint ) ) endPoint.addScalar( Number.EPSILON ); // avoid invalid frustum
 
 			var left = Math.min( startPoint.x, endPoint.x );
 			var top = Math.max( startPoint.y, endPoint.y );

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -70,7 +70,7 @@ var SelectionBox = ( function () {
 			endPoint.x = Math.max( startPoint.x, endPoint.x );
 			endPoint.y = Math.min( startPoint.y, endPoint.y );
 
-			vecNear.copy( this.camera.position );
+			vecNear.copy( this.camera.getWorldPosition() );
 			vecTopLeft.copy( tmpPoint );
 			vecTopRight.set( endPoint.x, tmpPoint.y, 0 );
 			vecDownRight.copy( endPoint );


### PR DESCRIPTION
I found these trying to implement selection for my own project:

* my selection box allows the user to select all items that overlap it, so the degenerate case of a long line should still work,
* my camera is inside a group that is translated from origin, and that broke selection for perspective camera.