### PR TITLE
TS: Fix type of material about GPUComputationRenderer

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -13,7 +13,7 @@ import {
 export interface Variable {
 	name: string;
 	initialValueTexture: Texture;
-	material: Material;
+	material: ShaderMaterial;
 	dependencies: Variable[];
 	renderTargets: RenderTarget[];
 	wrapS: number;


### PR DESCRIPTION
Fixing issue #19421

I noticed that the field variable `material` type in `interface Variable` should be `ShaderMaterial`
in the module `GPUComputationRenderer`.