### PR TITLE
Examples: Dark mode support for new layout

### DIFF
--- a/files/main.css
+++ b/files/main.css
@@ -2,6 +2,7 @@
 	color-scheme: light dark;
 
 	--background-color: #fff;
+	--secondary-background-color: #f7f7f7;
 
 	--color-blue: #049EF4;
 	--text-color: #444;
@@ -21,6 +22,7 @@
 
 	:root {
 		--background-color: #222;
+		--secondary-background-color: #2e2e2e;
 
 		--text-color: #bbb;
 		--secondary-text-color: #666;
@@ -467,7 +469,7 @@ iframe {
 .card {
 	border-radius: 3px;
 	overflow: hidden;
-	background-color: #f7f7f7;
+	background-color: var(--secondary-background-color);
 	padding-bottom: 6px;
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
As pointed out in https://github.com/mrdoob/three.js/pull/19375#issuecomment-630634119, I missed the dark theme styles in PR #19375. This fixes it.

<img width="1440" alt="Screenshot 2020-05-22 at 22 59 03" src="https://user-images.githubusercontent.com/7217420/82710374-02cf2480-9c83-11ea-9a63-98c946359c40.png">
