### PR TITLE
Fix lerpVectors for when v1 === this

### DIFF
--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -422,7 +422,10 @@ Object.assign( Vector2.prototype, {
 
 	lerpVectors: function ( v1, v2, alpha ) {
 
-		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+		this.x = v1.x + ( v2.x - v1.x ) * alpha;
+		this.y = v1.y + ( v2.y - v1.y ) * alpha;
+
+		return this;
 
 	},
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -502,7 +502,11 @@ Object.assign( Vector3.prototype, {
 
 	lerpVectors: function ( v1, v2, alpha ) {
 
-		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+		this.x = v1.x + ( v2.x - v1.x ) * alpha;
+		this.y = v1.y + ( v2.y - v1.y ) * alpha;
+		this.z = v1.z + ( v2.z - v1.z ) * alpha;
+
+		return this;
 
 	},
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -594,7 +594,12 @@ Object.assign( Vector4.prototype, {
 
 	lerpVectors: function ( v1, v2, alpha ) {
 
-		return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+		this.x = v1.x + ( v2.x - v1.x ) * alpha;
+		this.y = v1.y + ( v2.y - v1.y ) * alpha;
+		this.z = v1.z + ( v2.z - v1.z ) * alpha;
+		this.w = v1.w + ( v2.w - v1.w ) * alpha;
+
+		return this;
 
 	},
 


### PR DESCRIPTION
When calling `v.lerpVectors(v1, v2, alpha)` with `v1` being equal to `v`, the function gives incorrect output. I don't think we should have to do a check like

```js
if (v1 === v) v.lerp(v2, alpha)
else v.lerpVectors(v1, v2, alpha)
```

so I decided to fix the function.