### PR TITLE
Examples: Resizable grid view

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -81,12 +81,16 @@
 				header.setAttribute( 'data-category', key );
 				container.appendChild( header );
 
+				const grid = document.createElement( 'div' );
+				grid.classList.add( 'grid' );
+				container.appendChild( grid );
+
 				for ( let i = 0; i < section.length; i ++ ) {
 
 					const file = section[ i ];
 
 					const link = createLink( file );
-					container.appendChild( link );
+					grid.appendChild( link );
 
 					links[ file ] = link;
 					validRedirects.set( file, file + '.html' );
@@ -94,6 +98,14 @@
 				}
 
 			}
+
+			if ( window.innerWidth > 768 ) {
+
+				initResizer();
+
+			}
+
+
 
 			if ( window.location.hash !== '' ) {
 
@@ -192,7 +204,7 @@
 				<div class="card">
 					<a href="${file}.html" target="viewer">
 						<div class="cover">
-							<img src="screenshots/${ file }.jpg" loading="lazy" width="400" />
+							<img src="screenshots/${file}.jpg" loading="lazy" width="400" />
 						</div>
 						<div class="title">${getName( file )}</div>
 					</a>
@@ -210,6 +222,74 @@
 			} );
 
 			return link;
+
+		}
+
+		function initResizer() {
+
+			const resizer = document.createElement( 'div' );
+			resizer.id = 'resizer';
+			panel.appendChild( resizer );
+
+			let startX;
+			let initialPanelWidth;
+			const minPanelWidth = getPropertyPixelValue( '--panel-width' );
+
+			function startDragging( e ) {
+
+				startX = e.pageX;
+
+				initialPanelWidth = getPropertyPixelValue( '--panel-width' );
+
+				// disable some interactions
+				viewer.style.pointerEvents = 'none';
+				content.style.pointerEvents = 'none';
+				panel.style.userSelect = 'none';
+				panel.style.webkitUserSelect = 'none';
+
+				document.body.style.cursor = 'ew-resize';
+
+			}
+
+			function onDrag( e ) {
+
+				if ( ! startX ) return;
+
+				const distanceX = e.pageX - startX;
+
+				setPropertyPixelValue( '--panel-width', clamp( initialPanelWidth + distanceX, minPanelWidth, window.innerWidth / 2 ) );
+
+			}
+
+			function stopDragging( ) {
+
+				if ( ! startX ) return;
+
+				startX = undefined;
+
+				// re-enable the interactions
+				viewer.style.pointerEvents = null;
+				content.style.pointerEvents = null;
+				panel.style.userSelect = null;
+				panel.style.webkitUserSelect = null;
+
+				document.body.style.cursor = null;
+
+			}
+
+			resizer.addEventListener( 'pointerdown', startDragging );
+			document.body.addEventListener( 'pointermove', onDrag );
+			document.body.addEventListener( 'pointerup', stopDragging );
+			document.body.addEventListener( 'pointerleave', stopDragging );
+
+		}
+
+
+
+		function loadFile( file ) {
+
+			selectFile( file );
+			viewer.src = file + '.html';
 
 		}
 
@@ -360,6 +440,28 @@
 			const div = document.createElement( 'div' );
 			div.innerHTML = htmlString.trim();
 			return div.firstChild;
+
+		}
+
+		function getPropertyPixelValue( propertyName ) {
+
+			const rootStyles = window.getComputedStyle( document.documentElement );
+			const stringValue = rootStyles.getPropertyValue( propertyName );
+			return Number( stringValue.trim().slice( 0, - 2 ) );
+
+		}
+
+		function setPropertyPixelValue( propertyName, value ) {
+
+			const stringValue = String( value ) + 'px';
+			document.documentElement.style.setProperty( propertyName, stringValue );
+
+		}
+
+
+		function clamp( value, min, max ) {
+
+			return Math.min( Math.max( value, min ), max );
 
 		}
 

--- a/files/main.css
+++ b/files/main.css
@@ -373,7 +373,6 @@ h1 a {
 	bottom: 0;
 	left: 100%;
 	width: 16px;
-	transform: translateX(-50%);
 	cursor: ew-resize;
 }
 

--- a/files/main.css
+++ b/files/main.css
@@ -131,7 +131,6 @@ h1 a {
 	left: 0px;
 	width: var(--panel-width);
 	height: 100%;
-	overflow: auto;
 	border-right: var(--border-style);
 	display: flex;
 	flex-direction: column;
@@ -368,6 +367,16 @@ h1 a {
 			padding-top: 6px;
 		}
 
+#panel #resizer {
+	position: absolute;
+	top: var(--header-height);
+	bottom: 0;
+	left: 100%;
+	width: 16px;
+	transform: translateX(-50%);
+	cursor: ew-resize;
+}
+
 .spacer {
 	color: var(--secondary-text-color);
 	margin-left: 2px;
@@ -493,13 +502,17 @@ iframe {
 	}
 }
 
+.grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+	grid-gap: 16px;
+}
 
 .card {
 	border-radius: 3px;
 	overflow: hidden;
 	background-color: var(--secondary-background-color);
 	padding-bottom: 6px;
-	margin-bottom: 16px;
 }
 
 .card.selected {

--- a/files/main.css
+++ b/files/main.css
@@ -507,6 +507,10 @@ iframe {
 	grid-gap: 16px;
 }
 
+#panel #content.minimal .grid {
+	display: unset;
+}
+
 .card {
 	border-radius: 3px;
 	overflow: hidden;


### PR DESCRIPTION
Followup of #19375

I implemented a resizable examples view as suggested in https://github.com/mrdoob/three.js/pull/19375#issuecomment-629955667.

It is under a breakpoint, so it is enabled on landscape iPad and up.

I've set the minimum card width to `200px`, but it can be adjusted.

Note: on Chrome, in certain situations, the resizing may be a little bit laggy. This is because it triggers re-paint, and painting is handled on the CPU in Chrome.

[![demo](https://user-images.githubusercontent.com/7217420/82752966-2947a980-9dc2-11ea-8f86-2485ad8c4cd2.gif)](https://raw.githack.com/marcofugaro/three.js/example-mode-resizable-grid/examples/index.html)

### [Live demo](https://raw.githack.com/marcofugaro/three.js/example-mode-resizable-grid/examples/index.html)