### PR TITLE
Fix CubeCamera breaking in WebXR

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -66,7 +66,10 @@ function CubeCamera( near, far, renderTarget ) {
 
 		if ( this.parent === null ) this.updateMatrixWorld();
 
+		var currentXrEnabled = renderer.xr.enabled;
 		var currentRenderTarget = renderer.getRenderTarget();
+
+		renderer.xr.enabled = false;
 
 		var generateMipmaps = renderTarget.texture.generateMipmaps;
 
@@ -94,6 +97,7 @@ function CubeCamera( near, far, renderTarget ) {
 
 		renderer.setRenderTarget( currentRenderTarget );
 
+		renderer.xr.enabled = currentXrEnabled;
 	};
 
 	this.clear = function ( renderer, color, depth, stencil ) {

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -98,6 +98,7 @@ function CubeCamera( near, far, renderTarget ) {
 		renderer.setRenderTarget( currentRenderTarget );
 
 		renderer.xr.enabled = currentXrEnabled;
+
 	};
 
 	this.clear = function ( renderer, color, depth, stencil ) {

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -98,6 +98,7 @@ function CubeCamera( near, far, renderTarget ) {
 		renderer.setRenderTarget( currentRenderTarget );
 
 		renderer.xr.enabled = currentXrEnabled;
+		
 	};
 
 	this.clear = function ( renderer, color, depth, stencil ) {


### PR DESCRIPTION
implements @Mugen87's fix to #19428 by disabling WebXR before updating the cube render target and reenabling afterwards. 

Tested locally on an existing WebXR project and confirmed working (after slight refactoring to accommodate the new WebGLCubeRenderTarget injection method per #19137).

Fixed #19428.