### PR TITLE
Add Material.onAfterCompile callback

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -334,6 +334,16 @@
 		Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 		</p>
 
+		<h3>[method:null onAfterCompile]( [param:object compiled] )</h3>
+		<p>
+		compiled -- object containing vertexGlsl and fragmentGlsl.<br />
+		An optional callback that is executed after the shader program is compiled.
+		This function is called with the compiled glsl code as a parameter. Useful for the log and modification of the final materials.
+		</p>
+		<p>
+		Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+		</p>
+
 		<h3>[method:null setValues]( [param:object values] )</h3>
 		<p>
 		values -- a container with parameters.<br />

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -338,7 +338,7 @@
 		<p>
 		compiled -- object containing vertexGlsl and fragmentGlsl.<br />
 		An optional callback that is executed after the shader program is compiled.
-		This function is called with the compiled glsl code as a parameter. Useful for the log and modification of the final materials.
+		This function is called with the compiled glsl code as a parameter. Useful for log and view the final materials.
 		</p>
 		<p>
 		Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -290,7 +290,7 @@ Unlike properties, the callback is not supported by [page:Material.clone .clone]
 <h3>[method:null onAfterCompile]( [param:object compiled] )</h3>
 <p>
 compiled -- object containing vertexGlsl and fragmentGlsl.<br />
-在编译shader程序之后执行的可选回调。此函数使用编译后的glsl代码作为参数。用于log及修改最终材质。
+在编译shader程序之后执行的可选回调。此函数使用编译后的glsl代码作为参数。用于log及查看最终材质。
 </p>
 <p>
 Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -287,6 +287,15 @@ Defines whether vertex coloring is used. Default is *false*.
 Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 </p>
 
+<h3>[method:null onAfterCompile]( [param:object compiled] )</h3>
+<p>
+compiled -- object containing vertexGlsl and fragmentGlsl.<br />
+在编译shader程序之后执行的可选回调。此函数使用编译后的glsl代码作为参数。用于log及修改最终材质。
+</p>
+<p>
+Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+</p>
+
 <h3>[method:null setValues]( [param:object values] )</h3>
 <p> values -- 具有参数的容器。
 	根据*values*设置属性。<br/>

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -85,6 +85,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	onBeforeCompile: function () {},
 
+	onAfterCompile: function () {},
+
 	setValues: function ( values ) {
 
 		if ( values === undefined ) return;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -714,18 +714,13 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 	var vertexGlsl = prefixVertex + vertexShader;
 	var fragmentGlsl = prefixFragment + fragmentShader;
 
-	var compiled = {
-	  vertexGlsl,
-	  fragmentGlsl,
-	};
-
-	parameters.onAfterCompile( compiled );
+	parameters.onAfterCompile( vertexGlsl, fragmentGlsl );
 
 	// console.log( '*VERTEX*', vertexGlsl );
 	// console.log( '*FRAGMENT*', fragmentGlsl );
 
-	var glVertexShader = WebGLShader( gl, gl.VERTEX_SHADER, compiled.vertexGlsl );
-	var glFragmentShader = WebGLShader( gl, gl.FRAGMENT_SHADER, compiled.fragmentGlsl );
+	var glVertexShader = WebGLShader( gl, gl.VERTEX_SHADER, vertexGlsl );
+	var glFragmentShader = WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentGlsl );
 
 	gl.attachShader( program, glVertexShader );
 	gl.attachShader( program, glFragmentShader );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -714,11 +714,18 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 	var vertexGlsl = prefixVertex + vertexShader;
 	var fragmentGlsl = prefixFragment + fragmentShader;
 
+	var compiled = {
+	  vertexGlsl,
+	  fragmentGlsl,
+	}
+
+	parameters.onAfterCompile( compiled )
+
 	// console.log( '*VERTEX*', vertexGlsl );
 	// console.log( '*FRAGMENT*', fragmentGlsl );
 
-	var glVertexShader = WebGLShader( gl, gl.VERTEX_SHADER, vertexGlsl );
-	var glFragmentShader = WebGLShader( gl, gl.FRAGMENT_SHADER, fragmentGlsl );
+	var glVertexShader = WebGLShader( gl, gl.VERTEX_SHADER, compiled.vertexGlsl );
+	var glFragmentShader = WebGLShader( gl, gl.FRAGMENT_SHADER, compiled.fragmentGlsl );
 
 	gl.attachShader( program, glVertexShader );
 	gl.attachShader( program, glFragmentShader );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -717,9 +717,9 @@ function WebGLProgram( renderer, cacheKey, parameters ) {
 	var compiled = {
 	  vertexGlsl,
 	  fragmentGlsl,
-	}
+	};
 
-	parameters.onAfterCompile( compiled )
+	parameters.onAfterCompile( compiled );
 
 	// console.log( '*VERTEX*', vertexGlsl );
 	// console.log( '*FRAGMENT*', fragmentGlsl );

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -288,7 +288,8 @@ function WebGLPrograms( renderer, extensions, capabilities ) {
 			rendererExtensionDrawBuffers: isWebGL2 || extensions.get( 'WEBGL_draw_buffers' ) !== null,
 			rendererExtensionShaderTextureLod: isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) !== null,
 
-			onBeforeCompile: material.onBeforeCompile
+			onBeforeCompile: material.onBeforeCompile,
+			onAfterCompile: material.onAfterCompile,
 
 		};
 


### PR DESCRIPTION
Add **Material.onAfterCompile** - An optional callback that is executed after the shader program is compiled. This function is called with the compiled glsl code as a parameter. Useful for the log and modification of the final materials.