### PR TITLE
InstancedMesh: Support copying/cloning

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -85,6 +85,18 @@ InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 	updateMorphTargets: function () {
 
+	},
+	
+	copy: function ( source ) {
+
+		Mesh.prototype.copy.call( this, source );
+
+		this.instanceMatrix.copy( source.instanceMatrix );
+		
+		this.count = source.count;
+
+		return this;
+
 	}
 
 } );

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -86,13 +86,13 @@ InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 	updateMorphTargets: function () {
 
 	},
-	
+
 	copy: function ( source ) {
 
 		Mesh.prototype.copy.call( this, source );
 
 		this.instanceMatrix.copy( source.instanceMatrix );
-		
+
 		this.count = source.count;
 
 		return this;


### PR DESCRIPTION
In order to copy/clone an InstancedMesh succesfully, its additional properties need to be copied, too.

(This commit is untested, but hopefully straightforward enough to not warrant me to setup a full dev/test environment?)