### PR TITLE
GLTFExporter: Clean up.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -517,9 +517,9 @@ THREE.GLTFExporter.prototype = {
 					} else {
 
 						if ( a === 0 ) value = attribute.getX( i );
-						if ( a === 1 ) value = attribute.getY( i );
-						if ( a === 2 ) value = attribute.getZ( i );
-						if ( a === 3 ) value = attribute.getW( i );
+						else if ( a === 1 ) value = attribute.getY( i );
+						else if ( a === 2 ) value = attribute.getZ( i );
+						else if ( a === 3 ) value = attribute.getW( i );
 
 					}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -539,9 +539,9 @@ GLTFExporter.prototype = {
 					} else {
 
 						if ( a === 0 ) value = attribute.getX( i );
-						if ( a === 1 ) value = attribute.getY( i );
-						if ( a === 2 ) value = attribute.getZ( i );
-						if ( a === 3 ) value = attribute.getW( i );
+						else if ( a === 1 ) value = attribute.getY( i );
+						else if ( a === 2 ) value = attribute.getZ( i );
+						else if ( a === 3 ) value = attribute.getW( i );
 
 					}
 


### PR DESCRIPTION
Avoid unnecessary `if` evaluations (missed in 39fbd2c3d0dbf0f42a3c3fe486b39b6447ab270b).