### PR TITLE
Add 'importance' Priority Hint to ImageLoader

### DIFF
--- a/src/loaders/ImageLoader.d.ts
+++ b/src/loaders/ImageLoader.d.ts
@@ -13,8 +13,11 @@ export class ImageLoader extends Loader {
 		url: string,
 		onLoad?: ( image: HTMLImageElement ) => void,
 		onProgress?: ( event: ProgressEvent ) => void,
-		onError?: ( event: ErrorEvent ) => void,
-		priorityHint?: string
+		onError?: ( event: ErrorEvent ) => void
 	): HTMLImageElement;
+	
+	setPriorityHint(
+		priorityHint: string
+	);
 
 }

--- a/src/loaders/ImageLoader.d.ts
+++ b/src/loaders/ImageLoader.d.ts
@@ -15,7 +15,7 @@ export class ImageLoader extends Loader {
 		onProgress?: ( event: ProgressEvent ) => void,
 		onError?: ( event: ErrorEvent ) => void
 	): HTMLImageElement;
-	
+
 	setPriorityHint(
 		priorityHint: string
 	);

--- a/src/loaders/ImageLoader.d.ts
+++ b/src/loaders/ImageLoader.d.ts
@@ -13,7 +13,8 @@ export class ImageLoader extends Loader {
 		url: string,
 		onLoad?: ( image: HTMLImageElement ) => void,
 		onProgress?: ( event: ProgressEvent ) => void,
-		onError?: ( event: ErrorEvent ) => void
+		onError?: ( event: ErrorEvent ) => void,
+		priorityHint?: string
 	): HTMLImageElement;
 
 }

--- a/src/loaders/ImageLoader.d.ts
+++ b/src/loaders/ImageLoader.d.ts
@@ -18,6 +18,6 @@ export class ImageLoader extends Loader {
 
 	setPriorityHint(
 		priorityHint: string
-	);
+	): void;
 
 }

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -15,7 +15,7 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	constructor: ImageLoader,
 
-	load: function ( url, onLoad, onProgress, onError, priorityHint ) {
+	load: function ( url, onLoad, onProgress, onError ) {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
@@ -77,13 +77,19 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}
 
-		if ( priorityHint ) image.importance = priorityHint;
+		if ( this.priorityHint ) image.importance = priorityHint;
 
 		scope.manager.itemStart( url );
 
 		image.src = url;
 
 		return image;
+
+	},
+
+	setPriorityHint: function( priorityHint ) {
+
+		this.priorityHint = priorityHint
 
 	}
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -15,7 +15,7 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	constructor: ImageLoader,
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load: function ( url, onLoad, onProgress, onError, priorityHint ) {
 
 		if ( this.path !== undefined ) url = this.path + url;
 
@@ -76,6 +76,8 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 			if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
 
 		}
+
+		if ( priorityHint ) image.importance = priorityHint;
 
 		scope.manager.itemStart( url );
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -77,7 +77,7 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}
 
-		if ( this.priorityHint ) image.importance = priorityHint;
+		if ( this.priorityHint ) image.importance = this.priorityHint;
 
 		scope.manager.itemStart( url );
 
@@ -87,9 +87,9 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	},
 
-	setPriorityHint: function( priorityHint ) {
+	setPriorityHint: function ( priorityHint ) {
 
-		this.priorityHint = priorityHint
+		this.priorityHint = priorityHint;
 
 	}
 


### PR DESCRIPTION
Chrome has implemented Priority Hints to allow developers to specify a "low" or "high" priority for images to load. There is a community working group draft here: https://wicg.github.io/priority-hints/

This allows us to pass a priority hint string to ImageLoader to take advantage of the improved user experience (for example, but hinting that a browser should load items within the visible frustum first).