### PR TITLE
Bug fix in toNonIndexed - normalized

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -891,6 +891,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			var array = attribute.array;
 			var itemSize = attribute.itemSize;
+			var normalized = attribute.normalized === true;
 
 			var array2 = new array.constructor( indices.length * itemSize );
 
@@ -908,7 +909,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			}
 
-			return new BufferAttribute( array2, itemSize );
+			return new BufferAttribute( array2, itemSize, normalized );
 
 		}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -891,7 +891,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			var array = attribute.array;
 			var itemSize = attribute.itemSize;
-			var normalized = attribute.normalized === true;
+			var normalized = attribute.normalized;
 
 			var array2 = new array.constructor( indices.length * itemSize );
 


### PR DESCRIPTION
When using a normalized BufferAttribute, toNonIndexed loses it.