### PR TITLE
Examples: Ensure deprecation warning isn't copied 

### DIFF
--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -250,6 +250,10 @@ function convert( path, exampleDependencies, ignoreList ) {
 	var classNames = [];
 	var coreDependencies = {};
 
+	// remove examples/js deprecation warning
+
+	contents = contents.replace( /^console\.warn.*\n/, '' );
+
 	// imports
 
 	contents = contents.replace( /^\/\*+[^*]*\*+(?:[^/*][^*]*\*+)*\//, function ( match ) {


### PR DESCRIPTION
…from examples/js → … examples/jsm.

Followup to https://github.com/mrdoob/three.js/pull/18749.