### PR TITLE
Editor: Fix toolbar width.

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -424,7 +424,6 @@ select {
 #toolbar {
 	position: absolute;
 	left: calc(50% - 290px); /* ( ( 100% - 300px ) / 2.0 ) - 140px */
-	width: 280px;
 	bottom: 16px;
 	height: 32px;
 	background: #eee;
@@ -540,7 +539,6 @@ select {
 
 	#toolbar {
 		left: calc(50% - 140px);
-		width: 280px;
 		top: 68px;
 	}
 


### PR DESCRIPTION
Since the width of the toolbar depends on the language, using a fixed `width` does not work. Although the new toolbar will not be centered in all cases, it's much better than the current status since ugly line-breaks occur. Check out how the `Local` label of the checkbox is off.

![image](https://user-images.githubusercontent.com/12612165/83010097-09a9be80-a018-11ea-8edb-95901181b919.png)
