### PR TITLE
Fix crash in LineSegmentsGeometry when calling applyMatrix4()

### DIFF
--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -47,7 +47,7 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 			end.applyMatrix4( matrix );
 
-			start.data.needsUpdate = true;
+			start.needsUpdate = true;
 
 		}
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -48,6 +48,7 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 			end.applyMatrix4( matrix );
 
 			start.needsUpdate = true;
+			end.needsUpdate = true;
 
 		}
 


### PR DESCRIPTION
`BufferAttribute` has no `data` attribute, which causes the crash