### PR TITLE
WebGLRenderer: Call Scene.on*Render() only for scenes.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1171,7 +1171,7 @@ function WebGLRenderer( parameters ) {
 		}
 
 		//
-		scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
+		if ( scene.isScene ) scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
 
 		currentRenderState = renderStates.get( scene, camera );
 		currentRenderState.init();
@@ -1247,7 +1247,7 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		scene.onAfterRender( _this, scene, camera );
+		if ( scene.isScene ) scene.onAfterRender( _this, scene, camera );
 
 		//
 


### PR DESCRIPTION
Fixed #19477.