### PR TITLE
Editor: Fix usage of rendering settings.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -691,7 +691,12 @@ Editor.prototype = {
 			metadata: {},
 			project: {
 				shadows: this.config.getKey( 'project/renderer/shadows' ),
-				vr: this.config.getKey( 'project/vr' )
+				shadowType: this.config.getKey( 'project/renderer/shadowType' ),
+				vr: this.config.getKey( 'project/vr' ),
+				physicallyCorrectLights: this.config.getKey( 'project/renderer/physicallyCorrectLights' ),
+				toneMapping: this.config.getKey( 'project/renderer/toneMapping' ),
+				toneMappingExposure: this.config.getKey( 'project/renderer/toneMappingExposure' ),
+				toneMappingWhitePoint: this.config.getKey( 'project/renderer/toneMappingWhitePoint' ),
 			},
 			camera: this.camera.toJSON(),
 			scene: this.scene.toJSON(),

--- a/editor/js/Sidebar.Project.js
+++ b/editor/js/Sidebar.Project.js
@@ -262,6 +262,8 @@ var SidebarProject = function ( editor ) {
 		config.getKey( 'project/renderer/shadows' ),
 		config.getKey( 'project/renderer/shadowType' ),
 		config.getKey( 'project/renderer/toneMapping' ),
+		config.getKey( 'project/renderer/toneMappingExposure' ),
+		config.getKey( 'project/renderer/toneMappingWhitePoint' ),
 		config.getKey( 'project/renderer/physicallyCorrectLights' )
 	 );
 

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -30,8 +30,13 @@ var APP = {
 
 			var project = json.project;
 
-			renderer.shadowMap.enabled = project.shadows === true;
-			renderer.xr.enabled = project.vr === true;
+			if ( project.vr !== undefined ) renderer.xr.enabled = project.vr;
+			if ( project.shadows !== undefined ) renderer.shadowMap.enabled = project.shadows;
+			if ( project.shadowType !== undefined ) renderer.shadowMap.type = project.shadowType;
+			if ( project.toneMapping !== undefined ) renderer.toneMapping = project.toneMapping;
+			if ( project.toneMappingExposure !== undefined ) renderer.toneMappingExposure = project.toneMappingExposure;
+			if ( project.toneMappingWhitePoint !== undefined ) renderer.toneMappingWhitePoint = project.toneMappingWhitePoint;
+			if ( project.physicallyCorrectLights !== undefined ) renderer.physicallyCorrectLights = project.physicallyCorrectLights;
 
 			this.setScene( loader.parse( json.scene ) );
 			this.setCamera( loader.parse( json.camera ) );


### PR DESCRIPTION
Fixed #19494.
Fixed #19507.

Also fixed and issue that was introduced via #19434. It was missed to update the first call of `createRenderer()`.