### PR TITLE
Test for AnimationMixer.stopAllAction

### DIFF
--- a/test/unit/src/animation/AnimationMixer.tests.js
+++ b/test/unit/src/animation/AnimationMixer.tests.js
@@ -4,6 +4,28 @@
 /* global QUnit */
 
 import { AnimationMixer } from '../../../../src/animation/AnimationMixer';
+import { AnimationClip } from '../../../../src/animation/AnimationClip';
+import { VectorKeyframeTrack } from '../../../../src/animation/tracks/VectorKeyframeTrack';
+import { Object3D } from '../../../../src/core/Object3D'
+import {
+	zero3,
+	one3,
+	two3
+} from '../math/Constants.tests';
+
+function getClips(pos1, pos2, scale1, scale2, dur) {
+
+	const clips = [];
+
+	let track = new VectorKeyframeTrack( ".scale", [ 0, dur ], [ scale1.x, scale1.y, scale1.z, scale2.x, scale2.y, scale2.z ] );
+	clips.push( new AnimationClip( "scale", dur, [ track ] ) );
+
+	track = new VectorKeyframeTrack( ".position", [ 0, dur ], [ pos1.x, pos1.y, pos1.z, pos2.x, pos2.y, pos2.z ] );
+	clips.push( new AnimationClip( "position", dur, [ track ] ) );
+
+	return clips;
+
+}
 
 export default QUnit.module( 'Animation', () => {
 
@@ -36,9 +58,35 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.todo( "stopAllAction", ( assert ) => {
+		QUnit.test( "stopAllAction", ( assert ) => {
 
-			assert.ok( false, "everything's gonna be alright" );
+			const obj = new Object3D();
+			const animMixer = new AnimationMixer( obj );
+			const clips = getClips( zero3, one3, two3, one3, 1 );
+			const actionA = animMixer.clipAction( clips[ 0 ] );
+			const actionB = animMixer.clipAction( clips[ 1 ] );
+
+			actionA.play();
+			actionB.play();
+			animMixer.update( 0.1 );
+			animMixer.stopAllAction();
+
+			assert.ok(
+				!actionA.isRunning() &&
+				!actionB.isRunning(),
+				"All actions stopped" );
+			assert.ok(
+				obj.position.x == 0 &&
+				obj.position.y == 0 &&
+				obj.position.z == 0,
+				"Position reset as expected"
+			);
+			assert.ok(
+				obj.scale.x == 1 &&
+				obj.scale.y == 1 &&
+				obj.scale.z == 1,
+				"Scale reset as expected"
+			);
 
 		} );
 

--- a/test/unit/src/animation/AnimationMixer.tests.js
+++ b/test/unit/src/animation/AnimationMixer.tests.js
@@ -96,9 +96,11 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
-		QUnit.todo( "getRoot", ( assert ) => {
+		QUnit.test( "getRoot", ( assert ) => {
 
-			assert.ok( false, "everything's gonna be alright" );
+			const obj = new Object3D();
+			const animMixer = new AnimationMixer( obj );
+			assert.strictEqual( obj, animMixer.getRoot(), "Get original root object" );
 
 		} );
 


### PR DESCRIPTION
It took longer than expected, but I've added a test for AnimationMixer's stopAllAction() that should cover the previous issue of #19328 (PR: #19329)
I also added a simple test for getRoot() as it was low-hanging fruit :)

FWIW: To be able to get the tests running locally, I had to manually install the "rollup" package after the `npm i --prefix test` (node v12.17.0, npm v6.14.4).