### PR TITLE
TS: Clean up.

### DIFF
--- a/src/extras/core/Curve.d.ts
+++ b/src/extras/core/Curve.d.ts
@@ -4,7 +4,7 @@ import { Vector } from './../../math/Vector2';
 
 /**
  * An extensible curve object which contains methods for interpolation
- * class Curve&lt;T extends Vector&gt;
+ * class Curve<T extends Vector>
  */
 export class Curve<T extends Vector> {
 

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -2,7 +2,7 @@ import { Matrix4 } from './Matrix4';
 import { Vector3 } from './Vector3';
 
 /**
- * ( interface Matrix&lt;T&gt; )
+ * ( interface Matrix<T> )
  */
 export interface Matrix {
 	/**
@@ -44,7 +44,7 @@ export interface Matrix {
 }
 
 /**
- * ( class Matrix3 implements Matrix&lt;Matrix3&gt; )
+ * ( class Matrix3 implements Matrix<Matrix3> )
  */
 export class Matrix3 implements Matrix {
 

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -2,15 +2,19 @@ import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
 
 /**
- * ( interface Vector&lt;T&gt; )
+ * ( interface Vector<T> )
  *
- * Abstract interface of Vector2, Vector3 and Vector4.
+ * Abstract interface of {@link https://github.com/mrdoob/three.js/blob/master/src/math/Vector2.js|Vector2},
+ * {@link https://github.com/mrdoob/three.js/blob/master/src/math/Vector3.js|Vector3}
+ * and {@link https://github.com/mrdoob/three.js/blob/master/src/math/Vector4.js|Vector4}.
+ *
  * Currently the members of Vector is NOT type safe because it accepts different typed vectors.
+ *
  * Those definitions will be changed when TypeScript innovates Generics to be type safe.
  *
  * @example
  * const v:THREE.Vector = new THREE.Vector3();
- * v.addVectors(new THREE.Vector2(0, 1), new THREE.Vector2(2, 3));		// invalid but compiled successfully
+ * v.addVectors(new THREE.Vector2(0, 1), new THREE.Vector2(2, 3)); // invalid but compiled successfully
  */
 export interface Vector {
 	setComponent( index: number, value: number ): this;


### PR DESCRIPTION
Fixed typo and use @link for `Vector2`, `Vector3` and `Vector4`