### PR TITLE
Allow GLTFLoader to use ImageBitmapLoader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1416,6 +1416,12 @@ THREE.GLTFLoader = ( function () {
 		this.textureLoader = new THREE.TextureLoader( this.options.manager );
 		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 
+		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
+		// expensive work of uploading a texture to the GPU off the main thread.
+		if ( typeof createImageBitmap !== 'undefined' ) {
+			this.textureLoader.setImageLoader( new THREE.ImageBitmapLoader( this.options.manager ) );
+		}
+
 		this.fileLoader = new THREE.FileLoader( this.options.manager );
 		this.fileLoader.setResponseType( 'arraybuffer' );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1482,7 +1482,7 @@ var GLTFLoader = ( function () {
 
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
-		if (typeof createImageBitmap !== 'undefined') {
+		if ( typeof createImageBitmap !== 'undefined' ) {
 			this.textureLoader.setImageLoader( new ImageBitmapLoader( this.options.manager ) );
 		}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -19,6 +19,7 @@ import {
 	FileLoader,
 	FrontSide,
 	Group,
+	ImageBitmapLoader,
 	InterleavedBuffer,
 	InterleavedBufferAttribute,
 	Interpolant,
@@ -1476,7 +1477,14 @@ var GLTFLoader = ( function () {
 		// BufferGeometry caching
 		this.primitiveCache = {};
 
-		this.textureLoader = new TextureLoader( this.options.manager );
+		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
+		// expensive work of uploading a texture to the GPU off the main thread.
+		var imageLoader = null;
+		if (typeof createImageBitmap !== 'undefined') {
+			imageLoader = new ImageBitmapLoader( this.options.manager );
+		}
+
+		this.textureLoader = new TextureLoader( this.options.manager, imageLoader );
 		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 
 		this.fileLoader = new FileLoader( this.options.manager );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1477,15 +1477,14 @@ var GLTFLoader = ( function () {
 		// BufferGeometry caching
 		this.primitiveCache = {};
 
+		this.textureLoader = new TextureLoader( this.options.manager );
+		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
+
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
-		var imageLoader = null;
 		if (typeof createImageBitmap !== 'undefined') {
-			imageLoader = new ImageBitmapLoader( this.options.manager );
+			this.textureLoader.setImageLoader( new ImageBitmapLoader( this.options.manager ) );
 		}
-
-		this.textureLoader = new TextureLoader( this.options.manager, imageLoader );
-		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 
 		this.fileLoader = new FileLoader( this.options.manager );
 		this.fileLoader.setResponseType( 'arraybuffer' );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -12,6 +12,7 @@ import {
 	Box3,
 	BufferAttribute,
 	BufferGeometry,
+	CanvasTexture,
 	ClampToEdgeWrapping,
 	Color,
 	DirectionalLight,
@@ -1477,14 +1478,16 @@ var GLTFLoader = ( function () {
 		// BufferGeometry caching
 		this.primitiveCache = {};
 
-		this.textureLoader = new TextureLoader( this.options.manager );
-		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
+		this.useImageBitmap = typeof createImageBitmap !== 'undefined';
 
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
-		if ( typeof createImageBitmap !== 'undefined' ) {
-			this.textureLoader.setImageLoader( new ImageBitmapLoader( this.options.manager ) );
+		if ( this.useImageBitmap ) {
+			this.textureLoader = new ImageBitmapLoader( this.options.manager );
+		} else {
+			this.textureLoader = new TextureLoader( this.options.manager );
 		}
+		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 
 		this.fileLoader = new FileLoader( this.options.manager );
 		this.fileLoader.setResponseType( 'arraybuffer' );
@@ -1902,6 +1905,7 @@ var GLTFLoader = ( function () {
 		var parser = this;
 		var json = this.json;
 		var options = this.options;
+		var useImageBitmap = this.useImageBitmap;
 		var textureLoader = this.textureLoader;
 
 		var URL = self.URL || self.webkitURL;
@@ -1956,7 +1960,19 @@ var GLTFLoader = ( function () {
 
 			return new Promise( function ( resolve, reject ) {
 
-				loader.load( resolveURL( sourceURI, options.path ), resolve, undefined, reject );
+				var onLoad = resolve;
+
+				if ( useImageBitmap ) {
+
+					onLoad = function ( imageBitmap ) {
+
+						resolve( new CanvasTexture( imageBitmap ) );
+
+					};
+
+				}
+
+				loader.load( resolveURL( sourceURI, options.path ), onLoad, undefined, reject );
 
 			} );
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -7,9 +7,11 @@ import { ImageLoader } from './ImageLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { Loader } from './Loader.js';
 
-function TextureLoader( manager ) {
+function TextureLoader( manager, imageLoader ) {
 
 	Loader.call( this, manager );
+
+	this.imageLoader = imageLoader || new ImageLoader( manager );
 
 }
 
@@ -21,7 +23,7 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		const texture = new Texture();
 
-		const loader = new ImageLoader( this.manager );
+		const loader = this.imageLoader;
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -7,7 +7,7 @@ import { ImageLoader } from './ImageLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { Loader } from './Loader.js';
 
-function TextureLoader( manager, imageLoader ) {
+function TextureLoader( manager ) {
 
 	Loader.call( this, manager );
 
@@ -23,7 +23,7 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		const texture = new Texture();
 
-		if ( !this.imageLoader ) {
+		if ( ! this.imageLoader ) {
 
 			this.imageLoader = new ImageLoader( this.manager );
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -11,7 +11,7 @@ function TextureLoader( manager, imageLoader ) {
 
 	Loader.call( this, manager );
 
-	this.imageLoader = imageLoader || new ImageLoader( manager );
+	this.imageLoader = null;
 
 }
 
@@ -22,6 +22,12 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 	load: function ( url, onLoad, onProgress, onError ) {
 
 		const texture = new Texture();
+
+		if ( !this.imageLoader ) {
+
+			this.imageLoader = new ImageLoader( this.manager );
+
+		}
 
 		const loader = this.imageLoader;
 		loader.setCrossOrigin( this.crossOrigin );
@@ -46,6 +52,13 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		}, onProgress, onError );
 
 		return texture;
+
+	},
+
+	setImageLoader: function ( imageLoader ) {
+
+		this.imageLoader = imageLoader;
+		return this;
 
 	}
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -11,8 +11,6 @@ function TextureLoader( manager ) {
 
 	Loader.call( this, manager );
 
-	this.imageLoader = null;
-
 }
 
 TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
@@ -23,13 +21,7 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		const texture = new Texture();
 
-		if ( ! this.imageLoader ) {
-
-			this.imageLoader = new ImageLoader( this.manager );
-
-		}
-
-		const loader = this.imageLoader;
+		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 
@@ -52,13 +44,6 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		}, onProgress, onError );
 
 		return texture;
-
-	},
-
-	setImageLoader: function ( imageLoader ) {
-
-		this.imageLoader = imageLoader;
-		return this;
 
 	}
 


### PR DESCRIPTION
Fixes #19511

This is one potential approach for allowing GLTFLoader to utilize ImageBitmaps, which significantly reduce stalls in rendering when uploading textures to the GPU. Alternatively, if allowing a custom ImageLoader to be supplied to the TextureLoader is not desirable, we could use ImageBitmapLoader and CanvasTexture in this class directly when ImageBitmaps are supported and fallback to TextureLoader otherwise.

The reason this is limited to GLTFLoader for now is that ImageBitmap-based textures don't support Y-flipping in the same way that the traditional approach does. If a workaround is figured out for that then ImageBitmaps could be used more widely.