### PR TITLE
BufferGeometry: Retain interleaved data when using .toJSON().

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1026,7 +1026,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			const attribute = attributes[ key ];
 
-			const attributeData = attribute.toJSON();
+			const attributeData = attribute.toJSON( data.data, false );
 
 			if ( attribute.name !== '' ) attributeData.name = attribute.name;
 
@@ -1047,7 +1047,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				const attribute = attributeArray[ i ];
 
-				const attributeData = attribute.toJSON();
+				const attributeData = attribute.toJSON( data.data, false );
 
 				if ( attribute.name !== '' ) attributeData.name = attribute.name;
 

--- a/src/core/InterleavedBuffer.d.ts
+++ b/src/core/InterleavedBuffer.d.ts
@@ -16,6 +16,7 @@ export class InterleavedBuffer {
 	length: number;
 	count: number;
 	needsUpdate: boolean;
+	uuid: string;
 
 	setUsage( usage: Usage ): InterleavedBuffer;
 	clone(): this;
@@ -26,5 +27,11 @@ export class InterleavedBuffer {
 		index2: number
 	): InterleavedBuffer;
 	set( value: ArrayLike<number>, index: number ): InterleavedBuffer;
+	toJSON( data: object ): {
+		uuid: string,
+		buffer: string,
+		type: string,
+		stride: number
+	};
 
 }

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -112,7 +112,7 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		if ( data.arrayBuffers[ this.array.buffer._uuid ] === undefined ) {
 
-			data.arrayBuffers[ this.array.buffer._uuid ] = arrayBufferToBase64( this.array.buffer );
+			data.arrayBuffers[ this.array.buffer._uuid ] = Array.prototype.slice.call( new Uint32Array( this.array.buffer ) );
 
 		}
 
@@ -128,21 +128,5 @@ Object.assign( InterleavedBuffer.prototype, {
 	}
 
 } );
-
-function arrayBufferToBase64( buffer ) {
-
-	let binary = '';
-	const bytes = new Uint8Array( buffer );
-
-	for ( let i = 0, l = bytes.byteLength; i < l; i ++ ) {
-
-		binary += String.fromCharCode( bytes[ i ] );
-
-	}
-
-	return window.btoa( binary );
-
-}
-
 
 export { InterleavedBuffer };

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -1,3 +1,4 @@
+import { MathUtils } from '../math/MathUtils.js';
 import { StaticDrawUsage } from '../constants.js';
 
 /**
@@ -14,6 +15,8 @@ function InterleavedBuffer( array, stride ) {
 	this.updateRange = { offset: 0, count: - 1 };
 
 	this.version = 0;
+
+	this.uuid = MathUtils.generateUUID();
 
 }
 
@@ -89,9 +92,57 @@ Object.assign( InterleavedBuffer.prototype, {
 
 		return this;
 
+	},
+
+	toJSON: function ( data ) {
+
+		if ( data.arrayBuffers === undefined ) {
+
+			data.arrayBuffers = {};
+
+		}
+
+		// generate UUID for array buffer if necessary
+
+		if ( this.array.buffer._uuid === undefined ) {
+
+			this.array.buffer._uuid = MathUtils.generateUUID();
+
+		}
+
+		if ( data.arrayBuffers[ this.array.buffer._uuid ] === undefined ) {
+
+			data.arrayBuffers[ this.array.buffer._uuid ] = arrayBufferToBase64( this.array.buffer );
+
+		}
+
+		//
+
+		return {
+			uuid: this.uuid,
+			buffer: this.array.buffer._uuid,
+			type: this.array.constructor.name,
+			stride: this.stride
+		};
+
 	}
 
 } );
+
+function arrayBufferToBase64( buffer ) {
+
+	let binary = '';
+	const bytes = new Uint8Array( buffer );
+
+	for ( let i = 0, l = bytes.byteLength; i < l; i ++ ) {
+
+		binary += String.fromCharCode( bytes[ i ] );
+
+	}
+
+	return window.btoa( binary );
+
+}
 
 
 export { InterleavedBuffer };

--- a/src/core/InterleavedBufferAttribute.d.ts
+++ b/src/core/InterleavedBufferAttribute.d.ts
@@ -48,10 +48,11 @@ export class InterleavedBufferAttribute {
 		z: number,
 		w: number
 	): InterleavedBufferAttribute;
-	toJSON(): {
+	toJSON( data: object, deinterleave: boolean ): {
+		isInterleavedBufferAttribute: true,
 		itemSize: number,
-		type: string,
-		array: number[],
+		data: string,
+		offset: number,
 		normalized: boolean
 	};
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -179,32 +179,60 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 
 	},
 
-	toJSON: function () {
+	toJSON: function ( data = null, deinterleave = true ) {
 
-		console.log( 'THREE.InterleavedBufferAttribute.toJSON(): Serializing an interlaved buffer attribute will deinterleave buffer data.' );
+		if ( deinterleave === true ) {
 
-		const array = [];
+			console.log( 'THREE.InterleavedBufferAttribute.toJSON(): Serializing an interlaved buffer attribute will deinterleave buffer data.' );
 
-		for ( let i = 0; i < this.count; i ++ ) {
+			const array = [];
 
-			const index = i * this.data.stride + this.offset;
+			for ( let i = 0; i < this.count; i ++ ) {
 
-			for ( let j = 0; j < this.itemSize; j ++ ) {
+				const index = i * this.data.stride + this.offset;
 
-				array.push( this.data.array[ index + j ] );
+				for ( let j = 0; j < this.itemSize; j ++ ) {
+
+					array.push( this.data.array[ index + j ] );
+
+				}
 
 			}
 
+			// deinterleave data and save it as an ordinary buffer attribute for now
+
+			return {
+				itemSize: this.itemSize,
+				type: this.array.constructor.name,
+				array: array,
+				normalized: this.normalized
+			};
+
+		} else {
+
+			// save as true interlaved attribtue
+
+			if ( data.interleavedBuffers === undefined ) {
+
+				data.interleavedBuffers = {};
+
+			}
+
+			if ( data.interleavedBuffers[ this.data.uuid ] === undefined ) {
+
+				data.interleavedBuffers[ this.data.uuid ] = this.data.toJSON( data );
+
+			}
+
+			return {
+				isInterleavedBufferAttribute: true,
+				itemSize: this.itemSize,
+				data: this.data.uuid,
+				offset: this.offset,
+				normalized: this.normalized
+			};
+
 		}
-
-		// deinterleave data and save it as an ordinary buffer attribute for now
-
-		return {
-			itemSize: this.itemSize,
-			type: this.array.constructor.name,
-			array: array,
-			normalized: this.normalized
-		};
 
 	}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -86,7 +86,7 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 			const arrayBuffers = json.arrayBuffers;
 			const arrayBuffer = arrayBuffers[ uuid ];
 
-			const ab = base64ToArrayBuffer( arrayBuffer );
+			const ab = new Uint32Array( arrayBuffer ).buffer;
 
 			arrayBufferMap[ uuid ] = ab;
 
@@ -214,22 +214,6 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 	}
 
 } );
-
-function base64ToArrayBuffer( base64 ) {
-
-	const binaryString = window.atob( base64 );
-	const length = binaryString.length;
-	const bytes = new Uint8Array( length );
-
-	for ( let i = 0; i < length; i ++ ) {
-
-		bytes[ i ] = binaryString.charCodeAt( i );
-
-	}
-
-	return bytes.buffer;
-
-}
 
 const TYPED_ARRAYS = {
 	Int8Array: Int8Array,

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -6,6 +6,8 @@ import { FileLoader } from './FileLoader.js';
 import { Loader } from './Loader.js';
 import { InstancedBufferGeometry } from '../core/InstancedBufferGeometry.js';
 import { InstancedBufferAttribute } from '../core/InstancedBufferAttribute.js';
+import { InterleavedBufferAttribute } from '../core/InterleavedBufferAttribute.js';
+import { InterleavedBuffer } from '../core/InterleavedBuffer.js';
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -55,6 +57,43 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 
 	parse: function ( json ) {
 
+		const interleavedBufferMap = {};
+		const arrayBufferMap = {};
+
+		function getInterleavedBuffer( json, uuid ) {
+
+			if ( interleavedBufferMap[ uuid ] !== undefined ) return interleavedBufferMap[ uuid ];
+
+			const interleavedBuffers = json.interleavedBuffers;
+			const interleavedBuffer = interleavedBuffers[ uuid ];
+
+			const buffer = getArrayBuffer( json, interleavedBuffer.buffer );
+
+			const array = new TYPED_ARRAYS[ interleavedBuffer.type ]( buffer );
+			const ib = new InterleavedBuffer( array, interleavedBuffer.stride );
+			ib.uuid = interleavedBuffer.uuid;
+
+			interleavedBufferMap[ uuid ] = ib;
+
+			return ib;
+
+		}
+
+		function getArrayBuffer( json, uuid ) {
+
+			if ( arrayBufferMap[ uuid ] !== undefined ) return arrayBufferMap[ uuid ];
+
+			const arrayBuffers = json.arrayBuffers;
+			const arrayBuffer = arrayBuffers[ uuid ];
+
+			const ab = base64ToArrayBuffer( arrayBuffer );
+
+			arrayBufferMap[ uuid ] = ab;
+
+			return ab;
+
+		}
+
 		const geometry = json.isInstancedBufferGeometry ? new InstancedBufferGeometry() : new BufferGeometry();
 
 		const index = json.data.index;
@@ -71,9 +110,21 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 		for ( const key in attributes ) {
 
 			const attribute = attributes[ key ];
-			const typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
-			const bufferAttributeConstr = attribute.isInstancedBufferAttribute ? InstancedBufferAttribute : BufferAttribute;
-			const bufferAttribute = new bufferAttributeConstr( typedArray, attribute.itemSize, attribute.normalized );
+			let bufferAttribute;
+
+			if ( attribute.isInterleavedBufferAttribute ) {
+
+				const interleavedBuffer = getInterleavedBuffer( json.data, attribute.data );
+				bufferAttribute = new InterleavedBufferAttribute( interleavedBuffer, attribute.itemSize, attribute.offset, attribute.normalized );
+
+			} else {
+
+				const typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+				const bufferAttributeConstr = attribute.isInstancedBufferAttribute ? InstancedBufferAttribute : BufferAttribute;
+				bufferAttribute = new bufferAttributeConstr( typedArray, attribute.itemSize, attribute.normalized );
+
+			}
+
 			if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
 			geometry.setAttribute( key, bufferAttribute );
 
@@ -92,9 +143,20 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 				for ( let i = 0, il = attributeArray.length; i < il; i ++ ) {
 
 					const attribute = attributeArray[ i ];
-					const typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+					let bufferAttribute;
 
-					const bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
+					if ( attribute.isInterleavedBufferAttribute ) {
+
+						const interleavedBuffer = getInterleavedBuffer( json.data, attribute.data );
+						bufferAttribute = new InterleavedBufferAttribute( interleavedBuffer, attribute.itemSize, attribute.offset, attribute.normalized );
+
+					} else {
+
+						const typedArray = new TYPED_ARRAYS[ attribute.type ]( attribute.array );
+						bufferAttribute = new BufferAttribute( typedArray, attribute.itemSize, attribute.normalized );
+
+					}
+
 					if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
 					array.push( bufferAttribute );
 
@@ -152,6 +214,22 @@ BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype 
 	}
 
 } );
+
+function base64ToArrayBuffer( base64 ) {
+
+	const binaryString = window.atob( base64 );
+	const length = binaryString.length;
+	const bytes = new Uint8Array( length );
+
+	for ( let i = 0; i < length; i ++ ) {
+
+		bytes[ i ] = binaryString.charCodeAt( i );
+
+	}
+
+	return bytes.buffer;
+
+}
 
 const TYPED_ARRAYS = {
 	Int8Array: Int8Array,


### PR DESCRIPTION
Related #19486.

This PR adds support for retaining interleaved data when using `BufferGeometry.toJSON()`. I'd like to add the enhancement for `BufferGeometry.clone()` in a separate PR since this one is complex enough.

The implementation is outlined here: https://github.com/mrdoob/three.js/pull/19233#issuecomment-636933850