### PR TITLE
Fix css of startButton for device orientation examples

### DIFF
--- a/examples/css3d_panorama_deviceorientation.html
+++ b/examples/css3d_panorama_deviceorientation.html
@@ -8,10 +8,7 @@
 	</head>
 	<body>
 		<div id="overlay">
-			<div>
-				<button id="startButton">Start Demo</button>
-				<p>Using device orientation might require a user interaction.</p>
-			</div>
+			<button id="startButton">Start Demo</button>
 		</div>
 		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> css3d - panorama - device orientation.<br/>cubemap by <a href="http://www.humus.name/index.php?page=Textures" target="_blank" rel="noopener">Humus</a>.</div>
 

--- a/examples/misc_controls_deviceorientation.html
+++ b/examples/misc_controls_deviceorientation.html
@@ -8,10 +8,7 @@
 	</head>
 	<body>
 		<div id="overlay">
-			<div>
-				<button id="startButton">Start Demo</button>
-				<p>Using device orientation might require a user interaction.</p>
-			</div>
+			<button id="startButton">Start Demo</button>
 		</div>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - equirectangular panorama demo with DeviceOrientation controls.<br/>


### PR DESCRIPTION
In commit bc20838ed3df26c58bf74b2ccceee2fe920731d5 some examples were left out from the markup updates, making them look wonky. This fixes it.

### Before

<img width="310" alt="Screenshot 2020-06-02 at 22 17 30" src="https://user-images.githubusercontent.com/7217420/83566487-60376100-a520-11ea-8802-37a852cabd49.png">


### After

<img width="350" alt="Screenshot 2020-06-02 at 22 19 54" src="https://user-images.githubusercontent.com/7217420/83566507-66c5d880-a520-11ea-9f58-efb88416359f.png">
