### PR TITLE
Examples: Clean up JSM.

### DIFF
--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -1076,8 +1076,7 @@ THREE.MMDLoader = ( function () {
 
 							params.envMap = this._loadTexture(
 								fileNames[ 1 ],
-								textures,
-								{ sphericalReflectionMapping: true }
+								textures
 							);
 
 							params.combine = extension === '.sph'
@@ -1128,7 +1127,7 @@ THREE.MMDLoader = ( function () {
 
 						params.envMap = this._loadTexture(
 							data.textures[ material.envTextureIndex ],
-							textures, { sphericalReflectionMapping: true }
+							textures
 						);
 
 						params.combine = material.envFlag === 1
@@ -1343,12 +1342,6 @@ THREE.MMDLoader = ( function () {
 				delete texture.readyCallbacks;
 
 			}, onProgress, onError );
-
-			if ( params.sphericalReflectionMapping === true ) {
-
-				texture.mapping = THREE.SphericalReflectionMapping;
-
-			}
 
 			texture.readyCallbacks = [];
 

--- a/examples/js/utils/UVsDebug.js
+++ b/examples/js/utils/UVsDebug.js
@@ -34,13 +34,13 @@ THREE.UVsDebug = function ( geometry, size ) {
 	canvas.height = height;
 
 	var ctx = canvas.getContext( '2d' );
-	ctx.lineWidth = 2;
-	ctx.strokeStyle = 'rgba( 0, 0, 0, 1.0 )';
+	ctx.lineWidth = 1;
+	ctx.strokeStyle = 'rgb( 63, 63, 63 )';
 	ctx.textAlign = 'center';
 
 	// paint background white
 
-	ctx.fillStyle = 'rgba( 255, 255, 255, 1.0 )';
+	ctx.fillStyle = 'rgb( 255, 255, 255 )';
 	ctx.fillRect( 0, 0, width, height );
 
 	if ( geometry.isGeometry ) {
@@ -129,11 +129,11 @@ THREE.UVsDebug = function ( geometry, size ) {
 
 			if ( j === 0 ) {
 
-				ctx.moveTo( uv.x * width, ( 1 - uv.y ) * height );
+				ctx.moveTo( uv.x * ( width - 2 ) + 0.5, ( 1 - uv.y ) * ( height - 2 ) + 0.5 );
 
 			} else {
 
-				ctx.lineTo( uv.x * width, ( 1 - uv.y ) * height );
+				ctx.lineTo( uv.x * ( width - 2 ) + 0.5, ( 1 - uv.y ) * ( height - 2 ) + 0.5 );
 
 			}
 
@@ -148,8 +148,8 @@ THREE.UVsDebug = function ( geometry, size ) {
 
 		// label the face number
 
-		ctx.font = '12pt Arial bold';
-		ctx.fillStyle = 'rgba( 0, 0, 0, 1.0 )';
+		ctx.font = '18px Arial';
+		ctx.fillStyle = 'rgb( 63, 63, 63 )';
 		ctx.fillText( index, a.x * width, ( 1 - a.y ) * height );
 
 		if ( a.x > 0.95 ) {
@@ -162,8 +162,8 @@ THREE.UVsDebug = function ( geometry, size ) {
 
 		//
 
-		ctx.font = '8pt Arial bold';
-		ctx.fillStyle = 'rgba( 0, 0, 0, 1.0 )';
+		ctx.font = '12px Arial';
+		ctx.fillStyle = 'rgb( 191, 191, 191 )';
 
 		// label uv edge orders
 

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -1110,8 +1110,7 @@ var MMDLoader = ( function () {
 
 							params.envMap = this._loadTexture(
 								fileNames[ 1 ],
-								textures,
-								{ sphericalReflectionMapping: true }
+								textures
 							);
 
 							params.combine = extension === '.sph'
@@ -1162,7 +1161,7 @@ var MMDLoader = ( function () {
 
 						params.envMap = this._loadTexture(
 							data.textures[ material.envTextureIndex ],
-							textures, { sphericalReflectionMapping: true }
+							textures
 						);
 
 						params.combine = material.envFlag === 1
@@ -1377,12 +1376,6 @@ var MMDLoader = ( function () {
 				delete texture.readyCallbacks;
 
 			}, onProgress, onError );
-
-			if ( params.sphericalReflectionMapping === true ) {
-
-				texture.mapping = SphericalReflectionMapping;
-
-			}
 
 			texture.readyCallbacks = [];
 


### PR DESCRIPTION
- Updates `examples/js/utils/UVsDebug.js` (b2eaf43e202d92ef3ea5f122cdbf44a0e501f67a only updated the module version)
- Same for `MMDLoader`. Also removed the code related to `SphericalReflectionMapping` (see #19517). @takahirox Please revisit the `Texture.mapping` configuration in `MMDLoader`.