### PR TITLE
BasisTextureLoader: Support repeated loading of same texture

### DIFF
--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -112,30 +112,15 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 		loader.load( url, ( buffer ) => {
 
-			var taskKey = JSON.stringify( url );
-
 			// Check for an existing task using this buffer. A transferred buffer cannot be transferred
 			// again from this thread.
 			if ( THREE.BasisTextureLoader.taskCache.has( buffer ) ) {
 
 				var cachedTask = THREE.BasisTextureLoader.taskCache.get( buffer );
 
-				if ( cachedTask.key === taskKey ) {
+				if ( cachedTask.url === url ) {
 
 					return cachedTask.promise.then( onLoad ).catch( onError );
-
-				} else if ( buffer.byteLength === 0 ) {
-
-					// Technically, it would be possible to wait for the previous task to complete,
-					// transfer the buffer back, and decode again with the second configuration. That
-					// is complex, and I don't know of any reason to decode a Basis buffer twice in
-					// different ways, so this is left unimplemented.
-					throw new Error(
-
-						'THREE.BasisTextureLoader: Unable to re-decode a buffer with different ' +
-						'settings. Buffer has already been transferred.'
-
-					);
 
 				}
 
@@ -233,12 +218,10 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 			} );
 
-		var taskKey = JSON.stringify( url );
-
 		// Cache the task result.
 		THREE.BasisTextureLoader.taskCache.set( buffer, {
 
-			key: taskKey,
+			url: url,
 			promise: texturePending
 
 		} );

--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -118,11 +118,7 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 				var cachedTask = THREE.BasisTextureLoader.taskCache.get( buffer );
 
-				if ( cachedTask.url === url ) {
-
-					return cachedTask.promise.then( onLoad ).catch( onError );
-
-				}
+				return cachedTask.promise.then( onLoad ).catch( onError );
 
 			}
 

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -125,30 +125,15 @@ BasisTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ),
 
 		loader.load( url, ( buffer ) => {
 
-			var taskKey = JSON.stringify( url );
-
 			// Check for an existing task using this buffer. A transferred buffer cannot be transferred
 			// again from this thread.
 			if ( BasisTextureLoader.taskCache.has( buffer ) ) {
 
 				var cachedTask = BasisTextureLoader.taskCache.get( buffer );
 
-				if ( cachedTask.key === taskKey ) {
+				if ( cachedTask.url === url ) {
 
 					return cachedTask.promise.then( onLoad ).catch( onError );
-
-				} else if ( buffer.byteLength === 0 ) {
-
-					// Technically, it would be possible to wait for the previous task to complete,
-					// transfer the buffer back, and decode again with the second configuration. That
-					// is complex, and I don't know of any reason to decode a Basis buffer twice in
-					// different ways, so this is left unimplemented.
-					throw new Error(
-
-						'THREE.BasisTextureLoader: Unable to re-decode a buffer with different ' +
-						'settings. Buffer has already been transferred.'
-
-					);
 
 				}
 
@@ -246,12 +231,10 @@ BasisTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ),
 
 			} );
 
-		var taskKey = JSON.stringify( url );
-
 		// Cache the task result.
 		BasisTextureLoader.taskCache.set( buffer, {
 
-			key: taskKey,
+			url: url,
 			promise: texturePending
 
 		} );

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -131,11 +131,7 @@ BasisTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ),
 
 				var cachedTask = BasisTextureLoader.taskCache.get( buffer );
 
-				if ( cachedTask.url === url ) {
-
-					return cachedTask.promise.then( onLoad ).catch( onError );
-
-				}
+				return cachedTask.promise.then( onLoad ).catch( onError );
 
 			}
 


### PR DESCRIPTION
This PR takes code from DRACOLoader (#18136) by @donmccurdy and fixes loading of the same texture.

Issue description from #17546 by @jespertheend:
> I'm trying to replicate the issue in the example, but when I call `BasisTextureLoader.load()` more than once I get an error `Uncaught (in promise) DOMException: Failed to execute 'postMessage' on 'Worker': ArrayBuffer at index 0 is already detached.` Are you not supposed to reuse the same loader multiple times.

Issue examples:
http://upisfr.ee/three-basis/broken/
http://upisfr.ee/three-basis/fixed/