### PR TITLE
CI: Dynamically replace Math.random() with seeded random.

### DIFF
--- a/test/e2e/deterministic-injection.js
+++ b/test/e2e/deterministic-injection.js
@@ -7,7 +7,14 @@
 	/* Deterministic random */
 
 	let seed = Math.PI / 4;
-	window.Math.random = function () {
+	window._random = function() {
+
+		/*
+		try { throw new Error; }
+		catch(e) {
+			console.log(e.stack);
+		}
+		*/
 
 		const x = Math.sin( seed ++ ) * 10000;
 		return x - Math.floor( x );

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -75,6 +75,7 @@ const pup = puppeteer.launch( {
 	headless: ! process.env.VISIBLE,
 	args: [
 		'--use-gl=swiftshader',
+		'--disable-web-security',
 		'--no-sandbox',
 		'--enable-surface-synchronization'
 	]
@@ -142,7 +143,12 @@ const pup = puppeteer.launch( {
 
 			try {
 
-				await page.goto( `http://localhost:${ port }/examples/${ file }.html`, {
+				let html = fs.readFileSync( `examples/${ file }.html`, 'utf8' );
+				html = html.replace( /Math\.random/g, '_random' );
+				html = html.replace( '<head>', `<head><base href="http://localhost:${ port }/examples/">` );
+
+				await page.reload();
+				await page.setContent( html, {
 					waitUntil: 'networkidle2',
 					timeout: networkTimeout * attemptProgress
 				} );


### PR DESCRIPTION
This PR replaces`Math.random()` with a deterministic random dynamically when loading each example. The library's internal usage of `Math.random()` no longer interferes.

/ping @munrocket 