### PR TITLE
CI: Add ignores for the command npm install --prefix test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ npm-debug.log
 .jshintrc
 .vs/
 
+# npm install --prefix test adds files in the test folder.
+# There are 2 kindsof files, those without extension and those with cmd extension.
+# To ignore files without a extension, following precedure is nessecary:
+# - ignore all files in the test folder
+# - unignore all files in subdirectories of the test folder
+# - unignore all files with an extension in the test folder
 test/*
 !test/*/
 !test/*.*

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@
 npm-debug.log
 .jshintrc
 .vs/
-**/node_modules
+
+test/*
+!test/*/
+!test/*.*
+test/*.cmd
 test/unit/build
+
+
+**/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ npm-debug.log
 .jshintrc
 .vs/
 
-# npm install --prefix test adds files in the test folder (https://docs.npmjs.com/configuring-npm/folders.html#executables).
-# There are 2 kindsof files, those without extension and those with cmd extension.
-# To ignore files without a extension, following precedure is nessecary:
+# The command'npm install --prefix test' adds files in the test folder (https://docs.npmjs.com/configuring-npm/folders.html#executables).
+# There are 2 kinds of files, those without extension and those with cmd extension.
+# To ignore files without a extension, following procedure is nessecary:
 # - ignore all files in the test folder
 # - unignore all files in subdirectories of the test folder
 # - unignore all files with an extension in the test folder

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ npm-debug.log
 .jshintrc
 .vs/
 
-# npm install --prefix test adds files in the test folder.
+# npm install --prefix test adds files in the test folder (https://docs.npmjs.com/configuring-npm/folders.html#executables).
 # There are 2 kindsof files, those without extension and those with cmd extension.
 # To ignore files without a extension, following precedure is nessecary:
 # - ignore all files in the test folder


### PR DESCRIPTION
When running Tests, we need additional packages which get loaded by following command: 'npm install --prefix test'. This produces extra files which aren't ignored by the gitignore file. This is caused by npm because npm reacts differently with a prefix on Executables. See more in following [link](https://docs.npmjs.com/configuring-npm/folders.html#executables)

### To Reproduce:
- run 'npm install --prefix test'
- run 'git status'

### Issue
- There are 14 files ready to be staged.
![image](https://user-images.githubusercontent.com/155535/83703309-7112d000-a60f-11ea-9841-6a1a694a8f1a.png)

### Solution 
- Ignore such files with git ignore like we do for npm install without prefix 