### PR TITLE
Unit Tests: NothingsIsExportedYet means nothing is exported

### DIFF
--- a/test/unit/editor/Command.tests.js
+++ b/test/unit/editor/Command.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Command';
+import { } from '../../../editor/js/Command';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Config.tests.js
+++ b/test/unit/editor/Config.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Config';
+import { } from '../../../editor/js/Config';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Editor.tests.js
+++ b/test/unit/editor/Editor.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Editor';
+import { } from '../../../editor/js/Editor';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/History.tests.js
+++ b/test/unit/editor/History.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/History';
+import { } from '../../../editor/js/History';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Loader.tests.js
+++ b/test/unit/editor/Loader.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Loader';
+import { } from '../../../editor/js/Loader';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Add.tests.js
+++ b/test/unit/editor/Menubar.Add.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Add';
+import { } from '../../../editor/js/Menubar.Add';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Edit.tests.js
+++ b/test/unit/editor/Menubar.Edit.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Edit';
+import { } from '../../../editor/js/Menubar.Edit';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Examples.tests.js
+++ b/test/unit/editor/Menubar.Examples.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Examples';
+import { } from '../../../editor/js/Menubar.Examples';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.File.tests.js
+++ b/test/unit/editor/Menubar.File.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.File';
+import { } from '../../../editor/js/Menubar.File';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Help.tests.js
+++ b/test/unit/editor/Menubar.Help.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Help';
+import { } from '../../../editor/js/Menubar.Help';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Play.tests.js
+++ b/test/unit/editor/Menubar.Play.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Play';
+import { } from '../../../editor/js/Menubar.Play';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.Status.tests.js
+++ b/test/unit/editor/Menubar.Status.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.Status';
+import { } from '../../../editor/js/Menubar.Status';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.View.tests.js
+++ b/test/unit/editor/Menubar.View.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar.View';
+import { } from '../../../editor/js/Menubar.View';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Menubar.tests.js
+++ b/test/unit/editor/Menubar.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Menubar';
+import { } from '../../../editor/js/Menubar';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Player.tests.js
+++ b/test/unit/editor/Player.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Player';
+import { } from '../../../editor/js/Player';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Script.tests.js
+++ b/test/unit/editor/Script.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Script';
+import { } from '../../../editor/js/Script';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Animation.tests.js
+++ b/test/unit/editor/Sidebar.Animation.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Animation';
+import { } from '../../../editor/js/Sidebar.Animation';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.BoxGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.BoxGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.BoxGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.BoxGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.BufferGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.BufferGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.BufferGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.BufferGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.CircleGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.CircleGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.CircleGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.CircleGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.CylinderGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.CylinderGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.CylinderGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.CylinderGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.Geometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.Geometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry';
+import { } from '../../../editor/js/Sidebar.Geometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.IcosahedronGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.IcosahedronGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.IcosahedronGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.IcosahedronGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.LatheGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.LatheGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.LatheGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.LatheGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.Modifiers.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.Modifiers.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.Modifiers';
+import { } from '../../../editor/js/Sidebar.Geometry.Modifiers';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.PlaneGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.PlaneGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.PlaneGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.PlaneGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.SphereGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.SphereGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.SphereGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.SphereGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.TeapotBufferGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.TeapotBufferGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.TeapotBufferGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.TeapotBufferGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.TorusGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.TorusGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.TorusGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.TorusGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.TorusKnotGeometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.TorusKnotGeometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry.TorusKnotGeometry';
+import { } from '../../../editor/js/Sidebar.Geometry.TorusKnotGeometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Geometry.tests.js
+++ b/test/unit/editor/Sidebar.Geometry.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Geometry';
+import { } from '../../../editor/js/Sidebar.Geometry';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.History.tests.js
+++ b/test/unit/editor/Sidebar.History.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.History';
+import { } from '../../../editor/js/Sidebar.History';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Material.tests.js
+++ b/test/unit/editor/Sidebar.Material.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Material';
+import { } from '../../../editor/js/Sidebar.Material';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Object.tests.js
+++ b/test/unit/editor/Sidebar.Object.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Object';
+import { } from '../../../editor/js/Sidebar.Object';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Project.tests.js
+++ b/test/unit/editor/Sidebar.Project.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Project';
+import { } from '../../../editor/js/Sidebar.Project';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Properties.tests.js
+++ b/test/unit/editor/Sidebar.Properties.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Properties';
+import { } from '../../../editor/js/Sidebar.Properties';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Scene.tests.js
+++ b/test/unit/editor/Sidebar.Scene.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Scene';
+import { } from '../../../editor/js/Sidebar.Scene';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Script.tests.js
+++ b/test/unit/editor/Sidebar.Script.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Script';
+import { } from '../../../editor/js/Sidebar.Script';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.Settings.tests.js
+++ b/test/unit/editor/Sidebar.Settings.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar.Settings';
+import { } from '../../../editor/js/Sidebar.Settings';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Sidebar.tests.js
+++ b/test/unit/editor/Sidebar.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Sidebar';
+import { } from '../../../editor/js/Sidebar';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Storage.tests.js
+++ b/test/unit/editor/Storage.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Storage';
+import { } from '../../../editor/js/Storage';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Toolbar.tests.js
+++ b/test/unit/editor/Toolbar.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Toolbar';
+import { } from '../../../editor/js/Toolbar';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Viewport.Info.tests.js
+++ b/test/unit/editor/Viewport.Info.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Viewport.Info';
+import { } from '../../../editor/js/Viewport.Info';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/Viewport.tests.js
+++ b/test/unit/editor/Viewport.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../editor/js/Viewport';
+import { } from '../../../editor/js/Viewport';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/AddObjectCommand.tests.js
+++ b/test/unit/editor/commands/AddObjectCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/AddObjectCommand';
+import { } from '../../../../editor/js/commands/AddObjectCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/AddScriptCommand.tests.js
+++ b/test/unit/editor/commands/AddScriptCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/AddScriptCommand';
+import { } from '../../../../editor/js/commands/AddScriptCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/MoveObjectCommand.tests.js
+++ b/test/unit/editor/commands/MoveObjectCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/MoveObjectCommand';
+import { } from '../../../../editor/js/commands/MoveObjectCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/MultiCmdsCommand.tests.js
+++ b/test/unit/editor/commands/MultiCmdsCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/MultiCmdsCommand';
+import { } from '../../../../editor/js/commands/MultiCmdsCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/RemoveObjectCommand.tests.js
+++ b/test/unit/editor/commands/RemoveObjectCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/RemoveObjectCommand';
+import { } from '../../../../editor/js/commands/RemoveObjectCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/RemoveScriptCommand.tests.js
+++ b/test/unit/editor/commands/RemoveScriptCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/RemoveScriptCommand';
+import { } from '../../../../editor/js/commands/RemoveScriptCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetColorCommand.tests.js
+++ b/test/unit/editor/commands/SetColorCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetColorCommand';
+import { } from '../../../../editor/js/commands/SetColorCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetGeometryCommand.tests.js
+++ b/test/unit/editor/commands/SetGeometryCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetGeometryCommand';
+import { } from '../../../../editor/js/commands/SetGeometryCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetGeometryValueCommand.tests.js
+++ b/test/unit/editor/commands/SetGeometryValueCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetGeometryValueCommand';
+import { } from '../../../../editor/js/commands/SetGeometryValueCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetMaterialColorCommand.tests.js
+++ b/test/unit/editor/commands/SetMaterialColorCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetMaterialColorCommand';
+import { } from '../../../../editor/js/commands/SetMaterialColorCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetMaterialCommand.tests.js
+++ b/test/unit/editor/commands/SetMaterialCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetMaterialCommand';
+import { } from '../../../../editor/js/commands/SetMaterialCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetMaterialMapCommand.tests.js
+++ b/test/unit/editor/commands/SetMaterialMapCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetMaterialMapCommand';
+import { } from '../../../../editor/js/commands/SetMaterialMapCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetMaterialValueCommand.tests.js
+++ b/test/unit/editor/commands/SetMaterialValueCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetMaterialValueCommand';
+import { } from '../../../../editor/js/commands/SetMaterialValueCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetPositionCommand.tests.js
+++ b/test/unit/editor/commands/SetPositionCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetPositionCommand';
+import { } from '../../../../editor/js/commands/SetPositionCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetRotationCommand.tests.js
+++ b/test/unit/editor/commands/SetRotationCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetRotationCommand';
+import { } from '../../../../editor/js/commands/SetRotationCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetScaleCommand.tests.js
+++ b/test/unit/editor/commands/SetScaleCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetScaleCommand';
+import { } from '../../../../editor/js/commands/SetScaleCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetSceneCommand.tests.js
+++ b/test/unit/editor/commands/SetSceneCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetSceneCommand';
+import { } from '../../../../editor/js/commands/SetSceneCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetScriptValueCommand.tests.js
+++ b/test/unit/editor/commands/SetScriptValueCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetScriptValueCommand';
+import { } from '../../../../editor/js/commands/SetScriptValueCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetUuidCommand.tests.js
+++ b/test/unit/editor/commands/SetUuidCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetUuidCommand';
+import { } from '../../../../editor/js/commands/SetUuidCommand';
 
 export default QUnit.module( 'Editor', () => {
 

--- a/test/unit/editor/commands/SetValueCommand.tests.js
+++ b/test/unit/editor/commands/SetValueCommand.tests.js
@@ -3,7 +3,7 @@
  */
 /* global QUnit */
 
-import { NothingsIsExportedYet } from '../../../../editor/js/commands/SetValueCommand';
+import { } from '../../../../editor/js/commands/SetValueCommand';
 
 export default QUnit.module( 'Editor', () => {
 


### PR DESCRIPTION
When running the unittests, you get a warning about the import of non-existent exports.

### To Reproduce:
- run 'npm run test-unit'

### Issue
- The '(!) Import of non-existent exports' warning gets sent because the 'NothingsIsExportedYet' export doesn't exist.
![image](https://user-images.githubusercontent.com/155535/83818364-7f242780-a6c7-11ea-8a49-b2843dab2495.png)


### Solution 
- When nothing needs to be imported , then import nothing.