### PR TITLE
Update unit command to search in unit/build folder

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -13,6 +13,7 @@
     "pixelmatch": "^5.2.0",
     "puppeteer": "3.1.0",
     "qunit": "^2.10.0",
+    "rimraf": "^3.0.2",
     "serve-handler": "^6.1.2"
   },
   "license": "MIT"

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && cd unit && ..\\qunit -r failonlyreporter build\\three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && cd unit\\build && ..\\..\\qunit -r failonlyreporter three.source.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && cd unit\\build && ..\\..\\qunit -r failonlyreporter three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && cd unit/build && \"../../qunit\" -r failonlyreporter three.source.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && qunit -r failonlyreporter unit/build/three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && cd unit && ..\\qunit -r failonlyreporter build\\three.source.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && cd unit/build && \"../../qunit\" -r failonlyreporter three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter unit/build/three.source.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",


### PR DESCRIPTION
Running the unit tests on my machine takes upwards of 3 minutes while on the Ci build it takes only 15 seconds.

### To Reproduce:
- Start from fresh install of three.js
- run 'npm install'
- run 'npm install --prefix test'
- run 'npm run test-unit'

### Issue
- Running the command 'npm install --prefix test' creates a node_modules folder which contains a symbolic folder link to the three.js workspace. When qunit starts looking for files to unit test, It also starts running in the node_modules which contains the three.js workspace because it doesn't understand recursive symbolic links. 

### Solution 
- ~~Run the qunit command as close to the file it needs to test.~~ (This doesn't work because of differences in windows and Unix. [Example](https://github.com/mrdoob/three.js/runs/740448941#step:6:52)) 
- Remove the symbolic link to the three.js workspace.