### PR TITLE
Lut: Refactoring API and clean up docs.

### DIFF
--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -17,45 +17,49 @@
 		<h2>Code Example</h2>
 
 		<code>
-		// Lookup predefined colormap 'rainbow'
+		// predefined colormap 'rainbow' lookup
 		var lut = new Lut( 'rainbow', 512 );
 		var color = lut.getColor( 0.5 );
 
-		// Add colormap 'winter'
-		Lut.AddColorMap( 'winter', [
+		// custom colormap lookup
+		var lut = new Lut( [
 			[ 0.0, 0x1019f7 ],
 			[ 0.2, 0x0011e1 ],
 			[ 0.4, 0x115cca ],
 			[ 0.6, 0x33a5c5 ],
 			[ 0.8, 0x25cea5 ],
 			[ 1.0, 0x16f782 ]
-		] );
-
-		// Lookup colormap 'winter'
-		var lut = new Lut( 'winter', 512 );
+		], 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
+		<h3>[name]( [param:String map], [param:Integer numberOfColors] )</h3>
+		<h3>[name]( [param:Array map], [param:Integer numberOfColors] )</h3>
 		<p>
-			colormapName - The name of colormap. Optional, default is "rainbow".
+			map - The name of predefined colormap or Array of color stops. Optional; Default is "rainbow".
 			Other predefined colormaps: "cooltowarm", "blackbody" and "grayscale".<br/>
-			numberOfColors - Number of colors used to represent the data array. Optional, default is 32.
+			numberOfColors - Number of colors used to represent the data array. Optional; Default is 32.
 		</p>
 
 		<h2>Properties</h2>
 
-		<h3>[property:Array lut]</h3>
+		<h3>[property:Array colors]</h3>
 		<p>
-			Array of [page:Color]s.
+			The palette. Array of [page:Color]s
 		</p>
 
 		<h3>[property:Array map]</h3>
 		<p>
-			Array of color stops.
+			The colormap. Array of color stops. Used to construct the palette.
 		</p>
+		<code>
+		// Color stop examples 
+		[ 0.0, 0xff0000 ]
+		[ 0.0, 'red' ]
+		[ 0.0, new Color('red') ]
+		</code>
 
 		<h3>[property:Float minV]</h3>
 		<p>
@@ -67,16 +71,11 @@
 			The maximum value to be represented with the lookup table. Default is 1.
 		</p>
 
-		<h3>[property:Integer n]</h3>
-		<p>
-			Number of colors. Default is 32.
-		</p>
-
 		<h2>Methods</h2>
 
 		<h3>[method:HTMLCanvasElement createCanvas]()</h3>
 		<p>
-			Create a 1x[page:.n n] canvas; Draw colors onto it, from top to bottom.
+			Create a 1px wide canvas filled with [page:.colors].
 		</p>
 
 		<h3>[method:this copy]( [param:Lut lut] )</h3>
@@ -84,7 +83,7 @@
 			lut — Lut to copy.
 		</p>
 		<p>
-			Copies given lut.
+			Copy given lut into this. It is shallow copy, [page:.colors][] and [page:.map][] are shared.
 		</p>
 
 		<h3>[method:Color getColor]( [param:Float alpha] )</h3>
@@ -92,24 +91,20 @@
 			alpha — The data value to be displayed as a color. Clamped between [page:.minV] and [page:.maxV].
 		</p>
 		<p>
-			Pick a [page:Color] from [page:.lut lut][] based on data value, alpha.
+			Pick a [page:Color] from the palette based on data value, alpha.
 		</p>
 
-		<h3>[method:this set]( [param:Object object] )</h3>
+		<h3>[method:this setColorMap]( [param:String map], [param:Integer numberOfColors] )</h3>
+		<h3>[method:this setColorMap]( [param:Array map], [param:Integer numberOfColors] )</h3>
 		<p>
-			If object is a Lut, copy into this.
+			map - The name of predefined colormap or Array of color stops. Default is "rainbow".<br />
+			numberOfColors - Number of colors. Default is 32.
+		</p>
+		<p>
+			Construct a new palette.
 		</p>
 
-		<h3>[method:this setColorMap]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
-		<p>
-			colormapName - The name of colormap.<br />
-			numberOfColors - Number of colors.
-		</p>
-		<p>
-			Set colormap for this lut.
-		</p>
-
-		<h3>[method:Lut setMin]( [param:Float minV] )</h3>
+		<h3>[method:this setMin]( [param:Float minV] )</h3>
 		<p>
 			minV — The minimum value to be represented with the lookup table.
 		</p>
@@ -117,7 +112,7 @@
 			Sets this Lut with the minimum value to be represented.
 		</p>
 
-		<h3>[method:Lut setMax]( [param:Float maxV] )</h3>
+		<h3>[method:this setMax]( [param:Float maxV] )</h3>
 		<p>
 			maxV — The maximum value to be represented with the lookup table.
 		</p>
@@ -130,18 +125,7 @@
 			canvas — Canvas to be updated 
 		</p>
 		<p>
-			Draw colors onto given canvas.
-		</p>
-
-		<h2>Statics</h2>
-
-		<h3>[method:null AddColorMap]( [param:String colormapName], [param:Array arrayOfColorStops] )</h3>
-		<p>
-			colormapName — The name of colormap.<br />
-			arrayOfColorStops — Array of [stop, color] pairs.
-		</p>
-		<p>
-			Insert a new colormap into the set of available colormaps.
+			Draw [page:.colors] onto given canvas.
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -11,135 +11,149 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.
+			Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.
 		</p>
 
 		<h2>Code Example</h2>
 
 		<code>
+		// Lookup predefined colormap 'rainbow'
 		var lut = new Lut( 'rainbow', 512 );
+		var color = lut.getColor( 0.5 );
+
+		// Add colormap 'winter'
+		Lut.AddColorMap( 'winter', [
+			[ 0.0, 0x1019f7 ],
+			[ 0.2, 0x0011e1 ],
+			[ 0.4, 0x115cca ],
+			[ 0.6, 0x33a5c5 ],
+			[ 0.8, 0x25cea5 ],
+			[ 1.0, 0x16f782 ]
+		] );
+
+		// Lookup colormap 'winter'
+		var lut = new Lut( 'winter', 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
 		<h2>Constructor</h2>
 
-
-		<h3>[name]( colormap, numberOfColors )</h3>
+		<h3>[name]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
 		<p>
-		colormap - optional argument that sets a colormap from predefined colormaps. Available colormaps are : "rainbow", "cooltowarm", "blackbody".
-		numberOfColors - optional argument that sets the number of colors used to represent the data array.
+			colormapName - The name of colormap. Optional, default is "rainbow".
+			Other predefined colormaps: "cooltowarm", "blackbody" and "grayscale".<br/>
+			numberOfColors - Number of colors used to represent the data array. Optional, default is 32.
 		</p>
 
 		<h2>Properties</h2>
 
+		<h3>[property:Array lut]</h3>
+		<p>
+			Array of [page:Color]s.
+		</p>
+
+		<h3>[property:Array map]</h3>
+		<p>
+			Array of color stops.
+		</p>
+
 		<h3>[property:Float minV]</h3>
 		<p>
-		The minimum value to be represented with the lookup table. Default is 0.
+			The minimum value to be represented with the lookup table. Default is 0.
 		</p>
 
 		<h3>[property:Float maxV]</h3>
 		<p>
-		The maximum value to be represented with the lookup table. Default is 1.
+			The maximum value to be represented with the lookup table. Default is 1.
 		</p>
 
-		<h3>.[legend]</h3>
+		<h3>[property:Integer n]</h3>
 		<p>
-		The legend of the lookup table.
+			Number of colors. Default is 32.
 		</p>
 
 		<h2>Methods</h2>
 
-		<h3>[method:null copy]( [param:Lut lut] ) [param:Lut this]</h3>
+		<h3>[method:HTMLCanvasElement createCanvas]()</h3>
 		<p>
-		color — Lut to copy.
-		</p>
-		<p>
-		Copies given lut.
+			Create a 1x[page:.n n] canvas; Draw colors onto it, from top to bottom.
 		</p>
 
-		<h3>.setLegendOn [parameters]</h3>
+		<h3>[method:this copy]( [param:Lut lut] )</h3>
 		<p>
-		parameters - { layout: value, position: { x: value, y: value, z: value }, dimensions: { width: value, height: value } }
-		layout — Horizontal or vertical layout. Default is vertical.<br />
-		position — The position x,y,z of the legend.<br />
-		dimensions — The dimensions (width and height) of the legend.<br />
+			lut — Lut to copy.
 		</p>
 		<p>
-		Sets this Lut with the legend on.
+			Copies given lut.
 		</p>
 
-		<h3>.setLegendOff</h3>
+		<h3>[method:Color getColor]( [param:Float alpha] )</h3>
 		<p>
+			alpha — The data value to be displayed as a color. Clamped between [page:.minV] and [page:.maxV].
 		</p>
 		<p>
-		Sets this Lut with the legend off.
+			Pick a [page:Color] from [page:.lut lut][] based on data value, alpha.
 		</p>
 
-    <h3>.setLegendLabels [parameters, callback]</h3>
+		<h3>[method:this set]( [param:Object object] )</h3>
 		<p>
-		parameters - { fontsize: value, fontface: value, title: value, um: value, ticks: value, decimal: value, notation: value }
-		fontsize — Font size to be used for labels.<br />
-		fontface — Font type to be used for labels.<br />
-		title — The title of the legend.<br />
-		um — The unit of measurements of the legend.<br />
-		ticks — The number of ticks to be displayed.<br />
-		decimal — The number of decimals to be used for legend values.<br />
-		notation — Legend notation: standard (default) or scientific.<br />
-		callback — An optional callback to be used to format the legend labels.<br />
+			If object is a Lut, copy into this.
+		</p>
+
+		<h3>[method:this setColorMap]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
+		<p>
+			colormapName - The name of colormap.<br />
+			numberOfColors - Number of colors.
 		</p>
 		<p>
-		Sets the labels of the legend of this Lut.
+			Set colormap for this lut.
 		</p>
 
 		<h3>[method:Lut setMin]( [param:Float minV] )</h3>
 		<p>
-		minV — The minimum value to be represented with the lookup table.<br />
+			minV — The minimum value to be represented with the lookup table.
 		</p>
 		<p>
-		Sets this Lut with the minimum value to be represented.
+			Sets this Lut with the minimum value to be represented.
 		</p>
 
 		<h3>[method:Lut setMax]( [param:Float maxV] )</h3>
 		<p>
-		maxV — The maximum value to be represented with the lookup table.<br />
+			maxV — The maximum value to be represented with the lookup table.
 		</p>
 		<p>
-		Sets this Lut with the maximum value to be represented.
-		</p>
-
-		<h3>[method:Lut changeNumberOfColors]( [param:Float numberOfColors] )</h3>
-		<p>
-		numberOfColors — The number of colors to be used to represent the data array.<br />
-		</p>
-		<p>
-		Sets this Lut with the number of colors to be used.
+			Sets this Lut with the maximum value to be represented.
 		</p>
 
-		<h3>[method:Lut changeColorMap]( [param:Float colorMap] )</h3>
+		<h3>[method:HTMLCanvasElement updateCanvas]( [param:HTMLCanvasElement canvas] )</h3>
 		<p>
-		colorMap — The name of the color map to be used to represent the data array.<br />
+			canvas — Canvas to be updated 
 		</p>
 		<p>
-		Sets this Lut with the colormap to be used.
-		</p>
-
-		<h3>[method:Lut addColorMap]( colorMapName, arrayOfColors )</h3>
-		<p>
-		Insert a new color map into the set of available color maps.
+			Draw colors onto given canvas.
 		</p>
 
-		<h3>[method:Lut getColor]( value ) [param:Lut this]</h3>
+		<h2>Statics</h2>
+
+		<h3>[method:null AddColorMap]( [param:String colormapName], [param:Array arrayOfColorStops] )</h3>
 		<p>
-		value -- the data value to be displayed as a color.
+			colormapName — The name of colormap.<br />
+			arrayOfColorStops — Array of [stop, color] pairs.
 		</p>
 		<p>
-		Returns a [page:Color].
+			Insert a new colormap into the set of available colormaps.
+		</p>
+
+		<h2>Examples</h2>
+
+		<p>
+			[example:webgl_geometry_colors_lookuptable Geometry / Colors / LookupTable]
 		</p>
 
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/Lut.js examples/jsm/math/Lut.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/Lut.html
+++ b/docs/examples/zh/math/Lut.html
@@ -17,45 +17,49 @@
 		<h2>代码示例</h2>
 
 		<code>
-		// Lookup predefined colormap 'rainbow'
+		// predefined colormap 'rainbow' lookup
 		var lut = new Lut( 'rainbow', 512 );
 		var color = lut.getColor( 0.5 );
 
-		// Add colormap 'winter'
-		Lut.AddColorMap( 'winter', [
+		// custom colormap lookup
+		var lut = new Lut( [
 			[ 0.0, 0x1019f7 ],
 			[ 0.2, 0x0011e1 ],
 			[ 0.4, 0x115cca ],
 			[ 0.6, 0x33a5c5 ],
 			[ 0.8, 0x25cea5 ],
 			[ 1.0, 0x16f782 ]
-		] );
-
-		// Lookup colormap 'winter'
-		var lut = new Lut( 'winter', 512 );
+		], 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
+		<h3>[name]( [param:String map], [param:Integer numberOfColors] )</h3>
+		<h3>[name]( [param:Array map], [param:Integer numberOfColors] )</h3>
 		<p>
-			colormapName - The name of colormap. Optional, default is "rainbow".
+			map - The name of predefined colormap or Array of color stops. Optional; Default is "rainbow".
 			Other predefined colormaps: "cooltowarm", "blackbody" and "grayscale".<br/>
-			numberOfColors - Number of colors used to represent the data array. Optional, default is 32.
+			numberOfColors - Number of colors used to represent the data array. Optional; Default is 32.
 		</p>
 
 		<h2>Properties</h2>
 
-		<h3>[property:Array lut]</h3>
+		<h3>[property:Array colors]</h3>
 		<p>
-			Array of [page:Color]s.
+			The palette. Array of [page:Color]s
 		</p>
 
 		<h3>[property:Array map]</h3>
 		<p>
-			Array of color stops.
+			The colormap. Array of color stops. Used to construct the palette.
 		</p>
+		<code>
+		// Color stop examples 
+		[ 0.0, 0xff0000 ]
+		[ 0.0, 'red' ]
+		[ 0.0, new Color('red') ]
+		</code>
 
 		<h3>[property:Float minV]</h3>
 		<p>
@@ -67,16 +71,11 @@
 			The maximum value to be represented with the lookup table. Default is 1.
 		</p>
 
-		<h3>[property:Integer n]</h3>
-		<p>
-			Number of colors. Default is 32.
-		</p>
-
 		<h2>Methods</h2>
 
 		<h3>[method:HTMLCanvasElement createCanvas]()</h3>
 		<p>
-			Create a 1x[page:.n n] canvas; Draw colors onto it, from top to bottom.
+			Create a 1px wide canvas filled with [page:.colors].
 		</p>
 
 		<h3>[method:this copy]( [param:Lut lut] )</h3>
@@ -84,7 +83,7 @@
 			lut — Lut to copy.
 		</p>
 		<p>
-			Copies given lut.
+			Copy given lut into this. It is shallow copy, [page:.colors][] and [page:.map][] are shared.
 		</p>
 
 		<h3>[method:Color getColor]( [param:Float alpha] )</h3>
@@ -92,24 +91,20 @@
 			alpha — The data value to be displayed as a color. Clamped between [page:.minV] and [page:.maxV].
 		</p>
 		<p>
-			Pick a [page:Color] from [page:.lut lut][] based on data value, alpha.
+			Pick a [page:Color] from the palette based on data value, alpha.
 		</p>
 
-		<h3>[method:this set]( [param:Object object] )</h3>
+		<h3>[method:this setColorMap]( [param:String map], [param:Integer numberOfColors] )</h3>
+		<h3>[method:this setColorMap]( [param:Array map], [param:Integer numberOfColors] )</h3>
 		<p>
-			If object is a Lut, copy into this.
+			map - The name of predefined colormap or Array of color stops. Default is "rainbow".<br />
+			numberOfColors - Number of colors. Default is 32.
+		</p>
+		<p>
+			Construct a new palette.
 		</p>
 
-		<h3>[method:this setColorMap]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
-		<p>
-			colormapName - The name of colormap.<br />
-			numberOfColors - Number of colors.
-		</p>
-		<p>
-			Set colormap for this lut.
-		</p>
-
-		<h3>[method:Lut setMin]( [param:Float minV] )</h3>
+		<h3>[method:this setMin]( [param:Float minV] )</h3>
 		<p>
 			minV — The minimum value to be represented with the lookup table.
 		</p>
@@ -117,7 +112,7 @@
 			Sets this Lut with the minimum value to be represented.
 		</p>
 
-		<h3>[method:Lut setMax]( [param:Float maxV] )</h3>
+		<h3>[method:this setMax]( [param:Float maxV] )</h3>
 		<p>
 			maxV — The maximum value to be represented with the lookup table.
 		</p>
@@ -130,18 +125,7 @@
 			canvas — Canvas to be updated 
 		</p>
 		<p>
-			Draw colors onto given canvas.
-		</p>
-
-		<h2>Statics</h2>
-
-		<h3>[method:null AddColorMap]( [param:String colormapName], [param:Array arrayOfColorStops] )</h3>
-		<p>
-			colormapName — The name of colormap.<br />
-			arrayOfColorStops — Array of [stop, color] pairs.
-		</p>
-		<p>
-			Insert a new colormap into the set of available colormaps.
+			Draw [page:.colors] onto given canvas.
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/examples/zh/math/Lut.html
+++ b/docs/examples/zh/math/Lut.html
@@ -11,135 +11,149 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.
+			Represents a lookup table for colormaps. It is used to determine the color values from a range of data values.
 		</p>
 
-
 		<h2>代码示例</h2>
+
 		<code>
+		// Lookup predefined colormap 'rainbow'
 		var lut = new Lut( 'rainbow', 512 );
+		var color = lut.getColor( 0.5 );
+
+		// Add colormap 'winter'
+		Lut.AddColorMap( 'winter', [
+			[ 0.0, 0x1019f7 ],
+			[ 0.2, 0x0011e1 ],
+			[ 0.4, 0x115cca ],
+			[ 0.6, 0x33a5c5 ],
+			[ 0.8, 0x25cea5 ],
+			[ 1.0, 0x16f782 ]
+		] );
+
+		// Lookup colormap 'winter'
+		var lut = new Lut( 'winter', 512 );
 		var color = lut.getColor( 0.5 );
 		</code>
 
 		<h2>Constructor</h2>
 
-
-		<h3>[name]( colormap, numberOfColors )</h3>
+		<h3>[name]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
 		<p>
-		colormap - optional argument that sets a colormap from predefined colormaps. Available colormaps are : "rainbow", "cooltowarm", "blackbody".
-		numberOfColors - optional argument that sets the number of colors used to represent the data array.
+			colormapName - The name of colormap. Optional, default is "rainbow".
+			Other predefined colormaps: "cooltowarm", "blackbody" and "grayscale".<br/>
+			numberOfColors - Number of colors used to represent the data array. Optional, default is 32.
 		</p>
 
 		<h2>Properties</h2>
 
+		<h3>[property:Array lut]</h3>
+		<p>
+			Array of [page:Color]s.
+		</p>
+
+		<h3>[property:Array map]</h3>
+		<p>
+			Array of color stops.
+		</p>
+
 		<h3>[property:Float minV]</h3>
 		<p>
-		The minimum value to be represented with the lookup table. Default is 0.
+			The minimum value to be represented with the lookup table. Default is 0.
 		</p>
 
 		<h3>[property:Float maxV]</h3>
 		<p>
-		The maximum value to be represented with the lookup table. Default is 1.
+			The maximum value to be represented with the lookup table. Default is 1.
 		</p>
 
-		<h3>.[legend]</h3>
+		<h3>[property:Integer n]</h3>
 		<p>
-		The legend of the lookup table.
+			Number of colors. Default is 32.
 		</p>
 
 		<h2>Methods</h2>
 
-		<h3>[method:null copy]( [param:Lut lut] ) [param:Lut this]</h3>
+		<h3>[method:HTMLCanvasElement createCanvas]()</h3>
 		<p>
-		color — Lut to copy.
-		</p>
-		<p>
-		Copies given lut.
+			Create a 1x[page:.n n] canvas; Draw colors onto it, from top to bottom.
 		</p>
 
-		<h3>.setLegendOn [parameters]</h3>
+		<h3>[method:this copy]( [param:Lut lut] )</h3>
 		<p>
-		parameters - { layout: value, position: { x: value, y: value, z: value }, dimensions: { width: value, height: value } }
-		layout — Horizontal or vertical layout. Default is vertical.<br />
-		position — The position x,y,z of the legend.<br />
-		dimensions — The dimensions (width and height) of the legend.<br />
+			lut — Lut to copy.
 		</p>
 		<p>
-		Sets this Lut with the legend on.
+			Copies given lut.
 		</p>
 
-		<h3>.setLegendOff</h3>
+		<h3>[method:Color getColor]( [param:Float alpha] )</h3>
 		<p>
+			alpha — The data value to be displayed as a color. Clamped between [page:.minV] and [page:.maxV].
 		</p>
 		<p>
-		Sets this Lut with the legend off.
+			Pick a [page:Color] from [page:.lut lut][] based on data value, alpha.
 		</p>
 
-    <h3>.setLegendLabels [parameters, callback]</h3>
+		<h3>[method:this set]( [param:Object object] )</h3>
 		<p>
-		parameters - { fontsize: value, fontface: value, title: value, um: value, ticks: value, decimal: value, notation: value }
-		fontsize — Font size to be used for labels.<br />
-		fontface — Font type to be used for labels.<br />
-		title — The title of the legend.<br />
-		um — The unit of measurements of the legend.<br />
-		ticks — The number of ticks to be displayed.<br />
-		decimal — The number of decimals to be used for legend values.<br />
-		notation — Legend notation: standard (default) or scientific.<br />
-		callback — An optional callback to be used to format the legend labels.<br />
+			If object is a Lut, copy into this.
+		</p>
+
+		<h3>[method:this setColorMap]( [param:String colormapName], [param:Integer numberOfColors] )</h3>
+		<p>
+			colormapName - The name of colormap.<br />
+			numberOfColors - Number of colors.
 		</p>
 		<p>
-		Sets the labels of the legend of this Lut.
+			Set colormap for this lut.
 		</p>
 
 		<h3>[method:Lut setMin]( [param:Float minV] )</h3>
 		<p>
-		minV — The minimum value to be represented with the lookup table.<br />
+			minV — The minimum value to be represented with the lookup table.
 		</p>
 		<p>
-		Sets this Lut with the minimum value to be represented.
+			Sets this Lut with the minimum value to be represented.
 		</p>
 
 		<h3>[method:Lut setMax]( [param:Float maxV] )</h3>
 		<p>
-		maxV — The maximum value to be represented with the lookup table.<br />
+			maxV — The maximum value to be represented with the lookup table.
 		</p>
 		<p>
-		Sets this Lut with the maximum value to be represented.
-		</p>
-
-		<h3>[method:Lut changeNumberOfColors]( [param:Float numberOfColors] )</h3>
-		<p>
-		numberOfColors — The number of colors to be used to represent the data array.<br />
-		</p>
-		<p>
-		Sets this Lut with the number of colors to be used.
+			Sets this Lut with the maximum value to be represented.
 		</p>
 
-		<h3>[method:Lut changeColorMap]( [param:Float colorMap] )</h3>
+		<h3>[method:HTMLCanvasElement updateCanvas]( [param:HTMLCanvasElement canvas] )</h3>
 		<p>
-		colorMap — The name of the color map to be used to represent the data array.<br />
+			canvas — Canvas to be updated 
 		</p>
 		<p>
-		Sets this Lut with the colormap to be used.
-		</p>
-
-		<h3>[method:Lut addColorMap]( colorMapName, arrayOfColors )</h3>
-		<p>
-		Insert a new color map into the set of available color maps.
+			Draw colors onto given canvas.
 		</p>
 
-		<h3>[method:Lut getColor]( value ) [param:Lut this]</h3>
+		<h2>Statics</h2>
+
+		<h3>[method:null AddColorMap]( [param:String colormapName], [param:Array arrayOfColorStops] )</h3>
 		<p>
-		value -- the data value to be displayed as a color.
+			colormapName — The name of colormap.<br />
+			arrayOfColorStops — Array of [stop, color] pairs.
 		</p>
 		<p>
-		Returns a [page:Color].
+			Insert a new colormap into the set of available colormaps.
+		</p>
+
+		<h2>Examples</h2>
+
+		<p>
+			[example:webgl_geometry_colors_lookuptable Geometry / Colors / LookupTable]
 		</p>
 
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/Lut.js examples/jsm/math/Lut.js]
 		</p>
 	</body>
 </html>

--- a/examples/js/math/Lut.js
+++ b/examples/js/math/Lut.js
@@ -3,11 +3,17 @@ console.warn( "THREE.Lut: As part of the transition to ES6 Modules, the files in
  * @author daron1337 / http://daron1337.github.io/
  */
 
-THREE.Lut = function ( colormap, numberofcolors ) {
+THREE.Lut = function ( colormapName, numberOfColors ) {
 
 	this.lut = [];
-	this.setColorMap( colormap, numberofcolors );
+	this.setColorMap( colormapName, numberOfColors );
 	return this;
+
+};
+
+THREE.Lut.AddColorMap = function ( colormapName, arrayOfColorStops ) {
+
+	THREE.ColorMapKeywords[ colormapName ] = arrayOfColorStops;
 
 };
 
@@ -15,7 +21,7 @@ THREE.Lut.prototype = {
 
 	constructor: THREE.Lut,
 
-	lut: [], map: [], n: 256, minV: 0, maxV: 1,
+	lut: [], map: [], n: 32, minV: 0, maxV: 1,
 
 	set: function ( value ) {
 
@@ -45,10 +51,15 @@ THREE.Lut.prototype = {
 
 	},
 
-	setColorMap: function ( colormap, numberofcolors ) {
+	setColorMap: function ( colormapName, numberOfColors ) {
 
-		this.map = THREE.ColorMapKeywords[ colormap ] || THREE.ColorMapKeywords.rainbow;
-		this.n = numberofcolors || 32;
+		this.map = THREE.ColorMapKeywords[ colormapName ] || THREE.ColorMapKeywords.rainbow;
+		
+		if ( numberOfColors > 0 ) {
+			
+			this.n = Math.ceil( numberOfColors );
+		
+		}
 
 		var step = 1.0 / this.n;
 
@@ -112,9 +123,11 @@ THREE.Lut.prototype = {
 
 	},
 
-	addColorMap: function ( colormapName, arrayOfColors ) {
+	addColorMap: function ( colormapName, arrayOfColorStops ) {
 
-		THREE.ColorMapKeywords[ colormapName ] = arrayOfColors;
+		console.warn( 'Deprecated; Use static `Lut.AddColorMap()` instead.' );
+
+		THREE.ColorMapKeywords[ colormapName ] = arrayOfColorStops;
 
 	},
 

--- a/examples/jsm/math/Lut.d.ts
+++ b/examples/jsm/math/Lut.d.ts
@@ -2,33 +2,23 @@ import {
 	Color
 } from '../../../src/Three';
 
+type ColorStop = [ number, Color | number | string ];
+type MapName = 'rainbow' | 'cooltowarm' | 'blackbody' | 'grayscale';
+
 export class Lut {
 
-	constructor( colormapName?: string, numberOfColors?: number );
-	lut: Color[];
-	map: object[];
-	n: number;
+	constructor( map?: MapName | ColorStop[], numberOfColors?: number );
+	colors: Color[];
+	map: ColorStop[];
 	minV: number;
 	maxV: number;
 
-	set( object: any ): this;
 	setMin( min: number ): this;
 	setMax( max: number ): this;
-	setColorMap( colormapName?: string, numberOfColors?: number ): this;
+	setColorMap( map?: MapName | ColorStop[], numberOfColors?: number ): this;
 	copy( lut: Lut ): this;
 	getColor( alpha: number ): Color;
 	createCanvas(): HTMLCanvasElement;
 	updateCanvas( canvas: HTMLCanvasElement ): HTMLCanvasElement;
 
-	/** @deprecated Use static `Lut.AddColorMap()` instead. */
-	addColorMap( colormapName: string, arrayOfColorStops: number[][] ): void;
-	static AddColorMap( colormapName: string, arrayOfColorStops: number[][] ): void;
-	
-}
-
-export interface ColorMapKeywords {
-	rainbow: number[][];
-	cooltowarm: number[][];
-	blackbody: number[][];
-	grayscale: number[][];
 }

--- a/examples/jsm/math/Lut.d.ts
+++ b/examples/jsm/math/Lut.d.ts
@@ -4,23 +4,26 @@ import {
 
 export class Lut {
 
-	constructor( colormap?: string, numberofcolors?: number );
+	constructor( colormapName?: string, numberOfColors?: number );
 	lut: Color[];
 	map: object[];
 	n: number;
 	minV: number;
 	maxV: number;
 
-	set( value: Lut ): this;
+	set( object: any ): this;
 	setMin( min: number ): this;
 	setMax( max: number ): this;
-	setColorMap( colormap?: string, numberofcolors?: number ): this;
+	setColorMap( colormapName?: string, numberOfColors?: number ): this;
 	copy( lut: Lut ): this;
 	getColor( alpha: number ): Color;
-	addColorMap( colormapName: string, arrayOfColors: number[][] ): void;
 	createCanvas(): HTMLCanvasElement;
 	updateCanvas( canvas: HTMLCanvasElement ): HTMLCanvasElement;
 
+	/** @deprecated Use static `Lut.AddColorMap()` instead. */
+	addColorMap( colormapName: string, arrayOfColorStops: number[][] ): void;
+	static AddColorMap( colormapName: string, arrayOfColorStops: number[][] ): void;
+	
 }
 
 export interface ColorMapKeywords {

--- a/examples/jsm/math/Lut.js
+++ b/examples/jsm/math/Lut.js
@@ -6,11 +6,17 @@ import {
 	Color
 } from "../../../build/three.module.js";
 
-var Lut = function ( colormap, numberofcolors ) {
+var Lut = function ( colormapName, numberofcolors ) {
 
 	this.lut = [];
-	this.setColorMap( colormap, numberofcolors );
+	this.setColorMap( colormapName, numberofcolors );
 	return this;
+
+};
+
+Lut.AddColorMap = function ( colormapName, arrayOfColorStops ) {
+
+	ColorMapKeywords[ colormapName ] = arrayOfColorStops;
 
 };
 
@@ -18,7 +24,7 @@ Lut.prototype = {
 
 	constructor: Lut,
 
-	lut: [], map: [], n: 256, minV: 0, maxV: 1,
+	lut: [], map: [], n: 32, minV: 0, maxV: 1,
 
 	set: function ( value ) {
 
@@ -48,10 +54,15 @@ Lut.prototype = {
 
 	},
 
-	setColorMap: function ( colormap, numberofcolors ) {
+	setColorMap: function ( colormapName, numberOfColors ) {
 
-		this.map = ColorMapKeywords[ colormap ] || ColorMapKeywords.rainbow;
-		this.n = numberofcolors || 32;
+		this.map = ColorMapKeywords[ colormapName ] || ColorMapKeywords.rainbow;
+
+		if ( numberOfColors > 0 ) {
+
+			this.n = Math.ceil( numberOfColors );
+			
+		}
 
 		var step = 1.0 / this.n;
 
@@ -115,12 +126,6 @@ Lut.prototype = {
 
 	},
 
-	addColorMap: function ( colormapName, arrayOfColors ) {
-
-		ColorMapKeywords[ colormapName ] = arrayOfColors;
-
-	},
-
 	createCanvas: function () {
 
 		var canvas = document.createElement( 'canvas' );
@@ -176,7 +181,16 @@ Lut.prototype = {
 
 		return canvas;
 
+	},
+
+	addColorMap: function ( colormapName, arrayOfColorStops ) {
+
+		console.warn( 'Deprecated; Use static `Lut.AddColorMap()` instead.' );
+		
+		ColorMapKeywords[ colormapName ] = arrayOfColorStops;
+	
 	}
+
 };
 
 var ColorMapKeywords = {


### PR DESCRIPTION
examples/jsm/math/Lut.js:
examples/js/math/Lut.js:
- deprecated the `Lut#addColorMap()`; (added `console.warn(..)`)
- added static `Lut.AddColorMap()` 
- cleaned up the `.n`; default value is now defined in single place. 

examples/jsm/math/Lut.d.ts
- added tsdoc for `Lut#addColorMap()` (marked `@deprecated`)
- added `static AddColorMap(..);`

Docs Lut.html:
- removed obsoleted apis, e.g. legend...
- added missing apis, e.g. `.lut[]`, `createCanvas()` ...  
- updated "Code Example" section.
- added "Examples" section; added 1 example; links to "Geometry / Colors / LookupTable".
- added "Statics" section; added 1 func, `Lut.AddColorMap()`
- fixed source link