### PR TITLE
Docs: Add all types of buffer attributes to navigation.

### DIFF
--- a/docs/list.js
+++ b/docs/list.js
@@ -102,7 +102,16 @@ var list = {
 			},
 
 			"Core / BufferAttributes": {
-				"BufferAttribute Types": "api/en/core/bufferAttributeTypes/BufferAttributeTypes"
+				"BufferAttribute Types": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint8BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int8BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint8ClampedBufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint16BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int16BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint32BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int32BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Float32BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Float64BufferAttribute": "api/en/core/bufferAttributeTypes/BufferAttributeTypes"
 			},
 
 			"Extras": {
@@ -560,7 +569,16 @@ var list = {
 			},
 
 			"核心 / BufferAttributes": {
-				"BufferAttribute Types": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes"
+				"BufferAttribute Types": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint8BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int8BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint8ClampedBufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint16BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int16BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Uint32BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Int32BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Float32BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes",
+				"Float64BufferAttribute": "api/zh/core/bufferAttributeTypes/BufferAttributeTypes"
 			},
 
 			"附件": {


### PR DESCRIPTION
When searching in the documentation for Float32BufferAttribute, I found no results while there is documentation for Float32BufferAttribute.
![image](https://user-images.githubusercontent.com/155535/83967110-e9eb8380-a8be-11ea-9f23-84c48183508a.png)


### To Reproduce:
- Search in documentation for  'Float32BufferAttribute'

### Issue
- Found nothing

### Solution 
- Point Float32BufferAttribute to BufferAttributes documentation & allow the bufferattributes to be found. 