### PR TITLE
BufferAttribute: honor itemSize in applyMatrix3()

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -204,23 +204,18 @@ Object.assign( BufferAttribute.prototype, {
 
 			for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-				_vector2.x = this.getX( i );
-				_vector2.y = this.getY( i );
-
+				_vector2.fromBufferAttribute( this, i );
 				_vector2.applyMatrix3( m );
 
 				this.setXY( i, _vector2.x, _vector2.y, );
 
 			}
 
-		} else {
+		} else if ( this.itemSize === 3 ) {
 
 			for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-				_vector.x = this.getX( i );
-				_vector.y = this.getY( i );
-				_vector.z = this.getZ( i );
-
+				_vector.fromBufferAttribute( this, i );
 				_vector.applyMatrix3( m );
 
 				this.setXYZ( i, _vector.x, _vector.y, _vector.z );

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -9,6 +9,7 @@ import { StaticDrawUsage } from '../constants.js';
  */
 
 const _vector = new Vector3();
+const _vector2 = new Vector2();
 
 function BufferAttribute( array, itemSize, normalized ) {
 
@@ -199,15 +200,32 @@ Object.assign( BufferAttribute.prototype, {
 
 	applyMatrix3: function ( m ) {
 
-		for ( let i = 0, l = this.count; i < l; i ++ ) {
+		if ( this.itemSize === 2 ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.applyMatrix3( m );
+				_vector2.x = this.getX( i );
+				_vector2.y = this.getY( i );
 
-			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+				_vector2.applyMatrix3( m );
+
+				this.setXY( i, _vector2.x, _vector2.y, );
+
+			}
+
+		} else {
+
+			for ( let i = 0, l = this.count; i < l; i ++ ) {
+
+				_vector.x = this.getX( i );
+				_vector.y = this.getY( i );
+				_vector.z = this.getZ( i );
+
+				_vector.applyMatrix3( m );
+
+				this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+
+			}
 
 		}
 


### PR DESCRIPTION
Relative to issue #19567.

In the current version, the method `applyMatrix3` of `BufferAttribute` results in `NaN` in the attribute's array since it presumes that `itemSize` is 3. With this commit, `applyMatrix3` perform an initial check and so behaves correctly if `itemSize` is 2.

First PR here, I hope everything is fine :) .