### PR TITLE
Removed .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-examples/*
-!examples/js/
-test/
-utils/
-docs/
-editor/
-.DS_Store


### PR DESCRIPTION
Because the ```files``` field in package.json, .npmignore is unnecessary.

run ```npm pack``` to test the files:

before: 
<img width="456" alt="before" src="https://user-images.githubusercontent.com/800043/84045593-90c54200-a9db-11ea-8214-6821459a7356.png">

after: 
<img width="455" alt="after" src="https://user-images.githubusercontent.com/800043/84045622-9b7fd700-a9db-11ea-9237-0f9b569ff56f.png">


