### PR TITLE
Editor: Make sure to log an unsupported extension

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -232,7 +232,7 @@ var Loader = function ( editor ) {
 
 					if ( isGLTF1( contents ) ) {
 
-						console.error( 'Import of glTF asset not possible. Only versions >= 2.0 are supported. Please try to upgrade the file to glTF 2.0 using glTF-Pipeline.' );
+						alert( 'Import of glTF asset not possible. Only versions >= 2.0 are supported. Please try to upgrade the file to glTF 2.0 using glTF-Pipeline.' );
 
 					} else {
 
@@ -303,7 +303,7 @@ var Loader = function ( editor ) {
 
 					} catch ( error ) {
 
-						console.error( error );
+						alert( error );
 						return;
 
 					}

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -232,7 +232,7 @@ var Loader = function ( editor ) {
 
 					if ( isGLTF1( contents ) ) {
 
-						alert( 'Import of glTF asset not possible. Only versions >= 2.0 are supported. Please try to upgrade the file to glTF 2.0 using glTF-Pipeline.' );
+						console.error( 'Import of glTF asset not possible. Only versions >= 2.0 are supported. Please try to upgrade the file to glTF 2.0 using glTF-Pipeline.' );
 
 					} else {
 
@@ -303,7 +303,7 @@ var Loader = function ( editor ) {
 
 					} catch ( error ) {
 
-						alert( error );
+						console.error( error );
 						return;
 
 					}
@@ -521,7 +521,7 @@ var Loader = function ( editor ) {
 
 			default:
 
-				// alert( 'Unsupported file format (' + extension +  ').' );
+				console.error( 'Unsupported file format (' + extension + ').' );
 
 				break;
 


### PR DESCRIPTION
I wanted to load an exr file in the editor. So I tried to import the file in the editor. Nothing seemed to happen. Checking the dev tools didn't help either. The exr file isn't supported in the editor, I found that out by debugging the editor.   

### To Reproduce:
- Import an exr file in the editor

### Issue
- Nothing happens

### Solution 
- Log if the extension is not supported and make sure not to block because of multiple files loading. 