### PR TITLE
Docs: material-browser: bugfix 'combine' values change + add values to MeshPhongMaterial

### DIFF
--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -297,6 +297,17 @@
 
 			}
 
+			function updateCombine( material ) {
+
+				return function (combine) {
+
+					material.combine = parseInt( combine );
+					material.needsUpdate = true;
+
+				};
+
+			}
+
 			function updateTexture( material, materialKey, textures ) {
 
 				return function ( key ) {
@@ -395,7 +406,7 @@
 				folder.add( data, 'envMaps', envMapKeys ).onChange( updateTexture( material, 'envMap', envMaps ) );
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
-				folder.add( material, 'combine', constants.combine );
+				folder.add( material, 'combine', constants.combine ).onChange( updateCombine( material ) );
 				folder.add( material, 'reflectivity', 0, 1 );
 				folder.add( material, 'refractionRatio', 0, 1 );
 
@@ -466,7 +477,7 @@
 				folder.add( data, 'envMaps', envMapKeys ).onChange( updateTexture( material, 'envMap', envMaps ) );
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
-				folder.add( material, 'combine', constants.combine );
+				folder.add( material, 'combine', constants.combine ).onChange( updateCombine( material ) );
 				folder.add( material, 'reflectivity', 0, 1 );
 				folder.add( material, 'refractionRatio', 0, 1 );
 
@@ -514,6 +525,9 @@
 				folder.add( data, 'envMaps', envMapKeys ).onChange( updateTexture( material, 'envMap', envMaps ) );
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
+				folder.add( material, 'combine', constants.combine ).onChange( updateCombine( material ) );
+				folder.add( material, 'reflectivity', 0, 1 );
+				folder.add( material, 'refractionRatio', 0, 1 );
 
 			}
 


### PR DESCRIPTION
I first noticed that [`combine`](https://threejs.org/docs/#api/en/materials/MeshPhongMaterial.combine) value was missing from https://threejs.org/docs/scenes/material-browser.html#MeshPhongMaterial

Then I noticed that the `combine` value changes had no effect on [MeshLambertMaterial](https://threejs.org/docs/scenes/material-browser.html#MeshLambertMaterial) and [MeshBasicMaterial](https://threejs.org/docs/scenes/material-browser.html#MeshBasicMaterial).

So here's my attempt to fix this.