### PR TITLE
cache data urls of images in the editor

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -732,4 +732,18 @@ Editor.prototype = {
 
 };
 
+var getDataURL = THREE.ImageUtils.getDataURL;
+var Cache = {};
+THREE.ImageUtils.getDataURL = function ( image ) {
+
+	if ( ! Cache[ image.src ] ) {
+
+		Cache[ image.src ] = getDataURL( image );
+
+	}
+
+	return Cache[ image.src ];
+
+};
+
 export { Editor };


### PR DESCRIPTION
I was using the editor but every time I updated the position an object, there seems to be a long pause between actions. This happened because the editor was autosaving and every image got a new data URL generated for it. 

### To Reproduce:
- use editor when using large images as textures.

### Issue
- Long hangs between actions because of UI hanging

### Solution 
- Cache data URLs to prevent the regeneration of all images.