### PR TITLE
WebGLRenderer: Introduce webgl2 parameter.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -68,7 +68,9 @@
 		be neccesary to use this if dealing with huge differences in scale in a single scene. Note that this setting
 		uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
 		optimization and can cause a decrease in performance.
-		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
+		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.<br />
+
+		[page:Boolean webgl2] - whether to use a WebGL 2 rendering context. Default is *false*.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -56,7 +56,9 @@
 		[page:Boolean logarithmicDepthBuffer] -  是否使用对数深度缓存。如果要在单个场景中处理巨大的比例差异，就有必要使用。
 		Note that this setting uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
 		optimization and can cause a decrease in performance.
-		默认是*false*。 示例：[example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer]
+		默认是*false*。 示例：[example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer]<br />
+
+		[page:Boolean webgl2] - whether to use a WebGL 2 rendering context. Default is *false*.
 		</p>
 
 		<h2>属性</h2>

--- a/docs/manual/en/introduction/How-to-use-WebGL2.html
+++ b/docs/manual/en/introduction/How-to-use-WebGL2.html
@@ -43,20 +43,12 @@ if ( WEBGL.isWebGL2Available() === false ) {
 	</code>
 
 	<p>
-		Now it's time to create the renderer by applying the HTML5 canvas element and the respective WebGL 2 context
-		to the constructor of *WebGLRenderer*. As a result, three.js will internally use the given context for rendering and
-		automatically convert the built-in material's shader code to GLSL ES 3.00.
-	</p>
-
-	<p>
-		Since you are manually creating the WebGL 2 rendering context, you also have to pass in all necessary context attributes.
-		Note: It's not possible to modify these attributes after the context has been created, so passing them to the WebGLRenderer won't have any effect.
+		Now it's time to create the renderer by setting the *webgl2* parameter to *true*.
+		As a result, three.js will internally use a WebGL 2 rendering context and automatically convert the built-in material's shader code to GLSL ES 3.00.
 	</p>
 
 	<code>
-var canvas = document.createElement( 'canvas' );
-var context = canvas.getContext( 'webgl2', { alpha: false } );
-var renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+var renderer = new THREE.WebGLRenderer( { webgl2: true } );
 	</code>
 
 	<p>

--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -144,9 +144,7 @@
 
 				// renderer
 
-				var canvas = document.createElement( 'canvas' );
-				var context = canvas.getContext( 'webgl2', { alpha: false } );
-				renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, webgl2: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -122,10 +122,7 @@
 
 				// 2D Texture array is available on WebGL 2.0
 
-				var canvas = document.createElement( 'canvas' );
-				var context = canvas.getContext( 'webgl2', { alpha: false, antialias: false } );
-
-				renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+				renderer = new THREE.WebGLRenderer( { webgl2: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -43,9 +43,7 @@
 			scene = new THREE.Scene();
 
 			// Create renderer
-			var canvas = document.createElement( 'canvas' );
-			var context = canvas.getContext( 'webgl2', { alpha: false, antialias: false } );
-			renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+			renderer = new THREE.WebGLRenderer( { webgl2: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			document.body.appendChild( renderer.domElement );

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -106,10 +106,7 @@
 
 				//
 
-				var canvas = document.createElement( 'canvas' );
-				var context = canvas.getContext( 'webgl2', { alpha: false, antialias: false } );
-
-				renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+				renderer = new THREE.WebGLRenderer( { webgl2: true } );
 				renderer.autoClear = false;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( container.offsetWidth, container.offsetHeight );

--- a/examples/webgl2_sandbox.html
+++ b/examples/webgl2_sandbox.html
@@ -62,10 +62,7 @@
 
 				}
 
-				var canvas = document.createElement( 'canvas' );
-				var context = canvas.getContext( 'webgl2', { alpha: false, antialias: true } );
-
-				renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, webgl2: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );

--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -85,6 +85,11 @@ export interface WebGLRendererParameters {
 	 * default is false.
 	 */
 	logarithmicDepthBuffer?: boolean;
+
+	/**
+	 * default is false.
+	 */
+	webgl2?: boolean;
 }
 
 export interface WebGLDebug {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -60,7 +60,8 @@ function WebGLRenderer( parameters ) {
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 		_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
 		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default',
-		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false;
+		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false,
+		_webgl2 = parameters.webgl2 !== undefined ? parameters.webgl2 : false;
 
 	let currentRenderList = null;
 	let currentRenderState = null;
@@ -184,7 +185,7 @@ function WebGLRenderer( parameters ) {
 
 	// initialize
 
-	let _gl;
+	let _gl = _context;
 
 	try {
 
@@ -204,13 +205,31 @@ function WebGLRenderer( parameters ) {
 		_canvas.addEventListener( 'webglcontextlost', onContextLost, false );
 		_canvas.addEventListener( 'webglcontextrestored', onContextRestore, false );
 
-		_gl = _context || _canvas.getContext( 'webgl', contextAttributes ) || _canvas.getContext( 'experimental-webgl', contextAttributes );
+		if ( _gl === null ) {
+
+			if ( _webgl2 === true ) {
+
+				_gl = _canvas.getContext( 'webgl2', contextAttributes );
+
+			} else {
+
+				_gl = _canvas.getContext( 'webgl', contextAttributes ) || _canvas.getContext( 'experimental-webgl', contextAttributes );
+
+			}
+
+		}
+
+		//
 
 		if ( _gl === null ) {
 
-			if ( _canvas.getContext( 'webgl' ) !== null ) {
+			if ( _webgl2 === false && _canvas.getContext( 'webgl' ) !== null ) {
 
 				throw new Error( 'Error creating WebGL context with your selected attributes.' );
+
+			} else if ( _webgl2 === true && _canvas.getContext( 'webgl2' ) !== null ) {
+
+				throw new Error( 'Error creating WebGL 2 context with your selected attributes.' );
 
 			} else {
 


### PR DESCRIPTION
Fixed #19040.

This PR introduces a new parameter `webgl2` which controls the WebGL 2 context creation. Meaning it's now not necessary anymore to create the context on app level. This cleans up code nicely and avoids a parameters issue highlighted in #19040.