### PR TITLE
GLTFLoader: Avoid unnecessary ArrayBuffer copies.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -558,7 +558,7 @@ var GLTFLoader = ( function () {
 		var headerView = new DataView( data, 0, BINARY_EXTENSION_HEADER_LENGTH );
 
 		this.header = {
-			magic: LoaderUtils.decodeText( new Uint8Array( data.slice( 0, 4 ) ) ),
+			magic: LoaderUtils.decodeText( new Uint8Array( data, 0, 4 ) ),
 			version: headerView.getUint32( 4, true ),
 			length: headerView.getUint32( 8, true )
 		};
@@ -592,7 +592,7 @@ var GLTFLoader = ( function () {
 			} else if ( chunkType === BINARY_EXTENSION_CHUNK_TYPES.BIN ) {
 
 				var byteOffset = BINARY_EXTENSION_HEADER_LENGTH + chunkIndex;
-				this.body = data.slice( byteOffset, byteOffset + chunkLength );
+				this.body = new DataView( data, byteOffset, chunkLength );
 
 			}
 
@@ -668,7 +668,11 @@ var GLTFLoader = ( function () {
 
 			return new Promise( function ( resolve ) {
 
-				dracoLoader.decodeDracoFile( bufferView, function ( geometry ) {
+				// Copy compressed data out of the ArrayBuffer here, because DRACOLoader needs to
+				// transfer the ArrayBuffer it's decoding to a Web Worker.
+				var compressedBuffer = bufferView.buffer.slice( bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength );
+
+				dracoLoader.decodeDracoFile( compressedBuffer, function ( geometry ) {
 
 					for ( var attributeName in geometry.attributes ) {
 
@@ -1700,7 +1704,7 @@ var GLTFLoader = ( function () {
 	/**
 	 * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#buffers-and-buffer-views
 	 * @param {number} bufferIndex
-	 * @return {Promise<ArrayBuffer>}
+	 * @return {Promise<DataView>}
 	 */
 	GLTFParser.prototype.loadBuffer = function ( bufferIndex ) {
 
@@ -1724,7 +1728,11 @@ var GLTFLoader = ( function () {
 
 		return new Promise( function ( resolve, reject ) {
 
-			loader.load( resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
+			loader.load( resolveURL( bufferDef.uri, options.path ), function ( arrayBuffer ) {
+
+				resolve( new DataView( arrayBuffer ) );
+
+			}, undefined, function () {
 
 				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
@@ -1737,17 +1745,17 @@ var GLTFLoader = ( function () {
 	/**
 	 * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#buffers-and-buffer-views
 	 * @param {number} bufferViewIndex
-	 * @return {Promise<ArrayBuffer>}
+	 * @return {Promise<DataView>}
 	 */
 	GLTFParser.prototype.loadBufferView = function ( bufferViewIndex ) {
 
 		var bufferViewDef = this.json.bufferViews[ bufferViewIndex ];
 
-		return this.getDependency( 'buffer', bufferViewDef.buffer ).then( function ( buffer ) {
+		return this.getDependency( 'buffer', bufferViewDef.buffer ).then( function ( dataView ) {
 
 			var byteLength = bufferViewDef.byteLength || 0;
-			var byteOffset = bufferViewDef.byteOffset || 0;
-			return buffer.slice( byteOffset, byteOffset + byteLength );
+			var byteOffset = dataView.byteOffset + ( bufferViewDef.byteOffset || 0 );
+			return new DataView( dataView.buffer, byteOffset, byteLength )
 
 		} );
 
@@ -1819,7 +1827,7 @@ var GLTFLoader = ( function () {
 
 				if ( ! ib ) {
 
-					array = new TypedArray( bufferView, ibSlice * byteStride, accessorDef.count * byteStride / elementBytes );
+					array = new TypedArray( bufferView.buffer, bufferView.byteOffset + ibSlice * byteStride, accessorDef.count * byteStride / elementBytes );
 
 					// Integer parameters to IB/IBA are in array elements, not bytes.
 					ib = new InterleavedBuffer( array, byteStride / elementBytes );
@@ -1838,7 +1846,7 @@ var GLTFLoader = ( function () {
 
 				} else {
 
-					array = new TypedArray( bufferView, byteOffset, accessorDef.count * itemSize );
+					array = new TypedArray( bufferView.buffer, bufferView.byteOffset + byteOffset, accessorDef.count * itemSize );
 
 				}
 
@@ -1855,8 +1863,8 @@ var GLTFLoader = ( function () {
 				var byteOffsetIndices = accessorDef.sparse.indices.byteOffset || 0;
 				var byteOffsetValues = accessorDef.sparse.values.byteOffset || 0;
 
-				var sparseIndices = new TypedArrayIndices( bufferViews[ 1 ], byteOffsetIndices, accessorDef.sparse.count * itemSizeIndices );
-				var sparseValues = new TypedArray( bufferViews[ 2 ], byteOffsetValues, accessorDef.sparse.count * itemSize );
+				var sparseIndices = new TypedArrayIndices( bufferViews[ 1 ].buffer, bufferViews[ 1 ].byteOffset + byteOffsetIndices, accessorDef.sparse.count * itemSizeIndices );
+				var sparseValues = new TypedArray( bufferViews[ 2 ].buffer, bufferViews[ 2 ].byteOffset + byteOffsetValues, accessorDef.sparse.count * itemSize );
 
 				if ( bufferView !== null ) {
 


### PR DESCRIPTION
Need to test this a bit more, but it should ensure that reading the glTF binary buffer happens in place.