### PR TITLE
Camera: Added fovMode

### DIFF
--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -23,6 +23,8 @@ function PerspectiveCamera( fov, aspect, near, far ) {
 	this.focus = 10;
 
 	this.aspect = aspect !== undefined ? aspect : 1;
+	this.fit = 'auto';
+
 	this.view = null;
 
 	this.filmGauge = 35;	// width of the film (default in millimeters)
@@ -50,12 +52,25 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		this.focus = source.focus;
 
 		this.aspect = source.aspect;
+		this.fit = source.fit;
+
 		this.view = source.view === null ? null : Object.assign( {}, source.view );
 
 		this.filmGauge = source.filmGauge;
 		this.filmOffset = source.filmOffset;
 
 		return this;
+
+	},
+
+	/**
+	 * Option to control which dimension (vertical or horizontal) along which field of view angle fits.
+	 * Possible options are 'auto', 'horizontal' and 'vertical'.
+	 */
+	setFit: function ( value ) {
+
+		this.fit = value;
+		this.updateProjectionMatrix();
 
 	},
 
@@ -188,10 +203,21 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 	updateProjectionMatrix: function () {
 
+		const aspect = this.aspect;
+		const fit = this.fit;
+
+		let fov = this.fov;
+
+		if ( fit === 'horizontal' || ( fit === 'auto' && aspect < 1 ) ) {
+
+			fov = Math.atan( Math.tan( fov * Math.PI / 360 ) / aspect ) * 360 / Math.PI;
+
+		}
+
 		let near = this.near,
-			top = near * Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom,
+			top = near * Math.tan( MathUtils.DEG2RAD * 0.5 * fov ) / this.zoom,
 			height = 2 * top,
-			width = this.aspect * height,
+			width = aspect * height,
 			left = - 0.5 * width,
 			view = this.view;
 
@@ -228,6 +254,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		data.object.focus = this.focus;
 
 		data.object.aspect = this.aspect;
+		data.object.fit = this.fit;
 
 		if ( this.view !== null ) data.object.view = Object.assign( {}, this.view );
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -16,6 +16,8 @@ function PerspectiveCamera( fov, aspect, near, far ) {
 	this.type = 'PerspectiveCamera';
 
 	this.fov = fov !== undefined ? fov : 50;
+	this.fovMode = 'auto';
+
 	this.zoom = 1;
 
 	this.near = near !== undefined ? near : 0.1;
@@ -23,7 +25,6 @@ function PerspectiveCamera( fov, aspect, near, far ) {
 	this.focus = 10;
 
 	this.aspect = aspect !== undefined ? aspect : 1;
-	this.fit = 'auto';
 
 	this.view = null;
 
@@ -45,6 +46,8 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		Camera.prototype.copy.call( this, source, recursive );
 
 		this.fov = source.fov;
+		this.fovMode = source.fovMode;
+
 		this.zoom = source.zoom;
 
 		this.near = source.near;
@@ -52,7 +55,6 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		this.focus = source.focus;
 
 		this.aspect = source.aspect;
-		this.fit = source.fit;
 
 		this.view = source.view === null ? null : Object.assign( {}, source.view );
 
@@ -60,17 +62,6 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		this.filmOffset = source.filmOffset;
 
 		return this;
-
-	},
-
-	/**
-	 * Option to control which dimension (vertical or horizontal) along which field of view angle fits.
-	 * Possible options are 'auto', 'horizontal' and 'vertical'.
-	 */
-	setFit: function ( value ) {
-
-		this.fit = value;
-		this.updateProjectionMatrix();
 
 	},
 
@@ -204,11 +195,11 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 	updateProjectionMatrix: function () {
 
 		const aspect = this.aspect;
-		const fit = this.fit;
+		const fovMode = this.fovMode;
 
 		let fov = this.fov;
 
-		if ( fit === 'horizontal' || ( fit === 'auto' && aspect < 1 ) ) {
+		if ( fovMode === 'horizontal' || ( fovMode === 'auto' && aspect < 1 ) ) {
 
 			fov = Math.atan( Math.tan( fov * Math.PI / 360 ) / aspect ) * 360 / Math.PI;
 
@@ -247,6 +238,8 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		const data = Object3D.prototype.toJSON.call( this, meta );
 
 		data.object.fov = this.fov;
+		data.object.fovMode = this.fovMode;
+
 		data.object.zoom = this.zoom;
 
 		data.object.near = this.near;
@@ -254,7 +247,6 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 		data.object.focus = this.focus;
 
 		data.object.aspect = this.aspect;
-		data.object.fit = this.fit;
 
 		if ( this.view !== null ) data.object.view = Object.assign( {}, this.view );
 


### PR DESCRIPTION
Similarly to the [Camera's Sensor Fit in Blender](https://docs.blender.org/manual/en/latest/render/cameras.html), this lets the user configure the in which dimension the fov is being applied: `vertical`, `horizontal` or `auto`. **I'm also proposing to set it to `auto` by default.**

This affects mobiles specially. Previously the examples looked like this:

<img width="450" alt="Screen Shot 2020-06-10 at 2 38 00 PM" src="https://user-images.githubusercontent.com/97088/84321492-38926980-abae-11ea-9127-79194e65a1d0.png">

With the new default it looks like this:

<img width="449" alt="Screen Shot 2020-06-10 at 2 37 48 PM" src="https://user-images.githubusercontent.com/97088/84321508-41833b00-abae-11ea-97f3-d4df8f6a8a32.png">

Which I think is what you would expect when the render looks like this in landscape:

<img width="1158" alt="Screen Shot 2020-06-10 at 2 43 08 PM" src="https://user-images.githubusercontent.com/97088/84321862-f0277b80-abae-11ea-913d-2855d4464c39.png">

Not sure about the name `fovMode`. Any suggestions?