### PR TITLE
Shaders: Improve ACES Filmic tone mapping

### DIFF
--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -31,11 +31,42 @@ vec3 OptimizedCineonToneMapping( vec3 color ) {
 
 }
 
-// source: https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
+// source: https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs
+vec3 RRTAndODTFit( vec3 v ) {
+
+    vec3 a = v * ( v + 0.0245786 ) - 0.000090537;
+    vec3 b = v * ( 0.983729 * v + 0.4329510 ) + 0.238081;
+    return a / b;
+
+}
+
 vec3 ACESFilmicToneMapping( vec3 color ) {
 
-	color *= toneMappingExposure;
-	return saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );
+    // sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
+    const mat3 ACESInputMat = mat3(
+        vec3( 0.59719, 0.07600, 0.02840 ), // transposed from source
+        vec3( 0.35458, 0.90834, 0.13383 ),
+        vec3( 0.04823, 0.01566, 0.83777 )
+    );
+
+    // ODT_SAT => XYZ => D60_2_D65 => sRGB
+    const mat3 ACESOutputMat = mat3(
+        vec3(  1.60475, -0.10208, -0.00327 ), // transposed from source
+        vec3( -0.53108,  1.10813, -0.07276 ),
+        vec3( -0.07367, -0.00605,  1.07602 )
+    );
+
+    color *= toneMappingExposure;
+
+    color = ACESInputMat * color;
+
+    // Apply RRT and ODT
+    color = RRTAndODTFit( color );
+
+    color = ACESOutputMat * color;
+
+    // Clamp to [0, 1]
+    return saturate( color );
 
 }
 `;


### PR DESCRIPTION
Follow-on to https://github.com/mrdoob/three.js/pull/15277#issuecomment-440081720.

From the source of our existing code:

>Additionally, data was pre-exposed, so 1 on input maps to ~0.8 on output and resulting image’s brightness is more consistent with the one without any tone mapping curve at all.

In other words, the tone map curve we are currently using is shifted. But more importantly, the current implementation fails to desaturate highlights -- a feature of a proper ACES Filmic implementation.

The final render will be slightly darker now. Increase exposure slightly to achieve similar illumination.



