### PR TITLE
WebGLProgram: support cube uv refraction mapping

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -340,6 +340,7 @@ function generateEnvMapModeDefine( parameters ) {
 
 			case CubeRefractionMapping:
 			case EquirectangularRefractionMapping:
+			case CubeUVRefractionMapping:
 				envMapModeDefine = 'ENVMAP_MODE_REFRACTION';
 				break;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -341,6 +341,7 @@ function generateEnvMapModeDefine( parameters ) {
 			case CubeRefractionMapping:
 			case EquirectangularRefractionMapping:
 			case CubeUVRefractionMapping:
+
 				envMapModeDefine = 'ENVMAP_MODE_REFRACTION';
 				break;
 


### PR DESCRIPTION
Fixes #19611

[cube_uv_envmaps_example](https://rawcdn.githack.com/sciecode/three.js/688b9d58334c4f6030bbbc8519c8ea9a725b9fdf/examples/webgl_materials_envmaps.html)