### PR TITLE
ImageUtils.getDataURL(): A dataurl is already a dataurl

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -12,7 +12,11 @@ const ImageUtils = {
 
 		let canvas;
 
-		if ( typeof HTMLCanvasElement == 'undefined' ) {
+		if ( image.src.startsWith( "data:" ) ) {
+
+			return image.src;
+
+		} else if ( typeof HTMLCanvasElement == 'undefined' ) {
 
 			return image.src;
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -12,7 +12,8 @@ const ImageUtils = {
 
 		let canvas;
 
-		if ( image.src.indexOf( "data:" ) === 0 ) {
+		var src = image.src;
+		if ( src[ 0 ] === "d" && src[ 1 ] === "a" && src[ 2 ] === "t" && src[ 3 ] === "a" && src[ 4 ] === ":" ) {
 
 			return image.src;
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -13,7 +13,7 @@ const ImageUtils = {
 		let canvas;
 
 		var src = image.src;
-		if ( src[ 0 ] === "d" && src[ 1 ] === "a" && src[ 2 ] === "t" && src[ 3 ] === "a" && src[ 4 ] === ":" ) {
+		if ( /^data:/i.test( src ) ) {
 
 			return image.src;
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -12,7 +12,7 @@ const ImageUtils = {
 
 		let canvas;
 
-		if ( image.src.startsWith( "data:" ) ) {
+		if ( image.src.indexOf( "data:" ) === 0 ) {
 
 			return image.src;
 


### PR DESCRIPTION
Serializing a texture with a data URL as src to JSON takes a long time. 

### To Reproduce:
- https://jsfiddle.net/f6d34yk2/15/

### Issue
-It tries to recreate the data URL when it already exists

### Solution 
- Check if it is already a data URL as src