### PR TITLE
Examples: Fix parameters settings in webgl_shaders_tonemapping.

### DIFF
--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -333,9 +333,11 @@
 				var regularRenderTarget = new THREE.WebGLRenderTarget( windowThirdX, height, parameters );
 				ldrEffectComposer = new EffectComposer( renderer, regularRenderTarget );
 
-				if ( renderer.capabilities.isWebGL2 === false && renderer.extensions.get( 'OES_texture_half_float_linear' ) ) {
+				parameters.type = THREE.FloatType;
 
-					parameters.type = THREE.FloatType;
+				if ( renderer.capabilities.isWebGL2 === false && ! renderer.extensions.get( 'OES_texture_half_float_linear' ) ) {
+
+					parameters.type = undefined; // avoid usage of floating point textures
 
 				}
 


### PR DESCRIPTION
Small fix of #19625. `THREE.FloatType` should be the default.