### PR TITLE
Examples: Fix invalid usage of mapTexelToLinear().

### DIFF
--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -33,15 +33,9 @@
 
 			varying vec2 vUv;
 
-			vec4 getTexture( sampler2D texelToLinearTexture ) {
-
-				return mapTexelToLinear( texture2D( texelToLinearTexture , vUv ) );
-
-			}
-
 			void main() {
 
-				gl_FragColor = ( getTexture( baseTexture ) + vec4( 1.0 ) * getTexture( bloomTexture ) );
+				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) );
 
 			}
 


### PR DESCRIPTION
The custom shader code used `mapTexelToLinear()` with no `map` property. Meaning `mapTexelToLinear()` was never configured correctly.