### PR TITLE
Examples: Intuitive filter in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -220,7 +220,7 @@
 		function updateFilter() {
 
 			var v = filterInput.value.trim();
-			v = v.replace( '  ', ' ' ).replace( ' ', '|' );
+			v = v.replace( /\s+/gi, ' ' ).replace( ' ', '|' );
 
 			if ( v !== '' ) {
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -219,7 +219,8 @@
 
 		function updateFilter() {
 
-			var v = filterInput.value;
+			var v = filterInput.value.trim();
+			v = v.replace( '  ', ' ' ).replace( ' ', '|' );
 
 			if ( v !== '' ) {
 
@@ -253,7 +254,7 @@
 
 			var link = links[ file ];
 			var name = getName( file );
-			if ( file in tags ) file += tags[ file ].join( ' ' );
+			if ( file in tags ) file += ' ' + tags[ file ].join( ' ' );
 			var res = file.match( exp );
 			var text;
 


### PR DESCRIPTION
I was using the filter bar in examples and the filter results were weird. 

### To Reproduce:
- filter in examples with a single space, `clothp` and `physics integration`

### Issue
These results are just weird.
- A single space: This gave all examples with more than 1 tag.
- `clothp`: This gave only the animation/cloth example  .
- `physics integration`:  This gave only the animation/cloth example .

### Solution 
- A single space: All examples are shown.
- `clothp`:  no examples are shown.
- `physics integration`:  all examples are shown that have either the physics or integration tag.