### PR TITLE
Editor: Added feature to include remote scripts

### DIFF
--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -22,6 +22,8 @@ function Config() {
 		'project/renderer/physicallyCorrectLights': false,
 		'project/renderer/toneMapping': 0, // NoToneMapping
 		'project/renderer/toneMappingExposure': 1,
+		
+		'project/remoteScripts': 'https://code.jquery.com/jquery-3.5.1.min.js',
 
 		'settings/history': false,
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -296,6 +296,9 @@ function Strings( config ) {
 			'sidebar/project/toneMappingExposure': 'Exposure',
 			'sidebar/project/materials': 'Materials',
 			'sidebar/project/Assign': 'Assign',
+			'sidebar/project/remotescript': 'Remote Scripts',
+			'sidebar/project/remotescripthelp1': 'Enter one URL per line',
+			'sidebar/project/remotescripthelp2': 'Refresh to unload deleted scripts',
 
 			'sidebar/settings': 'Settings',
 			'sidebar/settings/language': 'Language',
@@ -610,6 +613,9 @@ function Strings( config ) {
 			'sidebar/project/toneMappingExposure': 'Réglage d\'exposition',
 			'sidebar/project/materials': 'Matériaux',
 			'sidebar/project/Assign': 'Attribuer',
+			'sidebar/project/remotescript': 'Scripts distants',
+			'sidebar/project/remotescripthelp1': 'Entrez une URL par ligne',
+			'sidebar/project/remotescripthelp2': 'Actualisez pour décharger le script supprimé',
 
 			'sidebar/settings': 'Paramètres',
 			'sidebar/settings/language': 'Langue',
@@ -898,6 +904,9 @@ function Strings( config ) {
 			'sidebar/project/toneMappingExposure': '曝光',
 			'sidebar/project/materials': '材质',
 			'sidebar/project/Assign': '应用',
+			'sidebar/project/remotescript': '遠程腳本',
+			'sidebar/project/remotescripthelp1': '每行輸入一個網址',
+			'sidebar/project/remotescripthelp2': '刷新以卸載已刪除的腳本',
 
 			'sidebar/settings': '设置',
 			'sidebar/settings/language': '语言',


### PR DESCRIPTION

## Description:

The feature is a textarea that, on change, sets the key value pair I added to the Config.js. It then appends the scripts with all valid src attributes to the header of the application, which allows them to be used by the editor scripts, or other included libraries.


## Added the following key value pair to Config.js for default value, which is updated whenever a new src is added:
`'project/remoteScripts': 'https://code.jquery.com/jquery-3.5.1.min.js'` 
    

### Added a feature to include remote scripts without having to copy and paste them into the editor.

### The files edited were:
- **Strings.js:** for language strings
- **Config.js:** for key value pair to store the src attributes added by users
- **Sidebar.Project.js:** the portion of code that adds the feature to the project tab of the sidebar, under the materials panel.
    

### Added the following key value pairs to Strings.js:

1.  **EN:**  
    `‘sidebar/project/remotescript’: ‘Remote Scripts’ `
    `'sidebar/project/remotescripthelp1': 'Enter one URL per line'` 
   `'sidebar/project/remotescripthelp2': 'Refresh to unload deleted scripts'`
    
2.  **FR:**  
    `'sidebar/project/remotescript': 'Scripts distants'`  
    `'sidebar/project/remotescripthelp1': 'Entrez une URL par ligne'`  
    `'sidebar/project/remotescripthelp2': 'Actualisez pour décharger le script supprimé'`
    
3.  **ZH:**  
    `'sidebar/project/remotescript': '遠程腳本'`  
    `'sidebar/project/remotescripthelp1': '每行輸入一個網址'`  
    `'sidebar/project/remotescripthelp2': '刷新以卸載已刪除的腳本'`
    

  
