### PR TITLE
MeshSurfaceSampler: Fix mid value in .binarySearch().

### DIFF
--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -128,7 +128,7 @@ var MeshSurfaceSampler = ( function () {
 
 			while ( start <= end ) {
 
-				var mid = Math.floor( ( start + end ) / 2 );
+				var mid = Math.ceil( ( start + end ) / 2 );
 
 				if ( mid === 0 || dist[ mid - 1 ] <= x && dist[ mid ] > x ) {
 


### PR DESCRIPTION
Fixed: #19632

Fixed fiddles: https://jsfiddle.net/vd1aLe74/,  https://jsfiddle.net/z68gj4bm/, https://jsfiddle.net/zjv6s1gw/

https://raw.githack.com/Mugen87/three.js/dev45/examples/webgl_instancing_scatter.html