### PR TITLE
Docs: Update Box3

### DIFF
--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -66,7 +66,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Box3 applyMatrix4]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:this applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>
 		[page:Matrix4 matrix] - The [page:Matrix4] to apply<br /><br />
 
@@ -99,7 +99,7 @@
 		Returns true if the specified [page:Vector3 point] lies within or on the boundaries of this box.
 		</p>
 
-		<h3>[method:Box3 copy]( [param:Box3 box] )</h3>
+		<h3>[method:this copy]( [param:Box3 box] )</h3>
 		<p>
 		[page:Box3 box]  - [page:Box3] to copy.<br /><br />
 
@@ -122,7 +122,7 @@
 		Returns true if this box and [page:Box3 box] share the same lower and upper bounds.
 		</p>
 
-		<h3>[method:Box3 expandByObject]( [param:Object3D object] )</h3>
+		<h3>[method:this expandByObject]( [param:Object3D object] )</h3>
 		<p>
 		[page:Object3D object] - [page:Object3D] to expand the box by.<br /><br />
 
@@ -132,14 +132,14 @@
 
 		</p>
 
-		<h3>[method:Box3 expandByPoint]( [param:Vector3 point] )</h3>
+		<h3>[method:this expandByPoint]( [param:Vector3 point] )</h3>
 		<p>
 		[page:Vector3 point] - [page:Vector3] that should be included in the box.<br /><br />
 
 		Expands the boundaries of this box to include [page:Vector3 point].
 		</p>
 
-		<h3>[method:Box3 expandByScalar]( [param:float scalar] )</h3>
+		<h3>[method:this expandByScalar]( [param:float scalar] )</h3>
 		<p>
 		[page:float scalar] - Distance to expand the box by.<br /><br />
 
@@ -147,7 +147,7 @@
 		will be contracted.
 		</p>
 
-		<h3>[method:Box3 expandByVector]( [param:Vector3 vector] )</h3>
+		<h3>[method:this expandByVector]( [param:Vector3 vector] )</h3>
 		<p>
 		[page:Vector3 vector] - [page:Vector3] to expand the box by.<br /><br />
 
@@ -186,13 +186,13 @@
 		Returns the width, height and depth of this box.
 		</p>
 
-		<h3>[method:Box3 intersect]( [param:Box3 box] )</h3>
+		<h3>[method:this intersect]( [param:Box3 box] )</h3>
 		<p>
 		[page:Box3 box] - Box to intersect with.<br /><br />
 
-		Returns the intersection of this and [page:Box3 box], setting the upper bound of this box to the lesser
+		Computes the intersection of this and [page:Box3 box], setting the upper bound of this box to the lesser
 		of the two boxes' upper bounds and the lower bound of this box to the greater of the two boxes'
-		lower bounds.
+		lower bounds. If there's no overlap, makes this box empty.
 		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>
@@ -230,10 +230,10 @@
 		the one both bounds share.
 		</p>
 
-		<h3>[method:Box3 makeEmpty]()</h3>
+		<h3>[method:this makeEmpty]()</h3>
 		<p>Makes this box empty.</p>
 
-		<h3>[method:Box3 set]( [param:Vector3 min], [param:Vector3 max] )</h3>
+		<h3>[method:this set]( [param:Vector3 min], [param:Vector3 max] )</h3>
 		<p>
 		[page:Vector3 min] - [page:Vector3] representing the lower (x, y, z) boundary of the box.<br />
 		[page:Vector3 max] - [page:Vector3] representing the lower upper (x, y, z) boundary of the box.<br /><br />
@@ -242,21 +242,21 @@
 		Please note that this method only copies the values from the given objects.
 		</p>
 
-		<h3>[method:Box3 setFromArray]( [param:Array array] ) [param:Box3 this]</h3>
+		<h3>[method:this setFromArray]( [param:Array array] )</h3>
 		<p>
 		array -- An array of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in *array*.
 		</p>
 
-		<h3>[method:Box3 setFromBufferAttribute]( [param:BufferAttribute attribute] ) [param:Box3 this]</h3>
+		<h3>[method:this setFromBufferAttribute]( [param:BufferAttribute attribute] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - A buffer attribute of position data that the resulting box will envelop.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the data in [page:BufferAttribute attribute].
 		</p>
 
-		<h3>[method:Box3 setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] ) [param:Box3 this]</h3>
+		<h3>[method:this setFromCenterAndSize]( [param:Vector3 center], [param:Vector3 size] )</h3>
 		<p>
 		[page:Vector3 center], - Desired center position of the box. <br>
 		[page:Vector3 size] - Desired x, y and z dimensions of the box.<br /><br />
@@ -265,7 +265,7 @@
 		in [page:Vector3 size]
 		</p>
 
-		<h3>[method:Box3 setFromObject]( [param:Object3D object] )</h3>
+		<h3>[method:this setFromObject]( [param:Object3D object] )</h3>
 		<p>
 		[page:Object3D object] - [page:Object3D] to compute the bounding box of.<br /><br />
 
@@ -275,14 +275,14 @@
 
 		</p>
 
-		<h3>[method:Box3 setFromPoints]( [param:Array points] )</h3>
+		<h3>[method:this setFromPoints]( [param:Array points] )</h3>
 		<p>
 		[page:Array points] - Array of [page:Vector3 Vector3s] that the resulting box will contain.<br /><br />
 
 		Sets the upper and lower bounds of this box to include all of the points in [page:Array points].
 		</p>
 
-		<h3>[method:Box3 translate]( [param:Vector3 offset] )</h3>
+		<h3>[method:this translate]( [param:Vector3 offset] )</h3>
 		<p>
 		[page:Vector3 offset] - Direction and distance of offset.<br /><br />
 
@@ -290,11 +290,11 @@
 		[page:Vector3 offset] units in 3D space.
 		</p>
 
-		<h3>[method:Box3 union]( [param:Box3 box] )</h3>
+		<h3>[method:this union]( [param:Box3 box] )</h3>
 		<p>
 		[page:Box3 box] - Box that will be unioned with this box.<br /><br />
 
-		Unions this box with [page:Box3 box], setting the upper bound of this box to the greater of the
+		Computes the union of this box and [page:Box3 box], setting the upper bound of this box to the greater of the
 		two boxes' upper bounds and the lower bound of this box to the lesser of the two boxes'
 		lower bounds.
 		</p>


### PR DESCRIPTION
1. Methods should update to return 'this' in docs; less confusion; especially .. `intersect()` and `union()`. 

- .applyMatrix4()
- .copy()
- .expandByObject()
- .expandByPoint()
- .expandByScalar()
- .expandByVector()
- .intersect()
- .makeEmpty()
- .set()
- .setFromArray()
- .setFromBufferAttribute()
- .setFromCenterAndSize()
- .setFromObject()
- .setFromPoints()
- .translate()
- .union()

2. Updated `.intersect()` desc
   "... If there's no overlap, make this box empty."

3. Updated `.union()` desc
   "Computes ..." 