### PR TITLE
Making outputEncoding fix more universal

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -40,7 +40,8 @@ THREE.Reflector = function ( geometry, options ) {
 		minFilter: THREE.LinearFilter,
 		magFilter: THREE.LinearFilter,
 		format: THREE.RGBFormat,
-		stencilBuffer: false
+		stencilBuffer: false,
+		encoding: renderer.outputEncoding
 	};
 
 	var renderTarget = new THREE.WebGLRenderTarget( textureWidth, textureHeight, parameters );
@@ -139,9 +140,9 @@ THREE.Reflector = function ( geometry, options ) {
 
 		// Render
 
-		if ( renderer.outputEncoding !== THREE.LinearEncoding ) {
+		if ( renderer.outputEncoding !== renderTarget.texture.encoding ) {
 
-			console.warn( 'THREE.Reflector: WebGLRenderer must use LinearEncoding as outputEncoding.' );
+			console.warn('THREE.Reflector: renderer outputEncoding(' + renderer.outputEncoding + ') and rendertarget encoding parameter(' + renderTarget.texture.encoding + ') must match.' );
 			scope.onBeforeRender = function () {};
 
 			return;


### PR DESCRIPTION
If trying to use this code elsewhere where the renderer's outputEncoding is non-linear (i.e. THREE.sRGBEncoding in A-Frame) the mirror will not render. Have modified to make sure that renderTarget encoding matches the renderer's outputEncoding, and that the warning message covers other use-cases.