### PR TITLE
Reflector/Refractor: Set .encoding to match renderer.outputEncoding

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -61,6 +61,12 @@ THREE.Reflector = function ( geometry, options ) {
 	material.uniforms[ "color" ].value = color;
 	material.uniforms[ "textureMatrix" ].value = textureMatrix;
 
+	material.onBeforeCompile = function ( shader, renderer ) {
+
+		this.uniforms[ "tDiffuse" ].value.encoding = renderer.outputEncoding;
+
+	}
+
 	this.material = material;
 
 	this.onBeforeRender = function ( renderer, scene, camera ) {
@@ -136,17 +142,6 @@ THREE.Reflector = function ( geometry, options ) {
 		projectionMatrix.elements[ 6 ] = clipPlane.y;
 		projectionMatrix.elements[ 10 ] = clipPlane.z + 1.0 - clipBias;
 		projectionMatrix.elements[ 14 ] = clipPlane.w;
-
-		// Render
-
-		if ( renderer.outputEncoding !== THREE.LinearEncoding ) {
-
-			console.warn( 'THREE.Reflector: WebGLRenderer must use LinearEncoding as outputEncoding.' );
-			scope.onBeforeRender = function () {};
-
-			return;
-
-		}
 
 		scope.visible = false;
 

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -61,6 +61,12 @@ THREE.Refractor = function ( geometry, options ) {
 	this.material.uniforms[ "tDiffuse" ].value = renderTarget.texture;
 	this.material.uniforms[ "textureMatrix" ].value = textureMatrix;
 
+	this.material.onBeforeCompile = function ( shader, renderer ) {
+
+		this.uniforms[ "tDiffuse" ].value.encoding = renderer.outputEncoding;
+
+	}
+
 	// functions
 
 	var visible = ( function () {
@@ -221,17 +227,6 @@ THREE.Refractor = function ( geometry, options ) {
 	//
 
 	this.onBeforeRender = function ( renderer, scene, camera ) {
-
-		// Render
-
-		if ( renderer.outputEncoding !== THREE.LinearEncoding ) {
-
-			console.warn( 'THREE.Refractor: WebGLRenderer must use LinearEncoding as outputEncoding.' );
-			scope.onBeforeRender = function () {};
-
-			return;
-
-		}
 
 		// ensure refractors are rendered only once per frame
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -4,7 +4,6 @@
 
 import {
 	Color,
-	LinearEncoding,
 	LinearFilter,
 	MathUtils,
 	Matrix4,
@@ -76,6 +75,12 @@ var Reflector = function ( geometry, options ) {
 	material.uniforms[ "tDiffuse" ].value = renderTarget.texture;
 	material.uniforms[ "color" ].value = color;
 	material.uniforms[ "textureMatrix" ].value = textureMatrix;
+
+	material.onBeforeCompile = function ( shader, renderer ) {
+
+		this.uniforms[ "tDiffuse" ].value.encoding = renderer.outputEncoding;
+
+	}
 
 	this.material = material;
 
@@ -152,17 +157,6 @@ var Reflector = function ( geometry, options ) {
 		projectionMatrix.elements[ 6 ] = clipPlane.y;
 		projectionMatrix.elements[ 10 ] = clipPlane.z + 1.0 - clipBias;
 		projectionMatrix.elements[ 14 ] = clipPlane.w;
-
-		// Render
-
-		if ( renderer.outputEncoding !== LinearEncoding ) {
-
-			console.warn( 'THREE.Reflector: WebGLRenderer must use LinearEncoding as outputEncoding.' );
-			scope.onBeforeRender = function () {};
-
-			return;
-
-		}
 
 		scope.visible = false;
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -5,7 +5,6 @@
 
 import {
 	Color,
-	LinearEncoding,
 	LinearFilter,
 	MathUtils,
 	Matrix4,
@@ -77,6 +76,12 @@ var Refractor = function ( geometry, options ) {
 	this.material.uniforms[ "color" ].value = color;
 	this.material.uniforms[ "tDiffuse" ].value = renderTarget.texture;
 	this.material.uniforms[ "textureMatrix" ].value = textureMatrix;
+
+	this.material.onBeforeCompile = function ( shader, renderer ) {
+
+		this.uniforms[ "tDiffuse" ].value.encoding = renderer.outputEncoding;
+
+	}
 
 	// functions
 
@@ -238,17 +243,6 @@ var Refractor = function ( geometry, options ) {
 	//
 
 	this.onBeforeRender = function ( renderer, scene, camera ) {
-
-		// Render
-
-		if ( renderer.outputEncoding !== LinearEncoding ) {
-
-			console.warn( 'THREE.Refractor: WebGLRenderer must use LinearEncoding as outputEncoding.' );
-			scope.onBeforeRender = function () {};
-
-			return;
-
-		}
 
 		// ensure refractors are rendered only once per frame
 

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -56,6 +56,11 @@
 				renderer.setSize( WIDTH, HEIGHT );
 				container.appendChild( renderer.domElement );
 
+				renderer.outputEncoding = THREE.sRGBEncoding;
+
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 0.5;
+
 				// scene
 				scene = new THREE.Scene();
 

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -92,6 +92,11 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				document.body.appendChild( renderer.domElement );
 
+				renderer.outputEncoding = THREE.sRGBEncoding;
+
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 0.5;
+
 				//
 
 				var controls = new OrbitControls( camera, renderer.domElement );


### PR DESCRIPTION
This PR is based on an idea suggested by @PlumCantaloupe in #19665.

After some experimentation, I think this implementation works well-enough for now, and is also an improvement since `renderer.outputEncoding` is no longer required to be linear when using reflectors.

There is no performance issue.
