### PR TITLE
ShadowMaterial: Fix handling shadow map offset

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1786,6 +1786,7 @@ function WebGLRenderer( parameters ) {
 				material.isMeshBasicMaterial ||
 				material.isMeshStandardMaterial ||
 				material.isShaderMaterial ||
+				material.isShadowMaterial ||
 				material.skinning ) {
 
 				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );

--- a/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
@@ -1,4 +1,5 @@
 export default /* glsl */`
+#include <common>
 #include <fog_pars_vertex>
 #include <shadowmap_pars_vertex>
 


### PR DESCRIPTION
ShadowMaterial vertex shader needs to include common and have access to the view matrix to be able to apply shadow normal offset. This fixes issue introduced in PR #18915.