### PR TITLE
Editor: Refactored Background/Environment code

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -44,6 +44,7 @@ function Editor() {
 		rendererUpdated: new Signal(),
 
 		sceneBackgroundChanged: new Signal(),
+		sceneEnvironmentChanged: new Signal(),
 		sceneFogChanged: new Signal(),
 		sceneGraphChanged: new Signal(),
 		sceneRendered: new Signal(),
@@ -94,7 +95,6 @@ function Editor() {
 
 	this.scene = new THREE.Scene();
 	this.scene.name = 'Scene';
-	this.scene.background = new THREE.Color( 0xaaaaaa );
 
 	this.sceneHelpers = new THREE.Scene();
 
@@ -612,9 +612,11 @@ Editor.prototype = {
 		this.storage.clear();
 
 		this.camera.copy( this.DEFAULT_CAMERA );
+
 		this.scene.name = "Scene";
 		this.scene.userData = {};
-		this.scene.background = new THREE.Color( 0xaaaaaa );
+		this.scene.background = null;
+		this.scene.environment = null;
 		this.scene.fog = null;
 
 		var objects = this.scene.children;

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -81,6 +81,7 @@ function Strings( config ) {
 
 			'sidebar/scene': 'Scene',
 			'sidebar/scene/background': 'Background',
+			'sidebar/scene/environment': 'Environment',
 			'sidebar/scene/fog': 'Fog',
 
 			'sidebar/properties/object': 'Object',
@@ -398,6 +399,7 @@ function Strings( config ) {
 
 			'sidebar/scene': 'Scène',
 			'sidebar/scene/background': 'Arrière Plan',
+			'sidebar/scene/environment': 'Environment',
 			'sidebar/scene/fog': 'Brouillard',
 
 			'sidebar/properties/object': 'Objet',
@@ -715,6 +717,7 @@ function Strings( config ) {
 
 			'sidebar/scene': '场景',
 			'sidebar/scene/background': '背景',
+			'sidebar/scene/environment': 'Environment',
 			'sidebar/scene/fog': '雾',
 
 			'sidebar/properties/object': '属性',


### PR DESCRIPTION
Cleaned up the "none" background behaviour, removed the `CubeTexture` background (for now) and made `Environment` opt-in.

<img width="1157" alt="Screen Shot 2020-06-19 at 9 53 34 PM" src="https://user-images.githubusercontent.com/97088/85192808-d8fb3300-b2fe-11ea-83ca-870fd8075922.png">
