### PR TITLE
WebGLRenderer: Accept null when using setAnimationLoop().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -957,7 +957,7 @@ function WebGLRenderer( parameters ) {
 		onAnimationFrameCallback = callback;
 		xr.setAnimationLoop( callback );
 
-		animation.start();
+		( callback === null ) ? animation.stop() : animation.start();
 
 	};
 

--- a/src/renderers/webgl/WebGLAnimation.js
+++ b/src/renderers/webgl/WebGLAnimation.js
@@ -11,8 +11,6 @@ function WebGLAnimation() {
 
 	function onAnimationFrame( time, frame ) {
 
-		if ( isAnimating === false ) return;
-
 		animationLoop( time, frame );
 
 		requestId = context.requestAnimationFrame( onAnimationFrame );

--- a/src/renderers/webgl/WebGLAnimation.js
+++ b/src/renderers/webgl/WebGLAnimation.js
@@ -7,6 +7,7 @@ function WebGLAnimation() {
 	let context = null;
 	let isAnimating = false;
 	let animationLoop = null;
+	let requestId = null;
 
 	function onAnimationFrame( time, frame ) {
 
@@ -14,7 +15,7 @@ function WebGLAnimation() {
 
 		animationLoop( time, frame );
 
-		context.requestAnimationFrame( onAnimationFrame );
+		requestId = context.requestAnimationFrame( onAnimationFrame );
 
 	}
 
@@ -25,13 +26,15 @@ function WebGLAnimation() {
 			if ( isAnimating === true ) return;
 			if ( animationLoop === null ) return;
 
-			context.requestAnimationFrame( onAnimationFrame );
+			requestId = context.requestAnimationFrame( onAnimationFrame );
 
 			isAnimating = true;
 
 		},
 
 		stop: function () {
+
+			context.cancelAnimationFrame( requestId );
 
 			isAnimating = false;
 


### PR DESCRIPTION
Fixed #19689.

`WebGLAnimation` also makes now use of `cancelAnimationFrame()`.

BTW: Was there a reason for not using `cancelAnimationFrame()` when implementing `WebGLAnimation`?