### PR TITLE
Shaders: apply exposure boost to ACES Filmic tone mapping

### DIFF
--- a/examples/js/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/js/shaders/ACESFilmicToneMappingShader.js
@@ -4,6 +4,9 @@ console.warn( "THREE.ACESFilmicToneMappingShader: As part of the transition to E
  *
  * ACES Filmic Tone Mapping Shader by Stephen Hill
  * source: https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs
+ *
+ * this implementation of ACES is modified to accommodate a brighter viewing environment.
+ * the scale factor of 1/0.6 is subjective. see discussion in #19621.
  */
 
 THREE.ACESFilmicToneMappingShader = {
@@ -78,7 +81,7 @@ THREE.ACESFilmicToneMappingShader = {
 
 		'	vec4 tex = texture2D( tDiffuse, vUv );',
 
-		'	tex.rgb *= exposure;', // pre-exposed, outside of the tone mapping function
+		'	tex.rgb *= exposure / 0.6;', // pre-exposed, outside of the tone mapping function
 
 		'	gl_FragColor = vec4( ACESFilmicToneMapping( tex.rgb ), tex.a );',
 

--- a/examples/jsm/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/jsm/shaders/ACESFilmicToneMappingShader.js
@@ -3,6 +3,9 @@
  *
  * ACES Filmic Tone Mapping Shader by Stephen Hill
  * source: https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs
+ *
+ * this implementation of ACES is modified to accommodate a brighter viewing environment.
+ * the scale factor of 1/0.6 is subjective. see discussion in #19621.
  */
 
 
@@ -79,7 +82,7 @@ var ACESFilmicToneMappingShader = {
 
 		'	vec4 tex = texture2D( tDiffuse, vUv );',
 
-		'	tex.rgb *= exposure;', // pre-exposed, outside of the tone mapping function
+		'	tex.rgb *= exposure / 0.6;', // pre-exposed, outside of the tone mapping function
 
 		'	gl_FragColor = vec4( ACESFilmicToneMapping( tex.rgb ), tex.a );',
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -40,6 +40,9 @@ vec3 RRTAndODTFit( vec3 v ) {
 
 }
 
+// this implementation of ACES is modified to accommodate a brighter viewing environment.
+// the scale factor of 1/0.6 is subjective. see discussion in #19621.
+
 vec3 ACESFilmicToneMapping( vec3 color ) {
 
     // sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
@@ -56,7 +59,7 @@ vec3 ACESFilmicToneMapping( vec3 color ) {
         vec3( -0.07367, -0.00605,  1.07602 )
     );
 
-    color *= toneMappingExposure;
+    color *= toneMappingExposure / 0.6;
 
     color = ACESInputMat * color;
 


### PR DESCRIPTION
See discussion in #19621.

todo: After merging, revert exposure boosts that were introduced into the examples following #19621.

todo: correct migration docs