### PR TITLE
Remove single instance of whitelist with allowlist

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -44276,7 +44276,7 @@
 
 				var objectName = results.nodeName.substring( lastDot + 1 );
 
-				// Object names must be checked against a whitelist. Otherwise, there
+				// Object names must be checked against an allowlist. Otherwise, there
 				// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
 				// 'bar' could be the objectName, or part of a nodeName (which can
 				// include '.' characters).

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -44244,7 +44244,7 @@ Object.assign( PropertyBinding, {
 
 			const objectName = results.nodeName.substring( lastDot + 1 );
 
-			// Object names must be checked against a whitelist. Otherwise, there
+			// Object names must be checked against an allowlist. Otherwise, there
 			// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
 			// 'bar' could be the objectName, or part of a nodeName (which can
 			// include '.' characters).

--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -173,7 +173,7 @@ Object.assign( PropertyBinding, {
 
 			const objectName = results.nodeName.substring( lastDot + 1 );
 
-			// Object names must be checked against a whitelist. Otherwise, there
+			// Object names must be checked against an allowlist. Otherwise, there
 			// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
 			// 'bar' could be the objectName, or part of a nodeName (which can
 			// include '.' characters).


### PR DESCRIPTION
Given the context, allowlist is an appropriate replacement for the
single usage of whitelist in the code. We could call it exactly what
it is, a supported sub-objects name list, but that is getting verbose.