### PR TITLE
[TS] Add generic type with default to Group children

### DIFF
--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -15,10 +15,12 @@ import { BufferGeometry } from './BufferGeometry';
 import { Intersection } from './Raycaster';
 import { AnimationClip } from '../animation/AnimationClip';
 
+type AliasObject3D = Object3D;
+
 /**
  * Base class for scene graph objects
  */
-export class Object3D extends EventDispatcher {
+export class Object3D<TChild extends Object3D = AliasObject3D> extends EventDispatcher {
 
 	constructor();
 
@@ -53,7 +55,7 @@ export class Object3D extends EventDispatcher {
 	 * Array with object's children.
 	 * @default []
 	 */
-	children: Object3D[];
+	children: TChild[];
 
 	/**
 	 * Up direction.
@@ -315,12 +317,12 @@ export class Object3D extends EventDispatcher {
 	/**
 	 * Adds object as child of this object.
 	 */
-	add( ...object: Object3D[] ): this;
+	add( ...object: TChild[] ): this;
 
 	/**
 	 * Removes object as child of this object.
 	 */
-	remove( ...object: Object3D[] ): this;
+	remove( ...object: TChild[] ): this;
 
 	/**
 	 * Removes all child objects.
@@ -330,21 +332,21 @@ export class Object3D extends EventDispatcher {
 	/**
 	 * Adds object as a child of this, while maintaining the object's world transform.
 	 */
-	attach( object: Object3D ): this;
+	attach( object: TChild ): this;
 
 	/**
 	 * Searches through the object's children and returns the first with a matching id.
 	 * @param id	Unique number of the object instance
 	 */
-	getObjectById( id: number ): Object3D | undefined;
+	getObjectById( id: number ): TChild | undefined;
 
 	/**
 	 * Searches through the object's children and returns the first with a matching name.
 	 * @param name	String to match to the children's Object3d.name property.
 	 */
-	getObjectByName( name: string ): Object3D | undefined;
+	getObjectByName( name: string ): TChild | undefined;
 
-	getObjectByProperty( name: string, value: string ): Object3D | undefined;
+	getObjectByProperty( name: string, value: string ): TChild | undefined;
 
 	getWorldPosition( target: Vector3 ): Vector3;
 	getWorldQuaternion( target: Quaternion ): Quaternion;

--- a/src/objects/Group.d.ts
+++ b/src/objects/Group.d.ts
@@ -1,9 +1,18 @@
 import { Object3D } from './../core/Object3D';
 
-export class Group extends Object3D {
+export class Group<TChild extends Object3D = Object3D> extends Object3D {
 
 	constructor();
+	children: TChild[];
 	type: 'Group';
 	readonly isGroup: true;
+
+	add( ...object: TChild[] ): this;
+	remove( ...object: TChild[] ): this;
+	attach( object: TChild ): this;
+
+	getObjectById( id: number ): TChild | undefined;
+	getObjectByName( name: string ): TChild | undefined;
+	getObjectByProperty( name: string, value: string ): TChild | undefined;
 
 }

--- a/src/objects/Group.d.ts
+++ b/src/objects/Group.d.ts
@@ -1,18 +1,9 @@
 import { Object3D } from './../core/Object3D';
 
-export class Group<TChild extends Object3D = Object3D> extends Object3D {
+export class Group extends Object3D {
 
 	constructor();
-	children: TChild[];
 	type: 'Group';
 	readonly isGroup: true;
-
-	add( ...object: TChild[] ): this;
-	remove( ...object: TChild[] ): this;
-	attach( object: TChild ): this;
-
-	getObjectById( id: number ): TChild | undefined;
-	getObjectByName( name: string ): TChild | undefined;
-	getObjectByProperty( name: string, value: string ): TChild | undefined;
 
 }

--- a/src/objects/Group.d.ts
+++ b/src/objects/Group.d.ts
@@ -1,6 +1,6 @@
 import { Object3D } from './../core/Object3D';
 
-export class Group extends Object3D {
+export class Group<TChild extends Object3D = Object3D> extends Object3D<TChild> {
 
 	constructor();
 	type: 'Group';

--- a/src/objects/Mesh.d.ts
+++ b/src/objects/Mesh.d.ts
@@ -4,7 +4,7 @@ import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Mesh extends Object3D {
+export class Mesh<TChild extends Object3D = Object3D> extends Object3D<TChild> {
 
 	constructor(
 		geometry?: BufferGeometry,


### PR DESCRIPTION
Based on a [discussion on Twitter](https://twitter.com/squidfunk/status/1273994680955518981), I suggest those modifications in the TypeScript definitions to introduce generics in Group children. This is a follow-up work of #19299 which introduced generics for Geometry and Material in Geometry types.

I also changed the type of the `type` property since people will be more likely to override Group and therefore have their own `type` string instead of 'Group'. I don't know if this is a good idea, but I think it would reduce the number of adaptations in an existing codebase to adopt this TS "feature". It is the case for one of my codebases at least.

Let me know what you think, especially @donmccurdy, since you suggested me the PR. Thanks !