### PR TITLE
Examples: specify tone mapping exposure for clarity #2

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -88,6 +88,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 1;
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -150,6 +150,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 1;
 				renderer.physicallyCorrectLights = true;
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl_pmrem_test.html
+++ b/examples/webgl_pmrem_test.html
@@ -46,6 +46,7 @@
 
 				// tonemapping
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 1;
 
 				document.body.appendChild( renderer.domElement );
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/19696#issuecomment-647177200.
