### PR TITLE
Examples: avoid using linear tone mapping

### DIFF
--- a/examples/webgl_lightprobe.html
+++ b/examples/webgl_lightprobe.html
@@ -46,8 +46,7 @@
 				document.body.appendChild( renderer.domElement );
 
 				// tone mapping
-				//renderer.toneMapping = LinearToneMapping;
-			 	//renderer.toneMappingExposure = API.exposure;
+				renderer.toneMapping = THREE.NoToneMapping;
 
 				renderer.outputEncoding = THREE.sRGBEncoding;
 

--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -40,7 +40,7 @@
 				document.body.appendChild( renderer.domElement );
 
 				// tone mapping
-				renderer.toneMapping = THREE.LinearToneMapping;
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 			 	renderer.toneMappingExposure = API.exposure;
 
 				renderer.outputEncoding = THREE.sRGBEncoding;

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -186,7 +186,7 @@
 			scene.background = new THREE.Color( 0x111111 );
 
 			var renderer = new THREE.WebGLRenderer();
-			renderer.toneMapping = THREE.LinearToneMapping;
+			renderer.toneMapping = THREE.NoToneMapping;
 			container.appendChild( renderer.domElement );
 
 			var renderTarget = new THREE.WebGLRenderTarget();
@@ -195,7 +195,7 @@
 			// At least one regular Pointlight is needed to activate light support
 			scene.add( new THREE.PointLight( 0xff0000, 0.1, 0.1 ) );
 
-			var bloom = new UnrealBloomPass( new THREE.Vector2(), 0.8, 0.6, 0.8 );
+			var bloom = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 0.8, 0.6, 0.8 );
 			bloom.renderToScreen = true;
 
 			var stats = new Stats();


### PR DESCRIPTION
Granted, these changes are a bit subjective, but I think `NoToneMapping` is a better stub, until the example is modified to warrant a more appropriate tone mapping technique.