### PR TITLE
Fix camera lookAt in orbit controls

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -217,7 +217,7 @@ var OrbitControls = function ( object, domElement ) {
 			if ( scope.object.isCamera || scope.object.isLight ) {
 				_m1.lookAt( position, scope.target, scope.object.up );
 			} else {
-				_m1.lookAt( scope.object.up, position, scope.object.up );
+				_m1.lookAt( scope.target, position, scope.object.up );
 			}
 			scope.object.quaternion.setFromRotationMatrix( _m1 );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -14,8 +14,11 @@ import {
 	Spherical,
 	TOUCH,
 	Vector2,
-	Vector3
+	Vector3,
+	Matrix4
 } from "../../../build/three.module.js";
+
+const _m1 = new Matrix4();
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
@@ -211,8 +214,12 @@ var OrbitControls = function ( object, domElement ) {
 			offset.applyQuaternion( quatInverse );
 
 			position.copy( scope.target ).add( offset );
-
-			scope.object.lookAt( scope.target );
+			if ( scope.object.isCamera || scope.object.isLight ) {
+				_m1.lookAt( position, scope.target, scope.object.up );
+			} else {
+				_m1.lookAt( scope.object.up, position, scope.object.up );
+			}
+			scope.object.quaternion.setFromRotationMatrix( _m1 );
 
 			if ( scope.enableDamping === true ) {
 


### PR DESCRIPTION
I might be wrong, but looks it's not using the correct way to lookAt back to the target. The orbit should only change the state in local coordinate, so could be bug if not on purpose