### PR TITLE
Make loop unrolling whitespace-insensitive

### DIFF
--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -54,9 +54,6 @@
 					<li>
 						The loop variable has to be *i*.
 					</li>
-					<li>
-						The loop has to use a certain whitespace formatting.
-					</li>
 				</ul>
 				<code>
 		#pragma unroll_loop_start

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -43,9 +43,6 @@
 					<li>
 						循环变量必须是*i*。
 					</li>
-					<li>
-						循环必须使用某种空格格式。
-					</li>
 				</ul>
 				<code>
 		#pragma unroll_loop_start

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -224,7 +224,7 @@ function includeReplacer( match, include ) {
 // Unroll Loops
 
 const deprecatedUnrollLoopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
-const unrollLoopPattern = /#pragma unroll_loop_start[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}[\s]+?#pragma unroll_loop_end/g;
+const unrollLoopPattern = /#pragma\s+unroll_loop_start\s+for\s*\(\s*int\s+i\s*=\s*(\d+)\s*;\s*i\s*<\s*(\d+)\s*;\s*i\s*\+\+\s*\)\s*{([\s\S]+?)}\s+#pragma\s+unroll_loop_end/g;
 
 function unrollLoops( string ) {
 
@@ -248,7 +248,7 @@ function loopReplacer( match, start, end, snippet ) {
 	for ( let i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
 		string += snippet
-			.replace( /\[ i \]/g, '[ ' + i + ' ]' )
+			.replace( /\[\s*i\s*\]/g, '[ ' + i + ' ]' )
 			.replace( /UNROLLED_LOOP_INDEX/g, i );
 
 	}


### PR DESCRIPTION
I'm trying to reduce the bundle size of THREE.js, and one of my strategies is to trim the whitespaces in GLSL code. However, loop unrolling requires a certain whitespace formatting, which makes it troublesome to do the work. I propose to make loop unrolling whitespace-insensitive. This will allow GLSL code to be more compact, as well as reduce the trouble when minifying GLSL code (you must be very careful, otherwise you may break loop rolling).