### PR TITLE
Add missing WebGL1Renderer to Typescript definitions

### DIFF
--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -3,6 +3,7 @@ export * from './renderers/WebGLMultisampleRenderTarget';
 export * from './renderers/WebGLCubeRenderTarget';
 export * from './renderers/WebGLRenderTarget';
 export * from './renderers/WebGLRenderer';
+export * from './renderers/WebGL1Renderer';
 export * from './renderers/shaders/ShaderLib';
 export * from './renderers/shaders/UniformsLib';
 export * from './renderers/shaders/UniformsUtils';


### PR DESCRIPTION
This adds the missing WebGL1Renderer export to the Typescript definitions. 
Useful to have for those who aren't yet ready to migrate the now default WebGL2 renderer :)