### PR TITLE
VRMLLoader lexer performance improvements

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -106,8 +106,11 @@ THREE.VRMLLoader = ( function () {
 
 				// from http://gun.teipir.gr/VRML-amgem/spec/part1/concepts.html#SyntaxBasics
 
-				var RouteIdentifier = createToken( { name: 'RouteIdentifier', pattern: /[^\x30-\x39\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d][^\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d]*[\.][^\x30-\x39\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d][^\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d]*/ } );
-				var Identifier = createToken( { name: 'Identifier', pattern: /[^\x30-\x39\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d][^\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d]*/, longer_alt: RouteIdentifier } );
+				// Converted to not use complement sets for performance reasons. See https://sap.github.io/chevrotain/docs/guide/resolving_lexer_errors.html#COMPLEMENT
+				// Original regex: /[^\x30-\x39\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d][^\0-\x20\x22\x27\x23\x2b\x2c\x2d\x2e\x5b\x5d\x5c\x7b\x7d]*
+
+				var RouteIdentifier = createToken( { name: 'RouteIdentifier', pattern: /[\u0021\u0024-\u0026\u0028-\u002a\u002f\u003a-\u005a\u005e-\u007a\u007c\u007e-\uffff][\u0021\u0024-\u0026\u0028-\u002a\u002f-\u005a\u005e-\u007a\u007c\u007e-\uffff]*[\.][\u0021\u0024-\u0026\u0028-\u002a\u002f\u003a-\u005a\u005e-\u007a\u007c\u007e-\uffff][\u0021\u0024-\u0026\u0028-\u002a\u002f-\u005a\u005e-\u007a\u007c\u007e-\uffff]*/ } );
+				var Identifier = createToken( { name: 'Identifier', pattern: /[\u0021\u0024-\u0026\u0028-\u002a\u002f\u003a-\u005a\u005e-\u007a\u007c\u007e-\uffff][\u0021\u0024-\u0026\u0028-\u002a\u002f-\u005a\u005e-\u007a\u007c\u007e-\uffff]*/, longer_alt: RouteIdentifier } );
 
 				// from http://gun.teipir.gr/VRML-amgem/spec/part1/nodesRef.html
 
@@ -3180,7 +3183,9 @@ THREE.VRMLLoader = ( function () {
 
 	function VRMLLexer( tokens ) {
 
-		this.lexer = new chevrotain.Lexer( tokens );
+		// ensureOptimizations will give console errors if lexer rules don't allow optimizations
+
+		this.lexer = new chevrotain.Lexer( tokens, { ensureOptimizations: true } );
 
 	}
 
@@ -3331,7 +3336,7 @@ THREE.VRMLLoader = ( function () {
 
 			$.AT_LEAST_ONE( function () {
 
-				$.OR( [
+				$.OR( $.altSingleFieldValue || ($.altSingleFieldValue = [
 					{ ALT: function () {
 
 						$.SUBRULE( $.node );
@@ -3372,7 +3377,7 @@ THREE.VRMLLoader = ( function () {
 						$.CONSUME( NullLiteral );
 
 					} }
-				] );
+				]) );
 
 
 			} );
@@ -3384,7 +3389,7 @@ THREE.VRMLLoader = ( function () {
 			$.CONSUME( LSquare );
 			$.MANY( function () {
 
-				$.OR( [
+				$.OR( $.altMultiFieldValue || ($.altMultiFieldValue = [
 					{ ALT: function () {
 
 						$.SUBRULE( $.node );
@@ -3415,7 +3420,7 @@ THREE.VRMLLoader = ( function () {
 						$.CONSUME( NullLiteral );
 
 					} }
-				] );
+				]) );
 
 			} );
 			$.CONSUME( RSquare );


### PR DESCRIPTION
### Issue ###
Poor performance when loading large (1MB+) VRML files.

### Resolution ###
Implemented suggestions at https://sap.github.io/chevrotain/docs/guide/performance.html#using-a-singleton-parser. Specifically, removing complement sets from regular expressions (as suggested here: https://sap.github.io/chevrotain/docs/guide/resolving_lexer_errors.html#COMPLEMENT) seems to have had the largest impact, with a roughly 20-30% decrease in lexer time overall. 