### PR TITLE
Skip both null and undefined overrideMaterials

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1237,7 +1237,7 @@ function WebGLRenderer( parameters ) {
 
 			const object = renderItem.object;
 			const geometry = renderItem.geometry;
-			const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
+			const material = overrideMaterial == null ? renderItem.material : overrideMaterial;
 			const group = renderItem.group;
 
 			if ( camera.isArrayCamera ) {


### PR DESCRIPTION
After updating to r118 my project failed inside WebGLRenderer as it was trying to access material properties on undefined. It did this because `scene.overrideMaterial` was set to `undefined`, and r118 performs a strict equality to `null` when determining if there's an overrideMaterial set. `undefined !== null` so WebGLRenderer assumes that `undefined` is a material. [Previously, there was a strict equality check against undefined instead](https://github.com/mrdoob/three.js/blob/cfa04293639fc6903386a95932c16b04c73c35fc/src/renderers/WebGLRenderer.js#L1414)

This PR changes the strict equality to a loose equality, so that overrideMaterial is not used if it is either `null` or `undefined`