### PR TITLE
Removed trailing comma (breaking strict es6 build)

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -207,7 +207,7 @@ Object.assign( BufferAttribute.prototype, {
 				_vector2.fromBufferAttribute( this, i );
 				_vector2.applyMatrix3( m );
 
-				this.setXY( i, _vector2.x, _vector2.y, );
+				this.setXY( i, _vector2.x, _vector2.y );
 
 			}
 


### PR DESCRIPTION
Here's a tiny fix that removes a trailing comma in the `transformDirection` method. While it generally isn't an issue, it would break builds where we use terser (https://github.com/terser/terser) in strict 'es6' mode. Unlikely to cause any side-effects.