### PR TITLE
WebGLRenderer: Add `compileAsync()`.

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -61,7 +61,13 @@
 						// model
 
 						const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
-						loader.load( 'DamagedHelmet.gltf', function ( gltf ) {
+						loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {
+
+							// Calling compileAsync returns a promise that resolves when gltf.scene can be added
+							// to scene without unnecessary stalling on shader compiation. This helps the page
+							// stay responsive during startup.
+
+							await renderer.compileAsync( gltf.scene, scene );
 
 							scene.add( gltf.scene );
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -64,7 +64,7 @@
 						loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {
 
 							// Calling compileAsync returns a promise that resolves when gltf.scene can be added
-							// to scene without unnecessary stalling on shader compiation. This helps the page
+							// to scene without unnecessary stalling on shader compilation. This helps the page
 							// stay responsive during startup.
 
 							await renderer.compileAsync( gltf.scene, scene );

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -67,7 +67,7 @@
 							// to scene without unnecessary stalling on shader compilation. This helps the page
 							// stay responsive during startup.
 
-							await renderer.compileAsync( gltf.scene, scene );
+							await renderer.compileAsync( gltf.scene, camera );
 
 							scene.add( gltf.scene );
 

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -65,10 +65,17 @@
 						new GLTFLoader()
 							.setPath( 'models/gltf/' )
 							.setDRACOLoader( new DRACOLoader().setDecoderPath( 'jsm/libs/draco/gltf/' ) )
-							.load( 'IridescentDishWithOlives.glb', function ( gltf ) {
+							.load( 'IridescentDishWithOlives.glb', async function ( gltf ) {
 
 								mixer = new THREE.AnimationMixer( gltf.scene );
 								mixer.clipAction( gltf.animations[ 0 ] ).play();
+
+								// Calling compileAsync returns a promise that resolves when gltf.scene can be added
+								// to scene without unnecessary stalling on shader compiation. This helps the page
+								// stay responsive during startup.
+
+								await renderer.compileAsync( gltf.scene, scene );
+
 								scene.add( gltf.scene );
 
 							} );

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -71,7 +71,7 @@
 								mixer.clipAction( gltf.animations[ 0 ] ).play();
 
 								// Calling compileAsync returns a promise that resolves when gltf.scene can be added
-								// to scene without unnecessary stalling on shader compiation. This helps the page
+								// to scene without unnecessary stalling on shader compilation. This helps the page
 								// stay responsive during startup.
 
 								await renderer.compileAsync( gltf.scene, scene );

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -74,7 +74,7 @@
 								// to scene without unnecessary stalling on shader compilation. This helps the page
 								// stay responsive during startup.
 
-								await renderer.compileAsync( gltf.scene, scene );
+								await renderer.compileAsync( gltf.scene, camera );
 
 								scene.add( gltf.scene );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -917,29 +917,29 @@ class WebGLRenderer {
 
 		// Compile
 
-		this.compile = function ( scene, camera ) {
+		function prepareMaterial( material, scene, object ) {
 
-			function prepare( material, scene, object ) {
+			if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
-				if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
+				material.side = BackSide;
+				material.needsUpdate = true;
+				getProgram( material, scene, object );
 
-					material.side = BackSide;
-					material.needsUpdate = true;
-					getProgram( material, scene, object );
+				material.side = FrontSide;
+				material.needsUpdate = true;
+				getProgram( material, scene, object );
 
-					material.side = FrontSide;
-					material.needsUpdate = true;
-					getProgram( material, scene, object );
+				material.side = DoubleSide;
 
-					material.side = DoubleSide;
+			} else {
 
-				} else {
-
-					getProgram( material, scene, object );
-
-				}
+				getProgram( material, scene, object );
 
 			}
+
+		}
+
+		this.compile = function ( scene, camera ) {
 
 			currentRenderState = renderStates.get( scene );
 			currentRenderState.init();
@@ -976,13 +976,13 @@ class WebGLRenderer {
 
 							const material2 = material[ i ];
 
-							prepare( material2, scene, object );
+							prepareMaterial( material2, scene, object );
 
 						}
 
 					} else {
 
-						prepare( material, scene, object );
+						prepareMaterial( material, scene, object );
 
 					}
 
@@ -992,6 +992,163 @@ class WebGLRenderer {
 
 			renderStateStack.pop();
 			currentRenderState = null;
+
+		};
+
+		// compileAsync
+
+		this.compileAsync = function ( scene, targetScene = null ) {
+
+			// If no explicit targetScene was given use the scene instead
+			if ( ! targetScene ) {
+
+				targetScene = scene;
+
+			}
+
+			currentRenderState = renderStates.get( targetScene );
+			currentRenderState.init();
+
+			renderStateStack.push( currentRenderState );
+
+			let foundScene = scene === targetScene;
+
+			// Gather lights from both the scene and the new object that will be added
+			// to the scene.
+			targetScene.traverseVisible( function ( object ) {
+
+				if ( object === scene ) {
+
+					foundScene = true;
+
+				}
+
+				if ( object.isLight ) {
+
+					currentRenderState.pushLight( object );
+
+					if ( object.castShadow ) {
+
+						currentRenderState.pushShadow( object );
+
+					}
+
+				}
+
+			} );
+
+			// If the scene wasn't already part of the targetScene, add any lights it
+			// contains as well.
+			if ( ! foundScene ) {
+
+				scene.traverseVisible( function ( object ) {
+
+					if ( object.isLight ) {
+
+						currentRenderState.pushLight( object );
+
+						if ( object.castShadow ) {
+
+							currentRenderState.pushShadow( object );
+
+						}
+
+					}
+
+				} );
+
+			}
+
+			currentRenderState.setupLights( _this._useLegacyLights );
+
+			const compiling = new Set();
+
+			// Only initialize materials in the new scene, not the targetScene.
+
+			scene.traverse( function ( object ) {
+
+				const material = object.material;
+
+				if ( material ) {
+
+					if ( Array.isArray( material ) ) {
+
+						for ( let i = 0; i < material.length; i ++ ) {
+
+							const material2 = material[ i ];
+
+							prepareMaterial( material2, targetScene, object );
+							compiling.add( material2 );
+
+						}
+
+					} else {
+
+						prepareMaterial( material, targetScene, object );
+						compiling.add( material );
+
+					}
+
+				}
+
+			} );
+
+			renderStateStack.pop();
+			currentRenderState = null;
+
+			// Wait for all the materials in the new object to indicate that they're
+			// ready to be used before resolving the promise.
+
+			return new Promise( ( resolve ) => {
+
+				function checkMaterialsReady() {
+
+					compiling.forEach( function ( material ) {
+
+						const materialProperties = properties.get( material );
+						const program = materialProperties.currentProgram;
+
+						if ( program.isReady() ) {
+
+							// remove any programs that report they're ready to use from the list
+							compiling.delete( material );
+
+						}
+
+					} );
+
+					// once the list of compiling materials is empty, call the callback
+
+					if ( compiling.size === 0 ) {
+
+						resolve( scene );
+						return;
+
+					}
+
+					// if some materials are still not ready, wait a bit and check again
+
+					setTimeout( checkMaterialsReady, 10 );
+
+				}
+
+				if ( extensions.get( 'KHR_parallel_shader_compile' ) !== null ) {
+
+					// If we can check the compilation status of the materials without
+					// blocking then do so right away.
+
+					checkMaterialsReady();
+
+				} else {
+
+					// Otherwise start by waiting a bit to give the materials we just
+					// initialized a chance to finish.
+
+					setTimeout( checkMaterialsReady, 10 );
+
+				}
+
+			} );
 
 		};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -997,33 +997,16 @@ class WebGLRenderer {
 
 		// compileAsync
 
-		this.compileAsync = function ( scene, targetScene = null ) {
+		this.compileAsync = function ( scene, camera ) {
 
-			// If no explicit targetScene was given use the scene instead
-			if ( ! targetScene ) {
-
-				targetScene = scene;
-
-			}
-
-			currentRenderState = renderStates.get( targetScene );
+			currentRenderState = renderStates.get( scene );
 			currentRenderState.init();
 
 			renderStateStack.push( currentRenderState );
 
-			let foundScene = scene === targetScene;
+			scene.traverseVisible( function ( object ) {
 
-			// Gather lights from both the scene and the new object that will be added
-			// to the scene.
-			targetScene.traverseVisible( function ( object ) {
-
-				if ( object === scene ) {
-
-					foundScene = true;
-
-				}
-
-				if ( object.isLight ) {
+				if ( object.isLight && object.layers.test( camera.layers ) ) {
 
 					currentRenderState.pushLight( object );
 
@@ -1037,33 +1020,9 @@ class WebGLRenderer {
 
 			} );
 
-			// If the scene wasn't already part of the targetScene, add any lights it
-			// contains as well.
-			if ( ! foundScene ) {
-
-				scene.traverseVisible( function ( object ) {
-
-					if ( object.isLight ) {
-
-						currentRenderState.pushLight( object );
-
-						if ( object.castShadow ) {
-
-							currentRenderState.pushShadow( object );
-
-						}
-
-					}
-
-				} );
-
-			}
-
 			currentRenderState.setupLights( _this._useLegacyLights );
 
 			const compiling = new Set();
-
-			// Only initialize materials in the new scene, not the targetScene.
 
 			scene.traverse( function ( object ) {
 
@@ -1077,14 +1036,14 @@ class WebGLRenderer {
 
 							const material2 = material[ i ];
 
-							prepareMaterial( material2, targetScene, object );
+							prepareMaterial( material2, scene, object );
 							compiling.add( material2 );
 
 						}
 
 					} else {
 
-						prepareMaterial( material, targetScene, object );
+						prepareMaterial( material, scene, object );
 						compiling.add( material );
 
 					}

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -4,6 +4,9 @@ import { ShaderChunk } from '../shaders/ShaderChunk.js';
 import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
+// From https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
+const COMPLETION_STATUS_KHR = 0x91B1;
+
 let programIdCount = 0;
 
 function handleSource( string, errorLine ) {
@@ -1011,6 +1014,24 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 		}
 
 		return cachedAttributes;
+
+	};
+
+	// indicate when the program is ready to be used
+
+	// if the KHR_parallel_shader_compile extension isn't supported, flag the
+	// program as ready immediately. It may cause a stall when it's first used.
+	let programReady = ! parameters.rendererExtensionParallelShaderCompile;
+
+	this.isReady = function () {
+
+		if ( ! programReady ) {
+
+			programReady = gl.getProgramParameter( program, COMPLETION_STATUS_KHR );
+
+		}
+
+		return programReady;
 
 	};
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1017,15 +1017,14 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 	};
 
-	// indicate when the program is ready to be used
+	// indicate when the program is ready to be used. if the KHR_parallel_shader_compile extension isn't supported,
+	// flag the program as ready immediately. It may cause a stall when it's first used.
 
-	// if the KHR_parallel_shader_compile extension isn't supported, flag the
-	// program as ready immediately. It may cause a stall when it's first used.
-	let programReady = ! parameters.rendererExtensionParallelShaderCompile;
+	let programReady = ( parameters.rendererExtensionParallelShaderCompile === false );
 
 	this.isReady = function () {
 
-		if ( ! programReady ) {
+		if ( programReady === false ) {
 
 			programReady = gl.getProgramParameter( program, COMPLETION_STATUS_KHR );
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -358,6 +358,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			rendererExtensionFragDepth: IS_WEBGL2 || extensions.has( 'EXT_frag_depth' ),
 			rendererExtensionDrawBuffers: IS_WEBGL2 || extensions.has( 'WEBGL_draw_buffers' ),
 			rendererExtensionShaderTextureLod: IS_WEBGL2 || extensions.has( 'EXT_shader_texture_lod' ),
+			rendererExtensionParallelShaderCompile: extensions.has( 'KHR_parallel_shader_compile' ),
 
 			customProgramCacheKey: material.customProgramCacheKey()
 


### PR DESCRIPTION
**TL;DR:** Provide a function like `renderer.compile()` that notifies a callback when the given object can be added to the scene with minimal blocking on shader program compiling/linking.

This proposal builds on #19745, would fix #16321, and is an alternative to #16662.

The longest blocking operations that tend to happen when an object is first added to a scene are textures uploads and shader compiles. While texture uploads can be dramatically reduced by either using ImageBitmaps (see #19518) or compressed textures, shader compiles are already asynchronous and the best practice for reducing the time that they block is to give them time to finish prior to first use. If the `KHR_parallel_shader_compile` extension is available we can do even better by polling to discover when the compile is finished prior to it's first use.

#19745 takes a step in the right direction by deferring any potentially blocking shader calls until the first time the shader is actually used for rendering, but Three's current architecture is such that most shader programs are compiled/linked immediately before their first use, which forces the worst-case scenario and causes the first query from the program (for example, a `getProgramInfoLog()` or `getUniformLocation()` call) to block while the compile finishes. You can see an example here recorded from the GLTF Loader example. Notice that the `getProgramInfoLog()` call takes 49ms

<img width="843" alt="no-precompile" src="https://user-images.githubusercontent.com/805273/85966140-b35fd080-b973-11ea-9418-b3c1b3d25568.png">

This PR suggests adding a new method to the `WebGLRenderer` which functions similarly to the existing `compile()` method with a couple key differences: It supports passing objects that are not yet part of the scene, and takes a callback which will be called when the shaders for the passed objects have finished compiling and can be added to the scene with minimal blocking.

This would functionally look something like this:

```js
loader.load( objectUrl, function ( loadedObject ) {
  // Notify the callback when loadedObject can be added to scene without blocking.
  // Not a fan of the name, though. :P
  renderer.compileTarget( scene, loadedObject, function() {
    scene.add( loadedObject  );
  } );
} );
```

Using this pattern and the code in this PR I get the same first load shown above looking like this:

<img width="827" alt="with-precompile" src="https://user-images.githubusercontent.com/805273/85969145-afd04780-b97b-11ea-9eeb-72638aaa4c9e.png">

Notice that the `getProgramInfoLog()` call that previously took 49ms has shrunk so much that you can't even see it without zooming in. It's now under 2ms. You just got back ~3 frames of stalled renderer! (Especially important for XR uses.)

<img width="537" alt="with-precompile-zoom" src="https://user-images.githubusercontent.com/805273/85969199-d0989d00-b97b-11ea-9907-a3d1c2850dfc.png">

(Also notice in the wider view of the timeline that the PMREM generator block, which is the first large column, is significantly faster too. That's actually a side effect of #19745, but ultimately it's following the same principle.)

To preemptively address a couple of questions that I feel will come out of this:

**Why not update the existing `compile()` function to support this?**

This is a very viable option! But in order to maintain backwards compatibility you're either grappling with some very non-intuitive argument ordering or forcing people using the call to attach the new object to the scene, call `compile()`, then immediately detach it again and wait for the callback to once again re-attach it. 😝 Otherwise they're doing very similar things.

**Why doesn't this method take a camera like `compile()`?**

Turns out that's not really necessary for what this method _and_ `compile()` are doing, which is simply preloading the material shaders. The camera is being passed to the light setup, which IS very necessary for the shaders, but it's only being used to compute the view matrix which only really affects specular computation and doesn't have any bearing on the shader compilation. FWIW I think `compile()` should drop the `camera` argument too.

**What about adding a `parallelCompile` property on the material, like in #16662?**

This was my first inclination as well, but it suffers from several drawbacks enforced due to Three's architecture. For one, it breaks the model of objects being visible as soon as they're added to the scene. They just "show up" at some point and the developer has no idea when. That's fine for some uses, not for others. Also, crucially, unless great lengths are taken to prevent it any changes to the scene's lighting setup will cause another parallel compile, during which the objects will flicker out of existence for a few frames. This is a far more objectionable artifact. Finally, some apps (like the glTF loader example) only draw when the user is interacting with the scene (like rotating the camera). Without an active animation loop the `parallelCompile` approach doesn't have a way of indicating that the object is ready for drawing and thus you get stuck with an empty scene until you click and drag, which is clearly unwanted behavior.

By making this an explicit call, the developer has exact control over what objects they are willing to wait on and what should happen when they're ready. It doesn't "magically" make existing apps better, but does offer an optimization path for devs that care about it.  
 