### PR TITLE
PMREMGenerator: fixes alpha component for LDR outputs

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -668,7 +668,7 @@ function _getBlurShader( maxSamples ) {
 
 				axis = normalize( axis );
 
-				gl_FragColor = vec4( 0.0 );
+				gl_FragColor = vec4( 0.0, 0.0, 0.0, 1.0 );
 				gl_FragColor.rgb += weights[ 0 ] * getSample( 0.0, axis );
 
 				for ( int i = 1; i < n; i++ ) {
@@ -732,7 +732,7 @@ function _getEquirectShader() {
 
 			void main() {
 
-				gl_FragColor = vec4( 0.0 );
+				gl_FragColor = vec4( 0.0, 0.0, 0.0, 1.0 );
 
 				vec3 outputDirection = normalize( vOutputDirection );
 				vec2 uv = equirectUv( outputDirection );
@@ -793,7 +793,7 @@ function _getCubemapShader() {
 
 			void main() {
 
-				gl_FragColor = vec4( 0.0 );
+				gl_FragColor = vec4( 0.0, 0.0, 0.0, 1.0 );
 				gl_FragColor.rgb = envMapTexelToLinear( textureCube( envMap, vec3( - vOutputDirection.x, vOutputDirection.yz ) ) ).rgb;
 				gl_FragColor = linearToOutputTexel( gl_FragColor );
 


### PR DESCRIPTION
As explained in #19764 observation.

Since we are currently setting the alpha channel to 0.0, unless the decoding step explicitly modifies the alpha, it will remain zeroed in the output PMREM, which is not relevant when the texture is used in the context of an envmap, because we internally ignore that channel.

But given the new workflow proposed in #19764 of allowing users to export and reuse PMREM textures, this has the side-effect of hiding the RGB channels information when visualizing the output EXR file. The image would either appear completely black or transparent ( depending on the viewer ), even though the RGB channels are present and correct.