### PR TITLE
Docs: Added .js extension to path of GLTFLoader.

### DIFF
--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -95,7 +95,7 @@
 	</p>
 
 	<code>
-		var loader = new THREE.GLTFLoader();
+		var loader = new GLTFLoader();
 
 		loader.load( 'path/to/model.glb', function ( gltf ) {
 

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -85,7 +85,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/zh/introduction/Loading-3D-models.html
+++ b/docs/manual/zh/introduction/Loading-3D-models.html
@@ -75,7 +75,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>
@@ -84,7 +84,7 @@
 	</p>
 
 	<code>
-		var loader = new THREE.GLTFLoader();
+		var loader = new GLTFLoader();
 
 		loader.load( 'path/to/model.glb', function ( gltf ) {
 


### PR DESCRIPTION
I got a 404 error when I ran the line as written, but the 404 error went away when I added .js.  So, should the path end in .js?  I am a new user of three.js.