### PR TITLE
Copy rotation.order when copying Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -823,6 +823,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		this.up.copy( source.up );
 
 		this.position.copy( source.position );
+		this.rotation.order = source.rotation.order;
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
 


### PR DESCRIPTION
Not sure if there is a technical reason behind why the euler rotation order isn't cloned by Object3D.copy(), but hey now it is.