### PR TITLE
GLTFLoader: Implement KHR_texture_basisu support

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -333,6 +333,7 @@ THREE.GLTFLoader = ( function () {
 		KHR_MATERIALS_CLEARCOAT: 'KHR_materials_clearcoat',
 		KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS: 'KHR_materials_pbrSpecularGlossiness',
 		KHR_MATERIALS_UNLIT: 'KHR_materials_unlit',
+		KHR_TEXTURE_BASISU: 'KHR_texture_basisu',
 		KHR_TEXTURE_TRANSFORM: 'KHR_texture_transform',
 		KHR_MESH_QUANTIZATION: 'KHR_mesh_quantization',
 		MSFT_TEXTURE_DDS: 'MSFT_texture_dds'
@@ -559,7 +560,7 @@ THREE.GLTFLoader = ( function () {
 	function GLTFTextureBasisU( parser ) {
 
 		this.parser = parser;
-		this.name = "KHR_texture_basisu";
+		this.name = EXTENSIONS.KHR_TEXTURE_BASISU;
 
 	}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -5,6 +5,7 @@ console.warn( "THREE.GLTFLoader: As part of the transition to ES6 Modules, the f
  * @author Tony Parisi / http://www.tonyparisi.com/
  * @author Takahiro / https://github.com/takahirox
  * @author Don McCurdy / https://www.donmccurdy.com
+ * @author Arseny Kapoulkine / https://github.com/zeux
  */
 
 THREE.GLTFLoader = ( function () {
@@ -15,11 +16,17 @@ THREE.GLTFLoader = ( function () {
 
 		this.dracoLoader = null;
 		this.ddsLoader = null;
+		this.ktx2Loader = null;
 
 		this.pluginCallbacks = [];
 		this.register( function ( parser ) {
 
 			return new GLTFMaterialsClearcoatExtension( parser );
+
+		} );
+		this.register( function ( parser ) {
+
+			return new GLTFTextureBasisU( parser );
 
 		} );
 
@@ -119,6 +126,13 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
+		setKTX2Loader: function ( ktx2Loader ) {
+
+			this.ktx2Loader = ktx2Loader;
+			return this;
+
+		},
+
 		register: function ( callback ) {
 
 			if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
@@ -193,7 +207,8 @@ THREE.GLTFLoader = ( function () {
 
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
-				manager: this.manager
+				manager: this.manager,
+				ktx2Loader: this.ktx2Loader
 
 			} );
 
@@ -532,6 +547,46 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		return Promise.all( pending );
+
+	};
+
+	/**
+	 * BasisU Texture Extension
+	 *
+	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu
+	 * (Link above TBD, currently in PR https://github.com/KhronosGroup/glTF/pull/1751)
+	 */
+	function GLTFTextureBasisU( parser ) {
+
+		this.parser = parser;
+		this.name = "KHR_texture_basisu";
+
+	}
+
+	GLTFTextureBasisU.prototype.loadTexture = function ( textureIndex ) {
+
+		var parser = this.parser;
+		var json = parser.json;
+
+		var textureDef = json.textures[ textureIndex ];
+
+		if ( ! textureDef.extensions || ! textureDef.extensions[ this.name ] ) {
+
+			return null;
+
+		}
+
+		var extension = textureDef.extensions[ this.name ];
+		var source = json.images[ extension.source ];
+		var loader = parser.options.ktx2Loader;
+
+		if ( !loader ) {
+
+			throw new Error( 'THREE.GLTFLoader: setKTX2Loader must be called before loading KTX2 textures' );
+
+		}
+
+		return parser.loadTextureImage( textureIndex, source, loader );
 
 	};
 
@@ -1696,7 +1751,11 @@ THREE.GLTFLoader = ( function () {
 					break;
 
 				case 'texture':
-					dependency = this.loadTexture( index );
+					dependency = this._invokeOne( function ( ext ) {
+
+						return ext.loadTexture && ext.loadTexture( index );
+
+					} );
 					break;
 
 				case 'skin':
@@ -1954,9 +2013,6 @@ THREE.GLTFLoader = ( function () {
 		var parser = this;
 		var json = this.json;
 		var options = this.options;
-		var textureLoader = this.textureLoader;
-
-		var URL = self.URL || self.webkitURL;
 
 		var textureDef = json.textures[ textureIndex ];
 
@@ -1973,6 +2029,36 @@ THREE.GLTFLoader = ( function () {
 			source = json.images[ textureDef.source ];
 
 		}
+
+		var loader;
+
+		if ( source.uri ) {
+
+			loader = options.manager.getHandler( source.uri );
+
+		}
+
+		if ( ! loader ) {
+
+			loader = textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ]
+			? parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
+			: this.textureLoader;
+
+		}
+
+		return this.loadTextureImage( textureIndex, source, loader );
+	};
+
+	GLTFParser.prototype.loadTextureImage = function ( textureIndex, source, loader ) {
+
+		var parser = this;
+		var json = this.json;
+		var options = this.options;
+
+		var textureDef = json.textures[ textureIndex ];
+		var textureExtensions = textureDef.extensions || {};
+
+		var URL = self.URL || self.webkitURL;
 
 		var sourceURI = source.uri;
 		var isObjectURL = false;
@@ -1993,18 +2079,6 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {
-
-			// Load Texture resource.
-
-			var loader = options.manager.getHandler( sourceURI );
-
-			if ( ! loader ) {
-
-				loader = textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ]
-					? parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
-					: textureLoader;
-
-			}
 
 			return new Promise( function ( resolve, reject ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -26,7 +26,7 @@ THREE.GLTFLoader = ( function () {
 		} );
 		this.register( function ( parser ) {
 
-			return new GLTFTextureBasisU( parser );
+			return new GLTFTextureBasisUExtension( parser );
 
 		} );
 
@@ -555,16 +555,16 @@ THREE.GLTFLoader = ( function () {
 	 * BasisU Texture Extension
 	 *
 	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu
-	 * (Link above TBD, currently in PR https://github.com/KhronosGroup/glTF/pull/1751)
+	 * (draft PR https://github.com/KhronosGroup/glTF/pull/1751)
 	 */
-	function GLTFTextureBasisU( parser ) {
+	function GLTFTextureBasisUExtension( parser ) {
 
 		this.parser = parser;
 		this.name = EXTENSIONS.KHR_TEXTURE_BASISU;
 
 	}
 
-	GLTFTextureBasisU.prototype.loadTexture = function ( textureIndex ) {
+	GLTFTextureBasisUExtension.prototype.loadTexture = function ( textureIndex ) {
 
 		var parser = this.parser;
 		var json = parser.json;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4,6 +4,7 @@
  * @author Tony Parisi / http://www.tonyparisi.com/
  * @author Takahiro / https://github.com/takahirox
  * @author Don McCurdy / https://www.donmccurdy.com
+ * @author Arseny Kapoulkine / https://github.com/zeux
  */
 
 import {
@@ -80,11 +81,17 @@ var GLTFLoader = ( function () {
 
 		this.dracoLoader = null;
 		this.ddsLoader = null;
+		this.ktx2Loader = null;
 
 		this.pluginCallbacks = [];
 		this.register( function ( parser ) {
 
 			return new GLTFMaterialsClearcoatExtension( parser );
+
+		} );
+		this.register( function ( parser ) {
+
+			return new GLTFTextureBasisU( parser );
 
 		} );
 
@@ -184,6 +191,13 @@ var GLTFLoader = ( function () {
 
 		},
 
+		setKTX2Loader: function ( ktx2Loader ) {
+
+			this.ktx2Loader = ktx2Loader;
+			return this;
+
+		},
+
 		register: function ( callback ) {
 
 			if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
@@ -258,7 +272,8 @@ var GLTFLoader = ( function () {
 
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
-				manager: this.manager
+				manager: this.manager,
+				ktx2Loader: this.ktx2Loader
 
 			} );
 
@@ -597,6 +612,46 @@ var GLTFLoader = ( function () {
 		}
 
 		return Promise.all( pending );
+
+	};
+
+	/**
+	 * BasisU Texture Extension
+	 *
+	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu
+	 * (Link above TBD, currently in PR https://github.com/KhronosGroup/glTF/pull/1751)
+	 */
+	function GLTFTextureBasisU( parser ) {
+
+		this.parser = parser;
+		this.name = "KHR_texture_basisu";
+
+	}
+
+	GLTFTextureBasisU.prototype.loadTexture = function ( textureIndex ) {
+
+		var parser = this.parser;
+		var json = parser.json;
+
+		var textureDef = json.textures[ textureIndex ];
+
+		if ( ! textureDef.extensions || ! textureDef.extensions[ this.name ] ) {
+
+			return Promise.resolve();
+
+		}
+
+		var extension = textureDef.extensions[ this.name ];
+		var source = json.images[ extension.source ];
+		var loader = parser.options.ktx2Loader;
+
+		if ( !loader ) {
+
+			throw new Error( 'THREE.GLTFLoader: setKTX2Loader must be called before loading KTX2 textures' );
+
+		}
+
+		return parser.loadTextureImage( textureIndex, source, loader );
 
 	};
 
@@ -1761,7 +1816,11 @@ var GLTFLoader = ( function () {
 					break;
 
 				case 'texture':
-					dependency = this.loadTexture( index );
+					dependency = this._invokeOne( function ( ext ) {
+
+						return ext.loadTexture && ext.loadTexture( index );
+
+					} );
 					break;
 
 				case 'skin':
@@ -2021,8 +2080,6 @@ var GLTFLoader = ( function () {
 		var options = this.options;
 		var textureLoader = this.textureLoader;
 
-		var URL = self.URL || self.webkitURL;
-
 		var textureDef = json.textures[ textureIndex ];
 
 		var textureExtensions = textureDef.extensions || {};
@@ -2038,6 +2095,19 @@ var GLTFLoader = ( function () {
 			source = json.images[ textureDef.source ];
 
 		}
+
+		return loadTextureImage( textureIndex, source );
+	};
+
+	GLTFParser.prototype.loadTextureImage = function ( textureIndex, source, loaderOverride ) {
+
+		var parser = this;
+		var json = this.json;
+		var options = this.options;
+
+		var textureDef = json.textures[ textureIndex ];
+
+		var URL = self.URL || self.webkitURL;
 
 		var sourceURI = source.uri;
 		var isObjectURL = false;
@@ -2059,9 +2129,13 @@ var GLTFLoader = ( function () {
 
 		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {
 
-			// Load Texture resource.
+			var loader = loaderOverride;
 
-			var loader = options.manager.getHandler( sourceURI );
+			if ( ! loader ) {
+
+				loader = options.manager.getHandler( sourceURI );
+
+			}
 
 			if ( ! loader ) {
 
@@ -2128,6 +2202,7 @@ var GLTFLoader = ( function () {
 		} );
 
 	};
+
 
 	/**
 	 * Asynchronously assigns a texture to the given material parameters.

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -637,7 +637,7 @@ var GLTFLoader = ( function () {
 
 		if ( ! textureDef.extensions || ! textureDef.extensions[ this.name ] ) {
 
-			return Promise.resolve();
+			return null;
 
 		}
 
@@ -2078,7 +2078,6 @@ var GLTFLoader = ( function () {
 		var parser = this;
 		var json = this.json;
 		var options = this.options;
-		var textureLoader = this.textureLoader;
 
 		var textureDef = json.textures[ textureIndex ];
 
@@ -2096,7 +2095,7 @@ var GLTFLoader = ( function () {
 
 		}
 
-		return loadTextureImage( textureIndex, source );
+		return this.loadTextureImage( textureIndex, source );
 	};
 
 	GLTFParser.prototype.loadTextureImage = function ( textureIndex, source, loaderOverride ) {
@@ -2105,7 +2104,10 @@ var GLTFLoader = ( function () {
 		var json = this.json;
 		var options = this.options;
 
+		var textureLoader = this.textureLoader;
+
 		var textureDef = json.textures[ textureIndex ];
+		var textureExtensions = textureDef.extensions || {};
 
 		var URL = self.URL || self.webkitURL;
 
@@ -2202,7 +2204,6 @@ var GLTFLoader = ( function () {
 		} );
 
 	};
-
 
 	/**
 	 * Asynchronously assigns a texture to the given material parameters.

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -398,6 +398,7 @@ var GLTFLoader = ( function () {
 		KHR_MATERIALS_CLEARCOAT: 'KHR_materials_clearcoat',
 		KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS: 'KHR_materials_pbrSpecularGlossiness',
 		KHR_MATERIALS_UNLIT: 'KHR_materials_unlit',
+		KHR_TEXTURE_BASISU: 'KHR_texture_basisu',
 		KHR_TEXTURE_TRANSFORM: 'KHR_texture_transform',
 		KHR_MESH_QUANTIZATION: 'KHR_mesh_quantization',
 		MSFT_TEXTURE_DDS: 'MSFT_texture_dds'
@@ -624,7 +625,7 @@ var GLTFLoader = ( function () {
 	function GLTFTextureBasisU( parser ) {
 
 		this.parser = parser;
-		this.name = "KHR_texture_basisu";
+		this.name = EXTENSIONS.KHR_TEXTURE_BASISU;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -91,7 +91,7 @@ var GLTFLoader = ( function () {
 		} );
 		this.register( function ( parser ) {
 
-			return new GLTFTextureBasisU( parser );
+			return new GLTFTextureBasisUExtension( parser );
 
 		} );
 
@@ -620,16 +620,16 @@ var GLTFLoader = ( function () {
 	 * BasisU Texture Extension
 	 *
 	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu
-	 * (Link above TBD, currently in PR https://github.com/KhronosGroup/glTF/pull/1751)
+	 * (draft PR https://github.com/KhronosGroup/glTF/pull/1751)
 	 */
-	function GLTFTextureBasisU( parser ) {
+	function GLTFTextureBasisUExtension( parser ) {
 
 		this.parser = parser;
 		this.name = EXTENSIONS.KHR_TEXTURE_BASISU;
 
 	}
 
-	GLTFTextureBasisU.prototype.loadTexture = function ( textureIndex ) {
+	GLTFTextureBasisUExtension.prototype.loadTexture = function ( textureIndex ) {
 
 		var parser = this.parser;
 		var json = parser.json;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2095,16 +2095,30 @@ var GLTFLoader = ( function () {
 
 		}
 
-		return this.loadTextureImage( textureIndex, source );
+		var loader;
+
+		if ( source.uri ) {
+
+			loader = options.manager.getHandler( source.uri );
+
+		}
+
+		if ( ! loader ) {
+
+			loader = textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ]
+			? parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
+			: this.textureLoader;
+
+		}
+
+		return this.loadTextureImage( textureIndex, source, loader );
 	};
 
-	GLTFParser.prototype.loadTextureImage = function ( textureIndex, source, loaderOverride ) {
+	GLTFParser.prototype.loadTextureImage = function ( textureIndex, source, loader ) {
 
 		var parser = this;
 		var json = this.json;
 		var options = this.options;
-
-		var textureLoader = this.textureLoader;
 
 		var textureDef = json.textures[ textureIndex ];
 		var textureExtensions = textureDef.extensions || {};
@@ -2130,22 +2144,6 @@ var GLTFLoader = ( function () {
 		}
 
 		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {
-
-			var loader = loaderOverride;
-
-			if ( ! loader ) {
-
-				loader = options.manager.getHandler( sourceURI );
-
-			}
-
-			if ( ! loader ) {
-
-				loader = textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ]
-					? parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
-					: textureLoader;
-
-			}
 
 			return new Promise( function ( resolve, reject ) {
 


### PR DESCRIPTION
This change implements support for (draft) KHR_texture_basisu extension
as described in https://github.com/KhronosGroup/glTF/pull/1751.

To make this work, two general changes to GLTFLoader were necessary:

- The plugin extension framework now supports overriding loadTexture
- To simplify implementation, the bulk of the loading functionality was
extracted into loadTextureImage.

As with other dependent loaders, it's the caller's responsibility to
call setKTX2Loader on the GLTFLoader before loading files with this
extension.