### PR TITLE
WebGLCubeRenderTarget: retain filter settings

### DIFF
--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -37,6 +37,10 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 	this.texture.format = texture.format;
 	this.texture.encoding = texture.encoding;
 
+	this.texture.generateMipmaps = texture.generateMipmaps;
+	this.texture.minFilter = texture.minFilter;
+	this.texture.magFilter = texture.magFilter;
+
 	const scene = new Scene();
 
 	const shader = {


### PR DESCRIPTION
... when converting from equirectangular.

The texture loader should now be setting these correctly.