### PR TITLE
SVGRenderer: Add getSize().

### DIFF
--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -59,6 +59,11 @@
 			Tells the renderer to clear its drawing surface.
 		</p>
 
+		<h3>[method:Object getSize]()</h3>
+		<p>
+			Returns an object containing the width and height of the renderer.
+		</p>
+
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
 		<p>
 			Renders a [page:Scene scene] using a [page:Camera camera].

--- a/docs/examples/zh/renderers/SVGRenderer.html
+++ b/docs/examples/zh/renderers/SVGRenderer.html
@@ -52,6 +52,11 @@
 			告诉渲染器来清除其绘图表面。
 		</p>
 
+		<h3>[method:Object getSize]()</h3>
+		<p>
+			返回一个包含有渲染器宽和高的对象。
+		</p>
+
 		<h3>[method:null render]( [param:Scene scene], [param:Camera camera] )</h3>
 		<p>
 			使用[page:Camera camera]来渲染一个[page:Scene scene]。

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -101,6 +101,15 @@ THREE.SVGRenderer = function () {
 
 	};
 
+	this.getSize = function () {
+
+		return {
+			width: _svgWidth,
+			height: _svgHeight
+		};
+
+	};
+
 	this.setPrecision = function ( precision ) {
 
 		_precision = precision;

--- a/examples/jsm/renderers/SVGRenderer.d.ts
+++ b/examples/jsm/renderers/SVGRenderer.d.ts
@@ -22,6 +22,7 @@ export class SVGRenderer {
 	overdraw: number;
 	info: {render: {vertices: number, faces: number}};
 
+	getSize(): { width: number, height: number };
 	setQuality( quality: string ): void;
 	setClearColor( color: Color, alpha: number ): void;
 	setPixelRatio(): void;

--- a/examples/jsm/renderers/SVGRenderer.js
+++ b/examples/jsm/renderers/SVGRenderer.js
@@ -114,6 +114,15 @@ var SVGRenderer = function () {
 
 	};
 
+	this.getSize = function () {
+
+		return {
+			width: _svgWidth,
+			height: _svgHeight
+		};
+
+	};
+
 	this.setPrecision = function ( precision ) {
 
 		_precision = precision;


### PR DESCRIPTION
Fixed: #19732

This implementation seems the most consistent one according to how the CSS renderers are implemented.