### PR TITLE
WebGLShadowMap: Add support for alpha test.

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -39,9 +39,8 @@
 		<h3>[property:Material customDepthMaterial]</h3>
 		<p>
 		Custom depth material to be used when rendering to the depth map. Can only be used in context of meshes.
-		When shadow-casting with a [page:DirectionalLight] or [page:SpotLight], if you are (a) modifying vertex positions in the vertex shader,
-		(b) using a displacement map, (c) using an alpha map with alphaTest, or (d) using a transparent texture with alphaTest,
-		you must specify a customDepthMaterial for proper shadows. Default is *undefined*.
+		When shadow-casting with a [page:DirectionalLight] or [page:SpotLight], if you are modifying vertex positions in the vertex shader or
+		using a displacement map you must specify a customDepthMaterial for proper shadows. Default is *undefined*.
 		</p>
 
 		<h3>[property:Material customDistanceMaterial]</h3>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -37,10 +37,10 @@
 	<p>含有对象的子级的数组。请参阅[page:Group]来了解将手动对象进行分组的相关信息。</p>
 
 	<h3>[property:Material customDepthMaterial]</h3>
-	<p>渲染到深度贴图时此材质要使用的自定义深度材质。
-		当使用[page:DirectionalLight]或[page:SpotLight]进行阴影投射时，如果您正在（a）修改顶点着色器中的顶点位置，
-		（b）使用位移贴图，（c）alphaTest中使用alpha贴图，或（d）alphaTest中使用透明纹理，
-		您必须指定customDepthMaterial以得到合适的阴影。默认值*undefined*。
+	<p>
+	Custom depth material to be used when rendering to the depth map. Can only be used in context of meshes.
+	When shadow-casting with a [page:DirectionalLight] or [page:SpotLight], if you are modifying vertex positions in the vertex shader or
+	using a displacement map you must specify a customDepthMaterial for proper shadows. Default is *undefined*.
 	</p>
 
 	<h3>[property:Material customDistanceMaterial]</h3>

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -477,12 +477,6 @@
 				object.castShadow = true;
 				scene.add( object );
 
-				object.customDepthMaterial = new THREE.MeshDepthMaterial( {
-					depthPacking: THREE.RGBADepthPacking,
-					map: clothTexture,
-					alphaTest: 0.5
-				} );
-
 				// sphere
 
 				var ballGeo = new THREE.SphereBufferGeometry( ballSize, 32, 16 );

--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -69,13 +69,6 @@
 					sphere.receiveShadow = true;
 					pointLight.add( sphere );
 
-					// custom distance material
-					var distanceMaterial = new THREE.MeshDistanceMaterial( {
-						alphaMap: material.alphaMap,
-						alphaTest: material.alphaTest
-					} );
-					sphere.customDistanceMaterial = distanceMaterial;
-
 					return pointLight;
 
 				}

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -327,7 +327,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 			const useInstancing = object.isInstancedMesh === true;
 
-			result = getMaterialVariant( useMorphing, useSkinning, useInstancing, material.alphaTest, material.alphaMap,  material.map );
+			result = getMaterialVariant( useMorphing, useSkinning, useInstancing, material.alphaTest, material.alphaMap, material.map );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -27,8 +27,8 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		_viewport = new Vector4(),
 
-		_depthMaterials = [],
-		_distanceMaterials = [],
+		_depthMaterials = {},
+		_distanceMaterials = {},
 
 		_materialCache = {};
 
@@ -233,25 +233,22 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	function getDepthMaterialVariant( useMorphing, useSkinning, useInstancing, alphaTest, alphaMap, map ) {
 
-		const index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
+		const key = ( useMorphing << 0 | useSkinning << 1 | useInstancing << 2 | ( !! alphaMap ) << 3 | ( !! map ) << 4 ) + ',' + alphaTest;
 
-		let material = _depthMaterials[ index ];
+		let material = _depthMaterials[ key ];
 
 		if ( material === undefined ) {
 
 			material = new MeshDepthMaterial( {
 
 				depthPacking: RGBADepthPacking,
-
 				morphTargets: useMorphing,
 				skinning: useSkinning,
-				alphaTest: alphaTest,
-				alphaMap: alphaMap,
-				map: map
+				alphaTest: alphaTest
 
 			} );
 
-			_depthMaterials[ index ] = material;
+			_depthMaterials[ key ] = material;
 
 		}
 
@@ -261,9 +258,9 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	function getDistanceMaterialVariant( useMorphing, useSkinning, useInstancing, alphaTest, alphaMap, map ) {
 
-		const index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
+		const key = ( useMorphing << 0 | useSkinning << 1 | useInstancing << 2 | ( !! alphaMap ) << 3 | ( !! map ) << 4 ) + ',' + alphaTest;
 
-		let material = _distanceMaterials[ index ];
+		let material = _distanceMaterials[ key ];
 
 		if ( material === undefined ) {
 
@@ -271,13 +268,11 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 				morphTargets: useMorphing,
 				skinning: useSkinning,
-				alphaTest: alphaTest,
-				alphaMap: alphaMap,
-				map: map
+				alphaTest: alphaTest
 
 			} );
 
-			_distanceMaterials[ index ] = material;
+			_distanceMaterials[ key ] = material;
 
 		}
 
@@ -334,6 +329,9 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 			result = customMaterial;
 
 		}
+
+		result.alphaMap = material.alphaMap;
+		result.map = material.map;
 
 		if ( _renderer.localClippingEnabled &&
 				material.clipShadows === true &&

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -231,7 +231,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	}
 
-	function getDepthMaterialVariant( useMorphing, useSkinning, useInstancing ) {
+	function getDepthMaterialVariant( useMorphing, useSkinning, useInstancing, alphaTest, alphaMap, map ) {
 
 		const index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
 
@@ -244,7 +244,10 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 				depthPacking: RGBADepthPacking,
 
 				morphTargets: useMorphing,
-				skinning: useSkinning
+				skinning: useSkinning,
+				alphaTest: alphaTest,
+				alphaMap: alphaMap,
+				map: map
 
 			} );
 
@@ -256,7 +259,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 	}
 
-	function getDistanceMaterialVariant( useMorphing, useSkinning, useInstancing ) {
+	function getDistanceMaterialVariant( useMorphing, useSkinning, useInstancing, alphaTest, alphaMap, map ) {
 
 		const index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
 
@@ -267,7 +270,10 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 			material = new MeshDistanceMaterial( {
 
 				morphTargets: useMorphing,
-				skinning: useSkinning
+				skinning: useSkinning,
+				alphaTest: alphaTest,
+				alphaMap: alphaMap,
+				map: map
 
 			} );
 
@@ -321,7 +327,7 @@ function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 			const useInstancing = object.isInstancedMesh === true;
 
-			result = getMaterialVariant( useMorphing, useSkinning, useInstancing );
+			result = getMaterialVariant( useMorphing, useSkinning, useInstancing, material.alphaTest, material.alphaMap,  material.map );
 
 		} else {
 


### PR DESCRIPTION
Fixed #4744.

Examples like `webgl_animation_cloth` and `webgl_shadowmap_pointlight` do not require custom depth materials anymore.