### PR TITLE
Quaternion: added identity()

### DIFF
--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -98,6 +98,11 @@
 		from an array.
 		</p>
 
+		<h3>[method:Quaternion identity]()</h3>
+		<p>
+			Sets this quaternion to the identity quaternion; that is, to the quaternion that represents "no rotation".
+		</p>
+
 		<h3>[method:Quaternion inverse]()</h3>
 		<p>
 			Inverts this quaternion - calculates the [page:.conjugate conjugate]. The quaternion is assumed to have unit length.

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -98,6 +98,11 @@
 		from an array.
 		</p>
 
+		<h3>[method:Quaternion identity]()</h3>
+		<p>
+			Sets this quaternion to the identity quaternion; that is, to the quaternion that represents "no rotation".
+		</p>
+
 		<h3>[method:Quaternion inverse]()</h3>
 		<p>
 			Inverts this quaternion - calculates the [page:.conjugate conjugate]. The quaternion is assumed to have unit length.

--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -62,6 +62,8 @@ export class Quaternion {
 	angleTo( q: Quaternion ): number;
 	rotateTowards( q: Quaternion, step: number ): Quaternion;
 
+	identity(): Quaternion;
+
 	/**
 	 * Inverts this quaternion.
 	 */

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -437,6 +437,12 @@ Object.assign( Quaternion.prototype, {
 
 	},
 
+	identity: function () {
+
+		return this.set( 0, 0, 0, 1 );
+
+	},
+
 	inverse: function () {
 
 		// quaternion is assumed to have unit length

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -528,6 +528,20 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "identity", ( assert ) => {
+
+			var a = new Quaternion();
+
+			a.set( x, y, z, w );
+			a.identity();
+
+			assert.ok( a.x == 0, "Passed!" );
+			assert.ok( a.y == 0, "Passed!" );
+			assert.ok( a.z === 0, "Passed!" );
+			assert.ok( a.w === 1, "Passed!" );
+
+		} );
+
 		QUnit.test( "inverse/conjugate", ( assert ) => {
 
 			var a = new Quaternion( x, y, z, w );


### PR DESCRIPTION
It is clear to users that setting the Euler rotation to `( 0, 0, 0 `) is "no rotation".

It is not so clear that the quaternion equivalent to "no rotation" is `( 0, 0, 0, 1 )`.

Application of the identity quaternion leaves the orientation unchanged.

