### PR TITLE
MaterialLoader: added missing transparency check

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -92,6 +92,7 @@ MaterialLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		if ( json.side !== undefined ) material.side = json.side;
 		if ( json.opacity !== undefined ) material.opacity = json.opacity;
 		if ( json.transparent !== undefined ) material.transparent = json.transparent;
+		if ( json.transparency !== undefined ) material.transparency = json.transparency;
 		if ( json.alphaTest !== undefined ) material.alphaTest = json.alphaTest;
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;


### PR DESCRIPTION
This fixes the missing transparency import from MaterialLoader supported by [MeshPhysicalMaterial](https://threejs.org/docs/index.html#api/en/materials/MeshPhysicalMaterial.transparency)