### PR TITLE
Editor: Refactor usage of default camera.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -10,12 +10,12 @@ import { History as _History } from './History.js';
 import { Strings } from './Strings.js';
 import { Storage as _Storage } from './Storage.js';
 
-function Editor() {
+var _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
+_DEFAULT_CAMERA.name = 'Camera';
+_DEFAULT_CAMERA.position.set( 0, 5, 10 );
+_DEFAULT_CAMERA.lookAt( new THREE.Vector3() );
 
-	this.DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
-	this.DEFAULT_CAMERA.name = 'Camera';
-	this.DEFAULT_CAMERA.position.set( 0, 5, 10 );
-	this.DEFAULT_CAMERA.lookAt( new THREE.Vector3() );
+function Editor() {
 
 	var Signal = signals.Signal;
 
@@ -51,6 +51,7 @@ function Editor() {
 		sceneRendered: new Signal(),
 
 		cameraChanged: new Signal(),
+		cameraResetted: new Signal(),
 
 		geometryChanged: new Signal(),
 
@@ -92,7 +93,7 @@ function Editor() {
 
 	this.loader = new Loader( this );
 
-	this.camera = this.DEFAULT_CAMERA.clone();
+	this.camera = _DEFAULT_CAMERA.clone();
 
 	this.scene = new THREE.Scene();
 	this.scene.name = 'Scene';
@@ -612,7 +613,8 @@ Editor.prototype = {
 		this.history.clear();
 		this.storage.clear();
 
-		this.camera.copy( this.DEFAULT_CAMERA );
+		this.camera.copy( _DEFAULT_CAMERA );
+		this.signals.cameraResetted.dispatch();
 
 		this.scene.name = "Scene";
 		this.scene.userData = {};
@@ -654,8 +656,7 @@ Editor.prototype = {
 		var camera = loader.parse( json.camera );
 
 		this.camera.copy( camera );
-		this.camera.aspect = this.DEFAULT_CAMERA.aspect;
-		this.camera.updateProjectionMatrix();
+		this.signals.cameraResetted.dispatch();
 
 		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -165,6 +165,13 @@ function Viewport( editor ) {
 
 	// events
 
+	function updateAspectRatio() {
+
+		camera.aspect = container.dom.offsetWidth / container.dom.offsetHeight;
+		camera.updateProjectionMatrix();
+
+	}
+
 	function getIntersects( point, objects ) {
 
 		mouse.set( ( point.x * 2 ) - 1, - ( point.y * 2 ) + 1 );
@@ -665,13 +672,7 @@ function Viewport( editor ) {
 
 	signals.windowResize.add( function () {
 
-		// TODO: Move this out?
-
-		editor.DEFAULT_CAMERA.aspect = container.dom.offsetWidth / container.dom.offsetHeight;
-		editor.DEFAULT_CAMERA.updateProjectionMatrix();
-
-		camera.aspect = container.dom.offsetWidth / container.dom.offsetHeight;
-		camera.updateProjectionMatrix();
+		updateAspectRatio();
 
 		renderer.setSize( container.dom.offsetWidth, container.dom.offsetHeight );
 
@@ -685,6 +686,8 @@ function Viewport( editor ) {
 		render();
 
 	} );
+
+	signals.cameraResetted.add( updateAspectRatio );
 
 	// animations
 


### PR DESCRIPTION
The PR slightly refactors the usage of the editor's default camera. It ensures

- that the fixes of 4abbce411072e3d63945b7107770d3ece45c7657 still work
- but handles `DEFAULT_CAMERA` now as a constant
- it's also a module scope variable now and does not leak anymore in `Viewport`

This is done by introducing a new signal `cameraResetted` that notifies `Viewport` to update the aspect ratio of the editor's camera.