### PR TITLE
Update link to paper in Sky.js

### DIFF
--- a/examples/js/objects/Sky.js
+++ b/examples/js/objects/Sky.js
@@ -4,7 +4,7 @@ console.warn( "THREE.Sky: As part of the transition to ES6 Modules, the files in
  *
  * Based on "A Practical Analytic Model for Daylight"
  * aka The Preetham Model, the de facto standard analytic skydome model
- * http://www.cs.utah.edu/~shirley/papers/sunsky/sunsky.pdf
+ * https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight
  *
  * First implemented by Simon Wallner
  * http://www.simonwallner.at/projects/atmospheric-scattering

--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -3,7 +3,7 @@
  *
  * Based on "A Practical Analytic Model for Daylight"
  * aka The Preetham Model, the de facto standard analytic skydome model
- * http://www.cs.utah.edu/~shirley/papers/sunsky/sunsky.pdf
+ * https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight
  *
  * First implemented by Simon Wallner
  * http://www.simonwallner.at/projects/atmospheric-scattering


### PR DESCRIPTION
The current link is no longer functional; this points to the latest source.