### PR TITLE
Editor: Don't overwrite editor camera in Viewport.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -532,7 +532,7 @@ Editor.prototype = {
 	setViewportCamera: function ( uuid ) {
 
 		this.viewportCamera = this.cameras[ uuid ];
-		this.signals.viewportCameraChanged.dispatch( this.viewportCamera );
+		this.signals.viewportCameraChanged.dispatch();
 
 	},
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -646,23 +646,24 @@ function Viewport( editor ) {
 
 	} );
 
-	signals.viewportCameraChanged.add( function ( viewportCamera ) {
+	signals.viewportCameraChanged.add( function () {
+
+		var viewportCamera = editor.viewportCamera;
 
 		if ( viewportCamera.isPerspectiveCamera ) {
 
 			viewportCamera.aspect = editor.camera.aspect;
 			viewportCamera.projectionMatrix.copy( editor.camera.projectionMatrix );
 
-		} else if ( ! viewportCamera.isOrthographicCamera ) {
+		} else if ( viewportCamera.isOrthographicCamera ) {
 
-			throw "Invalid camera set as viewport";
+			// TODO
 
 		}
 
-		// Disable EditorControls when setting a user camera
-		controls.enabled = viewportCamera === editor.camera;
+		// disable EditorControls when setting a user camera
 
-		camera = viewportCamera;
+		controls.enabled = ( viewportCamera === editor.camera );
 
 		render();
 
@@ -736,10 +737,10 @@ function Viewport( editor ) {
 
 		scene.add( grid );
 		renderer.setViewport( 0, 0, container.dom.offsetWidth, container.dom.offsetHeight );
-		renderer.render( scene, camera );
+		renderer.render( scene, editor.viewportCamera );
 		scene.remove( grid );
 
-		if ( camera === editor.camera ) {
+		if ( camera === editor.viewportCamera ) {
 
 			renderer.autoClear = false;
 			renderer.render( sceneHelpers, camera );


### PR DESCRIPTION
This PR fixes a subtle bug in `Viewport`. When the viewport camera is changed, the `viewportCameraChanged` handler assigns the new camera to `camera` and thus overwrites the references to the editor's default perspective camera. 

This actually breaks the resizing logic which is now encapsulated in `updateAspectRatio()`. To avoid this and for clarity reasons, it's best when the `camera` variable in `Viewport` always points to `editor.camera`.