### PR TITLE
Editor: Only process files during drag'n'drop.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -68,7 +68,7 @@ function Loader( editor ) {
 				return url;
 
 			} );
-			
+
 			manager.addHandler( /\.tga$/i, new TGALoader() );
 
 			for ( var i = 0; i < files.length; i ++ ) {

--- a/editor/js/LoaderUtils.js
+++ b/editor/js/LoaderUtils.js
@@ -77,7 +77,13 @@ var LoaderUtils = {
 
 		for ( var i = 0; i < items.length; i ++ ) {
 
-			handleEntry( items[ i ].webkitGetAsEntry() );
+			var item = items[ i ];
+
+			if ( item.kind === 'file' ) {
+
+				handleEntry( item.webkitGetAsEntry() );
+
+			}
 
 		}
 


### PR DESCRIPTION
Avoids a rare runtime error that occurs when you accidentally drag'n'drop e.g. a toolbar icon. In such a case, [item.kind](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/kind) is `string` which breaks the subsequent processing.