### PR TITLE
Editor: Avoid runtime error in outliner.

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -506,7 +506,7 @@ UIOutliner.prototype.setOptions = function ( options ) {
 
 	function onDrop( event ) {
 
-		if ( this === currentDrag ) return;
+		if ( this === currentDrag || currentDrag === undefined ) return;
 
 		this.className = 'option';
 


### PR DESCRIPTION
This PR avoids a rare runtime error in the outliner. It can happen if you accidentally drag'n'drop a non outliner entry onto the outliner. In this case, `currentDrag` is `undefined` and can't be processed.