### PR TITLE
Editor: make loadFile in UITexture works correctly

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -55,18 +55,59 @@ function UITexture( mapping ) {
 
 	function loadFile( file ) {
 
-		if ( file.type.match( 'image.*' ) ) {
+		var extension = file.name.split( '.' ).pop().toLowerCase()
+		var reader = new FileReader();
 
-			var reader = new FileReader();
+		if ( extension === 'hdr' ) {
 
-			if ( file.type === 'image/targa' ) {
+			reader.addEventListener( 'load', function ( event ) {
 
-				reader.addEventListener( 'load', function ( event ) {
+				// assuming RGBE/Radiance HDR iamge format
 
-					var canvas = new TGALoader().parse( event.target.result );
+				var loader = new RGBELoader().setDataType( THREE.UnsignedByteType );
+				loader.load( event.target.result, function ( hdrTexture ) {
 
-					var texture = new THREE.CanvasTexture( canvas, mapping );
+					hdrTexture.sourceFile = file.name;
+					hdrTexture.isHDRTexture = true;
+
+					scope.setValue( hdrTexture );
+
+					if ( scope.onChangeCallback ) scope.onChangeCallback( hdrTexture );
+
+				} );
+
+			} );
+
+			reader.readAsDataURL( file );
+
+		} else if ( extension === 'tga' ) {
+
+			reader.addEventListener( 'load', function ( event ) {
+
+				var canvas = new TGALoader().parse( event.target.result );
+
+				var texture = new THREE.CanvasTexture( canvas, mapping );
+				texture.sourceFile = file.name;
+
+				scope.setValue( texture );
+
+				if ( scope.onChangeCallback ) scope.onChangeCallback( texture );
+
+			}, false );
+
+			reader.readAsArrayBuffer( file );
+
+		} else if ( file.type.match( 'image.*' ) ) {
+
+			reader.addEventListener( 'load', function ( event ) {
+
+				var image = document.createElement( 'img' );
+				image.addEventListener( 'load', function () {
+
+					var texture = new THREE.Texture( this, mapping );
 					texture.sourceFile = file.name;
+					texture.format = file.type === 'image/jpeg' ? THREE.RGBFormat : THREE.RGBAFormat;
+					texture.needsUpdate = true;
 
 					scope.setValue( texture );
 
@@ -74,61 +115,11 @@ function UITexture( mapping ) {
 
 				}, false );
 
-				reader.readAsArrayBuffer( file );
+				image.src = event.target.result;
 
-			} else {
-
-				reader.addEventListener( 'load', function ( event ) {
-
-					var image = document.createElement( 'img' );
-					image.addEventListener( 'load', function () {
-
-						var texture = new THREE.Texture( this, mapping );
-						texture.sourceFile = file.name;
-						texture.format = file.type === 'image/jpeg' ? THREE.RGBFormat : THREE.RGBAFormat;
-						texture.needsUpdate = true;
-
-						scope.setValue( texture );
-
-						if ( scope.onChangeCallback ) scope.onChangeCallback( texture );
-
-					}, false );
-
-					image.src = event.target.result;
-
-				}, false );
-
-				reader.readAsDataURL( file );
-
-			}
-
-		} else {
-
-			var reader = new FileReader();
-			reader.addEventListener( 'load', function ( event ) {
-
-				if ( file.name.split( '.' ).pop() === 'hdr' ) {
-
-					// assuming RGBE/Radiance HDR iamge format
-
-					var loader = new RGBELoader().setDataType( THREE.UnsignedByteType );
-					loader.load( event.target.result, function ( hdrTexture ) {
-
-						hdrTexture.sourceFile = file.name;
-						hdrTexture.isHDRTexture = true;
-
-						scope.setValue( hdrTexture );
-
-						if ( scope.onChangeCallback ) scope.onChangeCallback( hdrTexture );
-
-					} );
-
-				}
-
-			} );
+			}, false );
 
 			reader.readAsDataURL( file );
-
 		}
 
 		form.reset();
@@ -157,6 +148,14 @@ UITexture.prototype.setValue = function ( texture ) {
 	var canvas = this.dom.children[ 0 ];
 	var context = canvas.getContext( '2d' );
 
+	// Seems like context can be null if the canvas is not visible
+	if ( context ) {
+
+		// Always clear the context before set new texture, because new texture may has transparency
+		context.clearRect( 0, 0, canvas.width, canvas.height );
+
+	}
+
 	if ( texture !== null ) {
 
 		var image = texture.image;
@@ -180,21 +179,12 @@ UITexture.prototype.setValue = function ( texture ) {
 		} else {
 
 			canvas.title = texture.sourceFile + ' (error)';
-			context.clearRect( 0, 0, canvas.width, canvas.height );
 
 		}
 
 	} else {
 
 		canvas.title = 'empty';
-
-		if ( context !== null ) {
-
-			// Seems like context can be null if the canvas is not visible
-
-			context.clearRect( 0, 0, canvas.width, canvas.height );
-
-		}
 
 	}
 


### PR DESCRIPTION
- `TGA` files may not have `type` property when load from input, current check logic could fail, check through extension now
![image](https://user-images.githubusercontent.com/8372385/87379862-cdc8b980-c5c3-11ea-9d4c-5cde14a32dbb.png)
- Should transform file extension into lower case before compare, that current `hdr` file check could fail 
- Should always clear the texture preview canvas before set new one, because new texture may contains transparency