### PR TITLE
KTX2Loader: Fix transcode target choices for UASTC on iOS. Add BC7.

### DIFF
--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -52,6 +52,7 @@
 			scene.add( mesh );
 
 			var formatStrings = {
+				[ THREE.RGBAFormat ]: "RGBA32",
 				[ THREE.RGBA_ASTC_4x4_Format ]: "RGBA_ASTC_4x4",
 				[ THREE.RGB_S3TC_DXT1_Format ]: "RGB_S3TC_DXT1",
 				[ THREE.RGBA_S3TC_DXT5_Format ]: "RGBA_S3TC_DXT5",
@@ -70,6 +71,7 @@
 					console.info( `transcoded to ${formatStrings[ texture.format ]}` );
 
 					material.map = texture;
+					material.transparent = true;
 
 					material.needsUpdate = true;
 


### PR DESCRIPTION
Fixes Basis UASTC decoding on iOS. We were trying to transcode to PVRTC, which failed. ~On devices that only support PVRTC, it seems like we can transcode ETC1S to PVRTC but UASTC must be decoded to RGBA32. @MarkCallow does that sound right? Or is that a temporary limitation in the transcoder?~ Transcoding to PVRTC requires that the texture have power of two dimensions.

~Excuse the extra logging, I'll clean that up shortly.~ Done.