### PR TITLE
WebGLRenderTarget: Add support for swapping textures

### DIFF
--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -101,6 +101,11 @@
 		Sets the size of the render target.
 		</p>
 
+		<h3>[method:Texture swapTexture]( [param:Texture newTexture] )</h3>
+		<p>
+		Detaches the color texture from the render target and returns it. A new replacement texture can be passed in, and if it is not passed in then one is created automatically with the same parameters as the old texture.
+		</p>
+
 		<h3>[method:WebGLRenderTarget clone]()</h3>
 		<p>
 		Creates a copy of this render target.

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -17,7 +17,7 @@
 			var camera, scene, renderer;
 			var cube, sphere, torus, material;
 
-			var count = 0, cubeCamera1, cubeCamera2, cubeRenderTarget1, cubeRenderTarget2;
+			var cubeCamera, cubeRenderTarget;
 
 			var onPointerDownPointerX, onPointerDownPointerY, onPointerDownLon, onPointerDownLat;
 
@@ -25,6 +25,8 @@
 			var phi = 0, theta = 0;
 
 			var textureLoader = new THREE.TextureLoader();
+
+			var frontBuffer = undefined;
 
 			textureLoader.load( 'textures/2294472375_24a3b8ef46_o.jpg', function ( texture ) {
 
@@ -57,21 +59,15 @@
 
 				//
 
-				cubeRenderTarget1 = new THREE.WebGLCubeRenderTarget( 256, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
-				cubeCamera1 = new THREE.CubeCamera( 1, 1000, cubeRenderTarget1 );
-				scene.add( cubeCamera1 );
-
-				cubeRenderTarget2 = new THREE.WebGLCubeRenderTarget( 256, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
-				cubeCamera2 = new THREE.CubeCamera( 1, 1000, cubeRenderTarget2 );
-				scene.add( cubeCamera2 );
+				cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 256, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+				cubeCamera = new THREE.CubeCamera( 1, 1000, cubeRenderTarget );
+				scene.add( cubeCamera );
 
 				document.body.appendChild( renderer.domElement );
 
 				//
 
-				material = new THREE.MeshBasicMaterial( {
-					envMap: cubeRenderTarget2.texture
-				} );
+				material = new THREE.MeshBasicMaterial();
 
 				sphere = new THREE.Mesh( new THREE.IcosahedronBufferGeometry( 20, 3 ), material );
 				scene.add( sphere );
@@ -178,19 +174,10 @@
 
 				// pingpong
 
-				if ( count % 2 === 0 ) {
-
-					cubeCamera1.update( renderer, scene );
-					material.envMap = cubeRenderTarget1.texture;
-
-				} else {
-
-					cubeCamera2.update( renderer, scene );
-					material.envMap = cubeRenderTarget2.texture;
-
-				}
-
-				count ++;
+				cubeCamera.update( renderer, scene );
+				frontBuffer = cubeRenderTarget.swapTexture( frontBuffer );
+				material.envMap = frontBuffer;
+				material.needsUpdate = true;
 
 				renderer.render( scene, camera );
 

--- a/src/renderers/WebGLRenderTarget.d.ts
+++ b/src/renderers/WebGLRenderTarget.d.ts
@@ -81,6 +81,7 @@ export class WebGLRenderTarget extends EventDispatcher {
 	generateMipmaps: any;
 
 	setSize( width: number, height: number ): void;
+	swapTexture( newTexture?: Texture ): Texture;
 	clone(): this;
 	copy( source: WebGLRenderTarget ): this;
 	dispose(): void;

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -74,9 +74,9 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 
 			newTexture = new Texture( undefined, oldTexture.mapping, oldTexture.wrapS, oldTexture.wrapT, oldTexture.magFilter, oldTexture.minFilter, oldTexture.format, oldTexture.type, oldTexture.anisotropy, oldTexture.encoding );
 
-			this.texture.image = {};
-			this.texture.image.width = this.width;
-			this.texture.image.height = this.height;
+			newTexture.image = {};
+			newTexture.image.width = this.width;
+			newTexture.image.height = this.height;
 
 		} else {
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -66,6 +66,64 @@ WebGLRenderTarget.prototype = Object.assign( Object.create( EventDispatcher.prot
 
 	},
 
+	swapTexture: function ( newTexture ) {
+
+		var oldTexture = this.texture;
+
+		if ( ! newTexture ) {
+
+			newTexture = new Texture( undefined, oldTexture.mapping, oldTexture.wrapS, oldTexture.wrapT, oldTexture.magFilter, oldTexture.minFilter, oldTexture.format, oldTexture.type, oldTexture.anisotropy, oldTexture.encoding );
+
+			this.texture.image = {};
+			this.texture.image.width = this.width;
+			this.texture.image.height = this.height;
+
+		} else {
+
+			// Check that the format and type of the new texture match the old - otherwise we can't swap.
+
+			if ( newTexture.isCubeTexture === true || newTexture.isCanvasTexture === true || newTexture.isCompressedTexture === true || newTexture.isDataTexture === true || newTexture.isDepthTexture === true || newTexture.isVideoTexture === true || newTexture.isDataTexture3D === true || newTexture.isDataTexture2DArray === true ) {
+
+				console.error( "Can only swap a regular Texture on a WebGLRenderTarget" );
+				return null;
+
+			}
+
+			if ( newTexture.format !== oldTexture.format ) {
+
+				console.error( "Render target texture can only be swapped with a texture with the same format." );
+				return null;
+
+			}
+
+			if ( newTexture.type !== oldTexture.type ) {
+
+				console.error( "Render target texture can only be swapped with a texture with the same type." );
+				return null;
+
+			}
+
+			if ( newTexture.image !== undefined ) {
+
+				if ( newTexture.image.width !== undefined && newTexture.image.height !== undefined ) {
+
+					this.width = newTexture.image.width;
+					this.height = newTexture.image.height;
+
+				}
+
+			}
+
+		}
+
+		this.texture = newTexture;
+
+		this.dispatchEvent( { type: 'textureAttachmentChange' } );
+
+		return oldTexture;
+
+	},
+
 	clone: function () {
 
 		return new this.constructor().copy( this );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -128,7 +128,6 @@ function WebGLRenderer( parameters ) {
 	let _currentActiveCubeFace = 0;
 	let _currentActiveMipmapLevel = 0;
 	let _currentRenderTarget = null;
-	let _currentFramebuffer = null;
 	let _currentMaterialId = - 1;
 
 	let _currentCamera = null;
@@ -1833,10 +1832,10 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		if ( _currentFramebuffer !== framebuffer ) {
+		if ( textures.currentFramebuffer !== framebuffer ) {
 
 			_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
-			_currentFramebuffer = framebuffer;
+			textures.currentFramebuffer = framebuffer;
 
 		}
 
@@ -1874,7 +1873,7 @@ function WebGLRenderer( parameters ) {
 
 			let restore = false;
 
-			if ( framebuffer !== _currentFramebuffer ) {
+			if ( framebuffer !== textures.currentFramebuffer ) {
 
 				_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
 
@@ -1924,7 +1923,7 @@ function WebGLRenderer( parameters ) {
 
 				if ( restore ) {
 
-					_gl.bindFramebuffer( _gl.FRAMEBUFFER, _currentFramebuffer );
+					_gl.bindFramebuffer( _gl.FRAMEBUFFER, textures.currentFramebuffer );
 
 				}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -22,6 +22,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	let useOffscreenCanvas = false;
 
+	let currentFramebuffer = null;
+
 	try {
 
 		useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
@@ -259,13 +261,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			}
 
-			_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+			_gl.bindFramebuffer( _gl.FRAMEBUFFER, currentFramebuffer );
 
 		} else {
 
 			_gl.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
 			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, textureProperties.__webglTexture, 0 );
-			_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+			_gl.bindFramebuffer( _gl.FRAMEBUFFER, currentFramebuffer );
 
 		}
 
@@ -879,7 +881,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		state.texImage2D( textureTarget, 0, glInternalFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
 		_gl.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
 		_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( renderTarget.texture ).__webglTexture, 0 );
-		_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+		_gl.bindFramebuffer( _gl.FRAMEBUFFER, currentFramebuffer );
 
 	}
 
@@ -1045,7 +1047,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+		_gl.bindFramebuffer( _gl.FRAMEBUFFER, currentFramebuffer );
 
 	}
 
@@ -1113,7 +1115,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					}
 
-					_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+					_gl.bindFramebuffer( _gl.FRAMEBUFFER, currentFramebuffer );
 
 
 				} else {
@@ -1333,6 +1335,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	this.safeSetTexture2D = safeSetTexture2D;
 	this.safeSetTextureCube = safeSetTextureCube;
+
+	Object.defineProperty(this, "currentFramebuffer", { get() { return currentFramebuffer; }, set(newValue) { currentFramebuffer = newValue; } })
 
 }
 


### PR DESCRIPTION
This can be used to save GPU memory or to avoid texture copy operations in situations where multiple textures need to be used as render targets but one shared depth/stencil buffer is enough.

The downside is that the WebGL implementation needs to validate the framebuffer again for completeness.

WebGLCubeRenderTarget returns Textures from this function, not CubeTextures.