### PR TITLE
InterleavedBufferAttribute: Introduce needsUpdate.

### DIFF
--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -50,14 +50,19 @@
 		Optional name for this attribute instance. Default is an empty string.
 		</p>
 
-		<h3>[property:Integer offset]</h3>
+		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-			The offset in the underlying array buffer where an item starts.
+			Default is *false*. Setting this to *true* will send the entire interleaved buffer (not just the specific attribute data) to the GPU again.
 		</p>
 
 		<h3>[property:Boolean normalized]</h3>
 		<p>
 			Default is *false*.
+		</p>
+
+		<h3>[property:Integer offset]</h3>
+		<p>
+			The offset in the underlying array buffer where an item starts.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/zh/core/InterleavedBufferAttribute.html
+++ b/docs/api/zh/core/InterleavedBufferAttribute.html
@@ -49,14 +49,19 @@
 		Optional name for this attribute instance. Default is an empty string.
 		</p>
 
-		<h3>[property:Integer offset]</h3>
+		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-			缓存队列中每个元素的起始位置的偏移量。
+			Default is *false*. Setting this to *true* will send the entire interleaved buffer (not just the specific attribute data) to the GPU again.
 		</p>
 
 		<h3>[property:Boolean normalized]</h3>
 		<p>
 			默认值为 *false*。
+		</p>
+
+		<h3>[property:Integer offset]</h3>
+		<p>
+			缓存队列中每个元素的起始位置的偏移量。
 		</p>
 
 		<h2>方法</h2>

--- a/src/core/InterleavedBufferAttribute.d.ts
+++ b/src/core/InterleavedBufferAttribute.d.ts
@@ -21,6 +21,7 @@ export class InterleavedBufferAttribute {
 
 	get count(): number;
 	get array(): ArrayLike<number>;
+	set needsUpdate( value: boolean );
 
 	readonly isInterleavedBufferAttribute: true;
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -39,6 +39,16 @@ Object.defineProperties( InterleavedBufferAttribute.prototype, {
 
 		}
 
+	},
+
+	needsUpdate: {
+
+		set: function ( value ) {
+
+			this.data.needsUpdate = value;
+
+		}
+
 	}
 
 } );


### PR DESCRIPTION
Fixed #9790.

This PR aligns `InterleavedBufferAttribute` to `BufferAttribute` by introducing the `needsUpdate` flag. If set to true, it just triggers the update on its interleaved buffer.

Although it's only a subtle change, it makes the life for devs somewhat easier since they can now handle the update of interleaved and non-interleaved attributes identical (assuming they are using the recommended `setXYZW()` methods). Meaning checks like https://github.com/mrdoob/three.js/issues/9790#issuecomment-529633697 are not necessary anymore.

BTW: It does not hurt if multiple attributes increase the version counter of the interleaved buffer at the same time in one frame. The renderer ensures to update the buffer only once.