### PR TITLE
TS: fixed GridHelper types

### DIFF
--- a/src/helpers/GridHelper.d.ts
+++ b/src/helpers/GridHelper.d.ts
@@ -6,12 +6,12 @@ export class GridHelper extends LineSegments {
 	constructor(
 		size: number,
 		divisions: number,
-		color1?: Color | number,
-		color2?: Color | number
+		color1?: Color | string | number,
+		color2?: Color | string | number
 	);
 	/**
 	 * @deprecated Colors should be specified in the constructor.
 	 */
-	setColors( color1?: Color | number, color2?: Color | number ): void;
+	setColors( color1?: Color | string | number, color2?: Color | string | number ): void;
 
 }


### PR DESCRIPTION
accept css names of type string for `color1` and `color2`