### PR TITLE
Docs: Fixed wrong file paths

### DIFF
--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -213,7 +213,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/convexhull/ConvexHull.html
+++ b/docs/examples/zh/math/convexhull/ConvexHull.html
@@ -213,7 +213,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/ConvexHull.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js examples/jsm/math/ConvexHull.js]
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
Hi,

I needed to get the path of the ConvexHull module, so I looked it up in the doc but found a wrong path.   
This is an update to the aforementioned path in the doc.