### PR TITLE
WebGLMaterials: Avoid undefined as maxMipLevel uniform value.

### DIFF
--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -154,7 +154,13 @@ function WebGLMaterials( properties ) {
 			uniforms.reflectivity.value = material.reflectivity;
 			uniforms.refractionRatio.value = material.refractionRatio;
 
-			uniforms.maxMipLevel.value = properties.get( envMap ).__maxMipLevel;
+			var maxMipLevel = properties.get( envMap ).__maxMipLevel;
+
+			if ( maxMipLevel !== undefined ) {
+
+				uniforms.maxMipLevel.value = maxMipLevel;
+
+			}
 
 		}
 


### PR DESCRIPTION
Related #19878.

`__maxMipLevel` is only computed when the env map is fully loaded and uploaded to the GPU. This fix avoids setting `undefined`.