### PR TITLE
Examples: Avoid NaN values in data textures in webgl_gpgpu_birds_gltf.

### DIFF
--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -261,13 +261,26 @@
 
 						if ( j < durationAnimation ) {
 
-							tData[ offset + i * 3 ] = Math.lerp( morphAttributes[ curMorph ].array[ i * 3 ], morphAttributes[ nextMorph ].array[ i * 3 ], lerpAmount );
-							tData[ offset + i * 3 + 1 ] = Math.lerp( morphAttributes[ curMorph ].array[ i * 3 + 1 ], morphAttributes[ nextMorph ].array[ i * 3 + 1 ], lerpAmount );
-							tData[ offset + i * 3 + 2 ] = Math.lerp( morphAttributes[ curMorph ].array[ i * 3 + 2 ], morphAttributes[ nextMorph ].array[ i * 3 + 2 ], lerpAmount );
+							var d0, d1;
+
+							d0 = morphAttributes[ curMorph ].array[ i * 3 ];
+							d1 = morphAttributes[ nextMorph ].array[ i * 3 ];
+
+							if ( d0 !== undefined && d1 !== undefined ) tData[ offset + i * 3 ] = Math.lerp( d0, d1, lerpAmount );
+
+							d0 = morphAttributes[ curMorph ].array[ i * 3 + 1 ];
+							d1 = morphAttributes[ nextMorph ].array[ i * 3 + 1 ];
+
+							if ( d0 !== undefined && d1 !== undefined ) tData[ offset + i * 3 + 1 ] = Math.lerp( d0, d1, lerpAmount );
+
+							d0 = morphAttributes[ curMorph ].array[ i * 3 + 2 ];
+							d1 = morphAttributes[ nextMorph ].array[ i * 3 + 2 ];
+
+							if ( d0 !== undefined && d1 !== undefined ) tData[ offset + i * 3 + 2 ] = Math.lerp( d0, d1, lerpAmount );
 
 						}
 
-		}
+					}
 
 				}
 


### PR DESCRIPTION
Fixed #19876.