### PR TITLE
NodeBuilder: Missing property in requires type definition

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.d.ts
+++ b/examples/jsm/nodes/core/NodeBuilder.d.ts
@@ -24,6 +24,8 @@ export class NodeBuilder {
 		color: boolean[];
 		lights: boolean;
 		fog: boolean;
+		transparent: boolean;
+		irradiance: boolean;
 	};
 
 	includes: {

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -64,7 +64,9 @@ function NodeBuilder() {
 		uv: [],
 		color: [],
 		lights: false,
-		fog: false
+		fog: false,
+		transparent: false,
+		irradiance: false,
 	};
 
 	this.includes = {

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -66,7 +66,7 @@ function NodeBuilder() {
 		lights: false,
 		fog: false,
 		transparent: false,
-		irradiance: false,
+		irradiance: false
 	};
 
 	this.includes = {


### PR DESCRIPTION
Used here for example: https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/materials/nodes/StandardNode.js#L229 and https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/materials/nodes/StandardNode.js#L241

cc. @sunag 