### PR TITLE
TS: generalize NodeMaterial vertex/fragment types

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.d.ts
+++ b/examples/jsm/nodes/materials/NodeMaterial.d.ts
@@ -3,9 +3,9 @@ import {
 	WebGLRenderer
 } from '../../../../src/Three';
 
+import { Node } from '../../core/Node.js';
 import { NodeBuilder } from '../core/NodeBuilder';
 import { NodeFrame } from '../core/NodeFrame';
-import { MeshStandardNode } from './nodes/MeshStandardNode';
 import { RawNode } from './nodes/RawNode';
 
 export interface NodeMaterialBuildParams {
@@ -15,10 +15,10 @@ export interface NodeMaterialBuildParams {
 
 export class NodeMaterial extends ShaderMaterial {
 
-	constructor( vertex: MeshStandardNode, fragment: MeshStandardNode );
+	constructor( vertex: Node, fragment: Node );
 
-	vertex: MeshStandardNode | RawNode;
-	fragment: MeshStandardNode | RawNode;
+	vertex: Node | RawNode;
+	fragment: Node | RawNode;
 
 	updaters: object[];
 


### PR DESCRIPTION
Generalize the constructor args types for the `NodeMaterial` class.

Please tell me if I am not correct, but taking a `MeshStandardNode` seems wrong anyway, as the `StandardNodeMaterial` class (which inherits from `NodeMaterial`) [passes a `StandardNode` instance](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/materials/StandardNodeMaterial.js#L11-L13) there, [which does not inherit from `MeshStandardNode`](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/materials/nodes/StandardNode.js#L16-L18).

cc. @sunag 