### PR TITLE
Use the src/Three.js file as the entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "three",
   "version": "0.118.3",
   "description": "JavaScript 3D library",
-  "main": "build/three.js",
-  "module": "build/three.module.js",
+  "main": "src/Three.js",
+  "module": "src/Three.js",
   "types": "src/Three.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a tiny change, but it is a breaking change, and has noteworthy implications. Also, this change is incomplete, but is intended for discussion.

- Everything is moving to ESM, including Node.js. Some more changes are still needed for this to work with Node ESM.
- Most modern build tools (f.e. Webpack, Babel) will understand the ESM syntax. This change works with modern tools.
- People who use Node CommonJS format in Node prior to Node 13.2 (f.e. people importing `three` into an Electron app via Node `require()`) can be instructed (by the threejs.org documentation) to `require('three/build/three')` explicitly, the "legacy" way.
- People importing `three` using Node's native ESM, they just `import {...} from 'three'`, or from specific files as in `import {...} from 'three/src/math/Vector3'`. _Again, this still needs a couple more changes to work properly with Node ESM._
- Users of globals via script tags can still use `<script src="./node_modules/three/build/three.js">`
- **Here's the best part**. This allows natural tree shaking by virtue of using ES Modules.
  - Currently, the only way to reliably import `three` with ESM (more on this below) is to import it like this: `import {...} from 'three'`
  - Importing from the index means _the entire library is always imported_, and it can only be tree-shaken by configuring build tools with certain often-difficult-to-understand configurations, and they are error-prone.

Expanding on the last point, the best part about this is that we can have "tree shaking" simply by using ES Modules without requirements specific to any build tools. A user could, for example, write an app like this:

```js
import {Vector3} from 'three/src/math/Vector3'

// This app, for example, needs Vector3 from 'three' to do some math, and needs nothing else.
```

The `Vector3` class imports only two things:

```js
import { _Math } from './Math.js';
import { Quaternion } from './Quaternion.js';
```

and `Quaternion` imports only `./Math.js`. The end result is that, even if this app is an app using native ES Modules in the browser, it will import only a tiny set of modules just for `Vector3` instead of importing the whole Three.js lib. If using a bundler, the bundler has to do no actual work to "tree shake", and will bundle only this small set of depedencies. Great! 

**Ok, but you may be wondering.... can't we already do this now, without this change?**

Yes, but here's the problem.

- Suppose someone wants to import from the Three.js source files directly instead of the index module, so to have an automatically-smaller set of modules without relying on build tools. F.e. They `import {MeshPhongMaterial} from 'three/src/materials/MeshPhongMaterial'` and do not want to include any other materials in their app (and don't want to waaste time parsing or loading those modules).
- Now, suppose they want to install `three.meshline` to render lines in their app.
- They install `three.meshline`, and bundle it into the app, or they set up an import map for native ES Modules in the browser.
- **They run the app, and now nothing shows up on the screen, and there are no errors in the console!** 

**Whaaaa? What happened???**

This happened to me. And being knowledgeable in ESM standards, etc, I knew the issue right away:

It turns out, `three.meshline` (and many many other 3rd-party three.js libs) import `from 'three'` which means they will import from `three/build/three.js`. Anyone else who is importing `from 'three/src/...'` is importing from an entirely _separate_ version of Three.js, despite that it comes from the same library.

What will happen is `three.meshline` will import materials and other things from one version of `three`, while the users app will import everything from the other version of Three.js that comes from `three/src`.

To fix these issues, each developer will have to make specific workaround for their environment. For example, in Webpack they'll need to set `resolve.alias`es. Native ES Module users will need to wire up specific import maps. 

Users of both Webpack and native ES Modules, for example, will need to also patch `three.meshline` to make it access the module in a slightly different way, because `three.meshline` uses `require('three')`, but this may be required even with the current change. The exports of `three/src/Three.js` need to be updated to support this case.

**Solution**

This change starts to get us to a better state. If we change `main`, and adopt ES Modules, there is more probability that libs that import from `three` or from `three/src/...`, and users who wish to import from `three` or `three/src/...`, will import a single version of all Three.js features, and such problems won't happen.

What's left to change:

- We need to set up the package.json field `"type": "module"`.
- Set up the package.json `exports` field, if more control is needed.
- Add fallbacks for CommonJS (which older build tools will read)

This way, at least people relying on the latest ESM will get the best experience, while users relying on old build tools or CommonJS will be in the same place they are now (and we should document this for them).

No effect on Global script tag users. They keep on keeping on.