### PR TITLE
VideoTexture: Make use of requestVideoFrameCallback().

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -16,6 +16,21 @@ function VideoTexture( video, mapping, wrapS, wrapT, magFilter, minFilter, forma
 
 	this.generateMipmaps = false;
 
+	const scope = this;
+
+	function updateVideo() {
+
+		scope.needsUpdate = true;
+		video.requestVideoFrameCallback( updateVideo );
+
+	}
+
+	if ( 'requestVideoFrameCallback' in video ) {
+
+		video.requestVideoFrameCallback( updateVideo );
+
+	}
+
 }
 
 VideoTexture.prototype = Object.assign( Object.create( Texture.prototype ), {
@@ -27,8 +42,9 @@ VideoTexture.prototype = Object.assign( Object.create( Texture.prototype ), {
 	update: function () {
 
 		const video = this.image;
+		const hasVideoFrameCallback = 'requestVideoFrameCallback' in video;
 
-		if ( video.readyState >= video.HAVE_CURRENT_DATA ) {
+		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA ) {
 
 			this.needsUpdate = true;
 


### PR DESCRIPTION
Replacement of #19905.

This makes the WebGL warnings in `webgl_video_panorama_equirectangular` go away.