### PR TITLE
Fix UASTC to BC7 target format selection

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -467,7 +467,7 @@ class KTX2Container {
 
 		} else if ( config.bptcSupported && texFormat === TextureFormat.UASTC4x4 ) {
 
-			targetFormat = hasAlpha ? TranscodeTarget.BC7_M5_RGBA : BC7_M6_RGB;
+			targetFormat = TranscodeTarget.BC7_M5_RGBA;
 			this.transcodedFormat = RGBA_BPTC_Format;
 
 		} else if ( config.dxtSupported ) {


### PR DESCRIPTION
Current code tries to access `BC7_M6_RGB` without a proper namespace and fails. Moreover, there's no need to check alpha presence for UASTC to BC7 transcoding.

FWIW, the proper enum name should be `BC7_RGBA` but [it's not exposed yet](https://github.com/KhronosGroup/KTX-Software/issues/280).

/cc @donmccurdy 

