### PR TITLE
Helpers: Simplify copy() and clone().

### DIFF
--- a/src/helpers/ArrowHelper.js
+++ b/src/helpers/ArrowHelper.js
@@ -126,10 +126,4 @@ ArrowHelper.prototype.copy = function ( source ) {
 
 };
 
-ArrowHelper.prototype.clone = function () {
-
-	return new this.constructor().copy( this );
-
-};
-
 export { ArrowHelper };

--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -110,10 +110,4 @@ BoxHelper.prototype.copy = function ( source ) {
 
 };
 
-BoxHelper.prototype.clone = function () {
-
-	return new this.constructor().copy( this );
-
-};
-
 export { BoxHelper };

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -47,27 +47,7 @@ function GridHelper( size, divisions, color1, color2 ) {
 
 }
 
-GridHelper.prototype = Object.assign( Object.create( LineSegments.prototype ), {
-
-	constructor: GridHelper,
-
-	copy: function ( source ) {
-
-		LineSegments.prototype.copy.call( this, source );
-
-		this.geometry.copy( source.geometry );
-		this.material.copy( source.material );
-
-		return this;
-
-	},
-
-	clone: function () {
-
-		return new this.constructor().copy( this );
-
-	}
-
-} );
+GridHelper.prototype = Object.create( LineSegments.prototype );
+GridHelper.prototype.constructor = GridHelper;
 
 export { GridHelper };


### PR DESCRIPTION
Some helpers support copy and clone operations.

The current implementation is based on assumptions before #19471 was merged. Since classes like `Line` or `Mesh` can use the `clone()` implementation from `Object3D` now, it's not necessary to overwrite the method in helpers.

Besides, `GridHelper.copy()` can now use the implementation of `LineSegments`.