### PR TITLE
WebGLCubeRenderTarget: default to RGBA format in .fromEquirectangularTexture()

### DIFF
--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -1,4 +1,4 @@
-import { BackSide, NoBlending } from '../constants.js';
+import { BackSide, NoBlending, RGBAFormat } from '../constants.js';
 import { Scene } from '../scenes/Scene.js';
 import { Mesh } from '../objects/Mesh.js';
 import { BoxBufferGeometry } from '../geometries/BoxGeometry.js';
@@ -34,7 +34,7 @@ WebGLCubeRenderTarget.prototype.isWebGLCubeRenderTarget = true;
 WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
 
 	this.texture.type = texture.type;
-	this.texture.format = texture.format;
+	this.texture.format = RGBAFormat; // see #18859
 	this.texture.encoding = texture.encoding;
 
 	this.texture.generateMipmaps = texture.generateMipmaps;


### PR DESCRIPTION
WebGL2 does not support rendering to RGB floating point targets.

After discussing with @sciecode, this seems to be a reasonable fix, and it prevents a `WebGLRenderer` warning.
