### PR TITLE
modularize.js supports CRLF new line code

### DIFF
--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -252,7 +252,7 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	// remove examples/js deprecation warning
 
-	contents = contents.replace( /^console\.warn.*\n/, '' );
+	contents = contents.replace( /^console\.warn.*(\r\n|\r|\n)/, '' );
 
 	// imports
 


### PR DESCRIPTION
The current `modularise.js` expects new line code as `LF(\n)` but it doesn't recognize new line on Windows because Windows generally uses `CRLF(\r\n)` as new line code. 

This PR lets `modularize.js` support `CRLF(\r\n)` new line code (and `CR(\r)` new line code used on MacOS until version 9, just in case).

Another solution may be requesting Windows users to configure `LF` new line code on their Git client or text editor. But this PR changes just one line so it would be reasonable.