### PR TITLE
GPGPU Examples Working on iPadOS Safari

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -26,6 +26,8 @@ export class GPUComputationRenderer {
 
 	constructor( sizeX: number, sizeY: number, renderer: WebGLRenderer );
 
+	setDataType ( type: TextureDataType ): void;
+
 	addVariable( variableName: string, computeFragmentShader: string, initialValueTexture: Texture ): Variable;
 	setVariableDependencies( variable: Variable, dependencies: Variable[] | null ): void;
 

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -102,7 +102,6 @@ import {
 	ClampToEdgeWrapping,
 	DataTexture,
 	FloatType,
-	HalfFloatType,
 	Mesh,
 	NearestFilter,
 	PlaneBufferGeometry,
@@ -118,6 +117,8 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 
 	this.currentTextureIndex = 0;
 
+	var dataType = FloatType;
+
 	var scene = new Scene();
 
 	var camera = new Camera();
@@ -132,6 +133,13 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 	var mesh = new Mesh( new PlaneBufferGeometry( 2, 2 ), passThruShader );
 	scene.add( mesh );
 
+
+	this.setDataType = function ( type ) {
+
+		dataType = type;
+		return this;
+
+	};
 
 	this.addVariable = function ( variableName, computeFragmentShader, initialValueTexture ) {
 
@@ -325,7 +333,7 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 			minFilter: minFilter,
 			magFilter: magFilter,
 			format: RGBAFormat,
-			type: ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) ? HalfFloatType : FloatType,
+			type: dataType,
 			stencilBuffer: false,
 			depthBuffer: false
 		} );

--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -483,6 +483,10 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
+				if ( isSafari() ) {
+					gpuCompute.setDataType( THREE.HalfFloatType );
+				}
+
 				var dtPosition = gpuCompute.createTexture();
 				var dtVelocity = gpuCompute.createTexture();
 				fillPositionTexture( dtPosition );
@@ -521,6 +525,10 @@
 
 				}
 
+			}
+
+			function isSafari() {
+				return !!navigator.userAgent.match(/Safari/i) && !navigator.userAgent.match(/Chrome/i);
 			}
 
 			function initBirds() {

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -431,6 +431,10 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
+				if ( isSafari() ) {
+					gpuCompute.setDataType( THREE.HalfFloatType );
+				}
+
 				var dtPosition = gpuCompute.createTexture();
 				var dtVelocity = gpuCompute.createTexture();
 				fillPositionTexture( dtPosition );
@@ -470,6 +474,10 @@
 
 				}
 
+			}
+
+			function isSafari() {
+				return !!navigator.userAgent.match(/Safari/i) && !navigator.userAgent.match(/Chrome/i);
 			}
 
 			function initBirds() {

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -316,6 +316,10 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
+				if ( isSafari() ) {
+					gpuCompute.setDataType( THREE.HalfFloatType );
+				}
+
 				var dtPosition = gpuCompute.createTexture();
 				var dtVelocity = gpuCompute.createTexture();
 
@@ -340,6 +344,10 @@
 
 				}
 
+			}
+
+			function isSafari() {
+				return !!navigator.userAgent.match(/Safari/i) && !navigator.userAgent.match(/Chrome/i);
 			}
 
 			function restartSimulation() {

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -444,6 +444,10 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
+				if ( isSafari() ) {
+					gpuCompute.setDataType( THREE.HalfFloatType );
+				}
+
 				var heightmap0 = gpuCompute.createTexture();
 
 				fillTexture( heightmap0 );
@@ -490,6 +494,10 @@
 					depthBuffer: false
 				} );
 
+			}
+
+			function isSafari() {
+				return !!navigator.userAgent.match(/Safari/i) && !navigator.userAgent.match(/Chrome/i);
 			}
 
 			function fillTexture( texture ) {


### PR DESCRIPTION
This commit addresses issues discussed in this issue: https://github.com/mrdoob/three.js/issues/19837

With a stop-gap remedy for a pending library that can do better feature detection instead of browser detection for assigning `THREE.HalfFloatType` to `GPUComputationRenderer.js` module.