### PR TITLE
Add conversion methods between Vector2 and Vector3

### DIFF
--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -332,6 +332,13 @@
 		Returns an array [x, y], or copies x and y into the provided [page:Array array].
 		</p>
 
+		<h3>[method:Vector3 toVector3]( [param:Integer z] )</h3>
+		<p>
+		[page:Integer z] - (optional) the value to use for z. Default is 0.<br /><br />
+
+		Returns a new [page:Vector3], containing this vectors [page:.x x] and [page:.y y] coordinate, and the given [page:Integer z] value.
+		</p>
+
 		<h3>[method:this random]()</h3>
 		<p>
 			Sets each component of this vector to a pseudo-random value between 0 and 1, excluding 1.

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -424,6 +424,9 @@
 		Returns an array [x, y, z], or copies x, y and z into the provided [page:Array array].
 		</p>
 
+		<h3>[method:Vector2 toVector2]()</h3>
+		<p>Returns a new [page:Vector2], containing this vectors [page:.x x] and [page:.y y] coordinate.</p>
+
 		<h3>[method:this transformDirection]( [param:Matrix4 m] )</h3>
 		<p>
 		Transforms the direction of this vector by a matrix (the upper left 3 x 3 subset of a [page:Matrix4 m])

--- a/docs/api/zh/math/Vector2.html
+++ b/docs/api/zh/math/Vector2.html
@@ -333,6 +333,13 @@
 		返回一个数组[x, y]，或者将x和y复制到所传入的[page:Array array]中。
 		</p>
 
+		<h3>[method:Vector3 toVector3]( [param:Integer z] )</h3>
+		<p>
+		[page:Integer z] - (optional) the value to use for z. Default is 0.<br /><br />
+
+		Returns a new [page:Vector3], containing this vectors [page:.x x] and [page:.y y] coordinate, and the given [page:Integer z] value.
+		</p>
+
 		<h3>[method:this random]()</h3>
 		<p>
 			Sets each component of this vector to a pseudo-random value between 0 and 1, excluding 1.

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -413,6 +413,9 @@
 		返回一个数组[x, y ,z]，或者将x、y和z复制到所传入的[page:Array array]中。
 		</p>
 
+		<h3>[method:Vector2 toVector2]()</h3>
+		<p>Returns a new [page:Vector2], containing this vectors [page:.x x] and [page:.y y] coordinate.</p>
+
 		<h3>[method:this transformDirection]( [param:Matrix4 m] )</h3>
 		<p>
 		通过传入的矩阵（[page:Matrix4 m]的左上角3 x 3子矩阵）变换向量的方向，

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -1,5 +1,6 @@
 import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
+import { Vector3 } from './Vector3';
 
 /**
  * ( interface Vector<T> )
@@ -428,6 +429,13 @@ export class Vector2 implements Vector {
 	 * @return The provided array-like.
 	 */
 	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
+
+	/**
+	 * Creates a new Vector3, containing this vectors x and y coordinate, and the given z value.
+	 * @param z the value to use for z (defaults to 0).
+	 * @return a new Vector3.
+	 */
+	toVector3( z: number ): Vector3;
 
 	/**
 	 * Sets this vector's x and y values from the attribute.

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -1,3 +1,5 @@
+import { Vector3 } from './Vector3.js';
+
 function Vector2( x = 0, y = 0 ) {
 
 	this.x = x;
@@ -448,6 +450,12 @@ Object.assign( Vector2.prototype, {
 		array[ offset + 1 ] = this.y;
 
 		return array;
+
+	},
+
+	toVector3: function ( z = 0 ) {
+
+		return new Vector3( this.x, this.y, z );
 
 	},
 

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -281,6 +281,12 @@ export class Vector3 implements Vector {
 	 */
 	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
+	/**
+	 * Creates a new Vector2, containing this vectors x and y coordinate.
+	 * @return a new Vector2.
+	 */
+	toVector2(): Vector3;
+
 	fromBufferAttribute(
 		attribute: BufferAttribute,
 		index: number

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -1,5 +1,6 @@
 import { MathUtils } from './MathUtils.js';
 import { Quaternion } from './Quaternion.js';
+import { Vector2 } from './Vector2.js';
 
 const _vector = new Vector3();
 const _quaternion = new Quaternion();
@@ -692,6 +693,12 @@ Object.assign( Vector3.prototype, {
 		array[ offset + 2 ] = this.z;
 
 		return array;
+
+	},
+
+	toVector2: function () {
+
+		return new Vector2( this.x, this.y );
 
 	},
 


### PR DESCRIPTION
When developing 3D-Applications with 2D-logic, it often happens that one needs to convert between these two vector types. Those new utility functions will make the code easier to write / understand:

```javascript
const myVec2 = myGetVec2();
const myVec3 = new Vector3(myVec2.x, myVec2.y);
```

... turns into ...


```javascript
const myVec3 = myGetVec2().toVector3();
```

... and similarly to convert it back.


If you think it is a good idea, I could also implement similar conversion methods from / to `Vector4`.

By the way: My changes introduced a cyclic import dependency between these two vector classes. Is this fine? If not, how could we avoid it?

-----

_This is my first time contributing here. Please tell me if I missed something in this PR. Happy to help :)_