### PR TITLE
WebGLProgram: Add GLSL version string to RawShaderMaterial (WebGL2).

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -433,6 +433,15 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 		}
 
+		if ( parameters.isWebGL2 === true ) {
+
+			const glslVersionString = '#version 300 es\n';
+
+			prefixVertex = glslVersionString + prefixVertex;
+			prefixFragment = glslVersionString + prefixFragment;
+
+		}
+
 	} else {
 
 		prefixVertex = [


### PR DESCRIPTION
Fixed #19959.

The PR always prepends the GLSL 3.0 version qualifier to the shader source of `RawShaderMaterial` when using WebGL 2.