### PR TITLE
Scene: Remove dispose().

### DIFF
--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -52,11 +52,6 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null dispose]()</h3>
-		<p>
-		Clears scene related data internally cached by [page:WebGLRenderer].
-		</p>
-
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>
 		<p>
 		meta -- object containing metadata such as textures or images for the scene.<br />

--- a/docs/api/zh/scenes/Scene.html
+++ b/docs/api/zh/scenes/Scene.html
@@ -55,11 +55,6 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null dispose]()</h3>
-		<p>
-			清除[page:WebGLRenderer]内部所缓存的场景相关的数据。
-		</p>
-
 		<h3>[method:JSON toJSON]</h3>
 		<p>
 			meta -- 包含有元数据的对象，例如场景中的的纹理或图片。

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -53,13 +53,6 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
-	<h2>Scenes</h2>
-
-	<p>
-		The renderer maintains for scenes special data structures for sorting and rendering. If for some reasons a scene object becomes obsolete in an application,
-		call [page:Scene.dispose]() in order to free these resources.
-	</p>
-
 	<h2>Miscellaneous</h2>
 
 	<p>

--- a/docs/manual/zh/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/zh/introduction/How-to-dispose-of-objects.html
@@ -53,13 +53,6 @@
 		这些对象仅能通过执行[page:WebGLRenderTarget.dispose]()来解除分配。
 	</p>
 
-	<h2>Scenes</h2>
-
-	<p>
-		The renderer maintains for scenes special data structures for sorting and rendering. If for some reasons a scene object becomes obsolete in an application,
-		call [page:Scene.dispose]() in order to free these resources.
-	</p>
-
 	<h2>杂项</h2>
 
 	<p>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -88,6 +88,7 @@ import { WebGLShadowMap } from './renderers/webgl/WebGLShadowMap.js';
 import { ImageUtils } from './extras/ImageUtils.js';
 import { Shape } from './extras/core/Shape.js';
 import { CubeCamera } from './cameras/CubeCamera.js';
+import { Scene } from './scenes/Scene.js';
 
 export { BoxGeometry as CubeGeometry };
 export { MathUtils as Math };
@@ -1460,6 +1461,18 @@ Object.assign( ExtrudeBufferGeometry.prototype, {
 	addShape: function () {
 
 		console.error( 'THREE.ExtrudeBufferGeometry: .addShape() has been removed.' );
+
+	}
+
+} );
+
+//
+
+Object.assign( Scene.prototype, {
+
+	dispose: function () {
+
+		console.error( 'THREE.Scene: .dispose() has been removed.' );
 
 	}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -174,16 +174,6 @@ function WebGLRenderLists( properties ) {
 
 	let lists = new WeakMap();
 
-	function onSceneDispose( event ) {
-
-		const scene = event.target;
-
-		scene.removeEventListener( 'dispose', onSceneDispose );
-
-		lists.delete( scene );
-
-	}
-
 	function get( scene, camera ) {
 
 		const cameras = lists.get( scene );
@@ -194,8 +184,6 @@ function WebGLRenderLists( properties ) {
 			list = new WebGLRenderList( properties );
 			lists.set( scene, new WeakMap() );
 			lists.get( scene ).set( camera, list );
-
-			scene.addEventListener( 'dispose', onSceneDispose );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -54,16 +54,6 @@ function WebGLRenderStates() {
 
 	let renderStates = new WeakMap();
 
-	function onSceneDispose( event ) {
-
-		const scene = event.target;
-
-		scene.removeEventListener( 'dispose', onSceneDispose );
-
-		renderStates.delete( scene );
-
-	}
-
 	function get( scene, camera ) {
 
 		let renderState;
@@ -73,8 +63,6 @@ function WebGLRenderStates() {
 			renderState = new WebGLRenderState();
 			renderStates.set( scene, new WeakMap() );
 			renderStates.get( scene ).set( camera, renderState );
-
-			scene.addEventListener( 'dispose', onSceneDispose );
 
 		} else {
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -55,12 +55,6 @@ Scene.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		return data;
 
-	},
-
-	dispose: function () {
-
-		this.dispatchEvent( { type: 'dispose' } );
-
 	}
 
 } );

--- a/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
@@ -34,23 +34,6 @@ export default QUnit.module( 'Renderers', () => {
 
 			} );
 
-			QUnit.test( "dispose", ( assert ) => {
-
-				var properties = new WebGLProperties();
-				var renderLists = new WebGLRenderLists( properties );
-				var scene = new Scene();
-				var camera = new Camera();
-
-				var list1 = renderLists.get( scene, camera );
-
-				scene.dispose();
-
-				var list2 = renderLists.get( scene, camera );
-
-				assert.ok( list1 !== list2, "New list should be different after disposing of the scene." );
-
-			} );
-
 		} );
 
 


### PR DESCRIPTION
`Scene.dispose()` was introduced with #15523 in order to clear cached objects in `WebGLRenderLists` and `WebGLRenderStates`. At that time, it was necessary since the caches were plain objects.

Later, #17242 turned these objects into weak maps. I've realized now that this change made explicit disposals of scenes superfluous since the entries in the maps are automatically removed if a scene object is not used anymore. If the entire `renderer` is disposed, the maps are cleared anyway.

In contrast to other engine entities like geometries or textures, render lists and states do not have a GPU pendant so deallocating data from the GPU is not necessary. 

This PR would also make #19645 not necessary anymore.