### PR TITLE
Preserve sourcemaps in Rollup transforms.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -160,7 +160,7 @@ function glconstants() {
 
 			return {
 				code: code,
-				map: { mappings: '' }
+				map: null
 			};
 
 		}
@@ -192,7 +192,7 @@ function glsl() {
 
 			return {
 				code: code,
-				map: { mappings: '' }
+				map: null
 			};
 
 		}
@@ -228,7 +228,7 @@ function bubleCleanup() {
 
 			return {
 				code: code,
-				map: { mappings: '' }
+				map: null
 			};
 
 		}


### PR DESCRIPTION
This fixes sourcemaps for me, but hopefully someone can confirm the correct behavior in https://github.com/mrdoob/three.js/pull/9745.

Context: #9745, #10954.