### PR TITLE
Fix bug when updating joints without requesting a hand in WebXR

### DIFF
--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -135,7 +135,7 @@ Object.assign( WebXRController.prototype, {
 
 		if ( inputSource ) {
 
-			if ( inputSource.hand ) {
+			if ( hand && inputSource.hand ) {
 
 				handPose = true;
 


### PR DESCRIPTION
The `WebXRController._hand` object is created just when you request a hand controller: `renderer.xr.getHandSpace()`.
So if you haven't requested a hand, that object won't be created and it will break when trying to set the joints in the update loop.