### PR TITLE
VRButton session callbacks

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -1,12 +1,6 @@
 var VRButton = {
 
-	createButton: function ( renderer, options ) {
-
-		if ( options ) {
-
-			console.error( 'THREE.VRButton: The "options" parameter has been removed. Please set the reference space type via renderer.xr.setReferenceSpaceType() instead.' );
-
-		}
+	createButton: function ( renderer, options = { } ) {
 
 		function showEnterVR( /*device*/ ) {
 
@@ -21,6 +15,8 @@ var VRButton = {
 
 				currentSession = session;
 
+				if (options.onSessionStarted) options.onSessionStarted(session);
+
 			}
 
 			function onSessionEnded( /*event*/ ) {
@@ -30,6 +26,8 @@ var VRButton = {
 				button.textContent = 'ENTER VR';
 
 				currentSession = null;
+
+				if (options.onSessionEnded) options.onSessionEnded();
 
 			}
 


### PR DESCRIPTION
This branch restores the use of VRButton `options` and adds session callbacks which are useful for setting up resources immediately after session startup (and only applicable to the VR view). 

Although VRButton is not part of the three.js library itself, I believe it is very commonly used, so providing configuration through an API is better than modifying the button in each project.