### PR TITLE
[WIP] Expose WebXRController from WebXRManager

### DIFF
--- a/examples/webxr_vr_ballshooter.html
+++ b/examples/webxr_vr_ballshooter.html
@@ -103,7 +103,7 @@
 
 				}
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				controller1.addEventListener( 'selectstart', onSelectStart );
 				controller1.addEventListener( 'selectend', onSelectEnd );
 				controller1.addEventListener( 'connected', function ( event ) {
@@ -118,7 +118,7 @@
 				} );
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				controller2.addEventListener( 'selectstart', onSelectStart );
 				controller2.addEventListener( 'selectend', onSelectEnd );
 				controller2.addEventListener( 'connected', function ( event ) {

--- a/examples/webxr_vr_cubes.html
+++ b/examples/webxr_vr_cubes.html
@@ -107,7 +107,7 @@
 
 				}
 
-				controller = renderer.xr.getController( 0 );
+				controller = renderer.xr.getControllerTargetRay( 0 );
 				controller.addEventListener( 'selectstart', onSelectStart );
 				controller.addEventListener( 'selectend', onSelectEnd );
 				controller.addEventListener( 'connected', function ( event ) {

--- a/examples/webxr_vr_dragging.html
+++ b/examples/webxr_vr_dragging.html
@@ -123,12 +123,12 @@
 
 				// controllers
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				controller1.addEventListener( 'selectstart', onSelectStart );
 				controller1.addEventListener( 'selectend', onSelectEnd );
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				controller2.addEventListener( 'selectstart', onSelectStart );
 				controller2.addEventListener( 'selectend', onSelectEnd );
 				scene.add( controller2 );

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -81,10 +81,10 @@
 
 				// controllers
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				scene.add( controller2 );
 
 				var controllerModelFactory = new XRControllerModelFactory();

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -91,10 +91,10 @@
 
 				// controllers
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				scene.add( controller2 );
 
 				var controllerModelFactory = new XRControllerModelFactory();

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -93,10 +93,10 @@
 
 				// controllers
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				scene.add( controller2 );
 
 				var controllerModelFactory = new XRControllerModelFactory();

--- a/examples/webxr_vr_paint.html
+++ b/examples/webxr_vr_paint.html
@@ -123,7 +123,7 @@
 
 				}
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				controller1.addEventListener( 'selectstart', onSelectStart );
 				controller1.addEventListener( 'selectend', onSelectEnd );
 				controller1.addEventListener( 'squeezestart', onSqueezeStart );
@@ -131,7 +131,7 @@
 				controller1.userData.painter = painter1;
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				controller2.addEventListener( 'selectstart', onSelectStart );
 				controller2.addEventListener( 'selectend', onSelectEnd );
 				controller2.addEventListener( 'squeezestart', onSqueezeStart );

--- a/examples/webxr_vr_sculpt.html
+++ b/examples/webxr_vr_sculpt.html
@@ -102,13 +102,13 @@
 
 				}
 
-				controller1 = renderer.xr.getController( 0 );
+				controller1 = renderer.xr.getControllerTargetRay( 0 );
 				controller1.addEventListener( 'selectstart', onSelectStart );
 				controller1.addEventListener( 'selectend', onSelectEnd );
 				controller1.userData.id = 0;
 				scene.add( controller1 );
 
-				controller2 = renderer.xr.getController( 1 );
+				controller2 = renderer.xr.getControllerTargetRay( 1 );
 				controller2.addEventListener( 'selectstart', onSelectStart );
 				controller2.addEventListener( 'selectend', onSelectEnd );
 				controller2.userData.id = 1;

--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -1,4 +1,5 @@
 import { Group } from '../../objects/Group.js';
+import { EventDispatcher } from '../../core/EventDispatcher.js';
 
 function WebXRController() {
 
@@ -6,9 +7,11 @@ function WebXRController() {
 	this._grip = null;
 	this._hand = null;
 
+	this.inputSource = null;
+
 }
 
-Object.assign( WebXRController.prototype, {
+WebXRController.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 	constructor: WebXRController,
 
@@ -97,7 +100,17 @@ Object.assign( WebXRController.prototype, {
 
 	},
 
+	connect: function ( inputSource ) {
+
+		this.inputSource = inputSource;
+
+		this.dispatchEvent( { type: 'connected', data: inputSource } );
+
+	},
+
 	disconnect: function ( inputSource ) {
+
+		this.inputSource = null;
 
 		this.dispatchEvent( { type: 'disconnected', data: inputSource } );
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -58,6 +58,21 @@ function WebXRManager( renderer, gl ) {
 
 		}
 
+		return controller;
+
+	};
+
+	this.getControllerTargetRay = function ( index ) {
+
+		let controller = controllers[ index ];
+
+		if ( controller === undefined ) {
+
+			controller = new WebXRController();
+			controllers[ index ] = controller;
+
+		}
+
 		return controller.getTargetRaySpace();
 
 	};
@@ -243,7 +258,7 @@ function WebXRManager( renderer, gl ) {
 
 			if ( controller ) {
 
-				controller.dispatchEvent( { type: 'disconnected', data: inputSource } );
+				controller.disconnect( inputSource );
 				inputSourcesMap.delete( inputSource );
 
 			}
@@ -259,7 +274,7 @@ function WebXRManager( renderer, gl ) {
 
 			if ( controller ) {
 
-				controller.dispatchEvent( { type: 'connected', data: inputSource } );
+				controller.connect( inputSource );
 
 			}
 


### PR DESCRIPTION
Currently there is not way to access `WebXRController`from `WebXRManager` as every time we call `getController/Grip/Hand` it uses a `WebXRController` instance internally but returns the `TargetRay/Grip/Hand` spaces (`THREE.Group`) but no the controller itself.
You also don't have access to the `InputSource` associated with that controller, the only way is to add a listener for connected and grab it there. Same goes for the `gamepad` reference.
Both can be handy to access if you want to detect specific state of the buttons, or if you want for example use the haptics.

I was thinking about the following change to get it working without much refactoring:
- `getController`: It will return the `WebXRController` instance
- `getControllerTargetRay` (previously `getController`): It will return the `TargetRay` space, it's more explicit, similar to how `getControllerGrip` or `getControllerHand` works.
- Introduced the `connect` and `disconnect` functions on `WebXRController` so they are called by the `WebXRManager` and they stored the `inputSource` reference inside the `WebXRController`.

So you could do also in your code:
```javascript
let controller = renderer.xr.getController(0);
controller.addEventListener("connected", onConnected);
controller.addEventListener("selectEnd", onSelectEnd);
controller.addEventListener("selectStart", () => {
    controller.vibrate(0.5, 100);
});

let targetRay = renderer.xr.getControllerTargetRay();
// or
let targetRay = controller.getTargetRaySpace();
targetRay.add(pointerLine);

let grip = renderer.xr.getControllerGrip();
// or
let grip = controller.getGripSpace();
grip.add(controllerModel);
```

So you could use the `controller` as the main handler for all the events on the controller, and the functions like `vibrate` or so. While the other space will be used for attaching models, detecting collisions and interactions and so on.

