### PR TITLE
 WebGLProgram: make unroll loop regexp accept other coding style

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -220,7 +220,7 @@ function includeReplacer( match, include ) {
 // Unroll Loops
 
 const deprecatedUnrollLoopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
-const unrollLoopPattern = /#pragma unroll_loop_start[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}[\s]+?#pragma unroll_loop_end/g;
+const unrollLoopPattern = /#pragma unroll_loop_start[\s]+?for\s*\(\s*int i \= (\d+)\; i < (\d+)\; i\s*\+\+\s*\)\s*{([\s\S]+?)(?=\})\}[\s]+?#pragma unroll_loop_end/g;
 
 function unrollLoops( string ) {
 


### PR DESCRIPTION
It often happens that my loop don't get unrolled because my coding style isn't as aired as the one from Three.js. Nothing fancy but this should allow to unroll loops like:

```c
// 1. Works with Allman curly brackets

#pragma unroll_loop_start
for ( int i = 0; i < 5; i ++ )
{
}
#pragma unroll_loop_end

// 2. Space or not in condition braces

#pragma unroll_loop_start
for (int i = 0; i < 5; i ++) {
}
#pragma unroll_loop_end

// 3. Space or not between `i` and `++`

#pragma unroll_loop_start
for (int i = 0; i < 5; i++) { }
#pragma unroll_loop_end
```

We can obviously go much more crazy and authorize `++i` or whatever, but I believe at least the brackets position is important, otherwise colleagues start to fix shaders coding style and no unrolling occurs 😄 

Other potential fix would be to do the unrolling directly in my codebase.