### PR TITLE
Package.json: Adding clarity to build-closure script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "start": "npm run dev",
     "test": "npm run test-lint && npm run test-unit",
     "build": "rollup -c utils/build/rollup.config.js",
-    "build-closure": "rollup -c utils/build/rollup.config.js && google-closure-compiler --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
+    "build-closure": "npm run build && google-closure-compiler --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"npm run dev --prefix test\" \"http-server -p 8080\"",
     "lint-docs": "eslint docs --ext html",


### PR DESCRIPTION
Instead of repeating `rollup -c utils/build/rollup.config.js`, simply `npm run build`.

hmm @mrdoob, after looking into `google-closure-compiler`, they don't support configs. This means eslint is the only package without a config atm. I'll still make the eslint config PR for us to look at it but my thoughts regarding [my earlier comment](https://github.com/mrdoob/three.js/pull/10129#issuecomment-667358065) have diminished