### PR TITLE
Quaternion: Fixed property typo in setFromEuler

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -216,7 +216,7 @@ Object.assign( Quaternion.prototype, {
 
 		}
 
-		const x = euler._x, y = euler._y, z = euler._z, order = euler.order;
+		const x = euler._x, y = euler._y, z = euler._z, order = euler._order;
 
 		// http://www.mathworks.com/matlabcentral/fileexchange/
 		// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/


### PR DESCRIPTION
This typo was returning improper warnings even when an order was defined.

euler.order -> euler._order