### PR TITLE
WebGLRenderer: Fix equirect texture conversion.

### DIFF
--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -104,6 +104,7 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 	const currentMinFilter = texture.minFilter;
 	const currentRenderList = renderer.getRenderList();
 	const currentRenderTarget = renderer.getRenderTarget();
+	const currentRenderState = renderer.getRenderState();
 
 	// Avoid blurred poles
 	if ( texture.minFilter === LinearMipmapLinearFilter ) texture.minFilter = LinearFilter;
@@ -115,6 +116,7 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 
 	renderer.setRenderTarget( currentRenderTarget );
 	renderer.setRenderList( currentRenderList );
+	renderer.setRenderState( currentRenderState );
 
 	mesh.geometry.dispose();
 	mesh.material.dispose();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1403,6 +1403,7 @@ function WebGLRenderer( parameters ) {
 
 		materialProperties.environment = material.isMeshStandardMaterial ? scene.environment : null;
 		materialProperties.fog = scene.fog;
+		materialProperties.envMap = cubemaps.get( material.envMap || materialProperties.environment );
 
 		// store the light setup it was created for
 
@@ -1451,6 +1452,7 @@ function WebGLRenderer( parameters ) {
 		const fog = scene.fog;
 		const environment = material.isMeshStandardMaterial ? scene.environment : null;
 		const encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
+		const envMap = cubemaps.get( material.envMap || environment );
 
 		const materialProperties = properties.get( material );
 		const lights = currentRenderState.state.lights;
@@ -1499,6 +1501,10 @@ function WebGLRenderer( parameters ) {
 				initMaterial( material, scene, object );
 
 			} else if ( materialProperties.outputEncoding !== encoding ) {
+
+				initMaterial( material, scene, object );
+
+			} else if ( materialProperties.envMap !== envMap ) {
 
 				initMaterial( material, scene, object );
 
@@ -1694,7 +1700,7 @@ function WebGLRenderer( parameters ) {
 
 			}
 
-			materials.refreshMaterialUniforms( m_uniforms, material, environment, _pixelRatio, _height );
+			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height );
 
 			// RectAreaLight Texture
 			// TODO (mrdoob): Find a nicer implementation
@@ -1785,6 +1791,18 @@ function WebGLRenderer( parameters ) {
 	this.setRenderList = function ( renderList ) {
 
 		currentRenderList = renderList;
+
+	};
+
+	this.getRenderState = function () {
+
+		return currentRenderState;
+
+	};
+
+	this.setRenderState = function ( renderState ) {
+
+		currentRenderState = renderState;
 
 	};
 

--- a/src/renderers/webgl/WebGLMaterials.d.ts
+++ b/src/renderers/webgl/WebGLMaterials.d.ts
@@ -1,14 +1,12 @@
 import { Material } from '../../materials/Material';
-import { Texture } from '../../textures/Texture';
 import { IFog } from '../../scenes/Fog';
 import { WebGLProperties } from './WebGLProperties';
-import { WebGLCubeMaps } from './WebGLCubeMaps';
 
 export class WebGLMaterials {
 
-	constructor( properties: WebGLProperties, cubemaps: WebGLCubeMaps );
+	constructor( properties: WebGLProperties );
 
-	refreshMaterialUniforms( uniforms: object, material: Material, environment: Texture, pixelRatio: number, height: number ): void;
+	refreshMaterialUniforms( uniforms: object, material: Material, pixelRatio: number, height: number ): void;
 	refreshFogUniforms( uniforms: object, fog: IFog ): void;
 
 }

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -1,6 +1,6 @@
 import { BackSide } from "../../constants.js";
 
-function WebGLMaterials( properties, cubemaps ) {
+function WebGLMaterials( properties ) {
 
 	function refreshFogUniforms( uniforms, fog ) {
 
@@ -19,7 +19,7 @@ function WebGLMaterials( properties, cubemaps ) {
 
 	}
 
-	function refreshMaterialUniforms( uniforms, material, environment, pixelRatio, height ) {
+	function refreshMaterialUniforms( uniforms, material, pixelRatio, height ) {
 
 		if ( material.isMeshBasicMaterial ) {
 
@@ -42,15 +42,15 @@ function WebGLMaterials( properties, cubemaps ) {
 
 		} else if ( material.isMeshStandardMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, environment );
+			refreshUniformsCommon( uniforms, material );
 
 			if ( material.isMeshPhysicalMaterial ) {
 
-				refreshUniformsPhysical( uniforms, material, environment );
+				refreshUniformsPhysical( uniforms, material );
 
 			} else {
 
-				refreshUniformsStandard( uniforms, material, environment );
+				refreshUniformsStandard( uniforms, material );
 
 			}
 
@@ -105,7 +105,7 @@ function WebGLMaterials( properties, cubemaps ) {
 
 	}
 
-	function refreshUniformsCommon( uniforms, material, environment ) {
+	function refreshUniformsCommon( uniforms, material ) {
 
 		uniforms.opacity.value = material.opacity;
 
@@ -139,7 +139,7 @@ function WebGLMaterials( properties, cubemaps ) {
 
 		}
 
-		const envMap = cubemaps.get( material.envMap || environment );
+		const envMap = properties.get( material ).envMap;
 
 		if ( envMap ) {
 
@@ -477,7 +477,7 @@ function WebGLMaterials( properties, cubemaps ) {
 
 	}
 
-	function refreshUniformsStandard( uniforms, material, environment ) {
+	function refreshUniformsStandard( uniforms, material ) {
 
 		uniforms.roughness.value = material.roughness;
 		uniforms.metalness.value = material.metalness;
@@ -524,7 +524,9 @@ function WebGLMaterials( properties, cubemaps ) {
 
 		}
 
-		if ( material.envMap || environment ) {
+		const envMap = properties.get( material ).envMap;
+
+		if ( envMap ) {
 
 			//uniforms.envMap.value = material.envMap; // part of uniforms common
 			uniforms.envMapIntensity.value = material.envMapIntensity;
@@ -533,9 +535,9 @@ function WebGLMaterials( properties, cubemaps ) {
 
 	}
 
-	function refreshUniformsPhysical( uniforms, material, environment ) {
+	function refreshUniformsPhysical( uniforms, material ) {
 
-		refreshUniformsStandard( uniforms, material, environment );
+		refreshUniformsStandard( uniforms, material );
 
 		uniforms.reflectivity.value = material.reflectivity; // also part of uniforms common
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/pull/20043#issuecomment-671636702

When you load an equirect texture, `WebGLCubeMaps` will return `null` if the texture is not loaded yet. When the loading process is completed and the cube map was created, an update of the shader program is required. This missing bit was responsible for the uniform location errors.