### PR TITLE
WebGLBindingStates: check if cachedAttribute is undefined

### DIFF
--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -175,6 +175,8 @@
 			const cachedAttribute = cachedAttributes[ key ];
 			const geometryAttribute = geometryAttributes[ key ];
 
+			if ( cachedAttribute === undefined ) return true;
+
 			if ( cachedAttribute.attribute !== geometryAttribute ) return true;
 
 			if ( cachedAttribute.data !== geometryAttribute.data ) return true;


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/20054