### PR TITLE
CSS3DRenderer: Force canvas size to be even

### DIFF
--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -92,18 +92,24 @@ THREE.CSS3DRenderer = function () {
 
 	};
 
+	function makeEven( value ) {
+
+		return 2 * Math.round( value / 2 );
+
+	}
+
 	this.setSize = function ( width, height ) {
 
-		_width = width;
-		_height = height;
+		_width = makeEven( width ); // #19854
+		_height = makeEven( height );
 		_widthHalf = _width / 2;
 		_heightHalf = _height / 2;
 
-		domElement.style.width = width + 'px';
-		domElement.style.height = height + 'px';
+		domElement.style.width = _width + 'px';
+		domElement.style.height = _height + 'px';
 
-		cameraElement.style.width = width + 'px';
-		cameraElement.style.height = height + 'px';
+		cameraElement.style.width = _width + 'px';
+		cameraElement.style.height = _height + 'px';
 
 	};
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -96,18 +96,24 @@ var CSS3DRenderer = function () {
 
 	};
 
+	function makeEven( value ) {
+
+		return 2 * Math.round( value / 2 );
+
+	}
+
 	this.setSize = function ( width, height ) {
 
-		_width = width;
-		_height = height;
+		_width = makeEven( width ); // #19854
+		_height = makeEven( height );
 		_widthHalf = _width / 2;
 		_heightHalf = _height / 2;
 
-		domElement.style.width = width + 'px';
-		domElement.style.height = height + 'px';
+		domElement.style.width = _width + 'px';
+		domElement.style.height = _height + 'px';
 
-		cameraElement.style.width = width + 'px';
-		cameraElement.style.height = height + 'px';
+		cameraElement.style.width = _width + 'px';
+		cameraElement.style.height = _height + 'px';
 
 	};
 


### PR DESCRIPTION
Possible approach to  addressing #19854. Posting as a DRAFT.

`CSS3DRenderer` translates by half-width, so this PR prevents fractional pixels.

It appears to work for every example I have tried.

Note that there is no three.js requirement that the passed-in canvas dimensions are whole numbers. This can happen, for example, if the user splits the screen.

/ping @JohannesDeml Can you please test this PR on all your examples?