### PR TITLE
Initialize Audio.source as null

### DIFF
--- a/src/audio/Audio.d.ts
+++ b/src/audio/Audio.d.ts
@@ -68,7 +68,7 @@ export class Audio<NodeType extends AudioNode = GainNode> extends Object3D {
 	 * @default 'empty'
 	 */
 	sourceType: string;
-	source: AudioBufferSourceNode;
+	source: null | AudioBufferSourceNode;
 
 	/**
 	 * @default []

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -26,6 +26,7 @@ class Audio extends Object3D {
 		this.playbackRate = 1;
 		this.isPlaying = false;
 		this.hasPlaybackControl = true;
+		this.source = null;
 		this.sourceType = 'empty';
 
 		this._startedAt = 0;


### PR DESCRIPTION
Small clean up for readability and consistency in the file, all other properties are initialized in the constructor.