### PR TITLE
WebGLRenderer: Make uniforms handling of RectAreaLight more consistent.

### DIFF
--- a/examples/js/lights/RectAreaLightUniformsLib.js
+++ b/examples/js/lights/RectAreaLightUniformsLib.js
@@ -34,13 +34,6 @@ THREE.RectAreaLightUniformsLib = {
 		THREE.UniformsLib.LTC_1 = ltc_1;
 		THREE.UniformsLib.LTC_2 = ltc_2;
 
-		// add ltc data textures to material uniforms
-
-		var ltc = { ltc_1: { value: null }, ltc_2: { value: null } };
-
-		Object.assign( THREE.ShaderLib.standard.uniforms, ltc );
-		Object.assign( THREE.ShaderLib.physical.uniforms, ltc );
-
 	}
 
 };

--- a/examples/jsm/lights/RectAreaLightUniformsLib.js
+++ b/examples/jsm/lights/RectAreaLightUniformsLib.js
@@ -5,7 +5,6 @@ import {
 	LinearFilter,
 	NearestFilter,
 	RGBAFormat,
-	ShaderLib,
 	UVMapping,
 	UniformsLib
 } from "../../../build/three.module.js";
@@ -43,13 +42,6 @@ var RectAreaLightUniformsLib = {
 
 		UniformsLib.LTC_1 = ltc_1;
 		UniformsLib.LTC_2 = ltc_2;
-
-		// add ltc data textures to material uniforms
-
-		var ltc = { ltc_1: { value: null }, ltc_2: { value: null } };
-
-		Object.assign( ShaderLib.standard.uniforms, ltc );
-		Object.assign( ShaderLib.physical.uniforms, ltc );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -10,7 +10,6 @@ import { MathUtils } from '../math/MathUtils.js';
 import { DataTexture } from '../textures/DataTexture.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
-import { UniformsLib } from './shaders/UniformsLib.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
@@ -1421,6 +1420,8 @@ function WebGLRenderer( parameters ) {
 			uniforms.spotLights.value = lights.state.spot;
 			uniforms.spotLightShadows.value = lights.state.spotShadow;
 			uniforms.rectAreaLights.value = lights.state.rectArea;
+			uniforms.ltc_1.value = lights.state.rectAreaLTC1;
+			uniforms.ltc_2.value = lights.state.rectAreaLTC2;
 			uniforms.pointLights.value = lights.state.point;
 			uniforms.pointLightShadows.value = lights.state.pointShadow;
 			uniforms.hemisphereLights.value = lights.state.hemi;
@@ -1435,9 +1436,8 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		const progUniforms = materialProperties.program.getUniforms(),
-			uniformsList =
-				WebGLUniforms.seqWithValue( progUniforms.seq, uniforms );
+		const progUniforms = materialProperties.program.getUniforms();
+		const uniformsList = WebGLUniforms.seqWithValue( progUniforms.seq, uniforms );
 
 		materialProperties.uniformsList = uniformsList;
 
@@ -1701,12 +1701,6 @@ function WebGLRenderer( parameters ) {
 			}
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height );
-
-			// RectAreaLight Texture
-			// TODO (mrdoob): Find a nicer implementation
-
-			if ( m_uniforms.ltc_1 !== undefined ) m_uniforms.ltc_1.value = UniformsLib.LTC_1;
-			if ( m_uniforms.ltc_2 !== undefined ) m_uniforms.ltc_2.value = UniformsLib.LTC_2;
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -178,7 +178,10 @@ const UniformsLib = {
 			position: {},
 			width: {},
 			height: {}
-		} }
+		} },
+
+		ltc_1: { value: null },
+		ltc_2: { value: null }
 
 	},
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -2,6 +2,7 @@ import { Color } from '../../math/Color.js';
 import { Matrix4 } from '../../math/Matrix4.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
+import { UniformsLib } from '../shaders/UniformsLib.js';
 
 function UniformsCache() {
 
@@ -182,6 +183,8 @@ function WebGLLights() {
 		spotShadowMap: [],
 		spotShadowMatrix: [],
 		rectArea: [],
+		rectAreaLTC1: null,
+		rectAreaLTC2: null,
 		point: [],
 		pointShadow: [],
 		pointShadowMap: [],
@@ -399,6 +402,13 @@ function WebGLLights() {
 				hemiLength ++;
 
 			}
+
+		}
+
+		if ( rectAreaLength > 0 ) {
+
+			state.rectAreaLTC1 = UniformsLib.LTC_1;
+			state.rectAreaLTC2 = UniformsLib.LTC_2;
 
 		}
 


### PR DESCRIPTION
Removes the uniform hack in `setProgram()` for setting `ltc_1` and `ltc_2` data textures.