### PR TITLE
WebGLRenderer: Avoid frame-late bug with converted env maps.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1330,7 +1330,11 @@ function WebGLRenderer( parameters ) {
 
 		} else if ( parameters.shaderID !== undefined ) {
 
-			// same glsl and uniform list
+			// same glsl and uniform list, envMap still needs the update here to avoid a frame-late effect
+
+			const environment = material.isMeshStandardMaterial ? scene.environment : null;
+			materialProperties.envMap = cubemaps.get( material.envMap || environment );
+
 			return;
 
 		} else {
@@ -1507,7 +1511,6 @@ function WebGLRenderer( parameters ) {
 			} else if ( materialProperties.envMap !== envMap ) {
 
 				initMaterial( material, scene, object );
-				materialProperties.envMap = envMap;
 
 			}
 


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/20081#issuecomment-674506070