### PR TITLE
Math interpolants and remainings: Move to es6 classes

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -28,19 +28,6 @@ const _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua'
 const _hslA = { h: 0, s: 0, l: 0 };
 const _hslB = { h: 0, s: 0, l: 0 };
 
-function Color( r, g, b ) {
-
-	if ( g === undefined && b === undefined ) {
-
-		// r is THREE.Color, hex or string
-		return this.set( r );
-
-	}
-
-	return this.setRGB( r, g, b );
-
-}
-
 function hue2rgb( p, q, t ) {
 
 	if ( t < 0 ) t += 1;
@@ -64,13 +51,22 @@ function LinearToSRGB( c ) {
 
 }
 
-Object.assign( Color.prototype, {
+class Color {
 
-	isColor: true,
+	constructor( r, g, b ) {
 
-	r: 1, g: 1, b: 1,
+		if ( g === undefined && b === undefined ) {
 
-	set: function ( value ) {
+			// r is THREE.Color, hex or string
+			return this.set( r );
+
+		}
+
+		return this.setRGB( r, g, b );
+
+	}
+
+	set( value ) {
 
 		if ( value && value.isColor ) {
 
@@ -88,9 +84,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setScalar: function ( scalar ) {
+	setScalar( scalar ) {
 
 		this.r = scalar;
 		this.g = scalar;
@@ -98,9 +94,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setHex: function ( hex ) {
+	setHex( hex ) {
 
 		hex = Math.floor( hex );
 
@@ -110,9 +106,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setRGB: function ( r, g, b ) {
+	setRGB( r, g, b ) {
 
 		this.r = r;
 		this.g = g;
@@ -120,9 +116,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setHSL: function ( h, s, l ) {
+	setHSL( h, s, l ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 		h = MathUtils.euclideanModulo( h, 1 );
@@ -146,9 +142,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setStyle: function ( style ) {
+	setStyle( style ) {
 
 		function handleAlpha( string ) {
 
@@ -263,9 +259,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setColorName: function ( style ) {
+	setColorName( style ) {
 
 		// color keywords
 		const hex = _colorKeywords[ style ];
@@ -284,15 +280,15 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	clone: function () {
+	clone() {
 
 		return new this.constructor( this.r, this.g, this.b );
 
-	},
+	}
 
-	copy: function ( color ) {
+	copy( color ) {
 
 		this.r = color.r;
 		this.g = color.g;
@@ -300,9 +296,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyGammaToLinear: function ( color, gammaFactor ) {
+	copyGammaToLinear( color, gammaFactor ) {
 
 		if ( gammaFactor === undefined ) gammaFactor = 2.0;
 
@@ -312,9 +308,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyLinearToGamma: function ( color, gammaFactor ) {
+	copyLinearToGamma( color, gammaFactor ) {
 
 		if ( gammaFactor === undefined ) gammaFactor = 2.0;
 
@@ -326,25 +322,25 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	convertGammaToLinear: function ( gammaFactor ) {
+	convertGammaToLinear( gammaFactor ) {
 
 		this.copyGammaToLinear( this, gammaFactor );
 
 		return this;
 
-	},
+	}
 
-	convertLinearToGamma: function ( gammaFactor ) {
+	convertLinearToGamma( gammaFactor ) {
 
 		this.copyLinearToGamma( this, gammaFactor );
 
 		return this;
 
-	},
+	}
 
-	copySRGBToLinear: function ( color ) {
+	copySRGBToLinear( color ) {
 
 		this.r = SRGBToLinear( color.r );
 		this.g = SRGBToLinear( color.g );
@@ -352,9 +348,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	copyLinearToSRGB: function ( color ) {
+	copyLinearToSRGB( color ) {
 
 		this.r = LinearToSRGB( color.r );
 		this.g = LinearToSRGB( color.g );
@@ -362,37 +358,37 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	convertSRGBToLinear: function () {
+	convertSRGBToLinear() {
 
 		this.copySRGBToLinear( this );
 
 		return this;
 
-	},
+	}
 
-	convertLinearToSRGB: function () {
+	convertLinearToSRGB() {
 
 		this.copyLinearToSRGB( this );
 
 		return this;
 
-	},
+	}
 
-	getHex: function () {
+	getHex() {
 
 		return ( this.r * 255 ) << 16 ^ ( this.g * 255 ) << 8 ^ ( this.b * 255 ) << 0;
 
-	},
+	}
 
-	getHexString: function () {
+	getHexString() {
 
 		return ( '000000' + this.getHex().toString( 16 ) ).slice( - 6 );
 
-	},
+	}
 
-	getHSL: function ( target ) {
+	getHSL( target ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 
@@ -440,15 +436,15 @@ Object.assign( Color.prototype, {
 
 		return target;
 
-	},
+	}
 
-	getStyle: function () {
+	getStyle() {
 
 		return 'rgb(' + ( ( this.r * 255 ) | 0 ) + ',' + ( ( this.g * 255 ) | 0 ) + ',' + ( ( this.b * 255 ) | 0 ) + ')';
 
-	},
+	}
 
-	offsetHSL: function ( h, s, l ) {
+	offsetHSL( h, s, l ) {
 
 		this.getHSL( _hslA );
 
@@ -458,9 +454,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	add: function ( color ) {
+	add( color ) {
 
 		this.r += color.r;
 		this.g += color.g;
@@ -468,9 +464,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addColors: function ( color1, color2 ) {
+	addColors( color1, color2 ) {
 
 		this.r = color1.r + color2.r;
 		this.g = color1.g + color2.g;
@@ -478,9 +474,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	addScalar: function ( s ) {
+	addScalar( s ) {
 
 		this.r += s;
 		this.g += s;
@@ -488,9 +484,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	sub: function ( color ) {
+	sub( color ) {
 
 		this.r = Math.max( 0, this.r - color.r );
 		this.g = Math.max( 0, this.g - color.g );
@@ -498,9 +494,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiply: function ( color ) {
+	multiply( color ) {
 
 		this.r *= color.r;
 		this.g *= color.g;
@@ -508,9 +504,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	multiplyScalar: function ( s ) {
+	multiplyScalar( s ) {
 
 		this.r *= s;
 		this.g *= s;
@@ -518,9 +514,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerp: function ( color, alpha ) {
+	lerp( color, alpha ) {
 
 		this.r += ( color.r - this.r ) * alpha;
 		this.g += ( color.g - this.g ) * alpha;
@@ -528,9 +524,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	lerpHSL: function ( color, alpha ) {
+	lerpHSL( color, alpha ) {
 
 		this.getHSL( _hslA );
 		color.getHSL( _hslB );
@@ -543,15 +539,15 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	equals: function ( c ) {
+	equals( c ) {
 
 		return ( c.r === this.r ) && ( c.g === this.g ) && ( c.b === this.b );
 
-	},
+	}
 
-	fromArray: function ( array, offset ) {
+	fromArray( array, offset ) {
 
 		if ( offset === undefined ) offset = 0;
 
@@ -561,9 +557,9 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toArray: function ( array, offset ) {
+	toArray( array, offset ) {
 
 		if ( array === undefined ) array = [];
 		if ( offset === undefined ) offset = 0;
@@ -574,9 +570,9 @@ Object.assign( Color.prototype, {
 
 		return array;
 
-	},
+	}
 
-	fromBufferAttribute: function ( attribute, index ) {
+	fromBufferAttribute( attribute, index ) {
 
 		this.r = attribute.getX( index );
 		this.g = attribute.getY( index );
@@ -594,16 +590,20 @@ Object.assign( Color.prototype, {
 
 		return this;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
 		return this.getHex();
 
 	}
 
-} );
+}
 
 Color.NAMES = _colorKeywords;
+Color.prototype.isColor = true;
+Color.prototype.r = 1;
+Color.prototype.g = 1;
+Color.prototype.b = 1;
 
 export { Color };

--- a/src/math/Interpolant.js
+++ b/src/math/Interpolant.js
@@ -17,6 +17,8 @@
  *
  * 		http://www.oodesign.com/template-method-pattern.html
  *
+ * Notice: Interpolant class can't be converted to ES6 class.
+ * see https://github.com/mrdoob/three.js/pull/19934#issuecomment-664240797
  */
 
 function Interpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {

--- a/src/math/interpolants/CubicInterpolant.js
+++ b/src/math/interpolants/CubicInterpolant.js
@@ -10,29 +10,20 @@ import { WrapAroundEnding, ZeroSlopeEnding } from '../../constants.js';
  * over their parameter interval.
  */
 
-function CubicInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class CubicInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-	this._weightPrev = - 0;
-	this._offsetPrev = - 0;
-	this._weightNext = - 0;
-	this._offsetNext = - 0;
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-}
+		this._weightPrev = - 0;
+		this._offsetPrev = - 0;
+		this._weightNext = - 0;
+		this._offsetNext = - 0;
 
-CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: CubicInterpolant,
-
-	DefaultSettings_: {
-
-		endingStart: ZeroCurvatureEnding,
-		endingEnd: ZeroCurvatureEnding
-
-	},
-
-	intervalChanged_: function ( i1, t0, t1 ) {
+	intervalChanged_( i1, t0, t1 ) {
 
 		const pp = this.parameterPositions;
 		let iPrev = i1 - 2,
@@ -109,9 +100,9 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 		this._offsetPrev = iPrev * stride;
 		this._offsetNext = iNext * stride;
 
-	},
+	}
 
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		const result = this.resultBuffer,
 			values = this.sampleValues,
@@ -148,7 +139,14 @@ CubicInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype
 
 	}
 
-} );
+}
+
+CubicInterpolant.prototype.DefaultSettings_ = {
+
+	endingStart: ZeroCurvatureEnding,
+	endingEnd: ZeroCurvatureEnding
+
+};
 
 
 export { CubicInterpolant };

--- a/src/math/interpolants/DiscreteInterpolant.js
+++ b/src/math/interpolants/DiscreteInterpolant.js
@@ -6,23 +6,21 @@ import { Interpolant } from '../Interpolant.js';
  * the parameter.
  */
 
-function DiscreteInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class DiscreteInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-DiscreteInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: DiscreteInterpolant,
-
-	interpolate_: function ( i1 /*, t0, t, t1 */ ) {
+	interpolate_( i1 /*, t0, t, t1 */ ) {
 
 		return this.copySampleValue_( i1 - 1 );
 
 	}
 
-} );
+}
 
 
 export { DiscreteInterpolant };

--- a/src/math/interpolants/LinearInterpolant.js
+++ b/src/math/interpolants/LinearInterpolant.js
@@ -1,16 +1,14 @@
 import { Interpolant } from '../Interpolant.js';
 
-function LinearInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class LinearInterpolant extends Interpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-LinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: LinearInterpolant,
-
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		const result = this.resultBuffer,
 			values = this.sampleValues,
@@ -34,7 +32,7 @@ LinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototyp
 
 	}
 
-} );
+}
 
 
 export { LinearInterpolant };

--- a/src/math/interpolants/QuaternionLinearInterpolant.js
+++ b/src/math/interpolants/QuaternionLinearInterpolant.js
@@ -5,17 +5,15 @@ import { Quaternion } from '../Quaternion.js';
  * Spherical linear unit quaternion interpolant.
  */
 
-function QuaternionLinearInterpolant( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+class QuaternionLinearInterpolant {
 
-	Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+	constructor ( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
-}
+		super( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
 
-QuaternionLinearInterpolant.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	}
 
-	constructor: QuaternionLinearInterpolant,
-
-	interpolate_: function ( i1, t0, t, t1 ) {
+	interpolate_( i1, t0, t, t1 ) {
 
 		const result = this.resultBuffer,
 			values = this.sampleValues,
@@ -35,7 +33,7 @@ QuaternionLinearInterpolant.prototype = Object.assign( Object.create( Interpolan
 
 	}
 
-} );
+}
 
 
 export { QuaternionLinearInterpolant };

--- a/src/math/interpolants/QuaternionLinearInterpolant.js
+++ b/src/math/interpolants/QuaternionLinearInterpolant.js
@@ -5,9 +5,9 @@ import { Quaternion } from '../Quaternion.js';
  * Spherical linear unit quaternion interpolant.
  */
 
-class QuaternionLinearInterpolant {
+class QuaternionLinearInterpolant extends Interpolant {
 
-	constructor ( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer ) {
 
 		super( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
 


### PR DESCRIPTION
A part of #19984.
A series of Math classes conversion, Part 3 of 3.

This PR contains:

- ~[ ] Interpolant (The base class)~
  - [ ] CubicInterpolant
  - [ ] DiscreteInterpolant
  - [ ] LinearInterpolant
  - [ ] QuaternionLinearInterpolant
- ~[ ] **Interpolant.tests.js** [*1]~

and
- [x] Color

---

~*1:
The test has to be changed as well because 'Interpolant.tests' was assuming `Interpolant` base class to be a Function (using `call` to extend the base class).~

---

edited: `Interpolant` base class [couldn't be converted](https://github.com/mrdoob/three.js/pull/20086#issuecomment-674514866). I keep it as it is.