### PR TITLE
Audio: Introduce _connected flag to fix setFilters bug

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -31,6 +31,7 @@ class Audio extends Object3D {
 
 		this._startedAt = 0;
 		this._progress = 0;
+		this._connected = false;
 
 		this.filters = [];
 
@@ -198,6 +199,8 @@ class Audio extends Object3D {
 
 		}
 
+		this._connected = true;
+
 		return this;
 
 	}
@@ -222,6 +225,8 @@ class Audio extends Object3D {
 
 		}
 
+		this._connected = false;
+
 		return this;
 
 	}
@@ -236,7 +241,7 @@ class Audio extends Object3D {
 
 		if ( ! value ) value = [];
 
-		if ( this.isPlaying === true ) {
+		if ( this._connected === true ) {
 
 			this.disconnect();
 			this.filters = value;


### PR DESCRIPTION
**Problem this PR fixes**

`Audio.setFilters()` resets connection by calling `.disconnect()` and `.connect()` if `.isPlaying` is `true`.

```javascript
setFilters( value ) {

	if ( ! value ) value = [];

	if ( this.isPlaying === true ) {

		this.disconnect();
		this.filters = value;
		this.connect();

	} else {

		this.filters = value;

	}

	return this;

}
```

The problem is `Audio` status can be "connected but `.isPlaying` is `false`". In that case connection won't be reset and then filters won't be applied.

The examples of "connected but `.isPlaying` is `false`".

* Call `.setNodeSource()`, `setMediaElementSource()`, or `setMediaStreamSource()`. And not call `.play()`.
* Call `.play()` and then call `.pause()` or `.stop()`.

**How to fix**

The root issue would be that `.isPlaying` is not corresponding to "connected". So I'd like to suggest introducing a new private boolean property `._connected` which is updated in `.connect/disconnect()` and shows exactly whether connected or not. And let `setFilters` use it to detect whether connected or not.
