### PR TITLE
WebGLRenderer: Remove superfluous program check in setProgram().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1479,11 +1479,7 @@ function WebGLRenderer( parameters ) {
 
 		if ( material.version === materialProperties.__version ) {
 
-			if ( materialProperties.program === undefined ) {
-
-				initMaterial( material, scene, object );
-
-			} else if ( material.fog && materialProperties.fog !== fog ) {
+			if ( material.fog && materialProperties.fog !== fog ) {
 
 				initMaterial( material, scene, object );
 


### PR DESCRIPTION
I think it's safe to remove this check since `materialProperties.program` can never be `undefined` if `materialProperties.__version` is equal to  `material.version`. If both values are equal, `initMaterial()` was called at least once which ensures that `materialProperties.program` is set.

Removing any access to `program` before `initMaterial()` is called is useful for further refactoring.