### PR TITLE
Audio: Copy filters array in setFilters

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -241,27 +241,15 @@ class Audio extends Object3D {
 
 		if ( ! value ) value = [];
 
-		this.filters.length = 0;
-
 		if ( this._connected === true ) {
 
 			this.disconnect();
-
-			for ( var i = 0; i < value.length; i ++ ) {
-
-				this.filters.push( value[ i ] );
-
-			}
-
+			this.filters = value.slice();
 			this.connect();
 
 		} else {
 
-			for ( var i = 0; i < value.length; i ++ ) {
-
-				this.filters.push( value[ i ] );
-
-			}
+			this.filters = value.slice();
 
 		}
 

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -241,15 +241,27 @@ class Audio extends Object3D {
 
 		if ( ! value ) value = [];
 
+		this.filters.length = 0;
+
 		if ( this._connected === true ) {
 
 			this.disconnect();
-			this.filters = value;
+
+			for ( var i = 0; i < value.length; i ++ ) {
+
+				this.filters.push( value[ i ] );
+
+			}
+
 			this.connect();
 
 		} else {
 
-			this.filters = value;
+			for ( var i = 0; i < value.length; i ++ ) {
+
+				this.filters.push( value[ i ] );
+
+			}
 
 		}
 


### PR DESCRIPTION
**Problem this PR fixes**

`Audio.setFilters()` stores a reference to passed array to `Audio.filters`. 

```javascript
setFilters( value ) {

	if ( ! value ) value = [];

	if ( this._connected === true ) {

		this.disconnect();
		this.filters = value;  // stores reference
		this.connect();

	} else {

		this.filters = value;  // stores reference

	}

	return this;

}
```

Then for example in the following example, an operation to `filters` array can have an effect to `audio.filters` even out of `Audio`. I don't think this is expected behavior for users.

```javascript
const audio = new Audio(listener);
const filters = [audio.context.createGain()];
audio.setFilters(filters);
filters.pop(); // This operation has an effect to audio.filters
```

**How this PR fixes**

I'd like to suggest copying an array in `Audio.setFilters()` instead of storing a reference. In the above example an operation to `filters` won't have an effect to `audio.filters`. I think it would be better capsulation.