### PR TITLE
EXRLoader: skip unknown header attributes

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1678,6 +1678,15 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 		}
 
+		function parsePreview( dataView, offset ) {
+
+			var width = parseUint32( dataView, offset );
+			var height = parseUint32( dataView, offset );
+
+			offset.value += 4 * width * height;
+
+		}
+
 		function parseInt32( dataView, offset ) {
 
 			var Int32 = dataView.getInt32( offset.value, true );
@@ -1984,6 +1993,10 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			} else if ( type === 'timecode' ) {
 
 				return parseTimecode( dataView, offset );
+
+			} else if ( type === 'preview' ) {
+
+				return parsePreview( dataView, offset );
 
 			} else {
 

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1678,15 +1678,6 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 		}
 
-		function parsePreview( dataView, offset ) {
-
-			var width = parseUint32( dataView, offset );
-			var height = parseUint32( dataView, offset );
-
-			offset.value += 4 * width * height;
-
-		}
-
 		function parseInt32( dataView, offset ) {
 
 			var Int32 = dataView.getInt32( offset.value, true );
@@ -1994,13 +1985,9 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 				return parseTimecode( dataView, offset );
 
-			} else if ( type === 'preview' ) {
-
-				return parsePreview( dataView, offset );
-
 			} else {
 
-				throw 'Cannot parse value for unsupported type: ' + type;
+				return undefined;
 
 			}
 
@@ -2035,7 +2022,16 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 				var attributeSize = parseUint32( bufferDataView, offset );
 				var attributeValue = parseValue( bufferDataView, buffer, offset, attributeType, attributeSize );
 
-				EXRHeader[ attributeName ] = attributeValue;
+				if ( attributeValue === undefined ) {
+
+					console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${attributeType}\'.` );
+					offset.value += attributeSize;
+
+				} else {
+
+					EXRHeader[ attributeName ] = attributeValue;
+
+				}
 
 			}
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1691,6 +1691,15 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 		}
 
+		function parsePreview( dataView, offset ) {
+
+			var width = parseUint32( dataView, offset );
+			var height = parseUint32( dataView, offset );
+
+			offset.value += 4 * width * height;
+
+		}
+
 		function parseInt32( dataView, offset ) {
 
 			var Int32 = dataView.getInt32( offset.value, true );
@@ -1997,6 +2006,10 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 			} else if ( type === 'timecode' ) {
 
 				return parseTimecode( dataView, offset );
+
+			} else if ( type === 'preview' ) {
+
+				return parsePreview( dataView, offset );
 
 			} else {
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1691,15 +1691,6 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 		}
 
-		function parsePreview( dataView, offset ) {
-
-			var width = parseUint32( dataView, offset );
-			var height = parseUint32( dataView, offset );
-
-			offset.value += 4 * width * height;
-
-		}
-
 		function parseInt32( dataView, offset ) {
 
 			var Int32 = dataView.getInt32( offset.value, true );
@@ -2007,13 +1998,9 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 				return parseTimecode( dataView, offset );
 
-			} else if ( type === 'preview' ) {
-
-				return parsePreview( dataView, offset );
-
 			} else {
 
-				throw 'Cannot parse value for unsupported type: ' + type;
+				return undefined;
 
 			}
 
@@ -2048,7 +2035,16 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 				var attributeSize = parseUint32( bufferDataView, offset );
 				var attributeValue = parseValue( bufferDataView, buffer, offset, attributeType, attributeSize );
 
-				EXRHeader[ attributeName ] = attributeValue;
+				if ( attributeValue === undefined ) {
+
+					console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${attributeType}\'.` );
+					offset.value += attributeSize;
+
+				} else {
+
+					EXRHeader[ attributeName ] = attributeValue;
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixes #20094

Implements EXR `preview` header attribute.

It actually just skips that header information as we don't have a use for it internally.