### PR TITLE
ES6 Classes: use Object.defineProperty() instead of accessing the prototype

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -6,6 +6,8 @@ class Box2 {
 
 	constructor( min, max ) {
 
+		Object.defineProperty( this, 'isBox2', { value: true } );
+
 		this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
 		this.max = ( max !== undefined ) ? max : new Vector2( - Infinity, - Infinity );
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -4,6 +4,8 @@ class Box3 {
 
 	constructor( min, max ) {
 
+		Object.defineProperty( this, 'isBox3', { value: true } );
+
 		this.min = ( min !== undefined ) ? min : new Vector3( + Infinity, + Infinity, + Infinity );
 		this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
 
@@ -515,8 +517,6 @@ function satForAxes( axes, v0, v1, v2, extents ) {
 	return true;
 
 }
-
-Box3.prototype.isBox3 = true;
 
 const _points = [
 	new Vector3(),

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -55,6 +55,8 @@ class Color {
 
 	constructor( r, g, b ) {
 
+		Object.defineProperty( this, 'isColor', { value: true } );
+
 		if ( g === undefined && b === undefined ) {
 
 			// r is THREE.Color, hex or string
@@ -601,9 +603,9 @@ class Color {
 }
 
 Color.NAMES = _colorKeywords;
-Color.prototype.isColor = true;
 Color.prototype.r = 1;
 Color.prototype.g = 1;
 Color.prototype.b = 1;
+
 
 export { Color };

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -320,11 +320,11 @@ class Euler {
 
 }
 
-const _matrix = new Matrix4();
-const _quaternion = new Quaternion();
-
 Euler.DefaultOrder = 'XYZ';
 Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
+
+const _matrix = new Matrix4();
+const _quaternion = new Quaternion();
 
 
 export { Euler };

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -7,6 +7,8 @@ class Euler {
 
 	constructor( x = 0, y = 0, z = 0, order = Euler.DefaultOrder ) {
 
+		Object.defineProperty( this, 'isEuler', { value: true } );
+
 		this._x = x;
 		this._y = y;
 		this._z = z;
@@ -318,12 +320,11 @@ class Euler {
 
 }
 
-Euler.DefaultOrder = 'XYZ';
-Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
-Euler.prototype.isEuler = true;
-
 const _matrix = new Matrix4();
 const _quaternion = new Quaternion();
+
+Euler.DefaultOrder = 'XYZ';
+Euler.RotationOrders = [ 'XYZ', 'YZX', 'ZXY', 'XZY', 'YXZ', 'ZYX' ];
 
 
 export { Euler };

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -2,6 +2,8 @@ class Matrix3 {
 
 	constructor() {
 
+		Object.defineProperty( this, 'isMatrix3', { value: true } );
+
 		this.elements = [
 
 			1, 0, 0,
@@ -344,6 +346,5 @@ class Matrix3 {
 
 }
 
-Matrix3.prototype.isMatrix3 = true;
 
 export { Matrix3 };

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -4,6 +4,8 @@ class Matrix4 {
 
 	constructor() {
 
+		Object.defineProperty( this, 'isMatrix4', { value: true } );
+
 		this.elements = [
 
 			1, 0, 0, 0,
@@ -866,8 +868,6 @@ class Matrix4 {
 	}
 
 }
-
-Matrix4.prototype.isMatrix4 = true;
 
 const _v1 = new Vector3();
 const _m1 = new Matrix4();

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -9,6 +9,8 @@ class Plane {
 
 	constructor( normal, constant ) {
 
+		Object.defineProperty( this, 'isPlane', { value: true } );
+
 		// normal is assumed to be normalized
 
 		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
@@ -220,8 +222,6 @@ class Plane {
 	}
 
 }
-
-Plane.prototype.isPlane = true;
 
 
 export { Plane };

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -4,6 +4,8 @@ class Quaternion {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
 
+		Object.defineProperty( this, 'isQuaternion', { value: true } );
+
 		this._x = x;
 		this._y = y;
 		this._z = z;
@@ -639,6 +641,5 @@ class Quaternion {
 
 }
 
-Quaternion.prototype.isQuaternion = true;
 
 export { Quaternion };

--- a/src/math/SphericalHarmonics3.js
+++ b/src/math/SphericalHarmonics3.js
@@ -14,6 +14,8 @@ class SphericalHarmonics3 {
 
 	constructor() {
 
+		Object.defineProperty( this, 'isSphericalHarmonics3', { value: true } );
+
 		this.coefficients = [];
 
 		for ( let i = 0; i < 9; i ++ ) {
@@ -242,8 +244,6 @@ class SphericalHarmonics3 {
 	}
 
 }
-
-SphericalHarmonics3.prototype.isSphericalHarmonics3 = true;
 
 
 export { SphericalHarmonics3 };

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -2,6 +2,8 @@ class Vector2 {
 
 	constructor( x = 0, y = 0 ) {
 
+		Object.defineProperty( this, 'isVector2', { value: true } );
+
 		this.x = x;
 		this.y = y;
 
@@ -477,6 +479,5 @@ class Vector2 {
 
 }
 
-Vector2.prototype.isVector2 = true;
 
 export { Vector2 };

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -5,6 +5,8 @@ class Vector3 {
 
 	constructor( x = 0, y = 0, z = 0 ) {
 
+		Object.defineProperty( this, 'isVector3', { value: true } );
+
 		this.x = x;
 		this.y = y;
 		this.z = z;
@@ -718,9 +720,8 @@ class Vector3 {
 
 }
 
-Vector3.prototype.isVector3 = true;
-
 const _vector = new Vector3();
 const _quaternion = new Quaternion();
+
 
 export { Vector3 };

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -2,6 +2,8 @@ class Vector4 {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
 
+		Object.defineProperty( this, 'isVector4', { value: true } );
+
 		this.x = x;
 		this.y = y;
 		this.z = z;
@@ -644,6 +646,5 @@ class Vector4 {
 
 }
 
-Vector4.prototype.isVector4 = true;
 
 export { Vector4 };

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -4,6 +4,8 @@ class Fog {
 
 	constructor( color, near, far ) {
 
+		Object.defineProperty( this, 'isFog', { value: true } );
+
 		this.name = '';
 
 		this.color = new Color( color );
@@ -32,6 +34,5 @@ class Fog {
 
 }
 
-Fog.prototype.isFog = true;
 
 export { Fog };

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -4,6 +4,8 @@ class FogExp2 {
 
 	constructor( color, density ) {
 
+		Object.defineProperty( this, 'isFogExp2', { value: true } );
+
 		this.name = '';
 
 		this.color = new Color( color );
@@ -29,6 +31,5 @@ class FogExp2 {
 
 }
 
-FogExp2.prototype.isFogExp2 = true;
 
 export { FogExp2 };

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -5,6 +5,9 @@ class Scene extends Object3D {
 	constructor() {
 
 		super();
+
+		Object.defineProperty( this, 'isScene', { value: true } );
+
 		this.type = 'Scene';
 
 		this.background = null;
@@ -54,6 +57,5 @@ class Scene extends Object3D {
 
 }
 
-Scene.prototype.isScene = true;
 
 export { Scene };


### PR DESCRIPTION
As explained in https://github.com/mrdoob/three.js/issues/19986#issuecomment-675368756.

Let's not mutate the prototype anymore since it makes the component non-treeshakeable.

Let's use [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) instead which by default creates a non-enumerable non-writable non-configurable property.