### PR TITLE
WebGLCubeRenderTarget: Moving renderer state logic to WebGLCubeMaps.

### DIFF
--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -102,9 +102,6 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 	const mesh = new Mesh( geometry, material );
 
 	const currentMinFilter = texture.minFilter;
-	const currentRenderList = renderer.getRenderList();
-	const currentRenderTarget = renderer.getRenderTarget();
-	const currentRenderState = renderer.getRenderState();
 
 	// Avoid blurred poles
 	if ( texture.minFilter === LinearMipmapLinearFilter ) texture.minFilter = LinearFilter;
@@ -113,10 +110,6 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 	camera.update( renderer, mesh );
 
 	texture.minFilter = currentMinFilter;
-
-	renderer.setRenderTarget( currentRenderTarget );
-	renderer.setRenderList( currentRenderList );
-	renderer.setRenderState( currentRenderState );
 
 	mesh.geometry.dispose();
 	mesh.material.dispose();

--- a/src/renderers/webgl/WebGLCubeMaps.js
+++ b/src/renderers/webgl/WebGLCubeMaps.js
@@ -40,9 +40,17 @@ function WebGLCubeMaps( renderer ) {
 
 					if ( image && image.height > 0 ) {
 
+						const currentRenderList = renderer.getRenderList();
+						const currentRenderTarget = renderer.getRenderTarget();
+						const currentRenderState = renderer.getRenderState();
+
 						const renderTarget = new WebGLCubeRenderTarget( image.height / 2 );
 						renderTarget.fromEquirectangularTexture( renderer, texture );
 						cubemaps.set( texture, renderTarget );
+
+						renderer.setRenderTarget( currentRenderTarget );
+						renderer.setRenderList( currentRenderList );
+						renderer.setRenderState( currentRenderState );
 
 						return mapTextureMapping( renderTarget.texture, texture.mapping );
 


### PR DESCRIPTION
When using `WebGLCubeRenderTarget.fromEquirectangularTexture()` not inside `WebGLRenderer.render()`, state saving and resetting is not necessary. Should we let the renderer (`WebGLCubeMaps`) handle this logic?