### PR TITLE
WebGLRenderer: Remove useless line from initMaterial().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1323,8 +1323,6 @@ function WebGLRenderer( parameters ) {
 
 		} else if ( materialProperties.lightsStateVersion !== lightsStateVersion ) {
 
-			materialProperties.lightsStateVersion = lightsStateVersion;
-
 			programChange = false;
 
 		} else if ( parameters.shaderID !== undefined ) {


### PR DESCRIPTION
I think this line can safely be removed since `lightsStateVersion` is set in `initMaterial()` some lines later.

https://github.com/mrdoob/three.js/blob/0a1f2ffa864b7ab80d9ec7df179f90e600f6d485/src/renderers/WebGLRenderer.js#L1413

If `materialProperties.lightsStateVersion !== lightsStateVersion` is `true`, the code definitely reaches line 1413.