### PR TITLE
NodeMaterial: Do not access materialProperties.

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -61,17 +61,11 @@ Object.defineProperties( NodeMaterial.prototype, {
 
 NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 
-	var materialProperties = renderer.properties.get( this );
+	this.build( { renderer: renderer } );
 
-	if ( this.version !== materialProperties.__version ) {
-
-		this.build( { renderer: renderer } );
-
-		shader.uniforms = this.uniforms;
-		shader.vertexShader = this.vertexShader;
-		shader.fragmentShader = this.fragmentShader;
-
-	}
+	shader.uniforms = this.uniforms;
+	shader.vertexShader = this.vertexShader;
+	shader.fragmentShader = this.fragmentShader;
 
 };
 


### PR DESCRIPTION
`NodeMaterial.onBeforeCompile()` should not access `materialProperties` which is for internal use only. AFAICS, after the introduction of `NodeMaterial.getHash()` and the refactoring of when `onBeforeCompile()` is executed in `WebGLRenderer`, this check is not necessary anymore.

Sidenote: In order to solve #15047, the access to renderer internals like `materialProperties` should stop anyway.