### PR TITLE
KTX2Loader: Fix loading of non-square textures

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -513,8 +513,8 @@ class KTX2Container {
 
 		for ( var level = 0; level < this.header.levelCount; level ++ ) {
 
-			var levelWidth = width / Math.pow( 2, level );
-			var levelHeight = height / Math.pow( 2, level );
+			var levelWidth = Math.ceil( width / Math.pow( 2, level ) );
+			var levelHeight = Math.ceil( height / Math.pow( 2, level ) );
 
 			var numImagesInLevel = 1; // TODO(donmccurdy): Support cubemaps, arrays and 3D.
 			var imageOffsetInLevel = 0;


### PR DESCRIPTION
Previously for non-square textures with a full mip chain one of the
sides for at least one level had non-integer size, which resulted in the
texture being incomplete and returning 0 during sampling.