### PR TITLE
Extend object classes in TypeScript with generic types

### DIFF
--- a/src/objects/InstancedMesh.d.ts
+++ b/src/objects/InstancedMesh.d.ts
@@ -8,7 +8,7 @@ import { Matrix4 } from './../math/Matrix4';
 export class InstancedMesh <
 	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
 	TMaterial extends Material | Material[] = Material | Material[]
-> extends Mesh {
+> extends Mesh<TGeometry, TMaterial> {
 
 	constructor(
 		geometry: TGeometry,

--- a/src/objects/LineLoop.d.ts
+++ b/src/objects/LineLoop.d.ts
@@ -6,7 +6,7 @@ import { BufferGeometry } from '../core/BufferGeometry';
 export class LineLoop <
 	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
 	TMaterial extends Material | Material[] = Material | Material[]
-> extends Line {
+> extends Line<TGeometry, TMaterial> {
 
 	constructor(
 		geometry?: TGeometry,

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -15,7 +15,7 @@ export const LinePieces: number;
 export class LineSegments <
 	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
 	TMaterial extends Material | Material[] = Material | Material[]
-> extends Line {
+> extends Line<TGeometry, TMaterial> {
 
 	constructor(
 		geometry?: TGeometry,

--- a/src/objects/SkinnedMesh.d.ts
+++ b/src/objects/SkinnedMesh.d.ts
@@ -8,7 +8,7 @@ import { BufferGeometry } from '../core/BufferGeometry';
 export class SkinnedMesh <
 	TGeometry extends Geometry | BufferGeometry = Geometry | BufferGeometry,
 	TMaterial extends Material | Material[] = Material | Material[]
-> extends Mesh {
+> extends Mesh<TGeometry, TMaterial> {
 
 	constructor(
 		geometry?: TGeometry,


### PR DESCRIPTION
I propose these changes to make it possible to use generics for inherited three.js object types.

An example:

```
function getMesh(): Mesh<BufferGeometry> {
  /* Do stuff */
  return new InstancedMesh(geometry, material, n);
}
```

This will currently give the TS error `Type 'InstancedMesh<BufferGeometry, Material>' is not assignable to type 'Mesh<BufferGeometry, Material | Material[]>'`.