### PR TITLE
Examples: Fix NaN bug in GLBufferAttribute demo.

### DIFF
--- a/examples/webgl_buffergeometry_glbufferattribute.html
+++ b/examples/webgl_buffergeometry_glbufferattribute.html
@@ -24,6 +24,7 @@
 			var points;
 
 			var particles = 300000;
+			var drawCount = 10000;
 
 			init();
 			animate();
@@ -155,7 +156,6 @@
 
 			}
 
-			var drawCount = 10000;
 			function render() {
 
 				drawCount = ( Math.max( 5000, drawCount ) + Math.floor( 500 * Math.random() ) ) % particles;


### PR DESCRIPTION
`drawCount` has to be defined earlier otherwise the first call of `render()` produces a `NaN` value.