### PR TITLE
RoughnessMipmapper: maintain texture parameters

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -7,7 +7,6 @@
  */
 
 import {
-	LinearMipMapLinearFilter,
 	MathUtils,
 	Mesh,
 	NoBlending,
@@ -72,7 +71,7 @@ RoughnessMipmapper.prototype = {
 
 		if ( width !== roughnessMap.image.width || height !== roughnessMap.image.height ) {
 
-			var newRoughnessTarget = new WebGLRenderTarget( width, height, { minFilter: LinearMipMapLinearFilter, depthBuffer: false } );
+			var newRoughnessTarget = new WebGLRenderTarget( width, height, { wrapS: roughnessMap.wrapS, wrapT: roughnessMap.wrapT, magFilter: roughnessMap.magFilter, minFilter: roughnessMap.minFilter, depthBuffer: false } );
 
 			newRoughnessTarget.texture.generateMipmaps = true;
 


### PR DESCRIPTION
Fixes https://github.com/google/model-viewer/issues/1462

When the roughness map and normal map are different sizes, I have to create a new roughness texture, but it should have the same parameters as the original. 