### PR TITLE
Lint fix update

### DIFF
--- a/examples/js/animation/TimelinerController.js
+++ b/examples/js/animation/TimelinerController.js
@@ -82,7 +82,7 @@ THREE.TimelinerController.prototype = {
 
 		var track = this._tracks[ channelName ],
 			times = track.times,
-			index = Timeliner.binarySearch( times, time ),
+			index = Timeliner.binarySearch( times, time ), // eslint-disable-line no-undef
 			values = track.values,
 			stride = track.getValueSize(),
 			offset = index * stride;
@@ -120,7 +120,7 @@ THREE.TimelinerController.prototype = {
 
 		var track = this._tracks[ channelName ],
 			times = track.times,
-			index = Timeliner.binarySearch( times, time );
+			index = Timeliner.binarySearch( times, time ); // eslint-disable-line no-undef
 
 		// we disallow to remove the keyframe when it is the last one we have,
 		// since the animation system is designed to always produce a defined
@@ -159,7 +159,7 @@ THREE.TimelinerController.prototype = {
 
 		var track = this._tracks[ channelName ],
 			times = track.times,
-			index = Timeliner.binarySearch( times, time );
+			index = Timeliner.binarySearch( times, time ); // eslint-disable-line no-undef
 
 		if ( index >= 0 ) {
 

--- a/examples/js/exporters/MMDExporter.js
+++ b/examples/js/exporters/MMDExporter.js
@@ -13,7 +13,7 @@ THREE.MMDExporter = function () {
 
 		if ( u2sTable === undefined ) {
 
-			var encoder = new MMDParser.CharsetEncoder();
+			var encoder = new MMDParser.CharsetEncoder(); // eslint-disable-line no-undef
 			var table = encoder.s2uTable;
 			u2sTable = {};
 

--- a/examples/js/loaders/3MFLoader.js
+++ b/examples/js/loaders/3MFLoader.js
@@ -88,7 +88,7 @@ THREE.ThreeMFLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 
 			try {
 
-				zip = new JSZip( data );
+				zip = new JSZip( data ); // eslint-disable-line no-undef
 
 			} catch ( e ) {
 

--- a/examples/js/loaders/AMFLoader.js
+++ b/examples/js/loaders/AMFLoader.js
@@ -77,7 +77,7 @@ THREE.AMFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 				try {
 
-					zip = new JSZip( data );
+					zip = new JSZip( data ); // eslint-disable-line no-undef
 
 				} catch ( e ) {
 

--- a/examples/js/loaders/AssimpLoader.js
+++ b/examples/js/loaders/AssimpLoader.js
@@ -1563,7 +1563,7 @@ THREE.AssimpLoader.prototype = Object.assign( Object.create( THREE.Loader.protot
 		function ReadBounds( stream, T /*p*/, n ) {
 
 			// not sure what to do here, the data isn't really useful.
-			return stream.Seek( sizeof( T ) * n, aiOrigin_CUR );
+			return stream.Seek( sizeof( T ) * n, aiOrigin_CUR ); // eslint-disable-line no-undef
 
 		}
 
@@ -2265,7 +2265,7 @@ THREE.AssimpLoader.prototype = Object.assign( Object.create( THREE.Loader.protot
 				var compressedData = [];
 				stream.Read( compressedData, 1, compressedSize );
 				var uncompressedData = [];
-				uncompress( uncompressedData, uncompressedSize, compressedData, compressedSize );
+				uncompress( uncompressedData, uncompressedSize, compressedData, compressedSize ); // eslint-disable-line no-undef
 				var buff = new ArrayBuffer( uncompressedData );
 				ReadBinaryScene( buff, pScene );
 

--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -435,7 +435,7 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 		transcoderPending = new Promise( ( resolve ) => {
 
 			BasisModule = { wasmBinary, onRuntimeInitialized: resolve };
-			BASIS( BasisModule );
+			BASIS( BasisModule ); // eslint-disable-line no-undef
 
 		} ).then( () => {
 

--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -427,7 +427,7 @@ THREE.DRACOLoader.DRACOWorker = function () {
 
 					};
 
-					DracoDecoderModule( decoderConfig );
+					DracoDecoderModule( decoderConfig ); // eslint-disable-line no-undef
 
 				} );
 				break;

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -938,7 +938,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 				for ( let comp = 0; comp < numComp; ++ comp ) {
 
-					let type = channelData[ cscSet.idx[ comp ] ].type;
+					const type = channelData[ cscSet.idx[ comp ] ].type;
 
 					for ( let y = 8 * blocky; y < 8 * blocky + maxY; ++ y ) {
 
@@ -946,7 +946,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 						for ( let blockx = 0; blockx < numFullBlocksX; ++ blockx ) {
 
-							let src = blockx * 64 + ( ( y & 0x7 ) * 8 );
+							const src = blockx * 64 + ( ( y & 0x7 ) * 8 );
 
 							dataView.setUint16( offset + 0 * INT16_SIZE * type, rowBlock[ comp ][ src + 0 ], true );
 							dataView.setUint16( offset + 1 * INT16_SIZE * type, rowBlock[ comp ][ src + 1 ], true );
@@ -969,8 +969,8 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 						for ( let y = 8 * blocky; y < 8 * blocky + maxY; ++ y ) {
 
-							let offset = rowOffsets[ comp ][ y ] + 8 * numFullBlocksX * INT16_SIZE * type;
-							let src = numFullBlocksX * 64 + ( ( y & 0x7 ) * 8 );
+							const offset = rowOffsets[ comp ][ y ] + 8 * numFullBlocksX * INT16_SIZE * type;
+							const src = numFullBlocksX * 64 + ( ( y & 0x7 ) * 8 );
 
 							for ( let x = 0; x < maxX; ++ x ) {
 
@@ -999,7 +999,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 				for ( var y = 0; y < height; ++ y ) {
 
-					let offset = rowOffsets[ comp ][ y ];
+					const offset = rowOffsets[ comp ][ y ];
 
 					for ( var x = 0; x < width; ++ x ) {
 
@@ -1416,7 +1416,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 			let tmpBufferEnd = 0;
 			let writePtr = 0;
-			let ptr = new Array( 4 );
+			const ptr = new Array( 4 );
 
 			for ( let y = 0; y < info.lines; y ++ ) {
 
@@ -2392,7 +2392,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 
 		}
 
-		let format = ( this.type === THREE.UnsignedByteType ) ? THREE.RGBEFormat : ( numChannels === 4 ) ? THREE.RGBAFormat : THREE.RGBFormat;
+		const format = ( this.type === THREE.UnsignedByteType ) ? THREE.RGBEFormat : ( numChannels === 4 ) ? THREE.RGBAFormat : THREE.RGBFormat;
 
 		return {
 			header: EXRHeader,

--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -1588,7 +1588,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 					case DEFLATE:
 
 						var compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.totalAcUncompressedCount );
-						var inflate = new Inflate( compressed, { resize: true, verify: true } );
+						var inflate = new Inflate( compressed, { resize: true, verify: true } ); // eslint-disable-line no-undef
 						var acBuffer = new Uint16Array( inflate.decompress().buffer );
 						inOffset.value += dwaHeader.totalAcUncompressedCount;
 						break;
@@ -1615,7 +1615,7 @@ THREE.EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoade
 			if ( dwaHeader.rleRawSize > 0 ) {
 
 				var compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.rleCompressedSize );
-				var inflate = new Inflate( compressed, { resize: true, verify: true } );
+				var inflate = new Inflate( compressed, { resize: true, verify: true } ); // eslint-disable-line no-undef
 				var rleBuffer = decodeRunLength( inflate.decompress().buffer );
 
 				inOffset.value += dwaHeader.rleCompressedSize;

--- a/examples/js/loaders/KMZLoader.js
+++ b/examples/js/loaders/KMZLoader.js
@@ -80,7 +80,7 @@ THREE.KMZLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		//
 
-		var zip = new JSZip( data );
+		var zip = new JSZip( data ); // eslint-disable-line no-undef
 
 		if ( zip.files[ 'doc.kml' ] ) {
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -300,7 +300,7 @@ THREE.MMDLoader = ( function () {
 
 				}
 
-				this.parser = new MMDParser.Parser();
+				this.parser = new MMDParser.Parser(); // eslint-disable-line no-undef
 
 			}
 

--- a/examples/js/loaders/TTFLoader.js
+++ b/examples/js/loaders/TTFLoader.js
@@ -209,7 +209,7 @@ THREE.TTFLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		}
 
-		return convert( opentype.parse( arraybuffer ), this.reversed );
+		return convert( opentype.parse( arraybuffer ), this.reversed ); // eslint-disable-line no-undef
 
 	}
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build-closure": "npm run build && google-closure-compiler --warning_level=VERBOSE --jscomp_off=globalThis --jscomp_off=checkTypes --externs utils/build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/three.js --js_output_file build/three.min.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"http-server -c-1 -p 8080\"",
     "dev-test": "concurrently --names \"ROLLUP,ROLLUPTEST,HTTP\" -c \"bgBlue.bold,bgRed.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"npm run dev --prefix test\" \"http-server -p 8080\"",
-    "lint-fix": "eslint src --ext js --ext ts --fix && eslint examples/jsm --ext js --ext ts --ignore-pattern libs --fix",
+    "lint-fix": "eslint src --ext js --ext ts --fix && eslint examples/js/ --ext js --ext ts --ignore-pattern libs --fix",
     "lint-docs": "eslint docs --ext html",
     "lint-examples": "eslint examples/jsm --ext js --ext ts --ignore-pattern libs && tsc -p utils/build/tsconfig-examples.lint.json",
     "test-lint": "eslint src --ext js --ext ts && tsc -p utils/build/tsconfig.lint.json",


### PR DESCRIPTION
This update removes linting of the `examples/jsm` folder, should've only been `examples/js/` in the beginning. my bad.

Updates 1 script regarding the 'prefer const' eslint rule.

Lastly, I've added eslint ignore no-undefined line comments for the various lines that would've showed up otherwise. see small snippet below:
```
...
C:\Users\DefinitelyMaybe\Documents\three.js\examples\js\loaders\TTFLoader.js
  212:19  warning  'opentype' is not defined  no-undef

✖ 15 problems (0 errors, 15 warnings)
```