### PR TITLE
TS: Fix types for Line2

### DIFF
--- a/examples/jsm/lines/Line2.d.ts
+++ b/examples/jsm/lines/Line2.d.ts
@@ -4,6 +4,9 @@ import { LineMaterial } from './LineMaterial';
 
 export class Line2 extends LineSegments2 {
 
+	geometry?: LineGeometry;
+	material?: LineMaterial;
+
 	constructor( geometry?: LineGeometry, material?: LineMaterial );
 	readonly isLine2: true;
 


### PR DESCRIPTION
Allow to access to the original LineGeometry and LineMaterial safely without an explicit cast