### PR TITLE
WebGLExtensions: Added isWebGL2 logic

### DIFF
--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -1,5 +1,10 @@
 function WebGLExtensions( gl ) {
 
+	/* eslint-disable no-undef */
+	const isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
+		( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
+	/* eslint-enable no-undef */
+
 	const extensions = {};
 
 	return {
@@ -20,8 +25,20 @@ function WebGLExtensions( gl ) {
 					extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
 					break;
 
+				case 'EXT_frag_depth':
+					extension = isWebGL2 || gl.getExtension( 'EXT_frag_depth' );
+					break;
+
+				case 'EXT_shader_texture_lod':
+					extension = isWebGL2 || gl.getExtension( 'EXT_shader_texture_lod' );
+					break;
+
 				case 'EXT_texture_filter_anisotropic':
 					extension = gl.getExtension( 'EXT_texture_filter_anisotropic' ) || gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' ) || gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
+					break;
+
+				case 'WEBGL_draw_buffers':
+					extension = isWebGL2 || gl.getExtension( 'WEBGL_draw_buffers' );
 					break;
 
 				case 'WEBGL_compressed_texture_s3tc':

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -113,13 +113,13 @@ function getToneMappingFunction( functionName, toneMapping ) {
 
 }
 
-function generateExtensions( parameters ) {
+function generateExtensions( parameters, extensions ) {
 
 	const chunks = [
 		( parameters.extensionDerivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
-		( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
-		( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
-		( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+		( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && extensions.has( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
+		( parameters.extensionDrawBuffers && extensions.has( 'WEBGL_draw_buffers' ) ) ? '#extension GL_EXT_draw_buffers : require' : '',
+		( parameters.extensionShaderTextureLOD || parameters.envMap ) && extensions.has( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
 
 	return chunks.filter( filterEmptyLine ).join( '\n' );
@@ -375,7 +375,7 @@ function generateEnvMapBlendingDefine( parameters ) {
 
 }
 
-function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
+function WebGLProgram( renderer, extensions, cacheKey, parameters, bindingStates ) {
 
 	const gl = renderer.getContext();
 
@@ -392,7 +392,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 	const gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;
 
-	const customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters );
+	const customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters, extensions );
 
 	const customDefines = generateDefines( defines );
 
@@ -491,7 +491,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+			( parameters.logarithmicDepthBuffer && extensions.has( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 			'uniform mat4 modelMatrix;',
 			'uniform mat4 modelViewMatrix;',
@@ -626,9 +626,9 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+			( parameters.logarithmicDepthBuffer && extensions.has( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-			( ( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ) ? '#define TEXTURE_LOD_EXT' : '',
+			( ( parameters.extensionShaderTextureLOD || parameters.envMap ) && extensions.has( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 
 			'uniform mat4 viewMatrix;',
 			'uniform vec3 cameraPosition;',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -266,10 +266,6 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 			extensionDrawBuffers: material.extensions && material.extensions.drawBuffers,
 			extensionShaderTextureLOD: material.extensions && material.extensions.shaderTextureLOD,
 
-			rendererExtensionFragDepth: isWebGL2 || extensions.get( 'EXT_frag_depth' ) !== null,
-			rendererExtensionDrawBuffers: isWebGL2 || extensions.get( 'WEBGL_draw_buffers' ) !== null,
-			rendererExtensionShaderTextureLod: isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) !== null,
-
 			customProgramCacheKey: material.customProgramCacheKey()
 
 		};
@@ -365,7 +361,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 
 		if ( program === undefined ) {
 
-			program = new WebGLProgram( renderer, cacheKey, parameters, bindingStates );
+			program = new WebGLProgram( renderer, extensions, cacheKey, parameters, bindingStates );
 			programs.push( program );
 
 		}


### PR DESCRIPTION
Apparently this code was logging warnings of WebGL1 devs for every material compiled:

https://github.com/mrdoob/three.js/blob/3a993b4180f5230e1f34a21b30caaff9eb8ac44f/src/renderers/webgl/WebGLPrograms.js#L269-L271

We were requesting extensions regardless of whether we needed them.

While trying to find a solution for this I realised that we can move the `isWebGL2` logic inside `WebGLExtensions`.

I think there are a few other instances in the renderer where we can apply this.

FYI @Mugen87 