### PR TITLE
WebGLExtension: Fix return value of `has()`.

### DIFF
--- a/src/renderers/webgl/WebGLExtensions.d.ts
+++ b/src/renderers/webgl/WebGLExtensions.d.ts
@@ -2,6 +2,7 @@ export class WebGLExtensions {
 
 	constructor( gl: WebGLRenderingContext );
 
+	has( name: string ): boolean;
 	get( name: string ): any;
 
 }

--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -8,7 +8,7 @@ function WebGLExtensions( gl ) {
 
 			if ( extensions[ name ] !== undefined ) {
 
-				return extensions[ name ];
+				return !! extensions[ name ];
 
 			}
 

--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -8,7 +8,7 @@ function WebGLExtensions( gl ) {
 
 			if ( extensions[ name ] !== undefined ) {
 
-				return !! extensions[ name ];
+				return extensions[ name ] !== null;
 
 			}
 
@@ -39,7 +39,7 @@ function WebGLExtensions( gl ) {
 
 			extensions[ name ] = extension;
 
-			return !! extension;
+			return extension !== null;
 
 		},
 


### PR DESCRIPTION
If `has()` is called multiple times, only the first invocation will return a boolean. Starting from the second invocation, it returns the actual extension object. The PR fixes this behavior and ensures to always returning a boolean.