### PR TITLE
TS: Use a variable instead of an interface for DepthLimitedBlurShader.BlurShaderUtils typing.

### DIFF
--- a/examples/jsm/shaders/DepthLimitedBlurShader.d.ts
+++ b/examples/jsm/shaders/DepthLimitedBlurShader.d.ts
@@ -24,7 +24,7 @@ export const DepthLimitedBlurShader: {
 	fragmentShader: string;
 };
 
-export interface BlurShaderUtils {
+export const BlurShaderUtils: {
 	createSampleWeights( kernelRadius: number, stdDev: number ): number[];
 	createSampleOffsets( kernelRadius: number, uvIncrement: Vector2 ): Vector2[];
 	configure( configure: Material, kernelRadius: number, stdDev: number, uvIncrement: Vector2 ): void;


### PR DESCRIPTION
I _believe_ this is necessary in order to use `BlurShaderUtils`, as BlurShaderUtils is a variable, not just an interface. Without this Typescript is removing my import lines from its output, causing `BlurShaderUtils` to be missing at runtime.