### PR TITLE
OrbitControls: Disable focus outline

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1180,6 +1180,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	if ( scope.domElement.tabIndex === - 1 ) {
 
 		scope.domElement.tabIndex = 0;
+		scope.domElement.style.outline = 'none';
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1188,6 +1188,7 @@ var OrbitControls = function ( object, domElement ) {
 	if ( scope.domElement.tabIndex === - 1 ) {
 
 		scope.domElement.tabIndex = 0;
+		scope.domElement.style.outline = 'none';
 
 	}
 


### PR DESCRIPTION
A small quality of life fix. I'm not sure if it was added recently or always have been there, but since CSS2DRenderer and CSS3DRenderer are both `div` elements rendered over webgl canvas, and both are given a `tabindex` attribute - they become focusable and receive an outline by default:

![screenshot](https://user-images.githubusercontent.com/9549760/91104461-292fa200-e66e-11ea-899e-2d3a9c8e35cb.png)
(Tested on Chrome 84. Small bluish outline isn't much of an issue with bright scenes, but quite visible on darker ones.)

It doesn't seem like an expected behaviour for a renderer. 🤔