### PR TITLE
FlyControls: Removed unnecessary computation

### DIFF
--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -200,9 +200,6 @@ THREE.FlyControls = function ( object, domElement ) {
 			scope.tmpQuaternion.set( scope.rotationVector.x * rotMult, scope.rotationVector.y * rotMult, scope.rotationVector.z * rotMult, 1 ).normalize();
 			scope.object.quaternion.multiply( scope.tmpQuaternion );
 
-			// expose the rotation vector for convenience
-			scope.object.rotation.setFromQuaternion( scope.object.quaternion, scope.object.rotation.order );
-
 			if (
 				lastPosition.distanceToSquared( scope.object.position ) > EPS ||
 				8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -204,9 +204,6 @@ var FlyControls = function ( object, domElement ) {
 			scope.tmpQuaternion.set( scope.rotationVector.x * rotMult, scope.rotationVector.y * rotMult, scope.rotationVector.z * rotMult, 1 ).normalize();
 			scope.object.quaternion.multiply( scope.tmpQuaternion );
 
-			// expose the rotation vector for convenience
-			scope.object.rotation.setFromQuaternion( scope.object.quaternion, scope.object.rotation.order );
-
 			if (
 				lastPosition.distanceToSquared( scope.object.position ) > EPS ||
 				8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS


### PR DESCRIPTION
This code block was added when we had the `.useQuaternion` property.
