### PR TITLE
NodeMaterial: Fix ExpressionNode contructor's type definition

### DIFF
--- a/examples/jsm/nodes/core/ExpressionNode.d.ts
+++ b/examples/jsm/nodes/core/ExpressionNode.d.ts
@@ -2,6 +2,6 @@ import { FunctionNode } from './FunctionNode';
 
 export class ExpressionNode extends FunctionNode {
 
-	constructor( src: string, includes?: object[], extensions?: object, keywords?: object, type?: string );
+	constructor( src: string, type?: string, keywords?: object, extensions?: object, includes?: object[] );
 
 }


### PR DESCRIPTION
The constructor type definition did not match the actual implementation (the order of the arguments was wrong), see https://github.com/mrdoob/three.js/blob/dev/examples/jsm/nodes/core/ExpressionNode.js#L3 

I wonder if this should be merged, or if we should instead change the implementation of the constructor so that it's more homogeneous with the FunctionNode constructor. What do you think @sunag ?