### PR TITLE
Editor: Do not enforce sRGB encoding for DataTexture.

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -1186,7 +1186,7 @@ function SidebarMaterial( editor ) {
 
 		if ( texture !== null ) {
 
-			if ( texture.encoding !== THREE.sRGBEncoding ) {
+			if ( texture.isDataTexture !== true && texture.encoding !== THREE.sRGBEncoding ) {
 
 				texture.encoding = THREE.sRGBEncoding;
 				var object = currentObject;


### PR DESCRIPTION
Related #16148.

Always enforcing `sRGB` breaks the usage of HDR textures applied as environment maps. These are data textures and the encoding should not be changed.

Issue at the forum: https://discourse.threejs.org/t/hdr-image-display-problem/18244