### PR TITLE
Vector3: Fix fromBufferAttribute type definition

### DIFF
--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -6,6 +6,7 @@ import { Camera } from './../cameras/Camera';
 import { Spherical } from './Spherical';
 import { Cylindrical } from './Cylindrical';
 import { BufferAttribute } from './../core/BufferAttribute';
+import { InterleavedBufferAttribute } from './../core/InterleavedBufferAttribute';
 import { Vector } from './Vector2';
 /**
  * 3D vector.
@@ -293,7 +294,7 @@ export class Vector3 implements Vector {
 	toArray( array: ArrayLike<number>, offset?: number ): ArrayLike<number>;
 
 	fromBufferAttribute(
-		attribute: BufferAttribute,
+		attribute: BufferAttribute | InterleavedBufferAttribute,
 		index: number
 	): this;
 


### PR DESCRIPTION
Hello,

I believe `Vector3.fromBufferAttribute` should be able to take an `InterleavedBufferAttribute` as well as a `BufferAttribute`.

This updates the Typescript definitions.

Thanks!