### PR TITLE
TransformControls: fix snap problems on mouse down and local transform

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -283,16 +283,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 				}
 
-				if ( space === 'local' && this.mode === 'rotate' ) {
-
-					var snap = this.rotationSnap;
-
-					if ( this.axis === 'X' && snap ) this.object.rotation.x = Math.round( this.object.rotation.x / snap ) * snap;
-					if ( this.axis === 'Y' && snap ) this.object.rotation.y = Math.round( this.object.rotation.y / snap ) * snap;
-					if ( this.axis === 'Z' && snap ) this.object.rotation.z = Math.round( this.object.rotation.z / snap ) * snap;
-
-				}
-
 				this.object.updateMatrixWorld();
 				this.object.parent.updateMatrixWorld();
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -304,16 +304,6 @@ var TransformControls = function ( camera, domElement ) {
 
 				}
 
-				if ( space === 'local' && this.mode === 'rotate' ) {
-
-					var snap = this.rotationSnap;
-
-					if ( this.axis === 'X' && snap ) this.object.rotation.x = Math.round( this.object.rotation.x / snap ) * snap;
-					if ( this.axis === 'Y' && snap ) this.object.rotation.y = Math.round( this.object.rotation.y / snap ) * snap;
-					if ( this.axis === 'Z' && snap ) this.object.rotation.z = Math.round( this.object.rotation.z / snap ) * snap;
-
-				}
-
 				this.object.updateMatrixWorld();
 				this.object.parent.updateMatrixWorld();
 


### PR DESCRIPTION
When snap is enabled in local transform, the object initial rotation is snap on mouse down.
I think this behaviour is not what is expected

![ezgif com-crop](https://user-images.githubusercontent.com/19568990/91994034-6662f680-ed36-11ea-9eea-bd77c7e8bf65.gif)
