### PR TITLE
Line2: Pass geometry and material into super constructor

### DIFF
--- a/examples/js/lines/Line2.js
+++ b/examples/js/lines/Line2.js
@@ -2,12 +2,12 @@ console.warn( "THREE.Line2: As part of the transition to ES6 Modules, the files 
 
 THREE.Line2 = function ( geometry, material ) {
 
+	if ( geometry === undefined ) geometry = new THREE.LineGeometry();
+	if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
+
 	THREE.LineSegments2.call( this, geometry, material );
 
 	this.type = 'Line2';
-
-	this.geometry = geometry !== undefined ? geometry : new THREE.LineGeometry();
-	this.material = material !== undefined ? material : new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
 
 };
 

--- a/examples/js/lines/Line2.js
+++ b/examples/js/lines/Line2.js
@@ -2,7 +2,7 @@ console.warn( "THREE.Line2: As part of the transition to ES6 Modules, the files 
 
 THREE.Line2 = function ( geometry, material ) {
 
-	THREE.LineSegments2.call( this );
+	THREE.LineSegments2.call( this, geometry, material );
 
 	this.type = 'Line2';
 

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -2,7 +2,7 @@ console.warn( "THREE.LineSegments2: As part of the transition to ES6 Modules, th
 
 THREE.LineSegments2 = function ( geometry, material ) {
 
-	THREE.Mesh.call( this );
+	THREE.Mesh.call( this, geometry, material );
 
 	this.type = 'LineSegments2';
 

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -2,12 +2,12 @@ console.warn( "THREE.LineSegments2: As part of the transition to ES6 Modules, th
 
 THREE.LineSegments2 = function ( geometry, material ) {
 
+	if ( geometry === undefined ) geometry = new THREE.LineSegmentsGeometry();
+	if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
+
 	THREE.Mesh.call( this, geometry, material );
 
 	this.type = 'LineSegments2';
-
-	this.geometry = geometry !== undefined ? geometry : new THREE.LineSegmentsGeometry();
-	this.material = material !== undefined ? material : new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
 
 };
 

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -5,12 +5,12 @@ import { LineMaterial } from "../lines/LineMaterial.js";
 
 var Line2 = function ( geometry, material ) {
 
+	if ( geometry === undefined ) geometry = new LineGeometry();
+	if ( material === undefined ) material = new LineMaterial( { color: Math.random() * 0xffffff } );
+
 	LineSegments2.call( this, geometry, material );
 
 	this.type = 'Line2';
-
-	this.geometry = geometry !== undefined ? geometry : new LineGeometry();
-	this.material = material !== undefined ? material : new LineMaterial( { color: Math.random() * 0xffffff } );
 
 };
 

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -5,7 +5,7 @@ import { LineMaterial } from "../lines/LineMaterial.js";
 
 var Line2 = function ( geometry, material ) {
 
-	LineSegments2.call( this );
+	LineSegments2.call( this, geometry, material );
 
 	this.type = 'Line2';
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -13,7 +13,7 @@ import { LineMaterial } from "../lines/LineMaterial.js";
 
 var LineSegments2 = function ( geometry, material ) {
 
-	Mesh.call( this );
+	Mesh.call( this, geometry, material );
 
 	this.type = 'LineSegments2';
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -13,12 +13,12 @@ import { LineMaterial } from "../lines/LineMaterial.js";
 
 var LineSegments2 = function ( geometry, material ) {
 
+	if ( geometry === undefined ) geometry = new LineSegmentsGeometry();
+	if ( material === undefined ) material = new LineMaterial( { color: Math.random() * 0xffffff } );
+
 	Mesh.call( this, geometry, material );
 
 	this.type = 'LineSegments2';
-
-	this.geometry = geometry !== undefined ? geometry : new LineSegmentsGeometry();
-	this.material = material !== undefined ? material : new LineMaterial( { color: Math.random() * 0xffffff } );
 
 };
 


### PR DESCRIPTION
Performance optimization to avoid constructing an extra mesh and material in the super class if geometry and material are passed in.