### PR TITLE
TS: Improve EventDispatcher declaration

### DIFF
--- a/src/core/EventDispatcher.d.ts
+++ b/src/core/EventDispatcher.d.ts
@@ -7,12 +7,14 @@ export interface Event {
 	[attachment: string]: any;
 }
 
+type Listener<E, T, U> = ( event: E & { type: T } & { target: U } ) => void;
+
 /**
  * JavaScript events for custom objects
  *
  * @source src/core/EventDispatcher.js
  */
-export class EventDispatcher {
+export class EventDispatcher<E extends Event = Event> {
 
 	/**
 	 * Creates eventDispatcher object. It needs to be call with '.call' to add the functionality to an object.
@@ -24,26 +26,26 @@ export class EventDispatcher {
 	 * @param type The type of event to listen to.
 	 * @param listener The function that gets called when the event is fired.
 	 */
-	addEventListener( type: string, listener: ( event: Event ) => void ): void;
+	addEventListener<T extends E["type"]>( type: T, listener: Listener<E, T, this> ): void;
 
 	/**
 	 * Checks if listener is added to an event type.
 	 * @param type The type of event to listen to.
 	 * @param listener The function that gets called when the event is fired.
 	 */
-	hasEventListener( type: string, listener: ( event: Event ) => void ): boolean;
+	hasEventListener<T extends E["type"]>( type: T, listener: Listener<E, T, this> ): boolean;
 
 	/**
 	 * Removes a listener from an event type.
 	 * @param type The type of the listener that gets removed.
 	 * @param listener The listener function that gets removed.
 	 */
-	removeEventListener( type: string, listener: ( event: Event ) => void ): void;
+	removeEventListener<T extends E["type"]>( type: T, listener: Listener<E, T, this> ): void;
 
 	/**
 	 * Fire an event type.
 	 * @param type The type of event that gets fired.
 	 */
-	dispatchEvent( event: { type: string; [attachment: string]: any } ): void;
+	dispatchEvent( event: E ): void;
 
 }

--- a/src/core/EventDispatcher.d.ts
+++ b/src/core/EventDispatcher.d.ts
@@ -14,7 +14,7 @@ type Listener<E, T, U> = ( event: E & { type: T } & { target: U } ) => void;
  *
  * @source src/core/EventDispatcher.js
  */
-export class EventDispatcher<E extends Event = Event> {
+export class EventDispatcher<E extends {type: string} = Event> {
 
 	/**
 	 * Creates eventDispatcher object. It needs to be call with '.call' to add the functionality to an object.


### PR DESCRIPTION
Hi.
I propose these changes to resolve some problems in EventDispatcher declaration file.

1. Collect type of event.target
Now, event.target is defined as any or undefined in listener args.
But, in js implementation, event.target must be EventDispatcher itself.
So, it has to be defined as this.

2. Enable to restrict method's args by type
Current declaration allows code below.
``` ts
class MyEventDispatcher extends EventDispatcher {
  someFunction(){
    this.dispatch({event: "onSomeEvent", attachment: 10});
  }
}

// somewhere
myEventDispatcher.addEventListener("onSomeEvent", e => console.log(e.attachmant))
// expected 10 but actually undefined because of typo
```
So I enable to restrict args like this.
``` ts
type Event = {type: "onSomeEvent", attachment: number} | {type: "onSomeEvent2", attachment2: string};
class MyEventDispatcher extends EventDispatcher<Event> {
  someFunction(){
    this.dispatch({event: "onSomeEvent", attachment: 10});
  }
}

// somewhere
myEventDispatcher.addEventListener("onSomeEvent", e => console.log(e.attachment))
// Auto-completion also works well.

// myEventDispatcher.addEventListener("onSomeEvent2", e => console.log(e.attachment))
// Error: Property 'attachment' does not exist on ...
```
