### PR TITLE
WebGPURenderer: Initialize WebGPU attribute buffer version as geometry attribute version

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -65,7 +65,7 @@ class WebGPUAttributes {
 		buffer.unmap();
 
 		return {
-			version: 0,
+			version: attribute.version,
 			buffer: buffer
 		};
 


### PR DESCRIPTION
This PR lets `WebGPUAttributes` initialize WebGPU attribute buffer version as geometry attribute version, as [`WebGLAttributes` does](https://github.com/mrdoob/three.js/blob/r120/src/renderers/webgl/WebGLAttributes.js#L59).

Otherwise, if geometry attribute version is already 1 or greater when WebGPU attribute buffer is created, `WebGPUAttributes` unexpectedly and unneccesarily updates buffer data next animation frame.