### PR TITLE
WebGPURenderer: Detect needsBindGroupRefresh more properly

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -115,11 +115,13 @@ class WebGPUBindings {
 				const material = object.material;
 				const texture = material[ binding.name ];
 
-				needsBindGroupRefresh = this.textures.updateSampler( texture );
+				this.textures.updateSampler( texture );
+				const samplerGPU = this.textures.getSampler( texture );
 
-				if ( needsBindGroupRefresh === true ) {
+				if ( binding.samplerGPU !== samplerGPU ) {
 
-					binding.samplerGPU = this.textures.getSampler( texture );
+					binding.samplerGPU = samplerGPU;
+					needsBindGroupRefresh = true;
 
 				}
 
@@ -128,11 +130,13 @@ class WebGPUBindings {
 				const material = object.material;
 				const texture = material[ binding.name ];
 
-				needsBindGroupRefresh = this.textures.updateTexture( texture );
+				this.textures.updateTexture( texture );
+				const textureGPU = this.textures.getTextureGPU( texture );
 
-				if ( needsBindGroupRefresh === true ) {
+				if ( binding.textureGPU !== textureGPU ) {
 
-					binding.textureGPU = this.textures.getTextureGPU( texture );
+					binding.textureGPU = textureGPU;
+					needsBindGroupRefresh = true;
 
 				}
 


### PR DESCRIPTION
This PR lets `WebGPURenderer` detect `needsBindGroupRefresh` more properly.

**Problem this PR fixes**

Renderer seems to have overlooked a case where texture is shared in multiple materials. Currently it determines whether bind group refresh is necessary or not just with comparing texture version and GPU texture version. But it doesn't work correctly if texture is shared in multiple materials. The second or later materials can't detect `needsBindGroupRefresh` because when they check the GPU texture version it has been already updated by the first material.

**Solution**

An easy solution would be comparing bind group's GPU texture with the one in texture property managed by `WebGPUTextures`. Refer to the code for detail.

Without this change. (An example many materials use the same texture.)

![image](https://user-images.githubusercontent.com/7637832/92313948-53466580-ef86-11ea-8628-353b928d2d28.png)

With this change.

![image](https://user-images.githubusercontent.com/7637832/92313915-fa76cd00-ef85-11ea-9307-97dcf3306019.png)
