### PR TITLE
WebGPURenderer: Single command encoder, pass encoder, and global rasterization settings for all renderable objects.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -112,8 +112,39 @@ class WebGPURenderer {
 		const opaqueObjects = this._currentRenderList.opaque;
 		const transparentObjects = this._currentRenderList.transparent;
 
-		if ( opaqueObjects.length > 0 ) this._renderObjects( opaqueObjects, camera );
-		if ( transparentObjects.length > 0 ) this._renderObjects( transparentObjects, camera );
+		const device = this._device;
+		const cmdEncoder = device.createCommandEncoder( {} );
+		const passEncoder = cmdEncoder.beginRenderPass( this._renderPassDescriptor );
+
+		// global rasterization settings for all renderable objects
+
+		const vp = this._viewport;
+
+		if ( vp !== null ) {
+
+			const width = Math.floor( vp.width * this._pixelRatio );
+			const height = Math.floor( vp.height * this._pixelRatio );
+
+			passEncoder.setViewport( vp.x, vp.y, width, height, vp.minDepth, vp.maxDepth );
+
+		}
+
+		const sc = this._scissor;
+
+		if ( sc !== null ) {
+
+			const width = Math.floor( sc.width * this._pixelRatio );
+			const height = Math.floor( sc.height * this._pixelRatio );
+
+			passEncoder.setScissorRect( sc.x, sc.y, width, height );
+
+		}
+
+		if ( opaqueObjects.length > 0 ) this._renderObjects( opaqueObjects, camera, passEncoder );
+		if ( transparentObjects.length > 0 ) this._renderObjects( transparentObjects, camera, passEncoder );
+
+		passEncoder.endPass();
+		device.defaultQueue.submit( [ cmdEncoder.finish() ] );
 
 	}
 
@@ -443,36 +474,7 @@ class WebGPURenderer {
 
 	}
 
-	_renderObjects( renderList, camera ) {
-
-		const device = this._device;
-
-		const cmdEncoder = device.createCommandEncoder( {} );
-		const passEncoder = cmdEncoder.beginRenderPass( this._renderPassDescriptor );
-
-		// global rasterization settings for all renderable objects
-
-		const vp = this._viewport;
-
-		if ( vp !== null ) {
-
-			const width = Math.floor( vp.width * this._pixelRatio );
-			const height = Math.floor( vp.height * this._pixelRatio );
-
-			passEncoder.setViewport( vp.x, vp.y, width, height, vp.minDepth, vp.maxDepth );
-
-		}
-
-		const sc = this._scissor;
-
-		if ( sc !== null ) {
-
-			const width = Math.floor( sc.width * this._pixelRatio );
-			const height = Math.floor( sc.height * this._pixelRatio );
-
-			passEncoder.setScissorRect( sc.x, sc.y, width, height );
-
-		}
+	_renderObjects( renderList, camera, passEncoder ) {
 
 		// process renderable objects
 
@@ -491,9 +493,6 @@ class WebGPURenderer {
 			this._renderObject( object, passEncoder );
 
 		}
-
-		passEncoder.endPass();
-		device.defaultQueue.submit( [ cmdEncoder.finish() ] );
 
 	}
 


### PR DESCRIPTION
Currently `WebGPURenderer` creates two command encoder, pass encoder, and global rasterization settings in a frame, one for opaque objects rendering pass and another one for transparent objects rendering pass.

I think we can use single encoders and global rasterization settings for the both.

(Even if the current implementation is intentional, we still need a change not to clear color, depth, and stencil in the second pass.)