### PR TITLE
WebGPURenderer: Initial color blending

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -250,6 +250,28 @@ class WebGPUBindings {
 
 		const cameraGroup = this.sharedUniformsGroups.get( 'cameraUniforms' );
 
+		const opacityGroup = new WebGPUUniformsGroup();
+		opacityGroup.setName( 'opacityUniforms' );
+		opacityGroup.setUniform( 'opacity', 1.0 );
+		opacityGroup.visibility = GPUShaderStage.FRAGMENT;
+		opacityGroup.setUpdateCallback( function ( array, object ) {
+
+			const material = object.material;
+			const opacity = material.transparent ? material.opacity : 1.0;
+
+			let updated = false;
+
+			if ( array[ 0 ] !== opacity ) {
+
+				array[ 0 ] = opacity;
+				updated = true;
+
+			}
+
+			return updated;
+
+		} );
+
 		// samplers
 
 		const diffuseSampler = new WebGPUSampler();
@@ -264,6 +286,7 @@ class WebGPUBindings {
 
 		bindings.push( modelGroup );
 		bindings.push( cameraGroup );
+		bindings.push( opacityGroup );
 		bindings.push( diffuseSampler );
 		bindings.push( diffuseTexture );
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
@@ -119,6 +119,20 @@ class WebGPURenderPipelines {
 
 			}
 
+			let colorBlend;
+
+			if ( material.transparent ) {
+
+				// @TODO: Should be customizable with material.blend* properties.
+
+				colorBlend = {
+					srcFactor: 'src-alpha',
+					dstFactor: 'one-minus-src-alpha',
+					operation: 'add'
+				};
+
+			}
+
 			// pipeline
 
 			const primitiveTopology = this._getPrimitiveTopology( object );
@@ -130,7 +144,10 @@ class WebGPURenderPipelines {
 				fragmentStage: moduleFragment,
 				primitiveTopology: primitiveTopology,
 				rasterizationState: rasterizationState,
-				colorStates: [ { format: GPUTextureFormat.BRGA8Unorm } ],
+				colorStates: [ {
+					format: GPUTextureFormat.BRGA8Unorm,
+					colorBlend: colorBlend
+				} ],
 				depthStencilState: {
 					depthWriteEnabled: material.depthWrite,
 					depthCompare: GPUCompareFunction.Less,
@@ -274,14 +291,19 @@ const ShaderLib = {
 			gl_Position = cameraUniforms.projectionMatrix * modelUniforms.modelViewMatrix * vec4( position, 1.0 );
 		}`,
 		fragmentShader: `#version 450
-		layout(set = 0, binding = 2) uniform sampler mySampler;
-		layout(set = 0, binding = 3) uniform texture2D myTexture;
+		layout(set = 0, binding = 2) uniform OpacityUniforms {
+			float opacity;
+		} opacityUniforms;
+
+		layout(set = 0, binding = 3) uniform sampler mySampler;
+		layout(set = 0, binding = 4) uniform texture2D myTexture;
 
 		layout(location = 0) in vec2 vUv;
 		layout(location = 0) out vec4 outColor;
 
 		void main() {
 			outColor = texture( sampler2D( myTexture, mySampler ), vUv );
+			outColor.a *= opacityUniforms.opacity;
 		}`
 	},
 	points_basic: {


### PR DESCRIPTION
This PR adds an initial color blending support to `WebGPURenderer`.

Screenshot of opaque and transparent objects in a scene (with #20272 and #20274).

![image](https://user-images.githubusercontent.com/7637832/92320476-9fb99180-efd6-11ea-9087-39733fce64e0.png)

You might like to wait for basic node based material system, but I think basic color blending logic won't change so much (other than shader code) even with node based material system. And the change is just about +50 lines and the code isn't so complex. I think it would be good for us that we can start color blending test with this small change.

What do you think?