### PR TITLE
Examples: Properly initialize helpers in envmaps_parallax example

### DIFF
--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -367,7 +367,7 @@
 				blueRectLight.lookAt( 0, 5, 0 );
 				scene.add( blueRectLight );
 
-				var blueRectLightHelper = new RectAreaLightHelper( blueRectLight, 0xffffff );
+				var blueRectLightHelper = new RectAreaLightHelper( blueRectLight );
 				blueRectLight.add( blueRectLightHelper );
 
 				var redRectLight = new THREE.RectAreaLight( 0x9aaeff, intensity, width, height );
@@ -375,7 +375,7 @@
 				redRectLight.lookAt( 0, 5, 0 );
 				scene.add( redRectLight );
 
-				var redRectLightHelper = new RectAreaLightHelper( redRectLight, 0xffffff );
+				var redRectLightHelper = new RectAreaLightHelper( redRectLight );
 				redRectLight.add( redRectLightHelper );
 
 				render();


### PR DESCRIPTION
A light helper will adapt to the light color if helper's color is not hardwired.

Now the blue area light has a blue helper.