### PR TITLE
WebGPURenderer: Initial Antialiasing

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
@@ -3,11 +3,12 @@ import { FrontSide, BackSide, DoubleSide } from '../../../../build/three.module.
 
 class WebGPURenderPipelines {
 
-	constructor( device, glslang, bindings ) {
+	constructor( device, glslang, bindings, sampleCount ) {
 
 		this.device = device;
 		this.glslang = glslang;
 		this.bindings = bindings;
+		this.sampleCount = sampleCount;
 
 		this.pipelines = new WeakMap();
 		this.shaderAttributes = new WeakMap();
@@ -161,7 +162,8 @@ class WebGPURenderPipelines {
 				vertexState: {
 					indexFormat: indexFormat,
 					vertexBuffers: vertexBuffers
-				}
+				},
+				sampleCount: this.sampleCount
 			} );
 
 			this.pipelines.set( object, pipeline );


### PR DESCRIPTION
This PR adds initial antialiasing support to `WebGPURenderer`.

**API**

`WebGPURenderer` constructor takes `antialias` parameter. Default is `false`.

`const new renderer = WebGPURenderer( { antialias: true } );`

**Screenshot**

Left with antialiasing and right without antialiasing.

![image](https://user-images.githubusercontent.com/7637832/92352364-ca692000-f092-11ea-9996-5c128ddffb8e.png)

**Changes**

In `WebGL`, `HTMLCanvasElement.getContext()` takes `antialias` parameter and if it's `true` hardware antialiasing is enabled.

In `WebGPU`, `HTMLCanvasElement.getContext()` doesn't take `antialias` and we seem to need to manually setup MSAA (at least now).