### PR TITLE
Make TypeScript type for ArrowHelper's color parameter more permissive

### DIFF
--- a/src/helpers/ArrowHelper.d.ts
+++ b/src/helpers/ArrowHelper.d.ts
@@ -20,7 +20,7 @@ export class ArrowHelper extends Object3D {
 		dir: Vector3,
 		origin?: Vector3,
 		length?: number,
-		color?: number,
+		color?: Color | string | number,
 		headLength?: number,
 		headWidth?: number
 	);


### PR DESCRIPTION
The TypeScript definition for `ArrowHelper` only allow a number to be passed as the `color` parameter. This value is being passed directly to the `Material`'s constructor, so there's no reason why it can't also be a string or `Color` object. This PR relaxes the definition to allow for this.