### PR TITLE
Docs: Add instanceMatrix to shader documentation

### DIFF
--- a/docs/api/en/renderers/webgl/WebGLProgram.html
+++ b/docs/api/en/renderers/webgl/WebGLProgram.html
@@ -92,6 +92,16 @@
 			attribute vec4 skinWeight;
 		#endif
 		</code>
+		<code>
+		#ifdef USE_INSTANCING
+			// Note that modelViewMatrix is not set when rendering an instanced model,
+			// but can be calculated from viewMatrix * modelMatrix.
+			//
+			// Basic Usage:
+			//   gl_Position = projectionMatrix * viewMatrix * modelMatrix * instanceMatrix * vec4(position, 1.0);
+			attribute mat4 instanceMatrix;
+		#endif
+		</code>
 		</div>
 
 		<h3>Fragment shader:</h3>


### PR DESCRIPTION
This change documents some speed bumps I ran into while trying to write a shader for instanced objects.
There are enough levels of indirection in reading the ShaderChunks source that figuring out how instanceMatrix is used was too difficult for me.  
Thankfully someone wrote [a medium article](https://medium.com/@pailhead011/instancing-with-three-js-36b4b62bc127) on the topic, but it took a lot of searching after bouncing off the official documentation.

As someone who has not done much work in shaders before, an explanation of how instanceMatrix is typically consumed was also helpful, so I included that as well.