### PR TITLE
TS: Update LineSegments

### DIFF
--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -19,14 +19,13 @@ export class LineSegments <
 
 	constructor(
 		geometry?: TGeometry,
-		material?: TMaterial,
-		mode?: number
+		material?: TMaterial
 	);
 
 	/**
 	 * @default 'LineSegments'
 	 */
-	type: 'LineSegments' | string;
+	type: 'LineSegments';
 	readonly isLineSegments: true;
 
 }

--- a/src/objects/LineSegments.d.ts
+++ b/src/objects/LineSegments.d.ts
@@ -25,7 +25,7 @@ export class LineSegments <
 	/**
 	 * @default 'LineSegments'
 	 */
-	type: 'LineSegments';
+	type: 'LineSegments' | string;
 	readonly isLineSegments: true;
 
 }


### PR DESCRIPTION
remove 3rd param, `mode` is redundant.
prop `type` is always "LineSegments", so use literal type is sufficient.