### PR TITLE
Propagate AudioContext.decodeAudioData's error to AudioLoader.load

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -33,6 +33,10 @@ AudioLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 					onLoad( audioBuffer );
 
+				}, function ( error ) {
+
+					throw error;
+
 				} );
 
 			} catch ( e ) {


### PR DESCRIPTION
In some cases AudioContext.decodeAudioData can fail. For example, Safari doesn't support .ogg files, and decoding one triggers AudioContext.decodeAudioData's error handler. Instead of failing silently, it can be helpful to propagate this error to AudioLoader.load

reference: https://www.w3.org/TR/webaudio/#callback-decodeerrorcallback-parameters