### PR TITLE
WebGLProgram: Allow for unrolling loops using define values

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -247,7 +247,7 @@ function loopReplacer( match, start, end, snippet ) {
 	let string = '';
 	if ( isNaN( start ) ) {
 
-		start = parsunrollDefines[ start ];
+		start = unrollDefines[ start ];
 
 	}
 


### PR DESCRIPTION
Unrolling loops can give a pretty good performance boost on some platforms but currently it only works if you use an explicit termination value. There are some cases where you'd like to dynamically unroll a loop based on a define value such as when modifying a blur radius, updating the number of raymarch steps, etc so this should enable more flexible and performant custom shaders.

This is sort of already done but only for internal light lengths with the [replaceLightNums function](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLProgram.js#L174-L186). Perhaps this functionality can replace that function in the future?

The following will now be functional:

```glsl
#pragma unroll_loop_start
for ( int i = 0; i < MY_DEFINE; i ++ ) {

    // ...

}
#pragma unroll_loop_end
```