### PR TITLE
WebGPURenderer: ShaderMaterial support prototype

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
@@ -19,7 +19,7 @@ class WebGPURenderPipelines {
 		this.sampleCount = sampleCount;
 
 		this.pipelines = new WeakMap();
-		this.shaderAttributes = new WeakMap();
+		this.shaderInfos = new WeakMap();
 		this.shaderModules = {
 			vertex: new WeakMap(),
 			fragment: new WeakMap()
@@ -52,6 +52,13 @@ class WebGPURenderPipelines {
 			} else if ( material.isLineBasicMaterial ) {
 
 				shader = ShaderLib.line_basic;
+
+			} else if ( material.isShaderMaterial ) {
+
+				shader = {
+					vertexShader: ShaderLib.shader.vertexShader + material.vertexShader,
+					fragmentShader: ShaderLib.shader.fragmentShader + material.fragmentShader
+				};
 
 			} else {
 
@@ -93,33 +100,25 @@ class WebGPURenderPipelines {
 
 			}
 
+			// parse attributes and uniforms in shader codes
+
+			const shaderAttributes = parseAttributes( shader.vertexShader );
+			const shaderUniforms = parseUniforms( shader.vertexShader, shader.fragmentShader );
+
 			// layout
 
-			const bindLayout = this.bindings.get( object ).layout;
+			const bindLayout = this.bindings.get( object, shaderUniforms ).layout;
 			const layout = device.createPipelineLayout( { bindGroupLayouts: [ bindLayout ] } );
 
 			// vertex buffers
 
 			const vertexBuffers = [];
-			const shaderAttributes = [];
 
-			// find "layout (location = num) in type name" in vertex shader
-
-			const regex = /^\s*layout\s*\(\s*location\s*=\s*(?<location>[0-9]+)\s*\)\s*in\s+(?<type>\w+)\s+(?<name>\w+)\s*;/gmi;
-
-			let shaderAttribute = null;
-
-			while ( shaderAttribute = regex.exec( shader.vertexShader ) ) {
-
-				const shaderLocation = parseInt( shaderAttribute.groups.location );
-				const arrayStride = this._getArrayStride( shaderAttribute.groups.type );
-				const vertexFormat = this._getVertexFormat( shaderAttribute.groups.type );
-
-				shaderAttributes.push( { name: shaderAttribute.groups.name, slot: shaderLocation } );
+			for ( const attribute of shaderAttributes ) {
 
 				vertexBuffers.push( {
-					arrayStride: arrayStride,
-					attributes: [ { shaderLocation: shaderLocation, offset: 0, format: vertexFormat } ]
+					arrayStride: attribute.arrayStride,
+					attributes: [ { shaderLocation: attribute.slot, offset: 0, format: attribute.format } ]
 				} );
 
 			}
@@ -200,8 +199,10 @@ class WebGPURenderPipelines {
 			} );
 
 			this.pipelines.set( object, pipeline );
-			this.shaderAttributes.set( pipeline, shaderAttributes );
-
+			this.shaderInfos.set( pipeline, {
+				attributes: shaderAttributes,
+				uniforms: shaderUniforms
+			} );
 
 		}
 
@@ -211,41 +212,24 @@ class WebGPURenderPipelines {
 
 	getShaderAttributes( pipeline ) {
 
-		return this.shaderAttributes.get( pipeline );
+		return this.shaderInfos.get( pipeline ).attributes;
+
+	}
+
+	getShaderUniforms( pipeline ) {
+
+		return this.shaderInfos.get( pipeline ).uniforms;
 
 	}
 
 	dispose() {
 
 		this.pipelines = new WeakMap();
-		this.shaderAttributes = new WeakMap();
+		this.shaderInfos = new WeakMap();
 		this.shaderModules = {
 			vertex: new WeakMap(),
 			fragment: new WeakMap()
 		};
-
-	}
-
-	_getArrayStride( type ) {
-
-		// @TODO: This code is GLSL specific. We need to update when we switch to WGSL.
-
-		if ( type === 'float' ) return 4;
-		if ( type === 'vec2' ) return 8;
-		if ( type === 'vec3' ) return 12;
-		if ( type === 'vec4' ) return 16;
-
-		if ( type === 'int' ) return 4;
-		if ( type === 'ivec2' ) return 8;
-		if ( type === 'ivec3' ) return 12;
-		if ( type === 'ivec4' ) return 16;
-
-		if ( type === 'uint' ) return 4;
-		if ( type === 'uvec2' ) return 8;
-		if ( type === 'uvec3' ) return 12;
-		if ( type === 'uvec4' ) return 16;
-
-		console.error( 'THREE.WebGPURenderer: Shader variable type not supported yet.', type );
 
 	}
 
@@ -684,30 +668,9 @@ class WebGPURenderPipelines {
 
 	}
 
-	_getVertexFormat( type ) {
-
-		// @TODO: This code is GLSL specific. We need to update when we switch to WGSL.
-
-		if ( type === 'float' ) return GPUVertexFormat.Float;
-		if ( type === 'vec2' ) return GPUVertexFormat.Float2;
-		if ( type === 'vec3' ) return GPUVertexFormat.Float3;
-		if ( type === 'vec4' ) return GPUVertexFormat.Float4;
-
-		if ( type === 'int' ) return GPUVertexFormat.Int;
-		if ( type === 'ivec2' ) return GPUVertexFormat.Int2;
-		if ( type === 'ivec3' ) return GPUVertexFormat.Int3;
-		if ( type === 'ivec4' ) return GPUVertexFormat.Int4;
-
-		if ( type === 'uint' ) return GPUVertexFormat.UInt;
-		if ( type === 'uvec2' ) return GPUVertexFormat.UInt2;
-		if ( type === 'uvec3' ) return GPUVertexFormat.UInt3;
-		if ( type === 'uvec4' ) return GPUVertexFormat.UInt4;
-
-		console.error( 'THREE.WebGPURenderer: Shader variable type not supported yet.', type );
-
-	}
-
 }
+
+// GLSL specific codes. We may switch to WGSL at some point.
 
 const ShaderLib = {
 	mesh_basic: {
@@ -799,7 +762,217 @@ const ShaderLib = {
 		void main() {
 			outColor = vec4( 1.0, 0.0, 0.0, 1.0 );
 		}`
+	},
+	// Shader headers for ShaderMaterial
+	shader: {
+		vertexShader: `#version 450
+
+		layout(location = 0) in vec3 position;
+		layout(location = 1) in vec2 uv;
+
+		layout(location = 0) out vec2 vUv;
+
+		layout(set = 0, binding = 0) uniform ModelUniforms {
+			mat4 modelMatrix;
+			mat4 modelViewMatrix;
+		} modelUniforms;
+
+		layout(set = 0, binding = 1) uniform CameraUniforms {
+			mat4 projectionMatrix;
+			mat4 viewMatrix;
+		} cameraUniforms;
+		`,
+		fragmentShader: `#version 450
+
+		layout(location = 0) in vec2 vUv;
+		layout(location = 0) out vec4 outColor;
+		`
 	}
 };
+
+function parseAttributes( vertexShader ) {
+
+	// Find "layout (location = num) in type name" in vertex shader
+	const regex = /^\s*layout\s*\(\s*location\s*=\s*(?<location>[0-9]+)\s*\)\s*in\s+(?<type>\w+)\s+(?<name>\w+)\s*;/gmi;
+	let shaderAttribute = null;
+
+	const attributes = [];
+
+	while ( shaderAttribute = regex.exec( vertexShader ) ) {
+
+		const shaderLocation = parseInt( shaderAttribute.groups.location );
+		const arrayStride = getGLSLArrayStride( shaderAttribute.groups.type );
+		const vertexFormat = getGLSLVertexFormat( shaderAttribute.groups.type );
+
+		attributes.push( {
+			name: shaderAttribute.groups.name,
+			arrayStride: arrayStride,
+			slot: shaderLocation,
+			format: vertexFormat
+		} );
+
+	}
+
+	return attributes.sort( function ( a, b ) {
+
+		return a.shaderLocation - b.shaderLocation;
+
+	} );
+
+}
+
+function parseUniforms( vertexShader, fragmentShader ) {
+
+	const uniforms = [
+		parseUniformsInternal( vertexShader, true ),
+		parseUniformsInternal( fragmentShader, false )
+	].flat().sort( function ( a, b ) {
+
+		return a.binding - b.binding;
+
+	} );
+
+	// Find uniforms existing in both vertex and fragment
+	let writeIndex = 0;
+	for ( let readIndex = 0; readIndex < uniforms.length; readIndex ++ ) {
+
+		const uniform1 = uniforms[ readIndex ];
+		const uniform2 = uniforms[ readIndex + 1 ];
+
+		if ( uniform2 && uniform1.binding === uniform2.binding ) {
+
+			uniform1.visibility = 'vertex|fragment';
+			readIndex ++;
+
+		}
+
+		uniforms[ writeIndex ++ ] = uniform1;
+
+	}
+	uniforms.length = writeIndex;
+
+	return uniforms;
+
+}
+
+function parseUniformsInternal( shader, isVertexShader ) {
+
+	// Find "layout (set = setNum, binding = bindingNum) uniform type name;"
+	const regex = /^\s*layout\s*\(\s*set\s*=\s*(?<set>[0-9]+)\s*,\s*binding\s*=\s*(?<binding>[0-9]+)\s*\)\s*uniform\s+(?<type>\w+)\s+(?<name>\w+)\s*;/gmi;
+	// Find "layout (set = setNum, binding = bindingNum) uniform type {
+	//   entries
+	// };
+	const blockRegex = /^\s*layout\s*\(\s*set\s*=\s*(?<set>[0-9]+)\s*,\s*binding\s*=\s*(?<binding>[0-9]+)\s*\)\s*uniform\s+(?<type>\w+)\s*\{(?<entries>[^}]*)\}\s*(?<name>\w+)\s*;/gmi;
+	// Find "type name;"
+	const entryRegex = /^\s*(?<type>\w+)\s+(?<name>\w+)\s*;/gmi;
+
+	const visibility = isVertexShader ? 'vertex' : 'fragment';
+	const uniforms = [];
+	let shaderUniform = null;
+
+	while ( shaderUniform = regex.exec( shader ) ) {
+
+		const binding = parseInt( shaderUniform.groups.binding );
+		const type = shaderUniform.groups.type;
+		const name = shaderUniform.groups.name;
+
+		let groupType;
+
+		switch ( type ) {
+			case 'sampler':
+				groupType = 'sampler';
+				break;
+			case 'texture2D':
+				groupType = 'sampled-texture';
+				break;
+			default:
+				console.error( 'WebGPURenderer: Unknown uniform type in shader ' + type );
+				break;
+		}
+
+		uniforms.push( {
+			binding: binding,
+			type: type,
+			name: name,
+			groupType: groupType,
+			visibility: visibility
+		} );
+
+	}
+
+	while ( shaderUniform = blockRegex.exec( shader ) ) {
+
+		const binding = parseInt( shaderUniform.groups.binding );
+		const type = shaderUniform.groups.type;
+		const name = shaderUniform.groups.name;
+		const shaderEntries = shaderUniform.groups.entries;
+
+		const entries = [];
+
+		while ( shaderUniform = entryRegex.exec( shaderEntries ) ) {
+
+			entries.push( {
+				type: shaderUniform.groups.type,
+				name: shaderUniform.groups.name
+			} );
+
+		}
+
+		uniforms.push( {
+			binding: binding,
+			type: type,
+			name: name,
+			entries: entries,
+			groupType: 'uniform-buffer',
+			visibility: visibility
+		} );
+
+	}
+
+	return uniforms;
+
+}
+
+function getGLSLArrayStride( type ) {
+
+	if ( type === 'float' ) return 4;
+	if ( type === 'vec2' ) return 8;
+	if ( type === 'vec3' ) return 12;
+	if ( type === 'vec4' ) return 16;
+
+	if ( type === 'int' ) return 4;
+	if ( type === 'ivec2' ) return 8;
+	if ( type === 'ivec3' ) return 12;
+	if ( type === 'ivec4' ) return 16;
+
+	if ( type === 'uint' ) return 4;
+	if ( type === 'uvec2' ) return 8;
+	if ( type === 'uvec3' ) return 12;
+	if ( type === 'uvec4' ) return 16;
+
+	console.error( 'THREE.WebGPURenderer: no this shader variable type support yet.', type );
+
+}
+
+function getGLSLVertexFormat( type ) {
+
+	if ( type === 'float' ) return GPUVertexFormat.Float;
+	if ( type === 'vec2' ) return GPUVertexFormat.Float2;
+	if ( type === 'vec3' ) return GPUVertexFormat.Float3;
+	if ( type === 'vec4' ) return GPUVertexFormat.Float4;
+
+	if ( type === 'int' ) return GPUVertexFormat.Int;
+	if ( type === 'ivec2' ) return GPUVertexFormat.Int2;
+	if ( type === 'ivec3' ) return GPUVertexFormat.Int3;
+	if ( type === 'ivec4' ) return GPUVertexFormat.Int4;
+
+	if ( type === 'uint' ) return GPUVertexFormat.UInt;
+	if ( type === 'uvec2' ) return GPUVertexFormat.UInt2;
+	if ( type === 'uvec3' ) return GPUVertexFormat.UInt3;
+	if ( type === 'uvec4' ) return GPUVertexFormat.UInt4;
+
+	console.error( 'THREE.WebGPURenderer: no this shader variable type support yet.', type );
+
+}
 
 export default WebGPURenderPipelines;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -675,8 +675,7 @@ class WebGPURenderer {
 
 						passEncoder.setViewport( vp.x, vp.y, vp.width, vp.height, minDepth, maxDepth );
 
-						this._bindings.update( object, camera2 );
-						this._renderObject( object, passEncoder );
+						this._renderObject( object, camera2, passEncoder );
 
 					}
 
@@ -684,8 +683,7 @@ class WebGPURenderer {
 
 			} else {
 
-				this._bindings.update( object, camera );
-				this._renderObject( object, passEncoder );
+				this._renderObject( object, camera, passEncoder );
 
 			}
 
@@ -693,7 +691,7 @@ class WebGPURenderer {
 
 	}
 
-	_renderObject( object, passEncoder ) {
+	_renderObject( object, camera, passEncoder ) {
 
 		const info = this._info;
 
@@ -704,6 +702,7 @@ class WebGPURenderer {
 
 		// bind group
 
+		this._bindings.update( object, camera );
 		const bindGroup = this._bindings.get( object ).group;
 		passEncoder.setBindGroup( 0, bindGroup );
 

--- a/examples/jsm/renderers/webgpu/WebGPUUniformsGroup.js
+++ b/examples/jsm/renderers/webgpu/WebGPUUniformsGroup.js
@@ -133,6 +133,20 @@ class WebGPUUniformsGroup extends WebGPUBinding {
 
 	}
 
+	updateByType( uniform, offset ) {
+
+		if ( typeof uniform === 'number' ) return this.updateNumber( uniform, offset );
+		if ( uniform.isVector2 ) return this.updateVector2( uniform, offset );
+		if ( uniform.isVector3 ) return this.updateVector3( uniform, offset );
+		if ( uniform.isColor ) return this.updateColor( uniform, offset );
+		if ( uniform.isVector4 ) return this.updateVector4( uniform, offset );
+		if ( uniform.isMatrix3 ) return this.updateMatrix3( uniform, offset );
+		if ( uniform.isMatrix4 ) return this.updateMatrix4( uniform, offset );
+
+		console.error( 'THREE.UniformGroup: Unsupported uniform value type.', uniform );
+
+	}
+
 	updateNumber( v, offset ) {
 
 		let updated = false;


### PR DESCRIPTION
You might like to wait for node base material for WebGPU and/or WGSL, but let me share my prototype work because I want to hear your folks opinion and feedback.

This draft PR adds `ShaderMaterial` support to `WebGPURenderer`.

**Background**

We would like the usage of node based materials right from the beginning https://github.com/mrdoob/three.js/pull/20254#issue-478104078. I agree with that, and we maybe shouldn't add new material support now.

But some basic features 3D graphics engine should have require some freedom of writing special shaders for them, for example [textured background](https://github.com/mrdoob/three.js/blob/r120/src/renderers/webgl/WebGLBackground.js#L67-L76) and post-processing.

We can't start to work on them until node based material system for WebGPU lands. But it may be a bit of unclear when it does. If we support `ShaderMaterial` we can move such basic features support forward.

And even if node based material lands I think there will still be some demands that user wants to directly write their shader codes. `ShaderMaterial` support can satisfy it.

Plus, currently node based material is compiled and it is handled as `ShaderMaterial` in (webgl) renderer. WebGL/WebGPU needs raw shader code so this design may not be so bad. If we do the same approach even in WebGPU renderer, we need `ShaderMaterial` support.

So I think adding `ShaderMaterial` support into WebGPU renderer now would be ok to me. What do you think?

**API**

We may need to brush up when node based material system for WebGPU lands.

Update: I noticed that @Mugen87 made UniformBufferObject support PR #15562 before (it hasn't been merged yet). Using it may be more right way?

```javascript
// Based on existing ShaderMaterial API
const texture = new TextureLoader.load( url );
const material = new ShaderMaterial( {
  // No need of binding number in uniforms because
  // renderer parses shader code and analyzes uniforms
  uniforms: {
    // uniform.value takes an array for Uniform block
    timeUniforms: {
      value: [
        0
      ]
    },
    colorUniforms: {
      value: [
        new THREE.Color( 0x888888 )
      ]
    },
    mySampler: { value: texture },
    myTexture: { value: texture }
  },
  // common headers like position attribute declaration are added
  // to vertex and fragment shaders respectively in renderer.
  // Need idea: I don't really like that binding number in user shader code
  // needs to start with non-zero...
  vertexShader: `
    layout(set = 0, binding = 2) uniform TimeUniforms {
      float time;
    } timeUniforms;

    void main(){
      vUv = uv;
      float time = timeUniforms.time;
      gl_Position = cameraUniforms.projectionMatrix * modelUniforms.modelViewMatrix
        * vec4( sin( time * 0.5 + 0.5 ) * position, 1.0 );
    }
  `,
  fragmentShader: `
    layout(set = 0, binding = 2) uniform TimeUniforms {
      float time;
    } timeUniforms;

    layout(set = 0, binding = 3) uniform ColorUniforms {
      vec3 color;
    } colorUniforms;

    layout(set = 0, binding = 4) uniform sampler mySampler;
    layout(set = 0, binding = 5) uniform texture2D myTexture;

    void main() {
      float time = timeUniforms.time;
      vec4 texelColor = texture( sampler2D( myTexture, mySampler ), vUv );
      outColor = vec4( texelColor.rgb * colorUniforms.color * ( sin( time ) * 0.5 + 0.5 ), texelColor.a );
    }
  `
} );

function render() {
  // update uniform value
  material.uniforms.timeUniforms.value[0] += clock.getDelta();
  renderer.render( scene, camera );
}
```

**Sample video**

https://twitter.com/superhoge/status/1304299232182980608

**Implementation note**

I add inline.