### PR TITLE
Examples: Fix view offset in webgl_interactive_cubes_gpu.html

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -191,7 +191,7 @@
 
 				// set the view offset to represent just a single pixel under the mouse
 
-				camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x * window.devicePixelRatio | 0, mouse.y * window.devicePixelRatio | 0, 1, 1 );
+				camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, mouse.x | 0, mouse.y | 0, 1, 1 );
 
 				// render the scene
 


### PR DESCRIPTION
You can't mix CSS pixel units and device pixel units.

/ping @greggman 


Also, I would think this example should be updated to accommodate touch -- if doing so make sense...

