### PR TITLE
WebGPURenderer: Simplify BindGroupLayout creation

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -5,12 +5,13 @@ import WebGPUSampledTexture from './WebGPUSampledTexture.js';
 
 class WebGPUBindings {
 
-	constructor( device, info, properties, textures ) {
+	constructor( device, info, properties, textures, pipelines ) {
 
 		this.device = device;
 		this.info = info;
 		this.properties = properties;
 		this.textures = textures;
+		this.pipelines = pipelines;
 
 		this.uniformsData = new WeakMap();
 
@@ -28,6 +29,7 @@ class WebGPUBindings {
 
 		if ( data === undefined ) {
 
+			const pipeline = this.pipelines.get( object );
 			const material = object.material;
 			let bindings;
 
@@ -53,7 +55,7 @@ class WebGPUBindings {
 
 			// setup (static) binding layout and (dynamic) binding group
 
-			const bindLayout = this._createBindLayout( bindings );
+			const bindLayout = pipeline.getBindGroupLayout( 0 );
 			const bindGroup = this._createBindGroup( bindings, bindLayout );
 
 			data = {
@@ -161,23 +163,6 @@ class WebGPUBindings {
 
 		this.uniformsData = new WeakMap();
 		this.updateMap = new WeakMap();
-
-	}
-
-	_createBindLayout( bindings ) {
-
-		let bindingPoint = 0;
-		const entries = [];
-
-		for ( const binding of bindings ) {
-
-			entries.push( { binding: bindingPoint, visibility: binding.visibility, type: binding.type } );
-
-			bindingPoint ++;
-
-		}
-
-		return this.device.createBindGroupLayout( { entries: entries } );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
@@ -11,11 +11,10 @@ import {
 
 class WebGPURenderPipelines {
 
-	constructor( device, glslang, bindings, sampleCount ) {
+	constructor( device, glslang, sampleCount ) {
 
 		this.device = device;
 		this.glslang = glslang;
-		this.bindings = bindings;
 		this.sampleCount = sampleCount;
 
 		this.pipelines = new WeakMap();
@@ -93,11 +92,6 @@ class WebGPURenderPipelines {
 
 			}
 
-			// layout
-
-			const bindLayout = this.bindings.get( object ).layout;
-			const layout = device.createPipelineLayout( { bindGroupLayouts: [ bindLayout ] } );
-
 			// determine shader attributes
 
 			const shaderAttributes = this._parseShaderAttributes( shader.vertexShader );
@@ -163,7 +157,6 @@ class WebGPURenderPipelines {
 			const depthCompare = this._getDepthCompare( material );
 
 			pipeline = device.createRenderPipeline( {
-				layout: layout,
 				vertexStage: moduleVertex,
 				fragmentStage: moduleFragment,
 				primitiveTopology: primitiveTopology,

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -172,9 +172,9 @@ class WebGPURenderer {
 		this._attributes = new WebGPUAttributes( device );
 		this._geometries = new WebGPUGeometries( this._attributes, this._info );
 		this._textures = new WebGPUTextures( device, this._properties, this._info, compiler );
-		this._bindings = new WebGPUBindings( device, this._info, this._properties, this._textures );
 		this._objects = new WebGPUObjects( this._geometries, this._info );
-		this._renderPipelines = new WebGPURenderPipelines( device, compiler, this._bindings, parameters.sampleCount );
+		this._renderPipelines = new WebGPURenderPipelines( device, compiler, parameters.sampleCount );
+		this._bindings = new WebGPUBindings( device, this._info, this._properties, this._textures, this._renderPipelines );
 		this._renderLists = new WebGPURenderLists();
 		this._background = new WebGPUBackground( this );
 


### PR DESCRIPTION
This PR simplifies BindGroupLayout Creation.

* `GPURenderPipelineDescriptor` seems to no longer take `layout`
  * https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpipelinedescriptor
* We don't seem to no longer need to create bind group layout manually if we use `pipeline.getBindGroupLayout()`
  * https://github.com/gpuweb/gpuweb/issues/446
  * https://gpuweb.github.io/gpuweb/#pipeline-base