### PR TITLE
Fixed bug in PointerLockControls example.

### DIFF
--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -287,6 +287,8 @@
 
 				requestAnimationFrame( animate );
 
+				var time = performance.now();
+
 				if ( controls.isLocked === true ) {
 
 					raycaster.ray.origin.copy( controls.getObject().position );
@@ -296,7 +298,6 @@
 
 					var onObject = intersections.length > 0;
 
-					var time = performance.now();
 					var delta = ( time - prevTime ) / 1000;
 
 					velocity.x -= velocity.x * 10.0 * delta;
@@ -332,9 +333,9 @@
 
 					}
 
-					prevTime = time;
-
 				}
+
+				prevTime = time;
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
There was a "camera teleport" bug with example caused by `prevTime` and `time` being updated only while `controls.isLocked === true`. The bug can be reproduced by pressing and holding any of the WASD keys before clicking to lock controls.