### PR TITLE
Updated TrackballControls to run `update()` automatically.

### DIFF
--- a/examples/css3d_molecules.html
+++ b/examples/css3d_molecules.html
@@ -502,7 +502,6 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
 
 				var time = Date.now() * 0.0004;
 

--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -429,8 +429,6 @@
 
 				TWEEN.update();
 
-				controls.update();
-
 			}
 
 			function render() {

--- a/examples/css3d_sandbox.html
+++ b/examples/css3d_sandbox.html
@@ -30,7 +30,7 @@
 			var controls;
 
 			init();
-			animate();
+			render();
 
 			function init() {
 
@@ -89,6 +89,8 @@
 
 				controls = new TrackballControls( camera, renderer2.domElement );
 
+				controls.addEventListener( 'change', render );
+
 				window.addEventListener( 'resize', onWindowResize, false );
 
 			}
@@ -105,11 +107,7 @@
 
 			}
 
-			function animate() {
-
-				requestAnimationFrame( animate );
-
-				controls.update();
+			function render() {
 
 				renderer.render( scene, camera );
 				renderer2.render( scene2, camera );

--- a/examples/css3d_sprites.html
+++ b/examples/css3d_sprites.html
@@ -189,7 +189,6 @@
 				requestAnimationFrame( animate );
 
 				TWEEN.update();
-				controls.update();
 
 				var time = performance.now();
 

--- a/examples/css3d_youtube.html
+++ b/examples/css3d_youtube.html
@@ -112,7 +112,6 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -62,7 +62,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 		_touchZoomDistanceEnd = 0,
 
 		_panStart = new THREE.Vector2(),
-		_panEnd = new THREE.Vector2();
+		_panEnd = new THREE.Vector2(),
+		_animating = false;
 
 	// for reset
 
@@ -311,7 +312,41 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	};
 
+	this._startUpdate = function () {
+
+		if (!_animating) {
+
+			_animating = true;
+			this._animate();
+
+		}
+
+	}
+
+	this._stopUpdate = function () {
+
+		_animating = false;
+
+	}
+
+	this._animate = function () {
+
+		if ( _animating ) {
+
+			requestAnimationFrame( this._animate );
+			this._update();
+
+		}
+
+	}.bind(this);
+
 	this.update = function () {
+
+		console.warn( 'THREE.TrackballControls: update() function has been deprecated!' );
+
+	}
+
+	this._update = function () {
 
 		_eye.subVectors( scope.object.position, scope.target );
 
@@ -347,6 +382,10 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 				lastPosition.copy( scope.object.position );
 
+			} else {
+
+				scope._stopUpdate();
+
 			}
 
 		} else if ( scope.object.isOrthographicCamera ) {
@@ -359,6 +398,10 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 				lastPosition.copy( scope.object.position );
 				lastZoom = scope.object.zoom;
+
+			} else {
+
+				scope._stopUpdate();
 
 			}
 
@@ -560,6 +603,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		}
 
+		scope._startUpdate();
+
 	}
 
 	function onMouseUp( event ) {
@@ -608,6 +653,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		scope.dispatchEvent( startEvent );
 		scope.dispatchEvent( endEvent );
+
+		scope._startUpdate();
 
 	}
 
@@ -668,6 +715,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 				break;
 
 		}
+
+		scope._startUpdate();
 
 	}
 
@@ -738,7 +787,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.handleResize();
 
 	// force an update at start
-	this.update();
+	this._update();
 
 };
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -68,7 +68,8 @@ var TrackballControls = function ( object, domElement ) {
 		_touchZoomDistanceEnd = 0,
 
 		_panStart = new Vector2(),
-		_panEnd = new Vector2();
+		_panEnd = new Vector2(),
+		_animating = false;
 
 	// for reset
 
@@ -317,7 +318,41 @@ var TrackballControls = function ( object, domElement ) {
 
 	};
 
+	this._startUpdate = function () {
+
+		if (!_animating) {
+
+			_animating = true;
+			this._animate();
+
+		}
+
+	}
+
+	this._stopUpdate = function () {
+
+		_animating = false;
+
+	}
+
+	this._animate = function () {
+
+		if ( _animating ) {
+
+			requestAnimationFrame( this._animate );
+			this._update();
+
+		}
+
+	}.bind(this);
+
 	this.update = function () {
+
+		console.warn( 'THREE.TrackballControls: update() function has been deprecated!' );
+
+	}
+
+	this._update = function () {
 
 		_eye.subVectors( scope.object.position, scope.target );
 
@@ -353,6 +388,10 @@ var TrackballControls = function ( object, domElement ) {
 
 				lastPosition.copy( scope.object.position );
 
+			} else {
+
+				scope._stopUpdate();
+
 			}
 
 		} else if ( scope.object.isOrthographicCamera ) {
@@ -365,6 +404,10 @@ var TrackballControls = function ( object, domElement ) {
 
 				lastPosition.copy( scope.object.position );
 				lastZoom = scope.object.zoom;
+
+			} else {
+
+				scope._stopUpdate();
 
 			}
 
@@ -566,6 +609,8 @@ var TrackballControls = function ( object, domElement ) {
 
 		}
 
+		scope._startUpdate();
+
 	}
 
 	function onMouseUp( event ) {
@@ -614,6 +659,8 @@ var TrackballControls = function ( object, domElement ) {
 
 		scope.dispatchEvent( startEvent );
 		scope.dispatchEvent( endEvent );
+
+		scope._startUpdate();
 
 	}
 
@@ -674,6 +721,8 @@ var TrackballControls = function ( object, domElement ) {
 				break;
 
 		}
+
+		scope._startUpdate();
 
 	}
 
@@ -744,7 +793,7 @@ var TrackballControls = function ( object, domElement ) {
 	this.handleResize();
 
 	// force an update at start
-	this.update();
+	this._update();
 
 };
 

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -40,7 +40,6 @@
 			var frustumSize = 400;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -119,11 +118,15 @@
 
 				controls = new TrackballControls( camera, renderer.domElement );
 
+				controls.addEventListener( 'change', render );
+
 				controls.rotateSpeed = 1.0;
 				controls.zoomSpeed = 1.2;
 				controls.panSpeed = 0.8;
 
 				controls.keys = [ 65, 83, 68 ];
+
+				render();
 
 			}
 
@@ -146,19 +149,9 @@
 
 			}
 
-			function animate() {
-
-				requestAnimationFrame( animate );
-
-				controls.update();
+			function render() {
 
 				stats.update();
-
-				render();
-
-			}
-
-			function render() {
 
 				var camera = ( params.orthographicCamera ) ? orthographicCamera : perspectiveCamera;
 

--- a/examples/models/obj/verify/verify.html
+++ b/examples/models/obj/verify/verify.html
@@ -212,7 +212,6 @@
 
 				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
-					this.controls.update();
 					this.renderer.render( this.scene, this.camera );
 				}
 			};

--- a/examples/webgl_buffergeometry_constructed_from_geometry.html
+++ b/examples/webgl_buffergeometry_constructed_from_geometry.html
@@ -23,7 +23,7 @@
 			var camera, scene, renderer, controls, stats;
 
 			init();
-			animate();
+			render();
 
 			function init() {
 
@@ -42,6 +42,8 @@
 				controls.minDistance = 100.0;
 				controls.maxDistance = 800.0;
 				controls.dynamicDampingFactor = 0.1;
+
+				controls.addEventListener( 'change', render );
 
 				scene.add( new THREE.AmbientLight( 0xffffff, 0.2 ) );
 
@@ -172,11 +174,8 @@
 
 			}
 
-			function animate() {
+			function render() {
 
-				requestAnimationFrame( animate );
-
-				controls.update();
 				stats.update();
 
 				renderer.render( scene, camera );

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -102,8 +102,6 @@
 				sphere.rotation.x = timer * 0.0003;
 				sphere.rotation.z = timer * 0.0002;
 
-				controls.update();
-
 				effect.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -26,7 +26,7 @@
 			var camera, scene, renderer, controls;
 
 			init();
-			animate();
+			render();
 
 			function init() {
 
@@ -54,6 +54,8 @@
 				controls = new TrackballControls( camera, renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 500;
+
+				controls.addEventListener( 'change', render );
 
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
@@ -172,11 +174,8 @@
 
 			}
 
-			function animate() {
+			function render() {
 
-				requestAnimationFrame( animate );
-
-				controls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -238,8 +238,6 @@
 
 			function render() {
 
-				controls.update();
-
 				pick();
 
 				renderer.setRenderTarget( null );

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -203,8 +203,6 @@
 				light6.position.x = Math.cos( time * 0.7 ) * d;
 				light6.position.z = Math.cos( time * 0.5 ) * d;
 
-				controls.update( clock.getDelta() );
-
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -86,7 +86,6 @@
 
 			function animate() {
 
-				controls.update();
 				renderer.render( scene, camera );
 
 				requestAnimationFrame( animate );

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -205,8 +205,6 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
-
 				//copy position of the camera into inset
 				camera2.position.copy( camera.position );
 				camera2.position.sub( controls.target );

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -176,7 +176,6 @@
 
 				render: function () {
 					if ( !this.renderer.autoClear ) this.renderer.clear();
-					this.controls.update();
 					this.renderer.render( this.scene, this.camera );
 				}
 			};

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -369,8 +369,6 @@
 				render: function () {
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 
-					this.controls.update();
-
 					this.cube.rotation.x += 0.05;
 					this.cube.rotation.y += 0.05;
 

--- a/examples/webgl_loader_pcd.html
+++ b/examples/webgl_loader_pcd.html
@@ -52,7 +52,6 @@
 					scene.add( points );
 					var center = points.geometry.boundingSphere.center;
 					controls.target.set( center.x, center.y, center.z );
-					controls.update();
 
 				} );
 
@@ -117,7 +116,6 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
 				renderer.render( scene, camera );
 				stats.update();
 

--- a/examples/webgl_loader_pdb.html
+++ b/examples/webgl_loader_pdb.html
@@ -275,7 +275,6 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
 
 				var time = Date.now() * 0.0004;
 

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -154,8 +154,6 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
-
 				renderer.render( scene, camera );
 
 				stats.update();

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -148,7 +148,6 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
 				renderer.render( scene, camera );
 
 				if ( statsEnabled ) stats.update();

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -219,8 +219,6 @@
 
 				uniforms.amplitude.value = 1.0 + Math.sin( time * 0.5 );
 
-				controls.update();
-
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -134,7 +134,6 @@
 
 			function update() {
 
-				controls.update();
 				updateGUI();
 
 				group.rotation.y += .0015;

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -245,6 +245,7 @@
 
 				controls = new TrackballControls( camera, renderer.domElement );
 				controls.target.set( 0, 120, 0 );
+				camera.lookAt( controls.target );
 
 				controls.rotateSpeed = 1.0;
 				controls.zoomSpeed = 1.2;
@@ -253,7 +254,6 @@
 				controls.staticMoving = true;
 
 				controls.keys = [ 65, 83, 68 ];
-
 
 				// STATS
 
@@ -334,8 +334,6 @@
 				// update
 
 				var delta = clock.getDelta();
-
-				controls.update();
 
 				if ( mixer ) {
 


### PR DESCRIPTION
Currently trackball example renders the scene permanently, even while nothing is changing in the scene. This can drain your laptop battery quickly if you leave the example tab open. Let's try to update the examples to be a little more energy efficient.