### PR TITLE
TS: Update Face3.d.ts

### DIFF
--- a/src/core/Face3.d.ts
+++ b/src/core/Face3.d.ts
@@ -89,7 +89,7 @@ export class Face3 {
 	vertexColors: Color[];
 
 	/**
-	 * Material index (points to {@link Geometry.materials}).
+	 * Material index (points to {@link Mesh.material}).
 	 * @default 0
 	 */
 	materialIndex: number;


### PR DESCRIPTION
- corrected the link from `Geometry.materials` (old api?) to `Mesh.material` (array)