### PR TITLE
Docs: Clarify behavior for Material blendDst, blendEquation, and blendSrc when null

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -45,7 +45,7 @@
 		</p>
 
 		<h3>[property:Integer blendDstAlpha]</h3>
-		<p>The transparency of the [page:.blendDst]. Default is *null*.</p>
+		<p>The transparency of the [page:.blendDst]. Uses [page:.blendDst] value if null. Default is *null*.</p>
 
 		<h3>[property:Integer blendEquation]</h3>
 		<p>
@@ -55,7 +55,7 @@
 		</p>
 
 		<h3>[property:Integer blendEquationAlpha]</h3>
-		<p>The tranparency of the [page:.blendEquation]. Default is *null*.</p>
+		<p>The transparency of the [page:.blendEquation]. Uses [page:.blendEquation] value if null. Default is *null*.</p>
 
 		<h3>[property:Blending blending]</h3>
 		<p>
@@ -72,7 +72,7 @@
 		</p>
 
 		<h3>[property:Integer blendSrcAlpha]</h3>
-		<p>The tranparency of the [page:.blendSrc]. Default is *null*.</p>
+		<p>The transparency of the [page:.blendSrc]. Uses [page:.blendSrc] value if null. Default is *null*.</p>
 
 		<h3>[property:Boolean clipIntersection]</h3>
 		<p>


### PR DESCRIPTION
Also is there a notation for specifying multiple type options in the docs? `blendDstAlpha` can be either an integer _or_ null, which is not clear when just looking at the type information. Something like this maybe?

```
[property:Integer|Null blendDstAlpha]
```