### PR TITLE
TS: Added `undefined` as `.defines` member

### DIFF
--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -139,7 +139,7 @@ export class Material extends EventDispatcher {
 	 * The pairs are defined in both vertex and fragment shaders. Default is undefined.
 	 * @default undefined
 	 */
-	defines: { [key: string]: any };
+	defines: undefined | { [key: string]: any };
 
 	/**
 	 * Which depth function to use. Default is {@link LessEqualDepth}. See the depth mode constants for all possible values.


### PR DESCRIPTION
`.defines` is not declared at https://github.com/mrdoob/three.js/blob/dev/src/materials/Material.js, so it is optional.