### PR TITLE
Removed override of .receiveShadow from Light.js

### DIFF
--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -539,7 +539,7 @@ function SidebarObject( editor ) {
 
 			}
 
-			if ( object.receiveShadow !== undefined && object.receiveShadow !== objectReceiveShadow.getValue() ) {
+			if ( object.receiveShadow !== objectReceiveShadow.getValue() ) {
 
 				if ( object.material !== undefined ) object.material.needsUpdate = true;
 				editor.execute( new SetValueCommand( editor, object, 'receiveShadow', objectReceiveShadow.getValue() ) );

--- a/src/lights/Light.d.ts
+++ b/src/lights/Light.d.ts
@@ -24,10 +24,6 @@ export class Light extends Object3D {
 	intensity: number;
 	readonly isLight: true;
 
-	/**
-	 * @default undefined
-	 */
-	receiveShadow: boolean;
 	shadow: LightShadow;
 	/**
 	 * @deprecated Use shadow.camera.fov instead.

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -10,8 +10,6 @@ function Light( color, intensity ) {
 	this.color = new Color( color );
 	this.intensity = intensity !== undefined ? intensity : 1;
 
-	this.receiveShadow = undefined;
-
 }
 
 Light.prototype = Object.assign( Object.create( Object3D.prototype ), {


### PR DESCRIPTION
use inherited value, 'false', from its base class Object3D.