### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -5,19 +5,13 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#vt { display:none }
-			#vt, #vt a { color:orange; }
-		</style>
 	</head>
 
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - (<span id="description">normal + ao + displacement + environment</span>) map demo.<br />
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - (normal + ao + displacement + environment) map demo.<br />
 			ninja head from <a href="https://gpuopen.com/archive/gamescgi/amd-gpu-meshmapper/" target="_blank" rel="noopener">AMD GPU MeshMapper</a>
-
-			<div id="vt">displacement mapping requires vertex textures</div>
 		</div>
 
 		<script type="module">
@@ -203,12 +197,6 @@
 					scene.add( mesh );
 
 				} );
-
-				//
-
-				var description = "normal + ao" + ( renderer.capabilities.vertexTextures ? " + displacement + environment" : " + <strike>displacement</strike>" );
-				document.getElementById( "description" ).innerHTML = description;
-				document.getElementById( "vt" ).style.display = renderer.capabilities.vertexTextures ? "none" : "block";
 
 				//
 

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -5,21 +5,12 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			#vt { display:none }
-			#vt, #vt a { color:orange; }
-		</style>
 	</head>
 
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - webgl normalmap demo.<br/>
 			<a href="http://graphics.cs.williams.edu/data/meshes.xml#14" target="_blank" rel="noopener">Lee Perry-Smith</a> head.
-
-			<div id="vt">displacement mapping needs vertex textures (GPU with Shader Model 3.0)<br/>
-			on Windows use <span class="code">Chrome --use-gl=desktop</span> or Firefox 4<br/>
-			please star this <a href="http://code.google.com/p/chromium/issues/detail?id=52497">Chrome issue</a> to get ANGLE support
-			</div>
 		</div>
 
 		<script type="module">


### PR DESCRIPTION
Removed obsolete checks in `webgl_materials_displacementmap` and `webgl_materials_normalmap`.