### PR TITLE
LineSegements2: Add a "threshold" Raycaster param

### DIFF
--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -70,12 +70,7 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 
 			}
 
-			var threshold = 0;
-			if ( 'Line2' in raycaster.params ) {
-
-				threshold = raycaster.params.Line2.threshold || 0.0;
-
-			}
+			var threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
 
 			var ray = raycaster.ray;
 			var camera = raycaster.camera;

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -70,6 +70,13 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 
 			}
 
+			var threshold = 0;
+			if ( 'Line2' in raycaster.params ) {
+
+				threshold = raycaster.params.Line2.threshold || 0.0;
+
+			}
+
 			var ray = raycaster.ray;
 			var camera = raycaster.camera;
 			var projectionMatrix = camera.projectionMatrix;
@@ -77,7 +84,7 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			var geometry = this.geometry;
 			var material = this.material;
 			var resolution = material.resolution;
-			var lineWidth = material.linewidth;
+			var lineWidth = material.linewidth + threshold;
 
 			var instanceStart = geometry.attributes.instanceStart;
 			var instanceEnd = geometry.attributes.instanceEnd;

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -83,11 +83,11 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 			var threshold = 0;
 			if ( 'Line2' in raycaster.params ) {
-			
-				threshold = raycaster.params.Lines2.threshold || 0.0
-			
+
+				threshold = raycaster.params.Line2.threshold || 0.0;
+
 			}
-			
+
 			var ray = raycaster.ray;
 			var camera = raycaster.camera;
 			var projectionMatrix = camera.projectionMatrix;

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -81,6 +81,13 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 			}
 
+			var threshold = 0;
+			if ( 'Line2' in raycaster.params ) {
+			
+				threshold = raycaster.params.Lines2.threshold || 0.0
+			
+			}
+			
 			var ray = raycaster.ray;
 			var camera = raycaster.camera;
 			var projectionMatrix = camera.projectionMatrix;
@@ -88,7 +95,7 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			var geometry = this.geometry;
 			var material = this.material;
 			var resolution = material.resolution;
-			var lineWidth = material.linewidth;
+			var lineWidth = material.linewidth + threshold;
 
 			var instanceStart = geometry.attributes.instanceStart;
 			var instanceEnd = geometry.attributes.instanceEnd;

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -81,12 +81,7 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 			}
 
-			var threshold = 0;
-			if ( 'Line2' in raycaster.params ) {
-
-				threshold = raycaster.params.Line2.threshold || 0.0;
-
-			}
+			var threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
 
 			var ray = raycaster.ray;
 			var camera = raycaster.camera;


### PR DESCRIPTION
Adds a threshold raycaster param like Lines uses so line segments 2 can be expanded by a pixel width for raycasting.

```js
const raycaster = new Raycaster();
raycaster.params.Line2 = { threshold: 2 };

// raycast...
```

ping @WestLangley 