### PR TITLE
OrbitControls: Cancel user interaction on disable

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -29,7 +29,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		set( value ) {
 
-			if ( ! value ) {
+			if ( ! value && state !== STATE.NONE ) {
+
+				scope.dispatchEvent( endEvent );
 
 				state = STATE.NONE;
 
@@ -986,12 +988,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function onMouseUp( event ) {
 
-		if ( scope.enabled === false ) return;
-
-		handleMouseUp( event );
-
 		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
 		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+		if ( scope.enabled === false || state === STATE.NONE ) return;
+
+		handleMouseUp( event );
 
 		scope.dispatchEvent( endEvent );
 
@@ -1167,7 +1169,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function onTouchEnd( event ) {
 
-		if ( scope.enabled === false ) return;
+		if ( scope.enabled === false || state === STATE.NONE ) return;
 
 		handleTouchEnd( event );
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1158,9 +1158,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		handleTouchEnd( event );
 
-		scope.dispatchEvent( endEvent );
-
-		state = STATE.NONE;
+		scope.cancel();
 
 	}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -116,7 +116,22 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		scope.update();
 
-		state = STATE.NONE;
+		scope.cancel();
+
+	};
+
+	this.cancel = function () {
+
+		if ( state !== STATE.NONE ) {
+
+			scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+			scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+			scope.dispatchEvent( endEvent );
+
+			state = STATE.NONE;
+
+		}
 
 	};
 
@@ -967,12 +982,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		handleMouseUp( event );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
-
-		scope.dispatchEvent( endEvent );
-
-		state = STATE.NONE;
+		scope.cancel();
 
 	}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -34,6 +34,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 				state = STATE.NONE;
 
 			}
+			enabled = value;
 
 		}
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -16,7 +16,29 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.domElement = domElement;
 
 	// Set to false to disable this control
-	this.enabled = true;
+	let enabled = true;
+	Object.defineProperty( this, 'enabled', {
+
+		enumerable: true,
+
+		get() {
+
+			return enabled;
+
+		},
+
+		set( value ) {
+
+			if ( ! value ) {
+
+				state = STATE.NONE;
+
+			}
+
+		}
+
+	} );
+
 
 	// "target" sets the location of focus, where the object orbits around
 	this.target = new THREE.Vector3();
@@ -116,22 +138,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		scope.update();
 
-		scope.cancel();
-
-	};
-
-	this.cancel = function () {
-
-		if ( state !== STATE.NONE ) {
-
-			scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-			scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
-
-			scope.dispatchEvent( endEvent );
-
-			state = STATE.NONE;
-
-		}
+		state = STATE.NONE;
 
 	};
 
@@ -982,7 +989,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		handleMouseUp( event );
 
-		scope.cancel();
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
 
 	}
 
@@ -1158,7 +1170,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		handleTouchEnd( event );
 
-		scope.cancel();
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -124,7 +124,22 @@ var OrbitControls = function ( object, domElement ) {
 
 		scope.update();
 
-		state = STATE.NONE;
+		scope.cancel();
+
+	};
+
+	this.cancel = function () {
+
+		if ( state !== STATE.NONE ) {
+
+			scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+			scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+			scope.dispatchEvent( endEvent );
+
+			state = STATE.NONE;
+
+		}
 
 	};
 
@@ -975,12 +990,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		handleMouseUp( event );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
-
-		scope.dispatchEvent( endEvent );
-
-		state = STATE.NONE;
+		scope.cancel();
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -24,7 +24,29 @@ var OrbitControls = function ( object, domElement ) {
 	this.domElement = domElement;
 
 	// Set to false to disable this control
-	this.enabled = true;
+	let enabled = true;
+	Object.defineProperty( this, 'enabled', {
+
+		enumerable: true,
+
+		get() {
+
+			return enabled;
+
+		},
+
+		set( value ) {
+
+			if ( ! value ) {
+
+				state = STATE.NONE;
+
+			}
+
+		}
+
+	} );
+
 
 	// "target" sets the location of focus, where the object orbits around
 	this.target = new Vector3();
@@ -124,22 +146,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		scope.update();
 
-		scope.cancel();
-
-	};
-
-	this.cancel = function () {
-
-		if ( state !== STATE.NONE ) {
-
-			scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-			scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
-
-			scope.dispatchEvent( endEvent );
-
-			state = STATE.NONE;
-
-		}
+		state = STATE.NONE;
 
 	};
 
@@ -990,7 +997,12 @@ var OrbitControls = function ( object, domElement ) {
 
 		handleMouseUp( event );
 
-		scope.cancel();
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
 
 	}
 
@@ -1166,7 +1178,9 @@ var OrbitControls = function ( object, domElement ) {
 
 		handleTouchEnd( event );
 
-		scope.cancel();
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -37,7 +37,9 @@ var OrbitControls = function ( object, domElement ) {
 
 		set( value ) {
 
-			if ( ! value ) {
+			if ( ! value && state !== STATE.NONE ) {
+
+				scope.dispatchEvent( endEvent );
 
 				state = STATE.NONE;
 
@@ -994,12 +996,12 @@ var OrbitControls = function ( object, domElement ) {
 
 	function onMouseUp( event ) {
 
-		if ( scope.enabled === false ) return;
-
-		handleMouseUp( event );
-
 		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
 		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+
+		if ( scope.enabled === false || state === STATE.NONE ) return;
+
+		handleMouseUp( event );
 
 		scope.dispatchEvent( endEvent );
 
@@ -1175,7 +1177,7 @@ var OrbitControls = function ( object, domElement ) {
 
 	function onTouchEnd( event ) {
 
-		if ( scope.enabled === false ) return;
+		if ( scope.enabled === false || state === STATE.NONE ) return;
 
 		handleTouchEnd( event );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1166,9 +1166,7 @@ var OrbitControls = function ( object, domElement ) {
 
 		handleTouchEnd( event );
 
-		scope.dispatchEvent( endEvent );
-
-		state = STATE.NONE;
+		scope.cancel();
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -42,6 +42,7 @@ var OrbitControls = function ( object, domElement ) {
 				state = STATE.NONE;
 
 			}
+			enabled = value;
 
 		}
 


### PR DESCRIPTION
My application currently disables orbit controls when the camera needs to be taken control of or the user is interacting with something else in the scene. Currently, however, when disabling OrbitControls they are left in the last drag state and never updated until they are reenabled again meaning it can miss pointer events like "mouseup" that would reset the state back to "NONE". In those cases if the controls must be disabled after the mousedown event is fired it will be in the drag state when they are reenabled and could result in the camera orbiting while the mouse is not clicked.

The `reset()` function _kind of_ addresses this but also resets the camera position and does not remove lingering event listeners.

This PR adds a `cancel` function to cancel the current user interaction if one is happening and clean up the event listeners the way it does in the `mouseup` callback. Just using `enabled = false` will still result in the behavior mentioned above unless `cancel` is called.

I tested this by adding a set interval every two seconds to call controls.cancel in the orbit controls example with damping both enabled and disabled. 