### PR TITLE
Rollup: Replace addons three.module.js dependency.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -170,6 +170,27 @@ function glconstants() {
 
 }
 
+function addons() {
+
+	return {
+
+		transform( code, id ) {
+
+			if ( /\/examples\/jsm\//.test( id ) === false ) return;
+
+			code = code.replace( 'build/three.module.js', 'src/Three.js' );
+
+			return {
+				code: code,
+				map: null
+			};
+
+		}
+
+	};
+
+}
+
 function glsl() {
 
 	return {
@@ -259,6 +280,7 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
+			addons(),
 			glconstants(),
 			glsl(),
 			buble( {
@@ -282,6 +304,7 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
+			addons(),
 			glconstants(),
 			glsl(),
 			buble( {
@@ -306,6 +329,7 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
+			addons(),
 			glconstants(),
 			glsl(),
 			header()


### PR DESCRIPTION
This allows producing custom builds that include addons.

For example, adding `OrbitControls`:
1. Add `export { OrbitControls } from '../examples/jsm/controls/OrbitControls.js';` in `./src/Three.js`.
2. Run `npm run build`

Fixes #20387