### PR TITLE
Doc: Updated Quaternion.setFromRotationMatrix() to specify the matrix needs to be pure

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -88,7 +88,7 @@ m.elements = [ 11, 21, 31, 41,
 					[page:Vector3.setFromMatrixScale]: can be used to extract the scale component.
 				</li>
 				<li>
-					[page:Quaternion.setFromRotationMatrix], [page:Euler.setFromRotationMatrix] or [page:.extractRotation extractRotation] can be used to extract the rotation component.
+					[page:Quaternion.setFromRotationMatrix], [page:Euler.setFromRotationMatrix] or [page:.extractRotation extractRotation] can be used to extract the rotation component from a pure (unscaled) matrix.
 				</li>
 				<li>
 					[page:.decompose decompose] can be used to extract position, rotation and scale all at once.

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -179,6 +179,8 @@
 
 		<h3>[method:Quaternion setFromRotationMatrix]( [param:Matrix4 m] )</h3>
 		<p>
+		[page:Matrix4 m] - a [page:Matrix4] of which the upper 3x3 of matrix is a pure
+		[link:https://en.wikipedia.org/wiki/Rotation_matrix rotation matrix] (i.e. unscaled).<br />
 		Sets this quaternion from rotation component of [page:Matrix4 m].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm here].
 		</p>


### PR DESCRIPTION
Related issues:

Fixed #20391 

**Description**

Update doc for Quaternion.setFromRotationMatrix() to specify the matrix needs to be pure
