### PR TITLE
Editor: Fix VTK import.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -511,7 +511,7 @@ function Loader( editor ) {
 					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
-				reader.readAsText( file );
+				reader.readAsArrayBuffer( file );
 
 				break;
 


### PR DESCRIPTION
`VTKLoader` expects its input as type of `ArrayBuffer`, not `string`.