### PR TITLE
Rollup: include polyfills only in browser bundle

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -1,4 +1,3 @@
-import './polyfills.js';
 import { REVISION } from './constants.js';
 
 export { WebGLMultisampleRenderTarget } from './renderers/WebGLMultisampleRenderTarget.js';

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -299,6 +299,30 @@ function header() {
 
 }
 
+function polyfills() {
+
+	return {
+
+		transform( code, filePath ) {
+
+			if ( filePath.endsWith( 'src/Three.js' ) ) {
+
+				code = "import './polyfills';\n" + code;
+
+			}
+
+
+			return {
+				code: code,
+				map: null
+			};
+
+		}
+
+	};
+
+}
+
 const babelrc = {
 	presets: [
 		[
@@ -327,6 +351,7 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
+			polyfills(),
 			addons(),
 			glconstants(),
 			glsl(),
@@ -351,6 +376,7 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
+			polyfills(),
 			addons(),
 			glconstants(),
 			glsl(),


### PR DESCRIPTION
As discussed in #20395, polyfills are not necessary in the `three.module.js`.

I added a rollup transform which imports the polyfills only in the bundles for the browser.
