### PR TITLE
ImprovedNoise correction

### DIFF
--- a/examples/js/math/ImprovedNoise.js
+++ b/examples/js/math/ImprovedNoise.js
@@ -63,7 +63,7 @@ THREE.ImprovedNoise = function () {
 			lerp( u, grad( p[ AB ], x, yMinus1, z ),
 				grad( p[ BB ], xMinus1, yMinus1, z ) ) ),
 			lerp( v, lerp( u, grad( p[ AA + 1 ], x, y, zMinus1 ),
-				grad( p[ BA + 1 ], xMinus1, y, z - 1 ) ),
+				grad( p[ BA + 1 ], xMinus1, y, zMinus1 ) ),
 			lerp( u, grad( p[ AB + 1 ], x, yMinus1, zMinus1 ),
 				grad( p[ BB + 1 ], xMinus1, yMinus1, zMinus1 ) ) ) );
 

--- a/examples/jsm/math/ImprovedNoise.js
+++ b/examples/jsm/math/ImprovedNoise.js
@@ -63,7 +63,7 @@ var ImprovedNoise = function () {
 			lerp( u, grad( p[ AB ], x, yMinus1, z ),
 				grad( p[ BB ], xMinus1, yMinus1, z ) ) ),
 			lerp( v, lerp( u, grad( p[ AA + 1 ], x, y, zMinus1 ),
-				grad( p[ BA + 1 ], xMinus1, y, z - 1 ) ),
+				grad( p[ BA + 1 ], xMinus1, y, zMinus1 ) ),
 			lerp( u, grad( p[ AB + 1 ], x, yMinus1, zMinus1 ),
 				grad( p[ BB + 1 ], xMinus1, yMinus1, zMinus1 ) ) ) );
 


### PR DESCRIPTION
Long story short, I ported the same Java version of Ken Perlin's Improved Noise for my own project with all the usual optimizations, only to realize it was already included as part of three.js. 🤦

When comparing I noticed a small difference in that one of the `zMinus1`'s was missed.