### PR TITLE
Docs: Geometry UVs are Vector2s

### DIFF
--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -95,7 +95,7 @@
 		<h3>[property:Array faceVertexUvs]</h3>
 		<p>
 		Array of face [link:https://en.wikipedia.org/wiki/UV_mapping UV] layers, used for mapping textures onto the geometry.<br />
-		Each UV layer is an array of [page:UV]s matching the order and number of vertices in faces.<br /><br />
+		Each UV layer is an array of [page:Vector2]s matching the order and number of vertices in faces.<br /><br />
 		To signal an update in this array, [page:Geometry Geometry.uvsNeedUpdate] needs to be set to true.
 		</p>
 


### PR DESCRIPTION
Related issues:

- The current docs have a dead link to a UV page (presumably that was a class once upon a time)
- A peek here suggests they are Vector2s: https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/UVsDebug.js

**Description**

Change the dead link to point to Vector2 instead