### PR TITLE
AnimationUtils: Define numTracks using referenceClip rather than targ…

### DIFF
--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -236,7 +236,7 @@ const AnimationUtils = {
 		if ( referenceClip === undefined ) referenceClip = targetClip;
 		if ( fps === undefined || fps <= 0 ) fps = 30;
 
-		const numTracks = targetClip.tracks.length;
+		const numTracks = referenceClip.tracks.length;
 		const referenceTime = referenceFrame / fps;
 
 		// Make each track's values relative to the values at the reference frame


### PR DESCRIPTION
Related issues:

#20409

**Description**

If using different clips for the targetClip and referenceClip parameters, an error will be thrown if the referenceClip has fewer tracks than the targetClip. This is happening because numTracks is defined using the number of tracks from the targetClip rather than the referenceClip so when looping using numTracks referenceTrack isn't necessarily always defined. Changing to `const numTracks = referenceClip.tracks.length;` fixes the issue.
