### PR TITLE
BufferGeometry: Chainable setIndex() method

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -278,7 +278,7 @@
 		Use [page:Object3D.scale] for typical real-time mesh scaling.
 		</p>
 
-		<h3>[method:null setIndex] ( [param:BufferAttribute index] )</h3>
+		<h3>[method:BufferGeometry setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>Set the [page:.index] buffer.</p>
 
 		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -261,7 +261,7 @@
 			缩放几何体。该操作一般在一次处理中完成，不会循环处理。典型的用法是通过调用 [page:Object3D.scale] 实时旋转几何体。
 		</p>
 
-		<h3>[method:null setIndex] ( [param:BufferAttribute index] )</h3>
+		<h3>[method:BufferGeometry setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>设置缓存的 [page:.index]。</p>
 
 		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>

--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -93,7 +93,7 @@ export class BufferGeometry extends EventDispatcher {
 	readonly isBufferGeometry: true;
 
 	getIndex(): BufferAttribute | null;
-	setIndex( index: BufferAttribute | number[] | null ): void;
+	setIndex( index: BufferAttribute | number[] | null ): BufferGeometry;
 
 	setAttribute( name: string, attribute: BufferAttribute | InterleavedBufferAttribute ): BufferGeometry;
 	getAttribute( name: string ): BufferAttribute | InterleavedBufferAttribute;

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -69,6 +69,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
+		return this;
+
 	},
 
 	getAttribute: function ( name ) {


### PR DESCRIPTION
This PR makes `BufferGeometry.setIndex()` chainable like the following code by returning `this` for the consistency with `.setAttribute()` and usability. 

```javascript
new BufferGeometry()
  .setIndex( index )
  .setAttribute( 'foo', fooAttribute )
  .setAttribute( 'bar', barAttribute );
```