### PR TITLE
TS: Added `setScaleSnap' type definition to TransformControls

### DIFF
--- a/examples/jsm/controls/TransformControls.d.ts
+++ b/examples/jsm/controls/TransformControls.d.ts
@@ -38,6 +38,7 @@ export class TransformControls extends Object3D {
 	setMode( mode: string ): void;
 	setTranslationSnap( translationSnap: Number | null ): void;
 	setRotationSnap( rotationSnap: Number | null ): void;
+	setScaleSnap( scaleSnap: Number | null ): void;
 	setSize( size: number ): void;
 	setSpace( space: string ): void;
 	dispose(): void;


### PR DESCRIPTION
**Description**

'TransformControls' already has type definitions for 'setTranslationSnap' and 'setRotationSnap', but not for 'setScaleSnap'.
Added 'setScaleSnap' type definition to 'TransformControls'.