### PR TITLE
TS: Fix "color" property type on LineBasicMaterial

### DIFF
--- a/src/materials/LineBasicMaterial.d.ts
+++ b/src/materials/LineBasicMaterial.d.ts
@@ -21,7 +21,7 @@ export class LineBasicMaterial extends Material {
 	/**
 	 * @default 0xffffff
 	 */
-	color: Color | string | number;
+	color: Color;
 
 	/**
 	 * @default 1

--- a/src/materials/LineBasicMaterial.d.ts
+++ b/src/materials/LineBasicMaterial.d.ts
@@ -2,7 +2,7 @@ import { Color } from './../math/Color';
 import { MaterialParameters, Material } from './Material';
 
 export interface LineBasicMaterialParameters extends MaterialParameters {
-	color?: Color;
+	color?: Color | string | number;
 	linewidth?: number;
 	linecap?: string;
 	linejoin?: string;

--- a/src/materials/LineBasicMaterial.d.ts
+++ b/src/materials/LineBasicMaterial.d.ts
@@ -2,7 +2,7 @@ import { Color } from './../math/Color';
 import { MaterialParameters, Material } from './Material';
 
 export interface LineBasicMaterialParameters extends MaterialParameters {
-	color?: Color | string | number;
+	color?: Color;
 	linewidth?: number;
 	linecap?: string;
 	linejoin?: string;


### PR DESCRIPTION
**Description**

The color property can only be a `Color`, it can't be a `string` or `number`.
