### PR TITLE
Converted TessellateModifier to recursive and made similar to SubdivisionModifier

### DIFF
--- a/examples/js/modifiers/SubdivisionModifier.js
+++ b/examples/js/modifiers/SubdivisionModifier.js
@@ -20,7 +20,9 @@ THREE.SubdivisionModifier = function ( subdivisions ) {
 // Applies the "modify" pattern
 THREE.SubdivisionModifier.prototype.modify = function ( geometry ) {
 
-	if ( geometry.isBufferGeometry ) {
+	var isBufferGeometry = geometry.isBufferGeometry;
+
+	if ( isBufferGeometry ) {
 
 		geometry = new THREE.Geometry().fromBufferGeometry( geometry );
 
@@ -30,7 +32,7 @@ THREE.SubdivisionModifier.prototype.modify = function ( geometry ) {
 
 	}
 
-	geometry.mergeVertices();
+	geometry.mergeVertices( 6 );
 
 	var repeats = this.subdivisions;
 
@@ -43,7 +45,15 @@ THREE.SubdivisionModifier.prototype.modify = function ( geometry ) {
 	geometry.computeFaceNormals();
 	geometry.computeVertexNormals();
 
-	return geometry;
+	if ( isBufferGeometry ) {
+
+		return new THREE.BufferGeometry().fromGeometry( geometry );
+
+	} else {
+
+		return geometry;
+
+	}
 
 };
 

--- a/examples/js/modifiers/TessellateModifier.js
+++ b/examples/js/modifiers/TessellateModifier.js
@@ -2,7 +2,7 @@
  * Break faces with edges longer than maxEdgeLength
  */
 
-THREE.TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
+THREE.TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = Infinity ) {
 
 	this.maxEdgeLength = maxEdgeLength;
 	this.maxIterations = maxIterations;
@@ -263,7 +263,7 @@ THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 
 	if ( isBufferGeometry ) {
 
-		return new THREE.BufferGeometry().fromGeometry(geometry);
+		return new THREE.BufferGeometry().fromGeometry( geometry );
 
 	} else {
 

--- a/examples/js/modifiers/TessellateModifier.js
+++ b/examples/js/modifiers/TessellateModifier.js
@@ -2,9 +2,11 @@
  * Break faces with edges longer than maxEdgeLength
  */
 
-THREE.TessellateModifier = function ( maxEdgeLength ) {
+THREE.TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
 
-	this.maxEdgeLength = ( maxEdgeLength === undefined ) ? 0.1 : maxEdgeLength;
+	this.maxEdgeLength = maxEdgeLength;
+	this.maxIterations = maxIterations;
+	this.maxFaces = maxFaces;
 
 };
 
@@ -26,16 +28,18 @@ THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 	geometry.mergeVertices( 6 );
 
 	let finalized = false;
+	let iteration = 0;
 	const maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
 
 	let edge;
 
-	while ( ! finalized ) {
+	while ( ! finalized && iteration < this.maxIterations && geometry.faces.length < this.maxFace ) {
 
 		const faces = [];
 		const faceVertexUvs = [];
 
 		finalized = true;
+		iteration ++;
 
 		for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
 
@@ -61,7 +65,9 @@ THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 				const dbc = vb.distanceToSquared( vc );
 				const dac = va.distanceToSquared( vc );
 
-				if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
+				const limitReached = ( faces.length + il - i ) >= this.maxFaces;
+
+				if ( ! limitReached && ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) ) {
 
 					finalized = false;
 

--- a/examples/js/modifiers/TessellateModifier.js
+++ b/examples/js/modifiers/TessellateModifier.js
@@ -33,7 +33,7 @@ THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 
 	let edge;
 
-	while ( ! finalized && iteration < this.maxIterations && geometry.faces.length < this.maxFace ) {
+	while ( ! finalized && iteration < this.maxIterations && geometry.faces.length < this.maxFaces ) {
 
 		const faces = [];
 		const faceVertexUvs = [];

--- a/examples/js/modifiers/TessellateModifier.js
+++ b/examples/js/modifiers/TessellateModifier.js
@@ -1,224 +1,248 @@
 /**
  * Break faces with edges longer than maxEdgeLength
- * - not recursive
  */
 
 THREE.TessellateModifier = function ( maxEdgeLength ) {
 
-	this.maxEdgeLength = maxEdgeLength;
+	this.maxEdgeLength = ( maxEdgeLength === undefined ) ? 0.1 : maxEdgeLength;
 
 };
 
+// Applies the "modify" pattern
 THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 
-	var edge;
+	const isBufferGeometry = geometry.isBufferGeometry;
 
-	var faces = [];
-	var faceVertexUvs = [];
-	var maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
+	if ( isBufferGeometry ) {
 
-	for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
+		geometry = new THREE.Geometry().fromBufferGeometry( geometry );
 
-		faceVertexUvs[ i ] = [];
+	} else {
+
+		geometry = geometry.clone();
 
 	}
 
-	for ( var i = 0, il = geometry.faces.length; i < il; i ++ ) {
+	geometry.mergeVertices( 6 );
 
-		var face = geometry.faces[ i ];
+	let finalized = false;
+	const maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
 
-		if ( face instanceof THREE.Face3 ) {
+	let edge;
 
-			var a = face.a;
-			var b = face.b;
-			var c = face.c;
+	while ( ! finalized ) {
 
-			var va = geometry.vertices[ a ];
-			var vb = geometry.vertices[ b ];
-			var vc = geometry.vertices[ c ];
+		const faces = [];
+		const faceVertexUvs = [];
 
-			var dab = va.distanceToSquared( vb );
-			var dbc = vb.distanceToSquared( vc );
-			var dac = va.distanceToSquared( vc );
+		finalized = true;
 
-			if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
+		for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
 
-				var m = geometry.vertices.length;
+			faceVertexUvs[ i ] = [];
 
-				var triA = face.clone();
-				var triB = face.clone();
+		}
 
-				if ( dab >= dbc && dab >= dac ) {
+		for ( var i = 0, il = geometry.faces.length; i < il; i ++ ) {
 
-					var vm = va.clone();
-					vm.lerp( vb, 0.5 );
+			const face = geometry.faces[ i ];
 
-					triA.a = a;
-					triA.b = m;
-					triA.c = c;
+			if ( face instanceof THREE.Face3 ) {
 
-					triB.a = m;
-					triB.b = b;
-					triB.c = c;
+				const a = face.a;
+				const b = face.b;
+				const c = face.c;
 
-					if ( face.vertexNormals.length === 3 ) {
+				const va = geometry.vertices[ a ];
+				const vb = geometry.vertices[ b ];
+				const vc = geometry.vertices[ c ];
 
-						var vnm = face.vertexNormals[ 0 ].clone();
-						vnm.lerp( face.vertexNormals[ 1 ], 0.5 );
+				const dab = va.distanceToSquared( vb );
+				const dbc = vb.distanceToSquared( vc );
+				const dac = va.distanceToSquared( vc );
 
-						triA.vertexNormals[ 1 ].copy( vnm );
-						triB.vertexNormals[ 0 ].copy( vnm );
+				if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
 
-					}
+					finalized = false;
 
-					if ( face.vertexColors.length === 3 ) {
+					const m = geometry.vertices.length;
 
-						var vcm = face.vertexColors[ 0 ].clone();
-						vcm.lerp( face.vertexColors[ 1 ], 0.5 );
+					const triA = face.clone();
+					const triB = face.clone();
 
-						triA.vertexColors[ 1 ].copy( vcm );
-						triB.vertexColors[ 0 ].copy( vcm );
+					if ( dab >= dbc && dab >= dac ) {
 
-					}
+						var vm = va.clone();
+						vm.lerp( vb, 0.5 );
 
-					edge = 0;
+						triA.a = a;
+						triA.b = m;
+						triA.c = c;
 
-				} else if ( dbc >= dab && dbc >= dac ) {
+						triB.a = m;
+						triB.b = b;
+						triB.c = c;
 
-					var vm = vb.clone();
-					vm.lerp( vc, 0.5 );
+						if ( face.vertexNormals.length === 3 ) {
 
-					triA.a = a;
-					triA.b = b;
-					triA.c = m;
+							var vnm = face.vertexNormals[ 0 ].clone();
+							vnm.lerp( face.vertexNormals[ 1 ], 0.5 );
 
-					triB.a = m;
-					triB.b = c;
-					triB.c = a;
-
-					if ( face.vertexNormals.length === 3 ) {
-
-						var vnm = face.vertexNormals[ 1 ].clone();
-						vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
-
-						triA.vertexNormals[ 2 ].copy( vnm );
-
-						triB.vertexNormals[ 0 ].copy( vnm );
-						triB.vertexNormals[ 1 ].copy( face.vertexNormals[ 2 ] );
-						triB.vertexNormals[ 2 ].copy( face.vertexNormals[ 0 ] );
-
-					}
-
-					if ( face.vertexColors.length === 3 ) {
-
-						var vcm = face.vertexColors[ 1 ].clone();
-						vcm.lerp( face.vertexColors[ 2 ], 0.5 );
-
-						triA.vertexColors[ 2 ].copy( vcm );
-
-						triB.vertexColors[ 0 ].copy( vcm );
-						triB.vertexColors[ 1 ].copy( face.vertexColors[ 2 ] );
-						triB.vertexColors[ 2 ].copy( face.vertexColors[ 0 ] );
-
-					}
-
-					edge = 1;
-
-				} else {
-
-					var vm = va.clone();
-					vm.lerp( vc, 0.5 );
-
-					triA.a = a;
-					triA.b = b;
-					triA.c = m;
-
-					triB.a = m;
-					triB.b = b;
-					triB.c = c;
-
-					if ( face.vertexNormals.length === 3 ) {
-
-						var vnm = face.vertexNormals[ 0 ].clone();
-						vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
-
-						triA.vertexNormals[ 2 ].copy( vnm );
-						triB.vertexNormals[ 0 ].copy( vnm );
-
-					}
-
-					if ( face.vertexColors.length === 3 ) {
-
-						var vcm = face.vertexColors[ 0 ].clone();
-						vcm.lerp( face.vertexColors[ 2 ], 0.5 );
-
-						triA.vertexColors[ 2 ].copy( vcm );
-						triB.vertexColors[ 0 ].copy( vcm );
-
-					}
-
-					edge = 2;
-
-				}
-
-				faces.push( triA, triB );
-				geometry.vertices.push( vm );
-
-				for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
-
-					if ( geometry.faceVertexUvs[ j ].length ) {
-
-						var uvs = geometry.faceVertexUvs[ j ][ i ];
-
-						var uvA = uvs[ 0 ];
-						var uvB = uvs[ 1 ];
-						var uvC = uvs[ 2 ];
-
-						// AB
-
-						if ( edge === 0 ) {
-
-							var uvM = uvA.clone();
-							uvM.lerp( uvB, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvM.clone(), uvC.clone() ];
-							var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
-
-							// BC
-
-						} else if ( edge === 1 ) {
-
-							var uvM = uvB.clone();
-							uvM.lerp( uvC, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
-							var uvsTriB = [ uvM.clone(), uvC.clone(), uvA.clone() ];
-
-							// AC
-
-						} else {
-
-							var uvM = uvA.clone();
-							uvM.lerp( uvC, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
-							var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+							triA.vertexNormals[ 1 ].copy( vnm );
+							triB.vertexNormals[ 0 ].copy( vnm );
 
 						}
 
-						faceVertexUvs[ j ].push( uvsTriA, uvsTriB );
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 0 ].clone();
+							vcm.lerp( face.vertexColors[ 1 ], 0.5 );
+
+							triA.vertexColors[ 1 ].copy( vcm );
+							triB.vertexColors[ 0 ].copy( vcm );
+
+						}
+
+						edge = 0;
+
+					} else if ( dbc >= dab && dbc >= dac ) {
+
+						var vm = vb.clone();
+						vm.lerp( vc, 0.5 );
+
+						triA.a = a;
+						triA.b = b;
+						triA.c = m;
+
+						triB.a = m;
+						triB.b = c;
+						triB.c = a;
+
+						if ( face.vertexNormals.length === 3 ) {
+
+							var vnm = face.vertexNormals[ 1 ].clone();
+							vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
+
+							triA.vertexNormals[ 2 ].copy( vnm );
+
+							triB.vertexNormals[ 0 ].copy( vnm );
+							triB.vertexNormals[ 1 ].copy( face.vertexNormals[ 2 ] );
+							triB.vertexNormals[ 2 ].copy( face.vertexNormals[ 0 ] );
+
+						}
+
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 1 ].clone();
+							vcm.lerp( face.vertexColors[ 2 ], 0.5 );
+
+							triA.vertexColors[ 2 ].copy( vcm );
+
+							triB.vertexColors[ 0 ].copy( vcm );
+							triB.vertexColors[ 1 ].copy( face.vertexColors[ 2 ] );
+							triB.vertexColors[ 2 ].copy( face.vertexColors[ 0 ] );
+
+						}
+
+						edge = 1;
+
+					} else {
+
+						var vm = va.clone();
+						vm.lerp( vc, 0.5 );
+
+						triA.a = a;
+						triA.b = b;
+						triA.c = m;
+
+						triB.a = m;
+						triB.b = b;
+						triB.c = c;
+
+						if ( face.vertexNormals.length === 3 ) {
+
+							var vnm = face.vertexNormals[ 0 ].clone();
+							vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
+
+							triA.vertexNormals[ 2 ].copy( vnm );
+							triB.vertexNormals[ 0 ].copy( vnm );
+
+						}
+
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 0 ].clone();
+							vcm.lerp( face.vertexColors[ 2 ], 0.5 );
+
+							triA.vertexColors[ 2 ].copy( vcm );
+							triB.vertexColors[ 0 ].copy( vcm );
+
+						}
+
+						edge = 2;
 
 					}
 
-				}
+					faces.push( triA, triB );
+					geometry.vertices.push( vm );
 
-			} else {
+					for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
 
-				faces.push( face );
+						if ( geometry.faceVertexUvs[ j ].length ) {
 
-				for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
+							const uvs = geometry.faceVertexUvs[ j ][ i ];
 
-					faceVertexUvs[ j ].push( geometry.faceVertexUvs[ j ][ i ] );
+							const uvA = uvs[ 0 ];
+							const uvB = uvs[ 1 ];
+							const uvC = uvs[ 2 ];
+
+							// AB
+
+							if ( edge === 0 ) {
+
+								var uvM = uvA.clone();
+								uvM.lerp( uvB, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvM.clone(), uvC.clone() ];
+								var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+
+								// BC
+
+							} else if ( edge === 1 ) {
+
+								var uvM = uvB.clone();
+								uvM.lerp( uvC, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
+								var uvsTriB = [ uvM.clone(), uvC.clone(), uvA.clone() ];
+
+								// AC
+
+							} else {
+
+								var uvM = uvA.clone();
+								uvM.lerp( uvC, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
+								var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+
+							}
+
+							faceVertexUvs[ j ].push( uvsTriA, uvsTriB );
+
+						}
+
+					}
+
+				} else {
+
+					faces.push( face );
+
+					for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
+
+						faceVertexUvs[ j ].push( geometry.faceVertexUvs[ j ][ i ] );
+
+					}
 
 				}
 
@@ -226,9 +250,19 @@ THREE.TessellateModifier.prototype.modify = function ( geometry ) {
 
 		}
 
+		geometry.faces = faces;
+		geometry.faceVertexUvs = faceVertexUvs;
+
 	}
 
-	geometry.faces = faces;
-	geometry.faceVertexUvs = faceVertexUvs;
+	if ( isBufferGeometry ) {
+
+		return new THREE.BufferGeometry().fromGeometry(geometry);
+
+	} else {
+
+		return geometry;
+
+	}
 
 };

--- a/examples/jsm/modifiers/SubdivisionModifier.d.ts
+++ b/examples/jsm/modifiers/SubdivisionModifier.d.ts
@@ -8,7 +8,7 @@ export class SubdivisionModifier {
 	constructor( subdivisions?: number );
 	subdivisions: number;
 
-	modify( geometry: BufferGeometry | Geometry ): Geometry;
+	modify( geometry: Geometry | BufferGeometry ): Geometry | BufferGeometry;
 	smooth( geometry: Geometry ): void;
 
 }

--- a/examples/jsm/modifiers/SubdivisionModifier.js
+++ b/examples/jsm/modifiers/SubdivisionModifier.js
@@ -1,4 +1,5 @@
 import {
+	BufferGeometry,
 	Face3,
 	Geometry,
 	Vector2,
@@ -27,7 +28,9 @@ var SubdivisionModifier = function ( subdivisions ) {
 // Applies the "modify" pattern
 SubdivisionModifier.prototype.modify = function ( geometry ) {
 
-	if ( geometry.isBufferGeometry ) {
+	var isBufferGeometry = geometry.isBufferGeometry;
+
+	if ( isBufferGeometry ) {
 
 		geometry = new Geometry().fromBufferGeometry( geometry );
 
@@ -37,7 +40,7 @@ SubdivisionModifier.prototype.modify = function ( geometry ) {
 
 	}
 
-	geometry.mergeVertices();
+	geometry.mergeVertices( 6 );
 
 	var repeats = this.subdivisions;
 
@@ -50,7 +53,15 @@ SubdivisionModifier.prototype.modify = function ( geometry ) {
 	geometry.computeFaceNormals();
 	geometry.computeVertexNormals();
 
-	return geometry;
+	if ( isBufferGeometry ) {
+
+		return new BufferGeometry().fromGeometry( geometry );
+
+	} else {
+
+		return geometry;
+
+	}
 
 };
 

--- a/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -5,10 +5,10 @@ import {
 
 export class TessellateModifier {
 
-	constructor( maxEdgeLength: number = 0.1, maxIterations: number = 6, maxFaces: number = 100000 );
-	maxEdgeLength: number;
-	maxIterations: number;
-	maxFaces: number;
+	constructor( maxEdgeLength?: number, maxIterations?: number, maxFaces?: number );
+	maxEdgeLength: number = 0.1;
+	maxIterations: number = 6;
+	maxFaces: number = 100000;
 
 	modify( geometry: Geometry | BufferGeometry ): Geometry | BufferGeometry;
 

--- a/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -5,8 +5,10 @@ import {
 
 export class TessellateModifier {
 
-	constructor( maxEdgeLength: number );
+	constructor( maxEdgeLength: number = 0.1, maxIterations: number = 6, maxFaces: number = 100000 );
 	maxEdgeLength: number;
+	maxIterations: number;
+	maxFaces: number;
 
 	modify( geometry: Geometry | BufferGeometry ): Geometry | BufferGeometry;
 

--- a/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -1,5 +1,6 @@
 import {
-	Geometry
+	Geometry,
+	BufferGeometry
 } from '../../../src/Three';
 
 export class TessellateModifier {
@@ -7,6 +8,6 @@ export class TessellateModifier {
 	constructor( maxEdgeLength: number );
 	maxEdgeLength: number;
 
-	modify( geometry: Geometry ): void;
+	modify( geometry: Geometry | BufferGeometry ): Geometry | BufferGeometry;
 
 }

--- a/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -8,7 +8,7 @@ export class TessellateModifier {
 	constructor( maxEdgeLength?: number, maxIterations?: number, maxFaces?: number );
 	maxEdgeLength: number = 0.1;
 	maxIterations: number = 6;
-	maxFaces: number = 100000;
+	maxFaces: number = Infinity;
 
 	modify( geometry: Geometry | BufferGeometry ): Geometry | BufferGeometry;
 

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -8,7 +8,7 @@ import {
  * Break faces with edges longer than maxEdgeLength
  */
 
-const TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
+var TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
 
 	this.maxEdgeLength = maxEdgeLength;
 	this.maxIterations = maxIterations;
@@ -269,7 +269,7 @@ TessellateModifier.prototype.modify = function ( geometry ) {
 
 	if ( isBufferGeometry ) {
 
-		return new BufferGeometry().fromGeometry(geometry);
+		return new BufferGeometry().fromGeometry( geometry );
 
 	} else {
 

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -1,228 +1,254 @@
 import {
-	Face3
+	BufferGeometry,
+	Face3,
+	Geometry
 } from "../../../build/three.module.js";
 
 /**
  * Break faces with edges longer than maxEdgeLength
- * - not recursive
  */
 
 var TessellateModifier = function ( maxEdgeLength ) {
 
-	this.maxEdgeLength = maxEdgeLength;
+	this.maxEdgeLength = ( maxEdgeLength === undefined ) ? 0.1 : maxEdgeLength;
 
 };
 
+// Applies the "modify" pattern
 TessellateModifier.prototype.modify = function ( geometry ) {
 
-	var edge;
+	const isBufferGeometry = geometry.isBufferGeometry;
 
-	var faces = [];
-	var faceVertexUvs = [];
-	var maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
+	if ( isBufferGeometry ) {
 
-	for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
+		geometry = new Geometry().fromBufferGeometry( geometry );
 
-		faceVertexUvs[ i ] = [];
+	} else {
+
+		geometry = geometry.clone();
 
 	}
 
-	for ( var i = 0, il = geometry.faces.length; i < il; i ++ ) {
+	geometry.mergeVertices( 6 );
 
-		var face = geometry.faces[ i ];
+	let finalized = false;
+	const maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
 
-		if ( face instanceof Face3 ) {
+	let edge;
 
-			var a = face.a;
-			var b = face.b;
-			var c = face.c;
+	while ( ! finalized ) {
 
-			var va = geometry.vertices[ a ];
-			var vb = geometry.vertices[ b ];
-			var vc = geometry.vertices[ c ];
+		const faces = [];
+		const faceVertexUvs = [];
 
-			var dab = va.distanceToSquared( vb );
-			var dbc = vb.distanceToSquared( vc );
-			var dac = va.distanceToSquared( vc );
+		finalized = true;
 
-			if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
+		for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
 
-				var m = geometry.vertices.length;
+			faceVertexUvs[ i ] = [];
 
-				var triA = face.clone();
-				var triB = face.clone();
+		}
 
-				if ( dab >= dbc && dab >= dac ) {
+		for ( var i = 0, il = geometry.faces.length; i < il; i ++ ) {
 
-					var vm = va.clone();
-					vm.lerp( vb, 0.5 );
+			const face = geometry.faces[ i ];
 
-					triA.a = a;
-					triA.b = m;
-					triA.c = c;
+			if ( face instanceof Face3 ) {
 
-					triB.a = m;
-					triB.b = b;
-					triB.c = c;
+				const a = face.a;
+				const b = face.b;
+				const c = face.c;
 
-					if ( face.vertexNormals.length === 3 ) {
+				const va = geometry.vertices[ a ];
+				const vb = geometry.vertices[ b ];
+				const vc = geometry.vertices[ c ];
 
-						var vnm = face.vertexNormals[ 0 ].clone();
-						vnm.lerp( face.vertexNormals[ 1 ], 0.5 );
+				const dab = va.distanceToSquared( vb );
+				const dbc = vb.distanceToSquared( vc );
+				const dac = va.distanceToSquared( vc );
 
-						triA.vertexNormals[ 1 ].copy( vnm );
-						triB.vertexNormals[ 0 ].copy( vnm );
+				if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
 
-					}
+					finalized = false;
 
-					if ( face.vertexColors.length === 3 ) {
+					const m = geometry.vertices.length;
 
-						var vcm = face.vertexColors[ 0 ].clone();
-						vcm.lerp( face.vertexColors[ 1 ], 0.5 );
+					const triA = face.clone();
+					const triB = face.clone();
 
-						triA.vertexColors[ 1 ].copy( vcm );
-						triB.vertexColors[ 0 ].copy( vcm );
+					if ( dab >= dbc && dab >= dac ) {
 
-					}
+						var vm = va.clone();
+						vm.lerp( vb, 0.5 );
 
-					edge = 0;
+						triA.a = a;
+						triA.b = m;
+						triA.c = c;
 
-				} else if ( dbc >= dab && dbc >= dac ) {
+						triB.a = m;
+						triB.b = b;
+						triB.c = c;
 
-					var vm = vb.clone();
-					vm.lerp( vc, 0.5 );
+						if ( face.vertexNormals.length === 3 ) {
 
-					triA.a = a;
-					triA.b = b;
-					triA.c = m;
+							var vnm = face.vertexNormals[ 0 ].clone();
+							vnm.lerp( face.vertexNormals[ 1 ], 0.5 );
 
-					triB.a = m;
-					triB.b = c;
-					triB.c = a;
-
-					if ( face.vertexNormals.length === 3 ) {
-
-						var vnm = face.vertexNormals[ 1 ].clone();
-						vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
-
-						triA.vertexNormals[ 2 ].copy( vnm );
-
-						triB.vertexNormals[ 0 ].copy( vnm );
-						triB.vertexNormals[ 1 ].copy( face.vertexNormals[ 2 ] );
-						triB.vertexNormals[ 2 ].copy( face.vertexNormals[ 0 ] );
-
-					}
-
-					if ( face.vertexColors.length === 3 ) {
-
-						var vcm = face.vertexColors[ 1 ].clone();
-						vcm.lerp( face.vertexColors[ 2 ], 0.5 );
-
-						triA.vertexColors[ 2 ].copy( vcm );
-
-						triB.vertexColors[ 0 ].copy( vcm );
-						triB.vertexColors[ 1 ].copy( face.vertexColors[ 2 ] );
-						triB.vertexColors[ 2 ].copy( face.vertexColors[ 0 ] );
-
-					}
-
-					edge = 1;
-
-				} else {
-
-					var vm = va.clone();
-					vm.lerp( vc, 0.5 );
-
-					triA.a = a;
-					triA.b = b;
-					triA.c = m;
-
-					triB.a = m;
-					triB.b = b;
-					triB.c = c;
-
-					if ( face.vertexNormals.length === 3 ) {
-
-						var vnm = face.vertexNormals[ 0 ].clone();
-						vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
-
-						triA.vertexNormals[ 2 ].copy( vnm );
-						triB.vertexNormals[ 0 ].copy( vnm );
-
-					}
-
-					if ( face.vertexColors.length === 3 ) {
-
-						var vcm = face.vertexColors[ 0 ].clone();
-						vcm.lerp( face.vertexColors[ 2 ], 0.5 );
-
-						triA.vertexColors[ 2 ].copy( vcm );
-						triB.vertexColors[ 0 ].copy( vcm );
-
-					}
-
-					edge = 2;
-
-				}
-
-				faces.push( triA, triB );
-				geometry.vertices.push( vm );
-
-				for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
-
-					if ( geometry.faceVertexUvs[ j ].length ) {
-
-						var uvs = geometry.faceVertexUvs[ j ][ i ];
-
-						var uvA = uvs[ 0 ];
-						var uvB = uvs[ 1 ];
-						var uvC = uvs[ 2 ];
-
-						// AB
-
-						if ( edge === 0 ) {
-
-							var uvM = uvA.clone();
-							uvM.lerp( uvB, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvM.clone(), uvC.clone() ];
-							var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
-
-							// BC
-
-						} else if ( edge === 1 ) {
-
-							var uvM = uvB.clone();
-							uvM.lerp( uvC, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
-							var uvsTriB = [ uvM.clone(), uvC.clone(), uvA.clone() ];
-
-							// AC
-
-						} else {
-
-							var uvM = uvA.clone();
-							uvM.lerp( uvC, 0.5 );
-
-							var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
-							var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+							triA.vertexNormals[ 1 ].copy( vnm );
+							triB.vertexNormals[ 0 ].copy( vnm );
 
 						}
 
-						faceVertexUvs[ j ].push( uvsTriA, uvsTriB );
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 0 ].clone();
+							vcm.lerp( face.vertexColors[ 1 ], 0.5 );
+
+							triA.vertexColors[ 1 ].copy( vcm );
+							triB.vertexColors[ 0 ].copy( vcm );
+
+						}
+
+						edge = 0;
+
+					} else if ( dbc >= dab && dbc >= dac ) {
+
+						var vm = vb.clone();
+						vm.lerp( vc, 0.5 );
+
+						triA.a = a;
+						triA.b = b;
+						triA.c = m;
+
+						triB.a = m;
+						triB.b = c;
+						triB.c = a;
+
+						if ( face.vertexNormals.length === 3 ) {
+
+							var vnm = face.vertexNormals[ 1 ].clone();
+							vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
+
+							triA.vertexNormals[ 2 ].copy( vnm );
+
+							triB.vertexNormals[ 0 ].copy( vnm );
+							triB.vertexNormals[ 1 ].copy( face.vertexNormals[ 2 ] );
+							triB.vertexNormals[ 2 ].copy( face.vertexNormals[ 0 ] );
+
+						}
+
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 1 ].clone();
+							vcm.lerp( face.vertexColors[ 2 ], 0.5 );
+
+							triA.vertexColors[ 2 ].copy( vcm );
+
+							triB.vertexColors[ 0 ].copy( vcm );
+							triB.vertexColors[ 1 ].copy( face.vertexColors[ 2 ] );
+							triB.vertexColors[ 2 ].copy( face.vertexColors[ 0 ] );
+
+						}
+
+						edge = 1;
+
+					} else {
+
+						var vm = va.clone();
+						vm.lerp( vc, 0.5 );
+
+						triA.a = a;
+						triA.b = b;
+						triA.c = m;
+
+						triB.a = m;
+						triB.b = b;
+						triB.c = c;
+
+						if ( face.vertexNormals.length === 3 ) {
+
+							var vnm = face.vertexNormals[ 0 ].clone();
+							vnm.lerp( face.vertexNormals[ 2 ], 0.5 );
+
+							triA.vertexNormals[ 2 ].copy( vnm );
+							triB.vertexNormals[ 0 ].copy( vnm );
+
+						}
+
+						if ( face.vertexColors.length === 3 ) {
+
+							var vcm = face.vertexColors[ 0 ].clone();
+							vcm.lerp( face.vertexColors[ 2 ], 0.5 );
+
+							triA.vertexColors[ 2 ].copy( vcm );
+							triB.vertexColors[ 0 ].copy( vcm );
+
+						}
+
+						edge = 2;
 
 					}
 
-				}
+					faces.push( triA, triB );
+					geometry.vertices.push( vm );
 
-			} else {
+					for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
 
-				faces.push( face );
+						if ( geometry.faceVertexUvs[ j ].length ) {
 
-				for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
+							const uvs = geometry.faceVertexUvs[ j ][ i ];
 
-					faceVertexUvs[ j ].push( geometry.faceVertexUvs[ j ][ i ] );
+							const uvA = uvs[ 0 ];
+							const uvB = uvs[ 1 ];
+							const uvC = uvs[ 2 ];
+
+							// AB
+
+							if ( edge === 0 ) {
+
+								var uvM = uvA.clone();
+								uvM.lerp( uvB, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvM.clone(), uvC.clone() ];
+								var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+
+								// BC
+
+							} else if ( edge === 1 ) {
+
+								var uvM = uvB.clone();
+								uvM.lerp( uvC, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
+								var uvsTriB = [ uvM.clone(), uvC.clone(), uvA.clone() ];
+
+								// AC
+
+							} else {
+
+								var uvM = uvA.clone();
+								uvM.lerp( uvC, 0.5 );
+
+								var uvsTriA = [ uvA.clone(), uvB.clone(), uvM.clone() ];
+								var uvsTriB = [ uvM.clone(), uvB.clone(), uvC.clone() ];
+
+							}
+
+							faceVertexUvs[ j ].push( uvsTriA, uvsTriB );
+
+						}
+
+					}
+
+				} else {
+
+					faces.push( face );
+
+					for ( var j = 0, jl = geometry.faceVertexUvs.length; j < jl; j ++ ) {
+
+						faceVertexUvs[ j ].push( geometry.faceVertexUvs[ j ][ i ] );
+
+					}
 
 				}
 
@@ -230,10 +256,20 @@ TessellateModifier.prototype.modify = function ( geometry ) {
 
 		}
 
+		geometry.faces = faces;
+		geometry.faceVertexUvs = faceVertexUvs;
+
 	}
 
-	geometry.faces = faces;
-	geometry.faceVertexUvs = faceVertexUvs;
+	if ( isBufferGeometry ) {
+
+		return new BufferGeometry().fromGeometry(geometry);
+
+	} else {
+
+		return geometry;
+
+	}
 
 };
 

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -8,7 +8,7 @@ import {
  * Break faces with edges longer than maxEdgeLength
  */
 
-var TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
+var TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = Infinity ) {
 
 	this.maxEdgeLength = maxEdgeLength;
 	this.maxIterations = maxIterations;

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -8,9 +8,11 @@ import {
  * Break faces with edges longer than maxEdgeLength
  */
 
-var TessellateModifier = function ( maxEdgeLength ) {
+const TessellateModifier = function ( maxEdgeLength = 0.1, maxIterations = 6, maxFaces = 1000000 ) {
 
-	this.maxEdgeLength = ( maxEdgeLength === undefined ) ? 0.1 : maxEdgeLength;
+	this.maxEdgeLength = maxEdgeLength;
+	this.maxIterations = maxIterations;
+	this.maxFaces = maxFaces;
 
 };
 
@@ -32,16 +34,18 @@ TessellateModifier.prototype.modify = function ( geometry ) {
 	geometry.mergeVertices( 6 );
 
 	let finalized = false;
+	let iteration = 0;
 	const maxEdgeLengthSquared = this.maxEdgeLength * this.maxEdgeLength;
 
 	let edge;
 
-	while ( ! finalized ) {
+	while ( ! finalized && iteration < this.maxIterations && geometry.faces.length < this.maxFaces ) {
 
 		const faces = [];
 		const faceVertexUvs = [];
 
 		finalized = true;
+		iteration ++;
 
 		for ( var i = 0, il = geometry.faceVertexUvs.length; i < il; i ++ ) {
 
@@ -67,7 +71,9 @@ TessellateModifier.prototype.modify = function ( geometry ) {
 				const dbc = vb.distanceToSquared( vc );
 				const dac = va.distanceToSquared( vc );
 
-				if ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) {
+				const limitReached = ( faces.length + il - i ) >= this.maxFaces;
+
+				if ( ! limitReached && ( dab > maxEdgeLengthSquared || dbc > maxEdgeLengthSquared || dac > maxEdgeLengthSquared ) ) {
 
 					finalized = false;
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -107,11 +107,7 @@
 
 				const tessellateModifier = new TessellateModifier( 8 );
 
-				for ( let i = 0; i < 6; i ++ ) {
-
-					tessellateModifier.modify( geometry );
-
-				}
+				geometry = tessellateModifier.modify( geometry );
 
 				//
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -105,7 +105,7 @@
 
 				geometry.center();
 
-				const tessellateModifier = new TessellateModifier( 8 );
+				const tessellateModifier = new TessellateModifier( 8, 6, 30000 );
 
 				geometry = tessellateModifier.modify( geometry );
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -105,7 +105,7 @@
 
 				geometry.center();
 
-				const tessellateModifier = new TessellateModifier( 8, 6, 30000 );
+				const tessellateModifier = new TessellateModifier( 8, 6 );
 
 				geometry = tessellateModifier.modify( geometry );
 

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -242,10 +242,10 @@ export class Geometry extends EventDispatcher {
 	mergeMesh( mesh: Mesh ): void;
 
 	/**
-	 * Checks for duplicate vertices using hashmap.
+	 * Checks for duplicate vertices using hashmap for specified number of decimal points, e.g. 4 for epsilon of 0.0001
 	 * Duplicated vertices are removed and faces' vertices are updated.
 	 */
-	mergeVertices(): number;
+	mergeVertices( precisionPoints: number ): number;
 
 	setFromPoints( points: Array<Vector2> | Array<Vector3> ): this;
 

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -245,7 +245,7 @@ export class Geometry extends EventDispatcher {
 	 * Checks for duplicate vertices using hashmap for specified number of decimal points, e.g. 4 for epsilon of 0.0001
 	 * Duplicated vertices are removed and faces' vertices are updated.
 	 */
-	mergeVertices( precisionPoints?: number = 4 ): number;
+	mergeVertices( precisionPoints?: number ): number;
 
 	setFromPoints( points: Array<Vector2> | Array<Vector3> ): this;
 

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -245,7 +245,7 @@ export class Geometry extends EventDispatcher {
 	 * Checks for duplicate vertices using hashmap for specified number of decimal points, e.g. 4 for epsilon of 0.0001
 	 * Duplicated vertices are removed and faces' vertices are updated.
 	 */
-	mergeVertices( precisionPoints: number ): number;
+	mergeVertices( precisionPoints?: number = 4 ): number;
 
 	setFromPoints( points: Array<Vector2> | Array<Vector3> ): this;
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -769,12 +769,11 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	 * and faces' vertices are updated.
 	 */
 
-	mergeVertices: function ( precisionPoints ) {
+	mergeVertices: function ( precisionPoints = 4 ) {
 
 		const verticesMap = {}; // Hashmap for looking up vertices by position coordinates (and making sure they are unique)
 		const unique = [], changes = [];
 
-		precisionPoints = precisionPoints || 4;
 		const precision = Math.pow( 10, precisionPoints );
 
 		for ( let i = 0, il = this.vertices.length; i < il; i ++ ) {

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -769,12 +769,12 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 	 * and faces' vertices are updated.
 	 */
 
-	mergeVertices: function () {
+	mergeVertices: function ( precisionPoints ) {
 
 		const verticesMap = {}; // Hashmap for looking up vertices by position coordinates (and making sure they are unique)
 		const unique = [], changes = [];
 
-		const precisionPoints = 4; // number of decimal points, e.g. 4 for epsilon of 0.0001
+		precisionPoints = precisionPoints || 4;
 		const precision = Math.pow( 10, precisionPoints );
 
 		for ( let i = 0, il = this.vertices.length; i < il; i ++ ) {


### PR DESCRIPTION
Currently `TessellateModifier` is not recursive and requires manual invocation of the `modify( geometry )` multiple times like [in the example here](https://github.com/mrdoob/three.js/blob/dev/examples/webgl_modifier_tessellation.html#L111).

The problem with this is that you can't know when the `maxEdgeLength` parameter is satisfied and the tessellation is complete. So you have to guess how many iterations you need. In the example `6` seems to do the job, in some other cases any number of iterations between `0 .. n` is needed.

### This change contains the following:

* Adds internal `while ( ! finalized )` tessellation loop that runs until no edge with `length > maxEdgeLength` exists.
* Instead of mutating geometry from `modify( geometry )` argument, it returns new geometry (same as `SubdivideModifier`).

It also contains a minor change affecting both `TessellateModifier` and `SubdivideModifier`:
* Output geometry is same type as input geometry (`Geometry` vs `BufferGeometry`)
* `Geometry.mergeVertices( precisionPoints )` now accepts optional `precisionPoints` argument.
* Increased vertex merging precision to `geometry.mergeVertices( 6 );` to avoid collapsing small triangles.
 
### Questions:

* Should `precisionPoints` for vertex merging also be a property of `TessellateModifier` and `SubdivideModifier?