### PR TITLE
Add layers for virtualCamera

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -46,6 +46,8 @@ var Reflector = function ( geometry, options ) {
 
 	var textureMatrix = new Matrix4();
 	var virtualCamera = new PerspectiveCamera();
+	virtualCamera.layers.disable(0);
+	virtualCamera.layers.enable(1);
 
 	var parameters = {
 		minFilter: LinearFilter,


### PR DESCRIPTION
Using layers is possible to select which objects should be reflected or not:
Layer 1 for objects to be reflected
Layer 0 for objects to do not be reflected

Related issues:

#XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.
