### PR TITLE
WebGLCubeMaps: Support Texture.dispose().

### DIFF
--- a/src/renderers/webgl/WebGLCubeMaps.js
+++ b/src/renderers/webgl/WebGLCubeMaps.js
@@ -52,6 +52,8 @@ function WebGLCubeMaps( renderer ) {
 						renderer.setRenderList( currentRenderList );
 						renderer.setRenderState( currentRenderState );
 
+						texture.addEventListener( 'dispose', onTextureDispose );
+
 						return mapTextureMapping( renderTarget.texture, texture.mapping );
 
 					} else {
@@ -69,6 +71,23 @@ function WebGLCubeMaps( renderer ) {
 		}
 
 		return texture;
+
+	}
+
+	function onTextureDispose( event ) {
+
+		const texture = event.target;
+
+		texture.removeEventListener( 'dispose', onTextureDispose );
+
+		const cubemap = cubemaps.get( texture );
+
+		if ( cubemap !== undefined ) {
+
+			cubemaps.delete( texture );
+			cubemap.dispose();
+
+		}
 
 	}
 


### PR DESCRIPTION
This PR ensures that internal cube render targets are properly removed when `Texture.dispose()` is called with an equirectangular texture. Otherwise a memory leak could occur.

I've noticed this when trying to integrate PMREM. It's necessary to the same for cubeUV maps, too.