### PR TITLE
Fixes size alignment in webgpu buffer creation

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -64,7 +64,7 @@ class WebGPUAttributes {
 	_createBuffer( attribute, usage ) {
 
 		const array = attribute.array;
-		const size = array.byteLength + ( array.byteLength % 4 ); // ensure 4 byte alignment
+		const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment
 
 		const buffer = this.device.createBuffer( {
 			size: size,


### PR DESCRIPTION
Fixes #20441

There was a little error when computing the proper 4-byte aligned size in the buffer.
