### PR TITLE
bitwise 4-byte alignment

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -64,7 +64,7 @@ class WebGPUAttributes {
 	_createBuffer( attribute, usage ) {
 
 		const array = attribute.array;
-		const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment, see #20441
+		const size = array.byteLength + ( 4 - array.byteLength & 3 ); // ensure 4 byte alignment
 
 		const buffer = this.device.createBuffer( {
 			size: size,


### PR DESCRIPTION
**Description**

<del>Uses `sizeInMult4 = byteLength + ( 4 - byteLength & 3 )`</del> **Updates 2025**: The formula should be simply...

```js
sizeInMult4 = byteLength + /*extra bytes count*/( -byteLength & 3 ) 
```

... which **derives extra byte count from remainder** by leveraging 2's complement of the `byteLength` two LSBs ...:

byteLength | 2's complement & 3 
-------------|------------------------
0bxxxx_xx00  (4n+0)|  0bxxxx_x100 & 3 = 0 
0bxxxx_xx01  (4n+1)|  0bxxxx_xx11 & 3 = 3 
0bxxxx_xx10  (4n+2)|  0bxxxx_xx10 & 3 = 2 
0bxxxx_xx11  (4n+3)|  0bxxxx_xx01 & 3 = 1 

... the numbers are exactly the extra bytes count we needed. 

