### PR TITLE
Fixes SSAOPass for orthographic cameras

### DIFF
--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -88,7 +88,7 @@ var SSAOShader = {
 
 		"	#else",
 
-		"		return texture2D( depthSampler, coord ).x;",
+		"		return texture2D( tDepth, screenPosition ).x;",
 
 		"	#endif",
 


### PR DESCRIPTION
This [change](https://github.com/mrdoob/three.js/commit/2f9bd634d4abd2aaf088d72ee508bf5cbd810086#diff-fb84a09fb2a3ca08134feaf5bce5a49eL110) desynced the names for the `tDepth` uniform and `screenPosition` parameters.
