### PR TITLE
VideoTexture: Fix error when detecting requestVideoFrameCallback

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -33,6 +33,12 @@ VideoTexture.prototype = Object.assign( Object.create( Texture.prototype ), {
 
 	constructor: VideoTexture,
 
+	clone: function () {
+
+		return new this.constructor( this.image ).copy( this );
+
+	},
+
 	isVideoTexture: true,
 
 	update: function () {


### PR DESCRIPTION
  Fixes `TypeError: video is not an Object.` regression in #19906

Related issues:

#19906

**Description**

When `VideoTexture` is constructed with an undefined video, the `requestVideoFrameCallback` detection on line 24 throws an error.