### PR TITLE
OutlinePass: Exclude point cloud and lines.

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -32,6 +32,8 @@ var OutlinePass = function ( resolution, scene, camera, selectedObjects ) {
 	this.downSampleRatio = 2;
 	this.pulsePeriod = 0;
 
+	this._visibilityCache = new Map();
+
 	Pass.call( this );
 
 	this.resolution = ( resolution !== undefined ) ? new Vector2( resolution.x, resolution.y ) : new Vector2( 256, 256 );
@@ -172,18 +174,19 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 	changeVisibilityOfSelectedObjects: function ( bVisible ) {
 
+		var cache = this._visibilityCache;
+
 		function gatherSelectedMeshesCallBack( object ) {
 
 			if ( object.isMesh ) {
 
-				if ( bVisible ) {
+				if ( bVisible === true ) {
 
-					object.visible = object.userData.oldVisible;
-					delete object.userData.oldVisible;
+					object.visible = cache.get( object );
 
 				} else {
 
-					object.userData.oldVisible = object.visible;
+					cache.set( object, object.visible );
 					object.visible = bVisible;
 
 				}
@@ -203,6 +206,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 	changeVisibilityOfNonSelectedObjects: function ( bVisible ) {
 
+		var cache = this._visibilityCache;
 		var selectedMeshes = [];
 
 		function gatherSelectedMeshesCallBack( object ) {
@@ -220,7 +224,9 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 		function VisibilityChangeCallBack( object ) {
 
-			if ( object.isMesh || object.isLine || object.isSprite ) {
+			if ( object.isMesh || object.isSprite ) {
+
+				// only meshes and sprites are supported by OutlinePass
 
 				var bFound = false;
 
@@ -237,13 +243,33 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 				}
 
-				if ( ! bFound ) {
+				if ( bFound === false ) {
 
 					var visibility = object.visible;
 
-					if ( ! bVisible || object.bVisible ) object.visible = bVisible;
+					if ( bVisible === false || cache.get( object ) === true ) {
 
-					object.bVisible = visibility;
+						object.visible = bVisible;
+
+					}
+
+					cache.set( object, visibility );
+
+				}
+
+			} else if ( object.isPoints || object.isLine ) {
+
+				// the visibilty of points and lines is always set to false in order to
+				// not affect the outline computation
+
+				if ( bVisible === true ) {
+
+					object.visible = cache.get( object ); // restore
+
+				} else {
+
+					cache.set( object, object.visible );
+					object.visible = bVisible;
 
 				}
 
@@ -294,6 +320,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 
 			// Make selected objects visible
 			this.changeVisibilityOfSelectedObjects( true );
+			this._visibilityCache.clear();
 
 			// Update Texture Matrix for Depth compare
 			this.updateTextureMatrix();
@@ -309,6 +336,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 			renderer.render( this.renderScene, this.renderCamera );
 			this.renderScene.overrideMaterial = null;
 			this.changeVisibilityOfNonSelectedObjects( true );
+			this._visibilityCache.clear();
 
 			this.renderScene.background = currentBackground;
 


### PR DESCRIPTION
Fixed #20428.

Te PR also refactors how visibility is controlled in `OutlinePass` so 3D objects are not polluted with custom properties anymore.