### PR TITLE
Add fallback for area lights in iOS 14.

### DIFF
--- a/examples/jsm/lights/RectAreaLightUniformsLib.js
+++ b/examples/jsm/lights/RectAreaLightUniformsLib.js
@@ -27,7 +27,7 @@ import {
 
 var RectAreaLightUniformsLib = {
 
-	init: function () {
+	init: function (renderer) {
 
 		// source: https://github.com/selfshadow/ltc_code/tree/master/fit/results/ltc.js
 
@@ -37,8 +37,14 @@ var RectAreaLightUniformsLib = {
 
 		// data textures
 
-		var ltc_1 = new DataTexture( new Float32Array( LTC_MAT_1 ), 64, 64, RGBAFormat, FloatType, UVMapping, ClampToEdgeWrapping, ClampToEdgeWrapping, LinearFilter, NearestFilter, 1 );
-		var ltc_2 = new DataTexture( new Float32Array( LTC_MAT_2 ), 64, 64, RGBAFormat, FloatType, UVMapping, ClampToEdgeWrapping, ClampToEdgeWrapping, LinearFilter, NearestFilter, 1 );
+		if ( renderer.capabilities.isWebGL2 === false && ! renderer.extensions.get( 'OES_texture_float_linear' ) ) {
+			var magFilter = NearestFilter;
+		} else {
+			var magFilter = LinearFilter;
+		}
+
+		var ltc_1 = new DataTexture( new Float32Array( LTC_MAT_1 ), 64, 64, RGBAFormat, FloatType, UVMapping, ClampToEdgeWrapping, ClampToEdgeWrapping, magFilter, NearestFilter, 1 );
+		var ltc_2 = new DataTexture( new Float32Array( LTC_MAT_2 ), 64, 64, RGBAFormat, FloatType, UVMapping, ClampToEdgeWrapping, ClampToEdgeWrapping, magFilter, NearestFilter, 1 );
 
 		UniformsLib.LTC_1 = ltc_1;
 		UniformsLib.LTC_2 = ltc_2;

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -56,13 +56,6 @@
 
 				}
 
-				if ( renderer.capabilities.isWebGL2 === false && ! renderer.extensions.get( 'OES_texture_float_linear' ) ) {
-
-					alert( 'OES_texture_float_linear not supported' );
-					throw 'missing webgl extension';
-
-				}
-
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 0, 20, 35 );
 
@@ -71,7 +64,7 @@
 				var ambient = new THREE.AmbientLight( 0xffffff, 0.1 );
 				scene.add( ambient );
 
-				RectAreaLightUniformsLib.init();
+				RectAreaLightUniformsLib.init(renderer);
 
 				rectLight = new THREE.RectAreaLight( 0xffffff, 1, 10, 10 );
 				rectLight.position.set( 5, 5, 0 );


### PR DESCRIPTION
Related issues:

#20415

**Description**

Area lighting is completely black on iOS 14 and on other devices which do not support the WebGL extension `OES_texture_float_linear`. This change detects whether the extension is available, and falls back to nearest-neighbourhood magnification filtering. This produces some banding artefacts in reflections of area lights, but I feel this is preferable to disabling area lights completely.

Currently I have implemented this by passing the renderer into `RectAreaLightUniformsLib.init()`, which is a breaking change to that API. I'm open to suggestions on how to avoid breaking the API.
