### PR TITLE
Object3D: Add removeAll().

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -314,6 +314,11 @@
 		Removes *object* as child of this object. An arbitrary number of objects may be removed.
 		</p>
 
+		<h3>[method:this removeAll]()</h3>
+		<p>
+		Removes all child objects.
+		</p>
+
 		<h3>[method:this rotateOnAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 		axis -- A normalized vector in object space. <br />

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -317,6 +317,11 @@ export class Object3D extends EventDispatcher {
 	remove( ...object: Object3D[] ): this;
 
 	/**
+	 * Removes all child objects.
+	 */
+	removeAll(): this;
+
+	/**
 	 * Adds object as a child of this, while maintaining the object's world transform.
 	 */
 	attach( object: Object3D ): this;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -370,6 +370,25 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
+	removeAll: function () {
+
+		for ( let i = 0; i < this.children.length; i ++ ) {
+
+			const object = this.children[ i ];
+
+			object.parent = null;
+
+			object.dispatchEvent( _removedEvent );
+
+		}
+
+		this.children.length = 0;
+
+		return this;
+
+
+	},
+
 	attach: function ( object ) {
 
 		// adds object as a child of this, while maintaining the object's world transform

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -296,7 +296,7 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( "add/remove", ( assert ) => {
+		QUnit.test( "add/remove/removeAll", ( assert ) => {
 
 			var a = new Object3D();
 			var child1 = new Object3D();
@@ -327,6 +327,13 @@ export default QUnit.module( 'Core', () => {
 			assert.strictEqual( a.children.length, 1, "The second one was added to the parent (no remove)" );
 			assert.strictEqual( a.children[ 0 ], child2, "The second one is now the parent's child again" );
 			assert.strictEqual( child1.children.length, 0, "The first one no longer has any children" );
+
+			a.add( child1 );
+			assert.strictEqual( a.children.length, 2, "The first child was added to the parent" );
+			a.removeAll();
+			assert.strictEqual( a.children.length, 0, "All childrens were removed" );
+			assert.strictEqual( child1.parent, null, "First child has no parent" );
+			assert.strictEqual( child2.parent, null, "Second child has no parent" );
 
 		} );
 


### PR DESCRIPTION
Related issues:

Fixed #20414.

**Description**

I like `removeAll()` more than the `clear()` since the relation to `remove()` is more obvious. Or in other words, it should be easier for user to figure out what `removeAll()` does if they are familiar with the semantics of `remove()`.
