### PR TITLE
WebGLGeometries: Fix memory leak when disposing Geometry.

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -37,7 +37,7 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 		}
 
-		bindingStates.releaseStatesOfGeometry( geometry );
+		bindingStates.releaseStatesOfGeometry( buffergeometry );
 
 		if ( geometry.isInstancedBufferGeometry === true ) {
 


### PR DESCRIPTION
Related issues:

https://stackoverflow.com/questions/64260963/three-js-vram-memory-leak-when-adding-removing-three-geometry-to-scene

**Description**

This PR fixes a bug in `WebGLGeometries`. `WebGLBindingstate.releaseStatesOfGeometry()` was called with the wrong geometry object. It always has to be the instance of `BufferGeometry`, not `Geometry`.