### PR TITLE
Make eslint rule an error instead of a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "@typescript-eslint"
     ],
     "rules": {
-      "@typescript-eslint/no-unused-vars": 1,
+      "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/indent": [
         "error",
         "tab",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "@typescript-eslint"
     ],
     "rules": {
-      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-unused-vars": ["error"],
       "@typescript-eslint/indent": [
         "error",
         "tab",


### PR DESCRIPTION
This will `@typescript-eslint/no-unused-vars` an error instead of a warning. It's helpful for the rule to error so that the build will fail so that you don't have to check the logs to see if there was a warning. See https://github.com/mrdoob/three.js/pull/20467 for context.
