### PR TITLE
STLExporter: Use BufferGeometry, supported skeletons.

### DIFF
--- a/examples/js/exporters/STLExporter.js
+++ b/examples/js/exporters/STLExporter.js
@@ -14,149 +14,191 @@ THREE.STLExporter.prototype = {
 
 	constructor: THREE.STLExporter,
 
-	parse: ( function () {
+	parse: function ( scene, options ) {
 
-		var vector = new THREE.Vector3();
-		var normalMatrixWorld = new THREE.Matrix3();
+		if ( options === undefined ) options = {};
 
-		return function parse( scene, options ) {
+		var binary = options.binary !== undefined ? options.binary : false;
 
-			if ( options === undefined ) options = {};
+		//
 
-			var binary = options.binary !== undefined ? options.binary : false;
+		var objects = [];
+		var triangles = 0;
 
-			//
+		scene.traverse( function ( object ) {
 
-			var objects = [];
-			var triangles = 0;
+			if ( object.isMesh ) {
 
-			scene.traverse( function ( object ) {
+				var geometry = object.geometry;
 
-				if ( object.isMesh ) {
+				if ( geometry.isGeometry ) {
 
-					var geometry = object.geometry;
-
-					if ( geometry.isBufferGeometry ) {
-
-						geometry = new THREE.Geometry().fromBufferGeometry( geometry );
-
-					}
-
-					if ( geometry.isGeometry ) {
-
-						triangles += geometry.faces.length;
-
-						objects.push( {
-
-							geometry: geometry,
-							matrixWorld: object.matrixWorld
-
-						} );
-
-					}
+					geometry = new THREE.BufferGeometry().fromGeometry( geometry );
 
 				}
 
-			} );
+				var index = geometry.index;
+				var positionAttribute = geometry.getAttribute( 'position' );
 
-			if ( binary ) {
+				triangles += ( index !== null ) ? ( index.count / 3 ) : ( positionAttribute.count / 3 );
 
-				var offset = 80; // skip header
-				var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
-				var arrayBuffer = new ArrayBuffer( bufferLength );
-				var output = new DataView( arrayBuffer );
-				output.setUint32( offset, triangles, true ); offset += 4;
-
-				for ( var i = 0, il = objects.length; i < il; i ++ ) {
-
-					var object = objects[ i ];
-
-					var vertices = object.geometry.vertices;
-					var faces = object.geometry.faces;
-					var matrixWorld = object.matrixWorld;
-
-					normalMatrixWorld.getNormalMatrix( matrixWorld );
-
-					for ( var j = 0, jl = faces.length; j < jl; j ++ ) {
-
-						var face = faces[ j ];
-
-						vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
-
-						output.setFloat32( offset, vector.x, true ); offset += 4; // normal
-						output.setFloat32( offset, vector.y, true ); offset += 4;
-						output.setFloat32( offset, vector.z, true ); offset += 4;
-
-						var indices = [ face.a, face.b, face.c ];
-
-						for ( var k = 0; k < 3; k ++ ) {
-
-							vector.copy( vertices[ indices[ k ] ] ).applyMatrix4( matrixWorld );
-
-							output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
-							output.setFloat32( offset, vector.y, true ); offset += 4;
-							output.setFloat32( offset, vector.z, true ); offset += 4;
-
-						}
-
-						output.setUint16( offset, 0, true ); offset += 2; // attribute byte count
-
-					}
-
-				}
-
-				return output;
-
-			} else {
-
-				var output = '';
-
-				output += 'solid exported\n';
-
-				for ( var i = 0, il = objects.length; i < il; i ++ ) {
-
-					var object = objects[ i ];
-
-					var vertices = object.geometry.vertices;
-					var faces = object.geometry.faces;
-					var matrixWorld = object.matrixWorld;
-
-					normalMatrixWorld.getNormalMatrix( matrixWorld );
-
-					for ( var j = 0, jl = faces.length; j < jl; j ++ ) {
-
-						var face = faces[ j ];
-
-						vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
-
-						output += '\tfacet normal ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
-						output += '\t\touter loop\n';
-
-						var indices = [ face.a, face.b, face.c ];
-
-						for ( var k = 0; k < 3; k ++ ) {
-
-							vector.copy( vertices[ indices[ k ] ] ).applyMatrix4( matrixWorld );
-
-							output += '\t\t\tvertex ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
-
-						}
-
-						output += '\t\tendloop\n';
-						output += '\tendfacet\n';
-
-					}
-
-				}
-
-				output += 'endsolid exported\n';
-
-				return output;
+				objects.push( {
+					object3d: object,
+					geometry: geometry
+				} );
 
 			}
 
-		};
+		} );
 
-	}() )
+		var output;
+		var offset = 80; // skip header
+
+		if ( binary === true ) {
+
+			var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
+			var arrayBuffer = new ArrayBuffer( bufferLength );
+			output = new DataView( arrayBuffer );
+			output.setUint32( offset, triangles, true ); offset += 4;
+
+		} else {
+
+			output = '';
+			output += 'solid exported\n';
+
+		}
+
+		var vA = new THREE.Vector3();
+		var vB = new THREE.Vector3();
+		var vC = new THREE.Vector3();
+		var cb = new THREE.Vector3();
+		var ab = new THREE.Vector3();
+		var normal = new THREE.Vector3();
+
+		for ( var i = 0, il = objects.length; i < il; i ++ ) {
+
+			var object = objects[ i ].object3d;
+			var geometry = objects[ i ].geometry;
+
+			var index = geometry.index;
+			var positionAttribute = geometry.getAttribute( 'position' );
+
+			if ( index !== null ) {
+
+				// indexed geometry
+
+				for ( var j = 0; j < index.count; j += 3 ) {
+
+					var a = index.getX( j + 0 );
+					var b = index.getX( j + 1 );
+					var c = index.getX( j + 2 );
+
+					writeFace( a, b, c, positionAttribute, object );
+
+				}
+
+			} else {
+
+				// non-indexed geometry
+
+				for ( var j = 0; j < positionAttribute.count; j += 3 ) {
+
+					var a = j + 0;
+					var b = j + 1;
+					var c = j + 2;
+
+					writeFace( a, b, c, positionAttribute, object );
+
+				}
+
+			}
+
+		}
+
+		if ( binary === false ) {
+
+			output += 'endsolid exported\n';
+
+		}
+
+		return output;
+
+		function writeFace( a, b, c, positionAttribute, object ) {
+
+			vA.fromBufferAttribute( positionAttribute, a );
+			vB.fromBufferAttribute( positionAttribute, b );
+			vC.fromBufferAttribute( positionAttribute, c );
+
+			if ( object.isSkinnedMesh === true ) {
+
+				object.boneTransform( a, vA );
+				object.boneTransform( b, vB );
+				object.boneTransform( c, vC );
+
+			}
+
+			vA.applyMatrix4( object.matrixWorld );
+			vB.applyMatrix4( object.matrixWorld );
+			vC.applyMatrix4( object.matrixWorld );
+
+			writeNormal( vA, vB, vC );
+
+			writeVertex( vA );
+			writeVertex( vB );
+			writeVertex( vC );
+
+			if ( binary === true ) {
+
+				output.setUint16( offset, 0, true ); offset += 2;
+
+			} else {
+
+				output += '\t\tendloop\n';
+				output += '\tendfacet\n';
+
+			}
+
+		}
+
+		function writeNormal( vA, vB, vC ) {
+
+			cb.subVectors( vC, vB );
+			ab.subVectors( vA, vB );
+			cb.cross( ab ).normalize();
+
+			normal.copy( cb ).normalize();
+
+			if ( binary === true ) {
+
+				output.setFloat32( offset, normal.x, true ); offset += 4;
+				output.setFloat32( offset, normal.y, true ); offset += 4;
+				output.setFloat32( offset, normal.z, true ); offset += 4;
+
+			} else {
+
+				output += '\tfacet normal ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
+				output += '\t\touter loop\n';
+
+			}
+
+		}
+
+		function writeVertex( vertex ) {
+
+			if ( binary === true ) {
+
+				output.setFloat32( offset, vertex.x, true ); offset += 4;
+				output.setFloat32( offset, vertex.y, true ); offset += 4;
+				output.setFloat32( offset, vertex.z, true ); offset += 4;
+
+			} else {
+
+				output += '\t\t\tvertex ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
+
+			}
+
+		}
+
+	}
 
 };

--- a/examples/jsm/exporters/STLExporter.js
+++ b/examples/jsm/exporters/STLExporter.js
@@ -1,6 +1,5 @@
 import {
-	Geometry,
-	Matrix3,
+	BufferGeometry,
 	Vector3
 } from "../../../build/three.module.js";
 /**
@@ -18,150 +17,192 @@ STLExporter.prototype = {
 
 	constructor: STLExporter,
 
-	parse: ( function () {
+	parse: function ( scene, options ) {
 
-		var vector = new Vector3();
-		var normalMatrixWorld = new Matrix3();
+		if ( options === undefined ) options = {};
 
-		return function parse( scene, options ) {
+		var binary = options.binary !== undefined ? options.binary : false;
 
-			if ( options === undefined ) options = {};
+		//
 
-			var binary = options.binary !== undefined ? options.binary : false;
+		var objects = [];
+		var triangles = 0;
 
-			//
+		scene.traverse( function ( object ) {
 
-			var objects = [];
-			var triangles = 0;
+			if ( object.isMesh ) {
 
-			scene.traverse( function ( object ) {
+				var geometry = object.geometry;
 
-				if ( object.isMesh ) {
+				if ( geometry.isGeometry ) {
 
-					var geometry = object.geometry;
-
-					if ( geometry.isBufferGeometry ) {
-
-						geometry = new Geometry().fromBufferGeometry( geometry );
-
-					}
-
-					if ( geometry.isGeometry ) {
-
-						triangles += geometry.faces.length;
-
-						objects.push( {
-
-							geometry: geometry,
-							matrixWorld: object.matrixWorld
-
-						} );
-
-					}
+					geometry = new BufferGeometry().fromGeometry( geometry );
 
 				}
 
-			} );
+				var index = geometry.index;
+				var positionAttribute = geometry.getAttribute( 'position' );
 
-			if ( binary ) {
+				triangles += ( index !== null ) ? ( index.count / 3 ) : ( positionAttribute.count / 3 );
 
-				var offset = 80; // skip header
-				var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
-				var arrayBuffer = new ArrayBuffer( bufferLength );
-				var output = new DataView( arrayBuffer );
-				output.setUint32( offset, triangles, true ); offset += 4;
-
-				for ( var i = 0, il = objects.length; i < il; i ++ ) {
-
-					var object = objects[ i ];
-
-					var vertices = object.geometry.vertices;
-					var faces = object.geometry.faces;
-					var matrixWorld = object.matrixWorld;
-
-					normalMatrixWorld.getNormalMatrix( matrixWorld );
-
-					for ( var j = 0, jl = faces.length; j < jl; j ++ ) {
-
-						var face = faces[ j ];
-
-						vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
-
-						output.setFloat32( offset, vector.x, true ); offset += 4; // normal
-						output.setFloat32( offset, vector.y, true ); offset += 4;
-						output.setFloat32( offset, vector.z, true ); offset += 4;
-
-						var indices = [ face.a, face.b, face.c ];
-
-						for ( var k = 0; k < 3; k ++ ) {
-
-							vector.copy( vertices[ indices[ k ] ] ).applyMatrix4( matrixWorld );
-
-							output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
-							output.setFloat32( offset, vector.y, true ); offset += 4;
-							output.setFloat32( offset, vector.z, true ); offset += 4;
-
-						}
-
-						output.setUint16( offset, 0, true ); offset += 2; // attribute byte count
-
-					}
-
-				}
-
-				return output;
-
-			} else {
-
-				var output = '';
-
-				output += 'solid exported\n';
-
-				for ( var i = 0, il = objects.length; i < il; i ++ ) {
-
-					var object = objects[ i ];
-
-					var vertices = object.geometry.vertices;
-					var faces = object.geometry.faces;
-					var matrixWorld = object.matrixWorld;
-
-					normalMatrixWorld.getNormalMatrix( matrixWorld );
-
-					for ( var j = 0, jl = faces.length; j < jl; j ++ ) {
-
-						var face = faces[ j ];
-
-						vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
-
-						output += '\tfacet normal ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
-						output += '\t\touter loop\n';
-
-						var indices = [ face.a, face.b, face.c ];
-
-						for ( var k = 0; k < 3; k ++ ) {
-
-							vector.copy( vertices[ indices[ k ] ] ).applyMatrix4( matrixWorld );
-
-							output += '\t\t\tvertex ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
-
-						}
-
-						output += '\t\tendloop\n';
-						output += '\tendfacet\n';
-
-					}
-
-				}
-
-				output += 'endsolid exported\n';
-
-				return output;
+				objects.push( {
+					object3d: object,
+					geometry: geometry
+				} );
 
 			}
 
-		};
+		} );
 
-	}() )
+		var output;
+		var offset = 80; // skip header
+
+		if ( binary === true ) {
+
+			var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
+			var arrayBuffer = new ArrayBuffer( bufferLength );
+			output = new DataView( arrayBuffer );
+			output.setUint32( offset, triangles, true ); offset += 4;
+
+		} else {
+
+			output = '';
+			output += 'solid exported\n';
+
+		}
+
+		var vA = new Vector3();
+		var vB = new Vector3();
+		var vC = new Vector3();
+		var cb = new Vector3();
+		var ab = new Vector3();
+		var normal = new Vector3();
+
+		for ( var i = 0, il = objects.length; i < il; i ++ ) {
+
+			var object = objects[ i ].object3d;
+			var geometry = objects[ i ].geometry;
+
+			var index = geometry.index;
+			var positionAttribute = geometry.getAttribute( 'position' );
+
+			if ( index !== null ) {
+
+				// indexed geometry
+
+				for ( var j = 0; j < index.count; j += 3 ) {
+
+					var a = index.getX( j + 0 );
+					var b = index.getX( j + 1 );
+					var c = index.getX( j + 2 );
+
+					writeFace( a, b, c, positionAttribute, object );
+
+				}
+
+			} else {
+
+				// non-indexed geometry
+
+				for ( var j = 0; j < positionAttribute.count; j += 3 ) {
+
+					var a = j + 0;
+					var b = j + 1;
+					var c = j + 2;
+
+					writeFace( a, b, c, positionAttribute, object );
+
+				}
+
+			}
+
+		}
+
+		if ( binary === false ) {
+
+			output += 'endsolid exported\n';
+
+		}
+
+		return output;
+
+		function writeFace( a, b, c, positionAttribute, object ) {
+
+			vA.fromBufferAttribute( positionAttribute, a );
+			vB.fromBufferAttribute( positionAttribute, b );
+			vC.fromBufferAttribute( positionAttribute, c );
+
+			if ( object.isSkinnedMesh === true ) {
+
+				object.boneTransform( a, vA );
+				object.boneTransform( b, vB );
+				object.boneTransform( c, vC );
+
+			}
+
+			vA.applyMatrix4( object.matrixWorld );
+			vB.applyMatrix4( object.matrixWorld );
+			vC.applyMatrix4( object.matrixWorld );
+
+			writeNormal( vA, vB, vC );
+
+			writeVertex( vA );
+			writeVertex( vB );
+			writeVertex( vC );
+
+			if ( binary === true ) {
+
+				output.setUint16( offset, 0, true ); offset += 2;
+
+			} else {
+
+				output += '\t\tendloop\n';
+				output += '\tendfacet\n';
+
+			}
+
+		}
+
+		function writeNormal( vA, vB, vC ) {
+
+			cb.subVectors( vC, vB );
+			ab.subVectors( vA, vB );
+			cb.cross( ab ).normalize();
+
+			normal.copy( cb ).normalize();
+
+			if ( binary === true ) {
+
+				output.setFloat32( offset, normal.x, true ); offset += 4;
+				output.setFloat32( offset, normal.y, true ); offset += 4;
+				output.setFloat32( offset, normal.z, true ); offset += 4;
+
+			} else {
+
+				output += '\tfacet normal ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
+				output += '\t\touter loop\n';
+
+			}
+
+		}
+
+		function writeVertex( vertex ) {
+
+			if ( binary === true ) {
+
+				output.setFloat32( offset, vertex.x, true ); offset += 4;
+				output.setFloat32( offset, vertex.y, true ); offset += 4;
+				output.setFloat32( offset, vertex.z, true ); offset += 4;
+
+			} else {
+
+				output += '\t\t\tvertex ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
+
+			}
+
+		}
+
+	}
 
 };
 


### PR DESCRIPTION
This PR ensures that `STLExporter` internally uses `BufferGeometry` instead of `Geometry` to generate the output. Besides, the PR makes use of `SkinnedMesh.boneTransform()` to correctly export skinned meshes.

Closes #16942 and also solves a request from the forum.