### PR TITLE
TS: Remove Scene.dispose definition

### DIFF
--- a/src/scenes/Scene.d.ts
+++ b/src/scenes/Scene.d.ts
@@ -68,6 +68,5 @@ export class Scene extends Object3D {
 	) => void;
 
 	toJSON( meta?: any ): any;
-	dispose(): void;
 
 }


### PR DESCRIPTION
**Description**

Remove Scene.dispose() from the definition file since the function was removed in r120
