### PR TITLE
Editor: Add 'New Project', 'Load Project' and 'Save Project'

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -44,12 +44,12 @@ function MenubarFile( editor ) {
 	option.setClass( 'option' );
 	option.setTextContent( strings.getKey( 'menubar/file/new' ) );
 	option.onClick( function () {
-		
+
 		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
-			
+
 			editor.clear();
 			config.setKey( 'project/title', 'untitled' );
-			
+
 		}
 	} );
 	options.add( option );
@@ -65,23 +65,23 @@ function MenubarFile( editor ) {
 	openfileInput.type = 'file';
 	openfileInput.accept = '.json';
 	openfileInput.addEventListener( 'change', function () {
-		
+
+		editor.clear();
 		editor.loader.loadFiles( openfileInput.files );
 		openform.reset();
-		
+
 	} );
-	openform.appendChild(openfileInput);
+	openform.appendChild( openfileInput );
 
 	var option = new UIRow();
 	option.setClass( 'option' );
 	option.setTextContent( strings.getKey( 'menubar/file/load' ) );
 	option.onClick( function() {
-		
+
 		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
-			
-			editor.clear();
+
 			openfileInput.click();
-			
+
 		}
 	} );
 	options.add( option );
@@ -92,24 +92,24 @@ function MenubarFile( editor ) {
 	option.setClass( 'option' );
 	option.setTextContent( strings.getKey( 'menubar/file/save' ) );
 	option.onClick(function () {
-		
+
 		var output = editor.toJSON();
 		output.metadata.type = 'App';
 
 		try {
 			output = JSON.stringify( output, parseNumber, '\t' );
 			output = output.replace( /[\n\t]+([\d\.e\-\[\]]+)/g, '$1' );
-			
+
 		} catch (e) {
-			
+
 			output = JSON.stringify( output );
-			
+
 		}
 
 		var title = config.getKey( 'project/title' );
 
 		saveString( output, ( title !== '' ? title : 'untitled' ) + '.json' );
-		
+
 	} );
 	options.add( option );
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -38,21 +38,67 @@ function MenubarFile( editor ) {
 	options.setClass( 'options' );
 	container.add( options );
 
-	// New
+	// New Project
 
 	var option = new UIRow();
-	option.setClass( 'option' );
-	option.setTextContent( strings.getKey( 'menubar/file/new' ) );
-	option.onClick( function () {
-
-		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
-
+	option.setClass("option");
+	option.setTextContent(strings.getKey("menubar/file/new"));
+	option.onClick(function() {
+		if (confirm("Any unsaved data will be lost. Are you sure?")) {
 			editor.clear();
+			config.setKey("project/title", "untitled");
+		}
+	});
+	options.add(option);
 
+	// Load Project
+
+	var openform = document.createElement("form");
+	openform.style.display = "none";
+	document.body.appendChild(openform);
+
+	var openfileInput = document.createElement("input");
+	openfileInput.multiple = false;
+	openfileInput.type = "file";
+	openfileInput.accept = ".json";
+	openfileInput.addEventListener("change", function() {
+		editor.loader.loadFiles(openfileInput.files);
+		openform.reset();
+	});
+	openform.appendChild(openfileInput);
+
+	var option = new UIRow();
+	option.setClass("option");
+	option.setTextContent(strings.getKey("menubar/file/load"));
+	option.onClick(function() {
+		if (confirm("Any unsaved data will be lost. Are you sure?")) {
+			editor.clear();
+			openfileInput.click();
+		}
+	});
+	options.add(option);
+
+	// Save Project
+
+	var option = new UIRow();
+	option.setClass("option");
+	option.setTextContent(strings.getKey("menubar/file/save"));
+	option.onClick(function() {
+		var output = editor.toJSON();
+		output.metadata.type = "App";
+
+		try {
+			output = JSON.stringify(output, parseNumber, "\t");
+			output = output.replace(/[\n\t]+([\d\.e\-\[\]]+)/g, "$1");
+		} catch (e) {
+			output = JSON.stringify(output);
 		}
 
-	} );
-	options.add( option );
+		var title = config.getKey("project/title");
+
+		saveString(output, (title !== "" ? title : "untitled") + ".json");
+	});
+	options.add(option);
 
 	//
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -41,64 +41,77 @@ function MenubarFile( editor ) {
 	// New Project
 
 	var option = new UIRow();
-	option.setClass("option");
-	option.setTextContent(strings.getKey("menubar/file/new"));
-	option.onClick(function() {
-		if (confirm("Any unsaved data will be lost. Are you sure?")) {
+	option.setClass( 'option' );
+	option.setTextContent( strings.getKey( 'menubar/file/new' ) );
+	option.onClick( function () {
+		
+		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
+			
 			editor.clear();
-			config.setKey("project/title", "untitled");
+			config.setKey( 'project/title', 'untitled' );
+			
 		}
-	});
-	options.add(option);
+	} );
+	options.add( option );
 
 	// Load Project
 
-	var openform = document.createElement("form");
-	openform.style.display = "none";
-	document.body.appendChild(openform);
+	var openform = document.createElement( 'form' );
+	openform.style.display = 'none';
+	document.body.appendChild( openform );
 
-	var openfileInput = document.createElement("input");
+	var openfileInput = document.createElement( 'input' );
 	openfileInput.multiple = false;
-	openfileInput.type = "file";
-	openfileInput.accept = ".json";
-	openfileInput.addEventListener("change", function() {
-		editor.loader.loadFiles(openfileInput.files);
+	openfileInput.type = 'file';
+	openfileInput.accept = '.json';
+	openfileInput.addEventListener( 'change', function () {
+		
+		editor.loader.loadFiles( openfileInput.files );
 		openform.reset();
-	});
+		
+	} );
 	openform.appendChild(openfileInput);
 
 	var option = new UIRow();
-	option.setClass("option");
-	option.setTextContent(strings.getKey("menubar/file/load"));
-	option.onClick(function() {
-		if (confirm("Any unsaved data will be lost. Are you sure?")) {
+	option.setClass( 'option' );
+	option.setTextContent( strings.getKey( 'menubar/file/load' ) );
+	option.onClick( function() {
+		
+		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
+			
 			editor.clear();
 			openfileInput.click();
+			
 		}
-	});
-	options.add(option);
+	} );
+	options.add( option );
 
 	// Save Project
 
 	var option = new UIRow();
-	option.setClass("option");
-	option.setTextContent(strings.getKey("menubar/file/save"));
-	option.onClick(function() {
+	option.setClass( 'option' );
+	option.setTextContent( strings.getKey( 'menubar/file/save' ) );
+	option.onClick(function () {
+		
 		var output = editor.toJSON();
-		output.metadata.type = "App";
+		output.metadata.type = 'App';
 
 		try {
-			output = JSON.stringify(output, parseNumber, "\t");
-			output = output.replace(/[\n\t]+([\d\.e\-\[\]]+)/g, "$1");
+			output = JSON.stringify( output, parseNumber, '\t' );
+			output = output.replace( /[\n\t]+([\d\.e\-\[\]]+)/g, '$1' );
+			
 		} catch (e) {
-			output = JSON.stringify(output);
+			
+			output = JSON.stringify( output );
+			
 		}
 
-		var title = config.getKey("project/title");
+		var title = config.getKey( 'project/title' );
 
-		saveString(output, (title !== "" ? title : "untitled") + ".json");
-	});
-	options.add(option);
+		saveString( output, ( title !== '' ? title : 'untitled' ) + '.json' );
+		
+	} );
+	options.add( option );
 
 	//
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -7,7 +7,9 @@ function Strings( config ) {
 		en: {
 
 			'menubar/file': 'File',
-			'menubar/file/new': 'New',
+			"menubar/file/new": 'New Project',
+			"menubar/file/load": 'Load Project',
+			"menubar/file/save": 'Save Project,
 			'menubar/file/import': 'Import',
 			'menubar/file/export/geometry': 'Export Geometry',
 			'menubar/file/export/object': 'Export Object',

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -332,7 +332,9 @@ function Strings( config ) {
 		fr: {
 
 			'menubar/file': 'Fichier',
-			'menubar/file/new': 'Nouveau',
+			'menubar/file/new': 'New Project',
+			'menubar/file/load': 'Load Project',
+			'menubar/file/save': 'Save Project',
 			'menubar/file/import': 'Importer',
 			'menubar/file/export/geometry': 'Exporter Geometrie',
 			'menubar/file/export/object': 'Exporter Objet',
@@ -655,7 +657,9 @@ function Strings( config ) {
 		zh: {
 
 			'menubar/file': '文件',
-			'menubar/file/new': '新建',
+			'menubar/file/new': 'New Project',
+			'menubar/file/load': 'Load Project',
+			'menubar/file/save': 'Save Project',
 			'menubar/file/import': '导入',
 			'menubar/file/export/geometry': '导出几何体',
 			'menubar/file/export/object': '导出物体',

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -7,9 +7,9 @@ function Strings( config ) {
 		en: {
 
 			'menubar/file': 'File',
-			"menubar/file/new": 'New Project',
-			"menubar/file/load": 'Load Project',
-			"menubar/file/save": 'Save Project,
+			'menubar/file/new': 'New Project',
+			'menubar/file/load': 'Load Project',
+			'menubar/file/save': 'Save Project',
 			'menubar/file/import': 'Import',
 			'menubar/file/export/geometry': 'Export Geometry',
 			'menubar/file/export/object': 'Export Object',


### PR DESCRIPTION
**Description**

Into Editor change "New" to "New Project" and add "Load Project" and "Save Project" to "File" Menu for higher productivity

Change translation "New" to "New Project" and add "Load Project" and "Save Project". 
French and Chinese translations would be missing.

![translations_menu](https://user-images.githubusercontent.com/560807/96031272-6d187980-0e5d-11eb-9643-f906f357349f.jpg)

