### PR TITLE
Docs: Added missing Doctype

### DIFF
--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -121,6 +121,7 @@
 		<p>The full code is available below and as an editable [link:https://jsfiddle.net/mkba0ecu/ live example]. Play around with it to get a better understanding of how it works.</p>
 
 		<code>
+		&lt;!DOCTYPE html&gt;
 		&lt;html&gt;
 			&lt;head&gt;
 				&lt;title&gt;My first three.js app&lt;/title&gt;


### PR DESCRIPTION
An html5 doctype declaration was missing.

<!DOCTYPE html>
