### PR TITLE
TS: Add missing DataTexture2DArray declaration

### DIFF
--- a/src/Three.d.ts
+++ b/src/Three.d.ts
@@ -25,6 +25,7 @@ export * from './objects/Points';
 export * from './objects/Group';
 export * from './textures/VideoTexture';
 export * from './textures/DataTexture';
+export * from './textures/DataTexture2DArray';
 export * from './textures/DataTexture3D';
 export * from './textures/CompressedTexture';
 export * from './textures/CubeTexture';


### PR DESCRIPTION
**Description**

DataTexture2DArray declare is missing in Three.d.ts
