### PR TITLE
Docs(zh):Modify the convenient Chinese interpretation of fromArray in Euler

### DIFF
--- a/docs/api/zh/math/Euler.html
+++ b/docs/api/zh/math/Euler.html
@@ -80,8 +80,8 @@
 		长度为3或4的一个 [page:Array array] 。array[3] 是一个可选的 [page:.order order] 参数。<br /><br />
 
 		将欧拉角的x分量设置为 array[0]。 <br />
-		将欧拉角的x分量设置为 array[1]。 <br />
-		将欧拉角的x分量设置为 array[2]。 <br />
+		将欧拉角的y分量设置为 array[1]。 <br />
+		将欧拉角的z分量设置为 array[2]。 <br />
 		将array[3]设置给欧拉角的 [page:.order order] 。可选。
 		</p>
 


### PR DESCRIPTION
Related issues:

#Modify the convenient Chinese interpretation of fromArray in Euler

**Description**
In the explanation of the fromArray method of Euler of Math in the Chinese document, the array is all assigned to x. This is incorrect. Modify this text

