### PR TITLE
Docs: Remove obsolete list.js import.

### DIFF
--- a/docs/api/ar/animation/AnimationAction.html
+++ b/docs/api/ar/animation/AnimationAction.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/AnimationClip.html
+++ b/docs/api/ar/animation/AnimationClip.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/AnimationMixer.html
+++ b/docs/api/ar/animation/AnimationMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/AnimationObjectGroup.html
+++ b/docs/api/ar/animation/AnimationObjectGroup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/AnimationUtils.html
+++ b/docs/api/ar/animation/AnimationUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/KeyframeTrack.html
+++ b/docs/api/ar/animation/KeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/PropertyBinding.html
+++ b/docs/api/ar/animation/PropertyBinding.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/PropertyMixer.html
+++ b/docs/api/ar/animation/PropertyMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/BooleanKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/ColorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/NumberKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/QuaternionKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/StringKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/VectorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/audio/Audio.html
+++ b/docs/api/ar/audio/Audio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/audio/AudioAnalyser.html
+++ b/docs/api/ar/audio/AudioAnalyser.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/audio/AudioContext.html
+++ b/docs/api/ar/audio/AudioContext.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/audio/AudioListener.html
+++ b/docs/api/ar/audio/AudioListener.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/audio/PositionalAudio.html
+++ b/docs/api/ar/audio/PositionalAudio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/cameras/ArrayCamera.html
+++ b/docs/api/ar/cameras/ArrayCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/cameras/Camera.html
+++ b/docs/api/ar/cameras/Camera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/ar/cameras/CubeCamera.html
+++ b/docs/api/ar/cameras/CubeCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/Polyfills.html
+++ b/docs/api/en/Polyfills.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/Template.html
+++ b/docs/api/en/Template.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/AnimationClip.html
+++ b/docs/api/en/animation/AnimationClip.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/AnimationMixer.html
+++ b/docs/api/en/animation/AnimationMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/AnimationObjectGroup.html
+++ b/docs/api/en/animation/AnimationObjectGroup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/KeyframeTrack.html
+++ b/docs/api/en/animation/KeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/PropertyBinding.html
+++ b/docs/api/en/animation/PropertyBinding.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/PropertyMixer.html
+++ b/docs/api/en/animation/PropertyMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/ColorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/NumberKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/VectorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/audio/AudioAnalyser.html
+++ b/docs/api/en/audio/AudioAnalyser.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/audio/AudioContext.html
+++ b/docs/api/en/audio/AudioContext.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/audio/AudioListener.html
+++ b/docs/api/en/audio/AudioListener.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/audio/PositionalAudio.html
+++ b/docs/api/en/audio/PositionalAudio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/ArrayCamera.html
+++ b/docs/api/en/cameras/ArrayCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/Camera.html
+++ b/docs/api/en/cameras/Camera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/cameras/StereoCamera.html
+++ b/docs/api/en/cameras/StereoCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/Animation.html
+++ b/docs/api/en/constants/Animation.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/Core.html
+++ b/docs/api/en/constants/Core.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/CustomBlendingEquations.html
+++ b/docs/api/en/constants/CustomBlendingEquations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/Materials.html
+++ b/docs/api/en/constants/Materials.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Clock.html
+++ b/docs/api/en/core/Clock.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/DirectGeometry.html
+++ b/docs/api/en/core/DirectGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/EventDispatcher.html
+++ b/docs/api/en/core/EventDispatcher.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Face3.html
+++ b/docs/api/en/core/Face3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/GLBufferAttribute.html
+++ b/docs/api/en/core/GLBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Geometry.html
+++ b/docs/api/en/core/Geometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/InstancedBufferAttribute.html
+++ b/docs/api/en/core/InstancedBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/InstancedBufferGeometry.html
+++ b/docs/api/en/core/InstancedBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/InstancedInterleavedBuffer.html
+++ b/docs/api/en/core/InstancedInterleavedBuffer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/InterleavedBuffer.html
+++ b/docs/api/en/core/InterleavedBuffer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/Uniform.html
+++ b/docs/api/en/core/Uniform.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/Earcut.html
+++ b/docs/api/en/extras/Earcut.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/ImageUtils.html
+++ b/docs/api/en/extras/ImageUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/PMREMGenerator.html
+++ b/docs/api/en/extras/PMREMGenerator.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/Curve.html
+++ b/docs/api/en/extras/core/Curve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/Font.html
+++ b/docs/api/en/extras/core/Font.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/Interpolations.html
+++ b/docs/api/en/extras/core/Interpolations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/Path.html
+++ b/docs/api/en/extras/core/Path.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/Shape.html
+++ b/docs/api/en/extras/core/Shape.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/core/ShapePath.html
+++ b/docs/api/en/extras/core/ShapePath.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/ArcCurve.html
+++ b/docs/api/en/extras/curves/ArcCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/en/extras/curves/CatmullRomCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/CubicBezierCurve.html
+++ b/docs/api/en/extras/curves/CubicBezierCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/en/extras/curves/CubicBezierCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/EllipseCurve.html
+++ b/docs/api/en/extras/curves/EllipseCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/LineCurve.html
+++ b/docs/api/en/extras/curves/LineCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/LineCurve3.html
+++ b/docs/api/en/extras/curves/LineCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/en/extras/curves/QuadraticBezierCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/en/extras/curves/QuadraticBezierCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/curves/SplineCurve.html
+++ b/docs/api/en/extras/curves/SplineCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/extras/objects/ImmediateRenderObject.html
+++ b/docs/api/en/extras/objects/ImmediateRenderObject.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/BoxBufferGeometry.html
+++ b/docs/api/en/geometries/BoxBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/BoxGeometry.html
+++ b/docs/api/en/geometries/BoxGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/CircleBufferGeometry.html
+++ b/docs/api/en/geometries/CircleBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/CircleGeometry.html
+++ b/docs/api/en/geometries/CircleGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ConeBufferGeometry.html
+++ b/docs/api/en/geometries/ConeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ConeGeometry.html
+++ b/docs/api/en/geometries/ConeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/CylinderBufferGeometry.html
+++ b/docs/api/en/geometries/CylinderBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/CylinderGeometry.html
+++ b/docs/api/en/geometries/CylinderGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/en/geometries/DodecahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/DodecahedronGeometry.html
+++ b/docs/api/en/geometries/DodecahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/EdgesGeometry.html
+++ b/docs/api/en/geometries/EdgesGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/en/geometries/ExtrudeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ExtrudeGeometry.html
+++ b/docs/api/en/geometries/ExtrudeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/en/geometries/IcosahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/IcosahedronGeometry.html
+++ b/docs/api/en/geometries/IcosahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/LatheBufferGeometry.html
+++ b/docs/api/en/geometries/LatheBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/LatheGeometry.html
+++ b/docs/api/en/geometries/LatheGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/en/geometries/OctahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/OctahedronGeometry.html
+++ b/docs/api/en/geometries/OctahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ParametricBufferGeometry.html
+++ b/docs/api/en/geometries/ParametricBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ParametricGeometry.html
+++ b/docs/api/en/geometries/ParametricGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/PlaneBufferGeometry.html
+++ b/docs/api/en/geometries/PlaneBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/PlaneGeometry.html
+++ b/docs/api/en/geometries/PlaneGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/en/geometries/PolyhedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/PolyhedronGeometry.html
+++ b/docs/api/en/geometries/PolyhedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/RingBufferGeometry.html
+++ b/docs/api/en/geometries/RingBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/RingGeometry.html
+++ b/docs/api/en/geometries/RingGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ShapeBufferGeometry.html
+++ b/docs/api/en/geometries/ShapeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/ShapeGeometry.html
+++ b/docs/api/en/geometries/ShapeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/SphereBufferGeometry.html
+++ b/docs/api/en/geometries/SphereBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/SphereGeometry.html
+++ b/docs/api/en/geometries/SphereGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/en/geometries/TetrahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TetrahedronGeometry.html
+++ b/docs/api/en/geometries/TetrahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TextBufferGeometry.html
+++ b/docs/api/en/geometries/TextBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TextGeometry.html
+++ b/docs/api/en/geometries/TextGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TorusBufferGeometry.html
+++ b/docs/api/en/geometries/TorusBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TorusGeometry.html
+++ b/docs/api/en/geometries/TorusGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/en/geometries/TorusKnotBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TorusKnotGeometry.html
+++ b/docs/api/en/geometries/TorusKnotGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TubeBufferGeometry.html
+++ b/docs/api/en/geometries/TubeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/TubeGeometry.html
+++ b/docs/api/en/geometries/TubeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/geometries/WireframeGeometry.html
+++ b/docs/api/en/geometries/WireframeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/ArrowHelper.html
+++ b/docs/api/en/helpers/ArrowHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/Box3Helper.html
+++ b/docs/api/en/helpers/Box3Helper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/BoxHelper.html
+++ b/docs/api/en/helpers/BoxHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/DirectionalLightHelper.html
+++ b/docs/api/en/helpers/DirectionalLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/HemisphereLightHelper.html
+++ b/docs/api/en/helpers/HemisphereLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/PlaneHelper.html
+++ b/docs/api/en/helpers/PlaneHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/PointLightHelper.html
+++ b/docs/api/en/helpers/PointLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/PolarGridHelper.html
+++ b/docs/api/en/helpers/PolarGridHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/SkeletonHelper.html
+++ b/docs/api/en/helpers/SkeletonHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/helpers/SpotLightHelper.html
+++ b/docs/api/en/helpers/SpotLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/AmbientLight.html
+++ b/docs/api/en/lights/AmbientLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/AmbientLightProbe.html
+++ b/docs/api/en/lights/AmbientLightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/DirectionalLight.html
+++ b/docs/api/en/lights/DirectionalLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/HemisphereLight.html
+++ b/docs/api/en/lights/HemisphereLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/HemisphereLightProbe.html
+++ b/docs/api/en/lights/HemisphereLightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/Light.html
+++ b/docs/api/en/lights/Light.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/LightProbe.html
+++ b/docs/api/en/lights/LightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/PointLight.html
+++ b/docs/api/en/lights/PointLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/RectAreaLight.html
+++ b/docs/api/en/lights/RectAreaLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/SpotLight.html
+++ b/docs/api/en/lights/SpotLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/shadows/DirectionalLightShadow.html
+++ b/docs/api/en/lights/shadows/DirectionalLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/lights/shadows/SpotLightShadow.html
+++ b/docs/api/en/lights/shadows/SpotLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/Cache.html
+++ b/docs/api/en/loaders/Cache.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/FontLoader.html
+++ b/docs/api/en/loaders/FontLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/ImageLoader.html
+++ b/docs/api/en/loaders/ImageLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/LoaderUtils.html
+++ b/docs/api/en/loaders/LoaderUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/TextureLoader.html
+++ b/docs/api/en/loaders/TextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/managers/DefaultLoadingManager.html
+++ b/docs/api/en/loaders/managers/DefaultLoadingManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshMatcapMaterial.html
+++ b/docs/api/en/materials/MeshMatcapMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/RawShaderMaterial.html
+++ b/docs/api/en/materials/RawShaderMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/ShadowMaterial.html
+++ b/docs/api/en/materials/ShadowMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/materials/SpriteMaterial.html
+++ b/docs/api/en/materials/SpriteMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Box2.html
+++ b/docs/api/en/math/Box2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Cylindrical.html
+++ b/docs/api/en/math/Cylindrical.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Interpolant.html
+++ b/docs/api/en/math/Interpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Spherical.html
+++ b/docs/api/en/math/Spherical.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/SphericalHarmonics3.html
+++ b/docs/api/en/math/SphericalHarmonics3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/interpolants/CubicInterpolant.html
+++ b/docs/api/en/math/interpolants/CubicInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/en/math/interpolants/DiscreteInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/interpolants/LinearInterpolant.html
+++ b/docs/api/en/math/interpolants/LinearInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Bone.html
+++ b/docs/api/en/objects/Bone.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Group.html
+++ b/docs/api/en/objects/Group.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Line.html
+++ b/docs/api/en/objects/Line.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/LineLoop.html
+++ b/docs/api/en/objects/LineLoop.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/LineSegments.html
+++ b/docs/api/en/objects/LineSegments.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Points.html
+++ b/docs/api/en/objects/Points.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Skeleton.html
+++ b/docs/api/en/objects/Skeleton.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/objects/Sprite.html
+++ b/docs/api/en/objects/Sprite.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/WebGL1Renderer.html
+++ b/docs/api/en/renderers/WebGL1Renderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/WebGLMultisampleRenderTarget.html
+++ b/docs/api/en/renderers/WebGLMultisampleRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/shaders/ShaderChunk.html
+++ b/docs/api/en/renderers/shaders/ShaderChunk.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/shaders/ShaderLib.html
+++ b/docs/api/en/renderers/shaders/ShaderLib.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/shaders/UniformsLib.html
+++ b/docs/api/en/renderers/shaders/UniformsLib.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/shaders/UniformsUtils.html
+++ b/docs/api/en/renderers/shaders/UniformsUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/webgl/WebGLProgram.html
+++ b/docs/api/en/renderers/webgl/WebGLProgram.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/webgl/WebGLShader.html
+++ b/docs/api/en/renderers/webgl/WebGLShader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/webgl/WebGLState.html
+++ b/docs/api/en/renderers/webgl/WebGLState.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/scenes/Fog.html
+++ b/docs/api/en/scenes/Fog.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/scenes/FogExp2.html
+++ b/docs/api/en/scenes/FogExp2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/CanvasTexture.html
+++ b/docs/api/en/textures/CanvasTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/CompressedTexture.html
+++ b/docs/api/en/textures/CompressedTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/CubeTexture.html
+++ b/docs/api/en/textures/CubeTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/DataTexture2DArray.html
+++ b/docs/api/en/textures/DataTexture2DArray.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/DataTexture3D.html
+++ b/docs/api/en/textures/DataTexture3D.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/Polyfills.html
+++ b/docs/api/zh/Polyfills.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/Template.html
+++ b/docs/api/zh/Template.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/AnimationAction.html
+++ b/docs/api/zh/animation/AnimationAction.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/AnimationClip.html
+++ b/docs/api/zh/animation/AnimationClip.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/AnimationMixer.html
+++ b/docs/api/zh/animation/AnimationMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/AnimationObjectGroup.html
+++ b/docs/api/zh/animation/AnimationObjectGroup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/AnimationUtils.html
+++ b/docs/api/zh/animation/AnimationUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/KeyframeTrack.html
+++ b/docs/api/zh/animation/KeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/PropertyBinding.html
+++ b/docs/api/zh/animation/PropertyBinding.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/PropertyMixer.html
+++ b/docs/api/zh/animation/PropertyMixer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/BooleanKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/ColorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/NumberKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/QuaternionKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/StringKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/VectorKeyframeTrack.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/audio/Audio.html
+++ b/docs/api/zh/audio/Audio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/audio/AudioAnalyser.html
+++ b/docs/api/zh/audio/AudioAnalyser.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/audio/AudioContext.html
+++ b/docs/api/zh/audio/AudioContext.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/audio/AudioListener.html
+++ b/docs/api/zh/audio/AudioListener.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/audio/PositionalAudio.html
+++ b/docs/api/zh/audio/PositionalAudio.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/ArrayCamera.html
+++ b/docs/api/zh/cameras/ArrayCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/Camera.html
+++ b/docs/api/zh/cameras/Camera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/CubeCamera.html
+++ b/docs/api/zh/cameras/CubeCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/OrthographicCamera.html
+++ b/docs/api/zh/cameras/OrthographicCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/PerspectiveCamera.html
+++ b/docs/api/zh/cameras/PerspectiveCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/cameras/StereoCamera.html
+++ b/docs/api/zh/cameras/StereoCamera.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/Animation.html
+++ b/docs/api/zh/constants/Animation.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/Core.html
+++ b/docs/api/zh/constants/Core.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/CustomBlendingEquations.html
+++ b/docs/api/zh/constants/CustomBlendingEquations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/Materials.html
+++ b/docs/api/zh/constants/Materials.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/Renderer.html
+++ b/docs/api/zh/constants/Renderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8" />
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/api/zh/core/BufferAttribute.html
+++ b/docs/api/zh/core/BufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Clock.html
+++ b/docs/api/zh/core/Clock.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/DirectGeometry.html
+++ b/docs/api/zh/core/DirectGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/EventDispatcher.html
+++ b/docs/api/zh/core/EventDispatcher.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Face3.html
+++ b/docs/api/zh/core/Face3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/GLBufferAttribute.html
+++ b/docs/api/zh/core/GLBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Geometry.html
+++ b/docs/api/zh/core/Geometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/InstancedBufferAttribute.html
+++ b/docs/api/zh/core/InstancedBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/InstancedBufferGeometry.html
+++ b/docs/api/zh/core/InstancedBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/InstancedInterleavedBuffer.html
+++ b/docs/api/zh/core/InstancedInterleavedBuffer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/InterleavedBuffer.html
+++ b/docs/api/zh/core/InterleavedBuffer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/InterleavedBufferAttribute.html
+++ b/docs/api/zh/core/InterleavedBufferAttribute.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Layers.html
+++ b/docs/api/zh/core/Layers.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8" />
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/api/zh/core/Raycaster.html
+++ b/docs/api/zh/core/Raycaster.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/Uniform.html
+++ b/docs/api/zh/core/Uniform.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/Earcut.html
+++ b/docs/api/zh/extras/Earcut.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/ImageUtils.html
+++ b/docs/api/zh/extras/ImageUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/PMREMGenerator.html
+++ b/docs/api/zh/extras/PMREMGenerator.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/ShapeUtils.html
+++ b/docs/api/zh/extras/ShapeUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/Curve.html
+++ b/docs/api/zh/extras/core/Curve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/CurvePath.html
+++ b/docs/api/zh/extras/core/CurvePath.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/Font.html
+++ b/docs/api/zh/extras/core/Font.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/Interpolations.html
+++ b/docs/api/zh/extras/core/Interpolations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/Path.html
+++ b/docs/api/zh/extras/core/Path.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/Shape.html
+++ b/docs/api/zh/extras/core/Shape.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/core/ShapePath.html
+++ b/docs/api/zh/extras/core/ShapePath.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/ArcCurve.html
+++ b/docs/api/zh/extras/curves/ArcCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/zh/extras/curves/CatmullRomCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/CubicBezierCurve.html
+++ b/docs/api/zh/extras/curves/CubicBezierCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/CubicBezierCurve3.html
+++ b/docs/api/zh/extras/curves/CubicBezierCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/EllipseCurve.html
+++ b/docs/api/zh/extras/curves/EllipseCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/LineCurve.html
+++ b/docs/api/zh/extras/curves/LineCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/LineCurve3.html
+++ b/docs/api/zh/extras/curves/LineCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/QuadraticBezierCurve.html
+++ b/docs/api/zh/extras/curves/QuadraticBezierCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/QuadraticBezierCurve3.html
+++ b/docs/api/zh/extras/curves/QuadraticBezierCurve3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/curves/SplineCurve.html
+++ b/docs/api/zh/extras/curves/SplineCurve.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/extras/objects/ImmediateRenderObject.html
+++ b/docs/api/zh/extras/objects/ImmediateRenderObject.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/BoxBufferGeometry.html
+++ b/docs/api/zh/geometries/BoxBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/BoxGeometry.html
+++ b/docs/api/zh/geometries/BoxGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/CircleBufferGeometry.html
+++ b/docs/api/zh/geometries/CircleBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/CircleGeometry.html
+++ b/docs/api/zh/geometries/CircleGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ConeBufferGeometry.html
+++ b/docs/api/zh/geometries/ConeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ConeGeometry.html
+++ b/docs/api/zh/geometries/ConeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/CylinderBufferGeometry.html
+++ b/docs/api/zh/geometries/CylinderBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/CylinderGeometry.html
+++ b/docs/api/zh/geometries/CylinderGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/DodecahedronBufferGeometry.html
+++ b/docs/api/zh/geometries/DodecahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/DodecahedronGeometry.html
+++ b/docs/api/zh/geometries/DodecahedronGeometry.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8" />
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/api/zh/geometries/EdgesGeometry.html
+++ b/docs/api/zh/geometries/EdgesGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ExtrudeBufferGeometry.html
+++ b/docs/api/zh/geometries/ExtrudeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ExtrudeGeometry.html
+++ b/docs/api/zh/geometries/ExtrudeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/IcosahedronBufferGeometry.html
+++ b/docs/api/zh/geometries/IcosahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/IcosahedronGeometry.html
+++ b/docs/api/zh/geometries/IcosahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/LatheBufferGeometry.html
+++ b/docs/api/zh/geometries/LatheBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/LatheGeometry.html
+++ b/docs/api/zh/geometries/LatheGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/OctahedronBufferGeometry.html
+++ b/docs/api/zh/geometries/OctahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/OctahedronGeometry.html
+++ b/docs/api/zh/geometries/OctahedronGeometry.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8" />
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/api/zh/geometries/ParametricBufferGeometry.html
+++ b/docs/api/zh/geometries/ParametricBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ParametricGeometry.html
+++ b/docs/api/zh/geometries/ParametricGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/PlaneBufferGeometry.html
+++ b/docs/api/zh/geometries/PlaneBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/PlaneGeometry.html
+++ b/docs/api/zh/geometries/PlaneGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/PolyhedronBufferGeometry.html
+++ b/docs/api/zh/geometries/PolyhedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/PolyhedronGeometry.html
+++ b/docs/api/zh/geometries/PolyhedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/RingBufferGeometry.html
+++ b/docs/api/zh/geometries/RingBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/RingGeometry.html
+++ b/docs/api/zh/geometries/RingGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ShapeBufferGeometry.html
+++ b/docs/api/zh/geometries/ShapeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/ShapeGeometry.html
+++ b/docs/api/zh/geometries/ShapeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/SphereBufferGeometry.html
+++ b/docs/api/zh/geometries/SphereBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/SphereGeometry.html
+++ b/docs/api/zh/geometries/SphereGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TetrahedronBufferGeometry.html
+++ b/docs/api/zh/geometries/TetrahedronBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TetrahedronGeometry.html
+++ b/docs/api/zh/geometries/TetrahedronGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TextBufferGeometry.html
+++ b/docs/api/zh/geometries/TextBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TextGeometry.html
+++ b/docs/api/zh/geometries/TextGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TorusBufferGeometry.html
+++ b/docs/api/zh/geometries/TorusBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TorusGeometry.html
+++ b/docs/api/zh/geometries/TorusGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TorusKnotBufferGeometry.html
+++ b/docs/api/zh/geometries/TorusKnotBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TorusKnotGeometry.html
+++ b/docs/api/zh/geometries/TorusKnotGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TubeBufferGeometry.html
+++ b/docs/api/zh/geometries/TubeBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/TubeGeometry.html
+++ b/docs/api/zh/geometries/TubeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/geometries/WireframeGeometry.html
+++ b/docs/api/zh/geometries/WireframeGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/ArrowHelper.html
+++ b/docs/api/zh/helpers/ArrowHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/AxesHelper.html
+++ b/docs/api/zh/helpers/AxesHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/Box3Helper.html
+++ b/docs/api/zh/helpers/Box3Helper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/BoxHelper.html
+++ b/docs/api/zh/helpers/BoxHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/CameraHelper.html
+++ b/docs/api/zh/helpers/CameraHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/DirectionalLightHelper.html
+++ b/docs/api/zh/helpers/DirectionalLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/GridHelper.html
+++ b/docs/api/zh/helpers/GridHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/HemisphereLightHelper.html
+++ b/docs/api/zh/helpers/HemisphereLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/PlaneHelper.html
+++ b/docs/api/zh/helpers/PlaneHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/PointLightHelper.html
+++ b/docs/api/zh/helpers/PointLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/PolarGridHelper.html
+++ b/docs/api/zh/helpers/PolarGridHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/SkeletonHelper.html
+++ b/docs/api/zh/helpers/SkeletonHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/helpers/SpotLightHelper.html
+++ b/docs/api/zh/helpers/SpotLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/AmbientLight.html
+++ b/docs/api/zh/lights/AmbientLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/AmbientLightProbe.html
+++ b/docs/api/zh/lights/AmbientLightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/DirectionalLight.html
+++ b/docs/api/zh/lights/DirectionalLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/HemisphereLight.html
+++ b/docs/api/zh/lights/HemisphereLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/HemisphereLightProbe.html
+++ b/docs/api/zh/lights/HemisphereLightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/Light.html
+++ b/docs/api/zh/lights/Light.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/LightProbe.html
+++ b/docs/api/zh/lights/LightProbe.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/PointLight.html
+++ b/docs/api/zh/lights/PointLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/RectAreaLight.html
+++ b/docs/api/zh/lights/RectAreaLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/SpotLight.html
+++ b/docs/api/zh/lights/SpotLight.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/shadows/DirectionalLightShadow.html
+++ b/docs/api/zh/lights/shadows/DirectionalLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/shadows/LightShadow.html
+++ b/docs/api/zh/lights/shadows/LightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/lights/shadows/SpotLightShadow.html
+++ b/docs/api/zh/lights/shadows/SpotLightShadow.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/AnimationLoader.html
+++ b/docs/api/zh/loaders/AnimationLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/AudioLoader.html
+++ b/docs/api/zh/loaders/AudioLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/BufferGeometryLoader.html
+++ b/docs/api/zh/loaders/BufferGeometryLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/Cache.html
+++ b/docs/api/zh/loaders/Cache.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/CompressedTextureLoader.html
+++ b/docs/api/zh/loaders/CompressedTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/CubeTextureLoader.html
+++ b/docs/api/zh/loaders/CubeTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/DataTextureLoader.html
+++ b/docs/api/zh/loaders/DataTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/FileLoader.html
+++ b/docs/api/zh/loaders/FileLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/FontLoader.html
+++ b/docs/api/zh/loaders/FontLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/ImageBitmapLoader.html
+++ b/docs/api/zh/loaders/ImageBitmapLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/ImageLoader.html
+++ b/docs/api/zh/loaders/ImageLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/Loader.html
+++ b/docs/api/zh/loaders/Loader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/LoaderUtils.html
+++ b/docs/api/zh/loaders/LoaderUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/MaterialLoader.html
+++ b/docs/api/zh/loaders/MaterialLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/TextureLoader.html
+++ b/docs/api/zh/loaders/TextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/managers/DefaultLoadingManager.html
+++ b/docs/api/zh/loaders/managers/DefaultLoadingManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/loaders/managers/LoadingManager.html
+++ b/docs/api/zh/loaders/managers/LoadingManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/LineDashedMaterial.html
+++ b/docs/api/zh/materials/LineDashedMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8"/>
 	<base href="../../../"/>
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css"/>
 </head>

--- a/docs/api/zh/materials/MeshBasicMaterial.html
+++ b/docs/api/zh/materials/MeshBasicMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshDepthMaterial.html
+++ b/docs/api/zh/materials/MeshDepthMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshDistanceMaterial.html
+++ b/docs/api/zh/materials/MeshDistanceMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshLambertMaterial.html
+++ b/docs/api/zh/materials/MeshLambertMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshMatcapMaterial.html
+++ b/docs/api/zh/materials/MeshMatcapMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshNormalMaterial.html
+++ b/docs/api/zh/materials/MeshNormalMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshPhongMaterial.html
+++ b/docs/api/zh/materials/MeshPhongMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/MeshToonMaterial.html
+++ b/docs/api/zh/materials/MeshToonMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/PointsMaterial.html
+++ b/docs/api/zh/materials/PointsMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/RawShaderMaterial.html
+++ b/docs/api/zh/materials/RawShaderMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/ShadowMaterial.html
+++ b/docs/api/zh/materials/ShadowMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/materials/SpriteMaterial.html
+++ b/docs/api/zh/materials/SpriteMaterial.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Box2.html
+++ b/docs/api/zh/math/Box2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Box3.html
+++ b/docs/api/zh/math/Box3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Color.html
+++ b/docs/api/zh/math/Color.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Cylindrical.html
+++ b/docs/api/zh/math/Cylindrical.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Euler.html
+++ b/docs/api/zh/math/Euler.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Frustum.html
+++ b/docs/api/zh/math/Frustum.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Interpolant.html
+++ b/docs/api/zh/math/Interpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Line3.html
+++ b/docs/api/zh/math/Line3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Plane.html
+++ b/docs/api/zh/math/Plane.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Ray.html
+++ b/docs/api/zh/math/Ray.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Sphere.html
+++ b/docs/api/zh/math/Sphere.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Spherical.html
+++ b/docs/api/zh/math/Spherical.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/SphericalHarmonics3.html
+++ b/docs/api/zh/math/SphericalHarmonics3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Triangle.html
+++ b/docs/api/zh/math/Triangle.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Vector2.html
+++ b/docs/api/zh/math/Vector2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/Vector4.html
+++ b/docs/api/zh/math/Vector4.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/interpolants/CubicInterpolant.html
+++ b/docs/api/zh/math/interpolants/CubicInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/zh/math/interpolants/DiscreteInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/interpolants/LinearInterpolant.html
+++ b/docs/api/zh/math/interpolants/LinearInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/zh/math/interpolants/QuaternionLinearInterpolant.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Bone.html
+++ b/docs/api/zh/objects/Bone.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Group.html
+++ b/docs/api/zh/objects/Group.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/InstancedMesh.html
+++ b/docs/api/zh/objects/InstancedMesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/LOD.html
+++ b/docs/api/zh/objects/LOD.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Line.html
+++ b/docs/api/zh/objects/Line.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/LineLoop.html
+++ b/docs/api/zh/objects/LineLoop.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/LineSegments.html
+++ b/docs/api/zh/objects/LineSegments.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Mesh.html
+++ b/docs/api/zh/objects/Mesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Points.html
+++ b/docs/api/zh/objects/Points.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8" />
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/api/zh/objects/Skeleton.html
+++ b/docs/api/zh/objects/Skeleton.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/SkinnedMesh.html
+++ b/docs/api/zh/objects/SkinnedMesh.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/objects/Sprite.html
+++ b/docs/api/zh/objects/Sprite.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/WebGL1Renderer.html
+++ b/docs/api/zh/renderers/WebGL1Renderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/WebGLMultisampleRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLMultisampleRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/shaders/ShaderChunk.html
+++ b/docs/api/zh/renderers/shaders/ShaderChunk.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/shaders/ShaderLib.html
+++ b/docs/api/zh/renderers/shaders/ShaderLib.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/shaders/UniformsLib.html
+++ b/docs/api/zh/renderers/shaders/UniformsLib.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/shaders/UniformsUtils.html
+++ b/docs/api/zh/renderers/shaders/UniformsUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/webgl/WebGLProgram.html
+++ b/docs/api/zh/renderers/webgl/WebGLProgram.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/webgl/WebGLShader.html
+++ b/docs/api/zh/renderers/webgl/WebGLShader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/webgl/WebGLState.html
+++ b/docs/api/zh/renderers/webgl/WebGLState.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/renderers/webxr/WebXRManager.html
+++ b/docs/api/zh/renderers/webxr/WebXRManager.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/scenes/Fog.html
+++ b/docs/api/zh/scenes/Fog.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/scenes/FogExp2.html
+++ b/docs/api/zh/scenes/FogExp2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/scenes/Scene.html
+++ b/docs/api/zh/scenes/Scene.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/CanvasTexture.html
+++ b/docs/api/zh/textures/CanvasTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/CompressedTexture.html
+++ b/docs/api/zh/textures/CompressedTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/CubeTexture.html
+++ b/docs/api/zh/textures/CubeTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/DataTexture.html
+++ b/docs/api/zh/textures/DataTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/DataTexture2DArray.html
+++ b/docs/api/zh/textures/DataTexture2DArray.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/DataTexture3D.html
+++ b/docs/api/zh/textures/DataTexture3D.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/DepthTexture.html
+++ b/docs/api/zh/textures/DepthTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/api/zh/textures/VideoTexture.html
+++ b/docs/api/zh/textures/VideoTexture.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/animations/CCDIKSolver.html
+++ b/docs/examples/en/animations/CCDIKSolver.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/animations/MMDAnimationHelper.html
+++ b/docs/examples/en/animations/MMDAnimationHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/animations/MMDPhysics.html
+++ b/docs/examples/en/animations/MMDPhysics.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/DeviceOrientationControls.html
+++ b/docs/examples/en/controls/DeviceOrientationControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/FirstPersonControls.html
+++ b/docs/examples/en/controls/FirstPersonControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/FlyControls.html
+++ b/docs/examples/en/controls/FlyControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/PointerLockControls.html
+++ b/docs/examples/en/controls/PointerLockControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/exporters/ColladaExporter.html
+++ b/docs/examples/en/exporters/ColladaExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/exporters/PLYExporter.html
+++ b/docs/examples/en/exporters/PLYExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/en/geometries/ConvexBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/examples/en/geometries/ConvexGeometry.html
+++ b/docs/examples/en/geometries/ConvexGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/geometries/DecalGeometry.html
+++ b/docs/examples/en/geometries/DecalGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/FaceNormalsHelper.html
+++ b/docs/examples/en/helpers/FaceNormalsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/LightProbeHelper.html
+++ b/docs/examples/en/helpers/LightProbeHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/PositionalAudioHelper.html
+++ b/docs/examples/en/helpers/PositionalAudioHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/RectAreaLightHelper.html
+++ b/docs/examples/en/helpers/RectAreaLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/VertexNormalsHelper.html
+++ b/docs/examples/en/helpers/VertexNormalsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/helpers/VertexTangentsHelper.html
+++ b/docs/examples/en/helpers/VertexTangentsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/lights/LightProbeGenerator.html
+++ b/docs/examples/en/lights/LightProbeGenerator.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/BasisTextureLoader.html
+++ b/docs/examples/en/loaders/BasisTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/MTLLoader.html
+++ b/docs/examples/en/loaders/MTLLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/OBJLoader2.html
+++ b/docs/examples/en/loaders/OBJLoader2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/OBJLoader2Parallel.html
+++ b/docs/examples/en/loaders/OBJLoader2Parallel.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/PRWMLoader.html
+++ b/docs/examples/en/loaders/PRWMLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/convexhull/Face.html
+++ b/docs/examples/en/math/convexhull/Face.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/convexhull/HalfEdge.html
+++ b/docs/examples/en/math/convexhull/HalfEdge.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/convexhull/VertexList.html
+++ b/docs/examples/en/math/convexhull/VertexList.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/math/convexhull/VertexNode.html
+++ b/docs/examples/en/math/convexhull/VertexNode.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/postprocessing/EffectComposer.html
+++ b/docs/examples/en/postprocessing/EffectComposer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/renderers/CSS2DRenderer.html
+++ b/docs/examples/en/renderers/CSS2DRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/renderers/CSS3DRenderer.html
+++ b/docs/examples/en/renderers/CSS3DRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/utils/SceneUtils.html
+++ b/docs/examples/en/utils/SceneUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/en/utils/SkeletonUtils.html
+++ b/docs/examples/en/utils/SkeletonUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/animations/CCDIKSolver.html
+++ b/docs/examples/zh/animations/CCDIKSolver.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/animations/MMDAnimationHelper.html
+++ b/docs/examples/zh/animations/MMDAnimationHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/animations/MMDPhysics.html
+++ b/docs/examples/zh/animations/MMDPhysics.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/DeviceOrientationControls.html
+++ b/docs/examples/zh/controls/DeviceOrientationControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/FirstPersonControls.html
+++ b/docs/examples/zh/controls/FirstPersonControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/FlyControls.html
+++ b/docs/examples/zh/controls/FlyControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/PointerLockControls.html
+++ b/docs/examples/zh/controls/PointerLockControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/TrackballControls.html
+++ b/docs/examples/zh/controls/TrackballControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/exporters/ColladaExporter.html
+++ b/docs/examples/zh/exporters/ColladaExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/exporters/GLTFExporter.html
+++ b/docs/examples/zh/exporters/GLTFExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/exporters/PLYExporter.html
+++ b/docs/examples/zh/exporters/PLYExporter.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/geometries/ConvexBufferGeometry.html
+++ b/docs/examples/zh/geometries/ConvexBufferGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />

--- a/docs/examples/zh/geometries/ConvexGeometry.html
+++ b/docs/examples/zh/geometries/ConvexGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/geometries/DecalGeometry.html
+++ b/docs/examples/zh/geometries/DecalGeometry.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/FaceNormalsHelper.html
+++ b/docs/examples/zh/helpers/FaceNormalsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/LightProbeHelper.html
+++ b/docs/examples/zh/helpers/LightProbeHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/PositionalAudioHelper.html
+++ b/docs/examples/zh/helpers/PositionalAudioHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/RectAreaLightHelper.html
+++ b/docs/examples/zh/helpers/RectAreaLightHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/VertexNormalsHelper.html
+++ b/docs/examples/zh/helpers/VertexNormalsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/helpers/VertexTangentsHelper.html
+++ b/docs/examples/zh/helpers/VertexTangentsHelper.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/lights/LightProbeGenerator.html
+++ b/docs/examples/zh/lights/LightProbeGenerator.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/BasisTextureLoader.html
+++ b/docs/examples/zh/loaders/BasisTextureLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/MMDLoader.html
+++ b/docs/examples/zh/loaders/MMDLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/MTLLoader.html
+++ b/docs/examples/zh/loaders/MTLLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/OBJLoader.html
+++ b/docs/examples/zh/loaders/OBJLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/OBJLoader2.html
+++ b/docs/examples/zh/loaders/OBJLoader2.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/OBJLoader2Parallel.html
+++ b/docs/examples/zh/loaders/OBJLoader2Parallel.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/PCDLoader.html
+++ b/docs/examples/zh/loaders/PCDLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/PDBLoader.html
+++ b/docs/examples/zh/loaders/PDBLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/PRWMLoader.html
+++ b/docs/examples/zh/loaders/PRWMLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/Lut.html
+++ b/docs/examples/zh/math/Lut.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/convexhull/ConvexHull.html
+++ b/docs/examples/zh/math/convexhull/ConvexHull.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/convexhull/Face.html
+++ b/docs/examples/zh/math/convexhull/Face.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/convexhull/HalfEdge.html
+++ b/docs/examples/zh/math/convexhull/HalfEdge.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/convexhull/VertexList.html
+++ b/docs/examples/zh/math/convexhull/VertexList.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/math/convexhull/VertexNode.html
+++ b/docs/examples/zh/math/convexhull/VertexNode.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/objects/Lensflare.html
+++ b/docs/examples/zh/objects/Lensflare.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/postprocessing/EffectComposer.html
+++ b/docs/examples/zh/postprocessing/EffectComposer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/renderers/CSS2DRenderer.html
+++ b/docs/examples/zh/renderers/CSS2DRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/renderers/CSS3DRenderer.html
+++ b/docs/examples/zh/renderers/CSS3DRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/renderers/SVGRenderer.html
+++ b/docs/examples/zh/renderers/SVGRenderer.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/utils/SceneUtils.html
+++ b/docs/examples/zh/utils/SceneUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/examples/zh/utils/SkeletonUtils.html
+++ b/docs/examples/zh/utils/SkeletonUtils.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/buildTools/Testing-with-NPM.html
+++ b/docs/manual/ar/buildTools/Testing-with-NPM.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Animation-system.html
+++ b/docs/manual/ar/introduction/Animation-system.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Browser-support.html
+++ b/docs/manual/ar/introduction/Browser-support.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Creating-a-scene.html
+++ b/docs/manual/ar/introduction/Creating-a-scene.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Creating-text.html
+++ b/docs/manual/ar/introduction/Creating-text.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Drawing-lines.html
+++ b/docs/manual/ar/introduction/Drawing-lines.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/FAQ.html
+++ b/docs/manual/ar/introduction/FAQ.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/How-to-create-VR-content.html
+++ b/docs/manual/ar/introduction/How-to-create-VR-content.html
@@ -4,7 +4,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/ar/introduction/How-to-dispose-of-objects.html
@@ -4,7 +4,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/How-to-run-things-locally.html
+++ b/docs/manual/ar/introduction/How-to-run-things-locally.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/How-to-update-things.html
+++ b/docs/manual/ar/introduction/How-to-update-things.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ar/introduction/How-to-use-post-processing.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Installation.html
+++ b/docs/manual/ar/introduction/Installation.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Loading-3D-models.html
+++ b/docs/manual/ar/introduction/Loading-3D-models.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/ar/introduction/Matrix-transformations.html
+++ b/docs/manual/ar/introduction/Matrix-transformations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Typescript-setup.html
+++ b/docs/manual/ar/introduction/Typescript-setup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/ar/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/ar/introduction/WebGL-compatibility-check.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/buildTools/Testing-with-NPM.html
+++ b/docs/manual/en/buildTools/Testing-with-NPM.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Animation-system.html
+++ b/docs/manual/en/introduction/Animation-system.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Browser-support.html
+++ b/docs/manual/en/introduction/Browser-support.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Drawing-lines.html
+++ b/docs/manual/en/introduction/Drawing-lines.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/FAQ.html
+++ b/docs/manual/en/introduction/FAQ.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Typescript-setup.html
+++ b/docs/manual/en/introduction/Typescript-setup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/en/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/en/introduction/WebGL-compatibility-check.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/buildTools/Testing-with-NPM.html
+++ b/docs/manual/zh/buildTools/Testing-with-NPM.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Animation-system.html
+++ b/docs/manual/zh/introduction/Animation-system.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Browser-support.html
+++ b/docs/manual/zh/introduction/Browser-support.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/zh/introduction/Creating-a-scene.html
+++ b/docs/manual/zh/introduction/Creating-a-scene.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Creating-text.html
+++ b/docs/manual/zh/introduction/Creating-text.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Drawing-lines.html
+++ b/docs/manual/zh/introduction/Drawing-lines.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/FAQ.html
+++ b/docs/manual/zh/introduction/FAQ.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/How-to-create-VR-content.html
+++ b/docs/manual/zh/introduction/How-to-create-VR-content.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/zh/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/zh/introduction/How-to-dispose-of-objects.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/zh/introduction/How-to-run-things-locally.html
+++ b/docs/manual/zh/introduction/How-to-run-things-locally.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/How-to-update-things.html
+++ b/docs/manual/zh/introduction/How-to-update-things.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/How-to-use-post-processing.html
+++ b/docs/manual/zh/introduction/How-to-use-post-processing.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Installation.html
+++ b/docs/manual/zh/introduction/Installation.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Loading-3D-models.html
+++ b/docs/manual/zh/introduction/Loading-3D-models.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<base href="../../../" />
-	<script src="list.js"></script>
 	<script src="page.js"></script>
 	<link type="text/css" rel="stylesheet" href="page.css" />
 </head>

--- a/docs/manual/zh/introduction/Matrix-transformations.html
+++ b/docs/manual/zh/introduction/Matrix-transformations.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Typescript-setup.html
+++ b/docs/manual/zh/introduction/Typescript-setup.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/manual/zh/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/zh/introduction/WebGL-compatibility-check.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		<base href="../../../" />
-		<script src="list.js"></script>
 		<script src="page.js"></script>
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>

--- a/docs/page.js
+++ b/docs/page.js
@@ -17,7 +17,9 @@ if ( ! window.frameElement && window.location.protocol !== 'file:' ) {
 
 	}
 
-	const pathSnippet = href.slice( splitIndex, - 5 );
+	const extension = href.split( '.' ).pop();
+	const end = ( extension === 'html' ) ? - 5 : href.length;
+	const pathSnippet = href.slice( splitIndex, end );
 
 	window.location.replace( docsBaseURL + '#' + pathSnippet + hash );
 


### PR DESCRIPTION
AFAICS, it's sufficient if `docs/index.html` imports `list.js`. This is not required for individual pages since `page.js` does not work with the navigation.

This PR also fixes a minor redirect issue. It ensures that a link like the following is properly processed:

https://threejs.org/docs/manual/en/introduction/Creating-a-scene

Right now, it only works if the link has a html extension

https://threejs.org/docs/manual/en/introduction/Creating-a-scene.html