### PR TITLE
AnimationObjectGroup: Fix uncache() when used with a single object.

### DIFF
--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -281,7 +281,12 @@ Object.assign( AnimationObjectGroup.prototype, {
 					const lastIndex = -- nObjects,
 						lastObject = objects[ lastIndex ];
 
-					indicesByUUID[ lastObject.uuid ] = index;
+					if ( lastIndex > 0 ) {
+
+						indicesByUUID[ lastObject.uuid ] = index;
+
+					}
+
 					objects[ index ] = lastObject;
 					objects.pop();
 


### PR DESCRIPTION
Related issues:

Fixed #20555.

**Description**

see https://github.com/mrdoob/three.js/issues/20555#issuecomment-715884554