### PR TITLE
Changes WebXR profiles URL to allow any v1 version

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -14,7 +14,7 @@ import {
 	MotionController
 } from '../libs/motion-controllers.module.js';
 
-const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles';
+const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@^1.0/dist/profiles';
 const DEFAULT_PROFILE = 'generic-trigger';
 
 function XRControllerModel( ) {


### PR DESCRIPTION
Needed to utilize new Oculus Quest 2 controller profiles added in immersive-web/webxr-input-profiles#183. Using the `^` will ensure that we don't need to update Three whenever new profiles are added.