### PR TITLE
CubeCamera: Moved clear() to WebGLCubeRenderTarget

### DIFF
--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -80,12 +80,6 @@
 		Call this to update the [page:CubeCamera.renderTarget renderTarget].
 		</p>
 
-		<h3>[method:null clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
-		<p>
-		Call this to clear the renderTarget's color, depth, and/or stencil buffers.
-		The color buffer is set to the renderer's current clear color. Arguments default to *true*.
-		</p>
-
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -64,6 +64,12 @@
 			Use this method if you want to convert an equirectangular panorama to the cubemap format.
 		</p>
 
+		<h3>[method:undefined clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
+		<p>
+			Call this to clear the renderTarget's color, depth, and/or stencil buffers.
+			The color buffer is set to the renderer's current clear color. Arguments default to *true*.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/zh/cameras/CubeCamera.html
+++ b/docs/api/zh/cameras/CubeCamera.html
@@ -82,12 +82,6 @@
 		这个方法用来更新[page:CubeCamera.renderTarget renderTarget]（渲染目标对象）。
 		</p>
 
-		<h3>[method:null clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
-		<p>
-		这个方法用来来清除[page:CubeCamera.renderTarget renderTarget]的颜色、深度和/或模板缓冲区。
-		颜色缓冲区设置为渲染器当前的“清除”色。参数默认值均为*true*。
-		</p>
-
 		<h2>源代码</h2>
 
 		<p>

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -61,6 +61,12 @@
 			如果你想将一张equirectangular格式的全景图转换到cubemap格式，则使用此方法。
 		</p>
 
+		<h3>[method:undefined clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
+		<p>
+			这个方法用来来清除renderTarget的颜色、深度和/或模板缓冲区。
+			颜色缓冲区设置为渲染器当前的“清除”色。参数默认值均为*true*。
+		</p>
+
 		<h2>源码</h2>
 
 		<p>

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -2106,6 +2106,13 @@ CubeCamera.prototype.updateCubeMap = function ( renderer, scene ) {
 
 };
 
+CubeCamera.prototype.clear = function ( renderer, color, depth, stencil ) {
+
+	console.warn( 'THREE.CubeCamera: .clear() is now .renderTarget.clear().' );
+	return this.renderTarget.clear( renderer, color, depth, stencil );
+
+};
+
 //
 
 export const GeometryUtils = {

--- a/src/cameras/CubeCamera.d.ts
+++ b/src/cameras/CubeCamera.d.ts
@@ -13,6 +13,4 @@ export class CubeCamera extends Object3D {
 
 	update( renderer: WebGLRenderer, scene: Scene ): void;
 
-	clear( renderer: WebGLRenderer, color: boolean, depth: boolean, stencil: boolean ): void;
-
 }

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -94,22 +94,6 @@ function CubeCamera( near, far, renderTarget ) {
 
 	};
 
-	this.clear = function ( renderer, color, depth, stencil ) {
-
-		const currentRenderTarget = renderer.getRenderTarget();
-
-		for ( let i = 0; i < 6; i ++ ) {
-
-			renderer.setRenderTarget( renderTarget, i );
-
-			renderer.clear( color, depth, stencil );
-
-		}
-
-		renderer.setRenderTarget( currentRenderTarget );
-
-	};
-
 }
 
 CubeCamera.prototype = Object.create( Object3D.prototype );

--- a/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -14,4 +14,6 @@ export class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	fromEquirectangularTexture( renderer: WebGLRenderer, texture: Texture ): this;
 
+	clear( renderer: WebGLRenderer, color: boolean, depth: boolean, stencil: boolean ): void;
+
 }

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -123,4 +123,20 @@ WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer
 
 };
 
+WebGLCubeRenderTarget.prototype.clear = function ( renderer, color, depth, stencil ) {
+
+	const currentRenderTarget = renderer.getRenderTarget();
+
+	for ( let i = 0; i < 6; i ++ ) {
+
+		renderer.setRenderTarget( this, i );
+
+		renderer.clear( color, depth, stencil );
+
+	}
+
+	renderer.setRenderTarget( currentRenderTarget );
+
+};
+
 export { WebGLCubeRenderTarget };


### PR DESCRIPTION
Related issues:

#20542

**Description**

I was planning on removing `CubeCamera` altogether, but seems like moving `clear()` to `WebGLCubeRenderTarget` is good enough for now. It makes more sense to have the `clear()` in `WebGLCubeRenderTarget` anyway.