### PR TITLE
Examples: Remove obsolete code in webxr_vr_video.

### DIFF
--- a/examples/webxr_vr_video.html
+++ b/examples/webxr_vr_video.html
@@ -47,10 +47,8 @@
 				video.play();
 
 				const texture = new THREE.Texture( video );
-				texture.generateMipmaps = false;
 				texture.minFilter = THREE.NearestFilter;
 				texture.magFilter = THREE.NearestFilter;
-				texture.format = THREE.RGBFormat;
 
 				setInterval( function () {
 

--- a/examples/webxr_vr_video.html
+++ b/examples/webxr_vr_video.html
@@ -47,8 +47,6 @@
 				video.play();
 
 				const texture = new THREE.Texture( video );
-				texture.minFilter = THREE.NearestFilter;
-				texture.magFilter = THREE.NearestFilter;
 
 				setInterval( function () {
 


### PR DESCRIPTION
Is there a special reason for using `NearestFilter` for the video texture?