### PR TITLE
MeshSurfaceSampler: Add a "setRandomGenerator" function

### DIFF
--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -35,6 +35,7 @@ var MeshSurfaceSampler = ( function () {
 		}
 
 		this.geometry = geometry;
+		this.randomFunction = Math.random;
 
 		this.positionAttribute = this.geometry.getAttribute( 'position' );
 		this.weightAttribute = null;
@@ -104,9 +105,10 @@ var MeshSurfaceSampler = ( function () {
 
 		},
 
-		getRandomNumber: function () {
+		setRandomFunction: function ( randomFunction ) {
 
-			return Math.random();
+			this.randomFunction = randomFunction;
+			return this;
 
 		},
 
@@ -114,7 +116,7 @@ var MeshSurfaceSampler = ( function () {
 
 			var cumulativeTotal = this.distribution[ this.distribution.length - 1 ];
 
-			var faceIndex = this.binarySearch( this.getRandomNumber() * cumulativeTotal );
+			var faceIndex = this.binarySearch( this.randomFunction() * cumulativeTotal );
 
 			return this.sampleFace( faceIndex, targetPosition, targetNormal );
 
@@ -156,8 +158,8 @@ var MeshSurfaceSampler = ( function () {
 
 		sampleFace: function ( faceIndex, targetPosition, targetNormal ) {
 
-			var u = this.getRandomNumber();
-			var v = this.getRandomNumber();
+			var u = this.randomFunction();
+			var v = this.randomFunction();
 
 			if ( u + v > 1 ) {
 

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -105,7 +105,7 @@ var MeshSurfaceSampler = ( function () {
 
 		},
 
-		setRandomFunction: function ( randomFunction ) {
+		setRandomGenerator: function ( randomFunction ) {
 
 			this.randomFunction = randomFunction;
 			return this;

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -104,11 +104,17 @@ var MeshSurfaceSampler = ( function () {
 
 		},
 
+		getRandomNumber: function () {
+
+			return Math.random();
+
+		},
+
 		sample: function ( targetPosition, targetNormal ) {
 
 			var cumulativeTotal = this.distribution[ this.distribution.length - 1 ];
 
-			var faceIndex = this.binarySearch( Math.random() * cumulativeTotal );
+			var faceIndex = this.binarySearch( this.getRandomNumber() * cumulativeTotal );
 
 			return this.sampleFace( faceIndex, targetPosition, targetNormal );
 
@@ -150,8 +156,8 @@ var MeshSurfaceSampler = ( function () {
 
 		sampleFace: function ( faceIndex, targetPosition, targetNormal ) {
 
-			var u = Math.random();
-			var v = Math.random();
+			var u = this.getRandomNumber();
+			var v = this.getRandomNumber();
 
 			if ( u + v > 1 ) {
 


### PR DESCRIPTION
This adds a `getRandomNumber` function to `MeshSurfaceSampler` class so it can be overridden to use a custom number generation approach.

I used `MeshSurfaceSampler` in [this demo that involved jittering lights](https://gkjohnson.github.io/threejs-sandbox/volume-lights/) and found that I wanted to seed the random surface point from the same starting location so the lighting would be consistent when moving the camera. In order to achieve this I overrode the global Math.random function with a custom one that supported a seed value I could reset and I figured it would be nice to have built in to the class.

In the future it might be nice to add a `getRandomVector2( target )` function that can be overridden for generating a random UV value in order to support using custom distributions like blue noise but I'd have to think more about if / how that would work given the way faces and uvs are picked currently.

cc @donmccurdy -- and very nice example addition! 