### PR TITLE
WebGLRenderer: Enable half float attributes.

### DIFF
--- a/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -19,6 +19,7 @@
 		<code>
 		THREE.Float64BufferAttribute
 		THREE.Float32BufferAttribute
+		THREE.Float16BufferAttribute
 		THREE.Uint32BufferAttribute
 		THREE.Int32BufferAttribute
 		THREE.Uint16BufferAttribute
@@ -59,6 +60,6 @@
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js src/core/BufferAttribute.js]
-		</p>	
+		</p>
 	</body>
 </html>

--- a/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -19,6 +19,7 @@
 		<code>
 		THREE.Float64BufferAttribute
 		THREE.Float32BufferAttribute
+		THREE.Float16BufferAttribute
 		THREE.Uint32BufferAttribute
 		THREE.Int32BufferAttribute
 		THREE.Uint16BufferAttribute

--- a/src/core/BufferAttribute.d.ts
+++ b/src/core/BufferAttribute.d.ts
@@ -251,6 +251,16 @@ export class Uint32BufferAttribute extends BufferAttribute {
 
 }
 
+export class Float16BufferAttribute extends BufferAttribute {
+
+	constructor(
+		array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+		itemSize: number,
+		normalized?: boolean
+	);
+
+}
+
 export class Float32BufferAttribute extends BufferAttribute {
 
 	constructor(

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -478,6 +478,15 @@ function Uint32BufferAttribute( array, itemSize, normalized ) {
 Uint32BufferAttribute.prototype = Object.create( BufferAttribute.prototype );
 Uint32BufferAttribute.prototype.constructor = Uint32BufferAttribute;
 
+function Float16BufferAttribute( array, itemSize, normalized ) {
+
+	BufferAttribute.call( this, new Uint16Array( array ), itemSize, normalized );
+
+}
+
+Float16BufferAttribute.prototype = Object.create( BufferAttribute.prototype );
+Float16BufferAttribute.prototype.constructor = Float16BufferAttribute;
+Float16BufferAttribute.prototype.isFloat16BufferAttribute = true;
 
 function Float32BufferAttribute( array, itemSize, normalized ) {
 
@@ -503,6 +512,7 @@ Float64BufferAttribute.prototype.constructor = Float64BufferAttribute;
 export {
 	Float64BufferAttribute,
 	Float32BufferAttribute,
+	Float16BufferAttribute,
 	Uint32BufferAttribute,
 	Int32BufferAttribute,
 	Uint16BufferAttribute,

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -28,7 +28,23 @@ function WebGLAttributes( gl, capabilities ) {
 
 		} else if ( array instanceof Uint16Array ) {
 
-			type = gl.UNSIGNED_SHORT;
+			if ( attribute.isFloat16BufferAttribute ) {
+
+				if ( isWebGL2 ) {
+
+					type = gl.HALF_FLOAT;
+
+				} else {
+
+					console.warn( 'THREE.WebGLAttributes: Usage of Float16BufferAttribute requires WebGL2.' );
+
+				}
+
+			} else {
+
+				type = gl.UNSIGNED_SHORT;
+
+			}
 
 		} else if ( array instanceof Int16Array ) {
 


### PR DESCRIPTION
Related issues:

Fixed #15480.

**Description**

The PR introduces `Float16BufferAttribute` so the renderer can detect half float buffer attribute data and correctly set the `gl.HALF_FLOAT` type. The change does not contain automatic data conversion for now. I've realized this would cause more changes in `WebGLAttributes` since you have to support the initial buffer upload as well as buffer updates. So the app has to perform the conversion via `DataUtils.toHalfFloat()` for now. Support for automatic conversion can be added later if it turns out to be a dev pain.
