### PR TITLE
SkinnedMesh: Added serialization/deserialization.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -664,9 +664,49 @@ Editor.prototype = {
 
 		} );
 
+		// animations
+
+		var animationsJSON = json.animations;
+
+		for ( var i = 0; i < animationsJSON.length; i ++ ) {
+
+			var objectJSON = animationsJSON[ i ];
+			var animations = [];
+
+			for ( var j = 0; j < objectJSON.animations.length; j ++ ) {
+
+				animations.push( THREE.AnimationClip.parse( objectJSON.animations[ j ] ) );
+
+			}
+
+			this.animations[ objectJSON.uuid ] = animations;
+
+		}
+
 	},
 
 	toJSON: function () {
+
+		// animations
+
+		var animations = this.animations;
+		var animationsJSON = [];
+
+		for ( var entry in animations ) {
+
+			var objectAnimations = animations[ entry ];
+			var objectJSON = { uuid: entry, animations: [] };
+
+			for ( var i = 0; i < objectAnimations.length; i ++ ) {
+
+				var objectAnimation = objectAnimations[ i ];
+				objectJSON.animations.push( THREE.AnimationClip.toJSON( objectAnimation ) );
+
+			}
+
+			animationsJSON.push( objectJSON );
+
+		}
 
 		// scripts clean up
 
@@ -701,7 +741,8 @@ Editor.prototype = {
 			camera: this.camera.toJSON(),
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
-			history: this.history.toJSON()
+			history: this.history.toJSON(),
+			animations: animationsJSON
 
 		};
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -658,7 +658,8 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 				materials: {},
 				textures: {},
 				images: {},
-				shapes: {}
+				shapes: {},
+				skeletons: {}
 			};
 
 			output.metadata = {
@@ -743,6 +744,21 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
+		if ( this.isSkinnedMesh ) {
+
+			object.bindMode = this.bindMode;
+			object.bindMatrix = this.bindMatrix.toArray();
+
+			if ( this.skeleton !== undefined ) {
+
+				serialize( meta.skeletons, this.skeleton );
+
+				object.skeleton = this.skeleton.uuid;
+
+			}
+
+		}
+
 		if ( this.material !== undefined ) {
 
 			if ( Array.isArray( this.material ) ) {
@@ -786,12 +802,14 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			const textures = extractFromCache( meta.textures );
 			const images = extractFromCache( meta.images );
 			const shapes = extractFromCache( meta.shapes );
+			const skeletons = extractFromCache( meta.skeletons );
 
 			if ( geometries.length > 0 ) output.geometries = geometries;
 			if ( materials.length > 0 ) output.materials = materials;
 			if ( textures.length > 0 ) output.textures = textures;
 			if ( images.length > 0 ) output.images = images;
 			if ( shapes.length > 0 ) output.shapes = shapes;
+			if ( skeletons.length > 0 ) output.skeletons = skeletons;
 
 		}
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -1,54 +1,63 @@
+import { Bone } from './Bone.js';
 import { Matrix4 } from '../math/Matrix4.js';
+import { MathUtils } from '../math/MathUtils.js';
 
 const _offsetMatrix = new Matrix4();
 const _identityMatrix = new Matrix4();
 
-function Skeleton( bones, boneInverses ) {
+function Skeleton( bones = [], boneInverses = [] ) {
 
-	// copy the bone array
-
-	bones = bones || [];
+	this.uuid = MathUtils.generateUUID();
 
 	this.bones = bones.slice( 0 );
-	this.boneMatrices = new Float32Array( this.bones.length * 16 );
+	this.boneInverses = boneInverses;
 
 	this.frame = - 1;
 
-	// use the supplied bone inverses or calculate the inverses
-
-	if ( boneInverses === undefined ) {
-
-		this.calculateInverses();
-
-	} else {
-
-		if ( this.bones.length === boneInverses.length ) {
-
-			this.boneInverses = boneInverses.slice( 0 );
-
-		} else {
-
-			console.warn( 'THREE.Skeleton boneInverses is the wrong length.' );
-
-			this.boneInverses = [];
-
-			for ( let i = 0, il = this.bones.length; i < il; i ++ ) {
-
-				this.boneInverses.push( new Matrix4() );
-
-			}
-
-		}
-
-	}
+	this.init();
 
 }
 
 Object.assign( Skeleton.prototype, {
 
+	init: function () {
+
+		const bones = this.bones;
+		const boneInverses = this.boneInverses;
+
+		this.boneMatrices = new Float32Array( bones.length * 16 );
+
+		// calculate inverse bone matrices if necessary
+
+		if ( boneInverses.length === 0 ) {
+
+			this.calculateInverses();
+
+		} else {
+
+			// handle special case
+
+			if ( bones.length !== boneInverses.length ) {
+
+				console.warn( 'THREE.Skeleton: Number of inverse bone matrices does not match amount of bones.' );
+
+				this.boneInverses = [];
+
+				for ( let i = 0, il = this.bones.length; i < il; i ++ ) {
+
+					this.boneInverses.push( new Matrix4() );
+
+				}
+
+			}
+
+		}
+
+	},
+
 	calculateInverses: function () {
 
-		this.boneInverses = [];
+		this.boneInverses.length = 0;
 
 		for ( let i = 0, il = this.bones.length; i < il; i ++ ) {
 
@@ -170,6 +179,64 @@ Object.assign( Skeleton.prototype, {
 			this.boneTexture = undefined;
 
 		}
+
+	},
+
+	fromJSON: function ( json, bones ) {
+
+		this.uuid = json.uuid;
+
+		for ( let i = 0, l = json.bones.length; i < l; i ++ ) {
+
+			const uuid = json.bones[ i ];
+			let bone = bones[ uuid ];
+
+			if ( bone === undefined ) {
+
+				console.warn( 'THREE.Skeleton: No bone found with UUID:', uuid );
+				bone = new Bone();
+
+			}
+
+			this.bones.push( bone );
+			this.boneInverses.push( new Matrix4().fromArray( json.boneInverses[ i ] ) );
+
+		}
+
+		this.init();
+
+		return this;
+
+	},
+
+	toJSON: function () {
+
+		const data = {
+			metadata: {
+				version: 4.5,
+				type: 'Skeleton',
+				generator: 'Skeleton.toJSON'
+			},
+			bones: [],
+			boneInverses: []
+		};
+
+		data.uuid = this.uuid;
+
+		const bones = this.bones;
+		const boneInverses = this.boneInverses;
+
+		for ( let i = 0, l = bones.length; i < l; i ++ ) {
+
+			const bone = bones[ i ];
+			data.bones.push( bone.uuid );
+
+			const boneInverse = boneInverses[ i ];
+			data.boneInverses.push( boneInverse.toArray() );
+
+		}
+
+		return data;
 
 	}
 


### PR DESCRIPTION
Related issues:

#16234

**Description**

This PR enables serialization/deserialization for `SkinnedMesh`. It also enhances the editor to save/reload animations. It's now possible to save/reload scenes with skinned mesh without loosing their type information and animations.

The change is a new attempt of #15413 however with an improved implementation. No changes to `BufferGeometry` are necessary anymore and the code uses now a bone lookup table to create the skeletons (see https://github.com/mrdoob/three.js/pull/15413/files#r240787588).
