### PR TITLE
LineMaterial: Add dash offset.

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -5,6 +5,7 @@
  *  dashed: <boolean>,
  *  dashScale: <float>,
  *  dashSize: <float>,
+ *  dashOffset: <float>,
  *  gapSize: <float>,
  *  resolution: <Vector2>, // to be set by renderer
  * }
@@ -16,6 +17,7 @@ THREE.UniformsLib.line = {
 	resolution: { value: new THREE.Vector2( 1, 1 ) },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
+	dashOffset: { value: 0 },
 	gapSize: { value: 1 }, // todo FIX - maybe change to totalSize
 	opacity: { value: 1 }
 
@@ -184,6 +186,7 @@ THREE.ShaderLib[ 'line' ] = {
 		#ifdef USE_DASH
 
 			uniform float dashSize;
+			uniform float dashOffset;
 			uniform float gapSize;
 
 		#endif
@@ -206,7 +209,7 @@ THREE.ShaderLib[ 'line' ] = {
 
 				if ( vUv.y < - 1.0 || vUv.y > 1.0 ) discard; // discard endcaps
 
-				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
+				if ( mod( vLineDistance + dashOffset, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
@@ -322,6 +325,24 @@ THREE.LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.dashSize.value = value;
+
+			}
+
+		},
+
+		dashOffset: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.dashOffset.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.dashOffset.value = value;
 
 			}
 

--- a/examples/jsm/lines/LineMaterial.d.ts
+++ b/examples/jsm/lines/LineMaterial.d.ts
@@ -10,6 +10,7 @@ export interface LineMaterialParameters extends MaterialParameters {
 	dashed?: boolean;
 	dashScale?: number;
 	dashSize?: number;
+	dashOffset?: number;
 	gapSize?: number;
 	linewidth?: number;
 	resolution?: Vector2;
@@ -22,6 +23,7 @@ export class LineMaterial extends ShaderMaterial {
 	dashed: boolean;
 	dashScale: number;
 	dashSize: number;
+	dashOffset: number;
 	gapSize: number;
 	opacity: number;
 	readonly isLineMaterial: true;

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -13,6 +13,7 @@ import {
  *  dashed: <boolean>,
  *  dashScale: <float>,
  *  dashSize: <float>,
+ *  dashOffset: <float>,
  *  gapSize: <float>,
  *  resolution: <Vector2>, // to be set by renderer
  * }
@@ -24,6 +25,7 @@ UniformsLib.line = {
 	resolution: { value: new Vector2( 1, 1 ) },
 	dashScale: { value: 1 },
 	dashSize: { value: 1 },
+	dashOffset: { value: 0 },
 	gapSize: { value: 1 }, // todo FIX - maybe change to totalSize
 	opacity: { value: 1 }
 
@@ -192,6 +194,7 @@ ShaderLib[ 'line' ] = {
 		#ifdef USE_DASH
 
 			uniform float dashSize;
+			uniform float dashOffset;
 			uniform float gapSize;
 
 		#endif
@@ -214,7 +217,7 @@ ShaderLib[ 'line' ] = {
 
 				if ( vUv.y < - 1.0 || vUv.y > 1.0 ) discard; // discard endcaps
 
-				if ( mod( vLineDistance, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
+				if ( mod( vLineDistance + dashOffset, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
 
@@ -330,6 +333,24 @@ var LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.dashSize.value = value;
+
+			}
+
+		},
+
+		dashOffset: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return this.uniforms.dashOffset.value;
+
+			},
+
+			set: function ( value ) {
+
+				this.uniforms.dashOffset.value = value;
 
 			}
 


### PR DESCRIPTION
Related issues:

Fixed #20592.

**Description**

Dashed lines can now be animated by doing `material.dashOffset -= 0.01;`.