### PR TITLE
Matrix3/4: Fix semantics of getInverse().

### DIFF
--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -107,9 +107,9 @@ zAxis = (c, f, i)
 
 		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
 		<p>
-		[page:Matrix3 m] - the matrix to take the inverse of.<br /><br />
+		[page:Matrix3 m] - the result will be copied into this matrix.<br /><br />
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix3 m],
+		Computes the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] matrix and stores it into the given matrix,
 		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
 		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -186,16 +186,15 @@ zAxis = (c, g, k)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix4 m] )</h3>
+		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
 		<p>
-		[page:Matrix4 m] - the matrix to take the inverse of.<br /><br />
+		[page:Matrix4 m] - the result will be copied into this matrix.<br /><br />
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix4 m],
-		using the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
+		Computes the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] matrix and stores it into the given matrix,
+		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
 		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
 		</p>
-
 
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>
 		<p>Gets the maximum scale value of the 3 axes.</p>

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -102,9 +102,9 @@ zAxis = (c, f, i)
 
 		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
 		<p>
-		[page:Matrix3 m] - 取逆的矩阵。<br /><br />
+		[page:Matrix3 m] - the result will be copied into this matrix.<br /><br />
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix3 m],
+		Computes the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] matrix and stores it into the given matrix,
 		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
 		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -170,14 +170,14 @@ zAxis = (c, g, k)
 			[page:Integer offset] - (可选参数) 数组的偏移量，默认值为 0。<br /><br />
 
 			使用基于列优先格式[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]的数组来设置该矩阵。
-			</p>
+		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix4 m] )</h3>
-		<p>
-			[page:Matrix3 m] - 取逆的矩阵。<br /><br />
+		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
+			<p>
+			[page:Matrix4 m] - the result will be copied into this matrix.<br /><br />
 
-			Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix4 m],
-			using the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
+			Computes the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] matrix and stores it into the given matrix,
+			using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
 			You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
 		</p>

--- a/examples/js/animation/CCDIKSolver.js
+++ b/examples/js/animation/CCDIKSolver.js
@@ -332,7 +332,7 @@ THREE.CCDIKSolver = ( function () {
 					var iks = this.iks;
 					var bones = mesh.skeleton.bones;
 
-					matrix.getInverse( mesh.matrixWorld );
+					mesh.matrixWorld.getInverse( matrix );
 
 					for ( var i = 0, il = iks.length; i < il; i ++ ) {
 

--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -1296,6 +1296,7 @@ THREE.MMDPhysics = ( function () {
 			var position = new THREE.Vector3();
 			var quaternion = new THREE.Quaternion();
 			var scale = new THREE.Vector3();
+			var matrixWorld = new THREE.Matrix4();
 			var matrixWorldInv = new THREE.Matrix4();
 
 			return function updateMatrixWorld( force ) {
@@ -1306,11 +1307,12 @@ THREE.MMDPhysics = ( function () {
 
 					var bodies = this.physics.bodies;
 
-					matrixWorldInv
+					matrixWorld
 						.copy( mesh.matrixWorld )
 						.decompose( position, quaternion, scale )
-						.compose( position, quaternion, scale.set( 1, 1, 1 ) )
-						.getInverse( matrixWorldInv );
+						.compose( position, quaternion, scale.set( 1, 1, 1 ) );
+
+					matrixWorld.getInverse( matrixWorldInv );
 
 					for ( var i = 0, il = bodies.length; i < il; i ++ ) {
 

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -129,7 +129,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_selected.parent.matrixWorld.getInverse( _inverseMatrix );
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}
@@ -210,7 +210,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_selected.parent.matrixWorld.getInverse( _inverseMatrix );
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}

--- a/examples/js/geometries/DecalGeometry.js
+++ b/examples/js/geometries/DecalGeometry.js
@@ -33,7 +33,8 @@ THREE.DecalGeometry = function ( mesh, position, orientation, size ) {
 	projectorMatrix.makeRotationFromEuler( orientation );
 	projectorMatrix.setPosition( position );
 
-	var projectorMatrixInverse = new THREE.Matrix4().getInverse( projectorMatrix );
+	var projectorMatrixInverse = new THREE.Matrix4();
+	projectorMatrix.getInverse( projectorMatrixInverse );
 
 	// generate buffers
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4013,7 +4013,7 @@ THREE.FBXLoader = ( function () {
 		lParentTM.copyPosition( lParentGX );
 
 		var lParentGSM = new THREE.Matrix4();
-		lParentGSM.getInverse( lParentGRM ).multiply( lParentGX );
+		lParentGRM.getInverse( lParentGSM ).multiply( lParentGX );
 
 		var lGlobalRS = new THREE.Matrix4();
 
@@ -4027,15 +4027,15 @@ THREE.FBXLoader = ( function () {
 
 		} else {
 
-			var lParentLSM_inv = new THREE.Matrix4().getInverse( lScalingM );
+			var lParentLSM_inv = lScalingM.getInverse( new THREE.Matrix4() );
 			var lParentGSM_noLocal = new THREE.Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
 			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lScalingM );
 
 		}
 
-		var lRotationPivotM_inv = new THREE.Matrix4().getInverse( lRotationPivotM );
-		var lScalingPivotM_inv = new THREE.Matrix4().getInverse( lScalingPivotM );
+		var lRotationPivotM_inv = lRotationPivotM.getInverse( new THREE.Matrix4() );
+		var lScalingPivotM_inv = lScalingPivotM.getInverse( new THREE.Matrix4() );
 		// Calculate the local transform matrix
 		var lTransform = new THREE.Matrix4();
 		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -407,7 +407,7 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 		}
 
 		volume.inverseMatrix = new THREE.Matrix4();
-		volume.inverseMatrix.getInverse( volume.matrix );
+		volume.matrix.getInverse( volume.inverseMatrix );
 		volume.RASDimensions = ( new THREE.Vector3( volume.xLength, volume.yLength, volume.zLength ) ).applyMatrix4( volume.matrix ).round().toArray().map( Math.abs );
 
 		// .. and set the default threshold

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -443,7 +443,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 				matrix.transpose();
 
 				var inverse = new THREE.Matrix4();
-				inverse.getInverse( matrix );
+				matrix.getInverse( inverse );
 				geometry.applyMatrix4( inverse );
 
 				matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -114,7 +114,7 @@ THREE.Refractor = function ( geometry, options ) {
 		return function updateVirtualCamera( camera ) {
 
 			virtualCamera.matrixWorld.copy( camera.matrixWorld );
-			virtualCamera.matrixWorldInverse.getInverse( virtualCamera.matrixWorld );
+			virtualCamera.matrixWorld.getInverse( virtualCamera.matrixWorldInverse );
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 			virtualCamera.far = camera.far; // used in WebGLBackground
 

--- a/examples/js/utils/SkeletonUtils.js
+++ b/examples/js/utils/SkeletonUtils.js
@@ -112,7 +112,7 @@ THREE.SkeletonUtils = {
 
 					} else {
 
-						relativeMatrix.getInverse( target.matrixWorld );
+						target.matrixWorld.getInverse( relativeMatrix );
 						relativeMatrix.multiply( boneTo.matrixWorld );
 
 					}
@@ -129,7 +129,7 @@ THREE.SkeletonUtils = {
 					if ( target.isObject3D ) {
 
 						var boneIndex = bones.indexOf( bone ),
-							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.getInverse( target.skeleton.boneInverses[ boneIndex ] );
+							wBindMatrix = bindBones ? bindBones[ boneIndex ] : target.skeleton.boneInverses[ boneIndex ].getInverse( bindBoneMatrix );
 
 						globalMatrix.multiply( wBindMatrix );
 
@@ -141,7 +141,7 @@ THREE.SkeletonUtils = {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.parent.matrixWorld.getInverse( bone.matrix );
 					bone.matrix.multiply( globalMatrix );
 
 				} else {

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -347,7 +347,7 @@ var CCDIKSolver = ( function () {
 					var iks = this.iks;
 					var bones = mesh.skeleton.bones;
 
-					matrix.getInverse( mesh.matrixWorld );
+					mesh.matrixWorld.getInverse( matrix );
 
 					for ( var i = 0, il = iks.length; i < il; i ++ ) {
 

--- a/examples/jsm/animation/MMDPhysics.js
+++ b/examples/jsm/animation/MMDPhysics.js
@@ -1311,6 +1311,7 @@ var MMDPhysics = ( function () {
 			var position = new Vector3();
 			var quaternion = new Quaternion();
 			var scale = new Vector3();
+			var matrixWorld = new Matrix4();
 			var matrixWorldInv = new Matrix4();
 
 			return function updateMatrixWorld( force ) {
@@ -1321,11 +1322,12 @@ var MMDPhysics = ( function () {
 
 					var bodies = this.physics.bodies;
 
-					matrixWorldInv
+					matrixWorld
 						.copy( mesh.matrixWorld )
 						.decompose( position, quaternion, scale )
-						.compose( position, quaternion, scale.set( 1, 1, 1 ) )
-						.getInverse( matrixWorldInv );
+						.compose( position, quaternion, scale.set( 1, 1, 1 ) );
+
+					matrixWorld.getInverse( matrixWorldInv );
 
 					for ( var i = 0, il = bodies.length; i < il; i ++ ) {
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -138,7 +138,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_selected.parent.matrixWorld.getInverse( _inverseMatrix );
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}
@@ -219,7 +219,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_selected.parent.matrixWorld.getInverse( _inverseMatrix );
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -35,7 +35,7 @@ export default class Frustum {
 
 		const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-		inverseProjectionMatrix.getInverse( projectionMatrix );
+		projectionMatrix.getInverse( inverseProjectionMatrix );
 
 		// 3 --- 0  vertices.near/far order
 		// |     |

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -40,7 +40,8 @@ var DecalGeometry = function ( mesh, position, orientation, size ) {
 	projectorMatrix.makeRotationFromEuler( orientation );
 	projectorMatrix.setPosition( position );
 
-	var projectorMatrixInverse = new Matrix4().getInverse( projectorMatrix );
+	var projectorMatrixInverse = new Matrix4();
+	projectorMatrix.getInverse( projectorMatrixInverse );
 
 	// generate buffers
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -4060,7 +4060,7 @@ var FBXLoader = ( function () {
 		lParentTM.copyPosition( lParentGX );
 
 		var lParentGSM = new Matrix4();
-		lParentGSM.getInverse( lParentGRM ).multiply( lParentGX );
+		lParentGRM.getInverse( lParentGSM ).multiply( lParentGX );
 
 		var lGlobalRS = new Matrix4();
 
@@ -4074,15 +4074,15 @@ var FBXLoader = ( function () {
 
 		} else {
 
-			var lParentLSM_inv = new Matrix4().getInverse( lScalingM );
+			var lParentLSM_inv = lScalingM.getInverse( new Matrix4() );
 			var lParentGSM_noLocal = new Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
 			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lScalingM );
 
 		}
 
-		var lRotationPivotM_inv = new Matrix4().getInverse( lRotationPivotM );
-		var lScalingPivotM_inv = new Matrix4().getInverse( lScalingPivotM );
+		var lRotationPivotM_inv = lRotationPivotM.getInverse( new Matrix4() );
+		var lScalingPivotM_inv = lScalingPivotM.getInverse( new Matrix4() );
 		// Calculate the local transform matrix
 		var lTransform = new Matrix4();
 		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -416,7 +416,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		}
 
 		volume.inverseMatrix = new Matrix4();
-		volume.inverseMatrix.getInverse( volume.matrix );
+		volume.matrix.getInverse( volume.inverseMatrix );
 		volume.RASDimensions = ( new Vector3( volume.xLength, volume.yLength, volume.zLength ) ).applyMatrix4( volume.matrix ).round().toArray().map( Math.abs );
 
 		// .. and set the default threshold

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -459,7 +459,7 @@ TDSLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				matrix.transpose();
 
 				var inverse = new Matrix4();
-				inverse.getInverse( matrix );
+				matrix.getInverse( inverse );
 				geometry.applyMatrix4( inverse );
 
 				matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );

--- a/examples/jsm/math/OBB.js
+++ b/examples/jsm/math/OBB.js
@@ -325,7 +325,7 @@ Object.assign( OBB.prototype, {
 
 		// transform ray to the local space of the OBB
 
-		localRay.copy( ray ).applyMatrix4( inverse.getInverse( matrix ) );
+		localRay.copy( ray ).applyMatrix4( matrix.getInverse( inverse ) );
 
 		// perform ray <-> AABB intersection test
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -131,7 +131,7 @@ var Refractor = function ( geometry, options ) {
 		return function updateVirtualCamera( camera ) {
 
 			virtualCamera.matrixWorld.copy( camera.matrixWorld );
-			virtualCamera.matrixWorldInverse.getInverse( virtualCamera.matrixWorld );
+			virtualCamera.matrixWorld.getInverse( virtualCamera.matrixWorldInverse );
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 			virtualCamera.far = camera.far; // used in WebGLBackground
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -125,7 +125,7 @@ var SkeletonUtils = {
 
 					} else {
 
-						relativeMatrix.getInverse( target.matrixWorld );
+						target.matrixWorld.getInverse( relativeMatrix );
 						relativeMatrix.multiply( boneTo.matrixWorld );
 
 					}
@@ -142,7 +142,7 @@ var SkeletonUtils = {
 					if ( target.isObject3D ) {
 
 						var boneIndex = bones.indexOf( bone ),
-							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.getInverse( target.skeleton.boneInverses[ boneIndex ] );
+							wBindMatrix = bindBones ? bindBones[ boneIndex ] : target.skeleton.boneInverses[ boneIndex ].getInverse( bindBoneMatrix );
 
 						globalMatrix.multiply( wBindMatrix );
 
@@ -154,7 +154,7 @@ var SkeletonUtils = {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.parent.matrixWorld.getInverse( bone.matrix );
 					bone.matrix.multiply( globalMatrix );
 
 				} else {

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -376,7 +376,7 @@
 
 				const parent = object.parent;
 				scene.updateMatrixWorld();
-				object.matrix.getInverse( parent.matrixWorld );
+				parent.matrixWorld.getInverse( object.matrix );
 				object.applyMatrix4( matrix );
 
 			}

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -55,7 +55,7 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		Object3D.prototype.updateMatrixWorld.call( this, force );
 
-		this.matrixWorldInverse.getInverse( this.matrixWorld );
+		this.matrixWorld.getInverse( this.matrixWorldInverse );
 
 	},
 
@@ -63,7 +63,7 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		Object3D.prototype.updateWorldMatrix.call( this, updateParents, updateChildren );
 
-		this.matrixWorldInverse.getInverse( this.matrixWorld );
+		this.matrixWorld.getInverse( this.matrixWorldInverse );
 
 	},
 

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -112,7 +112,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 		this.projectionMatrix.makeOrthographic( left, right, top, bottom, this.near, this.far );
 
-		this.projectionMatrixInverse.getInverse( this.projectionMatrix );
+		this.projectionMatrix.getInverse( this.projectionMatrixInverse );
 
 	},
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -205,7 +205,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 		this.projectionMatrix.makePerspective( left, left + width, top, top - height, near, this.far );
 
-		this.projectionMatrixInverse.getInverse( this.projectionMatrix );
+		this.projectionMatrix.getInverse( this.projectionMatrixInverse );
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -251,7 +251,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	worldToLocal: function ( vector ) {
 
-		return vector.applyMatrix4( _m1.getInverse( this.matrixWorld ) );
+		return vector.applyMatrix4( this.matrixWorld.getInverse( _m1 ) );
 
 	},
 
@@ -395,7 +395,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		this.updateWorldMatrix( true, false );
 
-		_m1.getInverse( this.matrixWorld );
+		this.matrixWorld.getInverse( _m1 );
 
 		if ( object.parent !== null ) {
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -65,7 +65,7 @@ class SkeletonHelper extends LineSegments {
 		const geometry = this.geometry;
 		const position = geometry.getAttribute( 'position' );
 
-		_matrixWorldInv.getInverse( this.root.matrixWorld );
+		this.root.matrixWorld.getInverse( _matrixWorldInv );
 
 		for ( let i = 0, j = 0; i < bones.length; i ++ ) {
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -157,20 +157,14 @@ class Matrix3 {
 
 	}
 
-	getInverse( matrix, throwOnDegenerate ) {
-
-		if ( throwOnDegenerate !== undefined ) {
-
-			console.warn( "THREE.Matrix3: .getInverse() can no longer be configured to throw on degenerate." );
-
-		}
+	getInverse( matrix ) {
 
 		const me = matrix.elements,
 			te = this.elements,
 
-			n11 = me[ 0 ], n21 = me[ 1 ], n31 = me[ 2 ],
-			n12 = me[ 3 ], n22 = me[ 4 ], n32 = me[ 5 ],
-			n13 = me[ 6 ], n23 = me[ 7 ], n33 = me[ 8 ],
+			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ],
+			n12 = te[ 3 ], n22 = te[ 4 ], n32 = te[ 5 ],
+			n13 = te[ 6 ], n23 = te[ 7 ], n33 = te[ 8 ],
 
 			t11 = n33 * n22 - n32 * n23,
 			t12 = n32 * n13 - n33 * n12,
@@ -178,23 +172,23 @@ class Matrix3 {
 
 			det = n11 * t11 + n21 * t12 + n31 * t13;
 
-		if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+		if ( det === 0 ) return matrix.set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
 		const detInv = 1 / det;
 
-		te[ 0 ] = t11 * detInv;
-		te[ 1 ] = ( n31 * n23 - n33 * n21 ) * detInv;
-		te[ 2 ] = ( n32 * n21 - n31 * n22 ) * detInv;
+		me[ 0 ] = t11 * detInv;
+		me[ 1 ] = ( n31 * n23 - n33 * n21 ) * detInv;
+		me[ 2 ] = ( n32 * n21 - n31 * n22 ) * detInv;
 
-		te[ 3 ] = t12 * detInv;
-		te[ 4 ] = ( n33 * n11 - n31 * n13 ) * detInv;
-		te[ 5 ] = ( n31 * n12 - n32 * n11 ) * detInv;
+		me[ 3 ] = t12 * detInv;
+		me[ 4 ] = ( n33 * n11 - n31 * n13 ) * detInv;
+		me[ 5 ] = ( n31 * n12 - n32 * n11 ) * detInv;
 
-		te[ 6 ] = t13 * detInv;
-		te[ 7 ] = ( n21 * n13 - n23 * n11 ) * detInv;
-		te[ 8 ] = ( n22 * n11 - n21 * n12 ) * detInv;
+		me[ 6 ] = t13 * detInv;
+		me[ 7 ] = ( n21 * n13 - n23 * n11 ) * detInv;
+		me[ 8 ] = ( n22 * n11 - n21 * n12 ) * detInv;
 
-		return this;
+		return matrix;
 
 	}
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -483,22 +483,16 @@ class Matrix4 {
 
 	}
 
-	getInverse( m, throwOnDegenerate ) {
-
-		if ( throwOnDegenerate !== undefined ) {
-
-			console.warn( "THREE.Matrix4: .getInverse() can no longer be configured to throw on degenerate." );
-
-		}
+	getInverse( m ) {
 
 		// based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 		const te = this.elements,
 			me = m.elements,
 
-			n11 = me[ 0 ], n21 = me[ 1 ], n31 = me[ 2 ], n41 = me[ 3 ],
-			n12 = me[ 4 ], n22 = me[ 5 ], n32 = me[ 6 ], n42 = me[ 7 ],
-			n13 = me[ 8 ], n23 = me[ 9 ], n33 = me[ 10 ], n43 = me[ 11 ],
-			n14 = me[ 12 ], n24 = me[ 13 ], n34 = me[ 14 ], n44 = me[ 15 ],
+			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ], n41 = te[ 3 ],
+			n12 = te[ 4 ], n22 = te[ 5 ], n32 = te[ 6 ], n42 = te[ 7 ],
+			n13 = te[ 8 ], n23 = te[ 9 ], n33 = te[ 10 ], n43 = te[ 11 ],
+			n14 = te[ 12 ], n24 = te[ 13 ], n34 = te[ 14 ], n44 = te[ 15 ],
 
 			t11 = n23 * n34 * n42 - n24 * n33 * n42 + n24 * n32 * n43 - n22 * n34 * n43 - n23 * n32 * n44 + n22 * n33 * n44,
 			t12 = n14 * n33 * n42 - n13 * n34 * n42 - n14 * n32 * n43 + n12 * n34 * n43 + n13 * n32 * n44 - n12 * n33 * n44,
@@ -507,31 +501,31 @@ class Matrix4 {
 
 		const det = n11 * t11 + n21 * t12 + n31 * t13 + n41 * t14;
 
-		if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+		if ( det === 0 ) return m.set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
 		const detInv = 1 / det;
 
-		te[ 0 ] = t11 * detInv;
-		te[ 1 ] = ( n24 * n33 * n41 - n23 * n34 * n41 - n24 * n31 * n43 + n21 * n34 * n43 + n23 * n31 * n44 - n21 * n33 * n44 ) * detInv;
-		te[ 2 ] = ( n22 * n34 * n41 - n24 * n32 * n41 + n24 * n31 * n42 - n21 * n34 * n42 - n22 * n31 * n44 + n21 * n32 * n44 ) * detInv;
-		te[ 3 ] = ( n23 * n32 * n41 - n22 * n33 * n41 - n23 * n31 * n42 + n21 * n33 * n42 + n22 * n31 * n43 - n21 * n32 * n43 ) * detInv;
+		me[ 0 ] = t11 * detInv;
+		me[ 1 ] = ( n24 * n33 * n41 - n23 * n34 * n41 - n24 * n31 * n43 + n21 * n34 * n43 + n23 * n31 * n44 - n21 * n33 * n44 ) * detInv;
+		me[ 2 ] = ( n22 * n34 * n41 - n24 * n32 * n41 + n24 * n31 * n42 - n21 * n34 * n42 - n22 * n31 * n44 + n21 * n32 * n44 ) * detInv;
+		me[ 3 ] = ( n23 * n32 * n41 - n22 * n33 * n41 - n23 * n31 * n42 + n21 * n33 * n42 + n22 * n31 * n43 - n21 * n32 * n43 ) * detInv;
 
-		te[ 4 ] = t12 * detInv;
-		te[ 5 ] = ( n13 * n34 * n41 - n14 * n33 * n41 + n14 * n31 * n43 - n11 * n34 * n43 - n13 * n31 * n44 + n11 * n33 * n44 ) * detInv;
-		te[ 6 ] = ( n14 * n32 * n41 - n12 * n34 * n41 - n14 * n31 * n42 + n11 * n34 * n42 + n12 * n31 * n44 - n11 * n32 * n44 ) * detInv;
-		te[ 7 ] = ( n12 * n33 * n41 - n13 * n32 * n41 + n13 * n31 * n42 - n11 * n33 * n42 - n12 * n31 * n43 + n11 * n32 * n43 ) * detInv;
+		me[ 4 ] = t12 * detInv;
+		me[ 5 ] = ( n13 * n34 * n41 - n14 * n33 * n41 + n14 * n31 * n43 - n11 * n34 * n43 - n13 * n31 * n44 + n11 * n33 * n44 ) * detInv;
+		me[ 6 ] = ( n14 * n32 * n41 - n12 * n34 * n41 - n14 * n31 * n42 + n11 * n34 * n42 + n12 * n31 * n44 - n11 * n32 * n44 ) * detInv;
+		me[ 7 ] = ( n12 * n33 * n41 - n13 * n32 * n41 + n13 * n31 * n42 - n11 * n33 * n42 - n12 * n31 * n43 + n11 * n32 * n43 ) * detInv;
 
-		te[ 8 ] = t13 * detInv;
-		te[ 9 ] = ( n14 * n23 * n41 - n13 * n24 * n41 - n14 * n21 * n43 + n11 * n24 * n43 + n13 * n21 * n44 - n11 * n23 * n44 ) * detInv;
-		te[ 10 ] = ( n12 * n24 * n41 - n14 * n22 * n41 + n14 * n21 * n42 - n11 * n24 * n42 - n12 * n21 * n44 + n11 * n22 * n44 ) * detInv;
-		te[ 11 ] = ( n13 * n22 * n41 - n12 * n23 * n41 - n13 * n21 * n42 + n11 * n23 * n42 + n12 * n21 * n43 - n11 * n22 * n43 ) * detInv;
+		me[ 8 ] = t13 * detInv;
+		me[ 9 ] = ( n14 * n23 * n41 - n13 * n24 * n41 - n14 * n21 * n43 + n11 * n24 * n43 + n13 * n21 * n44 - n11 * n23 * n44 ) * detInv;
+		me[ 10 ] = ( n12 * n24 * n41 - n14 * n22 * n41 + n14 * n21 * n42 - n11 * n24 * n42 - n12 * n21 * n44 + n11 * n22 * n44 ) * detInv;
+		me[ 11 ] = ( n13 * n22 * n41 - n12 * n23 * n41 - n13 * n21 * n42 + n11 * n23 * n42 + n12 * n21 * n43 - n11 * n22 * n43 ) * detInv;
 
-		te[ 12 ] = t14 * detInv;
-		te[ 13 ] = ( n13 * n24 * n31 - n14 * n23 * n31 + n14 * n21 * n33 - n11 * n24 * n33 - n13 * n21 * n34 + n11 * n23 * n34 ) * detInv;
-		te[ 14 ] = ( n14 * n22 * n31 - n12 * n24 * n31 - n14 * n21 * n32 + n11 * n24 * n32 + n12 * n21 * n34 - n11 * n22 * n34 ) * detInv;
-		te[ 15 ] = ( n12 * n23 * n31 - n13 * n22 * n31 + n13 * n21 * n32 - n11 * n23 * n32 - n12 * n21 * n33 + n11 * n22 * n33 ) * detInv;
+		me[ 12 ] = t14 * detInv;
+		me[ 13 ] = ( n13 * n24 * n31 - n14 * n23 * n31 + n14 * n21 * n33 - n11 * n24 * n33 - n13 * n21 * n34 + n11 * n23 * n34 ) * detInv;
+		me[ 14 ] = ( n14 * n22 * n31 - n12 * n24 * n31 - n14 * n21 * n32 + n11 * n24 * n32 + n12 * n21 * n34 - n11 * n22 * n34 ) * detInv;
+		me[ 15 ] = ( n12 * n23 * n31 - n13 * n22 * n31 + n13 * n21 * n32 - n11 * n23 * n32 - n12 * n21 * n33 + n11 * n22 * n33 ) * detInv;
 
-		return this;
+		return m;
 
 	}
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -118,7 +118,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		matrixWorld.getInverse( _inverseMatrix );
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -139,7 +139,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		matrixWorld.getInverse( _inverseMatrix );
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		// Check boundingBox before continuing

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -59,7 +59,7 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		matrixWorld.getInverse( _inverseMatrix );
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -53,10 +53,11 @@ Object.assign( Skeleton.prototype, {
 		for ( let i = 0, il = this.bones.length; i < il; i ++ ) {
 
 			const inverse = new Matrix4();
+			const bone = this.bones[ i ];
 
-			if ( this.bones[ i ] ) {
+			if ( bone ) {
 
-				inverse.getInverse( this.bones[ i ].matrixWorld );
+				 bone.matrixWorld.getInverse( inverse );
 
 			}
 
@@ -76,7 +77,7 @@ Object.assign( Skeleton.prototype, {
 
 			if ( bone ) {
 
-				bone.matrixWorld.getInverse( this.boneInverses[ i ] );
+				this.boneInverses[ i ].getInverse( bone.matrixWorld );
 
 			}
 
@@ -92,7 +93,7 @@ Object.assign( Skeleton.prototype, {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.parent.matrixWorld.getInverse( bone.matrix );
 					bone.matrix.multiply( bone.matrixWorld );
 
 				} else {

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -56,7 +56,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 		}
 
 		this.bindMatrix.copy( bindMatrix );
-		this.bindMatrixInverse.getInverse( bindMatrix );
+		bindMatrix.getInverse( this.bindMatrixInverse );
 
 	},
 
@@ -103,11 +103,11 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		if ( this.bindMode === 'attached' ) {
 
-			this.bindMatrixInverse.getInverse( this.matrixWorld );
+			this.matrixWorld.getInverse( this.bindMatrixInverse );
 
 		} else if ( this.bindMode === 'detached' ) {
 
-			this.bindMatrixInverse.getInverse( this.bindMatrix );
+			this.bindMatrix.getInverse( this.bindMatrixInverse );
 
 		} else {
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -311,7 +311,7 @@ function WebXRManager( renderer, gl ) {
 		camera.translateX( xOffset );
 		camera.translateZ( zOffset );
 		camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+		camera.matrixWorld.getInverse( camera.matrixWorldInverse );
 
 		// Find the union of the frustum values of the cameras and scale
 		// the values so that the near plane's position does not change in world space,
@@ -339,7 +339,7 @@ function WebXRManager( renderer, gl ) {
 
 		}
 
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+		camera.matrixWorld.getInverse( camera.matrixWorldInverse );
 
 	}
 

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -260,7 +260,7 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Matrix3().set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 			var b = new Matrix3();
 
-			b.getInverse( a );
+			a.getInverse( b );
 			assert.ok( matrixEquals3( b, zero ), "Matrix a is zero matrix" );
 
 			var testMatrices = [
@@ -279,7 +279,7 @@ export default QUnit.module( 'Maths', () => {
 				var m = testMatrices[ i ];
 
 				a.setFromMatrix4( m );
-				var mInverse3 = b.getInverse( a );
+				var mInverse3 = a.getInverse( b );
 
 				var mInverse = toMatrix4( mInverse3 );
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -463,7 +463,7 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Matrix4();
 			var b = new Matrix4().set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
-			a.getInverse( b );
+			b.getInverse( a );
 			assert.ok( matrixEquals4( a, zero ), "Passed!" );
 
 
@@ -485,7 +485,7 @@ export default QUnit.module( 'Maths', () => {
 
 				var m = testMatrices[ i ];
 
-				var mInverse = new Matrix4().getInverse( m );
+				var mInverse = m.getInverse( new Matrix4() );
 				var mSelfInverse = m.clone();
 				mSelfInverse.getInverse( mSelfInverse );
 


### PR DESCRIPTION
Related issues:

Fixed #20572.

**Description**

Changes `getInverse()` from `<target>.getInverse(<source>)`to `<source>.getInverse(<target>)`. In this way, it's equal to other `get*()` methods. Since this is a breaking change, a note in the migration guide is required.
