### PR TITLE
RoundedBoxBufferGeometry: Change constructor to fix corner normals

### DIFF
--- a/examples/jsm/geometries/RoundedBoxBufferGeometry.js
+++ b/examples/jsm/geometries/RoundedBoxBufferGeometry.js
@@ -7,7 +7,7 @@ class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 
 	constructor( width = 1, height = 1, depth = 1, segments = 1, radius = 1 ) {
 
-		super( width, height, depth, segments, segments, segments );
+		super( 1, 1, 1, segments, segments, segments );
 
 		const geometry2 = this.toNonIndexed();
 


### PR DESCRIPTION
Related to this ~twitter comment~ tweet:

https://twitter.com/garrettkjohnson/status/1323306603215351808

Effectively when the box is initialized to have a non equal width, depth, and height the normals as derived from the vertex positions will not be pointed in the correct direction for vertices at the rounded corners. More intuitively if you think about the normals that would be generated from a box with the dimensions ( 1, 10, 1 ) they will have much more height component than a box with dimensions ( 1, 1, 1 ). Changing the dimensions passed to the super constructor to 1, 1, 1 will give consistent (and expected) normals for the corners and does not affect the geometry of the box itself.

https://raw.githack.com/gkjohnson/three.js/patch-2/examples/webgl_loader_texture_lottie.html