### PR TITLE
Matrix3/4: Introduce invert().

### DIFF
--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -105,14 +105,11 @@ zAxis = (c, f, i)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
+		<h3>[method:this invert()]()</h3>
 		<p>
-		[page:Matrix3 m] - the matrix to take the inverse of.<br /><br />
+		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix3 m],
-		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
-
-		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
+		You can not invert with a determinant of zero. If you attempt this, the method produces a zero matrix instead.
 		</p>
 
 		<h3>[method:this getNormalMatrix]( [param:Matrix4 m] )</h3>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -186,16 +186,12 @@ zAxis = (c, g, k)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix4 m] )</h3>
+		<h3>[method:this invert()]()</h3>
 		<p>
-		[page:Matrix4 m] - the matrix to take the inverse of.<br /><br />
+		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix4 m],
-		using the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
-
-		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
+		You can not invert with a determinant of zero. If you attempt this, the method produces a zero matrix instead.
 		</p>
-
 
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>
 		<p>Gets the maximum scale value of the 3 axes.</p>

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -100,14 +100,11 @@ zAxis = (c, f, i)
 		使用基于列优先格式[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]的数组来设置该矩阵。
 		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix3 m] )</h3>
+		<h3>[method:this invert()]()</h3>
 		<p>
-		[page:Matrix3 m] - 取逆的矩阵。<br /><br />
+		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
-		Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix3 m],
-		using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
-
-		You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
+		You can not invert with a determinant of zero. If you attempt this, the method produces a zero matrix instead.
 		</p>
 
 		<h3>[method:this getNormalMatrix]( [param:Matrix4 m] )</h3>

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -170,16 +170,13 @@ zAxis = (c, g, k)
 			[page:Integer offset] - (可选参数) 数组的偏移量，默认值为 0。<br /><br />
 
 			使用基于列优先格式[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]的数组来设置该矩阵。
-			</p>
+		</p>
 
-		<h3>[method:this getInverse]( [param:Matrix4 m] )</h3>
+		<h3>[method:this invert()]()</h3>
 		<p>
-			[page:Matrix3 m] - 取逆的矩阵。<br /><br />
+		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 
-			Set this matrix to the [link:https://en.wikipedia.org/wiki/Invertible_matrix inverse] of the passed matrix [page:Matrix4 m],
-			using the method outlined [link:http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm here].
-
-			You can not invert a matrix with a determinant of zero. If you attempt this, the method returns a zero matrix instead.
+		You can not invert with a determinant of zero. If you attempt this, the method produces a zero matrix instead.
 		</p>
 
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>

--- a/examples/js/animation/CCDIKSolver.js
+++ b/examples/js/animation/CCDIKSolver.js
@@ -332,7 +332,7 @@ THREE.CCDIKSolver = ( function () {
 					var iks = this.iks;
 					var bones = mesh.skeleton.bones;
 
-					matrix.getInverse( mesh.matrixWorld );
+					matrix.copy( mesh.matrixWorld ).invert();
 
 					for ( var i = 0, il = iks.length; i < il; i ++ ) {
 

--- a/examples/js/animation/MMDPhysics.js
+++ b/examples/js/animation/MMDPhysics.js
@@ -1310,7 +1310,7 @@ THREE.MMDPhysics = ( function () {
 						.copy( mesh.matrixWorld )
 						.decompose( position, quaternion, scale )
 						.compose( position, quaternion, scale.set( 1, 1, 1 ) )
-						.getInverse( matrixWorldInv );
+						.invert();
 
 					for ( var i = 0, il = bodies.length; i < il; i ++ ) {
 

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -129,7 +129,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}
@@ -210,7 +210,7 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}

--- a/examples/js/geometries/DecalGeometry.js
+++ b/examples/js/geometries/DecalGeometry.js
@@ -33,7 +33,8 @@ THREE.DecalGeometry = function ( mesh, position, orientation, size ) {
 	projectorMatrix.makeRotationFromEuler( orientation );
 	projectorMatrix.setPosition( position );
 
-	var projectorMatrixInverse = new THREE.Matrix4().getInverse( projectorMatrix );
+	var projectorMatrixInverse = new THREE.Matrix4();
+	projectorMatrixInverse.copy( projectorMatrix ).invert();
 
 	// generate buffers
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -4013,7 +4013,7 @@ THREE.FBXLoader = ( function () {
 		lParentTM.copyPosition( lParentGX );
 
 		var lParentGSM = new THREE.Matrix4();
-		lParentGSM.getInverse( lParentGRM ).multiply( lParentGX );
+		lParentGSM.copy( lParentGRM ).invert().multiply( lParentGX );
 
 		var lGlobalRS = new THREE.Matrix4();
 
@@ -4027,15 +4027,18 @@ THREE.FBXLoader = ( function () {
 
 		} else {
 
-			var lParentLSM_inv = new THREE.Matrix4().getInverse( lScalingM );
+			var lParentLSM_inv = new THREE.Matrix4();
+			lParentLSM_inv.copy( lScalingM ).invert();
 			var lParentGSM_noLocal = new THREE.Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
 			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lScalingM );
 
 		}
 
-		var lRotationPivotM_inv = new THREE.Matrix4().getInverse( lRotationPivotM );
-		var lScalingPivotM_inv = new THREE.Matrix4().getInverse( lScalingPivotM );
+		var lRotationPivotM_inv = new THREE.Matrix4();
+		lRotationPivotM_inv.copy( lRotationPivotM ).invert();
+		var lScalingPivotM_inv = new THREE.Matrix4();
+		lScalingPivotM_inv.copy( lScalingPivotM ).invert();
 		// Calculate the local transform matrix
 		var lTransform = new THREE.Matrix4();
 		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -407,7 +407,7 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 		}
 
 		volume.inverseMatrix = new THREE.Matrix4();
-		volume.inverseMatrix.getInverse( volume.matrix );
+		volume.inverseMatrix.copy( volume.matrix ).invert();
 		volume.RASDimensions = ( new THREE.Vector3( volume.xLength, volume.yLength, volume.zLength ) ).applyMatrix4( volume.matrix ).round().toArray().map( Math.abs );
 
 		// .. and set the default threshold

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -443,7 +443,7 @@ THREE.TDSLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 				matrix.transpose();
 
 				var inverse = new THREE.Matrix4();
-				inverse.getInverse( matrix );
+				inverse.copy( matrix ).invert();
 				geometry.applyMatrix4( inverse );
 
 				matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );

--- a/examples/js/objects/Refractor.js
+++ b/examples/js/objects/Refractor.js
@@ -114,7 +114,7 @@ THREE.Refractor = function ( geometry, options ) {
 		return function updateVirtualCamera( camera ) {
 
 			virtualCamera.matrixWorld.copy( camera.matrixWorld );
-			virtualCamera.matrixWorldInverse.getInverse( virtualCamera.matrixWorld );
+			virtualCamera.matrixWorldInverse.copy( virtualCamera.matrixWorld ).invert();
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 			virtualCamera.far = camera.far; // used in WebGLBackground
 

--- a/examples/js/utils/SkeletonUtils.js
+++ b/examples/js/utils/SkeletonUtils.js
@@ -112,7 +112,7 @@ THREE.SkeletonUtils = {
 
 					} else {
 
-						relativeMatrix.getInverse( target.matrixWorld );
+						relativeMatrix.copy( target.matrixWorld ).invert();
 						relativeMatrix.multiply( boneTo.matrixWorld );
 
 					}
@@ -129,7 +129,7 @@ THREE.SkeletonUtils = {
 					if ( target.isObject3D ) {
 
 						var boneIndex = bones.indexOf( bone ),
-							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.getInverse( target.skeleton.boneInverses[ boneIndex ] );
+							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.copy( target.skeleton.boneInverses[ boneIndex ] ).invert();
 
 						globalMatrix.multiply( wBindMatrix );
 
@@ -141,7 +141,7 @@ THREE.SkeletonUtils = {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.matrix.copy( bone.parent.matrixWorld ).invert();
 					bone.matrix.multiply( globalMatrix );
 
 				} else {

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -347,7 +347,7 @@ var CCDIKSolver = ( function () {
 					var iks = this.iks;
 					var bones = mesh.skeleton.bones;
 
-					matrix.getInverse( mesh.matrixWorld );
+					matrix.copy( mesh.matrixWorld ).invert();
 
 					for ( var i = 0, il = iks.length; i < il; i ++ ) {
 

--- a/examples/jsm/animation/MMDPhysics.js
+++ b/examples/jsm/animation/MMDPhysics.js
@@ -1325,7 +1325,7 @@ var MMDPhysics = ( function () {
 						.copy( mesh.matrixWorld )
 						.decompose( position, quaternion, scale )
 						.compose( position, quaternion, scale.set( 1, 1, 1 ) )
-						.getInverse( matrixWorldInv );
+						.invert();
 
 					for ( var i = 0, il = bodies.length; i < il; i ++ ) {
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -138,7 +138,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}
@@ -219,7 +219,7 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 			if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-				_inverseMatrix.getInverse( _selected.parent.matrixWorld );
+				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
 			}

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -35,7 +35,7 @@ export default class Frustum {
 
 		const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-		inverseProjectionMatrix.getInverse( projectionMatrix );
+		inverseProjectionMatrix.copy( projectionMatrix ).invert();
 
 		// 3 --- 0  vertices.near/far order
 		// |     |

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -40,7 +40,8 @@ var DecalGeometry = function ( mesh, position, orientation, size ) {
 	projectorMatrix.makeRotationFromEuler( orientation );
 	projectorMatrix.setPosition( position );
 
-	var projectorMatrixInverse = new Matrix4().getInverse( projectorMatrix );
+	var projectorMatrixInverse = new Matrix4();
+	projectorMatrixInverse.copy( projectorMatrix ).invert();
 
 	// generate buffers
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -4060,7 +4060,7 @@ var FBXLoader = ( function () {
 		lParentTM.copyPosition( lParentGX );
 
 		var lParentGSM = new Matrix4();
-		lParentGSM.getInverse( lParentGRM ).multiply( lParentGX );
+		lParentGSM.copy( lParentGRM ).invert().multiply( lParentGX );
 
 		var lGlobalRS = new Matrix4();
 
@@ -4074,15 +4074,18 @@ var FBXLoader = ( function () {
 
 		} else {
 
-			var lParentLSM_inv = new Matrix4().getInverse( lScalingM );
+			var lParentLSM_inv = new Matrix4();
+			lParentLSM_inv.copy( lScalingM ).invert();
 			var lParentGSM_noLocal = new Matrix4().multiply( lParentGSM ).multiply( lParentLSM_inv );
 
 			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lScalingM );
 
 		}
 
-		var lRotationPivotM_inv = new Matrix4().getInverse( lRotationPivotM );
-		var lScalingPivotM_inv = new Matrix4().getInverse( lScalingPivotM );
+		var lRotationPivotM_inv = new Matrix4();
+		lRotationPivotM_inv.copy( lRotationPivotM ).invert();
+		var lScalingPivotM_inv = new Matrix4();
+		lScalingPivotM_inv.copy( lScalingPivotM ).invert();
 		// Calculate the local transform matrix
 		var lTransform = new Matrix4();
 		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -416,7 +416,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		}
 
 		volume.inverseMatrix = new Matrix4();
-		volume.inverseMatrix.getInverse( volume.matrix );
+		volume.inverseMatrix.copy( volume.matrix ).invert();
 		volume.RASDimensions = ( new Vector3( volume.xLength, volume.yLength, volume.zLength ) ).applyMatrix4( volume.matrix ).round().toArray().map( Math.abs );
 
 		// .. and set the default threshold

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -459,7 +459,7 @@ TDSLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				matrix.transpose();
 
 				var inverse = new Matrix4();
-				inverse.getInverse( matrix );
+				inverse.copy( matrix ).invert();
 				geometry.applyMatrix4( inverse );
 
 				matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );

--- a/examples/jsm/math/OBB.js
+++ b/examples/jsm/math/OBB.js
@@ -325,7 +325,8 @@ Object.assign( OBB.prototype, {
 
 		// transform ray to the local space of the OBB
 
-		localRay.copy( ray ).applyMatrix4( inverse.getInverse( matrix ) );
+		inverse.copy( matrix ).invert();
+		localRay.copy( ray ).applyMatrix4( inverse );
 
 		// perform ray <-> AABB intersection test
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -131,7 +131,7 @@ var Refractor = function ( geometry, options ) {
 		return function updateVirtualCamera( camera ) {
 
 			virtualCamera.matrixWorld.copy( camera.matrixWorld );
-			virtualCamera.matrixWorldInverse.getInverse( virtualCamera.matrixWorld );
+			virtualCamera.matrixWorldInverse.copy( virtualCamera.matrixWorld ).invert();
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 			virtualCamera.far = camera.far; // used in WebGLBackground
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -125,7 +125,7 @@ var SkeletonUtils = {
 
 					} else {
 
-						relativeMatrix.getInverse( target.matrixWorld );
+						relativeMatrix.copy( target.matrixWorld ).invert();
 						relativeMatrix.multiply( boneTo.matrixWorld );
 
 					}
@@ -142,7 +142,7 @@ var SkeletonUtils = {
 					if ( target.isObject3D ) {
 
 						var boneIndex = bones.indexOf( bone ),
-							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.getInverse( target.skeleton.boneInverses[ boneIndex ] );
+							wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.copy( target.skeleton.boneInverses[ boneIndex ] ).invert();
 
 						globalMatrix.multiply( wBindMatrix );
 
@@ -154,7 +154,7 @@ var SkeletonUtils = {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.matrix.copy( bone.parent.matrixWorld ).invert();
 					bone.matrix.multiply( globalMatrix );
 
 				} else {

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -376,7 +376,7 @@
 
 				const parent = object.parent;
 				scene.updateMatrixWorld();
-				object.matrix.getInverse( parent.matrixWorld );
+				object.matrix.copy( parent.matrixWorld ).invert();
 				object.applyMatrix4( matrix );
 
 			}

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -610,6 +610,12 @@ Object.assign( Matrix3.prototype, {
 
 		console.error( 'THREE.Matrix3: .applyToVector3Array() has been removed.' );
 
+	},
+	getInverse: function ( matrix ) {
+
+		console.warn( 'THREE.Matrix3: .getInverse() has been removed. Use matrixInv.copy( matrix ).invert(); instead.' );
+		return this.copy( matrix ).invert();
+
 	}
 
 } );
@@ -714,6 +720,12 @@ Object.assign( Matrix4.prototype, {
 
 		console.warn( 'THREE.Matrix4: .makeFrustum() has been removed. Use .makePerspective( left, right, top, bottom, near, far ) instead.' );
 		return this.makePerspective( left, right, top, bottom, near, far );
+
+	},
+	getInverse: function ( matrix ) {
+
+		console.warn( 'THREE.Matrix4: .getInverse() has been removed. Use matrixInv.copy( matrix ).invert(); instead.' );
+		return this.copy( matrix ).invert();
 
 	}
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -55,7 +55,7 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		Object3D.prototype.updateMatrixWorld.call( this, force );
 
-		this.matrixWorldInverse.getInverse( this.matrixWorld );
+		this.matrixWorldInverse.copy( this.matrixWorld ).invert();
 
 	},
 
@@ -63,7 +63,7 @@ Camera.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		Object3D.prototype.updateWorldMatrix.call( this, updateParents, updateChildren );
 
-		this.matrixWorldInverse.getInverse( this.matrixWorld );
+		this.matrixWorldInverse.copy( this.matrixWorld ).invert();
 
 	},
 

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -112,7 +112,7 @@ OrthographicCamera.prototype = Object.assign( Object.create( Camera.prototype ),
 
 		this.projectionMatrix.makeOrthographic( left, right, top, bottom, this.near, this.far );
 
-		this.projectionMatrixInverse.getInverse( this.projectionMatrix );
+		this.projectionMatrixInverse.copy( this.projectionMatrix ).invert();
 
 	},
 

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -205,7 +205,7 @@ PerspectiveCamera.prototype = Object.assign( Object.create( Camera.prototype ), 
 
 		this.projectionMatrix.makePerspective( left, left + width, top, top - height, near, this.far );
 
-		this.projectionMatrixInverse.getInverse( this.projectionMatrix );
+		this.projectionMatrixInverse.copy( this.projectionMatrix ).invert();
 
 	},
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -251,7 +251,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	worldToLocal: function ( vector ) {
 
-		return vector.applyMatrix4( _m1.getInverse( this.matrixWorld ) );
+		return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invert() );
 
 	},
 
@@ -395,7 +395,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		this.updateWorldMatrix( true, false );
 
-		_m1.getInverse( this.matrixWorld );
+		_m1.copy( this.matrixWorld ).invert();
 
 		if ( object.parent !== null ) {
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -65,7 +65,7 @@ class SkeletonHelper extends LineSegments {
 		const geometry = this.geometry;
 		const position = geometry.getAttribute( 'position' );
 
-		_matrixWorldInv.getInverse( this.root.matrixWorld );
+		_matrixWorldInv.copy( this.root.matrixWorld ).invert();
 
 		for ( let i = 0, j = 0; i < bones.length; i ++ ) {
 

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -28,14 +28,14 @@ export interface Matrix {
 	determinant(): number;
 
 	/**
-	 * getInverse(matrix:T):T;
-	 */
-	getInverse( matrix: Matrix ): Matrix;
-
-	/**
 	 * transpose():T;
 	 */
 	transpose(): Matrix;
+
+	/**
+	 * invert():T;
+	 */
+	invert(): Matrix;
 
 	/**
 	 * clone():T;
@@ -77,7 +77,11 @@ export class Matrix3 implements Matrix {
 	setFromMatrix4( m: Matrix4 ): Matrix3;
 	multiplyScalar( s: number ): Matrix3;
 	determinant(): number;
-	getInverse( matrix: Matrix3 ): Matrix3;
+
+	/**
+	 * Inverts this matrix in place.
+	 */
+	invert(): Matrix3;
 
 	/**
 	 * Transposes this matrix in place.
@@ -157,5 +161,10 @@ export class Matrix3 implements Matrix {
 	 * @deprecated Use {@link Matrix3#toArray .toArray()} instead.
 	 */
 	flattenToArrayOffset( array: number[], offset: number ): number[];
+
+	/**
+	 * @deprecated Use {@link Matrix3#invert .invert()} instead.
+	 */
+	getInverse( matrix: Matrix ): Matrix;
 
 }

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -157,20 +157,13 @@ class Matrix3 {
 
 	}
 
-	getInverse( matrix, throwOnDegenerate ) {
+	invert() {
 
-		if ( throwOnDegenerate !== undefined ) {
+		const te = this.elements,
 
-			console.warn( "THREE.Matrix3: .getInverse() can no longer be configured to throw on degenerate." );
-
-		}
-
-		const me = matrix.elements,
-			te = this.elements,
-
-			n11 = me[ 0 ], n21 = me[ 1 ], n31 = me[ 2 ],
-			n12 = me[ 3 ], n22 = me[ 4 ], n32 = me[ 5 ],
-			n13 = me[ 6 ], n23 = me[ 7 ], n33 = me[ 8 ],
+			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ],
+			n12 = te[ 3 ], n22 = te[ 4 ], n32 = te[ 5 ],
+			n13 = te[ 6 ], n23 = te[ 7 ], n33 = te[ 8 ],
 
 			t11 = n33 * n22 - n32 * n23,
 			t12 = n32 * n13 - n33 * n12,
@@ -213,7 +206,7 @@ class Matrix3 {
 
 	getNormalMatrix( matrix4 ) {
 
-		return this.setFromMatrix4( matrix4 ).getInverse( this ).transpose();
+		return this.setFromMatrix4( matrix4 ).copy( this ).invert().transpose();
 
 	}
 

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -115,10 +115,9 @@ export class Matrix4 implements Matrix {
 	setPosition( v: Vector3 | number, y?: number, z?: number ): Matrix4;
 
 	/**
-	 * Sets this matrix to the inverse of matrix m.
-	 * Based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm.
+	 * Inverts this matrix.
 	 */
-	getInverse( m: Matrix4 ): Matrix4;
+	invert(): Matrix;
 
 	/**
 	 * Multiplies the columns of this matrix by vector v.
@@ -284,5 +283,10 @@ export class Matrix4 implements Matrix {
 	 * @deprecated Use {@link Matrix4#toArray .toArray()} instead.
 	 */
 	flattenToArrayOffset( array: number[], offset: number ): number[];
+
+	/**
+	 * @deprecated Use {@link Matrix4#invert .invert()} instead.
+	 */
+	getInverse( matrix: Matrix ): Matrix;
 
 }

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -483,22 +483,15 @@ class Matrix4 {
 
 	}
 
-	getInverse( m, throwOnDegenerate ) {
-
-		if ( throwOnDegenerate !== undefined ) {
-
-			console.warn( "THREE.Matrix4: .getInverse() can no longer be configured to throw on degenerate." );
-
-		}
+	invert() {
 
 		// based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 		const te = this.elements,
-			me = m.elements,
 
-			n11 = me[ 0 ], n21 = me[ 1 ], n31 = me[ 2 ], n41 = me[ 3 ],
-			n12 = me[ 4 ], n22 = me[ 5 ], n32 = me[ 6 ], n42 = me[ 7 ],
-			n13 = me[ 8 ], n23 = me[ 9 ], n33 = me[ 10 ], n43 = me[ 11 ],
-			n14 = me[ 12 ], n24 = me[ 13 ], n34 = me[ 14 ], n44 = me[ 15 ],
+			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ], n41 = te[ 3 ],
+			n12 = te[ 4 ], n22 = te[ 5 ], n32 = te[ 6 ], n42 = te[ 7 ],
+			n13 = te[ 8 ], n23 = te[ 9 ], n33 = te[ 10 ], n43 = te[ 11 ],
+			n14 = te[ 12 ], n24 = te[ 13 ], n34 = te[ 14 ], n44 = te[ 15 ],
 
 			t11 = n23 * n34 * n42 - n24 * n33 * n42 + n24 * n32 * n43 - n22 * n34 * n43 - n23 * n32 * n44 + n22 * n33 * n44,
 			t12 = n14 * n33 * n42 - n13 * n34 * n42 - n14 * n32 * n43 + n12 * n34 * n43 + n13 * n32 * n44 - n12 * n33 * n44,

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -118,7 +118,7 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -139,7 +139,7 @@ Mesh.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		// Check boundingBox before continuing

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -59,7 +59,7 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 		//
 
-		_inverseMatrix.getInverse( matrixWorld );
+		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
 		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -56,7 +56,7 @@ Object.assign( Skeleton.prototype, {
 
 			if ( this.bones[ i ] ) {
 
-				inverse.getInverse( this.bones[ i ].matrixWorld );
+				inverse.copy( this.bones[ i ].matrixWorld ).invert();
 
 			}
 
@@ -76,7 +76,7 @@ Object.assign( Skeleton.prototype, {
 
 			if ( bone ) {
 
-				bone.matrixWorld.getInverse( this.boneInverses[ i ] );
+				bone.matrixWorld.copy( this.boneInverses[ i ] ).invert();
 
 			}
 
@@ -92,7 +92,7 @@ Object.assign( Skeleton.prototype, {
 
 				if ( bone.parent && bone.parent.isBone ) {
 
-					bone.matrix.getInverse( bone.parent.matrixWorld );
+					bone.matrix.copy( bone.parent.matrixWorld ).invert();
 					bone.matrix.multiply( bone.matrixWorld );
 
 				} else {

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -56,7 +56,7 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 		}
 
 		this.bindMatrix.copy( bindMatrix );
-		this.bindMatrixInverse.getInverse( bindMatrix );
+		this.bindMatrixInverse.copy( bindMatrix ).invert();
 
 	},
 
@@ -103,11 +103,11 @@ SkinnedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 		if ( this.bindMode === 'attached' ) {
 
-			this.bindMatrixInverse.getInverse( this.matrixWorld );
+			this.bindMatrixInverse.copy( this.matrixWorld ).invert();
 
 		} else if ( this.bindMode === 'detached' ) {
 
-			this.bindMatrixInverse.getInverse( this.bindMatrix );
+			this.bindMatrixInverse.copy( this.bindMatrix ).invert();
 
 		} else {
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -311,7 +311,7 @@ function WebXRManager( renderer, gl ) {
 		camera.translateX( xOffset );
 		camera.translateZ( zOffset );
 		camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+		camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
 
 		// Find the union of the frustum values of the cameras and scale
 		// the values so that the near plane's position does not change in world space,
@@ -339,7 +339,7 @@ function WebXRManager( renderer, gl ) {
 
 		}
 
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+		camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
 
 	}
 

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -253,14 +253,14 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "getInverse", ( assert ) => {
+		QUnit.test( "invert", ( assert ) => {
 
 			var zero = new Matrix3().set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 			var identity4 = new Matrix4();
 			var a = new Matrix3().set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 			var b = new Matrix3();
 
-			b.getInverse( a );
+			b.copy( a ).invert();
 			assert.ok( matrixEquals3( b, zero ), "Matrix a is zero matrix" );
 
 			var testMatrices = [
@@ -279,7 +279,7 @@ export default QUnit.module( 'Maths', () => {
 				var m = testMatrices[ i ];
 
 				a.setFromMatrix4( m );
-				var mInverse3 = b.getInverse( a );
+				var mInverse3 = b.copy( a ).invert();
 
 				var mInverse = toMatrix4( mInverse3 );
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -455,7 +455,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( "getInverse", ( assert ) => {
+		QUnit.test( "invert", ( assert ) => {
 
 			var zero = new Matrix4().set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 			var identity = new Matrix4();
@@ -463,7 +463,7 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Matrix4();
 			var b = new Matrix4().set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
-			a.getInverse( b );
+			a.copy( b ).invert();
 			assert.ok( matrixEquals4( a, zero ), "Passed!" );
 
 
@@ -485,9 +485,9 @@ export default QUnit.module( 'Maths', () => {
 
 				var m = testMatrices[ i ];
 
-				var mInverse = new Matrix4().getInverse( m );
+				var mInverse = new Matrix4().copy( m ).invert();
 				var mSelfInverse = m.clone();
-				mSelfInverse.getInverse( mSelfInverse );
+				mSelfInverse.copy( mSelfInverse ).invert();
 
 				// self-inverse should the same as inverse
 				assert.ok( matrixEquals4( mSelfInverse, mInverse ), "Passed!" );


### PR DESCRIPTION
Related issues:

Fixed #20572. 

**Description**

The PR also deprecates `getInverse()`. This change is backward-compatible since `getInverse()` can internally use the new method in `Three.Legacy.js`.
