### PR TITLE
TS: Added additional type information toArray( ) to support valid usage.

### DIFF
--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -1,6 +1,12 @@
 import { Matrix4 } from './Matrix4';
 import { Vector3 } from './Vector3';
 
+type Matrix3tuple = [
+	number, number, number,
+	number, number, number,
+	number, number, number,
+];
+
 /**
  * ( interface Matrix<T> )
  */
@@ -125,6 +131,7 @@ export class Matrix3 implements Matrix {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
+	toArray( array?: Matrix3tuple, offset?: 0 ): Matrix3tuple;
 
 	/**
 	 * Copies he values of this matrix into the provided array-like.

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -1,7 +1,7 @@
 import { Matrix4 } from './Matrix4';
 import { Vector3 } from './Vector3';
 
-type Matrix3tuple = [
+type Matrix3Tuple = [
 	number, number, number,
 	number, number, number,
 	number, number, number,
@@ -131,7 +131,7 @@ export class Matrix3 implements Matrix {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
-	toArray( array?: Matrix3tuple, offset?: 0 ): Matrix3tuple;
+	toArray( array?: Matrix3Tuple, offset?: 0 ): Matrix3Tuple;
 
 	/**
 	 * Copies he values of this matrix into the provided array-like.

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -3,7 +3,7 @@ import { Euler } from './Euler';
 import { Quaternion } from './Quaternion';
 import { Matrix } from './Matrix3';
 
-type Matrix4tuple = [
+type Matrix4Tuple = [
 	number, number, number, number,
 	number, number, number, number,
 	number, number, number, number,
@@ -243,7 +243,7 @@ export class Matrix4 implements Matrix {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
-	toArray( array?: Matrix4tuple, offset?: 0 ): Matrix4tuple;
+	toArray( array?: Matrix4Tuple, offset?: 0 ): Matrix4Tuple;
 
 	/**
 	 * Copies he values of this matrix into the provided array-like.

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -2,6 +2,14 @@ import { Vector3 } from './Vector3';
 import { Euler } from './Euler';
 import { Quaternion } from './Quaternion';
 import { Matrix } from './Matrix3';
+
+type Matrix4tuple = [
+	number, number, number, number,
+	number, number, number, number,
+	number, number, number, number,
+	number, number, number, number,
+];
+
 /**
  * A 4x4 Matrix.
  *
@@ -235,6 +243,7 @@ export class Matrix4 implements Matrix {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
+	toArray( array?: Matrix4tuple, offset?: 0 ): Matrix4tuple;
 
 	/**
 	 * Copies he values of this matrix into the provided array-like.

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -1,6 +1,8 @@
 import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
 
+type Vector2tuple = [number, number];
+
 /**
  * ( interface Vector<T> )
  *
@@ -427,6 +429,7 @@ export class Vector2 implements Vector {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
+	toArray( array?: Vector2tuple, offset?: 0 ): Vector2tuple;
 
 	/**
 	 * Copies x and y into the provided array-like.

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -9,7 +9,7 @@ import { BufferAttribute } from './../core/BufferAttribute';
 import { InterleavedBufferAttribute } from './../core/InterleavedBufferAttribute';
 import { Vector } from './Vector2';
 
-type Vector3tuple = [number, number, number];
+type Vector3Tuple = [number, number, number];
 
 /**
  * 3D vector.
@@ -287,7 +287,7 @@ export class Vector3 implements Vector {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
-	toArray( array?: Vector3tuple, offset?: 0 ): Vector3tuple;
+	toArray( array?: Vector3Tuple, offset?: 0 ): Vector3Tuple;
 
 	/**
 	 * Copies x, y and z into the provided array-like.

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -8,6 +8,9 @@ import { Cylindrical } from './Cylindrical';
 import { BufferAttribute } from './../core/BufferAttribute';
 import { InterleavedBufferAttribute } from './../core/InterleavedBufferAttribute';
 import { Vector } from './Vector2';
+
+type Vector3tuple = [number, number, number];
+
 /**
  * 3D vector.
  *
@@ -284,6 +287,7 @@ export class Vector3 implements Vector {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
+	toArray( array?: Vector3tuple, offset?: 0 ): Vector3tuple;
 
 	/**
 	 * Copies x, y and z into the provided array-like.

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -4,7 +4,7 @@ import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
 import { Vector } from './Vector2';
 
-type Vector4tuple = [number, number, number, number];
+type Vector4Tuple = [number, number, number, number];
 
 /**
  * 4D vector.
@@ -213,7 +213,7 @@ export class Vector4 implements Vector {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
-	toArray( array?: Vector4tuple, offset?: 0 ): Vector4tuple;
+	toArray( array?: Vector4Tuple, offset?: 0 ): Vector4Tuple;
 
 	/**
 	 * Copies x, y, z and w into the provided array-like.

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -4,6 +4,8 @@ import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
 import { Vector } from './Vector2';
 
+type Vector4tuple = [number, number, number, number];
+
 /**
  * 4D vector.
  *
@@ -211,6 +213,7 @@ export class Vector4 implements Vector {
 	 * @return The created or provided array.
 	 */
 	toArray( array?: number[], offset?: number ): number[];
+	toArray( array?: Vector4tuple, offset?: 0 ): Vector4tuple;
 
 	/**
 	 * Copies x, y, z and w into the provided array-like.


### PR DESCRIPTION
Added additional type information to Vector and Matrix toArray() methods.  This allows code involving the spread operator for function parameters (which works as expected) to compile in TypeScript.

Related issues:

Fixed #19303.

**Description**

This is the solution - defining tuples for brevity - was proposed by others and well recieved in my original bug report, so I thought I should write these definintions.
