### PR TITLE
WebGLRenderer: Set style.display to block in constructor.

### DIFF
--- a/examples/main.css
+++ b/examples/main.css
@@ -22,10 +22,6 @@ button {
 	text-transform: uppercase;
 }
 
-canvas {
-	display: block;
-}
-
 #info {
 	position: absolute;
 	top: 0px;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -39,11 +39,19 @@ import { WebGLUtils } from './webgl/WebGLUtils.js';
 import { WebXRManager } from './webxr/WebXRManager.js';
 import { WebGLMaterials } from "./webgl/WebGLMaterials.js";
 
+function createCanvasElement() {
+
+	const canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
+	canvas.style.display = 'block';
+	return canvas;
+
+}
+
 function WebGLRenderer( parameters ) {
 
 	parameters = parameters || {};
 
-	const _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' ),
+	const _canvas = parameters.canvas !== undefined ? parameters.canvas : createCanvasElement(),
 		_context = parameters.context !== undefined ? parameters.context : null,
 
 		_alpha = parameters.alpha !== undefined ? parameters.alpha : false,


### PR DESCRIPTION
**Description**

Even if `<canvas>` sets `style.display` to `inline` by default, setting it to `block` is more suitable for the common usage of the library and frees the developer of having to understand these CSS details.