### PR TITLE
OrbitControls: Removed tabIndex side effect.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -1173,14 +1173,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	scope.domElement.addEventListener( 'keydown', onKeyDown, false );
 
-	// make sure element can receive keys.
-
-	if ( scope.domElement.tabIndex === - 1 ) {
-
-		scope.domElement.tabIndex = 0;
-
-	}
-
 	// force an update at start
 
 	this.update();

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1183,14 +1183,6 @@ var OrbitControls = function ( object, domElement ) {
 
 	scope.domElement.addEventListener( 'keydown', onKeyDown, false );
 
-	// make sure element can receive keys.
-
-	if ( scope.domElement.tabIndex === - 1 ) {
-
-		scope.domElement.tabIndex = 0;
-
-	}
-
 	// force an update at start
 
 	this.update();


### PR DESCRIPTION
**Description**

Changing the page's `tabIndex` when constructing `OrbitControls` was definitely not the right thing to do.

This also solves the problem of outlines showing in recent versions of Chrome when using `OrbitControls`.