### PR TITLE
PLYLoader: Fix byte length computation of header.

### DIFF
--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -90,14 +90,15 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 			if ( result !== null ) {
 
 				headerText = result[ 1 ];
-				headerLength = result[ 0 ].length;
+				headerLength = new Blob( [ result[ 0 ] ] ).size;
 
 			}
 
 			var header = {
 				comments: [],
 				elements: [],
-				headerLength: headerLength
+				headerLength: headerLength,
+				objInfo: ''
 			};
 
 			var lines = headerText.split( '\n' );
@@ -174,6 +175,12 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 					case 'property':
 
 						currentElement.properties.push( make_ply_element_property( lineValues, scope.propertyNameMapping ) );
+
+						break;
+
+					case 'obj_info':
+
+						header.objInfo = line;
 
 						break;
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -98,14 +98,15 @@ PLYLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 			if ( result !== null ) {
 
 				headerText = result[ 1 ];
-				headerLength = result[ 0 ].length;
+				headerLength = new Blob( [ result[ 0 ] ] ).size;
 
 			}
 
 			var header = {
 				comments: [],
 				elements: [],
-				headerLength: headerLength
+				headerLength: headerLength,
+				objInfo: ''
 			};
 
 			var lines = headerText.split( '\n' );
@@ -182,6 +183,12 @@ PLYLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 					case 'property':
 
 						currentElement.properties.push( make_ply_element_property( lineValues, scope.propertyNameMapping ) );
+
+						break;
+
+					case 'obj_info':
+
+						header.objInfo = line;
 
 						break;
 


### PR DESCRIPTION
Related issues:

Fixed #20622.

**Description**

The loader now uses `Blob` to compute the header length in byte. It also ensures that extra info line `obj_info` is parsed and stored.
