### PR TITLE
NodeMaterial: Ensure defines are properly set.

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -63,6 +63,7 @@ NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 
 	this.build( { renderer: renderer } );
 
+	shader.defines = this.defines;
 	shader.uniforms = this.uniforms;
 	shader.vertexShader = this.vertexShader;
 	shader.fragmentShader = this.fragmentShader;


### PR DESCRIPTION
Related issues:

#20511

**Description**

Ensures that GLSL defines generated by node material are actually honored when creating the WebGL program. This was overlooked when  the usage of `onBeforeCompile()` was refactored. This fixes the broken `basic / physical` preset in `webgl_materials_nodes`.
