### PR TITLE
Keep OrbitControls' damping speed consistent at different fps.

### DIFF
--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -5,11 +5,10 @@
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
-
 THREE.OrbitControls = function ( object, domElement ) {
 
 	var clock = new THREE.Clock();
-	var _dampingFactor
+	var _dampingFactor;
 
 	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -5,9 +5,11 @@
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
-const clock = new THREE.Clock();
-let _dampingFactor
+
 THREE.OrbitControls = function ( object, domElement ) {
+
+	var clock = new THREE.Clock();
+	var _dampingFactor
 
 	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
@@ -43,7 +45,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
 	this.dampingFactor = 0.05;
-	_dampingFactor = this.dampingFactor
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming
@@ -154,8 +155,9 @@ THREE.OrbitControls = function ( object, domElement ) {
 			}
 
 			if ( scope.enableDamping ) {
-				const deltaTime = clock.getDelta()
-				_dampingFactor = scope.dampingFactor * deltaTime * 60
+				var deltaTime = clock.getDelta();
+				_dampingFactor = scope.dampingFactor * deltaTime * 60;
+				_dampingFactor = Math.min(_dampingFactor, 1);
 
 				spherical.theta += sphericalDelta.theta * _dampingFactor;
 				spherical.phi += sphericalDelta.phi * _dampingFactor;

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -5,6 +5,8 @@
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
+const clock = new THREE.Clock();
+let _dampingFactor
 THREE.OrbitControls = function ( object, domElement ) {
 
 	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
@@ -41,6 +43,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
 	this.dampingFactor = 0.05;
+	_dampingFactor = this.dampingFactor
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming
@@ -151,9 +154,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 			}
 
 			if ( scope.enableDamping ) {
+				const deltaTime = clock.getDelta()
+				_dampingFactor = scope.dampingFactor * deltaTime * 60
 
-				spherical.theta += sphericalDelta.theta * scope.dampingFactor;
-				spherical.phi += sphericalDelta.phi * scope.dampingFactor;
+				spherical.theta += sphericalDelta.theta * _dampingFactor;
+				spherical.phi += sphericalDelta.phi * _dampingFactor;
 
 			} else {
 
@@ -202,7 +207,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				scope.target.addScaledVector( panOffset, scope.dampingFactor );
+				scope.target.addScaledVector( panOffset, _dampingFactor );
 
 			} else {
 
@@ -221,10 +226,10 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
-				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+				sphericalDelta.theta *= ( 1 - _dampingFactor );
+				sphericalDelta.phi *= ( 1 - _dampingFactor );
 
-				panOffset.multiplyScalar( 1 - scope.dampingFactor );
+				panOffset.multiplyScalar( 1 - _dampingFactor );
 
 			} else {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -16,10 +16,10 @@ import {
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
-const clock = new Clock();
-let _dampingFactor;
-
 var OrbitControls = function ( object, domElement ) {
+
+	var clock = new THREE.Clock();
+	var _dampingFactor;
 
 	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
 	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
@@ -165,7 +165,7 @@ var OrbitControls = function ( object, domElement ) {
 			}
 
 			if ( scope.enableDamping ) {
-				const deltaTime = clock.getDelta();
+				var deltaTime = clock.getDelta();
 				_dampingFactor = scope.dampingFactor * deltaTime * 60;
 				_dampingFactor = Math.min(_dampingFactor, 1);
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -55,7 +55,6 @@ var OrbitControls = function ( object, domElement ) {
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
 	this.dampingFactor = 0.05;
-	_dampingFactor = this.dampingFactor
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming
@@ -166,8 +165,9 @@ var OrbitControls = function ( object, domElement ) {
 			}
 
 			if ( scope.enableDamping ) {
-				const deltaTime = clock.getDelta()
-				_dampingFactor = scope.dampingFactor * deltaTime * 60
+				const deltaTime = clock.getDelta();
+				_dampingFactor = scope.dampingFactor * deltaTime * 60;
+				_dampingFactor = Math.min(_dampingFactor, 1);
 
 				spherical.theta += sphericalDelta.theta * _dampingFactor;
 				spherical.phi += sphericalDelta.phi * _dampingFactor;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -5,7 +5,8 @@ import {
 	Spherical,
 	TOUCH,
 	Vector2,
-	Vector3
+	Vector3,
+	Clock
 } from "../../../build/three.module.js";
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
@@ -14,6 +15,9 @@ import {
 //    Orbit - left mouse / touch: one-finger move
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
+
+const clock = new Clock();
+let _dampingFactor
 
 var OrbitControls = function ( object, domElement ) {
 
@@ -51,6 +55,7 @@ var OrbitControls = function ( object, domElement ) {
 	// If damping is enabled, you must call controls.update() in your animation loop
 	this.enableDamping = false;
 	this.dampingFactor = 0.05;
+	_dampingFactor = this.dampingFactor
 
 	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 	// Set to false to disable zooming
@@ -161,9 +166,11 @@ var OrbitControls = function ( object, domElement ) {
 			}
 
 			if ( scope.enableDamping ) {
+				const deltaTime = clock.getDelta()
+				_dampingFactor = scope.dampingFactor * deltaTime * 60
 
-				spherical.theta += sphericalDelta.theta * scope.dampingFactor;
-				spherical.phi += sphericalDelta.phi * scope.dampingFactor;
+				spherical.theta += sphericalDelta.theta * _dampingFactor;
+				spherical.phi += sphericalDelta.phi * _dampingFactor;
 
 			} else {
 
@@ -212,7 +219,7 @@ var OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				scope.target.addScaledVector( panOffset, scope.dampingFactor );
+				scope.target.addScaledVector( panOffset, _dampingFactor );
 
 			} else {
 
@@ -231,10 +238,10 @@ var OrbitControls = function ( object, domElement ) {
 
 			if ( scope.enableDamping === true ) {
 
-				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
-				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+				sphericalDelta.theta *= ( 1 - _dampingFactor );
+				sphericalDelta.phi *= ( 1 - _dampingFactor );
 
-				panOffset.multiplyScalar( 1 - scope.dampingFactor );
+				panOffset.multiplyScalar( 1 - _dampingFactor );
 
 			} else {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -17,7 +17,7 @@ import {
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
 const clock = new Clock();
-let _dampingFactor
+let _dampingFactor;
 
 var OrbitControls = function ( object, domElement ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -18,7 +18,7 @@ import {
 
 var OrbitControls = function ( object, domElement ) {
 
-	var clock = new THREE.Clock();
+	var clock = new Clock();
 	var _dampingFactor;
 
 	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );


### PR DESCRIPTION
Current version damping-on and damping-off is almost the same if I change my screen fps to 300Hz.

This pr keep OrbitControls' damping speed consistent at different fps ( eg, 60Hz or 300Hz or under 60Hz).