### PR TITLE
WebGLBindingStates: Resolve memory leak caused by using Object.keys()

### DIFF
--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -169,7 +169,7 @@
 		const cachedAttributes = currentState.attributes;
 		const geometryAttributes = geometry.attributes;
 
-		if ( Object.keys( cachedAttributes ).length !== Object.keys( geometryAttributes ).length ) return true;
+		let attributesNum = 0;
 
 		for ( const key in geometryAttributes ) {
 
@@ -182,7 +182,11 @@
 
 			if ( cachedAttribute.data !== geometryAttribute.data ) return true;
 
+			attributesNum ++;
+
 		}
+
+		if ( currentState.attributesNum !== attributesNum ) return true;
 
 		if ( currentState.index !== index ) return true;
 
@@ -194,6 +198,7 @@
 
 		const cache = {};
 		const attributes = geometry.attributes;
+		let attributesNum = 0;
 
 		for ( const key in attributes ) {
 
@@ -210,9 +215,12 @@
 
 			cache[ key ] = data;
 
+			attributesNum ++;
+
 		}
 
 		currentState.attributes = cache;
+		currentState.attributesNum = attributesNum;
 
 		currentState.index = index;
 


### PR DESCRIPTION
Related issue: Fixed #20637.

**Description**

This PR resolves memory leak caused by using `Object.keys()` in `WebGLBindingStates` (refer to #20637 for more detail).

@Usnul I confirmed by using Firefox Memory allocation profiler that this change resolves the problem, and I'm happy if you test in your side just in case, too.