### PR TITLE
Correct examples/webgl_gpgpu_birds_gltf.html flapping speed.

### DIFF
--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -525,7 +525,7 @@
 
 						vec3 pos = tmpPos.xyz;
 						vec3 velocity = normalize(texture2D( textureVelocity, reference.xy ).xyz);
-						vec3 aniPos = texture2D( textureAnimation, vec2( reference.z, mod( ( time + seeds.x ) * ( ( 0.0004 + seeds.y / 10000.0) + normalize( velocity ) / 20000.0 ), reference.w ) ) ).xyz;
+						vec3 aniPos = texture2D( textureAnimation, vec2( reference.z, mod( time + ( seeds.x ) * ( ( 0.0004 + seeds.y / 10000.0) + normalize( velocity ) / 20000.0 ), reference.w ) ) ).xyz;
 						vec3 newPosition = position;
 
 						newPosition = mat3( modelMatrix ) * ( newPosition + aniPos );
@@ -649,7 +649,7 @@
 				positionUniforms[ "delta" ].value = delta;
 				velocityUniforms[ "time" ].value = now;
 				velocityUniforms[ "delta" ].value = delta;
-				if ( materialShader ) materialShader.uniforms[ "time" ].value = now;
+				if ( materialShader ) materialShader.uniforms[ "time" ].value = now / 1000;
 				if ( materialShader ) materialShader.uniforms[ "delta" ].value = delta;
 
 				velocityUniforms[ "predator" ].value.set( 0.5 * mouseX / windowHalfX, - 0.5 * mouseY / windowHalfY, 0 );


### PR DESCRIPTION
https://threejs.org/examples/?q=webgl_gpgpu_birds_gltf#webgl_gpgpu_birds_gltf

The longer the page is open, the faster the flapping speed will be. In the end it feels very unrealistic.
It will be more obvious if wait for about two minutes, or can directly add 200000 to the `now` at [here](https://github.com/mrdoob/three.js/blob/dev/examples/webgl_gpgpu_birds_gltf.html#L652) to see the result immediately.