### PR TITLE
Fix examples/webgl_gpgpu_birds_gltf.html cohesion 0 error

### DIFF
--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -184,7 +184,9 @@
 
 							// Attraction / Cohesion - move closer
 							float threshDelta = 1.0 - alignmentThresh;
-							float adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
+							float adjustedPercent;
+							if( threshDelta == 0. ) adjustedPercent = 1.;
+							else adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
 
 							f = ( 0.5 - ( cos( adjustedPercent * PI_2 ) * -0.5 + 0.5 ) ) * delta;
 

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -179,8 +179,9 @@
 
 							// Attraction / Cohesion - move closer
 							float threshDelta = 1.0 - alignmentThresh;
-							threshDelta = max( threshDelta, 1e-6 );
-							float adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
+							float adjustedPercent;
+							if( threshDelta == 0. ) adjustedPercent = 1.;
+							else adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
 
 							f = ( 0.5 - ( cos( adjustedPercent * PI_2 ) * -0.5 + 0.5 ) ) * delta;
 

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -179,6 +179,7 @@
 
 							// Attraction / Cohesion - move closer
 							float threshDelta = 1.0 - alignmentThresh;
+							threshDelta = max( threshDelta, 1e-6 );
 							float adjustedPercent = ( percent - alignmentThresh ) / threshDelta;
 
 							f = ( 0.5 - ( cos( adjustedPercent * PI_2 ) * -0.5 + 0.5 ) ) * delta;


### PR DESCRIPTION
https://threejs.org/examples/?q=webgl_gpgpu_birds_gltf#webgl_gpgpu_birds_gltf

Set gui cohesion to 0 will cause all birds dissaper and can't go back, because of when just set cohesion to 0 will let the divisor `threshDelta` to be 0.