### PR TITLE
NodeMaterial: Fix setting of extensions.

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -68,6 +68,11 @@ NodeMaterial.prototype.onBeforeCompile = function ( shader, renderer ) {
 	shader.vertexShader = this.vertexShader;
 	shader.fragmentShader = this.fragmentShader;
 
+	shader.extensionDerivatives = ( this.extensions.derivatives === true );
+	shader.extensionFragDepth = ( this.extensions.fragDepth === true );
+	shader.extensionDrawBuffers = ( this.extensions.drawBuffers === true );
+	shader.extensionShaderTextureLOD = ( this.extensions.shaderTextureLOD === true );
+
 };
 
 NodeMaterial.prototype.customProgramCacheKey = function () {


### PR DESCRIPTION
Related issue: Fixed #20653.

**Description**

Another side effect of refactoring the usage of `onBeforeCompile()` in `NodeMaterial`. Since the build of a node material is only done when using `onBeforeCompile()`, some information are not copied from the node builder to the actual material which are required in `WebGLPrograms.getParameters()`. `NodeMaterial` has to copy these properties manually now. It's essentially the same issue than lead to #20630.