### PR TITLE
RoundedBoxBufferGeometry: Fix normals, enforce odd segments

### DIFF
--- a/examples/jsm/geometries/RoundedBoxBufferGeometry.js
+++ b/examples/jsm/geometries/RoundedBoxBufferGeometry.js
@@ -41,7 +41,17 @@ class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 
 	constructor( width = 1, height = 1, depth = 1, segments = 1, radius = 1 ) {
 
+		// ensure segments is odd so we have a plane connecting the rounded corners
+		segments = segments % 2 === 0 ? segments + 1 : segments;
+
 		super( 1, 1, 1, segments, segments, segments );
+
+		// if we just have one segment we'r the same as a regular box
+		if ( segments === 1 ) {
+
+			return;
+
+		}
 
 		const geometry2 = this.toNonIndexed();
 
@@ -63,6 +73,7 @@ class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 
 		const faceTris = positions.length / 6;
 		const faceDirVector = new Vector3();
+		const halfSegmentSize = 0.5 / segments;
 
 		for ( let i = 0, j = 0; i < positions.length; i += 3, j += 2 ) {
 
@@ -72,6 +83,12 @@ class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 			positions[ i + 0 ] = box.x * Math.sign( position.x ) + normal.x * radius;
 			positions[ i + 1 ] = box.y * Math.sign( position.y ) + normal.y * radius;
 			positions[ i + 2 ] = box.z * Math.sign( position.z ) + normal.z * radius;
+
+			normal.copy( position );
+			normal.x -= Math.sign( normal.x ) * halfSegmentSize;
+			normal.y -= Math.sign( normal.y ) * halfSegmentSize;
+			normal.z -= Math.sign( normal.z ) * halfSegmentSize;
+			normal.normalize();
 
 			normals[ i + 0 ] = normal.x;
 			normals[ i + 1 ] = normal.y;


### PR DESCRIPTION
Fix #20665

- Enforce the "segments" argument to be odd
- Ensure normals are perpendicular to the primary faces

![image](https://user-images.githubusercontent.com/734200/98761676-d0c59200-238a-11eb-9b67-40f3257897f7.png)

