### PR TITLE
Examples: More clean up.

### DIFF
--- a/examples/js/modifiers/EdgeSplitModifier.js
+++ b/examples/js/modifiers/EdgeSplitModifier.js
@@ -162,6 +162,12 @@ THREE.EdgeSplitModifier = function () {
 
 		if ( geometry.index == null ) {
 
+			if ( THREE.BufferGeometryUtils === undefined ) {
+
+			 	throw 'THREE.EdgeSplitModifier relies on THREE.BufferGeometryUtils';
+
+			}
+
 			geometry = THREE.BufferGeometryUtils.mergeVertices( geometry );
 
 		}

--- a/examples/jsm/modifiers/EdgeSplitModifier.js
+++ b/examples/jsm/modifiers/EdgeSplitModifier.js
@@ -169,6 +169,12 @@ var EdgeSplitModifier = function () {
 
 		if ( geometry.index == null ) {
 
+			if ( BufferGeometryUtils === undefined ) {
+
+			 	throw 'THREE.EdgeSplitModifier relies on BufferGeometryUtils';
+
+			}
+
 			geometry = BufferGeometryUtils.mergeVertices( geometry );
 
 		}


### PR DESCRIPTION
Related issue: -

**Description**

`EdgeSplitModifier.js` uses `BufferGeometryUtils` without doing a dependency check.
