### PR TITLE
RoundedBoxBufferGeometry: Fix the total size to match box geometry

### DIFF
--- a/examples/jsm/geometries/RoundedBoxBufferGeometry.js
+++ b/examples/jsm/geometries/RoundedBoxBufferGeometry.js
@@ -39,14 +39,14 @@ function getUv( faceDirVector, normal, uvAxis, projectionAxis, radius, sideLengt
 
 class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 
-	constructor( width = 1, height = 1, depth = 1, segments = 1, radius = 1 ) {
+	constructor( width = 1, height = 1, depth = 1, segments = 4, radius = 0.1 ) {
 
 		// ensure segments is odd so we have a plane connecting the rounded corners
 		segments = segments % 2 === 0 ? segments + 1 : segments;
 
 		super( 1, 1, 1, segments, segments, segments );
 
-		// if we just have one segment we'r the same as a regular box
+		// if we just have one segment we're the same as a regular box
 		if ( segments === 1 ) {
 
 			return;

--- a/examples/jsm/geometries/RoundedBoxBufferGeometry.js
+++ b/examples/jsm/geometries/RoundedBoxBufferGeometry.js
@@ -78,17 +78,15 @@ class RoundedBoxBufferGeometry extends BoxBufferGeometry {
 		for ( let i = 0, j = 0; i < positions.length; i += 3, j += 2 ) {
 
 			position.fromArray( positions, i );
-			normal.copy( position ).normalize();
-
-			positions[ i + 0 ] = box.x * Math.sign( position.x ) + normal.x * radius;
-			positions[ i + 1 ] = box.y * Math.sign( position.y ) + normal.y * radius;
-			positions[ i + 2 ] = box.z * Math.sign( position.z ) + normal.z * radius;
-
 			normal.copy( position );
 			normal.x -= Math.sign( normal.x ) * halfSegmentSize;
 			normal.y -= Math.sign( normal.y ) * halfSegmentSize;
 			normal.z -= Math.sign( normal.z ) * halfSegmentSize;
 			normal.normalize();
+
+			positions[ i + 0 ] = box.x * Math.sign( position.x ) + normal.x * radius;
+			positions[ i + 1 ] = box.y * Math.sign( position.y ) + normal.y * radius;
+			positions[ i + 2 ] = box.z * Math.sign( position.z ) + normal.z * radius;
 
 			normals[ i + 0 ] = normal.x;
 			normals[ i + 1 ] = normal.y;


### PR DESCRIPTION
Fix issue mentioned in https://github.com/mrdoob/three.js/issues/20665#issuecomment-725422524

> Also, the bounding box is too small. It should be the same size as the equivalent `BoxBufferGeometry`.

The following code now yields the correct bounding box size:

```js
const geometry = new RoundedBoxBufferGeometry( 0.5, 1, 1.5, 15, 0.2 );
const size = new THREE.Vector3();
geometry.computeBoundingBox();
geometry.boundingBox.getSize( size );

console.log( size );

// x: 0.5, y: 1, z: 1.5,
```

cc @WestLangley 