### PR TITLE
Material: Add depth prepass option for transparent objects

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -856,6 +856,34 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( material.depthPrepass && material.transparent ) {
+
+			const originalDepthTest = state.buffers.depth.getTest();
+			const originalColorMask = state.buffers.color.getMask();
+			state.buffers.depth.setTest( true );
+			state.buffers.color.setMask( 0 );
+
+			if ( object.isInstancedMesh ) {
+
+				renderer.renderInstances( drawStart, drawCount, object.count );
+
+			} else if ( geometry.isInstancedBufferGeometry ) {
+
+				const instanceCount = Math.min( geometry.instanceCount, geometry._maxInstanceCount );
+
+				renderer.renderInstances( drawStart, drawCount, instanceCount );
+
+			} else {
+
+				renderer.render( drawStart, drawCount );
+
+			}
+
+			state.buffers.depth.setTest( originalDepthTest );
+			state.buffers.color.setMask( originalColorMask );
+
+		}
+
 		if ( object.isInstancedMesh ) {
 
 			renderer.renderInstances( drawStart, drawCount, object.count );

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -26,6 +26,12 @@ function WebGLState( gl, extensions, capabilities ) {
 
 			},
 
+			getMask: function () {
+
+				return currentColorMask;
+
+			},
+
 			setLocked: function ( lock ) {
 
 				locked = lock;
@@ -71,20 +77,33 @@ function WebGLState( gl, extensions, capabilities ) {
 		let currentDepthMask = null;
 		let currentDepthFunc = null;
 		let currentDepthClear = null;
+		let currentDepthTest = null;
 
 		return {
 
 			setTest: function ( depthTest ) {
 
-				if ( depthTest ) {
+				if ( depthTest !== currentDepthTest ) {
 
-					enable( gl.DEPTH_TEST );
+					if ( depthTest ) {
 
-				} else {
+						enable( gl.DEPTH_TEST );
 
-					disable( gl.DEPTH_TEST );
+					} else {
+
+						disable( gl.DEPTH_TEST );
+
+					}
+
+					currentDepthTest = depthTest;
 
 				}
+
+			},
+
+			getTest: function () {
+
+				return currentDepthTest;
 
 			},
 


### PR DESCRIPTION
As I suggested in https://github.com/mrdoob/three.js/pull/8676#issuecomment-725262431 this adds the option to perform a depth prepass for transparent objects by disabling color write which can help reduce transparency artifacts for overlapping triangles within a single mesh. The "pop" from reordering transparent object draw order as the camera moves will still show up, though. Simply disabling color write means that any shader (even user written) will "just work", though it may not be as optimally as it could. And it turns out that this is the same approach that [Babylon.js uses for performing a depth prepass for transparent objects](https://github.com/BabylonJS/Babylon.js/blob/bbd49d1e707e29a314d530044a9bcf37bfcfcd57/src/Rendering/renderingGroup.ts#L228-L231), as well.

In the future this could be expanded to provide an opaque scene depthPrepass, as well. Alternatively we could generate more optimal materials like the `WebGLShadowMap` does. I'll update docs etc if this there's interest in this PR from maintainers.

Here's a JSFiddle that uses renderOrder to show what the prepass looks like in action: 

https://jsfiddle.net/12wsrnhp/

**Before**

Both materials with `depthPrepass = false`.

![image](https://user-images.githubusercontent.com/734200/98870584-5a776d00-2428-11eb-82e5-b2d1a7c30db6.png)

**After**

Bot materials with `depthPrepass = true`.

![image](https://user-images.githubusercontent.com/734200/98870667-7844d200-2428-11eb-98cf-e8785c5d3210.png)
