### PR TITLE
KTX2Loader: Allow parse() method to initialize transcoder.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -4,11 +4,8 @@
  * - DFD: https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html#basicdescriptor
  *
  * To do:
- * - [ ] Cross-platform testing
- * - [ ] Specify JS/WASM transcoder path
  * - [ ] High-quality demo
  * - [ ] Documentation
- * - [ ] TypeScript definitions
  * - [ ] (Optional) Include BC5
  * - [ ] (Optional) Include EAC RG on mobile (WEBGL_compressed_texture_etc)
  * - [ ] (Optional) Include two-texture output mode (see: clearcoat + clearcoatRoughness)
@@ -136,20 +133,24 @@ class KTX2Loader extends CompressedTextureLoader {
 
 		} );
 
+		// parse() will call initModule() again, but starting the process early
+		// should allow the WASM to load in parallel with the texture.
 		this.initModule();
 
-		Promise.all( [ bufferPending, this.basisModulePending ] ).then( function ( [ buffer ] ) {
+		Promise.all( [ bufferPending, this.basisModulePending ] )
+			.then( function ( [ buffer ] ) {
 
-			scope.parse( buffer, function ( _texture ) {
+				scope.parse( buffer, function ( _texture ) {
 
-				texture.copy( _texture );
-				texture.needsUpdate = true;
+					texture.copy( _texture );
+					texture.needsUpdate = true;
 
-				if ( onLoad ) onLoad( texture );
+					if ( onLoad ) onLoad( texture );
 
-			}, onError );
+				}, onError );
 
-		} );
+			} )
+			.catch( onError );
 
 		return texture;
 
@@ -157,40 +158,50 @@ class KTX2Loader extends CompressedTextureLoader {
 
 	parse( buffer, onLoad, onError ) {
 
-		var BasisLzEtc1sImageTranscoder = this.basisModule.BasisLzEtc1sImageTranscoder;
-		var UastcImageTranscoder = this.basisModule.UastcImageTranscoder;
-		var TextureFormat = this.basisModule.TextureFormat;
+		var scope = this;
 
-		var ktx = new KTX2Container( this.basisModule, buffer );
+		// load() may have already called initModule(), but call it again here
+		// in case the user called parse() directly. Method is idempotent.
+		this.initModule();
 
-		// TODO(donmccurdy): Should test if texture is transcodable before attempting
-		// any transcoding. If supercompressionScheme is KTX_SS_BASIS_LZ and dfd
-		// colorModel is ETC1S (163) or if dfd colorModel is UASTCF (166)
-		// then texture must be transcoded.
-		var transcoder = ktx.getTexFormat() === TextureFormat.UASTC4x4
-			? new UastcImageTranscoder()
-			: new BasisLzEtc1sImageTranscoder();
+		this.basisModulePending.then( function () {
 
-		ktx.initMipmaps( transcoder, this.transcoderConfig )
-			.then( function () {
+			var BasisLzEtc1sImageTranscoder = scope.basisModule.BasisLzEtc1sImageTranscoder;
+			var UastcImageTranscoder = scope.basisModule.UastcImageTranscoder;
+			var TextureFormat = scope.basisModule.TextureFormat;
 
-				var texture = new CompressedTexture(
-					ktx.mipmaps,
-					ktx.getWidth(),
-					ktx.getHeight(),
-					ktx.transcodedFormat,
-					UnsignedByteType
-				);
+			var ktx = new KTX2Container( scope.basisModule, buffer );
 
-				texture.encoding = ktx.getEncoding();
-				texture.premultiplyAlpha = ktx.getPremultiplyAlpha();
-				texture.minFilter = ktx.mipmaps.length === 1 ? LinearFilter : LinearMipmapLinearFilter;
-				texture.magFilter = LinearFilter;
+			// TODO(donmccurdy): Should test if texture is transcodable before attempting
+			// any transcoding. If supercompressionScheme is KTX_SS_BASIS_LZ and dfd
+			// colorModel is ETC1S (163) or if dfd colorModel is UASTCF (166)
+			// then texture must be transcoded.
+			var transcoder = ktx.getTexFormat() === TextureFormat.UASTC4x4
+				? new UastcImageTranscoder()
+				: new BasisLzEtc1sImageTranscoder();
 
-				onLoad( texture );
+			ktx.initMipmaps( transcoder, scope.transcoderConfig )
+				.then( function () {
 
-			} )
-			.catch( onError );
+					var texture = new CompressedTexture(
+						ktx.mipmaps,
+						ktx.getWidth(),
+						ktx.getHeight(),
+						ktx.transcodedFormat,
+						UnsignedByteType
+					);
+
+					texture.encoding = ktx.getEncoding();
+					texture.premultiplyAlpha = ktx.getPremultiplyAlpha();
+					texture.minFilter = ktx.mipmaps.length === 1 ? LinearFilter : LinearMipmapLinearFilter;
+					texture.magFilter = LinearFilter;
+
+					onLoad( texture );
+
+				} )
+				.catch( onError );
+
+		} );
 
 		return this;
 


### PR DESCRIPTION
Currently `.load()` initializes the WASM transcoder automatically, but `.parse()` does not. Since the user may need to call either, depending on the situation, both should handle initialization.