### PR TITLE
Docs: Fix MathUtils.randFloatSpread style error.

### DIFF
--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -74,16 +74,16 @@
 		<p>Converts radians to degrees.</p>
 
 		<h3>[method:Float randFloat]( [param:Float low], [param:Float high] )</h3>
-		<p>Random float in the interval [page:Float low] to [page:Float high].</p>
+		<p>Random float in the interval [[page:Float low], [page:Float high]].</p>
 
 		<h3>[method:Float randFloatSpread]( [param:Float range] )</h3>
-		<p>Random float in the interval *- [page:Float range] / 2* to *[page:Float range] / 2*.</p>
+		<p>Random float in the interval [- [page:Float range] / 2, [page:Float range] / 2].</p>
 
 		<h3>[method:Integer randInt]( [param:Integer low], [param:Integer high] )</h3>
-		<p>Random integer in the interval [page:Float low] to [page:Float high].</p>
+		<p>Random integer in the interval [[page:Float low], [page:Float high]].</p>
 
 		<h3>[method:Float seededRandom]( [param:Integer seed] )</h3>
-		<p>Deterministic pseudo-random float in the interval [ 0, 1 ]. The integer [page:Integer seed] is optional.</p>
+		<p>Deterministic pseudo-random float in the interval [0, 1]. The integer [page:Integer seed] is optional.</p>
 
 		<h3>[method:Float smoothstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
 		<p>

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -44,7 +44,7 @@
 		<p>
 		[page:Float x] - 起始点。 <br />
 		[page:Float y] - 终点。 <br />
-		[page:Float t] - 封闭区间[0,1]内的插值因子。<br><br />
+		[page:Float t] - 闭区间 [0,1] 内的插值因子。<br><br />
 
 		返回给定区间的线性插值[link:https://en.wikipedia.org/wiki/Linear_interpolation linearly interpolated]结果 - [page:Float t] = 0 将会返回 [page:Float x]
 		如果 [page:Float t] = 1 将会返回 [page:Float y].
@@ -71,16 +71,16 @@
 		<p>将弧度转换为角度。</p>
 
 		<h3>[method:Float randFloat]( [param:Float low], [param:Float high] )</h3>
-		<p>在区间[page:Float low] 到 [page:Float high]随机一个浮点数。</p>
+		<p>在区间 [[page:Float low], [page:Float high]] 内随机一个浮点数。</p>
 
 		<h3>[method:Float randFloatSpread]( [param:Float range] )</h3>
-		<p>在区间*- [page:Float range] / 2* 到 *[page:Float range] / 2*随机一个浮点数。</p>
+		<p>在区间 [- [page:Float range] / 2, [page:Float range] / 2] 内随机一个浮点数。</p>
 
 		<h3>[method:Integer randInt]( [param:Integer low], [param:Integer high] )</h3>
-		<p>在区间[page:Float low] 到 [page:Float high]随机一个整数。</p>
+		<p>在区间 [[page:Float low], [page:Float high]] 内随机一个整数。</p>
 
 		<h3>[method:Float seededRandom]( [param:Integer seed] )</h3>
-		<p>Deterministic pseudo-random float in the interval [ 0, 1 ]. The integer [page:Integer seed] is optional.</p>
+		<p>在区间 [0, 1] 中生成确定性的伪随机浮点数。 整数种子是可选的。</p>
 
 		<h3>[method:Float smoothstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
 		<p>


### PR DESCRIPTION
Fix style error and unify interval format.
![image](https://user-images.githubusercontent.com/10785634/99058603-686bf000-25d8-11eb-946a-e47981fe21c6.png)
