### PR TITLE
3DMLoader: Read object names from .3dm file

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -494,7 +494,7 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				brepObject.userData[ 'attributes' ] = attributes;
 				brepObject.userData[ 'objectType' ] = obj.objectType;
-<				if( attributes.name ) {
+				if( attributes.name ) {
 					brepObject.name = attributes.name;
 				}
 

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -442,6 +442,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				var points = new Points( geometry, material );
 				points.userData[ 'attributes' ] = attributes;
 				points.userData[ 'objectType' ] = obj.objectType;
+				if( attributes.name ) {
+					points.name = attributes.name;
+				}
 				return points;
 
 			case 'Mesh':
@@ -468,6 +471,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				mesh.receiveShadow = attributes.receivesShadows;
 				mesh.userData[ 'attributes' ] = attributes;
 				mesh.userData[ 'objectType' ] = obj.objectType;
+				if( attributes.name ) {
+					mesh.name = attributes.name;
+				}
 
 				return mesh;
 
@@ -488,6 +494,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				brepObject.userData[ 'attributes' ] = attributes;
 				brepObject.userData[ 'objectType' ] = obj.objectType;
+<				if( attributes.name ) {
+					brepObject.name = attributes.name;
+				}
 
 				return brepObject;
 
@@ -504,6 +513,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 				var lines = new Line( geometry, material );
 				lines.userData[ 'attributes' ] = attributes;
 				lines.userData[ 'objectType' ] = obj.objectType;
+				if( attributes.name ) {
+					lines.name = attributes.name;
+				}
 
 				return lines;
 
@@ -546,6 +558,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 				sprite.userData[ 'attributes' ] = attributes;
 				sprite.userData[ 'objectType' ] = obj.objectType;
+				if( attributes.name ) {
+					sprite.name = attributes.name;
+				}
 
 				return sprite;
 


### PR DESCRIPTION
In Rhino object can have a name. This name is currently accessible using Object.userData[ 'attributes' ].name. For better coherence it would be nice to have the name directly on the Three.js object.