### PR TITLE
Add '#define USE_ENVMAP' to provide the needed code in the basic shader curve modifier example

### DIFF
--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -119,6 +119,7 @@ export function modifyShader( material, uniforms, numberOfCurves = 1 ) {
 		Object.assign( shader.uniforms, uniforms );
 
 		const vertexShader = `
+		#define USE_ENVMAP
 		uniform sampler2D spineTexture;
 		uniform float pathOffset;
 		uniform float pathSegment;


### PR DESCRIPTION
Related issue: #20687

Curve Modifier was breaking for Basic Shaders which did not have an environment map because it relies on shared code. 

This PR makes all Shaders Which use this have `#define USE_ENVMAP` so that shader code is available.
