### PR TITLE
Fix material rendering for CurveModifier

### DIFF
--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -180,7 +180,13 @@ vec3 transformed = basis
 	+ spinePos;
 
 vec3 transformedNormal = normalMatrix * (basis * objectNormal);
-`);
+`).replace(
+	'#include <project_vertex>',
+`
+vec4 mvPosition = modelViewMatrix * vec4( transformed, 1.0 );
+gl_Position = projectionMatrix * mvPosition;
+`
+);
 
 		shader.vertexShader = vertexShader;
 

--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -119,7 +119,6 @@ export function modifyShader( material, uniforms, numberOfCurves = 1 ) {
 		Object.assign( shader.uniforms, uniforms );
 
 		const vertexShader = `
-		#define USE_ENVMAP
 		uniform sampler2D spineTexture;
 		uniform float pathOffset;
 		uniform float pathSegment;
@@ -131,54 +130,57 @@ export function modifyShader( material, uniforms, numberOfCurves = 1 ) {
 		float textureStacks = ${TEXTURE_HEIGHT / 4}.;
 
 		${shader.vertexShader}
-		`.replace(
-		'#include <defaultnormal_vertex>',
 		`
-		vec4 worldPos = modelMatrix * vec4(position, 1.);
+		// chunk import moved in front of modified shader below
+		.replace('#include <beginnormal_vertex>', ``)
 
-		bool bend = flow > 0;
-		float xWeight = bend ? 0. : 1.;
+		// vec3 transformedNormal declaration overriden below
+		.replace('#include <defaultnormal_vertex>', ``)
 
-		#ifdef USE_INSTANCING
-		float pathOffsetFromInstanceMatrix = instanceMatrix[3][2];
-		float spineLengthFromInstanceMatrix = instanceMatrix[3][0];
-		float spinePortion = bend ? (worldPos.x + spineOffset) / spineLengthFromInstanceMatrix : 0.;
-		float mt = (spinePortion * pathSegment + pathOffset + pathOffsetFromInstanceMatrix)*textureStacks;
-		#else
-		float spinePortion = bend ? (worldPos.x + spineOffset) / spineLength : 0.;
-		float mt = (spinePortion * pathSegment + pathOffset)*textureStacks;
-		#endif
+		// vec3 transformed declaration overriden below
+		.replace('#include <begin_vertex>', ``)
 
-		mt = mod(mt, textureStacks);
-		float rowOffset = floor(mt);
+		// shader override
+		.replace(
+			/void\s*main\s*\(\)\s*\{/,
+`
+void main() {
+#include <beginnormal_vertex>
 
-		#ifdef USE_INSTANCING
-		rowOffset += instanceMatrix[3][1] * ${TEXTURE_HEIGHT}.;
-		#endif
+vec4 worldPos = modelMatrix * vec4(position, 1.);
 
-		vec3 spinePos = texture(spineTexture, vec2(mt, (0. + rowOffset + 0.5) / textureLayers)).xyz;
-		vec3 a =        texture(spineTexture, vec2(mt, (1. + rowOffset + 0.5) / textureLayers)).xyz;
-		vec3 b =        texture(spineTexture, vec2(mt, (2. + rowOffset + 0.5) / textureLayers)).xyz;
-		vec3 c =        texture(spineTexture, vec2(mt, (3. + rowOffset + 0.5) / textureLayers)).xyz;
-		mat3 basis = mat3(a, b, c);
+bool bend = flow > 0;
+float xWeight = bend ? 0. : 1.;
 
-		vec3 transformed = basis
-			* vec3(worldPos.x * xWeight, worldPos.y * 1., worldPos.z * 1.)
-			+ spinePos;
+#ifdef USE_INSTANCING
+float pathOffsetFromInstanceMatrix = instanceMatrix[3][2];
+float spineLengthFromInstanceMatrix = instanceMatrix[3][0];
+float spinePortion = bend ? (worldPos.x + spineOffset) / spineLengthFromInstanceMatrix : 0.;
+float mt = (spinePortion * pathSegment + pathOffset + pathOffsetFromInstanceMatrix)*textureStacks;
+#else
+float spinePortion = bend ? (worldPos.x + spineOffset) / spineLength : 0.;
+float mt = (spinePortion * pathSegment + pathOffset)*textureStacks;
+#endif
 
-		vec3 transformedNormal = normalMatrix * (basis * objectNormal);
-		`
-	).replace(
-		'#include <begin_vertex>',
-		''
-	).replace(
-		'#include <project_vertex>',
-		`
-			vec4 mvPosition = viewMatrix * vec4( transformed, 1.0 );
-			// vec4 mvPosition = viewMatrix * worldPos;
-			gl_Position = projectionMatrix * mvPosition;
-			`
-	);
+mt = mod(mt, textureStacks);
+float rowOffset = floor(mt);
+
+#ifdef USE_INSTANCING
+rowOffset += instanceMatrix[3][1] * ${TEXTURE_HEIGHT}.;
+#endif
+
+vec3 spinePos = texture(spineTexture, vec2(mt, (0. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 a =        texture(spineTexture, vec2(mt, (1. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 b =        texture(spineTexture, vec2(mt, (2. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 c =        texture(spineTexture, vec2(mt, (3. + rowOffset + 0.5) / textureLayers)).xyz;
+mat3 basis = mat3(a, b, c);
+
+vec3 transformed = basis
+	* vec3(worldPos.x * xWeight, worldPos.y * 1., worldPos.z * 1.)
+	+ spinePos;
+
+vec3 transformedNormal = normalMatrix * (basis * objectNormal);
+`);
 
 		shader.vertexShader = vertexShader;
 

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -58,7 +58,7 @@
 				];
 
 				const boxGeometry = new THREE.BoxBufferGeometry( 0.1, 0.1, 0.1 );
-				const boxMaterial = new THREE.MeshBasicMaterial( 0x99ff99 );
+				const boxMaterial = new THREE.MeshBasicMaterial( { color: 0x99ff99 } );
 
 				for ( const handlePos of initialPoints ) {
 
@@ -116,9 +116,7 @@
 
 					geometry.rotateX( Math.PI );
 
-					const material = new THREE.MeshStandardMaterial( {
-						color: 0x99ffff
-					} );
+					const material = new THREE.MeshNormalMaterial();
 
 					const objectToCurve = new THREE.Mesh( geometry, material );
 

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -58,7 +58,7 @@
 				];
 
 				const boxGeometry = new THREE.BoxBufferGeometry( 0.1, 0.1, 0.1 );
-				const boxMaterial = new THREE.MeshBasicMaterial( { color: 0x99ff99 } );
+				const boxMaterial = new THREE.MeshBasicMaterial();
 
 				for ( const handlePos of initialPoints ) {
 
@@ -116,7 +116,9 @@
 
 					geometry.rotateX( Math.PI );
 
-					const material = new THREE.MeshNormalMaterial();
+					const material = new THREE.MeshStandardMaterial( {
+						color: 0x99ffff
+					} );
 
 					const objectToCurve = new THREE.Mesh( geometry, material );
 

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -51,7 +51,7 @@
 				camera.lookAt( scene.position );
 
 				const boxGeometry = new THREE.BoxBufferGeometry( 0.1, 0.1, 0.1 );
-				const boxMaterial = new THREE.MeshBasicMaterial( 0x99ff99 );
+				const boxMaterial = new THREE.MeshBasicMaterial();
 
 				const curves = [[
 					{ x: 1, y: - 0.5, z: - 1 },


### PR DESCRIPTION
Solves #20687 (related #20688)

Since I was losing my mind trying to figure out the connections of shader chunks for materials anyway, I found a second to fix the issue with curve modifier - it should now work with all materials. Tested on:

- [x] MeshNormalMaterial
- [x] MeshBasicMaterial
- [x] MeshStandardMaterial
- [x] MeshPhysicalMaterial
- [x] MeshDepthMaterial
- [x] MeshDistanceMaterial
- [x] MeshLambertMaterial
- [x] MeshMatcapMaterial
- [x] MeshPhongMaterial
- [x] MeshToonMaterial

1. Adding `USE_ENVMAP` was technically a solution, @WestLangley - since it unlocks [this](https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl.js#L25) part of the basic material shader. But isn't necessary with this PR.

2. Typo fix (@AdaRoseCannon): I think this is not legal ([docs](https://threejs.org/docs/#api/en/materials/MeshBasicMaterial), if I'm not wrong, it just sets the color to default and passes number to [setValues](https://github.com/mrdoob/three.js/blob/dev/src/materials/MeshBasicMaterial.js#L70)):

https://github.com/mrdoob/three.js/blob/c9ee476a7b4e906289f03eaf8ae91689b7497acd/examples/webgl_modifier_curve.html#L61

3. There's no point 3, I'd just like to dedicate a single point on this list to the sanity of the person who will try to maintain these shader chunks in the future. :') 

4. Now the main part:

Removed `USE_ENVMAP`.

Removed includes that may duplicate declarations from the modified shader.

Moved the modified shader code to the beginning of the shader `void main` and placed `include`s in the correct order - this fixes the issue with different materials not rendering (incl. MeshBasicMaterial and MeshNormalMaterial.)

The main body of the modified shader is untouched.

[This substitution](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/modifiers/CurveModifier.js#L175) seemed to be the same as the [original shader chunk](https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/project_vertex.glsl.js). When commented out it does seem to change nothing, but I may be missing something - though if we'd put the values in right places new code looks just like the old one. 🤔