### PR TITLE
3DMLoader: Assure a minimum pointCount of 2.

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -1303,7 +1303,7 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 		if ( curve instanceof rhino.ArcCurve ) {
 
 			pointCount = Math.floor( curve.angleDegrees / 5 );
-			pointCount = pointCount < 1 ? 2 : pointCount;
+			pointCount = pointCount < 2 ? 2 : pointCount;
 			// alternative to this hardcoded version: https://stackoverflow.com/a/18499923/2179399
 
 		}


### PR DESCRIPTION
I have some .3dm-files that failed to load with 3dmloader.
I found out that the problems are caused by ArcCurves where the calculated pointCount is 1.
After setting the lower bound of pointCount to 2 my files can be loaded without problems.

