### PR TITLE
Examples: Remove usage of Camera.target.

### DIFF
--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -91,7 +91,6 @@
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 120;
-				camera.target = new THREE.Vector3();
 
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 50;

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -51,7 +51,6 @@
 					camera.position.x = 50;
 					camera.position.z = - 50;
 					camera.position.y = 30;
-					camera.target = new THREE.Vector3();
 
 					cloud = new THREE.TextureLoader().load( 'textures/lava/cloud.png' );
 					cloud.wrapS = cloud.wrapT = THREE.RepeatWrapping;

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -94,7 +94,6 @@
 				camera.position.x = 0;
 				camera.position.z = - 300;
 				camera.position.y = 200;
-				camera.target = new THREE.Vector3();
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 50;

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -128,8 +128,6 @@
 				camera.position.x = 50;
 				camera.position.z = - 50;
 				camera.position.y = 30;
-				camera.target = new THREE.Vector3();
-
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 50;

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -50,7 +50,6 @@
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.y = 300;
-				camera.target = new THREE.Vector3( 0, 150, 0 );
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xf0f0f0 );
@@ -126,7 +125,7 @@
 				camera.position.x = radius * Math.sin( THREE.MathUtils.degToRad( theta ) );
 				camera.position.z = radius * Math.cos( THREE.MathUtils.degToRad( theta ) );
 
-				camera.lookAt( camera.target );
+				camera.lookAt( 0, 150, 0 );
 
 				if ( mixer ) {
 

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -34,7 +34,6 @@
 				const container = document.getElementById( 'container' );
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1100 );
-				camera.target = new THREE.Vector3( 0, 0, 0 );
 
 				scene = new THREE.Scene();
 
@@ -178,16 +177,11 @@
 				phi = THREE.MathUtils.degToRad( 90 - lat );
 				theta = THREE.MathUtils.degToRad( lon );
 
-				camera.target.x = 500 * Math.sin( phi ) * Math.cos( theta );
-				camera.target.y = 500 * Math.cos( phi );
-				camera.target.z = 500 * Math.sin( phi ) * Math.sin( theta );
+				const x = 500 * Math.sin( phi ) * Math.cos( theta );
+				const y = 500 * Math.cos( phi );
+				const z = 500 * Math.sin( phi ) * Math.sin( theta );
 
-				camera.lookAt( camera.target );
-
-				/*
-				// distortion
-				camera.position.copy( camera.target ).negate();
-				*/
+				camera.lookAt( x, y, z );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -62,7 +62,6 @@
 
 				camera = new THREE.PerspectiveCamera( fov, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 100;
-				camera.target = new THREE.Vector3();
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 50;

--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -47,7 +47,6 @@
 				const container = document.getElementById( 'container' );
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1100 );
-				camera.target = new THREE.Vector3( 0, 0, 0 );
 
 				scene = new THREE.Scene();
 
@@ -134,7 +133,7 @@
 				camera.position.y = distance * Math.cos( phi );
 				camera.position.z = distance * Math.sin( phi ) * Math.sin( theta );
 
-				camera.lookAt( camera.target );
+				camera.lookAt( 0, 0, 0 );
 
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
Related issue: -

**Description**

`Camera.target` does not exists.
