### PR TITLE
WebGLRenderer: Remove geometry event listeners when disposed preventing memory leak with multiple renderers

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -599,6 +599,7 @@ function WebGLRenderer( parameters ) {
 		cubemaps.dispose();
 		objects.dispose();
 		bindingStates.dispose();
+		geometries.dispose();
 
 		xr.dispose();
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -224,19 +224,23 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 	function dispose() {
 
-		weakRefGeometries.forEach( handle => {
+		if ( useWeakRef ) {
 
-			const geometry = handle.deref();
-			if ( geometry ) {
+			weakRefGeometries.forEach( handle => {
 
-				onGeometryDispose( { target: geometry } );
+				const geometry = handle.deref();
+				if ( geometry ) {
 
-			}
+					onGeometryDispose( { target: geometry } );
 
-		} );
-		weakRefGeometries.clear();
+				}
+
+			} );
+			weakRefGeometries.clear();
+
+		}
+
 		geometries.clear();
-
 
 	}
 


### PR DESCRIPTION
Related issue: #20346, #17242, #16123, #19645

**Description**

See https://github.com/mrdoob/three.js/issues/20346#issuecomment-693606399. When a single scene is rendered with two WebGLRenderers both renderers add a `dispose` event listener to the geometry which only gets removed when `dispose()` is called on the geometry itself. Because `WeakMaps` were introduced in #17242 the event listeners cannot be removed when calling `WebGLRenderer.dispose` which ultimately keeps the `WebGLAttributes` instance and therefore `gl` context instance around because they are in the scope of the `onGeometryDispose` function.

This PR adds a reference to all geometry using WeakRefs (so GC is not prevented) in `WebGLGeometries` and adds a dispose function so those event handlers can be properly cleaned up when the renderer is finished with. Because WeakRefs are relatively new they are only used if the browser supports them. It looks like dispose event listeners are similarly added for textures, rendertargets, and materials -- I can add similar functionality for those classes if this change is agreeable.

