### PR TITLE
MeshSurfaceSampler: Support vertex colors.

### DIFF
--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -74,7 +74,7 @@
 
 		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor] )</h3>
 		<p>
-		Selects a random point on the surface of the input geometry, returning the position and optional the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
+		Selects a random point on the surface of the input geometry, returning the position and optionally the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -72,9 +72,9 @@
 		Processes the input geometry and prepares to return samples. Any configuration of the geometry or sampler must occur before this method is called. Time complexity is <i>O(n)</i> for a surface with <i>n</i> faces.
 		</p>
 
-		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal] )</h3>
+		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor] )</h3>
 		<p>
-		Selects a random point on the surface of the input geometry, returning the position and normal vector at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
+		Selects a random point on the surface of the input geometry, returning the position and optional the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -74,7 +74,7 @@
 
 		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor] )</h3>
 		<p>
-		Selects a random point on the surface of the input geometry, returning the position and optional the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
+		Selects a random point on the surface of the input geometry, returning the position and optionally the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
 
 		<h2>Source</h2>
 

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -72,9 +72,9 @@
 		Processes the input geometry and prepares to return samples. Any configuration of the geometry or sampler must occur before this method is called. Time complexity is <i>O(n)</i> for a surface with <i>n</i> faces.
 		</p>
 
-		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal] )</h3>
+		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor] )</h3>
 		<p>
-		Selects a random point on the surface of the input geometry, returning the position and normal vector at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
+		Selects a random point on the surface of the input geometry, returning the position and optional the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
 
 		<h2>Source</h2>
 

--- a/examples/jsm/math/MeshSurfaceSampler.d.ts
+++ b/examples/jsm/math/MeshSurfaceSampler.d.ts
@@ -1,5 +1,6 @@
 import {
 	BufferGeometry,
+	Color,
 	Mesh,
 	Vector3
 } from '../../../src/Three';
@@ -14,8 +15,8 @@ export class MeshSurfaceSampler {
 	constructor( mesh: Mesh );
 	binarySearch( x: number ): number;
 	build(): this;
-	sample( targetPosition: Vector3, targetNormal: Vector3 ): this;
-	sampleFace( faceIndex: number, targetPosition: Vector3, targetNormal: Vector3 ): this;
+	sample( targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color ): this;
+	sampleFace( faceIndex: number, targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color ): this;
 	setWeightAttribute( name: string | null ): this;
 
 }

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -1,5 +1,6 @@
 import {
-	Triangle
+	Triangle,
+	Vector3
 } from "../../../build/three.module.js";
 
 /**
@@ -15,6 +16,7 @@ import {
 var MeshSurfaceSampler = ( function () {
 
 	var _face = new Triangle();
+	var _color = new Vector3();
 
 	function MeshSurfaceSampler( mesh ) {
 
@@ -38,6 +40,7 @@ var MeshSurfaceSampler = ( function () {
 		this.randomFunction = Math.random;
 
 		this.positionAttribute = this.geometry.getAttribute( 'position' );
+		this.colorAttribute = this.geometry.getAttribute( 'color' );
 		this.weightAttribute = null;
 
 		this.distribution = null;
@@ -112,13 +115,13 @@ var MeshSurfaceSampler = ( function () {
 
 		},
 
-		sample: function ( targetPosition, targetNormal ) {
+		sample: function ( targetPosition, targetNormal, targetColor ) {
 
 			var cumulativeTotal = this.distribution[ this.distribution.length - 1 ];
 
 			var faceIndex = this.binarySearch( this.randomFunction() * cumulativeTotal );
 
-			return this.sampleFace( faceIndex, targetPosition, targetNormal );
+			return this.sampleFace( faceIndex, targetPosition, targetNormal, targetColor );
 
 		},
 
@@ -156,7 +159,7 @@ var MeshSurfaceSampler = ( function () {
 
 		},
 
-		sampleFace: function ( faceIndex, targetPosition, targetNormal ) {
+		sampleFace: function ( faceIndex, targetPosition, targetNormal, targetColor ) {
 
 			var u = this.randomFunction();
 			var v = this.randomFunction();
@@ -178,7 +181,29 @@ var MeshSurfaceSampler = ( function () {
 				.addScaledVector( _face.b, v )
 				.addScaledVector( _face.c, 1 - ( u + v ) );
 
-			_face.getNormal( targetNormal );
+			if ( targetNormal !== undefined ) {
+
+				_face.getNormal( targetNormal );
+
+			}
+
+			if ( targetColor !== undefined && this.colorAttribute !== undefined ) {
+
+				_face.a.fromBufferAttribute( this.colorAttribute, faceIndex * 3 );
+				_face.b.fromBufferAttribute( this.colorAttribute, faceIndex * 3 + 1 );
+				_face.c.fromBufferAttribute( this.colorAttribute, faceIndex * 3 + 2 );
+
+				_color
+					.set( 0, 0, 0 )
+					.addScaledVector( _face.a, u )
+					.addScaledVector( _face.b, v )
+					.addScaledVector( _face.c, 1 - ( u + v ) );
+
+				targetColor.r = _color.x;
+				targetColor.g = _color.y;
+				targetColor.b = _color.z;
+
+			}
 
 			return this;
 


### PR DESCRIPTION
Related issue: -

**Description**

I have a use case where I want to sample a mesh in order to produce a point cloud. Using `MeshSurfaceSampler` is perfect for this however it does not honor vertex colors. This PR adds the respective support.

It also makes `targetNormal` to an optional parameter since similar to color this value is not always required.
