### PR TITLE
Return XMLHttpRequest in PLYLoader

### DIFF
--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -46,7 +46,7 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
-		loader.load( url, function ( text ) {
+		var request = loader.load( url, function ( text ) {
 
 			try {
 
@@ -69,6 +69,8 @@ THREE.PLYLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 			}
 
 		}, onProgress, onError );
+
+		return request;
 
 	},
 

--- a/examples/jsm/loaders/PLYLoader.d.ts
+++ b/examples/jsm/loaders/PLYLoader.d.ts
@@ -10,7 +10,7 @@ export class PLYLoader extends Loader {
 	constructor( manager?: LoadingManager );
 	propertyNameMapping: object;
 
-	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
+	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : XMLHttpRequest;
 	setPropertyNameMapping( mapping: object ) : void;
 	parse( data: ArrayBuffer | string ) : BufferGeometry;
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -54,7 +54,7 @@ PLYLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
-		loader.load( url, function ( text ) {
+		var request = loader.load( url, function ( text ) {
 
 			try {
 
@@ -78,6 +78,7 @@ PLYLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}, onProgress, onError );
 
+		return request;
 	},
 
 	setPropertyNameMapping: function ( mapping ) {


### PR DESCRIPTION
**Description**

In a similar fashion to PR [6649](https://github.com/mrdoob/three.js/pull/6649), return the XMLHttpRequest on the PLYLoader's load method.