### PR TITLE
Rare uniform bones issue causing skinning malfunction

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1411,6 +1411,12 @@ function WebGLRenderer( parameters ) {
 
 		}
 
+		if ( material.skinning ) {
+
+			materialProperties.maxBones = parameters.maxBones;
+
+		}
+
 		const progUniforms = materialProperties.program.getUniforms();
 		const uniformsList = WebGLUniforms.seqWithValue( progUniforms.seq, uniforms );
 
@@ -1474,6 +1480,10 @@ function WebGLRenderer( parameters ) {
 				initMaterial( material, scene, object );
 
 			} else if ( materialProperties.envMap !== envMap ) {
+
+				initMaterial( material, scene, object );
+
+			} else if ( object.isSkinnedMesh && material.skinning && materialProperties.maxBones < object.skeleton.bones.size ) {
 
 				initMaterial( material, scene, object );
 


### PR DESCRIPTION
When using the same material on multiple `SkinnedMesh`es with different bone counts, sometimes it happens the skinning goes wrong when not using vertex textures. This happens more often for shadows (perhaps because of different object sorting strategy).

The cause of the issue is this:

- bone uniforms are counted in `getMaxBones` called from `initMaterial` / `getParameters`
- `WebGLRenderer.setProgram` currently does not call `initMaterial` when the mesh has a different bone count

When two skinned meshes are rendered after each other, and the second one contains more bones that the first one, the program is not refreshed. This is only a problem when not using vertex textures, because then the `#define MAX_BONES` in the vertex shader source depends on the model being rendered, therefore the shader is no longer valid for the second model (it has `boneMatrices[MAX_BONES]` declared which is unable to store all the matrices needed):

https://github.com/mrdoob/three.js/blob/e57b83acd8f42860559e1dd45ba23c2e16b8ee1d/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js#L36-L43

The fix is:

- stored the result of `getMaxBones` used to create `'#define MAX_BONES ' + parameters.maxBones` into `materialProperties`.
- call `initMaterial` from `setProgram` when the number of the bones is insufficient, similar to how other branches like `materialProperties.outputEncoding !== encoding` are handling such situations. 

The fix should have no effect when vertex textures are in use, as `maxBones` is always 1024 in such configuration.

If there is already the program loaded handling more bones, `initMaterial` is not called. My reasoning was if the program is already loaded which works well with more bones, there is no reason to switch it to a different one.
