### PR TITLE
Added getHand() typing in WebXRManager.d.ts

### DIFF
--- a/src/renderers/webxr/WebXRManager.d.ts
+++ b/src/renderers/webxr/WebXRManager.d.ts
@@ -19,6 +19,7 @@ export class WebXRManager extends EventDispatcher {
 
 	getController( id: number ): Group;
 	getControllerGrip( id: number ): Group;
+	getHand( id: number ): Group;
 	setFramebufferScaleFactor( value: number ): void;
 	setReferenceSpaceType( value: XRReferenceSpaceType ): void;
 	getReferenceSpace(): XRReferenceSpace;


### PR DESCRIPTION


**Missing typings for getHand(index) in WebXRManager**

Using the getHand() would not work in typescript. Added typing.
