### PR TITLE
Editor: Add support for loading DRACO encoded point clouds.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -187,12 +187,27 @@ function Loader( editor ) {
 					loader.setDecoderPath( '../examples/js/libs/draco/' );
 					loader.decodeDracoFile( contents, function ( geometry ) {
 
-						var material = new THREE.MeshStandardMaterial();
+						var object;
 
-						var mesh = new THREE.Mesh( geometry, material );
-						mesh.name = filename;
+						if ( geometry.index !== null ) {
 
-						editor.execute( new AddObjectCommand( editor, mesh ) );
+							var material = new THREE.MeshStandardMaterial();
+
+							object = new THREE.Mesh( geometry, material );
+							object.name = filename;
+
+						} else {
+
+							var material = new THREE.PointsMaterial( { size: 0.01 } );
+
+							if ( geometry.getAttribute( 'color' ) !== undefined ) material.vertexColors = true;
+
+							object = new THREE.Points( geometry, material );
+							object.name = filename;
+
+						}
+
+						editor.execute( new AddObjectCommand( editor, object ) );
 
 					} );
 


### PR DESCRIPTION
Related issue: -

**Description**

AFAIK, DRACO encoded mesh geometries always have an index. If it is missing, it's a point cloud. 

The editor uses now this information to create a point cloud instead of a mesh.