### PR TITLE
Types: Add missing definition of GLTFLoader methods

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -40,6 +40,8 @@ export class GLTFLoader extends Loader {
 	setDRACOLoader( dracoLoader: DRACOLoader ): GLTFLoader;
 	setDDSLoader( ddsLoader: DDSLoader ): GLTFLoader;
 	setKTX2Loader( ktx2Loader: KTX2Loader ): GLTFLoader;
+	setMeshoptDecoder( meshoptDecoder: /* MeshoptDecoder */ any ): GLTFLoader;
+
 	parse( data: ArrayBuffer | string, path: string, onLoad: ( gltf: GLTF ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 
 }

--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -11,6 +11,7 @@ import {
 
 import { DRACOLoader } from './DRACOLoader';
 import { DDSLoader } from './DDSLoader';
+import { KTX2Loader } from './KTX2Loader';
 
 export interface GLTF {
 	animations: AnimationClip[];
@@ -38,6 +39,7 @@ export class GLTFLoader extends Loader {
 	load( url: string, onLoad: ( gltf: GLTF ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	setDRACOLoader( dracoLoader: DRACOLoader ): GLTFLoader;
 	setDDSLoader( ddsLoader: DDSLoader ): GLTFLoader;
+	setKTX2Loader( ktx2Loader: KTX2Loader ): GLTFLoader;
 	parse( data: ArrayBuffer | string, path: string, onLoad: ( gltf: GLTF ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 
 }


### PR DESCRIPTION
See the diff, these are pretty obvious changes of `GLTFLoader.d.ts`

https://github.com/mrdoob/three.js/blob/f43ec7c849d7cecbc4831d152cf6a5d97c45ad3b/examples/jsm/loaders/GLTFLoader.js#L206-L218
