### PR TITLE
3dmLoader: Fix issue when files have many objects

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -830,11 +830,16 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 		//Handle objects
 
-		for ( var i = 0; i < doc.objects().count; i ++ ) {
+		var objs = doc.objects()
+		var cnt = objs.count
 
-			var _object = doc.objects().get( i );
+		for ( var i = 0; i < cnt; i ++ ) {
+
+			var _object = objs.get( i );
 
 			var object = extractObjectData( _object, doc );
+
+			_object.delete();
 
 			if ( object !== undefined ) {
 
@@ -848,8 +853,6 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 				objects.push( object );
 
 			}
-
-			_object.delete();
 
 		}
 

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -830,8 +830,8 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 		//Handle objects
 
-		var objs = doc.objects()
-		var cnt = objs.count
+		var objs = doc.objects();
+		var cnt = objs.count;
 
 		for ( var i = 0; i < cnt; i ++ ) {
 


### PR DESCRIPTION
Related issue: Reported by a Rhino3d user on our discourse.

**Description**

If 3dm files had too many objects, iterating through the object table would eventually result in a null document. This assigns the object table to a variable and tests of documents with over 32k objects load fine.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [McNeel EU](https://www.mcneel.com/eu/).
