### PR TITLE
GLTFLoader: Make KHR_materials_unlit able to be overridden

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -162,7 +162,9 @@ THREE.GLTFLoader = ( function () {
 
 			if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
 
-				this.pluginCallbacks.push( callback );
+				// Insert to the top of the list, prioritizing user defined plugins
+				// See: https://github.com/mrdoob/three.js/issues/20709
+				this.pluginCallbacks.unshift( callback );
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -227,7 +227,9 @@ var GLTFLoader = ( function () {
 
 			if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
 
-				this.pluginCallbacks.push( callback );
+				// Insert to the top of the list, prioritizing user defined plugins
+				// See: https://github.com/mrdoob/three.js/issues/20709
+				this.pluginCallbacks.unshift( callback );
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -78,6 +78,12 @@ var GLTFLoader = ( function () {
 
 		this.register( function ( parser ) {
 
+			return new GLTFMaterialsUnlitExtension( parser );
+
+		} );
+
+		this.register( function ( parser ) {
+
 			return new GLTFMaterialsClearcoatExtension( parser );
 
 		} );
@@ -320,10 +326,6 @@ var GLTFLoader = ( function () {
 					var extensionsRequired = json.extensionsRequired || [];
 
 					switch ( extensionName ) {
-
-						case EXTENSIONS.KHR_MATERIALS_UNLIT:
-							extensions[ extensionName ] = new GLTFMaterialsUnlitExtension();
-							break;
 
 						case EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS:
 							extensions[ extensionName ] = new GLTFMaterialsPbrSpecularGlossinessExtension();
@@ -571,47 +573,36 @@ var GLTFLoader = ( function () {
 	 *
 	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit
 	 */
-	function GLTFMaterialsUnlitExtension() {
+	function GLTFMaterialsUnlitExtension( parser ) {
 
+		this.parser = parser;
 		this.name = EXTENSIONS.KHR_MATERIALS_UNLIT;
 
 	}
 
-	GLTFMaterialsUnlitExtension.prototype.getMaterialType = function () {
+	GLTFMaterialsUnlitExtension.prototype.getMaterialType = function ( materialIndex ) {
+
+		var parser = this.parser;
+		var materialDef = parser.json.materials[ materialIndex ];
+
+		if ( ! materialDef.extensions || ! materialDef.extensions[ this.name ] ) return null;
 
 		return MeshBasicMaterial;
 
 	};
 
-	GLTFMaterialsUnlitExtension.prototype.extendParams = function ( materialParams, materialDef, parser ) {
+	GLTFMaterialsUnlitExtension.prototype.extendMaterialParams = function ( materialIndex, materialParams ) {
 
-		var pending = [];
+		var parser = this.parser;
+		var materialDef = parser.json.materials[ materialIndex ];
 
-		materialParams.color = new Color( 1.0, 1.0, 1.0 );
-		materialParams.opacity = 1.0;
+		if ( ! materialDef.extensions || ! materialDef.extensions[ this.name ] ) return null;
 
-		var metallicRoughness = materialDef.pbrMetallicRoughness;
+		// Removing material params that is not required to supress warnings.
+		delete materialParams.metalness;
+		delete materialParams.roughness;
 
-		if ( metallicRoughness ) {
-
-			if ( Array.isArray( metallicRoughness.baseColorFactor ) ) {
-
-				var array = metallicRoughness.baseColorFactor;
-
-				materialParams.color.fromArray( array );
-				materialParams.opacity = array[ 3 ];
-
-			}
-
-			if ( metallicRoughness.baseColorTexture !== undefined ) {
-
-				pending.push( parser.assignTexture( materialParams, 'map', metallicRoughness.baseColorTexture ) );
-
-			}
-
-		}
-
-		return Promise.all( pending );
+		return Promise.resolve();
 
 	};
 
@@ -2773,12 +2764,6 @@ var GLTFLoader = ( function () {
 			var sgExtension = extensions[ EXTENSIONS.KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS ];
 			materialType = sgExtension.getMaterialType();
 			pending.push( sgExtension.extendParams( materialParams, materialDef, parser ) );
-
-		} else if ( materialExtensions[ EXTENSIONS.KHR_MATERIALS_UNLIT ] ) {
-
-			var kmuExtension = extensions[ EXTENSIONS.KHR_MATERIALS_UNLIT ];
-			materialType = kmuExtension.getMaterialType();
-			pending.push( kmuExtension.extendParams( materialParams, materialDef, parser ) );
 
 		} else {
 


### PR DESCRIPTION
Will close #20709 

### What I did

- Replaced hardcoded behavior of `KHR_materials_unlit` with plugin system introduced in #19144 .
    - Current behavior completely ignores `getMaterialType` and `extendMaterialParams` of any plugin when `KHR_materials_unlit` exists in a material.
- `GLTFLoader.register` now registers the given plugin callback to the top of its plugin callback list instead of last.
    - Which means, GLTFLoader's plugin system now prioritizes user defined plugins than builtin ones.

### Motivation

As I mentioned in #20709, I want to load our own custom glTF material using GLTFLoader.
However, the glTF still have `KHR_materials_unlit` as a fallback, which is prioritized than any plugins registered.
With these changes, I can override the behavior of `KHR_materials_unlit`.

### Points need review

- `GLTFMaterialsUnlitExtension.extendMaterialParams` , does the "Removing material params" part look good?
- There still are parts that says `materialType !== MeshBasicMaterial` . I don't know how I can resolve this
