### PR TITLE
Make 'isPlaying' flag consider the delay

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -113,7 +113,7 @@ class Audio extends Object3D {
 		source.onended = this.onEnded.bind( this );
 		source.start( this._startedAt, this._progress + this.offset, this.duration );
 
-		this.isPlaying = true;
+		setTimeout( () => { this.isPlaying = true; }, delay * 1000);
 
 		this.source = source;
 


### PR DESCRIPTION
Hello,

The `isPlaying` flag of Audio class is set right whenever play() is called. This does not consider the possible 'delay' in the playing. If you need to check whether a file is actually playing or not yet you then have no consistent information.
This can be critical especially when you are scheduling several files in advance as I am doing in my current project.

I suggest correcting this by scheduling also the modification of the `isPlaying` flag.
NB: javascript `setTimeout()` method uses an argument in milliseconds while the THREE `play()` takes delay in second. Hence the 1000 factor.

This is my first pull request so I have no idea if this is the "correct" and efficient way to do it. Please, let me know and I will adapt.

Thank's

BenCello
