### PR TITLE
ObjectLoader: Ensure onLoad() is fired for DataTextures.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -138,9 +138,24 @@ class ObjectLoader extends Loader {
 
 		}
 
-		if ( json.images === undefined || json.images.length === 0 ) {
+		//
 
-			if ( onLoad !== undefined ) onLoad( object );
+		if ( onLoad !== undefined ) {
+
+			let hasImages = false;
+
+			for ( const uuid in images ) {
+
+				if ( images[ uuid ] instanceof HTMLImageElement ) {
+
+					hasImages = true;
+					break;
+
+				}
+
+			}
+
+			if ( hasImages === false ) onLoad( object );
 
 		}
 


### PR DESCRIPTION
Related issue: Follow-up of #17745.

**Description**

During testing in the editor, I've overlooked a use case in #17745. When a JSON only contains data textures and no instances of `HTMLImageElement`, `onLoad()` is currently not fired. That happens because of this line:
```js
if ( json.images === undefined || json.images.length === 0 ) {
```
The loader calls no `onLoad()` since it will be called when loading images via the internal `ImageLoader`. However, data textures don't use image loader which means `ObjectLoader.parse()` needs a different check.