### PR TITLE
Object3D: Add animations property.

### DIFF
--- a/docs/api/ar/animation/AnimationClip.html
+++ b/docs/api/ar/animation/AnimationClip.html
@@ -72,6 +72,11 @@
 			يضبط [page:.duration duration] للمقطع على أطول مدة [page:KeyframeTrack] ممكنة.
 		</p>
 
+		<h3>[method:Object toJSON]()</h3>
+		<p>
+			Returns a JSON object representing the serialized animation clip.
+		</p>
+
 		<h3>[method:this trim]()</h3>
 		<p>
 			اقتطاع كل المسارات حسب مدة المقطع.

--- a/docs/api/en/animation/AnimationClip.html
+++ b/docs/api/en/animation/AnimationClip.html
@@ -82,6 +82,11 @@
 			[page:KeyframeTrack].
 		</p>
 
+		<h3>[method:Object toJSON]()</h3>
+		<p>
+			Returns a JSON object representing the serialized animation clip.
+		</p>
+
 		<h3>[method:this trim]()</h3>
 		<p>
 			Trims all tracks to the clip's duration.

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -29,6 +29,9 @@
 
 		<h2>Properties</h2>
 
+		<h3>[property:AnimationClip animations]</h3>
+		<p>Array with object's animation clips.</p>
+
 		<h3>[property:Boolean castShadow]</h3>
 		<p>Whether the object gets rendered into shadow map. Default is *false*.</p>
 

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -130,9 +130,12 @@
 		This is used [page:.parse] to parse any textures in the JSON structure.
 		</p>
 
-		<h3>[method:Object3D parseObject]( [param:Object json] )</h3>
+		<h3>[method:Object3D parseObject]( [param:Object json], [param:BufferGeometry geometries], [param:Material materials], [param:AnimationClip animations] )</h3>
 		<p>
-		[page:Object json] — required. The JSON source to parse.<br /><br />
+		[page:Object json] — required. The JSON source to parse.<br />
+		[page:BufferGeometry geometries] — required. The geometries of the JSON.<br />
+		[page:Material materials] — required. The materials of the JSON.<br />
+		[page:AnimationClip animations] — required. The animations of the JSON.<br /><br />
 
 		This is used [page:.parse] to parse any objects in the JSON structure.
 		Objects can be of the following types:

--- a/docs/api/zh/animation/AnimationClip.html
+++ b/docs/api/zh/animation/AnimationClip.html
@@ -74,6 +74,11 @@
 			将剪辑的持续时间（[page:.duration duration]）设为最长的关键帧轨道([page:KeyframeTrack])的持续时间。
 		</p>
 
+		<h3>[method:Object toJSON]()</h3>
+		<p>
+			Returns a JSON object representing the serialized animation clip.
+		</p>
+
 		<h3>[method:this trim]()</h3>
 		<p>
 			修剪所有的轨道到该剪辑的持续时间。

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -29,6 +29,9 @@
 
 	<h2>属性</h2>
 
+	<h3>[property:AnimationClip animations]</h3>
+	<p>Array with object's animation clips.</p>
+
 	<h3>[property:Boolean castShadow]</h3>
 	<p>对象是否被渲染到阴影贴图中。默认值为*false*。</p>
 

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -128,9 +128,12 @@
 			此函数通过[page:.parse]来解析JSON结构中任意纹理。
 		</p>
 
-		<h3>[method:Object3D parseObject]( [param:Object json] )</h3>
+		<h3>[method:Object3D parseObject]( [param:Object json], [param:BufferGeometry geometries], [param:Material materials], [param:AnimationClip animations] )</h3>
 		<p>
-		[page:Object json] —  必选参数，需要被解析的JSON源。<br /><br />
+		[page:Object json] —  必选参数，需要被解析的JSON源。<br />
+		[page:BufferGeometry geometries] — required. The geometries of the JSON.<br />
+		[page:Material materials] — required. The materials of the JSON.<br />
+		[page:AnimationClip animations] — required. The animations of the JSON.<br /><br />
 
 			此函数通过[page:.parse]来解析JSON结构中任意对象。
 		对象可以为如下类型：

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -105,7 +105,6 @@ function Editor() {
 
 	this.materialsRefCounter = new Map(); // tracks how often is a material used by a 3D object
 
-	this.animations = {};
 	this.mixer = new THREE.AnimationMixer( this.scene );
 
 	this.selected = null;
@@ -354,16 +353,6 @@ Editor.prototype = {
 	addTexture: function ( texture ) {
 
 		this.textures[ texture.uuid ] = texture;
-
-	},
-
-	addAnimations: function ( object, animations ) {
-
-		if ( animations.length > 0 ) {
-
-			this.animations[ object.uuid ] = animations;
-
-		}
 
 	},
 
@@ -664,49 +653,9 @@ Editor.prototype = {
 
 		} );
 
-		// animations
-
-		var animationsJSON = json.animations;
-
-		for ( var i = 0; i < animationsJSON.length; i ++ ) {
-
-			var objectJSON = animationsJSON[ i ];
-			var animations = [];
-
-			for ( var j = 0; j < objectJSON.animations.length; j ++ ) {
-
-				animations.push( THREE.AnimationClip.parse( objectJSON.animations[ j ] ) );
-
-			}
-
-			this.animations[ objectJSON.uuid ] = animations;
-
-		}
-
 	},
 
 	toJSON: function () {
-
-		// animations
-
-		var animations = this.animations;
-		var animationsJSON = [];
-
-		for ( var entry in animations ) {
-
-			var objectAnimations = animations[ entry ];
-			var objectJSON = { uuid: entry, animations: [] };
-
-			for ( var i = 0; i < objectAnimations.length; i ++ ) {
-
-				var objectAnimation = objectAnimations[ i ];
-				objectJSON.animations.push( THREE.AnimationClip.toJSON( objectAnimation ) );
-
-			}
-
-			animationsJSON.push( objectJSON );
-
-		}
 
 		// scripts clean up
 
@@ -741,8 +690,7 @@ Editor.prototype = {
 			camera: this.camera.toJSON(),
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
-			history: this.history.toJSON(),
-			animations: animationsJSON
+			history: this.history.toJSON()
 
 		};
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -170,7 +170,7 @@ function Loader( editor ) {
 
 					collada.scene.name = filename;
 
-					editor.addAnimations( collada.scene, collada.animations );
+					collada.scene.animations.push( ...collada.animations );
 					editor.execute( new AddObjectCommand( editor, collada.scene ) );
 
 				}, false );
@@ -226,7 +226,6 @@ function Loader( editor ) {
 					var loader = new FBXLoader( manager );
 					var object = loader.parse( contents );
 
-					editor.addAnimations( object, object.animations );
 					editor.execute( new AddObjectCommand( editor, object ) );
 
 				}, false );
@@ -250,7 +249,7 @@ function Loader( editor ) {
 						var scene = result.scene;
 						scene.name = filename;
 
-						editor.addAnimations( scene, result.animations );
+						scene.animations.push( ...result.animations );
 						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
@@ -287,7 +286,7 @@ function Loader( editor ) {
 						var scene = result.scene;
 						scene.name = filename;
 
-						editor.addAnimations( scene, result.animations );
+						scene.animations.push( ...result.animations );
 						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
@@ -386,7 +385,7 @@ function Loader( editor ) {
 					mesh.mixer = new THREE.AnimationMixer( mesh );
 					mesh.name = filename;
 
-					editor.addAnimations( mesh, geometry.animations );
+					mesh.animations.push( ...geometry.animations );
 					editor.execute( new AddObjectCommand( editor, mesh ) );
 
 				}, false );
@@ -720,7 +719,7 @@ function Loader( editor ) {
 
 						var scene = result.scene;
 
-						editor.addAnimations( scene, result.animations );
+						scene.animations.push( ...result.animations );
 						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );
@@ -738,7 +737,7 @@ function Loader( editor ) {
 
 						var scene = result.scene;
 
-						editor.addAnimations( scene, result.animations );
+						scene.animations.push( ...result.animations );
 						editor.execute( new AddObjectCommand( editor, scene ) );
 
 					} );

--- a/editor/js/Sidebar.Animation.js
+++ b/editor/js/Sidebar.Animation.js
@@ -10,9 +10,9 @@ function SidebarAnimation( editor ) {
 
 	signals.objectSelected.add( function ( object ) {
 
-		var animations = editor.animations[ object !== null ? object.uuid : '' ];
+		if ( object !== null && object.animations.length > 0 ) {
 
-		if ( animations !== undefined ) {
+			var animations = object.animations;
 
 			container.setDisplay( '' );
 
@@ -42,9 +42,7 @@ function SidebarAnimation( editor ) {
 
 	signals.objectRemoved.add( function ( object ) {
 
-		var animations = editor.animations[ object !== null ? object.uuid : '' ];
-
-		if ( animations !== undefined ) {
+		if ( object !== null && object.animations.length > 0 ) {
 
 			mixer.uncacheRoot( object );
 

--- a/src/animation/AnimationClip.d.ts
+++ b/src/animation/AnimationClip.d.ts
@@ -27,6 +27,7 @@ export class AnimationClip {
 	validate(): boolean;
 	optimize(): AnimationClip;
 	clone(): AnimationClip;
+	toJSON( clip: AnimationClip ): any;
 
 	static CreateFromMorphTargetSequence(
 		name: string,

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -118,7 +118,10 @@ Object.assign( AnimationClip, {
 
 		}
 
-		return new AnimationClip( json.name, json.duration, tracks, json.blendMode );
+		const clip = new AnimationClip( json.name, json.duration, tracks, json.blendMode );
+		clip.uuid = json.uuid;
+
+		return clip;
 
 	},
 
@@ -459,6 +462,12 @@ Object.assign( AnimationClip.prototype, {
 		}
 
 		return new AnimationClip( this.name, this.duration, tracks, this.blendMode );
+
+	},
+
+	toJSON: function () {
+
+		return AnimationClip.toJSON( this );
 
 	}
 

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -14,6 +14,7 @@ import { Raycaster } from './Raycaster';
 import { EventDispatcher } from './EventDispatcher';
 import { BufferGeometry } from './BufferGeometry';
 import { Intersection } from './Raycaster';
+import { AnimationClip } from '../animation/AnimationClip';
 
 /**
  * Base class for scene graph objects
@@ -152,6 +153,12 @@ export class Object3D extends EventDispatcher {
 	 * @default 0
 	 */
 	renderOrder: number;
+
+	/**
+	 * Array with animation clips.
+	 * @default []
+	 */
+	animations: AnimationClip[];
 
 	/**
 	 * An object that can be used to store custom data about the Object3d. It should not hold references to functions as these will not be cloned.

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -103,6 +103,8 @@ function Object3D() {
 	this.frustumCulled = true;
 	this.renderOrder = 0;
 
+	this.animations = [];
+
 	this.userData = {};
 
 }
@@ -659,7 +661,8 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 				textures: {},
 				images: {},
 				shapes: {},
-				skeletons: {}
+				skeletons: {},
+				animations: {}
 			};
 
 			output.metadata = {
@@ -795,6 +798,22 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		}
 
+		//
+
+		if ( this.animations.length > 0 ) {
+
+			object.animations = [];
+
+			for ( let i = 0; i < this.animations.length; i ++ ) {
+
+				const animation = this.animations[ i ];
+
+				object.animations.push( serialize( meta.animations, animation ) );
+
+			}
+
+		}
+
 		if ( isRootObject ) {
 
 			const geometries = extractFromCache( meta.geometries );
@@ -803,6 +822,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			const images = extractFromCache( meta.images );
 			const shapes = extractFromCache( meta.shapes );
 			const skeletons = extractFromCache( meta.skeletons );
+			const animations = extractFromCache( meta.animations );
 
 			if ( geometries.length > 0 ) output.geometries = geometries;
 			if ( materials.length > 0 ) output.materials = materials;
@@ -810,6 +830,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			if ( images.length > 0 ) output.images = images;
 			if ( shapes.length > 0 ) output.shapes = shapes;
 			if ( skeletons.length > 0 ) output.skeletons = skeletons;
+			if ( animations.length > 0 ) output.animations = animations;
 
 		}
 

--- a/src/loaders/ObjectLoader.d.ts
+++ b/src/loaders/ObjectLoader.d.ts
@@ -27,7 +27,8 @@ export class ObjectLoader extends Loader {
 	parseObject<T extends Object3D>(
 		data: any,
 		geometries: any[],
-		materials: Material[]
+		materials: Material[],
+		animations: AnimationClip[]
 	): T;
 
 }

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -115,6 +115,7 @@ class ObjectLoader extends Loader {
 
 	parse( json, onLoad ) {
 
+		const animations = this.parseAnimations( json.animations );
 		const shapes = this.parseShapes( json.shapes );
 		const geometries = this.parseGeometries( json.geometries, shapes );
 
@@ -127,16 +128,10 @@ class ObjectLoader extends Loader {
 		const textures = this.parseTextures( json.textures, images );
 		const materials = this.parseMaterials( json.materials, textures );
 
-		const object = this.parseObject( json.object, geometries, materials );
+		const object = this.parseObject( json.object, geometries, materials, animations );
 		const skeletons = this.parseSkeletons( json.skeletons, object );
 
 		this.bindSkeletons( object, skeletons );
-
-		if ( json.animations ) {
-
-			object.animations = this.parseAnimations( json.animations );
-
-		}
 
 		//
 
@@ -554,17 +549,19 @@ class ObjectLoader extends Loader {
 
 	parseAnimations( json ) {
 
-		const animations = [];
+		const animations = {};
 
-		for ( let i = 0; i < json.length; i ++ ) {
+		if ( json !== undefined ) {
 
-			const data = json[ i ];
+			for ( let i = 0; i < json.length; i ++ ) {
 
-			const clip = AnimationClip.parse( data );
+				const data = json[ i ];
 
-			if ( data.uuid !== undefined ) clip.uuid = data.uuid;
+				const clip = AnimationClip.parse( data );
 
-			animations.push( clip );
+				animations[ clip.uuid ] = clip;
+
+			}
 
 		}
 
@@ -788,7 +785,7 @@ class ObjectLoader extends Loader {
 
 	}
 
-	parseObject( data, geometries, materials ) {
+	parseObject( data, geometries, materials, animations ) {
 
 		let object;
 
@@ -1071,7 +1068,21 @@ class ObjectLoader extends Loader {
 
 			for ( let i = 0; i < children.length; i ++ ) {
 
-				object.add( this.parseObject( children[ i ], geometries, materials ) );
+				object.add( this.parseObject( children[ i ], geometries, materials, animations ) );
+
+			}
+
+		}
+
+		if ( data.animations !== undefined ) {
+
+			const objectAnimations = data.animations;
+
+			for ( let i = 0; i < objectAnimations.length; i ++ ) {
+
+				const uuid = objectAnimations[ i ];
+
+				object.animations.push( animations[ uuid ] );
 
 			}
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/16234#issuecomment-731717434

**Description**

Animation clips of a 3D object can now be stored in `Object3D.animations`. This makes it possible to serialize/deserialize them as well as an easier integration of animation playback in the editor.
