### PR TITLE
TS: Object3D.quaternion description fix

### DIFF
--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -75,7 +75,7 @@ export class Object3D extends EventDispatcher {
 	readonly rotation: Euler;
 
 	/**
-	 * Global rotation.
+	 * Object's local rotation as a Quaternion.
 	 * @default new THREE.Quaternion()
 	 */
 	readonly quaternion: Quaternion;


### PR DESCRIPTION
**Description**

The `Object3D.d.ts` description for `Object3D.quaternion` currently says the property is the *global* quaternion. 

This change aligns the description with [the docs](https://threejs.org/docs/#api/en/core/Object3D), that it is the *local* Quaternion.
https://threejs.org/docs/#api/en/core/Object3D

New to Three in general, please let me know if I'm missing something obvious with this 😄 