### PR TITLE
Editor: Clean up.

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -483,9 +483,7 @@ function MenubarFile( editor ) {
 
 		scene.traverse( function ( object ) {
 
-			var objectAnimations = editor.animations[ object.uuid ];
-
-			if ( objectAnimations !== undefined ) animations.push( ... objectAnimations );
+			animations.push( ... object.animations );
 
 		} );
 


### PR DESCRIPTION
Related issue: Follow up of #20738.

**Description**

Removed a remaining reference to `Editor.animations`.