### PR TITLE
Editor: Trigger rendering when animation is stopped.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -79,7 +79,9 @@ function Editor() {
 		refreshSidebarObject3D: new Signal(),
 		historyChanged: new Signal(),
 
-		viewportCameraChanged: new Signal()
+		viewportCameraChanged: new Signal(),
+
+		animationStopped: new Signal()
 
 	};
 

--- a/editor/js/Sidebar.Animation.js
+++ b/editor/js/Sidebar.Animation.js
@@ -60,6 +60,8 @@ function SidebarAnimation( editor ) {
 
 		actions[ animationsSelect.getValue() ].stop();
 
+		signals.animationStopped.dispatch();
+
 	}
 
 	function changeTimeScale() {

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -511,6 +511,12 @@ function Viewport( editor ) {
 
 	} );
 
+	signals.animationStopped.add( function () {
+
+		render();
+
+	} );
+
 	// background
 
 	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture, backgroundEquirectangularTexture, environmentType ) {


### PR DESCRIPTION
Related issue: -

**Description**

When stoping an animation, the model will return to its T-Post but only when an action is performed that triggers a rendering (e.g. transform the camera). This PR ensures to immediately refresh the rendering when an animation is stopped.
