### PR TITLE
OBJLoader: Only add color attribute if necessary.

### DIFF
--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -875,7 +875,7 @@ THREE.OBJLoader = ( function () {
 
 					buffergeometry.setAttribute( 'position', new THREE.Float32BufferAttribute( state.vertices, 3 ) );
 
-					if ( state.colors.length > 0 ) {
+					if ( state.colors.length > 0 && state.colors[ 0 ] !== undefined ) {
 
 						buffergeometry.setAttribute( 'color', new THREE.Float32BufferAttribute( state.colors, 3 ) );
 						material.vertexColors = true;

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -891,7 +891,7 @@ var OBJLoader = ( function () {
 
 					buffergeometry.setAttribute( 'position', new Float32BufferAttribute( state.vertices, 3 ) );
 
-					if ( state.colors.length > 0 ) {
+					if ( state.colors.length > 0 && state.colors[ 0 ] !== undefined ) {
 
 						buffergeometry.setAttribute( 'color', new Float32BufferAttribute( state.colors, 3 ) );
 						material.vertexColors = true;


### PR DESCRIPTION
Related issue: Small fix for #20724.

**Description**

Ensures the new code path only adds a color attribute if valid color values are actually defined.
