### PR TITLE
ColladaLoader: Use Object3D.animations.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -170,7 +170,6 @@ function Loader( editor ) {
 
 					collada.scene.name = filename;
 
-					collada.scene.animations.push( ...collada.animations );
 					editor.execute( new AddObjectCommand( editor, collada.scene ) );
 
 				}, false );

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -3955,6 +3955,7 @@ THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 		setupKinematics();
 
 		var scene = parseScene( getElementsByTagName( collada, 'scene' )[ 0 ] );
+		scene.animations = animations;
 
 		if ( asset.upAxis === 'Z_UP' ) {
 
@@ -3965,7 +3966,12 @@ THREE.ColladaLoader.prototype = Object.assign( Object.create( THREE.Loader.proto
 		scene.scale.multiplyScalar( asset.unit );
 
 		return {
-			animations: animations,
+			get animations() {
+
+				console.warn( 'THREE.ColladaLoader: Please access animations over scene.animations now.' );
+				return animations;
+
+			},
 			kinematics: kinematics,
 			library: library,
 			scene: scene

--- a/examples/jsm/loaders/ColladaLoader.d.ts
+++ b/examples/jsm/loaders/ColladaLoader.d.ts
@@ -7,7 +7,6 @@ import {
 
 
 export interface Collada {
-	animations: AnimationClip[];
 	kinematics: object;
 	library: object;
 	scene: Scene;

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -3995,6 +3995,7 @@ ColladaLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		setupKinematics();
 
 		var scene = parseScene( getElementsByTagName( collada, 'scene' )[ 0 ] );
+		scene.animations = animations;
 
 		if ( asset.upAxis === 'Z_UP' ) {
 
@@ -4005,7 +4006,12 @@ ColladaLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		scene.scale.multiplyScalar( asset.unit );
 
 		return {
-			animations: animations,
+			get animations() {
+
+				console.warn( 'THREE.ColladaLoader: Please access animations over scene.animations now.' );
+				return animations;
+
+			},
 			kinematics: kinematics,
 			library: library,
 			scene: scene

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -45,8 +45,8 @@
 				const loader = new ColladaLoader();
 				loader.load( './models/collada/stormtrooper/stormtrooper.dae', function ( collada ) {
 
-					const animations = collada.animations;
 					const avatar = collada.scene;
+					const animations = avatar.animations;
 
 					avatar.traverse( function ( node ) {
 


### PR DESCRIPTION
Related issue: #20738

**Description**

Since `Object3D.animations` is now available, I suggest to migrate all loaders to use the new property (`FBXLoader` already uses this approach). In this way, no separate property in the result object is necessary anymore. Besides, the editor (and potentially other software) can lookup animation clips at a common place. 

The change in `ColladaLoader` is backwards compatible by introducing a getter for the old `animations` property. This could be removed after a few releases.

If the PR gets merged, I'll change the remaining loaders in the same fashion.