### PR TITLE
tweak shadow examples tags

### DIFF
--- a/examples/tags.json
+++ b/examples/tags.json
@@ -1,5 +1,5 @@
 {
-	"webgl_animation_cloth": [ "physics", "integration" ],
+	"webgl_animation_cloth": [ "physics", "integration", "shadow" ],
 	"webgl_clipping": [ "solid" ],
 	"webgl_clipping_advanced": [ "solid" ],
 	"webgl_clipping_intersection": [ "solid" ],
@@ -37,7 +37,7 @@
 	"webgl_materials_channels": [ "normal", "depth", "rgba packing" ],
 	"webgl_materials_cubemap_mipmaps": [ "envmap" ],
 	"webgl_materials_envmaps_parallax": [ "onBeforeCompile" ],
-	"webgl_materials_lightmap": [ "shadows" ],
+	"webgl_materials_lightmap": [ "shadow" ],
 	"webgl_materials_physical_clearcoat": [ "anisotropy" ],
 	"webgl_materials_physical_transmission": [ "alpha" ],
 	"webgl_materials_shaders_fresnel": [ "refraction" ],


### PR DESCRIPTION
Related issue: #18700

This fixes two issues with shadow examples tags,

1st, if you search for "shadow**s̲**", all shadow examples but webgl_materials_lightmap disappear - so this unifies that behavior;

2nd, an important example is removed from search results if you search for "shadow":
![Screen Shot 2020-11-27 at 9 56 29 ](https://user-images.githubusercontent.com/242577/100432068-59397780-3099-11eb-9225-39565015a6e1.png)
