### PR TITLE
SAOPass typing fix

### DIFF
--- a/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/examples/jsm/postprocessing/SAOPass.d.ts
@@ -13,8 +13,16 @@ import {
 
 import { Pass } from './Pass';
 
+export enum OUTPUT {
+	Beauty,
+	Default,
+	SAO,
+	Depth,
+	Normal
+}
+
 interface SAOPassParams {
-	output: SAOPass.OUTPUT;
+	output: OUTPUT;
 	saoBias: number;
 	saoIntensity: number;
 	saoScale: number;
@@ -52,13 +60,7 @@ export class SAOPass extends Pass {
 	fsQuad: object;
 	params: SAOPassParams;
 
-	static OUTPUT: {
-		Beauty: number;
-		Default: number;
-		SAO: number;
-		Depth: number;
-		Normal: number;
-	};
+	static OUTPUT: OUTPUT;
 
 	renderPass( renderer: WebGLRenderer, passMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;
 	renderOverride( renderer: WebGLRenderer, overrideMaterial: Material, renderTarget: WebGLRenderTarget, clearColor?: Color | string | number, clearAlpha?: number ): void;


### PR DESCRIPTION
Related issue: Fixed #20769.

**Description**

Replacing OUTPUT js object with a typescript Enum as type. 
Removes the typings error
