### PR TITLE
TS: Clean up WebGLRenderer.

### DIFF
--- a/src/renderers/WebGLRenderer.d.ts
+++ b/src/renderers/WebGLRenderer.d.ts
@@ -192,11 +192,6 @@ export class WebGLRenderer implements Renderer {
 	toneMappingExposure: number;
 
 	/**
-	 * @default false
-	 */
-	shadowMapDebug: boolean;
-
-	/**
 	 * @default 8
 	 */
 	maxMorphTargets: number;


### PR DESCRIPTION
Related issue: -

**Description**

`shadowMapDebug` seems to be a left-over from older days.