### PR TITLE
one word edit of mistake in How-to-dispose-of-objects.html

### DIFF
--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -80,7 +80,7 @@
 
 	<p>
 		Yes. It's possible to evaluate [page:WebGLRenderer.info], a special property of the renderer with a series of statistical information about the graphics board memory
-		and the rendering process. Among other things, it tells you have many textures, geometries and shader programs are internally stored. If you notice performance problems
+		and the rendering process. Among other things, it tells you how many textures, geometries and shader programs are internally stored. If you notice performance problems
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 


### PR DESCRIPTION
**Description**
"have" should be "how".
