### PR TITLE
Tests: Add Console wrapper to introduce logging level to console for unit tests

### DIFF
--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -2,6 +2,7 @@
 
 import { Color } from '../../../../src/math/Color';
 import { eps } from './Constants.tests';
+import { CONSOLE_LEVEL } from '../../utils/console-wrapper';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -483,7 +484,11 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "setStyleRGBARed", ( assert ) => {
 
 			var c = new Color();
+
+			console.level = CONSOLE_LEVEL.ERROR;
 			c.setStyle( 'rgba(255,0,0,0.5)' );
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			assert.ok( c.r == 1, "Red: " + c.r );
 			assert.ok( c.g === 0, "Green: " + c.g );
 			assert.ok( c.b === 0, "Blue: " + c.b );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -1,3 +1,4 @@
+import './utils/console-wrapper.js';
 import './utils/qunit-utils.js';
 
 //src

--- a/test/unit/utils/console-wrapper.js
+++ b/test/unit/utils/console-wrapper.js
@@ -12,11 +12,11 @@
 
 export const CONSOLE_LEVEL = {
 	OFF : 0,
-    ERROR : 1,
-    WARN : 2,
-    LOG : 3,
-    INFO : 4,
-    DEBUG : 5,
+	ERROR : 1,
+	WARN : 2,
+	LOG : 3,
+	INFO : 4,
+	DEBUG : 5,
 	ALL: 6,
 	DEFAULT: 6
 };
@@ -32,21 +32,31 @@ console._debug = console.debug;
 
 // Wrap console methods
 console.error = function () {
-  if (this.level >= CONSOLE_LEVEL.ERROR) this._error.apply(this, arguments);
+
+	if ( this.level >= CONSOLE_LEVEL.ERROR ) this._error.apply( this, arguments );
+
 };
 
 console.warn = function () {
-  if (this.level >= CONSOLE_LEVEL.WARN) this._warn.apply(this, arguments);
+
+	if ( this.level >= CONSOLE_LEVEL.WARN ) this._warn.apply( this, arguments );
+
 };
 
 console.log = function () {
-  if (this.level >= CONSOLE_LEVEL.LOG) this._log.apply(this, arguments);
+
+	if ( this.level >= CONSOLE_LEVEL.LOG ) this._log.apply( this, arguments );
+
 };
 
 console.info = function () {
-  if (this.level >= CONSOLE_LEVEL.INFO) this._info.apply(this, arguments);
+
+	if ( this.level >= CONSOLE_LEVEL.INFO ) this._info.apply( this, arguments );
+
 };
 
 console.debug = function () {
-  if (this.level >= CONSOLE_LEVEL.DEBUG) this._debug.apply(this, arguments);
+
+	if ( this.level >= CONSOLE_LEVEL.DEBUG ) this._debug.apply( this, arguments );
+
 };

--- a/test/unit/utils/console-wrapper.js
+++ b/test/unit/utils/console-wrapper.js
@@ -1,0 +1,52 @@
+// This easy console wrapper introduces the logging level to console for
+// preventing console outputs caused when we purposely test the code path
+// including console outputs.
+//
+// Example: Prevent the console warnings caused by Color.setStyle().
+//   const c = new Color();
+//   console.level = CONSOLE_LEVEL.ERROR;
+//   c.setStyle( 'rgba(255,0,0,0.5)' );
+//   console.level = CONSOLE_LEVEL.DEFAULT;
+//
+// See https://github.com/mrdoob/three.js/issues/20760#issuecomment-735190998
+
+export const CONSOLE_LEVEL = {
+	OFF : 0,
+    ERROR : 1,
+    WARN : 2,
+    LOG : 3,
+    INFO : 4,
+    DEBUG : 5,
+	ALL: 6,
+	DEFAULT: 6
+};
+
+console.level = CONSOLE_LEVEL.DEFAULT;
+
+// Save the original methods
+console._error = console.error;
+console._warn = console.warn;
+console._log = console.log;
+console._info = console.info;
+console._debug = console.debug;
+
+// Wrap console methods
+console.error = function () {
+  if (this.level >= CONSOLE_LEVEL.ERROR) this._error.apply(this, arguments);
+};
+
+console.warn = function () {
+  if (this.level >= CONSOLE_LEVEL.WARN) this._warn.apply(this, arguments);
+};
+
+console.log = function () {
+  if (this.level >= CONSOLE_LEVEL.LOG) this._log.apply(this, arguments);
+};
+
+console.info = function () {
+  if (this.level >= CONSOLE_LEVEL.INFO) this._info.apply(this, arguments);
+};
+
+console.debug = function () {
+  if (this.level >= CONSOLE_LEVEL.DEBUG) this._debug.apply(this, arguments);
+};


### PR DESCRIPTION
Related issue: #20760

**Description**

I suggested in #20760 that we should resolve the root issues of console warnings caused in the unit tests and make the result log clearer.

But as [@Mugen87 mentioned](https://github.com/mrdoob/three.js/issues/20760#issuecomment-734204561), some of them are on purpose. They test the code path including console warnings. And he suggested we could consider to monkey-patch console to prevent such console warnings.

This PR adds an easy console wrapper to introduce logging level to console for the unit tests to prevent console warning when we test the code path including console warnings [as I suggested](https://github.com/mrdoob/three.js/issues/20760#issuecomment-735190998)

Example:
```
const c = new Color();
console.level = CONSOLE_LEVEL.ERROR;
c.setStyle( 'rgba(255,0,0,0.5)' );
console.level = CONSOLE_LEVEL.DEFAULT;
```

Let me know if there is any nicer ways or existing libraries.