### PR TITLE
Docs: Add EXT_meshopt_compression to GLTFLoader extension support list

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -37,6 +37,7 @@
 			<li>KHR_texture_basisu <i>(experimental)</i></li>
 			<li>KHR_texture_transform<sup>2</sup></li>
 			<li>EXT_texture_webp</li>
+			<li>EXT_meshopt_compression</li>
 			<li>MSFT_texture_dds</li>
 		</ul>
 

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -35,6 +35,7 @@
 			<li>KHR_texture_basisu <i>(experimental)</i></li>
 			<li>KHR_texture_transform<sup>2</sup></li>
 			<li>EXT_texture_webp</li>
+			<li>EXT_meshopt_compression</li>
 			<li>MSFT_texture_dds</li>
 		</ul>
 


### PR DESCRIPTION
Related issue: #20508

**Description**

The `EXT_meshopt_compression` extension support has been added  to `GLTFLoader` in #20508. So let's add `EXT_meshopt_compression` to `GLTFLoader` extension support list in the document.

/cc @zeux @donmccurdy 