### PR TITLE
Docs: AxesHelper's examples link update

### DIFF
--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -25,9 +25,6 @@ scene.add( axesHelper );
 		<h2>Examples</h2>
 
 		<p>
-			[example:css2d_label Css2d / label]<br/>
-			[example:misc_animation_keys Misc / animation / keys]<br/>
-			[example:misc_exporter_gltf Misc / exporter / gltf]<br/>
 			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
 			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -27,7 +27,7 @@ scene.add( axesHelper );
 		<p>
 			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
-			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>
+			[example:webgl_loader_nrrd WebGL / loader / nrrd]
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -25,9 +25,12 @@ scene.add( axesHelper );
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl_geometries WebGL / geometries]<br/>
+			[example:css2d_label Css2d / label]<br/>
+			[example:misc_animation_keys Misc / animation / keys]<br/>
+			[example:misc_exporter_gltf Misc / exporter / gltf]<br/>
+			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
-			[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor]
+			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/zh/helpers/AxesHelper.html
+++ b/docs/api/zh/helpers/AxesHelper.html
@@ -24,9 +24,12 @@
 		<h2>例子</h2>
 
 		<p>
-			[example:webgl_geometries WebGL / geometries]<br/>
+			[example:css2d_label Css2d / label]<br/>
+			[example:misc_animation_keys Misc / animation / keys]<br/>
+			[example:misc_exporter_gltf Misc / exporter / gltf]<br/>
+			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
-			[example:webgl_geometry_spline_editor WebGL / geometry / spline / editor]
+			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>
 		</p>
 
 		<h2>构造函数</h2>

--- a/docs/api/zh/helpers/AxesHelper.html
+++ b/docs/api/zh/helpers/AxesHelper.html
@@ -26,7 +26,7 @@
 		<p>
 			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
-			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>
+			[example:webgl_loader_nrrd WebGL / loader / nrrd]
 		</p>
 
 		<h2>构造函数</h2>

--- a/docs/api/zh/helpers/AxesHelper.html
+++ b/docs/api/zh/helpers/AxesHelper.html
@@ -24,9 +24,6 @@
 		<h2>例子</h2>
 
 		<p>
-			[example:css2d_label Css2d / label]<br/>
-			[example:misc_animation_keys Misc / animation / keys]<br/>
-			[example:misc_exporter_gltf Misc / exporter / gltf]<br/>
 			[example:webgl_buffergeometry_compression WebGL / buffergeometry / compression]<br/>
 			[example:webgl_geometry_convex WebGL / geometry / convex]<br/>
 			[example:webgl_loader_nrrd WebGL / loader / nrrd]<br/>


### PR DESCRIPTION
Related issue: -

**Description**

AxesHelper is currently used in `css2d_label, misc_animation_keys, misc_exporter_gltf, webgl_buffergeometry_compression, webgl_geometry_convex, webgl_loader_nrrd` examples.
