### PR TITLE
Renamed controls variables for clarity and consistency

### DIFF
--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -104,9 +104,9 @@
 				labelRenderer.domElement.style.top = '0px';
 				document.body.appendChild( labelRenderer.domElement );
 
-				const controls = new OrbitControls( camera, labelRenderer.domElement );
-				controls.minDistance = 5;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, labelRenderer.domElement );
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 100;
 
 				//
 

--- a/examples/css3d_molecules.html
+++ b/examples/css3d_molecules.html
@@ -73,7 +73,7 @@
 			import { CSS3DRenderer, CSS3DObject, CSS3DSprite } from './jsm/renderers/CSS3DRenderer.js';
 
 			let camera, scene, renderer;
-			let controls;
+			let trackballControls;
 			let root;
 
 			const objects = [];
@@ -133,8 +133,8 @@
 
 				//
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.rotateSpeed = 0.5;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.rotateSpeed = 0.5;
 
 				//
 
@@ -492,7 +492,7 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
+				trackballControls.update();
 
 				const time = Date.now() * 0.0004;
 

--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -92,9 +92,9 @@
 				renderer2.domElement.style.top = 0;
 				document.body.appendChild( renderer2.domElement );
 
-				const controls = new OrbitControls( camera, renderer2.domElement );
-				controls.minZoom = 0.5;
-				controls.maxZoom = 2;
+				const orbitControls = new OrbitControls( camera, renderer2.domElement );
+				orbitControls.minZoom = 0.5;
+				orbitControls.maxZoom = 2;
 
 				function createPlane( width, height, cssColor, pos, rot ) {
 

--- a/examples/css3d_panorama_deviceorientation.html
+++ b/examples/css3d_panorama_deviceorientation.html
@@ -20,7 +20,7 @@
 			import { CSS3DRenderer, CSS3DObject } from './jsm/renderers/CSS3DRenderer.js';
 
 			let camera, scene, renderer;
-			let controls;
+			let deviceOrientationControls;
 
 			const startButton = document.getElementById( 'startButton' );
 			startButton.addEventListener( 'click', function () {
@@ -37,7 +37,7 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1000 );
 
-				controls = new DeviceOrientationControls( camera );
+				deviceOrientationControls = new DeviceOrientationControls( camera );
 
 				scene = new THREE.Scene();
 
@@ -115,7 +115,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				deviceOrientationControls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -221,7 +221,7 @@
 			];
 
 			let camera, scene, renderer;
-			let controls;
+			let trackballControls;
 
 			const objects = [];
 			const targets = { table: [], sphere: [], helix: [], grid: [] };
@@ -341,10 +341,10 @@
 
 				//
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = 500;
-				controls.maxDistance = 6000;
-				controls.addEventListener( 'change', render );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = 500;
+				trackballControls.maxDistance = 6000;
+				trackballControls.addEventListener( 'change', render );
 
 				const buttonTable = document.getElementById( 'table' );
 				buttonTable.addEventListener( 'click', function () {
@@ -427,7 +427,7 @@
 
 				TWEEN.update();
 
-				controls.update();
+				trackballControls.update();
 
 			}
 

--- a/examples/css3d_sandbox.html
+++ b/examples/css3d_sandbox.html
@@ -27,7 +27,7 @@
 
 			let scene2, renderer2;
 
-			let controls;
+			let trackballControls;
 
 			init();
 			animate();
@@ -87,7 +87,7 @@
 				renderer2.domElement.style.top = 0;
 				document.body.appendChild( renderer2.domElement );
 
-				controls = new TrackballControls( camera, renderer2.domElement );
+				trackballControls = new TrackballControls( camera, renderer2.domElement );
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -109,7 +109,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 
 				renderer.render( scene, camera );
 				renderer2.render( scene2, camera );

--- a/examples/css3d_sprites.html
+++ b/examples/css3d_sprites.html
@@ -29,7 +29,7 @@
 			import { CSS3DRenderer, CSS3DSprite } from './jsm/renderers/CSS3DRenderer.js';
 
 			let camera, scene, renderer;
-			let controls;
+			let trackballControls;
 
 			const particlesTotal = 512;
 			const positions = [];
@@ -138,7 +138,7 @@
 
 				//
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
 				//
 
@@ -189,7 +189,7 @@
 				requestAnimationFrame( animate );
 
 				TWEEN.update();
-				controls.update();
+				trackballControls.update();
 
 				const time = performance.now();
 

--- a/examples/css3d_youtube.html
+++ b/examples/css3d_youtube.html
@@ -31,7 +31,7 @@
 			import { CSS3DRenderer, CSS3DObject } from './jsm/renderers/CSS3DRenderer.js';
 
 			let camera, scene, renderer;
-			let controls;
+			let trackballControls;
 
 			function Element( id, x, y, z, ry ) {
 
@@ -53,7 +53,7 @@
 
 				return object;
 
-			};
+			}
 
 			init();
 			animate();
@@ -78,8 +78,8 @@
 				group.add( new Element( '9ubytEsCaS0', - 240, 0, 0, - Math.PI / 2 ) );
 				scene.add( group );
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.rotateSpeed = 4;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.rotateSpeed = 4;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -88,12 +88,12 @@
 				const blocker = document.getElementById( 'blocker' );
 				blocker.style.display = 'none';
 
-				controls.addEventListener( 'start', function () {
+				trackballControls.addEventListener( 'start', function () {
 
 					blocker.style.display = '';
 
 				} );
-				controls.addEventListener( 'end', function () {
+				trackballControls.addEventListener( 'end', function () {
 
 					blocker.style.display = 'none';
 
@@ -112,7 +112,7 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
+				trackballControls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/misc_controls_deviceorientation.html
+++ b/examples/misc_controls_deviceorientation.html
@@ -21,7 +21,7 @@
 
 			import { DeviceOrientationControls } from './jsm/controls/DeviceOrientationControls.js';
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, deviceOrientationControls;
 
 			const startButton = document.getElementById( 'startButton' );
 			startButton.addEventListener( 'click', function () {
@@ -38,7 +38,7 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 1100 );
 
-				controls = new DeviceOrientationControls( camera );
+				deviceOrientationControls = new DeviceOrientationControls( camera );
 
 				scene = new THREE.Scene();
 
@@ -76,7 +76,7 @@
 
 				window.requestAnimationFrame( animate );
 
-				controls.update();
+				deviceOrientationControls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -31,7 +31,7 @@
 
 			let container;
 			let camera, scene, renderer;
-			let controls, group;
+			let dragControls, group;
 			let enableSelection = false;
 
 			const objects = [];
@@ -104,8 +104,8 @@
 
 				container.appendChild( renderer.domElement );
 
-				controls = new DragControls( [ ... objects ], camera, renderer.domElement );
-				controls.addEventListener( 'drag', render );
+				dragControls = new DragControls( [ ... objects ], camera, renderer.domElement );
+				dragControls.addEventListener( 'drag', render );
 
 				//
 
@@ -148,7 +148,7 @@
 
 				if ( enableSelection === true ) {
 
-					const draggableObjects = controls.getObjects();
+					const draggableObjects = dragControls.getObjects();
 					draggableObjects.length = 0;
 
 					mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
@@ -174,14 +174,14 @@
 
 						}
 
-						controls.transformGroup = true;
+						dragControls.transformGroup = true;
 						draggableObjects.push( group );
 
 					}
 
 					if ( group.children.length === 0 ) {
 
-						controls.transformGroup = false;
+						dragControls.transformGroup = false;
 						draggableObjects.push( ...objects );
 
 					}

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -49,7 +49,7 @@
 			let SCREEN_HEIGHT = window.innerHeight - MARGIN * 2;
 			let SCREEN_WIDTH = window.innerWidth;
 
-			let camera, controls, scene, renderer, stats;
+			let camera, flyControls, scene, renderer, stats;
 			let geometry, meshPlanet, meshClouds, meshMoon;
 			let dirLight;
 
@@ -192,13 +192,13 @@
 
 				//
 
-				controls = new FlyControls( camera, renderer.domElement );
+				flyControls = new FlyControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 1000;
-				controls.domElement = renderer.domElement;
-				controls.rollSpeed = Math.PI / 24;
-				controls.autoForward = false;
-				controls.dragToLook = false;
+				flyControls.movementSpeed = 1000;
+				flyControls.domElement = renderer.domElement;
+				flyControls.rollSpeed = Math.PI / 24;
+				flyControls.autoForward = false;
+				flyControls.dragToLook = false;
 
 				//
 
@@ -267,8 +267,8 @@
 
 				}
 
-				controls.movementSpeed = 0.33 * d;
-				controls.update( delta );
+				flyControls.movementSpeed = 0.33 * d;
+				flyControls.update( delta );
 
 				composer.render( delta );
 

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -30,7 +30,7 @@
 
 			import { MapControls } from './jsm/controls/OrbitControls.js';
 
-			let camera, controls, scene, renderer;
+			let camera, mapControls, scene, renderer;
 
 			init();
 			//render(); // remove when using next line for animation loop (requestAnimationFrame)
@@ -52,19 +52,19 @@
 
 				// controls
 
-				controls = new MapControls( camera, renderer.domElement );
+				mapControls = new MapControls( camera, renderer.domElement );
 
-				//controls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
+				//mapControls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
 
-				controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
-				controls.dampingFactor = 0.05;
+				mapControls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
+				mapControls.dampingFactor = 0.05;
 
-				controls.screenSpacePanning = false;
+				mapControls.screenSpacePanning = false;
 
-				controls.minDistance = 100;
-				controls.maxDistance = 500;
+				mapControls.minDistance = 100;
+				mapControls.maxDistance = 500;
 
-				controls.maxPolarAngle = Math.PI / 2;
+				mapControls.maxPolarAngle = Math.PI / 2;
 
 				// world
 
@@ -106,7 +106,7 @@
 
 
 				const gui = new GUI();
-				gui.add( controls, 'screenSpacePanning' );
+				gui.add( mapControls, 'screenSpacePanning' );
 
 			}
 
@@ -123,7 +123,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
+				mapControls.update(); // only required if mapControls.enableDamping = true, or if mapControls.autoRotate = true
 
 				render();
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -28,7 +28,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let camera, controls, scene, renderer;
+			let camera, orbitControls, scene, renderer;
 
 			init();
 			//render(); // remove when using next line for animation loop (requestAnimationFrame)
@@ -50,19 +50,19 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				orbitControls = new OrbitControls( camera, renderer.domElement );
 
-				//controls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
+				//orbitControls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)
 
-				controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
-				controls.dampingFactor = 0.05;
+				orbitControls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled
+				orbitControls.dampingFactor = 0.05;
 
-				controls.screenSpacePanning = false;
+				orbitControls.screenSpacePanning = false;
 
-				controls.minDistance = 100;
-				controls.maxDistance = 500;
+				orbitControls.minDistance = 100;
+				orbitControls.maxDistance = 500;
 
-				controls.maxPolarAngle = Math.PI / 2;
+				orbitControls.maxPolarAngle = Math.PI / 2;
 
 				// world
 
@@ -113,7 +113,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
+				orbitControls.update(); // only required if orbitControls.enableDamping = true, or if orbitControls.autoRotate = true
 
 				render();
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -62,7 +62,7 @@
 
 			import { PointerLockControls } from './jsm/controls/PointerLockControls.js';
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, pointerLockControls;
 
 			const objects = [];
 
@@ -96,32 +96,32 @@
 				light.position.set( 0.5, 1, 0.75 );
 				scene.add( light );
 
-				controls = new PointerLockControls( camera, document.body );
+				pointerLockControls = new PointerLockControls( camera, document.body );
 
 				const blocker = document.getElementById( 'blocker' );
 				const instructions = document.getElementById( 'instructions' );
 
 				instructions.addEventListener( 'click', function () {
 
-					controls.lock();
+					pointerLockControls.lock();
 
 				}, false );
 
-				controls.addEventListener( 'lock', function () {
+				pointerLockControls.addEventListener( 'lock', function () {
 
 					instructions.style.display = 'none';
 					blocker.style.display = 'none';
 
 				} );
 
-				controls.addEventListener( 'unlock', function () {
+				pointerLockControls.addEventListener( 'unlock', function () {
 
 					blocker.style.display = 'block';
 					instructions.style.display = '';
 
 				} );
 
-				scene.add( controls.getObject() );
+				scene.add( pointerLockControls.getObject() );
 
 				const onKeyDown = function ( event ) {
 
@@ -288,9 +288,9 @@
 
 				const time = performance.now();
 
-				if ( controls.isLocked === true ) {
+				if ( pointerLockControls.isLocked === true ) {
 
-					raycaster.ray.origin.copy( controls.getObject().position );
+					raycaster.ray.origin.copy( pointerLockControls.getObject().position );
 					raycaster.ray.origin.y -= 10;
 
 					const intersections = raycaster.intersectObjects( objects );
@@ -318,15 +318,15 @@
 
 					}
 
-					controls.moveRight( - velocity.x * delta );
-					controls.moveForward( - velocity.z * delta );
+					pointerLockControls.moveRight( - velocity.x * delta );
+					pointerLockControls.moveForward( - velocity.z * delta );
 
-					controls.getObject().position.y += ( velocity.y * delta ); // new behavior
+					pointerLockControls.getObject().position.y += ( velocity.y * delta ); // new behavior
 
-					if ( controls.getObject().position.y < 10 ) {
+					if ( pointerLockControls.getObject().position.y < 10 ) {
 
 						velocity.y = 0;
-						controls.getObject().position.y = 10;
+						pointerLockControls.getObject().position.y = 10;
 
 						canJump = true;
 

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -31,7 +31,7 @@
 
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 
-			let perspectiveCamera, orthographicCamera, controls, scene, renderer, stats;
+			let perspectiveCamera, orthographicCamera, trackballControls, scene, renderer, stats;
 
 			const params = {
 				orthographicCamera: false
@@ -101,7 +101,7 @@
 				const gui = new GUI();
 				gui.add( params, 'orthographicCamera' ).name( 'use orthographic' ).onChange( function ( value ) {
 
-					controls.dispose();
+					trackballControls.dispose();
 
 					createControls( value ? orthographicCamera : perspectiveCamera );
 
@@ -117,13 +117,13 @@
 
 			function createControls( camera ) {
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
-				controls.rotateSpeed = 1.0;
-				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
+				trackballControls.rotateSpeed = 1.0;
+				trackballControls.zoomSpeed = 1.2;
+				trackballControls.panSpeed = 0.8;
 
-				controls.keys = [ 65, 83, 68 ];
+				trackballControls.keys = [ 65, 83, 68 ];
 
 			}
 
@@ -142,7 +142,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -150,7 +150,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 
 				stats.update();
 

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -23,7 +23,7 @@
 			import { TransformControls } from './jsm/controls/TransformControls.js';
 
 			let cameraPersp, cameraOrtho, currentCamera;
-			let scene, renderer, control, orbit;
+			let scene, renderer, transformControls, orbitControls;
 
 			init();
 			render();
@@ -57,24 +57,24 @@
 				const geometry = new THREE.BoxBufferGeometry( 200, 200, 200 );
 				const material = new THREE.MeshLambertMaterial( { map: texture, transparent: true } );
 
-				orbit = new OrbitControls( currentCamera, renderer.domElement );
-				orbit.update();
-				orbit.addEventListener( 'change', render );
+				orbitControls = new OrbitControls( currentCamera, renderer.domElement );
+				orbitControls.update();
+				orbitControls.addEventListener( 'change', render );
 
-				control = new TransformControls( currentCamera, renderer.domElement );
-				control.addEventListener( 'change', render );
+				transformControls = new TransformControls( currentCamera, renderer.domElement );
+				transformControls.addEventListener( 'change', render );
 
-				control.addEventListener( 'dragging-changed', function ( event ) {
+				transformControls.addEventListener( 'dragging-changed', function ( event ) {
 
-					orbit.enabled = ! event.value;
+					orbitControls.enabled = ! event.value;
 
 				} );
 
 				const mesh = new THREE.Mesh( geometry, material );
 				scene.add( mesh );
 
-				control.attach( mesh );
-				scene.add( control );
+				transformControls.attach( mesh );
+				scene.add( transformControls );
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -83,25 +83,25 @@
 					switch ( event.keyCode ) {
 
 						case 81: // Q
-							control.setSpace( control.space === "local" ? "world" : "local" );
+							transformControls.setSpace( transformControls.space === "local" ? "world" : "local" );
 							break;
 
 						case 16: // Shift
-							control.setTranslationSnap( 100 );
-							control.setRotationSnap( THREE.MathUtils.degToRad( 15 ) );
-							control.setScaleSnap( 0.25 );
+							transformControls.setTranslationSnap( 100 );
+							transformControls.setRotationSnap( THREE.MathUtils.degToRad( 15 ) );
+							transformControls.setScaleSnap( 0.25 );
 							break;
 
 						case 87: // W
-							control.setMode( "translate" );
+							transformControls.setMode( "translate" );
 							break;
 
 						case 69: // E
-							control.setMode( "rotate" );
+							transformControls.setMode( "rotate" );
 							break;
 
 						case 82: // R
-							control.setMode( "scale" );
+							transformControls.setMode( "scale" );
 							break;
 
 						case 67: // C
@@ -110,10 +110,10 @@
 							currentCamera = currentCamera.isPerspectiveCamera ? cameraOrtho : cameraPersp;
 							currentCamera.position.copy( position );
 
-							orbit.object = currentCamera;
-							control.camera = currentCamera;
+							orbitControls.object = currentCamera;
+							transformControls.camera = currentCamera;
 
-							currentCamera.lookAt( orbit.target.x, orbit.target.y, orbit.target.z );
+							currentCamera.lookAt( orbitControls.target.x, orbitControls.target.y, orbitControls.target.z );
 							onWindowResize();
 							break;
 
@@ -132,28 +132,28 @@
 
 						case 187:
 						case 107: // +, =, num+
-							control.setSize( control.size + 0.1 );
+							transformControls.setSize( transformControls.size + 0.1 );
 							break;
 
 						case 189:
 						case 109: // -, _, num-
-							control.setSize( Math.max( control.size - 0.1, 0.1 ) );
+							transformControls.setSize( Math.max( transformControls.size - 0.1, 0.1 ) );
 							break;
 
 						case 88: // X
-							control.showX = ! control.showX;
+							transformControls.showX = ! transformControls.showX;
 							break;
 
 						case 89: // Y
-							control.showY = ! control.showY;
+							transformControls.showY = ! transformControls.showY;
 							break;
 
 						case 90: // Z
-							control.showZ = ! control.showZ;
+							transformControls.showZ = ! transformControls.showZ;
 							break;
 
 						case 32: // Spacebar
-							control.enabled = ! control.enabled;
+							transformControls.enabled = ! transformControls.enabled;
 							break;
 
 					}
@@ -165,9 +165,9 @@
 					switch ( event.keyCode ) {
 
 						case 16: // Shift
-							control.setTranslationSnap( null );
-							control.setRotationSnap( null );
-							control.setScaleSnap( null );
+							transformControls.setTranslationSnap( null );
+							transformControls.setRotationSnap( null );
+							transformControls.setScaleSnap( null );
 							break;
 
 					}

--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -28,7 +28,6 @@
 			/*global window */
 
 			let camera, scene, renderer;
-			let cameraControls;
 			let effectController;
 			const teapotSize = 400;
 			let ambientLight, light;
@@ -80,8 +79,8 @@
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				// CONTROLS
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.addEventListener( 'change', render );
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
 
 				// TEXTURE MAP
 				const loader = new THREE.TextureLoader();

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -126,9 +126,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 25, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 25, 0 );
+				orbitControls.update();
 
 				//
 

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -82,9 +82,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 25, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 25, 0 );
+				orbitControls.update();
 
 				//
 

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -82,9 +82,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 25, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 25, 0 );
+				orbitControls.update();
 
 				//
 

--- a/examples/misc_legacy.html
+++ b/examples/misc_legacy.html
@@ -17,7 +17,7 @@
 		<script>
 
 			var camera, scene, renderer;
-			var controls;
+			var orbitControls;
 
 			init();
 			animate();
@@ -36,9 +36,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 20 );
 				camera.position.set( 1.5, 0.2, 1.5 );
 
-				controls = new THREE.OrbitControls( camera, document.body );
-				controls.autoRotate = true;
-				controls.autoRotateSpeed = - 1.0;
+				orbitControls = new THREE.OrbitControls( camera, document.body );
+				orbitControls.autoRotate = true;
+				orbitControls.autoRotateSpeed = - 1.0;
 
 				var pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
@@ -84,7 +84,7 @@
 
 				renderer.setAnimationLoop( animate );
 
-				controls.update();
+				orbitControls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/models/obj/verify/verify.html
+++ b/examples/models/obj/verify/verify.html
@@ -93,6 +93,7 @@
 			import { OBJLoader2 } from "../../../jsm/loaders/OBJLoader2.js";
 
 			const OBJLoaderVerify = function ( elementToBindTo ) {
+
 				this.renderer = null;
 				this.canvas = elementToBindTo;
 				this.aspectRatio = 1;
@@ -109,14 +110,16 @@
 				this.camera = null;
 				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				this.controls = null;
+				this.trackballControls = null;
+
 			};
 
-				OBJLoaderVerify.prototype = {
+			OBJLoaderVerify.prototype = {
 
-					constructor: OBJLoaderVerify,
+				constructor: OBJLoaderVerify,
 
-					initGL: function () {
+				initGL: function () {
+
 					this.renderer = new WebGLRenderer( {
 						canvas: this.canvas,
 						antialias: true,
@@ -128,104 +131,130 @@
 
 					this.camera = new PerspectiveCamera( this.cameraDefaults.fov, this.aspectRatio, this.cameraDefaults.near, this.cameraDefaults.far );
 					this.resetCamera();
-					this.controls = new TrackballControls( this.camera, this.renderer.domElement );
+					this.trackballControls = new TrackballControls( this.camera, this.renderer.domElement );
 
-					let ambientLight = new AmbientLight( 0x404040 );
-					let directionalLight1 = new DirectionalLight( 0xC0C090 );
-					let directionalLight2 = new DirectionalLight( 0xC0C090 );
+					const ambientLight = new AmbientLight( 0x404040 );
+					const directionalLight1 = new DirectionalLight( 0xC0C090 );
+					const directionalLight2 = new DirectionalLight( 0xC0C090 );
 
-					directionalLight1.position.set( -100, -50, 100 );
-					directionalLight2.position.set( 100, 50, -100 );
+					directionalLight1.position.set( - 100, - 50, 100 );
+					directionalLight2.position.set( 100, 50, - 100 );
 
 					this.scene.add( directionalLight1 );
 					this.scene.add( directionalLight2 );
 					this.scene.add( ambientLight );
 
-					let helper = new GridHelper( 1200, 60, 0xFF4444, 0x404040 );
+					const helper = new GridHelper( 1200, 60, 0xFF4444, 0x404040 );
 					this.scene.add( helper );
+
 				},
 
 				initContent: function () {
-					let modelName = 'verificationCubes';
+
+					const modelName = 'verificationCubes';
 					this._reportProgress( { detail: { text: 'Loading: ' + modelName } } );
 
-					let objLoader = new OBJLoader();
+					const objLoader = new OBJLoader();
 
-					let objLoader2 = new OBJLoader2();
+					const objLoader2 = new OBJLoader2();
 					objLoader2.setModelName( modelName );
 					objLoader2.setLogging( true, false );
 					objLoader2.setUseOAsMesh( true );
 
-					let scope = this;
-					let callbackOnLoad = function ( object3d ) {
+					const scope = this;
+					const callbackOnLoad = function ( object3d ) {
+
 						scope.scene.add( object3d );
 						console.log( 'Loading complete: ' + modelName );
 						scope._reportProgress( { detail: { text: '' } } );
+
 					};
 
-					let onLoadMtl = function ( mtlParseResult ) {
+					const onLoadMtl = function ( mtlParseResult ) {
+
 						objLoader.setMaterials( mtlParseResult );
 						objLoader.load( './verify.obj', function ( object ) {
-							object.position.y = -100;
+
+							object.position.y = - 100;
 							scope.scene.add( object );
+
 						} );
 
 						objLoader2.addMaterials( MtlObjBridge.addMaterialsFromMtlLoader( mtlParseResult ) );
 						objLoader2.load( './verify.obj', callbackOnLoad, null, null, null );
+
 					};
 
-					let mtlLoader = new MTLLoader();
+					const mtlLoader = new MTLLoader();
 					mtlLoader.load( './verify.mtl', onLoadMtl );
+
 				},
 
-				_reportProgress: function( event ) {
-					let output = ( event.detail !== undefined && event.detail !== null && event.detail.text !== undefined && event.detail.text !== null ) ? event.detail.text : '';
+				_reportProgress: function ( event ) {
+
+					const output = ( event.detail !== undefined && event.detail !== null && event.detail.text !== undefined && event.detail.text !== null ) ? event.detail.text : '';
 					console.log( 'Progress: ' + output );
 					document.getElementById( 'feedback' ).innerHTML = output;
+
 				},
 
 				resizeDisplayGL: function () {
-					this.controls.handleResize();
+
+					this.trackballControls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
 
 					this.updateCamera();
+
 				},
 
 				recalcAspectRatio: function () {
+
 					this.aspectRatio = ( this.canvas.offsetHeight === 0 ) ? 1 : this.canvas.offsetWidth / this.canvas.offsetHeight;
+
 				},
 
 				resetCamera: function () {
+
 					this.camera.position.copy( this.cameraDefaults.posCamera );
 					this.cameraTarget.copy( this.cameraDefaults.posCameraTarget );
 
 					this.updateCamera();
+
 				},
 
 				updateCamera: function () {
+
 					this.camera.aspect = this.aspectRatio;
 					this.camera.lookAt( this.cameraTarget );
 					this.camera.updateProjectionMatrix();
+
 				},
 
 				render: function () {
+
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
-					this.controls.update();
+					this.trackballControls.update();
 					this.renderer.render( this.scene, this.camera );
+
 				}
+
 			};
 
-			let app = new OBJLoaderVerify( document.getElementById( 'example' ) );
+			const app = new OBJLoaderVerify( document.getElementById( 'example' ) );
 
-			let resizeWindow = function () {
+			const resizeWindow = function () {
+
 				app.resizeDisplayGL();
+
 			};
 
-			let render = function () {
+			const render = function () {
+
 				requestAnimationFrame( render );
 				app.render();
+
 			};
 
 			window.addEventListener( 'resize', resizeWindow, false );

--- a/examples/physics_ammo_break.html
+++ b/examples/physics_ammo_break.html
@@ -30,7 +30,7 @@
 
 		// Graphics variables
 		let container, stats;
-		let camera, controls, scene, renderer;
+		let camera, scene, renderer;
 		let textureLoader;
 		const clock = new THREE.Clock();
 
@@ -113,9 +113,9 @@
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.target.set( 0, 2, 0 );
-			controls.update();
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.target.set( 0, 2, 0 );
+			orbitControls.update();
 
 			textureLoader = new THREE.TextureLoader();
 

--- a/examples/physics_ammo_cloth.html
+++ b/examples/physics_ammo_cloth.html
@@ -26,7 +26,7 @@
 
 			// Graphics variables
 			let container, stats;
-			let camera, controls, scene, renderer;
+			let camera, scene, renderer;
 			let textureLoader;
 			const clock = new THREE.Clock();
 
@@ -80,9 +80,9 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				textureLoader = new THREE.TextureLoader();
 
@@ -205,6 +205,7 @@
 						}
 
 					}
+
 					pos.y += brickHeight;
 
 				}

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -118,9 +118,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.y = 0.5;
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.y = 0.5;
+				orbitControls.update();
 
 				animate();
 

--- a/examples/physics_ammo_rope.html
+++ b/examples/physics_ammo_rope.html
@@ -25,7 +25,7 @@
 
 		// Graphics variables
 		let container, stats;
-		let camera, controls, scene, renderer;
+		let camera, scene, renderer;
 		let textureLoader;
 		const clock = new THREE.Clock();
 
@@ -83,9 +83,9 @@
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.target.set( 0, 2, 0 );
-			controls.update();
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.target.set( 0, 2, 0 );
+			orbitControls.update();
 
 			textureLoader = new THREE.TextureLoader();
 

--- a/examples/physics_ammo_terrain.html
+++ b/examples/physics_ammo_terrain.html
@@ -102,8 +102,8 @@
 				camera.position.z = terrainDepthExtents / 2;
 				camera.lookAt( 0, 0, 0 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
 
 				const geometry = new THREE.PlaneBufferGeometry( terrainWidthExtents, terrainDepthExtents, terrainWidth - 1, terrainDepth - 1 );
 				geometry.rotateX( - Math.PI / 2 );

--- a/examples/physics_ammo_volume.html
+++ b/examples/physics_ammo_volume.html
@@ -30,7 +30,7 @@
 
 			// Graphics variables
 			let container, stats;
-			let camera, controls, scene, renderer;
+			let camera, scene, renderer;
 			let textureLoader;
 			const clock = new THREE.Clock();
 			let clickRequest = false;
@@ -87,9 +87,9 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				textureLoader = new THREE.TextureLoader();
 

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -147,12 +147,12 @@
 
 			//
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.target.set( 0, 0.1, 0 );
-			controls.update();
-			controls.minDistance = 0.5;
-			controls.maxDistance = 10;
-			controls.maxPolarAngle = 0.5 * Math.PI;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.target.set( 0, 0.1, 0 );
+			orbitControls.update();
+			orbitControls.minDistance = 0.5;
+			orbitControls.maxDistance = 10;
+			orbitControls.maxPolarAngle = 0.5 * Math.PI;
 
 			//
 

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -26,7 +26,7 @@
 
 			import { FirstPersonControls } from './jsm/controls/FirstPersonControls.js';
 
-			let camera, controls, scene, renderer, light;
+			let camera, firstPersonControls, scene, renderer, light;
 
 			let material1, material2, material3;
 
@@ -209,12 +209,12 @@
 
 				//
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 70;
-				controls.lookSpeed = 0.05;
-				controls.noFly = true;
-				controls.lookVertical = false;
+				firstPersonControls.movementSpeed = 70;
+				firstPersonControls.lookSpeed = 0.05;
+				firstPersonControls.noFly = true;
+				firstPersonControls.lookVertical = false;
 
 				//
 
@@ -231,7 +231,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -247,7 +247,7 @@
 
 				const delta = clock.getDelta();
 
-				controls.update( delta );
+				firstPersonControls.update( delta );
 
 				material1.emissive.b = analyser1.getAverageFrequency() / 256;
 				material2.emissive.b = analyser2.getAverageFrequency() / 256;

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -136,9 +136,9 @@
 
 			//
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.minDistance = 1;
-			controls.maxDistance = 25;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.minDistance = 1;
+			orbitControls.maxDistance = 25;
 
 			//
 

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -31,7 +31,6 @@
 		let renderer,
 			scene,
 			camera,
-			controls,
 			material,
 			volconfig,
 			cmtextures;
@@ -56,12 +55,12 @@
 			camera.up.set( 0, 0, 1 ); // In our data, z is up
 
 			// Create controls
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.addEventListener( 'change', render );
-			controls.target.set( 64, 64, 128 );
-			controls.minZoom = 0.5;
-			controls.maxZoom = 4;
-			controls.update();
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.addEventListener( 'change', render );
+			orbitControls.target.set( 64, 64, 128 );
+			orbitControls.minZoom = 0.5;
+			orbitControls.maxZoom = 4;
+			orbitControls.update();
 
 			// scene.add( new AxesHelper( 128 ) );
 

--- a/examples/webgl2_volume_instancing.html
+++ b/examples/webgl2_volume_instancing.html
@@ -26,7 +26,7 @@
 			}
 
 			let renderer, scene, camera;
-			let controls;
+			let orbitControls;
 
 			init();
 			animate();
@@ -43,10 +43,10 @@
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.1, 1000 );
 				camera.position.set( 0, 0, 4 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.autoRotate = true;
-				controls.autoRotateSpeed = - 1.0;
-				controls.enableDamping = true;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.autoRotate = true;
+				orbitControls.autoRotateSpeed = - 1.0;
+				orbitControls.enableDamping = true;
 
 				// Material
 
@@ -244,7 +244,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -560,10 +560,10 @@
 				renderer.shadowMap.enabled = true;
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI * 0.5;
-				controls.minDistance = 1000;
-				controls.maxDistance = 5000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = Math.PI * 0.5;
+				orbitControls.minDistance = 1000;
+				orbitControls.maxDistance = 5000;
 
 				// performance monitor
 

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -57,11 +57,11 @@
 			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 100 );
 			camera.position.set( 5, 2, 8 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.target.set( 0, 0.5, 0 );
-			controls.update();
-			controls.enablePan = false;
-			controls.enableDamping = true;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.target.set( 0, 0.5, 0 );
+			orbitControls.update();
+			orbitControls.enablePan = false;
+			orbitControls.enableDamping = true;
 
 			scene.add( new THREE.HemisphereLight( 0xffffff, 0x000000, 0.4 ) );
 
@@ -126,7 +126,7 @@
 
 				mixer.update( delta );
 
-				controls.update();
+				orbitControls.update();
 
 				stats.update();
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -160,11 +160,11 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 100 );
 				camera.position.set( - 1, 2, 3 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enablePan = false;
-				controls.enableZoom = false;
-				controls.target.set( 0, 1, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enablePan = false;
+				orbitControls.enableZoom = false;
+				orbitControls.target.set( 0, 1, 0 );
+				orbitControls.update();
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_buffergeometry_compression.html
+++ b/examples/webgl_buffergeometry_compression.html
@@ -27,7 +27,7 @@
 
 			let container, stats, gui;
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, orbitControls;
 
 			const lights = [];
 
@@ -84,7 +84,7 @@
 				camera.position.y = 2 * radius;
 				camera.position.z = 2 * radius;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				orbitControls = new OrbitControls( camera, renderer.domElement );
 
 				//
 
@@ -224,7 +224,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 				updateLightsPossition();
 
 				renderer.render( scene, camera );

--- a/examples/webgl_buffergeometry_constructed_from_geometry.html
+++ b/examples/webgl_buffergeometry_constructed_from_geometry.html
@@ -20,7 +20,7 @@
 
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 
-			let camera, scene, renderer, controls, stats;
+			let camera, scene, renderer, trackballControls, stats;
 
 			init();
 			animate();
@@ -38,10 +38,10 @@
 				camera.position.z = 480.0;
 				scene.add( camera );
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = 100.0;
-				controls.maxDistance = 800.0;
-				controls.dynamicDampingFactor = 0.1;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = 100.0;
+				trackballControls.maxDistance = 800.0;
+				trackballControls.dynamicDampingFactor = 0.1;
 
 				scene.add( new THREE.AmbientLight( 0xffffff, 0.2 ) );
 
@@ -176,7 +176,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 				stats.update();
 
 				renderer.render( scene, camera );

--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -85,9 +85,9 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 4000 );
 				camera.position.z = 1750;
 
-				const controls = new OrbitControls( camera, container );
-				controls.minDistance = 1000;
-				controls.maxDistance = 3000;
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.minDistance = 1000;
+				orbitControls.maxDistance = 3000;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_buffergeometry_morphtargets.html
+++ b/examples/webgl_buffergeometry_morphtargets.html
@@ -61,8 +61,8 @@
 				} );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_clipping.html
+++ b/examples/webgl_clipping.html
@@ -115,9 +115,9 @@
 
 				// Controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 1, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 1, 0 );
+				orbitControls.update();
 
 				// GUI
 

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -288,11 +288,11 @@
 
 				// Controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 8;
-				controls.target.set( 0, 1, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 8;
+				orbitControls.target.set( 0, 1, 0 );
+				orbitControls.update();
 
 				// GUI
 

--- a/examples/webgl_clipping_intersection.html
+++ b/examples/webgl_clipping_intersection.html
@@ -47,11 +47,11 @@
 
 				camera.position.set( - 1.5, 2.5, 3.0 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use only if there is no animation loop
-				controls.minDistance = 1;
-				controls.maxDistance = 10;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use only if there is no animation loop
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 10;
+				orbitControls.enablePan = false;
 
 				const light = new THREE.HemisphereLight( 0xffffff, 0x080808, 1.5 );
 				light.position.set( - 1.25, 1, 1.25 );

--- a/examples/webgl_clipping_stencil.html
+++ b/examples/webgl_clipping_stencil.html
@@ -218,10 +218,10 @@
 				renderer.localClippingEnabled = true;
 
 				// Controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 2;
-				controls.maxDistance = 20;
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 2;
+				orbitControls.maxDistance = 20;
+				orbitControls.update();
 
 				// GUI
 				const gui = new GUI();

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -92,9 +92,9 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 120;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 200;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 200;
 
 				scene.add( new THREE.AmbientLight( 0x443333 ) );
 
@@ -124,7 +124,7 @@
 
 				let moved = false;
 
-				controls.addEventListener( 'change', function () {
+				orbitControls.addEventListener( 'change', function () {
 
 					moved = true;
 

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -71,7 +71,7 @@
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let camera, scene, renderer, controls, stats;
+			let camera, scene, renderer, orbitControls, stats;
 			let target;
 			let postScene, postCamera, postMaterial;
 			let supportsExtension = true;
@@ -111,8 +111,8 @@
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.z = 4;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableDamping = true;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableDamping = true;
 
 				// Create a render target with depth texture
 				setupRenderTarget();
@@ -234,7 +234,7 @@
 				renderer.setRenderTarget( null );
 				renderer.render( postScene, postCamera );
 
-				controls.update(); // required because damping is enabled
+				orbitControls.update(); // required because damping is enabled
 
 				stats.update();
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -17,7 +17,7 @@
 			import { AsciiEffect } from './jsm/effects/AsciiEffect.js';
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 
-			let camera, controls, scene, renderer, effect;
+			let camera, trackballControls, scene, renderer, effect;
 
 			let sphere, plane;
 
@@ -66,7 +66,7 @@
 
 				document.body.appendChild( effect.domElement );
 
-				controls = new TrackballControls( camera, effect.domElement );
+				trackballControls = new TrackballControls( camera, effect.domElement );
 
 				//
 
@@ -102,7 +102,7 @@
 				sphere.rotation.x = timer * 0.0003;
 				sphere.rotation.z = timer * 0.0002;
 
-				controls.update();
+				trackballControls.update();
 
 				effect.render( scene, camera );
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -115,8 +115,8 @@
 				//
 
 				const selection = document.getElementById( 'selection' );
-				const controls = new OrbitControls( camera, selection );
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, selection );
+				orbitControls.enablePan = false;
 
 				//
 

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -94,8 +94,8 @@
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
-				const controls = new OrbitControls( perpCamera, renderer.domElement );
-				controls.addEventListener( 'change', render );
+				const orbitControls = new OrbitControls( perpCamera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
 
 				const gui = new GUI();
 

--- a/examples/webgl_geometry_convex.html
+++ b/examples/webgl_geometry_convex.html
@@ -39,10 +39,10 @@
 
 				// controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 20;
-				controls.maxDistance = 50;
-				controls.maxPolarAngle = Math.PI / 2;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 20;
+				orbitControls.maxDistance = 50;
+				orbitControls.maxPolarAngle = Math.PI / 2;
 
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 

--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -26,7 +26,7 @@
 
 			import { FirstPersonControls } from './jsm/controls/FirstPersonControls.js';
 
-			let camera, controls, scene, renderer, stats;
+			let camera, firstPersonControls, scene, renderer, stats;
 
 			let mesh, geometry, material, clock;
 
@@ -73,10 +73,10 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 500;
-				controls.lookSpeed = 0.1;
+				firstPersonControls.movementSpeed = 500;
+				firstPersonControls.lookSpeed = 0.1;
 
 				stats = new Stats();
 				document.body.appendChild( stats.dom );
@@ -94,7 +94,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -125,7 +125,7 @@
 
 				position.needsUpdate = true;
 
-				controls.update( delta );
+				firstPersonControls.update( delta );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -23,7 +23,7 @@
 
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, trackballControls;
 
 			init();
 			animate();
@@ -51,9 +51,9 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 0, 0, 500 );
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 500;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = 200;
+				trackballControls.maxDistance = 500;
 
 				scene.add( new THREE.AmbientLight( 0x222222 ) );
 
@@ -176,7 +176,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -228,6 +228,7 @@
 									y1 = 2 * y - y1;
 
 								}
+
 								nx = eatNum();
 								ny = eatNum();
 								path.quadraticCurveTo( x1, y1, nx, ny );
@@ -431,9 +432,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 100;
-				controls.maxDistance = 1000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 100;
+				orbitControls.maxDistance = 1000;
 
 				//
 

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -259,9 +259,9 @@
 				} );
 				folderCamera.open();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 100;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 100;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -32,7 +32,7 @@
 
 			let container, stats;
 
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 
 			const worldWidth = 128, worldDepth = 128;
 			const worldHalfWidth = worldWidth / 2;
@@ -159,11 +159,11 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 1000;
-				controls.lookSpeed = 0.125;
-				controls.lookVertical = true;
+				firstPersonControls.movementSpeed = 1000;
+				firstPersonControls.lookSpeed = 0.125;
+				firstPersonControls.lookVertical = true;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -181,7 +181,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -231,7 +231,7 @@
 
 			function render() {
 
-				controls.update( clock.getDelta() );
+				firstPersonControls.update( clock.getDelta() );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_minecraft_ao.html
+++ b/examples/webgl_geometry_minecraft_ao.html
@@ -33,7 +33,7 @@
 
 			let container, stats;
 
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 
 			const worldWidth = 200, worldDepth = 200;
 			const worldHalfWidth = worldWidth / 2;
@@ -258,14 +258,14 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 1000;
-				controls.lookSpeed = 0.125;
-				controls.lookVertical = true;
-				controls.constrainVertical = true;
-				controls.verticalMin = 1.1;
-				controls.verticalMax = 2.2;
+				firstPersonControls.movementSpeed = 1000;
+				firstPersonControls.lookSpeed = 0.125;
+				firstPersonControls.lookVertical = true;
+				firstPersonControls.constrainVertical = true;
+				firstPersonControls.verticalMin = 1.1;
+				firstPersonControls.verticalMax = 2.2;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -283,7 +283,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -332,7 +332,7 @@
 
 			function render() {
 
-				controls.update( clock.getDelta() );
+				firstPersonControls.update( clock.getDelta() );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_normals.html
+++ b/examples/webgl_geometry_normals.html
@@ -122,8 +122,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
 
 				//
 

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -59,7 +59,7 @@
 			const onDownPosition = new THREE.Vector2();
 
 			const geometry = new THREE.BoxBufferGeometry( 20, 20, 20 );
-			let transformControl;
+			let transformControls;
 
 			const ARC_SEGMENTS = 200;
 
@@ -142,20 +142,20 @@
 				gui.open();
 
 				// Controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.damping = 0.2;
-				controls.addEventListener( 'change', render );
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.damping = 0.2;
+				orbitControls.addEventListener( 'change', render );
 
-				transformControl = new TransformControls( camera, renderer.domElement );
-				transformControl.addEventListener( 'change', render );
-				transformControl.addEventListener( 'dragging-changed', function ( event ) {
+				transformControls = new TransformControls( camera, renderer.domElement );
+				transformControls.addEventListener( 'change', render );
+				transformControls.addEventListener( 'dragging-changed', function ( event ) {
 
-					controls.enabled = ! event.value;
+					orbitControls.enabled = ! event.value;
 
 				} );
-				scene.add( transformControl );
+				scene.add( transformControls );
 
-				transformControl.addEventListener( 'objectChange', function () {
+				transformControls.addEventListener( 'objectChange', function () {
 
 					updateSplineOutline();
 
@@ -274,7 +274,7 @@
 				splinePointsLength --;
 				positions.pop();
 
-				if ( transformControl.object === point ) transformControl.detach();
+				if ( transformControls.object === point ) transformControls.detach();
 				scene.remove( point );
 
 				updateSplineOutline();
@@ -374,7 +374,7 @@
 				onUpPosition.x = event.clientX;
 				onUpPosition.y = event.clientY;
 
-				if ( onDownPosition.distanceTo( onUpPosition ) === 0 ) transformControl.detach();
+				if ( onDownPosition.distanceTo( onUpPosition ) === 0 ) transformControls.detach();
 
 			}
 
@@ -391,9 +391,9 @@
 
 					const object = intersects[ 0 ].object;
 
-					if ( object !== transformControl.object ) {
+					if ( object !== transformControls.object ) {
 
-						transformControl.attach( object );
+						transformControls.attach( object );
 
 					}
 

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -22,7 +22,7 @@
 			import { TeapotBufferGeometry } from './jsm/geometries/TeapotBufferGeometry.js';
 
 			let camera, scene, renderer;
-			let cameraControls;
+			let orbitControls;
 			let effectController;
 			const teapotSize = 400;
 			let ambientLight, light;
@@ -74,8 +74,8 @@
 				window.addEventListener( 'resize', onWindowResize, false );
 
 				// CONTROLS
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.addEventListener( 'change', render );
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
 
 				// TEXTURE MAP
 				const textureMap = new THREE.TextureLoader().load( 'textures/uv_grid_opengl.jpg' );

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -31,7 +31,7 @@
 
 			let container, stats;
 
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 
 			let mesh, texture;
 
@@ -79,9 +79,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
-				controls.movementSpeed = 1000;
-				controls.lookSpeed = 0.1;
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls.movementSpeed = 1000;
+				firstPersonControls.lookSpeed = 0.1;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -99,7 +99,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -206,7 +206,7 @@
 
 			function render() {
 
-				controls.update( clock.getDelta() );
+				firstPersonControls.update( clock.getDelta() );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_terrain_fog.html
+++ b/examples/webgl_geometry_terrain_fog.html
@@ -30,7 +30,7 @@
 			import { ImprovedNoise } from './jsm/math/ImprovedNoise.js';
 
 			let container, stats;
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 			let mesh, texture;
 
 			const worldWidth = 256, worldDepth = 256;
@@ -77,9 +77,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
-				controls.movementSpeed = 150;
-				controls.lookSpeed = 0.1;
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls.movementSpeed = 150;
+				firstPersonControls.lookSpeed = 0.1;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -98,7 +98,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -214,7 +214,7 @@
 
 			function render() {
 
-				controls.update( clock.getDelta() );
+				firstPersonControls.update( clock.getDelta() );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -31,7 +31,7 @@
 
 			let container, stats;
 
-			let camera, controls, scene, renderer;
+			let camera, scene, renderer;
 
 			let mesh, texture;
 
@@ -61,19 +61,19 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 10, 20000 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1000;
-				controls.maxDistance = 10000;
-				controls.maxPolarAngle = Math.PI / 2;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1000;
+				orbitControls.maxDistance = 10000;
+				orbitControls.maxPolarAngle = Math.PI / 2;
 
 				//
 
 				const data = generateHeight( worldWidth, worldDepth );
 
-				controls.target.y = data[ worldHalfWidth + worldHalfDepth * worldWidth ] + 500;
-				camera.position.y = controls.target.y + 2000;
+				orbitControls.target.y = data[ worldHalfWidth + worldHalfDepth * worldWidth ] + 500;
+				camera.position.y = orbitControls.target.y + 2000;
 				camera.position.x = 2000;
-				controls.update();
+				orbitControls.update();
 
 				const geometry = new THREE.PlaneBufferGeometry( 7500, 7500, worldWidth - 1, worldDepth - 1 );
 				geometry.rotateX( - Math.PI / 2 );

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -122,9 +122,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 0, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 0, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_geometry_text_stroke.html
+++ b/examples/webgl_geometry_text_stroke.html
@@ -126,9 +126,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 0, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 0, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -278,9 +278,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 100;
-				controls.maxDistance = 1000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 100;
+				orbitControls.maxDistance = 1000;
 
 				effectController = {
 					// Can be changed dynamically

--- a/examples/webgl_instancing_performance.html
+++ b/examples/webgl_instancing_performance.html
@@ -35,7 +35,7 @@
 		import { BufferGeometryUtils } from './jsm/utils/BufferGeometryUtils.js';
 
 		let container, stats, gui, guiStatsEl;
-		let camera, controls, scene, renderer, material;
+		let camera, orbitControls, scene, renderer, material;
 
 		// gui
 
@@ -257,8 +257,8 @@
 
 			// controls
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.autoRotate = true;
+			orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.autoRotate = true;
 
 			// stats
 
@@ -305,7 +305,7 @@
 
 			requestAnimationFrame( animate );
 
-			controls.update();
+			orbitControls.update();
 			stats.update();
 
 			render();

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -33,7 +33,7 @@
 			import { BufferGeometryUtils } from './jsm/utils/BufferGeometryUtils.js';
 
 			let container, stats;
-			let camera, controls, scene, renderer;
+			let camera, trackballControls, scene, renderer;
 			let pickingTexture, pickingScene;
 			let highlightBox;
 
@@ -153,14 +153,14 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.rotateSpeed = 1.0;
-				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
-				controls.noZoom = false;
-				controls.noPan = false;
-				controls.staticMoving = true;
-				controls.dynamicDampingFactor = 0.3;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.rotateSpeed = 1.0;
+				trackballControls.zoomSpeed = 1.2;
+				trackballControls.panSpeed = 0.8;
+				trackballControls.noZoom = false;
+				trackballControls.noPan = false;
+				trackballControls.staticMoving = true;
+				trackballControls.dynamicDampingFactor = 0.3;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -240,7 +240,7 @@
 
 			function render() {
 
-				controls.update();
+				trackballControls.update();
 
 				pick();
 

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -26,7 +26,7 @@
 			let container, stats;
 
 			let camera, scene, renderer;
-			let controls;
+			let flyControls;
 
 			const clock = new THREE.Clock();
 
@@ -120,13 +120,13 @@
 
 				//
 
-				controls = new FlyControls( camera, renderer.domElement );
+				flyControls = new FlyControls( camera, renderer.domElement );
 
-				controls.movementSpeed = 2500;
-				controls.domElement = container;
-				controls.rollSpeed = Math.PI / 6;
-				controls.autoForward = false;
-				controls.dragToLook = false;
+				flyControls.movementSpeed = 2500;
+				flyControls.domElement = container;
+				flyControls.rollSpeed = Math.PI / 6;
+				flyControls.autoForward = false;
+				flyControls.dragToLook = false;
 
 				// stats
 
@@ -165,7 +165,7 @@
 
 				const delta = clock.getDelta();
 
-				controls.update( delta );
+				flyControls.update( delta );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -335,10 +335,10 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
-				controls.target.y = ( conesDistance + coneHeight ) * 0.5;
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.05;
+				const orbitControls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				orbitControls.target.y = ( conesDistance + coneHeight ) * 0.5;
+				orbitControls.enableDamping = true;
+				orbitControls.dampingFactor = 0.05;
 
 				scene.userData.render = function ( time ) {
 
@@ -352,7 +352,7 @@
 
 					lightningStrike.update( time );
 
-					controls.update();
+					orbitControls.update();
 
 					// Update point light position to the middle of the ray
 					posLight.position.lerpVectors( lightningStrike.rayParameters.sourceOffset, lightningStrike.rayParameters.destOffset, 0.5 );
@@ -548,7 +548,7 @@
 
 					lightningStrike.update( time );
 
-					controls.update();
+					orbitControls.update();
 
 					outlinePass.enabled = scene.userData.outlineEnabled;
 
@@ -558,10 +558,10 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
-				controls.target.copy( sphereMesh.position );
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.05;
+				const orbitControls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				orbitControls.target.copy( sphereMesh.position );
+				orbitControls.enableDamping = true;
+				orbitControls.dampingFactor = 0.05;
 
 				// THREE.Sphere mouse raycasting
 
@@ -748,16 +748,16 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
-				controls.target.y = GROUND_SIZE * 0.05;
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.05;
+				const orbitControls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				orbitControls.target.y = GROUND_SIZE * 0.05;
+				orbitControls.enableDamping = true;
+				orbitControls.dampingFactor = 0.05;
 
 				scene.userData.render = function ( time ) {
 
 					storm.update( time );
 
-					controls.update();
+					orbitControls.update();
 
 					if ( scene.userData.outlineEnabled ) {
 

--- a/examples/webgl_lightprobe.html
+++ b/examples/webgl_lightprobe.html
@@ -58,11 +58,11 @@
 				camera.position.set( 0, 0, 30 );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 10;
-				controls.maxDistance = 50;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 50;
+				orbitControls.enablePan = false;
 
 				// probe
 				lightProbe = new THREE.LightProbe();

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -50,11 +50,11 @@
 				cubeCamera = new THREE.CubeCamera( 1, 1000, cubeRenderTarget );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 10;
-				controls.maxDistance = 50;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 50;
+				orbitControls.enablePan = false;
 
 				// probe
 				lightProbe = new THREE.LightProbe();

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -227,9 +227,9 @@
 				container.appendChild( renderer.domElement );
 
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 20;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 20;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_lights_pointlights2.html
+++ b/examples/webgl_lights_pointlights2.html
@@ -21,7 +21,7 @@
 
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, trackballControls;
 			let light1, light2, light3, light4, light5, light6;
 
 			const clock = new THREE.Clock();
@@ -137,15 +137,15 @@
 
 				// CONTROLS
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
-				controls.rotateSpeed = 1.0;
-				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
+				trackballControls.rotateSpeed = 1.0;
+				trackballControls.zoomSpeed = 1.2;
+				trackballControls.panSpeed = 0.8;
 
-				controls.dynamicDampingFactor = 0.15;
+				trackballControls.dynamicDampingFactor = 0.15;
 
-				controls.keys = [ 65, 83, 68 ];
+				trackballControls.keys = [ 65, 83, 68 ];
 
 				// STATS
 
@@ -165,7 +165,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -203,7 +203,7 @@
 				light6.position.x = Math.cos( time * 0.7 ) * d;
 				light6.position.z = Math.cos( time * 0.5 ) * d;
 
-				controls.update( clock.getDelta() );
+				trackballControls.update( clock.getDelta() );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -92,9 +92,9 @@
 				mshStdKnot.receiveShadow = true;
 				scene.add( mshStdKnot );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.copy( mshStdBox.position );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.copy( mshStdBox.position );
+				orbitControls.update();
 
 				// GUI
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -43,11 +43,11 @@
 				camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 160, 40, 10 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 20;
-				controls.maxDistance = 500;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 20;
+				orbitControls.maxDistance = 500;
+				orbitControls.enablePan = false;
 
 				const ambient = new THREE.AmbientLight( 0xffffff, 0.1 );
 				scene.add( ambient );

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -26,7 +26,7 @@
 
 			const camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 1, 2000 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
 
 			const scene = new THREE.Scene();
 
@@ -83,9 +83,9 @@
 				onResize();
 				window.addEventListener( 'resize', onResize, false );
 
-				controls.target.set( 0, 7, 0 );
-				controls.maxPolarAngle = Math.PI / 2;
-				controls.update();
+				orbitControls.target.set( 0, 7, 0 );
+				orbitControls.maxPolarAngle = Math.PI / 2;
+				orbitControls.update();
 
 			}
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -26,7 +26,7 @@
 			import { LineGeometry } from './jsm/lines/LineGeometry.js';
 			import { GeometryUtils } from './jsm/utils/GeometryUtils.js';
 
-			let line, renderer, scene, camera, camera2, controls;
+			let line, renderer, scene, camera, camera2;
 			let line1;
 			let matLine, matLineBasic, matLineDashed;
 			let stats;
@@ -55,9 +55,9 @@
 				camera2 = new THREE.PerspectiveCamera( 40, 1, 1, 1000 );
 				camera2.position.copy( camera.position );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 500;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 500;
 
 
 				// Position and THREE.Color Data

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -25,7 +25,7 @@
 			import { Wireframe } from './jsm/lines/Wireframe.js';
 			import { WireframeGeometry2 } from './jsm/lines/WireframeGeometry2.js';
 
-			let wireframe, renderer, scene, camera, camera2, controls;
+			let wireframe, renderer, scene, camera, camera2;
 			let wireframe1;
 			let matLine, matLineBasic, matLineDashed;
 			let stats;
@@ -54,9 +54,9 @@
 				camera2 = new THREE.PerspectiveCamera( 40, 1, 1, 1000 );
 				camera2.position.copy( camera.position );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 500;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 500;
 
 
 				// Wireframe ( WireframeGeometry2, LineMaterial )

--- a/examples/webgl_loader_3dm.html
+++ b/examples/webgl_loader_3dm.html
@@ -21,7 +21,7 @@
 
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 
-			let container, controls;
+			let container, orbitControls;
 			let camera, scene, renderer;
 			let gui;
 
@@ -63,7 +63,7 @@
 				renderer.setSize( width, height );
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, container );
+				orbitControls = new OrbitControls( camera, container );
 
 				window.addEventListener( 'resize', resize, false );
 
@@ -83,7 +83,7 @@
 
 			function animate() {
 
-				controls.update();
+				orbitControls.update();
 				renderer.render( scene, camera );
 
 				requestAnimationFrame( animate );

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -19,7 +19,7 @@
 			import { TrackballControls } from './jsm/controls/TrackballControls.js';
 			import { TDSLoader } from './jsm/loaders/TDSLoader.js';
 
-			let container, controls;
+			let container, trackballControls;
 			let camera, scene, renderer;
 
 			init();
@@ -68,7 +68,7 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
 				window.addEventListener( 'resize', resize, false );
 
@@ -85,7 +85,7 @@
 
 			function animate() {
 
-				controls.update();
+				trackballControls.update();
 				renderer.render( scene, camera );
 
 				requestAnimationFrame( animate );

--- a/examples/webgl_loader_3mf.html
+++ b/examples/webgl_loader_3mf.html
@@ -27,7 +27,7 @@
 			import { ThreeMFLoader } from './jsm/loaders/3MFLoader.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 
-			let camera, scene, renderer, object, loader, controls;
+			let camera, scene, renderer, object, loader, orbitControls;
 
 			const params = {
 				asset: 'cube_gears'
@@ -62,12 +62,12 @@
 				camera.position.set( - 100, - 250, 100 );
 				scene.add( camera );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 50;
-				controls.maxDistance = 400;
-				controls.enablePan = false;
-				controls.update();
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 400;
+				orbitControls.enablePan = false;
+				orbitControls.update();
 
 				const pointLight = new THREE.PointLight( 0xffffff, 0.8 );
 				camera.add( pointLight );
@@ -83,7 +83,7 @@
 					object.position.y += ( object.position.y - center.y );
 					object.position.z += ( object.position.z - center.z );
 
-					controls.reset();
+					orbitControls.reset();
 
 					scene.add( object );
 					render();

--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -105,13 +105,13 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 50;
-				controls.maxDistance = 200;
-				controls.enablePan = false;
-				controls.target.set( 0, 20, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 200;
+				orbitControls.enablePan = false;
+				orbitControls.target.set( 0, 20, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_amf.html
+++ b/examples/webgl_loader_amf.html
@@ -65,10 +65,10 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.target.set( 0, 1.2, 2 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.target.set( 0, 1.2, 2 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_assimp.html
+++ b/examples/webgl_loader_assimp.html
@@ -54,9 +54,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 750;
-				controls.maxDistance = 2500;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 750;
+				orbitControls.maxDistance = 2500;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -30,7 +30,7 @@
 
 			const clock = new THREE.Clock();
 
-			let camera, controls, scene, renderer;
+			let camera, scene, renderer;
 			let mixer, skeletonHelper;
 
 			init();
@@ -70,9 +70,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 300;
-				controls.maxDistance = 700;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 300;
+				orbitControls.maxDistance = 700;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -23,7 +23,7 @@
 			import { ColladaLoader } from './jsm/loaders/ColladaLoader.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let container, stats, clock, controls;
+			let container, stats, clock;
 			let camera, scene, renderer, mixer;
 
 			init();
@@ -88,12 +88,12 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.screenSpacePanning = true;
-				controls.minDistance = 5;
-				controls.maxDistance = 40;
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.screenSpacePanning = true;
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 40;
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				//
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -99,9 +99,9 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 100, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 100, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -65,9 +65,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 12, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 12, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_gcode.html
+++ b/examples/webgl_loader_gcode.html
@@ -49,10 +49,10 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.minDistance = 10;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 100;
 
 				window.addEventListener( 'resize', resize, false );
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -94,12 +94,12 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.minDistance = 2;
-				controls.maxDistance = 10;
-				controls.target.set( 0, 0, - 0.2 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.minDistance = 2;
+				orbitControls.maxDistance = 10;
+				orbitControls.target.set( 0, 0, - 0.2 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_gltf_variants.html
+++ b/examples/webgl_loader_gltf_variants.html
@@ -97,12 +97,12 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.minDistance = 2;
-				controls.maxDistance = 10;
-				controls.target.set( 0, 0.5, - 0.2 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.minDistance = 2;
+				orbitControls.maxDistance = 10;
+				orbitControls.target.set( 0, 0.5, - 0.2 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -57,9 +57,9 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -31,7 +31,7 @@
 
 			let container, progressBarDiv;
 
-			let camera, scene, renderer, controls, gui, guiData;
+			let camera, scene, renderer, orbitControls, gui, guiData;
 
 			let model, textureCube;
 
@@ -89,7 +89,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				orbitControls = new OrbitControls( camera, renderer.domElement );
 
 				//
 
@@ -227,9 +227,9 @@
 
 						if ( resetCamera ) {
 
-							controls.target0.copy( bbox.getCenter( new THREE.Vector3() ) );
-							controls.position0.set( - 2.3, 2, 2 ).multiplyScalar( radius ).add( controls.target0 );
-							controls.reset();
+							orbitControls.target0.copy( bbox.getCenter( new THREE.Vector3() ) );
+							orbitControls.position0.set( - 2.3, 2, 2 ).multiplyScalar( radius ).add( orbitControls.target0 );
+							orbitControls.reset();
 
 						}
 

--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -91,9 +91,9 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 1.33, 10, - 6.7 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 1.33, 10, - 6.7 );
+				orbitControls.update();
 
 				renderer.setAnimationLoop( function () {
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -40,8 +40,6 @@
 
 			};
 
-			let controls;
-
 			const clock = new THREE.Clock();
 
 			let stats;
@@ -131,9 +129,9 @@
 
 				// CONTROLS
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 50, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 50, 0 );
+				orbitControls.update();
 
 				// GUI
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -42,8 +42,6 @@
 			const characters = [];
 			let nCharacters = 0;
 
-			let cameraControls;
-
 			const controls = {
 
 				moveForward: false,
@@ -143,10 +141,10 @@
 
 				// CONTROLS
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.target.set( 0, 50, 0 );
-				cameraControls.enableKeys = false;
-				cameraControls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 50, 0 );
+				orbitControls.enableKeys = false;
+				orbitControls.update();
 
 				// CHARACTER
 

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -140,9 +140,9 @@
 
 				}, onProgress, null );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 100;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -31,7 +31,6 @@
 				const clock = new THREE.Clock(), fov = 50;
 				const frame = new NodeFrame();
 				let teapot, mesh, cloud;
-				let controls;
 				let gui;
 
 				const param = { load: 'caustic' };
@@ -55,9 +54,9 @@
 					cloud = new THREE.TextureLoader().load( 'textures/lava/cloud.png' );
 					cloud.wrapS = cloud.wrapT = THREE.RepeatWrapping;
 
-					controls = new OrbitControls( camera, renderer.domElement );
-					controls.minDistance = 50;
-					controls.maxDistance = 200;
+					const orbitControls = new OrbitControls( camera, renderer.domElement );
+					orbitControls.minDistance = 50;
+					orbitControls.maxDistance = 200;
 
 					scene.add( new THREE.AmbientLight( 0x464646 ) );
 

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -42,7 +42,7 @@
 			let container,
 				stats,
 				camera,
-				controls,
+				trackballControls,
 				scene,
 				renderer,
 				container2,
@@ -166,12 +166,12 @@
 				document.body.appendChild( container );
 				container.appendChild( renderer.domElement );
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = 100;
-				controls.maxDistance = 500;
-				controls.rotateSpeed = 5.0;
-				controls.zoomSpeed = 5;
-				controls.panSpeed = 2;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = 100;
+				trackballControls.maxDistance = 500;
+				trackballControls.rotateSpeed = 5.0;
+				trackballControls.zoomSpeed = 5;
+				trackballControls.panSpeed = 2;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -191,7 +191,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -199,11 +199,11 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 
 				//copy position of the camera into inset
 				camera2.position.copy( camera.position );
-				camera2.position.sub( controls.target );
+				camera2.position.sub( trackballControls.target );
 				camera2.position.setLength( 300 );
 				camera2.lookAt( scene2.position );
 

--- a/examples/webgl_loader_obj2.html
+++ b/examples/webgl_loader_obj2.html
@@ -79,7 +79,7 @@
 				this.camera = null;
 				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				this.controls = null;
+				this.trackballControls = null;
 
 			};
 
@@ -100,7 +100,7 @@
 
 					this.camera = new THREE.PerspectiveCamera( this.cameraDefaults.fov, this.aspectRatio, this.cameraDefaults.near, this.cameraDefaults.far );
 					this.resetCamera();
-					this.controls = new TrackballControls( this.camera, this.renderer.domElement );
+					this.trackballControls = new TrackballControls( this.camera, this.renderer.domElement );
 
 					const ambientLight = new THREE.AmbientLight( 0x404040 );
 					const directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
@@ -164,7 +164,7 @@
 
 				resizeDisplayGL: function () {
 
-					this.controls.handleResize();
+					this.trackballControls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
@@ -199,7 +199,7 @@
 				render: function () {
 
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
-					this.controls.update();
+					this.trackballControls.update();
 					this.renderer.render( this.scene, this.camera );
 
 				}

--- a/examples/webgl_loader_obj2_options.html
+++ b/examples/webgl_loader_obj2_options.html
@@ -80,7 +80,7 @@
 				this.camera = null;
 				this.cameraTarget = this.cameraDefaults.posCameraTarget;
 
-				this.controls = null;
+				this.trackballControls = null;
 
 				this.flatShading = false;
 				this.doubleSide = false;
@@ -109,7 +109,7 @@
 
 					this.camera = new THREE.PerspectiveCamera( this.cameraDefaults.fov, this.aspectRatio, this.cameraDefaults.near, this.cameraDefaults.far );
 					this.resetCamera();
-					this.controls = new TrackballControls( this.camera, this.renderer.domElement );
+					this.trackballControls = new TrackballControls( this.camera, this.renderer.domElement );
 
 					const ambientLight = new THREE.AmbientLight( 0x404040 );
 					const directionalLight1 = new THREE.DirectionalLight( 0xC0C090 );
@@ -387,7 +387,7 @@
 
 				resizeDisplayGL: function () {
 
-					this.controls.handleResize();
+					this.trackballControls.handleResize();
 
 					this.recalcAspectRatio();
 					this.renderer.setSize( this.canvas.offsetWidth, this.canvas.offsetHeight, false );
@@ -423,7 +423,7 @@
 
 					if ( ! this.renderer.autoClear ) this.renderer.clear();
 
-					this.controls.update();
+					this.trackballControls.update();
 
 					this.cube.rotation.x += 0.05;
 					this.cube.rotation.y += 0.05;

--- a/examples/webgl_loader_pcd.html
+++ b/examples/webgl_loader_pcd.html
@@ -25,7 +25,7 @@
 			import { PCDLoader } from './jsm/loaders/PCDLoader.js';
 
 			let container, stats;
-			let camera, controls, scene, renderer;
+			let camera, trackballControls, scene, renderer;
 
 			init();
 			animate();
@@ -51,8 +51,8 @@
 
 					scene.add( points );
 					const center = points.geometry.boundingSphere.center;
-					controls.target.set( center.x, center.y, center.z );
-					controls.update();
+					trackballControls.target.set( center.x, center.y, center.z );
+					trackballControls.update();
 
 				} );
 
@@ -60,16 +60,16 @@
 				document.body.appendChild( container );
 				container.appendChild( renderer.domElement );
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
-				controls.rotateSpeed = 2.0;
-				controls.zoomSpeed = 0.3;
-				controls.panSpeed = 0.2;
+				trackballControls.rotateSpeed = 2.0;
+				trackballControls.zoomSpeed = 0.3;
+				trackballControls.panSpeed = 0.2;
 
-				controls.staticMoving = true;
+				trackballControls.staticMoving = true;
 
-				controls.minDistance = 0.3;
-				controls.maxDistance = 0.3 * 100;
+				trackballControls.minDistance = 0.3;
+				trackballControls.maxDistance = 0.3 * 100;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -85,7 +85,7 @@
 				camera.aspect = window.innerWidth / window.innerHeight;
 				camera.updateProjectionMatrix();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -117,7 +117,7 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
+				trackballControls.update();
 				renderer.render( scene, camera );
 				stats.update();
 

--- a/examples/webgl_loader_pdb.html
+++ b/examples/webgl_loader_pdb.html
@@ -51,7 +51,7 @@
 			import { CSS2DRenderer, CSS2DObject } from './jsm/renderers/CSS2DRenderer.js';
 
 			let camera, scene, renderer, labelRenderer;
-			let controls;
+			let trackballControls;
 
 			let root;
 
@@ -119,9 +119,9 @@
 
 				//
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = 500;
-				controls.maxDistance = 2000;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = 500;
+				trackballControls.maxDistance = 2000;
 
 				//
 
@@ -275,7 +275,7 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-				controls.update();
+				trackballControls.update();
 
 				const time = Date.now() * 0.0004;
 

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -54,8 +54,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.screenSpacePanning = true;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.screenSpacePanning = true;
 
 				//
 

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -39,8 +39,8 @@
 			camera.lookAt( scene.position );
 			scene.add( camera );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.autoRotate = true;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.autoRotate = true;
 
 			// PlaneBufferGeometry UVs assume flipY=true, which compressed textures don't support.
 			const geometry = flipY( new THREE.PlaneBufferGeometry() );
@@ -83,7 +83,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_texture_tga.html
+++ b/examples/webgl_loader_texture_tga.html
@@ -78,8 +78,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
 
 				//
 

--- a/examples/webgl_loader_vox.html
+++ b/examples/webgl_loader_vox.html
@@ -19,7 +19,7 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { VOXLoader } from './jsm/loaders/VOXLoader.js';
 
-			let camera, controls, scene, renderer;
+			let camera, orbitControls, scene, renderer;
 
 			init();
 			animate();
@@ -97,9 +97,9 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = .1;
-				controls.maxDistance = 0.5;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = .1;
+				orbitControls.maxDistance = 0.5;
 
 				//
 
@@ -151,7 +151,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -24,7 +24,7 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { VRMLoader } from './jsm/loaders/VRMLoader.js';
 
-			let container, stats, controls;
+			let container, stats, orbitControls;
 			let camera, scene, renderer, light;
 
 			init();
@@ -96,12 +96,12 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 5;
-				controls.enableDamping = true;
-				controls.target.set( 0, 0.9, 0 );
-				controls.update();
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 5;
+				orbitControls.enableDamping = true;
+				orbitControls.target.set( 0, 0.9, 0 );
+				orbitControls.update();
 
 				window.addEventListener( 'resize', onWindowResize, false );
 
@@ -126,7 +126,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update(); // to support damping
+				orbitControls.update(); // to support damping
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -22,7 +22,7 @@
 			import { VRMLLoader } from './jsm/loaders/VRMLLoader.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 
-			let camera, scene, renderer, stats, controls, loader;
+			let camera, scene, renderer, stats, orbitControls, loader;
 
 			const params = {
 				asset: 'house'
@@ -78,10 +78,10 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 200;
-				controls.enableDamping = true;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 200;
+				orbitControls.enableDamping = true;
 
 				//
 
@@ -123,7 +123,7 @@
 
 					vrmlScene = object;
 					scene.add( object );
-					controls.reset();
+					orbitControls.reset();
 
 				} );
 
@@ -142,7 +142,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update(); // to support damping
+				orbitControls.update(); // to support damping
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -25,7 +25,7 @@
 
 			let container, stats;
 
-			let camera, controls, scene, renderer;
+			let camera, trackballControls, scene, renderer;
 
 			init();
 			animate();
@@ -125,10 +125,10 @@
 
 				// controls
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.minDistance = .1;
-				controls.maxDistance = 0.5;
-				controls.rotateSpeed = 5.0;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.minDistance = .1;
+				trackballControls.maxDistance = 0.5;
+				trackballControls.rotateSpeed = 5.0;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -146,7 +146,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -154,7 +154,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -27,7 +27,7 @@
 		import { OrbitControls } from './jsm/controls/OrbitControls.js';
 		import { XLoader } from './jsm/loaders/XLoader.js';
 
-		let container, stats, controls;
+		let container, stats;
 		let camera, scene, renderer;
 		const clock = new THREE.Clock();
 		let manager = null;
@@ -80,9 +80,9 @@
 			camera.position.set( 2, 10, - 28 );
 			camera.up.set( 0, 1, 0 );
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.target.set( 0, 5, 0 );
-			controls.update();
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.target.set( 0, 5, 0 );
+			orbitControls.update();
 
 			const light = new THREE.DirectionalLight( 0xffffff, 1 );
 			light.position.set( 10, 100, - 10 ).normalize();

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -20,7 +20,7 @@
 
 			let container;
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, flyControls;
 
 			const clock = new THREE.Clock();
 
@@ -89,9 +89,9 @@
 
 				//
 
-				controls = new FlyControls( camera, renderer.domElement );
-				controls.movementSpeed = 1000;
-				controls.rollSpeed = Math.PI / 10;
+				flyControls = new FlyControls( camera, renderer.domElement );
+				flyControls.movementSpeed = 1000;
+				flyControls.rollSpeed = Math.PI / 10;
 
 				//
 
@@ -117,7 +117,7 @@
 
 			function render() {
 
-				controls.update( clock.getDelta() );
+				flyControls.update( clock.getDelta() );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -99,9 +99,9 @@
 
 			// CONTROLS
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.minDistance = 500;
-			controls.maxDistance = 5000;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.minDistance = 500;
+			orbitControls.maxDistance = 5000;
 
 			// STATS
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -48,7 +48,6 @@
 			let stats;
 
 			let grid;
-			let controls;
 
 			const wheels = [];
 
@@ -75,9 +74,9 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.set( 4.25, 1.4, - 4.5 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 0.5, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 0.5, 0 );
+				orbitControls.update();
 
 				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -40,7 +40,7 @@
 			};
 
 			let cameraOrtho, cameraPerspective;
-			let controlsOrtho, controlsPerspective;
+			let orbitControlsOrtho, orbitControlsPerspective;
 
 			let mesh, materialStandard, materialDepthBasic, materialDepthRGBA, materialNormal;
 
@@ -87,17 +87,17 @@
 
 				camera = cameraPerspective;
 
-				controlsPerspective = new OrbitControls( cameraPerspective, renderer.domElement );
-				controlsPerspective.minDistance = 1000;
-				controlsPerspective.maxDistance = 2400;
-				controlsPerspective.enablePan = false;
-				controlsPerspective.enableDamping = true;
+				orbitControlsPerspective = new OrbitControls( cameraPerspective, renderer.domElement );
+				orbitControlsPerspective.minDistance = 1000;
+				orbitControlsPerspective.maxDistance = 2400;
+				orbitControlsPerspective.enablePan = false;
+				orbitControlsPerspective.enableDamping = true;
 
-				controlsOrtho = new OrbitControls( cameraOrtho, renderer.domElement );
-				controlsOrtho.minZoom = 0.5;
-				controlsOrtho.maxZoom = 1.5;
-				controlsOrtho.enablePan = false;
-				controlsOrtho.enableDamping = true;
+				orbitControlsOrtho = new OrbitControls( cameraOrtho, renderer.domElement );
+				orbitControlsOrtho.minZoom = 0.5;
+				orbitControlsOrtho.maxZoom = 1.5;
+				orbitControlsOrtho.enablePan = false;
+				orbitControlsOrtho.enableDamping = true;
 
 				// lights
 
@@ -280,8 +280,8 @@
 
 				}
 
-				controlsPerspective.update();
-				controlsOrtho.update(); // must update both controls for damping to complete
+				orbitControlsPerspective.update();
+				orbitControlsOrtho.update(); // must update both controls for damping to complete
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -58,7 +58,6 @@
 			const clock = new THREE.Clock(), fov = 50;
 			const frame = new NodeFrame();
 			let teapot;
-			let controls;
 			const meshes = [];
 
 			document.getElementById( "preload" ).addEventListener( 'click', function () {
@@ -95,9 +94,9 @@
 				camera.position.z = - 300;
 				camera.position.y = 200;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 400;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 400;
 
 				scene.add( new THREE.AmbientLight( 0x464646 ) );
 

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -99,11 +99,11 @@
 				container.appendChild( renderer.domElement );
 
 				//controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
-				controls.enablePan = false;
-				controls.minPolarAngle = Math.PI / 4;
-				controls.maxPolarAngle = Math.PI / 1.5;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
+				orbitControls.minPolarAngle = Math.PI / 4;
+				orbitControls.maxPolarAngle = Math.PI / 1.5;
 
 				//stats
 				stats = new Stats();

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -135,9 +135,9 @@
 				container.appendChild( renderer.domElement );
 
 				//controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minPolarAngle = Math.PI / 4;
-				controls.maxPolarAngle = Math.PI / 1.5;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minPolarAngle = Math.PI / 4;
+				orbitControls.maxPolarAngle = Math.PI / 1.5;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_curvature.html
+++ b/examples/webgl_materials_curvature.html
@@ -130,9 +130,9 @@
 				renderer.autoClear = false;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 20;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 20;
+				orbitControls.maxDistance = 100;
 
 				const loader = new OBJLoader();
 				//load the obj

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -25,7 +25,7 @@
 			import { OBJLoader } from './jsm/loaders/OBJLoader.js';
 			let stats;
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, orbitControls;
 			const settings = {
 				metalness: 1.0,
 				roughness: 0.4,
@@ -117,9 +117,9 @@
 				camera.position.z = 1500;
 				scene.add( camera );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
-				controls.enableDamping = true;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
+				orbitControls.enableDamping = true;
 
 				// lights
 
@@ -230,7 +230,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 
 				stats.begin();
 				render();

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -21,7 +21,7 @@
 			import { GUI } from './jsm/libs/dat.gui.module.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let controls, camera, scene, renderer;
+			let camera, scene, renderer;
 			let textureEquirec, textureCube;
 			let sphereMesh, sphereMaterial;
 
@@ -77,9 +77,9 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 500;
-				controls.maxDistance = 2500;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 500;
+				orbitControls.maxDistance = 2500;
 
 				//
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -30,7 +30,7 @@
 			};
 
 			let container, stats;
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer;
 			let torusMesh, planeMesh;
 			let pngCubeRenderTarget, exrCubeRenderTarget;
 			let pngBackground, exrBackground;
@@ -113,9 +113,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 300;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 300;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -33,7 +33,7 @@
 			};
 
 			let container, stats;
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer;
 			let torusMesh, planeMesh;
 			let generatedCubeRenderTarget, ldrCubeRenderTarget, hdrCubeRenderTarget, rgbmCubeRenderTarget;
 			let ldrCubeMap, hdrCubeMap, rgbmCubeMap;
@@ -178,9 +178,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 300;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 300;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_envmaps_hdr_nodes.html
+++ b/examples/webgl_materials_envmaps_hdr_nodes.html
@@ -37,7 +37,7 @@
 			};
 
 			let container, stats;
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer;
 			let torusMesh, torusMeshNode, planeMesh;
 			let generatedCubeRenderTarget, ldrCubeRenderTarget, hdrCubeRenderTarget, rgbmCubeRenderTarget;
 			let ldrCubeMap, hdrCubeMap, rgbmCubeMap;
@@ -184,9 +184,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 300;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 300;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -192,8 +192,6 @@
 
 			let camera, cubeCamera, scene, renderer;
 
-			let cameraControls;
-
 			let groundPlane, wallMat;
 
 			init();
@@ -238,12 +236,12 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 280, 106, - 5 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.target.set( 0, - 10, 0 );
-				cameraControls.maxDistance = 400;
-				cameraControls.minDistance = 10;
-				cameraControls.addEventListener( 'change', render );
-				cameraControls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, - 10, 0 );
+				orbitControls.maxDistance = 400;
+				orbitControls.minDistance = 10;
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.update();
 
 				// cube camera for environment map
 

--- a/examples/webgl_materials_envmaps_pmrem_nodes.html
+++ b/examples/webgl_materials_envmaps_pmrem_nodes.html
@@ -59,7 +59,7 @@
 			};
 
 			let container, stats;
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer;
 			let nodeMaterial, nodeTexture, nodeTextureIntensity, torusMesh, planeMesh;
 			let hdrCubeRenderTarget;
 			let hdrCubeMap;
@@ -137,9 +137,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 300;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 300;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -114,9 +114,9 @@
 
 				// CONTROLS
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = 0.9 * Math.PI / 2;
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = 0.9 * Math.PI / 2;
+				orbitControls.enableZoom = false;
 
 				// STATS
 

--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -53,10 +53,10 @@
 				camera.position.set( 0, 0, 13 );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.enableZoom = false;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
 
 				// manager
 				const manager = new THREE.LoadingManager( render );

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -56,9 +56,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 50;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 50;
 
 				//
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -33,7 +33,6 @@
 			const clock = new THREE.Clock(), fov = 50;
 			const frame = new Nodes.NodeFrame();
 			let teapot, mesh;
-			let controls;
 			let move = false;
 			let rtTexture, rtMaterial;
 			let gui;
@@ -129,9 +128,9 @@
 				camera.position.z = - 50;
 				camera.position.y = 30;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 200;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 200;
 
 				lightGroup = new THREE.Group();
 				scene.add( lightGroup );

--- a/examples/webgl_materials_normalmap_object_space.html
+++ b/examples/webgl_materials_normalmap_object_space.html
@@ -44,11 +44,11 @@
 				scene.add( camera );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 10;
-				controls.maxDistance = 50;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 50;
+				orbitControls.enablePan = false;
 
 				// ambient
 				scene.add( new THREE.AmbientLight( 0xffffff, .2 ) );

--- a/examples/webgl_materials_parallaxmap.html
+++ b/examples/webgl_materials_parallaxmap.html
@@ -86,9 +86,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 5;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 5;
 
 				//
 

--- a/examples/webgl_materials_physical_reflectivity.html
+++ b/examples/webgl_materials_physical_reflectivity.html
@@ -162,9 +162,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 20;
-				controls.maxDistance = 200;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 20;
+				orbitControls.maxDistance = 200;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_physical_sheen.html
+++ b/examples/webgl_materials_physical_sheen.html
@@ -28,7 +28,7 @@
 			import { FBXLoader } from './jsm/loaders/FBXLoader.js';
 
 			// Graphics variables
-			let camera, controls, scene, renderer, stats;
+			let camera, scene, renderer, stats;
 			let directionalLight;
 			let mesh, sphere, material, nodeMaterial;
 
@@ -91,9 +91,9 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				directionalLight = new THREE.DirectionalLight( 0xffffff, .5 );
 				directionalLight.position.set( 0, 10, 0 );

--- a/examples/webgl_materials_physical_transmission.html
+++ b/examples/webgl_materials_physical_transmission.html
@@ -145,9 +145,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 150;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 150;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -27,7 +27,7 @@
 
 			let container, stats;
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, trackballControls;
 
 			init();
 			animate();
@@ -53,7 +53,7 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 1000 );
 				camera.position.z = 2;
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
 				//
 
@@ -148,7 +148,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				trackballControls.update();
 				renderer.render( scene, camera );
 
 				if ( statsEnabled ) stats.update();

--- a/examples/webgl_materials_subsurface_scattering.html
+++ b/examples/webgl_materials_subsurface_scattering.html
@@ -74,9 +74,9 @@
 			stats = new Stats();
 			container.appendChild( stats.dom );
 
-			const controls = new OrbitControls( camera, container );
-			controls.minDistance = 500;
-			controls.maxDistance = 3000;
+			const orbitControls = new OrbitControls( camera, container );
+			orbitControls.minDistance = 500;
+			orbitControls.maxDistance = 3000;
 
 			window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_texture_rotation.html
+++ b/examples/webgl_materials_texture_rotation.html
@@ -48,11 +48,11 @@
 				camera.position.set( 10, 15, 25 );
 				scene.add( camera );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				controls.minDistance = 20;
-				controls.maxDistance = 50;
-				controls.maxPolarAngle = Math.PI / 2;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				orbitControls.minDistance = 20;
+				orbitControls.maxDistance = 50;
+				orbitControls.maxPolarAngle = Math.PI / 2;
 
 				const geometry = new THREE.BoxBufferGeometry( 10, 10, 10 );
 

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -152,9 +152,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -152,9 +152,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -159,9 +159,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -173,9 +173,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -176,9 +176,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -149,9 +149,9 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 200;
-				controls.maxDistance = 2000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 200;
+				orbitControls.maxDistance = 2000;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -60,9 +60,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_math_obb.html
+++ b/examples/webgl_math_obb.html
@@ -30,7 +30,7 @@
 
 			import Stats from './jsm/libs/stats.module.js';
 
-			let camera, scene, renderer, clock, controls, stats, raycaster, hitbox;
+			let camera, scene, renderer, clock, orbitControls, stats, raycaster, hitbox;
 
 			const objects = [], mouse = new THREE.Vector2();
 
@@ -101,8 +101,8 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableDamping = true;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableDamping = true;
 
 				//
 
@@ -185,7 +185,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update();
+				orbitControls.update();
 
 				// transform cubes
 

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -39,8 +39,6 @@
 
 			let camera, scene, renderer;
 
-			let cameraControls;
-
 			let sphereGroup, smallSphere;
 
 			init();
@@ -63,11 +61,11 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 0, 75, 160 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.target.set( 0, 40, 0 );
-				cameraControls.maxDistance = 400;
-				cameraControls.minDistance = 10;
-				cameraControls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 40, 0 );
+				orbitControls.maxDistance = 400;
+				orbitControls.minDistance = 10;
+				orbitControls.update();
 
 				//
 

--- a/examples/webgl_mirror_nodes.html
+++ b/examples/webgl_mirror_nodes.html
@@ -59,8 +59,6 @@
 			let camera, scene, renderer;
 			const clock = new THREE.Clock();
 
-			let cameraControls;
-
 			const gui = new GUI();
 
 			let sphereGroup, smallSphere;
@@ -82,11 +80,11 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 0, 75, 160 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
-				cameraControls.target.set( 0, 40, 0 );
-				cameraControls.maxDistance = 400;
-				cameraControls.minDistance = 10;
-				cameraControls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 40, 0 );
+				orbitControls.maxDistance = 400;
+				orbitControls.minDistance = 10;
+				orbitControls.update();
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -30,7 +30,7 @@
 				camera,
 				renderer,
 				rayCaster,
-				control,
+				transformControls,
 				flow,
 				action = ACTION_NONE;
 
@@ -138,8 +138,8 @@
 				renderer.domElement.addEventListener( 'pointerdown', onPointerDown, false );
 
 				rayCaster = new THREE.Raycaster();
-				control = new TransformControls( camera, renderer.domElement );
-				control.addEventListener( "dragging-changed", function ( event ) {
+				transformControls = new TransformControls( camera, renderer.domElement );
+				transformControls.addEventListener( "dragging-changed", function ( event ) {
 
 					if ( ! event.value ) {
 
@@ -187,8 +187,8 @@
 					if ( intersects.length ) {
 
 						const target = intersects[ 0 ].object;
-						control.attach( target );
-						scene.add( control );
+						transformControls.attach( target );
+						scene.add( transformControls );
 
 					}
 

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -30,7 +30,7 @@
 				camera,
 				renderer,
 				rayCaster,
-				control,
+				transformControls,
 				flow,
 				action = ACTION_NONE;
 
@@ -164,8 +164,8 @@
 				renderer.domElement.addEventListener( 'pointerdown', onPointerDown, false );
 
 				rayCaster = new THREE.Raycaster();
-				control = new TransformControls( camera, renderer.domElement );
-				control.addEventListener( "dragging-changed", function ( event ) {
+				transformControls = new TransformControls( camera, renderer.domElement );
+				transformControls.addEventListener( "dragging-changed", function ( event ) {
 
 					if ( ! event.value ) {
 
@@ -217,8 +217,8 @@
 					if ( intersects.length ) {
 
 						const target = intersects[ 0 ].object;
-						control.attach( target );
-						scene.add( control );
+						transformControls.attach( target );
+						scene.add( transformControls );
 
 					}
 

--- a/examples/webgl_modifier_edgesplit.html
+++ b/examples/webgl_modifier_edgesplit.html
@@ -49,12 +49,12 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.25;
-				controls.rotateSpeed = 0.35;
-				controls.minZoom = 1;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.enableDamping = true;
+				orbitControls.dampingFactor = 0.25;
+				orbitControls.rotateSpeed = 0.35;
+				orbitControls.minZoom = 1;
 				camera.position.set( 0, 0, 4 );
 
 				scene.add( new THREE.HemisphereLight( 0xffffff, 0x444444 ) );

--- a/examples/webgl_modifier_simplifier.html
+++ b/examples/webgl_modifier_simplifier.html
@@ -40,10 +40,10 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 15;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.enablePan = false;
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.enablePan = false;
+				orbitControls.enableZoom = false;
 
 				scene.add( new THREE.AmbientLight( 0xffffff, 0.2 ) );
 

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -94,9 +94,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 400;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 400;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -64,7 +64,7 @@
 
 			let renderer, scene, camera, stats;
 
-			let controls;
+			let trackballControls;
 
 			let mesh, uniforms;
 
@@ -178,7 +178,7 @@
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
 
-				controls = new TrackballControls( camera, renderer.domElement );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
 
 				stats = new Stats();
 				container.appendChild( stats.dom );
@@ -214,7 +214,7 @@
 
 				uniforms.amplitude.value = 1.0 + Math.sin( time * 0.5 );
 
-				controls.update();
+				trackballControls.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -145,9 +145,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 400;
-				controls.maxDistance = 1000;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 400;
+				orbitControls.maxDistance = 1000;
 
 				//
 

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -98,9 +98,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 20;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 20;
 
 				//
 

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -112,12 +112,12 @@
 					camera.position.z = 2;
 					scene.userData.camera = camera;
 
-					const controls = new OrbitControls( scene.userData.camera, scene.userData.element );
-					controls.minDistance = 2;
-					controls.maxDistance = 5;
-					controls.enablePan = false;
-					controls.enableZoom = false;
-					scene.userData.controls = controls;
+					const orbitControls = new OrbitControls( scene.userData.camera, scene.userData.element );
+					orbitControls.minDistance = 2;
+					orbitControls.maxDistance = 5;
+					orbitControls.enablePan = false;
+					orbitControls.enableZoom = false;
+					scene.userData.controls = orbitControls;
 
 					// add one random mesh to each scene
 					const geometry = geometries[ geometries.length * Math.random() | 0 ];

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -174,8 +174,8 @@
 					camera.position.set( 0, 0, 1.2 * balls );
 					scene.userData.camera = camera;
 
-					const controls = new OrbitControls( camera, views[ n ] );
-					scene.userData.controls = controls;
+					const orbitControls = new OrbitControls( camera, views[ n ] );
+					scene.userData.controls = orbitControls;
 
 					scenes.push( scene );
 
@@ -323,7 +323,7 @@
 
 		<script>
 
-			let parent = document.scripts[ document.scripts.length - 1 ].parentNode;
+			const parent = document.scripts[ document.scripts.length - 1 ].parentNode;
 
 			parent.displacement = function ( x, y, z, t, target ) {
 

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -44,7 +44,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let container, camera, renderer, controls;
+			let container, camera, renderer, orbitControls;
 			let sceneL, sceneR;
 
 			let sliderPos = window.innerWidth / 2;
@@ -64,7 +64,7 @@
 				camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.z = 6;
 
-				controls = new OrbitControls( camera, container );
+				orbitControls = new OrbitControls( camera, container );
 
 				const light = new THREE.HemisphereLight( 0xffffff, 0x444444, 1 );
 				light.position.set( - 2, 2, 2 );
@@ -105,7 +105,7 @@
 
 					if ( event.isPrimary === false ) return;
 
-					controls.enabled = false;
+					orbitControls.enabled = false;
 
 					window.addEventListener( 'pointermove', onPointerMove, false );
 					window.addEventListener( 'pointerup', onPointerUp, false );
@@ -114,7 +114,7 @@
 
 				function onPointerUp() {
 
-					controls.enabled = true;
+					orbitControls.enabled = true;
 
 					window.removeEventListener( 'pointermove', onPointerMove, false );
 					window.removeEventListener( 'pointerup', onPointerUp, false );

--- a/examples/webgl_nearestneighbour.html
+++ b/examples/webgl_nearestneighbour.html
@@ -58,7 +58,7 @@
 			import { TypedArrayUtils } from './jsm/utils/TypedArrayUtils.js';
 
 			let camera, scene, renderer;
-			let controls;
+			let firstPersonControls;
 
 			const amountOfParticles = 500000, maxDistance = Math.pow( 120, 2 );
 			let positions, alphas, particles, _particleGeom;
@@ -95,11 +95,11 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
-				controls.movementSpeed = 100;
-				controls.lookSpeed = 0.1;
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls.movementSpeed = 100;
+				firstPersonControls.lookSpeed = 0.1;
 
-				controls.lookAt( 500, 500, 500 );
+				firstPersonControls.lookAt( 500, 500, 500 );
 
 				// create the custom shader
 
@@ -163,7 +163,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -174,7 +174,7 @@
 				//
 				displayNearest( camera.position );
 
-				controls.update( clock.getDelta() );
+				firstPersonControls.update( clock.getDelta() );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_panorama_cube.html
+++ b/examples/webgl_panorama_cube.html
@@ -18,7 +18,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			let camera, controls;
+			let camera, orbitControls;
 			let renderer;
 			let scene;
 
@@ -39,11 +39,11 @@
 				camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.z = 0.01;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableZoom = false;
-				controls.enablePan = false;
-				controls.enableDamping = true;
-				controls.rotateSpeed = - 0.25;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
+				orbitControls.enableDamping = true;
+				orbitControls.rotateSpeed = - 0.25;
 
 				const textures = getTexturesFromAtlasFile( "textures/cube/sun_temple_stripe.jpg", 6 );
 
@@ -113,7 +113,7 @@
 
 				requestAnimationFrame( animate );
 
-				controls.update(); // required when damping is enabled
+				orbitControls.update(); // required when damping is enabled
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_pmrem_test.html
+++ b/examples/webgl_pmrem_test.html
@@ -28,7 +28,7 @@
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { RGBELoader } from './jsm/loaders/RGBELoader.js';
 
-			let scene, camera, controls, renderer;
+			let scene, camera, renderer;
 
 			function init() {
 
@@ -64,10 +64,10 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.minDistance = 4;
-				controls.maxDistance = 20;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.minDistance = 4;
+				orbitControls.maxDistance = 20;
 
 				// light
 

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -103,7 +103,7 @@
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 				container.appendChild( renderer.domElement );
-				
+			
 				const target = new THREE.WebGLRenderTarget( {
 					minFilter: THREE.LinearFilter,
 					magFilter: THREE.LinearFilter,
@@ -123,11 +123,11 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 2;
-				controls.maxDistance = 10;
-				controls.target.set( 0, 0, - 0.2 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 2;
+				orbitControls.maxDistance = 10;
+				orbitControls.target.set( 0, 0, - 0.2 );
+				orbitControls.update();
 
 				gui = new GUI();
 				gui.width = 350;

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -176,8 +176,8 @@
 				const copyPass = new ShaderPass( CopyShader );
 				composer.addPass( copyPass );
 
-				const controls = new OrbitControls( cameraP, renderer.domElement );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( cameraP, renderer.domElement );
+				orbitControls.enableZoom = false;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -91,9 +91,9 @@
 
 				renderer.autoClear = false;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 500;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 500;
 
 				//
 

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -27,7 +27,7 @@
 			import { FXAAShader } from './jsm/shaders/FXAAShader.js';
 
 			let container, stats;
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer, orbitControls;
 			let composer, effectFXAA, outlinePass;
 
 			let selectedObjects = [];
@@ -126,12 +126,12 @@
 				camera = new THREE.PerspectiveCamera( 45, width / height, 0.1, 100 );
 				camera.position.set( 0, 0, 8 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 5;
-				controls.maxDistance = 20;
-				controls.enablePan = false;
-				controls.enableDamping = true;
-				controls.dampingFactor = 0.05;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 20;
+				orbitControls.enablePan = false;
+				orbitControls.enableDamping = true;
+				orbitControls.dampingFactor = 0.05;
 
 				//
 
@@ -334,7 +334,7 @@
 
 				}
 
-				controls.update();
+				orbitControls.update();
 
 				composer.render();
 

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -26,7 +26,7 @@
 			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
 			import { PixelShader } from './jsm/shaders/PixelShader.js';
 
-			let camera, scene, renderer, gui, composer, controls;
+			let camera, scene, renderer, gui, composer, trackballControls;
 			let pixelPass, params;
 
 			let group;
@@ -60,10 +60,10 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.set( 0, 0, 30 );
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.rotateSpeed = 2.0;
-				controls.panSpeed = 0.8;
-				controls.zoomSpeed = 1.5;
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.rotateSpeed = 2.0;
+				trackballControls.panSpeed = 0.8;
+				trackballControls.zoomSpeed = 1.5;
 
 				scene = new THREE.Scene();
 
@@ -136,7 +136,7 @@
 
 			function update() {
 
-				controls.update();
+				trackballControls.update();
 				updateGUI();
 
 				group.rotation.y += .0015;

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -50,9 +50,9 @@
 				document.body.appendChild( stats.dom );
 
 				// camera controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 0, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 0, 0 );
+				orbitControls.update();
 
 				// scene
 

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -94,9 +94,9 @@
 				effectSobel.uniforms[ 'resolution' ].value.y = window.innerHeight * window.devicePixelRatio;
 				composer.addPass( effectSobel );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 100;
 
 				//
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -70,10 +70,10 @@
 				camera.position.set( - 5, 2.5, - 3.5 );
 				scene.add( camera );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI * 0.5;
-				controls.minDistance = 1;
-				controls.maxDistance = 10;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = Math.PI * 0.5;
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 10;
 
 				scene.add( new THREE.AmbientLight( 0x404040 ) );
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -81,11 +81,11 @@
 			camera.position.set( 0, 0, 20 );
 			camera.lookAt( 0, 0, 0 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.maxPolarAngle = Math.PI * 0.5;
-			controls.minDistance = 1;
-			controls.maxDistance = 100;
-			controls.addEventListener( 'change', render );
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.maxPolarAngle = Math.PI * 0.5;
+			orbitControls.minDistance = 1;
+			orbitControls.maxDistance = 100;
+			orbitControls.addEventListener( 'change', render );
 
 			scene.add( new THREE.AmbientLight( 0x404040 ) );
 

--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -25,7 +25,7 @@
 		import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
 		let renderer, scene, camera;
-		let controls, group;
+		let group;
 
 		init();
 		animate();
@@ -50,8 +50,8 @@
 			camera.position.set( 15, 15, 15 );
 			camera.lookAt( scene.position );
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.enableRotate = true;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.enableRotate = true;
 
 			// add sprites
 

--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -299,8 +299,8 @@
 				scene.add( mesh );
 
 				// Controls
-				const controls = new OrbitControls( camera, canvas );
-				controls.enableZoom = false;
+				const orbitControls = new OrbitControls( camera, canvas );
+				orbitControls.enableZoom = false;
 
 				// GUI
 				const gui = new GUI();

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -94,9 +94,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 10;
-				controls.maxDistance = 100;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 100;
 
 				//
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -26,7 +26,7 @@
 
 			let container, stats;
 			let camera, scene, renderer;
-			let controls, water, sun, mesh;
+			let water, sun, mesh;
 
 			init();
 			animate();
@@ -128,12 +128,12 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI * 0.495;
-				controls.target.set( 0, 10, 0 );
-				controls.minDistance = 40.0;
-				controls.maxDistance = 200.0;
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = Math.PI * 0.495;
+				orbitControls.target.set( 0, 10, 0 );
+				orbitControls.minDistance = 40.0;
+				orbitControls.maxDistance = 200.0;
+				orbitControls.update();
 
 				//
 

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -101,11 +101,11 @@
 				renderer.toneMappingExposure = 0.5;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render );
-				//controls.maxPolarAngle = Math.PI / 2;
-				controls.enableZoom = false;
-				controls.enablePan = false;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render );
+				//orbitControls.maxPolarAngle = Math.PI / 2;
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
 
 				initSky();
 

--- a/examples/webgl_shaders_vector.html
+++ b/examples/webgl_shaders_vector.html
@@ -68,7 +68,7 @@
 
 			let stats;
 
-			let camera, scene, renderer, controls;
+			let camera, scene, renderer;
 
 			let group;
 
@@ -284,9 +284,9 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 50, 100, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 50, 100, 0 );
+				orbitControls.update();
 
 				stats = new Stats();
 				document.body.appendChild( stats.dom );

--- a/examples/webgl_shading_physical.html
+++ b/examples/webgl_shading_physical.html
@@ -28,7 +28,7 @@
 
 			let mesh;
 
-			let controls;
+			let trackballControls;
 
 			let cubeCamera;
 
@@ -245,16 +245,16 @@
 
 				//
 
-				controls = new TrackballControls( camera, renderer.domElement );
-				controls.target.set( 0, 120, 0 );
+				trackballControls = new TrackballControls( camera, renderer.domElement );
+				trackballControls.target.set( 0, 120, 0 );
 
-				controls.rotateSpeed = 1.0;
-				controls.zoomSpeed = 1.2;
-				controls.panSpeed = 0.8;
+				trackballControls.rotateSpeed = 1.0;
+				trackballControls.zoomSpeed = 1.2;
+				trackballControls.panSpeed = 0.8;
 
-				controls.staticMoving = true;
+				trackballControls.staticMoving = true;
 
-				controls.keys = [ 65, 83, 68 ];
+				trackballControls.keys = [ 65, 83, 68 ];
 
 
 				// STATS
@@ -315,7 +315,7 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				controls.handleResize();
+				trackballControls.handleResize();
 
 			}
 
@@ -337,7 +337,7 @@
 
 				const delta = clock.getDelta();
 
-				controls.update();
+				trackballControls.update();
 
 				if ( mixer ) {
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -31,7 +31,7 @@
 			let SCREEN_HEIGHT = window.innerHeight;
 			const FLOOR = - 250;
 
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 			let container, stats;
 
 			const NEAR = 10, FAR = 3000;
@@ -106,14 +106,14 @@
 
 				// CONTROLS
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.lookSpeed = 0.0125;
-				controls.movementSpeed = 500;
-				controls.noFly = false;
-				controls.lookVertical = true;
+				firstPersonControls.lookSpeed = 0.0125;
+				firstPersonControls.movementSpeed = 500;
+				firstPersonControls.noFly = false;
+				firstPersonControls.lookVertical = true;
 
-				controls.lookAt( scene.position );
+				firstPersonControls.lookAt( scene.position );
 
 				// STATS
 
@@ -137,7 +137,7 @@
 
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -350,7 +350,7 @@
 
 				}
 
-				controls.update( delta );
+				firstPersonControls.update( delta );
 
 				renderer.clear();
 				renderer.render( scene, camera );

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -23,7 +23,7 @@
 			import { CSM } from './jsm/csm/CSM.js';
 			import { CSMHelper } from './jsm/csm/CSMHelper.js';
 
-			let renderer, scene, camera, orthoCamera, controls, csm, csmHelper;
+			let renderer, scene, camera, orthoCamera, orbitControls, csm, csmHelper;
 
 			const params = {
 				orthographic: false,
@@ -49,7 +49,7 @@
 
 			function updateOrthoCamera() {
 
-				const size = controls.target.distanceTo( camera.position );
+				const size = orbitControls.target.distanceTo( camera.position );
 				const aspect = camera.aspect;
 
 				orthoCamera.left = size * aspect / - 2;
@@ -76,11 +76,11 @@
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI / 2;
+				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = Math.PI / 2;
 				camera.position.set( 60, 60, 0 );
-				controls.target = new THREE.Vector3( - 100, 10, 0 );
-				controls.update();
+				orbitControls.target = new THREE.Vector3( - 100, 10, 0 );
+				orbitControls.update();
 
 				const ambientLight = new THREE.AmbientLight( 0xffffff, 0.5 );
 				scene.add( ambientLight );
@@ -258,7 +258,7 @@
 
 				camera.updateMatrixWorld();
 				csm.update();
-				controls.update();
+				orbitControls.update();
 
 				if ( params.orthographic ) {
 

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -242,12 +242,12 @@
 				renderer.shadowMap.enabled = true;
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI * 0.5;
-				controls.minDistance = 10;
-				controls.maxDistance = 75;
-				controls.target.set( 0, 2.5, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.maxPolarAngle = Math.PI * 0.5;
+				orbitControls.minDistance = 10;
+				orbitControls.maxDistance = 75;
+				orbitControls.target.set( 0, 2.5, 0 );
+				orbitControls.update();
 
 				// performance monitor
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -31,7 +31,7 @@
 
 			const ANIMATION_GROUPS = 25;
 
-			let camera, controls, scene, renderer;
+			let camera, firstPersonControls, scene, renderer;
 			let stats;
 
 			const NEAR = 5, FAR = 3000;
@@ -100,14 +100,14 @@
 
 				// CONTROLS
 
-				controls = new FirstPersonControls( camera, renderer.domElement );
+				firstPersonControls = new FirstPersonControls( camera, renderer.domElement );
 
-				controls.lookSpeed = 0.0125;
-				controls.movementSpeed = 500;
-				controls.noFly = false;
-				controls.lookVertical = true;
+				firstPersonControls.lookSpeed = 0.0125;
+				firstPersonControls.movementSpeed = 500;
+				firstPersonControls.noFly = false;
+				firstPersonControls.lookVertical = true;
 
-				controls.lookAt( scene.position );
+				firstPersonControls.lookAt( scene.position );
 
 				// STATS
 
@@ -130,7 +130,7 @@
 
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
-				controls.handleResize();
+				firstPersonControls.handleResize();
 
 			}
 
@@ -321,7 +321,7 @@
 
 				}
 
-				controls.update( delta );
+				firstPersonControls.update( delta );
 
 				renderer.clear();
 				renderer.render( scene, camera );

--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -110,9 +110,9 @@
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 10, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 10, 0 );
+				orbitControls.update();
 
 				stats = new Stats();
 				document.body.appendChild( stats.dom );

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -135,9 +135,9 @@
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 
 				// Mouse control
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				clock = new THREE.Clock();
 

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -166,9 +166,9 @@
 				renderer.setClearColor( 0xCCCCCC, 1 );
 
 				// Mouse control
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 2, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.target.set( 0, 2, 0 );
+				orbitControls.update();
 
 				clock = new THREE.Clock();
 

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -187,9 +187,9 @@
 
 				new SimpleGI( renderer, scene );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 10;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 1;
+				orbitControls.maxDistance = 10;
 
 				window.addEventListener( 'resize', onWindowResize, false );
 

--- a/examples/webgl_skinning_simple.html
+++ b/examples/webgl_skinning_simple.html
@@ -104,10 +104,10 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.enablePan = false;
-				controls.minDistance = 5;
-				controls.maxDistance = 50;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.enablePan = false;
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 50;
 
 			}
 

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -42,7 +42,6 @@
 			let sprite1, sprite2, sprite3;
 			let walkingManTexture, walkingManTextureURL;
 			const library = {};
-			let controls;
 
 			window.addEventListener( 'load', init );
 
@@ -63,9 +62,9 @@
 				camera = new THREE.PerspectiveCamera( fov, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 100;
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 50;
-				controls.maxDistance = 200;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 50;
+				orbitControls.maxDistance = 200;
 
 				//
 				// SpriteNode

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -202,9 +202,9 @@
 			const stats = new Stats();
 			container.appendChild( stats.dom );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.minDistance = 120;
-			controls.maxDistance = 320;
+			const orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.minDistance = 120;
+			orbitControls.maxDistance = 320;
 
 			const materials = [];
 
@@ -222,7 +222,7 @@
 
 				Object.keys( Heads ).forEach( function ( t, index ) {
 
-					let g = new THREE.Group();
+					const g = new THREE.Group();
 					const conf = Heads[ t ];
 					const ml = THREE.ShaderLib[ conf.type ];
 					const mtl = new THREE.ShaderMaterial( {

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -24,7 +24,7 @@
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 			import { RGBELoader } from './jsm/loaders/RGBELoader.js';
 
-			let mesh, renderer, scene, camera, controls;
+			let mesh, renderer, scene, camera;
 			let gui, guiExposure = null;
 
 			const params = {
@@ -77,12 +77,12 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.25, 20 );
 				camera.position.set( - 1.8, 0.6, 2.7 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.addEventListener( 'change', render ); // use if there is no animation loop
-				controls.enableZoom = false;
-				controls.enablePan = false;
-				controls.target.set( 0, 0, - 0.2 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.addEventListener( 'change', render ); // use if there is no animation loop
+				orbitControls.enableZoom = false;
+				orbitControls.enablePan = false;
+				orbitControls.target.set( 0, 0, - 0.2 );
+				orbitControls.update();
 
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -157,9 +157,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 5;
-				controls.maxDistance = 50;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 50;
 
 				//
 

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -99,9 +99,9 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 5;
-				controls.maxDistance = 50;
+				const orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls.minDistance = 5;
+				orbitControls.maxDistance = 50;
 
 				//
 

--- a/examples/webxr_vr_dragging.html
+++ b/examples/webxr_vr_dragging.html
@@ -29,7 +29,7 @@
 			const intersected = [];
 			const tempMatrix = new THREE.Matrix4();
 
-			let controls, group;
+			let group;
 
 			init();
 			animate();
@@ -45,9 +45,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const floorGeometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				const floorMaterial = new THREE.MeshStandardMaterial( {

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -27,8 +27,6 @@
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;
 
-			let controls;
-
 			init();
 			animate();
 
@@ -43,9 +41,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const floorGeometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				const floorMaterial = new THREE.MeshStandardMaterial( { color: 0x222222 } );

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -27,8 +27,6 @@
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;
 
-			let controls;
-
 			let grabbing = false;
 			const scaling = {
 				active: false,
@@ -53,9 +51,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const floorGeometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				const floorMaterial = new THREE.MeshStandardMaterial( { color: 0x222222 } );

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -37,8 +37,6 @@
 				right: null
 			};
 
-			let controls;
-
 			init();
 			animate();
 
@@ -55,9 +53,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const floorGeometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				const floorMaterial = new THREE.MeshStandardMaterial( { color: 0x222222 } );

--- a/examples/webxr_vr_haptics.html
+++ b/examples/webxr_vr_haptics.html
@@ -27,7 +27,7 @@
 
 			const controllers = [];
 			const oscillators = [];
-			let controls, group;
+			let group;
 			let audioCtx = null;
 
 			init();
@@ -74,9 +74,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const floorGeometry = new THREE.PlaneBufferGeometry( 4, 4 );
 				const floorMaterial = new THREE.MeshStandardMaterial( {

--- a/examples/webxr_vr_paint.html
+++ b/examples/webxr_vr_paint.html
@@ -24,8 +24,6 @@
 
 			const cursor = new THREE.Vector3();
 
-			let controls;
-
 			init();
 			animate();
 
@@ -40,9 +38,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const tableGeometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				const tableMaterial = new THREE.MeshStandardMaterial( {

--- a/examples/webxr_vr_sculpt.html
+++ b/examples/webxr_vr_sculpt.html
@@ -23,7 +23,7 @@
 			let camera, scene, renderer;
 			let controller1, controller2;
 
-			let controls, blob;
+			let blob;
 
 			let points = [];
 
@@ -42,9 +42,9 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
-				controls.target.set( 0, 1.6, 0 );
-				controls.update();
+				const orbitControls = new OrbitControls( camera, container );
+				orbitControls.target.set( 0, 1.6, 0 );
+				orbitControls.update();
 
 				const tableGeometry = new THREE.BoxBufferGeometry( 0.5, 0.8, 0.5 );
 				const tableMaterial = new THREE.MeshStandardMaterial( {


### PR DESCRIPTION
This is a trivial change but it affects almost all html files in examples/

The problem it solves:

There is a lot of inconsistency in variable naming of control instances across all examples. For example, instances of `OrbitControls` are sometimes named `orbitControls`, sometimes `cameraControls` but mostly just `controls` - even when there are other types of "controls" in the example.

This PR establishes a naming convention where names of instances of controls match their class names.

There is also inconsistency in where in the example scope these variables are defined.

This PR establishes a consistent variable scoping. Controls that need no interactions after creation are defined as `const` inside `init()` functions. Controls that need to be accessed outside the `init()` function are defined as `let` variables in top-level scope.