### PR TITLE
Added "controllermove" event to WebXRController

### DIFF
--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -227,17 +227,23 @@ Object.assign( WebXRController.prototype, {
 
 			targetRay.visible = ( inputPose !== null );
 
+			if ( targetRay.visible ) targetRay.dispatchEvent( { type: 'controllermove' } );
+
 		}
 
 		if ( grip !== null ) {
 
 			grip.visible = ( gripPose !== null );
 
+			if ( grip.visible ) grip.dispatchEvent( { type: 'controllermove' } );
+
 		}
 
 		if ( hand !== null ) {
 
 			hand.visible = ( handPose !== null );
+
+			if ( hand.visible ) hand.dispatchEvent( { type: 'controllermove' } );
 
 		}
 


### PR DESCRIPTION
This is a requirement to make #20720 work in WebXR.

The problem it solves:

Right now WebXRControllers emit various events such as `select`, `selectstart`, `selectend`, `squeeze`, `squeezestart`, `squeezeend`, `pinchend`, `pinchstart`, `connected` and `disconnected`. But no event is fired when controllers move. The only way to get controller movement is to continuously pull transformation from rAF.

I would like to be able to use controllers in a similar fashion as other input devices (mouse, touch, pen, keyboard...) strictly via event listeners. I think this PR will enable that at least for simple click (select) and drag gesture. 