### PR TITLE
Update test/unit/README.md

### DIFF
--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -7,4 +7,4 @@
 You can run the unit tests in two environments:
 
 - Node.js: Execute `npm run test-unit` from root folder
-- Browser: Execute `npm run dev-test` and call `http://localhost:8080/test/unit/UnitTests.html` (see [How to run things locally](https://threejs.org/docs/#manual/introduction/How-to-run-things-locally))
+- Browser: Execute `npm run dev` from root folder and call `http://localhost:8080/test/unit/UnitTests.html` (see [How to run things locally](https://threejs.org/docs/#manual/introduction/How-to-run-things-locally))


### PR DESCRIPTION
`test/unit/README.md` mentions to use `npm run dev-test` command but the command no longer exists. I speculate it should be `npm run dev`, shouldn't it?