### PR TITLE
GLTFExporter: Fix undefined node name bug in mergeMorphTargetTracks()

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -2282,7 +2282,7 @@ THREE.GLTFExporter.Utils = {
 
 				// We need to take into consideration the intended target node
 				// of our original un-merged morphTarget animation.
-				mergedTrack.name = sourceTrackBinding.nodeName + '.morphTargetInfluences';
+				mergedTrack.name = ( sourceTrackBinding.nodeName || '' ) + '.morphTargetInfluences';
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2305,7 +2305,7 @@ GLTFExporter.Utils = {
 
 				// We need to take into consideration the intended target node
 				// of our original un-merged morphTarget animation.
-				mergedTrack.name = sourceTrackBinding.nodeName + '.morphTargetInfluences';
+				mergedTrack.name = ( sourceTrackBinding.nodeName || '' ) + '.morphTargetInfluences';
 				mergedTrack.values = values;
 
 				mergedTracks[ sourceTrackNode.uuid ] = mergedTrack;


### PR DESCRIPTION
Related issue: Resolves #20792
Related PR: #19042

**Description**

This PR resolves an issue that ""GLTFExporter: parse - individual morph targets" unit test never ends". Refer to #20792 for the detail about the problem and the root issue.

/cc @donmccurdy 