### PR TITLE
CompressedTextureLoader: Fix type of CompressedTexture.image.

### DIFF
--- a/src/loaders/CompressedTextureLoader.js
+++ b/src/loaders/CompressedTextureLoader.js
@@ -26,7 +26,6 @@ CompressedTextureLoader.prototype = Object.assign( Object.create( Loader.prototy
 		const images = [];
 
 		const texture = new CompressedTexture();
-		texture.image = images;
 
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
@@ -53,9 +52,9 @@ CompressedTextureLoader.prototype = Object.assign( Object.create( Loader.prototy
 
 				if ( loaded === 6 ) {
 
-					if ( texDatas.mipmapCount === 1 )
-						texture.minFilter = LinearFilter;
+					if ( texDatas.mipmapCount === 1 ) texture.minFilter = LinearFilter;
 
+					texture.image = images;
 					texture.format = texDatas.format;
 					texture.needsUpdate = true;
 
@@ -101,6 +100,8 @@ CompressedTextureLoader.prototype = Object.assign( Object.create( Loader.prototy
 						}
 
 					}
+
+					texture.image = images;
 
 				} else {
 


### PR DESCRIPTION
Related issue: -

**Description**

`CompressedTextureLoader` always assigns an array to `CompressedTexture.image` right now. This is only valid in context of cube maps but not for normal textures.

This issue did not break code so far but it will be confusing if you serialize/deserialize  `CompressedTexture`.