### PR TITLE
Examples index: Use template string for HTML template 

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -188,16 +188,16 @@
 
 		function createLink( file ) {
 
-			const template = [
-				'<div class="card">',
-				'	<a href="' + file + '.html" target="viewer">',
-				'		<div class="cover">',
-				'			<img src="screenshots/' + file + '.jpg" loading="lazy" width="400" />',
-				'		</div>',
-				'		<div class="title">' + getName( file ) + '</div>',
-				'	</a>',
-				'</div>'
-			].join( "\n" );
+			const template = `
+				<div class="card">
+					<a href="${file}.html" target="viewer">
+						<div class="cover">
+							<img src="screenshots/${ file }.jpg" loading="lazy" width="400" />
+						</div>
+						<div class="title">${getName( file )}</div>
+					</a>
+				</div>
+			`;
 
 			const link = createElementFromHTML( template );
 


### PR DESCRIPTION
Related issue: b23a10f22fd3cc34a707c6a4e0af8057e3d8555b

**Description**

Since the `example/index.html` page now uses let/const, it seemed appropriate to use template strings as well, especially for the HTML template.