### PR TITLE
CompressedTexture: Add basic support for serialization/deserialization.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -48,6 +48,7 @@ import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 import { Scene } from '../scenes/Scene.js';
 import { CubeTexture } from '../textures/CubeTexture.js';
 import { Texture } from '../textures/Texture.js';
+import { CompressedTexture } from '../textures/CompressedTexture.js';
 import { DataTexture } from '../textures/DataTexture.js';
 import { ImageLoader } from './ImageLoader.js';
 import { LoadingManager } from './LoadingManager.js';
@@ -615,7 +616,10 @@ class ObjectLoader extends Loader {
 
 				} else {
 
-					return null;
+					return {
+						width: image.width || 0,
+						height: image.height || 0
+					};
 
 				}
 
@@ -733,14 +737,35 @@ class ObjectLoader extends Loader {
 					if ( image && image.data ) {
 
 						texture = new DataTexture( image.data, image.width, image.height );
+						texture.needsUpdate = true;
+
+					} else if ( image && Array.isArray( data.mipmaps ) ) {
+
+						const mipmaps = [];
+
+						for ( let i = 0, l = data.mipmaps.length; i < l; i ++ ) {
+
+							const mipmap = data.mipmaps[ i ];
+
+							mipmaps.push( {
+								data: getTypedArray( mipmap.type, mipmap.data ),
+								width: mipmap.width,
+								height: mipmap.height
+							} );
+
+						}
+
+						texture = new CompressedTexture( mipmaps, image.width, image.height );
+
+						if ( mipmaps.length > 0 ) texture.needsUpdate = true;
 
 					} else {
 
 						texture = new Texture( image );
 
-					}
+						if ( image ) texture.needsUpdate = true; // textures can have undefined image data
 
-					if ( image ) texture.needsUpdate = true; // textures can have undefined image data
+					}
 
 				}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -228,6 +228,22 @@ Texture.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
 
 		}
 
+		const mipmaps = this.mipmaps;
+
+		if ( Array.isArray( mipmaps ) === true ) {
+
+			output.mipmaps = [];
+
+			for ( let i = 0, l = mipmaps.length; i < l; i ++ ) {
+
+				const mipmap = mipmaps[ i ];
+
+				output.mipmaps.push( serializeImage( mipmap ) );
+
+			}
+
+		}
+
 		if ( ! isRootObject ) {
 
 			meta.textures[ this.uuid ] = output;
@@ -350,7 +366,7 @@ function serializeImage( image ) {
 
 		if ( image.data ) {
 
-			// images of DataTexture
+			// images of DataTexture and mipmaps of CompressedTexture
 
 			return {
 				data: Array.prototype.slice.call( image.data ),
@@ -361,8 +377,10 @@ function serializeImage( image ) {
 
 		} else {
 
-			console.warn( 'THREE.Texture: Unable to serialize Texture.' );
-			return {};
+			return {
+				width: image.width || 0,
+				height: image.height || 0
+			};
 
 		}
 


### PR DESCRIPTION
Related issue: Fixed #17974. Fixed  #7452.

**Description**

This PR adds basic support for serialization/deserialization of compressed textures. Not supported is the case where a single file contains a cube map (e.g. `textures/compressed/Mountains.dds`). I'm not sure it's ideal how these data are currently represented in `CompressedTexture`. A refactoring could enable an easier implementation in the future.

Users of Basis should be aware of https://github.com/mrdoob/three.js/issues/17974#issuecomment-557175750.
