### PR TITLE
InstancedMesh: Add dispose().

### DIFF
--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -66,6 +66,11 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
+		<h3>[method:null dispose]()</h3>
+		<p>
+			Frees the internal resources of this instance.
+		</p>
+
 		<h3>[method:null getColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].

--- a/docs/api/zh/objects/InstancedMesh.html
+++ b/docs/api/zh/objects/InstancedMesh.html
@@ -65,6 +65,11 @@
 		<h2>方法</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
+		<h3>[method:null dispose]()</h3>
+		<p>
+			Frees the internal resources of this instance.
+		</p>
+
 		<h3>[method:null getColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].

--- a/src/objects/InstancedMesh.d.ts
+++ b/src/objects/InstancedMesh.d.ts
@@ -26,5 +26,6 @@ export class InstancedMesh <
 	getMatrixAt( index: number, matrix: Matrix4 ): void;
 	setColorAt( index: number, color: Color ): void;
 	setMatrixAt( index: number, matrix: Matrix4 ): void;
+	dispose(): void;
 
 }

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -112,6 +112,12 @@ InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 
 	updateMorphTargets: function () {
 
+	},
+
+	dispose: function () {
+
+		this.dispatchEvent( { type: 'dispose' } );
+
 	}
 
 } );

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -27,6 +27,12 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 		if ( object.isInstancedMesh ) {
 
+			if ( object.hasEventListener( 'dispose', onInstancedMeshDispose ) === false ) {
+
+				object.addEventListener( 'dispose', onInstancedMeshDispose );
+
+			}
+
 			attributes.update( object.instanceMatrix, gl.ARRAY_BUFFER );
 
 			if ( object.instanceColor !== null ) {
@@ -44,6 +50,18 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 	function dispose() {
 
 		updateMap = new WeakMap();
+
+	}
+
+	function onInstancedMeshDispose( event ) {
+
+		const instancedMesh = event.target;
+
+		instancedMesh.removeEventListener( 'dispose', onInstancedMeshDispose );
+
+		attributes.remove( instancedMesh.instanceMatrix );
+
+		if ( instancedMesh.instanceColor !== null ) attributes.remove( instancedMesh.instanceColor );
 
 	}
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/17063#issuecomment-737882126

**Description**

Adds the missing `InstancedMesh.dispose()` to ensure the internal `instanceMatrix` and `instanceColor` can be released.
