### PR TITLE
Docs: Creating-text: Suggest three-mesh-ui first.

### DIFF
--- a/docs/manual/ar/introduction/Creating-text.html
+++ b/docs/manual/ar/introduction/Creating-text.html
@@ -89,7 +89,7 @@
 		<div>
 			<p>
 				تسمح BMFonts (الخطوط النقطية) بدمج الصور الرمزية في BufferGeometry واحد. يدعم عرض BMFont التفاف الكلمات ، وتباعد الأحرف ، وتقنين الأحرف ، وحقول المسافة الموقعة مع المشتقات القياسية ، وحقول المسافة الموقعة متعددة القنوات ، والخطوط متعددة الأنسجة ، والمزيد.
-				انظر [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text] or [link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui].
+				انظر [link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui] أو [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text].
 			</p>
 			<p>
 				تتوفر الخطوط في مشاريع مثل [link:https://github.com/etiennepinchon/aframe-fonts A-Frame Fonts] ، أو يمكنك إنشاء خطوطك الخاصة من أي خط .TTF ، مع التحسين لتضمين الأحرف المطلوبة  للمشروع.

--- a/docs/manual/ar/introduction/Creating-text.html
+++ b/docs/manual/ar/introduction/Creating-text.html
@@ -89,7 +89,7 @@
 		<div>
 			<p>
 				تسمح BMFonts (الخطوط النقطية) بدمج الصور الرمزية في BufferGeometry واحد. يدعم عرض BMFont التفاف الكلمات ، وتباعد الأحرف ، وتقنين الأحرف ، وحقول المسافة الموقعة مع المشتقات القياسية ، وحقول المسافة الموقعة متعددة القنوات ، والخطوط متعددة الأنسجة ، والمزيد.
-				انظر [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text].
+				انظر [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text] or [link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui].
 			</p>
 			<p>
 				تتوفر الخطوط في مشاريع مثل [link:https://github.com/etiennepinchon/aframe-fonts A-Frame Fonts] ، أو يمكنك إنشاء خطوطك الخاصة من أي خط .TTF ، مع التحسين لتضمين الأحرف المطلوبة  للمشروع.

--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -97,7 +97,7 @@
 				BMFonts (bitmap fonts) allow batching glyphs into a single BufferGeometry. BMFont rendering
 				supports word-wrapping, letter spacing, kerning, signed distance fields with standard
 				derivatives, multi-channel signed distance fields, multi-texture fonts, and more.
-				See [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text].
+				See [link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui] or [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text].
 			</p>
 			<p>
 				Stock fonts are available in projects like

--- a/docs/manual/zh/introduction/Creating-text.html
+++ b/docs/manual/zh/introduction/Creating-text.html
@@ -87,7 +87,7 @@
 		<div>
 			<p>
 				BMFonts (位图字体) 可以将字形批处理为单个BufferGeometry。BMFont的渲染支持自动换行、字母间距、字句调整、signed distance fields with standard derivatives、multi-channel signed distance fields、多纹理字体等特性。
-				详情请参阅[link:https://github.com/Jam3/three-bmfont-text three-bmfont-text]。
+				详情请参阅 [link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui] 或 [link:https://github.com/Jam3/three-bmfont-text three-bmfont-text]。
 			</p>
 			<p>
 				现有库存的字体在项目中同样可用，就像[link:https://github.com/etiennepinchon/aframe-fonts A-Frame Fonts]一样，


### PR DESCRIPTION
Related issue: -

**Description**

I tried to find that [three-mesh-ui](https://github.com/felixmariotto/three-mesh-ui) is much more convenient to use than [three-bmfont-text](https://github.com/Jam3/three-bmfont-text), and it provides `ordinary .js files` and `import` and `require` simultaneously.
In contrast, three-bmfont-text only provides `require` which I think is only used for nodejs and depends on `global.THREE`, in fact, I even failed to use three-bmfont-text successfully.
So I think it would be better to recommend three-mesh-ui first to beginners.
