### PR TITLE
PMREMGenerator: Add ability to set camera origin in fromScene

### DIFF
--- a/docs/api/en/extras/PMREMGenerator.html
+++ b/docs/api/en/extras/PMREMGenerator.html
@@ -27,15 +27,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:WebGLRenderTarget fromScene]( [param:Scene scene], [param:Number sigma], [param:Number near], [param:Number far] )</h3>
+		<h3>[method:WebGLRenderTarget fromScene]( [param:Scene scene], [param:Number sigma], [param:Number near], [param:Number far], [param:Vector3 origin] )</h3>
 		<p>
 			[page:Scene scene] - The given scene.<br>
 			[page:Number sigma] - (optional) Specifies a blur radius in radians to be applied to the scene before PMREM generation. Default is *0*.<br>
 			[page:Number near] - (optional) The near plane value. Default is *0.1*.<br>
-			[page:Number far] - (optional) The far plane value. Default is *100*.<br /><br />
+			[page:Number far] - (optional) The far plane value. Default is *100*.<br />
+			[page:Number origin] - (optional) The position to render the scene from. Default is *0, 0, 0*.<br /><br />
 
 			Generates a PMREM from a supplied Scene, which can be faster than using an image if networking bandwidth is low.
-			Optional near and far planes ensure the scene is rendered in its entirety (the cubeCamera is placed at the origin).
+			Optional near and far planes ensure the scene is rendered in its entirety.
 		</p>
 
 		<h3>[method:WebGLRenderTarget fromEquirectangular]( [param:Texture equirectangular] )</h3>

--- a/docs/api/zh/extras/PMREMGenerator.html
+++ b/docs/api/zh/extras/PMREMGenerator.html
@@ -27,15 +27,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:WebGLRenderTarget fromScene]( [param:Scene scene], [param:Number sigma], [param:Number near], [param:Number far] )</h3>
+		<h3>[method:WebGLRenderTarget fromScene]( [param:Scene scene], [param:Number sigma], [param:Number near], [param:Number far], [param:Vector3 origin] )</h3>
 		<p>
 			[page:Scene scene] - The given scene.<br>
 			[page:Number sigma] - (optional) Specifies a blur radius in radians to be applied to the scene before PMREM generation. Default is *0*.<br>
 			[page:Number near] - (optional) The near plane value. Default is *0.1*.<br>
 			[page:Number far] - (optional) The far plane value. Default is *100*.<br /><br />
+			[page:Number origin] - (optional) The position to render the scene from. Default is *0, 0, 0*.<br /><br />
 
 			Generates a PMREM from a supplied Scene, which can be faster than using an image if networking bandwidth is low.
-			Optional near and far planes ensure the scene is rendered in its entirety (the cubeCamera is placed at the origin).
+			Optional near and far planes ensure the scene is rendered in its entirety.
 		</p>
 
 		<h3>[method:WebGLRenderTarget fromEquirectangular]( [param:Texture equirectangular] )</h3>

--- a/src/extras/PMREMGenerator.d.ts
+++ b/src/extras/PMREMGenerator.d.ts
@@ -3,6 +3,7 @@ import { WebGLRenderTarget } from '../renderers/WebGLRenderTarget';
 import { Texture } from '../textures/Texture';
 import { CubeTexture } from '../textures/CubeTexture';
 import { Scene } from '../scenes/Scene';
+import { Vector3 } from '../math/Vector3';
 
 export class PMREMGenerator {
 

--- a/src/extras/PMREMGenerator.d.ts
+++ b/src/extras/PMREMGenerator.d.ts
@@ -7,7 +7,7 @@ import { Scene } from '../scenes/Scene';
 export class PMREMGenerator {
 
 	constructor( renderer:WebGLRenderer );
-	fromScene( scene:Scene, sigma?:number, near?:number, far?:number ): WebGLRenderTarget;
+	fromScene( scene:Scene, sigma?:number, near?:number, far?:number, origin?:Vector3 ): WebGLRenderTarget;
 	fromEquirectangular( equirectangular:Texture ): WebGLRenderTarget;
 	fromCubemap( cubemap:CubeTexture ): WebGLRenderTarget;
 	compileCubemapShader(): void;

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -106,12 +106,12 @@ class PMREMGenerator {
 	 * and far planes ensure the scene is rendered in its entirety (the cubeCamera
 	 * is placed at the origin).
 	 */
-	fromScene( scene, sigma = 0, near = 0.1, far = 100 ) {
+	fromScene( scene, sigma = 0, near = 0.1, far = 100, origin = new Vector3() ) {
 
 		_oldTarget = this._renderer.getRenderTarget();
 		const cubeUVRenderTarget = this._allocateTargets();
 
-		this._sceneToCubeUV( scene, near, far, cubeUVRenderTarget );
+		this._sceneToCubeUV( scene, near, far, cubeUVRenderTarget, origin );
 		if ( sigma > 0 ) {
 
 			this._blur( cubeUVRenderTarget, 0, 0, sigma );
@@ -246,7 +246,7 @@ class PMREMGenerator {
 
 	}
 
-	_sceneToCubeUV( scene, near, far, cubeUVRenderTarget ) {
+	_sceneToCubeUV( scene, near, far, cubeUVRenderTarget, origin ) {
 
 		const fov = 90;
 		const aspect = 1;
@@ -279,6 +279,7 @@ class PMREMGenerator {
 
 		for ( let i = 0; i < 6; i ++ ) {
 
+			cubeCamera.position.set( 0, 0, 0 );
 			const col = i % 3;
 			if ( col == 0 ) {
 
@@ -296,6 +297,7 @@ class PMREMGenerator {
 				cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
 
 			}
+			cubeCamera.position.copy( origin );
 
 			_setViewport( cubeUVRenderTarget,
 				col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -297,6 +297,7 @@ class PMREMGenerator {
 				cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
 
 			}
+
 			cubeCamera.position.copy( origin );
 
 			_setViewport( cubeUVRenderTarget,


### PR DESCRIPTION
Related issue: --

**Description**

Add the ability to set the position that the scene is rendered from when using `PMREMGenerator.fromScene`. This is useful particularly when you have an environment with something like terrain but positioning the camera at the origin places the camera underneath the terrain when you would like to include in the map.