### PR TITLE
Matrix3: Add missing return statement to setUvTransform().

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -239,6 +239,8 @@ class Matrix3 {
 			0, 0, 1
 		);
 
+		return this;
+
 	}
 
 	scale( sx, sy ) {


### PR DESCRIPTION
Related issue: Fixed #20826.

**Description**

Adds missing return statement to `setUvTransform()`.