### PR TITLE
Mesh.raycast: Check material.skinning before applying bone transform

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -410,7 +410,7 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 	}
 
-	if ( object.isSkinnedMesh ) {
+	if ( object.isSkinnedMesh && material.skinning ) {
 
 		object.boneTransform( a, _vA );
 		object.boneTransform( b, _vB );


### PR DESCRIPTION
#19178 introduced bone transformations during raytracing. However, if the object's material does not have `skinning` set to `true`, then it should *not* be applying the bone transformations. Since `material.morphTargets` is checked before applying the morph targets, it seems reasonable that `material.skinning` should be checked before applying bone transformations as well.
