### PR TITLE
Docs: Fix description of Layers.test().

### DIFF
--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -69,7 +69,7 @@
 		<p>
 			layers - a Layers object<br /><br />
 
-			Returns true if this and the passed *layers* object are members of the same set of layers.
+			Returns true if this and the passed *layers* object have at least one layer in common.
 		</p>
 
 		<h3>[method:null toggle]( [param:Integer layer] )</h3>


### PR DESCRIPTION
Clarify the workings of the 'Layers.test' method

**Description**

The description in documentation about what the 'Layers.test' method does leads to some confusion when trying to use it. This PR clarifies what the test method actually does.
