### PR TITLE
TiltLoader: Fix for loop.

### DIFF
--- a/examples/jsm/loaders/TiltLoader.js
+++ b/examples/jsm/loaders/TiltLoader.js
@@ -172,7 +172,7 @@ class StrokeGeometry extends BufferGeometry {
 
 		size = size / 2;
 
-		for ( let i = 3, j = 4; i <= positions.length; i += 3, j += 4 ) {
+		for ( let i = 0, j = 0; i < positions.length; i += 3, j += 4 ) {
 
 			position.fromArray( positions, i );
 			quaternion.fromArray( quaternions, j );


### PR DESCRIPTION
Related issue: Fixed #20835.

**Description**

I guess the `for` loop should initialize its loop variables to zero since `fromArray()` also uses the offset to identify the first element. 