### PR TITLE
WebGLMorphtargets: Allow changing number of morph targets

### DIFF
--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -34,7 +34,7 @@ function WebGLMorphtargets( gl ) {
 
 		let influences = influencesList[ geometry.id ];
 
-		if ( influences === undefined ) {
+		if ( influences === undefined || influences.length !== length ) {
 
 			// initialise list
 


### PR DESCRIPTION
Adding a new morph target attribute to a mesh after it has been rendered at least once with a material with `morphTargets` set to `true` results in the following error during rendering:

```
three.js:12235 Uncaught TypeError: Cannot set property '0' of undefined
    at Object.update (three.js:12235)
    at WebGLRenderer.renderBufferDirect (three.js:18471)
    at renderObject (three.js:18802)
    at renderObjects (three.js:18785)
    at WebGLRenderer.render (three.js:18657)
```

The line at error is shown below (with context, from the chrome web tools source viewer):

```

			for (var _i2 = 0; _i2 < length; _i2++) {
				var influence = influences[_i2];
				influence[0] = _i2; // <------------- Exception occurs here
				influence[1] = objectInfluences[_i2];
			}

			influences.sort(absNumericalSort);

```

Based on my understanding of the code, this is because `influences` is populated once the first time that the geometry is rendered (i.e., when `influences === undefined`). When a new morph target is added, then `influences.length` no longer matches `objectInfluences.length` causing an issue during the iteration of:

```
		// Collect influences
		for ( let i = 0; i < length; i ++ ) {
			const influence = influences[ i ];
```

My proposal is, for simplicity's sake, to simply recreate the influence list when there's been a change in the length. It could be reasonable to add / remove elements from the list as well, but that seems to needlessly complicate things in my personal opinion.

Unfortunately, there doesn't seem to me to be any way to reset the influences list short of creating an entirely new geometry and replacing the old one. I'm still working on trying to find a workaround.