### PR TITLE
Examples: Ensure single quotes when generating modules.

### DIFF
--- a/examples/jsm/animation/AnimationClipCreator.js
+++ b/examples/jsm/animation/AnimationClipCreator.js
@@ -5,7 +5,7 @@ import {
 	NumberKeyframeTrack,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var AnimationClipCreator = function () {};
 

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -11,7 +11,7 @@ import {
 	Quaternion,
 	SphereBufferGeometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * CCD Algorithm

--- a/examples/jsm/animation/MMDAnimationHelper.js
+++ b/examples/jsm/animation/MMDAnimationHelper.js
@@ -3,9 +3,9 @@ import {
 	Object3D,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
-import { CCDIKSolver } from "../animation/CCDIKSolver.js";
-import { MMDPhysics } from "../animation/MMDPhysics.js";
+} from '../../../build/three.module.js';
+import { CCDIKSolver } from '../animation/CCDIKSolver.js';
+import { MMDPhysics } from '../animation/MMDPhysics.js';
 
 /**
  * MMDAnimationHelper handles animation of MMD assets loaded by MMDLoader

--- a/examples/jsm/animation/MMDPhysics.js
+++ b/examples/jsm/animation/MMDPhysics.js
@@ -11,7 +11,7 @@ import {
 	Quaternion,
 	SphereBufferGeometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Dependencies

--- a/examples/jsm/cameras/CinematicCamera.js
+++ b/examples/jsm/cameras/CinematicCamera.js
@@ -9,9 +9,9 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { BokehShader } from "../shaders/BokehShader2.js";
-import { BokehDepthShader } from "../shaders/BokehShader2.js";
+} from '../../../build/three.module.js';
+import { BokehShader } from '../shaders/BokehShader2.js';
+import { BokehDepthShader } from '../shaders/BokehShader2.js';
 
 var CinematicCamera = function ( fov, aspect, near, far ) {
 

--- a/examples/jsm/controls/DeviceOrientationControls.js
+++ b/examples/jsm/controls/DeviceOrientationControls.js
@@ -4,7 +4,7 @@ import {
 	MathUtils,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -5,7 +5,7 @@ import {
 	Raycaster,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var DragControls = function ( _objects, _camera, _domElement ) {
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -2,7 +2,7 @@ import {
 	MathUtils,
 	Spherical,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var FirstPersonControls = function ( object, domElement ) {
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -2,7 +2,7 @@ import {
 	EventDispatcher,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var FlyControls = function ( object, domElement ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -6,7 +6,7 @@ import {
 	TOUCH,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -2,7 +2,7 @@ import {
 	Euler,
 	EventDispatcher,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var PointerLockControls = function ( camera, domElement ) {
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -4,7 +4,7 @@ import {
 	Quaternion,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var TrackballControls = function ( object, domElement ) {
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -19,7 +19,7 @@ import {
 	SphereBufferGeometry,
 	TorusBufferGeometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var TransformControls = function ( camera, domElement ) {
 

--- a/examples/jsm/curves/CurveExtras.js
+++ b/examples/jsm/curves/CurveExtras.js
@@ -1,7 +1,7 @@
 import {
 	Curve,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * A bunch of parametric curves

--- a/examples/jsm/curves/NURBSCurve.js
+++ b/examples/jsm/curves/NURBSCurve.js
@@ -2,8 +2,8 @@ import {
 	Curve,
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
-import { NURBSUtils } from "../curves/NURBSUtils.js";
+} from '../../../build/three.module.js';
+import { NURBSUtils } from '../curves/NURBSUtils.js';
 
 /**
  * NURBS curve object

--- a/examples/jsm/curves/NURBSSurface.js
+++ b/examples/jsm/curves/NURBSSurface.js
@@ -1,7 +1,7 @@
 import {
 	Vector4
-} from "../../../build/three.module.js";
-import { NURBSUtils } from "../curves/NURBSUtils.js";
+} from '../../../build/three.module.js';
+import { NURBSUtils } from '../curves/NURBSUtils.js';
 
 /**
  * NURBS surface object

--- a/examples/jsm/curves/NURBSUtils.js
+++ b/examples/jsm/curves/NURBSUtils.js
@@ -1,7 +1,7 @@
 import {
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * NURBS utils

--- a/examples/jsm/effects/AnaglyphEffect.js
+++ b/examples/jsm/effects/AnaglyphEffect.js
@@ -10,7 +10,7 @@ import {
 	ShaderMaterial,
 	StereoCamera,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var AnaglyphEffect = function ( renderer, width, height ) {
 

--- a/examples/jsm/effects/OutlineEffect.js
+++ b/examples/jsm/effects/OutlineEffect.js
@@ -4,7 +4,7 @@ import {
 	ShaderMaterial,
 	UniformsLib,
 	UniformsUtils
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Reference: https://en.wikipedia.org/wiki/Cel_shading

--- a/examples/jsm/effects/ParallaxBarrierEffect.js
+++ b/examples/jsm/effects/ParallaxBarrierEffect.js
@@ -9,7 +9,7 @@ import {
 	ShaderMaterial,
 	StereoCamera,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var ParallaxBarrierEffect = function ( renderer ) {
 

--- a/examples/jsm/effects/PeppersGhostEffect.js
+++ b/examples/jsm/effects/PeppersGhostEffect.js
@@ -2,7 +2,7 @@ import {
 	PerspectiveCamera,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * peppers ghost effect based on http://www.instructables.com/id/Reflective-Prism/?ALLSTEPS

--- a/examples/jsm/effects/StereoEffect.js
+++ b/examples/jsm/effects/StereoEffect.js
@@ -1,7 +1,7 @@
 import {
 	StereoCamera,
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var StereoEffect = function ( renderer ) {
 

--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -7,7 +7,7 @@ import {
 	Mesh,
 	MeshBasicMaterial,
 	MeshLambertMaterial
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * https://github.com/gkjohnson/collada-exporter-js

--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -1,6 +1,6 @@
 import {
 	BufferGeometry
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Export draco compressed files from threejs geometry objects.

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -19,7 +19,7 @@ import {
 	RepeatWrapping,
 	Scene,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 //------------------------------------------------------------------------------
 // Constants

--- a/examples/jsm/exporters/MMDExporter.js
+++ b/examples/jsm/exporters/MMDExporter.js
@@ -2,8 +2,8 @@ import {
 	Matrix4,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
-import { MMDParser } from "../libs/mmdparser.module.js";
+} from '../../../build/three.module.js';
+import { MMDParser } from '../libs/mmdparser.module.js';
 
 /**
  * Dependencies

--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -8,7 +8,7 @@ import {
 	Points,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var OBJExporter = function () {};
 

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -2,7 +2,7 @@ import {
 	BufferGeometry,
 	Matrix3,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * https://github.com/gkjohnson/ply-exporter-js

--- a/examples/jsm/exporters/STLExporter.js
+++ b/examples/jsm/exporters/STLExporter.js
@@ -1,7 +1,7 @@
 import {
 	BufferGeometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Usage:

--- a/examples/jsm/geometries/BoxLineGeometry.js
+++ b/examples/jsm/geometries/BoxLineGeometry.js
@@ -1,7 +1,7 @@
 import {
 	BufferGeometry,
 	Float32BufferAttribute
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var BoxLineGeometry = function ( width, height, depth, widthSegments, heightSegments, depthSegments ) {
 

--- a/examples/jsm/geometries/ConvexGeometry.js
+++ b/examples/jsm/geometries/ConvexGeometry.js
@@ -2,8 +2,8 @@ import {
 	BufferGeometry,
 	Float32BufferAttribute,
 	Geometry
-} from "../../../build/three.module.js";
-import { ConvexHull } from "../math/ConvexHull.js";
+} from '../../../build/three.module.js';
+import { ConvexHull } from '../math/ConvexHull.js';
 
 // ConvexGeometry
 

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -3,7 +3,7 @@ import {
 	Float32BufferAttribute,
 	Matrix4,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * You can use this geometry to create a decal mesh, that serves different kinds of purposes.

--- a/examples/jsm/geometries/LightningStrike.js
+++ b/examples/jsm/geometries/LightningStrike.js
@@ -5,8 +5,8 @@ import {
 	MathUtils,
 	Uint32BufferAttribute,
 	Vector3
-} from "../../../build/three.module.js";
-import { SimplexNoise } from "../math/SimplexNoise.js";
+} from '../../../build/three.module.js';
+import { SimplexNoise } from '../math/SimplexNoise.js';
 
 /**
  * @fileoverview LightningStrike object for creating lightning strikes and voltaic arcs.

--- a/examples/jsm/geometries/ParametricGeometries.js
+++ b/examples/jsm/geometries/ParametricGeometries.js
@@ -3,7 +3,7 @@ import {
 	Geometry,
 	ParametricGeometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Experimenting of primitive geometry creation using Surface Parametric equations

--- a/examples/jsm/geometries/TeapotBufferGeometry.js
+++ b/examples/jsm/geometries/TeapotBufferGeometry.js
@@ -4,7 +4,7 @@ import {
 	Matrix4,
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Tessellates the famous Utah teapot database by Martin Newell into triangles.

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -1,7 +1,7 @@
 import {
 	Frustum,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * This is a class to check whether objects are in a selection area in 3D space

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var SelectionHelper = ( function () {
 

--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -5,7 +5,7 @@ import {
 	SphericalHarmonics3,
 	Vector3,
 	sRGBEncoding
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var LightProbeGenerator = {
 

--- a/examples/jsm/lights/RectAreaLightUniformsLib.js
+++ b/examples/jsm/lights/RectAreaLightUniformsLib.js
@@ -9,7 +9,7 @@ import {
 	RGBAFormat,
 	UVMapping,
 	UniformsLib
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Uniforms library for RectAreaLight shared webgl shaders

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -1,6 +1,6 @@
-import { LineSegments2 } from "../lines/LineSegments2.js";
-import { LineGeometry } from "../lines/LineGeometry.js";
-import { LineMaterial } from "../lines/LineMaterial.js";
+import { LineSegments2 } from '../lines/LineSegments2.js';
+import { LineGeometry } from '../lines/LineGeometry.js';
+import { LineMaterial } from '../lines/LineMaterial.js';
 
 var Line2 = function ( geometry, material ) {
 

--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -1,4 +1,4 @@
-import { LineSegmentsGeometry } from "../lines/LineSegmentsGeometry.js";
+import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 
 var LineGeometry = function () {
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -4,7 +4,7 @@ import {
 	UniformsLib,
 	UniformsUtils,
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * parameters = {

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -7,9 +7,9 @@ import {
 	Mesh,
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
-import { LineSegmentsGeometry } from "../lines/LineSegmentsGeometry.js";
-import { LineMaterial } from "../lines/LineMaterial.js";
+} from '../../../build/three.module.js';
+import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
+import { LineMaterial } from '../lines/LineMaterial.js';
 
 var LineSegments2 = function ( geometry, material ) {
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -7,7 +7,7 @@ import {
 	Sphere,
 	Vector3,
 	WireframeGeometry
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var LineSegmentsGeometry = function () {
 

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -3,9 +3,9 @@ import {
 	InterleavedBufferAttribute,
 	Mesh,
 	Vector3
-} from "../../../build/three.module.js";
-import { LineSegmentsGeometry } from "../lines/LineSegmentsGeometry.js";
-import { LineMaterial } from "../lines/LineMaterial.js";
+} from '../../../build/three.module.js';
+import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
+import { LineMaterial } from '../lines/LineMaterial.js';
 
 var Wireframe = function ( geometry, material ) {
 

--- a/examples/jsm/lines/WireframeGeometry2.js
+++ b/examples/jsm/lines/WireframeGeometry2.js
@@ -1,7 +1,7 @@
 import {
 	WireframeGeometry
-} from "../../../build/three.module.js";
-import { LineSegmentsGeometry } from "../lines/LineSegmentsGeometry.js";
+} from '../../../build/three.module.js';
+import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 
 var WireframeGeometry2 = function ( geometry ) {
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -19,8 +19,8 @@ import {
 	RepeatWrapping,
 	TextureLoader,
 	sRGBEncoding
-} from "../../../build/three.module.js";
-import { JSZip } from "../libs/jszip.module.min.js";
+} from '../../../build/three.module.js';
+import { JSZip } from '../libs/jszip.module.min.js';
 
 /**
  *

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -8,8 +8,8 @@ import {
 	LoaderUtils,
 	Mesh,
 	MeshPhongMaterial
-} from "../../../build/three.module.js";
-import { JSZip } from "../libs/jszip.module.min.js";
+} from '../../../build/three.module.js';
+import { JSZip } from '../libs/jszip.module.min.js';
 
 /**
  * Description: Early release of an AMF Loader following the pattern of the

--- a/examples/jsm/loaders/AssimpLoader.js
+++ b/examples/jsm/loaders/AssimpLoader.js
@@ -16,7 +16,7 @@ import {
 	SkinnedMesh,
 	TextureLoader,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var AssimpLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/BVHLoader.js
+++ b/examples/jsm/loaders/BVHLoader.js
@@ -8,7 +8,7 @@ import {
 	Skeleton,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Description: reads BVH files and outputs a single Skeleton and an AnimationClip

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -10,7 +10,7 @@ import {
 	RGB_ETC1_Format,
 	RGB_PVRTC_4BPPV1_Format,
 	UnsignedByteType
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Loader for Basis Universal GPU Texture Codec.

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -35,8 +35,8 @@ import {
 	TextureLoader,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
-import { TGALoader } from "../loaders/TGALoader.js";
+} from '../../../build/three.module.js';
+import { TGALoader } from '../loaders/TGALoader.js';
 
 var ColladaLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/DDSLoader.js
+++ b/examples/jsm/loaders/DDSLoader.js
@@ -5,7 +5,7 @@ import {
 	RGBA_S3TC_DXT5_Format,
 	RGB_ETC1_Format,
 	RGB_S3TC_DXT1_Format
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var DDSLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -3,7 +3,7 @@ import {
 	BufferGeometry,
 	FileLoader,
 	Loader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var DRACOLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -11,8 +11,8 @@ import {
 	RGBEFormat,
 	RGBFormat,
 	UnsignedByteType
-} from "../../../build/three.module.js";
-import { Inflate } from "../libs/inflate.module.min.js";
+} from '../../../build/three.module.js';
+import { Inflate } from '../libs/inflate.module.min.js';
 
 /**
  * OpenEXR loader currently supports uncompressed, ZIP(S), RLE, PIZ and DWA/B compression.

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -41,9 +41,9 @@ import {
 	Vector4,
 	VectorKeyframeTrack,
 	sRGBEncoding
-} from "../../../build/three.module.js";
-import { Inflate } from "../libs/inflate.module.min.js";
-import { NURBSCurve } from "../curves/NURBSCurve.js";
+} from '../../../build/three.module.js';
+import { Inflate } from '../libs/inflate.module.min.js';
+import { NURBSCurve } from '../curves/NURBSCurve.js';
 
 /**
  * Loader loads FBX file and generates Group representing FBX scene.

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -7,7 +7,7 @@ import {
 	LineBasicMaterial,
 	LineSegments,
 	Loader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * GCodeLoader is used to load gcode files usually used for 3D printing or CNC applications.

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -61,7 +61,7 @@ import {
 	Vector3,
 	VectorKeyframeTrack,
 	sRGBEncoding
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var GLTFLoader = ( function () {
 

--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -12,8 +12,8 @@ import {
 	RGBEEncoding,
 	RGBFormat,
 	UnsignedByteType
-} from "../../../build/three.module.js";
-import { RGBELoader } from "../loaders/RGBELoader.js";
+} from '../../../build/three.module.js';
+import { RGBELoader } from '../loaders/RGBELoader.js';
 
 var HDRCubeTextureLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/KMZLoader.js
+++ b/examples/jsm/loaders/KMZLoader.js
@@ -3,9 +3,9 @@ import {
 	Group,
 	Loader,
 	LoadingManager
-} from "../../../build/three.module.js";
-import { ColladaLoader } from "../loaders/ColladaLoader.js";
-import { JSZip } from "../libs/jszip.module.min.js";
+} from '../../../build/three.module.js';
+import { ColladaLoader } from '../loaders/ColladaLoader.js';
+import { JSZip } from '../libs/jszip.module.min.js';
 
 var KMZLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/KTXLoader.js
+++ b/examples/jsm/loaders/KTXLoader.js
@@ -1,6 +1,6 @@
 import {
 	CompressedTextureLoader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * for description see https://www.khronos.org/opengles/sdk/tools/KTX/

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -14,7 +14,7 @@ import {
 	MeshStandardMaterial,
 	ShaderMaterial,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var LDrawLoader = ( function () {
 

--- a/examples/jsm/loaders/MD2Loader.js
+++ b/examples/jsm/loaders/MD2Loader.js
@@ -5,7 +5,7 @@ import {
 	Float32BufferAttribute,
 	Loader,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var MD2Loader = function ( manager ) {
 

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -29,9 +29,9 @@ import {
 	Uint16BufferAttribute,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
-import { TGALoader } from "../loaders/TGALoader.js";
-import { MMDParser } from "../libs/mmdparser.module.js";
+} from '../../../build/three.module.js';
+import { TGALoader } from '../loaders/TGALoader.js';
+import { MMDParser } from '../libs/mmdparser.module.js';
 
 /**
  * Dependencies

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -9,7 +9,7 @@ import {
 	RepeatWrapping,
 	TextureLoader,
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Loads a Wavefront .mtl file specifying materials

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -3,9 +3,9 @@ import {
 	Loader,
 	Matrix4,
 	Vector3
-} from "../../../build/three.module.js";
-import { Zlib } from "../libs/gunzip.module.min.js";
-import { Volume } from "../misc/Volume.js";
+} from '../../../build/three.module.js';
+import { Zlib } from '../libs/gunzip.module.min.js';
+import { Volume } from '../misc/Volume.js';
 
 var NRRDLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -12,7 +12,7 @@ import {
 	Points,
 	PointsMaterial,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var OBJLoader = ( function () {
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -6,7 +6,7 @@ import {
 	LoaderUtils,
 	Points,
 	PointsMaterial
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var PCDLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/PDBLoader.js
+++ b/examples/jsm/loaders/PDBLoader.js
@@ -3,7 +3,7 @@ import {
 	FileLoader,
 	Float32BufferAttribute,
 	Loader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var PDBLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -4,7 +4,7 @@ import {
 	Float32BufferAttribute,
 	Loader,
 	LoaderUtils
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Description: A THREE loader for PLY ASCII files (known as the Polygon

--- a/examples/jsm/loaders/PRWMLoader.js
+++ b/examples/jsm/loaders/PRWMLoader.js
@@ -3,7 +3,7 @@ import {
 	BufferGeometry,
 	FileLoader,
 	Loader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * See https://github.com/kchapelier/PRWM for more informations about this file format

--- a/examples/jsm/loaders/PVRLoader.js
+++ b/examples/jsm/loaders/PVRLoader.js
@@ -4,7 +4,7 @@ import {
 	RGBA_PVRTC_4BPPV1_Format,
 	RGB_PVRTC_2BPPV1_Format,
 	RGB_PVRTC_4BPPV1_Format
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /*
  *	 PVR v2 (legacy) parser

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -10,7 +10,7 @@ import {
 	RGBEFormat,
 	RGBFormat,
 	UnsignedByteType
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 // https://github.com/mrdoob/three.js/issues/5552
 // http://en.wikipedia.org/wiki/RGBE_image_format

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -6,7 +6,7 @@ import {
 	Loader,
 	LoaderUtils,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -8,7 +8,7 @@ import {
 	ShapePath,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var SVGLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -12,7 +12,7 @@ import {
 	Mesh,
 	MeshPhongMaterial,
 	TextureLoader
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Autodesk 3DS three.js file loader, based on lib3ds.

--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -2,7 +2,7 @@ import {
 	FileLoader,
 	Loader,
 	Texture
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var TGALoader = function ( manager ) {
 

--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -1,8 +1,8 @@
 import {
 	FileLoader,
 	Loader
-} from "../../../build/three.module.js";
-import { opentype } from "../libs/opentype.module.min.js";
+} from '../../../build/three.module.js';
+import { opentype } from '../libs/opentype.module.min.js';
 
 /**
  * Requires opentype.js to be included in the project.

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -33,8 +33,8 @@ import {
 	TextureLoader,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
-import { chevrotain } from "../libs/chevrotain.module.min.js";
+} from '../../../build/three.module.js';
+import { chevrotain } from '../libs/chevrotain.module.min.js';
 
 var VRMLLoader = ( function () {
 

--- a/examples/jsm/loaders/VRMLoader.js
+++ b/examples/jsm/loaders/VRMLoader.js
@@ -1,7 +1,7 @@
 import {
 	Loader
-} from "../../../build/three.module.js";
-import { GLTFLoader } from "../loaders/GLTFLoader.js";
+} from '../../../build/three.module.js';
+import { GLTFLoader } from '../loaders/GLTFLoader.js';
 
 // VRM Specification: https://dwango.github.io/vrm/vrm_spec/
 //

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -5,8 +5,8 @@ import {
 	Float32BufferAttribute,
 	Loader,
 	LoaderUtils
-} from "../../../build/three.module.js";
-import { Inflate } from "../libs/inflate.module.min.js";
+} from '../../../build/three.module.js';
+import { Inflate } from '../libs/inflate.module.min.js';
 
 var VTKLoader = function ( manager ) {
 

--- a/examples/jsm/loaders/XLoader.js
+++ b/examples/jsm/loaders/XLoader.js
@@ -18,7 +18,7 @@ import {
 	Uint16BufferAttribute,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var XLoader = ( function () {
 

--- a/examples/jsm/math/ColorConverter.js
+++ b/examples/jsm/math/ColorConverter.js
@@ -1,6 +1,6 @@
 import {
 	MathUtils
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var ColorConverter = {
 

--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -3,7 +3,7 @@ import {
 	Plane,
 	Triangle,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Ported from: https://github.com/maurizzzio/quickhull3d/ by Mauricio Poppe (https://github.com/maurizzzio)

--- a/examples/jsm/math/Lut.js
+++ b/examples/jsm/math/Lut.js
@@ -1,6 +1,6 @@
 import {
 	Color
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var Lut = function ( colormap, numberofcolors ) {
 

--- a/examples/jsm/misc/ConvexObjectBreaker.js
+++ b/examples/jsm/misc/ConvexObjectBreaker.js
@@ -3,8 +3,8 @@ import {
 	Mesh,
 	Plane,
 	Vector3
-} from "../../../build/three.module.js";
-import { ConvexBufferGeometry } from "../geometries/ConvexGeometry.js";
+} from '../../../build/three.module.js';
+import { ConvexBufferGeometry } from '../geometries/ConvexGeometry.js';
 
 /**
  * @fileoverview This class can be used to subdivide a convex Geometry object into pieces.

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -10,7 +10,7 @@ import {
 	Scene,
 	ShaderMaterial,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * GPUComputationRenderer, based on SimulationRenderer by zz85

--- a/examples/jsm/misc/Gyroscope.js
+++ b/examples/jsm/misc/Gyroscope.js
@@ -2,7 +2,7 @@ import {
 	Object3D,
 	Quaternion,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var Gyroscope = function () {
 

--- a/examples/jsm/misc/MD2Character.js
+++ b/examples/jsm/misc/MD2Character.js
@@ -7,8 +7,8 @@ import {
 	TextureLoader,
 	UVMapping,
 	sRGBEncoding
-} from "../../../build/three.module.js";
-import { MD2Loader } from "../loaders/MD2Loader.js";
+} from '../../../build/three.module.js';
+import { MD2Loader } from '../loaders/MD2Loader.js';
 
 var MD2Character = function () {
 

--- a/examples/jsm/misc/MD2CharacterComplex.js
+++ b/examples/jsm/misc/MD2CharacterComplex.js
@@ -6,9 +6,9 @@ import {
 	TextureLoader,
 	UVMapping,
 	sRGBEncoding
-} from "../../../build/three.module.js";
-import { MD2Loader } from "../loaders/MD2Loader.js";
-import { MorphBlendMesh } from "../misc/MorphBlendMesh.js";
+} from '../../../build/three.module.js';
+import { MD2Loader } from '../loaders/MD2Loader.js';
+import { MorphBlendMesh } from '../misc/MorphBlendMesh.js';
 
 var MD2CharacterComplex = function () {
 

--- a/examples/jsm/misc/MorphAnimMesh.js
+++ b/examples/jsm/misc/MorphAnimMesh.js
@@ -2,7 +2,7 @@ import {
 	AnimationClip,
 	AnimationMixer,
 	Mesh
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var MorphAnimMesh = function ( geometry, material ) {
 

--- a/examples/jsm/misc/MorphBlendMesh.js
+++ b/examples/jsm/misc/MorphBlendMesh.js
@@ -1,7 +1,7 @@
 import {
 	MathUtils,
 	Mesh
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var MorphBlendMesh = function ( geometry, material ) {
 

--- a/examples/jsm/misc/Ocean.js
+++ b/examples/jsm/misc/Ocean.js
@@ -16,8 +16,8 @@ import {
 	Vector2,
 	Vector3,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { OceanShaders } from "../shaders/OceanShaders.js";
+} from '../../../build/three.module.js';
+import { OceanShaders } from '../shaders/OceanShaders.js';
 
 var Ocean = function ( renderer, camera, scene, options ) {
 

--- a/examples/jsm/misc/RollerCoaster.js
+++ b/examples/jsm/misc/RollerCoaster.js
@@ -4,7 +4,7 @@ import {
 	Quaternion,
 	Raycaster,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var RollerCoasterGeometry = function ( curve, divisions ) {
 

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -2,8 +2,8 @@ import {
 	Matrix3,
 	Matrix4,
 	Vector3
-} from "../../../build/three.module.js";
-import { VolumeSlice } from "../misc/VolumeSlice.js";
+} from '../../../build/three.module.js';
+import { VolumeSlice } from '../misc/VolumeSlice.js';
 
 /**
  * This class had been written to handle the output of the NRRD loader.

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -6,7 +6,7 @@ import {
 	MeshBasicMaterial,
 	PlaneBufferGeometry,
 	Texture
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * This class has been made to hold a slice of a volume data

--- a/examples/jsm/modifiers/EdgeSplitModifier.js
+++ b/examples/jsm/modifiers/EdgeSplitModifier.js
@@ -2,8 +2,8 @@ import {
 	BufferAttribute,
 	BufferGeometry,
 	Vector3
-} from "../../../build/three.module.js";
-import { BufferGeometryUtils } from "../utils/BufferGeometryUtils.js";
+} from '../../../build/three.module.js';
+import { BufferGeometryUtils } from '../utils/BufferGeometryUtils.js';
 
 
 var EdgeSplitModifier = function () {

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -3,7 +3,7 @@ import {
 	Float32BufferAttribute,
 	Geometry,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  *	Simplification Geometry Modifier

--- a/examples/jsm/modifiers/SubdivisionModifier.js
+++ b/examples/jsm/modifiers/SubdivisionModifier.js
@@ -4,7 +4,7 @@ import {
 	Geometry,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  *	Subdivision Geometry Modifier

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -2,7 +2,7 @@ import {
 	BufferGeometry,
 	Face3,
 	Geometry
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Break faces with edges longer than maxEdgeLength

--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -15,7 +15,7 @@ import {
 	Vector2,
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var Lensflare = function () {
 

--- a/examples/jsm/objects/LightningStorm.js
+++ b/examples/jsm/objects/LightningStorm.js
@@ -3,8 +3,8 @@ import {
 	Mesh,
 	MeshBasicMaterial,
 	Object3D
-} from "../../../build/three.module.js";
-import { LightningStrike } from "../geometries/LightningStrike.js";
+} from '../../../build/three.module.js';
+import { LightningStrike } from '../geometries/LightningStrike.js';
 
 /**
  * @fileoverview Lightning strike object generator

--- a/examples/jsm/objects/MarchingCubes.js
+++ b/examples/jsm/objects/MarchingCubes.js
@@ -4,7 +4,7 @@ import {
 	Color,
 	ImmediateRenderObject,
 	NoColors
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Port of http://webglsamples.org/blob/blob.html

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -12,7 +12,7 @@ import {
 	Vector3,
 	Vector4,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var Reflector = function ( geometry, options ) {
 

--- a/examples/jsm/objects/ReflectorRTT.js
+++ b/examples/jsm/objects/ReflectorRTT.js
@@ -1,4 +1,4 @@
-import { Reflector } from "../objects/Reflector.js";
+import { Reflector } from '../objects/Reflector.js';
 
 var ReflectorRTT = function ( geometry, options ) {
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -13,7 +13,7 @@ import {
 	Vector3,
 	Vector4,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var Refractor = function ( geometry, options ) {
 

--- a/examples/jsm/objects/ShadowMesh.js
+++ b/examples/jsm/objects/ShadowMesh.js
@@ -2,7 +2,7 @@ import {
 	Matrix4,
 	Mesh,
 	MeshBasicMaterial
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * A shadow Mesh that follows a shadow-casting Mesh in the scene, but is confined to a single plane.

--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -5,7 +5,7 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Based on "A Practical Analytic Model for Daylight"

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -16,7 +16,7 @@ import {
 	Vector3,
 	Vector4,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Work based on :

--- a/examples/jsm/objects/Water2.js
+++ b/examples/jsm/objects/Water2.js
@@ -11,9 +11,9 @@ import {
 	UniformsUtils,
 	Vector2,
 	Vector4
-} from "../../../build/three.module.js";
-import { Reflector } from "../objects/Reflector.js";
-import { Refractor } from "../objects/Refractor.js";
+} from '../../../build/three.module.js';
+import { Reflector } from '../objects/Reflector.js';
+import { Refractor } from '../objects/Refractor.js';
 
 /**
  * References:

--- a/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
@@ -7,11 +7,11 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
-import { LuminosityShader } from "../shaders/LuminosityShader.js";
-import { ToneMapShader } from "../shaders/ToneMapShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+import { LuminosityShader } from '../shaders/LuminosityShader.js';
+import { ToneMapShader } from '../shaders/ToneMapShader.js';
 
 /**
  * Generate a texture that represents the luminosity of the current scene, adapted over time

--- a/examples/jsm/postprocessing/AfterimagePass.js
+++ b/examples/jsm/postprocessing/AfterimagePass.js
@@ -6,9 +6,9 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { AfterimageShader } from "../shaders/AfterimageShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { AfterimageShader } from '../shaders/AfterimageShader.js';
 
 var AfterimagePass = function ( damp ) {
 

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -6,10 +6,10 @@ import {
 	UniformsUtils,
 	Vector2,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
-import { ConvolutionShader } from "../shaders/ConvolutionShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+import { ConvolutionShader } from '../shaders/ConvolutionShader.js';
 
 var BloomPass = function ( strength, kernelSize, sigma, resolution ) {
 

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -7,9 +7,9 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { BokehShader } from "../shaders/BokehShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { BokehShader } from '../shaders/BokehShader.js';
 
 /**
  * Depth-of-field post-process with bokeh shader

--- a/examples/jsm/postprocessing/ClearPass.js
+++ b/examples/jsm/postprocessing/ClearPass.js
@@ -1,7 +1,7 @@
 import {
 	Color
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
 
 var ClearPass = function ( clearColor, clearAlpha ) {
 

--- a/examples/jsm/postprocessing/CubeTexturePass.js
+++ b/examples/jsm/postprocessing/CubeTexturePass.js
@@ -6,8 +6,8 @@ import {
 	Scene,
 	ShaderLib,
 	ShaderMaterial
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
 
 var CubeTexturePass = function ( camera, envMap, opacity ) {
 

--- a/examples/jsm/postprocessing/DotScreenPass.js
+++ b/examples/jsm/postprocessing/DotScreenPass.js
@@ -1,9 +1,9 @@
 import {
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { DotScreenShader } from "../shaders/DotScreenShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { DotScreenShader } from '../shaders/DotScreenShader.js';
 
 var DotScreenPass = function ( center, angle, scale ) {
 

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -7,11 +7,11 @@ import {
 	RGBAFormat,
 	Vector2,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { CopyShader } from "../shaders/CopyShader.js";
-import { ShaderPass } from "../postprocessing/ShaderPass.js";
-import { MaskPass } from "../postprocessing/MaskPass.js";
-import { ClearMaskPass } from "../postprocessing/MaskPass.js";
+} from '../../../build/three.module.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+import { ShaderPass } from '../postprocessing/ShaderPass.js';
+import { MaskPass } from '../postprocessing/MaskPass.js';
+import { ClearMaskPass } from '../postprocessing/MaskPass.js';
 
 var EffectComposer = function ( renderer, renderTarget ) {
 

--- a/examples/jsm/postprocessing/FilmPass.js
+++ b/examples/jsm/postprocessing/FilmPass.js
@@ -1,9 +1,9 @@
 import {
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { FilmShader } from "../shaders/FilmShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { FilmShader } from '../shaders/FilmShader.js';
 
 var FilmPass = function ( noiseIntensity, scanlinesIntensity, scanlinesCount, grayscale ) {
 

--- a/examples/jsm/postprocessing/GlitchPass.js
+++ b/examples/jsm/postprocessing/GlitchPass.js
@@ -5,9 +5,9 @@ import {
 	RGBFormat,
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { DigitalGlitch } from "../shaders/DigitalGlitch.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { DigitalGlitch } from '../shaders/DigitalGlitch.js';
 
 var GlitchPass = function ( dt_size ) {
 

--- a/examples/jsm/postprocessing/HalftonePass.js
+++ b/examples/jsm/postprocessing/HalftonePass.js
@@ -1,9 +1,9 @@
 import {
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { HalftoneShader } from "../shaders/HalftoneShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { HalftoneShader } from '../shaders/HalftoneShader.js';
 
 /**
  * RGB Halftone pass for three.js effects composer. Requires HalftoneShader.

--- a/examples/jsm/postprocessing/MaskPass.js
+++ b/examples/jsm/postprocessing/MaskPass.js
@@ -1,4 +1,4 @@
-import { Pass } from "../postprocessing/Pass.js";
+import { Pass } from '../postprocessing/Pass.js';
 
 var MaskPass = function ( scene, camera ) {
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -14,9 +14,9 @@ import {
 	Vector2,
 	Vector3,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
 
 var OutlinePass = function ( resolution, scene, camera, selectedObjects ) {
 

--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -1,7 +1,7 @@
 import {
 	Color
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
 
 var RenderPass = function ( scene, camera, overrideMaterial, clearColor, clearAlpha ) {
 

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -18,13 +18,13 @@ import {
 	Vector2,
 	WebGLRenderTarget,
 	ZeroFactor
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { SAOShader } from "../shaders/SAOShader.js";
-import { DepthLimitedBlurShader } from "../shaders/DepthLimitedBlurShader.js";
-import { BlurShaderUtils } from "../shaders/DepthLimitedBlurShader.js";
-import { CopyShader } from "../shaders/CopyShader.js";
-import { UnpackDepthRGBAShader } from "../shaders/UnpackDepthRGBAShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { SAOShader } from '../shaders/SAOShader.js';
+import { DepthLimitedBlurShader } from '../shaders/DepthLimitedBlurShader.js';
+import { BlurShaderUtils } from '../shaders/DepthLimitedBlurShader.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+import { UnpackDepthRGBAShader } from '../shaders/UnpackDepthRGBAShader.js';
 
 /**
  * SAO implementation inspired from bhouston previous SAO work

--- a/examples/jsm/postprocessing/SMAAPass.js
+++ b/examples/jsm/postprocessing/SMAAPass.js
@@ -7,11 +7,11 @@ import {
 	Texture,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { SMAAEdgesShader } from "../shaders/SMAAShader.js";
-import { SMAAWeightsShader } from "../shaders/SMAAShader.js";
-import { SMAABlendShader } from "../shaders/SMAAShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { SMAAEdgesShader } from '../shaders/SMAAShader.js';
+import { SMAAWeightsShader } from '../shaders/SMAAShader.js';
+import { SMAABlendShader } from '../shaders/SMAAShader.js';
 
 var SMAAPass = function ( width, height ) {
 

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -6,9 +6,9 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
 
 /**
 *

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -20,13 +20,13 @@ import {
 	Vector3,
 	WebGLRenderTarget,
 	ZeroFactor
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { SimplexNoise } from "../math/SimplexNoise.js";
-import { SSAOShader } from "../shaders/SSAOShader.js";
-import { SSAOBlurShader } from "../shaders/SSAOShader.js";
-import { SSAODepthShader } from "../shaders/SSAOShader.js";
-import { CopyShader } from "../shaders/CopyShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { SimplexNoise } from '../math/SimplexNoise.js';
+import { SSAOShader } from '../shaders/SSAOShader.js';
+import { SSAOBlurShader } from '../shaders/SSAOShader.js';
+import { SSAODepthShader } from '../shaders/SSAOShader.js';
+import { CopyShader } from '../shaders/CopyShader.js';
 
 var SSAOPass = function ( scene, camera, width, height ) {
 

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -4,9 +4,9 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
 
 var SavePass = function ( renderTarget ) {
 

--- a/examples/jsm/postprocessing/ShaderPass.js
+++ b/examples/jsm/postprocessing/ShaderPass.js
@@ -1,8 +1,8 @@
 import {
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
 
 var ShaderPass = function ( shader, textureID ) {
 

--- a/examples/jsm/postprocessing/TAARenderPass.js
+++ b/examples/jsm/postprocessing/TAARenderPass.js
@@ -1,7 +1,7 @@
 import {
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { SSAARenderPass } from "../postprocessing/SSAARenderPass.js";
+} from '../../../build/three.module.js';
+import { SSAARenderPass } from '../postprocessing/SSAARenderPass.js';
 
 /**
  *

--- a/examples/jsm/postprocessing/TexturePass.js
+++ b/examples/jsm/postprocessing/TexturePass.js
@@ -1,9 +1,9 @@
 import {
 	ShaderMaterial,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
 
 var TexturePass = function ( map, opacity ) {
 

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -9,10 +9,10 @@ import {
 	Vector2,
 	Vector3,
 	WebGLRenderTarget
-} from "../../../build/three.module.js";
-import { Pass } from "../postprocessing/Pass.js";
-import { CopyShader } from "../shaders/CopyShader.js";
-import { LuminosityHighPassShader } from "../shaders/LuminosityHighPassShader.js";
+} from '../../../build/three.module.js';
+import { Pass } from '../postprocessing/Pass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+import { LuminosityHighPassShader } from '../shaders/LuminosityHighPassShader.js';
 
 /**
  * UnrealBloomPass is inspired by the bloom pass of Unreal Engine. It creates a

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -2,7 +2,7 @@ import {
 	Matrix4,
 	Object3D,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var CSS2DObject = function ( element ) {
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -2,7 +2,7 @@ import {
 	Matrix4,
 	Object3D,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Based on http://www.emagix.net/academic/mscs-project/item/camera-sync-with-css3-and-webgl-threejs

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -18,7 +18,7 @@ import {
 	Vector2,
 	Vector3,
 	Vector4
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var RenderableObject = function () {
 

--- a/examples/jsm/renderers/SVGRenderer.js
+++ b/examples/jsm/renderers/SVGRenderer.js
@@ -6,11 +6,11 @@ import {
 	Matrix4,
 	Object3D,
 	Vector3
-} from "../../../build/three.module.js";
-import { Projector } from "../renderers/Projector.js";
-import { RenderableFace } from "../renderers/Projector.js";
-import { RenderableLine } from "../renderers/Projector.js";
-import { RenderableSprite } from "../renderers/Projector.js";
+} from '../../../build/three.module.js';
+import { Projector } from '../renderers/Projector.js';
+import { RenderableFace } from '../renderers/Projector.js';
+import { RenderableLine } from '../renderers/Projector.js';
+import { RenderableSprite } from '../renderers/Projector.js';
 
 var SVGObject = function ( node ) {
 

--- a/examples/jsm/shaders/BokehShader2.js
+++ b/examples/jsm/shaders/BokehShader2.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Depth-of-field shader with bokeh

--- a/examples/jsm/shaders/ColorCorrectionShader.js
+++ b/examples/jsm/shaders/ColorCorrectionShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Color correction

--- a/examples/jsm/shaders/ColorifyShader.js
+++ b/examples/jsm/shaders/ColorifyShader.js
@@ -1,6 +1,6 @@
 import {
 	Color
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Colorify shader

--- a/examples/jsm/shaders/ConvolutionShader.js
+++ b/examples/jsm/shaders/ConvolutionShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Convolution shader

--- a/examples/jsm/shaders/DepthLimitedBlurShader.js
+++ b/examples/jsm/shaders/DepthLimitedBlurShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * TODO

--- a/examples/jsm/shaders/DotScreenShader.js
+++ b/examples/jsm/shaders/DotScreenShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Dot screen shader

--- a/examples/jsm/shaders/FXAAShader.js
+++ b/examples/jsm/shaders/FXAAShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * NVIDIA FXAA by Timothy Lottes

--- a/examples/jsm/shaders/FreiChenShader.js
+++ b/examples/jsm/shaders/FreiChenShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Edge Detection Shader using Frei-Chen filter

--- a/examples/jsm/shaders/GodRaysShader.js
+++ b/examples/jsm/shaders/GodRaysShader.js
@@ -1,7 +1,7 @@
 import {
 	Color,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * God-rays (crepuscular rays)

--- a/examples/jsm/shaders/LuminosityHighPassShader.js
+++ b/examples/jsm/shaders/LuminosityHighPassShader.js
@@ -1,6 +1,6 @@
 import {
 	Color
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Luminosity

--- a/examples/jsm/shaders/NormalMapShader.js
+++ b/examples/jsm/shaders/NormalMapShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Normal map shader

--- a/examples/jsm/shaders/OceanShaders.js
+++ b/examples/jsm/shaders/OceanShaders.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 // Description: A deep water ocean shader set
 // based on an implementation of a Tessendorf Waves

--- a/examples/jsm/shaders/SAOShader.js
+++ b/examples/jsm/shaders/SAOShader.js
@@ -1,7 +1,7 @@
 import {
 	Matrix4,
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * TODO

--- a/examples/jsm/shaders/SMAAShader.js
+++ b/examples/jsm/shaders/SMAAShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * WebGL port of Subpixel Morphological Antialiasing (SMAA) v2.8

--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -1,7 +1,7 @@
 import {
 	Matrix4,
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * References:

--- a/examples/jsm/shaders/SobelOperatorShader.js
+++ b/examples/jsm/shaders/SobelOperatorShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Sobel Edge Detection (see https://youtu.be/uihBwtPIBxM)

--- a/examples/jsm/shaders/SubsurfaceScatteringShader.js
+++ b/examples/jsm/shaders/SubsurfaceScatteringShader.js
@@ -3,7 +3,7 @@ import {
 	ShaderChunk,
 	ShaderLib,
 	UniformsUtils
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * ------------------------------------------------------------------------------------------

--- a/examples/jsm/shaders/ToonShader.js
+++ b/examples/jsm/shaders/ToonShader.js
@@ -1,7 +1,7 @@
 import {
 	Color,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Currently contains:

--- a/examples/jsm/shaders/TriangleBlurShader.js
+++ b/examples/jsm/shaders/TriangleBlurShader.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Triangle blur shader

--- a/examples/jsm/shaders/VolumeShader.js
+++ b/examples/jsm/shaders/VolumeShader.js
@@ -1,7 +1,7 @@
 import {
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * Shaders to render 3D volumes using raycasting.

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -8,7 +8,7 @@ import {
 	TrianglesDrawMode,
 	Vector2,
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var BufferGeometryUtils = {
 

--- a/examples/jsm/utils/GeometryUtils.js
+++ b/examples/jsm/utils/GeometryUtils.js
@@ -1,6 +1,6 @@
 import {
 	Vector3
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var GeometryUtils = {
 

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -1,7 +1,7 @@
 import {
 	Group,
 	Mesh
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var SceneUtils = {
 

--- a/examples/jsm/utils/ShadowMapViewer.js
+++ b/examples/jsm/utils/ShadowMapViewer.js
@@ -9,8 +9,8 @@ import {
 	ShaderMaterial,
 	Texture,
 	UniformsUtils
-} from "../../../build/three.module.js";
-import { UnpackDepthRGBAShader } from "../shaders/UnpackDepthRGBAShader.js";
+} from '../../../build/three.module.js';
+import { UnpackDepthRGBAShader } from '../shaders/UnpackDepthRGBAShader.js';
 
 /**
  * This is a helper for visualising a given light's shadow map.

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -9,7 +9,7 @@ import {
 	Vector2,
 	Vector3,
 	VectorKeyframeTrack
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 var SkeletonUtils = {
 

--- a/examples/jsm/utils/UVsDebug.js
+++ b/examples/jsm/utils/UVsDebug.js
@@ -1,6 +1,6 @@
 import {
 	Vector2
-} from "../../../build/three.module.js";
+} from '../../../build/three.module.js';
 
 /**
  * tool for "unwrapping" and debugging three.js geometries UV mapping

--- a/utils/modularize.js
+++ b/utils/modularize.js
@@ -308,13 +308,13 @@ function convert( path, exampleDependencies, ignoreList ) {
 
 	// core imports
 
-	if ( keys ) imports.push( `import {${keys}\n} from "${pathPrefix}../../build/three.module.js";` );
+	if ( keys ) imports.push( `import {${keys}\n} from '${pathPrefix}../../build/three.module.js';` );
 
 	// example imports
 
 	for ( var dependency of exampleDependencies ) {
 
-		imports.push( `import { ${dependency.name} } from "${pathPrefix}${dependency.path}";` );
+		imports.push( `import { ${dependency.name} } from '${pathPrefix}${dependency.path}';` );
 
 	}
 


### PR DESCRIPTION
Related issue: -

Minor style clean up in modules.
