### PR TITLE
Examples: Fix broken node material presets.

### DIFF
--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -2500,7 +2500,7 @@
 
 								case 'prem':
 
-									mtl.color = new Nodes.TextureCubeNode( new Nodes.TextureNode( premTexture ), undefined, undefined, bias );
+									mtl.color = new Nodes.TextureCubeNode( new Nodes.TextureNode( premTexture ), undefined, bias );
 
 									break;
 
@@ -2947,7 +2947,7 @@
 
 						var blurtexture = new Nodes.FunctionNode( [
 							// Reference: TriangleBlurShader.js
-							"vec4 blurtexture(sampler2D texture, vec2 uv, vec2 delta) {",
+							"vec4 blurtexture(sampler2D map, vec2 uv, vec2 delta) {",
 							"	vec4 color = vec4( 0.0 );",
 							"	float total = 0.0;",
 							// randomize the lookup values to hide the fixed number of samples
@@ -2955,7 +2955,7 @@
 							"	for ( float t = -BLUR_ITERATIONS; t <= BLUR_ITERATIONS; t ++ ) {",
 							"		float percent = ( t + offset - 0.5 ) / BLUR_ITERATIONS;",
 							"		float weight = 1.0 - abs( percent );",
-							"		color += texture2D( texture, uv + delta * percent ) * weight;",
+							"		color += texture2D( map, uv + delta * percent ) * weight;",
 							"		total += weight;",
 							"	}",
 							"	return color / total;",
@@ -2963,7 +2963,7 @@
 						].join( "\n" ), [ new Nodes.ConstNode( "float BLUR_ITERATIONS 10.0" ) ] );
 
 						var blurredTexture = new Nodes.FunctionCallNode( blurtexture, {
-							texture: new Nodes.TextureNode( getTexture( "brick" ) ),
+							map: new Nodes.TextureNode( getTexture( "brick" ) ),
 							delta: delta,
 							uv: new Nodes.UVNode()
 						} );
@@ -3009,7 +3009,7 @@
 
 						var triplanarMapping = new Nodes.FunctionNode( [
 							// Reference: https://github.com/keijiro/StandardTriplanar
-							"vec4 triplanar_mapping( sampler2D texture, vec3 normal, vec3 position, float scale ) {",
+							"vec4 triplanar_mapping( sampler2D map, vec3 normal, vec3 position, float scale ) {",
 
 							// Blending factor of triplanar mapping
 							"	vec3 bf = normalize( abs( normal ) );",
@@ -3021,9 +3021,9 @@
 							"	vec2 tz = position.xy * scale;",
 
 							// Base color
-							"	vec4 cx = texture2D(texture, tx) * bf.x;",
-							"	vec4 cy = texture2D(texture, ty) * bf.y;",
-							"	vec4 cz = texture2D(texture, tz) * bf.z;",
+							"	vec4 cx = texture2D(map, tx) * bf.x;",
+							"	vec4 cy = texture2D(map, ty) * bf.y;",
+							"	vec4 cz = texture2D(map, tz) * bf.z;",
 
 							"	return cx + cy + cz;",
 
@@ -3031,7 +3031,7 @@
 						].join( "\n" ) );
 
 						var triplanarMappingTexture = new Nodes.FunctionCallNode( triplanarMapping, {
-							texture: new Nodes.TextureNode( getTexture( "brick" ) ),
+							map: new Nodes.TextureNode( getTexture( "brick" ) ),
 							normal: new Nodes.NormalNode( Nodes.NormalNode.WORLD ),
 							position: new Nodes.PositionNode( Nodes.PositionNode.WORLD ),
 							scale: scale,


### PR DESCRIPTION
Related issue: -

**Description**

In `webgl_materials_nodes`, the presets `adv / bias`, `adv / triangle-blur` and `adv / triplanar-mapping` are broken right now.
