### PR TITLE
CurveModifier: Fix WebGL 1 support.

### DIFF
--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -132,13 +132,13 @@ export function modifyShader( material, uniforms, numberOfCurves = 1 ) {
 		${shader.vertexShader}
 		`
 		// chunk import moved in front of modified shader below
-			.replace( '#include <beginnormal_vertex>', `` )
+			.replace( '#include <beginnormal_vertex>', '' )
 
 			// vec3 transformedNormal declaration overriden below
-			.replace( '#include <defaultnormal_vertex>', `` )
+			.replace( '#include <defaultnormal_vertex>', '' )
 
 			// vec3 transformed declaration overriden below
-			.replace( '#include <begin_vertex>', `` )
+			.replace( '#include <begin_vertex>', '' )
 
 			// shader override
 			.replace(
@@ -169,10 +169,10 @@ float rowOffset = floor(mt);
 rowOffset += instanceMatrix[3][1] * ${TEXTURE_HEIGHT}.;
 #endif
 
-vec3 spinePos = texture(spineTexture, vec2(mt, (0. + rowOffset + 0.5) / textureLayers)).xyz;
-vec3 a =        texture(spineTexture, vec2(mt, (1. + rowOffset + 0.5) / textureLayers)).xyz;
-vec3 b =        texture(spineTexture, vec2(mt, (2. + rowOffset + 0.5) / textureLayers)).xyz;
-vec3 c =        texture(spineTexture, vec2(mt, (3. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 spinePos = texture2D(spineTexture, vec2(mt, (0. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 a =        texture2D(spineTexture, vec2(mt, (1. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 b =        texture2D(spineTexture, vec2(mt, (2. + rowOffset + 0.5) / textureLayers)).xyz;
+vec3 c =        texture2D(spineTexture, vec2(mt, (3. + rowOffset + 0.5) / textureLayers)).xyz;
 mat3 basis = mat3(a, b, c);
 
 vec3 transformed = basis
@@ -315,7 +315,7 @@ export class InstancedFlow extends Flow {
 	 */
 	setCurve( index, curveNo ) {
 
-		if ( isNaN( curveNo ) ) throw Error( "curve index being set is Not a Number (NaN)" );
+		if ( isNaN( curveNo ) ) throw Error( 'curve index being set is Not a Number (NaN)' );
 		this.whichCurve[ index ] = curveNo;
 		this.writeChanges( index );
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/modifier-curve-threejs-example-does-not-run-in-safari-or-ios-chrome/21355/7

**Description**

Ensures `CurveModifier` also works with WebGL 1. 
