### PR TITLE
Docs: Fix links in Matrix4 page.

### DIFF
--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -105,7 +105,7 @@ zAxis = (c, f, i)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:this invert()]()</h3>
+		<h3>[method:this invert]()</h3>
 		<p>
 		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -186,7 +186,7 @@ zAxis = (c, g, k)
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major] format.
 		</p>
 
-		<h3>[method:this invert()]()</h3>
+		<h3>[method:this invert]()</h3>
 		<p>
 		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -100,7 +100,7 @@ zAxis = (c, f, i)
 		使用基于列优先格式[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]的数组来设置该矩阵。
 		</p>
 
-		<h3>[method:this invert()]()</h3>
+		<h3>[method:this invert]()</h3>
 		<p>
 		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -172,7 +172,7 @@ zAxis = (c, g, k)
 			使用基于列优先格式[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order column-major]的数组来设置该矩阵。
 		</p>
 
-		<h3>[method:this invert()]()</h3>
+		<h3>[method:this invert]()</h3>
 		<p>
 		Inverts this matrix, using the [link:https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution analytic method].
 


### PR DESCRIPTION
**Description**

Tiny fix for unlinkable syntax:

![Screenshot 2020-12-09 at 06 34 11](https://user-images.githubusercontent.com/9549760/101589374-8fa3ba80-39e8-11eb-8769-b0ebda89b7dc.png)
