### PR TITLE
Docs: Clarify CurvePath.getPoints().

### DIFF
--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -16,15 +16,12 @@
 		but retains the api of a curve.
 		</p>
 
-
 		<h2>Constructor</h2>
-
 
 		<h3>[name]()</h3>
 		<p>
 		The constructor take no parameters.
 		</p>
-
 
 		<h2>Properties</h2>
 		<p>See the base [page:Curve] class for common properties.</p>
@@ -34,10 +31,6 @@
 
 		<h3>[property:Boolean autoClose]</h3>
 		<p>Whether or not to automatically close the path.</p>
-
-
-
-
 
 		<h2>Methods</h2>
 		<p>See the base [page:Curve] class for common methods.</p>
@@ -62,7 +55,10 @@
 		<p>
 			divisions -- number of pieces to divide the curve into. Default is *12*.<br /><br />
 
-			Returns a set of divisions + 1 points using getPoint( t ).
+			Returns an array of points representing a sequence of curves. The *division* parameter defines
+			the number of pieces each curve is divided into. However, for optimization and quality purposes,
+			the actual sampling resolution for each curve depends on its type. For example, for a [page:LineCurve],
+			the returned number of points is always just 2.
 		</p>
 
 		<h3>[method:Array getSpacedPoints]( [param:Integer divisions] )</h3>


### PR DESCRIPTION
Related issue: Fixed #20771

**Description**

Improves the description of `CurvePath.getPoints()`.