### PR TITLE
3DMLoader: Added checks for null geometry and material

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -325,7 +325,8 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 					} else {
 
-						var _object = this._createObject( obj, null );
+						var material = this._createMaterial( );
+						var _object = this._createObject( obj, material );
 
 					}
 
@@ -1241,7 +1242,7 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 		}
 
-		if ( geometry ) {
+		if ( ( geometry && ! Array.isArray( geometry ) ) || ( Array.isArray( geometry ) && geometry.length ) ) {
 
 			var attributes = extractProperties( _attributes );
 			attributes.geometry = extractProperties( _geometry );
@@ -1265,6 +1266,10 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 			attributes.geometry.objectType = objectType;
 
 			return { geometry, attributes, objectType };
+
+		} else {
+
+			console.warn( 'THREE.3DMLoader: Object has no mesh geometry. Consider opening this in Rhino, using a shaded display mode, and exporting again.' );
 
 		}
 

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -1242,7 +1242,7 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 		}
 
-		if ( ( geometry && ! Array.isArray( geometry ) ) || ( Array.isArray( geometry ) && geometry.length ) ) {
+		if ( Array.isArray( geometry ) === false || geometry.length > 0 ) {
 
 			var attributes = extractProperties( _attributes );
 			attributes.geometry = extractProperties( _geometry );


### PR DESCRIPTION
**Description**

In order to convert non-mesh objects (BREPS, Extrusions, Surfaces, SubD, etc) to an appropriate three.js object, the user must have viewed the object in a shaded display mode in Rhino. If this is not the case the current 3DMLoader will continue, but there will be no resulting geometry. This PR adds a warning message.

Also, there was an error where an object might not have a material applied in Rhino (or the material was inherited by its layer). This PR adds a change to create a default material for that object.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [McNeel EU](https://www.mcneel.com).
