### PR TITLE
Tests: Suggestion, Introduce -webonly keyword to QUnit.module name for skipping the tests on Node.js

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter unit/build/three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter -f !-webonly unit/build/three.source.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",

--- a/test/unit/src/renderers/WebGLRenderer.tests.js
+++ b/test/unit/src/renderers/WebGLRenderer.tests.js
@@ -456,11 +456,11 @@ var customWebGLContext = function () {
 
 export default QUnit.module( 'Renderers', () => {
 
-	QUnit.module( 'WebGLRenderer', () => {
+	QUnit.module( 'WebGLRenderer-webonly', () => {
 
-		QUnit.todo( "Instancing", ( assert ) => {
+		QUnit.test( "Instancing", ( assert ) => {
 
-			assert.ok( false, "everything's gonna be alright" );
+			assert.ok( new WebGLRenderer(), "Can instantiate a renderer." );
 
 		} );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/20795#issuecomment-736062650

**Background:**

There are two ways to run our unit tests.

1. Run the tests on Node.js with `npm run test-unit` (or other) command.
2. Run the tests in web browser on `http://localhost:8080/test/unit/UnitTests.html`.

**Problem:**

The both run the same unit test sets. (I focus on core source code unit tests for now.) And Three.js partly has code including features Node.js doesn't natively support, for example DOM operation.

Then currently we can't add test cases using such features because the tests fail or terminate on Node.js.

**Suggestion:**

I'd like to suggest `-webonly` keyword (better name idea is welcome) to `QUnit.module` name for skipping such the tests on Node.js.

`QUnit.config.filter` can filter the tests. My idea is running the tests on Node.js excepts for the ones whose module name includes `-webonly` while running all the tests on Web.

https://api.qunitjs.com/config/QUnit.config/

**Example:**

```
export default QUnit.module( 'Foo', () => {
  QUnit.module('Bar', () => {
    QUnit.test('baz', ( assert ) => {
      // This test runs on both Node.js and Web.
    });
  });
  QUnit.module('Bar-webonly', () => {
    QUnit.test('baz', ( assert ) => {
      // This test runs only on Web.
    });
  });
});
```

I added `WebGLRenderer` instantiation test as an example in this PR. `new WebGLRenderer()` doesn't work as is on Node.js because it has a dependency with `document`.

The following two screenshots show that the tests pass on both Node.js and Web although the `WebGLRenderer()` instantiation test is added.

![image](https://user-images.githubusercontent.com/7637832/101944530-b78a4e00-3ba1-11eb-953c-e29519e98714.png)

![image](https://user-images.githubusercontent.com/7637832/101944368-772ad000-3ba1-11eb-95f2-04e6925166df.png)

**Benefits**

We can add the tests more to the unit tests. It helps keeping Three.js functionality.

**Alternative solutions**

1. Separating the unit tests which don't run on Node.js from the current unit test files. And Node.js runs the separated one while Web test runs the both.
2. Import polyfill or libraries which emulates the features Node.js natively doesn't support for the tests. For example headless-gl for WebGL.

Probably my idea is simpler than the alternatives. Disadvantage compared to 2 is we still can't run the tests using the features Node.js doesn't natively support on Node.js

This contribution is made at San Francisco International Airport.