### PR TITLE
RGBELoader: Make magic bytes regex less strict

### DIFF
--- a/examples/js/loaders/RGBELoader.js
+++ b/examples/js/loaders/RGBELoader.js
@@ -99,7 +99,7 @@ THREE.RGBELoader.prototype = Object.assign( Object.create( THREE.DataTextureLoad
 				var line, match,
 
 					// regexes to parse header info fields
-					magic_token_re = /^#\?(\S+)$/,
+					magic_token_re = /^#\?(\S+)/,
 					gamma_re = /^\s*GAMMA\s*=\s*(\d+(\.\d+)?)\s*$/,
 					exposure_re = /^\s*EXPOSURE\s*=\s*(\d+(\.\d+)?)\s*$/,
 					format_re = /^\s*FORMAT=(\S+)\s*$/,

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -113,7 +113,7 @@ RGBELoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype
 				var line, match,
 
 					// regexes to parse header info fields
-					magic_token_re = /^#\?(\S+)$/,
+					magic_token_re = /^#\?(\S+)/,
 					gamma_re = /^\s*GAMMA\s*=\s*(\d+(\.\d+)?)\s*$/,
 					exposure_re = /^\s*EXPOSURE\s*=\s*(\d+(\.\d+)?)\s*$/,
 					format_re = /^\s*FORMAT=(\S+)\s*$/,


### PR DESCRIPTION
Fix #20839

**Description**

Change RGBELoader with the fix I suggested in  https://github.com/mrdoob/three.js/issues/20839#issuecomment-739328921 so it does not require a newline for the magic bytes. Tested by @Usnul.

And here's an example file from this branch that uses RGBELoader to show it does not break:

https://raw.githack.com/gkjohnson/three.js/patch-4/examples/webgl_loader_gltf.html
