### PR TITLE
KTX2Loader: Fix calculation of level dimensions for NPOT textures.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -524,8 +524,8 @@ class KTX2Container {
 
 		for ( var level = 0; level < this.header.levelCount; level ++ ) {
 
-			var levelWidth = Math.ceil( width / Math.pow( 2, level ) );
-			var levelHeight = Math.ceil( height / Math.pow( 2, level ) );
+			var levelWidth = Math.floor( width / ( 1 << level ) ) || 1;
+			var levelHeight = Math.floor( height / ( 1 << level ) ) || 1;
 
 			var numImagesInLevel = 1; // TODO(donmccurdy): Support cubemaps, arrays and 3D.
 			var imageOffsetInLevel = 0;

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -524,8 +524,8 @@ class KTX2Container {
 
 		for ( var level = 0; level < this.header.levelCount; level ++ ) {
 
-			var levelWidth = Math.floor( width / ( 1 << level ) ) || 1;
-			var levelHeight = Math.floor( height / ( 1 << level ) ) || 1;
+			var levelWidth = Math.max( 1, Math.floor( width / Math.pow( 2, level ) ) );
+			var levelHeight = Math.max( 1, Math.floor( height / Math.pow( 2, level ) ) );
 
 			var numImagesInLevel = 1; // TODO(donmccurdy): Support cubemaps, arrays and 3D.
 			var imageOffsetInLevel = 0;


### PR DESCRIPTION
If original texture size is NPOT, sizes of mipmaps must be rounded down to the nearest integer, not up.