### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -24,14 +24,13 @@
 		const sampleMesh = new THREE.InstancedMesh( sampleGeometry, sampleMaterial, 100 );
 
 		const _position = new THREE.Vector3();
-		const _normal = new THREE.Vector3();
 		const _matrix = new THREE.Matrix4();
 
 		// Sample randomly from the surface, creating an instance of the sample
 		// geometry at each sample point.
 		for ( let i = 0; i < 100; i ++ ) {
 
-			sampler.sample( _position, _normal );
+			sampler.sample( _position );
 
 			_matrix.makeTranslation( _position.x, _position.y, _position.z );
 

--- a/docs/examples/en/postprocessing/EffectComposer.html
+++ b/docs/examples/en/postprocessing/EffectComposer.html
@@ -108,6 +108,14 @@
 			Used by [name] to determine when a pass should be rendered to screen.
 		</p>
 
+		<h3>[method:void removePass]( [param:Pass pass] )</h3>
+
+		<p>
+			pass -- The pass to remove from the pass chain.<br /><br />
+
+			Removes the given pass from the pass chain.
+		</p>
+
 		<h3>[method:void render]( [param:Float deltaTime] )</h3>
 
 		<p>

--- a/docs/examples/zh/math/MeshSurfaceSampler.html
+++ b/docs/examples/zh/math/MeshSurfaceSampler.html
@@ -24,14 +24,13 @@
 		const sampleMesh = new THREE.InstancedMesh( sampleGeometry, sampleMaterial, 100 );
 
 		const _position = new THREE.Vector3();
-		const _normal = new THREE.Vector3();
 		const _matrix = new THREE.Matrix4();
 
 		// Sample randomly from the surface, creating an instance of the sample
 		// geometry at each sample point.
 		for ( let i = 0; i < 100; i ++ ) {
 
-			sampler.sample( _position, _normal );
+			sampler.sample( _position );
 
 			_matrix.makeTranslation( _position.x, _position.y, _position.z );
 

--- a/docs/examples/zh/postprocessing/EffectComposer.html
+++ b/docs/examples/zh/postprocessing/EffectComposer.html
@@ -107,6 +107,14 @@
 			由[name]所使用，来决定哪一个过程应当被渲染到屏幕上。
 		</p>
 
+		<h3>[method:void removePass]( [param:Pass pass] )</h3>
+
+		<p>
+			pass -- The pass to remove from the pass chain.<br /><br />
+
+			Removes the given pass from the pass chain.
+		</p>
+
 		<h3>[method:void render]( [param:Float deltaTime] )</h3>
 
 		<p>


### PR DESCRIPTION
Related issue: -

**Description**

- Simplifies the code example for `MeshSurfaceSampler`.
- Adds the missing `EffectComposer.removePass()` method.
