### PR TITLE
Simplify RegExp of WebGLUniforms.js

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -749,7 +749,7 @@ StructuredUniform.prototype.setValue = function ( gl, value, textures ) {
 
 // Parser - builds up the property tree from the path strings
 
-const RePathPart = /([\w\d_]+)(\])?(\[|\.)?/g;
+const RePathPart = /(\w+)(\])?(\[|\.)?/g;
 
 // extracts
 // 	- the identifier (member name or array index)


### PR DESCRIPTION
Related issue: -

**Description**

`\w` already contains `\d` and `_`.


https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet

> \w: Matches any alphanumeric character from the basic Latin alphabet, including the underscore. Equivalent to [A-Za-z0-9_]. For example, /\w/ matches "a" in "apple", "5" in "$5.28", and "3" in "3D".