### PR TITLE
Docs: More clean up.

### DIFF
--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -80,7 +80,7 @@
 			blend between the two colors.
 		</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p>The environment map. Default is null.</p>
 
 		<h3>[property:Texture lightMap]</h3>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -107,7 +107,7 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p>Intensity of the emissive light. Modulates the emissive color. Default is 1.</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p>The environment map. Default is null.</p>
 
 		<h3>[property:Texture lightMap]</h3>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -139,9 +139,8 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p>Intensity of the emissive light. Modulates the emissive color. Default is 1.</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p>The environment map. Default is null.</p>
-
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -164,17 +164,9 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p>Intensity of the emissive light. Modulates the emissive color. Default is 1.</p>
 
-		<h3>[property:TextureCube envMap]</h3>
-		<p>The environment map. Default is null.  Note that in order for the material roughness
-		property to correctly blur out the environment map, the shader must have access to mipmaps
-		of the env texture.  TextureCubes created with default settings are correctly configured;
-		if adjusting texture parameters manually, ensure minFilter is set to one of the MipMap options,
-		and that mip maps have not been otherwise forcibly disabled.</p>
-		<p>
-		Note: only [link:https://threejs.org/docs/#api/textures/CubeTexture cube environment maps] are supported
-		for MeshStandardMaterial. If you want to use an equirectangular map you will need to use
-		[page:WebGLCubeRenderTarget.fromEquirectangularTexture WebGLCubeRenderTarget.fromEquirectangularTexture]().
-		See this [link:https://threejs.org/examples/webgl_materials_envmaps_exr.html example] for details.
+		<h3>[property:Texture envMap]</h3>
+		<p>The environment map. To ensure a physically correct rendering, you should only add
+			environment maps which were preprocessed by [page:PMREMGenerator]. Default is null.
 		</p>
 
 		<h3>[property:Float envMapIntensity]</h3>

--- a/docs/api/zh/materials/MeshBasicMaterial.html
+++ b/docs/api/zh/materials/MeshBasicMaterial.html
@@ -70,7 +70,7 @@
 			[page:Materials THREE.AddOperation]。如果选择多个，则使用[page:.reflectivity]在两种颜色之间进行混合。
 		</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p>环境贴图。默认值为null。</p>
 
 		<h3>[property:Texture lightMap]</h3>

--- a/docs/api/zh/materials/MeshLambertMaterial.html
+++ b/docs/api/zh/materials/MeshLambertMaterial.html
@@ -89,7 +89,7 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p> 放射光强度。调节发光颜色。默认为1。</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p> 环境贴图。默认值为null。</p>
 
 		<h3>[property:Texture lightMap]</h3>

--- a/docs/api/zh/materials/MeshPhongMaterial.html
+++ b/docs/api/zh/materials/MeshPhongMaterial.html
@@ -109,7 +109,7 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p>放射光强度。调节发光颜色。默认为1。</p>
 
-		<h3>[property:TextureCube envMap]</h3>
+		<h3>[property:Texture envMap]</h3>
 		<p>环境贴图。默认值为null。</p>
 
 

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -132,15 +132,9 @@
 		<h3>[property:Float emissiveIntensity]</h3>
 		<p>放射光强度。调节发光颜色。默认为1。</p>
 
-		<h3>[property:TextureCube envMap]</h3>
-		<p> 环境贴图。默认值为null。
-			请注意，为了使材质粗糙度属性能够正确地模糊环境贴图，shader必须能够访问环境纹理的mipmaps。
-			使用默认设置创建的TextureCubes已正确配置; 如果手动调整纹理参数，
-			请确保将minFilter设置为其中一个MipMap选项，并且未强制禁用mip贴图。</p>
-		<p>
-			注意：MeshStandardMaterial 仅支持[link:https://threejs.org/docs/#api/textures/CubeTexture cube environment maps]。
-			如果要使用equirectangular贴图，则需要使用 [page:WebGLCubeRenderTarget.fromEquirectangularTexture WebGLCubeRenderTarget.fromEquirectangularTexture]()。
-			详细信息请参阅此示例[link:https://threejs.org/examples/webgl_materials_envmaps_exr.html example]。
+		<h3>[property:Texture envMap]</h3>
+		<p>The environment map. To ensure a physically correct rendering, you should only add
+			environment maps which were preprocessed by [page:PMREMGenerator]. Default is null.
 		</p>
 
 		<h3>[property:Float envMapIntensity]</h3>


### PR DESCRIPTION
Related issue: -

**Description**

Improves the documentation about `envMap`.

- Removes references to the non-existing `TextureCube` class.
- Mentions `PMREMGenerator` in context of `MeshStandardMaterial`.