### PR TITLE
Examples: Improve webgl_loader_xyz demo.

### DIFF
--- a/examples/webgl_loader_xyz.html
+++ b/examples/webgl_loader_xyz.html
@@ -42,7 +42,9 @@
 
 					geometry.center();
 
-					const material = new THREE.PointsMaterial( { size: 0.1 } );
+					const vertexColors = ( geometry.hasAttribute( 'color' ) === true );
+
+					const material = new THREE.PointsMaterial( { size: 0.1, vertexColors: vertexColors } );
 
 					points = new THREE.Points( geometry, material );
 					scene.add( points );


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/20893#issuecomment-746572521

**Description**

This should make it easier for users to figure out the material setup when having vertex colors.