### PR TITLE
Tests: Suggestion, Add npm run test-unit-examples command

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lint-examples": "eslint examples/js examples/jsm --ext js --ext ts --ignore-pattern libs && tsc -p utils/build/tsconfig-examples.lint.json",
     "test-lint": "eslint src --ext js --ext ts && tsc -p utils/build/tsconfig.lint.json",
     "test-unit": "npm run unit --prefix test",
+    "test-unit-examples": "npm run unit-examples --prefix test",
     "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
     "make-screenshot": "node test/e2e/puppeteer.js --make"

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,8 @@
   "description": "This package hiding test dependincies from main repo because puppeteer is pretty big.",
   "scripts": {
     "dev": "rollup -c rollup.unit.config.js -w -m inline",
-    "unit": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter -f !-webonly unit/build/three.source.unit.js"
+    "unit": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter -f !-webonly unit/build/three.source.unit.js",
+    "unit-examples": "rollup -c rollup.unit.config.js && rimraf node_modules/three && qunit -r failonlyreporter -f !-webonly unit/build/three.example.unit.js"
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",

--- a/test/unit/example/loaders/GLTFLoader.tests.js
+++ b/test/unit/example/loaders/GLTFLoader.tests.js
@@ -22,6 +22,10 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+	} );
+
+	QUnit.module( 'GLTFLoader-webonly', () => {
+
 		QUnit.test( 'parse - basic', ( assert ) => {
 
 			var done = assert.async();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/20795#issuecomment-736062650

**Background**

Currently the examples unit tests are run only on `http://localhost:8080/test/unit/UnitTests.html` and there are no npm command to run them on Node.js.

**Suggestion**

I'd like to suggest to add a npm command to run the examples unit tests because it would be helpful for the quick tests.

**Changes**

- Add `npm run test-unit-examples` command to `package.json`
- Add `npm run unit-examples` command to `test/package.json`
- Move some test cases in `GLTFLoader/Exporter` which don't run on Node.js to `-webonly` (See #20884)

I haven't let the root `npm run test` command invoke `npm run test-unit-examples` yet because I'm on the fence about it. 

**Screenshot**

![image](https://user-images.githubusercontent.com/7637832/102560762-df891e00-4087-11eb-8dee-0de17a2b8f78.png)

It shows `npm run test-unit-examples` works. As you see the examples unit tests cause console warnings similar to #20760. I hope we can remove them in another PR.

This contribution is made at a hotel where I stay for quarantines.
