### PR TITLE
3dmLoader: Support parsing File3dm objects

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -156,32 +156,18 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	parse: function ( data, onLoad, onError ) {
 
-		if ( ! ( data instanceof ArrayBuffer ) ) {
+		// issue: https://github.com/mcneel/rhino3dm/issues/338
+		// issue: https://github.com/emscripten-core/emscripten/issues/13065
 
-			data = this._objToUint( data ).buffer;
+		if ( data instanceof Uint8Array ) {
+
+			data = new Uint8Array( data ).buffer;
 
 		}
 
 		this.decodeObjects( data, '' )
 			.then( onLoad )
 			.catch( onError );
-
-	},
-
-	// from https://stackoverflow.com/questions/35971566/store-a-json-object-in-arraybuffer/35971686#35971686
-	_objToUint: function ( obj ) {
-
-		var string = btoa( unescape( JSON.stringify( obj ) ) ),
-			charList = string.split( '' ),
-			uintArray = [];
-
-		for ( var i = 0; i < charList.length; i ++ ) {
-
-			uintArray.push( charList[ i ].charCodeAt( 0 ) );
-
-		}
-
-		return new Uint8Array( uintArray );
 
 	},
 
@@ -856,16 +842,6 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 	};
 
-	// from https://stackoverflow.com/questions/35971566/store-a-json-object-in-arraybuffer/35971686#35971686
-	function uintToObj( uintArray ) {
-
-		var encodedString = String.fromCharCode.apply( null, uintArray ),
-			decodedString = decodeURIComponent( escape( atob( encodedString ) ) );
-
-		return JSON.parse( decodedString );
-
-	}
-
 	function decodeObjects( rhino, buffer ) {
 
 		var arr = new Uint8Array( buffer );
@@ -879,15 +855,6 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 		var groups = [];
 
 		//Handle objects
-
-		if ( doc === null ) {
-
-			doc = new rhino.File3dm();
-			var obj = uintToObj( arr );
-			var rObj = rhino.CommonObject.decode( obj );
-			doc.objects().add( rObj, null );
-
-		}
 
 		var objs = doc.objects();
 		var cnt = objs.count;

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -156,9 +156,6 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	parse: function ( data, onLoad, onError ) {
 
-		// issue: https://github.com/mcneel/rhino3dm/issues/338
-		// issue: https://github.com/emscripten-core/emscripten/issues/13065
-
 		if ( data instanceof Uint8Array ) {
 
 			data = new Uint8Array( data ).buffer;

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -156,9 +156,32 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	parse: function ( data, onLoad, onError ) {
 
+		if ( ! ( data instanceof ArrayBuffer ) ) {
+
+			data = this._objToUint( data ).buffer;
+
+		}
+
 		this.decodeObjects( data, '' )
 			.then( onLoad )
 			.catch( onError );
+
+	},
+
+	// from https://stackoverflow.com/questions/35971566/store-a-json-object-in-arraybuffer/35971686#35971686
+	_objToUint: function ( obj ) {
+
+		var string = btoa( unescape( JSON.stringify( obj ) ) ),
+			charList = string.split( '' ),
+			uintArray = [];
+
+		for ( var i = 0; i < charList.length; i ++ ) {
+
+			uintArray.push( charList[ i ].charCodeAt( 0 ) );
+
+		}
+
+		return new Uint8Array( uintArray );
 
 	},
 
@@ -833,6 +856,16 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 
 	};
 
+	// from https://stackoverflow.com/questions/35971566/store-a-json-object-in-arraybuffer/35971686#35971686
+	function uintToObj( uintArray ) {
+
+		var encodedString = String.fromCharCode.apply( null, uintArray ),
+			decodedString = decodeURIComponent( escape( atob( encodedString ) ) );
+
+		return JSON.parse( decodedString );
+
+	}
+
 	function decodeObjects( rhino, buffer ) {
 
 		var arr = new Uint8Array( buffer );
@@ -846,6 +879,15 @@ Rhino3dmLoader.Rhino3dmWorker = function () {
 		var groups = [];
 
 		//Handle objects
+
+		if ( doc === null ) {
+
+			doc = new rhino.File3dm();
+			var obj = uintToObj( arr );
+			var rObj = rhino.CommonObject.decode( obj );
+			doc.objects().add( rObj, null );
+
+		}
 
 		var objs = doc.objects();
 		var cnt = objs.count;


### PR DESCRIPTION
**Description**

This PR adds support for parsing File3dm objects created programmatically (as opposed to loading them, for example, via FileReader). The condition is required because the Uint8Array.buffer we get from our wasm lib is a representation of the entire wasm memory. In order to pass a transferable array to the worker, the Uint8Array is recreated so that the underlying ArrayBuffer is correct. 

<!-- Remove the line below if is not relevant -->

This contribution is funded by [McNeel EU](https://www.rhino3d.com).
