### PR TITLE
Fixed link to source code for Lut

### DIFF
--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -138,7 +138,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/Lut.js examples/jsm/math/Lut.js]
 		</p>
 	</body>
 </html>

--- a/docs/examples/zh/math/Lut.html
+++ b/docs/examples/zh/math/Lut.html
@@ -138,7 +138,7 @@
 		<h2>源码</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/[path].js examples/jsm/math/[path].js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/Lut.js examples/jsm/math/Lut.js]
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
The link to get to the source code from the Lut does not work.
See [https://threejs.org/docs/index.html#examples/en/math/Lut](https://threejs.org/docs/index.html#examples/en/math/Lut) and click on _Source_ to reproduce.