### PR TITLE
FBXLoader - Speed up getTimesForAllAxes

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -2790,16 +2790,34 @@ THREE.FBXLoader = ( function () {
 			if ( curves.y !== undefined ) times = times.concat( curves.y.times );
 			if ( curves.z !== undefined ) times = times.concat( curves.z.times );
 
-			// then sort them and remove duplicates
+			// then sort them
 			times = times.sort( function ( a, b ) {
 
 				return a - b;
 
-			} ).filter( function ( elem, index, array ) {
-
-				return array.indexOf( elem ) == index;
-
 			} );
+
+			// and remove duplicates
+			if ( times.length > 1 ) {
+
+				var targetIndex = 1;
+				var lastValue = times[ 0 ];
+				for ( var i = 1; i < times.length; i ++ ) {
+
+					var currentValue = times[ i ];
+					if ( currentValue !== lastValue ) {
+
+						times[ targetIndex ] = currentValue;
+						lastValue = currentValue;
+						targetIndex ++;
+
+					}
+
+				}
+
+				times = times.slice( 0, targetIndex );
+
+			}
 
 			return times;
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2837,16 +2837,34 @@ var FBXLoader = ( function () {
 			if ( curves.y !== undefined ) times = times.concat( curves.y.times );
 			if ( curves.z !== undefined ) times = times.concat( curves.z.times );
 
-			// then sort them and remove duplicates
+			// then sort them
 			times = times.sort( function ( a, b ) {
 
 				return a - b;
 
-			} ).filter( function ( elem, index, array ) {
-
-				return array.indexOf( elem ) == index;
-
 			} );
+
+			// and remove duplicates
+			if ( times.length > 1 ) {
+
+				var targetIndex = 1;
+				var lastValue = times[ 0 ];
+				for ( var i = 1; i < times.length; i ++ ) {
+
+					var currentValue = times[ i ];
+					if ( currentValue !== lastValue ) {
+
+						times[ targetIndex ] = currentValue;
+						lastValue = currentValue;
+						targetIndex ++;
+
+					}
+
+				}
+
+				times = times.slice( 0, targetIndex );
+
+			}
 
 			return times;
 


### PR DESCRIPTION
**Description**

This pull request speeds up the getTimesForAllAxes function of FBXLoader.

Currently, the duplicate removal part of the function is using Array.indexOf for each element, which is an O(n) operation (it needs to perform a linear search on the whole array).

```javascript
times = times.sort( function ( a, b ) {

	return a - b;

} ).filter( function ( elem, index, array ) {

	return array.indexOf( elem ) == index;

} );
```

Doing this for each element of the array makes this part of the function have O(n^2) time complexity.
But since the array is already sorted, we can use an O(n) method to remove duplicates from it.
This can significantly reduce the loading time for files with long animations.
