### PR TITLE
Examples: mobile support for unreal_bloom_selective example

### DIFF
--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -181,7 +181,7 @@
 
 			setupScene();
 
-			function onDocumentPointerDown( event ) {
+			function onPointerDown( event ) {
 
 				event.preventDefault();
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -125,7 +125,7 @@
 
 			var mouse = new THREE.Vector2();
 
-			window.addEventListener( 'pointerdown', onDocumentPointerDown, false );
+			window.addEventListener( 'pointerdown', onPointerDown, false );
 
 			var gui = new GUI();
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -125,7 +125,7 @@
 
 			var mouse = new THREE.Vector2();
 
-			window.addEventListener( 'click', onDocumentMouseClick, false );
+			window.addEventListener( 'pointerdown', onDocumentPointerDown, false );
 
 			var gui = new GUI();
 
@@ -181,7 +181,7 @@
 
 			setupScene();
 
-			function onDocumentMouseClick( event ) {
+			function onDocumentPointerDown( event ) {
 
 				event.preventDefault();
 


### PR DESCRIPTION
Changed event listener and corresponding callback name from 'click' to 'pointerdown' so demo works on mobile. 
https://raw.githack.com/ajflores1604/three.js/unreal_bloom_selective_mobile/examples/webgl_postprocessing_unreal_bloom_selective.html
