### PR TITLE
LDrawLoader: Fix uniforms to support fog

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -998,14 +998,18 @@ THREE.LDrawLoader = ( function () {
 				edgeMaterial.userData.conditionalEdgeMaterial = new THREE.ShaderMaterial( {
 					vertexShader: conditionalLineVertShader,
 					fragmentShader: conditionalLineFragShader,
-					uniforms: {
-						diffuse: {
-							value: new THREE.Color( edgeColour )
-						},
-						opacity: {
-							value: alpha
+					uniforms: THREE.UniformsUtils.merge( [
+						THREE.UniformsLib.fog,
+						{
+							diffuse: {
+								value: new THREE.Color( edgeColour )
+							},
+							opacity: {
+								value: alpha
+							}
 						}
-					},
+					] ),
+					fog: true,
 					transparent: isTransparent,
 					depthWrite: ! isTransparent
 				} );

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -13,6 +13,8 @@ import {
 	MeshPhongMaterial,
 	MeshStandardMaterial,
 	ShaderMaterial,
+	UniformsLib,
+	UniformsUtils,
 	Vector3
 } from '../../../build/three.module.js';
 
@@ -1016,14 +1018,18 @@ var LDrawLoader = ( function () {
 				edgeMaterial.userData.conditionalEdgeMaterial = new ShaderMaterial( {
 					vertexShader: conditionalLineVertShader,
 					fragmentShader: conditionalLineFragShader,
-					uniforms: {
-						diffuse: {
-							value: new Color( edgeColour )
-						},
-						opacity: {
-							value: alpha
+					uniforms: UniformsUtils.merge( [
+						UniformsLib.fog,
+						{
+							diffuse: {
+								value: new Color( edgeColour )
+							},
+							opacity: {
+								value: alpha
+							}
 						}
-					},
+					] ),
+					fog: true,
 					transparent: isTransparent,
 					depthWrite: ! isTransparent
 				} );


### PR DESCRIPTION
Fixed uniforms of conditionalEdgeMaterial to support fog.
I think this is a bug, because its VertShader and FragShader are already support fog.