### PR TITLE
Fix type declaration of Vector4

### DIFF
--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -1,6 +1,5 @@
 import { Matrix4 } from './Matrix4';
 import { Quaternion } from './Quaternion';
-import { Matrix3 } from './Matrix3';
 import { BufferAttribute } from './../core/BufferAttribute';
 import { Vector } from './Vector2';
 
@@ -131,7 +130,7 @@ export class Vector4 implements Vector {
 	 * http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm
 	 * @param m assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 	 */
-	setAxisAngleFromRotationMatrix( m: Matrix3 ): this;
+	setAxisAngleFromRotationMatrix( m: Matrix4 ): this;
 
 	min( v: Vector4 ): this;
 	max( v: Vector4 ): this;


### PR DESCRIPTION
**Description**

The parameter type of `setAxisAngleFromRotationMatrix` should be `Matrix4`.

Refer to the doc:
https://github.com/mrdoob/three.js/blob/821df037305cec11de286ecb9492e0b2761a89a3/docs/api/en/math/Vector4.html#L266


