### PR TITLE
Docs: list.json curly braces symmetry.

### DIFF
--- a/docs/list.json
+++ b/docs/list.json
@@ -1037,9 +1037,9 @@
 		"레퍼런스": {
 
 			"애니메이션": {
-				"AnimationAction": "api/ko/animation/AnimationAction",
-
-			},
+				"AnimationAction": "api/ko/animation/AnimationAction"
+			}
+		},
 
 		"예제": {
 


### PR DESCRIPTION
Related issue: -

**Description**

The current docs will report an error and cannot be read because the curly braces in list.json are not closed properly.
