### PR TITLE
Docs: Clarify Raycaster.set().

### DIFF
--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -145,7 +145,7 @@
 		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
 		</p>
 		<p>
-		Updates the ray with a new origin and direction.
+		Updates the ray with a new origin and direction. Please note that this method only copies the values from the arguments.
 		</p>
 
 		<h3>[method:null setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>


### PR DESCRIPTION
Related issue: Fixed #20922.

**Description**

Makes it clear that `Raycaster.set()` does only copy values from the arguments (and does not assign references).
