### PR TITLE
ObjectLoader: Clean up.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -976,7 +976,7 @@ class ObjectLoader extends Loader {
 
 			case 'Line':
 
-				object = new Line( getGeometry( data.geometry ), getMaterial( data.material ), data.mode );
+				object = new Line( getGeometry( data.geometry ), getMaterial( data.material ) );
 
 				break;
 


### PR DESCRIPTION
Related issue: c20528a800ec1f39d9c3e6cacae09b98449ff7f0

**Description**

Removes a lgtm error in `ObjectLoader`.
