### PR TITLE
TS:Improved cloneable class declaration

### DIFF
--- a/src/core/BufferGeometry.d.ts
+++ b/src/core/BufferGeometry.d.ts
@@ -150,7 +150,7 @@ export class BufferGeometry extends EventDispatcher {
 	toNonIndexed(): BufferGeometry;
 
 	toJSON(): any;
-	clone(): this;
+	clone(): BufferGeometry;
 	copy( source: BufferGeometry ): this;
 
 	/**

--- a/src/core/Face3.d.ts
+++ b/src/core/Face3.d.ts
@@ -94,7 +94,7 @@ export class Face3 {
 	 */
 	materialIndex: number;
 
-	clone(): this;
+	clone(): Face3;
 	copy( source: Face3 ): this;
 
 }

--- a/src/core/Geometry.d.ts
+++ b/src/core/Geometry.d.ts
@@ -256,7 +256,7 @@ export class Geometry extends EventDispatcher {
 	/**
 	 * Creates a new clone of the Geometry.
 	 */
-	clone(): this;
+	clone(): Geometry;
 
 	copy( source: Geometry ): this;
 

--- a/src/core/InstancedBufferGeometry.d.ts
+++ b/src/core/InstancedBufferGeometry.d.ts
@@ -12,6 +12,8 @@ export class InstancedBufferGeometry extends BufferGeometry {
 	 */
 	type: string;
 
+	isInstancedBufferGeometry: boolean,
+
 	groups: { start: number; count: number; instances: number }[];
 
 	/**

--- a/src/core/InterleavedBuffer.d.ts
+++ b/src/core/InterleavedBuffer.d.ts
@@ -36,7 +36,7 @@ export class InterleavedBuffer {
 	uuid: string;
 
 	setUsage( usage: Usage ): InterleavedBuffer;
-	clone( data: object ): this;
+	clone( data: object ): InterleavedBuffer;
 	copy( source: InterleavedBuffer ): this;
 	copyAt(
 		index1: number,

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -379,7 +379,7 @@ export class Object3D extends EventDispatcher {
 		images: any;
 	} ): any;
 
-	clone( recursive?: boolean ): this;
+	clone( recursive?: boolean ): Object3D;
 
 	/**
 	 *

--- a/src/lights/LightShadow.d.ts
+++ b/src/lights/LightShadow.d.ts
@@ -57,7 +57,7 @@ export class LightShadow {
 	needsUpdate: boolean;
 
 	copy( source: LightShadow ): this;
-	clone( recursive?: boolean ): this;
+	clone( recursive?: boolean ): LightShadow;
 	toJSON(): any;
 	getFrustum(): number;
 	updateMatrices( light: Light, viewportIndex?: number ): void;

--- a/src/materials/Material.d.ts
+++ b/src/materials/Material.d.ts
@@ -355,7 +355,7 @@ export class Material extends EventDispatcher {
 	/**
 	 * Return a new material with the same parameters as this material.
 	 */
-	clone(): this;
+	clone(): Material;
 
 	/**
 	 * Copy the parameters from the passed material into this material.

--- a/src/math/Box2.d.ts
+++ b/src/math/Box2.d.ts
@@ -19,7 +19,7 @@ export class Box2 {
 	set( min: Vector2, max: Vector2 ): Box2;
 	setFromPoints( points: Vector2[] ): Box2;
 	setFromCenterAndSize( center: Vector2, size: Vector2 ): Box2;
-	clone(): this;
+	clone(): Box2;
 	copy( box: Box2 ): this;
 	makeEmpty(): Box2;
 	isEmpty(): boolean;

--- a/src/math/Box3.d.ts
+++ b/src/math/Box3.d.ts
@@ -27,7 +27,7 @@ export class Box3 {
 	setFromPoints( points: Vector3[] ): this;
 	setFromCenterAndSize( center: Vector3, size: Vector3 ): this;
 	setFromObject( object: Object3D ): this;
-	clone(): this;
+	clone(): Box3;
 	copy( box: Box3 ): this;
 	makeEmpty(): this;
 	isEmpty(): boolean;

--- a/src/math/Color.d.ts
+++ b/src/math/Color.d.ts
@@ -77,7 +77,7 @@ export class Color {
 	/**
 	 * Clones this color.
 	 */
-	clone(): this;
+	clone(): Color;
 
 	/**
 	 * Copies given color.

--- a/src/math/Cylindrical.d.ts
+++ b/src/math/Cylindrical.d.ts
@@ -19,7 +19,7 @@ export class Cylindrical {
 	 */
 	y: number;
 
-	clone(): this;
+	clone(): Cylindrical;
 	copy( other: Cylindrical ): this;
 	set( radius: number, theta: number, y: number ): this;
 	setFromVector3( vec3: Vector3 ): this;

--- a/src/math/Euler.d.ts
+++ b/src/math/Euler.d.ts
@@ -30,7 +30,7 @@ export class Euler {
 	_onChangeCallback: Function;
 
 	set( x: number, y: number, z: number, order?: string ): Euler;
-	clone(): this;
+	clone(): Euler;
 	copy( euler: Euler ): this;
 	setFromRotationMatrix( m: Matrix4, order?: string ): Euler;
 	setFromQuaternion( q: Quaternion, order?: string ): Euler;

--- a/src/math/Frustum.d.ts
+++ b/src/math/Frustum.d.ts
@@ -33,7 +33,7 @@ export class Frustum {
 		p4: Plane,
 		p5: Plane
 	): Frustum;
-	clone(): this;
+	clone(): Frustum;
 	copy( frustum: Frustum ): this;
 	setFromProjectionMatrix( m: Matrix4 ): this;
 	intersectsObject( object: Object3D ): boolean;

--- a/src/math/Line3.d.ts
+++ b/src/math/Line3.d.ts
@@ -16,7 +16,7 @@ export class Line3 {
 	end: Vector3;
 
 	set( start?: Vector3, end?: Vector3 ): Line3;
-	clone(): this;
+	clone(): Line3;
 	copy( line: Line3 ): this;
 	getCenter( target: Vector3 ): Vector3;
 	delta( target: Vector3 ): Vector3;

--- a/src/math/Matrix3.d.ts
+++ b/src/math/Matrix3.d.ts
@@ -46,7 +46,7 @@ export interface Matrix {
 	/**
 	 * clone():T;
 	 */
-	clone(): this;
+	clone(): Matrix;
 }
 
 /**
@@ -77,7 +77,7 @@ export class Matrix3 implements Matrix {
 		n33: number
 	): Matrix3;
 	identity(): Matrix3;
-	clone(): this;
+	clone(): Matrix3;
 	copy( m: Matrix3 ): this;
 	extractBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3 ): Matrix3;
 	setFromMatrix4( m: Matrix4 ): Matrix3;

--- a/src/math/Matrix4.d.ts
+++ b/src/math/Matrix4.d.ts
@@ -64,7 +64,7 @@ export class Matrix4 implements Matrix {
 	 * Resets this matrix to identity.
 	 */
 	identity(): Matrix4;
-	clone(): this;
+	clone(): Matrix4;
 	copy( m: Matrix4 ): this;
 	copyPosition( m: Matrix4 ): Matrix4;
 	extractBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3 ): Matrix4;

--- a/src/math/Plane.d.ts
+++ b/src/math/Plane.d.ts
@@ -25,7 +25,7 @@ export class Plane {
 	setComponents( x: number, y: number, z: number, w: number ): Plane;
 	setFromNormalAndCoplanarPoint( normal: Vector3, point: Vector3 ): Plane;
 	setFromCoplanarPoints( a: Vector3, b: Vector3, c: Vector3 ): Plane;
-	clone(): this;
+	clone(): Plane;
 	copy( plane: Plane ): this;
 	normalize(): Plane;
 	negate(): Plane;

--- a/src/math/Quaternion.d.ts
+++ b/src/math/Quaternion.d.ts
@@ -50,7 +50,7 @@ export class Quaternion {
 	/**
 	 * Clones this quaternion.
 	 */
-	clone(): this;
+	clone(): Quaternion;
 
 	/**
 	 * Copies values of q to this quaternion.

--- a/src/math/Ray.d.ts
+++ b/src/math/Ray.d.ts
@@ -19,7 +19,7 @@ export class Ray {
 	direction: Vector3;
 
 	set( origin: Vector3, direction: Vector3 ): Ray;
-	clone(): this;
+	clone(): Ray;
 	copy( ray: Ray ): this;
 	at( t: number, target: Vector3 ): Vector3;
 	lookAt( v: Vector3 ): Ray;

--- a/src/math/Sphere.d.ts
+++ b/src/math/Sphere.d.ts
@@ -19,7 +19,7 @@ export class Sphere {
 
 	set( center: Vector3, radius: number ): Sphere;
 	setFromPoints( points: Vector3[], optionalCenter?: Vector3 ): Sphere;
-	clone(): this;
+	clone(): Sphere;
 	copy( sphere: Sphere ): this;
 	isEmpty(): boolean;
 	makeEmpty(): this;

--- a/src/math/Spherical.d.ts
+++ b/src/math/Spherical.d.ts
@@ -20,7 +20,7 @@ export class Spherical {
 	theta: number;
 
 	set( radius: number, phi: number, theta: number ): this;
-	clone(): this;
+	clone(): Spherical;
 	copy( other: Spherical ): this;
 	makeSafe(): this;
 	setFromVector3( v: Vector3 ): this;

--- a/src/math/Triangle.d.ts
+++ b/src/math/Triangle.d.ts
@@ -29,7 +29,7 @@ export class Triangle {
 		i1: number,
 		i2: number
 	): Triangle;
-	clone(): this;
+	clone(): Triangle;
 	copy( triangle: Triangle ): this;
 	getArea(): number;
 	getMidpoint( target: Vector3 ): Vector3;

--- a/src/math/Vector2.d.ts
+++ b/src/math/Vector2.d.ts
@@ -128,7 +128,7 @@ export interface Vector {
 	/**
 	 * clone():T;
 	 */
-	clone(): this;
+	clone(): Vector;
 }
 
 /**
@@ -186,7 +186,7 @@ export class Vector2 implements Vector {
 	/**
 	 * Returns a new Vector2 instance with the same `x` and `y` values.
 	 */
-	clone(): this;
+	clone(): Vector2;
 
 	/**
 	 * Copies value of v to this vector.

--- a/src/math/Vector3.d.ts
+++ b/src/math/Vector3.d.ts
@@ -76,7 +76,7 @@ export class Vector3 implements Vector {
 	/**
 	 * Clones this vector.
 	 */
-	clone(): this;
+	clone(): Vector3;
 
 	/**
 	 * Copies value of v to this vector.

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -75,7 +75,7 @@ export class Vector4 implements Vector {
 	/**
 	 * Clones this vector.
 	 */
-	clone(): this;
+	clone(): Vector4;
 
 	/**
 	 * Copies value of v to this vector.

--- a/src/renderers/WebGLRenderTarget.d.ts
+++ b/src/renderers/WebGLRenderTarget.d.ts
@@ -97,7 +97,7 @@ export class WebGLRenderTarget extends EventDispatcher {
 	generateMipmaps: any;
 
 	setSize( width: number, height: number ): void;
-	clone(): this;
+	clone(): WebGLRenderTarget;
 	copy( source: WebGLRenderTarget ): this;
 	dispose(): void;
 

--- a/src/scenes/Fog.d.ts
+++ b/src/scenes/Fog.d.ts
@@ -3,7 +3,7 @@ import { Color } from './../math/Color';
 export interface IFog {
 	name: string;
 	color: Color;
-	clone(): this;
+	clone(): IFog;
 	toJSON(): any;
 }
 
@@ -38,7 +38,7 @@ export class Fog implements IFog {
 
 	readonly isFog: true;
 
-	clone(): this;
+	clone(): Fog;
 	toJSON(): any;
 
 }

--- a/src/scenes/FogExp2.d.ts
+++ b/src/scenes/FogExp2.d.ts
@@ -22,7 +22,7 @@ export class FogExp2 implements IFog {
 
 	readonly isFogExp2: true;
 
-	clone(): this;
+	clone(): FogExp2;
 	toJSON(): any;
 
 }

--- a/src/textures/Texture.d.ts
+++ b/src/textures/Texture.d.ts
@@ -165,7 +165,7 @@ export class Texture extends EventDispatcher {
 	static DEFAULT_IMAGE: any;
 	static DEFAULT_MAPPING: any;
 
-	clone(): this;
+	clone(): Texture;
 	copy( source: Texture ): this;
 	toJSON( meta: any ): any;
 	dispose(): void;


### PR DESCRIPTION
Hi,
I change the cloneable class typescript declaration.
  In some cases , I need to write a class inherit from those cloneable class 
  and override the member function "clone" . It will raise a typescript compile error because
  of the super class return type. In fact , the clone function return a new instance , not the instance "this"