### PR TITLE
Menubar.add.js: adjust the initial parameters of the new orthogonal camera

### DIFF
--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -446,7 +446,8 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/orthographiccamera' ) );
 	option.onClick( function () {
 
-		var camera = new THREE.OrthographicCamera();
+		var aspect = editor.camera.aspect;
+		var camera = new THREE.OrthographicCamera( - aspect, aspect );
 		camera.name = 'OrthographicCamera';
 
 		editor.execute( new AddObjectCommand( editor, camera ) );


### PR DESCRIPTION
**Description**

adjust the initial parameters of the new orthogonal camera to avoid model deformation during preview.

Example：

The scene contains a cube and an orthographic camera.
![image](https://user-images.githubusercontent.com/19889378/103164685-5c1aba00-4849-11eb-80e9-176409501691.png)

Before:
![image](https://user-images.githubusercontent.com/19889378/103164700-879da480-4849-11eb-9898-2fc7b6495169.png)

After:
![image](https://user-images.githubusercontent.com/19889378/103164705-9c7a3800-4849-11eb-9b68-b8b73465a59a.png)



