### PR TITLE
LDrawLoader: Fix filename formatting to support Windows PC

### DIFF
--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1132,7 +1132,7 @@ THREE.LDrawLoader = ( function () {
 						this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
 
 						// New embedded text file
-						currentEmbeddedFileName = line.substring( 7 );
+						currentEmbeddedFileName = line.substring( 7 ).trim().replace( /\\/g, '/' );
 						currentEmbeddedText = '';
 
 					} else {
@@ -1255,7 +1255,7 @@ THREE.LDrawLoader = ( function () {
 
 										// Start embedded text files parsing
 										parsingEmbeddedFiles = true;
-										currentEmbeddedFileName = lp.getRemainingString();
+										currentEmbeddedFileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
 										currentEmbeddedText = '';
 
 										bfcCertified = false;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1152,7 +1152,7 @@ var LDrawLoader = ( function () {
 						this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
 
 						// New embedded text file
-						currentEmbeddedFileName = line.substring( 7 );
+						currentEmbeddedFileName = line.substring( 7 ).trim().replace( /\\/g, '/' );
 						currentEmbeddedText = '';
 
 					} else {
@@ -1275,7 +1275,7 @@ var LDrawLoader = ( function () {
 
 										// Start embedded text files parsing
 										parsingEmbeddedFiles = true;
-										currentEmbeddedFileName = lp.getRemainingString();
+										currentEmbeddedFileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
 										currentEmbeddedText = '';
 
 										bfcCertified = false;


### PR DESCRIPTION
Fixed filename formatting to support Windows PC file paths separated by "\\".

issue:
I made a packed mpd file on Windows PC using "three.js/utils/packLDrawModel.js".
However, the mpd file cannot be loaded because of these formatting issues.
