### PR TITLE
packLDrawModel: Fix objectPath formatting to support Windows PC

### DIFF
--- a/utils/packLDrawModel.js
+++ b/utils/packLDrawModel.js
@@ -172,7 +172,7 @@ function parseObject( fileName, isRoot ) {
 
 	}
 
-	var objectPath = path.join( prefix, fileName );
+	var objectPath = path.join( prefix, fileName ).trim().replace( /\\/g, '/' );
 
 	if ( ! objectContent ) {
 


### PR DESCRIPTION
Fixed objectPath formatting to support Windows PC file paths separated by "\\".

issue:
I made a packed mpd file on Windows PC using this script.
However, the mpd file cannot be loaded because of these formatting issues.