### PR TITLE
[Examples - Skinning Simple] Example file not found, fixed

### DIFF
--- a/examples/webgl_skinning_simple.html
+++ b/examples/webgl_skinning_simple.html
@@ -9,8 +9,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - simple skinning -
-			<a href="https://github.com/mrdoob/three.js/blob/master/examples/models/skinned/simple/simple.blend" target="_blank" rel="noopener">Blender File</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - simple skinning
 		</div>
 
 		<script type="module">


### PR DESCRIPTION
**Example file not found on Skinning Simple Example**

To reproduce : 

go to ->
https://threejs.org/examples/?q=skin#webgl_skinning_simple

"Blender File"  link seems to be broken

I changed it to the proper file that is as GLTF file

Thanks you for your work