### PR TITLE
fix: add control to the mesh's shape

### DIFF
--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -151,7 +151,12 @@
 					mesh.rotation.y += step;
 
 					mesh.morphTargetInfluences[ 1 ] = mesh.morphTargetInfluences[ 1 ] + step * sign;
-
+					if (mesh.morphTargetInfluences[1] < 0) {
+						mesh.morphTargetInfluences[1] = 0
+					}
+					if (mesh.morphTargetInfluences[1] > 1) {
+						mesh.morphTargetInfluences[1] = 1
+					}
 					if ( mesh.morphTargetInfluences[ 1 ] <= 0 || mesh.morphTargetInfluences[ 1 ] >= 1 ) {
 
 						sign *= - 1;


### PR DESCRIPTION
Related issue: #XXXX

**Description**

after switch the tab out for a minute and then switch it back , the mesh's shape will be very bad.
Because of the raf is paused when the tab is inactive,  when clock.getDelta() may return a big value to cause like 'Through wall effect'

