### PR TITLE
Docs: Update WebGLRenderTarget documentation

### DIFF
--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -80,12 +80,12 @@
 
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>
-		Renders to the stencil buffer. Default is false.
+		渲染到模板缓冲区。默认为false
 		</p>
 
 		<h3>[property:DepthTexture depthTexture]</h3>
 		<p>
-		如果设置，那么场景的深度将会被渲染到慈纹理上。默认是null.
+		如果设置，那么场景的深度将会被渲染到此纹理上。默认为null
 		</p>
 
 


### PR DESCRIPTION
```diff
- Renders to the stencil buffer. Default is false.
+ 渲染到模板缓冲区。默认为false

- 如果设置，那么场景的深度将会被渲染到慈纹理上。默认是null.
+ 如果设置，那么场景的深度将会被渲染到此纹理上。默认是null.
```
