### PR TITLE
Docs: Add LightProbe to the object list in ObjectLoader

### DIFF
--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -166,6 +166,9 @@
 				[page:HemisphereLight]
 			</li>
 			<li>
+				[page:LightProbe]
+			</li>
+			<li>
 				[page:Mesh]
 			</li>
 			<li>


### PR DESCRIPTION
Added LightProbe to the list of parse-able objects in the ObjectLoader documentation