### PR TITLE
TS: fix KeyframeTrack constructor types

### DIFF
--- a/src/animation/KeyframeTrack.d.ts
+++ b/src/animation/KeyframeTrack.d.ts
@@ -13,8 +13,8 @@ export class KeyframeTrack {
 	 */
 	constructor(
 		name: string,
-		times: any[],
-		values: any[],
+		times: Record<number, any>,
+		values: Record<number, any>,
 		interpolation?: InterpolationModes
 	);
 

--- a/src/animation/KeyframeTrack.d.ts
+++ b/src/animation/KeyframeTrack.d.ts
@@ -13,8 +13,8 @@ export class KeyframeTrack {
 	 */
 	constructor(
 		name: string,
-		times: Record<number, any>,
-		values: Record<number, any>,
+		times: ArrayLike<any>,
+		values: ArrayLike<any>,
 		interpolation?: InterpolationModes
 	);
 


### PR DESCRIPTION
**Description**

KeyframeTrack's type definition only allows Arrays to pass in for `times` & `values` parameters,
but as I need to pass `Float32Array`, I found they might actually support any record in number key type.
https://github.com/mrdoob/three.js/blob/f3bfe7d3a7d58c8c41bdde335d61d256a06484c9/src/animation/AnimationUtils.js#L22-L35
