### PR TITLE
Examples: Refactor webgl_simple_gi.

### DIFF
--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -18,15 +18,19 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			// HACK:
+			class GIMesh extends THREE.Mesh {
 
-			THREE.Mesh.prototype.clone = function () {
+				copy( source ) {
 
-				const newMaterial = ( this.material.isMaterial ) ? this.material.clone() : this.material.slice();
+					super.copy( source );
 
-				return new this.constructor( this.geometry.clone(), newMaterial ).copy( this );
+					this.geometry = source.geometry.clone();
 
-			};
+					return this;
+
+				}
+
+			}
 
 			//
 
@@ -41,11 +45,7 @@
 				let clone = scene.clone();
 				clone.autoUpdate = false;
 
-				const rt = new THREE.WebGLRenderTarget( SIZE, SIZE, {
-					wrapS: THREE.ClampToEdgeWrapping,
-					wrapT: THREE.ClampToEdgeWrapping,
-					depthBuffer: true
-				} );
+				const rt = new THREE.WebGLRenderTarget( SIZE, SIZE );
 
 				const normalMatrix = new THREE.Matrix3();
 
@@ -62,7 +62,7 @@
 
 					if ( bounces === 3 ) return;
 
-					const object = scene.children[ 0 ];
+					const object = scene.children[ 0 ]; // torusKnot
 					const geometry = object.geometry;
 
 					const attributes = geometry.attributes;
@@ -160,7 +160,7 @@
 				const torusGeometry = new THREE.TorusKnotBufferGeometry( 0.75, 0.3, 128, 32, 1 );
 				const material = new THREE.MeshBasicMaterial( { vertexColors: true } );
 
-				const torusKnot = new THREE.Mesh( torusGeometry, material );
+				const torusKnot = new GIMesh( torusGeometry, material );
 				scene.add( torusKnot );
 
 				// room


### PR DESCRIPTION
Related issue: -

**Description**

Monkey-patching `THREE.Mesh.prototype.clone` like in the example was considered as a hack. It seems more robust to just derive a custom class `GIMesh` and overwrite the implementation.

Because of #19471, we should not modify `clone()` anymore but `copy()`.

 