### PR TITLE
[TypeScript] Add loadAsync typing

### DIFF
--- a/examples/jsm/loaders/3DMLoader.d.ts
+++ b/examples/jsm/loaders/3DMLoader.d.ts
@@ -14,4 +14,6 @@ export class Rhino3dmLoader extends Loader {
 	setWorkerLimit( workerLimit: number ): Rhino3dmLoader;
 	dispose(): Rhino3dmLoader;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Object3D>;
+
 }

--- a/examples/jsm/loaders/3MFLoader.d.ts
+++ b/examples/jsm/loaders/3MFLoader.d.ts
@@ -13,4 +13,6 @@ export class ThreeMFLoader extends Loader {
 	parse( data: ArrayBuffer ): Group;
 	addExtension( extension: object ):void
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/AMFLoader.d.ts
+++ b/examples/jsm/loaders/AMFLoader.d.ts
@@ -11,4 +11,6 @@ export class AMFLoader extends Loader {
 	load( url: string, onLoad: ( object: Group ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer ): Group;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/AssimpLoader.d.ts
+++ b/examples/jsm/loaders/AssimpLoader.d.ts
@@ -17,4 +17,6 @@ export class AssimpLoader extends Loader {
 	load( url: string, onLoad: ( result: Assimp ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( buffer: ArrayBuffer, path: string ) : Assimp;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Assimp>;
+
 }

--- a/examples/jsm/loaders/BVHLoader.d.ts
+++ b/examples/jsm/loaders/BVHLoader.d.ts
@@ -20,4 +20,6 @@ export class BVHLoader extends Loader {
 	load( url: string, onLoad: ( bvh: BVH ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( text: string ) : BVH;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BVH>;
+
 }

--- a/examples/jsm/loaders/BasisTextureLoader.d.ts
+++ b/examples/jsm/loaders/BasisTextureLoader.d.ts
@@ -27,6 +27,8 @@ export class BasisTextureLoader extends Loader {
 	detectSupport( renderer: WebGLRenderer ): this;
 	dispose(): void;
 	load( url: string, onLoad: ( texture: CompressedTexture ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<CompressedTexture>;
+
 	setTranscoderPath( path: string ): this;
 	setWorkerLimit( workerLimit: number ): this;
 

--- a/examples/jsm/loaders/ColladaLoader.d.ts
+++ b/examples/jsm/loaders/ColladaLoader.d.ts
@@ -18,4 +18,6 @@ export class ColladaLoader extends Loader {
 	load( url: string, onLoad: ( collada: Collada ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( text: string, path: string ) : Collada;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Collada>;
+
 }

--- a/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/examples/jsm/loaders/DRACOLoader.d.ts
@@ -15,4 +15,6 @@ export class DRACOLoader extends Loader {
 	preload(): DRACOLoader;
 	dispose(): DRACOLoader;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/examples/jsm/loaders/FBXLoader.d.ts
+++ b/examples/jsm/loaders/FBXLoader.d.ts
@@ -11,4 +11,6 @@ export class FBXLoader extends Loader {
 	load( url: string, onLoad: ( object: Group ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( FBXBuffer: ArrayBuffer | string, path: string ) : Group;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/GCodeLoader.d.ts
+++ b/examples/jsm/loaders/GCodeLoader.d.ts
@@ -12,4 +12,6 @@ export class GCodeLoader extends Loader {
 	load( url: string, onLoad: ( object: Group ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: string ) : Group;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/examples/jsm/loaders/GLTFLoader.d.ts
@@ -50,6 +50,8 @@ export class GLTFLoader extends Loader {
 
 	parse( data: ArrayBuffer | string, path: string, onLoad: ( gltf: GLTF ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<GLTF>;
+
 }
 
 export interface GLTFReference {

--- a/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
@@ -16,4 +16,6 @@ export class HDRCubeTextureLoader extends Loader {
 	load( urls: string[], onLoad: ( texture: CubeTexture ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	setDataType( type: TextureDataType ): this;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<CubeTexture>;
+
 }

--- a/examples/jsm/loaders/KMZLoader.d.ts
+++ b/examples/jsm/loaders/KMZLoader.d.ts
@@ -12,4 +12,6 @@ export class KMZLoader extends Loader {
 	load( url: string, onLoad: ( kmz: Collada ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer ): Collada;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Collada>;
+
 }

--- a/examples/jsm/loaders/LDrawLoader.d.ts
+++ b/examples/jsm/loaders/LDrawLoader.d.ts
@@ -18,4 +18,6 @@ export class LDrawLoader extends Loader {
 	addMaterial( material: Material ): void;
 	getMaterial( colourCode: string ): Material | null;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/LUT3dlLoader.d.ts
+++ b/examples/jsm/loaders/LUT3dlLoader.d.ts
@@ -25,4 +25,6 @@ export class LUT3dlLoader extends Loader {
 	);
 	parse( data: string ): LUT3dlResult;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<LUT3dlResult>;
+
 }

--- a/examples/jsm/loaders/LUTCubeLoader.d.ts
+++ b/examples/jsm/loaders/LUTCubeLoader.d.ts
@@ -29,4 +29,6 @@ export class LUTCubeLoader extends Loader {
 	);
 	parse( data: string ): LUTCubeResult;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<LUTCubeResult>;
+
 }

--- a/examples/jsm/loaders/LWOLoader.d.ts
+++ b/examples/jsm/loaders/LWOLoader.d.ts
@@ -26,4 +26,6 @@ export class LWOLoader extends Loader {
 	load( url: string, onLoad: ( lwo: LWO ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer, path: string, modelName: string ): LWO;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<LWO>;
+
 }

--- a/examples/jsm/loaders/LottieLoader.d.ts
+++ b/examples/jsm/loaders/LottieLoader.d.ts
@@ -12,4 +12,6 @@ export class LottieLoader extends Loader {
 
 	setQuality( value: Number ) : void;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<CanvasTexture>;
+
 }

--- a/examples/jsm/loaders/MD2Loader.d.ts
+++ b/examples/jsm/loaders/MD2Loader.d.ts
@@ -11,4 +11,6 @@ export class MD2Loader extends Loader {
 	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer ): BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/examples/jsm/loaders/MDDLoader.d.ts
+++ b/examples/jsm/loaders/MDDLoader.d.ts
@@ -17,4 +17,6 @@ export class MDDLoader extends Loader {
 	load( url: string, onLoad: ( result: MDD ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer ) : MDD;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<MDD>;
+
 }

--- a/examples/jsm/loaders/MMDLoader.d.ts
+++ b/examples/jsm/loaders/MMDLoader.d.ts
@@ -29,4 +29,6 @@ export class MMDLoader extends Loader {
 	loadWithAnimation( url: string, vmdUrl: string | string[], onLoad: ( object: MMDLoaderAnimationObject ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	setAnimationPath( animationPath: string ): this;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<SkinnedMesh>;
+
 }

--- a/examples/jsm/loaders/MTLLoader.d.ts
+++ b/examples/jsm/loaders/MTLLoader.d.ts
@@ -48,6 +48,8 @@ export class MTLLoader extends Loader {
 	parse( text: string, path: string ) : MTLLoader.MaterialCreator;
 	setMaterialOptions( value: MaterialCreatorOptions ) : void;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<MTLLoader.MaterialCreator>;
+
 }
 
 export interface MaterialInfo {

--- a/examples/jsm/loaders/OBJLoader.d.ts
+++ b/examples/jsm/loaders/OBJLoader.d.ts
@@ -16,4 +16,6 @@ export class OBJLoader extends Loader {
 	parse( data: string ) : Group;
 	setMaterials( materials: MTLLoader.MaterialCreator ) : this;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/OBJLoader2.d.ts
+++ b/examples/jsm/loaders/OBJLoader2.d.ts
@@ -42,4 +42,6 @@ export class OBJLoader2 extends Loader {
 	load( url: string, onLoad: ( object3d: Object3D ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void, onMeshAlter?: ( meshData: object ) => void ): void;
 	parse( content: ArrayBuffer | string ): Object3D;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Object3D>;
+
 }

--- a/examples/jsm/loaders/PCDLoader.d.ts
+++ b/examples/jsm/loaders/PCDLoader.d.ts
@@ -13,4 +13,6 @@ export class PCDLoader extends Loader {
 	load( url: string, onLoad: ( points: Points ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer | string, url: string ) : Points;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Points>;
+
 }

--- a/examples/jsm/loaders/PDBLoader.d.ts
+++ b/examples/jsm/loaders/PDBLoader.d.ts
@@ -20,4 +20,6 @@ export class PDBLoader extends Loader {
 	load( url: string, onLoad: ( pdb: PDB ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( text: string ) : PDB;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<PDB>;
+
 }

--- a/examples/jsm/loaders/PLYLoader.d.ts
+++ b/examples/jsm/loaders/PLYLoader.d.ts
@@ -14,4 +14,6 @@ export class PLYLoader extends Loader {
 	setPropertyNameMapping( mapping: object ) : void;
 	parse( data: ArrayBuffer | string ) : BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/examples/jsm/loaders/PRWMLoader.d.ts
+++ b/examples/jsm/loaders/PRWMLoader.d.ts
@@ -12,6 +12,8 @@ export class PRWMLoader extends Loader {
 	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer ) : BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 	static isBigEndianPlatform(): boolean;
 
 }

--- a/examples/jsm/loaders/STLLoader.d.ts
+++ b/examples/jsm/loaders/STLLoader.d.ts
@@ -12,4 +12,6 @@ export class STLLoader extends Loader {
 	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer | string ) : BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/examples/jsm/loaders/SVGLoader.d.ts
+++ b/examples/jsm/loaders/SVGLoader.d.ts
@@ -29,6 +29,8 @@ export class SVGLoader extends Loader {
 	load( url: string, onLoad: ( data: SVGResult ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( text: string ) : SVGResult;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<SVGResult>;
+
 	static getStrokeStyle( width?: number, color?: string, lineJoin?: string, lineCap?: string, miterLimit?: number ): StrokeStyle;
 	static pointsToStroke( points: Vector3[], style: StrokeStyle, arcDivisions?: number, minDistance?: number ): BufferGeometry;
 	static pointsToStrokeWithBuffers( points: Vector3[], style: StrokeStyle, arcDivisions?: number, minDistance?: number, vertices?: number[], normals?: number[], uvs?: number[], vertexOffset?: number ): number;

--- a/examples/jsm/loaders/TDSLoader.d.ts
+++ b/examples/jsm/loaders/TDSLoader.d.ts
@@ -21,6 +21,8 @@ export class TDSLoader extends Loader {
 	load( url: string, onLoad: ( object: Group ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( arraybuffer: ArrayBuffer, path: string ): Group;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 	debugMessage( message: object ): void;
 	endChunk( chunk: object ): void;
 	nextChunk( data: DataView, chunk: object ): void;

--- a/examples/jsm/loaders/TGALoader.d.ts
+++ b/examples/jsm/loaders/TGALoader.d.ts
@@ -11,4 +11,6 @@ export class TGALoader extends Loader {
 	load( url: string, onLoad: ( texture: Texture ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: ArrayBuffer ) : Texture;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Texture>;
+
 }

--- a/examples/jsm/loaders/TTFLoader.d.ts
+++ b/examples/jsm/loaders/TTFLoader.d.ts
@@ -11,4 +11,6 @@ export class TTFLoader extends Loader {
 	load( url: string, onLoad: ( json: object ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( arraybuffer: ArrayBuffer ): object;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<object>;
+
 }

--- a/examples/jsm/loaders/TiltLoader.d.ts
+++ b/examples/jsm/loaders/TiltLoader.d.ts
@@ -11,4 +11,6 @@ export class TiltLoader extends Loader {
 	load( url: string, onLoad: ( object: Group ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer ): Group;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Group>;
+
 }

--- a/examples/jsm/loaders/VOXLoader.d.ts
+++ b/examples/jsm/loaders/VOXLoader.d.ts
@@ -10,4 +10,6 @@ export class VOXLoader extends Loader {
 	load( url: string, onLoad: ( chunks: Array<object> ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer ): Array<object>;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Array<object>>;
+
 }

--- a/examples/jsm/loaders/VRMLLoader.d.ts
+++ b/examples/jsm/loaders/VRMLLoader.d.ts
@@ -11,4 +11,6 @@ export class VRMLLoader extends Loader {
 	load( url: string, onLoad: ( scene: Scene ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ) : void;
 	parse( data: string, path: string ) : Scene;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Scene>;
+
 }

--- a/examples/jsm/loaders/VRMLoader.d.ts
+++ b/examples/jsm/loaders/VRMLoader.d.ts
@@ -15,4 +15,6 @@ export class VRMLoader extends Loader {
 	parse( gltf: GLTF, onLoad: ( scene: GLTF ) => void ): void;
 	setDRACOLoader( dracoLoader: DRACOLoader ): this;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<GLTF>;
+
 }

--- a/examples/jsm/loaders/VTKLoader.d.ts
+++ b/examples/jsm/loaders/VTKLoader.d.ts
@@ -11,4 +11,6 @@ export class VTKLoader extends Loader {
 	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer | string, path: string ): BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/examples/jsm/loaders/XLoader.d.ts
+++ b/examples/jsm/loaders/XLoader.d.ts
@@ -16,4 +16,6 @@ export class XLoader extends Loader {
 	load( url: string, onLoad: ( object: XResult ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: ArrayBuffer | string, onLoad: ( object: object ) => void ): object;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<XResult>;
+
 }

--- a/examples/jsm/loaders/XYZLoader.d.ts
+++ b/examples/jsm/loaders/XYZLoader.d.ts
@@ -11,4 +11,6 @@ export class XYZLoader extends Loader {
 	load( url: string, onLoad: ( geometry: BufferGeometry ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	parse( data: string, onLoad: ( geometry: BufferGeometry ) => void ): object;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<BufferGeometry>;
+
 }

--- a/src/loaders/AnimationLoader.d.ts
+++ b/src/loaders/AnimationLoader.d.ts
@@ -14,4 +14,6 @@ export class AnimationLoader extends Loader {
 	): void;
 	parse( json: any ): AnimationClip[];
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<AnimationClip[]>;
+
 }

--- a/src/loaders/AudioLoader.d.ts
+++ b/src/loaders/AudioLoader.d.ts
@@ -12,4 +12,6 @@ export class AudioLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): void;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<AudioBuffer>;
+
 }

--- a/src/loaders/BufferGeometryLoader.d.ts
+++ b/src/loaders/BufferGeometryLoader.d.ts
@@ -15,4 +15,6 @@ export class BufferGeometryLoader extends Loader {
 	): void;
 	parse( json: any ): InstancedBufferGeometry | BufferGeometry;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<InstancedBufferGeometry | BufferGeometry>;
+
 }

--- a/src/loaders/CompressedTextureLoader.d.ts
+++ b/src/loaders/CompressedTextureLoader.d.ts
@@ -13,4 +13,6 @@ export class CompressedTextureLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): CompressedTexture;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<CompressedTexture>;
+
 }

--- a/src/loaders/CubeTextureLoader.d.ts
+++ b/src/loaders/CubeTextureLoader.d.ts
@@ -13,4 +13,6 @@ export class CubeTextureLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): CubeTexture;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<CubeTexture>;
+
 }

--- a/src/loaders/DataTextureLoader.d.ts
+++ b/src/loaders/DataTextureLoader.d.ts
@@ -13,4 +13,6 @@ export class DataTextureLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): void;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<DataTexture>;
+
 }

--- a/src/loaders/FileLoader.d.ts
+++ b/src/loaders/FileLoader.d.ts
@@ -17,4 +17,6 @@ export class FileLoader extends Loader {
 	setMimeType( mimeType: MimeType ): FileLoader;
 	setResponseType( responseType: string ): FileLoader;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<string | ArrayBuffer>;
+
 }

--- a/src/loaders/FontLoader.d.ts
+++ b/src/loaders/FontLoader.d.ts
@@ -14,4 +14,6 @@ export class FontLoader extends Loader {
 	): void;
 	parse( json: any ): Font;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Font>;
+
 }

--- a/src/loaders/ImageBitmapLoader.d.ts
+++ b/src/loaders/ImageBitmapLoader.d.ts
@@ -20,4 +20,6 @@ export class ImageBitmapLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): any;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<ImageBitmap>;
+
 }

--- a/src/loaders/ImageLoader.d.ts
+++ b/src/loaders/ImageLoader.d.ts
@@ -16,4 +16,6 @@ export class ImageLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): HTMLImageElement;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<HTMLImageElement>;
+
 }

--- a/src/loaders/MaterialLoader.d.ts
+++ b/src/loaders/MaterialLoader.d.ts
@@ -21,4 +21,6 @@ export class MaterialLoader extends Loader {
 	setTextures( textures: { [key: string]: Texture } ): this;
 	parse( json: any ): Material;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Material>;
+
 }

--- a/src/loaders/ObjectLoader.d.ts
+++ b/src/loaders/ObjectLoader.d.ts
@@ -31,4 +31,6 @@ export class ObjectLoader extends Loader {
 		animations: AnimationClip[]
 	): T;
 
+	loadAsync<ObjectType extends Object3D>( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<ObjectType>;
+
 }

--- a/src/loaders/TextureLoader.d.ts
+++ b/src/loaders/TextureLoader.d.ts
@@ -17,4 +17,6 @@ export class TextureLoader extends Loader {
 		onError?: ( event: ErrorEvent ) => void
 	): Texture;
 
+	loadAsync( url: string, onProgress?: ( event: ProgressEvent ) => void ): Promise<Texture>;
+
 }


### PR DESCRIPTION
As mentioned by user MikeJF on general discord: 

![Screenshot 2021-01-04 at 20 27 24](https://user-images.githubusercontent.com/9549760/103571502-4487a500-4ecb-11eb-8243-4930fab9bb05.png)

**Description**

Right now all `loadAsync` default to `Promise<any>`. Added typing for `loadAsync` in Loaders to resemble proper `load` typing.
