### PR TITLE
DRACOExporter: Stop support for Geometry.

### DIFF
--- a/examples/js/exporters/DRACOExporter.js
+++ b/examples/js/exporters/DRACOExporter.js
@@ -22,7 +22,7 @@ THREE.DRACOExporter.prototype = {
 
 	parse: function ( object, options ) {
 
-		if ( object.isBufferGeometry === true || object.isGeometry === true ) {
+		if ( object.isBufferGeometry === true ) {
 
 			throw new Error( 'DRACOExporter: The first parameter of parse() is now an instance of Mesh or Points.' );
 
@@ -57,17 +57,10 @@ THREE.DRACOExporter.prototype = {
 		var builder;
 		var dracoObject;
 
-		if ( geometry.isGeometry === true ) {
-
-			var bufferGeometry = new THREE.BufferGeometry();
-			bufferGeometry.setFromObject( object );
-			geometry = bufferGeometry;
-
-		}
 
 		if ( geometry.isBufferGeometry !== true ) {
 
-			throw new Error( 'THREE.DRACOExporter.parse(geometry, options): geometry is not a THREE.Geometry or THREE.BufferGeometry instance.' );
+			throw new Error( 'THREE.DRACOExporter.parse(geometry, options): geometry is not a THREE.BufferGeometry instance.' );
 
 		}
 

--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -26,7 +26,7 @@ DRACOExporter.prototype = {
 
 	parse: function ( object, options ) {
 
-		if ( object.isBufferGeometry === true || object.isGeometry === true ) {
+		if ( object.isBufferGeometry === true ) {
 
 			throw new Error( 'DRACOExporter: The first parameter of parse() is now an instance of Mesh or Points.' );
 
@@ -61,17 +61,10 @@ DRACOExporter.prototype = {
 		var builder;
 		var dracoObject;
 
-		if ( geometry.isGeometry === true ) {
-
-			var bufferGeometry = new BufferGeometry();
-			bufferGeometry.setFromObject( object );
-			geometry = bufferGeometry;
-
-		}
 
 		if ( geometry.isBufferGeometry !== true ) {
 
-			throw new Error( 'THREE.DRACOExporter.parse(geometry, options): geometry is not a THREE.Geometry or BufferGeometry instance.' );
+			throw new Error( 'THREE.DRACOExporter.parse(geometry, options): geometry is not a BufferGeometry instance.' );
 
 		}
 

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -19,8 +19,6 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - draco<br/><br/>
-			<button id="createGeometry">Geometry</button>
-			<button id="createBufferGeometry">BufferGeometry</button> |
 			<button id="exportFile">Export DRC</button>
 		</div>
 
@@ -37,32 +35,6 @@
 
 			init();
 			animate();
-
-			function createBufferGeometry() {
-
-				scene.remove( mesh );
-
-				const geometry = new THREE.TorusKnotBufferGeometry( 50, 15, 200, 30 );
-				const material = new THREE.MeshPhongMaterial( { color: 0x00ff00 } );
-				mesh = new THREE.Mesh( geometry, material );
-				mesh.castShadow = true;
-				mesh.position.y = 25;
-				scene.add( mesh );
-
-			}
-
-			function createGeometry() {
-
-				scene.remove( mesh );
-
-				const geometry = new THREE.TorusKnotGeometry( 50, 15, 200, 30 );
-				const material = new THREE.MeshPhongMaterial( { color: 0x00ff00 } );
-				mesh = new THREE.Mesh( geometry, material );
-				mesh.castShadow = true;
-				mesh.position.y = 25;
-				scene.add( mesh );
-
-			}
 
 			function init() {
 
@@ -133,12 +105,6 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize, false );
-
-				const createGeometryButton = document.getElementById( 'createGeometry' );
-				createGeometryButton.addEventListener( 'click', createGeometry );
-
-				const createBufferGeometryButton = document.getElementById( 'createBufferGeometry' );
-				createBufferGeometryButton.addEventListener( 'click', createBufferGeometry );
 
 				const exportButton = document.getElementById( 'exportFile' );
 				exportButton.addEventListener( 'click', exportFile );


### PR DESCRIPTION
Related issue: -

**Description**

This PR ensures `DRACOExporter` does not support `Geometry` anymore. If users want to use the exporter with `Geometry`, they have to perform the conversion to `BufferGeometry` by themselves.