### PR TITLE
Docs: Add plugins and libraries page

### DIFF
--- a/docs/list.json
+++ b/docs/list.json
@@ -15,7 +15,8 @@
 				"Creating text": "manual/en/introduction/Creating-text",
 				"Loading 3D models": "manual/en/introduction/Loading-3D-models",
 				"FAQ": "manual/en/introduction/FAQ",
-				"Useful links": "manual/en/introduction/Useful-links"
+				"Useful links": "manual/en/introduction/Useful-links",
+				"Libraries and Plugins": "manual/en/introduction/Libraries-and-Plugins"
 			},
 
 			"Next Steps": {

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -51,6 +51,7 @@
 		<ul>
 			<li>[link:https://github.com/gkjohnson/urdf-loaders/tree/master/javascript urdf-loader]</li>
 			<li>[link:https://github.com/NASA-AMMOS/3DTilesRendererJS 3d-tiles-renderer-js]</li>
+			<li>[link:https://github.com/kaisalmen/WWOBJLoader WebWorker OBJLoader]</li>
 		</ul>
 
 		<h3>3D Text and Layout</h3>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -26,6 +26,11 @@
 
 		<h3>Postprocessing</h3>
 		
+		<p>
+			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing official three.js postprocessing effects],
+			support for some additional effects and frameworks are available through external libraries.
+		</p>
+
 		<ul>
 			<li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
 		</ul>
@@ -37,6 +42,11 @@
 		</ul>
 
 		<h3>File Formats</h3>
+
+		<p>
+			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders official three.js loaders],
+			support for some additional formats is available through external libraries.
+		</p>
 
 		<ul>
 			<li>[link:https://github.com/gkjohnson/urdf-loaders/tree/master/javascript urdf-loader]</li>
@@ -68,6 +78,7 @@
 		<ul>
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
+			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 		</ul>
 
 	</body>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<p class="desc">
+			Listed here are externally developed compatible libraries and plugins for three.js. This
+			list and the associated packages are maintained by the community and not guaranteed
+			to be up to date. If you'd like to update this list make PR!
+		</p>
+
+		<h3>Physics</h3>
+
+		<ul>
+			<li>[link:https://github.com/lo-th/Oimo.js/ Oimo.js]</li>
+			<li>[link:https://enable3d.io/ enable3d]</li>
+			<li>[link:https://github.com/kripken/ammo.js/ ammo.js]</li>
+			<li>[link:https://github.com/pmndrs/cannon-es cannon-es]</li>
+		</ul>
+
+		<h3>Postprocessing</h3>
+		
+		<ul>
+			<li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
+		</ul>
+
+		<h3>Intersection and Raycasting Performance</h3>
+		
+		<ul>
+			<li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
+		</ul>
+
+		<h3>File Formats</h3>
+
+		<ul>
+			<li>[link:https://github.com/gkjohnson/urdf-loaders/tree/master/javascript urdf-loader]</li>
+			<li>[link:https://github.com/NASA-AMMOS/3DTilesRendererJS 3d-tiles-renderer-js]</li>
+		</ul>
+
+		<h3>3D Text and Layout</h3>
+
+		<ul>
+			<li>[link:https://github.com/protectwise/troika/tree/master/packages/troika-three-text troika-three-text]</li>
+			<li>[link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui]</li>
+		</ul>
+
+		<h3>Particle Systems</h3>
+
+		<ul>
+			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
+		</ul>
+
+		<h3>Game AI</h3>
+
+		<ul>
+			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
+			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+		</ul>
+
+		<h3>Wrappers and Frameworks</h3>
+		
+		<ul>
+			<li>[link:https://aframe.io/ A-Frame]</li>
+			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
+		</ul>
+
+	</body>
+</html>


### PR DESCRIPTION
Fix #19353

**Description**

Here's a first pass at a page documenting some external libraries and plugins that work with three.js or are otherwise solutions to common questions in three.js (physics engines, etc). Here's the live link:

https://raw.githack.com/gkjohnson/three.js/plugins-and-libraries/docs/#manual/en/introduction/Libraries-and-Plugins

I tried to add packages that seemed reasonably maintained but it might be worth documenting out of date ones in case someone wants to submit PRs / update them. I haven't added them in this PR but here are some other out of date packages that I still see come up every once and awhile:

- [partykals](https://github.com/RonenNess/partykals)
- [ShaderParticleEngine](https://github.com/squarefeet/ShaderParticleEngine)
- [TrailRendererJS](https://github.com/mkkellogg/TrailRendererJS)
- [Wagner Postprocessing](https://github.com/spite/Wagner)
- [THREE.MeshLine](https://github.com/spite/THREE.MeshLine)
- [dat.guiVR](https://github.com/xinaesthete/dat.guiVR) (which does have a maintained fork for WebXR [here](https://github.com/xinaesthete/dat.guiVR))
- [three_js_outline](https://www.npmjs.com/package/three_js_outline)
- [THREE.DrawCallInspector](https://discourse.threejs.org/t/three-drawcallinspector-visualize-draw-call-cost-experimental/)
- THREE.BLAS
- GSAP
- tween.js

The list here is what I had at the forefront of my mind -- others should feel free to add / suggest more!