### PR TITLE
Examples: More clean up.

### DIFF
--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -89,7 +89,7 @@
 
 				//
 
-				let geometry = new THREE.TextGeometry( "THREE.JS", {
+				let geometry = new THREE.TextBufferGeometry( 'THREE.JS', {
 
 					font: font,
 
@@ -110,8 +110,6 @@
 				geometry = tessellateModifier.modify( geometry );
 
 				//
-
-				geometry = new THREE.BufferGeometry().fromGeometry( geometry );
 
 				const numFaces = geometry.attributes.position.count / 3;
 


### PR DESCRIPTION
Related issue: -

**Description**

AFAICS, the back and forth geometry conversion is not necessary. `TessellateModifier` can do this, too.
