### PR TITLE
Make texture dispatch a load event when the image loads

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -37,6 +37,8 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			}
 
+			texture.dispatchEvent( { type: 'load' } );
+
 		}, onProgress, onError );
 
 		return texture;


### PR DESCRIPTION
Related issue: -

**Description**

Just like you can do `image.addEventListener('load', () => {})`, it would be useful to do:

```js
const texture = new THREE.TextureLoader().load('./path/image.png')

// ...

texture.addEventListener('load', () => {
  // ...
})
```

In my particular case, I wrote [a library](https://github.com/marcofugaro/three-projected-material) where the user has to provide as input a texture. For this reason, I have no access to the `TextureLoader` and I have to result to a workaround using `setInterval` to check if the image has loaded:

https://github.com/marcofugaro/three-projected-material/blob/605b6c3bddbdc22cf18d0987a4aea077aac4cf9c/src/three-utils.js#L30-L43
