### PR TITLE
InstancedMesh: Honor instanceColor in copy().

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -33,6 +33,9 @@ InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
 		Mesh.prototype.copy.call( this, source );
 
 		this.instanceMatrix.copy( source.instanceMatrix );
+
+		if ( source.instanceColor !== null ) this.instanceColor = source.instanceColor.clone();
+
 		this.count = source.count;
 
 		return this;


### PR DESCRIPTION
Related issue: Fixed #21027.

**Description**

Honors `instanceColor` when copying `InstancedMesh`. This operation was indeed missing.
