### PR TITLE
Object3D.toJSON : Add demo implementation to retain typed buffers in result

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -392,12 +392,12 @@ Object.assign( BufferAttribute.prototype, {
 
 	},
 
-	toJSON: function () {
+	toJSON: function ( meta, cloneTransferableTypes = true ) {
 
 		return {
 			itemSize: this.itemSize,
 			type: this.array.constructor.name,
-			array: Array.prototype.slice.call( this.array ),
+			array: cloneTransferableTypes ? Array.prototype.slice.call( this.array ) : this.array,
 			normalized: this.normalized
 		};
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -988,7 +988,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	},
 
-	toJSON: function () {
+	toJSON: function ( meta, cloneTransferableTypes = true ) {
 
 		const data = {
 			metadata: {
@@ -1027,7 +1027,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			data.data.index = {
 				type: index.array.constructor.name,
-				array: Array.prototype.slice.call( index.array )
+				array: cloneTransferableTypes ? Array.prototype.slice.call( index.array ) : index.array,
 			};
 
 		}
@@ -1038,7 +1038,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			const attribute = attributes[ key ];
 
-			const attributeData = attribute.toJSON( data.data );
+			const attributeData = attribute.toJSON( data.data, cloneTransferableTypes );
 
 			if ( attribute.name !== '' ) attributeData.name = attribute.name;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -642,7 +642,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
-	toJSON: function ( meta ) {
+	toJSON: function ( meta, cloneTransferableTypes = true ) {
 
 		// meta is a string when called from JSON.stringify
 		const isRootObject = ( meta === undefined || typeof meta === 'string' );
@@ -709,7 +709,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			if ( library[ element.uuid ] === undefined ) {
 
-				library[ element.uuid ] = element.toJSON( meta );
+				library[ element.uuid ] = element.toJSON( meta, cloneTransferableTypes );
 
 			}
 
@@ -792,7 +792,7 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 			for ( let i = 0; i < this.children.length; i ++ ) {
 
-				object.children.push( this.children[ i ].toJSON( meta ).object );
+				object.children.push( this.children[ i ].toJSON( meta, cloneTransferableTypes ).object );
 
 			}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,16 @@ const TYPED_ARRAYS = {
 
 function getTypedArray( type, buffer ) {
 
-	return new TYPED_ARRAYS[ type ]( buffer );
+	const arrayType = TYPED_ARRAYS[ type ];
+	if ( buffer instanceof arrayType ) {
+
+		return buffer;
+
+	} else {
+
+		return new arrayType( buffer );
+
+	}
 
 }
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/11746#issuecomment-753421942

**Description**

As requested in https://github.com/mrdoob/three.js/issues/11746#issuecomment-756691160 here's a quick PR demonstrating what has to change in order for `Object3D.toJSON` to retain BufferGeometry typed arrays when serializing and for ObjectLoader to reuse the buffers when deserializing. A second argument has been added to `Object3D.toJSON( meta, cloneTransferableTypes )` to give the option for transferable types to not be cloned and instead be returned by reference. The default setting defaults to true which means the behavior is unchanged from three.js master.

As mentioned in https://github.com/mrdoob/three.js/issues/11746#issuecomment-753421942 removing the conversion of arrays in `toJSON` and `ObjectLoader` _greatly_ improves the performance in both cases and would make it viable for users to load and perform longer running processes on geometry in web workers because the serialization, deserialization, and transfer time to the main thread is much faster.

Here are some possible next steps for a full implementation which can be done in steps:

- Update all three.js types (DataTextures, at least) that use typed arrays to respect the setting for returning typed array references
- Update `Texture` and `ObjectLoader` to return a reference to and directly use `ImageBitmap`
- Optionally return a list of transferrable types so they can be passed to the worker (granted these can be collected manually after serialization, as well)