### PR TITLE
Line2: Fix missed intersections when segment extends behind camera near plane

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -95,6 +95,9 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			var instanceStart = geometry.attributes.instanceStart;
 			var instanceEnd = geometry.attributes.instanceEnd;
 
+			// camera forward is negative
+			var near = - camera.near;
+
 			// pick a point 1 unit out along the ray to avoid the ray origin
 			// sitting at the camera origin which will cause "w" to be 0 when
 			// applying the projection matrix.
@@ -128,6 +131,29 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 				start.applyMatrix4( mvMatrix );
 				end.applyMatrix4( mvMatrix );
 
+				// skip the segment if it's entirely behind the camera
+				var isBehindCameraNear = start.z > near && end.z > near;
+				if ( isBehindCameraNear ) {
+
+					continue;
+
+				}
+
+				// trim the segment if it extends behind camera near
+				if ( start.z > near ) {
+
+					const deltaDist = start.z - end.z;
+					const t = ( start.z - near ) / deltaDist;
+					start.lerp( end, t );
+
+				} else if ( end.z > near ) {
+
+					const deltaDist = end.z - start.z;
+					const t = ( end.z - near ) / deltaDist;
+					end.lerp( start, t );
+
+				}
+
 				// clip space
 				start.applyMatrix4( projectionMatrix );
 				end.applyMatrix4( projectionMatrix );
@@ -135,15 +161,6 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 				// ndc space [ - 1.0, 1.0 ]
 				start.multiplyScalar( 1 / start.w );
 				end.multiplyScalar( 1 / end.w );
-
-				// skip the segment if it's outside the camera near and far planes
-				var isBehindCameraNear = start.z < - 1 && end.z < - 1;
-				var isPastCameraFar = start.z > 1 && end.z > 1;
-				if ( isBehindCameraNear || isPastCameraFar ) {
-
-					continue;
-
-				}
 
 				// screen space
 				start.x *= resolution.x / 2;


### PR DESCRIPTION
Related issue: --

**Description**

This fixes a case when raycasting against Line2 where intersections can be missed or incorrectly reported if a segment extends beyond the camera near plane. Also removes a check that prevented intersections if a line segment was further than the far plane to be more consistent with other raycast functions.

Tested by logging intersections in the `webgl_lines_fat` example and changing the line to extend from `0, 0, 0` to `0, 0, 50` and moving the camera so the line intersects the near plane.

Relevant forum thread [here](https://discourse.threejs.org/t/fat-lines-intersection-bug/22144/3).

cc @WestLangley 