### PR TITLE
Fixed rollup.config.js Windows support

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -209,7 +209,7 @@ function glsl() {
 
 			if ( /\.glsl.js$/.test( id ) === false ) return;
 
-			code = code.replace( /\/\* glsl \*\/\`((.|\n)*)\`/, function ( match, p1 ) {
+			code = code.replace( /\/\* glsl \*\/\`((.|\r|\n)*)\`/, function ( match, p1 ) {
 
 				return JSON.stringify(
 					p1
@@ -274,7 +274,7 @@ function polyfills() {
 
 		transform( code, filePath ) {
 
-			if ( filePath.endsWith( 'src/Three.js' ) ) {
+			if ( filePath.endsWith( 'src/Three.js' ) || filePath.endsWith( 'src\\Three.js' ) ) {
 
 				code = "import './polyfills';\n" + code;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20944

**Description**

Fixed the judgment in Window 10

<!-- Remove the line below if is not relevant -->

screenshot for debug:

![image](https://user-images.githubusercontent.com/23699926/104121717-6675a180-537b-11eb-9c1b-665a15256e7d.png)

![image](https://user-images.githubusercontent.com/23699926/104121732-7db48f00-537b-11eb-9100-387f450a13c9.png)
