### PR TITLE
TS: Improved Skeleton and SkeletonUtils types

### DIFF
--- a/examples/jsm/utils/SkeletonUtils.d.ts
+++ b/examples/jsm/utils/SkeletonUtils.d.ts
@@ -28,5 +28,6 @@ export namespace SkeletonUtils {
 
 	export function getEqualsBonesNames( skeleton: Skeleton, targetSkeleton: Skeleton ): string[];
 
-	export function clone( source: Object3D | Skeleton ): Object3D | Skeleton;
+	export function clone( source: Object3D ): Object3D;
+	export function clone( source: Skeleton ): Skeleton;
 }

--- a/examples/jsm/utils/SkeletonUtils.d.ts
+++ b/examples/jsm/utils/SkeletonUtils.d.ts
@@ -29,5 +29,4 @@ export namespace SkeletonUtils {
 	export function getEqualsBonesNames( skeleton: Skeleton, targetSkeleton: Skeleton ): string[];
 
 	export function clone( source: Object3D ): Object3D;
-	export function clone( source: Skeleton ): Skeleton;
 }

--- a/src/objects/Skeleton.d.ts
+++ b/src/objects/Skeleton.d.ts
@@ -15,7 +15,7 @@ export class Skeleton {
 	frame: number;
 
 	init(): void;
-	calculateInverses( bone: Bone ): void;
+	calculateInverses(): void;
 	pose(): void;
 	update(): void;
 	clone(): Skeleton;


### PR DESCRIPTION
Skeleton.calculateInverses() wrongly required an argument.

SekeltonUtils.clone() is more accurately typed as overloaded functions.