### PR TITLE
Improved: locking the stencil buffer now also locks the test and operations

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -213,17 +213,15 @@ function WebGLState( gl, extensions, capabilities ) {
 
 			setTest: function ( stencilTest ) {
 
-				if ( ! locked ) {
+				if ( locked ) return;
 
-					if ( stencilTest ) {
+				if ( stencilTest ) {
 
-						enable( gl.STENCIL_TEST );
+					enable( gl.STENCIL_TEST );
 
-					} else {
+				} else {
 
-						disable( gl.STENCIL_TEST );
-
-					}
+					disable( gl.STENCIL_TEST );
 
 				}
 
@@ -231,7 +229,9 @@ function WebGLState( gl, extensions, capabilities ) {
 
 			setMask: function ( stencilMask ) {
 
-				if ( currentStencilMask !== stencilMask && ! locked ) {
+				if ( locked ) return;
+
+				if ( currentStencilMask !== stencilMask ) {
 
 					gl.stencilMask( stencilMask );
 					currentStencilMask = stencilMask;
@@ -241,6 +241,8 @@ function WebGLState( gl, extensions, capabilities ) {
 			},
 
 			setFunc: function ( stencilFunc, stencilRef, stencilMask ) {
+
+				if ( locked ) return;
 
 				if ( currentStencilFunc !== stencilFunc ||
 				     currentStencilRef !== stencilRef ||
@@ -257,6 +259,8 @@ function WebGLState( gl, extensions, capabilities ) {
 			},
 
 			setOp: function ( stencilFail, stencilZFail, stencilZPass ) {
+
+				if ( locked ) return;
 
 				if ( currentStencilFail !== stencilFail ||
 				     currentStencilZFail !== stencilZFail ||


### PR DESCRIPTION
The way WebGLState locking works isn't currently useful for making custom use of the stencil buffer as it only locks whether stencil operations are active and which bits are allowed to be read from or written to, but not what is actually being tested, and what operations are to occur.

This means that if you set up a stencil operation and lock the buffer, objects with custom material stencil settings can still modify the tests and operations mid-render and affect all later rendered objects, despite the buffer being locked.

Note that the lock did originally lock *just* the bits, and not even if stencil operations were active. This was previously amended to include activation state by #17136, who did also mention that `func` and `op` should likely also be locked, but decided not to at the time unless it was later mentioned.

This PR now locks those as well.