### PR TITLE
pointerlock controls example : fix key listeners

### DIFF
--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -125,29 +125,29 @@
 
 				const onKeyDown = function ( event ) {
 
-					switch ( event.keyCode ) {
+					switch ( event.code ) {
 
-						case 38: // up
-						case 87: // w
+						case 'ArrowUp': // up
+						case 'KeyW': // w
 							moveForward = true;
 							break;
 
-						case 37: // left
-						case 65: // a
+						case 'ArrowLeft': // left
+						case 'KeyA': // a
 							moveLeft = true;
 							break;
 
-						case 40: // down
-						case 83: // s
+						case 'ArrowDown': // down
+						case 'KeyS': // s
 							moveBackward = true;
 							break;
 
-						case 39: // right
-						case 68: // d
+						case 'ArrowRight': // right
+						case 'KeyD': // d
 							moveRight = true;
 							break;
 
-						case 32: // space
+						case 'Space': // space
 							if ( canJump === true ) velocity.y += 350;
 							canJump = false;
 							break;
@@ -158,25 +158,25 @@
 
 				const onKeyUp = function ( event ) {
 
-					switch ( event.keyCode ) {
+					switch ( event.code ) {
 
-						case 38: // up
-						case 87: // w
+						case 'ArrowUp': // up
+						case 'KeyW': // w
 							moveForward = false;
 							break;
 
-						case 37: // left
-						case 65: // a
+						case 'ArrowLeft': // left
+						case 'KeyA': // a
 							moveLeft = false;
 							break;
 
-						case 40: // down
-						case 83: // s
+						case 'ArrowDown': // down
+						case 'KeyS': // s
 							moveBackward = false;
 							break;
 
-						case 39: // right
-						case 68: // d
+						case 'ArrowRight': // right
+						case 'KeyD': // d
 							moveRight = false;
 							break;
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -127,27 +127,27 @@
 
 					switch ( event.code ) {
 
-						case 'ArrowUp': // up
-						case 'KeyW': // w
+						case 'ArrowUp':
+						case 'KeyW':
 							moveForward = true;
 							break;
 
-						case 'ArrowLeft': // left
-						case 'KeyA': // a
+						case 'ArrowLeft':
+						case 'KeyA':
 							moveLeft = true;
 							break;
 
-						case 'ArrowDown': // down
-						case 'KeyS': // s
+						case 'ArrowDown':
+						case 'KeyS':
 							moveBackward = true;
 							break;
 
-						case 'ArrowRight': // right
-						case 'KeyD': // d
+						case 'ArrowRight':
+						case 'KeyD':
 							moveRight = true;
 							break;
 
-						case 'Space': // space
+						case 'Space':
 							if ( canJump === true ) velocity.y += 350;
 							canJump = false;
 							break;
@@ -160,23 +160,23 @@
 
 					switch ( event.code ) {
 
-						case 'ArrowUp': // up
-						case 'KeyW': // w
+						case 'ArrowUp':
+						case 'KeyW':
 							moveForward = false;
 							break;
 
-						case 'ArrowLeft': // left
-						case 'KeyA': // a
+						case 'ArrowLeft':
+						case 'KeyA':
 							moveLeft = false;
 							break;
 
-						case 'ArrowDown': // down
-						case 'KeyS': // s
+						case 'ArrowDown':
+						case 'KeyS':
 							moveBackward = false;
 							break;
 
-						case 'ArrowRight': // right
-						case 'KeyD': // d
+						case 'ArrowRight':
+						case 'KeyD':
 							moveRight = false;
 							break;
 


### PR DESCRIPTION
Issue : the pointerlock example, FirstPersonControls and FlyControls checked the `keyCode` property of the `keydown` and `keyup` events, which means it was bound to **characters**. Some keyboard layouts, like the French one displayed bellow, don't map the WASD keys at the same place, whereas we actually play with the same keys as everybody, only these keys represent different characters.

![Screenshot_1](https://user-images.githubusercontent.com/46470486/104171304-b64b7b80-5402-11eb-9aee-bf03244860e5.png)

The present PR solves this by using the [event.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) propery, which is layout-independant. It will also solve the problem for Russian or Chinese layouts for instance.
