### PR TITLE
examples : use event.code instead of event.keyCode

### DIFF
--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -149,22 +149,22 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 		//event.preventDefault();
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 38: /*up*/
-			case 87: /*W*/ this.moveForward = true; break;
+			case 'ArrowUp': /*up*/
+			case 'KeyW': /*W*/ this.moveForward = true; break;
 
-			case 37: /*left*/
-			case 65: /*A*/ this.moveLeft = true; break;
+			case 'ArrowLeft': /*left*/
+			case 'KeyA': /*A*/ this.moveLeft = true; break;
 
-			case 40: /*down*/
-			case 83: /*S*/ this.moveBackward = true; break;
+			case 'ArrowDown': /*down*/
+			case 'KeyS': /*S*/ this.moveBackward = true; break;
 
-			case 39: /*right*/
-			case 68: /*D*/ this.moveRight = true; break;
+			case 'ArrowRight': /*right*/
+			case 'KeyD': /*D*/ this.moveRight = true; break;
 
-			case 82: /*R*/ this.moveUp = true; break;
-			case 70: /*F*/ this.moveDown = true; break;
+			case 'KeyR': /*R*/ this.moveUp = true; break;
+			case 'KeyF': /*F*/ this.moveDown = true; break;
 
 		}
 
@@ -172,22 +172,22 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 	this.onKeyUp = function ( event ) {
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 38: /*up*/
-			case 87: /*W*/ this.moveForward = false; break;
+			case 'ArrowUp': /*up*/
+			case 'KeyW': /*W*/ this.moveForward = false; break;
 
-			case 37: /*left*/
-			case 65: /*A*/ this.moveLeft = false; break;
+			case 'ArrowLeft': /*left*/
+			case 'KeyA': /*A*/ this.moveLeft = false; break;
 
-			case 40: /*down*/
-			case 83: /*S*/ this.moveBackward = false; break;
+			case 'ArrowDown': /*down*/
+			case 'KeyS': /*S*/ this.moveBackward = false; break;
 
-			case 39: /*right*/
-			case 68: /*D*/ this.moveRight = false; break;
+			case 'ArrowRight': /*right*/
+			case 'KeyD': /*D*/ this.moveRight = false; break;
 
-			case 82: /*R*/ this.moveUp = false; break;
-			case 70: /*F*/ this.moveDown = false; break;
+			case 'KeyR': /*R*/ this.moveUp = false; break;
+			case 'KeyF': /*F*/ this.moveDown = false; break;
 
 		}
 

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -151,20 +151,20 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ArrowUp': /*up*/
-			case 'KeyW': /*W*/ this.moveForward = true; break;
+			case 'ArrowUp':
+			case 'KeyW': this.moveForward = true; break;
 
-			case 'ArrowLeft': /*left*/
-			case 'KeyA': /*A*/ this.moveLeft = true; break;
+			case 'ArrowLeft':
+			case 'KeyA': this.moveLeft = true; break;
 
-			case 'ArrowDown': /*down*/
-			case 'KeyS': /*S*/ this.moveBackward = true; break;
+			case 'ArrowDown':
+			case 'KeyS': this.moveBackward = true; break;
 
-			case 'ArrowRight': /*right*/
-			case 'KeyD': /*D*/ this.moveRight = true; break;
+			case 'ArrowRight':
+			case 'KeyD': this.moveRight = true; break;
 
-			case 'KeyR': /*R*/ this.moveUp = true; break;
-			case 'KeyF': /*F*/ this.moveDown = true; break;
+			case 'KeyR': this.moveUp = true; break;
+			case 'KeyF': this.moveDown = true; break;
 
 		}
 
@@ -174,20 +174,20 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ArrowUp': /*up*/
-			case 'KeyW': /*W*/ this.moveForward = false; break;
+			case 'ArrowUp':
+			case 'KeyW': this.moveForward = false; break;
 
-			case 'ArrowLeft': /*left*/
-			case 'KeyA': /*A*/ this.moveLeft = false; break;
+			case 'ArrowLeft':
+			case 'KeyA': this.moveLeft = false; break;
 
-			case 'ArrowDown': /*down*/
-			case 'KeyS': /*S*/ this.moveBackward = false; break;
+			case 'ArrowDown':
+			case 'KeyS': this.moveBackward = false; break;
 
-			case 'ArrowRight': /*right*/
-			case 'KeyD': /*D*/ this.moveRight = false; break;
+			case 'ArrowRight':
+			case 'KeyD': this.moveRight = false; break;
 
-			case 'KeyR': /*R*/ this.moveUp = false; break;
-			case 'KeyF': /*F*/ this.moveDown = false; break;
+			case 'KeyR': this.moveUp = false; break;
+			case 'KeyF': this.moveDown = false; break;
 
 		}
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -46,27 +46,28 @@ THREE.FlyControls = function ( object, domElement ) {
 
 		//event.preventDefault();
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 16: /* shift */ this.movementSpeedMultiplier = .1; break;
+			case 'ShiftLeft': /* shift left */
+			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = .1; break;
 
-			case 87: /*W*/ this.moveState.forward = 1; break;
-			case 83: /*S*/ this.moveState.back = 1; break;
+			case 'KeyW': /*W*/ this.moveState.forward = 1; break;
+			case 'KeyS': /*S*/ this.moveState.back = 1; break;
 
-			case 65: /*A*/ this.moveState.left = 1; break;
-			case 68: /*D*/ this.moveState.right = 1; break;
+			case 'KeyA': /*A*/ this.moveState.left = 1; break;
+			case 'KeyD': /*D*/ this.moveState.right = 1; break;
 
-			case 82: /*R*/ this.moveState.up = 1; break;
-			case 70: /*F*/ this.moveState.down = 1; break;
+			case 'KeyR': /*R*/ this.moveState.up = 1; break;
+			case 'KeyF': /*F*/ this.moveState.down = 1; break;
 
-			case 38: /*up*/ this.moveState.pitchUp = 1; break;
-			case 40: /*down*/ this.moveState.pitchDown = 1; break;
+			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 1; break;
+			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 1; break;
 
-			case 37: /*left*/ this.moveState.yawLeft = 1; break;
-			case 39: /*right*/ this.moveState.yawRight = 1; break;
+			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 1; break;
+			case 'ArrowRight': /*right*/ this.moveState.yawRight = 1; break;
 
-			case 81: /*Q*/ this.moveState.rollLeft = 1; break;
-			case 69: /*E*/ this.moveState.rollRight = 1; break;
+			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 1; break;
+			case 'KeyE': /*E*/ this.moveState.rollRight = 1; break;
 
 		}
 
@@ -77,27 +78,28 @@ THREE.FlyControls = function ( object, domElement ) {
 
 	this.keyup = function ( event ) {
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 16: /* shift */ this.movementSpeedMultiplier = 1; break;
+			case 'ShiftLeft': /* shift left */
+			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = 1; break;
 
-			case 87: /*W*/ this.moveState.forward = 0; break;
-			case 83: /*S*/ this.moveState.back = 0; break;
+			case 'KeyW': /*W*/ this.moveState.forward = 0; break;
+			case 'KeyS': /*S*/ this.moveState.back = 0; break;
 
-			case 65: /*A*/ this.moveState.left = 0; break;
-			case 68: /*D*/ this.moveState.right = 0; break;
+			case 'KeyA': /*A*/ this.moveState.left = 0; break;
+			case 'KeyD': /*D*/ this.moveState.right = 0; break;
 
-			case 82: /*R*/ this.moveState.up = 0; break;
-			case 70: /*F*/ this.moveState.down = 0; break;
+			case 'KeyR': /*R*/ this.moveState.up = 0; break;
+			case 'KeyF': /*F*/ this.moveState.down = 0; break;
 
-			case 38: /*up*/ this.moveState.pitchUp = 0; break;
-			case 40: /*down*/ this.moveState.pitchDown = 0; break;
+			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 0; break;
+			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 0; break;
 
-			case 37: /*left*/ this.moveState.yawLeft = 0; break;
-			case 39: /*right*/ this.moveState.yawRight = 0; break;
+			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 0; break;
+			case 'ArrowRight': /*right*/ this.moveState.yawRight = 0; break;
 
-			case 81: /*Q*/ this.moveState.rollLeft = 0; break;
-			case 69: /*E*/ this.moveState.rollRight = 0; break;
+			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 0; break;
+			case 'KeyE': /*E*/ this.moveState.rollRight = 0; break;
 
 		}
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -48,26 +48,26 @@ THREE.FlyControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ShiftLeft': /* shift left */
-			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = .1; break;
+			case 'ShiftLeft':
+			case 'ShiftRight': this.movementSpeedMultiplier = .1; break;
 
-			case 'KeyW': /*W*/ this.moveState.forward = 1; break;
-			case 'KeyS': /*S*/ this.moveState.back = 1; break;
+			case 'KeyW': this.moveState.forward = 1; break;
+			case 'KeyS': this.moveState.back = 1; break;
 
-			case 'KeyA': /*A*/ this.moveState.left = 1; break;
-			case 'KeyD': /*D*/ this.moveState.right = 1; break;
+			case 'KeyA': this.moveState.left = 1; break;
+			case 'KeyD': this.moveState.right = 1; break;
 
-			case 'KeyR': /*R*/ this.moveState.up = 1; break;
-			case 'KeyF': /*F*/ this.moveState.down = 1; break;
+			case 'KeyR': this.moveState.up = 1; break;
+			case 'KeyF': this.moveState.down = 1; break;
 
-			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 1; break;
-			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 1; break;
+			case 'ArrowUp': this.moveState.pitchUp = 1; break;
+			case 'ArrowDown': this.moveState.pitchDown = 1; break;
 
-			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 1; break;
-			case 'ArrowRight': /*right*/ this.moveState.yawRight = 1; break;
+			case 'ArrowLeft': this.moveState.yawLeft = 1; break;
+			case 'ArrowRight': this.moveState.yawRight = 1; break;
 
-			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 1; break;
-			case 'KeyE': /*E*/ this.moveState.rollRight = 1; break;
+			case 'KeyQ': this.moveState.rollLeft = 1; break;
+			case 'KeyE': this.moveState.rollRight = 1; break;
 
 		}
 
@@ -80,26 +80,26 @@ THREE.FlyControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ShiftLeft': /* shift left */
-			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = 1; break;
+			case 'ShiftLeft':
+			case 'ShiftRight': this.movementSpeedMultiplier = 1; break;
 
-			case 'KeyW': /*W*/ this.moveState.forward = 0; break;
-			case 'KeyS': /*S*/ this.moveState.back = 0; break;
+			case 'KeyW': this.moveState.forward = 0; break;
+			case 'KeyS': this.moveState.back = 0; break;
 
-			case 'KeyA': /*A*/ this.moveState.left = 0; break;
-			case 'KeyD': /*D*/ this.moveState.right = 0; break;
+			case 'KeyA': this.moveState.left = 0; break;
+			case 'KeyD': this.moveState.right = 0; break;
 
-			case 'KeyR': /*R*/ this.moveState.up = 0; break;
-			case 'KeyF': /*F*/ this.moveState.down = 0; break;
+			case 'KeyR': this.moveState.up = 0; break;
+			case 'KeyF': this.moveState.down = 0; break;
 
-			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 0; break;
-			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 0; break;
+			case 'ArrowUp': this.moveState.pitchUp = 0; break;
+			case 'ArrowDown': this.moveState.pitchDown = 0; break;
 
-			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 0; break;
-			case 'ArrowRight': /*right*/ this.moveState.yawRight = 0; break;
+			case 'ArrowLeft': this.moveState.yawLeft = 0; break;
+			case 'ArrowRight': this.moveState.yawRight = 0; break;
 
-			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 0; break;
-			case 'KeyE': /*E*/ this.moveState.rollRight = 0; break;
+			case 'KeyQ': this.moveState.rollLeft = 0; break;
+			case 'KeyE': this.moveState.rollRight = 0; break;
 
 		}
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -155,22 +155,22 @@ var FirstPersonControls = function ( object, domElement ) {
 
 		//event.preventDefault();
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 38: /*up*/
-			case 87: /*W*/ this.moveForward = true; break;
+			case 'ArrowUp': /*up*/
+			case 'KeyW': /*W*/ this.moveForward = true; break;
 
-			case 37: /*left*/
-			case 65: /*A*/ this.moveLeft = true; break;
+			case 'ArrowLeft': /*left*/
+			case 'KeyA': /*A*/ this.moveLeft = true; break;
 
-			case 40: /*down*/
-			case 83: /*S*/ this.moveBackward = true; break;
+			case 'ArrowDown': /*down*/
+			case 'KeyS': /*S*/ this.moveBackward = true; break;
 
-			case 39: /*right*/
-			case 68: /*D*/ this.moveRight = true; break;
+			case 'ArrowRight': /*right*/
+			case 'KeyD': /*D*/ this.moveRight = true; break;
 
-			case 82: /*R*/ this.moveUp = true; break;
-			case 70: /*F*/ this.moveDown = true; break;
+			case 'KeyR': /*R*/ this.moveUp = true; break;
+			case 'KeyF': /*F*/ this.moveDown = true; break;
 
 		}
 
@@ -178,22 +178,22 @@ var FirstPersonControls = function ( object, domElement ) {
 
 	this.onKeyUp = function ( event ) {
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 38: /*up*/
-			case 87: /*W*/ this.moveForward = false; break;
+			case 'ArrowUp': /*up*/
+			case 'KeyW': /*W*/ this.moveForward = false; break;
 
-			case 37: /*left*/
-			case 65: /*A*/ this.moveLeft = false; break;
+			case 'ArrowLeft': /*left*/
+			case 'KeyA': /*A*/ this.moveLeft = false; break;
 
-			case 40: /*down*/
-			case 83: /*S*/ this.moveBackward = false; break;
+			case 'ArrowDown': /*down*/
+			case 'KeyS': /*S*/ this.moveBackward = false; break;
 
-			case 39: /*right*/
-			case 68: /*D*/ this.moveRight = false; break;
+			case 'ArrowRight': /*right*/
+			case 'KeyD': /*D*/ this.moveRight = false; break;
 
-			case 82: /*R*/ this.moveUp = false; break;
-			case 70: /*F*/ this.moveDown = false; break;
+			case 'KeyR': /*R*/ this.moveUp = false; break;
+			case 'KeyF': /*F*/ this.moveDown = false; break;
 
 		}
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -157,20 +157,20 @@ var FirstPersonControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ArrowUp': /*up*/
-			case 'KeyW': /*W*/ this.moveForward = true; break;
+			case 'ArrowUp':
+			case 'KeyW': this.moveForward = true; break;
 
-			case 'ArrowLeft': /*left*/
-			case 'KeyA': /*A*/ this.moveLeft = true; break;
+			case 'ArrowLeft':
+			case 'KeyA': this.moveLeft = true; break;
 
-			case 'ArrowDown': /*down*/
-			case 'KeyS': /*S*/ this.moveBackward = true; break;
+			case 'ArrowDown':
+			case 'KeyS': this.moveBackward = true; break;
 
-			case 'ArrowRight': /*right*/
-			case 'KeyD': /*D*/ this.moveRight = true; break;
+			case 'ArrowRight':
+			case 'KeyD': this.moveRight = true; break;
 
-			case 'KeyR': /*R*/ this.moveUp = true; break;
-			case 'KeyF': /*F*/ this.moveDown = true; break;
+			case 'KeyR': this.moveUp = true; break;
+			case 'KeyF': this.moveDown = true; break;
 
 		}
 
@@ -180,20 +180,20 @@ var FirstPersonControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ArrowUp': /*up*/
-			case 'KeyW': /*W*/ this.moveForward = false; break;
+			case 'ArrowUp':
+			case 'KeyW': this.moveForward = false; break;
 
-			case 'ArrowLeft': /*left*/
-			case 'KeyA': /*A*/ this.moveLeft = false; break;
+			case 'ArrowLeft':
+			case 'KeyA': this.moveLeft = false; break;
 
-			case 'ArrowDown': /*down*/
-			case 'KeyS': /*S*/ this.moveBackward = false; break;
+			case 'ArrowDown':
+			case 'KeyS': this.moveBackward = false; break;
 
-			case 'ArrowRight': /*right*/
-			case 'KeyD': /*D*/ this.moveRight = false; break;
+			case 'ArrowRight':
+			case 'KeyD': this.moveRight = false; break;
 
-			case 'KeyR': /*R*/ this.moveUp = false; break;
-			case 'KeyF': /*F*/ this.moveDown = false; break;
+			case 'KeyR': this.moveUp = false; break;
+			case 'KeyF': this.moveDown = false; break;
 
 		}
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -52,27 +52,28 @@ var FlyControls = function ( object, domElement ) {
 
 		//event.preventDefault();
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 16: /* shift */ this.movementSpeedMultiplier = .1; break;
+			case 'ShiftLeft': /* shift left */
+			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = .1; break;
 
-			case 87: /*W*/ this.moveState.forward = 1; break;
-			case 83: /*S*/ this.moveState.back = 1; break;
+			case 'KeyW': /*W*/ this.moveState.forward = 1; break;
+			case 'KeyS': /*S*/ this.moveState.back = 1; break;
 
-			case 65: /*A*/ this.moveState.left = 1; break;
-			case 68: /*D*/ this.moveState.right = 1; break;
+			case 'KeyA': /*A*/ this.moveState.left = 1; break;
+			case 'KeyD': /*D*/ this.moveState.right = 1; break;
 
-			case 82: /*R*/ this.moveState.up = 1; break;
-			case 70: /*F*/ this.moveState.down = 1; break;
+			case 'KeyR': /*R*/ this.moveState.up = 1; break;
+			case 'KeyF': /*F*/ this.moveState.down = 1; break;
 
-			case 38: /*up*/ this.moveState.pitchUp = 1; break;
-			case 40: /*down*/ this.moveState.pitchDown = 1; break;
+			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 1; break;
+			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 1; break;
 
-			case 37: /*left*/ this.moveState.yawLeft = 1; break;
-			case 39: /*right*/ this.moveState.yawRight = 1; break;
+			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 1; break;
+			case 'ArrowRight': /*right*/ this.moveState.yawRight = 1; break;
 
-			case 81: /*Q*/ this.moveState.rollLeft = 1; break;
-			case 69: /*E*/ this.moveState.rollRight = 1; break;
+			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 1; break;
+			case 'KeyE': /*E*/ this.moveState.rollRight = 1; break;
 
 		}
 
@@ -83,27 +84,28 @@ var FlyControls = function ( object, domElement ) {
 
 	this.keyup = function ( event ) {
 
-		switch ( event.keyCode ) {
+		switch ( event.code ) {
 
-			case 16: /* shift */ this.movementSpeedMultiplier = 1; break;
+			case 'ShiftLeft': /* shift left */
+			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = 1; break;
 
-			case 87: /*W*/ this.moveState.forward = 0; break;
-			case 83: /*S*/ this.moveState.back = 0; break;
+			case 'KeyW': /*W*/ this.moveState.forward = 0; break;
+			case 'KeyS': /*S*/ this.moveState.back = 0; break;
 
-			case 65: /*A*/ this.moveState.left = 0; break;
-			case 68: /*D*/ this.moveState.right = 0; break;
+			case 'KeyA': /*A*/ this.moveState.left = 0; break;
+			case 'KeyD': /*D*/ this.moveState.right = 0; break;
 
-			case 82: /*R*/ this.moveState.up = 0; break;
-			case 70: /*F*/ this.moveState.down = 0; break;
+			case 'KeyR': /*R*/ this.moveState.up = 0; break;
+			case 'KeyF': /*F*/ this.moveState.down = 0; break;
 
-			case 38: /*up*/ this.moveState.pitchUp = 0; break;
-			case 40: /*down*/ this.moveState.pitchDown = 0; break;
+			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 0; break;
+			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 0; break;
 
-			case 37: /*left*/ this.moveState.yawLeft = 0; break;
-			case 39: /*right*/ this.moveState.yawRight = 0; break;
+			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 0; break;
+			case 'ArrowRight': /*right*/ this.moveState.yawRight = 0; break;
 
-			case 81: /*Q*/ this.moveState.rollLeft = 0; break;
-			case 69: /*E*/ this.moveState.rollRight = 0; break;
+			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 0; break;
+			case 'KeyE': /*E*/ this.moveState.rollRight = 0; break;
 
 		}
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -54,26 +54,26 @@ var FlyControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ShiftLeft': /* shift left */
-			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = .1; break;
+			case 'ShiftLeft':
+			case 'ShiftRight': this.movementSpeedMultiplier = .1; break;
 
-			case 'KeyW': /*W*/ this.moveState.forward = 1; break;
-			case 'KeyS': /*S*/ this.moveState.back = 1; break;
+			case 'KeyW': this.moveState.forward = 1; break;
+			case 'KeyS': this.moveState.back = 1; break;
 
-			case 'KeyA': /*A*/ this.moveState.left = 1; break;
-			case 'KeyD': /*D*/ this.moveState.right = 1; break;
+			case 'KeyA': this.moveState.left = 1; break;
+			case 'KeyD': this.moveState.right = 1; break;
 
-			case 'KeyR': /*R*/ this.moveState.up = 1; break;
-			case 'KeyF': /*F*/ this.moveState.down = 1; break;
+			case 'KeyR': this.moveState.up = 1; break;
+			case 'KeyF': this.moveState.down = 1; break;
 
-			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 1; break;
-			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 1; break;
+			case 'ArrowUp': this.moveState.pitchUp = 1; break;
+			case 'ArrowDown': this.moveState.pitchDown = 1; break;
 
-			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 1; break;
-			case 'ArrowRight': /*right*/ this.moveState.yawRight = 1; break;
+			case 'ArrowLeft': this.moveState.yawLeft = 1; break;
+			case 'ArrowRight': this.moveState.yawRight = 1; break;
 
-			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 1; break;
-			case 'KeyE': /*E*/ this.moveState.rollRight = 1; break;
+			case 'KeyQ': this.moveState.rollLeft = 1; break;
+			case 'KeyE': this.moveState.rollRight = 1; break;
 
 		}
 
@@ -86,26 +86,26 @@ var FlyControls = function ( object, domElement ) {
 
 		switch ( event.code ) {
 
-			case 'ShiftLeft': /* shift left */
-			case 'ShiftRight': /* shift right */ this.movementSpeedMultiplier = 1; break;
+			case 'ShiftLeft':
+			case 'ShiftRight': this.movementSpeedMultiplier = 1; break;
 
-			case 'KeyW': /*W*/ this.moveState.forward = 0; break;
-			case 'KeyS': /*S*/ this.moveState.back = 0; break;
+			case 'KeyW': this.moveState.forward = 0; break;
+			case 'KeyS': this.moveState.back = 0; break;
 
-			case 'KeyA': /*A*/ this.moveState.left = 0; break;
-			case 'KeyD': /*D*/ this.moveState.right = 0; break;
+			case 'KeyA': this.moveState.left = 0; break;
+			case 'KeyD': this.moveState.right = 0; break;
 
-			case 'KeyR': /*R*/ this.moveState.up = 0; break;
-			case 'KeyF': /*F*/ this.moveState.down = 0; break;
+			case 'KeyR': this.moveState.up = 0; break;
+			case 'KeyF': this.moveState.down = 0; break;
 
-			case 'ArrowUp': /*up*/ this.moveState.pitchUp = 0; break;
-			case 'ArrowDown': /*down*/ this.moveState.pitchDown = 0; break;
+			case 'ArrowUp': this.moveState.pitchUp = 0; break;
+			case 'ArrowDown': this.moveState.pitchDown = 0; break;
 
-			case 'ArrowLeft': /*left*/ this.moveState.yawLeft = 0; break;
-			case 'ArrowRight': /*right*/ this.moveState.yawRight = 0; break;
+			case 'ArrowLeft': this.moveState.yawLeft = 0; break;
+			case 'ArrowRight': this.moveState.yawRight = 0; break;
 
-			case 'KeyQ': /*Q*/ this.moveState.rollLeft = 0; break;
-			case 'KeyE': /*E*/ this.moveState.rollRight = 0; break;
+			case 'KeyQ': this.moveState.rollLeft = 0; break;
+			case 'KeyE': this.moveState.rollRight = 0; break;
 
 		}
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -248,23 +248,24 @@
 
 			function onKeyDown( event ) {
 
-				switch ( event.keyCode ) {
+				switch ( event.code ) {
 
-					case 38: /*up*/
-					case 87: /*W*/ 	controls.moveForward = true; break;
+					case 'ArrowUp': /*up*/
+					case 'KeyW': /*W*/ 	controls.moveForward = true; break;
 
-					case 40: /*down*/
-					case 83: /*S*/ 	 controls.moveBackward = true; break;
+					case 'ArrowDown': /*down*/
+					case 'KeyS': /*S*/ 	 controls.moveBackward = true; break;
 
-					case 37: /*left*/
-					case 65: /*A*/ controls.moveLeft = true; break;
+					case 'ArrowLeft': /*left*/
+					case 'KeyA': /*A*/ controls.moveLeft = true; break;
 
-					case 39: /*right*/
-					case 68: /*D*/ controls.moveRight = true; break;
+					case 'ArrowRight': /*right*/
+					case 'KeyD': /*D*/ controls.moveRight = true; break;
 
-					//case 67: /*C*/     controls.crouch = true; break;
-					//case 32: /*space*/ controls.jump = true; break;
-					//case 17: /*ctrl*/  controls.attack = true; break;
+					// case 'KeyC': /*C*/ controls.crouch = true; break;
+					//case 'Space': /*space*/ controls.jump = true; break;
+					//case 'ControlLeft': /*ctrl*/
+					//case 'ControlRight': controls.attack = true; break;
 
 				}
 
@@ -272,23 +273,24 @@
 
 			function onKeyUp( event ) {
 
-				switch ( event.keyCode ) {
+				switch ( event.code ) {
 
-					case 38: /*up*/
-					case 87: /*W*/ controls.moveForward = false; break;
+					case 'ArrowUp': /*up*/
+					case 'KeyW': /*W*/ controls.moveForward = false; break;
 
-					case 40: /*down*/
-					case 83: /*S*/ 	 controls.moveBackward = false; break;
+					case 'ArrowDown': /*down*/
+					case 'KeyS': /*S*/ 	 controls.moveBackward = false; break;
 
-					case 37: /*left*/
-					case 65: /*A*/ 	 controls.moveLeft = false; break;
+					case 'ArrowLeft': /*left*/
+					case 'KeyA': /*A*/ 	 controls.moveLeft = false; break;
 
-					case 39: /*right*/
-					case 68: /*D*/ controls.moveRight = false; break;
+					case 'ArrowRight': /*right*/
+					case 'KeyD': /*D*/ controls.moveRight = false; break;
 
-					//case 67: /*C*/     controls.crouch = false; break;
-					//case 32: /*space*/ controls.jump = false; break;
-					//case 17: /*ctrl*/  controls.attack = false; break;
+					// case 'KeyC': /*C*/ controls.crouch = false; break;
+					//case 'Space': /*space*/ controls.jump = false; break;
+					//case 'ControlLeft': /*ctrl*/
+					//case 'ControlRight': controls.attack = false; break;
 
 				}
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -250,22 +250,22 @@
 
 				switch ( event.code ) {
 
-					case 'ArrowUp': /*up*/
-					case 'KeyW': /*W*/ 	controls.moveForward = true; break;
+					case 'ArrowUp':
+					case 'KeyW': controls.moveForward = true; break;
 
-					case 'ArrowDown': /*down*/
-					case 'KeyS': /*S*/ 	 controls.moveBackward = true; break;
+					case 'ArrowDown':
+					case 'KeyS': controls.moveBackward = true; break;
 
-					case 'ArrowLeft': /*left*/
-					case 'KeyA': /*A*/ controls.moveLeft = true; break;
+					case 'ArrowLeft':
+					case 'KeyA': controls.moveLeft = true; break;
 
-					case 'ArrowRight': /*right*/
-					case 'KeyD': /*D*/ controls.moveRight = true; break;
+					case 'ArrowRight':
+					case 'KeyD': controls.moveRight = true; break;
 
-					// case 'KeyC': /*C*/ controls.crouch = true; break;
-					//case 'Space': /*space*/ controls.jump = true; break;
-					//case 'ControlLeft': /*ctrl*/
-					//case 'ControlRight': controls.attack = true; break;
+					// case 'KeyC': controls.crouch = true; break;
+					// case 'Space': controls.jump = true; break;
+					// case 'ControlLeft':
+					// case 'ControlRight': controls.attack = true; break;
 
 				}
 
@@ -275,22 +275,22 @@
 
 				switch ( event.code ) {
 
-					case 'ArrowUp': /*up*/
-					case 'KeyW': /*W*/ controls.moveForward = false; break;
+					case 'ArrowUp':
+					case 'KeyW': controls.moveForward = false; break;
 
-					case 'ArrowDown': /*down*/
-					case 'KeyS': /*S*/ 	 controls.moveBackward = false; break;
+					case 'ArrowDown':
+					case 'KeyS': controls.moveBackward = false; break;
 
-					case 'ArrowLeft': /*left*/
-					case 'KeyA': /*A*/ 	 controls.moveLeft = false; break;
+					case 'ArrowLeft':
+					case 'KeyA': controls.moveLeft = false; break;
 
-					case 'ArrowRight': /*right*/
-					case 'KeyD': /*D*/ controls.moveRight = false; break;
+					case 'ArrowRight':
+					case 'KeyD': controls.moveRight = false; break;
 
-					// case 'KeyC': /*C*/ controls.crouch = false; break;
-					//case 'Space': /*space*/ controls.jump = false; break;
-					//case 'ControlLeft': /*ctrl*/
-					//case 'ControlRight': controls.attack = false; break;
+					// case 'KeyC': controls.crouch = false; break;
+					// case 'Space': controls.jump = false; break;
+					// case 'ControlLeft':
+					// case 'ControlRight': controls.attack = false; break;
 
 				}
 


### PR DESCRIPTION
following #21055

> Issue : the pointerlock example, FirstPersonControls and FlyControls checked the keyCode property of the keydown and keyup events, which means it was bound to characters. Some keyboard layouts, like the French one displayed bellow, don't map the WASD keys at the same place, whereas we actually play with the same keys as everybody, only these keys represent different characters.
>
> ![Screenshot_1](https://user-images.githubusercontent.com/46470486/104189181-9f188800-541a-11eb-86ed-8d45a81492f8.png)

This PR continues to fix this issue in various examples by using [event.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code), which is layout-independant. 
