### PR TITLE
TS: add uuid as a type to Shape

### DIFF
--- a/src/extras/core/Shape.d.ts
+++ b/src/extras/core/Shape.d.ts
@@ -14,6 +14,11 @@ export class Shape extends Path {
 	type: string;
 
 	/**
+	 *
+	 */
+	uuid: string;
+
+	/**
 	 * @default []
 	 */
 	holes: Path[];


### PR DESCRIPTION
Related issue: #XXXX

**Description**

`src/extras/core/Shape.js` defines this.uuid but was missing from `Shape.d.ts` leading to type errors while calling it. My particular problem was I wanted to use it as the key in a react based `map` function.

```js
function Shape( points ) {

	Path.call( this, points );

	this.uuid = MathUtils.generateUUID();

	this.type = 'Shape';

	this.holes = [];

}
```
