### PR TITLE
TS: add userData to SVGResult.paths

### DIFF
--- a/examples/jsm/loaders/SVGLoader.d.ts
+++ b/examples/jsm/loaders/SVGLoader.d.ts
@@ -6,8 +6,14 @@ import {
 	Vector3
 } from '../../../src/Three';
 
+interface SVGResultPaths extends ShapePath {
+	userData?: {
+		[key: string]: any
+	}
+}
+
 export interface SVGResult {
-	paths: ShapePath[];
+	paths: SVGResultPaths[];
 	xml: XMLDocument;
 }
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Type error with `SVGResult` returned from `SVGLoader`. `SVGLoader.parse` contains a function `parseNode` which attaches the property `userData` onto the paths it returns. However, `ShapePath` does not have this property in it's `.d.ts` file. It wasn't meantioned in the documentation underneath `ShapePath` so i've assumed this is strictly an effect from the `SVGLoader` hence i've kept the type inside `SVGLoader.d.ts` but i'm happy to move it upon review.

This was causing TS issues when trying to acess the style properties.
