### PR TITLE
Examples: Fix contact shadow example

### DIFF
--- a/examples/webgl_shadow_contact.html
+++ b/examples/webgl_shadow_contact.html
@@ -115,10 +115,11 @@
 					map: renderTarget.texture,
 					opacity: state.shadow.opacity,
 					transparent: true,
+					depthWrite: false,
 				} );
 				plane = new THREE.Mesh( planeGeometry, planeMaterial );
-				plane.material.polygonOffset = true;
-				plane.material.polygonOffsetFactor = -.1;
+				// make sure it's rendered ahead the fillPlane
+				plane.renderOrder = 1;
 				shadowGroup.add( plane );
 
 				// the y from the texture is flipped!
@@ -134,6 +135,7 @@
 					color: state.plane.color,
 					opacity: state.plane.opacity,
 					transparent: true,
+					depthWrite: false,
 				} );
 				fillPlane = new THREE.Mesh( planeGeometry, fillPlaneMaterial );
 				fillPlane.rotateX( Math.PI );

--- a/examples/webgl_shadow_contact.html
+++ b/examples/webgl_shadow_contact.html
@@ -118,7 +118,7 @@
 					depthWrite: false,
 				} );
 				plane = new THREE.Mesh( planeGeometry, planeMaterial );
-				// make sure it's rendered ahead the fillPlane
+				// make sure it's rendered after the fillPlane
 				plane.renderOrder = 1;
 				shadowGroup.add( plane );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/20849#issuecomment-757932398

**Description**

With the `polygonOffset` sorting method the fillPlane was not being shown. By using `renderOrder` we make sure the shadow plane is on top while still showing the fillPlane.

https://raw.githack.com/marcofugaro/three.js/contact-shadow-fix/examples/webgl_shadow_contact.html

| Before | After |
|------|---------|
| <img width="780" alt="Screenshot 2021-01-11 at 21 11 23" src="https://user-images.githubusercontent.com/7217420/104235133-cf7d1800-5454-11eb-90d5-8a9efe2baaf7.png"> | <img width="855" alt="Screenshot 2021-01-11 at 21 31 08" src="https://user-images.githubusercontent.com/7217420/104235153-d73cbc80-5454-11eb-9858-e26a953b7e7c.png"> |