### PR TITLE
BufferGeometryUtils: Added computeMorphedBufferGeometry().

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -1,4 +1,4 @@
-import { BufferAttribute, BufferGeometry, InterleavedBufferAttribute, TrianglesDrawModes } from '../../../src/Three';
+import { BufferAttribute, BufferGeometry, InterleavedBufferAttribute, TrianglesDrawModes, Object3D } from '../../../src/Three';
 
 export namespace BufferGeometryUtils {
 	export function mergeBufferGeometries( geometries: BufferGeometry[], useGroups?: boolean ): BufferGeometry;
@@ -8,4 +8,5 @@ export namespace BufferGeometryUtils {
 	export function estimateBytesUsed( geometry: BufferGeometry ): number;
 	export function mergeVertices( geometry: BufferGeometry, tolerance?: number ): BufferGeometry;
 	export function toTrianglesDrawMode( geometry: BufferGeometry, drawMode: TrianglesDrawModes ): BufferGeometry;
+	export function computeMorphedBufferGeometry( object: Object3D ): Object;
 }


### PR DESCRIPTION
**Description**

When dealing with `BufferGeometries` that are **morphed or skinned**, the position and normal attributes are the original ones, not the _current_ ones. Reading the actual buffers is required whenever the _current_ geometry is needed. For instance, to apply a `DecalGeometry` over a morphed `BufferGeometry`, or could be used to memoize (given a certain set of morphed factors) the _current_ normal and position attributes to speed up raytracing.

The `computeMorphedBufferGeometry` function reads the _current_ buffer attributes and returns them together with the original ones.

