### PR TITLE
Add Vector4.multiply()

### DIFF
--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -241,6 +241,9 @@
 		that value with the corresponding min value.
 		</p>
 
+		<h3>[method:this multiply]( [param:Vector4 v] )</h3>
+		<p>Multiplies this vector by [page:Vector4 v].</p>
+
 		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>Multiplies this vector by scalar [page:Float s].</p>
 

--- a/docs/api/zh/math/Vector4.html
+++ b/docs/api/zh/math/Vector4.html
@@ -240,6 +240,9 @@
 		则将该值替换为对应的最小值。
 		</p>
 
+		<h3>[method:this multiply]( [param:Vector4 v] )</h3>
+		<p>将该向量与所传入的向量[page:Vector4 v]进行相乘。</p>
+
 		<h3>[method:this multiplyScalar]( [param:Float s] )</h3>
 		<p>将该向量与所传入的标量[page:Float s]进行相乘。</p>
 

--- a/src/math/Vector4.d.ts
+++ b/src/math/Vector4.d.ts
@@ -107,6 +107,8 @@ export class Vector4 implements Vector {
 	 */
 	subVectors( a: Vector4, b: Vector4 ): this;
 
+	multiply( v: Vector4 ): this;
+
 	/**
 	 * Multiplies this vector by scalar s.
 	 */

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -227,14 +227,7 @@ class Vector4 {
 
 	}
 
-	multiply( v, w ) {
-
-		if ( w !== undefined ) {
-
-			console.warn( 'THREE.Vector4: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
-			return this.multiplyVectors( v, w );
-
-		}
+	multiply( v ) {
 
 		this.x *= v.x;
 		this.y *= v.y;

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -227,6 +227,24 @@ class Vector4 {
 
 	}
 
+	multiply( v, w ) {
+
+		if ( w !== undefined ) {
+
+			console.warn( 'THREE.Vector4: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
+			return this.multiplyVectors( v, w );
+
+		}
+
+		this.x *= v.x;
+		this.y *= v.y;
+		this.z *= v.z;
+		this.w *= v.w;
+
+		return this;
+
+	}
+
 	multiplyScalar( scalar ) {
 
 		this.x *= scalar;


### PR DESCRIPTION
Related issue: https://discord.com/channels/685241246557667386/685241247233081362/797517091993419796

**Description**

This PR adds the `Vector4.multiply()` method. 

Any reason in particular this wasn't there?