### PR TITLE
Bugfix/object3d-types

### DIFF
--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -15,6 +15,7 @@ import { EventDispatcher } from './EventDispatcher';
 import { BufferGeometry } from './BufferGeometry';
 import { Intersection } from './Raycaster';
 import { AnimationClip } from '../animation/AnimationClip';
+import { Mesh } from '../objects/Mesh'
 
 /**
  * Base class for scene graph objects
@@ -54,7 +55,7 @@ export class Object3D extends EventDispatcher {
 	 * Array with object's children.
 	 * @default []
 	 */
-	children: Object3D[];
+	children: Mesh[];
 
 	/**
 	 * Up direction.

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -15,7 +15,7 @@ import { EventDispatcher } from './EventDispatcher';
 import { BufferGeometry } from './BufferGeometry';
 import { Intersection } from './Raycaster';
 import { AnimationClip } from '../animation/AnimationClip';
-import { Mesh } from '../objects/Mesh'
+import { Mesh } from '../objects/Mesh';
 
 /**
  * Base class for scene graph objects


### PR DESCRIPTION
**Description**

When using the ObjectLoader, the children presented are `type: Mesh` which means the have both `geometry` and `material` when using Typescript, because in `Object3D` children are type `Object3D` accessing there `geometry` will throw an error. 

I've changed it but looking at other loads such as `LWO`:
```ts
export interface LWO {
	materials: Material[];
	meshes: Object3D[];
}
```

I'm wondering if `meshes` should also be `Mesh[]`... Didn't want to do sweeping changes until review as you'll have more of an idea of the library than I.