### PR TITLE
Fix getting float render target extensions

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1894,9 +1894,11 @@ function WebGLRenderer( parameters ) {
 
 				}
 
+				const halfFloatSupportedByExt = textureType === HalfFloatType && ( extensions.get( 'EXT_color_buffer_half_float' ) || ( capabilities.isWebGL2 && extensions.get( 'EXT_color_buffer_float' ) ) );
+
 				if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // IE11, Edge and Chrome Mac < 52 (#9513)
 					! ( textureType === FloatType && ( capabilities.isWebGL2 || extensions.get( 'OES_texture_float' ) || extensions.get( 'WEBGL_color_buffer_float' ) ) ) && // Chrome Mac >= 52 and Firefox
-					! ( textureType === HalfFloatType && ( capabilities.isWebGL2 ? extensions.get( 'EXT_color_buffer_float' ) : extensions.get( 'EXT_color_buffer_half_float' ) ) ) ) {
+					! halfFloatSupportedByExt ) {
 
 					console.error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );
 					return;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -276,7 +276,11 @@ function WebGLRenderer( parameters ) {
 
 		capabilities = new WebGLCapabilities( _gl, extensions, parameters );
 
-		if ( capabilities.isWebGL2 === false ) {
+		if ( capabilities.isWebGL2 ) {
+
+			extensions.get( 'EXT_color_buffer_float' );
+
+		} else {
 
 			extensions.get( 'WEBGL_depth_texture' );
 			extensions.get( 'OES_texture_float' );
@@ -290,6 +294,7 @@ function WebGLRenderer( parameters ) {
 		}
 
 		extensions.get( 'OES_texture_float_linear' );
+		extensions.get( 'EXT_color_buffer_half_float' );
 
 		utils = new WebGLUtils( _gl, extensions, capabilities );
 


### PR DESCRIPTION
WebGLRenderer now requests all the different floating point render target extensions from the GL context. On WebGL 2, float render targets are enabled by EXT_color_buffer_float, and EXT_color_buffer_half_float may provide half float render target support on both WebGL 1 and WebGL 2.

This contribution is funded by [Higharc](https://higharc.com).