### PR TITLE
KeyframeTrack: Fix typo in optimize().

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -363,7 +363,7 @@ Object.assign( KeyframeTrack.prototype, {
 
 			// remove adjacent keyframes scheduled at the same time
 
-			if ( time !== timeNext && ( i !== 1 || time !== time[ 0 ] ) ) {
+			if ( time !== timeNext && ( i !== 1 || time !== times[ 0 ] ) ) {
 
 				if ( ! smoothInterpolation ) {
 


### PR DESCRIPTION
Fixes what appears to be a typo in `track.optimize()`. I haven't run into a reproducible issue but accessing `time[0]` where `time` is a number does not seem correct.

Aside: The `optimize()` function currently only eliminates duplicate keyframes. Have we considered changing the implementation to remove keyframes that can be linearly interpolated from the prev/next keyframes? I think that could remove a lot more from animations that were 'baked' in software like Blender.