### PR TITLE
Examples: Add replacement for BufferGeometry.setFromObject().

### DIFF
--- a/examples/jsm/deprecated/Geometry.d.ts
+++ b/examples/jsm/deprecated/Geometry.d.ts
@@ -12,7 +12,8 @@ import {
 	Mesh,
 	Bone,
 	AnimationClip,
-	EventDispatcher
+	EventDispatcher,
+	Object3D
 } from '../../../src/Three';
 
 /**
@@ -254,6 +255,8 @@ export class Geometry extends EventDispatcher {
 	sortFacesByMaterialIndex(): void;
 
 	toBufferGeometry(): BufferGeometry;
+
+	static createBufferGeometryFromObject( object: Object3D ): BufferGeometry;
 
 	toJSON(): any;
 

--- a/examples/jsm/deprecated/Geometry.js
+++ b/examples/jsm/deprecated/Geometry.js
@@ -1491,6 +1491,50 @@ Geometry.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 } );
 
+Geometry.createBufferGeometryFromObject = function ( object ) {
+
+	let buffergeometry = new BufferGeometry();
+
+	const geometry = object.geometry;
+
+	if ( object.isPoints || object.isLine ) {
+
+		const positions = new Float32BufferAttribute( geometry.vertices.length * 3, 3 );
+		const colors = new Float32BufferAttribute( geometry.colors.length * 3, 3 );
+
+		buffergeometry.setAttribute( 'position', positions.copyVector3sArray( geometry.vertices ) );
+		buffergeometry.setAttribute( 'color', colors.copyColorsArray( geometry.colors ) );
+
+		if ( geometry.lineDistances && geometry.lineDistances.length === geometry.vertices.length ) {
+
+			const lineDistances = new Float32BufferAttribute( geometry.lineDistances.length, 1 );
+
+			buffergeometry.setAttribute( 'lineDistance', lineDistances.copyArray( geometry.lineDistances ) );
+
+		}
+
+		if ( geometry.boundingSphere !== null ) {
+
+			buffergeometry.boundingSphere = geometry.boundingSphere.clone();
+
+		}
+
+		if ( geometry.boundingBox !== null ) {
+
+			buffergeometry.boundingBox = geometry.boundingBox.clone();
+
+		}
+
+	} else if ( object.isMesh ) {
+
+		buffergeometry = geometry.toBufferGeometry();
+
+	}
+
+	return buffergeometry;
+
+};
+
 class DirectGeometry {
 
 	constructor() {


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/21031#issuecomment-759342916

**Description**

Adds a new static method to `Geometry` so line and point geometries can be converted to `BufferGeometry`, too.