### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -628,9 +628,9 @@ THREE.BufferGeometryUtils = {
 	 */
 	computeMorphedAttributes: function ( object ) {
 
-		if ( ! object.geometry.isBufferGeometry ) {
+		if ( object.geometry.isBufferGeometry !== true ) {
 
-			console.error( 'Geometry is not a BufferGeometry' );
+			console.error( 'THREE.BufferGeometryUtils: Geometry is not of type THREE.BufferGeometry.' );
 			return null;
 
 		}

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -10,7 +10,6 @@ import {
 var _v1 = new Vector3();
 var _v2 = new Vector3();
 var _normalMatrix = new Matrix3();
-var _keys = [ 'a', 'b', 'c' ];
 
 function VertexNormalsHelper( object, size, hex ) {
 
@@ -28,7 +27,8 @@ function VertexNormalsHelper( object, size, hex ) {
 
 	if ( objGeometry && objGeometry.isGeometry ) {
 
-		nNormals = objGeometry.faces.length * 3;
+		console.error( 'THREE.VertexNormalsHelper no longer supports Geometry. Use BufferGeometry instead.' );
+		return;
 
 	} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 
@@ -75,37 +75,8 @@ VertexNormalsHelper.prototype.update = function () {
 
 	if ( objGeometry && objGeometry.isGeometry ) {
 
-		var vertices = objGeometry.vertices;
-
-		var faces = objGeometry.faces;
-
-		var idx = 0;
-
-		for ( var i = 0, l = faces.length; i < l; i ++ ) {
-
-			var face = faces[ i ];
-
-			for ( var j = 0, jl = face.vertexNormals.length; j < jl; j ++ ) {
-
-				var vertex = vertices[ face[ _keys[ j ] ] ];
-
-				var normal = face.vertexNormals[ j ];
-
-				_v1.copy( vertex ).applyMatrix4( matrixWorld );
-
-				_v2.copy( normal ).applyMatrix3( _normalMatrix ).normalize().multiplyScalar( this.size ).add( _v1 );
-
-				position.setXYZ( idx, _v1.x, _v1.y, _v1.z );
-
-				idx = idx + 1;
-
-				position.setXYZ( idx, _v2.x, _v2.y, _v2.z );
-
-				idx = idx + 1;
-
-			}
-
-		}
+		console.error( 'THREE.VertexNormalsHelper no longer supports Geometry. Use BufferGeometry instead.' );
+		return;
 
 	} else if ( objGeometry && objGeometry.isBufferGeometry ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

- Minor clean up in `BufferGeometryUtils`.
- Stop support for `Geometry` in `VertexNormalsHelper`.
