### PR TITLE
Add MathUtils.pingpong()

### DIFF
--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -64,6 +64,13 @@
 		Linear mapping of [page:Float x] from range [[page:Float a1], [page:Float a2]] to range [[page:Float b1], [page:Float b2]].
 		</p>
 
+		<h3>[method:Float pingPong]( [param:Float t], [param:Float length] )</h3>
+		<p>
+		[page:Float x] — The value to pingPong.<br />
+		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />
+
+		Returns a value that alternates between 0 and [param:Float length].</p>
+
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</p>
 

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -64,7 +64,7 @@
 		Linear mapping of [page:Float x] from range [[page:Float a1], [page:Float a2]] to range [[page:Float b1], [page:Float b2]].
 		</p>
 
-		<h3>[method:Float pingPong]( [param:Float t], [param:Float length] )</h3>
+		<h3>[method:Float pingPong]( [param:Float x], [param:Float length] )</h3>
 		<p>
 		[page:Float x] — The value to pingPong.<br />
 		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -64,10 +64,10 @@
 		Linear mapping of [page:Float x] from range [[page:Float a1], [page:Float a2]] to range [[page:Float b1], [page:Float b2]].
 		</p>
 
-		<h3>[method:Float pingPong]( [param:Float x], [param:Float length] )</h3>
+		<h3>[method:Float pingpong]( [param:Float x], [param:Float length] )</h3>
 		<p>
-		[page:Float x] — The value to pingPong.<br />
-		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />
+		[page:Float x] — The value to pingpong.<br />
+		[page:Float length] — The positive value the function will pingpong to. Default is 1.<br /><br />
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
 

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -61,10 +61,10 @@
 		x从范围[[page:Float a1], [page:Float a2]] 到范围[[page:Float b1], [page:Float b2]]的线性映射。
 		</p>
 
-		<h3>[method:Float pingPong]( [param:Float x], [param:Float length] )</h3>
+		<h3>[method:Float pingpong]( [param:Float x], [param:Float length] )</h3>
 		<p>
-		[page:Float x] — The value to pingPong.<br />
-		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />
+		[page:Float x] — The value to pingpong.<br />
+		[page:Float length] — The positive value the function will pingpong to. Default is 1.<br /><br />
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
 

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -61,7 +61,7 @@
 		x从范围[[page:Float a1], [page:Float a2]] 到范围[[page:Float b1], [page:Float b2]]的线性映射。
 		</p>
 
-		<h3>[method:Float pingPong]( [param:Float t], [param:Float length] )</h3>
+		<h3>[method:Float pingPong]( [param:Float x], [param:Float length] )</h3>
 		<p>
 		[page:Float x] — The value to pingPong.<br />
 		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -61,6 +61,13 @@
 		x从范围[[page:Float a1], [page:Float a2]] 到范围[[page:Float b1], [page:Float b2]]的线性映射。
 		</p>
 
+		<h3>[method:Float pingPong]( [param:Float t], [param:Float length] )</h3>
+		<p>
+		[page:Float x] — The value to pingPong.<br />
+		[page:Float length] — The positive value the function will pingPong to. Default is 1.<br /><br />
+
+		Returns a value that alternates between 0 and [param:Float length].</p>
+
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>返回大于等于 [page:Number n] 的2的最小次幂。</p>
 

--- a/src/math/MathUtils.d.ts
+++ b/src/math/MathUtils.d.ts
@@ -88,11 +88,11 @@ export namespace MathUtils {
 	/**
 	 * Returns a value that alternates between 0 and length.
 	 *
-	 * @param x The value to pingPong.
-	 * @param length The positive value the function will pingPong to. Default is 1.
+	 * @param x The value to pingpong.
+	 * @param length The positive value the function will pingpong to. Default is 1.
 	 * @return {number}
 	 */
-	export function pingPong( x: number, length?: number ): number;
+	export function pingpong( x: number, length?: number ): number;
 
 	/**
 	 * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}

--- a/src/math/MathUtils.d.ts
+++ b/src/math/MathUtils.d.ts
@@ -86,6 +86,15 @@ export namespace MathUtils {
 	export function lerp( x: number, y: number, t: number ): number;
 
 	/**
+	 * Returns a value that alternates between 0 and length.
+	 *
+	 * @param x The value to pingPong.
+	 * @param length The positive value the function will pingPong to. Default is 1.
+	 * @return {number}
+	 */
+	export function pingPong( x: number, length?: number ): number;
+
+	/**
 	 * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}
 	 */
 	export function nearestPowerOfTwo( value: number ): number;

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -62,6 +62,14 @@ const MathUtils = {
 
 	},
 
+	// https://www.desmos.com/calculator/vcsjnyz7x4
+
+	pingPong: function ( x, length = 1 ) {
+
+		return length - Math.abs( x % ( length * 2 ) - length );
+
+	},
+
 	// http://en.wikipedia.org/wiki/Smoothstep
 
 	smoothstep: function ( x, min, max ) {

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -66,7 +66,7 @@ const MathUtils = {
 
 	pingPong: function ( x, length = 1 ) {
 
-		return length - Math.abs( x % ( length * 2 ) - length );
+		return length - Math.abs( MathUtils.euclideanModulo( x, length * 2 ) - length );
 
 	},
 

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -64,7 +64,7 @@ const MathUtils = {
 
 	// https://www.desmos.com/calculator/vcsjnyz7x4
 
-	pingPong: function ( x, length = 1 ) {
+	pingpong: function ( x, length = 1 ) {
 
 		return length - Math.abs( MathUtils.euclideanModulo( x, length * 2 ) - length );
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -153,11 +153,11 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 
-		QUnit.test( "pingPong", ( assert ) => {
+		QUnit.test( "pingpong", ( assert ) => {
 
-			assert.strictEqual( MathUtils.pingPong( 2.5 ), 0.5, "Value at 2.5 is 0.5" );
-			assert.strictEqual( MathUtils.pingPong( 2.5, 2 ), 1.5, "Value at 2.5 with length of 2 is 1.5" );
-			assert.strictEqual( MathUtils.pingPong( - 1.5 ), 0.5, "Value at -1.5 is 0.5" );
+			assert.strictEqual( MathUtils.pingpong( 2.5 ), 0.5, "Value at 2.5 is 0.5" );
+			assert.strictEqual( MathUtils.pingpong( 2.5, 2 ), 1.5, "Value at 2.5 with length of 2 is 1.5" );
+			assert.strictEqual( MathUtils.pingpong( - 1.5 ), 0.5, "Value at -1.5 is 0.5" );
 
 		} );
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -157,7 +157,7 @@ export default QUnit.module( 'Maths', () => {
 
 			assert.strictEqual( MathUtils.pingPong( 2.5 ), 0.5, "Value at 2.5 is 0.5" );
 			assert.strictEqual( MathUtils.pingPong( 2.5, 2 ), 1.5, "Value at 2.5 with length of 2 is 1.5" );
-			assert.strictEqual( MathUtils.pingPong( - 2 ), 0, "Value at -2 is 0" );
+			assert.strictEqual( MathUtils.pingPong( - 1.5 ), 0.5, "Value at -1.5 is 0.5" );
 
 		} );
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -152,6 +152,15 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+
+		QUnit.test( "pingPong", ( assert ) => {
+
+			assert.strictEqual( MathUtils.pingPong( 2.5 ), 0.5, "Value at 2.5 is 0.5" );
+			assert.strictEqual( MathUtils.pingPong( 2.5, 2 ), 1.5, "Value at 2.5 with length of 2 is 1.5" );
+			assert.strictEqual( MathUtils.pingPong( - 2 ), 0, "Value at -2 is 0" );
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
Related issue: -

**Description**

One function I find useful is the [pingPong](https://docs.unity3d.com/ScriptReference/Mathf.PingPong.html) function. It alternates between two values, you can use it to alternate between two colors for example.
It also can be combined with the in-out eases from [Robert Penner's Easing Functions](http://robertpenner.com/easing/) to create a differently shaped alternating function.

Here is how the function looks like:
https://www.desmos.com/calculator/vcsjnyz7x4

[![image](https://user-images.githubusercontent.com/7217420/104728444-317c9c80-5737-11eb-8dc6-494b00eb4202.png)](https://www.desmos.com/calculator/vcsjnyz7x4)
