### PR TITLE
README: Fixed GB punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If everything went well, you should see [this](https://jsfiddle.net/zdjankqw/).
 
 ### Cloning this repository ###
 
-Cloning the repo with all its history results in a ~2GB download. If you don't need the whole history you can use the `depth` parameter to significantly reduce download size.
+Cloning the repo with all its history results in a ~2 GB download. If you don't need the whole history you can use the `depth` parameter to significantly reduce download size.
 
 ```sh
 git clone --depth=1 https://github.com/mrdoob/three.js.git


### PR DESCRIPTION
**Description**
Insert a space between the numerical value and the unit symbol: “2 GB”