### PR TITLE
Add MathUtils.damp() for framerate independent lerping

### DIFF
--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -71,6 +71,17 @@
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
 
+		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
+		<p>
+		[page:Float x] - Current point. <br />
+		[page:Float y] - Target point. <br />
+		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
+		[page:Float dt] - Delta time in seconds.<br><br />
+
+		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
+		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame Rate Independent Damping Using Lerp].
+		</p>
+
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</p>
 

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -53,6 +53,17 @@
 		and [page:Float t] = 1 will return [page:Float y].
 		</p>
 
+		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
+		<p>
+		[page:Float x] - Current point. <br />
+		[page:Float y] - Target point. <br />
+		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
+		[page:Float dt] - Delta time in seconds.<br><br />
+
+		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
+		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame rate independent damping using lerp].
+		</p>
+
 		<h3>[method:Float mapLinear]( [param:Float x], [param:Float a1], [param:Float a2], [param:Float b1], [param:Float b2] )</h3>
 		<p>
 		[page:Float x] — Value to be mapped.<br />
@@ -70,17 +81,6 @@
 		[page:Float length] — The positive value the function will pingpong to. Default is 1.<br /><br />
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
-
-		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
-		<p>
-		[page:Float x] - Current point. <br />
-		[page:Float y] - Target point. <br />
-		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
-		[page:Float dt] - Delta time in seconds.<br><br />
-
-		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
-		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame Rate Independent Damping Using Lerp].
-		</p>
 
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>Returns the smallest power of 2 that is greater than or equal to [page:Number n].</p>

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -50,6 +50,17 @@
 		如果 [page:Float t] = 1 将会返回 [page:Float y].
 		</p>
 
+		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
+		<p>
+		[page:Float x] - Current point. <br />
+		[page:Float y] - Target point. <br />
+		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
+		[page:Float dt] - Delta time in seconds.<br><br />
+
+		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
+		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame rate independent damping using lerp].
+		</p>
+
 		<h3>[method:Float mapLinear]( [param:Float x], [param:Float a1], [param:Float a2], [param:Float b1], [param:Float b2] )</h3>
 		<p>
 		[page:Float x] — 用于映射的值。<br />
@@ -67,17 +78,6 @@
 		[page:Float length] — The positive value the function will pingpong to. Default is 1.<br /><br />
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
-
-		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
-		<p>
-		[page:Float x] - Current point. <br />
-		[page:Float y] - Target point. <br />
-		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
-		[page:Float dt] - Delta time in seconds.<br><br />
-
-		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
-		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame Rate Independent Damping Using Lerp].
-		</p>
 
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>返回大于等于 [page:Number n] 的2的最小次幂。</p>

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -68,6 +68,17 @@
 
 		Returns a value that alternates between 0 and [param:Float length].</p>
 
+		<h3>[method:Float damp]( [param:Float x], [param:Float y], [param:Float lambda], [param:Float dt] )</h3>
+		<p>
+		[page:Float x] - Current point. <br />
+		[page:Float y] - Target point. <br />
+		[page:Float lambda] - A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual. <br />
+		[page:Float dt] - Delta time in seconds.<br><br />
+
+		Smoothly interpolate a number from [page:Float x] toward [page:Float y] in a spring-like manner using the [page:Float dt] to maintain frame rate independent movement.
+		For details, see [link:http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/ Frame Rate Independent Damping Using Lerp].
+		</p>
+
 		<h3>[method:Integer ceilPowerOfTwo]( [param:Number n] )</h3>
 		<p>返回大于等于 [page:Number n] 的2的最小次幂。</p>
 

--- a/src/math/MathUtils.d.ts
+++ b/src/math/MathUtils.d.ts
@@ -95,6 +95,18 @@ export namespace MathUtils {
 	export function pingpong( x: number, length?: number ): number;
 
 	/**
+	 * Smoothly interpolate a number from x toward y in a spring-like
+	 * manner using the dt to maintain frame rate independent movement.
+	 *
+	 * @param x Current point.
+	 * @param y Target point.
+	 * @param lambda A higher lambda value will make the movement more sudden, and a lower value will make the movement more gradual.
+	 * @param dt Delta time in seconds.
+	 * @return {number}
+	 */
+	export function damp( x: number, y: number, lambda: number, dt: number ): number;
+
+	/**
 	 * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}
 	 */
 	export function nearestPowerOfTwo( value: number ): number;

--- a/src/math/MathUtils.d.ts
+++ b/src/math/MathUtils.d.ts
@@ -86,15 +86,6 @@ export namespace MathUtils {
 	export function lerp( x: number, y: number, t: number ): number;
 
 	/**
-	 * Returns a value that alternates between 0 and length.
-	 *
-	 * @param x The value to pingpong.
-	 * @param length The positive value the function will pingpong to. Default is 1.
-	 * @return {number}
-	 */
-	export function pingpong( x: number, length?: number ): number;
-
-	/**
 	 * Smoothly interpolate a number from x toward y in a spring-like
 	 * manner using the dt to maintain frame rate independent movement.
 	 *
@@ -105,6 +96,15 @@ export namespace MathUtils {
 	 * @return {number}
 	 */
 	export function damp( x: number, y: number, lambda: number, dt: number ): number;
+
+	/**
+	 * Returns a value that alternates between 0 and length.
+	 *
+	 * @param x The value to pingpong.
+	 * @param length The positive value the function will pingpong to. Default is 1.
+	 * @return {number}
+	 */
+	export function pingpong( x: number, length?: number ): number;
 
 	/**
 	 * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -70,6 +70,14 @@ const MathUtils = {
 
 	},
 
+	// http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
+
+	damp: function ( x, y, lambda, dt ) {
+
+		return MathUtils.lerp( x, y, 1 - Math.exp( - lambda * dt ) );
+
+	},
+
 	// http://en.wikipedia.org/wiki/Smoothstep
 
 	smoothstep: function ( x, min, max ) {

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -62,19 +62,19 @@ const MathUtils = {
 
 	},
 
-	// https://www.desmos.com/calculator/vcsjnyz7x4
-
-	pingpong: function ( x, length = 1 ) {
-
-		return length - Math.abs( MathUtils.euclideanModulo( x, length * 2 ) - length );
-
-	},
-
 	// http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
 
 	damp: function ( x, y, lambda, dt ) {
 
 		return MathUtils.lerp( x, y, 1 - Math.exp( - lambda * dt ) );
+
+	},
+
+	// https://www.desmos.com/calculator/vcsjnyz7x4
+
+	pingpong: function ( x, length = 1 ) {
+
+		return length - Math.abs( MathUtils.euclideanModulo( x, length * 2 ) - length );
 
 	},
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -55,6 +55,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "damp", ( assert ) => {
+
+			assert.strictEqual( MathUtils.damp( 1, 2, 0, 0.016 ), 1, "Value equal to lower boundary" );
+			assert.strictEqual( MathUtils.damp( 1, 2, 10, 0.016 ), 1.1478562110337887, "Value within range" );
+
+		} );
+
 		QUnit.test( "smoothstep", ( assert ) => {
 
 			assert.strictEqual( MathUtils.smoothstep( - 1, 0, 2 ), 0, "Value lower than minimum" );


### PR DESCRIPTION
Related issue: -

**Description**

Another useful function is the damp function, which lets you interpolate in a spring-like manner, while being framerate independent.

The implementation comes from this article: [Frame rate independent damping using lerp](http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/), where basically the author finds a better way of doing `lerp(x, y, value * dt)`.

<img src="https://user-images.githubusercontent.com/7217420/104856911-59c1f200-5915-11eb-92de-cc44196f2a13.png" width="500" />


Unity also has this function nowadays, it's called [SmoothDamp](https://docs.unity3d.com/ScriptReference/Mathf.SmoothDamp.html), however [its implementation is a bit more complex](https://github.com/Unity-Technologies/UnityCsReference/blob/61f92bd79ae862c4465d35270f9d1d57befd1761/Runtime/Export/Math/Mathf.cs#L302-L331).

