### PR TITLE
XRHandModelFactory: Added types for XRHandModel and its methods.

### DIFF
--- a/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -3,8 +3,6 @@ import {
 	Object3D,
 } from '../../../src/Three';
 
-import { GLTFLoader } from '../loaders/GLTFLoader';
-
 export class XRHandModel extends Object3D {
 
 	constructor();
@@ -15,14 +13,13 @@ export class XRHandModel extends Object3D {
 
 export class XRHandModelFactory {
 
-	constructor( gltfLoader?: GLTFLoader );
-	gltfLoader: GLTFLoader | null;
+	constructor();
 	path: string;
 
 	createHandModel(
 		controller: Group,
 		profile?: 'spheres' | 'boxes' | 'oculus',
-		options?: { primitive: 'sphere' | 'box' }
+		options?: { model?: 'lowpoly', primitive?: 'sphere' | 'box' }
 	): XRHandModel;
 
 }

--- a/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -13,16 +13,16 @@ export class XRHandModel extends Object3D {
 
 }
 
-export class XRControllerModelFactory {
+export class XRHandModelFactory {
 
 	constructor( gltfLoader?: GLTFLoader );
 	gltfLoader: GLTFLoader | null;
 	path: string;
 
 	createHandModel(
-    controller: Group,
-    profile?: 'spheres' | 'boxes' | 'oculus',
-    options?: { primitive: 'sphere' | 'box' }
-  ): XRHandModel;
+		controller: Group,
+		profile?: 'spheres' | 'boxes' | 'oculus',
+		options?: { primitive: 'sphere' | 'box' }
+	): XRHandModel;
 
 }

--- a/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -1,0 +1,28 @@
+import {
+	Group,
+	Object3D,
+} from '../../../src/Three';
+
+import { GLTFLoader } from '../loaders/GLTFLoader';
+
+export class XRHandModel extends Object3D {
+
+	constructor();
+
+	motionController: any;
+
+}
+
+export class XRControllerModelFactory {
+
+	constructor( gltfLoader?: GLTFLoader );
+	gltfLoader: GLTFLoader | null;
+	path: string;
+
+	createHandModel(
+    controller: Group,
+    profile?: 'spheres' | 'boxes' | 'oculus',
+    options?: { primitive: 'sphere' | 'box' }
+  ): XRHandModel;
+
+}


### PR DESCRIPTION
Related issue: -

**Description**

This pull request adds the missing types for [XRHandModelFactory](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/webxr/XRHandModelFactory.js) including any profiles and options I could find hidden in [XRHandOculusMeshModel](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/webxr/XRHandOculusMeshModel.js) and [XRHandPrimitiveModel](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/webxr/XRHandPrimitiveModel.js).
