### PR TITLE
Docs: Update import instructions in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The aim of the project is to create an easy to use, lightweight, 3D library with
 This code creates a scene, a camera, and a geometric cube, and it adds the cube to the scene. It then creates a `WebGL` renderer for the scene and camera, and it adds that viewport to the `document.body` element. Finally, it animates the cube within the scene for the camera.
 
 ```javascript
-import * as THREE from './js/three.module.js';
+import * as THREE from 'three';
 
 let camera, scene, renderer;
 let geometry, material, mesh;


### PR DESCRIPTION
The import instructions from README.md are shown on the npm package homepage (https://www.npmjs.com/package/three) and may create confusion about how to import the library. I think it's best to advise imports from the `three` namespace — any workflow involving copying files into project folders will be messy, running into issues like duplicate imports.