### PR TITLE
Examples: Fix missing target vectors for .getWorldPosition()

### DIFF
--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -27,6 +27,9 @@
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;
 
+			const tmpVector1 = new THREE.Vector3();
+			const tmpVector2 = new THREE.Vector3();
+
 			let controls;
 
 			let grabbing = false;
@@ -205,7 +208,7 @@
 				for ( let i = 0; i < spheres.length; i ++ ) {
 
 					const sphere = spheres[ i ];
-					const distance = indexTip.getWorldPosition().distanceTo( sphere.getWorldPosition() );
+					const distance = indexTip.getWorldPosition( tmpVector1 ).distanceTo( sphere.getWorldPosition( tmpVector2 ) );
 
 					if ( distance < sphere.geometry.boundingSphere.radius * sphere.scale.x ) {
 


### PR DESCRIPTION
This PR fixes missing target vectors for `.getWorldPosition()` in `webxr_vr_handinput_cubes.html`.

This problem is found with the WebXR Emulator Extension https://twitter.com/superhoge/status/1349560469837672452