### PR TITLE
CanvasTexture can receive an imageBitmap (used in workers)

### DIFF
--- a/src/textures/CanvasTexture.d.ts
+++ b/src/textures/CanvasTexture.d.ts
@@ -22,7 +22,7 @@ export class CanvasTexture extends Texture {
 	 * @param [encoding=THREE.LinearEncoding]
 	 */
 	constructor(
-		canvas: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+		canvas: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap,
 		mapping?: Mapping,
 		wrapS?: Wrapping,
 		wrapT?: Wrapping,


### PR DESCRIPTION
A `CanvasTexture` can also receive an `ImageBitmap`, and this is how textures are loaded in worker threads.

The supported types should include an `ImageBitmap`.

Related discussion: https://discourse.threejs.org/t/offscreen-canvas-with-textures/11678

This example implements a CanvasTexture using an ImageBitmap:
https://github.com/mrdoob/three.js/blob/e9f31ad154d2cc314f37b5a8da4bdddd4f1bde7e/examples/js/offscreen/scene.js#L17-L21

