### PR TITLE
GLTFLoader: Respect file contents length defined in header

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -899,10 +899,11 @@ THREE.GLTFLoader = ( function () {
 
 		}
 
+		var chunkContentsLength = this.header.length - BINARY_EXTENSION_HEADER_LENGTH;
 		var chunkView = new DataView( data, BINARY_EXTENSION_HEADER_LENGTH );
 		var chunkIndex = 0;
 
-		while ( chunkIndex < chunkView.byteLength ) {
+		while ( chunkIndex < chunkContentsLength ) {
 
 			var chunkLength = chunkView.getUint32( chunkIndex, true );
 			chunkIndex += 4;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -964,10 +964,11 @@ var GLTFLoader = ( function () {
 
 		}
 
+		var chunkContentsLength = this.header.length - BINARY_EXTENSION_HEADER_LENGTH;
 		var chunkView = new DataView( data, BINARY_EXTENSION_HEADER_LENGTH );
 		var chunkIndex = 0;
 
-		while ( chunkIndex < chunkView.byteLength ) {
+		while ( chunkIndex < chunkContentsLength ) {
 
 			var chunkLength = chunkView.getUint32( chunkIndex, true );
 			chunkIndex += 4;


### PR DESCRIPTION
Related issue: --

**Description**

Right now GLTFLoader assumes the entire buffer makes up the contents of the file when parsing chunks in processing a binary GLTF but that can cause problems when the length defined in the GLTF header is different that the remaining size of the buffer.

I found this when helping a user in https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/153 load a 3d tile set and found that the B3DM files ([spec](https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel)), which seem to define the GLTF buffer as being 4 bytes longer than the inner GLTF header does, were failing to load. In the referenced issue the B3DM files are further packed into a CMPT file ([spec](https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Composite)), as well.

The files load correctly without error in Cesium and it parses them the same way resulting in the 4 extra bytes in the buffer. However when parsing the file contents Cesium uses the header length to iterate over the buffer chunks rather than the remaining array length, which seems like a more correct interpretation of the spec:

https://github.com/CesiumGS/cesium/blob/master/Source/ThirdParty/GltfPipeline/parseGlb.js#L83-L87

cc @donmccurdy 