### PR TITLE
Don't auto-split SVG floats before a -.

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -975,7 +975,7 @@ THREE.SVGLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype
 
 		function parseFloats( string ) {
 
-			var array = string.split( /[\s,]+|(?=\s?[+\-])/ );
+			var array = string.split( /[\s,]+/ );
 
 			for ( var i = 0; i < array.length; i ++ ) {
 

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -987,7 +987,7 @@ SVGLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		function parseFloats( string ) {
 
-			var array = string.split( /[\s,]+|(?=\s?[+\-])/ );
+			var array = string.split( /[\s,]+/ );
 
 			for ( var i = 0; i < array.length; i ++ ) {
 


### PR DESCRIPTION
This is necessary to support numbers like 1e-6 with a - in the middle,
which happens in SVG produced by Inkscape.

**Description**

When SVGLoader loads an SVG file with a number like 1e-6 in a path, it parses that path incorrectly resulting in broken behavior. Because standard SVG-editing tools like Inkscape produce SVGs that contain numbers of this form, it can be easy to inadvertently produce SVGs that have this issue.

The attached [broken.svg.zip](https://github.com/mrdoob/three.js/files/5847293/broken.svg.zip) contains a file that is handled correctly after this change and not before it.


