### PR TITLE
Docs: Clarify onBeforeRender() and onAfterRender().

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -105,16 +105,26 @@
 
 		<h3>[property:Function onAfterRender]</h3>
 		<p>
-		An optional callback that is executed immediately after the Object3D is rendered.
+		An optional callback that is executed immediately after a 3D object is rendered.
 		This function is called with the following parameters: renderer, scene, camera, geometry,
 		material, group.
+		</p>
+		<p>
+		Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+		appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
+		Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
 		</p>
 
 		<h3>[property:Function onBeforeRender]</h3>
 		<p>
-		An optional callback that is executed immediately before the Object3D is rendered.
+		An optional callback that is executed immediately before a 3D object is rendered.
 		This function is called with the following parameters: renderer, scene, camera, geometry,
 		material, group.
+		</p>
+		<p>
+		Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+		appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
+		Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
 		</p>
 
 		<h3>[property:Object3D parent]</h3>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -104,11 +104,21 @@
 		一个可选的回调函数，在Object3D渲染之后直接执行。
 		使用以下参数来调用此函数：renderer，scene，camera，geometry，material，group。
 	</p>
+	<p>
+	Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+	appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
+	Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
+	</p>
 
 	<h3>[property:Function onBeforeRender]</h3>
 	<p>
 		一个可选的回调函数，在Object3D渲染之前直接执行。
 		使用以下参数来调用此函数：renderer，scene，camera，geometry，material，group。
+	</p>
+	<p>
+	Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+	appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
+	Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
 	</p>
 
 	<h3>[property:Object3D parent]</h3>


### PR DESCRIPTION
Related issue: Fixed #11306.

**Description**

This PR clarifies that only _renderable_ objects can fire `onBeforeRender()` and `onAfterRender()`.