### PR TITLE
Examples: remove third param from addEventListener calls

### DIFF
--- a/examples/js/controls/DeviceOrientationControls.js
+++ b/examples/js/controls/DeviceOrientationControls.js
@@ -68,8 +68,8 @@ THREE.DeviceOrientationControls = function ( object ) {
 
 				if ( response == 'granted' ) {
 
-					window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-					window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+					window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+					window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 				}
 
@@ -81,8 +81,8 @@ THREE.DeviceOrientationControls = function ( object ) {
 
 		} else {
 
-			window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-			window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+			window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+			window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 		}
 
@@ -92,8 +92,8 @@ THREE.DeviceOrientationControls = function ( object ) {
 
 	this.disconnect = function () {
 
-		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 		scope.enabled = false;
 

--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -18,25 +18,25 @@ THREE.DragControls = function ( _objects, _camera, _domElement ) {
 
 	function activate() {
 
-		_domElement.addEventListener( 'pointermove', onPointerMove, false );
-		_domElement.addEventListener( 'pointerdown', onPointerDown, false );
-		_domElement.addEventListener( 'pointerup', onPointerCancel, false );
-		_domElement.addEventListener( 'pointerleave', onPointerCancel, false );
-		_domElement.addEventListener( 'touchmove', onTouchMove, false );
-		_domElement.addEventListener( 'touchstart', onTouchStart, false );
-		_domElement.addEventListener( 'touchend', onTouchEnd, false );
+		_domElement.addEventListener( 'pointermove', onPointerMove );
+		_domElement.addEventListener( 'pointerdown', onPointerDown );
+		_domElement.addEventListener( 'pointerup', onPointerCancel );
+		_domElement.addEventListener( 'pointerleave', onPointerCancel );
+		_domElement.addEventListener( 'touchmove', onTouchMove );
+		_domElement.addEventListener( 'touchstart', onTouchStart );
+		_domElement.addEventListener( 'touchend', onTouchEnd );
 
 	}
 
 	function deactivate() {
 
-		_domElement.removeEventListener( 'pointermove', onPointerMove, false );
-		_domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		_domElement.removeEventListener( 'pointerup', onPointerCancel, false );
-		_domElement.removeEventListener( 'pointerleave', onPointerCancel, false );
-		_domElement.removeEventListener( 'touchmove', onTouchMove, false );
-		_domElement.removeEventListener( 'touchstart', onTouchStart, false );
-		_domElement.removeEventListener( 'touchend', onTouchEnd, false );
+		_domElement.removeEventListener( 'pointermove', onPointerMove );
+		_domElement.removeEventListener( 'pointerdown', onPointerDown );
+		_domElement.removeEventListener( 'pointerup', onPointerCancel );
+		_domElement.removeEventListener( 'pointerleave', onPointerCancel );
+		_domElement.removeEventListener( 'touchmove', onTouchMove );
+		_domElement.removeEventListener( 'touchstart', onTouchStart );
+		_domElement.removeEventListener( 'touchend', onTouchEnd );
 
 		_domElement.style.cursor = '';
 

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -293,13 +293,13 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
-		this.domElement.removeEventListener( 'mousedown', _onMouseDown, false );
-		this.domElement.removeEventListener( 'mousemove', _onMouseMove, false );
-		this.domElement.removeEventListener( 'mouseup', _onMouseUp, false );
+		this.domElement.removeEventListener( 'contextmenu', contextmenu );
+		this.domElement.removeEventListener( 'mousedown', _onMouseDown );
+		this.domElement.removeEventListener( 'mousemove', _onMouseMove );
+		this.domElement.removeEventListener( 'mouseup', _onMouseUp );
 
-		window.removeEventListener( 'keydown', _onKeyDown, false );
-		window.removeEventListener( 'keyup', _onKeyUp, false );
+		window.removeEventListener( 'keydown', _onKeyDown );
+		window.removeEventListener( 'keyup', _onKeyUp );
 
 	};
 
@@ -309,13 +309,13 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 	var _onKeyDown = bind( this, this.onKeyDown );
 	var _onKeyUp = bind( this, this.onKeyUp );
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
-	this.domElement.addEventListener( 'mousemove', _onMouseMove, false );
-	this.domElement.addEventListener( 'mousedown', _onMouseDown, false );
-	this.domElement.addEventListener( 'mouseup', _onMouseUp, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
+	this.domElement.addEventListener( 'mousemove', _onMouseMove );
+	this.domElement.addEventListener( 'mousedown', _onMouseDown );
+	this.domElement.addEventListener( 'mouseup', _onMouseUp );
 
-	window.addEventListener( 'keydown', _onKeyDown, false );
-	window.addEventListener( 'keyup', _onKeyUp, false );
+	window.addEventListener( 'keydown', _onKeyDown );
+	window.addEventListener( 'keyup', _onKeyUp );
 
 	function bind( scope, fn ) {
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -275,13 +275,13 @@ THREE.FlyControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
-		this.domElement.removeEventListener( 'mousedown', _mousedown, false );
-		this.domElement.removeEventListener( 'mousemove', _mousemove, false );
-		this.domElement.removeEventListener( 'mouseup', _mouseup, false );
+		this.domElement.removeEventListener( 'contextmenu', contextmenu );
+		this.domElement.removeEventListener( 'mousedown', _mousedown );
+		this.domElement.removeEventListener( 'mousemove', _mousemove );
+		this.domElement.removeEventListener( 'mouseup', _mouseup );
 
-		window.removeEventListener( 'keydown', _keydown, false );
-		window.removeEventListener( 'keyup', _keyup, false );
+		window.removeEventListener( 'keydown', _keydown );
+		window.removeEventListener( 'keyup', _keyup );
 
 	};
 
@@ -291,14 +291,14 @@ THREE.FlyControls = function ( object, domElement ) {
 	var _keydown = bind( this, this.keydown );
 	var _keyup = bind( this, this.keyup );
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
 
-	this.domElement.addEventListener( 'mousemove', _mousemove, false );
-	this.domElement.addEventListener( 'mousedown', _mousedown, false );
-	this.domElement.addEventListener( 'mouseup', _mouseup, false );
+	this.domElement.addEventListener( 'mousemove', _mousemove );
+	this.domElement.addEventListener( 'mousedown', _mousedown );
+	this.domElement.addEventListener( 'mouseup', _mouseup );
 
-	window.addEventListener( 'keydown', _keydown, false );
-	window.addEventListener( 'keyup', _keyup, false );
+	window.addEventListener( 'keydown', _keydown );
+	window.addEventListener( 'keyup', _keyup );
 
 	this.updateMovementVector();
 	this.updateRotationVector();

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -97,7 +97,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.listenToKeyEvents = function ( domElement ) {
 
-		domElement.addEventListener( 'keydown', onKeyDown, false );
+		domElement.addEventListener( 'keydown', onKeyDown );
 		this._domElementKeyEvents = domElement;
 
 	};
@@ -269,22 +269,22 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
+		scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
 
-		scope.domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		scope.domElement.removeEventListener( 'wheel', onMouseWheel, false );
+		scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+		scope.domElement.removeEventListener( 'wheel', onMouseWheel );
 
-		scope.domElement.removeEventListener( 'touchstart', onTouchStart, false );
-		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
-		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
+		scope.domElement.removeEventListener( 'touchstart', onTouchStart );
+		scope.domElement.removeEventListener( 'touchend', onTouchEnd );
+		scope.domElement.removeEventListener( 'touchmove', onTouchMove );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
 
 		if ( scope._domElementKeyEvents !== null ) {
 
-			scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown, false );
+			scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
 
 		}
 
@@ -924,8 +924,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( state !== STATE.NONE ) {
 
-			scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-			scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+			scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+			scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 			scope.dispatchEvent( startEvent );
 
@@ -971,8 +971,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	function onMouseUp( event ) {
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
 		if ( scope.enabled === false ) return;
 
@@ -1172,14 +1172,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	//
 
-	scope.domElement.addEventListener( 'contextmenu', onContextMenu, false );
+	scope.domElement.addEventListener( 'contextmenu', onContextMenu );
 
-	scope.domElement.addEventListener( 'pointerdown', onPointerDown, false );
-	scope.domElement.addEventListener( 'wheel', onMouseWheel, false );
+	scope.domElement.addEventListener( 'pointerdown', onPointerDown );
+	scope.domElement.addEventListener( 'wheel', onMouseWheel );
 
-	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
-	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
-	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+	scope.domElement.addEventListener( 'touchstart', onTouchStart );
+	scope.domElement.addEventListener( 'touchend', onTouchEnd );
+	scope.domElement.addEventListener( 'touchmove', onTouchMove );
 
 	// force an update at start
 

--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -77,17 +77,17 @@ THREE.PointerLockControls = function ( camera, domElement ) {
 
 	this.connect = function () {
 
-		scope.domElement.ownerDocument.addEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerlockChange, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerlockError, false );
+		scope.domElement.ownerDocument.addEventListener( 'mousemove', onMouseMove );
+		scope.domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerlockChange );
+		scope.domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerlockError );
 
 	};
 
 	this.disconnect = function () {
 
-		scope.domElement.ownerDocument.removeEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerlockchange', onPointerlockChange, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerlockerror', onPointerlockError, false );
+		scope.domElement.ownerDocument.removeEventListener( 'mousemove', onMouseMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerlockchange', onPointerlockChange );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerlockerror', onPointerlockError );
 
 	};
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -476,7 +476,7 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		_keyState = STATE.NONE;
 
-		window.addEventListener( 'keydown', keydown, false );
+		window.addEventListener( 'keydown', keydown );
 
 	}
 
@@ -527,8 +527,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		}
 
-		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 		scope.dispatchEvent( startEvent );
 
@@ -701,37 +701,37 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		scope.domElement.removeEventListener( 'contextmenu', contextmenu, false );
+		scope.domElement.removeEventListener( 'contextmenu', contextmenu );
 
-		scope.domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		scope.domElement.removeEventListener( 'wheel', mousewheel, false );
+		scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+		scope.domElement.removeEventListener( 'wheel', mousewheel );
 
-		scope.domElement.removeEventListener( 'touchstart', touchstart, false );
-		scope.domElement.removeEventListener( 'touchend', touchend, false );
-		scope.domElement.removeEventListener( 'touchmove', touchmove, false );
+		scope.domElement.removeEventListener( 'touchstart', touchstart );
+		scope.domElement.removeEventListener( 'touchend', touchend );
+		scope.domElement.removeEventListener( 'touchmove', touchmove );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
-		window.removeEventListener( 'keydown', keydown, false );
-		window.removeEventListener( 'keyup', keyup, false );
+		window.removeEventListener( 'keydown', keydown );
+		window.removeEventListener( 'keyup', keyup );
 
 	};
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
 
-	this.domElement.addEventListener( 'pointerdown', onPointerDown, false );
-	this.domElement.addEventListener( 'wheel', mousewheel, false );
+	this.domElement.addEventListener( 'pointerdown', onPointerDown );
+	this.domElement.addEventListener( 'wheel', mousewheel );
 
-	this.domElement.addEventListener( 'touchstart', touchstart, false );
-	this.domElement.addEventListener( 'touchend', touchend, false );
-	this.domElement.addEventListener( 'touchmove', touchmove, false );
+	this.domElement.addEventListener( 'touchstart', touchstart );
+	this.domElement.addEventListener( 'touchend', touchend );
+	this.domElement.addEventListener( 'touchmove', touchmove );
 
-	this.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-	this.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+	this.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+	this.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
-	window.addEventListener( 'keydown', keydown, false );
-	window.addEventListener( 'keyup', keyup, false );
+	window.addEventListener( 'keydown', keydown );
+	window.addEventListener( 'keyup', keyup );
 
 	this.handleResize();
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -123,9 +123,9 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 	{
 
-		domElement.addEventListener( 'pointerdown', onPointerDown, false );
-		domElement.addEventListener( 'pointermove', onPointerHover, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+		domElement.addEventListener( 'pointerdown', onPointerDown );
+		domElement.addEventListener( 'pointermove', onPointerHover );
+		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 	}
 
@@ -627,7 +627,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( ! scope.enabled ) return;
 
 		scope.domElement.style.touchAction = 'none'; // disable touch scroll
-		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
 
 		scope.pointerHover( getPointer( event ) );
 		scope.pointerDown( getPointer( event ) );
@@ -647,7 +647,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( ! scope.enabled ) return;
 
 		scope.domElement.style.touchAction = '';
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
 
 		scope.pointerUp( getPointer( event ) );
 

--- a/examples/js/interactive/SelectionHelper.js
+++ b/examples/js/interactive/SelectionHelper.js
@@ -19,7 +19,7 @@ THREE.SelectionHelper = ( function () {
 			this.isDown = true;
 			this.onSelectStart( event );
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 		this.renderer.domElement.addEventListener( 'pointermove', function ( event ) {
 
@@ -29,14 +29,14 @@ THREE.SelectionHelper = ( function () {
 
 			}
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 		this.renderer.domElement.addEventListener( 'pointerup', function ( event ) {
 
 			this.isDown = false;
 			this.onSelectOver( event );
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 	}
 

--- a/examples/jsm/controls/DeviceOrientationControls.js
+++ b/examples/jsm/controls/DeviceOrientationControls.js
@@ -76,8 +76,8 @@ var DeviceOrientationControls = function ( object ) {
 
 				if ( response == 'granted' ) {
 
-					window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-					window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+					window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+					window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 				}
 
@@ -89,8 +89,8 @@ var DeviceOrientationControls = function ( object ) {
 
 		} else {
 
-			window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-			window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+			window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+			window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 		}
 
@@ -100,8 +100,8 @@ var DeviceOrientationControls = function ( object ) {
 
 	this.disconnect = function () {
 
-		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
-		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+		window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent );
+		window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent );
 
 		scope.enabled = false;
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -27,25 +27,25 @@ var DragControls = function ( _objects, _camera, _domElement ) {
 
 	function activate() {
 
-		_domElement.addEventListener( 'pointermove', onPointerMove, false );
-		_domElement.addEventListener( 'pointerdown', onPointerDown, false );
-		_domElement.addEventListener( 'pointerup', onPointerCancel, false );
-		_domElement.addEventListener( 'pointerleave', onPointerCancel, false );
-		_domElement.addEventListener( 'touchmove', onTouchMove, false );
-		_domElement.addEventListener( 'touchstart', onTouchStart, false );
-		_domElement.addEventListener( 'touchend', onTouchEnd, false );
+		_domElement.addEventListener( 'pointermove', onPointerMove );
+		_domElement.addEventListener( 'pointerdown', onPointerDown );
+		_domElement.addEventListener( 'pointerup', onPointerCancel );
+		_domElement.addEventListener( 'pointerleave', onPointerCancel );
+		_domElement.addEventListener( 'touchmove', onTouchMove );
+		_domElement.addEventListener( 'touchstart', onTouchStart );
+		_domElement.addEventListener( 'touchend', onTouchEnd );
 
 	}
 
 	function deactivate() {
 
-		_domElement.removeEventListener( 'pointermove', onPointerMove, false );
-		_domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		_domElement.removeEventListener( 'pointerup', onPointerCancel, false );
-		_domElement.removeEventListener( 'pointerleave', onPointerCancel, false );
-		_domElement.removeEventListener( 'touchmove', onTouchMove, false );
-		_domElement.removeEventListener( 'touchstart', onTouchStart, false );
-		_domElement.removeEventListener( 'touchend', onTouchEnd, false );
+		_domElement.removeEventListener( 'pointermove', onPointerMove );
+		_domElement.removeEventListener( 'pointerdown', onPointerDown );
+		_domElement.removeEventListener( 'pointerup', onPointerCancel );
+		_domElement.removeEventListener( 'pointerleave', onPointerCancel );
+		_domElement.removeEventListener( 'touchmove', onTouchMove );
+		_domElement.removeEventListener( 'touchstart', onTouchStart );
+		_domElement.removeEventListener( 'touchend', onTouchEnd );
 
 		_domElement.style.cursor = '';
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -299,13 +299,13 @@ var FirstPersonControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
-		this.domElement.removeEventListener( 'mousedown', _onMouseDown, false );
-		this.domElement.removeEventListener( 'mousemove', _onMouseMove, false );
-		this.domElement.removeEventListener( 'mouseup', _onMouseUp, false );
+		this.domElement.removeEventListener( 'contextmenu', contextmenu );
+		this.domElement.removeEventListener( 'mousedown', _onMouseDown );
+		this.domElement.removeEventListener( 'mousemove', _onMouseMove );
+		this.domElement.removeEventListener( 'mouseup', _onMouseUp );
 
-		window.removeEventListener( 'keydown', _onKeyDown, false );
-		window.removeEventListener( 'keyup', _onKeyUp, false );
+		window.removeEventListener( 'keydown', _onKeyDown );
+		window.removeEventListener( 'keyup', _onKeyUp );
 
 	};
 
@@ -315,13 +315,13 @@ var FirstPersonControls = function ( object, domElement ) {
 	var _onKeyDown = bind( this, this.onKeyDown );
 	var _onKeyUp = bind( this, this.onKeyUp );
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
-	this.domElement.addEventListener( 'mousemove', _onMouseMove, false );
-	this.domElement.addEventListener( 'mousedown', _onMouseDown, false );
-	this.domElement.addEventListener( 'mouseup', _onMouseUp, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
+	this.domElement.addEventListener( 'mousemove', _onMouseMove );
+	this.domElement.addEventListener( 'mousedown', _onMouseDown );
+	this.domElement.addEventListener( 'mouseup', _onMouseUp );
 
-	window.addEventListener( 'keydown', _onKeyDown, false );
-	window.addEventListener( 'keyup', _onKeyUp, false );
+	window.addEventListener( 'keydown', _onKeyDown );
+	window.addEventListener( 'keyup', _onKeyUp );
 
 	function bind( scope, fn ) {
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -281,13 +281,13 @@ var FlyControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		this.domElement.removeEventListener( 'contextmenu', contextmenu, false );
-		this.domElement.removeEventListener( 'mousedown', _mousedown, false );
-		this.domElement.removeEventListener( 'mousemove', _mousemove, false );
-		this.domElement.removeEventListener( 'mouseup', _mouseup, false );
+		this.domElement.removeEventListener( 'contextmenu', contextmenu );
+		this.domElement.removeEventListener( 'mousedown', _mousedown );
+		this.domElement.removeEventListener( 'mousemove', _mousemove );
+		this.domElement.removeEventListener( 'mouseup', _mouseup );
 
-		window.removeEventListener( 'keydown', _keydown, false );
-		window.removeEventListener( 'keyup', _keyup, false );
+		window.removeEventListener( 'keydown', _keydown );
+		window.removeEventListener( 'keyup', _keyup );
 
 	};
 
@@ -297,14 +297,14 @@ var FlyControls = function ( object, domElement ) {
 	var _keydown = bind( this, this.keydown );
 	var _keyup = bind( this, this.keyup );
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
 
-	this.domElement.addEventListener( 'mousemove', _mousemove, false );
-	this.domElement.addEventListener( 'mousedown', _mousedown, false );
-	this.domElement.addEventListener( 'mouseup', _mouseup, false );
+	this.domElement.addEventListener( 'mousemove', _mousemove );
+	this.domElement.addEventListener( 'mousedown', _mousedown );
+	this.domElement.addEventListener( 'mouseup', _mouseup );
 
-	window.addEventListener( 'keydown', _keydown, false );
-	window.addEventListener( 'keyup', _keyup, false );
+	window.addEventListener( 'keydown', _keydown );
+	window.addEventListener( 'keyup', _keyup );
 
 	this.updateMovementVector();
 	this.updateRotationVector();

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -107,7 +107,7 @@ var OrbitControls = function ( object, domElement ) {
 
 	this.listenToKeyEvents = function ( domElement ) {
 
-		domElement.addEventListener( 'keydown', onKeyDown, false );
+		domElement.addEventListener( 'keydown', onKeyDown );
 		this._domElementKeyEvents = domElement;
 
 	};
@@ -279,22 +279,22 @@ var OrbitControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
+		scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
 
-		scope.domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		scope.domElement.removeEventListener( 'wheel', onMouseWheel, false );
+		scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+		scope.domElement.removeEventListener( 'wheel', onMouseWheel );
 
-		scope.domElement.removeEventListener( 'touchstart', onTouchStart, false );
-		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
-		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
+		scope.domElement.removeEventListener( 'touchstart', onTouchStart );
+		scope.domElement.removeEventListener( 'touchend', onTouchEnd );
+		scope.domElement.removeEventListener( 'touchmove', onTouchMove );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
 
 		if ( scope._domElementKeyEvents !== null ) {
 
-			scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown, false );
+			scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
 
 		}
 
@@ -934,8 +934,8 @@ var OrbitControls = function ( object, domElement ) {
 
 		if ( state !== STATE.NONE ) {
 
-			scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-			scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+			scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+			scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 			scope.dispatchEvent( startEvent );
 
@@ -981,8 +981,8 @@ var OrbitControls = function ( object, domElement ) {
 
 	function onMouseUp( event ) {
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
 		if ( scope.enabled === false ) return;
 
@@ -1182,14 +1182,14 @@ var OrbitControls = function ( object, domElement ) {
 
 	//
 
-	scope.domElement.addEventListener( 'contextmenu', onContextMenu, false );
+	scope.domElement.addEventListener( 'contextmenu', onContextMenu );
 
-	scope.domElement.addEventListener( 'pointerdown', onPointerDown, false );
-	scope.domElement.addEventListener( 'wheel', onMouseWheel, false );
+	scope.domElement.addEventListener( 'pointerdown', onPointerDown );
+	scope.domElement.addEventListener( 'wheel', onMouseWheel );
 
-	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
-	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
-	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+	scope.domElement.addEventListener( 'touchstart', onTouchStart );
+	scope.domElement.addEventListener( 'touchend', onTouchEnd );
+	scope.domElement.addEventListener( 'touchmove', onTouchMove );
 
 	// force an update at start
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -83,17 +83,17 @@ var PointerLockControls = function ( camera, domElement ) {
 
 	this.connect = function () {
 
-		scope.domElement.ownerDocument.addEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerlockChange, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerlockError, false );
+		scope.domElement.ownerDocument.addEventListener( 'mousemove', onMouseMove );
+		scope.domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerlockChange );
+		scope.domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerlockError );
 
 	};
 
 	this.disconnect = function () {
 
-		scope.domElement.ownerDocument.removeEventListener( 'mousemove', onMouseMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerlockchange', onPointerlockChange, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerlockerror', onPointerlockError, false );
+		scope.domElement.ownerDocument.removeEventListener( 'mousemove', onMouseMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerlockchange', onPointerlockChange );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerlockerror', onPointerlockError );
 
 	};
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -484,7 +484,7 @@ var TrackballControls = function ( object, domElement ) {
 
 		_keyState = STATE.NONE;
 
-		window.addEventListener( 'keydown', keydown, false );
+		window.addEventListener( 'keydown', keydown );
 
 	}
 
@@ -535,8 +535,8 @@ var TrackballControls = function ( object, domElement ) {
 
 		}
 
-		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 		scope.dispatchEvent( startEvent );
 
@@ -709,37 +709,37 @@ var TrackballControls = function ( object, domElement ) {
 
 	this.dispose = function () {
 
-		scope.domElement.removeEventListener( 'contextmenu', contextmenu, false );
+		scope.domElement.removeEventListener( 'contextmenu', contextmenu );
 
-		scope.domElement.removeEventListener( 'pointerdown', onPointerDown, false );
-		scope.domElement.removeEventListener( 'wheel', mousewheel, false );
+		scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+		scope.domElement.removeEventListener( 'wheel', mousewheel );
 
-		scope.domElement.removeEventListener( 'touchstart', touchstart, false );
-		scope.domElement.removeEventListener( 'touchend', touchend, false );
-		scope.domElement.removeEventListener( 'touchmove', touchmove, false );
+		scope.domElement.removeEventListener( 'touchstart', touchstart );
+		scope.domElement.removeEventListener( 'touchend', touchend );
+		scope.domElement.removeEventListener( 'touchmove', touchmove );
 
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
-		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
+		scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
 
-		window.removeEventListener( 'keydown', keydown, false );
-		window.removeEventListener( 'keyup', keyup, false );
+		window.removeEventListener( 'keydown', keydown );
+		window.removeEventListener( 'keyup', keyup );
 
 	};
 
-	this.domElement.addEventListener( 'contextmenu', contextmenu, false );
+	this.domElement.addEventListener( 'contextmenu', contextmenu );
 
-	this.domElement.addEventListener( 'pointerdown', onPointerDown, false );
-	this.domElement.addEventListener( 'wheel', mousewheel, false );
+	this.domElement.addEventListener( 'pointerdown', onPointerDown );
+	this.domElement.addEventListener( 'wheel', mousewheel );
 
-	this.domElement.addEventListener( 'touchstart', touchstart, false );
-	this.domElement.addEventListener( 'touchend', touchend, false );
-	this.domElement.addEventListener( 'touchmove', touchmove, false );
+	this.domElement.addEventListener( 'touchstart', touchstart );
+	this.domElement.addEventListener( 'touchend', touchend );
+	this.domElement.addEventListener( 'touchmove', touchmove );
 
-	this.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
-	this.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+	this.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
+	this.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
-	window.addEventListener( 'keydown', keydown, false );
-	window.addEventListener( 'keyup', keyup, false );
+	window.addEventListener( 'keydown', keydown );
+	window.addEventListener( 'keyup', keyup );
 
 	this.handleResize();
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -146,9 +146,9 @@ var TransformControls = function ( camera, domElement ) {
 
 	{
 
-		domElement.addEventListener( 'pointerdown', onPointerDown, false );
-		domElement.addEventListener( 'pointermove', onPointerHover, false );
-		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp, false );
+		domElement.addEventListener( 'pointerdown', onPointerDown );
+		domElement.addEventListener( 'pointermove', onPointerHover );
+		scope.domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
 	}
 
@@ -650,7 +650,7 @@ var TransformControls = function ( camera, domElement ) {
 		if ( ! scope.enabled ) return;
 
 		scope.domElement.style.touchAction = 'none'; // disable touch scroll
-		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove );
 
 		scope.pointerHover( getPointer( event ) );
 		scope.pointerDown( getPointer( event ) );
@@ -670,7 +670,7 @@ var TransformControls = function ( camera, domElement ) {
 		if ( ! scope.enabled ) return;
 
 		scope.domElement.style.touchAction = '';
-		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, false );
+		scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
 
 		scope.pointerUp( getPointer( event ) );
 

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -23,7 +23,7 @@ var SelectionHelper = ( function () {
 			this.isDown = true;
 			this.onSelectStart( event );
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 		this.renderer.domElement.addEventListener( 'pointermove', function ( event ) {
 
@@ -33,14 +33,14 @@ var SelectionHelper = ( function () {
 
 			}
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 		this.renderer.domElement.addEventListener( 'pointerup', function ( event ) {
 
 			this.isDown = false;
 			this.onSelectOver( event );
 
-		}.bind( this ), false );
+		}.bind( this ) );
 
 	}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -640,9 +640,9 @@ var BufferGeometryUtils = {
 	 */
 	computeMorphedAttributes: function ( object ) {
 
-		if ( ! object.geometry.isBufferGeometry ) {
+		if ( object.geometry.isBufferGeometry !== true ) {
 
-			console.warn( 'Geometry is not a BufferGeometry' );
+			console.error( 'THREE.BufferGeometryUtils: Geometry is not of type BufferGeometry.' );
 			return null;
 
 		}

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -133,8 +133,8 @@
 
 			function onPointerUp() {
 
-				document.removeEventListener( 'pointermove', onPointerMove, false );
-				document.removeEventListener( 'pointerup', onPointerUp, false );
+				document.removeEventListener( 'pointermove', onPointerMove );
+				document.removeEventListener( 'pointerup', onPointerUp );
 
 			}
 

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -116,8 +116,8 @@
 
 					controls.enabled = true;
 
-					window.removeEventListener( 'pointermove', onPointerMove, false );
-					window.removeEventListener( 'pointerup', onPointerUp, false );
+					window.removeEventListener( 'pointermove', onPointerMove );
+					window.removeEventListener( 'pointerup', onPointerUp );
 
 				}
 


### PR DESCRIPTION
Related issue: #21100

**Description**

Remove the remaining third parameter from `addEventListener`s and `removeEventListener`s in `examples/js` and run modularize script to update `examples/jsm`