### PR TITLE
Three.js: Log a warning when importing multiple instances of the library

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -164,3 +164,14 @@ if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
 	/* eslint-enable no-undef */
 
 }
+
+if ( typeof __THREE__ !== undefined ) {
+
+	console.warn( 'WARNING: Multiple instances of Three.js being imported.' );
+
+} else {
+
+	// eslint-disable-next-line no-undef
+	__THREE__ = REVISION;
+
+}


### PR DESCRIPTION
Related issue: #17482

**Description**

This change warns the user when they're importing the library more than once.

<img width="541" alt="Screen Shot 2021-01-21 at 5 19 12 PM" src="https://user-images.githubusercontent.com/97088/105387502-86c01e80-5c0d-11eb-9043-3e7e143dc6f2.png">

This would only work from r125+
