### PR TITLE
KTX2Loader + BasisTextureLoader: Clean up.

### DIFF
--- a/examples/js/loaders/BasisTextureLoader.js
+++ b/examples/js/loaders/BasisTextureLoader.js
@@ -23,6 +23,7 @@ THREE.BasisTextureLoader = function ( manager ) {
 	this.workerNextTaskID = 1;
 	this.workerSourceURL = '';
 	this.workerConfig = null;
+
 };
 
 THREE.BasisTextureLoader.taskCache = new WeakMap();
@@ -104,7 +105,7 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 	/** Low-level transcoding API, exposed for use by THREE.KTX2Loader. */
 	parseInternalAsync: function ( options ) {
 
-		var { levels, hasAlpha, basisFormat } = options;
+		var { levels } = options;
 
 		var buffers = new Set();
 
@@ -153,8 +154,6 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 			} )
 			.then( ( message ) => {
-
-				var config = this.workerConfig;
 
 				var { mipmaps, width, height, format } = message;
 
@@ -221,9 +220,9 @@ THREE.BasisTextureLoader.prototype = Object.assign( Object.create( THREE.Loader.
 
 					var body = [
 						'/* constants */',
-						'var _EngineFormat = ' + JSON.stringify( BasisTextureLoader.EngineFormat ),
-						'var _TranscoderFormat = ' + JSON.stringify( BasisTextureLoader.TranscoderFormat ),
-						'var _BasisFormat = ' + JSON.stringify( BasisTextureLoader.BasisFormat ),
+						'var _EngineFormat = ' + JSON.stringify( THREE.BasisTextureLoader.EngineFormat ),
+						'var _TranscoderFormat = ' + JSON.stringify( THREE.BasisTextureLoader.TranscoderFormat ),
+						'var _BasisFormat = ' + JSON.stringify( THREE.BasisTextureLoader.BasisFormat ),
 						'/* basis_transcoder.js */',
 						jsContent,
 						'/* worker */',
@@ -430,7 +429,7 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function transcodeLowLevel ( taskConfig ) {
+	function transcodeLowLevel( taskConfig ) {
 
 		var { basisFormat, width, height, hasAlpha } = taskConfig;
 
@@ -517,7 +516,7 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 					hasAlpha,
 					false,
 					0, 0,
-					-1, -1
+					- 1, - 1
 				);
 
 				assert( ok, 'THREE.BasisTextureLoader: transcodeUASTCImage() failed for level ' + level.index + '.' );
@@ -611,64 +610,72 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 	var FORMAT_OPTIONS = [
 		{
 			if: 'astcSupported',
-			basisFormat: [BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ASTC_4x4, TranscoderFormat.ASTC_4x4],
-			engineFormat: [EngineFormat.RGBA_ASTC_4x4_Format, EngineFormat.RGBA_ASTC_4x4_Format],
+			basisFormat: [ BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ASTC_4x4, TranscoderFormat.ASTC_4x4 ],
+			engineFormat: [ EngineFormat.RGBA_ASTC_4x4_Format, EngineFormat.RGBA_ASTC_4x4_Format ],
 			priorityETC1S: Infinity,
 			priorityUASTC: 1,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'bptcSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.BC7_M5, TranscoderFormat.BC7_M5],
-			engineFormat: [EngineFormat.RGBA_BPTC_Format, EngineFormat.RGBA_BPTC_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.BC7_M5, TranscoderFormat.BC7_M5 ],
+			engineFormat: [ EngineFormat.RGBA_BPTC_Format, EngineFormat.RGBA_BPTC_Format ],
 			priorityETC1S: 3,
 			priorityUASTC: 2,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'dxtSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.BC1, TranscoderFormat.BC3],
-			engineFormat: [EngineFormat.RGB_S3TC_DXT1_Format, EngineFormat.RGBA_S3TC_DXT5_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.BC1, TranscoderFormat.BC3 ],
+			engineFormat: [ EngineFormat.RGB_S3TC_DXT1_Format, EngineFormat.RGBA_S3TC_DXT5_Format ],
 			priorityETC1S: 4,
 			priorityUASTC: 5,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'etc2Supported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ETC1, TranscoderFormat.ETC2],
-			engineFormat: [EngineFormat.RGB_ETC2_Format, EngineFormat.RGBA_ETC2_EAC_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ETC1, TranscoderFormat.ETC2 ],
+			engineFormat: [ EngineFormat.RGB_ETC2_Format, EngineFormat.RGBA_ETC2_EAC_Format ],
 			priorityETC1S: 1,
 			priorityUASTC: 3,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'etc1Supported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ETC1, TranscoderFormat.ETC1],
-			engineFormat: [EngineFormat.RGB_ETC1_Format, EngineFormat.RGB_ETC1_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ETC1, TranscoderFormat.ETC1 ],
+			engineFormat: [ EngineFormat.RGB_ETC1_Format, EngineFormat.RGB_ETC1_Format ],
 			priorityETC1S: 2,
 			priorityUASTC: 4,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'pvrtcSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.PVRTC1_4_RGB, TranscoderFormat.PVRTC1_4_RGBA],
-			engineFormat: [EngineFormat.RGB_PVRTC_4BPPV1_Format, EngineFormat.RGBA_PVRTC_4BPPV1_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.PVRTC1_4_RGB, TranscoderFormat.PVRTC1_4_RGBA ],
+			engineFormat: [ EngineFormat.RGB_PVRTC_4BPPV1_Format, EngineFormat.RGBA_PVRTC_4BPPV1_Format ],
 			priorityETC1S: 5,
 			priorityUASTC: 6,
 			needsPowerOfTwo: true,
 		},
 	];
 
-	var ETC1S_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) { return a.priorityETC1S - b.priorityETC1S; } );
-	var UASTC_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) { return a.priorityUASTC - b.priorityUASTC; } );
+	var ETC1S_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) {
 
-	function getTranscoderFormat ( basisFormat, width, height, hasAlpha ) {
+		return a.priorityETC1S - b.priorityETC1S;
+
+	} );
+	var UASTC_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) {
+
+		return a.priorityUASTC - b.priorityUASTC;
+
+	} );
+
+	function getTranscoderFormat( basisFormat, width, height, hasAlpha ) {
 
 		var transcoderFormat;
 		var engineFormat;
@@ -699,25 +706,25 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function assert ( ok, message ) {
+	function assert( ok, message ) {
 
 		if ( ! ok ) throw new Error( message );
 
 	}
 
-	function getWidthInBlocks ( transcoderFormat, width ) {
+	function getWidthInBlocks( transcoderFormat, width ) {
 
 		return Math.ceil( width / BasisModule.getFormatBlockWidth( transcoderFormat ) );
 
 	}
 
-	function getHeightInBlocks ( transcoderFormat, height ) {
+	function getHeightInBlocks( transcoderFormat, height ) {
 
 		return Math.ceil( height / BasisModule.getFormatBlockHeight( transcoderFormat ) );
 
 	}
 
-	function getTranscodedImageByteLength ( transcoderFormat, width, height ) {
+	function getTranscodedImageByteLength( transcoderFormat, width, height ) {
 
 		var blockByteLength = BasisModule.getBytesPerBlockOrPixel( transcoderFormat );
 
@@ -745,7 +752,7 @@ THREE.BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function isPowerOfTwo ( value ) {
+	function isPowerOfTwo( value ) {
 
 		if ( value <= 2 ) return true;
 

--- a/examples/jsm/loaders/BasisTextureLoader.js
+++ b/examples/jsm/loaders/BasisTextureLoader.js
@@ -42,6 +42,7 @@ var BasisTextureLoader = function ( manager ) {
 	this.workerNextTaskID = 1;
 	this.workerSourceURL = '';
 	this.workerConfig = null;
+
 };
 
 BasisTextureLoader.taskCache = new WeakMap();
@@ -123,7 +124,7 @@ BasisTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ),
 	/** Low-level transcoding API, exposed for use by KTX2Loader. */
 	parseInternalAsync: function ( options ) {
 
-		var { levels, hasAlpha, basisFormat } = options;
+		var { levels } = options;
 
 		var buffers = new Set();
 
@@ -172,8 +173,6 @@ BasisTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ),
 
 			} )
 			.then( ( message ) => {
-
-				var config = this.workerConfig;
 
 				var { mipmaps, width, height, format } = message;
 
@@ -449,7 +448,7 @@ BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function transcodeLowLevel ( taskConfig ) {
+	function transcodeLowLevel( taskConfig ) {
 
 		var { basisFormat, width, height, hasAlpha } = taskConfig;
 
@@ -536,7 +535,7 @@ BasisTextureLoader.BasisWorker = function () {
 					hasAlpha,
 					false,
 					0, 0,
-					-1, -1
+					- 1, - 1
 				);
 
 				assert( ok, 'THREE.BasisTextureLoader: transcodeUASTCImage() failed for level ' + level.index + '.' );
@@ -630,64 +629,72 @@ BasisTextureLoader.BasisWorker = function () {
 	var FORMAT_OPTIONS = [
 		{
 			if: 'astcSupported',
-			basisFormat: [BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ASTC_4x4, TranscoderFormat.ASTC_4x4],
-			engineFormat: [EngineFormat.RGBA_ASTC_4x4_Format, EngineFormat.RGBA_ASTC_4x4_Format],
+			basisFormat: [ BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ASTC_4x4, TranscoderFormat.ASTC_4x4 ],
+			engineFormat: [ EngineFormat.RGBA_ASTC_4x4_Format, EngineFormat.RGBA_ASTC_4x4_Format ],
 			priorityETC1S: Infinity,
 			priorityUASTC: 1,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'bptcSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.BC7_M5, TranscoderFormat.BC7_M5],
-			engineFormat: [EngineFormat.RGBA_BPTC_Format, EngineFormat.RGBA_BPTC_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.BC7_M5, TranscoderFormat.BC7_M5 ],
+			engineFormat: [ EngineFormat.RGBA_BPTC_Format, EngineFormat.RGBA_BPTC_Format ],
 			priorityETC1S: 3,
 			priorityUASTC: 2,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'dxtSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.BC1, TranscoderFormat.BC3],
-			engineFormat: [EngineFormat.RGB_S3TC_DXT1_Format, EngineFormat.RGBA_S3TC_DXT5_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.BC1, TranscoderFormat.BC3 ],
+			engineFormat: [ EngineFormat.RGB_S3TC_DXT1_Format, EngineFormat.RGBA_S3TC_DXT5_Format ],
 			priorityETC1S: 4,
 			priorityUASTC: 5,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'etc2Supported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ETC1, TranscoderFormat.ETC2],
-			engineFormat: [EngineFormat.RGB_ETC2_Format, EngineFormat.RGBA_ETC2_EAC_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ETC1, TranscoderFormat.ETC2 ],
+			engineFormat: [ EngineFormat.RGB_ETC2_Format, EngineFormat.RGBA_ETC2_EAC_Format ],
 			priorityETC1S: 1,
 			priorityUASTC: 3,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'etc1Supported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.ETC1, TranscoderFormat.ETC1],
-			engineFormat: [EngineFormat.RGB_ETC1_Format, EngineFormat.RGB_ETC1_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.ETC1, TranscoderFormat.ETC1 ],
+			engineFormat: [ EngineFormat.RGB_ETC1_Format, EngineFormat.RGB_ETC1_Format ],
 			priorityETC1S: 2,
 			priorityUASTC: 4,
 			needsPowerOfTwo: false,
 		},
 		{
 			if: 'pvrtcSupported',
-			basisFormat: [BasisFormat.ETC1S, BasisFormat.UASTC_4x4],
-			transcoderFormat: [TranscoderFormat.PVRTC1_4_RGB, TranscoderFormat.PVRTC1_4_RGBA],
-			engineFormat: [EngineFormat.RGB_PVRTC_4BPPV1_Format, EngineFormat.RGBA_PVRTC_4BPPV1_Format],
+			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
+			transcoderFormat: [ TranscoderFormat.PVRTC1_4_RGB, TranscoderFormat.PVRTC1_4_RGBA ],
+			engineFormat: [ EngineFormat.RGB_PVRTC_4BPPV1_Format, EngineFormat.RGBA_PVRTC_4BPPV1_Format ],
 			priorityETC1S: 5,
 			priorityUASTC: 6,
 			needsPowerOfTwo: true,
 		},
 	];
 
-	var ETC1S_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) { return a.priorityETC1S - b.priorityETC1S; } );
-	var UASTC_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) { return a.priorityUASTC - b.priorityUASTC; } );
+	var ETC1S_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) {
 
-	function getTranscoderFormat ( basisFormat, width, height, hasAlpha ) {
+		return a.priorityETC1S - b.priorityETC1S;
+
+	} );
+	var UASTC_OPTIONS = FORMAT_OPTIONS.sort( function ( a, b ) {
+
+		return a.priorityUASTC - b.priorityUASTC;
+
+	} );
+
+	function getTranscoderFormat( basisFormat, width, height, hasAlpha ) {
 
 		var transcoderFormat;
 		var engineFormat;
@@ -718,25 +725,25 @@ BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function assert ( ok, message ) {
+	function assert( ok, message ) {
 
 		if ( ! ok ) throw new Error( message );
 
 	}
 
-	function getWidthInBlocks ( transcoderFormat, width ) {
+	function getWidthInBlocks( transcoderFormat, width ) {
 
 		return Math.ceil( width / BasisModule.getFormatBlockWidth( transcoderFormat ) );
 
 	}
 
-	function getHeightInBlocks ( transcoderFormat, height ) {
+	function getHeightInBlocks( transcoderFormat, height ) {
 
 		return Math.ceil( height / BasisModule.getFormatBlockHeight( transcoderFormat ) );
 
 	}
 
-	function getTranscodedImageByteLength ( transcoderFormat, width, height ) {
+	function getTranscodedImageByteLength( transcoderFormat, width, height ) {
 
 		var blockByteLength = BasisModule.getBytesPerBlockOrPixel( transcoderFormat );
 
@@ -764,7 +771,7 @@ BasisTextureLoader.BasisWorker = function () {
 
 	}
 
-	function isPowerOfTwo ( value ) {
+	function isPowerOfTwo( value ) {
 
 		if ( value <= 2 ) return true;
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -19,10 +19,6 @@ import {
 	CompressedTextureLoader,
 	FileLoader,
 	LinearEncoding,
-	LinearFilter,
-	LinearMipmapLinearFilter,
-	MathUtils,
-	UnsignedByteType,
 	sRGBEncoding,
 } from '../../../build/three.module.js';
 
@@ -54,11 +50,11 @@ var DFDChannel = {
 
 var SupercompressionScheme = {
 	ZSTD: 2
-}
+};
 
 var Transfer = {
 	SRGB: 2
-}
+};
 
 //
 
@@ -86,7 +82,7 @@ class KTX2Loader extends CompressedTextureLoader {
 
 	}
 
-	setTranscoderPath ( path ) {
+	setTranscoderPath( path ) {
 
 		this.basisLoader.setTranscoderPath( path );
 
@@ -94,7 +90,7 @@ class KTX2Loader extends CompressedTextureLoader {
 
 	}
 
-	setWorkerLimit ( path ) {
+	setWorkerLimit( path ) {
 
 		this.basisLoader.setWorkerLimit( path );
 
@@ -102,7 +98,7 @@ class KTX2Loader extends CompressedTextureLoader {
 
 	}
 
-	detectSupport ( renderer ) {
+	detectSupport( renderer ) {
 
 		this.basisLoader.detectSupport( renderer );
 
@@ -110,7 +106,7 @@ class KTX2Loader extends CompressedTextureLoader {
 
 	}
 
-	dispose () {
+	dispose() {
 
 		this.basisLoader.dispose();
 
@@ -131,7 +127,7 @@ class KTX2Loader extends CompressedTextureLoader {
 				.setResponseType( 'arraybuffer' )
 				.load( url, resolve, onProgress, reject );
 
-		} )
+		} );
 
 		bufferPending
 			.then( function ( buffer ) {
@@ -211,7 +207,7 @@ class KTX2Loader extends CompressedTextureLoader {
 
 			onLoad( texture );
 
-		} );
+		} ).catch( onError );
 
 		return this;
 
@@ -306,6 +302,6 @@ var KTX2Utils = {
 
 	},
 
-}
+};
 
 export { KTX2Loader };


### PR DESCRIPTION
Lint cleanup from #21131 and #21137.

@mrdoob The linter caught an issue that was broken in `examples/js/loaders/BasisTextureLoader` but not occurring when running the examples via the `examples/jsm` version, so it would be great if we could include this in r125 as well. Thanks!