### PR TITLE
WebXRManager: Reset _currentDepthNear/_currentDepthFar in onSessionEnd

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -116,6 +116,9 @@ function WebXRManager( renderer, gl ) {
 
 		inputSourcesMap.clear();
 
+		_currentDepthNear = null;
+		_currentDepthFar = null;
+
 		//
 
 		renderer.setFramebuffer( null );


### PR DESCRIPTION
`WebXRManager` stores `_currentDepthNear` and `_currentDepthFar` and only calls `updateRenderState` if they're different. However these fields were not reset if the session was ended so if a new session was started the clipping planes were not set.