### PR TITLE
Mesh: Remove dependency to Face3.

### DIFF
--- a/src/core/Raycaster.d.ts
+++ b/src/core/Raycaster.d.ts
@@ -1,17 +1,24 @@
 import { Vector3 } from './../math/Vector3';
-import { Face3 } from './Face3';
 import { Object3D } from './Object3D';
 import { Vector2 } from './../math/Vector2';
 import { Ray } from './../math/Ray';
 import { Camera } from './../cameras/Camera';
 import { Layers } from './Layers';
 
+export interface Face {
+	a: number;
+	b: number;
+	c: number;
+	normal: Vector3;
+	materialIndex: number;
+}
+
 export interface Intersection {
 	distance: number;
 	distanceToRay?: number;
 	point: Vector3;
 	index?: number;
-	face?: Face3 | null;
+	face?: Face | null;
 	faceIndex?: number;
 	object: Object3D;
 	uv?: Vector2;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -5,7 +5,6 @@ import { Ray } from '../math/Ray.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
 import { Triangle } from '../math/Triangle.js';
-import { Face3 } from '../core/Face3.js';
 import { DoubleSide, BackSide } from '../constants.js';
 import { MeshBasicMaterial } from '../materials/MeshBasicMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
@@ -401,7 +400,14 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 		}
 
-		const face = new Face3( a, b, c );
+		const face = {
+			a: a,
+			b: a,
+			c: c,
+			normal: new Vector3(),
+			materialIndex: 0
+		};
+
 		Triangle.getNormal( _vA, _vB, _vC, face.normal );
 
 		intersection.face = face;


### PR DESCRIPTION
Related issue: -

**Description**

Instead of using `Face3`, `Mesh.raycast()` now creates custom objects for faces.

I'd like to suggest this change since `Face3` was originally related to `Geometry`. Besides, it seems `Mesh` is the only place in the core and examples which uses `Face3`. If this PR is merged, we could consider to move the `Face3` definition into `examples/jsm/deprecated/Geometry.js`.