### PR TITLE
OrbitControls: add getDistance()

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -283,6 +283,11 @@ controls.touches = {
 			Get the current vertical rotation, in radians.
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance.
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -285,7 +285,7 @@ controls.touches = {
 
 		<h3>[method:radians getDistance] ()</h3>
 		<p>
-			Get the current dolly distance.
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -280,7 +280,7 @@ controls.touches = {
 
 		<h3>[method:radians getDistance] ()</h3>
 		<p>
-			Get the current dolly distance.
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -278,6 +278,11 @@ controls.touches = {
 			라디안 단위로 현재 수직 회전값을 가져옵니다.
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance.
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -282,7 +282,7 @@ controls.touches = {
 
 		<h3>[method:radians getDistance] ()</h3>
 		<p>
-			Get the current dolly distance.
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -280,6 +280,11 @@ controls.touches = {
 			获得当前的垂直旋转，单位为弧度。
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance.
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			为指定的DOM元素添加按键监听。推荐将window作为指定的DOM元素。

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -95,6 +95,14 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	};
 
+
+	this.getDistance = function () {
+
+		return spherical.radius;
+
+	};
+
+
 	this.listenToKeyEvents = function ( domElement ) {
 
 		domElement.addEventListener( 'keydown', onKeyDown );

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -95,13 +95,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	};
 
-
 	this.getDistance = function () {
 
 		return spherical.radius;
 
 	};
-
 
 	this.listenToKeyEvents = function ( domElement ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -70,7 +70,7 @@ var OrbitControls = function ( object, domElement ) {
 	// Set to true to automatically rotate around the target
 	// If auto-rotate is enabled, you must call controls.update() in your animation loop
 	this.autoRotate = false;
-	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
+	this.autoRotateSpeed = 2.0; // 30 seconds per orbit when fps is 60
 
 	// The four arrow keys
 	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
@@ -104,6 +104,14 @@ var OrbitControls = function ( object, domElement ) {
 		return spherical.theta;
 
 	};
+
+
+	this.getDistance = function () {
+
+		return spherical.radius;
+
+	};
+
 
 	this.listenToKeyEvents = function ( domElement ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -105,13 +105,11 @@ var OrbitControls = function ( object, domElement ) {
 
 	};
 
-
 	this.getDistance = function () {
 
 		return spherical.radius;
 
 	};
-
 
 	this.listenToKeyEvents = function ( domElement ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2695,7 +2695,7 @@ var GLTFLoader = ( function () {
 				if ( useFlatShading ) cachedMaterial.flatShading = true;
 				if ( useMorphTargets ) cachedMaterial.morphTargets = true;
 				if ( useMorphNormals ) cachedMaterial.morphNormals = true;
-
+				
 				if ( useVertexTangents ) {
 
 					cachedMaterial.vertexTangents = true;


### PR DESCRIPTION
Related issue: -

**Description**

Add `OrbitControls.getDistance()` which exposes `spherical.radius`.

This is useful for example if you want to enable zooming in but disable zooming out from the start position:

```js
const controls = new OrbitControls(camera, renderer.domElement);
const currentDistance = controls.getDistance();
controls.maxDistance = currentDistance;
```