### PR TITLE
Material: Honor lightMapIntensity in toJSON().

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -200,7 +200,13 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.map && this.map.isTexture ) data.map = this.map.toJSON( meta ).uuid;
 		if ( this.matcap && this.matcap.isTexture ) data.matcap = this.matcap.toJSON( meta ).uuid;
 		if ( this.alphaMap && this.alphaMap.isTexture ) data.alphaMap = this.alphaMap.toJSON( meta ).uuid;
-		if ( this.lightMap && this.lightMap.isTexture ) data.lightMap = this.lightMap.toJSON( meta ).uuid;
+
+		if ( this.lightMap && this.lightMap.isTexture ) {
+
+			data.lightMap = this.lightMap.toJSON( meta ).uuid;
+			data.lightMapIntensity = this.lightMapIntensity;
+
+		}
 
 		if ( this.aoMap && this.aoMap.isTexture ) {
 


### PR DESCRIPTION
Related issue: see https://discourse.threejs.org/t/light-map-intensity-tojson/22917

**Description**

This PR ensures `lightMapIntensity` is honored in `Material.toJSON()`.
