### PR TITLE
use Map.get insteadof Array.indexOf because loop takes up too much time

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2886,11 +2886,21 @@ var FBXLoader = ( function () {
 			var yIndex = - 1;
 			var zIndex = - 1;
 
+			const indexMap = {}
+            for(const k of ['x', 'y', 'z']) {
+                const map = indexMap[k] = new Map()
+                curves[k].times.forEach((item, index) => {
+                    if (!map.has(item)) {
+                        map.set(item, index)
+                    }
+                })
+            }
+
 			times.forEach( function ( time ) {
 
-				if ( curves.x ) xIndex = curves.x.times.indexOf( time );
-				if ( curves.y ) yIndex = curves.y.times.indexOf( time );
-				if ( curves.z ) zIndex = curves.z.times.indexOf( time );
+				if ( curves.x ) xIndex = indexMap.x.get(time)
+                if ( curves.y ) yIndex = indexMap.y.get(time)
+                if ( curves.z ) zIndex = indexMap.z.get(time)
 
 				// if there is an x value defined for this frame, use that
 				if ( xIndex !== - 1 ) {


### PR DESCRIPTION
Related issue: #XXXX

**Description**
use Map.get insteadof Array.indexOf because loop takes up too much time
![performance](https://user-images.githubusercontent.com/30542005/106242101-213de480-6242-11eb-8e25-0c5874db85dc.png)


