### PR TITLE
Examples: Update tags.json.

### DIFF
--- a/examples/tags.json
+++ b/examples/tags.json
@@ -36,6 +36,7 @@
 	"webgl_materials_blending_custom": [ "alpha" ],
 	"webgl_materials_channels": [ "normal", "depth", "rgba packing" ],
 	"webgl_materials_cubemap_mipmaps": [ "envmap" ],
+	"webgl_materials_envmaps_hdr": [ "rgbm" ],
 	"webgl_materials_envmaps_parallax": [ "onBeforeCompile" ],
 	"webgl_materials_lightmap": [ "shadow" ],
 	"webgl_materials_physical_clearcoat": [ "anisotropy" ],


### PR DESCRIPTION
Related issue: -

**Description**

Ensures the search returns `webgl_materials_envmaps_hdr` when looking for `rgbm`. Otherwise you only find `webgl_loader_texture_rgbm`. 
