### PR TITLE
GLTFLoader: Make error when loading textures with no data clear

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2443,6 +2443,10 @@ THREE.GLTFLoader = ( function () {
 
 			} );
 
+		} else if ( source.uri === undefined ) {
+
+			throw new Error( 'THREE.GLTFLoader: Image ' + textureIndex + ' is missing URI and bufferView' );
+
 		}
 
 		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {
@@ -2626,7 +2630,7 @@ THREE.GLTFLoader = ( function () {
 				if ( useFlatShading ) cachedMaterial.flatShading = true;
 				if ( useMorphTargets ) cachedMaterial.morphTargets = true;
 				if ( useMorphNormals ) cachedMaterial.morphNormals = true;
-				
+
 				if ( useVertexTangents ) {
 
 					cachedMaterial.vertexTangents = true;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2508,6 +2508,10 @@ var GLTFLoader = ( function () {
 
 			} );
 
+		} else if ( source.uri === undefined ) {
+
+			throw new Error( 'THREE.GLTFLoader: Image ' + textureIndex + ' is missing URI and bufferView' );
+
 		}
 
 		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {


### PR DESCRIPTION
If GLTFLoader is used to load a texture with no uri or bufferView, it
uses an empty uri which results in FileLoader loading the HTML document
from which the call originates. The resulting document is then fed into
an actual image loader such as KTX2Loader or BitmapLoader, which tends
to generate hard to understand errors.

This change detects the error early and throws a special message to make
debugging easier.