### PR TITLE
Docs: Fix broken example links.

### DIFF
--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -27,7 +27,7 @@
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl_buffergeometry_drawcalls WebGL / buffergeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_drawrange WebGL / buffergeometry / drawrange]<br />
 			[example:webgl_buffergeometry_lines WebGL / buffergeometry / lines]<br />
 			[example:webgl_buffergeometry_lines_indexed WebGL / buffergeometry / lines / indexed]<br />
 			[example:webgl_decals WebGL / decals]<br />

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -40,7 +40,7 @@
 		<h2>Examples</h2>
 		<p>
 			[example:misc_controls_fly misc / controls / fly]<br />
-			[example:webgl_buffergeometry_drawcalls WebGL / BufferGeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_drawrange WebGL / BufferGeometry / drawrange]<br />
 			[example:webgl_buffergeometry_points WebGL / BufferGeometry / points]<br />
 			[example:webgl_buffergeometry_points_interleaved WebGL / BufferGeometry / points / interleaved]<br />
 			[example:webgl_camera WebGL / camera ]<br />

--- a/docs/api/en/materials/RawShaderMaterial.html
+++ b/docs/api/en/materials/RawShaderMaterial.html
@@ -33,11 +33,11 @@
 		<p>
 			[example:webgl_buffergeometry_rawshader WebGL / buffergeometry / rawshader]<br />
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
-			[example:webgl_buffergeometry_instancing_dynamic WebGL / buffergeometry / instancing / dynamic]<br />
-			[example:webgl_buffergeometry_instancing_interleaved_dynamic WebGL / buffergeometry / instancing / interleaved / dynamic]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
-			[example:webgl_interactive_instances_gpu WebGL / interactive / instances /gpu]<br />
-			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]
+			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
+			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
+			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
+			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -103,17 +103,14 @@
 			[example:webgl_gpgpu_birds webgl / gpgpu / birds]<br />
 			[example:webgl_gpgpu_protoplanet webgl / gpgpu / protoplanet]<br />
 			[example:webgl_gpgpu_water webgl / gpgpu / water]<br />
-			[example:webgl_hdr webgl / hdr]<br />
 			[example:webgl_interactive_points webgl / interactive / points]<br />
-			[example:webgl_kinect webgl / kinect]<br />
+			[example:webgl_video_kinect webgl / video / kinect]<br />
 			[example:webgl_lights_hemisphere webgl / lights / hemisphere]<br />
 			[example:webgl_marchingcubes webgl / marchingcubes]<br />
-			[example:webgl_materials_bumpmap_skin webgl / materials / bumpmap / skin]<br />
 			[example:webgl_materials_envmaps webgl / materials / envmaps]<br />
 			[example:webgl_materials_lightmap webgl / materials / lightmap]<br />
 			[example:webgl_materials_parallaxmap webgl / materials / parallaxmap]<br />
 			[example:webgl_materials_shaders_fresnel webgl / materials / shaders / fresnel]<br />
-			[example:webgl_materials_skin webgl / materials / skin]<br />
 			[example:webgl_materials_wireframe webgl / materials / wireframe]<br />
 			[example:webgl_modifier_tessellation webgl / modifier / tessellation]<br />
 			[example:webgl_postprocessing_dof2 webgl / postprocessing / dof2]<br />

--- a/docs/api/en/materials/SpriteMaterial.html
+++ b/docs/api/en/materials/SpriteMaterial.html
@@ -26,9 +26,9 @@
 
 		<h2>Examples</h2>
 		<p>
-			[example:webgl_sprites webGL / sprites]<br />
-			[example:svg_sandbox svg / sandbox]<br />
-			[example:webgl_materials_cubemap_dynamic webgl / materials / cubemap / dynamic]
+			[example:webgl_raycast_sprite WebGL / raycast / sprite]<br />
+			[example:webgl_sprites WebGL / sprites]<br />
+			[example:svg_sandbox SVG / sandbox]
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -27,7 +27,7 @@
 		<h2>例子</h2>
 
 		<p>
-			[example:webgl_buffergeometry_drawcalls WebGL / buffergeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_drawrange WebGL / buffergeometry / drawrange]<br />
 			[example:webgl_buffergeometry_lines WebGL / buffergeometry / lines]<br />
 			[example:webgl_buffergeometry_lines_indexed WebGL / buffergeometry / lines / indexed]<br />
 			[example:webgl_decals WebGL / decals]<br />

--- a/docs/api/zh/materials/PointsMaterial.html
+++ b/docs/api/zh/materials/PointsMaterial.html
@@ -41,7 +41,7 @@
 		<h2>例子</h2>
 		<p>
 			[example:misc_controls_fly misc / controls / fly]<br />
-			[example:webgl_buffergeometry_drawcalls WebGL / BufferGeometry / drawcalls]<br />
+			[example:webgl_buffergeometry_drawrange WebGL / BufferGeometry / drawrange]<br />
 			[example:webgl_buffergeometry_points WebGL / BufferGeometry / points]<br />
 			[example:webgl_buffergeometry_points_interleaved WebGL / BufferGeometry / points / interleaved]<br />
 			[example:webgl_camera WebGL / camera ]<br />

--- a/docs/api/zh/materials/RawShaderMaterial.html
+++ b/docs/api/zh/materials/RawShaderMaterial.html
@@ -32,11 +32,11 @@
 		<p>
 			[example:webgl_buffergeometry_rawshader WebGL / buffergeometry / rawshader]<br />
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
-			[example:webgl_buffergeometry_instancing_dynamic WebGL / buffergeometry / instancing / dynamic]<br />
-			[example:webgl_buffergeometry_instancing_interleaved_dynamic WebGL / buffergeometry / instancing / interleaved / dynamic]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
-			[example:webgl_interactive_instances_gpu WebGL / interactive / instances /gpu]<br />
-			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]
+			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
+			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
+			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
+			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
 		</p>
 
 		<h2>构造函数(Constructor)</h2>

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -93,18 +93,14 @@
 			[example:webgl_gpgpu_birds webgl / gpgpu / birds]<br />
 			[example:webgl_gpgpu_protoplanet webgl / gpgpu / protoplanet]<br />
 			[example:webgl_gpgpu_water webgl / gpgpu / water]<br />
-			[example:webgl_hdr webgl / hdr]<br />
 			[example:webgl_interactive_points webgl / interactive / points]<br />
-			[example:webgl_kinect webgl / kinect]<br />
+			[example:webgl_video_kinect webgl / video / kinect]<br />
 			[example:webgl_lights_hemisphere webgl / lights / hemisphere]<br />
 			[example:webgl_marchingcubes webgl / marchingcubes]<br />
-			[example:webgl_materials_bumpmap_skin webgl / materials / bumpmap / skin]<br />
 			[example:webgl_materials_envmaps webgl / materials / envmaps]<br />
 			[example:webgl_materials_lightmap webgl / materials / lightmap]<br />
 			[example:webgl_materials_parallaxmap webgl / materials / parallaxmap]<br />
 			[example:webgl_materials_shaders_fresnel webgl / materials / shaders / fresnel]<br />
-			[example:webgl_materials_skin webgl / materials / skin]<br />
-			[example:webgl_materials_texture_hdr webgl / materials / texture / hdr]<br />
 			[example:webgl_materials_wireframe webgl / materials / wireframe]<br />
 			[example:webgl_modifier_tessellation webgl / modifier / tessellation]<br />
 			[example:webgl_postprocessing_dof2 webgl / postprocessing / dof2]<br />

--- a/docs/api/zh/materials/SpriteMaterial.html
+++ b/docs/api/zh/materials/SpriteMaterial.html
@@ -26,9 +26,9 @@
 
 		<h2>例子</h2>
 		<p>
+			[example:webgl_raycast_sprite WebGL / raycast / sprite]<br />
 			[example:webgl_sprites WebGL / sprites]<br />
-			[example:svg_sandbox svg / sandbox]<br />
-			[example:webgl_materials_cubemap_dynamic webgl / materials / cubemap / dynamic]
+			[example:svg_sandbox SVG / sandbox]
 		</p>
 
 		<h2>构造函数(Constructor)</h2>


### PR DESCRIPTION
Related issue: -

**Description**

Fixes some broken example links in the documentation.