### PR TITLE
Three.Legacy.js: Remove GeometryUtils.

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -2049,37 +2049,6 @@ CubeCamera.prototype.clear = function ( renderer, color, depth, stencil ) {
 
 };
 
-//
-
-export const GeometryUtils = {
-
-	merge: function ( geometry1, geometry2, materialIndexOffset ) {
-
-		console.warn( 'THREE.GeometryUtils: .merge() has been moved to Geometry. Use geometry.merge( geometry2, matrix, materialIndexOffset ) instead.' );
-		let matrix;
-
-		if ( geometry2.isMesh ) {
-
-			geometry2.matrixAutoUpdate && geometry2.updateMatrix();
-
-			matrix = geometry2.matrix;
-			geometry2 = geometry2.geometry;
-
-		}
-
-		geometry1.merge( geometry2, matrix, materialIndexOffset );
-
-	},
-
-	center: function ( geometry ) {
-
-		console.warn( 'THREE.GeometryUtils: .center() has been moved to Geometry. Use geometry.center() instead.' );
-		return geometry.center();
-
-	}
-
-};
-
 ImageUtils.crossOrigin = undefined;
 
 ImageUtils.loadTexture = function ( url, mapping, onLoad, onError ) {


### PR DESCRIPTION
Related issue: -

**Description**

Since `Geometry` has been removed, I think it's safe to remove `GeometryUtils` from `Three.Legacy.js`.
