### PR TITLE
Quaternion: Return early from slerpFlat if t is 0 or 1

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -33,6 +33,26 @@ class Quaternion {
 			z1 = src1[ srcOffset1 + 2 ],
 			w1 = src1[ srcOffset1 + 3 ];
 
+		if ( t === 0 ) {
+
+			dst[ dstOffset ] = x0;
+			dst[ dstOffset + 1 ] = y0;
+			dst[ dstOffset + 2 ] = z0;
+			dst[ dstOffset + 3 ] = w0;
+			return;
+
+		}
+
+		if ( t === 1 ) {
+
+			dst[ dstOffset ] = x1;
+			dst[ dstOffset + 1 ] = y1;
+			dst[ dstOffset + 2 ] = z1;
+			dst[ dstOffset + 3 ] = w1;
+			return;
+
+		}
+
 		if ( w0 !== w1 || x0 !== x1 || y0 !== y1 || z0 !== z1 ) {
 
 			let s = 1 - t;


### PR DESCRIPTION
**Description**

In `Quaternion.slerp` we return early if `t` is 0 or 1, returning `qa` if `t` 0 and `qb` if `t` 1. We don't do the same in `slerpFlat` and it impacts performance in certain cases.

1.000.000 slerpFlats without early return in msec (using the quats in in `Quaternion.tests.js`):

| t  | time in msec | 
| --------  | ------------------- |
|0| **56.661** |
|1| **60.9848** |
|0.5| 50.9151 |
|0.25| 47.1928 |
|0.75| 47.2224 |
|0.5| 36.2757 |
|0.5| 39.1083 |

1.000.000 slerpFlats with early return:

| t  | time in msec | 
| --------  | ------------------- |
|0 | **12.8091**|
|1 | **14.754**|
|0.5 | 52.2216|
|0.25 | 48.1502|
|0.75 | 47.7769|
|0.5 | 34.5647|
|0.5 | 37.7248|

There is some natural variation, but for `t` 0 and `t` 1 the early return variant is on average 4-5x faster.

In a real world example where `slerpFlat` is used to interpolate between player rotations in a multiplayer scenario, I'm definitely seeing an improvement.

Happy to code golf it a bit more, but I'm looking for feedback on whether the change is appropriate first.