### PR TITLE
GLTFLoader: Revert usage of computeTangents().

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3243,21 +3243,6 @@ THREE.GLTFLoader = ( function () {
 						? new THREE.SkinnedMesh( geometry, material )
 						: new THREE.Mesh( geometry, material );
 
-					// Fix double sided rendered models on certain mobile devices, see https://github.com/mrdoob/three.js/issues/20997#issuecomment-756082184
-
-					if ( material.isMeshStandardMaterial === true &&
-						material.side === THREE.DoubleSide &&
-						geometry.getIndex() !== null &&
-						geometry.hasAttribute( 'position' ) === true &&
-						geometry.hasAttribute( 'normal' ) === true &&
-						geometry.hasAttribute( 'uv' ) === true &&
-						geometry.hasAttribute( 'tangent' ) === false ) {
-
-						geometry.computeTangents();
-						material.vertexTangents = true;
-
-					}
-
 					if ( mesh.isSkinnedMesh === true && ! mesh.geometry.attributes.skinWeight.normalized ) {
 
 						// we normalize floating point skin weight array to fix malformed assets (see #15319)

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3308,21 +3308,6 @@ var GLTFLoader = ( function () {
 						? new SkinnedMesh( geometry, material )
 						: new Mesh( geometry, material );
 
-					// Fix double sided rendered models on certain mobile devices, see https://github.com/mrdoob/three.js/issues/20997#issuecomment-756082184
-
-					if ( material.isMeshStandardMaterial === true &&
-						material.side === DoubleSide &&
-						geometry.getIndex() !== null &&
-						geometry.hasAttribute( 'position' ) === true &&
-						geometry.hasAttribute( 'normal' ) === true &&
-						geometry.hasAttribute( 'uv' ) === true &&
-						geometry.hasAttribute( 'tangent' ) === false ) {
-
-						geometry.computeTangents();
-						material.vertexTangents = true;
-
-					}
-
 					if ( mesh.isSkinnedMesh === true && ! mesh.geometry.attributes.skinWeight.normalized ) {
 
 						// we normalize floating point skin weight array to fix malformed assets (see #15319)


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/11438#issuecomment-770797791

**Description**

It seems computing tangents currently breaks [NormalTangentTest](https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/NormalTangentTest/README.md) test asset. Reverting the change solves the issue for now.

I guess we have to find another way to fix double sided rendered models.
