### PR TITLE
Fix initial material configuration in example

### DIFF
--- a/examples/webgl_materials_envmaps_hdr_nodes.html
+++ b/examples/webgl_materials_envmaps_hdr_nodes.html
@@ -101,16 +101,16 @@
 
 				let material = new THREE.MeshStandardMaterial();
 				material.color = new THREE.Color( 0xffffff );
-				material.roughness = params.metalness;
-				material.metalness = params.roguhness;
+				material.roughness = params.roughness;
+				material.metalness = params.metalness;
 
 				torusMesh = new THREE.Mesh( geometry, material );
 				scene.add( torusMesh );
 
 				material = new MeshStandardNodeMaterial();
 				material.color = new THREE.Color( 0xffffff );
-				material.roughness = params.metalness;
-				material.metalness = params.roguhness;
+				material.roughness = params.roughness;
+				material.metalness = params.metalness;
 
 				torusMeshNode = new THREE.Mesh( geometry, material );
 				scene.add( torusMeshNode );


### PR DESCRIPTION
This is a small fix for the envmap example. No related Github issue.

**Description**

The example for envmaps swapped the initial parameters and uses the inexistent `roguhness`-member of `params`. This example works as expected only as long as `metallness` is intialized with `0.0`.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Renuo AG](https://www.renuo.ch).
