### PR TITLE
SkinnedMesh: Remove warning.

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -13,12 +13,6 @@ const _matrix = new Matrix4();
 
 function SkinnedMesh( geometry, material ) {
 
-	if ( geometry && geometry.isGeometry ) {
-
-		console.error( 'THREE.SkinnedMesh no longer supports THREE.Geometry. Use THREE.BufferGeometry instead.' );
-
-	}
-
 	Mesh.call( this, geometry, material );
 
 	this.type = 'SkinnedMesh';


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/21189#issuecomment-771525519

**Description**

This check comes from a time where `Geometry` support was removed from `SkinnedMesh`, see  #15314.

With removing `Geometry` from core this specific check is now obsolete (since we haven't it in `Mesh` or `InstancedMesh`).