### PR TITLE
WebGPURenderer: Update to latest WebGPU API.

### DIFF
--- a/examples/jsm/renderers/nodes/accessors/ModelViewProjectionMatrixNode.js
+++ b/examples/jsm/renderers/nodes/accessors/ModelViewProjectionMatrixNode.js
@@ -4,7 +4,7 @@ import ModelNode from '../accessors/ModelNode.js';
 import OperatorNode from '../math/OperatorNode.js';
 import PositionNode from '../accessors/PositionNode.js';
 
-class GLPositionNode extends Node {
+class ModelViewProjectionMatrixNode extends Node {
 
 	constructor( position = new PositionNode() ) {
 
@@ -29,4 +29,4 @@ class GLPositionNode extends Node {
 
 }
 
-export default GLPositionNode;
+export default ModelViewProjectionMatrixNode;

--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -95,7 +95,7 @@ class WebGPUAttributes {
 
 			// Not using update ranges
 
-			this.device.defaultQueue.writeBuffer(
+			this.device.queue.writeBuffer(
 				buffer,
 				0,
 				array,
@@ -104,7 +104,7 @@ class WebGPUAttributes {
 
 		} else {
 
-			this.device.defaultQueue.writeBuffer(
+			this.device.queue.writeBuffer(
 				buffer,
 				0,
 				array,

--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -108,7 +108,7 @@ class WebGPUBindings {
 
 				if ( needsBufferWrite === true ) {
 
-					this.device.defaultQueue.writeBuffer(
+					this.device.queue.writeBuffer(
 						bufferGPU,
 						0,
 						array,

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -312,7 +312,7 @@ class WebGPURenderer {
 		// finish render pass
 
 		passEncoder.endPass();
-		device.defaultQueue.submit( [ cmdEncoder.finish() ] );
+		device.queue.submit( [ cmdEncoder.finish() ] );
 
 	}
 
@@ -568,7 +568,7 @@ class WebGPURenderer {
 		}
 
 		passEncoder.endPass();
-		device.defaultQueue.submit( [ cmdEncoder.finish() ] );
+		device.queue.submit( [ cmdEncoder.finish() ] );
 
 	}
 
@@ -856,7 +856,7 @@ class WebGPURenderer {
 				},
 				sampleCount: this._parameters.sampleCount,
 				format: GPUTextureFormat.BRGA8Unorm,
-				usage: GPUTextureUsage.OUTPUT_ATTACHMENT
+				usage: GPUTextureUsage.RENDER_ATTACHMENT
 			} );
 
 		}
@@ -879,7 +879,7 @@ class WebGPURenderer {
 				},
 				sampleCount: this._parameters.sampleCount,
 				format: GPUTextureFormat.Depth24PlusStencil8,
-				usage: GPUTextureUsage.OUTPUT_ATTACHMENT
+				usage: GPUTextureUsage.RENDER_ATTACHMENT
 			} );
 
 		}

--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -136,7 +136,7 @@ class WebGPUTextureUtils {
 
 		}
 
-		this.device.defaultQueue.submit( [ commandEncoder.finish() ] );
+		this.device.queue.submit( [ commandEncoder.finish() ] );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -206,7 +206,7 @@ class WebGPUTextures {
 					depth: 1
 				},
 				format: colorTextureFormat,
-				usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.SAMPLED
+				usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED
 			} );
 
 			this.info.memory.textures ++;
@@ -234,7 +234,7 @@ class WebGPUTextures {
 						depth: 1
 					},
 					format: depthTextureFormat,
-					usage: GPUTextureUsage.OUTPUT_ATTACHMENT
+					usage: GPUTextureUsage.RENDER_ATTACHMENT
 				} );
 
 				this.info.memory.textures ++;
@@ -320,9 +320,9 @@ class WebGPUTextures {
 
 		if ( needsMipmaps === true ) {
 
-			// current mipmap generation requires OUTPUT_ATTACHMENT
+			// current mipmap generation requires RENDER_ATTACHMENT
 
-			usage |= GPUTextureUsage.OUTPUT_ATTACHMENT;
+			usage |= GPUTextureUsage.RENDER_ATTACHMENT;
 
 		}
 
@@ -390,7 +390,7 @@ class WebGPUTextures {
 		const bytesPerTexel = this._getBytesPerTexel( format );
 		const bytesPerRow = Math.ceil( image.width * bytesPerTexel / 256 ) * 256;
 
-		this.device.defaultQueue.writeTexture(
+		this.device.queue.writeTexture(
 			{
 				texture: textureGPU,
 				mipLevel: 0
@@ -426,7 +426,7 @@ class WebGPUTextures {
 
 	_copyImageBitmapToTexture( image, textureGPU, origin = { x: 0, y: 0, z: 0 } ) {
 
-		this.device.defaultQueue.copyImageBitmapToTexture(
+		this.device.queue.copyImageBitmapToTexture(
 			{
 				imageBitmap: image
 			}, {
@@ -457,7 +457,7 @@ class WebGPUTextures {
 
 			const bytesPerRow = Math.ceil( width / blockData.width ) * blockData.byteLength;
 
-			this.device.defaultQueue.writeTexture(
+			this.device.queue.writeTexture(
 				{
 					texture: textureGPU,
 					mipLevel: i

--- a/examples/jsm/renderers/webgpu/nodes/ShaderLib.js
+++ b/examples/jsm/renderers/webgpu/nodes/ShaderLib.js
@@ -8,7 +8,7 @@ NODE_HEADER_VARYS
 
 void main(){
 	NODE_BODY_VARYS
-	gl_Position = NODE_GL_POSITION;
+	gl_Position = NODE_MVP;
 }`,
 		fragmentShader: `#version 450
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -49,7 +49,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			}
 
-			this.addSlot( 'vertex', new NodeSlot( mvpNode, 'GL_POSITION', 'vec4' ) );
+			this.addSlot( 'vertex', new NodeSlot( mvpNode, 'MVP', 'vec4' ) );
 
 			if ( material.colorNode !== undefined ) {
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -8,7 +8,7 @@ import { WebGPUSampledTexture } from '../WebGPUSampledTexture.js';
 
 import NodeSlot from '../../nodes/core/NodeSlot.js';
 import NodeBuilder from '../../nodes/core/NodeBuilder.js';
-import GLPositionNode from '../../nodes/accessors/GLPositionNode.js';
+import ModelViewProjectionMatrixNode from '../../nodes/accessors/ModelViewProjectionMatrixNode.js';
 
 import ShaderLib from './ShaderLib.js';
 
@@ -41,15 +41,15 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		if ( material.isMeshBasicMaterial || material.isPointsMaterial || material.isLineBasicMaterial ) {
 
-			const glPositionNode = new GLPositionNode();
+			const mvpNode = new ModelViewProjectionMatrixNode();
 
 			if ( material.positionNode !== undefined ) {
 
-				glPositionNode.position = material.positionNode;
+				mvpNode.position = material.positionNode;
 
 			}
 
-			this.addSlot( 'vertex', new NodeSlot( glPositionNode, 'GL_POSITION', 'vec4' ) );
+			this.addSlot( 'vertex', new NodeSlot( mvpNode, 'GL_POSITION', 'vec4' ) );
 
 			if ( material.colorNode !== undefined ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/21170#discussion_r569311828

**Description**

This PR

- renames `defaultQueue` to `queue` (WebGPU API change)
- renames `OUTPUT_ATTACHMENT` to `RENDER_ATTACHMENT`  (WebGPU API change)
- renames `GLPositionNode` to  `ModelViewProjectionMatrixNode`