### PR TITLE
BokehShader - fix aspect correction

### DIFF
--- a/examples/js/shaders/BokehShader.js
+++ b/examples/js/shaders/BokehShader.js
@@ -75,7 +75,7 @@ THREE.BokehShader = {
 
 		'void main() {',
 
-		'	vec2 aspectcorrect = vec2( 1.0, aspect );',
+		'	vec2 aspectcorrect = vec2( 1.0 / aspect, 1.0 );',
 
 		'	float viewZ = getViewZ( getDepth( vUv ) );',
 

--- a/examples/jsm/shaders/BokehShader.js
+++ b/examples/jsm/shaders/BokehShader.js
@@ -75,7 +75,7 @@ var BokehShader = {
 
 		'void main() {',
 
-		'	vec2 aspectcorrect = vec2( 1.0, aspect );',
+		'	vec2 aspectcorrect = vec2( 1.0 / aspect, 1.0 );',
 
 		'	float viewZ = getViewZ( getDepth( vUv ) );',
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -140,7 +140,7 @@
 
 					focus: 500.0,
 					aperture: 5,
-					maxblur: 0.015
+					maxblur: 0.02
 
 				};
 
@@ -155,7 +155,7 @@
 				const gui = new GUI();
 				gui.add( effectController, "focus", 10.0, 3000.0, 10 ).onChange( matChanger );
 				gui.add( effectController, "aperture", 0, 10, 0.1 ).onChange( matChanger );
-				gui.add( effectController, "maxblur", 0.0, 0.015, 0.001 ).onChange( matChanger );
+				gui.add( effectController, "maxblur", 0.0, 0.02, 0.001 ).onChange( matChanger );
 				gui.close();
 
 				matChanger();
@@ -194,7 +194,7 @@
 				const bokehPass = new BokehPass( scene, camera, {
 					focus: 1.0,
 					aperture: 0.025,
-					maxblur: 0.015,
+					maxblur: 0.02,
 
 					width: width,
 					height: height

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -140,7 +140,7 @@
 
 					focus: 500.0,
 					aperture: 5,
-					maxblur: 0.01
+					maxblur: 0.015
 
 				};
 
@@ -155,7 +155,7 @@
 				const gui = new GUI();
 				gui.add( effectController, "focus", 10.0, 3000.0, 10 ).onChange( matChanger );
 				gui.add( effectController, "aperture", 0, 10, 0.1 ).onChange( matChanger );
-				gui.add( effectController, "maxblur", 0.0, 0.01, 0.001 ).onChange( matChanger );
+				gui.add( effectController, "maxblur", 0.0, 0.015, 0.001 ).onChange( matChanger );
 				gui.close();
 
 				matChanger();
@@ -194,7 +194,7 @@
 				const bokehPass = new BokehPass( scene, camera, {
 					focus: 1.0,
 					aperture: 0.025,
-					maxblur: 0.01,
+					maxblur: 0.015,
 
 					width: width,
 					height: height


### PR DESCRIPTION
Hello,

BokehShader currently fixes aspect ratio tweaking Y, which produces inconsistent results on different window sizes. I've changed it so it affects X instead.

This picture shows the before and after. As you can see in the bottom images the blur amount is consistent.

![dof](https://user-images.githubusercontent.com/11018451/106883205-fa6b2c80-66df-11eb-8a9b-0595f4dbe2f4.jpg)

