### PR TITLE
Material: Move flatShading to supported materials.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -162,11 +162,6 @@
 		Which stencil operation to perform when the comparison function returns true and the depth test passes. Default is [page:Materials KeepStencilOp]. See the stencil operations [page:Materials constants] for all possible values.
 		</p>
 
-		<h3>[property:Boolean flatShading]</h3>
-		<p>
-		Define whether the material is rendered with flat shading. Default is false.
-		</p>
-
 		<h3>[property:Boolean fog]</h3>
 		<p>Whether the material is affected by fog. Default is *true*.</p>
 

--- a/docs/api/en/materials/MeshMatcapMaterial.html
+++ b/docs/api/en/materials/MeshMatcapMaterial.html
@@ -95,6 +95,11 @@
 			Without a displacement map set, this value is not applied. Default is 0.
 		</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p>
+		Define whether the material is rendered with flat shading. Default is false.
+		</p>
+
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</p>
 

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -75,6 +75,11 @@
 			Without a displacement map set, this value is not applied. Default is 0.
 		</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p>
+		Define whether the material is rendered with flat shading. Default is false.
+		</p>
+
 		<h3>[property:Boolean fog]</h3>
 		<p>Whether the material is affected by fog. Default is *false*.</p>
 

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -142,6 +142,11 @@
 		<h3>[property:Texture envMap]</h3>
 		<p>The environment map. Default is null.</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p>
+		Define whether the material is rendered with flat shading. Default is false.
+		</p>
+
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
 

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -172,6 +172,10 @@
 		<h3>[property:Float envMapIntensity]</h3>
 		<p>Scales the effect of the environment map by multiplying its color.</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p>
+		Define whether the material is rendered with flat shading. Default is false.
+		</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -142,10 +142,6 @@ Which stencil operation to perform when the comparison function returns true but
 Which stencil operation to perform when the comparison function returns true and the depth test passes. Default is [page:Materials KeepStencilOp]. See the stencil operations [page:Materials constants] for all possible values.
 </p>
 
-<h3>[property:Boolean flatShading]</h3>
-<p> 定义材质是否使用平面着色进行渲染。默认值为false。
-</p>
-
 <h3>[property:Boolean fog]</h3>
 <p>材质是否受雾影响。默认为*true*。</p>
 

--- a/docs/api/zh/materials/MeshMatcapMaterial.html
+++ b/docs/api/zh/materials/MeshMatcapMaterial.html
@@ -80,6 +80,10 @@
 			位移贴图在网格顶点上的偏移量。如果没有设置位移贴图，则不会应用此值。默认值为0。
 		</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p> 定义材质是否使用平面着色进行渲染。默认值为false。
+		</p>
+
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。纹理贴图颜色由漫反射颜色[page:.color]调节。</p>
 

--- a/docs/api/zh/materials/MeshNormalMaterial.html
+++ b/docs/api/zh/materials/MeshNormalMaterial.html
@@ -62,6 +62,10 @@
 			位移贴图在网格顶点上的偏移量。如果没有设置位移贴图，则不会应用此值。默认值为0。
 		</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p> 定义材质是否使用平面着色进行渲染。默认值为false。
+		</p>
+
 		<h3>[property:Boolean fog]</h3>
 		<p>材质是否受雾影响。默认值为*false*。</p>
 

--- a/docs/api/zh/materials/MeshPhongMaterial.html
+++ b/docs/api/zh/materials/MeshPhongMaterial.html
@@ -112,6 +112,9 @@
 		<h3>[property:Texture envMap]</h3>
 		<p>环境贴图。默认值为null。</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p> 定义材质是否使用平面着色进行渲染。默认值为false。
+		</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>光照贴图。默认值为null。lightMap需要第二组UV。</p>

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -140,6 +140,9 @@
 		<h3>[property:Float envMapIntensity]</h3>
 		<p> 通过乘以环境贴图的颜色来缩放环境贴图的效果。</p>
 
+		<h3>[property:Boolean flatShading]</h3>
+		<p> 定义材质是否使用平面着色进行渲染。默认值为false。
+		</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>光照贴图。默认值为null。lightMap需要第二组UV。</p>

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -490,6 +490,8 @@
 				const folder = gui.addFolder( 'THREE.MeshMatcapMaterial' );
 
 				folder.addColor( data, 'color' ).onChange( handleColorChange( material.color ) );
+
+				folder.add( material, 'flatShading' ).onChange( needsUpdate( material, geometry ) );
 				folder.add( data, 'matcap', matcapKeys ).onChange( updateTexture( material, 'matcap', matcaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
 
@@ -539,7 +541,6 @@
 				const folder = gui.addFolder( 'THREE.MeshToonMaterial' );
 
 				folder.addColor( data, 'color' ).onChange( handleColorChange( material.color ) );
-
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'gradientMap', gradientMapKeys ).onChange( updateTexture( material, 'gradientMap', gradientMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );

--- a/examples/webxr_vr_rollercoaster.html
+++ b/examples/webxr_vr_rollercoaster.html
@@ -154,8 +154,7 @@
 
 			geometry = new THREE.CylinderGeometry( 10, 10, 5, 15 );
 			material = new THREE.MeshLambertMaterial( {
-				color: 0xff8080,
-				//flatShading: true // Lambert does not support flat shading
+				color: 0xff8080
 			} );
 			mesh = new THREE.Mesh( geometry, material );
 			mesh.position.set( - 80, 10, - 70 );
@@ -166,8 +165,7 @@
 
 			geometry = new THREE.CylinderGeometry( 5, 6, 4, 10 );
 			material = new THREE.MeshLambertMaterial( {
-				color: 0x8080ff,
-				//flatShading: true // Lambert does not support flat shading
+				color: 0x8080ff
 			} );
 			mesh = new THREE.Mesh( geometry, material );
 			mesh.position.set( 50, 2, 30 );

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -17,7 +17,6 @@ function Material() {
 
 	this.blending = NormalBlending;
 	this.side = FrontSide;
-	this.flatShading = false;
 	this.vertexColors = false;
 
 	this.opacity = 1;
@@ -265,7 +264,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.sizeAttenuation !== undefined ) data.sizeAttenuation = this.sizeAttenuation;
 
 		if ( this.blending !== NormalBlending ) data.blending = this.blending;
-		if ( this.flatShading === true ) data.flatShading = this.flatShading;
 		if ( this.side !== FrontSide ) data.side = this.side;
 		if ( this.vertexColors ) data.vertexColors = true;
 
@@ -310,6 +308,8 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.morphTargets === true ) data.morphTargets = true;
 		if ( this.morphNormals === true ) data.morphNormals = true;
 		if ( this.skinning === true ) data.skinning = true;
+
+		if ( this.flatShading === true ) data.flatShading = this.flatShading;
 
 		if ( this.visible === false ) data.visible = false;
 
@@ -363,7 +363,6 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 		this.blending = source.blending;
 		this.side = source.side;
-		this.flatShading = source.flatShading;
 		this.vertexColors = source.vertexColors;
 
 		this.opacity = source.opacity;

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -28,6 +28,8 @@ import { Color } from '../math/Color.js';
  *  skinning: <bool>,
  *  morphTargets: <bool>,
  *  morphNormals: <bool>
+ *
+ *  flatShading: <bool>
  * }
  */
 
@@ -61,6 +63,8 @@ function MeshMatcapMaterial( parameters ) {
 	this.skinning = false;
 	this.morphTargets = false;
 	this.morphNormals = false;
+
+	this.flatShading = false;
 
 	this.setValues( parameters );
 
@@ -99,6 +103,8 @@ MeshMatcapMaterial.prototype.copy = function ( source ) {
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
+
+	this.flatShading = source.flatShading;
 
 	return this;
 

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -22,7 +22,9 @@ import { Vector2 } from '../math/Vector2.js';
  *
  *  skinning: <bool>,
  *  morphTargets: <bool>,
- *  morphNormals: <bool>
+ *  morphNormals: <bool>,
+ *
+ *  flatShading: <bool>
  * }
  */
 
@@ -51,6 +53,8 @@ function MeshNormalMaterial( parameters ) {
 	this.skinning = false;
 	this.morphTargets = false;
 	this.morphNormals = false;
+
+	this.flatShading = false;
 
 	this.setValues( parameters );
 
@@ -82,6 +86,8 @@ MeshNormalMaterial.prototype.copy = function ( source ) {
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
+
+	this.flatShading = source.flatShading;
 
 	return this;
 

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -47,7 +47,9 @@ import { Color } from '../math/Color.js';
  *
  *  skinning: <bool>,
  *  morphTargets: <bool>,
- *  morphNormals: <bool>
+ *  morphNormals: <bool>,
+ *
+ *  flatShading: <bool>
  * }
  */
 
@@ -101,6 +103,8 @@ function MeshPhongMaterial( parameters ) {
 	this.skinning = false;
 	this.morphTargets = false;
 	this.morphNormals = false;
+
+	this.flatShading = false;
 
 	this.setValues( parameters );
 
@@ -159,6 +163,8 @@ MeshPhongMaterial.prototype.copy = function ( source ) {
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
+
+	this.flatShading = source.flatShading;
 
 	return this;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -49,7 +49,9 @@ import { Color } from '../math/Color.js';
  *
  *  skinning: <bool>,
  *  morphTargets: <bool>,
- *  morphNormals: <bool>
+ *  morphNormals: <bool>,
+ *
+ *  flatShading: <bool>
  * }
  */
 
@@ -107,6 +109,8 @@ function MeshStandardMaterial( parameters ) {
 	this.skinning = false;
 	this.morphTargets = false;
 	this.morphNormals = false;
+
+	this.flatShading = false;
 
 	this.vertexTangents = false;
 
@@ -171,6 +175,8 @@ MeshStandardMaterial.prototype.copy = function ( source ) {
 	this.skinning = source.skinning;
 	this.morphTargets = source.morphTargets;
 	this.morphNormals = source.morphNormals;
+
+	this.flatShading = source.flatShading;
 
 	this.vertexTangents = source.vertexTangents;
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -216,7 +216,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 			useFog: material.fog,
 			fogExp2: ( fog && fog.isFogExp2 ),
 
-			flatShading: material.flatShading,
+			flatShading: !! material.flatShading,
 
 			sizeAttenuation: material.sizeAttenuation,
 			logarithmicDepthBuffer: logarithmicDepthBuffer,


### PR DESCRIPTION
Related issue: Fixed #7130.

**Description**

`flatShading` is no longer a property of `Material`. The only materials supporting flat shading are:

- MeshPhongMaterial
- MeshStandardMaterial
- MeshPhysicalMaterial
- MeshNormalMaterial
- MeshMatcapMaterial

It looks horrible when using it when `MeshToonMaterial` so I have left it out.