### PR TITLE
Line3: Add equalsLoose()

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -137,6 +137,12 @@ class Line3 {
 		return line.start.equals( this.start ) && line.end.equals( this.end );
 
 	}
+	
+	equalsLoose( line ) {
+
+		return (line.start.equals( this.start ) && line.end.equals( this.end )) || (line.start.equals( this.end ) && line.end.equals( this.start ));
+
+	}
 
 }
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -137,10 +137,10 @@ class Line3 {
 		return line.start.equals( this.start ) && line.end.equals( this.end );
 
 	}
-	
+
 	equalsLoose( line ) {
 
-		return (line.start.equals( this.start ) && line.end.equals( this.end )) || (line.start.equals( this.end ) && line.end.equals( this.start ));
+		return ( line.start.equals( this.start ) && line.end.equals( this.end ) ) || ( line.start.equals( this.end ) && line.end.equals( this.start ) );
 
 	}
 


### PR DESCRIPTION
Hello,
I propose a new method for Line3 to check if two lines are loosely the same, as in one line has the start point of the other line as an end point and vice versa. Currently there is (at least to my knowledge) no way to check wether two lines are loosely the same in a convenient manner (i.e. without for example instantiating a new line with swapped start and end points).