### PR TITLE
ShaderChunks: isFrontFacing boolean to faceDirection float

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
@@ -22,7 +22,7 @@ export default /* glsl */`
 
 	}
 
-	vec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy, bool isFrontFacing ) {
+	vec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy, float faceDirection ) {
 
 		// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
@@ -33,9 +33,7 @@ export default /* glsl */`
 		vec3 R1 = cross( vSigmaY, vN );
 		vec3 R2 = cross( vN, vSigmaX );
 
-		float fDet = dot( vSigmaX, R1 );
-
-		fDet *= ( float( isFrontFacing ) * 2.0 - 1.0 );
+		float fDet = dot( vSigmaX, R1 ) * faceDirection;
 
 		vec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );
 		return normalize( abs( fDet ) * surf_norm - vGrad );

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
@@ -10,7 +10,7 @@ export default /* glsl */`
 
 	#else
 
-		clearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatMapN, isFrontFacing );
+		clearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatMapN, faceDirection );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-bool isFrontFacing = true;
+float faceDirection = 1.0;
 
 #ifdef FLAT_SHADED
 
@@ -9,7 +9,7 @@ bool isFrontFacing = true;
 	vec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );
 	vec3 normal = normalize( cross( fdx, fdy ) );
 
-	isFrontFacing = dot( vec3( 0, 0, 1 ), normal ) > 0.0;
+	faceDirection = sign( dot( vec3( 0, 0, 1 ), normal ) );
 
 #else
 
@@ -25,9 +25,9 @@ bool isFrontFacing = true;
 		// Workaround for Adreno GPUs broken gl_FrontFacing implementation
 		// https://stackoverflow.com/a/32621243
 
-		isFrontFacing = dot( normal, normalize( cross( fdx, fdy ) ) ) > 0.0;
+		faceDirection = sign( dot( normal, normalize( cross( fdx, fdy ) ) ) );
 
-		normal = normal * ( float( isFrontFacing ) * 2.0 - 1.0 );
+		normal = normal * faceDirection;
 
 	#endif
 
@@ -38,8 +38,8 @@ bool isFrontFacing = true;
 
 		#ifdef DOUBLE_SIDED
 
-			tangent = tangent * ( float( isFrontFacing ) * 2.0 - 1.0 );
-			bitangent = bitangent * ( float( isFrontFacing ) * 2.0 - 1.0 );
+			tangent = tangent * faceDirection;
+			bitangent = bitangent * faceDirection;
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -12,7 +12,7 @@ export default /* glsl */`
 
 	#ifdef DOUBLE_SIDED
 
-		// We can't compute isFrontFacing if the model doesn't have normals
+		// We can't compute faceDirection if the model doesn't have normals
 
 		normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
 
@@ -31,13 +31,13 @@ export default /* glsl */`
 
 	#else
 
-		normal = perturbNormal2Arb( -vViewPosition, normal, mapN, isFrontFacing );
+		normal = perturbNormal2Arb( -vViewPosition, normal, mapN, faceDirection );
 
 	#endif
 
 #elif defined( USE_BUMPMAP )
 
-	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd(), isFrontFacing );
+	normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd(), faceDirection );
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -17,7 +17,7 @@ export default /* glsl */`
 	// Per-Pixel Tangent Space Normal Mapping
 	// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
 
-	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN, bool isFrontFacing ) {
+	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN, float faceDirection ) {
 
 		// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
@@ -34,7 +34,7 @@ export default /* glsl */`
 
 		mat3 tsn = mat3( S, T, N );
 
-		mapN.xy *= ( float( isFrontFacing ) * 2.0 - 1.0 );
+		mapN.xy *= faceDirection;
 
 		return normalize( tsn * mapN );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/21202#issuecomment-773398276

**Description**

Now that we no longer need `gl_FrontFacing` we can just do a float with the direction.