### PR TITLE
ShaderChunk: Bring gl_FrontFacing back

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-float faceDirection = 1.0;
+float faceDirection = float( gl_FrontFacing ) * 2.0 - 1.0;
 
 #ifdef FLAT_SHADED
 
@@ -9,23 +9,11 @@ float faceDirection = 1.0;
 	vec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );
 	vec3 normal = normalize( cross( fdx, fdy ) );
 
-	faceDirection = sign( dot( vec3( 0, 0, 1 ), normal ) );
-
 #else
 
 	vec3 normal = normalize( vNormal );
 
 	#ifdef DOUBLE_SIDED
-
-		// Workaround for Adreno GPUs not able to do dFdx( vViewPosition )
-
-		vec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );
-		vec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );
-
-		// Workaround for Adreno GPUs broken gl_FrontFacing implementation
-		// https://stackoverflow.com/a/32621243
-
-		faceDirection = sign( dot( normal, normalize( cross( fdx, fdy ) ) ) );
 
 		normal = normal * faceDirection;
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -12,9 +12,7 @@ export default /* glsl */`
 
 	#ifdef DOUBLE_SIDED
 
-		// We can't compute faceDirection if the model doesn't have normals
-
-		normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+		normal = normal * faceDirection;
 
 	#endif
 


### PR DESCRIPTION
Related issue: #21202 #21203

**Description**

Plot twist! Turns out [the Adreno bug is only when gl_FrontFacing is inside a function](https://bugs.chromium.org/p/chromium/issues/detail?id=1154842). After today's refactoring we only refer to it in `main()` so we can now bring it back and get rid of the workaround.