### PR TITLE
GLTFLoader: Add before/afterRoot hookpoints

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1963,13 +1963,21 @@ var GLTFLoader = ( function () {
 
 		} );
 
-		Promise.all( [
+		Promise.all( this._invokeAll( function ( ext ) {
 
-			this.getDependencies( 'scene' ),
-			this.getDependencies( 'animation' ),
-			this.getDependencies( 'camera' ),
+			return ext.beforeRoot && ext.beforeRoot();
 
-		] ).then( function ( dependencies ) {
+		} ) ).then( function () {
+
+			return Promise.all( [
+
+				parser.getDependencies( 'scene' ),
+				parser.getDependencies( 'animation' ),
+				parser.getDependencies( 'camera' ),
+
+			] );
+
+		} ).then( function ( dependencies ) {
 
 			var result = {
 				scene: dependencies[ 0 ][ json.scene || 0 ],
@@ -1985,7 +1993,15 @@ var GLTFLoader = ( function () {
 
 			assignExtrasToUserData( result, json );
 
-			onLoad( result );
+			Promise.all( parser._invokeAll( function ( ext ) {
+
+				return ext.afterRoot && ext.afterRoot( result );
+
+			} ) ).then( function () {
+
+				onLoad( result );
+
+			} );
 
 		} ).catch( onError );
 


### PR DESCRIPTION
Related PR: #20789

**Description**

This PR adds invokeAll `before/afterRoot` hookpoints.

`beforeRoot()` hook is called before starting the entre glTF but after for parsing glTF binary to JSON. The main use case would be for hacking glTF definition. (I remember some devs requested it.) And handlers for extensions under the root may need it.

`afterRoot(result)` hook is called after generating all Three.js objects. The main use case would be handling extensions under the root and/or apply some changes to the generated Three.js objects. My material variants extension handler plugin needs this hook point.
