### PR TITLE
Update TextureLoader.js

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -19,6 +19,7 @@ TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
+		loader.setWithCredentials( this.withCredentials );
 		loader.setPath( this.path );
 
 		loader.load( url, function ( image ) {


### PR DESCRIPTION
Adding support for `withCredentials`

Related issue: none

**Description**

I'm in a use case where I need to load textures & glTF files from a URL requiring cookies to be set properly in a CORS situation.
The glTF loader already supports `withCredentials` to deal with that, but not the TextureLoader.