### PR TITLE
NRRDLoader: Improved gzip detection code

### DIFF
--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -309,7 +309,7 @@ THREE.NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototyp
 		parseHeader( _header );
 
 		var _data = _bytes.subarray( _data_start ); // the data without header
-		if ( headerObject.encoding === 'gzip' || headerObject.encoding === 'gz' ) {
+		if ( headerObject.encoding.substring( 0, 2 ) === 'gz' ) {
 
 			// we need to decompress the datastream
 			// here we start the unzipping and get a typed Uint8Array back

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -318,7 +318,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		parseHeader( _header );
 
 		var _data = _bytes.subarray( _data_start ); // the data without header
-		if ( headerObject.encoding === 'gzip' || headerObject.encoding === 'gz' ) {
+		if ( headerObject.encoding === 'gzip' || headerObject.encoding === 'gz' || headerObject.encoding === 'gzi' ) {
 
 			// we need to decompress the datastream
 			// here we start the unzipping and get a typed Uint8Array back

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -318,7 +318,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		parseHeader( _header );
 
 		var _data = _bytes.subarray( _data_start ); // the data without header
-		if ( headerObject.encoding === 'gzip' || headerObject.encoding === 'gz' || headerObject.encoding === 'gzi' ) {
+		if ( headerObject.encoding.substring( 0, 2 ) === 'gz' ) {
 
 			// we need to decompress the datastream
 			// here we start the unzipping and get a typed Uint8Array back


### PR DESCRIPTION
**Description**

NRRD files exported using some of the NRRD libraries, such as pynrrd, uses `gzi` as an encoding name rather than `gzip` or `gz`, and these files could not be loaded previously. 
Here, I added `gzi` encoding option to `examples/jsm/loaders/NRRDLoaders.js` so it recognizes `gzi` as `gzip` encoding.
