### PR TITLE
Update WebGL-compatibility-check.html

### DIFF
--- a/docs/manual/zh/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/zh/introduction/WebGL-compatibility-check.html
@@ -17,7 +17,7 @@
         	</p>
 
 <code>
-if (WEBGL.isWebGLAvailable()) {
+if (THREE.WEBGL.isWebGLAvailable()) {
     // Initiate function or other initializations here
     animate();
 } else {


### PR DESCRIPTION
Tiny fix: https://github.com/mrdoob/three.js/blob/master/examples/js/WebGL.js puts its content into `THREE.WEBGL` instead of `WEBGL`.
