### PR TITLE
VRMLLoader: Apply DEF-name to node names.

### DIFF
--- a/examples/js/loaders/VRMLLoader.js
+++ b/examples/js/loaders/VRMLLoader.js
@@ -723,6 +723,12 @@ THREE.VRMLLoader = ( function () {
 
 				}
 
+				if ( build !== undefined && node.DEF !== undefined && build.hasOwnProperty( 'name' ) === true ) {
+
+					build.name = node.DEF;
+
+				}
+
 				return build;
 
 			}

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -761,6 +761,12 @@ var VRMLLoader = ( function () {
 
 				}
 
+				if ( build !== undefined && node.DEF !== undefined && build.hasOwnProperty( 'name' ) === true ) {
+
+					build.name = node.DEF;
+
+				}
+
 				return build;
 
 			}


### PR DESCRIPTION
Related issue: -

**Description**

Applies the `DEF-name` to a node if possible.
