### PR TITLE
Docs: Fixed broken links for WhitestormJS

### DIFF
--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -103,7 +103,7 @@
 			[link:http://www.physgl.org/ physgl.org] - واجهة JavaScript الأمامية مع أغلفة لـ three.js ، لجلب رسومات WebGL للطلاب الذين يتعلمون الفيزياء والرياضيات.
 		 </li>
 		 <li>
-			 [link:https://whs.io/ Whitestorm.js] – إطار عمل modular three.js مع البرنامج المساعد AmmoNext للفيزياء.
+			 [link:https://whsjs.readme.io/ Whitestorm.js] – إطار عمل modular three.js مع البرنامج المساعد AmmoNext للفيزياء.
 		 </li>
 
 		<li>

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -113,7 +113,7 @@
  			graphics to students learning physics and math.
 		 </li>
 		 <li>
-			 [link:https://whs.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
+			 [link:https://whsjs.readme.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
 		 </li>
 
 		<li>

--- a/docs/manual/ko/introduction/Useful-links.html
+++ b/docs/manual/ko/introduction/Useful-links.html
@@ -112,7 +112,7 @@
  			graphics to students learning physics and math.
 		 </li>
 		 <li>
-			 [link:https://whs.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
+			 [link:https://whsjs.readme.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
 		 </li>
 
 		<li>

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -114,7 +114,7 @@
  			graphics to students learning physics and math.
 		 </li>
 		 <li>
-			 [link:https://whs.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
+			 [link:https://whsjs.readme.io/ Whitestorm.js] – Modular three.js framework with AmmoNext physics plugin.
 		 </li>
 
 		<li>


### PR DESCRIPTION
Related issue:  -

**Description**

Addresses for WhitestormJS were out of date, updated from https://whs.io (404s) to https://whsjs.readme.io.