### PR TITLE
OrbitControls.target() is not a function

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -237,12 +237,6 @@ controls.mouseButtons = {
 			Used internally by the [method:saveState] and [method:reset] methods.
 		</p>
 
-		<h3>[property:Vector3 target]</h3>
-		<p>
-			The focus point of the controls, the [page:.object] orbits around this. It can be updated manually at any point to change
-			the focus of the controls.
-		</p>
-
 		<h3>[property:Object touches]</h3>
 		<p>
 			This object contains references to the touch actions used by the controls.


### PR DESCRIPTION
The docs suggest you can change the target of OrbitControls using target() by passing a Vector3. Console suggests target() is not a function available in the OrbitControls object.

**Description**

From my testing target() simply is not an available function and should be removed from the docs.
