### PR TITLE
fix Audio clone

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -37,6 +37,10 @@ class Audio extends Object3D {
 
 	}
 
+	clone( recursive ) {
+		return new this.constructor( this.listener.clone( recursive ) ).copy( this, recursive );
+	}
+
 	getOutput() {
 
 		return this.gain;


### PR DESCRIPTION
Related issue: none

**Description**

**Problem:** failed to clone `Audio`

**Reason:** An `AudioListener` parameter is needed by the constructor of `Audio`, the `Audio` class does not has a `clone()` method itself, thus the `clone()` method of `Object3D`, which has no listener parameter, is used.

**My solution:** add a `clone()` method for `Audio` that takes a cloned `AudioListener` as parameter

**Test:** https://github.com/xiasun/three.js/blob/e130c81888dfd8ef7b855e15e8d29f6db21aec99/examples/webaudio_sandbox.html#L123

 