### PR TITLE
OrbitControls: Introduce listenToPointerEvents().

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -28,7 +28,8 @@
 
 		const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
-		const controls = new OrbitControls( camera, renderer.domElement );
+		const controls = new OrbitControls( camera );
+		controls.listenToPointerEvents( renderer.domElement );
 
 		//controls.update() must be called after any manual changes to the camera's transform
 		camera.position.set( 0, 20, 100 );
@@ -286,6 +287,11 @@ controls.touches = {
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.
+		</p>
+
+		<h3>[method:void listenToPointerEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<p>
+			Adds pointer event listeners to the given DOM element. *renderer.domElement* is a recommended argument for using this method.
 		</p>
 
 		<h3>[method:null reset] ()</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -27,7 +27,8 @@
 
 		const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
-		const controls = new OrbitControls( camera, renderer.domElement );
+		const controls = new OrbitControls( camera );
+		controls.listenToPointerEvents( renderer.domElement );
 
 		//controls.update()는 카메라 변환설정을 수동으로 변경한 후에 호출해야 합니다.
 		camera.position.set( 0, 20, 100 );
@@ -281,6 +282,11 @@ controls.touches = {
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.
+		</p>
+
+		<h3>[method:void listenToPointerEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<p>
+			Adds pointer event listeners to the given DOM element. *renderer.domElement* is a recommended argument for using this method.
 		</p>
 
 		<h3>[method:null reset] ()</h3>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -28,7 +28,8 @@
 
 		const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 10000 );
 
-		const controls = new OrbitControls( camera, renderer.domElement );
+		const controls = new OrbitControls( camera );
+		controls.listenToPointerEvents( renderer.domElement );
 
 		//controls.update() must be called after any manual changes to the camera's transform
 		camera.position.set( 0, 20, 100 );
@@ -283,6 +284,11 @@ controls.touches = {
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			为指定的DOM元素添加按键监听。推荐将window作为指定的DOM元素。
+		</p>
+
+		<h3>[method:void listenToPointerEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<p>
+			Adds pointer event listeners to the given DOM element. *renderer.domElement* is a recommended argument for using this method.
 		</p>
 
 		<h3>[method:null reset] ()</h3>

--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -104,7 +104,8 @@
 				labelRenderer.domElement.style.top = '0px';
 				document.body.appendChild( labelRenderer.domElement );
 
-				const controls = new OrbitControls( camera, labelRenderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( labelRenderer.domElement );
 				controls.minDistance = 5;
 				controls.maxDistance = 100;
 

--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -92,7 +92,8 @@
 				renderer2.domElement.style.top = 0;
 				document.body.appendChild( renderer2.domElement );
 
-				const controls = new OrbitControls( camera, renderer2.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer2.domElement );
 				controls.minZoom = 0.5;
 				controls.maxZoom = 2;
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -7,11 +7,8 @@
 
 THREE.OrbitControls = function ( object, domElement ) {
 
-	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
-
 	this.object = object;
-	this.domElement = domElement;
+	this.domElement = null;
 
 	// Set to false to disable this control
 	this.enabled = true;
@@ -99,6 +96,21 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		domElement.addEventListener( 'keydown', onKeyDown );
 		this._domElementKeyEvents = domElement;
+
+	};
+
+	this.listenToPointerEvents = function ( domElement ) {
+
+		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+		domElement.addEventListener( 'contextmenu', onContextMenu );
+		domElement.addEventListener( 'pointerdown', onPointerDown );
+		domElement.addEventListener( 'wheel', onMouseWheel );
+		domElement.addEventListener( 'touchstart', onTouchStart );
+		domElement.addEventListener( 'touchend', onTouchEnd );
+		domElement.addEventListener( 'touchmove', onTouchMove );
+
+		this.domElement = domElement;
 
 	};
 
@@ -1172,14 +1184,12 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 	//
 
-	scope.domElement.addEventListener( 'contextmenu', onContextMenu );
+	if ( domElement !== undefined ) {
 
-	scope.domElement.addEventListener( 'pointerdown', onPointerDown );
-	scope.domElement.addEventListener( 'wheel', onMouseWheel );
+		console.warn( 'THREE.OrbitControls: The domElement constructor param has been deprecated. Use .listenToPointerEvents() instead.' );
+		this.listenToPointerEvents( domElement );
 
-	scope.domElement.addEventListener( 'touchstart', onTouchStart );
-	scope.domElement.addEventListener( 'touchend', onTouchEnd );
-	scope.domElement.addEventListener( 'touchmove', onTouchMove );
+	}
 
 	// force an update at start
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -17,11 +17,8 @@ import {
 
 var OrbitControls = function ( object, domElement ) {
 
-	if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-	if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
-
 	this.object = object;
-	this.domElement = domElement;
+	this.domElement = null;
 
 	// Set to false to disable this control
 	this.enabled = true;
@@ -109,6 +106,21 @@ var OrbitControls = function ( object, domElement ) {
 
 		domElement.addEventListener( 'keydown', onKeyDown );
 		this._domElementKeyEvents = domElement;
+
+	};
+
+	this.listenToPointerEvents = function ( domElement ) {
+
+		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+		domElement.addEventListener( 'contextmenu', onContextMenu );
+		domElement.addEventListener( 'pointerdown', onPointerDown );
+		domElement.addEventListener( 'wheel', onMouseWheel );
+		domElement.addEventListener( 'touchstart', onTouchStart );
+		domElement.addEventListener( 'touchend', onTouchEnd );
+		domElement.addEventListener( 'touchmove', onTouchMove );
+
+		this.domElement = domElement;
 
 	};
 
@@ -1182,14 +1194,12 @@ var OrbitControls = function ( object, domElement ) {
 
 	//
 
-	scope.domElement.addEventListener( 'contextmenu', onContextMenu );
+	if ( domElement !== undefined ) {
 
-	scope.domElement.addEventListener( 'pointerdown', onPointerDown );
-	scope.domElement.addEventListener( 'wheel', onMouseWheel );
+		console.warn( 'THREE.OrbitControls: The domElement constructor param has been deprecated. Use .listenToPointerEvents() instead.' );
+		this.listenToPointerEvents( domElement );
 
-	scope.domElement.addEventListener( 'touchstart', onTouchStart );
-	scope.domElement.addEventListener( 'touchend', onTouchEnd );
-	scope.domElement.addEventListener( 'touchmove', onTouchMove );
+	}
 
 	// force an update at start
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -50,7 +50,8 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement ); // mandatory
 				controls.listenToKeyEvents( window ); // optional
 
 				//controls.addEventListener( 'change', render ); // call this only in static scenes (i.e., if there is no animation loop)

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -57,7 +57,8 @@
 				const geometry = new THREE.BoxGeometry( 200, 200, 200 );
 				const material = new THREE.MeshLambertMaterial( { map: texture, transparent: true } );
 
-				orbit = new OrbitControls( currentCamera, renderer.domElement );
+				orbit = new OrbitControls( currentCamera );
+				orbit.listenToPointerEvents( renderer.domElement );
 				orbit.update();
 				orbit.addEventListener( 'change', render );
 

--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -80,7 +80,8 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				// CONTROLS
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.addEventListener( 'change', render );
 
 				// TEXTURE MAP

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -98,7 +98,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 25, 0 );
 				controls.update();
 

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -82,7 +82,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 25, 0 );
 				controls.update();
 

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -82,7 +82,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 25, 0 );
 				controls.update();
 

--- a/examples/physics_ammo_break.html
+++ b/examples/physics_ammo_break.html
@@ -113,7 +113,8 @@
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
-			controls = new OrbitControls( camera, renderer.domElement );
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.target.set( 0, 2, 0 );
 			controls.update();
 

--- a/examples/physics_ammo_cloth.html
+++ b/examples/physics_ammo_cloth.html
@@ -80,7 +80,8 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 2, 0 );
 				controls.update();
 

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -118,7 +118,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.y = 0.5;
 				controls.update();
 

--- a/examples/physics_ammo_rope.html
+++ b/examples/physics_ammo_rope.html
@@ -83,7 +83,8 @@
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
-			controls = new OrbitControls( camera, renderer.domElement );
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.target.set( 0, 2, 0 );
 			controls.update();
 

--- a/examples/physics_ammo_terrain.html
+++ b/examples/physics_ammo_terrain.html
@@ -102,7 +102,8 @@
 				camera.position.z = terrainDepthExtents / 2;
 				camera.lookAt( 0, 0, 0 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 
 				const geometry = new THREE.PlaneGeometry( terrainWidthExtents, terrainDepthExtents, terrainWidth - 1, terrainDepth - 1 );

--- a/examples/physics_ammo_volume.html
+++ b/examples/physics_ammo_volume.html
@@ -87,7 +87,8 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 2, 0 );
 				controls.update();
 

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -147,7 +147,8 @@
 
 			//
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.target.set( 0, 0.1, 0 );
 			controls.update();
 			controls.minDistance = 0.5;

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -136,7 +136,8 @@
 
 			//
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.minDistance = 1;
 			controls.maxDistance = 25;
 

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -56,7 +56,8 @@
 			camera.up.set( 0, 0, 1 ); // In our data, z is up
 
 			// Create controls
-			controls = new OrbitControls( camera, renderer.domElement );
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.addEventListener( 'change', render );
 			controls.target.set( 64, 64, 128 );
 			controls.minZoom = 0.5;

--- a/examples/webgl2_volume_instancing.html
+++ b/examples/webgl2_volume_instancing.html
@@ -43,7 +43,8 @@
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.1, 1000 );
 				camera.position.set( 0, 0, 4 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.autoRotate = true;
 				controls.autoRotateSpeed = - 1.0;
 				controls.enableDamping = true;

--- a/examples/webgl_animation_cloth.html
+++ b/examples/webgl_animation_cloth.html
@@ -560,7 +560,8 @@
 				renderer.shadowMap.enabled = true;
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.maxPolarAngle = Math.PI * 0.5;
 				controls.minDistance = 1000;
 				controls.maxDistance = 5000;

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -57,7 +57,8 @@
 			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 100 );
 			camera.position.set( 5, 2, 8 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.target.set( 0, 0.5, 0 );
 			controls.update();
 			controls.enablePan = false;

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -154,7 +154,8 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 100 );
 				camera.position.set( - 1, 2, 3 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enablePan = false;
 				controls.enableZoom = false;
 				controls.target.set( 0, 1, 0 );

--- a/examples/webgl_buffergeometry_compression.html
+++ b/examples/webgl_buffergeometry_compression.html
@@ -84,7 +84,8 @@
 				camera.position.y = 2 * radius;
 				camera.position.z = 2 * radius;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 
 				//
 

--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -85,7 +85,8 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 4000 );
 				camera.position.z = 1750;
 
-				const controls = new OrbitControls( camera, container );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.minDistance = 1000;
 				controls.maxDistance = 3000;
 

--- a/examples/webgl_clipping.html
+++ b/examples/webgl_clipping.html
@@ -115,7 +115,8 @@
 
 				// Controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 1, 0 );
 				controls.update();
 

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -288,7 +288,8 @@
 
 				// Controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 8;
 				controls.target.set( 0, 1, 0 );

--- a/examples/webgl_clipping_intersection.html
+++ b/examples/webgl_clipping_intersection.html
@@ -47,7 +47,8 @@
 
 				camera.position.set( - 1.5, 2.5, 3.0 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use only if there is no animation loop
 				controls.minDistance = 1;
 				controls.maxDistance = 10;

--- a/examples/webgl_clipping_stencil.html
+++ b/examples/webgl_clipping_stencil.html
@@ -218,7 +218,8 @@
 				renderer.localClippingEnabled = true;
 
 				// Controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 2;
 				controls.maxDistance = 20;
 				controls.update();

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -92,7 +92,8 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 120;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 200;
 

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -111,7 +111,8 @@
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.z = 4;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableDamping = true;
 
 				// Create a render target with depth texture

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -121,7 +121,8 @@
 				//
 
 				const selection = document.getElementById( 'selection' );
-				const controls = new OrbitControls( camera, selection );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( selection );
 				controls.enablePan = false;
 
 				//

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -94,7 +94,8 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				const controls = new OrbitControls( perpCamera, renderer.domElement );
+				const controls = new OrbitControls( perpCamera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 
 				const gui = new GUI();

--- a/examples/webgl_geometry_convex.html
+++ b/examples/webgl_geometry_convex.html
@@ -40,7 +40,8 @@
 
 				// controls
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 20;
 				controls.maxDistance = 50;
 				controls.maxPolarAngle = Math.PI / 2;

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -431,7 +431,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 100;
 				controls.maxDistance = 1000;
 

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -259,7 +259,8 @@
 				} );
 				folderCamera.open();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 100;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_geometry_normals.html
+++ b/examples/webgl_geometry_normals.html
@@ -122,7 +122,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 
 				//

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -128,7 +128,8 @@
 				gui.open();
 
 				// Controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.damping = 0.2;
 				controls.addEventListener( 'change', render );
 

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -74,7 +74,8 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				// CONTROLS
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.addEventListener( 'change', render );
 
 				// TEXTURE MAP

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -61,7 +61,8 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 10, 20000 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1000;
 				controls.maxDistance = 10000;
 				controls.maxPolarAngle = Math.PI / 2;

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -122,7 +122,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 0, 0 );
 				controls.update();
 

--- a/examples/webgl_geometry_text_stroke.html
+++ b/examples/webgl_geometry_text_stroke.html
@@ -126,7 +126,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 0, 0 );
 				controls.update();
 

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -278,7 +278,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 100;
 				controls.maxDistance = 1000;
 

--- a/examples/webgl_instancing_performance.html
+++ b/examples/webgl_instancing_performance.html
@@ -257,7 +257,8 @@
 
 			// controls
 
-			controls = new OrbitControls( camera, renderer.domElement );
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.autoRotate = true;
 
 			// stats

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -335,7 +335,8 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				const controls = new OrbitControls( scene.userData.camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.y = ( conesDistance + coneHeight ) * 0.5;
 				controls.enableDamping = true;
 				controls.dampingFactor = 0.05;
@@ -558,7 +559,8 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				const controls = new OrbitControls( scene.userData.camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.copy( sphereMesh.position );
 				controls.enableDamping = true;
 				controls.dampingFactor = 0.05;
@@ -748,7 +750,8 @@
 
 				// Controls
 
-				const controls = new OrbitControls( scene.userData.camera, renderer.domElement );
+				const controls = new OrbitControls( scene.userData.camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.y = GROUND_SIZE * 0.05;
 				controls.enableDamping = true;
 				controls.dampingFactor = 0.05;

--- a/examples/webgl_lightprobe.html
+++ b/examples/webgl_lightprobe.html
@@ -58,7 +58,8 @@
 				camera.position.set( 0, 0, 30 );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 10;
 				controls.maxDistance = 50;

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -50,7 +50,8 @@
 				cubeCamera = new THREE.CubeCamera( 1, 1000, cubeRenderTarget );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 10;
 				controls.maxDistance = 50;

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -227,7 +227,8 @@
 				container.appendChild( renderer.domElement );
 
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 20;
 

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -72,7 +72,8 @@
 				meshKnot.position.set( 0, 5, 0 );
 				scene.add( meshKnot );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.copy( meshKnot.position );
 				controls.update();
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -43,7 +43,8 @@
 				camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 160, 40, 10 );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 20;
 				controls.maxDistance = 500;

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -26,7 +26,8 @@
 
 			const camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 1, 2000 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 
 			const scene = new THREE.Scene();
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -55,7 +55,8 @@
 				camera2 = new THREE.PerspectiveCamera( 40, 1, 1, 1000 );
 				camera2.position.copy( camera.position );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 500;
 

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -54,7 +54,8 @@
 				camera2 = new THREE.PerspectiveCamera( 40, 1, 1, 1000 );
 				camera2.position.copy( camera.position );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 500;
 

--- a/examples/webgl_loader_3dm.html
+++ b/examples/webgl_loader_3dm.html
@@ -63,7 +63,8 @@
 				renderer.setSize( width, height );
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 
 				window.addEventListener( 'resize', resize );
 

--- a/examples/webgl_loader_3mf.html
+++ b/examples/webgl_loader_3mf.html
@@ -62,7 +62,8 @@
 				camera.position.set( - 100, - 250, 100 );
 				scene.add( camera );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 50;
 				controls.maxDistance = 400;

--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -105,7 +105,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 50;
 				controls.maxDistance = 200;

--- a/examples/webgl_loader_amf.html
+++ b/examples/webgl_loader_amf.html
@@ -65,7 +65,8 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.target.set( 0, 1.2, 2 );
 				controls.update();

--- a/examples/webgl_loader_assimp.html
+++ b/examples/webgl_loader_assimp.html
@@ -54,7 +54,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 750;
 				controls.maxDistance = 2500;
 

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -70,7 +70,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 300;
 				controls.maxDistance = 700;
 

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -88,7 +88,8 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.screenSpacePanning = true;
 				controls.minDistance = 5;
 				controls.maxDistance = 40;

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -99,7 +99,8 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 100, 0 );
 				controls.update();
 

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -65,7 +65,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 12, 0 );
 				controls.update();
 

--- a/examples/webgl_loader_gcode.html
+++ b/examples/webgl_loader_gcode.html
@@ -49,7 +49,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.minDistance = 10;
 				controls.maxDistance = 100;

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -94,7 +94,8 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.minDistance = 2;
 				controls.maxDistance = 10;

--- a/examples/webgl_loader_gltf_compressed.html
+++ b/examples/webgl_loader_gltf_compressed.html
@@ -80,7 +80,8 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.minDistance = 400;
 				controls.maxDistance = 1000;

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -237,7 +237,8 @@
 
 				// TODO: Reuse existing OrbitControls, GLTFLoaders, and so on
 
-				orbitControls = new OrbitControls( camera, renderer.domElement );
+				orbitControls = new OrbitControls( camera );
+				orbitControls.listenToPointerEvents( renderer.domElement );
 
 				if ( sceneInfo.addGround ) {
 

--- a/examples/webgl_loader_gltf_variants.html
+++ b/examples/webgl_loader_gltf_variants.html
@@ -97,7 +97,8 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.minDistance = 2;
 				controls.maxDistance = 10;

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -57,7 +57,8 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.update();
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -89,7 +89,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 
 				//
 

--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -91,7 +91,8 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 1.33, 10, - 6.7 );
 				controls.update();
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -131,7 +131,8 @@
 
 				// CONTROLS
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 50, 0 );
 				controls.update();
 

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -143,9 +143,9 @@
 
 				// CONTROLS
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.target.set( 0, 50, 0 );
-				cameraControls.enableKeys = false;
 				cameraControls.update();
 
 				// CHARACTER

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -140,7 +140,8 @@
 
 				}, onProgress, null );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 100;
 

--- a/examples/webgl_loader_nodes.html
+++ b/examples/webgl_loader_nodes.html
@@ -55,7 +55,8 @@
 					cloud = new THREE.TextureLoader().load( 'textures/lava/cloud.png' );
 					cloud.wrapS = cloud.wrapT = THREE.RepeatWrapping;
 
-					controls = new OrbitControls( camera, renderer.domElement );
+					controls = new OrbitControls( camera );
+					controls.listenToPointerEvents( renderer.domElement );
 					controls.minDistance = 50;
 					controls.maxDistance = 200;
 

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -54,7 +54,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.screenSpacePanning = true;
 
 				//

--- a/examples/webgl_loader_texture_basis.html
+++ b/examples/webgl_loader_texture_basis.html
@@ -40,7 +40,8 @@
 				camera.position.set( 0, 0, 1 );
 				camera.lookAt( scene.position );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 
 				const geometry = flipY( new THREE.PlaneBufferGeometry() );

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -37,7 +37,8 @@
 			camera.lookAt( scene.position );
 			scene.add( camera );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.autoRotate = true;
 
 			// PlaneGeometry UVs assume flipY=true, which compressed textures don't support.

--- a/examples/webgl_loader_texture_tga.html
+++ b/examples/webgl_loader_texture_tga.html
@@ -78,7 +78,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 
 				//

--- a/examples/webgl_loader_tilt.html
+++ b/examples/webgl_loader_tilt.html
@@ -51,7 +51,8 @@
 
 				} );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.target.y = camera.position.y;
 				controls.update();

--- a/examples/webgl_loader_vox.html
+++ b/examples/webgl_loader_vox.html
@@ -71,7 +71,8 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = .1;
 				controls.maxDistance = 0.5;
 

--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -96,7 +96,8 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 5;
 				controls.enableDamping = true;

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -78,7 +78,8 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 200;
 				controls.enableDamping = true;

--- a/examples/webgl_loader_x.html
+++ b/examples/webgl_loader_x.html
@@ -80,7 +80,8 @@
 			camera.position.set( 2, 10, - 28 );
 			camera.up.set( 0, 1, 0 );
 
-			controls = new OrbitControls( camera, renderer.domElement );
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.target.set( 0, 5, 0 );
 			controls.update();
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -99,7 +99,8 @@
 
 			// CONTROLS
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.minDistance = 500;
 			controls.maxDistance = 5000;
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -75,7 +75,8 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.set( 4.25, 1.4, - 4.5 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 0.5, 0 );
 				controls.update();
 

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -87,13 +87,15 @@
 
 				camera = cameraPerspective;
 
-				controlsPerspective = new OrbitControls( cameraPerspective, renderer.domElement );
+				controlsPerspective = new OrbitControls( cameraPerspective );
+				controlsPerspective.listenToPointerEvents( renderer.domElement );
 				controlsPerspective.minDistance = 1000;
 				controlsPerspective.maxDistance = 2400;
 				controlsPerspective.enablePan = false;
 				controlsPerspective.enableDamping = true;
 
-				controlsOrtho = new OrbitControls( cameraOrtho, renderer.domElement );
+				controlsOrtho = new OrbitControls( cameraOrtho );
+				controlsOrtho.listenToPointerEvents( renderer.domElement );
 				controlsOrtho.minZoom = 0.5;
 				controlsOrtho.maxZoom = 1.5;
 				controlsOrtho.enablePan = false;

--- a/examples/webgl_materials_compile.html
+++ b/examples/webgl_materials_compile.html
@@ -95,7 +95,8 @@
 				camera.position.z = - 300;
 				camera.position.y = 200;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 400;
 

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -99,7 +99,8 @@
 				container.appendChild( renderer.domElement );
 
 				//controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 				controls.enablePan = false;
 				controls.minPolarAngle = Math.PI / 4;

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -135,7 +135,8 @@
 				container.appendChild( renderer.domElement );
 
 				//controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minPolarAngle = Math.PI / 4;
 				controls.maxPolarAngle = Math.PI / 1.5;
 

--- a/examples/webgl_materials_curvature.html
+++ b/examples/webgl_materials_curvature.html
@@ -130,7 +130,8 @@
 				renderer.autoClear = false;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 20;
 				controls.maxDistance = 100;
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -117,7 +117,8 @@
 				camera.position.z = 1500;
 				scene.add( camera );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 				controls.enableDamping = true;
 

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -77,7 +77,8 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 500;
 				controls.maxDistance = 2500;
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -113,7 +113,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 300;
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -175,7 +175,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 300;
 

--- a/examples/webgl_materials_envmaps_hdr_nodes.html
+++ b/examples/webgl_materials_envmaps_hdr_nodes.html
@@ -181,7 +181,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 300;
 

--- a/examples/webgl_materials_envmaps_parallax.html
+++ b/examples/webgl_materials_envmaps_parallax.html
@@ -238,7 +238,8 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 280, 106, - 5 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.target.set( 0, - 10, 0 );
 				cameraControls.maxDistance = 400;
 				cameraControls.minDistance = 10;

--- a/examples/webgl_materials_envmaps_pmrem_nodes.html
+++ b/examples/webgl_materials_envmaps_pmrem_nodes.html
@@ -137,7 +137,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 300;
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -114,7 +114,8 @@
 
 				// CONTROLS
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.maxPolarAngle = 0.9 * Math.PI / 2;
 				controls.enableZoom = false;
 

--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -53,7 +53,8 @@
 				camera.position.set( 0, 0, 13 );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.enableZoom = false;
 				controls.enablePan = false;

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -56,7 +56,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 50;
 

--- a/examples/webgl_materials_nodes.html
+++ b/examples/webgl_materials_nodes.html
@@ -129,7 +129,8 @@
 				camera.position.z = - 50;
 				camera.position.y = 30;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 200;
 

--- a/examples/webgl_materials_normalmap_object_space.html
+++ b/examples/webgl_materials_normalmap_object_space.html
@@ -44,7 +44,8 @@
 				scene.add( camera );
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 10;
 				controls.maxDistance = 50;

--- a/examples/webgl_materials_parallaxmap.html
+++ b/examples/webgl_materials_parallaxmap.html
@@ -86,7 +86,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 5;
 

--- a/examples/webgl_materials_physical_reflectivity.html
+++ b/examples/webgl_materials_physical_reflectivity.html
@@ -162,7 +162,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 20;
 				controls.maxDistance = 200;
 

--- a/examples/webgl_materials_physical_sheen.html
+++ b/examples/webgl_materials_physical_sheen.html
@@ -91,7 +91,8 @@
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 2, 0 );
 				controls.update();
 

--- a/examples/webgl_materials_physical_transmission.html
+++ b/examples/webgl_materials_physical_transmission.html
@@ -145,7 +145,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 150;
 

--- a/examples/webgl_materials_subsurface_scattering.html
+++ b/examples/webgl_materials_subsurface_scattering.html
@@ -75,6 +75,7 @@
 			container.appendChild( stats.dom );
 
 			const controls = new OrbitControls( camera, container );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.minDistance = 500;
 			controls.maxDistance = 3000;
 

--- a/examples/webgl_materials_texture_rotation.html
+++ b/examples/webgl_materials_texture_rotation.html
@@ -48,7 +48,8 @@
 				camera.position.set( 10, 15, 25 );
 				scene.add( camera );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.minDistance = 20;
 				controls.maxDistance = 50;

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -152,7 +152,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -152,7 +152,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -159,7 +159,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -173,7 +173,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -176,7 +176,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -149,7 +149,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 200;
 				controls.maxDistance = 2000;
 

--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -60,7 +60,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 				controls.enablePan = false;
 

--- a/examples/webgl_math_obb.html
+++ b/examples/webgl_math_obb.html
@@ -101,7 +101,8 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableDamping = true;
 
 				//

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -63,7 +63,8 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 0, 75, 160 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.target.set( 0, 40, 0 );
 				cameraControls.maxDistance = 400;
 				cameraControls.minDistance = 10;

--- a/examples/webgl_mirror_nodes.html
+++ b/examples/webgl_mirror_nodes.html
@@ -82,7 +82,8 @@
 				camera = new THREE.PerspectiveCamera( VIEW_ANGLE, ASPECT, NEAR, FAR );
 				camera.position.set( 0, 75, 160 );
 
-				cameraControls = new OrbitControls( camera, renderer.domElement );
+				cameraControls = new OrbitControls( camera );
+				cameraControls.listenToPointerEvents( renderer.domElement );
 				cameraControls.target.set( 0, 40, 0 );
 				cameraControls.maxDistance = 400;
 				cameraControls.minDistance = 10;

--- a/examples/webgl_modifier_edgesplit.html
+++ b/examples/webgl_modifier_edgesplit.html
@@ -52,7 +52,8 @@
 
 				camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.enableDamping = true;
 				controls.dampingFactor = 0.25;

--- a/examples/webgl_modifier_simplifier.html
+++ b/examples/webgl_modifier_simplifier.html
@@ -40,7 +40,8 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 15;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.enablePan = false;
 				controls.enableZoom = false;

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -64,7 +64,8 @@
 				} );
 				container.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -98,7 +98,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 20;
 

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -112,7 +112,8 @@
 					camera.position.z = 2;
 					scene.userData.camera = camera;
 
-					const controls = new OrbitControls( scene.userData.camera, scene.userData.element );
+					const controls = new OrbitControls( scene.userData.camera );
+					controls.listenToPointerEvents( scene.userData.element );
 					controls.minDistance = 2;
 					controls.maxDistance = 5;
 					controls.enablePan = false;

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -174,7 +174,8 @@
 					camera.position.set( 0, 0, 1.2 * balls );
 					scene.userData.camera = camera;
 
-					const controls = new OrbitControls( camera, views[ n ] );
+					const controls = new OrbitControls( camera );
+					controls.listenToPointerEvents( views[ n ] );
 					scene.userData.controls = controls;
 
 					scenes.push( scene );

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -64,7 +64,8 @@
 				camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.z = 6;
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 
 				const light = new THREE.HemisphereLight( 0xffffff, 0x444444, 1 );
 				light.position.set( - 2, 2, 2 );

--- a/examples/webgl_panorama_cube.html
+++ b/examples/webgl_panorama_cube.html
@@ -39,7 +39,8 @@
 				camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.z = 0.01;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 				controls.enablePan = false;
 				controls.enableDamping = true;

--- a/examples/webgl_pmrem_test.html
+++ b/examples/webgl_pmrem_test.html
@@ -64,7 +64,8 @@
 
 				// controls
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.minDistance = 4;
 				controls.maxDistance = 20;

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -123,7 +123,8 @@
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 				pmremGenerator.compileEquirectangularShader();
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 2;
 				controls.maxDistance = 10;
 				controls.target.set( 0, 0, - 0.2 );

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -176,7 +176,8 @@
 				const copyPass = new ShaderPass( CopyShader );
 				composer.addPass( copyPass );
 
-				const controls = new OrbitControls( cameraP, renderer.domElement );
+				const controls = new OrbitControls( cameraP );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enableZoom = false;
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -91,7 +91,8 @@
 
 				renderer.autoClear = false;
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 500;
 

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -126,7 +126,8 @@
 				camera = new THREE.PerspectiveCamera( 45, width / height, 0.1, 100 );
 				camera.position.set( 0, 0, 8 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 5;
 				controls.maxDistance = 20;
 				controls.enablePan = false;

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -50,7 +50,8 @@
 				document.body.appendChild( stats.dom );
 
 				// camera controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 0, 0 );
 				controls.update();
 

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -94,7 +94,8 @@
 				effectSobel.uniforms[ 'resolution' ].value.y = window.innerHeight * window.devicePixelRatio;
 				composer.addPass( effectSobel );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 100;
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -70,7 +70,8 @@
 				camera.position.set( - 5, 2.5, - 3.5 );
 				scene.add( camera );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.maxPolarAngle = Math.PI * 0.5;
 				controls.minDistance = 1;
 				controls.maxDistance = 10;

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -81,7 +81,8 @@
 			camera.position.set( 0, 0, 20 );
 			camera.lookAt( 0, 0, 0 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.maxPolarAngle = Math.PI * 0.5;
 			controls.minDistance = 1;
 			controls.maxDistance = 100;

--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -50,8 +50,8 @@
 			camera.position.set( 15, 15, 15 );
 			camera.lookAt( scene.position );
 
-			controls = new OrbitControls( camera, renderer.domElement );
-			controls.enableRotate = true;
+			controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 
 			// add sprites
 

--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -299,7 +299,8 @@
 				scene.add( mesh );
 
 				// Controls
-				const controls = new OrbitControls( camera, canvas );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( canvas );
 				controls.enableZoom = false;
 
 				// GUI

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -94,7 +94,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 10;
 				controls.maxDistance = 100;
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -128,7 +128,7 @@
 
 				//
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
 				controls.maxPolarAngle = Math.PI * 0.495;
 				controls.target.set( 0, 10, 0 );
 				controls.minDistance = 40.0;

--- a/examples/webgl_shaders_ocean2.html
+++ b/examples/webgl_shaders_ocean2.html
@@ -45,7 +45,8 @@
 					this.ms_Camera.lookAt( 0, 0, 0 );
 
 					// Initialize Orbit control
-					this.ms_Controls = new OrbitControls( this.ms_Camera, this.ms_Renderer.domElement );
+					this.ms_Controls = new OrbitControls( this.ms_Camera );
+					this.ms_Controls.listenToPointerEvents( this.ms_Renderer.domElement );
 					this.ms_Controls.userPan = false;
 					this.ms_Controls.userPanSpeed = 0.0;
 					this.ms_Controls.minDistance = 0;

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -101,7 +101,8 @@
 				renderer.toneMappingExposure = 0.5;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render );
 				//controls.maxPolarAngle = Math.PI / 2;
 				controls.enableZoom = false;

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -97,7 +97,8 @@
 				cameraBG = new THREE.OrthographicCamera( - windowHalfX, windowHalfX, windowHalfY, - windowHalfY, - 10000, 10000 );
 				cameraBG.position.z = 100;
 
-				orbitControls = new OrbitControls( camera, container );
+				orbitControls = new OrbitControls( camera );
+				orbitControls.listenToPointerEvents( container );
 				orbitControls.autoRotate = true;
 				orbitControls.autoRotateSpeed = 1;
 

--- a/examples/webgl_shaders_vector.html
+++ b/examples/webgl_shaders_vector.html
@@ -284,7 +284,8 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 50, 100, 0 );
 				controls.update();
 

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -76,7 +76,8 @@
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.maxPolarAngle = Math.PI / 2;
 				camera.position.set( 60, 60, 0 );
 				controls.target = new THREE.Vector3( - 100, 10, 0 );

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -242,7 +242,8 @@
 				renderer.shadowMap.enabled = true;
 
 				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.maxPolarAngle = Math.PI * 0.5;
 				controls.minDistance = 10;
 				controls.maxDistance = 75;

--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -110,7 +110,8 @@
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 				document.body.appendChild( renderer.domElement );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 10, 0 );
 				controls.update();
 

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -135,7 +135,8 @@
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 
 				// Mouse control
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 2, 0 );
 				controls.update();
 

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -166,7 +166,8 @@
 				renderer.setClearColor( 0xCCCCCC, 1 );
 
 				// Mouse control
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.target.set( 0, 2, 0 );
 				controls.update();
 

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -187,7 +187,8 @@
 
 				new SimpleGI( renderer, scene );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 1;
 				controls.maxDistance = 10;
 

--- a/examples/webgl_skinning_simple.html
+++ b/examples/webgl_skinning_simple.html
@@ -103,7 +103,8 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.enablePan = false;
 				controls.minDistance = 5;
 				controls.maxDistance = 50;

--- a/examples/webgl_sprites_nodes.html
+++ b/examples/webgl_sprites_nodes.html
@@ -63,7 +63,8 @@
 				camera = new THREE.PerspectiveCamera( fov, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 100;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 50;
 				controls.maxDistance = 200;
 

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -202,7 +202,8 @@
 			const stats = new Stats();
 			container.appendChild( stats.dom );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera );
+			controls.listenToPointerEvents( renderer.domElement );
 			controls.minDistance = 120;
 			controls.maxDistance = 320;
 

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -77,7 +77,8 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.25, 20 );
 				camera.position.set( - 1.8, 0.6, 2.7 );
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.addEventListener( 'change', render ); // use if there is no animation loop
 				controls.enableZoom = false;
 				controls.enablePan = false;

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -157,7 +157,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 5;
 				controls.maxDistance = 50;
 

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -99,7 +99,8 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( renderer.domElement );
 				controls.minDistance = 5;
 				controls.maxDistance = 50;
 

--- a/examples/webxr_vr_dragging.html
+++ b/examples/webxr_vr_dragging.html
@@ -45,7 +45,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -43,7 +43,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -56,7 +56,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -55,7 +55,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_haptics.html
+++ b/examples/webxr_vr_haptics.html
@@ -74,7 +74,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.1, 10 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_paint.html
+++ b/examples/webxr_vr_paint.html
@@ -40,7 +40,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 

--- a/examples/webxr_vr_sculpt.html
+++ b/examples/webxr_vr_sculpt.html
@@ -42,7 +42,8 @@
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.01, 50 );
 				camera.position.set( 0, 1.6, 3 );
 
-				controls = new OrbitControls( camera, container );
+				controls = new OrbitControls( camera );
+				controls.listenToPointerEvents( container );
 				controls.target.set( 0, 1.6, 0 );
 				controls.update();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20575#issuecomment-774527294

**Description**

Introduce `listenToPointerEvents()` which must be used to add event listeners for point events. The second parameter of `OrbitControls` is now deprecated (but still functional).

To me, the change has one minor flaw. `listenToPointerEvents()` does not only register event listeners to pointer events but to `contextmenu`, `wheel` and `touch*` events, too. 

However, as far as I understand the point is to create an instance of `OrbitControls` without adding event listeners in the ctor. Still, the name of `listenToPointerEvents()` is not quite right...
