### PR TITLE
Tests: Add BufferAttribute.toJSON() unit test

### DIFF
--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -243,6 +243,18 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( "toJSON", ( assert ) => {
+
+			const attr = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3, true );
+			assert.deepEqual( attr.toJSON(), {
+				itemSize: 3,
+				type: 'Float32Array',
+				array: [ 1, 2, 3, 4, 5, 6 ],
+				normalized: true
+			}, 'Serialized to JSON as expected' );
+
+		} );
+
 		// OTHERS
 		QUnit.test( "count", ( assert ) => {
 


### PR DESCRIPTION
**Description**

This PR adds `BufferAttribute.toJSON()` unit test.

I realized that `.name` and `.usage` are not serialized. Is it intentional because `.name` is optional and (if I'm right) isn't used in core, and appropriate `.usage` should depend on app, not data?

<!-- Remove the line below if is not relevant -->

This contribution is made in a hospital.
