### PR TITLE
Light: Convert to ES6 class

### DIFF
--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -1,37 +1,34 @@
 import { Object3D } from '../core/Object3D.js';
 import { Color } from '../math/Color.js';
 
-function Light( color, intensity = 1 ) {
+class Light extends Object3D {
 
-	Object3D.call( this );
+	constructor( color, intensity = 1 ) {
 
-	this.type = 'Light';
+		super( );
 
-	this.color = new Color( color );
-	this.intensity = intensity;
+		this.type = 'Light';
 
-}
+		this.color = new Color( color );
+		this.intensity = intensity;
+		Object.defineProperty( this, 'isLight', { value: true } );
 
-Light.prototype = Object.assign( Object.create( Object3D.prototype ), {
+	}
 
-	constructor: Light,
+	copy( source ) {
 
-	isLight: true,
-
-	copy: function ( source ) {
-
-		Object3D.prototype.copy.call( this, source );
+		super.copy( source );
 
 		this.color.copy( source.color );
 		this.intensity = source.intensity;
 
 		return this;
 
-	},
+	}
 
-	toJSON: function ( meta ) {
+	toJSON( meta ) {
 
-		const data = Object3D.prototype.toJSON.call( this, meta );
+		const data = super.toJSON( meta );
 
 		data.object.color = this.color.getHex();
 		data.object.intensity = this.intensity;
@@ -49,7 +46,7 @@ Light.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 	}
 
-} );
+}
 
 
 export { Light };


### PR DESCRIPTION
Related issue: #19986

**Description**

Just the `src/lights/light.js` file changed to es6 class syntax
