### PR TITLE
AmbientLight: Convert to ES6 Class

### DIFF
--- a/src/lights/AmbientLight.js
+++ b/src/lights/AmbientLight.js
@@ -1,20 +1,17 @@
 import { Light } from './Light.js';
 
-function AmbientLight( color, intensity ) {
+class AmbientLight extends Light {
 
-	Light.call( this, color, intensity );
+	constructor( color, intensity ) {
 
-	this.type = 'AmbientLight';
+		super( color, intensity );
+
+		this.type = 'AmbientLight';
+		Object.defineProperty( this, 'isAmbientLight', { value: true } );
+
+	}
 
 }
-
-AmbientLight.prototype = Object.assign( Object.create( Light.prototype ), {
-
-	constructor: AmbientLight,
-
-	isAmbientLight: true
-
-} );
 
 
 export { AmbientLight };


### PR DESCRIPTION
Related issue: #19986

**Description**

Changing `src/lights/ambientlight.js` to es6 class syntax
