### PR TITLE
Editor: Move commands to ES6.

### DIFF
--- a/editor/js/Command.js
+++ b/editor/js/Command.js
@@ -1,38 +1,41 @@
-
 /**
  * @param editor pointer to main editor object used to initialize
  *        each command object with a reference to the editor
  * @constructor
  */
 
-function Command( editor ) {
+class Command {
 
-	this.id = - 1;
-	this.inMemory = false;
-	this.updatable = false;
-	this.type = '';
-	this.name = '';
-	this.editor = editor;
+	constructor( editor ) {
+
+		this.id = - 1;
+		this.inMemory = false;
+		this.updatable = false;
+		this.type = '';
+		this.name = '';
+		this.editor = editor;
+
+	}
+
+	toJSON() {
+
+		const output = {};
+		output.type = this.type;
+		output.id = this.id;
+		output.name = this.name;
+		return output;
+
+	}
+
+	fromJSON( json ) {
+
+		this.inMemory = true;
+		this.type = json.type;
+		this.id = json.id;
+		this.name = json.name;
+
+	}
 
 }
-
-Command.prototype.toJSON = function () {
-
-	var output = {};
-	output.type = this.type;
-	output.id = this.id;
-	output.name = this.name;
-	return output;
-
-};
-
-Command.prototype.fromJSON = function ( json ) {
-
-	this.inMemory = true;
-	this.type = json.type;
-	this.id = json.id;
-	this.name = json.name;
-
-};
 
 export { Command };

--- a/editor/js/commands/AddObjectCommand.js
+++ b/editor/js/commands/AddObjectCommand.js
@@ -1,66 +1,67 @@
 import { Command } from '../Command.js';
-import * as THREE from '../../../build/three.module.js';
+import { ObjectLoader } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
  * @param object THREE.Object3D
  * @constructor
  */
-function AddObjectCommand( editor, object ) {
+class AddObjectCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object ) {
 
-	this.type = 'AddObjectCommand';
+		super( editor );
 
-	this.object = object;
-	if ( object !== undefined ) {
+		this.type = 'AddObjectCommand';
 
-		this.name = 'Add Object: ' + object.name;
+		this.object = object;
+		if ( object !== undefined ) {
+
+			this.name = `Add Object: ${object.name}`;
+
+		}
 
 	}
 
-}
-
-AddObjectCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.editor.addObject( this.object );
 		this.editor.select( this.object );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.editor.removeObject( this.object );
 		this.editor.deselect();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
+
 		output.object = this.object.toJSON();
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.object.object.uuid );
 
 		if ( this.object === undefined ) {
 
-			var loader = new THREE.ObjectLoader();
+			const loader = new ObjectLoader();
 			this.object = loader.parse( json.object );
 
 		}
 
 	}
 
-};
+}
 
 export { AddObjectCommand };

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -6,21 +6,21 @@ import { Command } from '../Command.js';
  * @param script javascript object
  * @constructor
  */
-function AddScriptCommand( editor, object, script ) {
+class AddScriptCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, script ) {
 
-	this.type = 'AddScriptCommand';
-	this.name = 'Add Script';
+		super( editor );
 
-	this.object = object;
-	this.script = script;
+		this.type = 'AddScriptCommand';
+		this.name = 'Add Script';
 
-}
+		this.object = object;
+		this.script = script;
 
-AddScriptCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		if ( this.editor.scripts[ this.object.uuid ] === undefined ) {
 
@@ -32,13 +32,13 @@ AddScriptCommand.prototype = {
 
 		this.editor.signals.scriptAdded.dispatch( this.script );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		if ( this.editor.scripts[ this.object.uuid ] === undefined ) return;
 
-		var index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
+		const index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
 
 		if ( index !== - 1 ) {
 
@@ -48,28 +48,28 @@ AddScriptCommand.prototype = {
 
 		this.editor.signals.scriptRemoved.dispatch( this.script );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.script = this.script;
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.script = json.script;
 		this.object = this.editor.objectByUuid( json.objectUuid );
 
 	}
 
-};
+}
 
 export { AddScriptCommand };

--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -7,67 +7,67 @@ import { Command } from '../Command.js';
  * @param newBefore THREE.Object3D
  * @constructor
  */
-function MoveObjectCommand( editor, object, newParent, newBefore ) {
+class MoveObjectCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newParent, newBefore ) {
 
-	this.type = 'MoveObjectCommand';
-	this.name = 'Move Object';
+		super( editor );
 
-	this.object = object;
-	this.oldParent = ( object !== undefined ) ? object.parent : undefined;
-	this.oldIndex = ( this.oldParent !== undefined ) ? this.oldParent.children.indexOf( this.object ) : undefined;
-	this.newParent = newParent;
+		this.type = 'MoveObjectCommand';
+		this.name = 'Move Object';
 
-	if ( newBefore !== undefined ) {
+		this.object = object;
+		this.oldParent = ( object !== undefined ) ? object.parent : undefined;
+		this.oldIndex = ( this.oldParent !== undefined ) ? this.oldParent.children.indexOf( this.object ) : undefined;
+		this.newParent = newParent;
 
-		this.newIndex = ( newParent !== undefined ) ? newParent.children.indexOf( newBefore ) : undefined;
+		if ( newBefore !== undefined ) {
 
-	} else {
+			this.newIndex = ( newParent !== undefined ) ? newParent.children.indexOf( newBefore ) : undefined;
 
-		this.newIndex = ( newParent !== undefined ) ? newParent.children.length : undefined;
+		} else {
+
+			this.newIndex = ( newParent !== undefined ) ? newParent.children.length : undefined;
+
+		}
+
+		if ( this.oldParent === this.newParent && this.newIndex > this.oldIndex ) {
+
+			this.newIndex --;
+
+		}
+
+		this.newBefore = newBefore;
 
 	}
 
-	if ( this.oldParent === this.newParent && this.newIndex > this.oldIndex ) {
-
-		this.newIndex --;
-
-	}
-
-	this.newBefore = newBefore;
-
-}
-
-MoveObjectCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.oldParent.remove( this.object );
 
-		var children = this.newParent.children;
+		const children = this.newParent.children;
 		children.splice( this.newIndex, 0, this.object );
 		this.object.parent = this.newParent;
 
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.newParent.remove( this.object );
 
-		var children = this.oldParent.children;
+		const children = this.oldParent.children;
 		children.splice( this.oldIndex, 0, this.object );
 		this.object.parent = this.oldParent;
 
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.newParentUuid = this.newParent.uuid;
@@ -77,11 +77,11 @@ MoveObjectCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.oldParent = this.editor.objectByUuid( json.oldParentUuid );
@@ -104,6 +104,6 @@ MoveObjectCommand.prototype = {
 
 	}
 
-};
+}
 
 export { MoveObjectCommand };

--- a/editor/js/commands/MultiCmdsCommand.js
+++ b/editor/js/commands/MultiCmdsCommand.js
@@ -5,24 +5,24 @@ import { Command } from '../Command.js';
  * @param cmdArray array containing command objects
  * @constructor
  */
-function MultiCmdsCommand( editor, cmdArray ) {
+class MultiCmdsCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, cmdArray ) {
 
-	this.type = 'MultiCmdsCommand';
-	this.name = 'Multiple Changes';
+		super( editor );
 
-	this.cmdArray = ( cmdArray !== undefined ) ? cmdArray : [];
+		this.type = 'MultiCmdsCommand';
+		this.name = 'Multiple Changes';
 
-}
+		this.cmdArray = ( cmdArray !== undefined ) ? cmdArray : [];
 
-MultiCmdsCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.editor.signals.sceneGraphChanged.active = false;
 
-		for ( var i = 0; i < this.cmdArray.length; i ++ ) {
+		for ( let i = 0; i < this.cmdArray.length; i ++ ) {
 
 			this.cmdArray[ i ].execute();
 
@@ -31,13 +31,13 @@ MultiCmdsCommand.prototype = {
 		this.editor.signals.sceneGraphChanged.active = true;
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.editor.signals.sceneGraphChanged.active = false;
 
-		for ( var i = this.cmdArray.length - 1; i >= 0; i -- ) {
+		for ( let i = this.cmdArray.length - 1; i >= 0; i -- ) {
 
 			this.cmdArray[ i ].undo();
 
@@ -46,14 +46,14 @@ MultiCmdsCommand.prototype = {
 		this.editor.signals.sceneGraphChanged.active = true;
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
-		var cmds = [];
-		for ( var i = 0; i < this.cmdArray.length; i ++ ) {
+		const cmds = [];
+		for ( let i = 0; i < this.cmdArray.length; i ++ ) {
 
 			cmds.push( this.cmdArray[ i ].toJSON() );
 
@@ -63,16 +63,16 @@ MultiCmdsCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
-		var cmds = json.cmds;
-		for ( var i = 0; i < cmds.length; i ++ ) {
+		const cmds = json.cmds;
+		for ( let i = 0; i < cmds.length; i ++ ) {
 
-			var cmd = new window[ cmds[ i ].type ]();	// creates a new object of type "json.type"
+			const cmd = new window[ cmds[ i ].type ]();	// creates a new object of type "json.type"
 			cmd.fromJSON( cmds[ i ] );
 			this.cmdArray.push( cmd );
 
@@ -80,6 +80,6 @@ MultiCmdsCommand.prototype = {
 
 	}
 
-};
+}
 
 export { MultiCmdsCommand };

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -1,60 +1,60 @@
-
 import { Command } from '../Command.js';
 
-import * as THREE from '../../../build/three.module.js';
+import { ObjectLoader } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
  * @param object THREE.Object3D
  * @constructor
  */
-function RemoveObjectCommand( editor, object ) {
+class RemoveObjectCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object ) {
 
-	this.type = 'RemoveObjectCommand';
-	this.name = 'Remove Object';
+		super( editor );
 
-	this.object = object;
-	this.parent = ( object !== undefined ) ? object.parent : undefined;
-	if ( this.parent !== undefined ) {
+		this.type = 'RemoveObjectCommand';
+		this.name = 'Remove Object';
 
-		this.index = this.parent.children.indexOf( this.object );
+		this.object = object;
+		this.parent = ( object !== undefined ) ? object.parent : undefined;
+		if ( this.parent !== undefined ) {
+
+			this.index = this.parent.children.indexOf( this.object );
+
+		}
 
 	}
 
-}
-
-RemoveObjectCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.editor.removeObject( this.object );
 		this.editor.deselect();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.editor.addObject( this.object, this.parent, this.index );
 		this.editor.select( this.object );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
+
 		output.object = this.object.toJSON();
 		output.index = this.index;
 		output.parentUuid = this.parent.uuid;
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.parent = this.editor.objectByUuid( json.parentUuid );
 		if ( this.parent === undefined ) {
@@ -66,15 +66,16 @@ RemoveObjectCommand.prototype = {
 		this.index = json.index;
 
 		this.object = this.editor.objectByUuid( json.object.object.uuid );
+
 		if ( this.object === undefined ) {
 
-			var loader = new THREE.ObjectLoader();
+			const loader = new ObjectLoader();
 			this.object = loader.parse( json.object );
 
 		}
 
 	}
 
-};
+}
 
 export { RemoveObjectCommand };

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -6,26 +6,26 @@ import { Command } from '../Command.js';
  * @param script javascript object
  * @constructor
  */
-function RemoveScriptCommand( editor, object, script ) {
+class RemoveScriptCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, script ) {
 
-	this.type = 'RemoveScriptCommand';
-	this.name = 'Remove Script';
+		super( editor );
 
-	this.object = object;
-	this.script = script;
-	if ( this.object && this.script ) {
+		this.type = 'RemoveScriptCommand';
+		this.name = 'Remove Script';
 
-		this.index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
+		this.object = object;
+		this.script = script;
+		if ( this.object && this.script ) {
+
+			this.index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
+
+		}
 
 	}
 
-}
-
-RemoveScriptCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		if ( this.editor.scripts[ this.object.uuid ] === undefined ) return;
 
@@ -37,9 +37,9 @@ RemoveScriptCommand.prototype = {
 
 		this.editor.signals.scriptRemoved.dispatch( this.script );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		if ( this.editor.scripts[ this.object.uuid ] === undefined ) {
 
@@ -51,11 +51,11 @@ RemoveScriptCommand.prototype = {
 
 		this.editor.signals.scriptAdded.dispatch( this.script );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.script = this.script;
@@ -63,11 +63,11 @@ RemoveScriptCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.script = json.script;
 		this.index = json.index;
@@ -75,6 +75,6 @@ RemoveScriptCommand.prototype = {
 
 	}
 
-};
+}
 
 export { RemoveScriptCommand };

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -7,46 +7,46 @@ import { Command } from '../Command.js';
  * @param newValue integer representing a hex color value
  * @constructor
  */
-function SetColorCommand( editor, object, attributeName, newValue ) {
+class SetColorCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue ) {
 
-	this.type = 'SetColorCommand';
-	this.name = 'Set ' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.attributeName = attributeName;
-	this.oldValue = ( object !== undefined ) ? this.object[ this.attributeName ].getHex() : undefined;
-	this.newValue = newValue;
+		this.type = 'SetColorCommand';
+		this.name = `Set ${attributeName}`;
+		this.updatable = true;
 
-}
+		this.object = object;
+		this.attributeName = attributeName;
+		this.oldValue = ( object !== undefined ) ? this.object[ this.attributeName ].getHex() : undefined;
+		this.newValue = newValue;
 
-SetColorCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.object[ this.attributeName ].setHex( this.newValue );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object[ this.attributeName ].setHex( this.oldValue );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -55,11 +55,11 @@ SetColorCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.attributeName = json.attributeName;
@@ -68,6 +68,6 @@ SetColorCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetColorCommand };

--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -1,6 +1,5 @@
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { ObjectLoader } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -9,23 +8,23 @@ import * as THREE from '../../../build/three.module.js';
  * @constructor
  */
 
-function SetGeometryCommand( editor, object, newGeometry ) {
+class SetGeometryCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newGeometry ) {
 
-	this.type = 'SetGeometryCommand';
-	this.name = 'Set Geometry';
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.oldGeometry = ( object !== undefined ) ? object.geometry : undefined;
-	this.newGeometry = newGeometry;
+		this.type = 'SetGeometryCommand';
+		this.name = 'Set Geometry';
+		this.updatable = true;
 
-}
+		this.object = object;
+		this.oldGeometry = ( object !== undefined ) ? object.geometry : undefined;
+		this.newGeometry = newGeometry;
 
-SetGeometryCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.object.geometry.dispose();
 		this.object.geometry = this.newGeometry;
@@ -34,9 +33,9 @@ SetGeometryCommand.prototype = {
 		this.editor.signals.geometryChanged.dispatch( this.object );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.geometry.dispose();
 		this.object.geometry = this.oldGeometry;
@@ -45,17 +44,17 @@ SetGeometryCommand.prototype = {
 		this.editor.signals.geometryChanged.dispatch( this.object );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newGeometry = cmd.newGeometry;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.oldGeometry = this.object.geometry.toJSON();
@@ -63,11 +62,11 @@ SetGeometryCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 
@@ -76,13 +75,13 @@ SetGeometryCommand.prototype = {
 
 		function parseGeometry( data ) {
 
-			var loader = new THREE.ObjectLoader();
+			const loader = new ObjectLoader();
 			return loader.parseGeometries( [ data ] )[ data.uuid ];
 
 		}
 
 	}
 
-};
+}
 
 export { SetGeometryCommand };

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -7,43 +7,43 @@ import { Command } from '../Command.js';
  * @param newValue number, string, boolean or object
  * @constructor
  */
-function SetGeometryValueCommand( editor, object, attributeName, newValue ) {
+class SetGeometryValueCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue ) {
 
-	this.type = 'SetGeometryValueCommand';
-	this.name = 'Set Geometry.' + attributeName;
+		super( editor );
 
-	this.object = object;
-	this.attributeName = attributeName;
-	this.oldValue = ( object !== undefined ) ? object.geometry[ attributeName ] : undefined;
-	this.newValue = newValue;
+		this.type = 'SetGeometryValueCommand';
+		this.name = `Set Geometry.${attributeName}`;
 
-}
+		this.object = object;
+		this.attributeName = attributeName;
+		this.oldValue = ( object !== undefined ) ? object.geometry[ attributeName ] : undefined;
+		this.newValue = newValue;
 
-SetGeometryValueCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.object.geometry[ this.attributeName ] = this.newValue;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.geometryChanged.dispatch();
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.geometry[ this.attributeName ] = this.oldValue;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.geometryChanged.dispatch();
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -52,11 +52,11 @@ SetGeometryValueCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.attributeName = json.attributeName;
@@ -65,6 +65,6 @@ SetGeometryValueCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetGeometryValueCommand };

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -7,51 +7,51 @@ import { Command } from '../Command.js';
  * @param newValue integer representing a hex color value
  * @constructor
  */
-function SetMaterialColorCommand( editor, object, attributeName, newValue, materialSlot ) {
+class SetMaterialColorCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue, materialSlot ) {
 
-	this.type = 'SetMaterialColorCommand';
-	this.name = 'Set Material.' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.material = this.editor.getObjectMaterial( object, materialSlot );
+		this.type = 'SetMaterialColorCommand';
+		this.name = `Set Material.${attributeName}`;
+		this.updatable = true;
 
-	this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].getHex() : undefined;
-	this.newValue = newValue;
+		this.object = object;
+		this.material = ( this.object !== undefined ) ? this.editor.getObjectMaterial( object, materialSlot ) : undefined;
 
-	this.attributeName = attributeName;
+		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].getHex() : undefined;
+		this.newValue = newValue;
 
-}
+		this.attributeName = attributeName;
 
-SetMaterialColorCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.material[ this.attributeName ].setHex( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.material[ this.attributeName ].setHex( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -60,11 +60,11 @@ SetMaterialColorCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.attributeName = json.attributeName;
@@ -73,6 +73,6 @@ SetMaterialColorCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetMaterialColorCommand };

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -1,6 +1,5 @@
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { ObjectLoader } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -8,40 +7,40 @@ import * as THREE from '../../../build/three.module.js';
  * @param newMaterial THREE.Material
  * @constructor
  */
-function SetMaterialCommand( editor, object, newMaterial, materialSlot ) {
+class SetMaterialCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newMaterial, materialSlot ) {
 
-	this.type = 'SetMaterialCommand';
-	this.name = 'New Material';
+		super( editor );
 
-	this.object = object;
-	this.materialSlot = materialSlot;
+		this.type = 'SetMaterialCommand';
+		this.name = 'New Material';
 
-	this.oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
-	this.newMaterial = newMaterial;
+		this.object = object;
+		this.materialSlot = materialSlot;
 
-}
+		this.oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
+		this.newMaterial = newMaterial;
 
-SetMaterialCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.editor.setObjectMaterial( this.object, this.materialSlot, this.newMaterial );
 		this.editor.signals.materialChanged.dispatch( this.newMaterial );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.editor.setObjectMaterial( this.object, this.materialSlot, this.oldMaterial );
 		this.editor.signals.materialChanged.dispatch( this.oldMaterial );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.oldMaterial = this.oldMaterial.toJSON();
@@ -49,11 +48,11 @@ SetMaterialCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.oldMaterial = parseMaterial( json.oldMaterial );
@@ -61,16 +60,16 @@ SetMaterialCommand.prototype = {
 
 		function parseMaterial( json ) {
 
-			var loader = new THREE.ObjectLoader();
-			var images = loader.parseImages( json.images );
-			var textures = loader.parseTextures( json.textures, images );
-			var materials = loader.parseMaterials( [ json ], textures );
+			const loader = new ObjectLoader();
+			const images = loader.parseImages( json.images );
+			const textures = loader.parseTextures( json.textures, images );
+			const materials = loader.parseMaterials( [ json ], textures );
 			return materials[ json.uuid ];
 
 		}
 
 	}
 
-};
+}
 
 export { SetMaterialCommand };

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -1,7 +1,5 @@
-
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { ObjectLoader } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -10,26 +8,26 @@ import * as THREE from '../../../build/three.module.js';
  * @param newMap THREE.Texture
  * @constructor
  */
-function SetMaterialMapCommand( editor, object, mapName, newMap, materialSlot ) {
+class SetMaterialMapCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, mapName, newMap, materialSlot ) {
 
-	this.type = 'SetMaterialMapCommand';
-	this.name = 'Set Material.' + mapName;
+		super( editor );
 
-	this.object = object;
-	this.material = this.editor.getObjectMaterial( object, materialSlot );
+		this.type = 'SetMaterialMapCommand';
+		this.name = `Set Material.${mapName}`;
 
-	this.oldMap = ( object !== undefined ) ? this.material[ mapName ] : undefined;
-	this.newMap = newMap;
+		this.object = object;
+		this.material = this.editor.getObjectMaterial( object, materialSlot );
 
-	this.mapName = mapName;
+		this.oldMap = ( object !== undefined ) ? this.material[ mapName ] : undefined;
+		this.newMap = newMap;
 
-}
+		this.mapName = mapName;
 
-SetMaterialMapCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		if ( this.oldMap !== null && this.oldMap !== undefined ) this.oldMap.dispose();
 
@@ -38,20 +36,20 @@ SetMaterialMapCommand.prototype = {
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.material[ this.mapName ] = this.oldMap;
 		this.material.needsUpdate = true;
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.mapName = this.mapName;
@@ -66,15 +64,15 @@ SetMaterialMapCommand.prototype = {
 
 			if ( map === null || map === undefined ) return null;
 
-			var meta = {
+			const meta = {
 				geometries: {},
 				materials: {},
 				textures: {},
 				images: {}
 			};
 
-			var json = map.toJSON( meta );
-			var images = extractFromCache( meta.images );
+			const json = map.toJSON( meta );
+			const images = extractFromCache( meta.images );
 			if ( images.length > 0 ) json.images = images;
 			json.sourceFile = map.sourceFile;
 
@@ -89,10 +87,10 @@ SetMaterialMapCommand.prototype = {
 		// and return as array
 		function extractFromCache( cache ) {
 
-			var values = [];
-			for ( var key in cache ) {
+			const values = [];
+			for ( const key in cache ) {
 
-				var data = cache[ key ];
+				const data = cache[ key ];
 				delete data.metadata;
 				values.push( data );
 
@@ -102,11 +100,11 @@ SetMaterialMapCommand.prototype = {
 
 		}
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.mapName = json.mapName;
@@ -115,12 +113,12 @@ SetMaterialMapCommand.prototype = {
 
 		function parseTexture( json ) {
 
-			var map = null;
+			let map = null;
 			if ( json !== null ) {
 
-				var loader = new THREE.ObjectLoader();
-				var images = loader.parseImages( json.images );
-				var textures = loader.parseTextures( [ json ], images );
+				const loader = new ObjectLoader();
+				const images = loader.parseImages( json.images );
+				const textures = loader.parseTextures( [ json ], images );
 				map = textures[ json.uuid ];
 				map.sourceFile = json.sourceFile;
 
@@ -132,6 +130,6 @@ SetMaterialMapCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetMaterialMapCommand };

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -7,27 +7,27 @@ import { Command } from '../Command.js';
  * @param newValue number, string, boolean or object
  * @constructor
  */
-function SetMaterialValueCommand( editor, object, attributeName, newValue, materialSlot ) {
+class SetMaterialValueCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue, materialSlot ) {
 
-	this.type = 'SetMaterialValueCommand';
-	this.name = 'Set Material.' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.material = this.editor.getObjectMaterial( object, materialSlot );
+		this.type = 'SetMaterialValueCommand';
+		this.name = `Set Material.${attributeName}`;
+		this.updatable = true;
 
-	this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ] : undefined;
-	this.newValue = newValue;
+		this.object = object;
+		this.material = this.editor.getObjectMaterial( object, materialSlot );
 
-	this.attributeName = attributeName;
+		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ] : undefined;
+		this.newValue = newValue;
 
-}
+		this.attributeName = attributeName;
 
-SetMaterialValueCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.material[ this.attributeName ] = this.newValue;
 		this.material.needsUpdate = true;
@@ -35,9 +35,9 @@ SetMaterialValueCommand.prototype = {
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.material[ this.attributeName ] = this.oldValue;
 		this.material.needsUpdate = true;
@@ -45,17 +45,17 @@ SetMaterialValueCommand.prototype = {
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -64,11 +64,11 @@ SetMaterialValueCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
@@ -77,6 +77,6 @@ SetMaterialValueCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetMaterialValueCommand };

--- a/editor/js/commands/SetMaterialVectorCommand.js
+++ b/editor/js/commands/SetMaterialVectorCommand.js
@@ -1,50 +1,50 @@
 import { Command } from '../Command.js';
 
-function SetMaterialVectorCommand( editor, object, attributeName, newValue, materialSlot ) {
+class SetMaterialVectorCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue, materialSlot ) {
 
-	this.type = 'SetMaterialColorCommand';
-	this.name = 'Set Material.' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.material = this.editor.getObjectMaterial( object, materialSlot );
+		this.type = 'SetMaterialColorCommand';
+		this.name = `Set Material.${attributeName}`;
+		this.updatable = true;
 
-	this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].toArray() : undefined;
-	this.newValue = newValue;
+		this.object = object;
+		this.material = this.editor.getObjectMaterial( object, materialSlot );
 
-	this.attributeName = attributeName;
+		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].toArray() : undefined;
+		this.newValue = newValue;
 
-}
+		this.attributeName = attributeName;
 
-SetMaterialVectorCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.material[ this.attributeName ].fromArray( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.material[ this.attributeName ].fromArray( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.material );
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -53,11 +53,11 @@ SetMaterialVectorCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.attributeName = json.attributeName;
@@ -66,6 +66,6 @@ SetMaterialVectorCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetMaterialVectorCommand };

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -1,6 +1,5 @@
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { Vector3 } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -9,58 +8,58 @@ import * as THREE from '../../../build/three.module.js';
  * @param optionalOldPosition THREE.Vector3
  * @constructor
  */
-function SetPositionCommand( editor, object, newPosition, optionalOldPosition ) {
+class SetPositionCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newPosition, optionalOldPosition ) {
 
-	this.type = 'SetPositionCommand';
-	this.name = 'Set Position';
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
+		this.type = 'SetPositionCommand';
+		this.name = 'Set Position';
+		this.updatable = true;
 
-	if ( object !== undefined && newPosition !== undefined ) {
+		this.object = object;
 
-		this.oldPosition = object.position.clone();
-		this.newPosition = newPosition.clone();
+		if ( object !== undefined && newPosition !== undefined ) {
+
+			this.oldPosition = object.position.clone();
+			this.newPosition = newPosition.clone();
+
+		}
+
+		if ( optionalOldPosition !== undefined ) {
+
+			this.oldPosition = optionalOldPosition.clone();
+
+		}
 
 	}
 
-	if ( optionalOldPosition !== undefined ) {
-
-		this.oldPosition = optionalOldPosition.clone();
-
-	}
-
-}
-
-SetPositionCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.object.position.copy( this.newPosition );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.position.copy( this.oldPosition );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	update: function ( command ) {
+	update( command ) {
 
 		this.newPosition.copy( command.newPosition );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.oldPosition = this.oldPosition.toArray();
@@ -68,18 +67,18 @@ SetPositionCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
-		this.oldPosition = new THREE.Vector3().fromArray( json.oldPosition );
-		this.newPosition = new THREE.Vector3().fromArray( json.newPosition );
+		this.oldPosition = new Vector3().fromArray( json.oldPosition );
+		this.newPosition = new Vector3().fromArray( json.newPosition );
 
 	}
 
-};
+}
 
 export { SetPositionCommand };

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -1,6 +1,5 @@
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { Euler } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -9,58 +8,58 @@ import * as THREE from '../../../build/three.module.js';
  * @param optionalOldRotation THREE.Euler
  * @constructor
  */
-function SetRotationCommand( editor, object, newRotation, optionalOldRotation ) {
+class SetRotationCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newRotation, optionalOldRotation ) {
 
-	this.type = 'SetRotationCommand';
-	this.name = 'Set Rotation';
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
+		this.type = 'SetRotationCommand';
+		this.name = 'Set Rotation';
+		this.updatable = true;
 
-	if ( object !== undefined && newRotation !== undefined ) {
+		this.object = object;
 
-		this.oldRotation = object.rotation.clone();
-		this.newRotation = newRotation.clone();
+		if ( object !== undefined && newRotation !== undefined ) {
+
+			this.oldRotation = object.rotation.clone();
+			this.newRotation = newRotation.clone();
+
+		}
+
+		if ( optionalOldRotation !== undefined ) {
+
+			this.oldRotation = optionalOldRotation.clone();
+
+		}
 
 	}
 
-	if ( optionalOldRotation !== undefined ) {
-
-		this.oldRotation = optionalOldRotation.clone();
-
-	}
-
-}
-
-SetRotationCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.object.rotation.copy( this.newRotation );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.rotation.copy( this.oldRotation );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	update: function ( command ) {
+	update( command ) {
 
 		this.newRotation.copy( command.newRotation );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.oldRotation = this.oldRotation.toArray();
@@ -68,18 +67,18 @@ SetRotationCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
-		this.oldRotation = new THREE.Euler().fromArray( json.oldRotation );
-		this.newRotation = new THREE.Euler().fromArray( json.newRotation );
+		this.oldRotation = new Euler().fromArray( json.oldRotation );
+		this.newRotation = new Euler().fromArray( json.newRotation );
 
 	}
 
-};
+}
 
 export { SetRotationCommand };

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -1,6 +1,5 @@
 import { Command } from '../Command.js';
-
-import * as THREE from '../../../build/three.module.js';
+import { Vector3 } from '../../../build/three.module.js';
 
 /**
  * @param editor Editor
@@ -9,58 +8,58 @@ import * as THREE from '../../../build/three.module.js';
  * @param optionalOldScale THREE.Vector3
  * @constructor
  */
-function SetScaleCommand( editor, object, newScale, optionalOldScale ) {
+class SetScaleCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newScale, optionalOldScale ) {
 
-	this.type = 'SetScaleCommand';
-	this.name = 'Set Scale';
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
+		this.type = 'SetScaleCommand';
+		this.name = 'Set Scale';
+		this.updatable = true;
 
-	if ( object !== undefined && newScale !== undefined ) {
+		this.object = object;
 
-		this.oldScale = object.scale.clone();
-		this.newScale = newScale.clone();
+		if ( object !== undefined && newScale !== undefined ) {
+
+			this.oldScale = object.scale.clone();
+			this.newScale = newScale.clone();
+
+		}
+
+		if ( optionalOldScale !== undefined ) {
+
+			this.oldScale = optionalOldScale.clone();
+
+		}
 
 	}
 
-	if ( optionalOldScale !== undefined ) {
-
-		this.oldScale = optionalOldScale.clone();
-
-	}
-
-}
-
-SetScaleCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.object.scale.copy( this.newScale );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.scale.copy( this.oldScale );
 		this.object.updateMatrixWorld( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
-	},
+	}
 
-	update: function ( command ) {
+	update( command ) {
 
 		this.newScale.copy( command.newScale );
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.oldScale = this.oldScale.toArray();
@@ -68,18 +67,18 @@ SetScaleCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.object = this.editor.objectByUuid( json.objectUuid );
-		this.oldScale = new THREE.Vector3().fromArray( json.oldScale );
-		this.newScale = new THREE.Vector3().fromArray( json.newScale );
+		this.oldScale = new Vector3().fromArray( json.oldScale );
+		this.newScale = new Vector3().fromArray( json.newScale );
 
 	}
 
-};
+}
 
 export { SetScaleCommand };

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -8,39 +8,39 @@ import { AddObjectCommand } from './AddObjectCommand.js';
  * @param scene containing children to import
  * @constructor
  */
-function SetSceneCommand( editor, scene ) {
+class SetSceneCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, scene ) {
 
-	this.type = 'SetSceneCommand';
-	this.name = 'Set Scene';
+		super( editor );
 
-	this.cmdArray = [];
+		this.type = 'SetSceneCommand';
+		this.name = 'Set Scene';
 
-	if ( scene !== undefined ) {
+		this.cmdArray = [];
 
-		this.cmdArray.push( new SetUuidCommand( this.editor, this.editor.scene, scene.uuid ) );
-		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );
-		this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'userData', JSON.parse( JSON.stringify( scene.userData ) ) ) );
+		if ( scene !== undefined ) {
 
-		while ( scene.children.length > 0 ) {
+			this.cmdArray.push( new SetUuidCommand( this.editor, this.editor.scene, scene.uuid ) );
+			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );
+			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'userData', JSON.parse( JSON.stringify( scene.userData ) ) ) );
 
-			var child = scene.children.pop();
-			this.cmdArray.push( new AddObjectCommand( this.editor, child ) );
+			while ( scene.children.length > 0 ) {
+
+				const child = scene.children.pop();
+				this.cmdArray.push( new AddObjectCommand( this.editor, child ) );
+
+			}
 
 		}
 
 	}
 
-}
-
-SetSceneCommand.prototype = {
-
-	execute: function () {
+	execute() {
 
 		this.editor.signals.sceneGraphChanged.active = false;
 
-		for ( var i = 0; i < this.cmdArray.length; i ++ ) {
+		for ( let i = 0; i < this.cmdArray.length; i ++ ) {
 
 			this.cmdArray[ i ].execute();
 
@@ -49,13 +49,13 @@ SetSceneCommand.prototype = {
 		this.editor.signals.sceneGraphChanged.active = true;
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.editor.signals.sceneGraphChanged.active = false;
 
-		for ( var i = this.cmdArray.length - 1; i >= 0; i -- ) {
+		for ( let i = this.cmdArray.length - 1; i >= 0; i -- ) {
 
 			this.cmdArray[ i ].undo();
 
@@ -64,32 +64,33 @@ SetSceneCommand.prototype = {
 		this.editor.signals.sceneGraphChanged.active = true;
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
-		var cmds = [];
-		for ( var i = 0; i < this.cmdArray.length; i ++ ) {
+		const cmds = [];
+		for ( let i = 0; i < this.cmdArray.length; i ++ ) {
 
 			cmds.push( this.cmdArray[ i ].toJSON() );
 
 		}
+
 		output.cmds = cmds;
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
-		var cmds = json.cmds;
-		for ( var i = 0; i < cmds.length; i ++ ) {
+		const cmds = json.cmds;
+		for ( let i = 0; i < cmds.length; i ++ ) {
 
-			var cmd = new window[ cmds[ i ].type ]();	// creates a new object of type "json.type"
+			const cmd = new window[ cmds[ i ].type ]();	// creates a new object of type "json.type"
 			cmd.fromJSON( cmds[ i ] );
 			this.cmdArray.push( cmd );
 
@@ -97,6 +98,6 @@ SetSceneCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetSceneCommand };

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -8,50 +8,50 @@ import { Command } from '../Command.js';
  * @param newValue string, object
  * @constructor
  */
-function SetScriptValueCommand( editor, object, script, attributeName, newValue ) {
+class SetScriptValueCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, script, attributeName, newValue ) {
 
-	this.type = 'SetScriptValueCommand';
-	this.name = 'Set Script.' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.script = script;
+		this.type = 'SetScriptValueCommand';
+		this.name = `Set Script.${attributeName}`;
+		this.updatable = true;
 
-	this.attributeName = attributeName;
-	this.oldValue = ( script !== undefined ) ? script[ this.attributeName ] : undefined;
-	this.newValue = newValue;
+		this.object = object;
+		this.script = script;
 
-}
+		this.attributeName = attributeName;
+		this.oldValue = ( script !== undefined ) ? script[ this.attributeName ] : undefined;
+		this.newValue = newValue;
 
-SetScriptValueCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.script[ this.attributeName ] = this.newValue;
 
 		this.editor.signals.scriptChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.script[ this.attributeName ] = this.oldValue;
 
 		this.editor.signals.scriptChanged.dispatch();
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
@@ -61,11 +61,11 @@ SetScriptValueCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
@@ -75,6 +75,6 @@ SetScriptValueCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetScriptValueCommand };

--- a/editor/js/commands/SetUuidCommand.js
+++ b/editor/js/commands/SetUuidCommand.js
@@ -6,52 +6,52 @@ import { Command } from '../Command.js';
  * @param newUuid string
  * @constructor
  */
-function SetUuidCommand( editor, object, newUuid ) {
+class SetUuidCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, newUuid ) {
 
-	this.type = 'SetUuidCommand';
-	this.name = 'Update UUID';
+		super( editor );
 
-	this.object = object;
+		this.type = 'SetUuidCommand';
+		this.name = 'Update UUID';
 
-	this.oldUuid = ( object !== undefined ) ? object.uuid : undefined;
-	this.newUuid = newUuid;
+		this.object = object;
 
-}
+		this.oldUuid = ( object !== undefined ) ? object.uuid : undefined;
+		this.newUuid = newUuid;
 
-SetUuidCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.object.uuid = this.newUuid;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object.uuid = this.oldUuid;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.oldUuid = this.oldUuid;
 		output.newUuid = this.newUuid;
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.oldUuid = json.oldUuid;
 		this.newUuid = json.newUuid;
@@ -65,6 +65,6 @@ SetUuidCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetUuidCommand };

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -7,48 +7,48 @@ import { Command } from '../Command.js';
  * @param newValue number, string, boolean or object
  * @constructor
  */
-function SetValueCommand( editor, object, attributeName, newValue ) {
+class SetValueCommand extends Command {
 
-	Command.call( this, editor );
+	constructor( editor, object, attributeName, newValue ) {
 
-	this.type = 'SetValueCommand';
-	this.name = 'Set ' + attributeName;
-	this.updatable = true;
+		super( editor );
 
-	this.object = object;
-	this.attributeName = attributeName;
-	this.oldValue = ( object !== undefined ) ? object[ attributeName ] : undefined;
-	this.newValue = newValue;
+		this.type = 'SetValueCommand';
+		this.name = `Set ${attributeName}`;
+		this.updatable = true;
 
-}
+		this.object = object;
+		this.attributeName = attributeName;
+		this.oldValue = ( object !== undefined ) ? object[ attributeName ] : undefined;
+		this.newValue = newValue;
 
-SetValueCommand.prototype = {
+	}
 
-	execute: function () {
+	execute() {
 
 		this.object[ this.attributeName ] = this.newValue;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		// this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	undo: function () {
+	undo() {
 
 		this.object[ this.attributeName ] = this.oldValue;
 		this.editor.signals.objectChanged.dispatch( this.object );
 		// this.editor.signals.sceneGraphChanged.dispatch();
 
-	},
+	}
 
-	update: function ( cmd ) {
+	update( cmd ) {
 
 		this.newValue = cmd.newValue;
 
-	},
+	}
 
-	toJSON: function () {
+	toJSON() {
 
-		var output = Command.prototype.toJSON.call( this );
+		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
 		output.attributeName = this.attributeName;
@@ -57,11 +57,11 @@ SetValueCommand.prototype = {
 
 		return output;
 
-	},
+	}
 
-	fromJSON: function ( json ) {
+	fromJSON( json ) {
 
-		Command.prototype.fromJSON.call( this, json );
+		super.fromJSON( json );
 
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
@@ -70,6 +70,6 @@ SetValueCommand.prototype = {
 
 	}
 
-};
+}
 
 export { SetValueCommand };


### PR DESCRIPTION
Related issue: #21229

**Description**

Converted all command classes to ES6 code.

Also fixed an issue with `SetMaterialColorCommand` which produces a runtime error when persistent history was enabled.
