### PR TITLE
USDZExporter: Added textures support

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -390,7 +390,7 @@ function MenubarFile( editor ) {
 
 		var exporter = new USDZExporter();
 
-		saveArrayBuffer( exporter.parse( editor.scene, { binary: true } ), 'model.usdz' );
+		saveArrayBuffer( await exporter.parse( editor.scene, { binary: true } ), 'model.usdz' );
 
 	} );
 	options.add( option );


### PR DESCRIPTION
Fixes: #21241

**Description**

Added basic support for `diffuse`, `normal`, `occlusion`, `roughness`, `metalness` and `emissive` textures.
Texture wrap types and second uv set not yet implemented.

<img width="918" alt="Screen Shot 2021-02-10 at 12 57 31 AM" src="https://user-images.githubusercontent.com/97088/107449163-fce3e100-6b3a-11eb-8b8e-fcec9f041363.png">

