### PR TITLE
Examples: Simplify instanced colors in scatter example.

### DIFF
--- a/examples/webgl_instancing_scatter.html
+++ b/examples/webgl_instancing_scatter.html
@@ -70,11 +70,8 @@
 				const _stemMesh = gltf.scene.getObjectByName( 'Stem' );
 				const _blossomMesh = gltf.scene.getObjectByName( 'Blossom' );
 
-				stemGeometry = new THREE.InstancedBufferGeometry();
-				blossomGeometry = new THREE.InstancedBufferGeometry();
-
-				THREE.BufferGeometry.prototype.copy.call( stemGeometry, _stemMesh.geometry );
-				THREE.BufferGeometry.prototype.copy.call( blossomGeometry, _blossomMesh.geometry );
+				stemGeometry = _stemMesh.geometry.clone();
+				blossomGeometry = _blossomMesh.geometry.clone();
 
 				const defaultTransform = new THREE.Matrix4()
 					.makeRotationX( Math.PI )
@@ -86,23 +83,19 @@
 				stemMaterial = _stemMesh.material;
 				blossomMaterial = _blossomMesh.material;
 
+				stemMesh = new THREE.InstancedMesh( stemGeometry, stemMaterial, count );
+				blossomMesh = new THREE.InstancedMesh( blossomGeometry, blossomMaterial, count );
+
 				// Assign random colors to the blossoms.
-				const _color = new THREE.Color();
-				const color = new Float32Array( count * 3 );
+				const color = new THREE.Color();
 				const blossomPalette = [ 0xF20587, 0xF2D479, 0xF2C879, 0xF2B077, 0xF24405 ];
 
 				for ( let i = 0; i < count; i ++ ) {
 
-					_color.setHex( blossomPalette[ Math.floor( Math.random() * blossomPalette.length ) ] );
-					_color.toArray( color, i * 3 );
+					color.setHex( blossomPalette[ Math.floor( Math.random() * blossomPalette.length ) ] );
+					blossomMesh.setColorAt( i, color );
 
 				}
-
-				blossomGeometry.setAttribute( 'color', new THREE.InstancedBufferAttribute( color, 3 ) );
-				blossomMaterial.vertexColors = true;
-
-				stemMesh = new THREE.InstancedMesh( stemGeometry, stemMaterial, count );
-				blossomMesh = new THREE.InstancedMesh( blossomGeometry, blossomMaterial, count );
 
 				// Instance matrices will be updated every frame.
 				stemMesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage );


### PR DESCRIPTION
Related issue: -

**Description**

This PR ensures `webgl_instancing_scatter` uses `InstancedMesh.instanceColor` instead of creating a custom instanced buffer attribute. This workflow was actually confusing for some users. One example: 

https://stackoverflow.com/questions/66023258/using-parts-of-gltf-as-an-instancedmesh

