### PR TITLE
NodeMaterial: Rename ModelViewProjectionMatrixNode -> ModelViewProjectionNode

### DIFF
--- a/examples/jsm/renderers/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/renderers/nodes/accessors/ModelViewProjectionNode.js
@@ -4,7 +4,7 @@ import ModelNode from '../accessors/ModelNode.js';
 import OperatorNode from '../math/OperatorNode.js';
 import PositionNode from '../accessors/PositionNode.js';
 
-class ModelViewProjectionMatrixNode extends Node {
+class ModelViewProjectionNode extends Node {
 
 	constructor( position = new PositionNode() ) {
 
@@ -29,4 +29,4 @@ class ModelViewProjectionMatrixNode extends Node {
 
 }
 
-export default ModelViewProjectionMatrixNode;
+export default ModelViewProjectionNode;

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -8,7 +8,7 @@ import { WebGPUSampledTexture } from '../WebGPUSampledTexture.js';
 
 import NodeSlot from '../../nodes/core/NodeSlot.js';
 import NodeBuilder from '../../nodes/core/NodeBuilder.js';
-import ModelViewProjectionMatrixNode from '../../nodes/accessors/ModelViewProjectionMatrixNode.js';
+import ModelViewProjectionNode from '../../nodes/accessors/ModelViewProjectionNode.js';
 
 import ShaderLib from './ShaderLib.js';
 
@@ -41,7 +41,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		if ( material.isMeshBasicMaterial || material.isPointsMaterial || material.isLineBasicMaterial ) {
 
-			const mvpNode = new ModelViewProjectionMatrixNode();
+			const mvpNode = new ModelViewProjectionNode();
 
 			if ( material.positionNode !== undefined ) {
 


### PR DESCRIPTION
I think it would be a definite name for this class. 
It describes the name of the technique used and does not deduce a wrong output for the `node`.
( Besides shortening the name )