### PR TITLE
Eslint: add support for class properties

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,21 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": ">0.3%, not dead",
+        "loose": true,
+        "bugfixes": true
+      }
+    ]
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-proposal-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,41 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.12.13.tgz",
+      "integrity": "sha512-+VF2M8ZWXc2KVf6L0tFcv6w8IZkCc1rvN65oj6hXxhYtOanlCA6ONpgEdy/HVGmcogu4El4ohdzuyfWYxSsKow==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
@@ -3078,7 +3113,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "test"
   },
   "eslintConfig": {
+    "parser": "@babel/eslint-parser",
     "root": true,
     "extends": "mdcs",
     "plugins": [
@@ -83,6 +84,7 @@
   "homepage": "https://threejs.org/",
   "devDependencies": {
     "@babel/core": "^7.12.10",
+    "@babel/eslint-parser": "^7.12.13",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
     "@rollup/plugin-babel": "^5.2.2",

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -1,16 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
-
-if ( String.prototype.replaceAll === undefined ) {
-
-	String.prototype.replaceAll = function ( find, replace ) {
-
-		return this.split( find ).join( replace );
-
-	};
-
-}
+import babelrc from '../../.babelrc.json';
 
 function glconstants() {
 
@@ -293,30 +284,6 @@ function polyfills() {
 	};
 
 }
-
-const babelrc = {
-	presets: [
-		[
-			'@babel/preset-env',
-			{
-				modules: false,
-				// the supported browsers of the three.js browser bundle
-				// https://browsersl.ist/?q=%3E0.3%25%2C+not+dead
-				targets: '>0.3%, not dead',
-				loose: true,
-				bugfixes: true,
-			},
-		],
-	],
-	plugins: [
-		[
-			'@babel/plugin-proposal-class-properties',
-			{
-				loose: true
-			}
-		]
-	]
-};
 
 export default [
 	{


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/20009#discussion_r572429691 (remake of #21238)

**Description**

Eslint also needs to know about babel to support class properties.
In this PR I added @babel/eslint-parser as a parser for eslint. This does not change the current eslint bahaviour.

Third time the charm?
