### PR TITLE
Docs: Add KHR_materials_variants extension to the list in GLTFLoader and GLTFExporter documents

### DIFF
--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -33,6 +33,14 @@
 			<li>KHR_texture_transform</li>
 		</ul>
 
+		<p>
+			The following glTF 2.0 extension is supported by an external user plugin
+		</p>
+
+		<ul>
+			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]</li>
+		</ul>
+
 		<h2>Code Example</h2>
 
 		<code>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -41,6 +41,14 @@
 			<li>MSFT_texture_dds</li>
 		</ul>
 
+		<p>
+			The following glTF 2.0 extension is supported by an external user plugin
+		</p>
+
+		<ul>
+			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]<sup>3</sup></li>
+		</ul>
+
 		<p><i>
 			<sup>1</sup>Requires [link:https://threejs.org/docs/#api/en/renderers/WebGLRenderer.physicallyCorrectLights physicallyCorrectLights] to be enabled.
 		</i></p>
@@ -52,6 +60,10 @@
 			transform will result in an additional GPU texture upload. See
 			#[link:https://github.com/mrdoob/three.js/pull/13831 13831] and
 			#[link:https://github.com/mrdoob/three.js/issues/12788 12788].
+		</i></p>
+
+		<p><i>
+			<sup>3</sup>You can also manually process the extension after loading in your application. See [link:https://threejs.org/examples/#webgl_loader_gltf_variants Three.js glTF materials variants example].
 		</i></p>
 
 		<h2>Code Example</h2>


### PR DESCRIPTION
Related PR comment: https://github.com/mrdoob/three.js/pull/20789#issuecomment-777932034

**Description**

This PR adds `KHR_materials_variants` extension next to the supported extensions list in `GLTFLoader` and `GLTFExporter` documents.

I would be happy if review the wording. If it looks ok, I apply the same changes for other languages.

This contribution is made from a hospital.
