### PR TITLE
add link to github draft PR page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,6 +77,6 @@ When you’ve decided to make changes, start with the following:
 
 * Once done with a patch / feature do not add more commits to a feature branch
 * Create separate branches per patch or feature.
-* If you make a PR but it is not actually ready to be pulled into the dev branch, add `[Draft]` into the PR title and/or convert it to a draft PR
+* If you make a PR but it is not actually ready to be pulled into the dev branch then please [convert it to a draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
 
 This project is currently contributed to mostly via everyone's spare time. Please keep that in mind as it may take some time for the appropriate feedback to get to you. If you are unsure about adding a new feature, it might be better to ask first to see whether other people think it's a good idea.


### PR DESCRIPTION
removed add [draft] from title. draft PR is enough and should be perfered