### PR TITLE
UniformUtils.cloneUniforms(): Also clone quaternions

### DIFF
--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -17,7 +17,7 @@ export function cloneUniforms( src ) {
 			if ( property && ( property.isColor ||
 				property.isMatrix3 || property.isMatrix4 ||
 				property.isVector2 || property.isVector3 || property.isVector4 ||
-				property.isTexture ) ) {
+				property.isTexture || property.isQuaternion ) ) {
 
 				dst[ u ][ p ] = property.clone();
 


### PR DESCRIPTION
**Description**

`UniformsUtils.clone` does not clone quaternions, resulting in the same instance of a given `THREE.Quaternion` uniform value being reused when that is specifically not desired.

This PR proposes a fix for that - it adds a check if the property `isQuaternion` and clones it if it is.