### PR TITLE
add constraints on panning x or y axis for TrackballControls

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -22,6 +22,8 @@ THREE.TrackballControls = function ( object, domElement ) {
 	this.noRotate = false;
 	this.noZoom = false;
 	this.noPan = false;
+	this.noPanX = false;
+	this.noPanY = false;
 
 	this.staticMoving = false;
 	this.dynamicDampingFactor = 0.2;
@@ -250,6 +252,18 @@ THREE.TrackballControls = function ( object, domElement ) {
 		return function panCamera() {
 
 			mouseChange.copy( _panEnd ).sub( _panStart );
+
+			if (this.noPanX) {
+
+				mouseChange.x = 0
+
+			}
+
+			if (this.noPanY) {
+
+				mouseChange.y = 0
+
+			}
 
 			if ( mouseChange.lengthSq() ) {
 
@@ -663,6 +677,19 @@ THREE.TrackballControls = function ( object, domElement ) {
 				var x = ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX ) / 2;
 				var y = ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY ) / 2;
 				_panEnd.copy( getMouseOnScreen( x, y ) );
+
+				if (scope.noPanX) {
+		
+					_panEnd.x = _panStart.x
+		
+				}
+		
+				if (scope.noPanY) {
+		
+					_panEnd.y = _panStart.y
+		
+				}
+				
 				break;
 
 		}

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -30,6 +30,8 @@ var TrackballControls = function ( object, domElement ) {
 	this.noRotate = false;
 	this.noZoom = false;
 	this.noPan = false;
+	this.noPanX = false;
+	this.noPanY = false;
 
 	this.staticMoving = false;
 	this.dynamicDampingFactor = 0.2;
@@ -258,6 +260,18 @@ var TrackballControls = function ( object, domElement ) {
 		return function panCamera() {
 
 			mouseChange.copy( _panEnd ).sub( _panStart );
+
+			if (this.noPanX) {
+
+				mouseChange.x = 0
+
+			}
+
+			if (this.noPanY) {
+
+				mouseChange.y = 0
+
+			}
 
 			if ( mouseChange.lengthSq() ) {
 
@@ -671,6 +685,19 @@ var TrackballControls = function ( object, domElement ) {
 				var x = ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX ) / 2;
 				var y = ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY ) / 2;
 				_panEnd.copy( getMouseOnScreen( x, y ) );
+
+				if (scope.noPanX) {
+		
+					_panEnd.x = _panStart.x
+		
+				}
+		
+				if (scope.noPanY) {
+		
+					_panEnd.y = _panStart.y
+		
+				}
+				
 				break;
 
 		}

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -34,7 +34,9 @@
 			let perspectiveCamera, orthographicCamera, controls, scene, renderer, stats;
 
 			const params = {
-				orthographicCamera: false
+				orthographicCamera: false, 
+				noPanX: false, 
+				noPanY: false
 			};
 
 			const frustumSize = 400;
@@ -106,6 +108,10 @@
 					createControls( value ? orthographicCamera : perspectiveCamera );
 
 				} );
+
+				gui.add( params, 'noPanX' ).name( 'disable pan: X axis' ).onChange( function ( value ) { controls.noPanX = value; } );
+				gui.add( params, 'noPanY' ).name( 'disable pan: Y axis' ).onChange( function ( value ) { controls.noPanY = value; } );
+
 
 				//
 


### PR DESCRIPTION
Related issue: #21269

**Description**

The existing TrackballControls provides no method of constraining movement via pan along a single axis.

This PR seeks to enable the panning motion to be constrained to the x or y axis independently.