### PR TITLE
Docs: Add MSFT_texture_dds to GLTFLoader doc

### DIFF
--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -38,7 +38,7 @@
 		</p>
 
 		<ul>
-			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]</li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]</li>
 		</ul>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -45,7 +45,8 @@
 		</p>
 
 		<ul>
-			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]<sup>3</sup></li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]<sup>3</sup></li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions MSFT_texture_dds]</li>
 		</ul>
 
 		<p><i>

--- a/docs/examples/zh/exporters/GLTFExporter.html
+++ b/docs/examples/zh/exporters/GLTFExporter.html
@@ -38,7 +38,7 @@
 		</p>
 
 		<ul>
-			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]</li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]</li>
 		</ul>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -43,7 +43,8 @@
 		</p>
 
 		<ul>
-			<li>[link:https://github.com/takahirox/three-gltf-plugins KHR_materials_variants]<sup>3</sup></li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]<sup>3</sup></li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions MSFT_texture_dds]</li>
 		</ul>
 
 		<p><i>


### PR DESCRIPTION
**Description**

This PR adds `MSFT_texture_dds` to `GLTFLoader` document because I added `GLTFLoader` `MSFT_texture_dds` extension plugin to my https://github.com/takahirox/three-gltf-extensions.

And also I renamed the repository from `three-gltf-plugins` to `three-gltf-extensions` so updated the links in the PR.