### PR TITLE
BufferAttribute .name, .usage, .updateRange serialization

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -394,12 +394,18 @@ Object.assign( BufferAttribute.prototype, {
 
 	toJSON: function () {
 
-		return {
+		const data = {
 			itemSize: this.itemSize,
 			type: this.array.constructor.name,
 			array: Array.prototype.slice.call( this.array ),
 			normalized: this.normalized
 		};
+
+		if ( this.name !== '' ) data.name = this.name;
+		if ( this.usage !== StaticDrawUsage ) data.usage = this.usage;
+		if ( this.updateRange.offset !== 0 || this.updateRange.count !== - 1 ) data.updateRange = this.updateRange;
+
+		return data;
 
 	}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -929,11 +929,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 			const attribute = attributes[ key ];
 
-			const attributeData = attribute.toJSON( data.data );
-
-			if ( attribute.name !== '' ) attributeData.name = attribute.name;
-
-			data.data.attributes[ key ] = attributeData;
+			data.data.attributes[ key ] = attribute.toJSON( data.data );
 
 		}
 
@@ -950,11 +946,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 				const attribute = attributeArray[ i ];
 
-				const attributeData = attribute.toJSON( data.data );
-
-				if ( attribute.name !== '' ) attributeData.name = attribute.name;
-
-				array.push( attributeData );
+				array.push( attribute.toJSON( data.data ) );
 
 			}
 

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -123,6 +123,15 @@ class BufferGeometryLoader extends Loader {
 			}
 
 			if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
+			if ( attribute.usage !== undefined ) bufferAttribute.setUsage( attribute.usage );
+
+			if ( attribute.updateRange !== undefined ) {
+
+				bufferAttribute.updateRange.offset = attribute.updateRange.offset;
+				bufferAttribute.updateRange.count = attribute.updateRange.count;
+
+			}
+
 			geometry.setAttribute( key, bufferAttribute );
 
 		}

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -245,13 +245,28 @@ export default QUnit.module( 'Core', () => {
 
 		QUnit.test( "toJSON", ( assert ) => {
 
-			const attr = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3, true );
+			const attr = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
 			assert.deepEqual( attr.toJSON(), {
 				itemSize: 3,
 				type: 'Float32Array',
 				array: [ 1, 2, 3, 4, 5, 6 ],
-				normalized: true
+				normalized: false
 			}, 'Serialized to JSON as expected' );
+
+			const attr2 = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3, true );
+			attr2.name = 'attributeName';
+			attr2.setUsage( DynamicDrawUsage );
+			attr2.updateRange.offset = 1;
+			attr2.updateRange.count = 2;
+			assert.deepEqual( attr2.toJSON(), {
+				itemSize: 3,
+				type: 'Float32Array',
+				array: [ 1, 2, 3, 4, 5, 6 ],
+				normalized: true,
+				name: 'attributeName',
+				usage: DynamicDrawUsage,
+				updateRange: { offset: 1, count: 2 }
+			}, 'Serialized to JSON as expected with non-default values' );
 
 		} );
 

--- a/test/unit/src/loaders/BufferGeometryLoader.tests.js
+++ b/test/unit/src/loaders/BufferGeometryLoader.tests.js
@@ -1,6 +1,9 @@
 /* global QUnit */
 
+import { BufferAttribute } from '../../../../src/core/BufferAttribute';
+import { BufferGeometry } from '../../../../src/core/BufferGeometry';
 import { BufferGeometryLoader } from '../../../../src/loaders/BufferGeometryLoader';
+import { DynamicDrawUsage } from '../../../../src/constants';
 
 export default QUnit.module( 'Loaders', () => {
 
@@ -23,6 +26,31 @@ export default QUnit.module( 'Loaders', () => {
 		QUnit.todo( "parse", ( assert ) => {
 
 			assert.ok( false, "everything's gonna be alright" );
+
+		} );
+
+		QUnit.test( "parser - attributes - circlable", ( assert ) => {
+
+			const loader = new BufferGeometryLoader();
+			const geometry = new BufferGeometry();
+			const attr = new BufferAttribute( new Float32Array( [ 7, 8, 9, 10, 11, 12 ] ), 2, true );
+			attr.name = 'attribute';
+			attr.setUsage( DynamicDrawUsage );
+			attr.updateRange.offset = 1;
+			attr.updateRange.count = 2;
+
+			geometry.setAttribute( 'attr', attr );
+
+			const geometry2 = loader.parse( geometry.toJSON() );
+
+			assert.ok( geometry2.getAttribute( 'attr' ),
+				'Serialized attribute can be deserialized under the same attribute key.' );
+
+			assert.deepEqual(
+				geometry.getAttribute( 'attr' ),
+				geometry2.getAttribute( 'attr' ),
+				'Serialized attribute can be deserialized correctly.'
+			);
 
 		} );
 


### PR DESCRIPTION
Related PR: #21225

**Description**

This PR adds missing `BufferAttribute` `.name`, `.usage`, and `.updateRange` serialization and deserialization to `BufferAttribute.toJSON()` and `BufferGeometryLoader.parse()` and adds unit tests to check them.
