### PR TITLE
Raycaster: Simplify code.

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -1,13 +1,13 @@
 import { Ray } from '../math/Ray.js';
 import { Layers } from './Layers.js';
 
-function Raycaster( origin, direction, near, far ) {
+function Raycaster( origin, direction, near = 0, far = Infinity ) {
 
 	this.ray = new Ray( origin, direction );
 	// direction is assumed to be normalized (for accurate distance calculations)
 
-	this.near = near || 0;
-	this.far = far || Infinity;
+	this.near = near;
+	this.far = far;
 	this.camera = null;
 	this.layers = new Layers();
 
@@ -92,9 +92,7 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObject: function ( object, recursive, optionalTarget ) {
-
-		const intersects = optionalTarget || [];
+	intersectObject: function ( object, recursive = false, intersects = [] ) {
 
 		intersectObject( object, this, intersects, recursive );
 
@@ -104,16 +102,7 @@ Object.assign( Raycaster.prototype, {
 
 	},
 
-	intersectObjects: function ( objects, recursive, optionalTarget ) {
-
-		const intersects = optionalTarget || [];
-
-		if ( Array.isArray( objects ) === false ) {
-
-			console.warn( 'THREE.Raycaster.intersectObjects: objects is not an Array.' );
-			return intersects;
-
-		}
+	intersectObjects: function ( objects, recursive = false, intersects = [] ) {
 
 		for ( let i = 0, l = objects.length; i < l; i ++ ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

- Uses default parameters in `intersectObject()`, `intersectObjects()` and the ctor.
- Remove the array check in `intersectObjects()` (since the policy is to not validate input parameter). 
