### PR TITLE
Loader: Add "setFromFetchOptions" function

### DIFF
--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -63,6 +63,32 @@ Object.assign( Loader.prototype, {
 		this.requestHeader = requestHeader;
 		return this;
 
+	},
+
+	setFromFetchOptions: function ( fetchOptions ) {
+
+		this.setWithCredentials( fetchOptions.credentials === 'include' );
+
+		if ( fetchOptions.credentials === 'include' && fetchOptions.mode === 'cors' ) {
+
+			this.setCrossOrigin( 'use-credentials' );
+
+		} else {
+
+			this.setCrossOrigin( 'anonymous' );
+
+		}
+
+		if ( fetchOptions.headers ) {
+
+			this.setRequestHeader( fetchOptions.headers );
+
+		} else {
+
+			this.setRequestHeader( {} );
+
+		}
+
 	}
 
 } );

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -67,25 +67,23 @@ Object.assign( Loader.prototype, {
 
 	setFromFetchOptions: function ( fetchOptions ) {
 
-		this.setWithCredentials( fetchOptions.credentials === 'include' );
+		const defaultedOptions = Object.assign( {
+			credentials: 'same-origin',
+			mode: 'cors',
+			headers: {},
 
-		if ( fetchOptions.credentials === 'include' && fetchOptions.mode === 'cors' ) {
+		}, fetchOptions );
+
+		this.setWithCredentials( defaultedOptions.credentials === 'include' );
+		this.setRequestHeader( defaultedOptions.headers );
+
+		if ( defaultedOptions.credentials === 'include' && defaultedOptions.mode === 'cors' ) {
 
 			this.setCrossOrigin( 'use-credentials' );
 
 		} else {
 
 			this.setCrossOrigin( 'anonymous' );
-
-		}
-
-		if ( fetchOptions.headers ) {
-
-			this.setRequestHeader( fetchOptions.headers );
-
-		} else {
-
-			this.setRequestHeader( {} );
 
 		}
 


### PR DESCRIPTION
Related issue: --

**Description**

This is a suggestion to add a `setFromFetchOptions( fetchOptions )` function to `Loader`. `fetch` has become the predominant way to perform requests and it comes with a (in my opinion) more intuitive set of options for defining the request that is not supported by the three.js loaders. In my apps I carry around a common fetch options object that defines the "mode", "credentials", and necessary "headers" needed to make a request for a certain set of resources and it's not immediately clear how to map those options to the old XMLHttpRequest / three.js Loader model. `setFromFetchOptions` makes it easy to map the more modern `fetch` options to those needed by the loader ultimately calling `setWithCredentials`, `setCrossOrigin`, and `setRequestHeader` with ( as far as I can tell) the equivalent values.