### PR TITLE
Adds missing parameter to `MeshDepthMaterialParameters`

### DIFF
--- a/src/materials/MeshDepthMaterial.d.ts
+++ b/src/materials/MeshDepthMaterial.d.ts
@@ -9,6 +9,7 @@ export interface MeshDepthMaterialParameters extends MaterialParameters {
 	displacementMap?: Texture | null;
 	displacementScale?: number;
 	displacementBias?: number;
+	morphTargets?: boolean;
 	wireframe?: boolean;
 	wireframeLinewidth?: number;
 }


### PR DESCRIPTION
A simple TS typings change to correct a definition-use mismatch.

The parameter is used here: https://github.com/mrdoob/three.js/blob/c7253d4715a5a017e2f95c07d02e9e31d84dad03/src/renderers/webgl/WebGLShadowMap.js#L241
