### PR TITLE
A minimal conversion example

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -6,21 +6,24 @@ import { PropertyMixer } from './PropertyMixer.js';
 import { AnimationClip } from './AnimationClip.js';
 import { NormalAnimationBlendMode } from '../constants.js';
 
-function AnimationMixer( root ) {
+class AnimationMixer extends EventDispatcher {
 
-	this._root = root;
-	this._initMemoryManager();
-	this._accuIndex = 0;
+	constructor( root ) {
 
-	this.time = 0;
+		super();
+		this._root = root;
+		this._initMemoryManager();
+		this._accuIndex = 0;
 
-	this.timeScale = 1.0;
+		this.time = 0;
+
+		this.timeScale = 1.0;
+
+	}
 
 }
 
-AnimationMixer.prototype = Object.assign( Object.create( EventDispatcher.prototype ), {
-
-	constructor: AnimationMixer,
+Object.assign( AnimationMixer.prototype, {
 
 	_bindAction: function ( action, prototypeAction ) {
 


### PR DESCRIPTION
Related issue: #19986

details:

* change constructor function to class. add constructor function within class.
* extend as appropriate
  * call `super()` within constructor if extended
* simplify `Object.assign( )` call

Edit:
For future reference, it was a 10/10 pass on all checks.