### PR TITLE
BufferGeometryUtils: Fix assignment bug in computeMorphedAttributes().

### DIFF
--- a/examples/js/utils/BufferGeometryUtils.js
+++ b/examples/js/utils/BufferGeometryUtils.js
@@ -674,13 +674,13 @@ THREE.BufferGeometryUtils = {
 				for ( var i = 0, il = morphAttribute.length; i < il; i ++ ) {
 
 					var influence = morphInfluences[ i ];
-					var morphAttribute = morphAttribute[ i ];
+					var morph = morphAttribute[ i ];
 
 					if ( influence === 0 ) continue;
 
-					_tempA.fromBufferAttribute( morphAttribute, a );
-					_tempB.fromBufferAttribute( morphAttribute, b );
-					_tempC.fromBufferAttribute( morphAttribute, c );
+					_tempA.fromBufferAttribute( morph, a );
+					_tempB.fromBufferAttribute( morph, b );
+					_tempC.fromBufferAttribute( morph, c );
 
 					if ( morphTargetsRelative ) {
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -686,13 +686,13 @@ var BufferGeometryUtils = {
 				for ( var i = 0, il = morphAttribute.length; i < il; i ++ ) {
 
 					var influence = morphInfluences[ i ];
-					var morphAttribute = morphAttribute[ i ];
+					var morph = morphAttribute[ i ];
 
 					if ( influence === 0 ) continue;
 
-					_tempA.fromBufferAttribute( morphAttribute, a );
-					_tempB.fromBufferAttribute( morphAttribute, b );
-					_tempC.fromBufferAttribute( morphAttribute, c );
+					_tempA.fromBufferAttribute( morph, a );
+					_tempB.fromBufferAttribute( morph, b );
+					_tempC.fromBufferAttribute( morph, c );
 
 					if ( morphTargetsRelative ) {
 


### PR DESCRIPTION
Related issue: Fixed #21287

**Description**

The PR fixes a quite obvious bug in `computeMorphedAttributes()`.

Side note: To me, the code was never tested with a morphed mesh otherwise the original contributor of this code should have detected this issue.