### PR TITLE
WebGLCubeRenderTarget: Add missing texture configuration.

### DIFF
--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -36,6 +36,7 @@
 		[page:Constant wrapT] - default is [page:Textures ClampToEdgeWrapping]. <br />
 		[page:Constant magFilter] - default is [page:Textures .LinearFilter]. <br />
 		[page:Constant minFilter] - default is [page:Textures LinearFilter]. <br />
+		[page:Boolean generateMipmaps] - default is *false*.<br />
 		[page:Constant format] - default is [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - default is *1*. See [page:Texture.anistropy]<br />

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -33,6 +33,7 @@
 		[page:Constant wrapT] - 默认是[page:Textures ClampToEdgeWrapping]. <br />
 		[page:Constant magFilter] - 默认是[page:Textures .LinearFilter]. <br />
 		[page:Constant minFilter] - 默认是[page:Textures LinearFilter]. <br />
+		[page:Boolean generateMipmaps] - 默认是*false*.<br />
 		[page:Constant format] - 默认是[page:Textures RGBAFormat]. <br />
 		[page:Constant type] - 默认是[page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - 默认是 *1*. 参见[page:Texture.anistropy]<br />

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -25,6 +25,9 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 		this.texture = new CubeTexture( undefined, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
+		this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
+		this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;
+
 		this.texture._needsFlipEnvMap = false;
 
 	}


### PR DESCRIPTION
Related issue: -

**Description**

When working on #21308, I've realized that `WebGLCubeRenderTarget` missed two lines that need to be in place for proper default values.