### PR TITLE
Matrix3: Remove superfluous  copy.

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -198,7 +198,7 @@ class Matrix3 {
 
 	getNormalMatrix( matrix4 ) {
 
-		return this.setFromMatrix4( matrix4 ).copy( this ).invert().transpose();
+		return this.setFromMatrix4( matrix4 ).invert().transpose();
 
 	}
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/20611#discussion_r579307605

**Description**

This PR removes a superfluous copy operation from `getNormalMatrix()`.
