### PR TITLE
Docs: Clarified WebGLRenderTarget optional parameters

### DIFF
--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -23,8 +23,8 @@
 		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 
 		<p>
-		[page:Float width] - The width of the renderTarget. <br />
-		[page:Float height] - The height of the renderTarget.<br />
+		[page:Float width] - (optional) The width of the renderTarget.<br />
+		[page:Float height] - (optional) The height of the renderTarget.<br />
 		options - (optional object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 


### PR DESCRIPTION
**Description**

`new THREE.WebGLRenderTarget`'s constructor arguments are actually optional as seen here: https://github.com/mrdoob/three.js/blob/9ee6ec8fcf6ef04a4fc53d9e58070093899790c3/examples/webgl2_rendertarget_texture2darray.html#L134 although it doesn't make sense unless you call `.setSize` straight after(?).... Anyway, this had to be updated in the `.d.ts` definitions and it was [suggested](https://discord.com/channels/685241246557667386/686304808994340865/812696719686238258) to add this update to the docs.
