### PR TITLE
CSS3DRenderer | CSS2DRenderer: Remove old css prefixes

### DIFF
--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -92,13 +92,8 @@ THREE.CSS2DRenderer = function () {
 			vector.applyMatrix4( viewProjectionMatrix );
 
 			var element = object.element;
-			var style = 'translate(-50%,-50%) translate(' + ( vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - vector.y * _heightHalf + _heightHalf ) + 'px)';
 
-			element.style.WebkitTransform = style;
-			element.style.MozTransform = style;
-			element.style.oTransform = style;
-			element.style.transform = style;
-
+			element.style.transform = 'translate(-50%,-50%) translate(' + ( vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - vector.y * _heightHalf + _heightHalf ) + 'px)';
 			element.style.display = ( object.visible && vector.z >= - 1 && vector.z <= 1 ) ? '' : 'none';
 
 			var objectData = {

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -74,7 +74,6 @@ THREE.CSS3DRenderer = function () {
 
 	var cameraElement = document.createElement( 'div' );
 
-	cameraElement.style.WebkitTransformStyle = 'preserve-3d';
 	cameraElement.style.transformStyle = 'preserve-3d';
 	cameraElement.style.pointerEvents = 'none';
 
@@ -196,7 +195,6 @@ THREE.CSS3DRenderer = function () {
 
 			if ( cachedObject === undefined || cachedObject.style !== style ) {
 
-				element.style.WebkitTransform = style;
 				element.style.transform = style;
 
 				var objectData = { style: style };
@@ -230,18 +228,7 @@ THREE.CSS3DRenderer = function () {
 
 		if ( cache.camera.fov !== fov ) {
 
-			if ( camera.isPerspectiveCamera ) {
-
-				domElement.style.WebkitPerspective = fov + 'px';
-				domElement.style.perspective = fov + 'px';
-
-			} else {
-
-				domElement.style.WebkitPerspective = '';
-				domElement.style.perspective = '';
-
-			}
-
+			domElement.style.perspective = camera.isPerspectiveCamera ? fov + 'px' : '';
 			cache.camera.fov = fov;
 
 		}
@@ -265,7 +252,6 @@ THREE.CSS3DRenderer = function () {
 
 		if ( cache.camera.style !== style ) {
 
-			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.transform = style;
 
 			cache.camera.style = style;

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -98,13 +98,8 @@ var CSS2DRenderer = function () {
 			vector.applyMatrix4( viewProjectionMatrix );
 
 			var element = object.element;
-			var style = 'translate(-50%,-50%) translate(' + ( vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - vector.y * _heightHalf + _heightHalf ) + 'px)';
 
-			element.style.WebkitTransform = style;
-			element.style.MozTransform = style;
-			element.style.oTransform = style;
-			element.style.transform = style;
-
+			element.style.transform = 'translate(-50%,-50%) translate(' + ( vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - vector.y * _heightHalf + _heightHalf ) + 'px)';
 			element.style.display = ( object.visible && vector.z >= - 1 && vector.z <= 1 ) ? '' : 'none';
 
 			var objectData = {

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -79,7 +79,6 @@ var CSS3DRenderer = function () {
 
 	var cameraElement = document.createElement( 'div' );
 
-	cameraElement.style.WebkitTransformStyle = 'preserve-3d';
 	cameraElement.style.transformStyle = 'preserve-3d';
 	cameraElement.style.pointerEvents = 'none';
 
@@ -201,7 +200,6 @@ var CSS3DRenderer = function () {
 
 			if ( cachedObject === undefined || cachedObject.style !== style ) {
 
-				element.style.WebkitTransform = style;
 				element.style.transform = style;
 
 				var objectData = { style: style };
@@ -235,18 +233,7 @@ var CSS3DRenderer = function () {
 
 		if ( cache.camera.fov !== fov ) {
 
-			if ( camera.isPerspectiveCamera ) {
-
-				domElement.style.WebkitPerspective = fov + 'px';
-				domElement.style.perspective = fov + 'px';
-
-			} else {
-
-				domElement.style.WebkitPerspective = '';
-				domElement.style.perspective = '';
-
-			}
-
+			domElement.style.perspective = camera.isPerspectiveCamera ? fov + 'px' : '';
 			cache.camera.fov = fov;
 
 		}
@@ -270,7 +257,6 @@ var CSS3DRenderer = function () {
 
 		if ( cache.camera.style !== style ) {
 
-			cameraElement.style.WebkitTransform = style;
 			cameraElement.style.transform = style;
 
 			cache.camera.style = style;


### PR DESCRIPTION
Related to https://github.com/mrdoob/three.js/pull/21317

**Description**

This PR is to remove the prefixes.

CSS prefix for `transform` property is no longer needed.
[According to Caniuse](https://caniuse.com/?search=transform), the browser versions that require the prefix are:

- IE9
- Chrome 35 and older
- Firefox 15 and older
- Safari 8.4 and older