### PR TITLE
GLTFLoader: No texture image color space conversion for ImageBitmap to follow the spec

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1836,6 +1836,9 @@ THREE.GLTFLoader = ( function () {
 		if ( typeof createImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false ) {
 
 			this.textureLoader = new THREE.ImageBitmapLoader( this.options.manager );
+			// in glTF any colorspace information (such as ICC profiles, intents, etc)
+			// from PNG or JPEG containers must be ignored.
+			this.textureLoader.setOptions( { colorSpaceConversion: 'none' } );
 
 		} else {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1901,6 +1901,9 @@ var GLTFLoader = ( function () {
 		if ( typeof createImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false ) {
 
 			this.textureLoader = new ImageBitmapLoader( this.options.manager );
+			// in glTF any colorspace information (such as ICC profiles, intents, etc)
+			// from PNG or JPEG containers must be ignored.
+			this.textureLoader.setOptions( { colorSpaceConversion: 'none' } );
 
 		} else {
 


### PR DESCRIPTION
Related issue: #21318

**Description**

As I wrote in https://github.com/mrdoob/three.js/issues/21318#issuecomment-782807454, any colorspace information (such as ICC profiles, intents, etc) from PNG or JPEG containers must be ignored in glTF.

So this PR adds `colorSpaceConversion: 'none'` option for `ImageBitmap` creation in `GLTFLoader`. With this change, Texture Encoding test looks correct.

![image](https://user-images.githubusercontent.com/7637832/108617768-d2f9ac80-73cd-11eb-92a6-3a3a0f02b911.png)

`GLTFLoader` uses regular `TextureLoader` and regular image for platforms where `ImageBitmap` is not available. In that case, `gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE)` should be called at texture uploading but currently `WebGLRenderer` doesn't manage `gl.UNPACK_COLORSPACE_CONVERSION_WEBGL`.

So I would like to suggest to add a new property to `Texture` to control `gl.UNPACK_COLORSPACE_CONVERSION_WEBGL` like `Texture.colorSpaceConversion (BrowserDefaultWebGL or None)`. It will be a change in core so I would like to make a another separated PR and discuss more there.