### PR TITLE
Examples: Remove superfluous texture settings in (S)SAO pass.

### DIFF
--- a/examples/js/postprocessing/SAOPass.js
+++ b/examples/js/postprocessing/SAOPass.js
@@ -54,7 +54,7 @@ THREE.SAOPass = function ( scene, camera, depthTexture, useNormals, resolution )
 		var depthTexture = new THREE.DepthTexture();
 		depthTexture.type = THREE.UnsignedShortType;
 		depthTexture.minFilter = THREE.NearestFilter;
-		depthTexture.maxFilter = THREE.NearestFilter;
+		depthTexture.magFilter = THREE.NearestFilter;
 
 		this.beautyRenderTarget.depthTexture = depthTexture;
 		this.beautyRenderTarget.depthBuffer = true;

--- a/examples/js/postprocessing/SAOPass.js
+++ b/examples/js/postprocessing/SAOPass.js
@@ -53,8 +53,6 @@ THREE.SAOPass = function ( scene, camera, depthTexture, useNormals, resolution )
 
 		var depthTexture = new THREE.DepthTexture();
 		depthTexture.type = THREE.UnsignedShortType;
-		depthTexture.minFilter = THREE.NearestFilter;
-		depthTexture.magFilter = THREE.NearestFilter;
 
 		this.beautyRenderTarget.depthTexture = depthTexture;
 		this.beautyRenderTarget.depthBuffer = true;

--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -31,7 +31,7 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 	var depthTexture = new THREE.DepthTexture();
 	depthTexture.type = THREE.UnsignedShortType;
 	depthTexture.minFilter = THREE.NearestFilter;
-	depthTexture.maxFilter = THREE.NearestFilter;
+	depthTexture.magFilter = THREE.NearestFilter;
 
 	this.beautyRenderTarget = new THREE.WebGLRenderTarget( this.width, this.height, {
 		minFilter: THREE.LinearFilter,

--- a/examples/js/postprocessing/SSAOPass.js
+++ b/examples/js/postprocessing/SSAOPass.js
@@ -30,8 +30,6 @@ THREE.SSAOPass = function ( scene, camera, width, height ) {
 
 	var depthTexture = new THREE.DepthTexture();
 	depthTexture.type = THREE.UnsignedShortType;
-	depthTexture.minFilter = THREE.NearestFilter;
-	depthTexture.magFilter = THREE.NearestFilter;
 
 	this.beautyRenderTarget = new THREE.WebGLRenderTarget( this.width, this.height, {
 		minFilter: THREE.LinearFilter,

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -82,7 +82,7 @@ var SAOPass = function ( scene, camera, depthTexture, useNormals, resolution ) {
 		var depthTexture = new DepthTexture();
 		depthTexture.type = UnsignedShortType;
 		depthTexture.minFilter = NearestFilter;
-		depthTexture.maxFilter = NearestFilter;
+		depthTexture.magFilter = NearestFilter;
 
 		this.beautyRenderTarget.depthTexture = depthTexture;
 		this.beautyRenderTarget.depthBuffer = true;

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -81,8 +81,6 @@ var SAOPass = function ( scene, camera, depthTexture, useNormals, resolution ) {
 
 		var depthTexture = new DepthTexture();
 		depthTexture.type = UnsignedShortType;
-		depthTexture.minFilter = NearestFilter;
-		depthTexture.magFilter = NearestFilter;
 
 		this.beautyRenderTarget.depthTexture = depthTexture;
 		this.beautyRenderTarget.depthBuffer = true;

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -60,8 +60,6 @@ var SSAOPass = function ( scene, camera, width, height ) {
 
 	var depthTexture = new DepthTexture();
 	depthTexture.type = UnsignedShortType;
-	depthTexture.minFilter = NearestFilter;
-	depthTexture.magFilter = NearestFilter;
 
 	this.beautyRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 		minFilter: LinearFilter,

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -61,7 +61,7 @@ var SSAOPass = function ( scene, camera, width, height ) {
 	var depthTexture = new DepthTexture();
 	depthTexture.type = UnsignedShortType;
 	depthTexture.minFilter = NearestFilter;
-	depthTexture.maxFilter = NearestFilter;
+	depthTexture.magFilter = NearestFilter;
 
 	this.beautyRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 		minFilter: LinearFilter,


### PR DESCRIPTION
Change typo `maxFilter` to `magFilter` in SAO and SSAO examples.