### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl2_rendertarget_texture2darray.html
+++ b/examples/webgl2_rendertarget_texture2darray.html
@@ -131,9 +131,9 @@
 			renderTargetTexture.format = THREE.RedFormat;
 			renderTargetTexture.type = THREE.UnsignedByteType;
 
-			const renderTarget = new THREE.WebGLRenderTarget();
+			const renderTarget = new THREE.WebGLRenderTarget( DIMENSIONS.width, DIMENSIONS.height );
+			renderTarget.depth = DIMENSIONS.depth;
 			renderTarget.setTexture( renderTargetTexture );
-			renderTarget.setSize( DIMENSIONS.width, DIMENSIONS.height, DIMENSIONS.depth );
 
 			const postProcessMaterial = new THREE.ShaderMaterial( {
 				uniforms: {


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/21315#issuecomment-782836925

**Description**

The first two parameters of `WebGLRenderTarget`'s ctor are mandatory.
