### PR TITLE
KeyframeTrack: Fix toJSON static override check

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -34,7 +34,7 @@ class KeyframeTrack {
 		let json;
 
 		// derived classes can define a static toJSON method
-		if ( trackType.toJSON !== undefined ) {
+		if ( trackType.toJSON !== this.toJSON ) {
 
 			json = trackType.toJSON( track );
 


### PR DESCRIPTION
  Subclasses of KeyframeTrack classes will never have undefined static toJSON

Related issue: https://github.com/mrdoob/three.js/pull/20013#issuecomment-784173128

**Description**

Fixes `Uncaught RangeError: Maximum call stack size exceeded` regression after ES6 class conversion.