### PR TITLE
Font: Remove IE11 support.

### DIFF
--- a/examples/misc_legacy.html
+++ b/examples/misc_legacy.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 
-		<script src="https://polyfill.io/v3/polyfill.min.js?features=Function.name%2CMath.log2%2CMath.sign%2CNumber.EPSILON%2CNumber.isInteger%2CObject.assign%2CObject.values%2CPromise"></script>
+		<script src="https://polyfill.io/v3/polyfill.min.js?features=Function.name%2CMath.log2%2CMath.sign%2CNumber.EPSILON%2CNumber.isInteger%2CObject.assign%2CObject.values%2CPromise%2CArray.from"></script>
 
 		<script src="../build/three.js"></script>
 		<script src="./js/controls/OrbitControls.js"></script>

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -29,7 +29,7 @@ class Font {
 
 function createPaths( text, size, data ) {
 
-	const chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // workaround for IE11, see #13988
+	const chars = Array.from( text );
 	const scale = size / data.resolution;
 	const line_height = ( data.boundingBox.yMax - data.boundingBox.yMin + data.underlineThickness ) * scale;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1895,7 +1895,7 @@ function WebGLRenderer( parameters ) {
 
 				const halfFloatSupportedByExt = ( textureType === HalfFloatType ) && ( extensions.has( 'EXT_color_buffer_half_float' ) || ( capabilities.isWebGL2 && extensions.has( 'EXT_color_buffer_float' ) ) );
 
-				if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // IE11, Edge and Chrome Mac < 52 (#9513)
+				if ( textureType !== UnsignedByteType && utils.convert( textureType ) !== _gl.getParameter( _gl.IMPLEMENTATION_COLOR_READ_TYPE ) && // Edge and Chrome Mac < 52 (#9513)
 					! ( textureType === FloatType && ( capabilities.isWebGL2 || extensions.has( 'OES_texture_float' ) || extensions.has( 'WEBGL_color_buffer_float' ) ) ) && // Chrome Mac >= 52 and Firefox
 					! halfFloatSupportedByExt ) {
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/21313#issuecomment-783784867

**Description**

IE 11 users now have to add a polyfill for `Array.from()`.
