### PR TITLE
Controls: Remove calls of stopPropagation().

### DIFF
--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -92,7 +92,6 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 		}
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.activeLook ) {
 
@@ -112,7 +111,6 @@ THREE.FirstPersonControls = function ( object, domElement ) {
 	this.onMouseUp = function ( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.activeLook ) {
 

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -117,7 +117,6 @@ THREE.FlyControls = function ( object, domElement ) {
 		}
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.dragToLook ) {
 
@@ -158,7 +157,6 @@ THREE.FlyControls = function ( object, domElement ) {
 	this.mouseup = function ( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.dragToLook ) {
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -989,7 +989,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false || scope.enableZoom === false || ( state !== STATE.NONE && state !== STATE.ROTATE ) ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		scope.dispatchEvent( startEvent );
 
@@ -1098,7 +1097,6 @@ THREE.OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault(); // prevent scrolling
-		event.stopPropagation();
 
 		switch ( state ) {
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -483,7 +483,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 	function onMouseDown( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( _state === STATE.NONE ) {
 
@@ -539,7 +538,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		var state = ( _keyState !== STATE.NONE ) ? _keyState : _state;
 
@@ -565,7 +563,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		_state = STATE.NONE;
 
@@ -583,7 +580,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 		if ( scope.noZoom === true ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		switch ( event.deltaMode ) {
 
@@ -646,7 +642,6 @@ THREE.TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		switch ( event.touches.length ) {
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -98,7 +98,6 @@ var FirstPersonControls = function ( object, domElement ) {
 		}
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.activeLook ) {
 
@@ -118,7 +117,6 @@ var FirstPersonControls = function ( object, domElement ) {
 	this.onMouseUp = function ( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.activeLook ) {
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -123,7 +123,6 @@ var FlyControls = function ( object, domElement ) {
 		}
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.dragToLook ) {
 
@@ -164,7 +163,6 @@ var FlyControls = function ( object, domElement ) {
 	this.mouseup = function ( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( this.dragToLook ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -999,7 +999,6 @@ var OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false || scope.enableZoom === false || ( state !== STATE.NONE && state !== STATE.ROTATE ) ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		scope.dispatchEvent( startEvent );
 
@@ -1108,7 +1107,6 @@ var OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault(); // prevent scrolling
-		event.stopPropagation();
 
 		switch ( state ) {
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -491,7 +491,6 @@ var TrackballControls = function ( object, domElement ) {
 	function onMouseDown( event ) {
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		if ( _state === STATE.NONE ) {
 
@@ -547,7 +546,6 @@ var TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		var state = ( _keyState !== STATE.NONE ) ? _keyState : _state;
 
@@ -573,7 +571,6 @@ var TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		_state = STATE.NONE;
 
@@ -591,7 +588,6 @@ var TrackballControls = function ( object, domElement ) {
 		if ( scope.noZoom === true ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		switch ( event.deltaMode ) {
 
@@ -654,7 +650,6 @@ var TrackballControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 
 		event.preventDefault();
-		event.stopPropagation();
 
 		switch ( event.touches.length ) {
 


### PR DESCRIPTION
Related issue: Fixed #21339.

**Description**

Removes all calls of `stopPropagation()` from the control classes.
