### PR TITLE
Add nodes-field to default toJSON-meta

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -662,7 +662,8 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 				images: {},
 				shapes: {},
 				skeletons: {},
-				animations: {}
+				animations: {},
+				nodes: {}
 			};
 
 			output.metadata = {


### PR DESCRIPTION
Related issue: #21352

**Description**

Adds a `nodes` field to default toJSON-meta, as this is a field which is required when serializing a NodeMaterial.
Previous serialization of Object3D-objects with nested NodeMaterials threw an error before this fix.
