### PR TITLE
FunctionNode: Improve regex.

### DIFF
--- a/examples/jsm/nodes/core/FunctionNode.js
+++ b/examples/jsm/nodes/core/FunctionNode.js
@@ -1,7 +1,7 @@
 import { TempNode } from './TempNode.js';
 import { NodeLib } from './NodeLib.js';
 
-var declarationRegexp = /^\s*([a-z_0-9]+)\s([a-z_0-9]+)\s*\((.*?)\)/i,
+var declarationRegexp = /^\s*([a-z_0-9]+)\s+([a-z_0-9]+)\s*\(([\s\S]*?)\)/i,
 	propertiesRegexp = /[a-z_0-9]+/ig;
 
 function FunctionNode( src, includes, extensions, keywords, type ) {


### PR DESCRIPTION
Related issue: Fixed #19971.

**Description**

`FunctionNode` can now handle signatures with line breaks. Meaning:
```
vec3 satrgb( vec3 rgb, 
    float adjustment ) {

    vec3 intensity = vec3( luminance( rgb ) );
    return mix( intensity, rgb, adjustment );

}
```