### PR TITLE
Added ability to have linked object in Intersection

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -94,7 +94,17 @@ Object.assign( Raycaster.prototype, {
 
 	intersectObject: function ( object, recursive = false, intersects = [] ) {
 
-		intersectObject( object, this, intersects, recursive );
+		const objectIntersects = [];
+
+		intersectObject( object, this, objectIntersects, recursive );
+
+		for ( let i = 0, l = objectIntersects.length; i < l; i ++ ) {
+
+			objectIntersects[ i ].linkedParent = object;
+
+		}
+
+		intersects = intersects.concat( objectIntersects );
 
 		intersects.sort( ascSort );
 
@@ -106,7 +116,17 @@ Object.assign( Raycaster.prototype, {
 
 		for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
-			intersectObject( objects[ i ], this, intersects, recursive );
+			const objectIntersects = [];
+
+			intersectObject( objects[ i ], this, objectIntersects, recursive );
+
+			for ( let j = 0, l2 = objectIntersects.length; j < l2; j ++ ) {
+
+				objectIntersects[ j ].linkedParent = objects[ i ];
+
+			}
+
+			intersects = intersects.concat( objectIntersects );
 
 		}
 


### PR DESCRIPTION
**Description**

Added ability to get linked object after deep/recursive intersection.
Here is simple example of usage:
* Code before this change
```
const objects = [object3D, object3D];
// ^^ Each object3D has own Meshes
const firstIntersection = raycaster.intersectObjects(objects, true)[0];
// here firstIntersection.object isn't object3D from objects array, only meshes from their children
// So if we need to understand which object it is, we have to create while loop to get know parent from that array
```
* Code after this change
```
const objects = [object3D, object3D];
// ^^ Each object3D has own Meshes
const firstIntersection = raycaster.intersectObjects(objects, true)[0];
// here firstIntersection.linkedObject is object3D from objects array
// firstIntersection.object is still available for backward compatibility
```

PS: Don't know where to find d.ts files to update `Intersection` interface... 