### PR TITLE
Examples: Postprocessing fullscreen triangle optimization

### DIFF
--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -261,11 +261,11 @@ Object.assign( THREE.Pass.prototype, {
 THREE.Pass.FullScreenQuad = ( function () {
 
 	var camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-  var geometry = new THREE.BufferGeometry();
-  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
-  geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
-  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
-  geometry.setAttribute("uv", new THREE.BufferAttribute(uv, 2));
+	var geometry = new THREE.BufferGeometry();
+	const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+	geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+	const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+	geometry.setAttribute("uv", new THREE.BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 

--- a/examples/js/postprocessing/EffectComposer.js
+++ b/examples/js/postprocessing/EffectComposer.js
@@ -261,7 +261,11 @@ Object.assign( THREE.Pass.prototype, {
 THREE.Pass.FullScreenQuad = ( function () {
 
 	var camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	var geometry = new THREE.PlaneGeometry( 2, 2 );
+  var geometry = new THREE.BufferGeometry();
+  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+  geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+  geometry.setAttribute("uv", new THREE.BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -3,7 +3,8 @@ import {
 	LinearFilter,
 	Mesh,
 	OrthographicCamera,
-	PlaneGeometry,
+  BufferGeometry,
+  BufferAttribute,
 	RGBAFormat,
 	Vector2,
 	WebGLRenderTarget
@@ -276,7 +277,11 @@ Object.assign( Pass.prototype, {
 Pass.FullScreenQuad = ( function () {
 
 	var camera = new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	var geometry = new PlaneGeometry( 2, 2 );
+  var geometry = new BufferGeometry();
+  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+  geometry.setAttribute("position", new BufferAttribute(vertices, 3));
+  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+  geometry.setAttribute("uv", new BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -3,8 +3,8 @@ import {
 	LinearFilter,
 	Mesh,
 	OrthographicCamera,
-  BufferGeometry,
-  BufferAttribute,
+	BufferGeometry,
+	BufferAttribute,
 	RGBAFormat,
 	Vector2,
 	WebGLRenderTarget
@@ -277,11 +277,11 @@ Object.assign( Pass.prototype, {
 Pass.FullScreenQuad = ( function () {
 
 	var camera = new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-  var geometry = new BufferGeometry();
-  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
-  geometry.setAttribute("position", new BufferAttribute(vertices, 3));
-  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
-  geometry.setAttribute("uv", new BufferAttribute(uv, 2));
+	var geometry = new BufferGeometry();
+	const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+	geometry.setAttribute("position", new BufferAttribute(vertices, 3));
+	const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+	geometry.setAttribute("uv", new BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 

--- a/examples/jsm/postprocessing/Pass.js
+++ b/examples/jsm/postprocessing/Pass.js
@@ -1,6 +1,7 @@
 import {
 	OrthographicCamera,
-	PlaneGeometry,
+  BufferGeometry,
+  BufferAttribute,
 	Mesh
 } from '../../../build/three.module.js';
 
@@ -41,7 +42,11 @@ Object.assign( Pass.prototype, {
 Pass.FullScreenQuad = ( function () {
 
 	var camera = new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-	var geometry = new PlaneGeometry( 2, 2 );
+  var geometry = new BufferGeometry();
+  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+  geometry.setAttribute("position", new BufferAttribute(vertices, 3));
+  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+  geometry.setAttribute("uv", new BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 

--- a/examples/jsm/postprocessing/Pass.js
+++ b/examples/jsm/postprocessing/Pass.js
@@ -1,7 +1,7 @@
 import {
 	OrthographicCamera,
-  BufferGeometry,
-  BufferAttribute,
+	BufferGeometry,
+	BufferAttribute,
 	Mesh
 } from '../../../build/three.module.js';
 
@@ -42,11 +42,11 @@ Object.assign( Pass.prototype, {
 Pass.FullScreenQuad = ( function () {
 
 	var camera = new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-  var geometry = new BufferGeometry();
-  const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
-  geometry.setAttribute("position", new BufferAttribute(vertices, 3));
-  const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
-  geometry.setAttribute("uv", new BufferAttribute(uv, 2));
+	var geometry = new BufferGeometry();
+	const vertices = new Float32Array([-1, 3, 0, -1, -1, 0, 3, -1, 0]);
+	geometry.setAttribute("position", new BufferAttribute(vertices, 3));
+	const uv = new Float32Array([0, 2, 0, 0, 2, 0]);
+	geometry.setAttribute("uv", new BufferAttribute(uv, 2));
 
 	var FullScreenQuad = function ( material ) {
 


### PR DESCRIPTION
**Description**

The postprocessing is using a fullscreen PlaneGeometry for fullscreen fragmentShader, it can lead to [quad overshading](https://stackoverflow.com/questions/55197347/webgl-full-screen-quad-or-triangle-for-invoking-fragment-shader-for-every-pixel). Here a fullscreen Triangle instead.

![alt text](https://randallr.files.wordpress.com/2014/06/glscreenspacetriangle1.png "Giant Triangle !")

<!-- Remove the line below if is not relevant -->
