### PR TITLE
WebGLBackground: Remove support for WebGLCubeRenderTarget.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -58,7 +58,7 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 		}
 
-		if ( background && ( background.isCubeTexture || background.isWebGLCubeRenderTarget || background.mapping === CubeUVReflectionMapping ) ) {
+		if ( background && ( background.isCubeTexture || background.mapping === CubeUVReflectionMapping ) ) {
 
 			if ( boxMesh === undefined ) {
 
@@ -97,14 +97,6 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 				} );
 
 				objects.update( boxMesh );
-
-			}
-
-			if ( background.isWebGLCubeRenderTarget ) {
-
-				// TODO Deprecate
-
-				background = background.texture;
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

Since the new `PMREMGenerator` does not output `WebGLCubeRenderTarget` anymore, it seems the existing support for such render targets in `WebGLBackground` is obsolete. Similar to other texture properties, we should encourage users to use the `texture` property of render targets.

BTW: This change also simplifies the serialization/deserialization process of `Scene.background` since there is no need to check for render targets anymore.