### PR TITLE
WebGLRenderer: Move invocation of Scene.onAfterRender().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1076,10 +1076,6 @@ function WebGLRenderer( parameters ) {
 
 		//
 
-		if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
-
-		//
-
 		if ( _currentRenderTarget !== null ) {
 
 			// Generate mipmap if we're using any kind of mipmap filtering
@@ -1091,6 +1087,10 @@ function WebGLRenderer( parameters ) {
 			textures.updateMultisampleRenderTarget( _currentRenderTarget );
 
 		}
+
+		//
+
+		if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
 
 		// Ensure depth buffer writing is enabled so it can be cleared on next render
 


### PR DESCRIPTION
Related issue: Fixed #17761.

**Description**

The reason for this change is explained in #17710.

> scene.onAfterRender must be called after ~~multiview or~~ multisampled rendertargets do their blitFramebuffer for post proc to have valid data in the renderTarget.

The original PR was hard to test because it contained too many changes at once. #18626 implemented one part of it. This PR is about `onAfterRender()`. The changes related to `WebGLMutliview` are not relevant anymore. And the issue in `WebGLTextures` should be solved via #18904.
