### PR TITLE
WebXRController: Make targetRay available in hands mode

### DIFF
--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -119,6 +119,19 @@ Object.assign( WebXRController.prototype, {
 
 		if ( inputSource && frame.session.visibilityState !== 'visible-blurred' ) {
 
+			if ( targetRay !== null ) {
+
+				inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
+
+				if ( inputPose !== null ) {
+
+					targetRay.matrix.fromArray( inputPose.transform.matrix );
+					targetRay.matrix.decompose( targetRay.position, targetRay.rotation, targetRay.scale );
+
+				}
+
+			}
+
 			if ( hand && inputSource.hand ) {
 
 				handPose = true;
@@ -185,19 +198,6 @@ Object.assign( WebXRController.prototype, {
 				}
 
 			} else {
-
-				if ( targetRay !== null ) {
-
-					inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
-
-					if ( inputPose !== null ) {
-
-						targetRay.matrix.fromArray( inputPose.transform.matrix );
-						targetRay.matrix.decompose( targetRay.position, targetRay.rotation, targetRay.scale );
-
-					}
-
-				}
 
 				if ( grip !== null && inputSource.gripSpace ) {
 


### PR DESCRIPTION
Issue: 
WebXRController only calculates the targetRay data when controllers are active, however in oculus browser, targetRaySpace is also populated when hands are active, and this piece of data can be useful when using hands to point and select or interact with elements in VR.

This change addresses this issue by calculating the targetRay data regardless of whether hands or controllers are active input methods.
