### PR TITLE
EventDispatcher: add class Event

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -2,6 +2,13 @@
  * https://github.com/mrdoob/eventdispatcher.js/
  */
 
+class Event {
+	constructor(type, target = undefined) {
+		this.type = String(type);
+		this.target = target;
+	}
+}
+
 function EventDispatcher() {}
 
 Object.assign( EventDispatcher.prototype, {
@@ -84,4 +91,4 @@ Object.assign( EventDispatcher.prototype, {
 } );
 
 
-export { EventDispatcher };
+export { Event, EventDispatcher };


### PR DESCRIPTION
Related issue: -

**Description**

Add `Event` in EventDispatcher.js

```diff
+ class Event {
+     constructor(type, target = undefined) {
+         this.type = String(type);
+         this.target = target;
+     }
+ }

- export { EventDispatcher };
+ export { Event, EventDispatcher };
```

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Example](https://example.com).
