### PR TITLE
EventDispatcher: add class Event

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -2,6 +2,18 @@
  * https://github.com/mrdoob/eventdispatcher.js/
  */
 
+class Event {
+
+	constructor( type, target = undefined ) {
+
+		this.type = String( type );
+
+		this.target = target;
+
+	}
+
+}
+
 function EventDispatcher() {}
 
 Object.assign( EventDispatcher.prototype, {
@@ -84,4 +96,4 @@ Object.assign( EventDispatcher.prototype, {
 } );
 
 
-export { EventDispatcher };
+export { Event, EventDispatcher };


### PR DESCRIPTION
Related issue: -

**Description**

Add `Event` in EventDispatcher.js

```diff
+ class Event {
+ 
+ 	constructor( type, target = undefined ) {
+ 
+ 		this.type = String( type );
+ 
+ 		this.target = target;
+ 
+ 	}
+
+ }

- export { EventDispatcher };
+ export { Event, EventDispatcher };
```

