### PR TITLE
ImageUtils.getDataURL: Added warning when saving image as jpg.

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -47,7 +47,7 @@ const ImageUtils = {
 
 		if ( canvas.width > 2048 || canvas.height > 2048 ) {
 
-			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );			
+			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );
 
 			return canvas.toDataURL( 'image/jpeg', 0.6 );
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -47,6 +47,8 @@ const ImageUtils = {
 
 		if ( canvas.width > 2048 || canvas.height > 2048 ) {
 
+			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );			
+
 			return canvas.toDataURL( 'image/jpeg', 0.6 );
 
 		} else {


### PR DESCRIPTION
**Description**

Log a warning when converting a image to jpeg due to its dimensions.
Seems like I forgot what issue/pr discussed this a few days ago. @Mugen87 do you remember?