### PR TITLE
Examples: Remove alpha option from ocean demo.

### DIFF
--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -67,7 +67,6 @@
 							texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
 
 						} ),
-						alpha: 1.0,
 						sunDirection: new THREE.Vector3(),
 						sunColor: 0xffffff,
 						waterColor: 0x001e0f,
@@ -154,7 +153,6 @@
 				const folderWater = gui.addFolder( 'Water' );
 				folderWater.add( waterUniforms.distortionScale, 'value', 0, 8, 0.1 ).name( 'distortionScale' );
 				folderWater.add( waterUniforms.size, 'value', 0.1, 10, 0.1 ).name( 'size' );
-				folderWater.add( waterUniforms.alpha, 'value', 0.9, 1, .001 ).name( 'alpha' );
 				folderWater.open();
 
 				//


### PR DESCRIPTION
Related issue: see #21392

**Description**

Removes the alpha configuration from the GUI.
