### PR TITLE
Mesh: Fix face indices in intersection object.

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -402,7 +402,7 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 		const face = {
 			a: a,
-			b: a,
+			b: b,
 			c: c,
 			normal: new Vector3(),
 			materialIndex: 0


### PR DESCRIPTION
Hi!

I stumbled upon this `{ a: a, b: a, c: c, ... }` error, looks like a copy-paste error introduced in #21161 cc @Mugen87.

This could be simplified to `{ a, b, c, ... }` if Three.js is targeting a recent enough version of ECMAScript?