### PR TITLE
Examples: Better show WebGL2 error messages.

### DIFF
--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -48,6 +48,14 @@
 
 			import * as THREE from '../build/three.module.js';
 
+			import { WEBGL } from './jsm/WebGL.js';
+
+			if ( WEBGL.isWebGL2Available() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGL2ErrorMessage() );
+
+			}
+
 			let camera, scene, renderer, mesh;
 
 			init();

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -43,20 +43,20 @@
 			import { CopyShader } from './jsm/shaders/CopyShader.js';
 			import { WEBGL } from './jsm/WebGL.js';
 
-			if ( WEBGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WEBGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let camera, renderer, clock, group, container;
 
 			let composer1, composer2;
 
 			init();
-			animate();
 
 			function init() {
+
+				if ( WEBGL.isWebGL2Available() === false ) {
+
+					document.body.appendChild( WEBGL.getWebGL2ErrorMessage() );
+					return;
+
+				}
 
 				container = document.getElementById( 'container' );
 
@@ -139,6 +139,8 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
+
+				animate();
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

- `webgl2_buffergeometry_attributes_integer` now shows an error message like other WebGL 2 demos, too.
- `webgl2_multisampled_renderbuffers` ensures the message is not hidden behind a container element anymore.