### PR TITLE
modify url(Viewport_meta_tag)

### DIFF
--- a/docs/manual/ar/introduction/FAQ.html
+++ b/docs/manual/ar/introduction/FAQ.html
@@ -27,7 +27,7 @@
 
 				<p>[link:https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html Safari: Using the Viewport]</p>
 
-				<p>[link:https://developer.mozilla.org/en/Mobile/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
+				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
 		<h2>كيف يمكن الحفاظ على مقياس المشهد عند تغيير الحجم؟</h2>

--- a/docs/manual/en/introduction/FAQ.html
+++ b/docs/manual/en/introduction/FAQ.html
@@ -27,7 +27,7 @@
 
 				<p>[link:https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html Safari: Using the Viewport]</p>
 
-				<p>[link:https://developer.mozilla.org/en/Mobile/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
+				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
 		<h2>How can scene scale be preserved on resize?</h2>

--- a/docs/manual/ko/introduction/FAQ.html
+++ b/docs/manual/ko/introduction/FAQ.html
@@ -27,7 +27,7 @@
 
 				<p>[link:https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html Safari: Using the Viewport]</p>
 
-				<p>[link:https://developer.mozilla.org/en/Mobile/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
+				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
 		<h2>화면 확대 정도가 리사이징 시에 유지될 수 있나요?</h2>

--- a/docs/manual/zh/introduction/FAQ.html
+++ b/docs/manual/zh/introduction/FAQ.html
@@ -29,7 +29,7 @@
 
 				<p>[link:https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html Safari: Using the Viewport]</p>
 
-				<p>[link:https://developer.mozilla.org/en/Mobile/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
+				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
 		<h2>如何在窗口调整大小时保持场景比例不变？</h2>


### PR DESCRIPTION
Related issue: #21405

**Description**

Change URL from "now to "expect".

now: https://developer.mozilla.org/en/Mobile/Viewport_meta_tag
expect: https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag