### PR TITLE
Box3: Fix computation of world matrix in setFromObject().

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -113,6 +113,8 @@ class Box3 {
 
 		this.makeEmpty();
 
+		object.updateWorldMatrix( true, false );
+
 		return this.expandByObject( object );
 
 	}


### PR DESCRIPTION
Related issue: Fixed #21404

**Description**

Ensures the world matrix is properly computed by honoring the transformations of all ancestors.  Related #19969.

With this change, `expandByObject()` will compute the world matrix of the first node twice. So there is a small additional overhead. However, `setFromObject()` is now correct.
