### PR TITLE
Helpers: Ensure light helpers are not frame-late.

### DIFF
--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -15,7 +15,6 @@ class DirectionalLightHelper extends Object3D {
 
 		super();
 		this.light = light;
-		this.light.updateMatrixWorld();
 
 		this.matrix = light.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -58,6 +57,9 @@ class DirectionalLightHelper extends Object3D {
 	}
 
 	update() {
+
+		this.light.updateWorldMatrix( true, false );
+		this.light.target.updateWorldMatrix( true, false );
 
 		_v1.setFromMatrixPosition( this.light.matrixWorld );
 		_v2.setFromMatrixPosition( this.light.target.matrixWorld );

--- a/src/helpers/HemisphereLightHelper.js
+++ b/src/helpers/HemisphereLightHelper.js
@@ -16,7 +16,6 @@ class HemisphereLightHelper extends Object3D {
 
 		super();
 		this.light = light;
-		this.light.updateMatrixWorld();
 
 		this.matrix = light.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -73,6 +72,8 @@ class HemisphereLightHelper extends Object3D {
 			colors.needsUpdate = true;
 
 		}
+
+		this.light.updateWorldMatrix( true, false );
 
 		mesh.lookAt( _vector.setFromMatrixPosition( this.light.matrixWorld ).negate() );
 

--- a/src/helpers/PointLightHelper.js
+++ b/src/helpers/PointLightHelper.js
@@ -12,7 +12,7 @@ class PointLightHelper extends Mesh {
 		super( geometry, material );
 
 		this.light = light;
-		this.light.updateMatrixWorld();
+		this.light.updateWorldMatrix( true, false );
 
 		this.color = color;
 

--- a/src/helpers/PointLightHelper.js
+++ b/src/helpers/PointLightHelper.js
@@ -12,7 +12,6 @@ class PointLightHelper extends Mesh {
 		super( geometry, material );
 
 		this.light = light;
-		this.light.updateWorldMatrix( true, false );
 
 		this.color = color;
 
@@ -57,6 +56,8 @@ class PointLightHelper extends Mesh {
 	}
 
 	update() {
+
+		this.light.updateWorldMatrix( true, false );
 
 		if ( this.color !== undefined ) {
 

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -13,7 +13,6 @@ class SpotLightHelper extends Object3D {
 
 		super();
 		this.light = light;
-		this.light.updateMatrixWorld();
 
 		this.matrix = light.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -62,7 +61,8 @@ class SpotLightHelper extends Object3D {
 
 	update() {
 
-		this.light.updateMatrixWorld();
+		this.light.updateWorldMatrix( true, false );
+		this.light.target.updateWorldMatrix( true, false );
 
 		const coneLength = this.light.distance ? this.light.distance : 1000;
 		const coneWidth = coneLength * Math.tan( this.light.angle );


### PR DESCRIPTION
Fixed #14801.

**Description**

Ensures the world matrices of lights and targets are up-to-date when evaluated in light helpers.
