### PR TITLE
Fix link to the shading paper in the docs

### DIFF
--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -49,7 +49,7 @@
 		</p>
 		<p>
 			Technical details of the approach used in three.js (and most other PBR systems) can be found is this
-			[link:https://disney-animation.s3.amazonaws.com/library/s2012_pbs_disney_brdf_notes_v2.pdf paper from Disney] (pdf),
+			[link:https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf paper from Disney] (pdf),
 			by Brent Burley.
 		</p>
 

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -37,7 +37,7 @@
 			</ul>
 		</p>
 		<p>在 three.js（以及其他大多数PBR系统）中使用方法的技术细节，
-			可以在Brent Burley撰写的[link:https://disney-animation.s3.amazonaws.com/library/s2012_pbs_disney_brdf_notes_v2.pdf paper from Disney] (pdf)
+			可以在Brent Burley撰写的[link:https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf paper from Disney] (pdf)
 			中查看。
 		</p>
 


### PR DESCRIPTION
This link in the documentation on `MeshStandardMaterial` is no longer valid ("The specified bucket does not exist"): 
https://disney-animation.s3.amazonaws.com/library/s2012_pbs_disney_brdf_notes_v2.pdf

I replaced the link with the one from the Disney website: https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf