### PR TITLE
Editor: Fixed grid depth glitches.

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -41,7 +41,19 @@ function Viewport( editor ) {
 
 	// helpers
 
-	var grid = new THREE.GridHelper( 30, 30, 0x444444, 0x888888 );
+	var grid = new THREE.Group();
+
+	var grid1 = new THREE.GridHelper( 30, 30, 0x888888 );
+	grid1.material.color.setHex( 0x888888 );
+	grid1.material.vertexColors = false;
+	grid.add( grid1 );
+
+	var grid2 = new THREE.GridHelper( 30, 6, 0x222222 );
+	grid2.material.color.setHex( 0x222222 );
+	grid2.material.depthFunc = THREE.AlwaysDepth;
+	grid2.material.vertexColors = false;
+	grid.add( grid2 );
+
 	var viewHelper = new ViewHelper( camera, container );
 	var vr = new VR( editor );
 
@@ -357,14 +369,14 @@ function Viewport( editor ) {
 			mediaQuery.addListener( function ( event ) {
 
 				renderer.setClearColor( event.matches ? 0x333333 : 0xaaaaaa );
-				updateGridColors( grid, event.matches ? [ 0x888888, 0x222222 ] : [ 0x282828, 0x888888 ] );
+				updateGridColors( grid1, grid2, event.matches ? [ 0x222222, 0x888888 ] : [ 0x888888, 0x282828 ] );
 
 				render();
 
 			} );
 
 			renderer.setClearColor( mediaQuery.matches ? 0x333333 : 0xaaaaaa );
-			updateGridColors( grid, mediaQuery.matches ? [ 0x888888, 0x222222 ] : [ 0x282828, 0x888888 ] );
+			updateGridColors( grid1, grid2, mediaQuery.matches ? [ 0x222222, 0x888888 ] : [ 0x888888, 0x282828 ] );
 
 		}
 
@@ -765,27 +777,10 @@ function Viewport( editor ) {
 
 }
 
-function updateGridColors( grid, colors ) {
+function updateGridColors( grid1, grid2, colors ) {
 
-	const color1 = new THREE.Color( colors[ 0 ] );
-	const color2 = new THREE.Color( colors[ 1 ] );
-
-	const attribute = grid.geometry.attributes.color;
-	const array = attribute.array;
-
-	for ( var i = 0; i < array.length; i += 12 ) {
-
-		const color = ( i % ( 12 * 5 ) === 0 ) ? color1 : color2;
-
-		for ( var j = 0; j < 12; j += 3 ) {
-
-			color.toArray( array, i + j );
-
-		}
-
-	}
-
-	attribute.needsUpdate = true;
+	grid1.material.color.setHex( colors[ 0 ] );
+	grid2.material.color.setHex( colors[ 1 ] );
 
 }
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

There is no way to control how lines draw on top of each other when using the `vertexColors` approach and we can see some z-fighting glitches in some angles (and also in VR).

Instead, we now create 2 separate grids and we render the second one using  `depthFunc = THREE.AlwaysDepth`.

Before:

<img width="444" alt="Screen Shot 2021-03-08 at 12 33 42 PM" src="https://user-images.githubusercontent.com/97088/110322346-e9794800-800a-11eb-8943-4cdd1ebedee1.png">

After:

<img width="459" alt="Screen Shot 2021-03-08 at 12 33 52 PM" src="https://user-images.githubusercontent.com/97088/110322334-e4b49400-800a-11eb-91e5-7a37ca394a0c.png">
