### PR TITLE
GridHelper: Removed colorCenterLine

### DIFF
--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -30,12 +30,11 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:number size], [param:Number divisions], [param:Color colorCenterLine], [param:Color colorGrid] )</h3>
+		<h3>[name]( [param:number size], [param:Number divisions], [param:Color color] )</h3>
 		<p>
 		size -- The size of the grid. Default is 10. <br />
 		divisions -- The number of divisions across the grid. Default is 10. <br />
-		colorCenterLine -- The color of the centerline. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
-		colorGrid -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
+		color -- The color of the lines of the grid. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
 		</p>
 		<p>
 		Creates a new [name] of size 'size' and divided into 'divisions' segments per side. Colors are optional.

--- a/src/helpers/GridHelper.js
+++ b/src/helpers/GridHelper.js
@@ -2,40 +2,27 @@ import { LineSegments } from '../objects/LineSegments.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
-import { Color } from '../math/Color.js';
 
 class GridHelper extends LineSegments {
 
-	constructor( size = 10, divisions = 10, color1 = 0x444444, color2 = 0x888888 ) {
+	constructor( size = 10, divisions = 10, color = 0x444444 ) {
 
-		color1 = new Color( color1 );
-		color2 = new Color( color2 );
-
-		const center = divisions / 2;
 		const step = size / divisions;
 		const halfSize = size / 2;
 
-		const vertices = [], colors = [];
+		const vertices = [];
 
-		for ( let i = 0, j = 0, k = - halfSize; i <= divisions; i ++, k += step ) {
+		for ( let i = 0, k = - halfSize; i <= divisions; i ++, k += step ) {
 
 			vertices.push( - halfSize, 0, k, halfSize, 0, k );
 			vertices.push( k, 0, - halfSize, k, 0, halfSize );
-
-			const color = i === center ? color1 : color2;
-
-			color.toArray( colors, j ); j += 3;
-			color.toArray( colors, j ); j += 3;
-			color.toArray( colors, j ); j += 3;
-			color.toArray( colors, j ); j += 3;
 
 		}
 
 		const geometry = new BufferGeometry();
 		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		const material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+		const material = new LineBasicMaterial( { color: color, toneMapped: false } );
 
 		super( geometry, material );
 


### PR DESCRIPTION
Related issue: #21430

**Description**

After working on #21430 I now think that adding a `colorCenterLine` to `GridHelper` was a mistake. The GPU render all lines at the same time and that produces z fighting glitches in the intersections.

We can achieve something similar (and good looking) like this:

```js
const grid1 = new THREE.GridHelper( 30, 30, 0x888888 );
scene.add( grid1 );

// center line
const grid2 = new THREE.GridHelper( 30, 2, 0x222222 );
grid2.material.depthFunc = THREE.AlwaysDepth;
scene.add( grid2 );
```

This is somewhat a breaking change.