### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -181,7 +181,7 @@
 				},
 
 				"flat": {
-					m: new THREE.MeshLambertMaterial( { color: 0x000000, flatShading: true } ),
+					m: new THREE.MeshLambertMaterial( { color: 0x000000 } ),
 					h: 0, s: 0, l: 1
 				},
 


### PR DESCRIPTION
Related issue: -

**Description**

`MeshLambertMaterial` has no `flatShading` property.