### PR TITLE
Make `applyMatrix4` work on a `BufferGeometry` with `InterleavedBufferAttribute` normals.

### DIFF
--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -69,6 +69,12 @@
 		<h3>[method:this applyMatrix4]( [param:Matrix4 m] )</h3>
 		<p>Applies matrix [page:Matrix4 m] to every Vector3 element of this InterleavedBufferAttribute.</p>
 
+		<h3>[method:this applyNormalMatrix]( [param:Matrix3 m] )</h3>
+		<p>Applies normal matrix [page:Matrix3 m] to every Vector3 element of this InterleavedBufferAttribute.</p>
+
+		<h3>[method:this transformDirection]( [param:Matrix4 m] )</h3>
+		<p>Applies matrix [page:Matrix4 m] to every Vector3 element of this InterleavedBufferAttribute, interpreting the elements as a direction vectors.</p>
+
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>Returns the x component of the item at the given index.</p>
 

--- a/docs/api/zh/core/InterleavedBufferAttribute.html
+++ b/docs/api/zh/core/InterleavedBufferAttribute.html
@@ -68,6 +68,12 @@
 		<h3>[method:this applyMatrix4]( [param:Matrix4 m] )</h3>
 		<p>Applies matrix [page:Matrix4 m] to every Vector3 element of this InterleavedBufferAttribute.</p>
 
+		<h3>[method:this applyNormalMatrix]( [param:Matrix3 m] )</h3>
+		<p>Applies normal matrix [page:Matrix3 m] to every Vector3 element of this InterleavedBufferAttribute.</p>
+
+		<h3>[method:this transformDirection]( [param:Matrix4 m] )</h3>
+		<p>Applies matrix [page:Matrix4 m] to every Vector3 element of this InterleavedBufferAttribute, interpreting the elements as a direction vectors.</p>
+
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>返回给定索引矢量的第一个元素 （X 值）。</p>
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -71,6 +71,42 @@ Object.assign( InterleavedBufferAttribute.prototype, {
 
 	},
 
+	applyNormalMatrix: function ( m ) {
+
+		for ( let i = 0, l = this.count; i < l; i ++ ) {
+
+			_vector.x = this.getX( i );
+			_vector.y = this.getY( i );
+			_vector.z = this.getZ( i );
+
+			_vector.applyNormalMatrix( m );
+
+			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+
+		}
+
+		return this;
+
+	},
+
+	transformDirection: function ( m ) {
+
+		for ( let i = 0, l = this.count; i < l; i ++ ) {
+
+			_vector.x = this.getX( i );
+			_vector.y = this.getY( i );
+			_vector.z = this.getZ( i );
+
+			_vector.transformDirection( m );
+
+			this.setXYZ( i, _vector.x, _vector.y, _vector.z );
+
+		}
+
+		return this;
+
+	},
+
 	setX: function ( index, x ) {
 
 		this.data.array[ index * this.data.stride + this.offset ] = x;


### PR DESCRIPTION
Closes #21433

**Description**

Allow `applyMatrix4` to be called on a `BufferGeometry` with normal or tangent attributes from an `InterleavedBufferAttribute` by adding the `applyNormalMatrix` and `transformDirection` methods. Method implementations are copied from `BufferAttribute`.