### PR TITLE
Fix resize issue in OutlinePass

### DIFF
--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -134,6 +134,7 @@ THREE.OutlinePass.prototype = Object.assign( Object.create( THREE.Pass.prototype
 	setSize: function ( width, height ) {
 
 		this.renderTargetMaskBuffer.setSize( width, height );
+		this.renderTargetDepthBuffer.setSize( width, height );
 
 		var resx = Math.round( width / this.downSampleRatio );
 		var resy = Math.round( height / this.downSampleRatio );

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -154,6 +154,7 @@ OutlinePass.prototype = Object.assign( Object.create( Pass.prototype ), {
 	setSize: function ( width, height ) {
 
 		this.renderTargetMaskBuffer.setSize( width, height );
+		this.renderTargetDepthBuffer.setSize( width, height );
 
 		var resx = Math.round( width / this.downSampleRatio );
 		var resy = Math.round( height / this.downSampleRatio );


### PR DESCRIPTION
Related issue: #XXXX

**Description**

This PR fixes an issue when resolution is passed as 0x0. The resize function couldn't properly resize `renderTargetDepthBuffer`, and it certainly breaks the outline effect.
