### PR TITLE
WebGLState: Change viewport and scissor setup.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -282,8 +282,6 @@ function WebGLRenderer( parameters ) {
 		utils = new WebGLUtils( _gl, extensions, capabilities );
 
 		state = new WebGLState( _gl, extensions, capabilities );
-		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor() );
-		state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor() );
 
 		info = new WebGLInfo( _gl );
 		properties = new WebGLProperties();

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -357,8 +357,8 @@ function WebGLState( gl, extensions, capabilities ) {
 	let currentTextureSlot = null;
 	let currentBoundTextures = {};
 
-	const currentScissor = new Vector4();
-	const currentViewport = new Vector4();
+	const currentScissor = new Vector4( 0, 0, gl.canvas.width, gl.canvas.height );
+	const currentViewport = new Vector4( 0, 0, gl.canvas.width, gl.canvas.height );
 
 	function createTexture( type, target, count ) {
 
@@ -947,6 +947,9 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		currentPolygonOffsetFactor = null;
 		currentPolygonOffsetUnits = null;
+
+		currentScissor.set( 0, 0, gl.canvas.width, gl.canvas.height );
+		currentViewport.set( 0, 0, gl.canvas.width, gl.canvas.height );
 
 		colorBuffer.reset();
 		depthBuffer.reset();


### PR DESCRIPTION
Related issue: -

**Description**

The default dimensions of the viewport and scissor box are the width and height of the canvas.

`initGLContext()` performs a redundant state configuration right after creating `WebGLState`. Instead of doing this, one can setup the cached scissor and viewport variables in  `WebGLState` with the true defaults to achieve the same internal state as before.
