### PR TITLE
WebGLRenderer: Reset framebuffer in resetState().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2093,6 +2093,14 @@ function WebGLRenderer( parameters ) {
 
 	this.resetState = function () {
 
+		_framebuffer = null;
+		_currentActiveCubeFace = 0;
+		_currentActiveMipmapLevel = 0;
+		_currentRenderTarget = null;
+		_currentFramebuffer = null;
+
+		_gl.bindFramebuffer( _gl.FRAMEBUFFER, null );
+
 		state.reset();
 		bindingStates.reset();
 


### PR DESCRIPTION
Related issue: Fixed #12338.

**Description**

The framebuffer state is managed in `WebGLRenderer` and currently not honored in `WebGLRenderer.resetState()`. If a engine like pixi changes the framebuffer for some reasons, `three.js` gets out-of-sync even when calling `WebGLRenderer.resetState()`. This does not happen after this PR anymore.

Users should bear in mind that calling `WebGLRenderer.resetState()` will undo the current render target configuration. Meaning they have to call `setRenderTarget()` again to configure a proper state for RTT. However, the pixi fiddles from #12338 are already doing this.