### PR TITLE
WebGPURenderer: Fix rendering of line segments.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipelines.js
@@ -133,7 +133,7 @@ class WebGPURenderPipelines {
 
 			let indexFormat;
 
-			if ( object.isLine ) {
+			if ( object.isLine === true && object.isLineSegments !== true ) {
 
 				const count = ( geometry.index ) ? geometry.index.count : geometry.attributes.position.count;
 
@@ -598,8 +598,8 @@ class WebGPURenderPipelines {
 
 		if ( object.isMesh ) return GPUPrimitiveTopology.TriangleList;
 		else if ( object.isPoints ) return GPUPrimitiveTopology.PointList;
-		else if ( object.isLine ) return GPUPrimitiveTopology.LineStrip;
 		else if ( object.isLineSegments ) return GPUPrimitiveTopology.LineList;
+		else if ( object.isLine ) return GPUPrimitiveTopology.LineStrip;
 
 	}
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/21208#issuecomment-774514722

**Description**

Line segments rendering was broken because of a wrong evaluation of `isLineSegments` in `WebGPURenderPipelines`. The problem is that `isLine` is `true` for all an instances of `LineSegments` :man_facepalming:.
