### PR TITLE
Update TransformControls.js (arrow heads)

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -863,18 +863,18 @@ var TransformControlsGizmo = function () {
 
 	var gizmoTranslate = {
 		X: [
-			[ new Mesh( arrowGeometry, matRed ), [ 1, 0, 0 ], [ 0, 0, - Math.PI / 2 ], null, 'fwd' ],
+			[ new Mesh( arrowGeometry, matRed ), [ 1, 0, 0 ], [ 0, 0, Math.PI / 2 ], null, 'fwd' ],
 			[ new Mesh( arrowGeometry, matRed ), [ 1, 0, 0 ], [ 0, 0, Math.PI / 2 ], null, 'bwd' ],
 			[ new Line( lineGeometry, matLineRed ) ]
 		],
 		Y: [
 			[ new Mesh( arrowGeometry, matGreen ), [ 0, 1, 0 ], null, null, 'fwd' ],
-			[ new Mesh( arrowGeometry, matGreen ), [ 0, 1, 0 ], [ Math.PI, 0, 0 ], null, 'bwd' ],
+			[ new Mesh( arrowGeometry, matGreen ), [ 0, 1, 0 ], null, null, 'bwd' ],
 			[ new Line( lineGeometry, matLineGreen ), null, [ 0, 0, Math.PI / 2 ]]
 		],
 		Z: [
 			[ new Mesh( arrowGeometry, matBlue ), [ 0, 0, 1 ], [ Math.PI / 2, 0, 0 ], null, 'fwd' ],
-			[ new Mesh( arrowGeometry, matBlue ), [ 0, 0, 1 ], [ - Math.PI / 2, 0, 0 ], null, 'bwd' ],
+			[ new Mesh( arrowGeometry, matBlue ), [ 0, 0, 1 ], [ Math.PI / 2, 0, 0 ], null, 'bwd' ],
 			[ new Line( lineGeometry, matLineBlue ), null, [ 0, - Math.PI / 2, 0 ]]
 		],
 		XYZ: [


### PR DESCRIPTION
Fixed translation arrow head directions.

**Description**

Backward (bwd) arrow heads get inverted when ocluded by an axis, so there's no need to rotate their default orientation when creating them. The problem was that they would be rotated to face backwards when created, and then when ocluded they get scaled to -1, so they end up in wrong direction.

