### PR TITLE
Remove regenerator-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "eslint": "^7.21.0",
         "eslint-config-mdcs": "^5.0.0",
         "eslint-plugin-html": "^6.1.1",
-        "regenerator-runtime": "^0.13.7",
         "rollup": "^2.40.0",
         "rollup-plugin-filesize": "^9.1.1",
         "rollup-plugin-terser": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "eslint": "^7.21.0",
     "eslint-config-mdcs": "^5.0.0",
     "eslint-plugin-html": "^6.1.1",
-    "regenerator-runtime": "^0.13.7",
     "rollup": "^2.40.0",
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-terser": "^7.0.2",

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -272,29 +272,6 @@ ${ code }`;
 
 }
 
-function polyfills() {
-
-	return {
-
-		transform( code, filePath ) {
-
-			if ( filePath.endsWith( 'src/Three.js' ) || filePath.endsWith( 'src\\Three.js' ) ) {
-
-				code = 'import \'regenerator-runtime\';\n' + code;
-
-			}
-
-			return {
-				code: code,
-				map: null
-			};
-
-		}
-
-	};
-
-}
-
 const babelrc = {
 	presets: [
 		[
@@ -313,7 +290,6 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
-			polyfills(),
 			nodeResolve(),
 			addons(),
 			glconstants(),
@@ -339,7 +315,6 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
-			polyfills(),
 			nodeResolve(),
 			addons(),
 			glconstants(),

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 
 function glconstants() {
@@ -290,7 +289,6 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
-			nodeResolve(),
 			addons(),
 			glconstants(),
 			glsl(),
@@ -315,7 +313,6 @@ export default [
 	{
 		input: 'src/Three.js',
 		plugins: [
-			nodeResolve(),
 			addons(),
 			glconstants(),
 			glsl(),


### PR DESCRIPTION
Related issue: #21413

**Description**

`regenerator-runtime` was introduced in #20761 to correctly transpile async/await for IE.

However, since #21413, the bundle does not support IE11 anymore and ships with async/await directly. This makes the `regenerator-runtime` unnecessary.