### PR TITLE
Line2: Add support for Alpha To Coverage

### DIFF
--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -213,22 +213,32 @@ THREE.ShaderLib[ 'line' ] = {
 
 			#endif
 
+			float alpha = opacity;
 			if ( abs( vUv.y ) > 1.0 ) {
 
 				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 
+				#ifdef ALPHA_TO_COVERAGE
+
+				float dlen = fwidth( len2 );
+				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+
+				#else
+
 				if ( len2 > 1.0 ) discard;
+
+				#endif
 
 			}
 
-			vec4 diffuseColor = vec4( diffuse, opacity );
+			vec4 diffuseColor = vec4( diffuse, alpha );
 
 			#include <logdepthbuf_fragment>
 			#include <color_fragment>
 
-			gl_FragColor = vec4( diffuseColor.rgb, diffuseColor.a );
+			gl_FragColor = vec4( diffuseColor.rgb, alpha );
 
 			#include <tonemapping_fragment>
 			#include <encodings_fragment>
@@ -397,6 +407,38 @@ THREE.LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.resolution.value.copy( value );
+
+			}
+
+		},
+
+		alphaToCoverage: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
+
+			},
+
+			set: function ( value ) {
+
+				if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
+
+					this.needsUpdate = true;
+
+				}
+
+				if ( value ) {
+
+					this.defines.ALPHA_TO_COVERAGE = '';
+
+				} else {
+
+					delete this.defines.ALPHA_TO_COVERAGE;
+
+				}
 
 			}
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -215,27 +215,33 @@ THREE.ShaderLib[ 'line' ] = {
 
 			float alpha = opacity;
 
-			// define len2 outside of the conditional so it's available for the derivative
-			// taken in the conditional with ALPHA_TO_COVERAGE
+			#ifdef ALPHA_TO_COVERAGE
+
+			// artifacts appear on some hardware if a derivative is taken within a conditional
 			float a = vUv.x;
-			float len2 = a * a;
+			float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
+			float len2 = a * a + b * b;
+			float dlen = fwidth( len2 );
+
 			if ( abs( vUv.y ) > 1.0 ) {
 
+				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
+
+			}
+
+			#else
+
+			if ( abs( vUv.y ) > 1.0 ) {
+
+				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 
-				#ifdef ALPHA_TO_COVERAGE
-
-				float dlen = fwidth( sqrt( len2 ) );
-				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
-
-				#else
-
 				if ( len2 > 1.0 ) discard;
 
-				#endif
-
 			}
+
+			#endif
 
 			vec4 diffuseColor = vec4( diffuse, alpha );
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -226,8 +226,8 @@ THREE.ShaderLib[ 'line' ] = {
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				float dlen = fwidth( len2 );
-				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+				float dlen = fwidth( sqrt( len2 ) );
+				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
 
 				#else
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -214,9 +214,13 @@ THREE.ShaderLib[ 'line' ] = {
 			#endif
 
 			float alpha = opacity;
+
+			// define len2 outside of the conditional so it's available for the derivative
+			// taken in the conditional with ALPHA_TO_COVERAGE
+			float a = vUv.x;
+			float len2 = a * a;
 			if ( abs( vUv.y ) > 1.0 ) {
 
-				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -222,8 +222,7 @@ THREE.ShaderLib[ 'line' ] = {
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				float dlen = fwidth( len2 );
-				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+				alpha = 1.0 - smoothstep( 1.0 - fwidth( len2 ), 1.0, len2 );
 
 				#else
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -222,7 +222,8 @@ THREE.ShaderLib[ 'line' ] = {
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				alpha = 1.0 - smoothstep( 1.0 - fwidth( len2 ), 1.0, len2 );
+				float dlen = fwidth( len2 );
+				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
 
 				#else
 

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -433,10 +433,12 @@ THREE.LineMaterial = function ( parameters ) {
 				if ( value ) {
 
 					this.defines.ALPHA_TO_COVERAGE = '';
+					this.extensions.derivatives = true;
 
 				} else {
 
 					delete this.defines.ALPHA_TO_COVERAGE;
+					this.extensions.derivatives = false;
 
 				}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -222,15 +222,20 @@ ShaderLib[ 'line' ] = {
 			#endif
 
 			float alpha = opacity;
+
+			// define len2 outside of the conditional so it's available for the derivative
+			// taken in the conditional with ALPHA_TO_COVERAGE
+			float a = vUv.x;
+			float len2 = a * a;
 			if ( abs( vUv.y ) > 1.0 ) {
 
-				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				alpha = 1.0 - smoothstep( 1.0 - fwidth( len2 ), 1.0, len2 );
+				float dlen = fwidth( len2 );
+				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
 
 				#else
 
@@ -440,10 +445,12 @@ var LineMaterial = function ( parameters ) {
 				if ( value ) {
 
 					this.defines.ALPHA_TO_COVERAGE = '';
+					this.extensions.derivatives = true;
 
 				} else {
 
 					delete this.defines.ALPHA_TO_COVERAGE;
+					this.extensions.derivatives = false;
 
 				}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -221,22 +221,32 @@ ShaderLib[ 'line' ] = {
 
 			#endif
 
+			float alpha = opacity;
 			if ( abs( vUv.y ) > 1.0 ) {
 
 				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 
+				#ifdef ALPHA_TO_COVERAGE
+
+				float dlen = fwidth( len2 );
+				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+
+				#else
+
 				if ( len2 > 1.0 ) discard;
+
+				#endif
 
 			}
 
-			vec4 diffuseColor = vec4( diffuse, opacity );
+			vec4 diffuseColor = vec4( diffuse, alpha );
 
 			#include <logdepthbuf_fragment>
 			#include <color_fragment>
 
-			gl_FragColor = vec4( diffuseColor.rgb, diffuseColor.a );
+			gl_FragColor = vec4( diffuseColor.rgb, alpha );
 
 			#include <tonemapping_fragment>
 			#include <encodings_fragment>
@@ -405,6 +415,38 @@ var LineMaterial = function ( parameters ) {
 			set: function ( value ) {
 
 				this.uniforms.resolution.value.copy( value );
+
+			}
+
+		},
+
+		alphaToCoverage: {
+
+			enumerable: true,
+
+			get: function () {
+
+				return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
+
+			},
+
+			set: function ( value ) {
+
+				if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
+
+					this.needsUpdate = true;
+
+				}
+
+				if ( value ) {
+
+					this.defines.ALPHA_TO_COVERAGE = '';
+
+				} else {
+
+					delete this.defines.ALPHA_TO_COVERAGE;
+
+				}
 
 			}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -223,27 +223,33 @@ ShaderLib[ 'line' ] = {
 
 			float alpha = opacity;
 
-			// define len2 outside of the conditional so it's available for the derivative
-			// taken in the conditional with ALPHA_TO_COVERAGE
+			#ifdef ALPHA_TO_COVERAGE
+
+			// artifacts appear on some hardware if a derivative is taken within a conditional
 			float a = vUv.x;
-			float len2 = a * a;
+			float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
+			float len2 = a * a + b * b;
+			float dlen = fwidth( len2 );
+
 			if ( abs( vUv.y ) > 1.0 ) {
 
+				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
+
+			}
+
+			#else
+
+			if ( abs( vUv.y ) > 1.0 ) {
+
+				float a = vUv.x;
 				float b = ( vUv.y > 0.0 ) ? vUv.y - 1.0 : vUv.y + 1.0;
 				float len2 = a * a + b * b;
 
-				#ifdef ALPHA_TO_COVERAGE
-
-				float dlen = fwidth( sqrt( len2 ) );
-				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
-
-				#else
-
 				if ( len2 > 1.0 ) discard;
 
-				#endif
-
 			}
+
+			#endif
 
 			vec4 diffuseColor = vec4( diffuse, alpha );
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -230,8 +230,7 @@ ShaderLib[ 'line' ] = {
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				float dlen = fwidth( len2 );
-				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+				alpha = 1.0 - smoothstep( 1.0 - fwidth( len2 ), 1.0, len2 );
 
 				#else
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -234,8 +234,8 @@ ShaderLib[ 'line' ] = {
 
 				#ifdef ALPHA_TO_COVERAGE
 
-				float dlen = fwidth( len2 );
-				alpha = 1.0 - smoothstep( 1.0 - dlen * 0.75, 1.0 + dlen * 0.25, len2 );
+				float dlen = fwidth( sqrt( len2 ) );
+				alpha = 1.0 - smoothstep( 1.0 - dlen, 1.0 + dlen, len2 );
 
 				#else
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -97,7 +97,8 @@
 					linewidth: 5, // in pixels
 					vertexColors: true,
 					//resolution:  // to be set by renderer, eventually
-					dashed: false
+					dashed: false,
+					alphaToCoverage: true,
 
 				} );
 
@@ -198,6 +199,7 @@
 				const param = {
 					'line type': 0,
 					'width (px)': 5,
+					'alphaToCoverage': true,
 					'dashed': false,
 					'dash scale': 1,
 					'dash / gap': 1
@@ -225,9 +227,15 @@
 
 				} );
 
-				gui.add( param, 'width (px)', 1, 10 ).onChange( function ( val ) {
+				gui.add( param, 'width (px)', 1, 50 ).onChange( function ( val ) {
 
 					matLine.linewidth = val;
+
+				} );
+
+				gui.add( param, 'alphaToCoverage' ).onChange( function ( val ) { 
+
+					matLine.alphaToCoverage = val;
 
 				} );
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -227,7 +227,7 @@
 
 				} );
 
-				gui.add( param, 'width (px)', 1, 50 ).onChange( function ( val ) {
+				gui.add( param, 'width (px)', 1, 10 ).onChange( function ( val ) {
 
 					matLine.linewidth = val;
 


### PR DESCRIPTION
Related issue: --

**Description**

Adds support for `alphaToCoverage` to Line2. It's a subtle effect but it enables anti aliasing on the rounded tips of the line segments which can be seen on the line ends and when the line is curving in the demo:

https://raw.githack.com/gkjohnson/three.js/atc-line2/examples/webgl_lines_fat.html

cc @WestLangley 