### PR TITLE
WebGLTextures.js: fix render texture re-uploaded on first use

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1036,6 +1036,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		renderTarget.addEventListener( 'dispose', onRenderTargetDispose );
 
 		textureProperties.__webglTexture = _gl.createTexture();
+		textureProperties.__version = texture.version;
 
 		info.memory.textures ++;
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/render-to-datatexture2darray-does-not-work-correctly-is-it-a-bug/24251/5

**Description**

When rendering to a render target with a custom texture (assigned via `setTexture`), the `version` attribute of the texture is updated, but the render target will not save the latest version when creating the GL object. 

