### PR TITLE
BufferGeometry: Add comment to toJSON().

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -910,6 +910,8 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 		}
 
+		// for simplicity the code assumes attributes are not shared across geometries, see #15811
+
 		data.data = { attributes: {} };
 
 		const index = this.index;


### PR DESCRIPTION
Related issue: Closes #15811.

**Description**

The PR adds a comment to highlight that `BufferGeometry.toJSON()` assumes attributes are not shared across geometries. If attributes are shared, the serialization does not break but deserialization does not restore the shared attribute state.