### PR TITLE
Plane: Return null instead of undefined in intersectLine().

### DIFF
--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -79,7 +79,7 @@
 		[page:Line3 line] - the [page:Line3] to check for intersection.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
-		Returns the intersection point of the passed line and the plane. Returns undefined
+		Returns the intersection point of the passed line and the plane. Returns null
 		 if the line does not intersect. Returns the line's starting point if the line is
 		 coplanar with the plane.
 		</p>

--- a/docs/api/zh/math/Plane.html
+++ b/docs/api/zh/math/Plane.html
@@ -75,7 +75,7 @@
 		[page:Line3 line] - 检测是否相交的三维几何线段 [page:Line3]。<br />
 		[page:Vector3 target] — 结果将会写入该向量中。<br /><br />
 
-		返回给定线段和平面的交点。如果不相交则返回undefined。如果线与平面共面，则返回该线段的起始点。
+		返回给定线段和平面的交点。如果不相交则返回null。如果线与平面共面，则返回该线段的起始点。
 		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>

--- a/examples/js/misc/ConvexObjectBreaker.js
+++ b/examples/js/misc/ConvexObjectBreaker.js
@@ -347,7 +347,7 @@ THREE.ConvexObjectBreaker.prototype = {
 					var intersection = new THREE.Vector3();
 					intersection = localPlane.intersectLine( this.tempLine1, intersection );
 
-					if ( intersection === undefined ) {
+					if ( intersection === null ) {
 
 						// Shouldn't happen
 						console.error( 'Internal error: segment does not intersect plane.' );

--- a/examples/jsm/misc/ConvexObjectBreaker.js
+++ b/examples/jsm/misc/ConvexObjectBreaker.js
@@ -355,7 +355,7 @@ ConvexObjectBreaker.prototype = {
 					var intersection = new Vector3();
 					intersection = localPlane.intersectLine( this.tempLine1, intersection );
 
-					if ( intersection === undefined ) {
+					if ( intersection === null ) {
 
 						// Shouldn't happen
 						console.error( 'Internal error: segment does not intersect plane.' );

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -133,7 +133,7 @@ class Plane {
 			}
 
 			// Unsure if this is the correct method to handle this case.
-			return undefined;
+			return null;
 
 		}
 
@@ -141,7 +141,7 @@ class Plane {
 
 		if ( t < 0 || t > 1 ) {
 
-			return undefined;
+			return null;
 
 		}
 


### PR DESCRIPTION
Related issue: Fixed #19784.

**Description**

Similar to other `intersect*()` methods, `Plane.intersectLine()` now uses `null` instead of `undefined` to represent "no intersection found".

I've considered to make the same change in `Object3D.getObjectByProperty()` however this might potentially break a lot of code. I also think it is not that urgent since all `getObjectBy*()` methods behave consistently (which is not true for the intersection routines).