### PR TITLE
WebGPURenderer: Follow the latest GPURenderPipelineDescriptor format

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -53,11 +53,11 @@ class WebGPUTextureUtils {
 		this.pipelines = {};
 
 		this.mipmapVertexShaderModule = device.createShaderModule( {
-			 code: glslang.compileGLSL( mipmapVertexSource, 'vertex' ),
-		 } );
-		 this.mipmapFragmentShaderModule = device.createShaderModule( {
-			 code: glslang.compileGLSL( mipmapFragmentSource, 'fragment' ),
-		 } );
+			code: glslang.compileGLSL( mipmapVertexSource, 'vertex' ),
+		} );
+		this.mipmapFragmentShaderModule = device.createShaderModule( {
+			code: glslang.compileGLSL( mipmapFragmentSource, 'fragment' ),
+		} );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -68,19 +68,19 @@ class WebGPUTextureUtils {
 		if ( pipeline === undefined ) {
 
 			pipeline = this.device.createRenderPipeline( {
-				vertexStage: {
+				vertex: {
 					module: this.mipmapVertexShaderModule,
 					entryPoint: 'main',
 				},
-				fragmentStage: {
+				fragment: {
 					module: this.mipmapFragmentShaderModule,
 					entryPoint: 'main',
+					targets: [ { format } ],
 				},
-				primitiveTopology: GPUPrimitiveTopology.TriangleStrip,
-				vertexState: {
-					indexFormat: GPUIndexFormat.Uint32
-				},
-				colorStates: [ { format } ],
+				primitive: {
+					topology: GPUPrimitiveTopology.TriangleStrip,
+					stripIndexFormat: GPUIndexFormat.Uint32
+				}
 			} );
 			this.pipelines[ format ] = pipeline;
 


### PR DESCRIPTION
**Description**

This PR updates `WebGPURenderPipelines` and `WebGPUTextureUtils.js` to follow the latest [`WebGPU GPURenderPipelineDescriptor`](https://gpuweb.github.io/gpuweb/#render-pipeline-creation) and removes the console warning

```
WebGPURenderPipelines.js:180 The format of GPURenderPipelineDescriptor has changed, and will soon require the new structure. Please begin using the vertex, primitive, depthStencil, multisample, and fragment members
```
