### PR TITLE
Line/Points: Avoid raw array access in raycast().

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -122,12 +122,10 @@ Line.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( index !== null ) {
 
-				const indices = index.array;
+				for ( let i = 0, l = index.count - 1; i < l; i += step ) {
 
-				for ( let i = 0, l = indices.length - 1; i < l; i += step ) {
-
-					const a = indices[ i ];
-					const b = indices[ i + 1 ];
+					const a = index.getX( i );
+					const b = index.getX( i + 1 );
 
 					vStart.fromBufferAttribute( positionAttribute, a );
 					vEnd.fromBufferAttribute( positionAttribute, b );

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -73,11 +73,9 @@ Points.prototype = Object.assign( Object.create( Object3D.prototype ), {
 
 			if ( index !== null ) {
 
-				const indices = index.array;
+				for ( let i = 0, il = index.count; i < il; i ++ ) {
 
-				for ( let i = 0, il = indices.length; i < il; i ++ ) {
-
-					const a = indices[ i ];
+					const a = index.getX( i );
 
 					_position.fromBufferAttribute( positionAttribute, a );
 


### PR DESCRIPTION
Related issue: -

**Description**

This makes the code similar to `Mesh.raycast()` and automatically compatible with interleaved data.