### PR TITLE
Docs(zh): Fix typo in Box3 page

### DIFF
--- a/docs/api/zh/math/Box3.html
+++ b/docs/api/zh/math/Box3.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			表示二维空间中的一个轴对齐包围盒（axis-aligned bounding box，AABB）。
+			表示三维空间中的一个轴对齐包围盒（axis-aligned bounding box，AABB）。
 		</p>
 
 		<h2>代码示例</h2>


### PR DESCRIPTION
Related issue: None

**Description**

二维空间 -> 三维空间

( 2D space -> 3D space )


