### PR TITLE
Quaternion: Use Number.EPSILON in setFromUnitVectors().

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -363,11 +363,11 @@ class Quaternion {
 
 		// assumes direction vectors vFrom and vTo are normalized
 
-		const EPS = 0.000001;
-
 		let r = vFrom.dot( vTo ) + 1;
 
-		if ( r < EPS ) {
+		if ( r < Number.EPSILON ) {
+
+			// vFrom and vTo point in opposite directions
 
 			r = 0;
 


### PR DESCRIPTION
Related issue: Fixed #21477.

**Description**

Use `Number.EPSILON` instead of `0.000001` as epsilon value.