### PR TITLE
InstancedMesh:  Honor instanceColor in toJSON() and ObjectLoader.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -700,6 +700,8 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			object.type = 'InstancedMesh';
 			object.count = this.count;
 			object.instanceMatrix = this.instanceMatrix.toJSON();
+			object.instanceColor = null;
+			if ( this.instanceColor !== null ) object.instanceColor = this.instanceColor.toJSON();
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -700,7 +700,6 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 			object.type = 'InstancedMesh';
 			object.count = this.count;
 			object.instanceMatrix = this.instanceMatrix.toJSON();
-			object.instanceColor = null;
 			if ( this.instanceColor !== null ) object.instanceColor = this.instanceColor.toJSON();
 
 		}

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -965,7 +965,7 @@ class ObjectLoader extends Loader {
 
 				object = new InstancedMesh( geometry, material, count );
 				object.instanceMatrix = new BufferAttribute( new Float32Array( instanceMatrix.array ), 16 );
-				if ( instanceColor !== null ) object.instanceColor = new BufferAttribute( new Float32Array( instanceColor.array ), 3 );
+				if ( instanceColor !== undefined ) object.instanceColor = new BufferAttribute( new Float32Array( instanceColor.array ), 3 );
 
 				break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -961,9 +961,11 @@ class ObjectLoader extends Loader {
 				material = getMaterial( data.material );
 				const count = data.count;
 				const instanceMatrix = data.instanceMatrix;
+				const instanceColor = data.instanceColor;
 
 				object = new InstancedMesh( geometry, material, count );
 				object.instanceMatrix = new BufferAttribute( new Float32Array( instanceMatrix.array ), 16 );
+				if ( instanceColor !== null ) object.instanceColor = new BufferAttribute( new Float32Array( instanceColor.array ), 3 );
 
 				break;
 


### PR DESCRIPTION
**Description**

I was having troubles transferring InstancedMesh data due to the Object3D.toJSON and ObjectLoader.parseObject functions not accounting for the instanceColor attribute. 

I've added instanceColor to the InstancedMesh cases in the respective functions. 
Since instanceColor is optional, I've mimicked the behavior in InstanceMesh.copy() to check if it's null. 
