### PR TITLE
Fix some picking/raycast examples for touch devices

### DIFF
--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -103,7 +103,6 @@
 				helper = new THREE.Mesh( geometryHelper, new THREE.MeshNormalMaterial() );
 				scene.add( helper );
 
-				container.addEventListener( 'mousemove', onMouseMove );
 				container.addEventListener( 'pointermove', onMouseMove );
 
 				stats = new Stats();

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -104,6 +104,7 @@
 				scene.add( helper );
 
 				container.addEventListener( 'mousemove', onMouseMove );
+				container.addEventListener( 'pointermove', onMouseMove );
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -165,7 +165,6 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				renderer.domElement.addEventListener( 'mousemove', onMouseMove, false );
 				renderer.domElement.addEventListener( 'pointermove', onMouseMove, false );
 
 			}

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -165,13 +165,16 @@
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
-				renderer.domElement.addEventListener( 'mousemove', onMouseMove );
+				renderer.domElement.addEventListener( 'mousemove', onMouseMove, false );
+				renderer.domElement.addEventListener( 'pointermove', onMouseMove, false );
 
 			}
 
 			//
 
 			function onMouseMove( e ) {
+
+				e.preventDefault();
 
 				mouse.x = e.clientX;
 				mouse.y = e.clientY;

--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -82,6 +82,7 @@
 
 			window.addEventListener( 'resize', onWindowResize );
 			window.addEventListener( "mousemove", onDocumentMouseMove, false );
+			window.addEventListener( "pointermove", onDocumentMouseMove, false );
 
 		}
 

--- a/examples/webgl_raycast_sprite.html
+++ b/examples/webgl_raycast_sprite.html
@@ -81,7 +81,6 @@
 			group2.add( sprite3 );
 
 			window.addEventListener( 'resize', onWindowResize );
-			window.addEventListener( "mousemove", onDocumentMouseMove, false );
 			window.addEventListener( "pointermove", onDocumentMouseMove, false );
 
 		}


### PR DESCRIPTION
TrackballControls and OrbitControls listen to pointer events, which can cause mouse events not to fire on Android devices. Fix some picking examples by listening to pointer events in them as well.

This contribution is funded by [Higharc](https://higharc.com).