### PR TITLE
Line2: Convert Line2 example scripts to ES6 Classes

### DIFF
--- a/examples/js/lines/Line2.js
+++ b/examples/js/lines/Line2.js
@@ -1,18 +1,16 @@
-THREE.Line2 = function ( geometry, material ) {
+THREE.Line2 = class Line2 extends THREE.LineSegments2 {
 
-	if ( geometry === undefined ) geometry = new THREE.LineGeometry();
-	if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
+	constructor( geometry, material ) {
 
-	THREE.LineSegments2.call( this, geometry, material );
+		if ( geometry === undefined ) geometry = new THREE.LineGeometry();
+		if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
 
-	this.type = 'Line2';
+		super( geometry, material );
 
-};
+		this.type = 'Line2';
 
-THREE.Line2.prototype = Object.assign( Object.create( THREE.LineSegments2.prototype ), {
+	}
 
-	constructor: THREE.Line2,
+}
 
-	isLine2: true
-
-} );
+THREE.Line2.prototype.isLine2 = true;

--- a/examples/js/lines/LineGeometry.js
+++ b/examples/js/lines/LineGeometry.js
@@ -1,18 +1,13 @@
-THREE.LineGeometry = function () {
+THREE.LineGeometry = class LineGeometry extends THREE.LineSegmentsGeometry {
 
-	THREE.LineSegmentsGeometry.call( this );
+	constructor() {
 
-	this.type = 'LineGeometry';
+		super();
+		this.type = 'LineGeometry';
 
-};
+	}
 
-THREE.LineGeometry.prototype = Object.assign( Object.create( THREE.LineSegmentsGeometry.prototype ), {
-
-	constructor: THREE.LineGeometry,
-
-	isLineGeometry: true,
-
-	setPositions: function ( array ) {
+	setPositions( array ) {
 
 		// converts [ x1, y1, z1,  x2, y2, z2, ... ] to pairs format
 
@@ -35,9 +30,9 @@ THREE.LineGeometry.prototype = Object.assign( Object.create( THREE.LineSegmentsG
 
 		return this;
 
-	},
+	}
 
-	setColors: function ( array ) {
+	setColors( array ) {
 
 		// converts [ r1, g1, b1,  r2, g2, b2, ... ] to pairs format
 
@@ -60,9 +55,9 @@ THREE.LineGeometry.prototype = Object.assign( Object.create( THREE.LineSegmentsG
 
 		return this;
 
-	},
+	}
 
-	fromLine: function ( line ) {
+	fromLine( line ) {
 
 		var geometry = line.geometry;
 
@@ -81,9 +76,9 @@ THREE.LineGeometry.prototype = Object.assign( Object.create( THREE.LineSegmentsG
 
 		return this;
 
-	},
+	}
 
-	copy: function ( /* source */ ) {
+	copy( /* source */ ) {
 
 		// todo
 
@@ -91,4 +86,6 @@ THREE.LineGeometry.prototype = Object.assign( Object.create( THREE.LineSegmentsG
 
 	}
 
-} );
+}
+
+THREE.LineGeometry.isLineGeometry = true;

--- a/examples/js/lines/LineMaterial.js
+++ b/examples/js/lines/LineMaterial.js
@@ -259,210 +259,211 @@ THREE.ShaderLib[ 'line' ] = {
 		`
 };
 
-THREE.LineMaterial = function ( parameters ) {
+THREE.LineMaterial = class LineMaterial extends THREE.ShaderMaterial {
 
-	THREE.ShaderMaterial.call( this, {
+	constructor( parameters ) {
 
-		type: 'LineMaterial',
+		super( {
 
-		uniforms: THREE.UniformsUtils.clone( THREE.ShaderLib[ 'line' ].uniforms ),
+			type: 'LineMaterial',
 
-		vertexShader: THREE.ShaderLib[ 'line' ].vertexShader,
-		fragmentShader: THREE.ShaderLib[ 'line' ].fragmentShader,
+			uniforms: THREE.UniformsUtils.clone( THREE.ShaderLib[ 'line' ].uniforms ),
 
-		clipping: true // required for clipping support
+			vertexShader: THREE.ShaderLib[ 'line' ].vertexShader,
+			fragmentShader: THREE.ShaderLib[ 'line' ].fragmentShader,
 
-	} );
+			clipping: true // required for clipping support
 
-	this.dashed = false;
+		} );
 
-	Object.defineProperties( this, {
+		this.dashed = false;
 
-		color: {
+		Object.defineProperties( this, {
 
-			enumerable: true,
+			color: {
 
-			get: function () {
+				enumerable: true,
 
-				return this.uniforms.diffuse.value;
+				get: function () {
 
-			},
+					return this.uniforms.diffuse.value;
 
-			set: function ( value ) {
+				},
 
-				this.uniforms.diffuse.value = value;
+				set: function ( value ) {
 
-			}
-
-		},
-
-		linewidth: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.linewidth.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.linewidth.value = value;
-
-			}
-
-		},
-
-		dashScale: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashScale.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashScale.value = value;
-
-			}
-
-		},
-
-		dashSize: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashSize.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashSize.value = value;
-
-			}
-
-		},
-
-		dashOffset: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashOffset.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashOffset.value = value;
-
-			}
-
-		},
-
-		gapSize: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.gapSize.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.gapSize.value = value;
-
-			}
-
-		},
-
-		opacity: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.opacity.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.opacity.value = value;
-
-			}
-
-		},
-
-		resolution: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.resolution.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.resolution.value.copy( value );
-
-			}
-
-		},
-
-		alphaToCoverage: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
-
-			},
-
-			set: function ( value ) {
-
-				if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
-
-					this.needsUpdate = true;
+					this.uniforms.diffuse.value = value;
 
 				}
 
-				if ( value ) {
+			},
 
-					this.defines.ALPHA_TO_COVERAGE = '';
-					this.extensions.derivatives = true;
+			linewidth: {
 
-				} else {
+				enumerable: true,
 
-					delete this.defines.ALPHA_TO_COVERAGE;
-					this.extensions.derivatives = false;
+				get: function () {
+
+					return this.uniforms.linewidth.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.linewidth.value = value;
+
+				}
+
+			},
+
+			dashScale: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashScale.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashScale.value = value;
+
+				}
+
+			},
+
+			dashSize: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashSize.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashSize.value = value;
+
+				}
+
+			},
+
+			dashOffset: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashOffset.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashOffset.value = value;
+
+				}
+
+			},
+
+			gapSize: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.gapSize.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.gapSize.value = value;
+
+				}
+
+			},
+
+			opacity: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.opacity.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.opacity.value = value;
+
+				}
+
+			},
+
+			resolution: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.resolution.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.resolution.value.copy( value );
+
+				}
+
+			},
+
+			alphaToCoverage: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
+
+				},
+
+				set: function ( value ) {
+
+					if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
+
+						this.needsUpdate = true;
+
+					}
+
+					if ( value ) {
+
+						this.defines.ALPHA_TO_COVERAGE = '';
+						this.extensions.derivatives = true;
+
+					} else {
+
+						delete this.defines.ALPHA_TO_COVERAGE;
+						this.extensions.derivatives = false;
+
+					}
 
 				}
 
 			}
 
-		}
+		} );
 
-	} );
+		this.setValues( parameters );
 
-	this.setValues( parameters );
+	}
 
-};
-
-THREE.LineMaterial.prototype = Object.create( THREE.ShaderMaterial.prototype );
-THREE.LineMaterial.prototype.constructor = THREE.LineMaterial;
+}
 
 THREE.LineMaterial.prototype.isLineMaterial = true;

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -1,211 +1,210 @@
-THREE.LineSegments2 = function ( geometry, material ) {
 
-	if ( geometry === undefined ) geometry = new THREE.LineSegmentsGeometry();
-	if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
+THREE.LineSegments2 = class LineSegments2 extends THREE.Mesh {
 
-	THREE.Mesh.call( this, geometry, material );
+	constructor( geometry, material ) {
 
-	this.type = 'LineSegments2';
+		if ( geometry === undefined ) geometry = new THREE.LineSegmentsGeometry();
+		if ( material === undefined ) material = new THREE.LineMaterial( { color: Math.random() * 0xffffff } );
+
+		super( geometry, material );
+
+		this.type = 'LineSegments2';
+
+	}
 
 };
 
-THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototype ), {
+THREE.LineSegments2.prototype.computeLineDistances = ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
 
-	constructor: THREE.LineSegments2,
+	var start = new THREE.Vector3();
+	var end = new THREE.Vector3();
 
-	isLineSegments2: true,
+	return function computeLineDistances() {
 
-	computeLineDistances: ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
+		var geometry = this.geometry;
 
-		var start = new THREE.Vector3();
-		var end = new THREE.Vector3();
+		var instanceStart = geometry.attributes.instanceStart;
+		var instanceEnd = geometry.attributes.instanceEnd;
+		var lineDistances = new Float32Array( 2 * instanceStart.count );
 
-		return function computeLineDistances() {
+		for ( var i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
 
-			var geometry = this.geometry;
+			start.fromBufferAttribute( instanceStart, i );
+			end.fromBufferAttribute( instanceEnd, i );
 
-			var instanceStart = geometry.attributes.instanceStart;
-			var instanceEnd = geometry.attributes.instanceEnd;
-			var lineDistances = new Float32Array( 2 * instanceStart.count );
+			lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
+			lineDistances[ j + 1 ] = lineDistances[ j ] + start.distanceTo( end );
 
-			for ( var i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
+		}
 
-				start.fromBufferAttribute( instanceStart, i );
-				end.fromBufferAttribute( instanceEnd, i );
+		var instanceDistanceBuffer = new THREE.InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
 
-				lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
-				lineDistances[ j + 1 ] = lineDistances[ j ] + start.distanceTo( end );
+		geometry.setAttribute( 'instanceDistanceStart', new THREE.InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
+		geometry.setAttribute( 'instanceDistanceEnd', new THREE.InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+
+		return this;
+
+	};
+
+}() );
+
+THREE.LineSegments2.prototype.raycast = ( function () {
+
+	var start = new THREE.Vector4();
+	var end = new THREE.Vector4();
+
+	var ssOrigin = new THREE.Vector4();
+	var ssOrigin3 = new THREE.Vector3();
+	var mvMatrix = new THREE.Matrix4();
+	var line = new THREE.Line3();
+	var closestPoint = new THREE.Vector3();
+
+	return function raycast( raycaster, intersects ) {
+
+		if ( raycaster.camera === null ) {
+
+			console.error( 'LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2.' );
+
+		}
+
+		var threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
+
+		var ray = raycaster.ray;
+		var camera = raycaster.camera;
+		var projectionMatrix = camera.projectionMatrix;
+
+		var geometry = this.geometry;
+		var material = this.material;
+		var resolution = material.resolution;
+		var lineWidth = material.linewidth + threshold;
+
+		var instanceStart = geometry.attributes.instanceStart;
+		var instanceEnd = geometry.attributes.instanceEnd;
+
+		// camera forward is negative
+		var near = - camera.near;
+
+		// pick a point 1 unit out along the ray to avoid the ray origin
+		// sitting at the camera origin which will cause "w" to be 0 when
+		// applying the projection matrix.
+		ray.at( 1, ssOrigin );
+
+		// ndc space [ - 1.0, 1.0 ]
+		ssOrigin.w = 1;
+		ssOrigin.applyMatrix4( camera.matrixWorldInverse );
+		ssOrigin.applyMatrix4( projectionMatrix );
+		ssOrigin.multiplyScalar( 1 / ssOrigin.w );
+
+		// screen space
+		ssOrigin.x *= resolution.x / 2;
+		ssOrigin.y *= resolution.y / 2;
+		ssOrigin.z = 0;
+
+		ssOrigin3.copy( ssOrigin );
+
+		var matrixWorld = this.matrixWorld;
+		mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
+
+		for ( var i = 0, l = instanceStart.count; i < l; i ++ ) {
+
+			start.fromBufferAttribute( instanceStart, i );
+			end.fromBufferAttribute( instanceEnd, i );
+
+			start.w = 1;
+			end.w = 1;
+
+			// camera space
+			start.applyMatrix4( mvMatrix );
+			end.applyMatrix4( mvMatrix );
+
+			// skip the segment if it's entirely behind the camera
+			var isBehindCameraNear = start.z > near && end.z > near;
+			if ( isBehindCameraNear ) {
+
+				continue;
 
 			}
 
-			var instanceDistanceBuffer = new THREE.InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
+			// trim the segment if it extends behind camera near
+			if ( start.z > near ) {
 
-			geometry.setAttribute( 'instanceDistanceStart', new THREE.InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
-			geometry.setAttribute( 'instanceDistanceEnd', new THREE.InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+				const deltaDist = start.z - end.z;
+				const t = ( start.z - near ) / deltaDist;
+				start.lerp( end, t );
 
-			return this;
+			} else if ( end.z > near ) {
 
-		};
-
-	}() ),
-
-	raycast: ( function () {
-
-		var start = new THREE.Vector4();
-		var end = new THREE.Vector4();
-
-		var ssOrigin = new THREE.Vector4();
-		var ssOrigin3 = new THREE.Vector3();
-		var mvMatrix = new THREE.Matrix4();
-		var line = new THREE.Line3();
-		var closestPoint = new THREE.Vector3();
-
-		return function raycast( raycaster, intersects ) {
-
-			if ( raycaster.camera === null ) {
-
-				console.error( 'LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2.' );
+				const deltaDist = end.z - start.z;
+				const t = ( end.z - near ) / deltaDist;
+				end.lerp( start, t );
 
 			}
 
-			var threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
-
-			var ray = raycaster.ray;
-			var camera = raycaster.camera;
-			var projectionMatrix = camera.projectionMatrix;
-
-			var geometry = this.geometry;
-			var material = this.material;
-			var resolution = material.resolution;
-			var lineWidth = material.linewidth + threshold;
-
-			var instanceStart = geometry.attributes.instanceStart;
-			var instanceEnd = geometry.attributes.instanceEnd;
-
-			// camera forward is negative
-			var near = - camera.near;
-
-			// pick a point 1 unit out along the ray to avoid the ray origin
-			// sitting at the camera origin which will cause "w" to be 0 when
-			// applying the projection matrix.
-			ray.at( 1, ssOrigin );
+			// clip space
+			start.applyMatrix4( projectionMatrix );
+			end.applyMatrix4( projectionMatrix );
 
 			// ndc space [ - 1.0, 1.0 ]
-			ssOrigin.w = 1;
-			ssOrigin.applyMatrix4( camera.matrixWorldInverse );
-			ssOrigin.applyMatrix4( projectionMatrix );
-			ssOrigin.multiplyScalar( 1 / ssOrigin.w );
+			start.multiplyScalar( 1 / start.w );
+			end.multiplyScalar( 1 / end.w );
 
 			// screen space
-			ssOrigin.x *= resolution.x / 2;
-			ssOrigin.y *= resolution.y / 2;
-			ssOrigin.z = 0;
+			start.x *= resolution.x / 2;
+			start.y *= resolution.y / 2;
 
-			ssOrigin3.copy( ssOrigin );
+			end.x *= resolution.x / 2;
+			end.y *= resolution.y / 2;
 
-			var matrixWorld = this.matrixWorld;
-			mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
+			// create 2d segment
+			line.start.copy( start );
+			line.start.z = 0;
 
-			for ( var i = 0, l = instanceStart.count; i < l; i ++ ) {
+			line.end.copy( end );
+			line.end.z = 0;
 
-				start.fromBufferAttribute( instanceStart, i );
-				end.fromBufferAttribute( instanceEnd, i );
+			// get closest point on ray to segment
+			var param = line.closestPointToPointParameter( ssOrigin3, true );
+			line.at( param, closestPoint );
 
-				start.w = 1;
-				end.w = 1;
+			// check if the intersection point is within clip space
+			var zPos = THREE.MathUtils.lerp( start.z, end.z, param );
+			var isInClipSpace = zPos >= - 1 && zPos <= 1;
 
-				// camera space
-				start.applyMatrix4( mvMatrix );
-				end.applyMatrix4( mvMatrix );
+			var isInside = ssOrigin3.distanceTo( closestPoint ) < lineWidth * 0.5;
 
-				// skip the segment if it's entirely behind the camera
-				var isBehindCameraNear = start.z > near && end.z > near;
-				if ( isBehindCameraNear ) {
+			if ( isInClipSpace && isInside ) {
 
-					continue;
+				line.start.fromBufferAttribute( instanceStart, i );
+				line.end.fromBufferAttribute( instanceEnd, i );
 
-				}
+				line.start.applyMatrix4( matrixWorld );
+				line.end.applyMatrix4( matrixWorld );
 
-				// trim the segment if it extends behind camera near
-				if ( start.z > near ) {
+				var pointOnLine = new THREE.Vector3();
+				var point = new THREE.Vector3();
 
-					const deltaDist = start.z - end.z;
-					const t = ( start.z - near ) / deltaDist;
-					start.lerp( end, t );
+				ray.distanceSqToSegment( line.start, line.end, point, pointOnLine );
 
-				} else if ( end.z > near ) {
+				intersects.push( {
 
-					const deltaDist = end.z - start.z;
-					const t = ( end.z - near ) / deltaDist;
-					end.lerp( start, t );
+					point: point,
+					pointOnLine: pointOnLine,
+					distance: ray.origin.distanceTo( point ),
 
-				}
+					object: this,
+					face: null,
+					faceIndex: i,
+					uv: null,
+					uv2: null,
 
-				// clip space
-				start.applyMatrix4( projectionMatrix );
-				end.applyMatrix4( projectionMatrix );
-
-				// ndc space [ - 1.0, 1.0 ]
-				start.multiplyScalar( 1 / start.w );
-				end.multiplyScalar( 1 / end.w );
-
-				// screen space
-				start.x *= resolution.x / 2;
-				start.y *= resolution.y / 2;
-
-				end.x *= resolution.x / 2;
-				end.y *= resolution.y / 2;
-
-				// create 2d segment
-				line.start.copy( start );
-				line.start.z = 0;
-
-				line.end.copy( end );
-				line.end.z = 0;
-
-				// get closest point on ray to segment
-				var param = line.closestPointToPointParameter( ssOrigin3, true );
-				line.at( param, closestPoint );
-
-				// check if the intersection point is within clip space
-				var zPos = THREE.MathUtils.lerp( start.z, end.z, param );
-				var isInClipSpace = zPos >= - 1 && zPos <= 1;
-
-				var isInside = ssOrigin3.distanceTo( closestPoint ) < lineWidth * 0.5;
-
-				if ( isInClipSpace && isInside ) {
-
-					line.start.fromBufferAttribute( instanceStart, i );
-					line.end.fromBufferAttribute( instanceEnd, i );
-
-					line.start.applyMatrix4( matrixWorld );
-					line.end.applyMatrix4( matrixWorld );
-
-					var pointOnLine = new THREE.Vector3();
-					var point = new THREE.Vector3();
-
-					ray.distanceSqToSegment( line.start, line.end, point, pointOnLine );
-
-					intersects.push( {
-
-						point: point,
-						pointOnLine: pointOnLine,
-						distance: ray.origin.distanceTo( point ),
-
-						object: this,
-						face: null,
-						faceIndex: i,
-						uv: null,
-						uv2: null,
-
-					} );
-
-				}
+				} );
 
 			}
 
-		};
+		}
 
-	}() )
+	};
 
-} );
+}() );
+
+THREE.LineSegments2.prototype.isLineSegments2 = true;

--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -1,26 +1,22 @@
-THREE.LineSegmentsGeometry = function () {
+THREE.LineSegmentsGeometry = class LineSegmentsGeometry extends THREE.InstancedBufferGeometry {
 
-	THREE.InstancedBufferGeometry.call( this );
+	constructor() {
 
-	this.type = 'LineSegmentsGeometry';
+		super();
 
-	var positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
-	var uvs = [ - 1, 2, 1, 2, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 2, 1, - 2 ];
-	var index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
+		this.type = 'LineSegmentsGeometry';
 
-	this.setIndex( index );
-	this.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
-	this.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
+		var positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
+		var uvs = [ - 1, 2, 1, 2, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 2, 1, - 2 ];
+		var index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
 
-};
+		this.setIndex( index );
+		this.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
+		this.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
 
-THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.InstancedBufferGeometry.prototype ), {
+	}
 
-	constructor: THREE.LineSegmentsGeometry,
-
-	isLineSegmentsGeometry: true,
-
-	applyMatrix4: function ( matrix ) {
+	applyMatrix4( matrix ) {
 
 		var start = this.attributes.instanceStart;
 		var end = this.attributes.instanceEnd;
@@ -49,9 +45,9 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		return this;
 
-	},
+	}
 
-	setPositions: function ( array ) {
+	setPositions( array ) {
 
 		var lineSegments;
 
@@ -77,9 +73,9 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		return this;
 
-	},
+	}
 
-	setColors: function ( array ) {
+	setColors( array ) {
 
 		var colors;
 
@@ -100,25 +96,25 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		return this;
 
-	},
+	}
 
-	fromWireframeGeometry: function ( geometry ) {
-
-		this.setPositions( geometry.attributes.position.array );
-
-		return this;
-
-	},
-
-	fromEdgesGeometry: function ( geometry ) {
+	fromWireframeGeometry( geometry ) {
 
 		this.setPositions( geometry.attributes.position.array );
 
 		return this;
 
-	},
+	}
 
-	fromMesh: function ( mesh ) {
+	fromEdgesGeometry( geometry ) {
+
+		this.setPositions( geometry.attributes.position.array );
+
+		return this;
+
+	}
+
+	fromMesh( mesh ) {
 
 		this.fromWireframeGeometry( new THREE.WireframeGeometry( mesh.geometry ) );
 
@@ -126,9 +122,9 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		return this;
 
-	},
+	}
 
-	fromLineSegments: function ( lineSegments ) {
+	fromLineSegments( lineSegments ) {
 
 		var geometry = lineSegments.geometry;
 
@@ -147,97 +143,15 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 		return this;
 
-	},
+	}
 
-	computeBoundingBox: function () {
-
-		var box = new THREE.Box3();
-
-		return function computeBoundingBox() {
-
-			if ( this.boundingBox === null ) {
-
-				this.boundingBox = new THREE.Box3();
-
-			}
-
-			var start = this.attributes.instanceStart;
-			var end = this.attributes.instanceEnd;
-
-			if ( start !== undefined && end !== undefined ) {
-
-				this.boundingBox.setFromBufferAttribute( start );
-
-				box.setFromBufferAttribute( end );
-
-				this.boundingBox.union( box );
-
-			}
-
-		};
-
-	}(),
-
-	computeBoundingSphere: function () {
-
-		var vector = new THREE.Vector3();
-
-		return function computeBoundingSphere() {
-
-			if ( this.boundingSphere === null ) {
-
-				this.boundingSphere = new THREE.Sphere();
-
-			}
-
-			if ( this.boundingBox === null ) {
-
-				this.computeBoundingBox();
-
-			}
-
-			var start = this.attributes.instanceStart;
-			var end = this.attributes.instanceEnd;
-
-			if ( start !== undefined && end !== undefined ) {
-
-				var center = this.boundingSphere.center;
-
-				this.boundingBox.getCenter( center );
-
-				var maxRadiusSq = 0;
-
-				for ( var i = 0, il = start.count; i < il; i ++ ) {
-
-					vector.fromBufferAttribute( start, i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
-
-					vector.fromBufferAttribute( end, i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
-
-				}
-
-				this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
-
-				if ( isNaN( this.boundingSphere.radius ) ) {
-
-					console.error( 'THREE.LineSegmentsGeometry.computeBoundingSphere(): Computed radius is NaN. The instanced position data is likely to have NaN values.', this );
-
-				}
-
-			}
-
-		};
-
-	}(),
-
-	toJSON: function () {
+	toJSON() {
 
 		// todo
 
-	},
+	}
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix( matrix ) {
 
 		console.warn( 'THREE.LineSegmentsGeometry: applyMatrix() has been renamed to applyMatrix4().' );
 
@@ -245,4 +159,88 @@ THREE.LineSegmentsGeometry.prototype = Object.assign( Object.create( THREE.Insta
 
 	}
 
-} );
+}
+
+THREE.LineSegmentsGeometry.prototype.computeBoundingBox = function () {
+
+	var box = new THREE.Box3();
+
+	return function computeBoundingBox() {
+
+		if ( this.boundingBox === null ) {
+
+			this.boundingBox = new THREE.Box3();
+
+		}
+
+		var start = this.attributes.instanceStart;
+		var end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			this.boundingBox.setFromBufferAttribute( start );
+
+			box.setFromBufferAttribute( end );
+
+			this.boundingBox.union( box );
+
+		}
+
+	};
+
+}();
+
+THREE.LineSegmentsGeometry.prototype.computeBoundingSphere = function () {
+
+	var vector = new THREE.Vector3();
+
+	return function computeBoundingSphere() {
+
+		if ( this.boundingSphere === null ) {
+
+			this.boundingSphere = new THREE.Sphere();
+
+		}
+
+		if ( this.boundingBox === null ) {
+
+			this.computeBoundingBox();
+
+		}
+
+		var start = this.attributes.instanceStart;
+		var end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			var center = this.boundingSphere.center;
+
+			this.boundingBox.getCenter( center );
+
+			var maxRadiusSq = 0;
+
+			for ( var i = 0, il = start.count; i < il; i ++ ) {
+
+				vector.fromBufferAttribute( start, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+				vector.fromBufferAttribute( end, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+			}
+
+			this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+
+			if ( isNaN( this.boundingSphere.radius ) ) {
+
+				console.error( 'THREE.LineSegmentsGeometry.computeBoundingSphere(): Computed radius is NaN. The instanced position data is likely to have NaN values.', this );
+
+			}
+
+		}
+
+	};
+
+}();
+
+THREE.LineSegmentsGeometry.prototype.isLineSegmentsGeometry = true;

--- a/examples/js/lines/Wireframe.js
+++ b/examples/js/lines/Wireframe.js
@@ -13,7 +13,7 @@ THREE.Wireframe = class Wireframe extends THREE.Mesh {
 
 };
 
-THREE.Wireframe.prototype.computeLineDistances = computeLineDistances = ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
+THREE.Wireframe.prototype.computeLineDistances = ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
 
 	var start = new THREE.Vector3();
 	var end = new THREE.Vector3();

--- a/examples/js/lines/WireframeGeometry2.js
+++ b/examples/js/lines/WireframeGeometry2.js
@@ -1,19 +1,17 @@
-THREE.WireframeGeometry2 = function ( geometry ) {
+THREE.WireframeGeometry2 = class WireframeGeometry2 extends THREE.LineSegmentsGeometry {
 
-	THREE.LineSegmentsGeometry.call( this );
+	constructor( geometry ) {
 
-	this.type = 'WireframeGeometry2';
+		super();
 
-	this.fromWireframeGeometry( new THREE.WireframeGeometry( geometry ) );
+		this.type = 'WireframeGeometry2';
 
-	// set colors, maybe
+		this.fromWireframeGeometry( new THREE.WireframeGeometry( geometry ) );
+
+		// set colors, maybe
+
+	}
 
 };
 
-THREE.WireframeGeometry2.prototype = Object.assign( Object.create( THREE.LineSegmentsGeometry.prototype ), {
-
-	constructor: THREE.WireframeGeometry2,
-
-	isWireframeGeometry2: true
-
-} );
+THREE.WireframeGeometry2.prototype.isWireframeGeometry2 = true;

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -2,23 +2,21 @@ import { LineSegments2 } from '../lines/LineSegments2.js';
 import { LineGeometry } from '../lines/LineGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
 
-var Line2 = function ( geometry, material ) {
+var Line2 = class Line2 extends LineSegments2 {
 
-	if ( geometry === undefined ) geometry = new LineGeometry();
-	if ( material === undefined ) material = new LineMaterial( { color: Math.random() * 0xffffff } );
+	constructor( geometry, material ) {
 
-	LineSegments2.call( this, geometry, material );
+		if ( geometry === undefined ) geometry = new LineGeometry();
+		if ( material === undefined ) material = new LineMaterial( { color: Math.random() * 0xffffff } );
 
-	this.type = 'Line2';
+		super( geometry, material );
 
-};
+		this.type = 'Line2';
 
-Line2.prototype = Object.assign( Object.create( LineSegments2.prototype ), {
+	}
 
-	constructor: Line2,
+}
 
-	isLine2: true
-
-} );
+Line2.prototype.isLine2 = true;
 
 export { Line2 };

--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -1,20 +1,15 @@
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 
-var LineGeometry = function () {
+var LineGeometry = class LineGeometry extends LineSegmentsGeometry {
 
-	LineSegmentsGeometry.call( this );
+	constructor() {
 
-	this.type = 'LineGeometry';
+		super();
+		this.type = 'LineGeometry';
 
-};
+	}
 
-LineGeometry.prototype = Object.assign( Object.create( LineSegmentsGeometry.prototype ), {
-
-	constructor: LineGeometry,
-
-	isLineGeometry: true,
-
-	setPositions: function ( array ) {
+	setPositions( array ) {
 
 		// converts [ x1, y1, z1,  x2, y2, z2, ... ] to pairs format
 
@@ -37,9 +32,9 @@ LineGeometry.prototype = Object.assign( Object.create( LineSegmentsGeometry.prot
 
 		return this;
 
-	},
+	}
 
-	setColors: function ( array ) {
+	setColors( array ) {
 
 		// converts [ r1, g1, b1,  r2, g2, b2, ... ] to pairs format
 
@@ -62,9 +57,9 @@ LineGeometry.prototype = Object.assign( Object.create( LineSegmentsGeometry.prot
 
 		return this;
 
-	},
+	}
 
-	fromLine: function ( line ) {
+	fromLine( line ) {
 
 		var geometry = line.geometry;
 
@@ -83,9 +78,9 @@ LineGeometry.prototype = Object.assign( Object.create( LineSegmentsGeometry.prot
 
 		return this;
 
-	},
+	}
 
-	copy: function ( /* source */ ) {
+	copy( /* source */ ) {
 
 		// todo
 
@@ -93,6 +88,8 @@ LineGeometry.prototype = Object.assign( Object.create( LineSegmentsGeometry.prot
 
 	}
 
-} );
+}
+
+LineGeometry.isLineGeometry = true;
 
 export { LineGeometry };

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -267,211 +267,212 @@ ShaderLib[ 'line' ] = {
 		`
 };
 
-var LineMaterial = function ( parameters ) {
+var LineMaterial = class LineMaterial extends ShaderMaterial {
 
-	ShaderMaterial.call( this, {
+	constructor( parameters ) {
 
-		type: 'LineMaterial',
+		super( {
 
-		uniforms: UniformsUtils.clone( ShaderLib[ 'line' ].uniforms ),
+			type: 'LineMaterial',
 
-		vertexShader: ShaderLib[ 'line' ].vertexShader,
-		fragmentShader: ShaderLib[ 'line' ].fragmentShader,
+			uniforms: UniformsUtils.clone( ShaderLib[ 'line' ].uniforms ),
 
-		clipping: true // required for clipping support
+			vertexShader: ShaderLib[ 'line' ].vertexShader,
+			fragmentShader: ShaderLib[ 'line' ].fragmentShader,
 
-	} );
+			clipping: true // required for clipping support
 
-	this.dashed = false;
+		} );
 
-	Object.defineProperties( this, {
+		this.dashed = false;
 
-		color: {
+		Object.defineProperties( this, {
 
-			enumerable: true,
+			color: {
 
-			get: function () {
+				enumerable: true,
 
-				return this.uniforms.diffuse.value;
+				get: function () {
 
-			},
+					return this.uniforms.diffuse.value;
 
-			set: function ( value ) {
+				},
 
-				this.uniforms.diffuse.value = value;
+				set: function ( value ) {
 
-			}
-
-		},
-
-		linewidth: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.linewidth.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.linewidth.value = value;
-
-			}
-
-		},
-
-		dashScale: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashScale.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashScale.value = value;
-
-			}
-
-		},
-
-		dashSize: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashSize.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashSize.value = value;
-
-			}
-
-		},
-
-		dashOffset: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.dashOffset.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.dashOffset.value = value;
-
-			}
-
-		},
-
-		gapSize: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.gapSize.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.gapSize.value = value;
-
-			}
-
-		},
-
-		opacity: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.opacity.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.opacity.value = value;
-
-			}
-
-		},
-
-		resolution: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return this.uniforms.resolution.value;
-
-			},
-
-			set: function ( value ) {
-
-				this.uniforms.resolution.value.copy( value );
-
-			}
-
-		},
-
-		alphaToCoverage: {
-
-			enumerable: true,
-
-			get: function () {
-
-				return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
-
-			},
-
-			set: function ( value ) {
-
-				if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
-
-					this.needsUpdate = true;
+					this.uniforms.diffuse.value = value;
 
 				}
 
-				if ( value ) {
+			},
 
-					this.defines.ALPHA_TO_COVERAGE = '';
-					this.extensions.derivatives = true;
+			linewidth: {
 
-				} else {
+				enumerable: true,
 
-					delete this.defines.ALPHA_TO_COVERAGE;
-					this.extensions.derivatives = false;
+				get: function () {
+
+					return this.uniforms.linewidth.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.linewidth.value = value;
+
+				}
+
+			},
+
+			dashScale: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashScale.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashScale.value = value;
+
+				}
+
+			},
+
+			dashSize: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashSize.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashSize.value = value;
+
+				}
+
+			},
+
+			dashOffset: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.dashOffset.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.dashOffset.value = value;
+
+				}
+
+			},
+
+			gapSize: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.gapSize.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.gapSize.value = value;
+
+				}
+
+			},
+
+			opacity: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.opacity.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.opacity.value = value;
+
+				}
+
+			},
+
+			resolution: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return this.uniforms.resolution.value;
+
+				},
+
+				set: function ( value ) {
+
+					this.uniforms.resolution.value.copy( value );
+
+				}
+
+			},
+
+			alphaToCoverage: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return Boolean( 'ALPHA_TO_COVERAGE' in this.defines );
+
+				},
+
+				set: function ( value ) {
+
+					if ( Boolean( value ) !== Boolean( 'ALPHA_TO_COVERAGE' in this.defines ) ) {
+
+						this.needsUpdate = true;
+
+					}
+
+					if ( value ) {
+
+						this.defines.ALPHA_TO_COVERAGE = '';
+						this.extensions.derivatives = true;
+
+					} else {
+
+						delete this.defines.ALPHA_TO_COVERAGE;
+						this.extensions.derivatives = false;
+
+					}
 
 				}
 
 			}
 
-		}
+		} );
 
-	} );
+		this.setValues( parameters );
 
-	this.setValues( parameters );
+	}
 
-};
-
-LineMaterial.prototype = Object.create( ShaderMaterial.prototype );
-LineMaterial.prototype.constructor = LineMaterial;
+}
 
 LineMaterial.prototype.isLineMaterial = true;
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -9,29 +9,25 @@ import {
 	WireframeGeometry
 } from '../../../build/three.module.js';
 
-var LineSegmentsGeometry = function () {
+var LineSegmentsGeometry = class LineSegmentsGeometry extends InstancedBufferGeometry {
 
-	InstancedBufferGeometry.call( this );
+	constructor() {
 
-	this.type = 'LineSegmentsGeometry';
+		super();
 
-	var positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
-	var uvs = [ - 1, 2, 1, 2, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 2, 1, - 2 ];
-	var index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
+		this.type = 'LineSegmentsGeometry';
 
-	this.setIndex( index );
-	this.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-	this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		var positions = [ - 1, 2, 0, 1, 2, 0, - 1, 1, 0, 1, 1, 0, - 1, 0, 0, 1, 0, 0, - 1, - 1, 0, 1, - 1, 0 ];
+		var uvs = [ - 1, 2, 1, 2, - 1, 1, 1, 1, - 1, - 1, 1, - 1, - 1, - 2, 1, - 2 ];
+		var index = [ 0, 2, 1, 2, 3, 1, 2, 4, 3, 4, 5, 3, 4, 6, 5, 6, 7, 5 ];
 
-};
+		this.setIndex( index );
+		this.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
-LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGeometry.prototype ), {
+	}
 
-	constructor: LineSegmentsGeometry,
-
-	isLineSegmentsGeometry: true,
-
-	applyMatrix4: function ( matrix ) {
+	applyMatrix4( matrix ) {
 
 		var start = this.attributes.instanceStart;
 		var end = this.attributes.instanceEnd;
@@ -60,9 +56,9 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		return this;
 
-	},
+	}
 
-	setPositions: function ( array ) {
+	setPositions( array ) {
 
 		var lineSegments;
 
@@ -88,9 +84,9 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		return this;
 
-	},
+	}
 
-	setColors: function ( array ) {
+	setColors( array ) {
 
 		var colors;
 
@@ -111,25 +107,25 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		return this;
 
-	},
+	}
 
-	fromWireframeGeometry: function ( geometry ) {
-
-		this.setPositions( geometry.attributes.position.array );
-
-		return this;
-
-	},
-
-	fromEdgesGeometry: function ( geometry ) {
+	fromWireframeGeometry( geometry ) {
 
 		this.setPositions( geometry.attributes.position.array );
 
 		return this;
 
-	},
+	}
 
-	fromMesh: function ( mesh ) {
+	fromEdgesGeometry( geometry ) {
+
+		this.setPositions( geometry.attributes.position.array );
+
+		return this;
+
+	}
+
+	fromMesh( mesh ) {
 
 		this.fromWireframeGeometry( new WireframeGeometry( mesh.geometry ) );
 
@@ -137,9 +133,9 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		return this;
 
-	},
+	}
 
-	fromLineSegments: function ( lineSegments ) {
+	fromLineSegments( lineSegments ) {
 
 		var geometry = lineSegments.geometry;
 
@@ -158,97 +154,15 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 		return this;
 
-	},
+	}
 
-	computeBoundingBox: function () {
-
-		var box = new Box3();
-
-		return function computeBoundingBox() {
-
-			if ( this.boundingBox === null ) {
-
-				this.boundingBox = new Box3();
-
-			}
-
-			var start = this.attributes.instanceStart;
-			var end = this.attributes.instanceEnd;
-
-			if ( start !== undefined && end !== undefined ) {
-
-				this.boundingBox.setFromBufferAttribute( start );
-
-				box.setFromBufferAttribute( end );
-
-				this.boundingBox.union( box );
-
-			}
-
-		};
-
-	}(),
-
-	computeBoundingSphere: function () {
-
-		var vector = new Vector3();
-
-		return function computeBoundingSphere() {
-
-			if ( this.boundingSphere === null ) {
-
-				this.boundingSphere = new Sphere();
-
-			}
-
-			if ( this.boundingBox === null ) {
-
-				this.computeBoundingBox();
-
-			}
-
-			var start = this.attributes.instanceStart;
-			var end = this.attributes.instanceEnd;
-
-			if ( start !== undefined && end !== undefined ) {
-
-				var center = this.boundingSphere.center;
-
-				this.boundingBox.getCenter( center );
-
-				var maxRadiusSq = 0;
-
-				for ( var i = 0, il = start.count; i < il; i ++ ) {
-
-					vector.fromBufferAttribute( start, i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
-
-					vector.fromBufferAttribute( end, i );
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
-
-				}
-
-				this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
-
-				if ( isNaN( this.boundingSphere.radius ) ) {
-
-					console.error( 'THREE.LineSegmentsGeometry.computeBoundingSphere(): Computed radius is NaN. The instanced position data is likely to have NaN values.', this );
-
-				}
-
-			}
-
-		};
-
-	}(),
-
-	toJSON: function () {
+	toJSON() {
 
 		// todo
 
-	},
+	}
 
-	applyMatrix: function ( matrix ) {
+	applyMatrix( matrix ) {
 
 		console.warn( 'THREE.LineSegmentsGeometry: applyMatrix() has been renamed to applyMatrix4().' );
 
@@ -256,6 +170,90 @@ LineSegmentsGeometry.prototype = Object.assign( Object.create( InstancedBufferGe
 
 	}
 
-} );
+}
+
+LineSegmentsGeometry.prototype.computeBoundingBox = function () {
+
+	var box = new Box3();
+
+	return function computeBoundingBox() {
+
+		if ( this.boundingBox === null ) {
+
+			this.boundingBox = new Box3();
+
+		}
+
+		var start = this.attributes.instanceStart;
+		var end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			this.boundingBox.setFromBufferAttribute( start );
+
+			box.setFromBufferAttribute( end );
+
+			this.boundingBox.union( box );
+
+		}
+
+	};
+
+}();
+
+LineSegmentsGeometry.prototype.computeBoundingSphere = function () {
+
+	var vector = new Vector3();
+
+	return function computeBoundingSphere() {
+
+		if ( this.boundingSphere === null ) {
+
+			this.boundingSphere = new Sphere();
+
+		}
+
+		if ( this.boundingBox === null ) {
+
+			this.computeBoundingBox();
+
+		}
+
+		var start = this.attributes.instanceStart;
+		var end = this.attributes.instanceEnd;
+
+		if ( start !== undefined && end !== undefined ) {
+
+			var center = this.boundingSphere.center;
+
+			this.boundingBox.getCenter( center );
+
+			var maxRadiusSq = 0;
+
+			for ( var i = 0, il = start.count; i < il; i ++ ) {
+
+				vector.fromBufferAttribute( start, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+				vector.fromBufferAttribute( end, i );
+				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+
+			}
+
+			this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+
+			if ( isNaN( this.boundingSphere.radius ) ) {
+
+				console.error( 'THREE.LineSegmentsGeometry.computeBoundingSphere(): Computed radius is NaN. The instanced position data is likely to have NaN values.', this );
+
+			}
+
+		}
+
+	};
+
+}();
+
+LineSegmentsGeometry.prototype.isLineSegmentsGeometry = true;
 
 export { LineSegmentsGeometry };

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -7,57 +7,55 @@ import {
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
 
-var Wireframe = function ( geometry, material ) {
+var Wireframe = class Wireframe extends Mesh {
 
-	Mesh.call( this );
+	constructor( geometry, material ) {
 
-	this.type = 'Wireframe';
+		super();
 
-	this.geometry = geometry !== undefined ? geometry : new LineSegmentsGeometry();
-	this.material = material !== undefined ? material : new LineMaterial( { color: Math.random() * 0xffffff } );
+		this.type = 'Wireframe';
+
+		this.geometry = geometry !== undefined ? geometry : new LineSegmentsGeometry();
+		this.material = material !== undefined ? material : new LineMaterial( { color: Math.random() * 0xffffff } );
+
+	}
 
 };
 
-Wireframe.prototype = Object.assign( Object.create( Mesh.prototype ), {
+Wireframe.prototype.computeLineDistances = ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
 
-	constructor: Wireframe,
+	var start = new Vector3();
+	var end = new Vector3();
 
-	isWireframe: true,
+	return function computeLineDistances() {
 
-	computeLineDistances: ( function () { // for backwards-compatability, but could be a method of LineSegmentsGeometry...
+		var geometry = this.geometry;
 
-		var start = new Vector3();
-		var end = new Vector3();
+		var instanceStart = geometry.attributes.instanceStart;
+		var instanceEnd = geometry.attributes.instanceEnd;
+		var lineDistances = new Float32Array( 2 * instanceStart.count );
 
-		return function computeLineDistances() {
+		for ( var i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
 
-			var geometry = this.geometry;
+			start.fromBufferAttribute( instanceStart, i );
+			end.fromBufferAttribute( instanceEnd, i );
 
-			var instanceStart = geometry.attributes.instanceStart;
-			var instanceEnd = geometry.attributes.instanceEnd;
-			var lineDistances = new Float32Array( 2 * instanceStart.count );
+			lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
+			lineDistances[ j + 1 ] = lineDistances[ j ] + start.distanceTo( end );
 
-			for ( var i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
+		}
 
-				start.fromBufferAttribute( instanceStart, i );
-				end.fromBufferAttribute( instanceEnd, i );
+		var instanceDistanceBuffer = new InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
 
-				lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
-				lineDistances[ j + 1 ] = lineDistances[ j ] + start.distanceTo( end );
+		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
+		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
 
-			}
+		return this;
 
-			var instanceDistanceBuffer = new InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
+	};
 
-			geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
-			geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+}() );
 
-			return this;
-
-		};
-
-	}() )
-
-} );
+Wireframe.prototype.isWireframe = true;
 
 export { Wireframe };

--- a/examples/jsm/lines/WireframeGeometry2.js
+++ b/examples/jsm/lines/WireframeGeometry2.js
@@ -3,24 +3,22 @@ import {
 } from '../../../build/three.module.js';
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 
-var WireframeGeometry2 = function ( geometry ) {
+var WireframeGeometry2 = class WireframeGeometry2 extends LineSegmentsGeometry {
 
-	LineSegmentsGeometry.call( this );
+	constructor( geometry ) {
 
-	this.type = 'WireframeGeometry2';
+		super();
 
-	this.fromWireframeGeometry( new WireframeGeometry( geometry ) );
+		this.type = 'WireframeGeometry2';
 
-	// set colors, maybe
+		this.fromWireframeGeometry( new WireframeGeometry( geometry ) );
+
+		// set colors, maybe
+
+	}
 
 };
 
-WireframeGeometry2.prototype = Object.assign( Object.create( LineSegmentsGeometry.prototype ), {
-
-	constructor: WireframeGeometry2,
-
-	isWireframeGeometry2: true
-
-} );
+WireframeGeometry2.prototype.isWireframeGeometry2 = true;
 
 export { WireframeGeometry2 };


### PR DESCRIPTION
Related issue: #19986

**Description**

Converts the `examples/js/line/` files to use ES6 classes. Once the js files are removed (or built from the jsm files) the iife function definitions can be removed. Tested by running the following examples:

https://raw.githack.com/gkjohnson/three.js/line2-class/examples/webgl_lines_fat.html

https://raw.githack.com/gkjohnson/three.js/line2-class/examples/webgl_lines_fat_wireframe.html

And locally modifying the first to ensure raycasting returned hits only when hovering on the line

cc @WestLangley @DefinitelyMaybe 