### PR TITLE
LineSegments2: Check bounding box and bounding sphere when raycasting

### DIFF
--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -90,7 +90,8 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			// camera forward is negative
 			var near = - camera.near;
 
-			// clip space is [ - 1, 1 ]
+			// clip space is [ - 1, 1 ] so multiply by two to get the full
+			// width in clip space
 			var ssMaxWidth = 2.0 * Math.max( lineWidth / resolution.width, lineWidth / resolution.height );
 
 			//

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -90,8 +90,8 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			// camera forward is negative
 			var near = - camera.near;
 
-			var ssMaxWidth = 2.0 * Math.max( lineWidth / resolution.width, lineWidth / resolution.height ) - 1.0;
-			var cameraRange = camera.far - camera.near;
+			// clip space is [ - 1, 1 ]
+			var ssMaxWidth = 2.0 * Math.max( lineWidth / resolution.width, lineWidth / resolution.height );
 
 			//
 
@@ -105,10 +105,10 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
 			var distancetoSphere = Math.max( 0.0, sphere.distanceToPoint( ray.origin ) );
 
-			// near to far is mapped from [ - 1, 1 ]
-			clipToWorldVector
-				.set( 0, 0, 2.0 * ( ( distancetoSphere - camera.near ) / cameraRange ) - 1.0, 1.0 )
-				.applyMatrix4( camera.projectionMatrixInverse );
+			// get the w component to scale the world space line width
+			clipToWorldVector.set( 0, 0, distancetoSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
+			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
 			// increase the sphere bounds by the worst case line screen space width
 			var sphereMargin = Math.abs( ssMaxWidth / clipToWorldVector.w ) * 0.5;
@@ -132,10 +132,10 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
 			var distanceToBox = box.distanceToPoint( ray.origin );
 
-			// near to far is mapped from [ - 1, 1 ]
-			clipToWorldVector
-				.set( 0, 0, 2.0 * ( ( distanceToBox - camera.near ) / cameraRange ) - 1.0, 1.0 )
-				.applyMatrix4( camera.projectionMatrixInverse );
+			// get the w component to scale the world space line width
+			clipToWorldVector.set( 0, 0, distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
+			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
 			// increase the sphere bounds by the worst case line screen space width
 			var boxMargin = Math.abs( ssMaxWidth / clipToWorldVector.w ) * 0.5;

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -104,10 +104,10 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			}
 
 			sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
-			var distancetoSphere = Math.max( 0.0, sphere.distanceToPoint( ray.origin ) );
+			var distanceToSphere = Math.max( camera.near, sphere.distanceToPoint( ray.origin ) );
 
 			// get the w component to scale the world space line width
-			clipToWorldVector.set( 0, 0, distancetoSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.set( 0, 0, - distanceToSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
 			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
 			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
@@ -131,10 +131,10 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			}
 
 			box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
-			var distanceToBox = box.distanceToPoint( ray.origin );
+			var distanceToBox = Math.max( camera.near, box.distanceToPoint( ray.origin ) );
 
 			// get the w component to scale the world space line width
-			clipToWorldVector.set( 0, 0, distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.set( 0, 0, - distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
 			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
 			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
@@ -143,9 +143,9 @@ THREE.LineSegments2.prototype = Object.assign( Object.create( THREE.Mesh.prototy
 			box.max.x += boxMargin;
 			box.max.y += boxMargin;
 			box.max.z += boxMargin;
-			box.min.x += boxMargin;
-			box.min.y += boxMargin;
-			box.min.z += boxMargin;
+			box.min.x -= boxMargin;
+			box.min.y -= boxMargin;
+			box.min.z -= boxMargin;
 
 			if ( raycaster.ray.intersectsBox( box ) === false ) {
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -105,7 +105,8 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			// camera forward is negative
 			var near = - camera.near;
 
-			// clip space is [ - 1, 1 ]
+			// clip space is [ - 1, 1 ] so multiply by two to get the full
+			// width in clip space
 			var ssMaxWidth = 2.0 * Math.max( lineWidth / resolution.width, lineWidth / resolution.height );
 
 			//

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -119,10 +119,10 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			}
 
 			sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
-			var distancetoSphere = Math.max( 0.0, sphere.distanceToPoint( ray.origin ) );
+			var distanceToSphere = Math.max( camera.near, sphere.distanceToPoint( ray.origin ) );
 
 			// get the w component to scale the world space line width
-			clipToWorldVector.set( 0, 0, distancetoSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.set( 0, 0, - distanceToSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
 			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
 			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
@@ -146,10 +146,10 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			}
 
 			box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
-			var distanceToBox = box.distanceToPoint( ray.origin );
+			var distanceToBox = Math.max( camera.near, box.distanceToPoint( ray.origin ) );
 
 			// get the w component to scale the world space line width
-			clipToWorldVector.set( 0, 0, distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
+			clipToWorldVector.set( 0, 0, - distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
 			clipToWorldVector.multiplyScalar( 1.0 / clipToWorldVector.w );
 			clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
 
@@ -158,9 +158,9 @@ LineSegments2.prototype = Object.assign( Object.create( Mesh.prototype ), {
 			box.max.x += boxMargin;
 			box.max.y += boxMargin;
 			box.max.z += boxMargin;
-			box.min.x += boxMargin;
-			box.min.y += boxMargin;
-			box.min.z += boxMargin;
+			box.min.x -= boxMargin;
+			box.min.y -= boxMargin;
+			box.min.z -= boxMargin;
 
 			if ( raycaster.ray.intersectsBox( box ) === false ) {
 


### PR DESCRIPTION
Related issue: --

**Description**

Improve LineSegments2 raycasting performance by checking against the bounding sphere and bounding box including a margin computed from the closest distance to the bounds and the screen space line width. Tested by locally adding raycasting to the "webgl_lines_fat" example and zooming inside the bounds as well out far while checking that intersections are returned for both thin (1px) and thick (50px) lines.

| | 50px width | 1px width |
|---|---|---|
| box margin | ~17.6 units | ~0.37 units |
| box screenshot | ![image](https://user-images.githubusercontent.com/734200/112097568-7b319b00-8b5d-11eb-89bd-0e090ff310d6.png) | ![image](https://user-images.githubusercontent.com/734200/112097608-8f759800-8b5d-11eb-996c-60b281c9b076.png) |
| sphere margin | ~23.6 units | ~0.47 units |
| sphere screenshot | ![image](https://user-images.githubusercontent.com/734200/112097278-f6468180-8b5c-11eb-9da3-030d0d51a31b.png) | ![image](https://user-images.githubusercontent.com/734200/112097357-170ed700-8b5d-11eb-9ea2-416d11ac154e.png) |

@WestLangley your eyes on the logic would be appreciated here 😁 
