### PR TITLE
GPGPU Protoplanets example: fix pixel trails

### DIFF
--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -221,6 +221,8 @@
 
 			void main() {
 
+				if ( vColor.y == 0.0 ) discard;
+
 				float f = length( gl_PointCoord - vec2( 0.5, 0.5 ) );
 				if ( f > 0.5 ) {
 					discard;


### PR DESCRIPTION
Related issue: -

**Description**

The GPGPU Protoplanets example vertex shader used to set GLPointSize to 0 so that collided particles don't show anymore.

It seems something changed in WebGL or in a lower software layer, that now makes particles with GLPointSize set to 0 visible as 1-pixel dots (enlarge the image to see the individual pixels):

![imagen](https://user-images.githubusercontent.com/2453652/112416893-d9f64080-8d26-11eb-8d58-8db84ec69f2a.png)

This PR fixes it with a small change that discards the particle in the fragment shader if it has 0 mass:

![imagen](https://user-images.githubusercontent.com/2453652/112417088-26418080-8d27-11eb-969c-17a2013152b1.png)

