### PR TITLE
RoughnessMipmapper: Preserve texture UV transform

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -95,6 +95,16 @@ RoughnessMipmapper.prototype = {
 
 			if ( material.aoMap == roughnessMap ) material.aoMap = material.roughnessMap;
 
+			// Copy UV transform parameters
+
+			material.roughnessMap.offset.copy( roughnessMap.offset );
+			material.roughnessMap.repeat.copy( roughnessMap.repeat );
+			material.roughnessMap.center.copy( roughnessMap.center );
+			material.roughnessMap.rotation = roughnessMap.rotation;
+
+			material.roughnessMap.matrixAutoUpdate = roughnessMap.matrixAutoUpdate;
+			material.roughnessMap.matrix.copy( roughnessMap.matrix );
+
 		}
 
 		_mipmapMaterial.uniforms.roughnessMap.value = roughnessMap;


### PR DESCRIPTION
RoughnessMipmapper created a new texture and replaced existing material
textures with the copy - however, the copy didn't inherit the UV
transform properties from the source.

This could be problematic when for example the roughness map came from
the glTF file that used KHR_texture_transform extension. When rendered
with standard three.js material this by itself would not be a problem
since three.js only supports one shared transform for most material maps
but when the user overrode the material with a custom one (which
happens inside model-viewer as far as I can tell), the incorrect
offset/repeat values in the cloned texture could result in incorrect
rendering.

This was originally reported in https://github.com/zeux/meshoptimizer/discussions/251, cc @Bketting