### PR TITLE
Example webgl_gpgpu_water: Remove mention to orbiting the camera.

### DIFF
--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -221,6 +221,8 @@
 
 			void main() {
 
+				if ( vColor.y == 0.0 ) discard;
+
 				float f = length( gl_PointCoord - vec2( 0.5, 0.5 ) );
 				if ( f > 0.5 ) {
 					discard;

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -11,7 +11,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - <span id="waterSize"></span> webgl gpgpu water<br/>
 			Move mouse to disturb water.<br>
-			Press mouse button to orbit around. 'W' key toggles wireframe.
+			'W' key toggles wireframe.
 		</div>
 
 


### PR DESCRIPTION
Related issue: -

**Description**

Removed the mention to orbiting the camera in the title (webgl_gpgpu_water example), since the OrbitControls was removed here, in favour of mobile interaction:

https://github.com/mrdoob/three.js/commit/0a1131fb92cf54c6ac05e1a39bd2c71efe07faeb#diff-bb9b931af0d177421b7a619f663d44b21d6201289e0adb70c104d5fa29efcd1b
