### PR TITLE
TransformControls: Expose raycaster.

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -100,6 +100,12 @@
 			The 3D object being controlled.
 		</p>
 
+		<h3>[property:Raycaster raycaster]</h3>
+		<p>
+			The contorl's raycaster used to implement interactivity. This object is exposed so it's possible to configure the raycaster's
+			[page:Raycaster.layers layers] property.
+		</p>
+
 		<h3>[property:Number rotationSnap]</h3>
 		<p>
 			By default, 3D objects are continuously rotated. If you set this property to a numeric value (radians), you can define in which

--- a/docs/examples/ko/controls/TransformControls.html
+++ b/docs/examples/ko/controls/TransformControls.html
@@ -16,7 +16,7 @@
 			다른 컨트롤과 달리, 해당 기능은 카메라의 장면 변환을 의미하지 않습니다.<br /><br />
 
 			[name] 는 연결된 3D 객체가 씬(scene) 그래프의 일부 입니다.
-		
+
 		</p>
 
 		<h2>예시</h2>
@@ -41,7 +41,7 @@
 
 		<h3>change</h3>
 		<p>
-			어떤 유형 (객체 또는 속성 변경) 의 변경이 수행할 경우 호출됩니다. 속성 변경은 이벤트 리스너를 추가 할 수 있는 별도의 이벤트입니다. 
+			어떤 유형 (객체 또는 속성 변경) 의 변경이 수행할 경우 호출됩니다. 속성 변경은 이벤트 리스너를 추가 할 수 있는 별도의 이벤트입니다.
 			이벤트의 타입은 "propertyname-changed" 입니다.
 		</p>
 
@@ -76,7 +76,7 @@
 
 		<h3>[property:HTMLDOMElement domElement]</h3>
 		<p>
-			HTMLDOMElement는 마우스 / 터치 이벤트를 사용하는데 이용됩니다. 이것은 생성자에 의해 설정되어야 합니다; 
+			HTMLDOMElement는 마우스 / 터치 이벤트를 사용하는데 이용됩니다. 이것은 생성자에 의해 설정되어야 합니다;
 			생성자를 통해 설정되지 않을 경우 새 이벤트 리스너에 설정되지 않습니다.
 		</p>
 
@@ -98,6 +98,12 @@
 		<h3>[property:Object3D object]</h3>
 		<p>
 			제어 될 3D 객체를 지정합니다.
+		</p>
+
+		<h3>[property:Raycaster raycaster]</h3>
+		<p>
+			The contorl's raycaster used to implement interactivity. This object is exposed so it's possible to configure the raycaster's
+			[page:Raycaster.layers layers] property.
 		</p>
 
 		<h3>[property:Number rotationSnap]</h3>

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -99,6 +99,12 @@
 			正在被控制的3D对象。
 		</p>
 
+		<h3>[property:Raycaster raycaster]</h3>
+		<p>
+			The contorl's raycaster used to implement interactivity. This object is exposed so it's possible to configure the raycaster's
+			[page:Raycaster.layers layers] property.
+		</p>
+
 		<h3>[property:Number rotationSnap]</h3>
 		<p>
 			默认情况下，3D对象是可以被连续旋转的。如果你将该值设为一个数值（弧度），则你将可以定义每次旋转3D对象时的步幅。

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -9,6 +9,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 	THREE.Object3D.call( this );
 
+	this.raycaster = new THREE.Raycaster();
 	this.visible = false;
 	this.domElement = domElement;
 
@@ -45,8 +46,6 @@ THREE.TransformControls = function ( camera, domElement ) {
 	var objectChangeEvent = { type: 'objectChange' };
 
 	// Reusable utility variables
-
-	var raycaster = new THREE.Raycaster();
 
 	function intersectObjectWithRay( object, raycaster, includeInvisible ) {
 
@@ -239,6 +238,8 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		if ( this.object === undefined || this.dragging === true ) return;
 
+		var raycaster = this.raycaster;
+
 		raycaster.setFromCamera( pointer, this.camera );
 
 		var intersect = intersectObjectWithRay( _gizmo.picker[ this.mode ], raycaster );
@@ -260,6 +261,8 @@ THREE.TransformControls = function ( camera, domElement ) {
 		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
 
 		if ( this.axis !== null ) {
+
+			var raycaster = this.raycaster;
 
 			raycaster.setFromCamera( pointer, this.camera );
 
@@ -316,6 +319,7 @@ THREE.TransformControls = function ( camera, domElement ) {
 		var mode = this.mode;
 		var object = this.object;
 		var space = this.space;
+		var raycaster = this.raycaster;
 
 		if ( mode === 'scale' ) {
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -32,6 +32,7 @@ var TransformControls = function ( camera, domElement ) {
 
 	Object3D.call( this );
 
+	this.raycaster = new Raycaster();
 	this.visible = false;
 	this.domElement = domElement;
 
@@ -68,8 +69,6 @@ var TransformControls = function ( camera, domElement ) {
 	var objectChangeEvent = { type: 'objectChange' };
 
 	// Reusable utility variables
-
-	var raycaster = new Raycaster();
 
 	function intersectObjectWithRay( object, raycaster, includeInvisible ) {
 
@@ -262,6 +261,8 @@ var TransformControls = function ( camera, domElement ) {
 
 		if ( this.object === undefined || this.dragging === true ) return;
 
+		var raycaster = this.raycaster;
+
 		raycaster.setFromCamera( pointer, this.camera );
 
 		var intersect = intersectObjectWithRay( _gizmo.picker[ this.mode ], raycaster );
@@ -283,6 +284,8 @@ var TransformControls = function ( camera, domElement ) {
 		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
 
 		if ( this.axis !== null ) {
+
+			var raycaster = this.raycaster;
 
 			raycaster.setFromCamera( pointer, this.camera );
 
@@ -339,6 +342,7 @@ var TransformControls = function ( camera, domElement ) {
 		var mode = this.mode;
 		var object = this.object;
 		var space = this.space;
+		var raycaster = this.raycaster;
 
 		if ( mode === 'scale' ) {
 


### PR DESCRIPTION
Related issue: see https://discourse.threejs.org/t/transformcontrols-no-longer-works-after-three-js-update/20467/7

**Description**

Exposes the internal raycaster so users can add layer configurations.
