### PR TITLE
WebGLState: Fix state of DRAW_FRAMEBUFFER.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -439,8 +439,6 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	function bindFramebuffer( target, framebuffer ) {
 
-		if ( target === gl.DRAW_FRAMEBUFFER ) target = gl.FRAMEBUFFER;
-
 		if ( framebuffer === null && xrFramebuffer !== null ) framebuffer = xrFramebuffer; // use active XR framebuffer if available
 
 		if ( currentBoundFramebuffers[ target ] !== framebuffer ) {
@@ -945,14 +943,12 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		gl.activeTexture( gl.TEXTURE0 );
 
+		gl.bindFramebuffer( gl.FRAMEBUFFER, null );
+
 		if ( isWebGL2 === true ) {
 
-			gl.bindFramebuffer( gl.DRAW_FRAMEBUFFER, null ); // Equivalent to gl.FRAMEBUFFER
+			gl.bindFramebuffer( gl.DRAW_FRAMEBUFFER, null );
 			gl.bindFramebuffer( gl.READ_FRAMEBUFFER, null );
-
-		} else {
-
-			gl.bindFramebuffer( gl.FRAMEBUFFER, null );
 
 		}
 


### PR DESCRIPTION
Related issue: Fixed #21517

**Description**

`DRAW_FRAMEBUFFER` needs to be managed separately.