### PR TITLE
Dev: Keep WebGL constants in three.js build.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -290,7 +290,6 @@ export default [
 		input: 'src/Three.js',
 		plugins: [
 			addons(),
-			glconstants(),
 			glsl(),
 			babel( {
 				babelHelpers: 'bundled',


### PR DESCRIPTION
Related issue: Fixed #16066.

**Description**

Thanks to terser this is now easy to implement.
