### PR TITLE
WebGLRenderer: Remove morph target properties.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -205,18 +205,6 @@
 		<h3>[property:Boolean localClippingEnabled]</h3>
 		<p>Defines whether the renderer respects object-level clipping planes. Default is *false*.</p>
 
-		<h3>[property:Integer maxMorphTargets]</h3>
-		<p>
-		Default is 8. The maximum number of MorphTargets allowed in a shader.
-			Keep in mind that the standard materials only allow 8 MorphTargets.
-		</p>
-
-		<h3>[property:Integer maxMorphNormals]</h3>
-		<p>
-		Default is 4. The maximum number of MorphNormals allowed in a shader.
-			Keep in mind that the standard materials only allow 4 MorphNormals.
-		</p>
-
 		<h3>[property:Boolean physicallyCorrectLights]</h3>
 		<p>
 		Whether to use physically correct lighting mode. Default is *false*.

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -184,18 +184,6 @@
 		<h3>[property:Boolean localClippingEnabled]</h3>
 		<p>定义渲染器是否考虑对象级剪切平面。 默认为*false*.</p>
 
-		<h3>[property:Integer maxMorphTargets]</h3>
-		<p>
-		默认是8。 一个着色器中允许的最大MorphTargets数。
-		切记标准材质只允许8个MorphTargets。
-		</p>
-
-		<h3>[property:Integer maxMorphNormals]</h3>
-		<p>
-		默认是4。 色器中允许的最大MorphNormal数。
-		切记标准材质只允许4个MorphNormal。
-		</p>
-
 		<h3>[property:Boolean physicallyCorrectLights]</h3>
 		<p>
 		是否使用物理上正确的光照模式。 默认是*false*。

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -117,11 +117,6 @@ function WebGLRenderer( parameters ) {
 	this.toneMapping = NoToneMapping;
 	this.toneMappingExposure = 1.0;
 
-	// morphs
-
-	this.maxMorphTargets = 8;
-	this.maxMorphNormals = 4;
-
 	// internal properties
 
 	const _this = this;

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -40,8 +40,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 		'roughnessMap', 'metalnessMap', 'gradientMap',
 		'alphaMap', 'combine', 'vertexColors', 'vertexTangents', 'vertexUvs', 'uvsVertexOnly', 'fog', 'useFog', 'fogExp2',
 		'flatShading', 'sizeAttenuation', 'logarithmicDepthBuffer', 'skinning',
-		'maxBones', 'useVertexTexture', 'morphTargets', 'morphNormals',
-		'maxMorphTargets', 'maxMorphNormals', 'premultipliedAlpha',
+		'maxBones', 'useVertexTexture', 'morphTargets', 'morphNormals', 'premultipliedAlpha',
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
 		'numDirLightShadows', 'numPointLightShadows', 'numSpotLightShadows',
 		'shadowMapEnabled', 'shadowMapType', 'toneMapping', 'physicallyCorrectLights',
@@ -227,8 +226,6 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 
 			morphTargets: material.morphTargets,
 			morphNormals: material.morphNormals,
-			maxMorphTargets: renderer.maxMorphTargets,
-			maxMorphNormals: renderer.maxMorphNormals,
 
 			numDirLights: lights.directional.length,
 			numPointLights: lights.point.length,


### PR DESCRIPTION
Related issue: -

**Description**

`maxMorphTargets` and `maxMorphNormals` have currently no effect. I suggest to remove them to avoid confusion until #14441 is solved.
