### PR TITLE
Docs: Use AudioNode as type for Audio.filters.

### DIFF
--- a/docs/api/ar/audio/Audio.html
+++ b/docs/api/ar/audio/Audio.html
@@ -65,7 +65,8 @@
 		<p>تعديل درجة الصوت ، مقاسة بالسنت. +/- 100 نصف نغمة. +/- 1200 هو *octave*. الافتراضي هو *0*.</p>
 
 		<h3>[property:Array filters]</h3>
-		<p>يمثل مجموعة من [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. يمكن استخدامه لتطبيق مجموعة متنوعة من المرشحات ذات الترتيب المنخفض لإنشاء مؤثرات صوتية أكثر تعقيدًا. يتم ضبط المرشحات عبر [page:Audio.setFilter] أو [page:Audio.setFilters].</p>
+		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioNode AudioNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects.
+			In most cases, the array contains instances of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. Filters are set via [page:Audio.setFilter] or [page:Audio.setFilters].</p>
 
 		<h3>[property:GainNode gain]</h3>
 		<p>[link:https://developer.mozilla.org/en-US/docs/Web/API/GainNode GainNode] تم إنشاؤه باستخدام [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain AudioContext.createGain]().</p>
@@ -163,13 +164,13 @@
 
 		<h3>[method:Audio setFilter]( filter )</h3>
 		<p>
-		يطبق [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNode] واحدًا على الصوت.
+		Applies a single filter node to the audio.
 		</p>
 
 		<h3>[method:Audio setFilters]( [param:Array value] )</h3>
 		<p>
-		value - جداول (صفائف) المرشحات.<br />
-		يطبق جدول (مصفوفة) من [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes] على الصوت.
+		value - arrays of filters.<br />
+		Applies an array of filter nodes to the audio.
 		</p>
 
 		<h3>[method:Audio setLoop]( [param:Boolean value] )</h3>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -65,7 +65,8 @@
 		<p>Modify pitch, measured in cents. +/- 100 is a semitone. +/- 1200 is an octave. Default is *0*.</p>
 
 		<h3>[property:Array filters]</h3>
-		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects. Filters are set via [page:Audio.setFilter] or [page:Audio.setFilters].</p>
+		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioNode AudioNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects.
+			In most cases, the array contains instances of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. Filters are set via [page:Audio.setFilter] or [page:Audio.setFilters].</p>
 
 		<h3>[property:GainNode gain]</h3>
 		<p>A [link:https://developer.mozilla.org/en-US/docs/Web/API/GainNode GainNode] created
@@ -169,13 +170,13 @@
 
 		<h3>[method:Audio setFilter]( filter )</h3>
 		<p>
-		Applies a single [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNode] to the audio.
+		Applies a single filter node to the audio.
 		</p>
 
 		<h3>[method:Audio setFilters]( [param:Array value] )</h3>
 		<p>
 		value - arrays of filters.<br />
-		Applies an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes] to the audio.
+		Applies an array of filter nodes to the audio.
 		</p>
 
 		<h3>[method:Audio setLoop]( [param:Boolean value] )</h3>

--- a/docs/api/ko/audio/Audio.html
+++ b/docs/api/ko/audio/Audio.html
@@ -65,8 +65,8 @@
 		<p>피치를 조정하며 100 단위로 조절합니다. +/- 100 은 세미톤 조절. +/- 1200 은 옥타브 조절. 기본값은 *0*입니다.</p>
 
 		<h3>[property:Array filters]</h3>
-		<p>[link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes] 배열입니다. 
-			다양한 저차 필터를 적용하여 보다 복잡한 사운드 효과를 만들 수 있습니다. 필터는 [page.Audio.setFilter] 또는 [page:Audio.setFilters]로 설정합니다.</p>
+		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioNode AudioNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects.
+			In most cases, the array contains instances of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. Filters are set via [page:Audio.setFilter] or [page:Audio.setFilters].</p>
 
 		<h3>[property:GainNode gain]</h3>
 		<p> [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain AudioContext.createGain]()를 사용해 만들어진 [link:https://developer.mozilla.org/en-US/docs/Web/API/GainNode GainNode].</p>
@@ -167,13 +167,13 @@
 
 		<h3>[method:Audio setFilter]( filter )</h3>
 		<p>
-		오디오에 새 [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNode]를 적용합니다.
+		Applies a single filter node to the audio.
 		</p>
 
 		<h3>[method:Audio setFilters]( [param:Array value] )</h3>
 		<p>
-		필터 배열들의 값<br />
-		오디오에 [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes] 배열을 적용합니다.
+		value - arrays of filters.<br />
+		Applies an array of filter nodes to the audio.
 		</p>
 
 		<h3>[method:Audio setLoop]( [param:Boolean value] )</h3>

--- a/docs/api/zh/audio/Audio.html
+++ b/docs/api/zh/audio/Audio.html
@@ -65,7 +65,8 @@
 		<p>修改音高，以音分为单位。 +/- 100为一个半音， +/- 1200为一个八度。默认值为0。</p>
 
 		<h3>[property:Array filters]</h3>
-		<p>表示[link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]的数组. 可以使用多种不同的低阶filters去创建复杂的音效. filters可以通过 [page:Audio.setFilter] 或者 [page:Audio.setFilters]设置.</p>
+		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioNode AudioNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects.
+			In most cases, the array contains instances of [link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]. Filters are set via [page:Audio.setFilter] or [page:Audio.setFilters].</p>
 
 		<h3>[property:GainNode gain]</h3>
 		<p>使用[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain AudioContext.createGain]()创建的[link:https://developer.mozilla.org/en-US/docs/Web/API/GainNode GainNode].</p>
@@ -74,10 +75,10 @@
 		<p>是否可以使用 [page:Audio.play play](),
 			[page:Audio.pause pause]()等方法控制播放. 默认为 *true*.</p>
 
-		<h3>[property:Boolean isPlaying]</h3>	
-		<p>是否正在播放</p>	
+		<h3>[property:Boolean isPlaying]</h3>
+		<p>是否正在播放</p>
 
-		<h3>[property:AudioListener listener]</h3>	
+		<h3>[property:AudioListener listener]</h3>
 		<p>A reference to the listener object of this audio.</p>
 
 		<h3>[property:Number playbackRate]</h3>
@@ -165,13 +166,13 @@
 
 		<h3>[method:Audio setFilter]( filter )</h3>
 		<p>
-		设置一个[link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNode]给Audio.
+		Applies a single filter node to the audio.
 		</p>
 
 		<h3>[method:Audio setFilters]( [param:Array value] )</h3>
 		<p>
-		value--filters数组.<br />
-		应用[link:https://developer.mozilla.org/en-US/docs/Web/API/BiquadFilterNode BiquadFilterNodes]数组给Audio.
+		value - arrays of filters.<br />
+		Applies an array of filter nodes to the audio.
 		</p>
 
 		<h3>[method:Audio setLoop]( [param:Boolean value] )</h3>


### PR DESCRIPTION
Related issue: Fixed #20145.

**Description**

Use the more generic `AudioNode` type for `Audio.filters`.
