### PR TITLE
PointLightShadow: Use PointLight.distance for far value if set.

### DIFF
--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -41,8 +41,6 @@
 
 					const light = new THREE.PointLight( color, intensity, 20 );
 					light.castShadow = true;
-					light.shadow.camera.near = 1;
-					light.shadow.camera.far = 60;
 					light.shadow.bias = - 0.005; // reduces self-shadowing on double-sided objects
 
 					let geometry = new THREE.SphereGeometry( 0.3, 12, 6 );

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -64,6 +64,15 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
+		const far = light.distance || camera.far;
+
+		if ( far !== camera.far ) {
+
+			camera.far = far;
+			camera.updateProjectionMatrix();
+
+		}
+
 		_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
 		camera.position.copy( _lightPositionWorld );
 


### PR DESCRIPTION
Related issue: Fixed #14414

**Description**

In this way, the logic in `PointLightShadow` is similar to `SpotLightShadow`.
