### PR TITLE
SpotLightShadow: Add missing copy() method.

### DIFF
--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -33,6 +33,16 @@ class SpotLightShadow extends LightShadow {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.focus = source.focus;
+
+		return this;
+
+	}
+
 }
 
 SpotLightShadow.prototype.isSpotLightShadow = true;


### PR DESCRIPTION
Related issue: see #20218

**Description**

Added missing `copy()` method which is now required in order to honor `focus`.
