### PR TITLE
LUTPass: Fix LUTPass in WebGL1

### DIFF
--- a/examples/jsm/postprocessing/LUTPass.js
+++ b/examples/jsm/postprocessing/LUTPass.js
@@ -31,10 +31,10 @@ const LUTShader = {
 
 
 	fragmentShader: /* glsl */`
-		precision highp sampler3D;
 
 		uniform float lutSize;
 		#if USE_3DTEXTURE
+		precision highp sampler3D;
 		uniform sampler3D lut3d;
 		#else
 		uniform sampler2D lut;


### PR DESCRIPTION
Fix #21502

**Description**

Well that was a lot simpler than expected...

Move sampler3D precision declaration inside #ifdef.