### PR TITLE
Fix polymorphism in BufferGeometry.clone()

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -994,31 +994,7 @@ BufferGeometry.prototype = Object.assign( Object.create( EventDispatcher.prototy
 
 	clone: function () {
 
-		/*
-		 // Handle primitives
-
-		 const parameters = this.parameters;
-
-		 if ( parameters !== undefined ) {
-
-		 const values = [];
-
-		 for ( const key in parameters ) {
-
-		 values.push( parameters[ key ] );
-
-		 }
-
-		 const geometry = Object.create( this.constructor.prototype );
-		 this.constructor.apply( geometry, values );
-		 return geometry;
-
-		 }
-
-		 return new this.constructor().copy( this );
-		 */
-
-		return new BufferGeometry().copy( this );
+		return new this.constructor().copy( this );
 
 	},
 


### PR DESCRIPTION
Using `this.constructor` to clone `BufferGeometry` is consistent with other types in the library and supports subtyping.

**Description**

If you create a type extended from `BufferGeometry`, calling `clone()` would "slice" the object down to a `BufferGeometry`.
By using `this.constructor`, this problem is avoided, and is consistent with most of the rest of threejs.