### PR TITLE
SSRPass: Correct Reflector depth 2.

### DIFF
--- a/examples/webgl_postprocessing_ssr.html
+++ b/examples/webgl_postprocessing_ssr.html
@@ -131,7 +131,6 @@
 			geometry = new THREE.PlaneBufferGeometry( 1, 1 );
 			groundReflector = new ReflectorForSSRPass( geometry, {
 				clipBias: 0,
-				worldYBias: - 0.027450980392156862,
 				textureWidth: window.innerWidth,
 				textureHeight: window.innerHeight,
 				color: 0x888888,


### PR DESCRIPTION
Turned out that [this problem](https://github.com/gonnavis/three.js/blob/b5eca713fe8cdbffade55f0522d97df39917ce9c/examples/jsm/objects/ReflectorForSSRPass.js#L364) is caused by inconsistent `virtualCamera.projectionMatrix` and `virtualCamera.projectionMatrixInverse`. 

Because of  `projectionMatrix` is copied from `camera`, so need use `camera`'s `projectionMatrixInverse` too. No need `worldYBias` now.

This also solved slight `worldY` change problem when rotating, and solved the newly found more severe change problem when pan, all caused by the same reason.

[before](https://raw.githack.com/gonnavis/three.js/SSRPassCorrectReflectorDepth/examples/webgl_postprocessing_ssr.html) vs [after](https://raw.githack.com/gonnavis/three.js/SSRPassCorrectReflectorDepth2Pr/examples/webgl_postprocessing_ssr.html) ( try pan the scene )