### PR TITLE
LatheGeometry: Make all parameters optional.

### DIFF
--- a/docs/api/en/geometries/LatheGeometry.html
+++ b/docs/api/en/geometries/LatheGeometry.html
@@ -48,7 +48,7 @@
 
 		<h3>[name]([param:Array points], [param:Integer segments], [param:Float phiStart], [param:Float phiLength])</h3>
 		<p>
-		points — Array of Vector2s. The x-coordinate of each point must be greater than zero.<br />
+		points — Array of Vector2s. The x-coordinate of each point must be greater than zero. Default is an array with (1,0) and (0.5,1) which creates a simple lamp shade.<br />
 		segments — the number of circumference segments to generate. Default is 12.<br />
 		phiStart — the starting angle in radians. Default is 0.<br />
 		phiLength — the radian (0 to 2PI) range of the lathed section 2PI is a closed lathe, less than 2PI is a portion. Default is 2PI.

--- a/docs/api/zh/geometries/LatheGeometry.html
+++ b/docs/api/zh/geometries/LatheGeometry.html
@@ -48,7 +48,7 @@
 
 		<h3>[name]([param:Array points], [param:Integer segments], [param:Float phiStart], [param:Float phiLength])</h3>
 		<p>
-		points — 一个Vector2对象数组。每个点的X坐标必须大于0。<br />
+		points — 一个Vector2对象数组。每个点的X坐标必须大于0。Default is an array with (1,0) and (0.5,1) which creates a simple lamp shade.<br />
 		segments — 要生成的车削几何体圆周分段的数量，默认值是12。<br />
 		phiStart — 以弧度表示的起始角度，默认值为0。<br />
 		phiLength — 车削部分的弧度（0-2PI）范围，2PI将是一个完全闭合的、完整的车削几何体，小于2PI是部分的车削。默认值是2PI。

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -6,7 +6,7 @@ import { MathUtils } from '../math/MathUtils.js';
 
 class LatheGeometry extends BufferGeometry {
 
-	constructor( points, segments = 12, phiStart = 0, phiLength = Math.PI * 2 ) {
+	constructor( points = [ new Vector2( 1, 0 ), new Vector2( 0.5, 1 ) ], segments = 12, phiStart = 0, phiLength = Math.PI * 2 ) {
 
 		super();
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/21536#discussion_r602851506

**Description**

Ensures users can do `new LatheGeometry()` like with other generators. Right now a runtime error occurs.

The default shape is a simple lamp shade.