### PR TITLE
Examples: Clean up CSM imports

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -7,8 +7,8 @@ import {
 	Matrix4,
 	Box3
 } from '../../../build/three.module.js';
-import Frustum from './Frustum.js';
-import Shader from './Shader.js';
+import { Frustum } from './Frustum.js';
+import { CSMShader } from './CSMShader.js';
 
 const _cameraToLightMatrix = new Matrix4();
 const _lightSpaceFrustum = new Frustum();
@@ -239,8 +239,8 @@ export class CSM {
 
 	injectInclude() {
 
-		ShaderChunk.lights_fragment_begin = Shader.lights_fragment_begin;
-		ShaderChunk.lights_pars_begin = Shader.lights_pars_begin;
+		ShaderChunk.lights_fragment_begin = CSMShader.lights_fragment_begin;
+		ShaderChunk.lights_pars_begin = CSMShader.lights_pars_begin;
 
 	}
 

--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -1,6 +1,6 @@
 import { ShaderChunk } from '../../../build/three.module.js';
 
-export default {
+const CSMShader = {
 	lights_fragment_begin: /* glsl */`
 GeometricContext geometry;
 
@@ -231,3 +231,5 @@ uniform float shadowFar;
 #endif
 	` + ShaderChunk.lights_pars_begin
 };
+
+export { CSMShader };

--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -2,7 +2,7 @@ import { Vector3, Matrix4 } from '../../../build/three.module.js';
 
 const inverseProjectionMatrix = new Matrix4();
 
-export default class Frustum {
+class Frustum {
 
 	constructor( data ) {
 
@@ -148,3 +148,5 @@ export default class Frustum {
 	}
 
 }
+
+export { Frustum };


### PR DESCRIPTION
Related issue: -

**Description**
Normalize the imports/exports of the CSM files. Make them conform to the other `examples/jsm` files.
