### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/js/curves/NURBSUtils.js
+++ b/examples/js/curves/NURBSUtils.js
@@ -238,7 +238,7 @@
 
 			}
 
-			const r = p;
+			let r = p;
 
 			for ( let k = 1; k <= n; ++ k ) {
 

--- a/examples/jsm/curves/NURBSUtils.js
+++ b/examples/jsm/curves/NURBSUtils.js
@@ -257,7 +257,7 @@ class NURBSUtils {
 
 		}
 
-		const r = p;
+		let r = p;
 
 		for ( let k = 1; k <= n; ++ k ) {
 


### PR DESCRIPTION
Related issue: Follow-up of #21593.

**Description**

Use `let` instead of `const` at one place.