### PR TITLE
Examples: fix param use2DLut in 3dlut example

### DIFF
--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -34,7 +34,7 @@
 				enabled: true,
 				lut: 'Bourbon 64.CUBE',
 				intensity: 1,
-				use2dLut: false,
+				use2DLut: false,
 			};
 
 			const lutMap = {
@@ -137,7 +137,7 @@
 
 				if ( renderer.capabilities.isWebGL2 ) {
 
-					gui.add( params, 'use2dLut' );
+					gui.add( params, 'use2DLut' );
 
 				} else {
 


### PR DESCRIPTION
A typo led to the use2DLut param of the 3dlut example to be ignored. The 2d textures were never used because of a difference of case in the parameter (use2**d**Lut vs use2**D**Lut). It may also have caused browsers without WebGL2 support to have issue on this example.

https://raw.githack.com/kchapelier/three.js/lutexamplefix/examples/webgl_postprocessing_3dlut.html