### PR TITLE
Add frustum property to SelectionBox

### DIFF
--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -37,6 +37,7 @@ var SelectionBox = ( function () {
 		this.endPoint = new Vector3();
 		this.collection = [];
 		this.deep = deep || Number.MAX_VALUE;
+		this.frustum = frustum
 
 	}
 


### PR DESCRIPTION
**Description**

Unable to access frustum from SelectionBox is hard to utlize SelectionBox

Current SelectionBox only check center when select Object (probably for performance)

But I think there is need to use `frustum.intersectsObject()` or `frustum.containsPoint()` directly

So I added frustum to SelectionBox