### PR TITLE
Examples: Convert loaders to ES6 Part III.

### DIFF
--- a/examples/js/loaders/EXRLoader.js
+++ b/examples/js/loaders/EXRLoader.js
@@ -67,16 +67,16 @@
 	// ///////////////////////////////////////////////////////////////////////////
 	// // End of OpenEXR license -------------------------------------------------
 
-	var EXRLoader = function ( manager ) {
+	class EXRLoader extends THREE.DataTextureLoader {
 
-		THREE.DataTextureLoader.call( this, manager );
-		this.type = THREE.FloatType;
+		constructor( manager ) {
 
-	};
+			super( manager );
+			this.type = THREE.FloatType;
 
-	EXRLoader.prototype = Object.assign( Object.create( THREE.DataTextureLoader.prototype ), {
-		constructor: EXRLoader,
-		parse: function ( buffer ) {
+		}
+
+		parse( buffer ) {
 
 			const USHORT_RANGE = 1 << 16;
 			const BITMAP_SIZE = USHORT_RANGE >> 3;
@@ -2155,14 +2155,16 @@
 				type: this.type
 			};
 
-		},
-		setDataType: function ( value ) {
+		}
+
+		setDataType( value ) {
 
 			this.type = value;
 			return this;
 
-		},
-		load: function ( url, onLoad, onProgress, onError ) {
+		}
+
+		load( url, onLoad, onProgress, onError ) {
 
 			function onLoadCallback( texture, texData ) {
 
@@ -2191,10 +2193,11 @@
 
 			}
 
-			return THREE.DataTextureLoader.prototype.load.call( this, url, onLoadCallback, onProgress, onError );
+			return super.load( url, onLoadCallback, onProgress, onError );
 
 		}
-	} );
+
+	}
 
 	THREE.EXRLoader = EXRLoader;
 

--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -16,189 +16,190 @@
  *		https://code.blender.org/2013/08/fbx-binary-file-format-specification/
  */
 
-	var FBXLoader = function () {
+	let fbxTree;
+	let connections;
+	let sceneGraph;
 
-		var fbxTree;
-		var connections;
-		var sceneGraph;
+	class FBXLoader extends THREE.Loader {
 
-		function FBXLoader( manager ) {
+		constructor( manager ) {
 
-			THREE.Loader.call( this, manager );
+			super( manager );
 
 		}
 
-		FBXLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-			constructor: FBXLoader,
-			load: function ( url, onLoad, onProgress, onError ) {
+		load( url, onLoad, onProgress, onError ) {
 
-				var scope = this;
-				var path = scope.path === '' ? THREE.LoaderUtils.extractUrlBase( url ) : scope.path;
-				var loader = new THREE.FileLoader( this.manager );
-				loader.setPath( scope.path );
-				loader.setResponseType( 'arraybuffer' );
-				loader.setRequestHeader( scope.requestHeader );
-				loader.setWithCredentials( scope.withCredentials );
-				loader.load( url, function ( buffer ) {
+			const scope = this;
+			const path = scope.path === '' ? THREE.LoaderUtils.extractUrlBase( url ) : scope.path;
+			const loader = new THREE.FileLoader( this.manager );
+			loader.setPath( scope.path );
+			loader.setResponseType( 'arraybuffer' );
+			loader.setRequestHeader( scope.requestHeader );
+			loader.setWithCredentials( scope.withCredentials );
+			loader.load( url, function ( buffer ) {
 
-					try {
+				try {
 
-						onLoad( scope.parse( buffer, path ) );
+					onLoad( scope.parse( buffer, path ) );
 
-					} catch ( e ) {
+				} catch ( e ) {
 
-						if ( onError ) {
+					if ( onError ) {
 
-							onError( e );
+						onError( e );
 
-						} else {
+					} else {
 
-							console.error( e );
-
-						}
-
-						scope.manager.itemError( url );
+						console.error( e );
 
 					}
 
-				}, onProgress, onError );
+					scope.manager.itemError( url );
 
-			},
-			parse: function ( FBXBuffer, path ) {
+				}
 
-				if ( isFbxFormatBinary( FBXBuffer ) ) {
+			}, onProgress, onError );
 
-					fbxTree = new BinaryParser().parse( FBXBuffer );
+		}
 
-				} else {
+		parse( FBXBuffer, path ) {
 
-					var FBXText = convertArrayBufferToString( FBXBuffer );
+			if ( isFbxFormatBinary( FBXBuffer ) ) {
 
-					if ( ! isFbxFormatASCII( FBXText ) ) {
+				fbxTree = new BinaryParser().parse( FBXBuffer );
 
-						throw new Error( 'THREE.FBXLoader: Unknown format.' );
+			} else {
 
-					}
+				const FBXText = convertArrayBufferToString( FBXBuffer );
 
-					if ( getFbxVersion( FBXText ) < 7000 ) {
+				if ( ! isFbxFormatASCII( FBXText ) ) {
 
-						throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + getFbxVersion( FBXText ) );
+					throw new Error( 'THREE.FBXLoader: Unknown format.' );
 
-					}
+				}
 
-					fbxTree = new TextParser().parse( FBXText );
+				if ( getFbxVersion( FBXText ) < 7000 ) {
 
-				} // console.log( fbxTree );
+					throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + getFbxVersion( FBXText ) );
+
+				}
+
+				fbxTree = new TextParser().parse( FBXText );
+
+			} // console.log( fbxTree );
 
 
-				var textureLoader = new THREE.TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
-				return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
+			const textureLoader = new THREE.TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+			return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
 
-			}
-		} ); // Parse the FBXTree object returned by the BinaryParser or TextParser and return a THREE.Group
+		}
 
-		function FBXTreeParser( textureLoader, manager ) {
+	} // Parse the FBXTree object returned by the BinaryParser or TextParser and return a THREE.Group
+
+
+	class FBXTreeParser {
+
+		constructor( textureLoader, manager ) {
 
 			this.textureLoader = textureLoader;
 			this.manager = manager;
 
 		}
 
-		FBXTreeParser.prototype = {
-			constructor: FBXTreeParser,
-			parse: function () {
+		parse() {
 
-				connections = this.parseConnections();
-				var images = this.parseImages();
-				var textures = this.parseTextures( images );
-				var materials = this.parseMaterials( textures );
-				var deformers = this.parseDeformers();
-				var geometryMap = new GeometryParser().parse( deformers );
-				this.parseScene( deformers, geometryMap, materials );
-				return sceneGraph;
+			connections = this.parseConnections();
+			const images = this.parseImages();
+			const textures = this.parseTextures( images );
+			const materials = this.parseMaterials( textures );
+			const deformers = this.parseDeformers();
+			const geometryMap = new GeometryParser().parse( deformers );
+			this.parseScene( deformers, geometryMap, materials );
+			return sceneGraph;
 
-			},
-			// Parses FBXTree.Connections which holds parent-child connections between objects (e.g. material -> texture, model->geometry )
-			// and details the connection type
-			parseConnections: function () {
+		} // Parses FBXTree.Connections which holds parent-child connections between objects (e.g. material -> texture, model->geometry )
+		// and details the connection type
 
-				var connectionMap = new Map();
 
-				if ( 'Connections' in fbxTree ) {
+		parseConnections() {
 
-					var rawConnections = fbxTree.Connections.connections;
-					rawConnections.forEach( function ( rawConnection ) {
+			const connectionMap = new Map();
 
-						var fromID = rawConnection[ 0 ];
-						var toID = rawConnection[ 1 ];
-						var relationship = rawConnection[ 2 ];
+			if ( 'Connections' in fbxTree ) {
 
-						if ( ! connectionMap.has( fromID ) ) {
+				const rawConnections = fbxTree.Connections.connections;
+				rawConnections.forEach( function ( rawConnection ) {
 
-							connectionMap.set( fromID, {
-								parents: [],
-								children: []
-							} );
+					const fromID = rawConnection[ 0 ];
+					const toID = rawConnection[ 1 ];
+					const relationship = rawConnection[ 2 ];
 
-						}
+					if ( ! connectionMap.has( fromID ) ) {
 
-						var parentRelationship = {
-							ID: toID,
-							relationship: relationship
-						};
-						connectionMap.get( fromID ).parents.push( parentRelationship );
+						connectionMap.set( fromID, {
+							parents: [],
+							children: []
+						} );
 
-						if ( ! connectionMap.has( toID ) ) {
+					}
 
-							connectionMap.set( toID, {
-								parents: [],
-								children: []
-							} );
+					const parentRelationship = {
+						ID: toID,
+						relationship: relationship
+					};
+					connectionMap.get( fromID ).parents.push( parentRelationship );
 
-						}
+					if ( ! connectionMap.has( toID ) ) {
 
-						var childRelationship = {
-							ID: fromID,
-							relationship: relationship
-						};
-						connectionMap.get( toID ).children.push( childRelationship );
+						connectionMap.set( toID, {
+							parents: [],
+							children: []
+						} );
 
-					} );
+					}
 
-				}
+					const childRelationship = {
+						ID: fromID,
+						relationship: relationship
+					};
+					connectionMap.get( toID ).children.push( childRelationship );
 
-				return connectionMap;
+				} );
 
-			},
-			// Parse FBXTree.Objects.Video for embedded image data
-			// These images are connected to textures in FBXTree.Objects.Textures
-			// via FBXTree.Connections.
-			parseImages: function () {
+			}
 
-				var images = {};
-				var blobs = {};
+			return connectionMap;
 
-				if ( 'Video' in fbxTree.Objects ) {
+		} // Parse FBXTree.Objects.Video for embedded image data
+		// These images are connected to textures in FBXTree.Objects.Textures
+		// via FBXTree.Connections.
 
-					var videoNodes = fbxTree.Objects.Video;
 
-					for ( var nodeID in videoNodes ) {
+		parseImages() {
 
-						var videoNode = videoNodes[ nodeID ];
-						var id = parseInt( nodeID );
-						images[ id ] = videoNode.RelativeFilename || videoNode.Filename; // raw image data is in videoNode.Content
+			const images = {};
+			const blobs = {};
 
-						if ( 'Content' in videoNode ) {
+			if ( 'Video' in fbxTree.Objects ) {
 
-							var arrayBufferContent = videoNode.Content instanceof ArrayBuffer && videoNode.Content.byteLength > 0;
-							var base64Content = typeof videoNode.Content === 'string' && videoNode.Content !== '';
+				const videoNodes = fbxTree.Objects.Video;
 
-							if ( arrayBufferContent || base64Content ) {
+				for ( const nodeID in videoNodes ) {
 
-								var image = this.parseImage( videoNodes[ nodeID ] );
-								blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
+					const videoNode = videoNodes[ nodeID ];
+					const id = parseInt( nodeID );
+					images[ id ] = videoNode.RelativeFilename || videoNode.Filename; // raw image data is in videoNode.Content
 
-							}
+					if ( 'Content' in videoNode ) {
+
+						const arrayBufferContent = videoNode.Content instanceof ArrayBuffer && videoNode.Content.byteLength > 0;
+						const base64Content = typeof videoNode.Content === 'string' && videoNode.Content !== '';
+
+						if ( arrayBufferContent || base64Content ) {
+
+							const image = this.parseImage( videoNodes[ nodeID ] );
+							blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
 
 						}
 
@@ -206,3069 +207,3142 @@
 
 				}
 
-				for ( var id in images ) {
+			}
 
-					var filename = images[ id ];
-					if ( blobs[ filename ] !== undefined ) images[ id ] = blobs[ filename ]; else images[ id ] = images[ id ].split( '\\' ).pop();
+			for ( const id in images ) {
 
-				}
+				const filename = images[ id ];
+				if ( blobs[ filename ] !== undefined ) images[ id ] = blobs[ filename ]; else images[ id ] = images[ id ].split( '\\' ).pop();
 
-				return images;
+			}
 
-			},
-			// Parse embedded image data in FBXTree.Video.Content
-			parseImage: function ( videoNode ) {
+			return images;
 
-				var content = videoNode.Content;
-				var fileName = videoNode.RelativeFilename || videoNode.Filename;
-				var extension = fileName.slice( fileName.lastIndexOf( '.' ) + 1 ).toLowerCase();
-				var type;
+		} // Parse embedded image data in FBXTree.Video.Content
 
-				switch ( extension ) {
 
-					case 'bmp':
-						type = 'image/bmp';
-						break;
+		parseImage( videoNode ) {
 
-					case 'jpg':
-					case 'jpeg':
-						type = 'image/jpeg';
-						break;
+			const content = videoNode.Content;
+			const fileName = videoNode.RelativeFilename || videoNode.Filename;
+			const extension = fileName.slice( fileName.lastIndexOf( '.' ) + 1 ).toLowerCase();
+			let type;
 
-					case 'png':
-						type = 'image/png';
-						break;
+			switch ( extension ) {
 
-					case 'tif':
-						type = 'image/tiff';
-						break;
+				case 'bmp':
+					type = 'image/bmp';
+					break;
 
-					case 'tga':
-						if ( this.manager.getHandler( '.tga' ) === null ) {
+				case 'jpg':
+				case 'jpeg':
+					type = 'image/jpeg';
+					break;
 
-							console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
+				case 'png':
+					type = 'image/png';
+					break;
 
-						}
+				case 'tif':
+					type = 'image/tiff';
+					break;
 
-						type = 'image/tga';
-						break;
+				case 'tga':
+					if ( this.manager.getHandler( '.tga' ) === null ) {
 
-					default:
-						console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
-						return;
-
-				}
-
-				if ( typeof content === 'string' ) {
-
-					// ASCII format
-					return 'data:' + type + ';base64,' + content;
-
-				} else {
-
-					// Binary Format
-					var array = new Uint8Array( content );
-					return window.URL.createObjectURL( new Blob( [ array ], {
-						type: type
-					} ) );
-
-				}
-
-			},
-			// Parse nodes in FBXTree.Objects.Texture
-			// These contain details such as UV scaling, cropping, rotation etc and are connected
-			// to images in FBXTree.Objects.Video
-			parseTextures: function ( images ) {
-
-				var textureMap = new Map();
-
-				if ( 'Texture' in fbxTree.Objects ) {
-
-					var textureNodes = fbxTree.Objects.Texture;
-
-					for ( var nodeID in textureNodes ) {
-
-						var texture = this.parseTexture( textureNodes[ nodeID ], images );
-						textureMap.set( parseInt( nodeID ), texture );
+						console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
 
 					}
 
-				}
+					type = 'image/tga';
+					break;
 
-				return textureMap;
+				default:
+					console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
+					return;
 
-			},
-			// Parse individual node in FBXTree.Objects.Texture
-			parseTexture: function ( textureNode, images ) {
+			}
 
-				var texture = this.loadTexture( textureNode, images );
-				texture.ID = textureNode.id;
-				texture.name = textureNode.attrName;
-				var wrapModeU = textureNode.WrapModeU;
-				var wrapModeV = textureNode.WrapModeV;
-				var valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
-				var valueV = wrapModeV !== undefined ? wrapModeV.value : 0; // http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
-				// 0: repeat(default), 1: clamp
+			if ( typeof content === 'string' ) {
 
-				texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
-				texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+				// ASCII format
+				return 'data:' + type + ';base64,' + content;
 
-				if ( 'Scaling' in textureNode ) {
+			} else {
 
-					var values = textureNode.Scaling.value;
-					texture.repeat.x = values[ 0 ];
-					texture.repeat.y = values[ 1 ];
+				// Binary Format
+				const array = new Uint8Array( content );
+				return window.URL.createObjectURL( new Blob( [ array ], {
+					type: type
+				} ) );
 
-				}
+			}
 
-				return texture;
+		} // Parse nodes in FBXTree.Objects.Texture
+		// These contain details such as UV scaling, cropping, rotation etc and are connected
+		// to images in FBXTree.Objects.Video
 
-			},
-			// load a texture specified as a blob or data URI, or via an external URL using THREE.TextureLoader
-			loadTexture: function ( textureNode, images ) {
 
-				var fileName;
-				var currentPath = this.textureLoader.path;
-				var children = connections.get( textureNode.id ).children;
+		parseTextures( images ) {
 
-				if ( children !== undefined && children.length > 0 && images[ children[ 0 ].ID ] !== undefined ) {
+			const textureMap = new Map();
 
-					fileName = images[ children[ 0 ].ID ];
+			if ( 'Texture' in fbxTree.Objects ) {
 
-					if ( fileName.indexOf( 'blob:' ) === 0 || fileName.indexOf( 'data:' ) === 0 ) {
+				const textureNodes = fbxTree.Objects.Texture;
 
-						this.textureLoader.setPath( undefined );
+				for ( const nodeID in textureNodes ) {
 
-					}
+					const texture = this.parseTexture( textureNodes[ nodeID ], images );
+					textureMap.set( parseInt( nodeID ), texture );
 
 				}
 
-				var texture;
-				var extension = textureNode.FileName.slice( - 3 ).toLowerCase();
+			}
 
-				if ( extension === 'tga' ) {
+			return textureMap;
 
-					var loader = this.manager.getHandler( '.tga' );
+		} // Parse individual node in FBXTree.Objects.Texture
 
-					if ( loader === null ) {
 
-						console.warn( 'FBXLoader: TGA loader not found, creating placeholder texture for', textureNode.RelativeFilename );
-						texture = new THREE.Texture();
+		parseTexture( textureNode, images ) {
 
-					} else {
+			const texture = this.loadTexture( textureNode, images );
+			texture.ID = textureNode.id;
+			texture.name = textureNode.attrName;
+			const wrapModeU = textureNode.WrapModeU;
+			const wrapModeV = textureNode.WrapModeV;
+			const valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
+			const valueV = wrapModeV !== undefined ? wrapModeV.value : 0; // http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
+			// 0: repeat(default), 1: clamp
 
-						texture = loader.load( fileName );
+			texture.wrapS = valueU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+			texture.wrapT = valueV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 
-					}
+			if ( 'Scaling' in textureNode ) {
 
-				} else if ( extension === 'psd' ) {
+				const values = textureNode.Scaling.value;
+				texture.repeat.x = values[ 0 ];
+				texture.repeat.y = values[ 1 ];
 
-					console.warn( 'FBXLoader: PSD textures are not supported, creating placeholder texture for', textureNode.RelativeFilename );
+			}
+
+			return texture;
+
+		} // load a texture specified as a blob or data URI, or via an external URL using THREE.TextureLoader
+
+
+		loadTexture( textureNode, images ) {
+
+			let fileName;
+			const currentPath = this.textureLoader.path;
+			const children = connections.get( textureNode.id ).children;
+
+			if ( children !== undefined && children.length > 0 && images[ children[ 0 ].ID ] !== undefined ) {
+
+				fileName = images[ children[ 0 ].ID ];
+
+				if ( fileName.indexOf( 'blob:' ) === 0 || fileName.indexOf( 'data:' ) === 0 ) {
+
+					this.textureLoader.setPath( undefined );
+
+				}
+
+			}
+
+			let texture;
+			const extension = textureNode.FileName.slice( - 3 ).toLowerCase();
+
+			if ( extension === 'tga' ) {
+
+				const loader = this.manager.getHandler( '.tga' );
+
+				if ( loader === null ) {
+
+					console.warn( 'FBXLoader: TGA loader not found, creating placeholder texture for', textureNode.RelativeFilename );
 					texture = new THREE.Texture();
 
 				} else {
 
-					texture = this.textureLoader.load( fileName );
+					texture = loader.load( fileName );
 
 				}
 
-				this.textureLoader.setPath( currentPath );
-				return texture;
+			} else if ( extension === 'psd' ) {
 
-			},
-			// Parse nodes in FBXTree.Objects.Material
-			parseMaterials: function ( textureMap ) {
+				console.warn( 'FBXLoader: PSD textures are not supported, creating placeholder texture for', textureNode.RelativeFilename );
+				texture = new THREE.Texture();
 
-				var materialMap = new Map();
+			} else {
 
-				if ( 'Material' in fbxTree.Objects ) {
+				texture = this.textureLoader.load( fileName );
 
-					var materialNodes = fbxTree.Objects.Material;
+			}
 
-					for ( var nodeID in materialNodes ) {
+			this.textureLoader.setPath( currentPath );
+			return texture;
 
-						var material = this.parseMaterial( materialNodes[ nodeID ], textureMap );
-						if ( material !== null ) materialMap.set( parseInt( nodeID ), material );
+		} // Parse nodes in FBXTree.Objects.Material
+
+
+		parseMaterials( textureMap ) {
+
+			const materialMap = new Map();
+
+			if ( 'Material' in fbxTree.Objects ) {
+
+				const materialNodes = fbxTree.Objects.Material;
+
+				for ( const nodeID in materialNodes ) {
+
+					const material = this.parseMaterial( materialNodes[ nodeID ], textureMap );
+					if ( material !== null ) materialMap.set( parseInt( nodeID ), material );
+
+				}
+
+			}
+
+			return materialMap;
+
+		} // Parse single node in FBXTree.Objects.Material
+		// Materials are connected to texture maps in FBXTree.Objects.Textures
+		// FBX format currently only supports Lambert and Phong shading models
+
+
+		parseMaterial( materialNode, textureMap ) {
+
+			const ID = materialNode.id;
+			const name = materialNode.attrName;
+			let type = materialNode.ShadingModel; // Case where FBX wraps shading model in property object.
+
+			if ( typeof type === 'object' ) {
+
+				type = type.value;
+
+			} // Ignore unused materials which don't have any connections.
+
+
+			if ( ! connections.has( ID ) ) return null;
+			const parameters = this.parseParameters( materialNode, textureMap, ID );
+			let material;
+
+			switch ( type.toLowerCase() ) {
+
+				case 'phong':
+					material = new THREE.MeshPhongMaterial();
+					break;
+
+				case 'lambert':
+					material = new THREE.MeshLambertMaterial();
+					break;
+
+				default:
+					console.warn( 'THREE.FBXLoader: unknown material type "%s". Defaulting to THREE.MeshPhongMaterial.', type );
+					material = new THREE.MeshPhongMaterial();
+					break;
+
+			}
+
+			material.setValues( parameters );
+			material.name = name;
+			return material;
+
+		} // Parse FBX material and return parameters suitable for a three.js material
+		// Also parse the texture map and return any textures associated with the material
+
+
+		parseParameters( materialNode, textureMap, ID ) {
+
+			const parameters = {};
+
+			if ( materialNode.BumpFactor ) {
+
+				parameters.bumpScale = materialNode.BumpFactor.value;
+
+			}
+
+			if ( materialNode.Diffuse ) {
+
+				parameters.color = new THREE.Color().fromArray( materialNode.Diffuse.value );
+
+			} else if ( materialNode.DiffuseColor && ( materialNode.DiffuseColor.type === 'Color' || materialNode.DiffuseColor.type === 'ColorRGB' ) ) {
+
+				// The blender exporter exports diffuse here instead of in materialNode.Diffuse
+				parameters.color = new THREE.Color().fromArray( materialNode.DiffuseColor.value );
+
+			}
+
+			if ( materialNode.DisplacementFactor ) {
+
+				parameters.displacementScale = materialNode.DisplacementFactor.value;
+
+			}
+
+			if ( materialNode.Emissive ) {
+
+				parameters.emissive = new THREE.Color().fromArray( materialNode.Emissive.value );
+
+			} else if ( materialNode.EmissiveColor && ( materialNode.EmissiveColor.type === 'Color' || materialNode.EmissiveColor.type === 'ColorRGB' ) ) {
+
+				// The blender exporter exports emissive color here instead of in materialNode.Emissive
+				parameters.emissive = new THREE.Color().fromArray( materialNode.EmissiveColor.value );
+
+			}
+
+			if ( materialNode.EmissiveFactor ) {
+
+				parameters.emissiveIntensity = parseFloat( materialNode.EmissiveFactor.value );
+
+			}
+
+			if ( materialNode.Opacity ) {
+
+				parameters.opacity = parseFloat( materialNode.Opacity.value );
+
+			}
+
+			if ( parameters.opacity < 1.0 ) {
+
+				parameters.transparent = true;
+
+			}
+
+			if ( materialNode.ReflectionFactor ) {
+
+				parameters.reflectivity = materialNode.ReflectionFactor.value;
+
+			}
+
+			if ( materialNode.Shininess ) {
+
+				parameters.shininess = materialNode.Shininess.value;
+
+			}
+
+			if ( materialNode.Specular ) {
+
+				parameters.specular = new THREE.Color().fromArray( materialNode.Specular.value );
+
+			} else if ( materialNode.SpecularColor && materialNode.SpecularColor.type === 'Color' ) {
+
+				// The blender exporter exports specular color here instead of in materialNode.Specular
+				parameters.specular = new THREE.Color().fromArray( materialNode.SpecularColor.value );
+
+			}
+
+			const scope = this;
+			connections.get( ID ).children.forEach( function ( child ) {
+
+				const type = child.relationship;
+
+				switch ( type ) {
+
+					case 'Bump':
+						parameters.bumpMap = scope.getTexture( textureMap, child.ID );
+						break;
+
+					case 'Maya|TEX_ao_map':
+						parameters.aoMap = scope.getTexture( textureMap, child.ID );
+						break;
+
+					case 'DiffuseColor':
+					case 'Maya|TEX_color_map':
+						parameters.map = scope.getTexture( textureMap, child.ID );
+						parameters.map.encoding = THREE.sRGBEncoding;
+						break;
+
+					case 'DisplacementColor':
+						parameters.displacementMap = scope.getTexture( textureMap, child.ID );
+						break;
+
+					case 'EmissiveColor':
+						parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
+						parameters.emissiveMap.encoding = THREE.sRGBEncoding;
+						break;
+
+					case 'NormalMap':
+					case 'Maya|TEX_normal_map':
+						parameters.normalMap = scope.getTexture( textureMap, child.ID );
+						break;
+
+					case 'ReflectionColor':
+						parameters.envMap = scope.getTexture( textureMap, child.ID );
+						parameters.envMap.mapping = THREE.EquirectangularReflectionMapping;
+						parameters.envMap.encoding = THREE.sRGBEncoding;
+						break;
+
+					case 'SpecularColor':
+						parameters.specularMap = scope.getTexture( textureMap, child.ID );
+						parameters.specularMap.encoding = THREE.sRGBEncoding;
+						break;
+
+					case 'TransparentColor':
+					case 'TransparencyFactor':
+						parameters.alphaMap = scope.getTexture( textureMap, child.ID );
+						parameters.transparent = true;
+						break;
+
+					case 'AmbientColor':
+					case 'ShininessExponent': // AKA glossiness map
+
+					case 'SpecularFactor': // AKA specularLevel
+
+					case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
+
+					default:
+						console.warn( 'THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type );
+						break;
+
+				}
+
+			} );
+			return parameters;
+
+		} // get a texture from the textureMap for use by a material.
+
+
+		getTexture( textureMap, id ) {
+
+			// if the texture is a layered texture, just use the first layer and issue a warning
+			if ( 'LayeredTexture' in fbxTree.Objects && id in fbxTree.Objects.LayeredTexture ) {
+
+				console.warn( 'THREE.FBXLoader: layered textures are not supported in three.js. Discarding all but first layer.' );
+				id = connections.get( id ).children[ 0 ].ID;
+
+			}
+
+			return textureMap.get( id );
+
+		} // Parse nodes in FBXTree.Objects.Deformer
+		// Deformer node can contain skinning or Vertex Cache animation data, however only skinning is supported here
+		// Generates map of THREE.Skeleton-like objects for use later when generating and binding skeletons.
+
+
+		parseDeformers() {
+
+			const skeletons = {};
+			const morphTargets = {};
+
+			if ( 'Deformer' in fbxTree.Objects ) {
+
+				const DeformerNodes = fbxTree.Objects.Deformer;
+
+				for ( const nodeID in DeformerNodes ) {
+
+					const deformerNode = DeformerNodes[ nodeID ];
+					const relationships = connections.get( parseInt( nodeID ) );
+
+					if ( deformerNode.attrType === 'Skin' ) {
+
+						const skeleton = this.parseSkeleton( relationships, DeformerNodes );
+						skeleton.ID = nodeID;
+						if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: skeleton attached to more than one geometry is not supported.' );
+						skeleton.geometryID = relationships.parents[ 0 ].ID;
+						skeletons[ nodeID ] = skeleton;
+
+					} else if ( deformerNode.attrType === 'BlendShape' ) {
+
+						const morphTarget = {
+							id: nodeID
+						};
+						morphTarget.rawTargets = this.parseMorphTargets( relationships, DeformerNodes );
+						morphTarget.id = nodeID;
+						if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: morph target attached to more than one geometry is not supported.' );
+						morphTargets[ nodeID ] = morphTarget;
 
 					}
 
 				}
 
-				return materialMap;
+			}
 
-			},
-			// Parse single node in FBXTree.Objects.Material
-			// Materials are connected to texture maps in FBXTree.Objects.Textures
-			// FBX format currently only supports Lambert and Phong shading models
-			parseMaterial: function ( materialNode, textureMap ) {
+			return {
+				skeletons: skeletons,
+				morphTargets: morphTargets
+			};
 
-				var ID = materialNode.id;
-				var name = materialNode.attrName;
-				var type = materialNode.ShadingModel; // Case where FBX wraps shading model in property object.
-
-				if ( typeof type === 'object' ) {
-
-					type = type.value;
-
-				} // Ignore unused materials which don't have any connections.
+		} // Parse single nodes in FBXTree.Objects.Deformer
+		// The top level skeleton node has type 'Skin' and sub nodes have type 'Cluster'
+		// Each skin node represents a skeleton and each cluster node represents a bone
 
 
-				if ( ! connections.has( ID ) ) return null;
-				var parameters = this.parseParameters( materialNode, textureMap, ID );
-				var material;
+		parseSkeleton( relationships, deformerNodes ) {
 
-				switch ( type.toLowerCase() ) {
+			const rawBones = [];
+			relationships.children.forEach( function ( child ) {
 
-					case 'phong':
-						material = new THREE.MeshPhongMaterial();
+				const boneNode = deformerNodes[ child.ID ];
+				if ( boneNode.attrType !== 'Cluster' ) return;
+				const rawBone = {
+					ID: child.ID,
+					indices: [],
+					weights: [],
+					transformLink: new THREE.Matrix4().fromArray( boneNode.TransformLink.a ) // transform: new THREE.Matrix4().fromArray( boneNode.Transform.a ),
+					// linkMode: boneNode.Mode,
+
+				};
+
+				if ( 'Indexes' in boneNode ) {
+
+					rawBone.indices = boneNode.Indexes.a;
+					rawBone.weights = boneNode.Weights.a;
+
+				}
+
+				rawBones.push( rawBone );
+
+			} );
+			return {
+				rawBones: rawBones,
+				bones: []
+			};
+
+		} // The top level morph deformer node has type "BlendShape" and sub nodes have type "BlendShapeChannel"
+
+
+		parseMorphTargets( relationships, deformerNodes ) {
+
+			const rawMorphTargets = [];
+
+			for ( let i = 0; i < relationships.children.length; i ++ ) {
+
+				const child = relationships.children[ i ];
+				const morphTargetNode = deformerNodes[ child.ID ];
+				const rawMorphTarget = {
+					name: morphTargetNode.attrName,
+					initialWeight: morphTargetNode.DeformPercent,
+					id: morphTargetNode.id,
+					fullWeights: morphTargetNode.FullWeights.a
+				};
+				if ( morphTargetNode.attrType !== 'BlendShapeChannel' ) return;
+				rawMorphTarget.geoID = connections.get( parseInt( child.ID ) ).children.filter( function ( child ) {
+
+					return child.relationship === undefined;
+
+				} )[ 0 ].ID;
+				rawMorphTargets.push( rawMorphTarget );
+
+			}
+
+			return rawMorphTargets;
+
+		} // create the main THREE.Group() to be returned by the loader
+
+
+		parseScene( deformers, geometryMap, materialMap ) {
+
+			sceneGraph = new THREE.Group();
+			const modelMap = this.parseModels( deformers.skeletons, geometryMap, materialMap );
+			const modelNodes = fbxTree.Objects.Model;
+			const scope = this;
+			modelMap.forEach( function ( model ) {
+
+				const modelNode = modelNodes[ model.ID ];
+				scope.setLookAtProperties( model, modelNode );
+				const parentConnections = connections.get( model.ID ).parents;
+				parentConnections.forEach( function ( connection ) {
+
+					const parent = modelMap.get( connection.ID );
+					if ( parent !== undefined ) parent.add( model );
+
+				} );
+
+				if ( model.parent === null ) {
+
+					sceneGraph.add( model );
+
+				}
+
+			} );
+			this.bindSkeleton( deformers.skeletons, geometryMap, modelMap );
+			this.createAmbientLight();
+			this.setupMorphMaterials();
+			sceneGraph.traverse( function ( node ) {
+
+				if ( node.userData.transformData ) {
+
+					if ( node.parent ) {
+
+						node.userData.transformData.parentMatrix = node.parent.matrix;
+						node.userData.transformData.parentMatrixWorld = node.parent.matrixWorld;
+
+					}
+
+					const transform = generateTransform( node.userData.transformData );
+					node.applyMatrix4( transform );
+					node.updateWorldMatrix();
+
+				}
+
+			} );
+			const animations = new AnimationParser().parse(); // if all the models where already combined in a single group, just return that
+
+			if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
+
+				sceneGraph.children[ 0 ].animations = animations;
+				sceneGraph = sceneGraph.children[ 0 ];
+
+			}
+
+			sceneGraph.animations = animations;
+
+		} // parse nodes in FBXTree.Objects.Model
+
+
+		parseModels( skeletons, geometryMap, materialMap ) {
+
+			const modelMap = new Map();
+			const modelNodes = fbxTree.Objects.Model;
+
+			for ( const nodeID in modelNodes ) {
+
+				const id = parseInt( nodeID );
+				const node = modelNodes[ nodeID ];
+				const relationships = connections.get( id );
+				let model = this.buildSkeleton( relationships, skeletons, id, node.attrName );
+
+				if ( ! model ) {
+
+					switch ( node.attrType ) {
+
+						case 'Camera':
+							model = this.createCamera( relationships );
+							break;
+
+						case 'Light':
+							model = this.createLight( relationships );
+							break;
+
+						case 'Mesh':
+							model = this.createMesh( relationships, geometryMap, materialMap );
+							break;
+
+						case 'NurbsCurve':
+							model = this.createCurve( relationships, geometryMap );
+							break;
+
+						case 'LimbNode':
+						case 'Root':
+							model = new THREE.Bone();
+							break;
+
+						case 'Null':
+						default:
+							model = new THREE.Group();
+							break;
+
+					}
+
+					model.name = node.attrName ? THREE.PropertyBinding.sanitizeNodeName( node.attrName ) : '';
+					model.ID = id;
+
+				}
+
+				this.getTransformData( model, node );
+				modelMap.set( id, model );
+
+			}
+
+			return modelMap;
+
+		}
+
+		buildSkeleton( relationships, skeletons, id, name ) {
+
+			let bone = null;
+			relationships.parents.forEach( function ( parent ) {
+
+				for ( const ID in skeletons ) {
+
+					const skeleton = skeletons[ ID ];
+					skeleton.rawBones.forEach( function ( rawBone, i ) {
+
+						if ( rawBone.ID === parent.ID ) {
+
+							const subBone = bone;
+							bone = new THREE.Bone();
+							bone.matrixWorld.copy( rawBone.transformLink ); // set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
+
+							bone.name = name ? THREE.PropertyBinding.sanitizeNodeName( name ) : '';
+							bone.ID = id;
+							skeleton.bones[ i ] = bone; // In cases where a bone is shared between multiple meshes
+							// duplicate the bone here and and it as a child of the first bone
+
+							if ( subBone !== null ) {
+
+								bone.add( subBone );
+
+							}
+
+						}
+
+					} );
+
+				}
+
+			} );
+			return bone;
+
+		} // create a THREE.PerspectiveCamera or THREE.OrthographicCamera
+
+
+		createCamera( relationships ) {
+
+			let model;
+			let cameraAttribute;
+			relationships.children.forEach( function ( child ) {
+
+				const attr = fbxTree.Objects.NodeAttribute[ child.ID ];
+
+				if ( attr !== undefined ) {
+
+					cameraAttribute = attr;
+
+				}
+
+			} );
+
+			if ( cameraAttribute === undefined ) {
+
+				model = new THREE.Object3D();
+
+			} else {
+
+				let type = 0;
+
+				if ( cameraAttribute.CameraProjectionType !== undefined && cameraAttribute.CameraProjectionType.value === 1 ) {
+
+					type = 1;
+
+				}
+
+				let nearClippingPlane = 1;
+
+				if ( cameraAttribute.NearPlane !== undefined ) {
+
+					nearClippingPlane = cameraAttribute.NearPlane.value / 1000;
+
+				}
+
+				let farClippingPlane = 1000;
+
+				if ( cameraAttribute.FarPlane !== undefined ) {
+
+					farClippingPlane = cameraAttribute.FarPlane.value / 1000;
+
+				}
+
+				let width = window.innerWidth;
+				let height = window.innerHeight;
+
+				if ( cameraAttribute.AspectWidth !== undefined && cameraAttribute.AspectHeight !== undefined ) {
+
+					width = cameraAttribute.AspectWidth.value;
+					height = cameraAttribute.AspectHeight.value;
+
+				}
+
+				const aspect = width / height;
+				let fov = 45;
+
+				if ( cameraAttribute.FieldOfView !== undefined ) {
+
+					fov = cameraAttribute.FieldOfView.value;
+
+				}
+
+				const focalLength = cameraAttribute.FocalLength ? cameraAttribute.FocalLength.value : null;
+
+				switch ( type ) {
+
+					case 0:
+					// Perspective
+						model = new THREE.PerspectiveCamera( fov, aspect, nearClippingPlane, farClippingPlane );
+						if ( focalLength !== null ) model.setFocalLength( focalLength );
 						break;
 
-					case 'lambert':
-						material = new THREE.MeshLambertMaterial();
+					case 1:
+					// Orthographic
+						model = new THREE.OrthographicCamera( - width / 2, width / 2, height / 2, - height / 2, nearClippingPlane, farClippingPlane );
 						break;
 
 					default:
-						console.warn( 'THREE.FBXLoader: unknown material type "%s". Defaulting to THREE.MeshPhongMaterial.', type );
-						material = new THREE.MeshPhongMaterial();
+						console.warn( 'THREE.FBXLoader: Unknown camera type ' + type + '.' );
+						model = new THREE.Object3D();
 						break;
 
 				}
 
-				material.setValues( parameters );
-				material.name = name;
-				return material;
+			}
 
-			},
-			// Parse FBX material and return parameters suitable for a three.js material
-			// Also parse the texture map and return any textures associated with the material
-			parseParameters: function ( materialNode, textureMap, ID ) {
+			return model;
 
-				var parameters = {};
+		} // Create a THREE.DirectionalLight, THREE.PointLight or THREE.SpotLight
 
-				if ( materialNode.BumpFactor ) {
 
-					parameters.bumpScale = materialNode.BumpFactor.value;
+		createLight( relationships ) {
 
-				}
+			let model;
+			let lightAttribute;
+			relationships.children.forEach( function ( child ) {
 
-				if ( materialNode.Diffuse ) {
+				const attr = fbxTree.Objects.NodeAttribute[ child.ID ];
 
-					parameters.color = new THREE.Color().fromArray( materialNode.Diffuse.value );
+				if ( attr !== undefined ) {
 
-				} else if ( materialNode.DiffuseColor && ( materialNode.DiffuseColor.type === 'Color' || materialNode.DiffuseColor.type === 'ColorRGB' ) ) {
-
-					// The blender exporter exports diffuse here instead of in materialNode.Diffuse
-					parameters.color = new THREE.Color().fromArray( materialNode.DiffuseColor.value );
+					lightAttribute = attr;
 
 				}
 
-				if ( materialNode.DisplacementFactor ) {
+			} );
 
-					parameters.displacementScale = materialNode.DisplacementFactor.value;
+			if ( lightAttribute === undefined ) {
 
-				}
+				model = new THREE.Object3D();
 
-				if ( materialNode.Emissive ) {
+			} else {
 
-					parameters.emissive = new THREE.Color().fromArray( materialNode.Emissive.value );
+				let type; // LightType can be undefined for Point lights
 
-				} else if ( materialNode.EmissiveColor && ( materialNode.EmissiveColor.type === 'Color' || materialNode.EmissiveColor.type === 'ColorRGB' ) ) {
+				if ( lightAttribute.LightType === undefined ) {
 
-					// The blender exporter exports emissive color here instead of in materialNode.Emissive
-					parameters.emissive = new THREE.Color().fromArray( materialNode.EmissiveColor.value );
-
-				}
-
-				if ( materialNode.EmissiveFactor ) {
-
-					parameters.emissiveIntensity = parseFloat( materialNode.EmissiveFactor.value );
-
-				}
-
-				if ( materialNode.Opacity ) {
-
-					parameters.opacity = parseFloat( materialNode.Opacity.value );
-
-				}
-
-				if ( parameters.opacity < 1.0 ) {
-
-					parameters.transparent = true;
-
-				}
-
-				if ( materialNode.ReflectionFactor ) {
-
-					parameters.reflectivity = materialNode.ReflectionFactor.value;
-
-				}
-
-				if ( materialNode.Shininess ) {
-
-					parameters.shininess = materialNode.Shininess.value;
-
-				}
-
-				if ( materialNode.Specular ) {
-
-					parameters.specular = new THREE.Color().fromArray( materialNode.Specular.value );
-
-				} else if ( materialNode.SpecularColor && materialNode.SpecularColor.type === 'Color' ) {
-
-					// The blender exporter exports specular color here instead of in materialNode.Specular
-					parameters.specular = new THREE.Color().fromArray( materialNode.SpecularColor.value );
-
-				}
-
-				var scope = this;
-				connections.get( ID ).children.forEach( function ( child ) {
-
-					var type = child.relationship;
-
-					switch ( type ) {
-
-						case 'Bump':
-							parameters.bumpMap = scope.getTexture( textureMap, child.ID );
-							break;
-
-						case 'Maya|TEX_ao_map':
-							parameters.aoMap = scope.getTexture( textureMap, child.ID );
-							break;
-
-						case 'DiffuseColor':
-						case 'Maya|TEX_color_map':
-							parameters.map = scope.getTexture( textureMap, child.ID );
-							parameters.map.encoding = THREE.sRGBEncoding;
-							break;
-
-						case 'DisplacementColor':
-							parameters.displacementMap = scope.getTexture( textureMap, child.ID );
-							break;
-
-						case 'EmissiveColor':
-							parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
-							parameters.emissiveMap.encoding = THREE.sRGBEncoding;
-							break;
-
-						case 'NormalMap':
-						case 'Maya|TEX_normal_map':
-							parameters.normalMap = scope.getTexture( textureMap, child.ID );
-							break;
-
-						case 'ReflectionColor':
-							parameters.envMap = scope.getTexture( textureMap, child.ID );
-							parameters.envMap.mapping = THREE.EquirectangularReflectionMapping;
-							parameters.envMap.encoding = THREE.sRGBEncoding;
-							break;
-
-						case 'SpecularColor':
-							parameters.specularMap = scope.getTexture( textureMap, child.ID );
-							parameters.specularMap.encoding = THREE.sRGBEncoding;
-							break;
-
-						case 'TransparentColor':
-						case 'TransparencyFactor':
-							parameters.alphaMap = scope.getTexture( textureMap, child.ID );
-							parameters.transparent = true;
-							break;
-
-						case 'AmbientColor':
-						case 'ShininessExponent': // AKA glossiness map
-
-						case 'SpecularFactor': // AKA specularLevel
-
-						case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
-
-						default:
-							console.warn( 'THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type );
-							break;
-
-					}
-
-				} );
-				return parameters;
-
-			},
-			// get a texture from the textureMap for use by a material.
-			getTexture: function ( textureMap, id ) {
-
-				// if the texture is a layered texture, just use the first layer and issue a warning
-				if ( 'LayeredTexture' in fbxTree.Objects && id in fbxTree.Objects.LayeredTexture ) {
-
-					console.warn( 'THREE.FBXLoader: layered textures are not supported in three.js. Discarding all but first layer.' );
-					id = connections.get( id ).children[ 0 ].ID;
-
-				}
-
-				return textureMap.get( id );
-
-			},
-			// Parse nodes in FBXTree.Objects.Deformer
-			// Deformer node can contain skinning or Vertex Cache animation data, however only skinning is supported here
-			// Generates map of THREE.Skeleton-like objects for use later when generating and binding skeletons.
-			parseDeformers: function () {
-
-				var skeletons = {};
-				var morphTargets = {};
-
-				if ( 'Deformer' in fbxTree.Objects ) {
-
-					var DeformerNodes = fbxTree.Objects.Deformer;
-
-					for ( var nodeID in DeformerNodes ) {
-
-						var deformerNode = DeformerNodes[ nodeID ];
-						var relationships = connections.get( parseInt( nodeID ) );
-
-						if ( deformerNode.attrType === 'Skin' ) {
-
-							var skeleton = this.parseSkeleton( relationships, DeformerNodes );
-							skeleton.ID = nodeID;
-							if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: skeleton attached to more than one geometry is not supported.' );
-							skeleton.geometryID = relationships.parents[ 0 ].ID;
-							skeletons[ nodeID ] = skeleton;
-
-						} else if ( deformerNode.attrType === 'BlendShape' ) {
-
-							var morphTarget = {
-								id: nodeID
-							};
-							morphTarget.rawTargets = this.parseMorphTargets( relationships, DeformerNodes );
-							morphTarget.id = nodeID;
-							if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: morph target attached to more than one geometry is not supported.' );
-							morphTargets[ nodeID ] = morphTarget;
-
-						}
-
-					}
-
-				}
-
-				return {
-					skeletons: skeletons,
-					morphTargets: morphTargets
-				};
-
-			},
-			// Parse single nodes in FBXTree.Objects.Deformer
-			// The top level skeleton node has type 'Skin' and sub nodes have type 'Cluster'
-			// Each skin node represents a skeleton and each cluster node represents a bone
-			parseSkeleton: function ( relationships, deformerNodes ) {
-
-				var rawBones = [];
-				relationships.children.forEach( function ( child ) {
-
-					var boneNode = deformerNodes[ child.ID ];
-					if ( boneNode.attrType !== 'Cluster' ) return;
-					var rawBone = {
-						ID: child.ID,
-						indices: [],
-						weights: [],
-						transformLink: new THREE.Matrix4().fromArray( boneNode.TransformLink.a ) // transform: new THREE.Matrix4().fromArray( boneNode.Transform.a ),
-						// linkMode: boneNode.Mode,
-
-					};
-
-					if ( 'Indexes' in boneNode ) {
-
-						rawBone.indices = boneNode.Indexes.a;
-						rawBone.weights = boneNode.Weights.a;
-
-					}
-
-					rawBones.push( rawBone );
-
-				} );
-				return {
-					rawBones: rawBones,
-					bones: []
-				};
-
-			},
-			// The top level morph deformer node has type "BlendShape" and sub nodes have type "BlendShapeChannel"
-			parseMorphTargets: function ( relationships, deformerNodes ) {
-
-				var rawMorphTargets = [];
-
-				for ( var i = 0; i < relationships.children.length; i ++ ) {
-
-					var child = relationships.children[ i ];
-					var morphTargetNode = deformerNodes[ child.ID ];
-					var rawMorphTarget = {
-						name: morphTargetNode.attrName,
-						initialWeight: morphTargetNode.DeformPercent,
-						id: morphTargetNode.id,
-						fullWeights: morphTargetNode.FullWeights.a
-					};
-					if ( morphTargetNode.attrType !== 'BlendShapeChannel' ) return;
-					rawMorphTarget.geoID = connections.get( parseInt( child.ID ) ).children.filter( function ( child ) {
-
-						return child.relationship === undefined;
-
-					} )[ 0 ].ID;
-					rawMorphTargets.push( rawMorphTarget );
-
-				}
-
-				return rawMorphTargets;
-
-			},
-			// create the main THREE.Group() to be returned by the loader
-			parseScene: function ( deformers, geometryMap, materialMap ) {
-
-				sceneGraph = new THREE.Group();
-				var modelMap = this.parseModels( deformers.skeletons, geometryMap, materialMap );
-				var modelNodes = fbxTree.Objects.Model;
-				var scope = this;
-				modelMap.forEach( function ( model ) {
-
-					var modelNode = modelNodes[ model.ID ];
-					scope.setLookAtProperties( model, modelNode );
-					var parentConnections = connections.get( model.ID ).parents;
-					parentConnections.forEach( function ( connection ) {
-
-						var parent = modelMap.get( connection.ID );
-						if ( parent !== undefined ) parent.add( model );
-
-					} );
-
-					if ( model.parent === null ) {
-
-						sceneGraph.add( model );
-
-					}
-
-				} );
-				this.bindSkeleton( deformers.skeletons, geometryMap, modelMap );
-				this.createAmbientLight();
-				this.setupMorphMaterials();
-				sceneGraph.traverse( function ( node ) {
-
-					if ( node.userData.transformData ) {
-
-						if ( node.parent ) {
-
-							node.userData.transformData.parentMatrix = node.parent.matrix;
-							node.userData.transformData.parentMatrixWorld = node.parent.matrixWorld;
-
-						}
-
-						var transform = generateTransform( node.userData.transformData );
-						node.applyMatrix4( transform );
-						node.updateWorldMatrix();
-
-					}
-
-				} );
-				var animations = new AnimationParser().parse(); // if all the models where already combined in a single group, just return that
-
-				if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
-
-					sceneGraph.children[ 0 ].animations = animations;
-					sceneGraph = sceneGraph.children[ 0 ];
-
-				}
-
-				sceneGraph.animations = animations;
-
-			},
-			// parse nodes in FBXTree.Objects.Model
-			parseModels: function ( skeletons, geometryMap, materialMap ) {
-
-				var modelMap = new Map();
-				var modelNodes = fbxTree.Objects.Model;
-
-				for ( var nodeID in modelNodes ) {
-
-					var id = parseInt( nodeID );
-					var node = modelNodes[ nodeID ];
-					var relationships = connections.get( id );
-					var model = this.buildSkeleton( relationships, skeletons, id, node.attrName );
-
-					if ( ! model ) {
-
-						switch ( node.attrType ) {
-
-							case 'Camera':
-								model = this.createCamera( relationships );
-								break;
-
-							case 'Light':
-								model = this.createLight( relationships );
-								break;
-
-							case 'Mesh':
-								model = this.createMesh( relationships, geometryMap, materialMap );
-								break;
-
-							case 'NurbsCurve':
-								model = this.createCurve( relationships, geometryMap );
-								break;
-
-							case 'LimbNode':
-							case 'Root':
-								model = new THREE.Bone();
-								break;
-
-							case 'Null':
-							default:
-								model = new THREE.Group();
-								break;
-
-						}
-
-						model.name = node.attrName ? THREE.PropertyBinding.sanitizeNodeName( node.attrName ) : '';
-						model.ID = id;
-
-					}
-
-					this.getTransformData( model, node );
-					modelMap.set( id, model );
-
-				}
-
-				return modelMap;
-
-			},
-			buildSkeleton: function ( relationships, skeletons, id, name ) {
-
-				var bone = null;
-				relationships.parents.forEach( function ( parent ) {
-
-					for ( var ID in skeletons ) {
-
-						var skeleton = skeletons[ ID ];
-						skeleton.rawBones.forEach( function ( rawBone, i ) {
-
-							if ( rawBone.ID === parent.ID ) {
-
-								var subBone = bone;
-								bone = new THREE.Bone();
-								bone.matrixWorld.copy( rawBone.transformLink ); // set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
-
-								bone.name = name ? THREE.PropertyBinding.sanitizeNodeName( name ) : '';
-								bone.ID = id;
-								skeleton.bones[ i ] = bone; // In cases where a bone is shared between multiple meshes
-								// duplicate the bone here and and it as a child of the first bone
-
-								if ( subBone !== null ) {
-
-									bone.add( subBone );
-
-								}
-
-							}
-
-						} );
-
-					}
-
-				} );
-				return bone;
-
-			},
-			// create a THREE.PerspectiveCamera or THREE.OrthographicCamera
-			createCamera: function ( relationships ) {
-
-				var model;
-				var cameraAttribute;
-				relationships.children.forEach( function ( child ) {
-
-					var attr = fbxTree.Objects.NodeAttribute[ child.ID ];
-
-					if ( attr !== undefined ) {
-
-						cameraAttribute = attr;
-
-					}
-
-				} );
-
-				if ( cameraAttribute === undefined ) {
-
-					model = new THREE.Object3D();
+					type = 0;
 
 				} else {
 
-					var type = 0;
-
-					if ( cameraAttribute.CameraProjectionType !== undefined && cameraAttribute.CameraProjectionType.value === 1 ) {
-
-						type = 1;
-
-					}
-
-					var nearClippingPlane = 1;
-
-					if ( cameraAttribute.NearPlane !== undefined ) {
-
-						nearClippingPlane = cameraAttribute.NearPlane.value / 1000;
-
-					}
-
-					var farClippingPlane = 1000;
-
-					if ( cameraAttribute.FarPlane !== undefined ) {
-
-						farClippingPlane = cameraAttribute.FarPlane.value / 1000;
-
-					}
-
-					var width = window.innerWidth;
-					var height = window.innerHeight;
-
-					if ( cameraAttribute.AspectWidth !== undefined && cameraAttribute.AspectHeight !== undefined ) {
-
-						width = cameraAttribute.AspectWidth.value;
-						height = cameraAttribute.AspectHeight.value;
-
-					}
-
-					var aspect = width / height;
-					var fov = 45;
-
-					if ( cameraAttribute.FieldOfView !== undefined ) {
-
-						fov = cameraAttribute.FieldOfView.value;
-
-					}
-
-					var focalLength = cameraAttribute.FocalLength ? cameraAttribute.FocalLength.value : null;
-
-					switch ( type ) {
-
-						case 0:
-						// Perspective
-							model = new THREE.PerspectiveCamera( fov, aspect, nearClippingPlane, farClippingPlane );
-							if ( focalLength !== null ) model.setFocalLength( focalLength );
-							break;
-
-						case 1:
-						// Orthographic
-							model = new THREE.OrthographicCamera( - width / 2, width / 2, height / 2, - height / 2, nearClippingPlane, farClippingPlane );
-							break;
-
-						default:
-							console.warn( 'THREE.FBXLoader: Unknown camera type ' + type + '.' );
-							model = new THREE.Object3D();
-							break;
-
-					}
+					type = lightAttribute.LightType.value;
 
 				}
 
-				return model;
+				let color = 0xffffff;
 
-			},
-			// Create a THREE.DirectionalLight, THREE.PointLight or THREE.SpotLight
-			createLight: function ( relationships ) {
+				if ( lightAttribute.Color !== undefined ) {
 
-				var model;
-				var lightAttribute;
-				relationships.children.forEach( function ( child ) {
+					color = new THREE.Color().fromArray( lightAttribute.Color.value );
 
-					var attr = fbxTree.Objects.NodeAttribute[ child.ID ];
+				}
 
-					if ( attr !== undefined ) {
+				let intensity = lightAttribute.Intensity === undefined ? 1 : lightAttribute.Intensity.value / 100; // light disabled
 
-						lightAttribute = attr;
+				if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0 ) {
 
-					}
+					intensity = 0;
 
-				} );
+				}
 
-				if ( lightAttribute === undefined ) {
+				let distance = 0;
 
-					model = new THREE.Object3D();
+				if ( lightAttribute.FarAttenuationEnd !== undefined ) {
 
-				} else {
+					if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === 0 ) {
 
-					var type; // LightType can be undefined for Point lights
-
-					if ( lightAttribute.LightType === undefined ) {
-
-						type = 0;
+						distance = 0;
 
 					} else {
 
-						type = lightAttribute.LightType.value;
+						distance = lightAttribute.FarAttenuationEnd.value;
 
 					}
 
-					var color = 0xffffff;
+				} // TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
 
-					if ( lightAttribute.Color !== undefined ) {
 
-						color = new THREE.Color().fromArray( lightAttribute.Color.value );
+				const decay = 1;
+
+				switch ( type ) {
+
+					case 0:
+					// Point
+						model = new THREE.PointLight( color, intensity, distance, decay );
+						break;
+
+					case 1:
+					// Directional
+						model = new THREE.DirectionalLight( color, intensity );
+						break;
+
+					case 2:
+					// Spot
+						let angle = Math.PI / 3;
+
+						if ( lightAttribute.InnerAngle !== undefined ) {
+
+							angle = THREE.MathUtils.degToRad( lightAttribute.InnerAngle.value );
+
+						}
+
+						let penumbra = 0;
+
+						if ( lightAttribute.OuterAngle !== undefined ) {
+
+							// TODO: this is not correct - FBX calculates outer and inner angle in degrees
+							// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
+							// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
+							penumbra = THREE.MathUtils.degToRad( lightAttribute.OuterAngle.value );
+							penumbra = Math.max( penumbra, 1 );
+
+						}
+
+						model = new THREE.SpotLight( color, intensity, distance, angle, penumbra, decay );
+						break;
+
+					default:
+						console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType.value + ', defaulting to a THREE.PointLight.' );
+						model = new THREE.PointLight( color, intensity );
+						break;
+
+				}
+
+				if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === 1 ) {
+
+					model.castShadow = true;
+
+				}
+
+			}
+
+			return model;
+
+		}
+
+		createMesh( relationships, geometryMap, materialMap ) {
+
+			let model;
+			let geometry = null;
+			let material = null;
+			const materials = []; // get geometry and materials(s) from connections
+
+			relationships.children.forEach( function ( child ) {
+
+				if ( geometryMap.has( child.ID ) ) {
+
+					geometry = geometryMap.get( child.ID );
+
+				}
+
+				if ( materialMap.has( child.ID ) ) {
+
+					materials.push( materialMap.get( child.ID ) );
+
+				}
+
+			} );
+
+			if ( materials.length > 1 ) {
+
+				material = materials;
+
+			} else if ( materials.length > 0 ) {
+
+				material = materials[ 0 ];
+
+			} else {
+
+				material = new THREE.MeshPhongMaterial( {
+					color: 0xcccccc
+				} );
+				materials.push( material );
+
+			}
+
+			if ( 'color' in geometry.attributes ) {
+
+				materials.forEach( function ( material ) {
+
+					material.vertexColors = true;
+
+				} );
+
+			}
+
+			if ( geometry.FBX_Deformer ) {
+
+				materials.forEach( function ( material ) {
+
+					material.skinning = true;
+
+				} );
+				model = new THREE.SkinnedMesh( geometry, material );
+				model.normalizeSkinWeights();
+
+			} else {
+
+				model = new THREE.Mesh( geometry, material );
+
+			}
+
+			return model;
+
+		}
+
+		createCurve( relationships, geometryMap ) {
+
+			const geometry = relationships.children.reduce( function ( geo, child ) {
+
+				if ( geometryMap.has( child.ID ) ) geo = geometryMap.get( child.ID );
+				return geo;
+
+			}, null ); // FBX does not list materials for Nurbs lines, so we'll just put our own in here.
+
+			const material = new THREE.LineBasicMaterial( {
+				color: 0x3300ff,
+				linewidth: 1
+			} );
+			return new THREE.Line( geometry, material );
+
+		} // parse the model node for transform data
+
+
+		getTransformData( model, modelNode ) {
+
+			const transformData = {};
+			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
+			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value ); else transformData.eulerOrder = 'ZYX';
+			if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
+			if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
+			if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
+			if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
+			if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
+			if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
+			if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
+			if ( 'RotationOffset' in modelNode ) transformData.rotationOffset = modelNode.RotationOffset.value;
+			if ( 'RotationPivot' in modelNode ) transformData.rotationPivot = modelNode.RotationPivot.value;
+			model.userData.transformData = transformData;
+
+		}
+
+		setLookAtProperties( model, modelNode ) {
+
+			if ( 'LookAtProperty' in modelNode ) {
+
+				const children = connections.get( model.ID ).children;
+				children.forEach( function ( child ) {
+
+					if ( child.relationship === 'LookAtProperty' ) {
+
+						const lookAtTarget = fbxTree.Objects.Model[ child.ID ];
+
+						if ( 'Lcl_Translation' in lookAtTarget ) {
+
+							const pos = lookAtTarget.Lcl_Translation.value; // THREE.DirectionalLight, THREE.SpotLight
+
+							if ( model.target !== undefined ) {
+
+								model.target.position.fromArray( pos );
+								sceneGraph.add( model.target );
+
+							} else {
+
+								// Cameras and other Object3Ds
+								model.lookAt( new THREE.Vector3().fromArray( pos ) );
+
+							}
+
+						}
 
 					}
 
-					var intensity = lightAttribute.Intensity === undefined ? 1 : lightAttribute.Intensity.value / 100; // light disabled
+				} );
 
-					if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0 ) {
+			}
 
-						intensity = 0;
+		}
+
+		bindSkeleton( skeletons, geometryMap, modelMap ) {
+
+			const bindMatrices = this.parsePoseNodes();
+
+			for ( const ID in skeletons ) {
+
+				const skeleton = skeletons[ ID ];
+				const parents = connections.get( parseInt( skeleton.ID ) ).parents;
+				parents.forEach( function ( parent ) {
+
+					if ( geometryMap.has( parent.ID ) ) {
+
+						const geoID = parent.ID;
+						const geoRelationships = connections.get( geoID );
+						geoRelationships.parents.forEach( function ( geoConnParent ) {
+
+							if ( modelMap.has( geoConnParent.ID ) ) {
+
+								const model = modelMap.get( geoConnParent.ID );
+								model.bind( new THREE.Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
+
+							}
+
+						} );
 
 					}
 
-					var distance = 0;
+				} );
 
-					if ( lightAttribute.FarAttenuationEnd !== undefined ) {
+			}
 
-						if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === 0 ) {
+		}
 
-							distance = 0;
+		parsePoseNodes() {
+
+			const bindMatrices = {};
+
+			if ( 'Pose' in fbxTree.Objects ) {
+
+				const BindPoseNode = fbxTree.Objects.Pose;
+
+				for ( const nodeID in BindPoseNode ) {
+
+					if ( BindPoseNode[ nodeID ].attrType === 'BindPose' ) {
+
+						const poseNodes = BindPoseNode[ nodeID ].PoseNode;
+
+						if ( Array.isArray( poseNodes ) ) {
+
+							poseNodes.forEach( function ( poseNode ) {
+
+								bindMatrices[ poseNode.Node ] = new THREE.Matrix4().fromArray( poseNode.Matrix.a );
+
+							} );
 
 						} else {
 
-							distance = lightAttribute.FarAttenuationEnd.value;
+							bindMatrices[ poseNodes.Node ] = new THREE.Matrix4().fromArray( poseNodes.Matrix.a );
 
 						}
 
-					} // TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
-
-
-					var decay = 1;
-
-					switch ( type ) {
-
-						case 0:
-						// Point
-							model = new THREE.PointLight( color, intensity, distance, decay );
-							break;
-
-						case 1:
-						// Directional
-							model = new THREE.DirectionalLight( color, intensity );
-							break;
-
-						case 2:
-						// Spot
-							var angle = Math.PI / 3;
-
-							if ( lightAttribute.InnerAngle !== undefined ) {
-
-								angle = THREE.MathUtils.degToRad( lightAttribute.InnerAngle.value );
-
-							}
-
-							var penumbra = 0;
-
-							if ( lightAttribute.OuterAngle !== undefined ) {
-
-								// TODO: this is not correct - FBX calculates outer and inner angle in degrees
-								// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
-								// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
-								penumbra = THREE.MathUtils.degToRad( lightAttribute.OuterAngle.value );
-								penumbra = Math.max( penumbra, 1 );
-
-							}
-
-							model = new THREE.SpotLight( color, intensity, distance, angle, penumbra, decay );
-							break;
-
-						default:
-							console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType.value + ', defaulting to a THREE.PointLight.' );
-							model = new THREE.PointLight( color, intensity );
-							break;
-
-					}
-
-					if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === 1 ) {
-
-						model.castShadow = true;
-
 					}
 
 				}
-
-				return model;
-
-			},
-			createMesh: function ( relationships, geometryMap, materialMap ) {
-
-				var model;
-				var geometry = null;
-				var material = null;
-				var materials = []; // get geometry and materials(s) from connections
-
-				relationships.children.forEach( function ( child ) {
-
-					if ( geometryMap.has( child.ID ) ) {
-
-						geometry = geometryMap.get( child.ID );
-
-					}
-
-					if ( materialMap.has( child.ID ) ) {
-
-						materials.push( materialMap.get( child.ID ) );
-
-					}
-
-				} );
-
-				if ( materials.length > 1 ) {
-
-					material = materials;
-
-				} else if ( materials.length > 0 ) {
-
-					material = materials[ 0 ];
-
-				} else {
-
-					material = new THREE.MeshPhongMaterial( {
-						color: 0xcccccc
-					} );
-					materials.push( material );
-
-				}
-
-				if ( 'color' in geometry.attributes ) {
-
-					materials.forEach( function ( material ) {
-
-						material.vertexColors = true;
-
-					} );
-
-				}
-
-				if ( geometry.FBX_Deformer ) {
-
-					materials.forEach( function ( material ) {
-
-						material.skinning = true;
-
-					} );
-					model = new THREE.SkinnedMesh( geometry, material );
-					model.normalizeSkinWeights();
-
-				} else {
-
-					model = new THREE.Mesh( geometry, material );
-
-				}
-
-				return model;
-
-			},
-			createCurve: function ( relationships, geometryMap ) {
-
-				var geometry = relationships.children.reduce( function ( geo, child ) {
-
-					if ( geometryMap.has( child.ID ) ) geo = geometryMap.get( child.ID );
-					return geo;
-
-				}, null ); // FBX does not list materials for Nurbs lines, so we'll just put our own in here.
-
-				var material = new THREE.LineBasicMaterial( {
-					color: 0x3300ff,
-					linewidth: 1
-				} );
-				return new THREE.Line( geometry, material );
-
-			},
-			// parse the model node for transform data
-			getTransformData: function ( model, modelNode ) {
-
-				var transformData = {};
-				if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-				if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value ); else transformData.eulerOrder = 'ZYX';
-				if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
-				if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
-				if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
-				if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
-				if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
-				if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
-				if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
-				if ( 'RotationOffset' in modelNode ) transformData.rotationOffset = modelNode.RotationOffset.value;
-				if ( 'RotationPivot' in modelNode ) transformData.rotationPivot = modelNode.RotationPivot.value;
-				model.userData.transformData = transformData;
-
-			},
-			setLookAtProperties: function ( model, modelNode ) {
-
-				if ( 'LookAtProperty' in modelNode ) {
-
-					var children = connections.get( model.ID ).children;
-					children.forEach( function ( child ) {
-
-						if ( child.relationship === 'LookAtProperty' ) {
-
-							var lookAtTarget = fbxTree.Objects.Model[ child.ID ];
-
-							if ( 'Lcl_Translation' in lookAtTarget ) {
-
-								var pos = lookAtTarget.Lcl_Translation.value; // THREE.DirectionalLight, THREE.SpotLight
-
-								if ( model.target !== undefined ) {
-
-									model.target.position.fromArray( pos );
-									sceneGraph.add( model.target );
-
-								} else {
-
-									// Cameras and other Object3Ds
-									model.lookAt( new THREE.Vector3().fromArray( pos ) );
-
-								}
-
-							}
-
-						}
-
-					} );
-
-				}
-
-			},
-			bindSkeleton: function ( skeletons, geometryMap, modelMap ) {
-
-				var bindMatrices = this.parsePoseNodes();
-
-				for ( var ID in skeletons ) {
-
-					var skeleton = skeletons[ ID ];
-					var parents = connections.get( parseInt( skeleton.ID ) ).parents;
-					parents.forEach( function ( parent ) {
-
-						if ( geometryMap.has( parent.ID ) ) {
-
-							var geoID = parent.ID;
-							var geoRelationships = connections.get( geoID );
-							geoRelationships.parents.forEach( function ( geoConnParent ) {
-
-								if ( modelMap.has( geoConnParent.ID ) ) {
-
-									var model = modelMap.get( geoConnParent.ID );
-									model.bind( new THREE.Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
-
-								}
-
-							} );
-
-						}
-
-					} );
-
-				}
-
-			},
-			parsePoseNodes: function () {
-
-				var bindMatrices = {};
-
-				if ( 'Pose' in fbxTree.Objects ) {
-
-					var BindPoseNode = fbxTree.Objects.Pose;
-
-					for ( var nodeID in BindPoseNode ) {
-
-						if ( BindPoseNode[ nodeID ].attrType === 'BindPose' ) {
-
-							var poseNodes = BindPoseNode[ nodeID ].PoseNode;
-
-							if ( Array.isArray( poseNodes ) ) {
-
-								poseNodes.forEach( function ( poseNode ) {
-
-									bindMatrices[ poseNode.Node ] = new THREE.Matrix4().fromArray( poseNode.Matrix.a );
-
-								} );
-
-							} else {
-
-								bindMatrices[ poseNodes.Node ] = new THREE.Matrix4().fromArray( poseNodes.Matrix.a );
-
-							}
-
-						}
-
-					}
-
-				}
-
-				return bindMatrices;
-
-			},
-			// Parse ambient color in FBXTree.GlobalSettings - if it's not set to black (default), create an ambient light
-			createAmbientLight: function () {
-
-				if ( 'GlobalSettings' in fbxTree && 'AmbientColor' in fbxTree.GlobalSettings ) {
-
-					var ambientColor = fbxTree.GlobalSettings.AmbientColor.value;
-					var r = ambientColor[ 0 ];
-					var g = ambientColor[ 1 ];
-					var b = ambientColor[ 2 ];
-
-					if ( r !== 0 || g !== 0 || b !== 0 ) {
-
-						var color = new THREE.Color( r, g, b );
-						sceneGraph.add( new THREE.AmbientLight( color, 1 ) );
-
-					}
-
-				}
-
-			},
-			setupMorphMaterials: function () {
-
-				var scope = this;
-				sceneGraph.traverse( function ( child ) {
-
-					if ( child.isMesh ) {
-
-						if ( child.geometry.morphAttributes.position && child.geometry.morphAttributes.position.length ) {
-
-							if ( Array.isArray( child.material ) ) {
-
-								child.material.forEach( function ( material, i ) {
-
-									scope.setupMorphMaterial( child, material, i );
-
-								} );
-
-							} else {
-
-								scope.setupMorphMaterial( child, child.material );
-
-							}
-
-						}
-
-					}
-
-				} );
-
-			},
-			setupMorphMaterial: function ( child, material, index ) {
-
-				var uuid = child.uuid;
-				var matUuid = material.uuid; // if a geometry has morph targets, it cannot share the material with other geometries
-
-				var sharedMat = false;
-				sceneGraph.traverse( function ( node ) {
-
-					if ( node.isMesh ) {
-
-						if ( Array.isArray( node.material ) ) {
-
-							node.material.forEach( function ( mat ) {
-
-								if ( mat.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-							} );
-
-						} else if ( node.material.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-					}
-
-				} );
-
-				if ( sharedMat === true ) {
-
-					var clonedMat = material.clone();
-					clonedMat.morphTargets = true;
-					if ( index === undefined ) child.material = clonedMat; else child.material[ index ] = clonedMat;
-
-				} else material.morphTargets = true;
 
 			}
-		}; // parse Geometry data from FBXTree and return map of BufferGeometries
 
-		function GeometryParser() {}
+			return bindMatrices;
 
-		GeometryParser.prototype = {
-			constructor: GeometryParser,
-			// Parse nodes in FBXTree.Objects.Geometry
-			parse: function ( deformers ) {
+		} // Parse ambient color in FBXTree.GlobalSettings - if it's not set to black (default), create an ambient light
 
-				var geometryMap = new Map();
 
-				if ( 'Geometry' in fbxTree.Objects ) {
+		createAmbientLight() {
 
-					var geoNodes = fbxTree.Objects.Geometry;
+			if ( 'GlobalSettings' in fbxTree && 'AmbientColor' in fbxTree.GlobalSettings ) {
 
-					for ( var nodeID in geoNodes ) {
+				const ambientColor = fbxTree.GlobalSettings.AmbientColor.value;
+				const r = ambientColor[ 0 ];
+				const g = ambientColor[ 1 ];
+				const b = ambientColor[ 2 ];
 
-						var relationships = connections.get( parseInt( nodeID ) );
-						var geo = this.parseGeometry( relationships, geoNodes[ nodeID ], deformers );
-						geometryMap.set( parseInt( nodeID ), geo );
+				if ( r !== 0 || g !== 0 || b !== 0 ) {
+
+					const color = new THREE.Color( r, g, b );
+					sceneGraph.add( new THREE.AmbientLight( color, 1 ) );
+
+				}
+
+			}
+
+		}
+
+		setupMorphMaterials() {
+
+			const scope = this;
+			sceneGraph.traverse( function ( child ) {
+
+				if ( child.isMesh ) {
+
+					if ( child.geometry.morphAttributes.position && child.geometry.morphAttributes.position.length ) {
+
+						if ( Array.isArray( child.material ) ) {
+
+							child.material.forEach( function ( material, i ) {
+
+								scope.setupMorphMaterial( child, material, i );
+
+							} );
+
+						} else {
+
+							scope.setupMorphMaterial( child, child.material );
+
+						}
 
 					}
 
 				}
 
-				return geometryMap;
+			} );
 
-			},
-			// Parse single node in FBXTree.Objects.Geometry
-			parseGeometry: function ( relationships, geoNode, deformers ) {
+		}
 
-				switch ( geoNode.attrType ) {
+		setupMorphMaterial( child, material, index ) {
 
-					case 'Mesh':
-						return this.parseMeshGeometry( relationships, geoNode, deformers );
-						break;
+			const uuid = child.uuid;
+			const matUuid = material.uuid; // if a geometry has morph targets, it cannot share the material with other geometries
 
-					case 'NurbsCurve':
-						return this.parseNurbsGeometry( geoNode );
-						break;
+			let sharedMat = false;
+			sceneGraph.traverse( function ( node ) {
+
+				if ( node.isMesh ) {
+
+					if ( Array.isArray( node.material ) ) {
+
+						node.material.forEach( function ( mat ) {
+
+							if ( mat.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
+
+						} );
+
+					} else if ( node.material.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
 
 				}
 
-			},
-			// Parse single node mesh geometry in FBXTree.Objects.Geometry
-			parseMeshGeometry: function ( relationships, geoNode, deformers ) {
+			} );
 
-				var skeletons = deformers.skeletons;
-				var morphTargets = [];
-				var modelNodes = relationships.parents.map( function ( parent ) {
+			if ( sharedMat === true ) {
 
-					return fbxTree.Objects.Model[ parent.ID ];
+				const clonedMat = material.clone();
+				clonedMat.morphTargets = true;
+				if ( index === undefined ) child.material = clonedMat; else child.material[ index ] = clonedMat;
 
-				} ); // don't create geometry if it is not associated with any models
+			} else material.morphTargets = true;
 
-				if ( modelNodes.length === 0 ) return;
-				var skeleton = relationships.children.reduce( function ( skeleton, child ) {
+		}
 
-					if ( skeletons[ child.ID ] !== undefined ) skeleton = skeletons[ child.ID ];
-					return skeleton;
+	} // parse Geometry data from FBXTree and return map of BufferGeometries
 
-				}, null );
-				relationships.children.forEach( function ( child ) {
 
-					if ( deformers.morphTargets[ child.ID ] !== undefined ) {
+	class GeometryParser {
 
-						morphTargets.push( deformers.morphTargets[ child.ID ] );
+		// Parse nodes in FBXTree.Objects.Geometry
+		parse( deformers ) {
+
+			const geometryMap = new Map();
+
+			if ( 'Geometry' in fbxTree.Objects ) {
+
+				const geoNodes = fbxTree.Objects.Geometry;
+
+				for ( const nodeID in geoNodes ) {
+
+					const relationships = connections.get( parseInt( nodeID ) );
+					const geo = this.parseGeometry( relationships, geoNodes[ nodeID ], deformers );
+					geometryMap.set( parseInt( nodeID ), geo );
+
+				}
+
+			}
+
+			return geometryMap;
+
+		} // Parse single node in FBXTree.Objects.Geometry
+
+
+		parseGeometry( relationships, geoNode, deformers ) {
+
+			switch ( geoNode.attrType ) {
+
+				case 'Mesh':
+					return this.parseMeshGeometry( relationships, geoNode, deformers );
+					break;
+
+				case 'NurbsCurve':
+					return this.parseNurbsGeometry( geoNode );
+					break;
+
+			}
+
+		} // Parse single node mesh geometry in FBXTree.Objects.Geometry
+
+
+		parseMeshGeometry( relationships, geoNode, deformers ) {
+
+			const skeletons = deformers.skeletons;
+			const morphTargets = [];
+			const modelNodes = relationships.parents.map( function ( parent ) {
+
+				return fbxTree.Objects.Model[ parent.ID ];
+
+			} ); // don't create geometry if it is not associated with any models
+
+			if ( modelNodes.length === 0 ) return;
+			const skeleton = relationships.children.reduce( function ( skeleton, child ) {
+
+				if ( skeletons[ child.ID ] !== undefined ) skeleton = skeletons[ child.ID ];
+				return skeleton;
+
+			}, null );
+			relationships.children.forEach( function ( child ) {
+
+				if ( deformers.morphTargets[ child.ID ] !== undefined ) {
+
+					morphTargets.push( deformers.morphTargets[ child.ID ] );
+
+				}
+
+			} ); // Assume one model and get the preRotation from that
+			// if there is more than one model associated with the geometry this may cause problems
+
+			const modelNode = modelNodes[ 0 ];
+			const transformData = {};
+			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
+			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
+			if ( 'GeometricTranslation' in modelNode ) transformData.translation = modelNode.GeometricTranslation.value;
+			if ( 'GeometricRotation' in modelNode ) transformData.rotation = modelNode.GeometricRotation.value;
+			if ( 'GeometricScaling' in modelNode ) transformData.scale = modelNode.GeometricScaling.value;
+			const transform = generateTransform( transformData );
+			return this.genGeometry( geoNode, skeleton, morphTargets, transform );
+
+		} // Generate a THREE.BufferGeometry from a node in FBXTree.Objects.Geometry
+
+
+		genGeometry( geoNode, skeleton, morphTargets, preTransform ) {
+
+			const geo = new THREE.BufferGeometry();
+			if ( geoNode.attrName ) geo.name = geoNode.attrName;
+			const geoInfo = this.parseGeoNode( geoNode, skeleton );
+			const buffers = this.genBuffers( geoInfo );
+			const positionAttribute = new THREE.Float32BufferAttribute( buffers.vertex, 3 );
+			positionAttribute.applyMatrix4( preTransform );
+			geo.setAttribute( 'position', positionAttribute );
+
+			if ( buffers.colors.length > 0 ) {
+
+				geo.setAttribute( 'color', new THREE.Float32BufferAttribute( buffers.colors, 3 ) );
+
+			}
+
+			if ( skeleton ) {
+
+				geo.setAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( buffers.weightsIndices, 4 ) );
+				geo.setAttribute( 'skinWeight', new THREE.Float32BufferAttribute( buffers.vertexWeights, 4 ) ); // used later to bind the skeleton to the model
+
+				geo.FBX_Deformer = skeleton;
+
+			}
+
+			if ( buffers.normal.length > 0 ) {
+
+				const normalMatrix = new THREE.Matrix3().getNormalMatrix( preTransform );
+				const normalAttribute = new THREE.Float32BufferAttribute( buffers.normal, 3 );
+				normalAttribute.applyNormalMatrix( normalMatrix );
+				geo.setAttribute( 'normal', normalAttribute );
+
+			}
+
+			buffers.uvs.forEach( function ( uvBuffer, i ) {
+
+				// subsequent uv buffers are called 'uv1', 'uv2', ...
+				let name = 'uv' + ( i + 1 ).toString(); // the first uv buffer is just called 'uv'
+
+				if ( i === 0 ) {
+
+					name = 'uv';
+
+				}
+
+				geo.setAttribute( name, new THREE.Float32BufferAttribute( buffers.uvs[ i ], 2 ) );
+
+			} );
+
+			if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
+
+				// Convert the material indices of each vertex into rendering groups on the geometry.
+				let prevMaterialIndex = buffers.materialIndex[ 0 ];
+				let startIndex = 0;
+				buffers.materialIndex.forEach( function ( currentIndex, i ) {
+
+					if ( currentIndex !== prevMaterialIndex ) {
+
+						geo.addGroup( startIndex, i - startIndex, prevMaterialIndex );
+						prevMaterialIndex = currentIndex;
+						startIndex = i;
 
 					}
 
-				} ); // Assume one model and get the preRotation from that
-				// if there is more than one model associated with the geometry this may cause problems
+				} ); // the loop above doesn't add the last group, do that here.
 
-				var modelNode = modelNodes[ 0 ];
-				var transformData = {};
-				if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
-				if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-				if ( 'GeometricTranslation' in modelNode ) transformData.translation = modelNode.GeometricTranslation.value;
-				if ( 'GeometricRotation' in modelNode ) transformData.rotation = modelNode.GeometricRotation.value;
-				if ( 'GeometricScaling' in modelNode ) transformData.scale = modelNode.GeometricScaling.value;
-				var transform = generateTransform( transformData );
-				return this.genGeometry( geoNode, skeleton, morphTargets, transform );
+				if ( geo.groups.length > 0 ) {
 
-			},
-			// Generate a THREE.BufferGeometry from a node in FBXTree.Objects.Geometry
-			genGeometry: function ( geoNode, skeleton, morphTargets, preTransform ) {
+					const lastGroup = geo.groups[ geo.groups.length - 1 ];
+					const lastIndex = lastGroup.start + lastGroup.count;
 
-				var geo = new THREE.BufferGeometry();
-				if ( geoNode.attrName ) geo.name = geoNode.attrName;
-				var geoInfo = this.parseGeoNode( geoNode, skeleton );
-				var buffers = this.genBuffers( geoInfo );
-				var positionAttribute = new THREE.Float32BufferAttribute( buffers.vertex, 3 );
-				positionAttribute.applyMatrix4( preTransform );
-				geo.setAttribute( 'position', positionAttribute );
+					if ( lastIndex !== buffers.materialIndex.length ) {
 
-				if ( buffers.colors.length > 0 ) {
-
-					geo.setAttribute( 'color', new THREE.Float32BufferAttribute( buffers.colors, 3 ) );
-
-				}
-
-				if ( skeleton ) {
-
-					geo.setAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( buffers.weightsIndices, 4 ) );
-					geo.setAttribute( 'skinWeight', new THREE.Float32BufferAttribute( buffers.vertexWeights, 4 ) ); // used later to bind the skeleton to the model
-
-					geo.FBX_Deformer = skeleton;
-
-				}
-
-				if ( buffers.normal.length > 0 ) {
-
-					var normalMatrix = new THREE.Matrix3().getNormalMatrix( preTransform );
-					var normalAttribute = new THREE.Float32BufferAttribute( buffers.normal, 3 );
-					normalAttribute.applyNormalMatrix( normalMatrix );
-					geo.setAttribute( 'normal', normalAttribute );
-
-				}
-
-				buffers.uvs.forEach( function ( uvBuffer, i ) {
-
-					// subsequent uv buffers are called 'uv1', 'uv2', ...
-					var name = 'uv' + ( i + 1 ).toString(); // the first uv buffer is just called 'uv'
-
-					if ( i === 0 ) {
-
-						name = 'uv';
+						geo.addGroup( lastIndex, buffers.materialIndex.length - lastIndex, prevMaterialIndex );
 
 					}
 
-					geo.setAttribute( name, new THREE.Float32BufferAttribute( buffers.uvs[ i ], 2 ) );
+				} // case where there are multiple materials but the whole geometry is only
+				// using one of them
+
+
+				if ( geo.groups.length === 0 ) {
+
+					geo.addGroup( 0, buffers.materialIndex.length, buffers.materialIndex[ 0 ] );
+
+				}
+
+			}
+
+			this.addMorphTargets( geo, geoNode, morphTargets, preTransform );
+			return geo;
+
+		}
+
+		parseGeoNode( geoNode, skeleton ) {
+
+			const geoInfo = {};
+			geoInfo.vertexPositions = geoNode.Vertices !== undefined ? geoNode.Vertices.a : [];
+			geoInfo.vertexIndices = geoNode.PolygonVertexIndex !== undefined ? geoNode.PolygonVertexIndex.a : [];
+
+			if ( geoNode.LayerElementColor ) {
+
+				geoInfo.color = this.parseVertexColors( geoNode.LayerElementColor[ 0 ] );
+
+			}
+
+			if ( geoNode.LayerElementMaterial ) {
+
+				geoInfo.material = this.parseMaterialIndices( geoNode.LayerElementMaterial[ 0 ] );
+
+			}
+
+			if ( geoNode.LayerElementNormal ) {
+
+				geoInfo.normal = this.parseNormals( geoNode.LayerElementNormal[ 0 ] );
+
+			}
+
+			if ( geoNode.LayerElementUV ) {
+
+				geoInfo.uv = [];
+				let i = 0;
+
+				while ( geoNode.LayerElementUV[ i ] ) {
+
+					if ( geoNode.LayerElementUV[ i ].UV ) {
+
+						geoInfo.uv.push( this.parseUVs( geoNode.LayerElementUV[ i ] ) );
+
+					}
+
+					i ++;
+
+				}
+
+			}
+
+			geoInfo.weightTable = {};
+
+			if ( skeleton !== null ) {
+
+				geoInfo.skeleton = skeleton;
+				skeleton.rawBones.forEach( function ( rawBone, i ) {
+
+					// loop over the bone's vertex indices and weights
+					rawBone.indices.forEach( function ( index, j ) {
+
+						if ( geoInfo.weightTable[ index ] === undefined ) geoInfo.weightTable[ index ] = [];
+						geoInfo.weightTable[ index ].push( {
+							id: i,
+							weight: rawBone.weights[ j ]
+						} );
+
+					} );
 
 				} );
+
+			}
+
+			return geoInfo;
+
+		}
+
+		genBuffers( geoInfo ) {
+
+			const buffers = {
+				vertex: [],
+				normal: [],
+				colors: [],
+				uvs: [],
+				materialIndex: [],
+				vertexWeights: [],
+				weightsIndices: []
+			};
+			let polygonIndex = 0;
+			let faceLength = 0;
+			let displayedWeightsWarning = false; // these will hold data for a single face
+
+			let facePositionIndexes = [];
+			let faceNormals = [];
+			let faceColors = [];
+			let faceUVs = [];
+			let faceWeights = [];
+			let faceWeightIndices = [];
+			const scope = this;
+			geoInfo.vertexIndices.forEach( function ( vertexIndex, polygonVertexIndex ) {
+
+				let materialIndex;
+				let endOfFace = false; // Face index and vertex index arrays are combined in a single array
+				// A cube with quad faces looks like this:
+				// PolygonVertexIndex: *24 {
+				//	a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
+				//	}
+				// Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
+				// to find index of last vertex bit shift the index: ^ - 1
+
+				if ( vertexIndex < 0 ) {
+
+					vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
+
+					endOfFace = true;
+
+				}
+
+				let weightIndices = [];
+				let weights = [];
+				facePositionIndexes.push( vertexIndex * 3, vertexIndex * 3 + 1, vertexIndex * 3 + 2 );
+
+				if ( geoInfo.color ) {
+
+					const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.color );
+					faceColors.push( data[ 0 ], data[ 1 ], data[ 2 ] );
+
+				}
+
+				if ( geoInfo.skeleton ) {
+
+					if ( geoInfo.weightTable[ vertexIndex ] !== undefined ) {
+
+						geoInfo.weightTable[ vertexIndex ].forEach( function ( wt ) {
+
+							weights.push( wt.weight );
+							weightIndices.push( wt.id );
+
+						} );
+
+					}
+
+					if ( weights.length > 4 ) {
+
+						if ( ! displayedWeightsWarning ) {
+
+							console.warn( 'THREE.FBXLoader: Vertex has more than 4 skinning weights assigned to vertex. Deleting additional weights.' );
+							displayedWeightsWarning = true;
+
+						}
+
+						const wIndex = [ 0, 0, 0, 0 ];
+						const Weight = [ 0, 0, 0, 0 ];
+						weights.forEach( function ( weight, weightIndex ) {
+
+							let currentWeight = weight;
+							let currentIndex = weightIndices[ weightIndex ];
+							Weight.forEach( function ( comparedWeight, comparedWeightIndex, comparedWeightArray ) {
+
+								if ( currentWeight > comparedWeight ) {
+
+									comparedWeightArray[ comparedWeightIndex ] = currentWeight;
+									currentWeight = comparedWeight;
+									const tmp = wIndex[ comparedWeightIndex ];
+									wIndex[ comparedWeightIndex ] = currentIndex;
+									currentIndex = tmp;
+
+								}
+
+							} );
+
+						} );
+						weightIndices = wIndex;
+						weights = Weight;
+
+					} // if the weight array is shorter than 4 pad with 0s
+
+
+					while ( weights.length < 4 ) {
+
+						weights.push( 0 );
+						weightIndices.push( 0 );
+
+					}
+
+					for ( let i = 0; i < 4; ++ i ) {
+
+						faceWeights.push( weights[ i ] );
+						faceWeightIndices.push( weightIndices[ i ] );
+
+					}
+
+				}
+
+				if ( geoInfo.normal ) {
+
+					const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.normal );
+					faceNormals.push( data[ 0 ], data[ 1 ], data[ 2 ] );
+
+				}
 
 				if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
 
-					// Convert the material indices of each vertex into rendering groups on the geometry.
-					var prevMaterialIndex = buffers.materialIndex[ 0 ];
-					var startIndex = 0;
-					buffers.materialIndex.forEach( function ( currentIndex, i ) {
+					materialIndex = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material )[ 0 ];
 
-						if ( currentIndex !== prevMaterialIndex ) {
+				}
 
-							geo.addGroup( startIndex, i - startIndex, prevMaterialIndex );
-							prevMaterialIndex = currentIndex;
-							startIndex = i;
+				if ( geoInfo.uv ) {
+
+					geoInfo.uv.forEach( function ( uv, i ) {
+
+						const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, uv );
+
+						if ( faceUVs[ i ] === undefined ) {
+
+							faceUVs[ i ] = [];
 
 						}
 
-					} ); // the loop above doesn't add the last group, do that here.
-
-					if ( geo.groups.length > 0 ) {
-
-						var lastGroup = geo.groups[ geo.groups.length - 1 ];
-						var lastIndex = lastGroup.start + lastGroup.count;
-
-						if ( lastIndex !== buffers.materialIndex.length ) {
-
-							geo.addGroup( lastIndex, buffers.materialIndex.length - lastIndex, prevMaterialIndex );
-
-						}
-
-					} // case where there are multiple materials but the whole geometry is only
-					// using one of them
-
-
-					if ( geo.groups.length === 0 ) {
-
-						geo.addGroup( 0, buffers.materialIndex.length, buffers.materialIndex[ 0 ] );
-
-					}
-
-				}
-
-				this.addMorphTargets( geo, geoNode, morphTargets, preTransform );
-				return geo;
-
-			},
-			parseGeoNode: function ( geoNode, skeleton ) {
-
-				var geoInfo = {};
-				geoInfo.vertexPositions = geoNode.Vertices !== undefined ? geoNode.Vertices.a : [];
-				geoInfo.vertexIndices = geoNode.PolygonVertexIndex !== undefined ? geoNode.PolygonVertexIndex.a : [];
-
-				if ( geoNode.LayerElementColor ) {
-
-					geoInfo.color = this.parseVertexColors( geoNode.LayerElementColor[ 0 ] );
-
-				}
-
-				if ( geoNode.LayerElementMaterial ) {
-
-					geoInfo.material = this.parseMaterialIndices( geoNode.LayerElementMaterial[ 0 ] );
-
-				}
-
-				if ( geoNode.LayerElementNormal ) {
-
-					geoInfo.normal = this.parseNormals( geoNode.LayerElementNormal[ 0 ] );
-
-				}
-
-				if ( geoNode.LayerElementUV ) {
-
-					geoInfo.uv = [];
-					var i = 0;
-
-					while ( geoNode.LayerElementUV[ i ] ) {
-
-						if ( geoNode.LayerElementUV[ i ].UV ) {
-
-							geoInfo.uv.push( this.parseUVs( geoNode.LayerElementUV[ i ] ) );
-
-						}
-
-						i ++;
-
-					}
-
-				}
-
-				geoInfo.weightTable = {};
-
-				if ( skeleton !== null ) {
-
-					geoInfo.skeleton = skeleton;
-					skeleton.rawBones.forEach( function ( rawBone, i ) {
-
-						// loop over the bone's vertex indices and weights
-						rawBone.indices.forEach( function ( index, j ) {
-
-							if ( geoInfo.weightTable[ index ] === undefined ) geoInfo.weightTable[ index ] = [];
-							geoInfo.weightTable[ index ].push( {
-								id: i,
-								weight: rawBone.weights[ j ]
-							} );
-
-						} );
+						faceUVs[ i ].push( data[ 0 ] );
+						faceUVs[ i ].push( data[ 1 ] );
 
 					} );
 
 				}
 
-				return geoInfo;
-
-			},
-			genBuffers: function ( geoInfo ) {
-
-				var buffers = {
-					vertex: [],
-					normal: [],
-					colors: [],
-					uvs: [],
-					materialIndex: [],
-					vertexWeights: [],
-					weightsIndices: []
-				};
-				var polygonIndex = 0;
-				var faceLength = 0;
-				var displayedWeightsWarning = false; // these will hold data for a single face
-
-				var facePositionIndexes = [];
-				var faceNormals = [];
-				var faceColors = [];
-				var faceUVs = [];
-				var faceWeights = [];
-				var faceWeightIndices = [];
-				var scope = this;
-				geoInfo.vertexIndices.forEach( function ( vertexIndex, polygonVertexIndex ) {
-
-					var endOfFace = false; // Face index and vertex index arrays are combined in a single array
-					// A cube with quad faces looks like this:
-					// PolygonVertexIndex: *24 {
-					//	a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
-					//	}
-					// Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
-					// to find index of last vertex bit shift the index: ^ - 1
-
-					if ( vertexIndex < 0 ) {
-
-						vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
-
-						endOfFace = true;
-
-					}
-
-					var weightIndices = [];
-					var weights = [];
-					facePositionIndexes.push( vertexIndex * 3, vertexIndex * 3 + 1, vertexIndex * 3 + 2 );
-
-					if ( geoInfo.color ) {
-
-						var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.color );
-						faceColors.push( data[ 0 ], data[ 1 ], data[ 2 ] );
-
-					}
-
-					if ( geoInfo.skeleton ) {
-
-						if ( geoInfo.weightTable[ vertexIndex ] !== undefined ) {
-
-							geoInfo.weightTable[ vertexIndex ].forEach( function ( wt ) {
-
-								weights.push( wt.weight );
-								weightIndices.push( wt.id );
-
-							} );
-
-						}
-
-						if ( weights.length > 4 ) {
-
-							if ( ! displayedWeightsWarning ) {
-
-								console.warn( 'THREE.FBXLoader: Vertex has more than 4 skinning weights assigned to vertex. Deleting additional weights.' );
-								displayedWeightsWarning = true;
-
-							}
-
-							var wIndex = [ 0, 0, 0, 0 ];
-							var Weight = [ 0, 0, 0, 0 ];
-							weights.forEach( function ( weight, weightIndex ) {
-
-								var currentWeight = weight;
-								var currentIndex = weightIndices[ weightIndex ];
-								Weight.forEach( function ( comparedWeight, comparedWeightIndex, comparedWeightArray ) {
-
-									if ( currentWeight > comparedWeight ) {
-
-										comparedWeightArray[ comparedWeightIndex ] = currentWeight;
-										currentWeight = comparedWeight;
-										var tmp = wIndex[ comparedWeightIndex ];
-										wIndex[ comparedWeightIndex ] = currentIndex;
-										currentIndex = tmp;
-
-									}
-
-								} );
-
-							} );
-							weightIndices = wIndex;
-							weights = Weight;
-
-						} // if the weight array is shorter than 4 pad with 0s
-
-
-						while ( weights.length < 4 ) {
-
-							weights.push( 0 );
-							weightIndices.push( 0 );
-
-						}
-
-						for ( var i = 0; i < 4; ++ i ) {
-
-							faceWeights.push( weights[ i ] );
-							faceWeightIndices.push( weightIndices[ i ] );
-
-						}
-
-					}
-
-					if ( geoInfo.normal ) {
-
-						var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.normal );
-						faceNormals.push( data[ 0 ], data[ 1 ], data[ 2 ] );
-
-					}
-
-					if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
-
-						var materialIndex = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material )[ 0 ];
-
-					}
-
-					if ( geoInfo.uv ) {
-
-						geoInfo.uv.forEach( function ( uv, i ) {
-
-							var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, uv );
-
-							if ( faceUVs[ i ] === undefined ) {
-
-								faceUVs[ i ] = [];
-
-							}
-
-							faceUVs[ i ].push( data[ 0 ] );
-							faceUVs[ i ].push( data[ 1 ] );
-
-						} );
-
-					}
-
-					faceLength ++;
-
-					if ( endOfFace ) {
-
-						scope.genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength );
-						polygonIndex ++;
-						faceLength = 0; // reset arrays for the next face
-
-						facePositionIndexes = [];
-						faceNormals = [];
-						faceColors = [];
-						faceUVs = [];
-						faceWeights = [];
-						faceWeightIndices = [];
-
-					}
-
-				} );
-				return buffers;
-
-			},
-			// Generate data for a single face in a geometry. If the face is a quad then split it into 2 tris
-			genFace: function ( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength ) {
-
-				for ( var i = 2; i < faceLength; i ++ ) {
-
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 0 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 1 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 2 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 1 ] ] );
-					buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 2 ] ] );
-
-					if ( geoInfo.skeleton ) {
-
-						buffers.vertexWeights.push( faceWeights[ 0 ] );
-						buffers.vertexWeights.push( faceWeights[ 1 ] );
-						buffers.vertexWeights.push( faceWeights[ 2 ] );
-						buffers.vertexWeights.push( faceWeights[ 3 ] );
-						buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 ] );
-						buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
-						buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
-						buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
-						buffers.vertexWeights.push( faceWeights[ i * 4 ] );
-						buffers.vertexWeights.push( faceWeights[ i * 4 + 1 ] );
-						buffers.vertexWeights.push( faceWeights[ i * 4 + 2 ] );
-						buffers.vertexWeights.push( faceWeights[ i * 4 + 3 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ 0 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ 1 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ 2 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ 3 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ i * 4 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 1 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 2 ] );
-						buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 3 ] );
-
-					}
-
-					if ( geoInfo.color ) {
-
-						buffers.colors.push( faceColors[ 0 ] );
-						buffers.colors.push( faceColors[ 1 ] );
-						buffers.colors.push( faceColors[ 2 ] );
-						buffers.colors.push( faceColors[ ( i - 1 ) * 3 ] );
-						buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 1 ] );
-						buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 2 ] );
-						buffers.colors.push( faceColors[ i * 3 ] );
-						buffers.colors.push( faceColors[ i * 3 + 1 ] );
-						buffers.colors.push( faceColors[ i * 3 + 2 ] );
-
-					}
-
-					if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
-
-						buffers.materialIndex.push( materialIndex );
-						buffers.materialIndex.push( materialIndex );
-						buffers.materialIndex.push( materialIndex );
-
-					}
-
-					if ( geoInfo.normal ) {
-
-						buffers.normal.push( faceNormals[ 0 ] );
-						buffers.normal.push( faceNormals[ 1 ] );
-						buffers.normal.push( faceNormals[ 2 ] );
-						buffers.normal.push( faceNormals[ ( i - 1 ) * 3 ] );
-						buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 1 ] );
-						buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 2 ] );
-						buffers.normal.push( faceNormals[ i * 3 ] );
-						buffers.normal.push( faceNormals[ i * 3 + 1 ] );
-						buffers.normal.push( faceNormals[ i * 3 + 2 ] );
-
-					}
-
-					if ( geoInfo.uv ) {
-
-						geoInfo.uv.forEach( function ( uv, j ) {
-
-							if ( buffers.uvs[ j ] === undefined ) buffers.uvs[ j ] = [];
-							buffers.uvs[ j ].push( faceUVs[ j ][ 0 ] );
-							buffers.uvs[ j ].push( faceUVs[ j ][ 1 ] );
-							buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 ] );
-							buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
-							buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 ] );
-							buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 + 1 ] );
-
-						} );
-
-					}
+				faceLength ++;
+
+				if ( endOfFace ) {
+
+					scope.genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength );
+					polygonIndex ++;
+					faceLength = 0; // reset arrays for the next face
+
+					facePositionIndexes = [];
+					faceNormals = [];
+					faceColors = [];
+					faceUVs = [];
+					faceWeights = [];
+					faceWeightIndices = [];
 
 				}
 
-			},
-			addMorphTargets: function ( parentGeo, parentGeoNode, morphTargets, preTransform ) {
+			} );
+			return buffers;
 
-				if ( morphTargets.length === 0 ) return;
-				parentGeo.morphTargetsRelative = true;
-				parentGeo.morphAttributes.position = []; // parentGeo.morphAttributes.normal = []; // not implemented
+		} // Generate data for a single face in a geometry. If the face is a quad then split it into 2 tris
 
-				var scope = this;
-				morphTargets.forEach( function ( morphTarget ) {
 
-					morphTarget.rawTargets.forEach( function ( rawTarget ) {
+		genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength ) {
 
-						var morphGeoNode = fbxTree.Objects.Geometry[ rawTarget.geoID ];
+			for ( let i = 2; i < faceLength; i ++ ) {
 
-						if ( morphGeoNode !== undefined ) {
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 0 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 1 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 2 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 1 ] ] );
+				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 2 ] ] );
 
-							scope.genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, rawTarget.name );
+				if ( geoInfo.skeleton ) {
 
-						}
+					buffers.vertexWeights.push( faceWeights[ 0 ] );
+					buffers.vertexWeights.push( faceWeights[ 1 ] );
+					buffers.vertexWeights.push( faceWeights[ 2 ] );
+					buffers.vertexWeights.push( faceWeights[ 3 ] );
+					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 ] );
+					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
+					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
+					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
+					buffers.vertexWeights.push( faceWeights[ i * 4 ] );
+					buffers.vertexWeights.push( faceWeights[ i * 4 + 1 ] );
+					buffers.vertexWeights.push( faceWeights[ i * 4 + 2 ] );
+					buffers.vertexWeights.push( faceWeights[ i * 4 + 3 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ 0 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ 1 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ 2 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ 3 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ i * 4 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 1 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 2 ] );
+					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 3 ] );
+
+				}
+
+				if ( geoInfo.color ) {
+
+					buffers.colors.push( faceColors[ 0 ] );
+					buffers.colors.push( faceColors[ 1 ] );
+					buffers.colors.push( faceColors[ 2 ] );
+					buffers.colors.push( faceColors[ ( i - 1 ) * 3 ] );
+					buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 1 ] );
+					buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 2 ] );
+					buffers.colors.push( faceColors[ i * 3 ] );
+					buffers.colors.push( faceColors[ i * 3 + 1 ] );
+					buffers.colors.push( faceColors[ i * 3 + 2 ] );
+
+				}
+
+				if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
+
+					buffers.materialIndex.push( materialIndex );
+					buffers.materialIndex.push( materialIndex );
+					buffers.materialIndex.push( materialIndex );
+
+				}
+
+				if ( geoInfo.normal ) {
+
+					buffers.normal.push( faceNormals[ 0 ] );
+					buffers.normal.push( faceNormals[ 1 ] );
+					buffers.normal.push( faceNormals[ 2 ] );
+					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 ] );
+					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 1 ] );
+					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 2 ] );
+					buffers.normal.push( faceNormals[ i * 3 ] );
+					buffers.normal.push( faceNormals[ i * 3 + 1 ] );
+					buffers.normal.push( faceNormals[ i * 3 + 2 ] );
+
+				}
+
+				if ( geoInfo.uv ) {
+
+					geoInfo.uv.forEach( function ( uv, j ) {
+
+						if ( buffers.uvs[ j ] === undefined ) buffers.uvs[ j ] = [];
+						buffers.uvs[ j ].push( faceUVs[ j ][ 0 ] );
+						buffers.uvs[ j ].push( faceUVs[ j ][ 1 ] );
+						buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 ] );
+						buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
+						buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 ] );
+						buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 + 1 ] );
 
 					} );
 
-				} );
+				}
 
-			},
-			// a morph geometry node is similar to a standard	node, and the node is also contained
-			// in FBXTree.Objects.Geometry, however it can only have attributes for position, normal
-			// and a special attribute Index defining which vertices of the original geometry are affected
-			// Normal and position attributes only have data for the vertices that are affected by the morph
-			genMorphGeometry: function ( parentGeo, parentGeoNode, morphGeoNode, preTransform, name ) {
+			}
 
-				var vertexIndices = parentGeoNode.PolygonVertexIndex !== undefined ? parentGeoNode.PolygonVertexIndex.a : [];
-				var morphPositionsSparse = morphGeoNode.Vertices !== undefined ? morphGeoNode.Vertices.a : [];
-				var indices = morphGeoNode.Indexes !== undefined ? morphGeoNode.Indexes.a : [];
-				var length = parentGeo.attributes.position.count * 3;
-				var morphPositions = new Float32Array( length );
+		}
 
-				for ( var i = 0; i < indices.length; i ++ ) {
+		addMorphTargets( parentGeo, parentGeoNode, morphTargets, preTransform ) {
 
-					var morphIndex = indices[ i ] * 3;
-					morphPositions[ morphIndex ] = morphPositionsSparse[ i * 3 ];
-					morphPositions[ morphIndex + 1 ] = morphPositionsSparse[ i * 3 + 1 ];
-					morphPositions[ morphIndex + 2 ] = morphPositionsSparse[ i * 3 + 2 ];
+			if ( morphTargets.length === 0 ) return;
+			parentGeo.morphTargetsRelative = true;
+			parentGeo.morphAttributes.position = []; // parentGeo.morphAttributes.normal = []; // not implemented
 
-				} // TODO: add morph normal support
+			const scope = this;
+			morphTargets.forEach( function ( morphTarget ) {
 
+				morphTarget.rawTargets.forEach( function ( rawTarget ) {
 
-				var morphGeoInfo = {
-					vertexIndices: vertexIndices,
-					vertexPositions: morphPositions
-				};
-				var morphBuffers = this.genBuffers( morphGeoInfo );
-				var positionAttribute = new THREE.Float32BufferAttribute( morphBuffers.vertex, 3 );
-				positionAttribute.name = name || morphGeoNode.attrName;
-				positionAttribute.applyMatrix4( preTransform );
-				parentGeo.morphAttributes.position.push( positionAttribute );
+					const morphGeoNode = fbxTree.Objects.Geometry[ rawTarget.geoID ];
 
-			},
-			// Parse normal from FBXTree.Objects.Geometry.LayerElementNormal if it exists
-			parseNormals: function ( NormalNode ) {
+					if ( morphGeoNode !== undefined ) {
 
-				var mappingType = NormalNode.MappingInformationType;
-				var referenceType = NormalNode.ReferenceInformationType;
-				var buffer = NormalNode.Normals.a;
-				var indexBuffer = [];
-
-				if ( referenceType === 'IndexToDirect' ) {
-
-					if ( 'NormalIndex' in NormalNode ) {
-
-						indexBuffer = NormalNode.NormalIndex.a;
-
-					} else if ( 'NormalsIndex' in NormalNode ) {
-
-						indexBuffer = NormalNode.NormalsIndex.a;
+						scope.genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, rawTarget.name );
 
 					}
 
-				}
+				} );
 
-				return {
-					dataSize: 3,
-					buffer: buffer,
-					indices: indexBuffer,
-					mappingType: mappingType,
-					referenceType: referenceType
-				};
+			} );
 
-			},
-			// Parse UVs from FBXTree.Objects.Geometry.LayerElementUV if it exists
-			parseUVs: function ( UVNode ) {
+		} // a morph geometry node is similar to a standard	node, and the node is also contained
+		// in FBXTree.Objects.Geometry, however it can only have attributes for position, normal
+		// and a special attribute Index defining which vertices of the original geometry are affected
+		// Normal and position attributes only have data for the vertices that are affected by the morph
 
-				var mappingType = UVNode.MappingInformationType;
-				var referenceType = UVNode.ReferenceInformationType;
-				var buffer = UVNode.UV.a;
-				var indexBuffer = [];
 
-				if ( referenceType === 'IndexToDirect' ) {
+		genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, name ) {
 
-					indexBuffer = UVNode.UVIndex.a;
+			const vertexIndices = parentGeoNode.PolygonVertexIndex !== undefined ? parentGeoNode.PolygonVertexIndex.a : [];
+			const morphPositionsSparse = morphGeoNode.Vertices !== undefined ? morphGeoNode.Vertices.a : [];
+			const indices = morphGeoNode.Indexes !== undefined ? morphGeoNode.Indexes.a : [];
+			const length = parentGeo.attributes.position.count * 3;
+			const morphPositions = new Float32Array( length );
 
-				}
+			for ( let i = 0; i < indices.length; i ++ ) {
 
-				return {
-					dataSize: 2,
-					buffer: buffer,
-					indices: indexBuffer,
-					mappingType: mappingType,
-					referenceType: referenceType
-				};
+				const morphIndex = indices[ i ] * 3;
+				morphPositions[ morphIndex ] = morphPositionsSparse[ i * 3 ];
+				morphPositions[ morphIndex + 1 ] = morphPositionsSparse[ i * 3 + 1 ];
+				morphPositions[ morphIndex + 2 ] = morphPositionsSparse[ i * 3 + 2 ];
 
-			},
-			// Parse Vertex Colors from FBXTree.Objects.Geometry.LayerElementColor if it exists
-			parseVertexColors: function ( ColorNode ) {
+			} // TODO: add morph normal support
 
-				var mappingType = ColorNode.MappingInformationType;
-				var referenceType = ColorNode.ReferenceInformationType;
-				var buffer = ColorNode.Colors.a;
-				var indexBuffer = [];
 
-				if ( referenceType === 'IndexToDirect' ) {
+			const morphGeoInfo = {
+				vertexIndices: vertexIndices,
+				vertexPositions: morphPositions
+			};
+			const morphBuffers = this.genBuffers( morphGeoInfo );
+			const positionAttribute = new THREE.Float32BufferAttribute( morphBuffers.vertex, 3 );
+			positionAttribute.name = name || morphGeoNode.attrName;
+			positionAttribute.applyMatrix4( preTransform );
+			parentGeo.morphAttributes.position.push( positionAttribute );
 
-					indexBuffer = ColorNode.ColorIndex.a;
+		} // Parse normal from FBXTree.Objects.Geometry.LayerElementNormal if it exists
 
-				}
 
-				return {
-					dataSize: 4,
-					buffer: buffer,
-					indices: indexBuffer,
-					mappingType: mappingType,
-					referenceType: referenceType
-				};
+		parseNormals( NormalNode ) {
 
-			},
-			// Parse mapping and material data in FBXTree.Objects.Geometry.LayerElementMaterial if it exists
-			parseMaterialIndices: function ( MaterialNode ) {
+			const mappingType = NormalNode.MappingInformationType;
+			const referenceType = NormalNode.ReferenceInformationType;
+			const buffer = NormalNode.Normals.a;
+			let indexBuffer = [];
 
-				var mappingType = MaterialNode.MappingInformationType;
-				var referenceType = MaterialNode.ReferenceInformationType;
+			if ( referenceType === 'IndexToDirect' ) {
 
-				if ( mappingType === 'NoMappingInformation' ) {
+				if ( 'NormalIndex' in NormalNode ) {
 
-					return {
-						dataSize: 1,
-						buffer: [ 0 ],
-						indices: [ 0 ],
-						mappingType: 'AllSame',
-						referenceType: referenceType
-					};
+					indexBuffer = NormalNode.NormalIndex.a;
+
+				} else if ( 'NormalsIndex' in NormalNode ) {
+
+					indexBuffer = NormalNode.NormalsIndex.a;
 
 				}
 
-				var materialIndexBuffer = MaterialNode.Materials.a; // Since materials are stored as indices, there's a bit of a mismatch between FBX and what
-				// we expect.So we create an intermediate buffer that points to the index in the buffer,
-				// for conforming with the other functions we've written for other data.
+			}
 
-				var materialIndices = [];
+			return {
+				dataSize: 3,
+				buffer: buffer,
+				indices: indexBuffer,
+				mappingType: mappingType,
+				referenceType: referenceType
+			};
 
-				for ( var i = 0; i < materialIndexBuffer.length; ++ i ) {
+		} // Parse UVs from FBXTree.Objects.Geometry.LayerElementUV if it exists
 
-					materialIndices.push( i );
 
-				}
+		parseUVs( UVNode ) {
+
+			const mappingType = UVNode.MappingInformationType;
+			const referenceType = UVNode.ReferenceInformationType;
+			const buffer = UVNode.UV.a;
+			let indexBuffer = [];
+
+			if ( referenceType === 'IndexToDirect' ) {
+
+				indexBuffer = UVNode.UVIndex.a;
+
+			}
+
+			return {
+				dataSize: 2,
+				buffer: buffer,
+				indices: indexBuffer,
+				mappingType: mappingType,
+				referenceType: referenceType
+			};
+
+		} // Parse Vertex Colors from FBXTree.Objects.Geometry.LayerElementColor if it exists
+
+
+		parseVertexColors( ColorNode ) {
+
+			const mappingType = ColorNode.MappingInformationType;
+			const referenceType = ColorNode.ReferenceInformationType;
+			const buffer = ColorNode.Colors.a;
+			let indexBuffer = [];
+
+			if ( referenceType === 'IndexToDirect' ) {
+
+				indexBuffer = ColorNode.ColorIndex.a;
+
+			}
+
+			return {
+				dataSize: 4,
+				buffer: buffer,
+				indices: indexBuffer,
+				mappingType: mappingType,
+				referenceType: referenceType
+			};
+
+		} // Parse mapping and material data in FBXTree.Objects.Geometry.LayerElementMaterial if it exists
+
+
+		parseMaterialIndices( MaterialNode ) {
+
+			const mappingType = MaterialNode.MappingInformationType;
+			const referenceType = MaterialNode.ReferenceInformationType;
+
+			if ( mappingType === 'NoMappingInformation' ) {
 
 				return {
 					dataSize: 1,
-					buffer: materialIndexBuffer,
-					indices: materialIndices,
-					mappingType: mappingType,
+					buffer: [ 0 ],
+					indices: [ 0 ],
+					mappingType: 'AllSame',
 					referenceType: referenceType
 				};
 
-			},
-			// Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
-			parseNurbsGeometry: function ( geoNode ) {
+			}
 
-				if ( THREE.NURBSCurve === undefined ) {
+			const materialIndexBuffer = MaterialNode.Materials.a; // Since materials are stored as indices, there's a bit of a mismatch between FBX and what
+			// we expect.So we create an intermediate buffer that points to the index in the buffer,
+			// for conforming with the other functions we've written for other data.
 
-					console.error( 'THREE.FBXLoader: The loader relies on THREE.NURBSCurve for any nurbs present in the model. Nurbs will show up as empty geometry.' );
-					return new THREE.BufferGeometry();
+			const materialIndices = [];
 
-				}
+			for ( let i = 0; i < materialIndexBuffer.length; ++ i ) {
 
-				var order = parseInt( geoNode.Order );
-
-				if ( isNaN( order ) ) {
-
-					console.error( 'THREE.FBXLoader: Invalid Order %s given for geometry ID: %s', geoNode.Order, geoNode.id );
-					return new THREE.BufferGeometry();
-
-				}
-
-				var degree = order - 1;
-				var knots = geoNode.KnotVector.a;
-				var controlPoints = [];
-				var pointsValues = geoNode.Points.a;
-
-				for ( var i = 0, l = pointsValues.length; i < l; i += 4 ) {
-
-					controlPoints.push( new THREE.Vector4().fromArray( pointsValues, i ) );
-
-				}
-
-				var startKnot, endKnot;
-
-				if ( geoNode.Form === 'Closed' ) {
-
-					controlPoints.push( controlPoints[ 0 ] );
-
-				} else if ( geoNode.Form === 'Periodic' ) {
-
-					startKnot = degree;
-					endKnot = knots.length - 1 - startKnot;
-
-					for ( var i = 0; i < degree; ++ i ) {
-
-						controlPoints.push( controlPoints[ i ] );
-
-					}
-
-				}
-
-				var curve = new THREE.NURBSCurve( degree, knots, controlPoints, startKnot, endKnot );
-				var vertices = curve.getPoints( controlPoints.length * 7 );
-				var positions = new Float32Array( vertices.length * 3 );
-				vertices.forEach( function ( vertex, i ) {
-
-					vertex.toArray( positions, i * 3 );
-
-				} );
-				var geometry = new THREE.BufferGeometry();
-				geometry.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
-				return geometry;
+				materialIndices.push( i );
 
 			}
-		}; // parse animation data from FBXTree
 
-		function AnimationParser() {}
+			return {
+				dataSize: 1,
+				buffer: materialIndexBuffer,
+				indices: materialIndices,
+				mappingType: mappingType,
+				referenceType: referenceType
+			};
 
-		AnimationParser.prototype = {
-			constructor: AnimationParser,
-			// take raw animation clips and turn them into three.js animation clips
-			parse: function () {
+		} // Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
 
-				var animationClips = [];
-				var rawClips = this.parseClips();
 
-				if ( rawClips !== undefined ) {
+		parseNurbsGeometry( geoNode ) {
 
-					for ( var key in rawClips ) {
+			if ( THREE.NURBSCurve === undefined ) {
 
-						var rawClip = rawClips[ key ];
-						var clip = this.addClip( rawClip );
-						animationClips.push( clip );
+				console.error( 'THREE.FBXLoader: The loader relies on THREE.NURBSCurve for any nurbs present in the model. Nurbs will show up as empty geometry.' );
+				return new THREE.BufferGeometry();
 
-					}
+			}
 
-				}
+			const order = parseInt( geoNode.Order );
 
-				return animationClips;
+			if ( isNaN( order ) ) {
 
-			},
-			parseClips: function () {
+				console.error( 'THREE.FBXLoader: Invalid Order %s given for geometry ID: %s', geoNode.Order, geoNode.id );
+				return new THREE.BufferGeometry();
 
-				// since the actual transformation data is stored in FBXTree.Objects.AnimationCurve,
-				// if this is undefined we can safely assume there are no animations
-				if ( fbxTree.Objects.AnimationCurve === undefined ) return undefined;
-				var curveNodesMap = this.parseAnimationCurveNodes();
-				this.parseAnimationCurves( curveNodesMap );
-				var layersMap = this.parseAnimationLayers( curveNodesMap );
-				var rawClips = this.parseAnimStacks( layersMap );
-				return rawClips;
+			}
 
-			},
-			// parse nodes in FBXTree.Objects.AnimationCurveNode
-			// each AnimationCurveNode holds data for an animation transform for a model (e.g. left arm rotation )
-			// and is referenced by an AnimationLayer
-			parseAnimationCurveNodes: function () {
+			const degree = order - 1;
+			const knots = geoNode.KnotVector.a;
+			const controlPoints = [];
+			const pointsValues = geoNode.Points.a;
 
-				var rawCurveNodes = fbxTree.Objects.AnimationCurveNode;
-				var curveNodesMap = new Map();
+			for ( let i = 0, l = pointsValues.length; i < l; i += 4 ) {
 
-				for ( var nodeID in rawCurveNodes ) {
+				controlPoints.push( new THREE.Vector4().fromArray( pointsValues, i ) );
 
-					var rawCurveNode = rawCurveNodes[ nodeID ];
+			}
 
-					if ( rawCurveNode.attrName.match( /S|R|T|DeformPercent/ ) !== null ) {
+			let startKnot, endKnot;
 
-						var curveNode = {
-							id: rawCurveNode.id,
-							attr: rawCurveNode.attrName,
-							curves: {}
-						};
-						curveNodesMap.set( curveNode.id, curveNode );
+			if ( geoNode.Form === 'Closed' ) {
 
-					}
+				controlPoints.push( controlPoints[ 0 ] );
+
+			} else if ( geoNode.Form === 'Periodic' ) {
+
+				startKnot = degree;
+				endKnot = knots.length - 1 - startKnot;
+
+				for ( let i = 0; i < degree; ++ i ) {
+
+					controlPoints.push( controlPoints[ i ] );
 
 				}
 
-				return curveNodesMap;
+			}
 
-			},
-			// parse nodes in FBXTree.Objects.AnimationCurve and connect them up to
-			// previously parsed AnimationCurveNodes. Each AnimationCurve holds data for a single animated
-			// axis ( e.g. times and values of x rotation)
-			parseAnimationCurves: function ( curveNodesMap ) {
+			const curve = new THREE.NURBSCurve( degree, knots, controlPoints, startKnot, endKnot );
+			const vertices = curve.getPoints( controlPoints.length * 7 );
+			const positions = new Float32Array( vertices.length * 3 );
+			vertices.forEach( function ( vertex, i ) {
 
-				var rawCurves = fbxTree.Objects.AnimationCurve; // TODO: Many values are identical up to roundoff error, but won't be optimised
-				// e.g. position times: [0, 0.4, 0. 8]
-				// position values: [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.235384487103147e-7, 93.67520904541016, -0.9982695579528809]
-				// clearly, this should be optimised to
-				// times: [0], positions [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809]
-				// this shows up in nearly every FBX file, and generally time array is length > 100
+				vertex.toArray( positions, i * 3 );
 
-				for ( var nodeID in rawCurves ) {
+			} );
+			const geometry = new THREE.BufferGeometry();
+			geometry.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+			return geometry;
 
-					var animationCurve = {
-						id: rawCurves[ nodeID ].id,
-						times: rawCurves[ nodeID ].KeyTime.a.map( convertFBXTimeToSeconds ),
-						values: rawCurves[ nodeID ].KeyValueFloat.a
+		}
+
+	} // parse animation data from FBXTree
+
+
+	class AnimationParser {
+
+		// take raw animation clips and turn them into three.js animation clips
+		parse() {
+
+			const animationClips = [];
+			const rawClips = this.parseClips();
+
+			if ( rawClips !== undefined ) {
+
+				for ( const key in rawClips ) {
+
+					const rawClip = rawClips[ key ];
+					const clip = this.addClip( rawClip );
+					animationClips.push( clip );
+
+				}
+
+			}
+
+			return animationClips;
+
+		}
+
+		parseClips() {
+
+			// since the actual transformation data is stored in FBXTree.Objects.AnimationCurve,
+			// if this is undefined we can safely assume there are no animations
+			if ( fbxTree.Objects.AnimationCurve === undefined ) return undefined;
+			const curveNodesMap = this.parseAnimationCurveNodes();
+			this.parseAnimationCurves( curveNodesMap );
+			const layersMap = this.parseAnimationLayers( curveNodesMap );
+			const rawClips = this.parseAnimStacks( layersMap );
+			return rawClips;
+
+		} // parse nodes in FBXTree.Objects.AnimationCurveNode
+		// each AnimationCurveNode holds data for an animation transform for a model (e.g. left arm rotation )
+		// and is referenced by an AnimationLayer
+
+
+		parseAnimationCurveNodes() {
+
+			const rawCurveNodes = fbxTree.Objects.AnimationCurveNode;
+			const curveNodesMap = new Map();
+
+			for ( const nodeID in rawCurveNodes ) {
+
+				const rawCurveNode = rawCurveNodes[ nodeID ];
+
+				if ( rawCurveNode.attrName.match( /S|R|T|DeformPercent/ ) !== null ) {
+
+					const curveNode = {
+						id: rawCurveNode.id,
+						attr: rawCurveNode.attrName,
+						curves: {}
 					};
-					var relationships = connections.get( animationCurve.id );
+					curveNodesMap.set( curveNode.id, curveNode );
 
-					if ( relationships !== undefined ) {
+				}
 
-						var animationCurveID = relationships.parents[ 0 ].ID;
-						var animationCurveRelationship = relationships.parents[ 0 ].relationship;
+			}
 
-						if ( animationCurveRelationship.match( /X/ ) ) {
+			return curveNodesMap;
 
-							curveNodesMap.get( animationCurveID ).curves[ 'x' ] = animationCurve;
+		} // parse nodes in FBXTree.Objects.AnimationCurve and connect them up to
+		// previously parsed AnimationCurveNodes. Each AnimationCurve holds data for a single animated
+		// axis ( e.g. times and values of x rotation)
 
-						} else if ( animationCurveRelationship.match( /Y/ ) ) {
 
-							curveNodesMap.get( animationCurveID ).curves[ 'y' ] = animationCurve;
+		parseAnimationCurves( curveNodesMap ) {
 
-						} else if ( animationCurveRelationship.match( /Z/ ) ) {
+			const rawCurves = fbxTree.Objects.AnimationCurve; // TODO: Many values are identical up to roundoff error, but won't be optimised
+			// e.g. position times: [0, 0.4, 0. 8]
+			// position values: [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.235384487103147e-7, 93.67520904541016, -0.9982695579528809]
+			// clearly, this should be optimised to
+			// times: [0], positions [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809]
+			// this shows up in nearly every FBX file, and generally time array is length > 100
 
-							curveNodesMap.get( animationCurveID ).curves[ 'z' ] = animationCurve;
+			for ( const nodeID in rawCurves ) {
 
-						} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) && curveNodesMap.has( animationCurveID ) ) {
+				const animationCurve = {
+					id: rawCurves[ nodeID ].id,
+					times: rawCurves[ nodeID ].KeyTime.a.map( convertFBXTimeToSeconds ),
+					values: rawCurves[ nodeID ].KeyValueFloat.a
+				};
+				const relationships = connections.get( animationCurve.id );
 
-							curveNodesMap.get( animationCurveID ).curves[ 'morph' ] = animationCurve;
+				if ( relationships !== undefined ) {
 
-						}
+					const animationCurveID = relationships.parents[ 0 ].ID;
+					const animationCurveRelationship = relationships.parents[ 0 ].relationship;
+
+					if ( animationCurveRelationship.match( /X/ ) ) {
+
+						curveNodesMap.get( animationCurveID ).curves[ 'x' ] = animationCurve;
+
+					} else if ( animationCurveRelationship.match( /Y/ ) ) {
+
+						curveNodesMap.get( animationCurveID ).curves[ 'y' ] = animationCurve;
+
+					} else if ( animationCurveRelationship.match( /Z/ ) ) {
+
+						curveNodesMap.get( animationCurveID ).curves[ 'z' ] = animationCurve;
+
+					} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) && curveNodesMap.has( animationCurveID ) ) {
+
+						curveNodesMap.get( animationCurveID ).curves[ 'morph' ] = animationCurve;
 
 					}
 
 				}
 
-			},
-			// parse nodes in FBXTree.Objects.AnimationLayer. Each layers holds references
-			// to various AnimationCurveNodes and is referenced by an AnimationStack node
-			// note: theoretically a stack can have multiple layers, however in practice there always seems to be one per stack
-			parseAnimationLayers: function ( curveNodesMap ) {
+			}
 
-				var rawLayers = fbxTree.Objects.AnimationLayer;
-				var layersMap = new Map();
+		} // parse nodes in FBXTree.Objects.AnimationLayer. Each layers holds references
+		// to various AnimationCurveNodes and is referenced by an AnimationStack node
+		// note: theoretically a stack can have multiple layers, however in practice there always seems to be one per stack
 
-				for ( var nodeID in rawLayers ) {
 
-					var layerCurveNodes = [];
-					var connection = connections.get( parseInt( nodeID ) );
+		parseAnimationLayers( curveNodesMap ) {
 
-					if ( connection !== undefined ) {
+			const rawLayers = fbxTree.Objects.AnimationLayer;
+			const layersMap = new Map();
 
-						// all the animationCurveNodes used in the layer
-						var children = connection.children;
-						children.forEach( function ( child, i ) {
+			for ( const nodeID in rawLayers ) {
 
-							if ( curveNodesMap.has( child.ID ) ) {
+				const layerCurveNodes = [];
+				const connection = connections.get( parseInt( nodeID ) );
 
-								var curveNode = curveNodesMap.get( child.ID ); // check that the curves are defined for at least one axis, otherwise ignore the curveNode
+				if ( connection !== undefined ) {
 
-								if ( curveNode.curves.x !== undefined || curveNode.curves.y !== undefined || curveNode.curves.z !== undefined ) {
+					// all the animationCurveNodes used in the layer
+					const children = connection.children;
+					children.forEach( function ( child, i ) {
 
-									if ( layerCurveNodes[ i ] === undefined ) {
+						if ( curveNodesMap.has( child.ID ) ) {
 
-										var modelID = connections.get( child.ID ).parents.filter( function ( parent ) {
+							const curveNode = curveNodesMap.get( child.ID ); // check that the curves are defined for at least one axis, otherwise ignore the curveNode
 
-											return parent.relationship !== undefined;
+							if ( curveNode.curves.x !== undefined || curveNode.curves.y !== undefined || curveNode.curves.z !== undefined ) {
 
-										} )[ 0 ].ID;
+								if ( layerCurveNodes[ i ] === undefined ) {
 
-										if ( modelID !== undefined ) {
+									const modelID = connections.get( child.ID ).parents.filter( function ( parent ) {
 
-											var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
+										return parent.relationship !== undefined;
 
-											if ( rawModel === undefined ) {
+									} )[ 0 ].ID;
 
-												console.warn( 'THREE.FBXLoader: Encountered a unused curve.', child );
-												return;
+									if ( modelID !== undefined ) {
 
-											}
+										const rawModel = fbxTree.Objects.Model[ modelID.toString() ];
 
-											var node = {
-												modelName: rawModel.attrName ? THREE.PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
-												ID: rawModel.id,
-												initialPosition: [ 0, 0, 0 ],
-												initialRotation: [ 0, 0, 0 ],
-												initialScale: [ 1, 1, 1 ]
-											};
-											sceneGraph.traverse( function ( child ) {
+										if ( rawModel === undefined ) {
 
-												if ( child.ID === rawModel.id ) {
-
-													node.transform = child.matrix;
-													if ( child.userData.transformData ) node.eulerOrder = child.userData.transformData.eulerOrder;
-
-												}
-
-											} );
-											if ( ! node.transform ) node.transform = new THREE.Matrix4(); // if the animated model is pre rotated, we'll have to apply the pre rotations to every
-											// animation value as well
-
-											if ( 'PreRotation' in rawModel ) node.preRotation = rawModel.PreRotation.value;
-											if ( 'PostRotation' in rawModel ) node.postRotation = rawModel.PostRotation.value;
-											layerCurveNodes[ i ] = node;
+											console.warn( 'THREE.FBXLoader: Encountered a unused curve.', child );
+											return;
 
 										}
 
-									}
-
-									if ( layerCurveNodes[ i ] ) layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
-
-								} else if ( curveNode.curves.morph !== undefined ) {
-
-									if ( layerCurveNodes[ i ] === undefined ) {
-
-										var deformerID = connections.get( child.ID ).parents.filter( function ( parent ) {
-
-											return parent.relationship !== undefined;
-
-										} )[ 0 ].ID;
-										var morpherID = connections.get( deformerID ).parents[ 0 ].ID;
-										var geoID = connections.get( morpherID ).parents[ 0 ].ID; // assuming geometry is not used in more than one model
-
-										var modelID = connections.get( geoID ).parents[ 0 ].ID;
-										var rawModel = fbxTree.Objects.Model[ modelID ];
-										var node = {
+										const node = {
 											modelName: rawModel.attrName ? THREE.PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
-											morphName: fbxTree.Objects.Deformer[ deformerID ].attrName
+											ID: rawModel.id,
+											initialPosition: [ 0, 0, 0 ],
+											initialRotation: [ 0, 0, 0 ],
+											initialScale: [ 1, 1, 1 ]
 										};
+										sceneGraph.traverse( function ( child ) {
+
+											if ( child.ID === rawModel.id ) {
+
+												node.transform = child.matrix;
+												if ( child.userData.transformData ) node.eulerOrder = child.userData.transformData.eulerOrder;
+
+											}
+
+										} );
+										if ( ! node.transform ) node.transform = new THREE.Matrix4(); // if the animated model is pre rotated, we'll have to apply the pre rotations to every
+										// animation value as well
+
+										if ( 'PreRotation' in rawModel ) node.preRotation = rawModel.PreRotation.value;
+										if ( 'PostRotation' in rawModel ) node.postRotation = rawModel.PostRotation.value;
 										layerCurveNodes[ i ] = node;
 
 									}
 
-									layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+								}
+
+								if ( layerCurveNodes[ i ] ) layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+
+							} else if ( curveNode.curves.morph !== undefined ) {
+
+								if ( layerCurveNodes[ i ] === undefined ) {
+
+									const deformerID = connections.get( child.ID ).parents.filter( function ( parent ) {
+
+										return parent.relationship !== undefined;
+
+									} )[ 0 ].ID;
+									const morpherID = connections.get( deformerID ).parents[ 0 ].ID;
+									const geoID = connections.get( morpherID ).parents[ 0 ].ID; // assuming geometry is not used in more than one model
+
+									const modelID = connections.get( geoID ).parents[ 0 ].ID;
+									const rawModel = fbxTree.Objects.Model[ modelID ];
+									const node = {
+										modelName: rawModel.attrName ? THREE.PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
+										morphName: fbxTree.Objects.Deformer[ deformerID ].attrName
+									};
+									layerCurveNodes[ i ] = node;
 
 								}
 
+								layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+
 							}
 
-						} );
-						layersMap.set( parseInt( nodeID ), layerCurveNodes );
-
-					}
-
-				}
-
-				return layersMap;
-
-			},
-			// parse nodes in FBXTree.Objects.AnimationStack. These are the top level node in the animation
-			// hierarchy. Each Stack node will be used to create a THREE.AnimationClip
-			parseAnimStacks: function ( layersMap ) {
-
-				var rawStacks = fbxTree.Objects.AnimationStack; // connect the stacks (clips) up to the layers
-
-				var rawClips = {};
-
-				for ( var nodeID in rawStacks ) {
-
-					var children = connections.get( parseInt( nodeID ) ).children;
-
-					if ( children.length > 1 ) {
-
-						// it seems like stacks will always be associated with a single layer. But just in case there are files
-						// where there are multiple layers per stack, we'll display a warning
-						console.warn( 'THREE.FBXLoader: Encountered an animation stack with multiple layers, this is currently not supported. Ignoring subsequent layers.' );
-
-					}
-
-					var layer = layersMap.get( children[ 0 ].ID );
-					rawClips[ nodeID ] = {
-						name: rawStacks[ nodeID ].attrName,
-						layer: layer
-					};
-
-				}
-
-				return rawClips;
-
-			},
-			addClip: function ( rawClip ) {
-
-				var tracks = [];
-				var scope = this;
-				rawClip.layer.forEach( function ( rawTracks ) {
-
-					tracks = tracks.concat( scope.generateTracks( rawTracks ) );
-
-				} );
-				return new THREE.AnimationClip( rawClip.name, - 1, tracks );
-
-			},
-			generateTracks: function ( rawTracks ) {
-
-				var tracks = [];
-				var initialPosition = new THREE.Vector3();
-				var initialRotation = new THREE.Quaternion();
-				var initialScale = new THREE.Vector3();
-				if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
-				initialPosition = initialPosition.toArray();
-				initialRotation = new THREE.Euler().setFromQuaternion( initialRotation, rawTracks.eulerOrder ).toArray();
-				initialScale = initialScale.toArray();
-
-				if ( rawTracks.T !== undefined && Object.keys( rawTracks.T.curves ).length > 0 ) {
-
-					var positionTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position' );
-					if ( positionTrack !== undefined ) tracks.push( positionTrack );
-
-				}
-
-				if ( rawTracks.R !== undefined && Object.keys( rawTracks.R.curves ).length > 0 ) {
-
-					var rotationTrack = this.generateRotationTrack( rawTracks.modelName, rawTracks.R.curves, initialRotation, rawTracks.preRotation, rawTracks.postRotation, rawTracks.eulerOrder );
-					if ( rotationTrack !== undefined ) tracks.push( rotationTrack );
-
-				}
-
-				if ( rawTracks.S !== undefined && Object.keys( rawTracks.S.curves ).length > 0 ) {
-
-					var scaleTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.S.curves, initialScale, 'scale' );
-					if ( scaleTrack !== undefined ) tracks.push( scaleTrack );
-
-				}
-
-				if ( rawTracks.DeformPercent !== undefined ) {
-
-					var morphTrack = this.generateMorphTrack( rawTracks );
-					if ( morphTrack !== undefined ) tracks.push( morphTrack );
-
-				}
-
-				return tracks;
-
-			},
-			generateVectorTrack: function ( modelName, curves, initialValue, type ) {
-
-				var times = this.getTimesForAllAxes( curves );
-				var values = this.getKeyframeTrackValues( times, curves, initialValue );
-				return new THREE.VectorKeyframeTrack( modelName + '.' + type, times, values );
-
-			},
-			generateRotationTrack: function ( modelName, curves, initialValue, preRotation, postRotation, eulerOrder ) {
-
-				if ( curves.x !== undefined ) {
-
-					this.interpolateRotations( curves.x );
-					curves.x.values = curves.x.values.map( THREE.MathUtils.degToRad );
-
-				}
-
-				if ( curves.y !== undefined ) {
-
-					this.interpolateRotations( curves.y );
-					curves.y.values = curves.y.values.map( THREE.MathUtils.degToRad );
-
-				}
-
-				if ( curves.z !== undefined ) {
-
-					this.interpolateRotations( curves.z );
-					curves.z.values = curves.z.values.map( THREE.MathUtils.degToRad );
-
-				}
-
-				var times = this.getTimesForAllAxes( curves );
-				var values = this.getKeyframeTrackValues( times, curves, initialValue );
-
-				if ( preRotation !== undefined ) {
-
-					preRotation = preRotation.map( THREE.MathUtils.degToRad );
-					preRotation.push( eulerOrder );
-					preRotation = new THREE.Euler().fromArray( preRotation );
-					preRotation = new THREE.Quaternion().setFromEuler( preRotation );
-
-				}
-
-				if ( postRotation !== undefined ) {
-
-					postRotation = postRotation.map( THREE.MathUtils.degToRad );
-					postRotation.push( eulerOrder );
-					postRotation = new THREE.Euler().fromArray( postRotation );
-					postRotation = new THREE.Quaternion().setFromEuler( postRotation ).invert();
-
-				}
-
-				var quaternion = new THREE.Quaternion();
-				var euler = new THREE.Euler();
-				var quaternionValues = [];
-
-				for ( var i = 0; i < values.length; i += 3 ) {
-
-					euler.set( values[ i ], values[ i + 1 ], values[ i + 2 ], eulerOrder );
-					quaternion.setFromEuler( euler );
-					if ( preRotation !== undefined ) quaternion.premultiply( preRotation );
-					if ( postRotation !== undefined ) quaternion.multiply( postRotation );
-					quaternion.toArray( quaternionValues, i / 3 * 4 );
-
-				}
-
-				return new THREE.QuaternionKeyframeTrack( modelName + '.quaternion', times, quaternionValues );
-
-			},
-			generateMorphTrack: function ( rawTracks ) {
-
-				var curves = rawTracks.DeformPercent.curves.morph;
-				var values = curves.values.map( function ( val ) {
-
-					return val / 100;
-
-				} );
-				var morphNum = sceneGraph.getObjectByName( rawTracks.modelName ).morphTargetDictionary[ rawTracks.morphName ];
-				return new THREE.NumberKeyframeTrack( rawTracks.modelName + '.morphTargetInfluences[' + morphNum + ']', curves.times, values );
-
-			},
-			// For all animated objects, times are defined separately for each axis
-			// Here we'll combine the times into one sorted array without duplicates
-			getTimesForAllAxes: function ( curves ) {
-
-				var times = []; // first join together the times for each axis, if defined
-
-				if ( curves.x !== undefined ) times = times.concat( curves.x.times );
-				if ( curves.y !== undefined ) times = times.concat( curves.y.times );
-				if ( curves.z !== undefined ) times = times.concat( curves.z.times ); // then sort them
-
-				times = times.sort( function ( a, b ) {
-
-					return a - b;
-
-				} ); // and remove duplicates
-
-				if ( times.length > 1 ) {
-
-					var targetIndex = 1;
-					var lastValue = times[ 0 ];
-
-					for ( var i = 1; i < times.length; i ++ ) {
-
-						var currentValue = times[ i ];
-
-						if ( currentValue !== lastValue ) {
-
-							times[ targetIndex ] = currentValue;
-							lastValue = currentValue;
-							targetIndex ++;
-
 						}
 
-					}
-
-					times = times.slice( 0, targetIndex );
-
-				}
-
-				return times;
-
-			},
-			getKeyframeTrackValues: function ( times, curves, initialValue ) {
-
-				var prevValue = initialValue;
-				var values = [];
-				var xIndex = - 1;
-				var yIndex = - 1;
-				var zIndex = - 1;
-				times.forEach( function ( time ) {
-
-					if ( curves.x ) xIndex = curves.x.times.indexOf( time );
-					if ( curves.y ) yIndex = curves.y.times.indexOf( time );
-					if ( curves.z ) zIndex = curves.z.times.indexOf( time ); // if there is an x value defined for this frame, use that
-
-					if ( xIndex !== - 1 ) {
-
-						var xValue = curves.x.values[ xIndex ];
-						values.push( xValue );
-						prevValue[ 0 ] = xValue;
-
-					} else {
-
-						// otherwise use the x value from the previous frame
-						values.push( prevValue[ 0 ] );
-
-					}
-
-					if ( yIndex !== - 1 ) {
-
-						var yValue = curves.y.values[ yIndex ];
-						values.push( yValue );
-						prevValue[ 1 ] = yValue;
-
-					} else {
-
-						values.push( prevValue[ 1 ] );
-
-					}
-
-					if ( zIndex !== - 1 ) {
-
-						var zValue = curves.z.values[ zIndex ];
-						values.push( zValue );
-						prevValue[ 2 ] = zValue;
-
-					} else {
-
-						values.push( prevValue[ 2 ] );
-
-					}
-
-				} );
-				return values;
-
-			},
-			// Rotations are defined as THREE.Euler angles which can have values	of any size
-			// These will be converted to quaternions which don't support values greater than
-			// PI, so we'll interpolate large rotations
-			interpolateRotations: function ( curve ) {
-
-				for ( var i = 1; i < curve.values.length; i ++ ) {
-
-					var initialValue = curve.values[ i - 1 ];
-					var valuesSpan = curve.values[ i ] - initialValue;
-					var absoluteSpan = Math.abs( valuesSpan );
-
-					if ( absoluteSpan >= 180 ) {
-
-						var numSubIntervals = absoluteSpan / 180;
-						var step = valuesSpan / numSubIntervals;
-						var nextValue = initialValue + step;
-						var initialTime = curve.times[ i - 1 ];
-						var timeSpan = curve.times[ i ] - initialTime;
-						var interval = timeSpan / numSubIntervals;
-						var nextTime = initialTime + interval;
-						var interpolatedTimes = [];
-						var interpolatedValues = [];
-
-						while ( nextTime < curve.times[ i ] ) {
-
-							interpolatedTimes.push( nextTime );
-							nextTime += interval;
-							interpolatedValues.push( nextValue );
-							nextValue += step;
-
-						}
-
-						curve.times = inject( curve.times, i, interpolatedTimes );
-						curve.values = inject( curve.values, i, interpolatedValues );
-
-					}
+					} );
+					layersMap.set( parseInt( nodeID ), layerCurveNodes );
 
 				}
 
 			}
-		}; // parse an FBX file in ASCII format
 
-		function TextParser() {}
+			return layersMap;
 
-		TextParser.prototype = {
-			constructor: TextParser,
-			getPrevNode: function () {
+		} // parse nodes in FBXTree.Objects.AnimationStack. These are the top level node in the animation
+		// hierarchy. Each Stack node will be used to create a THREE.AnimationClip
 
-				return this.nodeStack[ this.currentIndent - 2 ];
 
-			},
-			getCurrentNode: function () {
+		parseAnimStacks( layersMap ) {
 
-				return this.nodeStack[ this.currentIndent - 1 ];
+			const rawStacks = fbxTree.Objects.AnimationStack; // connect the stacks (clips) up to the layers
 
-			},
-			getCurrentProp: function () {
+			const rawClips = {};
 
-				return this.currentProp;
+			for ( const nodeID in rawStacks ) {
 
-			},
-			pushStack: function ( node ) {
+				const children = connections.get( parseInt( nodeID ) ).children;
 
-				this.nodeStack.push( node );
-				this.currentIndent += 1;
+				if ( children.length > 1 ) {
 
-			},
-			popStack: function () {
+					// it seems like stacks will always be associated with a single layer. But just in case there are files
+					// where there are multiple layers per stack, we'll display a warning
+					console.warn( 'THREE.FBXLoader: Encountered an animation stack with multiple layers, this is currently not supported. Ignoring subsequent layers.' );
 
-				this.nodeStack.pop();
-				this.currentIndent -= 1;
+				}
 
-			},
-			setCurrentProp: function ( val, name ) {
+				const layer = layersMap.get( children[ 0 ].ID );
+				rawClips[ nodeID ] = {
+					name: rawStacks[ nodeID ].attrName,
+					layer: layer
+				};
 
-				this.currentProp = val;
-				this.currentPropName = name;
+			}
 
-			},
-			parse: function ( text ) {
+			return rawClips;
 
-				this.currentIndent = 0;
-				this.allNodes = new FBXTree();
-				this.nodeStack = [];
-				this.currentProp = [];
-				this.currentPropName = '';
-				var scope = this;
-				var split = text.split( /[\r\n]+/ );
-				split.forEach( function ( line, i ) {
+		}
 
-					var matchComment = line.match( /^[\s\t]*;/ );
-					var matchEmpty = line.match( /^[\s\t]*$/ );
-					if ( matchComment || matchEmpty ) return;
-					var matchBeginning = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):(.*){', '' );
-					var matchProperty = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):[\\s\\t\\r\\n](.*)' );
-					var matchEnd = line.match( '^\\t{' + ( scope.currentIndent - 1 ) + '}}' );
+		addClip( rawClip ) {
 
-					if ( matchBeginning ) {
+			let tracks = [];
+			const scope = this;
+			rawClip.layer.forEach( function ( rawTracks ) {
 
-						scope.parseNodeBegin( line, matchBeginning );
+				tracks = tracks.concat( scope.generateTracks( rawTracks ) );
 
-					} else if ( matchProperty ) {
+			} );
+			return new THREE.AnimationClip( rawClip.name, - 1, tracks );
 
-						scope.parseNodeProperty( line, matchProperty, split[ ++ i ] );
+		}
 
-					} else if ( matchEnd ) {
+		generateTracks( rawTracks ) {
 
-						scope.popStack();
+			const tracks = [];
+			let initialPosition = new THREE.Vector3();
+			let initialRotation = new THREE.Quaternion();
+			let initialScale = new THREE.Vector3();
+			if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
+			initialPosition = initialPosition.toArray();
+			initialRotation = new THREE.Euler().setFromQuaternion( initialRotation, rawTracks.eulerOrder ).toArray();
+			initialScale = initialScale.toArray();
 
-					} else if ( line.match( /^[^\s\t}]/ ) ) {
+			if ( rawTracks.T !== undefined && Object.keys( rawTracks.T.curves ).length > 0 ) {
 
-						// large arrays are split over multiple lines terminated with a ',' character
-						// if this is encountered the line needs to be joined to the previous line
-						scope.parseNodePropertyContinued( line );
+				const positionTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position' );
+				if ( positionTrack !== undefined ) tracks.push( positionTrack );
+
+			}
+
+			if ( rawTracks.R !== undefined && Object.keys( rawTracks.R.curves ).length > 0 ) {
+
+				const rotationTrack = this.generateRotationTrack( rawTracks.modelName, rawTracks.R.curves, initialRotation, rawTracks.preRotation, rawTracks.postRotation, rawTracks.eulerOrder );
+				if ( rotationTrack !== undefined ) tracks.push( rotationTrack );
+
+			}
+
+			if ( rawTracks.S !== undefined && Object.keys( rawTracks.S.curves ).length > 0 ) {
+
+				const scaleTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.S.curves, initialScale, 'scale' );
+				if ( scaleTrack !== undefined ) tracks.push( scaleTrack );
+
+			}
+
+			if ( rawTracks.DeformPercent !== undefined ) {
+
+				const morphTrack = this.generateMorphTrack( rawTracks );
+				if ( morphTrack !== undefined ) tracks.push( morphTrack );
+
+			}
+
+			return tracks;
+
+		}
+
+		generateVectorTrack( modelName, curves, initialValue, type ) {
+
+			const times = this.getTimesForAllAxes( curves );
+			const values = this.getKeyframeTrackValues( times, curves, initialValue );
+			return new THREE.VectorKeyframeTrack( modelName + '.' + type, times, values );
+
+		}
+
+		generateRotationTrack( modelName, curves, initialValue, preRotation, postRotation, eulerOrder ) {
+
+			if ( curves.x !== undefined ) {
+
+				this.interpolateRotations( curves.x );
+				curves.x.values = curves.x.values.map( THREE.MathUtils.degToRad );
+
+			}
+
+			if ( curves.y !== undefined ) {
+
+				this.interpolateRotations( curves.y );
+				curves.y.values = curves.y.values.map( THREE.MathUtils.degToRad );
+
+			}
+
+			if ( curves.z !== undefined ) {
+
+				this.interpolateRotations( curves.z );
+				curves.z.values = curves.z.values.map( THREE.MathUtils.degToRad );
+
+			}
+
+			const times = this.getTimesForAllAxes( curves );
+			const values = this.getKeyframeTrackValues( times, curves, initialValue );
+
+			if ( preRotation !== undefined ) {
+
+				preRotation = preRotation.map( THREE.MathUtils.degToRad );
+				preRotation.push( eulerOrder );
+				preRotation = new THREE.Euler().fromArray( preRotation );
+				preRotation = new THREE.Quaternion().setFromEuler( preRotation );
+
+			}
+
+			if ( postRotation !== undefined ) {
+
+				postRotation = postRotation.map( THREE.MathUtils.degToRad );
+				postRotation.push( eulerOrder );
+				postRotation = new THREE.Euler().fromArray( postRotation );
+				postRotation = new THREE.Quaternion().setFromEuler( postRotation ).invert();
+
+			}
+
+			const quaternion = new THREE.Quaternion();
+			const euler = new THREE.Euler();
+			const quaternionValues = [];
+
+			for ( let i = 0; i < values.length; i += 3 ) {
+
+				euler.set( values[ i ], values[ i + 1 ], values[ i + 2 ], eulerOrder );
+				quaternion.setFromEuler( euler );
+				if ( preRotation !== undefined ) quaternion.premultiply( preRotation );
+				if ( postRotation !== undefined ) quaternion.multiply( postRotation );
+				quaternion.toArray( quaternionValues, i / 3 * 4 );
+
+			}
+
+			return new THREE.QuaternionKeyframeTrack( modelName + '.quaternion', times, quaternionValues );
+
+		}
+
+		generateMorphTrack( rawTracks ) {
+
+			const curves = rawTracks.DeformPercent.curves.morph;
+			const values = curves.values.map( function ( val ) {
+
+				return val / 100;
+
+			} );
+			const morphNum = sceneGraph.getObjectByName( rawTracks.modelName ).morphTargetDictionary[ rawTracks.morphName ];
+			return new THREE.NumberKeyframeTrack( rawTracks.modelName + '.morphTargetInfluences[' + morphNum + ']', curves.times, values );
+
+		} // For all animated objects, times are defined separately for each axis
+		// Here we'll combine the times into one sorted array without duplicates
+
+
+		getTimesForAllAxes( curves ) {
+
+			let times = []; // first join together the times for each axis, if defined
+
+			if ( curves.x !== undefined ) times = times.concat( curves.x.times );
+			if ( curves.y !== undefined ) times = times.concat( curves.y.times );
+			if ( curves.z !== undefined ) times = times.concat( curves.z.times ); // then sort them
+
+			times = times.sort( function ( a, b ) {
+
+				return a - b;
+
+			} ); // and remove duplicates
+
+			if ( times.length > 1 ) {
+
+				let targetIndex = 1;
+				let lastValue = times[ 0 ];
+
+				for ( let i = 1; i < times.length; i ++ ) {
+
+					const currentValue = times[ i ];
+
+					if ( currentValue !== lastValue ) {
+
+						times[ targetIndex ] = currentValue;
+						lastValue = currentValue;
+						targetIndex ++;
 
 					}
 
-				} );
-				return this.allNodes;
+				}
 
-			},
-			parseNodeBegin: function ( line, property ) {
+				times = times.slice( 0, targetIndex );
 
-				var nodeName = property[ 1 ].trim().replace( /^"/, '' ).replace( /"$/, '' );
-				var nodeAttrs = property[ 2 ].split( ',' ).map( function ( attr ) {
+			}
 
-					return attr.trim().replace( /^"/, '' ).replace( /"$/, '' );
+			return times;
 
-				} );
-				var node = {
-					name: nodeName
-				};
-				var attrs = this.parseNodeAttr( nodeAttrs );
-				var currentNode = this.getCurrentNode(); // a top node
+		}
 
-				if ( this.currentIndent === 0 ) {
+		getKeyframeTrackValues( times, curves, initialValue ) {
 
-					this.allNodes.add( nodeName, node );
+			const prevValue = initialValue;
+			const values = [];
+			let xIndex = - 1;
+			let yIndex = - 1;
+			let zIndex = - 1;
+			times.forEach( function ( time ) {
+
+				if ( curves.x ) xIndex = curves.x.times.indexOf( time );
+				if ( curves.y ) yIndex = curves.y.times.indexOf( time );
+				if ( curves.z ) zIndex = curves.z.times.indexOf( time ); // if there is an x value defined for this frame, use that
+
+				if ( xIndex !== - 1 ) {
+
+					const xValue = curves.x.values[ xIndex ];
+					values.push( xValue );
+					prevValue[ 0 ] = xValue;
 
 				} else {
 
-					// a subnode
-					// if the subnode already exists, append it
-					if ( nodeName in currentNode ) {
+					// otherwise use the x value from the previous frame
+					values.push( prevValue[ 0 ] );
 
-						// special case Pose needs PoseNodes as an array
-						if ( nodeName === 'PoseNode' ) {
+				}
 
-							currentNode.PoseNode.push( node );
+				if ( yIndex !== - 1 ) {
 
-						} else if ( currentNode[ nodeName ].id !== undefined ) {
+					const yValue = curves.y.values[ yIndex ];
+					values.push( yValue );
+					prevValue[ 1 ] = yValue;
 
-							currentNode[ nodeName ] = {};
-							currentNode[ nodeName ][ currentNode[ nodeName ].id ] = currentNode[ nodeName ];
+				} else {
 
-						}
+					values.push( prevValue[ 1 ] );
 
-						if ( attrs.id !== '' ) currentNode[ nodeName ][ attrs.id ] = node;
+				}
 
-					} else if ( typeof attrs.id === 'number' ) {
+				if ( zIndex !== - 1 ) {
+
+					const zValue = curves.z.values[ zIndex ];
+					values.push( zValue );
+					prevValue[ 2 ] = zValue;
+
+				} else {
+
+					values.push( prevValue[ 2 ] );
+
+				}
+
+			} );
+			return values;
+
+		} // Rotations are defined as THREE.Euler angles which can have values	of any size
+		// These will be converted to quaternions which don't support values greater than
+		// PI, so we'll interpolate large rotations
+
+
+		interpolateRotations( curve ) {
+
+			for ( let i = 1; i < curve.values.length; i ++ ) {
+
+				const initialValue = curve.values[ i - 1 ];
+				const valuesSpan = curve.values[ i ] - initialValue;
+				const absoluteSpan = Math.abs( valuesSpan );
+
+				if ( absoluteSpan >= 180 ) {
+
+					const numSubIntervals = absoluteSpan / 180;
+					const step = valuesSpan / numSubIntervals;
+					let nextValue = initialValue + step;
+					const initialTime = curve.times[ i - 1 ];
+					const timeSpan = curve.times[ i ] - initialTime;
+					const interval = timeSpan / numSubIntervals;
+					let nextTime = initialTime + interval;
+					const interpolatedTimes = [];
+					const interpolatedValues = [];
+
+					while ( nextTime < curve.times[ i ] ) {
+
+						interpolatedTimes.push( nextTime );
+						nextTime += interval;
+						interpolatedValues.push( nextValue );
+						nextValue += step;
+
+					}
+
+					curve.times = inject( curve.times, i, interpolatedTimes );
+					curve.values = inject( curve.values, i, interpolatedValues );
+
+				}
+
+			}
+
+		}
+
+	} // parse an FBX file in ASCII format
+
+
+	class TextParser {
+
+		getPrevNode() {
+
+			return this.nodeStack[ this.currentIndent - 2 ];
+
+		}
+
+		getCurrentNode() {
+
+			return this.nodeStack[ this.currentIndent - 1 ];
+
+		}
+
+		getCurrentProp() {
+
+			return this.currentProp;
+
+		}
+
+		pushStack( node ) {
+
+			this.nodeStack.push( node );
+			this.currentIndent += 1;
+
+		}
+
+		popStack() {
+
+			this.nodeStack.pop();
+			this.currentIndent -= 1;
+
+		}
+
+		setCurrentProp( val, name ) {
+
+			this.currentProp = val;
+			this.currentPropName = name;
+
+		}
+
+		parse( text ) {
+
+			this.currentIndent = 0;
+			this.allNodes = new FBXTree();
+			this.nodeStack = [];
+			this.currentProp = [];
+			this.currentPropName = '';
+			const scope = this;
+			const split = text.split( /[\r\n]+/ );
+			split.forEach( function ( line, i ) {
+
+				const matchComment = line.match( /^[\s\t]*;/ );
+				const matchEmpty = line.match( /^[\s\t]*$/ );
+				if ( matchComment || matchEmpty ) return;
+				const matchBeginning = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):(.*){', '' );
+				const matchProperty = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):[\\s\\t\\r\\n](.*)' );
+				const matchEnd = line.match( '^\\t{' + ( scope.currentIndent - 1 ) + '}}' );
+
+				if ( matchBeginning ) {
+
+					scope.parseNodeBegin( line, matchBeginning );
+
+				} else if ( matchProperty ) {
+
+					scope.parseNodeProperty( line, matchProperty, split[ ++ i ] );
+
+				} else if ( matchEnd ) {
+
+					scope.popStack();
+
+				} else if ( line.match( /^[^\s\t}]/ ) ) {
+
+					// large arrays are split over multiple lines terminated with a ',' character
+					// if this is encountered the line needs to be joined to the previous line
+					scope.parseNodePropertyContinued( line );
+
+				}
+
+			} );
+			return this.allNodes;
+
+		}
+
+		parseNodeBegin( line, property ) {
+
+			const nodeName = property[ 1 ].trim().replace( /^"/, '' ).replace( /"$/, '' );
+			const nodeAttrs = property[ 2 ].split( ',' ).map( function ( attr ) {
+
+				return attr.trim().replace( /^"/, '' ).replace( /"$/, '' );
+
+			} );
+			const node = {
+				name: nodeName
+			};
+			const attrs = this.parseNodeAttr( nodeAttrs );
+			const currentNode = this.getCurrentNode(); // a top node
+
+			if ( this.currentIndent === 0 ) {
+
+				this.allNodes.add( nodeName, node );
+
+			} else {
+
+				// a subnode
+				// if the subnode already exists, append it
+				if ( nodeName in currentNode ) {
+
+					// special case Pose needs PoseNodes as an array
+					if ( nodeName === 'PoseNode' ) {
+
+						currentNode.PoseNode.push( node );
+
+					} else if ( currentNode[ nodeName ].id !== undefined ) {
 
 						currentNode[ nodeName ] = {};
-						currentNode[ nodeName ][ attrs.id ] = node;
-
-					} else if ( nodeName !== 'Properties70' ) {
-
-						if ( nodeName === 'PoseNode' ) currentNode[ nodeName ] = [ node ]; else currentNode[ nodeName ] = node;
+						currentNode[ nodeName ][ currentNode[ nodeName ].id ] = currentNode[ nodeName ];
 
 					}
 
-				}
+					if ( attrs.id !== '' ) currentNode[ nodeName ][ attrs.id ] = node;
 
-				if ( typeof attrs.id === 'number' ) node.id = attrs.id;
-				if ( attrs.name !== '' ) node.attrName = attrs.name;
-				if ( attrs.type !== '' ) node.attrType = attrs.type;
-				this.pushStack( node );
+				} else if ( typeof attrs.id === 'number' ) {
 
-			},
-			parseNodeAttr: function ( attrs ) {
+					currentNode[ nodeName ] = {};
+					currentNode[ nodeName ][ attrs.id ] = node;
 
-				var id = attrs[ 0 ];
+				} else if ( nodeName !== 'Properties70' ) {
 
-				if ( attrs[ 0 ] !== '' ) {
-
-					id = parseInt( attrs[ 0 ] );
-
-					if ( isNaN( id ) ) {
-
-						id = attrs[ 0 ];
-
-					}
+					if ( nodeName === 'PoseNode' ) currentNode[ nodeName ] = [ node ]; else currentNode[ nodeName ] = node;
 
 				}
 
-				var name = '',
-					type = '';
+			}
 
-				if ( attrs.length > 1 ) {
+			if ( typeof attrs.id === 'number' ) node.id = attrs.id;
+			if ( attrs.name !== '' ) node.attrName = attrs.name;
+			if ( attrs.type !== '' ) node.attrType = attrs.type;
+			this.pushStack( node );
 
-					name = attrs[ 1 ].replace( /^(\w+)::/, '' );
-					type = attrs[ 2 ];
+		}
 
-				}
+		parseNodeAttr( attrs ) {
 
-				return {
-					id: id,
-					name: name,
-					type: type
-				};
+			let id = attrs[ 0 ];
 
-			},
-			parseNodeProperty: function ( line, property, contentLine ) {
+			if ( attrs[ 0 ] !== '' ) {
 
-				var propName = property[ 1 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
-				var propValue = property[ 2 ].replace( /^"/, '' ).replace( /"$/, '' ).trim(); // for special case: base64 image data follows "Content: ," line
-				//	Content: ,
-				//	 "/9j/4RDaRXhpZgAATU0A..."
+				id = parseInt( attrs[ 0 ] );
 
-				if ( propName === 'Content' && propValue === ',' ) {
+				if ( isNaN( id ) ) {
 
-					propValue = contentLine.replace( /"/g, '' ).replace( /,$/, '' ).trim();
+					id = attrs[ 0 ];
 
 				}
 
-				var currentNode = this.getCurrentNode();
-				var parentName = currentNode.name;
+			}
 
-				if ( parentName === 'Properties70' ) {
+			let name = '',
+				type = '';
 
-					this.parseNodeSpecialProperty( line, propName, propValue );
-					return;
+			if ( attrs.length > 1 ) {
 
-				} // Connections
+				name = attrs[ 1 ].replace( /^(\w+)::/, '' );
+				type = attrs[ 2 ];
+
+			}
+
+			return {
+				id: id,
+				name: name,
+				type: type
+			};
+
+		}
+
+		parseNodeProperty( line, property, contentLine ) {
+
+			let propName = property[ 1 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
+			let propValue = property[ 2 ].replace( /^"/, '' ).replace( /"$/, '' ).trim(); // for special case: base64 image data follows "Content: ," line
+			//	Content: ,
+			//	 "/9j/4RDaRXhpZgAATU0A..."
+
+			if ( propName === 'Content' && propValue === ',' ) {
+
+				propValue = contentLine.replace( /"/g, '' ).replace( /,$/, '' ).trim();
+
+			}
+
+			const currentNode = this.getCurrentNode();
+			const parentName = currentNode.name;
+
+			if ( parentName === 'Properties70' ) {
+
+				this.parseNodeSpecialProperty( line, propName, propValue );
+				return;
+
+			} // Connections
 
 
-				if ( propName === 'C' ) {
+			if ( propName === 'C' ) {
 
-					var connProps = propValue.split( ',' ).slice( 1 );
-					var from = parseInt( connProps[ 0 ] );
-					var to = parseInt( connProps[ 1 ] );
-					var rest = propValue.split( ',' ).slice( 3 );
-					rest = rest.map( function ( elem ) {
+				const connProps = propValue.split( ',' ).slice( 1 );
+				const from = parseInt( connProps[ 0 ] );
+				const to = parseInt( connProps[ 1 ] );
+				let rest = propValue.split( ',' ).slice( 3 );
+				rest = rest.map( function ( elem ) {
 
-						return elem.trim().replace( /^"/, '' );
+					return elem.trim().replace( /^"/, '' );
 
-					} );
-					propName = 'connections';
-					propValue = [ from, to ];
-					append( propValue, rest );
+				} );
+				propName = 'connections';
+				propValue = [ from, to ];
+				append( propValue, rest );
 
-					if ( currentNode[ propName ] === undefined ) {
+				if ( currentNode[ propName ] === undefined ) {
 
-						currentNode[ propName ] = [];
+					currentNode[ propName ] = [];
 
-					}
+				}
 
-				} // Node
+			} // Node
 
 
-				if ( propName === 'Node' ) currentNode.id = propValue; // connections
+			if ( propName === 'Node' ) currentNode.id = propValue; // connections
 
-				if ( propName in currentNode && Array.isArray( currentNode[ propName ] ) ) {
+			if ( propName in currentNode && Array.isArray( currentNode[ propName ] ) ) {
 
-					currentNode[ propName ].push( propValue );
+				currentNode[ propName ].push( propValue );
+
+			} else {
+
+				if ( propName !== 'a' ) currentNode[ propName ] = propValue; else currentNode.a = propValue;
+
+			}
+
+			this.setCurrentProp( currentNode, propName ); // convert string to array, unless it ends in ',' in which case more will be added to it
+
+			if ( propName === 'a' && propValue.slice( - 1 ) !== ',' ) {
+
+				currentNode.a = parseNumberArray( propValue );
+
+			}
+
+		}
+
+		parseNodePropertyContinued( line ) {
+
+			const currentNode = this.getCurrentNode();
+			currentNode.a += line; // if the line doesn't end in ',' we have reached the end of the property value
+			// so convert the string to an array
+
+			if ( line.slice( - 1 ) !== ',' ) {
+
+				currentNode.a = parseNumberArray( currentNode.a );
+
+			}
+
+		} // parse "Property70"
+
+
+		parseNodeSpecialProperty( line, propName, propValue ) {
+
+			// split this
+			// P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+			// into array like below
+			// ["Lcl Scaling", "Lcl Scaling", "", "A", "1,1,1" ]
+			const props = propValue.split( '",' ).map( function ( prop ) {
+
+				return prop.trim().replace( /^\"/, '' ).replace( /\s/, '_' );
+
+			} );
+			const innerPropName = props[ 0 ];
+			const innerPropType1 = props[ 1 ];
+			const innerPropType2 = props[ 2 ];
+			const innerPropFlag = props[ 3 ];
+			let innerPropValue = props[ 4 ]; // cast values where needed, otherwise leave as strings
+
+			switch ( innerPropType1 ) {
+
+				case 'int':
+				case 'enum':
+				case 'bool':
+				case 'ULongLong':
+				case 'double':
+				case 'Number':
+				case 'FieldOfView':
+					innerPropValue = parseFloat( innerPropValue );
+					break;
+
+				case 'Color':
+				case 'ColorRGB':
+				case 'Vector3D':
+				case 'Lcl_Translation':
+				case 'Lcl_Rotation':
+				case 'Lcl_Scaling':
+					innerPropValue = parseNumberArray( innerPropValue );
+					break;
+
+			} // CAUTION: these props must append to parent's parent
+
+
+			this.getPrevNode()[ innerPropName ] = {
+				'type': innerPropType1,
+				'type2': innerPropType2,
+				'flag': innerPropFlag,
+				'value': innerPropValue
+			};
+			this.setCurrentProp( this.getPrevNode(), innerPropName );
+
+		}
+
+	} // Parse an FBX file in Binary format
+
+
+	class BinaryParser {
+
+		parse( buffer ) {
+
+			const reader = new BinaryReader( buffer );
+			reader.skip( 23 ); // skip magic 23 bytes
+
+			const version = reader.getUint32();
+
+			if ( version < 6400 ) {
+
+				throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + version );
+
+			}
+
+			const allNodes = new FBXTree();
+
+			while ( ! this.endOfContent( reader ) ) {
+
+				const node = this.parseNode( reader, version );
+				if ( node !== null ) allNodes.add( node.name, node );
+
+			}
+
+			return allNodes;
+
+		} // Check if reader has reached the end of content.
+
+
+		endOfContent( reader ) {
+
+			// footer size: 160bytes + 16-byte alignment padding
+			// - 16bytes: magic
+			// - padding til 16-byte alignment (at least 1byte?)
+			//	(seems like some exporters embed fixed 15 or 16bytes?)
+			// - 4bytes: magic
+			// - 4bytes: version
+			// - 120bytes: zero
+			// - 16bytes: magic
+			if ( reader.size() % 16 === 0 ) {
+
+				return ( reader.getOffset() + 160 + 16 & ~ 0xf ) >= reader.size();
+
+			} else {
+
+				return reader.getOffset() + 160 + 16 >= reader.size();
+
+			}
+
+		} // recursively parse nodes until the end of the file is reached
+
+
+		parseNode( reader, version ) {
+
+			const node = {}; // The first three data sizes depends on version.
+
+			const endOffset = version >= 7500 ? reader.getUint64() : reader.getUint32();
+			const numProperties = version >= 7500 ? reader.getUint64() : reader.getUint32();
+			version >= 7500 ? reader.getUint64() : reader.getUint32(); // the returned propertyListLen is not used
+
+			const nameLen = reader.getUint8();
+			const name = reader.getString( nameLen ); // Regards this node as NULL-record if endOffset is zero
+
+			if ( endOffset === 0 ) return null;
+			const propertyList = [];
+
+			for ( let i = 0; i < numProperties; i ++ ) {
+
+				propertyList.push( this.parseProperty( reader ) );
+
+			} // Regards the first three elements in propertyList as id, attrName, and attrType
+
+
+			const id = propertyList.length > 0 ? propertyList[ 0 ] : '';
+			const attrName = propertyList.length > 1 ? propertyList[ 1 ] : '';
+			const attrType = propertyList.length > 2 ? propertyList[ 2 ] : ''; // check if this node represents just a single property
+			// like (name, 0) set or (name2, [0, 1, 2]) set of {name: 0, name2: [0, 1, 2]}
+
+			node.singleProperty = numProperties === 1 && reader.getOffset() === endOffset ? true : false;
+
+			while ( endOffset > reader.getOffset() ) {
+
+				const subNode = this.parseNode( reader, version );
+				if ( subNode !== null ) this.parseSubNode( name, node, subNode );
+
+			}
+
+			node.propertyList = propertyList; // raw property list used by parent
+
+			if ( typeof id === 'number' ) node.id = id;
+			if ( attrName !== '' ) node.attrName = attrName;
+			if ( attrType !== '' ) node.attrType = attrType;
+			if ( name !== '' ) node.name = name;
+			return node;
+
+		}
+
+		parseSubNode( name, node, subNode ) {
+
+			// special case: child node is single property
+			if ( subNode.singleProperty === true ) {
+
+				const value = subNode.propertyList[ 0 ];
+
+				if ( Array.isArray( value ) ) {
+
+					node[ subNode.name ] = subNode;
+					subNode.a = value;
 
 				} else {
 
-					if ( propName !== 'a' ) currentNode[ propName ] = propValue; else currentNode.a = propValue;
+					node[ subNode.name ] = value;
 
 				}
 
-				this.setCurrentProp( currentNode, propName ); // convert string to array, unless it ends in ',' in which case more will be added to it
+			} else if ( name === 'Connections' && subNode.name === 'C' ) {
 
-				if ( propName === 'a' && propValue.slice( - 1 ) !== ',' ) {
+				const array = [];
+				subNode.propertyList.forEach( function ( property, i ) {
 
-					currentNode.a = parseNumberArray( propValue );
-
-				}
-
-			},
-			parseNodePropertyContinued: function ( line ) {
-
-				var currentNode = this.getCurrentNode();
-				currentNode.a += line; // if the line doesn't end in ',' we have reached the end of the property value
-				// so convert the string to an array
-
-				if ( line.slice( - 1 ) !== ',' ) {
-
-					currentNode.a = parseNumberArray( currentNode.a );
-
-				}
-
-			},
-			// parse "Property70"
-			parseNodeSpecialProperty: function ( line, propName, propValue ) {
-
-				// split this
-				// P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
-				// into array like below
-				// ["Lcl Scaling", "Lcl Scaling", "", "A", "1,1,1" ]
-				var props = propValue.split( '",' ).map( function ( prop ) {
-
-					return prop.trim().replace( /^\"/, '' ).replace( /\s/, '_' );
+					// first Connection is FBX type (OO, OP, etc.). We'll discard these
+					if ( i !== 0 ) array.push( property );
 
 				} );
-				var innerPropName = props[ 0 ];
-				var innerPropType1 = props[ 1 ];
-				var innerPropType2 = props[ 2 ];
-				var innerPropFlag = props[ 3 ];
-				var innerPropValue = props[ 4 ]; // cast values where needed, otherwise leave as strings
 
-				switch ( innerPropType1 ) {
+				if ( node.connections === undefined ) {
 
-					case 'int':
-					case 'enum':
-					case 'bool':
-					case 'ULongLong':
-					case 'double':
-					case 'Number':
-					case 'FieldOfView':
-						innerPropValue = parseFloat( innerPropValue );
-						break;
+					node.connections = [];
 
-					case 'Color':
-					case 'ColorRGB':
-					case 'Vector3D':
-					case 'Lcl_Translation':
-					case 'Lcl_Rotation':
-					case 'Lcl_Scaling':
-						innerPropValue = parseNumberArray( innerPropValue );
-						break;
+				}
 
-				} // CAUTION: these props must append to parent's parent
+				node.connections.push( array );
+
+			} else if ( subNode.name === 'Properties70' ) {
+
+				const keys = Object.keys( subNode );
+				keys.forEach( function ( key ) {
+
+					node[ key ] = subNode[ key ];
+
+				} );
+
+			} else if ( name === 'Properties70' && subNode.name === 'P' ) {
+
+				let innerPropName = subNode.propertyList[ 0 ];
+				let innerPropType1 = subNode.propertyList[ 1 ];
+				const innerPropType2 = subNode.propertyList[ 2 ];
+				const innerPropFlag = subNode.propertyList[ 3 ];
+				let innerPropValue;
+				if ( innerPropName.indexOf( 'Lcl ' ) === 0 ) innerPropName = innerPropName.replace( 'Lcl ', 'Lcl_' );
+				if ( innerPropType1.indexOf( 'Lcl ' ) === 0 ) innerPropType1 = innerPropType1.replace( 'Lcl ', 'Lcl_' );
+
+				if ( innerPropType1 === 'Color' || innerPropType1 === 'ColorRGB' || innerPropType1 === 'Vector' || innerPropType1 === 'Vector3D' || innerPropType1.indexOf( 'Lcl_' ) === 0 ) {
+
+					innerPropValue = [ subNode.propertyList[ 4 ], subNode.propertyList[ 5 ], subNode.propertyList[ 6 ] ];
+
+				} else {
+
+					innerPropValue = subNode.propertyList[ 4 ];
+
+				} // this will be copied to parent, see above
 
 
-				this.getPrevNode()[ innerPropName ] = {
+				node[ innerPropName ] = {
 					'type': innerPropType1,
 					'type2': innerPropType2,
 					'flag': innerPropFlag,
 					'value': innerPropValue
 				};
-				this.setCurrentProp( this.getPrevNode(), innerPropName );
+
+			} else if ( node[ subNode.name ] === undefined ) {
+
+				if ( typeof subNode.id === 'number' ) {
+
+					node[ subNode.name ] = {};
+					node[ subNode.name ][ subNode.id ] = subNode;
+
+				} else {
+
+					node[ subNode.name ] = subNode;
+
+				}
+
+			} else {
+
+				if ( subNode.name === 'PoseNode' ) {
+
+					if ( ! Array.isArray( node[ subNode.name ] ) ) {
+
+						node[ subNode.name ] = [ node[ subNode.name ] ];
+
+					}
+
+					node[ subNode.name ].push( subNode );
+
+				} else if ( node[ subNode.name ][ subNode.id ] === undefined ) {
+
+					node[ subNode.name ][ subNode.id ] = subNode;
+
+				}
 
 			}
-		}; // Parse an FBX file in Binary format
 
-		function BinaryParser() {}
+		}
 
-		BinaryParser.prototype = {
-			constructor: BinaryParser,
-			parse: function ( buffer ) {
+		parseProperty( reader ) {
 
-				var reader = new BinaryReader( buffer );
-				reader.skip( 23 ); // skip magic 23 bytes
+			const type = reader.getString( 1 );
+			let length;
 
-				var version = reader.getUint32();
+			switch ( type ) {
 
-				if ( version < 6400 ) {
+				case 'C':
+					return reader.getBoolean();
 
-					throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + version );
+				case 'D':
+					return reader.getFloat64();
 
-				}
+				case 'F':
+					return reader.getFloat32();
 
-				var allNodes = new FBXTree();
+				case 'I':
+					return reader.getInt32();
 
-				while ( ! this.endOfContent( reader ) ) {
+				case 'L':
+					return reader.getInt64();
 
-					var node = this.parseNode( reader, version );
-					if ( node !== null ) allNodes.add( node.name, node );
+				case 'R':
+					length = reader.getUint32();
+					return reader.getArrayBuffer( length );
 
-				}
+				case 'S':
+					length = reader.getUint32();
+					return reader.getString( length );
 
-				return allNodes;
+				case 'Y':
+					return reader.getInt16();
 
-			},
-			// Check if reader has reached the end of content.
-			endOfContent: function ( reader ) {
+				case 'b':
+				case 'c':
+				case 'd':
+				case 'f':
+				case 'i':
+				case 'l':
+					const arrayLength = reader.getUint32();
+					const encoding = reader.getUint32(); // 0: non-compressed, 1: compressed
 
-				// footer size: 160bytes + 16-byte alignment padding
-				// - 16bytes: magic
-				// - padding til 16-byte alignment (at least 1byte?)
-				//	(seems like some exporters embed fixed 15 or 16bytes?)
-				// - 4bytes: magic
-				// - 4bytes: version
-				// - 120bytes: zero
-				// - 16bytes: magic
-				if ( reader.size() % 16 === 0 ) {
+					const compressedLength = reader.getUint32();
 
-					return ( reader.getOffset() + 160 + 16 & ~ 0xf ) >= reader.size();
-
-				} else {
-
-					return reader.getOffset() + 160 + 16 >= reader.size();
-
-				}
-
-			},
-			// recursively parse nodes until the end of the file is reached
-			parseNode: function ( reader, version ) {
-
-				var node = {}; // The first three data sizes depends on version.
-
-				var endOffset = version >= 7500 ? reader.getUint64() : reader.getUint32();
-				var numProperties = version >= 7500 ? reader.getUint64() : reader.getUint32();
-				version >= 7500 ? reader.getUint64() : reader.getUint32(); // the returned propertyListLen is not used
-
-				var nameLen = reader.getUint8();
-				var name = reader.getString( nameLen ); // Regards this node as NULL-record if endOffset is zero
-
-				if ( endOffset === 0 ) return null;
-				var propertyList = [];
-
-				for ( var i = 0; i < numProperties; i ++ ) {
-
-					propertyList.push( this.parseProperty( reader ) );
-
-				} // Regards the first three elements in propertyList as id, attrName, and attrType
-
-
-				var id = propertyList.length > 0 ? propertyList[ 0 ] : '';
-				var attrName = propertyList.length > 1 ? propertyList[ 1 ] : '';
-				var attrType = propertyList.length > 2 ? propertyList[ 2 ] : ''; // check if this node represents just a single property
-				// like (name, 0) set or (name2, [0, 1, 2]) set of {name: 0, name2: [0, 1, 2]}
-
-				node.singleProperty = numProperties === 1 && reader.getOffset() === endOffset ? true : false;
-
-				while ( endOffset > reader.getOffset() ) {
-
-					var subNode = this.parseNode( reader, version );
-					if ( subNode !== null ) this.parseSubNode( name, node, subNode );
-
-				}
-
-				node.propertyList = propertyList; // raw property list used by parent
-
-				if ( typeof id === 'number' ) node.id = id;
-				if ( attrName !== '' ) node.attrName = attrName;
-				if ( attrType !== '' ) node.attrType = attrType;
-				if ( name !== '' ) node.name = name;
-				return node;
-
-			},
-			parseSubNode: function ( name, node, subNode ) {
-
-				// special case: child node is single property
-				if ( subNode.singleProperty === true ) {
-
-					var value = subNode.propertyList[ 0 ];
-
-					if ( Array.isArray( value ) ) {
-
-						node[ subNode.name ] = subNode;
-						subNode.a = value;
-
-					} else {
-
-						node[ subNode.name ] = value;
-
-					}
-
-				} else if ( name === 'Connections' && subNode.name === 'C' ) {
-
-					var array = [];
-					subNode.propertyList.forEach( function ( property, i ) {
-
-						// first Connection is FBX type (OO, OP, etc.). We'll discard these
-						if ( i !== 0 ) array.push( property );
-
-					} );
-
-					if ( node.connections === undefined ) {
-
-						node.connections = [];
-
-					}
-
-					node.connections.push( array );
-
-				} else if ( subNode.name === 'Properties70' ) {
-
-					var keys = Object.keys( subNode );
-					keys.forEach( function ( key ) {
-
-						node[ key ] = subNode[ key ];
-
-					} );
-
-				} else if ( name === 'Properties70' && subNode.name === 'P' ) {
-
-					var innerPropName = subNode.propertyList[ 0 ];
-					var innerPropType1 = subNode.propertyList[ 1 ];
-					var innerPropType2 = subNode.propertyList[ 2 ];
-					var innerPropFlag = subNode.propertyList[ 3 ];
-					var innerPropValue;
-					if ( innerPropName.indexOf( 'Lcl ' ) === 0 ) innerPropName = innerPropName.replace( 'Lcl ', 'Lcl_' );
-					if ( innerPropType1.indexOf( 'Lcl ' ) === 0 ) innerPropType1 = innerPropType1.replace( 'Lcl ', 'Lcl_' );
-
-					if ( innerPropType1 === 'Color' || innerPropType1 === 'ColorRGB' || innerPropType1 === 'Vector' || innerPropType1 === 'Vector3D' || innerPropType1.indexOf( 'Lcl_' ) === 0 ) {
-
-						innerPropValue = [ subNode.propertyList[ 4 ], subNode.propertyList[ 5 ], subNode.propertyList[ 6 ] ];
-
-					} else {
-
-						innerPropValue = subNode.propertyList[ 4 ];
-
-					} // this will be copied to parent, see above
-
-
-					node[ innerPropName ] = {
-						'type': innerPropType1,
-						'type2': innerPropType2,
-						'flag': innerPropFlag,
-						'value': innerPropValue
-					};
-
-				} else if ( node[ subNode.name ] === undefined ) {
-
-					if ( typeof subNode.id === 'number' ) {
-
-						node[ subNode.name ] = {};
-						node[ subNode.name ][ subNode.id ] = subNode;
-
-					} else {
-
-						node[ subNode.name ] = subNode;
-
-					}
-
-				} else {
-
-					if ( subNode.name === 'PoseNode' ) {
-
-						if ( ! Array.isArray( node[ subNode.name ] ) ) {
-
-							node[ subNode.name ] = [ node[ subNode.name ] ];
-
-						}
-
-						node[ subNode.name ].push( subNode );
-
-					} else if ( node[ subNode.name ][ subNode.id ] === undefined ) {
-
-						node[ subNode.name ][ subNode.id ] = subNode;
-
-					}
-
-				}
-
-			},
-			parseProperty: function ( reader ) {
-
-				var type = reader.getString( 1 );
-
-				switch ( type ) {
-
-					case 'C':
-						return reader.getBoolean();
-
-					case 'D':
-						return reader.getFloat64();
-
-					case 'F':
-						return reader.getFloat32();
-
-					case 'I':
-						return reader.getInt32();
-
-					case 'L':
-						return reader.getInt64();
-
-					case 'R':
-						var length = reader.getUint32();
-						return reader.getArrayBuffer( length );
-
-					case 'S':
-						var length = reader.getUint32();
-						return reader.getString( length );
-
-					case 'Y':
-						return reader.getInt16();
-
-					case 'b':
-					case 'c':
-					case 'd':
-					case 'f':
-					case 'i':
-					case 'l':
-						var arrayLength = reader.getUint32();
-						var encoding = reader.getUint32(); // 0: non-compressed, 1: compressed
-
-						var compressedLength = reader.getUint32();
-
-						if ( encoding === 0 ) {
-
-							switch ( type ) {
-
-								case 'b':
-								case 'c':
-									return reader.getBooleanArray( arrayLength );
-
-								case 'd':
-									return reader.getFloat64Array( arrayLength );
-
-								case 'f':
-									return reader.getFloat32Array( arrayLength );
-
-								case 'i':
-									return reader.getInt32Array( arrayLength );
-
-								case 'l':
-									return reader.getInt64Array( arrayLength );
-
-							}
-
-						}
-
-						if ( typeof fflate === 'undefined' ) {
-
-							console.error( 'THREE.FBXLoader: External library fflate.min.js required.' );
-
-						}
-
-						var data = fflate.unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) ); // eslint-disable-line no-undef
-
-						var reader2 = new BinaryReader( data.buffer );
+					if ( encoding === 0 ) {
 
 						switch ( type ) {
 
 							case 'b':
 							case 'c':
-								return reader2.getBooleanArray( arrayLength );
+								return reader.getBooleanArray( arrayLength );
 
 							case 'd':
-								return reader2.getFloat64Array( arrayLength );
+								return reader.getFloat64Array( arrayLength );
 
 							case 'f':
-								return reader2.getFloat32Array( arrayLength );
+								return reader.getFloat32Array( arrayLength );
 
 							case 'i':
-								return reader2.getInt32Array( arrayLength );
+								return reader.getInt32Array( arrayLength );
 
 							case 'l':
-								return reader2.getInt64Array( arrayLength );
+								return reader.getInt64Array( arrayLength );
 
 						}
 
-					default:
-						throw new Error( 'THREE.FBXLoader: Unknown property type ' + type );
+					}
 
-				}
+					if ( typeof fflate === 'undefined' ) {
+
+						console.error( 'THREE.FBXLoader: External library fflate.min.js required.' );
+
+					}
+
+					const data = fflate.unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) ); // eslint-disable-line no-undef
+
+					const reader2 = new BinaryReader( data.buffer );
+
+					switch ( type ) {
+
+						case 'b':
+						case 'c':
+							return reader2.getBooleanArray( arrayLength );
+
+						case 'd':
+							return reader2.getFloat64Array( arrayLength );
+
+						case 'f':
+							return reader2.getFloat32Array( arrayLength );
+
+						case 'i':
+							return reader2.getInt32Array( arrayLength );
+
+						case 'l':
+							return reader2.getInt64Array( arrayLength );
+
+					}
+
+				default:
+					throw new Error( 'THREE.FBXLoader: Unknown property type ' + type );
 
 			}
-		};
 
-		function BinaryReader( buffer, littleEndian ) {
+		}
+
+	}
+
+	class BinaryReader {
+
+		constructor( buffer, littleEndian ) {
 
 			this.dv = new DataView( buffer );
 			this.offset = 0;
@@ -3276,512 +3350,526 @@
 
 		}
 
-		BinaryReader.prototype = {
-			constructor: BinaryReader,
-			getOffset: function () {
+		getOffset() {
 
-				return this.offset;
-
-			},
-			size: function () {
-
-				return this.dv.buffer.byteLength;
-
-			},
-			skip: function ( length ) {
-
-				this.offset += length;
-
-			},
-			// seems like true/false representation depends on exporter.
-			// true: 1 or 'Y'(=0x59), false: 0 or 'T'(=0x54)
-			// then sees LSB.
-			getBoolean: function () {
-
-				return ( this.getUint8() & 1 ) === 1;
-
-			},
-			getBooleanArray: function ( size ) {
-
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a.push( this.getBoolean() );
-
-				}
-
-				return a;
-
-			},
-			getUint8: function () {
-
-				var value = this.dv.getUint8( this.offset );
-				this.offset += 1;
-				return value;
-
-			},
-			getInt16: function () {
-
-				var value = this.dv.getInt16( this.offset, this.littleEndian );
-				this.offset += 2;
-				return value;
-
-			},
-			getInt32: function () {
-
-				var value = this.dv.getInt32( this.offset, this.littleEndian );
-				this.offset += 4;
-				return value;
-
-			},
-			getInt32Array: function ( size ) {
-
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a.push( this.getInt32() );
-
-				}
-
-				return a;
-
-			},
-			getUint32: function () {
-
-				var value = this.dv.getUint32( this.offset, this.littleEndian );
-				this.offset += 4;
-				return value;
-
-			},
-			// JavaScript doesn't support 64-bit integer so calculate this here
-			// 1 << 32 will return 1 so using multiply operation instead here.
-			// There's a possibility that this method returns wrong value if the value
-			// is out of the range between Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER.
-			// TODO: safely handle 64-bit integer
-			getInt64: function () {
-
-				var low, high;
-
-				if ( this.littleEndian ) {
-
-					low = this.getUint32();
-					high = this.getUint32();
-
-				} else {
-
-					high = this.getUint32();
-					low = this.getUint32();
-
-				} // calculate negative value
-
-
-				if ( high & 0x80000000 ) {
-
-					high = ~ high & 0xFFFFFFFF;
-					low = ~ low & 0xFFFFFFFF;
-					if ( low === 0xFFFFFFFF ) high = high + 1 & 0xFFFFFFFF;
-					low = low + 1 & 0xFFFFFFFF;
-					return - ( high * 0x100000000 + low );
-
-				}
-
-				return high * 0x100000000 + low;
-
-			},
-			getInt64Array: function ( size ) {
-
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a.push( this.getInt64() );
-
-				}
-
-				return a;
-
-			},
-			// Note: see getInt64() comment
-			getUint64: function () {
-
-				var low, high;
-
-				if ( this.littleEndian ) {
-
-					low = this.getUint32();
-					high = this.getUint32();
-
-				} else {
-
-					high = this.getUint32();
-					low = this.getUint32();
-
-				}
-
-				return high * 0x100000000 + low;
-
-			},
-			getFloat32: function () {
-
-				var value = this.dv.getFloat32( this.offset, this.littleEndian );
-				this.offset += 4;
-				return value;
-
-			},
-			getFloat32Array: function ( size ) {
-
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a.push( this.getFloat32() );
-
-				}
-
-				return a;
-
-			},
-			getFloat64: function () {
-
-				var value = this.dv.getFloat64( this.offset, this.littleEndian );
-				this.offset += 8;
-				return value;
-
-			},
-			getFloat64Array: function ( size ) {
-
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a.push( this.getFloat64() );
-
-				}
-
-				return a;
-
-			},
-			getArrayBuffer: function ( size ) {
-
-				var value = this.dv.buffer.slice( this.offset, this.offset + size );
-				this.offset += size;
-				return value;
-
-			},
-			getString: function ( size ) {
-
-				// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
-				var a = [];
-
-				for ( var i = 0; i < size; i ++ ) {
-
-					a[ i ] = this.getUint8();
-
-				}
-
-				var nullByte = a.indexOf( 0 );
-				if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
-				return THREE.LoaderUtils.decodeText( new Uint8Array( a ) );
-
-			}
-		}; // FBXTree holds a representation of the FBX data, returned by the TextParser ( FBX ASCII format)
-		// and BinaryParser( FBX Binary format)
-
-		function FBXTree() {}
-
-		FBXTree.prototype = {
-			constructor: FBXTree,
-			add: function ( key, val ) {
-
-				this[ key ] = val;
-
-			}
-		}; // ************** UTILITY FUNCTIONS **************
-
-		function isFbxFormatBinary( buffer ) {
-
-			var CORRECT = 'Kaydara FBX Binary	\0';
-			return buffer.byteLength >= CORRECT.length && CORRECT === convertArrayBufferToString( buffer, 0, CORRECT.length );
+			return this.offset;
 
 		}
 
-		function isFbxFormatASCII( text ) {
+		size() {
 
-			var CORRECT = [ 'K', 'a', 'y', 'd', 'a', 'r', 'a', '\\', 'F', 'B', 'X', '\\', 'B', 'i', 'n', 'a', 'r', 'y', '\\', '\\' ];
-			var cursor = 0;
-
-			function read( offset ) {
-
-				var result = text[ offset - 1 ];
-				text = text.slice( cursor + offset );
-				cursor ++;
-				return result;
-
-			}
-
-			for ( var i = 0; i < CORRECT.length; ++ i ) {
-
-				var num = read( 1 );
-
-				if ( num === CORRECT[ i ] ) {
-
-					return false;
-
-				}
-
-			}
-
-			return true;
+			return this.dv.buffer.byteLength;
 
 		}
 
-		function getFbxVersion( text ) {
+		skip( length ) {
 
-			var versionRegExp = /FBXVersion: (\d+)/;
-			var match = text.match( versionRegExp );
+			this.offset += length;
 
-			if ( match ) {
-
-				var version = parseInt( match[ 1 ] );
-				return version;
-
-			}
-
-			throw new Error( 'THREE.FBXLoader: Cannot find the version number for the file given.' );
-
-		} // Converts FBX ticks into real time seconds.
+		} // seems like true/false representation depends on exporter.
+		// true: 1 or 'Y'(=0x59), false: 0 or 'T'(=0x54)
+		// then sees LSB.
 
 
-		function convertFBXTimeToSeconds( time ) {
+		getBoolean() {
 
-			return time / 46186158000;
+			return ( this.getUint8() & 1 ) === 1;
 
 		}
 
-		var dataArray = []; // extracts the data from the correct position in the FBX array based on indexing type
+		getBooleanArray( size ) {
 
-		function getData( polygonVertexIndex, polygonIndex, vertexIndex, infoObject ) {
+			const a = [];
 
-			var index;
+			for ( let i = 0; i < size; i ++ ) {
 
-			switch ( infoObject.mappingType ) {
-
-				case 'ByPolygonVertex':
-					index = polygonVertexIndex;
-					break;
-
-				case 'ByPolygon':
-					index = polygonIndex;
-					break;
-
-				case 'ByVertice':
-					index = vertexIndex;
-					break;
-
-				case 'AllSame':
-					index = infoObject.indices[ 0 ];
-					break;
-
-				default:
-					console.warn( 'THREE.FBXLoader: unknown attribute mapping type ' + infoObject.mappingType );
-
-			}
-
-			if ( infoObject.referenceType === 'IndexToDirect' ) index = infoObject.indices[ index ];
-			var from = index * infoObject.dataSize;
-			var to = from + infoObject.dataSize;
-			return slice( dataArray, infoObject.buffer, from, to );
-
-		}
-
-		var tempEuler = new THREE.Euler();
-		var tempVec = new THREE.Vector3(); // generate transformation from FBX transform data
-		// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
-		// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
-
-		function generateTransform( transformData ) {
-
-			var lTranslationM = new THREE.Matrix4();
-			var lPreRotationM = new THREE.Matrix4();
-			var lRotationM = new THREE.Matrix4();
-			var lPostRotationM = new THREE.Matrix4();
-			var lScalingM = new THREE.Matrix4();
-			var lScalingPivotM = new THREE.Matrix4();
-			var lScalingOffsetM = new THREE.Matrix4();
-			var lRotationOffsetM = new THREE.Matrix4();
-			var lRotationPivotM = new THREE.Matrix4();
-			var lParentGX = new THREE.Matrix4();
-			var lParentLX = new THREE.Matrix4();
-			var lGlobalT = new THREE.Matrix4();
-			var inheritType = transformData.inheritType ? transformData.inheritType : 0;
-			if ( transformData.translation ) lTranslationM.setPosition( tempVec.fromArray( transformData.translation ) );
-
-			if ( transformData.preRotation ) {
-
-				var array = transformData.preRotation.map( THREE.MathUtils.degToRad );
-				array.push( transformData.eulerOrder );
-				lPreRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-
-			}
-
-			if ( transformData.rotation ) {
-
-				var array = transformData.rotation.map( THREE.MathUtils.degToRad );
-				array.push( transformData.eulerOrder );
-				lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-
-			}
-
-			if ( transformData.postRotation ) {
-
-				var array = transformData.postRotation.map( THREE.MathUtils.degToRad );
-				array.push( transformData.eulerOrder );
-				lPostRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-				lPostRotationM.invert();
-
-			}
-
-			if ( transformData.scale ) lScalingM.scale( tempVec.fromArray( transformData.scale ) ); // Pivots and offsets
-
-			if ( transformData.scalingOffset ) lScalingOffsetM.setPosition( tempVec.fromArray( transformData.scalingOffset ) );
-			if ( transformData.scalingPivot ) lScalingPivotM.setPosition( tempVec.fromArray( transformData.scalingPivot ) );
-			if ( transformData.rotationOffset ) lRotationOffsetM.setPosition( tempVec.fromArray( transformData.rotationOffset ) );
-			if ( transformData.rotationPivot ) lRotationPivotM.setPosition( tempVec.fromArray( transformData.rotationPivot ) ); // parent transform
-
-			if ( transformData.parentMatrixWorld ) {
-
-				lParentLX.copy( transformData.parentMatrix );
-				lParentGX.copy( transformData.parentMatrixWorld );
-
-			}
-
-			var lLRM = new THREE.Matrix4().copy( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ); // Global Rotation
-
-			var lParentGRM = new THREE.Matrix4();
-			lParentGRM.extractRotation( lParentGX ); // Global Shear*Scaling
-
-			var lParentTM = new THREE.Matrix4();
-			lParentTM.copyPosition( lParentGX );
-			var lParentGSM = new THREE.Matrix4();
-			var lParentGRSM = new THREE.Matrix4().copy( lParentTM ).invert().multiply( lParentGX );
-			lParentGSM.copy( lParentGRM ).invert().multiply( lParentGRSM );
-			var lLSM = lScalingM;
-			var lGlobalRS = new THREE.Matrix4();
-
-			if ( inheritType === 0 ) {
-
-				lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
-
-			} else if ( inheritType === 1 ) {
-
-				lGlobalRS.copy( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
-
-			} else {
-
-				var lParentLSM = new THREE.Matrix4().scale( new THREE.Vector3().setFromMatrixScale( lParentLX ) );
-				var lParentLSM_inv = new THREE.Matrix4().copy( lParentLSM ).invert();
-				var lParentGSM_noLocal = new THREE.Matrix4().copy( lParentGSM ).multiply( lParentLSM_inv );
-				lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
-
-			}
-
-			var lRotationPivotM_inv = new THREE.Matrix4();
-			lRotationPivotM_inv.copy( lRotationPivotM ).invert();
-			var lScalingPivotM_inv = new THREE.Matrix4();
-			lScalingPivotM_inv.copy( lScalingPivotM ).invert(); // Calculate the local transform matrix
-
-			var lTransform = new THREE.Matrix4();
-			lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
-			var lLocalTWithAllPivotAndOffsetInfo = new THREE.Matrix4().copyPosition( lTransform );
-			var lGlobalTranslation = new THREE.Matrix4().copy( lParentGX ).multiply( lLocalTWithAllPivotAndOffsetInfo );
-			lGlobalT.copyPosition( lGlobalTranslation );
-			lTransform = new THREE.Matrix4().copy( lGlobalT ).multiply( lGlobalRS ); // from global to local
-
-			lTransform.premultiply( lParentGX.invert() );
-			return lTransform;
-
-		} // Returns the three.js intrinsic THREE.Euler order corresponding to FBX extrinsic THREE.Euler order
-		// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
-
-
-		function getEulerOrder( order ) {
-
-			order = order || 0;
-			var enums = [ 'ZYX', // -> XYZ extrinsic
-				'YZX', // -> XZY extrinsic
-				'XZY', // -> YZX extrinsic
-				'ZXY', // -> YXZ extrinsic
-				'YXZ', // -> ZXY extrinsic
-				'XYZ' // -> ZYX extrinsic
-				//'SphericXYZ', // not possible to support
-			];
-
-			if ( order === 6 ) {
-
-				console.warn( 'THREE.FBXLoader: unsupported THREE.Euler Order: Spherical XYZ. Animations and rotations may be incorrect.' );
-				return enums[ 0 ];
-
-			}
-
-			return enums[ order ];
-
-		} // Parses comma separated list of numbers and returns them an array.
-		// Used internally by the TextParser
-
-
-		function parseNumberArray( value ) {
-
-			var array = value.split( ',' ).map( function ( val ) {
-
-				return parseFloat( val );
-
-			} );
-			return array;
-
-		}
-
-		function convertArrayBufferToString( buffer, from, to ) {
-
-			if ( from === undefined ) from = 0;
-			if ( to === undefined ) to = buffer.byteLength;
-			return THREE.LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) );
-
-		}
-
-		function append( a, b ) {
-
-			for ( var i = 0, j = a.length, l = b.length; i < l; i ++, j ++ ) {
-
-				a[ j ] = b[ i ];
-
-			}
-
-		}
-
-		function slice( a, b, from, to ) {
-
-			for ( var i = from, j = 0; i < to; i ++, j ++ ) {
-
-				a[ j ] = b[ i ];
+				a.push( this.getBoolean() );
 
 			}
 
 			return a;
 
-		} // inject array a2 into array a1 at index
+		}
 
+		getUint8() {
 
-		function inject( a1, index, a2 ) {
-
-			return a1.slice( 0, index ).concat( a2 ).concat( a1.slice( index ) );
+			const value = this.dv.getUint8( this.offset );
+			this.offset += 1;
+			return value;
 
 		}
 
-		return FBXLoader;
+		getInt16() {
 
-	}();
+			const value = this.dv.getInt16( this.offset, this.littleEndian );
+			this.offset += 2;
+			return value;
+
+		}
+
+		getInt32() {
+
+			const value = this.dv.getInt32( this.offset, this.littleEndian );
+			this.offset += 4;
+			return value;
+
+		}
+
+		getInt32Array( size ) {
+
+			const a = [];
+
+			for ( let i = 0; i < size; i ++ ) {
+
+				a.push( this.getInt32() );
+
+			}
+
+			return a;
+
+		}
+
+		getUint32() {
+
+			const value = this.dv.getUint32( this.offset, this.littleEndian );
+			this.offset += 4;
+			return value;
+
+		} // JavaScript doesn't support 64-bit integer so calculate this here
+		// 1 << 32 will return 1 so using multiply operation instead here.
+		// There's a possibility that this method returns wrong value if the value
+		// is out of the range between Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER.
+		// TODO: safely handle 64-bit integer
+
+
+		getInt64() {
+
+			let low, high;
+
+			if ( this.littleEndian ) {
+
+				low = this.getUint32();
+				high = this.getUint32();
+
+			} else {
+
+				high = this.getUint32();
+				low = this.getUint32();
+
+			} // calculate negative value
+
+
+			if ( high & 0x80000000 ) {
+
+				high = ~ high & 0xFFFFFFFF;
+				low = ~ low & 0xFFFFFFFF;
+				if ( low === 0xFFFFFFFF ) high = high + 1 & 0xFFFFFFFF;
+				low = low + 1 & 0xFFFFFFFF;
+				return - ( high * 0x100000000 + low );
+
+			}
+
+			return high * 0x100000000 + low;
+
+		}
+
+		getInt64Array( size ) {
+
+			const a = [];
+
+			for ( let i = 0; i < size; i ++ ) {
+
+				a.push( this.getInt64() );
+
+			}
+
+			return a;
+
+		} // Note: see getInt64() comment
+
+
+		getUint64() {
+
+			let low, high;
+
+			if ( this.littleEndian ) {
+
+				low = this.getUint32();
+				high = this.getUint32();
+
+			} else {
+
+				high = this.getUint32();
+				low = this.getUint32();
+
+			}
+
+			return high * 0x100000000 + low;
+
+		}
+
+		getFloat32() {
+
+			const value = this.dv.getFloat32( this.offset, this.littleEndian );
+			this.offset += 4;
+			return value;
+
+		}
+
+		getFloat32Array( size ) {
+
+			const a = [];
+
+			for ( let i = 0; i < size; i ++ ) {
+
+				a.push( this.getFloat32() );
+
+			}
+
+			return a;
+
+		}
+
+		getFloat64() {
+
+			const value = this.dv.getFloat64( this.offset, this.littleEndian );
+			this.offset += 8;
+			return value;
+
+		}
+
+		getFloat64Array( size ) {
+
+			const a = [];
+
+			for ( let i = 0; i < size; i ++ ) {
+
+				a.push( this.getFloat64() );
+
+			}
+
+			return a;
+
+		}
+
+		getArrayBuffer( size ) {
+
+			const value = this.dv.buffer.slice( this.offset, this.offset + size );
+			this.offset += size;
+			return value;
+
+		}
+
+		getString( size ) {
+
+			// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
+			let a = [];
+
+			for ( let i = 0; i < size; i ++ ) {
+
+				a[ i ] = this.getUint8();
+
+			}
+
+			const nullByte = a.indexOf( 0 );
+			if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
+			return THREE.LoaderUtils.decodeText( new Uint8Array( a ) );
+
+		}
+
+	} // FBXTree holds a representation of the FBX data, returned by the TextParser ( FBX ASCII format)
+	// and BinaryParser( FBX Binary format)
+
+
+	class FBXTree {
+
+		add( key, val ) {
+
+			this[ key ] = val;
+
+		}
+
+	} // ************** UTILITY FUNCTIONS **************
+
+
+	function isFbxFormatBinary( buffer ) {
+
+		const CORRECT = 'Kaydara FBX Binary	\0';
+		return buffer.byteLength >= CORRECT.length && CORRECT === convertArrayBufferToString( buffer, 0, CORRECT.length );
+
+	}
+
+	function isFbxFormatASCII( text ) {
+
+		const CORRECT = [ 'K', 'a', 'y', 'd', 'a', 'r', 'a', '\\', 'F', 'B', 'X', '\\', 'B', 'i', 'n', 'a', 'r', 'y', '\\', '\\' ];
+		let cursor = 0;
+
+		function read( offset ) {
+
+			const result = text[ offset - 1 ];
+			text = text.slice( cursor + offset );
+			cursor ++;
+			return result;
+
+		}
+
+		for ( let i = 0; i < CORRECT.length; ++ i ) {
+
+			const num = read( 1 );
+
+			if ( num === CORRECT[ i ] ) {
+
+				return false;
+
+			}
+
+		}
+
+		return true;
+
+	}
+
+	function getFbxVersion( text ) {
+
+		const versionRegExp = /FBXVersion: (\d+)/;
+		const match = text.match( versionRegExp );
+
+		if ( match ) {
+
+			const version = parseInt( match[ 1 ] );
+			return version;
+
+		}
+
+		throw new Error( 'THREE.FBXLoader: Cannot find the version number for the file given.' );
+
+	} // Converts FBX ticks into real time seconds.
+
+
+	function convertFBXTimeToSeconds( time ) {
+
+		return time / 46186158000;
+
+	}
+
+	const dataArray = []; // extracts the data from the correct position in the FBX array based on indexing type
+
+	function getData( polygonVertexIndex, polygonIndex, vertexIndex, infoObject ) {
+
+		let index;
+
+		switch ( infoObject.mappingType ) {
+
+			case 'ByPolygonVertex':
+				index = polygonVertexIndex;
+				break;
+
+			case 'ByPolygon':
+				index = polygonIndex;
+				break;
+
+			case 'ByVertice':
+				index = vertexIndex;
+				break;
+
+			case 'AllSame':
+				index = infoObject.indices[ 0 ];
+				break;
+
+			default:
+				console.warn( 'THREE.FBXLoader: unknown attribute mapping type ' + infoObject.mappingType );
+
+		}
+
+		if ( infoObject.referenceType === 'IndexToDirect' ) index = infoObject.indices[ index ];
+		const from = index * infoObject.dataSize;
+		const to = from + infoObject.dataSize;
+		return slice( dataArray, infoObject.buffer, from, to );
+
+	}
+
+	const tempEuler = new THREE.Euler();
+	const tempVec = new THREE.Vector3(); // generate transformation from FBX transform data
+	// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
+	// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
+
+	function generateTransform( transformData ) {
+
+		const lTranslationM = new THREE.Matrix4();
+		const lPreRotationM = new THREE.Matrix4();
+		const lRotationM = new THREE.Matrix4();
+		const lPostRotationM = new THREE.Matrix4();
+		const lScalingM = new THREE.Matrix4();
+		const lScalingPivotM = new THREE.Matrix4();
+		const lScalingOffsetM = new THREE.Matrix4();
+		const lRotationOffsetM = new THREE.Matrix4();
+		const lRotationPivotM = new THREE.Matrix4();
+		const lParentGX = new THREE.Matrix4();
+		const lParentLX = new THREE.Matrix4();
+		const lGlobalT = new THREE.Matrix4();
+		const inheritType = transformData.inheritType ? transformData.inheritType : 0;
+		if ( transformData.translation ) lTranslationM.setPosition( tempVec.fromArray( transformData.translation ) );
+
+		if ( transformData.preRotation ) {
+
+			const array = transformData.preRotation.map( THREE.MathUtils.degToRad );
+			array.push( transformData.eulerOrder );
+			lPreRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+
+		}
+
+		if ( transformData.rotation ) {
+
+			const array = transformData.rotation.map( THREE.MathUtils.degToRad );
+			array.push( transformData.eulerOrder );
+			lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+
+		}
+
+		if ( transformData.postRotation ) {
+
+			const array = transformData.postRotation.map( THREE.MathUtils.degToRad );
+			array.push( transformData.eulerOrder );
+			lPostRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+			lPostRotationM.invert();
+
+		}
+
+		if ( transformData.scale ) lScalingM.scale( tempVec.fromArray( transformData.scale ) ); // Pivots and offsets
+
+		if ( transformData.scalingOffset ) lScalingOffsetM.setPosition( tempVec.fromArray( transformData.scalingOffset ) );
+		if ( transformData.scalingPivot ) lScalingPivotM.setPosition( tempVec.fromArray( transformData.scalingPivot ) );
+		if ( transformData.rotationOffset ) lRotationOffsetM.setPosition( tempVec.fromArray( transformData.rotationOffset ) );
+		if ( transformData.rotationPivot ) lRotationPivotM.setPosition( tempVec.fromArray( transformData.rotationPivot ) ); // parent transform
+
+		if ( transformData.parentMatrixWorld ) {
+
+			lParentLX.copy( transformData.parentMatrix );
+			lParentGX.copy( transformData.parentMatrixWorld );
+
+		}
+
+		const lLRM = new THREE.Matrix4().copy( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ); // Global Rotation
+
+		const lParentGRM = new THREE.Matrix4();
+		lParentGRM.extractRotation( lParentGX ); // Global Shear*Scaling
+
+		const lParentTM = new THREE.Matrix4();
+		lParentTM.copyPosition( lParentGX );
+		const lParentGSM = new THREE.Matrix4();
+		const lParentGRSM = new THREE.Matrix4().copy( lParentTM ).invert().multiply( lParentGX );
+		lParentGSM.copy( lParentGRM ).invert().multiply( lParentGRSM );
+		const lLSM = lScalingM;
+		const lGlobalRS = new THREE.Matrix4();
+
+		if ( inheritType === 0 ) {
+
+			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
+
+		} else if ( inheritType === 1 ) {
+
+			lGlobalRS.copy( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
+
+		} else {
+
+			const lParentLSM = new THREE.Matrix4().scale( new THREE.Vector3().setFromMatrixScale( lParentLX ) );
+			const lParentLSM_inv = new THREE.Matrix4().copy( lParentLSM ).invert();
+			const lParentGSM_noLocal = new THREE.Matrix4().copy( lParentGSM ).multiply( lParentLSM_inv );
+			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
+
+		}
+
+		const lRotationPivotM_inv = new THREE.Matrix4();
+		lRotationPivotM_inv.copy( lRotationPivotM ).invert();
+		const lScalingPivotM_inv = new THREE.Matrix4();
+		lScalingPivotM_inv.copy( lScalingPivotM ).invert(); // Calculate the local transform matrix
+
+		let lTransform = new THREE.Matrix4();
+		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
+		const lLocalTWithAllPivotAndOffsetInfo = new THREE.Matrix4().copyPosition( lTransform );
+		const lGlobalTranslation = new THREE.Matrix4().copy( lParentGX ).multiply( lLocalTWithAllPivotAndOffsetInfo );
+		lGlobalT.copyPosition( lGlobalTranslation );
+		lTransform = new THREE.Matrix4().copy( lGlobalT ).multiply( lGlobalRS ); // from global to local
+
+		lTransform.premultiply( lParentGX.invert() );
+		return lTransform;
+
+	} // Returns the three.js intrinsic THREE.Euler order corresponding to FBX extrinsic THREE.Euler order
+	// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
+
+
+	function getEulerOrder( order ) {
+
+		order = order || 0;
+		const enums = [ 'ZYX', // -> XYZ extrinsic
+			'YZX', // -> XZY extrinsic
+			'XZY', // -> YZX extrinsic
+			'ZXY', // -> YXZ extrinsic
+			'YXZ', // -> ZXY extrinsic
+			'XYZ' // -> ZYX extrinsic
+			//'SphericXYZ', // not possible to support
+		];
+
+		if ( order === 6 ) {
+
+			console.warn( 'THREE.FBXLoader: unsupported THREE.Euler Order: Spherical XYZ. Animations and rotations may be incorrect.' );
+			return enums[ 0 ];
+
+		}
+
+		return enums[ order ];
+
+	} // Parses comma separated list of numbers and returns them an array.
+	// Used internally by the TextParser
+
+
+	function parseNumberArray( value ) {
+
+		const array = value.split( ',' ).map( function ( val ) {
+
+			return parseFloat( val );
+
+		} );
+		return array;
+
+	}
+
+	function convertArrayBufferToString( buffer, from, to ) {
+
+		if ( from === undefined ) from = 0;
+		if ( to === undefined ) to = buffer.byteLength;
+		return THREE.LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) );
+
+	}
+
+	function append( a, b ) {
+
+		for ( let i = 0, j = a.length, l = b.length; i < l; i ++, j ++ ) {
+
+			a[ j ] = b[ i ];
+
+		}
+
+	}
+
+	function slice( a, b, from, to ) {
+
+		for ( let i = from, j = 0; i < to; i ++, j ++ ) {
+
+			a[ j ] = b[ i ];
+
+		}
+
+		return a;
+
+	} // inject array a2 into array a1 at index
+
+
+	function inject( a1, index, a2 ) {
+
+		return a1.slice( 0, index ).concat( a2 ).concat( a1.slice( index ) );
+
+	}
 
 	THREE.FBXLoader = FBXLoader;
 

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -9,19 +9,19 @@
  * @param {Manager} manager Loading manager.
  */
 
-	var GCodeLoader = function ( manager ) {
+	class GCodeLoader extends THREE.Loader {
 
-		THREE.Loader.call( this, manager );
-		this.splitLayer = false;
+		constructor( manager ) {
 
-	};
+			super( manager );
+			this.splitLayer = false;
 
-	GCodeLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-		constructor: GCodeLoader,
-		load: function ( url, onLoad, onProgress, onError ) {
+		}
 
-			var scope = this;
-			var loader = new THREE.FileLoader( scope.manager );
+		load( url, onLoad, onProgress, onError ) {
+
+			const scope = this;
+			const loader = new THREE.FileLoader( scope.manager );
 			loader.setPath( scope.path );
 			loader.setRequestHeader( scope.requestHeader );
 			loader.setWithCredentials( scope.withCredentials );
@@ -49,8 +49,9 @@
 
 			}, onProgress, onError );
 
-		},
-		parse: function ( data ) {
+		}
+
+		parse( data ) {
 
 			var state = {
 				x: 0,
@@ -248,7 +249,8 @@
 			return object;
 
 		}
-	} );
+
+	}
 
 	THREE.GCodeLoader = GCodeLoader;
 

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -1,10 +1,25 @@
 ( function () {
 
-	var LDrawLoader = function () {
+	// Note: "MATERIAL" tag (e.g. GLITTER, SPECKLE) is not implemented
 
-		var conditionalLineVertShader =
-	/* glsl */
-	`
+	const FINISH_TYPE_DEFAULT = 0;
+	const FINISH_TYPE_CHROME = 1;
+	const FINISH_TYPE_PEARLESCENT = 2;
+	const FINISH_TYPE_RUBBER = 3;
+	const FINISH_TYPE_MATTE_METALLIC = 4;
+	const FINISH_TYPE_METAL = 5; // State machine to search a subobject path.
+	// The LDraw standard establishes these various possible subfolders.
+
+	const FILE_LOCATION_AS_IS = 0;
+	const FILE_LOCATION_TRY_PARTS = 1;
+	const FILE_LOCATION_TRY_P = 2;
+	const FILE_LOCATION_TRY_MODELS = 3;
+	const FILE_LOCATION_TRY_RELATIVE = 4;
+	const FILE_LOCATION_TRY_ABSOLUTE = 5;
+	const FILE_LOCATION_NOT_FOUND = 6;
+	const conditionalLineVertShader =
+/* glsl */
+`
 	attribute vec3 control0;
 	attribute vec3 control1;
 	attribute vec3 direction;
@@ -51,9 +66,9 @@
 		#include <fog_vertex>
 	}
 	`;
-		var conditionalLineFragShader =
-	/* glsl */
-	`
+	const conditionalLineFragShader =
+/* glsl */
+`
 	uniform vec3 diffuse;
 	uniform float opacity;
 	varying float discardFlag;
@@ -80,173 +95,173 @@
 		#include <premultiplied_alpha_fragment>
 	}
 	`;
-		var tempVec0 = new THREE.Vector3();
-		var tempVec1 = new THREE.Vector3();
 
-		function smoothNormals( triangles, lineSegments ) {
+	const _tempVec0 = new THREE.Vector3();
 
-			function hashVertex( v ) {
+	const _tempVec1 = new THREE.Vector3();
 
-				// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
-				// to be smoothed as expected (see minifig arms). The errors between edges
-				// could be due to matrix multiplication.
-				var x = ~ ~ ( v.x * 1e2 );
-				var y = ~ ~ ( v.y * 1e2 );
-				var z = ~ ~ ( v.z * 1e2 );
-				return `${x},${y},${z}`;
+	function smoothNormals( triangles, lineSegments ) {
+
+		function hashVertex( v ) {
+
+			// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
+			// to be smoothed as expected (see minifig arms). The errors between edges
+			// could be due to matrix multiplication.
+			const x = ~ ~ ( v.x * 1e2 );
+			const y = ~ ~ ( v.y * 1e2 );
+			const z = ~ ~ ( v.z * 1e2 );
+			return `${x},${y},${z}`;
+
+		}
+
+		function hashEdge( v0, v1 ) {
+
+			return `${hashVertex( v0 )}_${hashVertex( v1 )}`;
+
+		}
+
+		const hardEdges = new Set();
+		const halfEdgeList = {};
+		const fullHalfEdgeList = {};
+		const normals = []; // Save the list of hard edges by hash
+
+		for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
+
+			const ls = lineSegments[ i ];
+			const v0 = ls.v0;
+			const v1 = ls.v1;
+			hardEdges.add( hashEdge( v0, v1 ) );
+			hardEdges.add( hashEdge( v1, v0 ) );
+
+		} // track the half edges associated with each triangle
+
+
+		for ( let i = 0, l = triangles.length; i < l; i ++ ) {
+
+			const tri = triangles[ i ];
+
+			for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+
+				const index = i2;
+				const next = ( i2 + 1 ) % 3;
+				const v0 = tri[ `v${index}` ];
+				const v1 = tri[ `v${next}` ];
+				const hash = hashEdge( v0, v1 ); // don't add the triangle if the edge is supposed to be hard
+
+				if ( hardEdges.has( hash ) ) continue;
+				halfEdgeList[ hash ] = tri;
+				fullHalfEdgeList[ hash ] = tri;
 
 			}
 
-			function hashEdge( v0, v1 ) {
-
-				return `${hashVertex( v0 )}_${hashVertex( v1 )}`;
-
-			}
-
-			var hardEdges = new Set();
-			var halfEdgeList = {};
-			var fullHalfEdgeList = {};
-			var normals = []; // Save the list of hard edges by hash
-
-			for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
-
-				var ls = lineSegments[ i ];
-				var v0 = ls.v0;
-				var v1 = ls.v1;
-				hardEdges.add( hashEdge( v0, v1 ) );
-				hardEdges.add( hashEdge( v1, v0 ) );
-
-			} // track the half edges associated with each triangle
+		} // NOTE: Some of the normals wind up being skewed in an unexpected way because
+		// quads provide more "influence" to some vertex normals than a triangle due to
+		// the fact that a quad is made up of two triangles and all triangles are weighted
+		// equally. To fix this quads could be tracked separately so their vertex normals
+		// are weighted appropriately or we could try only adding a normal direction
+		// once per normal.
+		// Iterate until we've tried to connect all triangles to share normals
 
 
-			for ( var i = 0, l = triangles.length; i < l; i ++ ) {
+		while ( true ) {
 
-				var tri = triangles[ i ];
+			// Stop if there are no more triangles left
+			const halfEdges = Object.keys( halfEdgeList );
+			if ( halfEdges.length === 0 ) break; // Exhaustively find all connected triangles
 
-				for ( var i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+			let i = 0;
+			const queue = [ fullHalfEdgeList[ halfEdges[ 0 ] ] ];
 
-					var index = i2;
-					var next = ( i2 + 1 ) % 3;
-					var v0 = tri[ `v${index}` ];
-					var v1 = tri[ `v${next}` ];
-					var hash = hashEdge( v0, v1 ); // don't add the triangle if the edge is supposed to be hard
+			while ( i < queue.length ) {
 
-					if ( hardEdges.has( hash ) ) continue;
-					halfEdgeList[ hash ] = tri;
-					fullHalfEdgeList[ hash ] = tri;
+				// initialize all vertex normals in this triangle
+				const tri = queue[ i ];
+				i ++;
+				const faceNormal = tri.faceNormal;
+
+				if ( tri.n0 === null ) {
+
+					tri.n0 = faceNormal.clone();
+					normals.push( tri.n0 );
 
 				}
 
-			} // NOTE: Some of the normals wind up being skewed in an unexpected way because
-			// quads provide more "influence" to some vertex normals than a triangle due to
-			// the fact that a quad is made up of two triangles and all triangles are weighted
-			// equally. To fix this quads could be tracked separately so their vertex normals
-			// are weighted appropriately or we could try only adding a normal direction
-			// once per normal.
-			// Iterate until we've tried to connect all triangles to share normals
+				if ( tri.n1 === null ) {
+
+					tri.n1 = faceNormal.clone();
+					normals.push( tri.n1 );
+
+				}
+
+				if ( tri.n2 === null ) {
+
+					tri.n2 = faceNormal.clone();
+					normals.push( tri.n2 );
+
+				} // Check if any edge is connected to another triangle edge
 
 
-			while ( true ) {
+				for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
 
-				// Stop if there are no more triangles left
-				var halfEdges = Object.keys( halfEdgeList );
-				if ( halfEdges.length === 0 ) break; // Exhaustively find all connected triangles
+					const index = i2;
+					const next = ( i2 + 1 ) % 3;
+					const v0 = tri[ `v${index}` ];
+					const v1 = tri[ `v${next}` ]; // delete this triangle from the list so it won't be found again
 
-				var i = 0;
-				var queue = [ fullHalfEdgeList[ halfEdges[ 0 ] ] ];
+					const hash = hashEdge( v0, v1 );
+					delete halfEdgeList[ hash ];
+					const reverseHash = hashEdge( v1, v0 );
+					const otherTri = fullHalfEdgeList[ reverseHash ];
 
-				while ( i < queue.length ) {
+					if ( otherTri ) {
 
-					// initialize all vertex normals in this triangle
-					var tri = queue[ i ];
-					i ++;
-					var faceNormal = tri.faceNormal;
+						// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
+						// hard edge. There are some cases where the line segments do not line up exactly
+						// with or span multiple triangle edges (see Lunar Vehicle wheels).
+						if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
 
-					if ( tri.n0 === null ) {
+							continue;
 
-						tri.n0 = faceNormal.clone();
-						normals.push( tri.n0 );
-
-					}
-
-					if ( tri.n1 === null ) {
-
-						tri.n1 = faceNormal.clone();
-						normals.push( tri.n1 );
-
-					}
-
-					if ( tri.n2 === null ) {
-
-						tri.n2 = faceNormal.clone();
-						normals.push( tri.n2 );
-
-					} // Check if any edge is connected to another triangle edge
+						} // if this triangle has already been traversed then it won't be in
+						// the halfEdgeList. If it has not then add it to the queue and delete
+						// it so it won't be found again.
 
 
-					for ( var i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+						if ( reverseHash in halfEdgeList ) {
 
-						var index = i2;
-						var next = ( i2 + 1 ) % 3;
-						var v0 = tri[ `v${index}` ];
-						var v1 = tri[ `v${next}` ]; // delete this triangle from the list so it won't be found again
+							queue.push( otherTri );
+							delete halfEdgeList[ reverseHash ];
 
-						var hash = hashEdge( v0, v1 );
-						delete halfEdgeList[ hash ];
-						var reverseHash = hashEdge( v1, v0 );
-						var otherTri = fullHalfEdgeList[ reverseHash ];
-
-						if ( otherTri ) {
-
-							// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
-							// hard edge. There are some cases where the line segments do not line up exactly
-							// with or span multiple triangle edges (see Lunar Vehicle wheels).
-							if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
-
-								continue;
-
-							} // if this triangle has already been traversed then it won't be in
-							// the halfEdgeList. If it has not then add it to the queue and delete
-							// it so it won't be found again.
+						} // Find the matching edge in this triangle and copy the normal vector over
 
 
-							if ( reverseHash in halfEdgeList ) {
+						for ( let i3 = 0, l3 = 3; i3 < l3; i3 ++ ) {
 
-								queue.push( otherTri );
-								delete halfEdgeList[ reverseHash ];
+							const otherIndex = i3;
+							const otherNext = ( i3 + 1 ) % 3;
+							const otherV0 = otherTri[ `v${otherIndex}` ];
+							const otherV1 = otherTri[ `v${otherNext}` ];
+							const otherHash = hashEdge( otherV0, otherV1 );
 
-							} // Find the matching edge in this triangle and copy the normal vector over
+							if ( otherHash === reverseHash ) {
 
+								if ( otherTri[ `n${otherIndex}` ] === null ) {
 
-							for ( var i3 = 0, l3 = 3; i3 < l3; i3 ++ ) {
-
-								var otherIndex = i3;
-								var otherNext = ( i3 + 1 ) % 3;
-								var otherV0 = otherTri[ `v${otherIndex}` ];
-								var otherV1 = otherTri[ `v${otherNext}` ];
-								var otherHash = hashEdge( otherV0, otherV1 );
-
-								if ( otherHash === reverseHash ) {
-
-									if ( otherTri[ `n${otherIndex}` ] === null ) {
-
-										var norm = tri[ `n${next}` ];
-										otherTri[ `n${otherIndex}` ] = norm;
-										norm.add( otherTri.faceNormal );
-
-									}
-
-									if ( otherTri[ `n${otherNext}` ] === null ) {
-
-										var norm = tri[ `n${index}` ];
-										otherTri[ `n${otherNext}` ] = norm;
-										norm.add( otherTri.faceNormal );
-
-									}
-
-									break;
+									const norm = tri[ `n${next}` ];
+									otherTri[ `n${otherIndex}` ] = norm;
+									norm.add( otherTri.faceNormal );
 
 								}
+
+								if ( otherTri[ `n${otherNext}` ] === null ) {
+
+									const norm = tri[ `n${index}` ];
+									otherTri[ `n${otherNext}` ] = norm;
+									norm.add( otherTri.faceNormal );
+
+								}
+
+								break;
 
 							}
 
@@ -256,24 +271,28 @@
 
 				}
 
-			} // The normals of each face have been added up so now we average them by normalizing the vector.
-
-
-			for ( var i = 0, l = normals.length; i < l; i ++ ) {
-
-				normals[ i ].normalize();
-
 			}
 
+		} // The normals of each face have been added up so now we average them by normalizing the vector.
+
+
+		for ( let i = 0, l = normals.length; i < l; i ++ ) {
+
+			normals[ i ].normalize();
+
 		}
 
-		function isPrimitiveType( type ) {
+	}
 
-			return /primitive/i.test( type ) || type === 'Subpart';
+	function isPrimitiveType( type ) {
 
-		}
+		return /primitive/i.test( type ) || type === 'Subpart';
 
-		function LineParser( line, lineNumber ) {
+	}
+
+	class LineParser {
+
+		constructor( line, lineNumber ) {
 
 			this.line = line;
 			this.lineLength = line.length;
@@ -283,219 +302,225 @@
 
 		}
 
-		LineParser.prototype = {
-			constructor: LineParser,
-			seekNonSpace: function () {
+		seekNonSpace() {
 
-				while ( this.currentCharIndex < this.lineLength ) {
+			while ( this.currentCharIndex < this.lineLength ) {
 
-					this.currentChar = this.line.charAt( this.currentCharIndex );
+				this.currentChar = this.line.charAt( this.currentCharIndex );
 
-					if ( this.currentChar !== ' ' && this.currentChar !== '\t' ) {
+				if ( this.currentChar !== ' ' && this.currentChar !== '\t' ) {
 
-						return;
-
-					}
-
-					this.currentCharIndex ++;
+					return;
 
 				}
 
-			},
-			getToken: function () {
-
-				var pos0 = this.currentCharIndex ++; // Seek space
-
-				while ( this.currentCharIndex < this.lineLength ) {
-
-					this.currentChar = this.line.charAt( this.currentCharIndex );
-
-					if ( this.currentChar === ' ' || this.currentChar === '\t' ) {
-
-						break;
-
-					}
-
-					this.currentCharIndex ++;
-
-				}
-
-				var pos1 = this.currentCharIndex;
-				this.seekNonSpace();
-				return this.line.substring( pos0, pos1 );
-
-			},
-			getRemainingString: function () {
-
-				return this.line.substring( this.currentCharIndex, this.lineLength );
-
-			},
-			isAtTheEnd: function () {
-
-				return this.currentCharIndex >= this.lineLength;
-
-			},
-			setToEnd: function () {
-
-				this.currentCharIndex = this.lineLength;
-
-			},
-			getLineNumberString: function () {
-
-				return this.lineNumber >= 0 ? ' at line ' + this.lineNumber : '';
+				this.currentCharIndex ++;
 
 			}
-		};
-
-		function sortByMaterial( a, b ) {
-
-			if ( a.colourCode === b.colourCode ) {
-
-				return 0;
-
-			}
-
-			if ( a.colourCode < b.colourCode ) {
-
-				return - 1;
-
-			}
-
-			return 1;
 
 		}
 
-		function createObject( elements, elementSize, isConditionalSegments ) {
+		getToken() {
 
-			// Creates a THREE.LineSegments (elementSize = 2) or a THREE.Mesh (elementSize = 3 )
-			// With per face / segment material, implemented with mesh groups and materials array
-			// Sort the triangles or line segments by colour code to make later the mesh groups
-			elements.sort( sortByMaterial );
-			var positions = [];
-			var normals = [];
-			var materials = [];
-			var bufferGeometry = new THREE.BufferGeometry();
-			var prevMaterial = null;
-			var index0 = 0;
-			var numGroupVerts = 0;
+			const pos0 = this.currentCharIndex ++; // Seek space
 
-			for ( var iElem = 0, nElem = elements.length; iElem < nElem; iElem ++ ) {
+			while ( this.currentCharIndex < this.lineLength ) {
 
-				var elem = elements[ iElem ];
-				var v0 = elem.v0;
-				var v1 = elem.v1; // Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
+				this.currentChar = this.line.charAt( this.currentCharIndex );
 
-				positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
+				if ( this.currentChar === ' ' || this.currentChar === '\t' ) {
 
-				if ( elementSize === 3 ) {
-
-					positions.push( elem.v2.x, elem.v2.y, elem.v2.z );
-					var n0 = elem.n0 || elem.faceNormal;
-					var n1 = elem.n1 || elem.faceNormal;
-					var n2 = elem.n2 || elem.faceNormal;
-					normals.push( n0.x, n0.y, n0.z );
-					normals.push( n1.x, n1.y, n1.z );
-					normals.push( n2.x, n2.y, n2.z );
+					break;
 
 				}
 
-				if ( prevMaterial !== elem.material ) {
-
-					if ( prevMaterial !== null ) {
-
-						bufferGeometry.addGroup( index0, numGroupVerts, materials.length - 1 );
-
-					}
-
-					materials.push( elem.material );
-					prevMaterial = elem.material;
-					index0 = iElem * elementSize;
-					numGroupVerts = elementSize;
-
-				} else {
-
-					numGroupVerts += elementSize;
-
-				}
+				this.currentCharIndex ++;
 
 			}
 
-			if ( numGroupVerts > 0 ) {
+			const pos1 = this.currentCharIndex;
+			this.seekNonSpace();
+			return this.line.substring( pos0, pos1 );
 
-				bufferGeometry.addGroup( index0, Infinity, materials.length - 1 );
+		}
 
-			}
+		getRemainingString() {
 
-			bufferGeometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
+			return this.line.substring( this.currentCharIndex, this.lineLength );
+
+		}
+
+		isAtTheEnd() {
+
+			return this.currentCharIndex >= this.lineLength;
+
+		}
+
+		setToEnd() {
+
+			this.currentCharIndex = this.lineLength;
+
+		}
+
+		getLineNumberString() {
+
+			return this.lineNumber >= 0 ? ' at line ' + this.lineNumber : '';
+
+		}
+
+	}
+
+	function sortByMaterial( a, b ) {
+
+		if ( a.colourCode === b.colourCode ) {
+
+			return 0;
+
+		}
+
+		if ( a.colourCode < b.colourCode ) {
+
+			return - 1;
+
+		}
+
+		return 1;
+
+	}
+
+	function createObject( elements, elementSize, isConditionalSegments ) {
+
+		// Creates a THREE.LineSegments (elementSize = 2) or a THREE.Mesh (elementSize = 3 )
+		// With per face / segment material, implemented with mesh groups and materials array
+		// Sort the triangles or line segments by colour code to make later the mesh groups
+		elements.sort( sortByMaterial );
+		const positions = [];
+		const normals = [];
+		const materials = [];
+		const bufferGeometry = new THREE.BufferGeometry();
+		let prevMaterial = null;
+		let index0 = 0;
+		let numGroupVerts = 0;
+
+		for ( let iElem = 0, nElem = elements.length; iElem < nElem; iElem ++ ) {
+
+			const elem = elements[ iElem ];
+			const v0 = elem.v0;
+			const v1 = elem.v1; // Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
+
+			positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
 
 			if ( elementSize === 3 ) {
 
-				bufferGeometry.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+				positions.push( elem.v2.x, elem.v2.y, elem.v2.z );
+				const n0 = elem.n0 || elem.faceNormal;
+				const n1 = elem.n1 || elem.faceNormal;
+				const n2 = elem.n2 || elem.faceNormal;
+				normals.push( n0.x, n0.y, n0.z );
+				normals.push( n1.x, n1.y, n1.z );
+				normals.push( n2.x, n2.y, n2.z );
 
 			}
 
-			var object3d = null;
+			if ( prevMaterial !== elem.material ) {
 
-			if ( elementSize === 2 ) {
+				if ( prevMaterial !== null ) {
 
-				object3d = new THREE.LineSegments( bufferGeometry, materials );
-
-			} else if ( elementSize === 3 ) {
-
-				object3d = new THREE.Mesh( bufferGeometry, materials );
-
-			}
-
-			if ( isConditionalSegments ) {
-
-				object3d.isConditionalLine = true;
-				var controlArray0 = new Float32Array( elements.length * 3 * 2 );
-				var controlArray1 = new Float32Array( elements.length * 3 * 2 );
-				var directionArray = new Float32Array( elements.length * 3 * 2 );
-
-				for ( var i = 0, l = elements.length; i < l; i ++ ) {
-
-					var os = elements[ i ];
-					var c0 = os.c0;
-					var c1 = os.c1;
-					var v0 = os.v0;
-					var v1 = os.v1;
-					var index = i * 3 * 2;
-					controlArray0[ index + 0 ] = c0.x;
-					controlArray0[ index + 1 ] = c0.y;
-					controlArray0[ index + 2 ] = c0.z;
-					controlArray0[ index + 3 ] = c0.x;
-					controlArray0[ index + 4 ] = c0.y;
-					controlArray0[ index + 5 ] = c0.z;
-					controlArray1[ index + 0 ] = c1.x;
-					controlArray1[ index + 1 ] = c1.y;
-					controlArray1[ index + 2 ] = c1.z;
-					controlArray1[ index + 3 ] = c1.x;
-					controlArray1[ index + 4 ] = c1.y;
-					controlArray1[ index + 5 ] = c1.z;
-					directionArray[ index + 0 ] = v1.x - v0.x;
-					directionArray[ index + 1 ] = v1.y - v0.y;
-					directionArray[ index + 2 ] = v1.z - v0.z;
-					directionArray[ index + 3 ] = v1.x - v0.x;
-					directionArray[ index + 4 ] = v1.y - v0.y;
-					directionArray[ index + 5 ] = v1.z - v0.z;
+					bufferGeometry.addGroup( index0, numGroupVerts, materials.length - 1 );
 
 				}
 
-				bufferGeometry.setAttribute( 'control0', new THREE.BufferAttribute( controlArray0, 3, false ) );
-				bufferGeometry.setAttribute( 'control1', new THREE.BufferAttribute( controlArray1, 3, false ) );
-				bufferGeometry.setAttribute( 'direction', new THREE.BufferAttribute( directionArray, 3, false ) );
+				materials.push( elem.material );
+				prevMaterial = elem.material;
+				index0 = iElem * elementSize;
+				numGroupVerts = elementSize;
+
+			} else {
+
+				numGroupVerts += elementSize;
 
 			}
 
-			return object3d;
+		}
 
-		} //
+		if ( numGroupVerts > 0 ) {
+
+			bufferGeometry.addGroup( index0, Infinity, materials.length - 1 );
+
+		}
+
+		bufferGeometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
+
+		if ( elementSize === 3 ) {
+
+			bufferGeometry.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+
+		}
+
+		let object3d = null;
+
+		if ( elementSize === 2 ) {
+
+			object3d = new THREE.LineSegments( bufferGeometry, materials );
+
+		} else if ( elementSize === 3 ) {
+
+			object3d = new THREE.Mesh( bufferGeometry, materials );
+
+		}
+
+		if ( isConditionalSegments ) {
+
+			object3d.isConditionalLine = true;
+			const controlArray0 = new Float32Array( elements.length * 3 * 2 );
+			const controlArray1 = new Float32Array( elements.length * 3 * 2 );
+			const directionArray = new Float32Array( elements.length * 3 * 2 );
+
+			for ( let i = 0, l = elements.length; i < l; i ++ ) {
+
+				const os = elements[ i ];
+				const c0 = os.c0;
+				const c1 = os.c1;
+				const v0 = os.v0;
+				const v1 = os.v1;
+				const index = i * 3 * 2;
+				controlArray0[ index + 0 ] = c0.x;
+				controlArray0[ index + 1 ] = c0.y;
+				controlArray0[ index + 2 ] = c0.z;
+				controlArray0[ index + 3 ] = c0.x;
+				controlArray0[ index + 4 ] = c0.y;
+				controlArray0[ index + 5 ] = c0.z;
+				controlArray1[ index + 0 ] = c1.x;
+				controlArray1[ index + 1 ] = c1.y;
+				controlArray1[ index + 2 ] = c1.z;
+				controlArray1[ index + 3 ] = c1.x;
+				controlArray1[ index + 4 ] = c1.y;
+				controlArray1[ index + 5 ] = c1.z;
+				directionArray[ index + 0 ] = v1.x - v0.x;
+				directionArray[ index + 1 ] = v1.y - v0.y;
+				directionArray[ index + 2 ] = v1.z - v0.z;
+				directionArray[ index + 3 ] = v1.x - v0.x;
+				directionArray[ index + 4 ] = v1.y - v0.y;
+				directionArray[ index + 5 ] = v1.z - v0.z;
+
+			}
+
+			bufferGeometry.setAttribute( 'control0', new THREE.BufferAttribute( controlArray0, 3, false ) );
+			bufferGeometry.setAttribute( 'control1', new THREE.BufferAttribute( controlArray1, 3, false ) );
+			bufferGeometry.setAttribute( 'direction', new THREE.BufferAttribute( directionArray, 3, false ) );
+
+		}
+
+		return object3d;
+
+	} //
 
 
-		function LDrawLoader( manager ) {
+	class LDrawLoader extends THREE.Loader {
 
-			THREE.Loader.call( this, manager ); // This is a stack of 'parse scopes' with one level per subobject loaded file.
+		constructor( manager ) {
+
+			super( manager ); // This is a stack of 'parse scopes' with one level per subobject loaded file.
 			// Each level contains a material lib and also other runtime variables passed between parent and child subobjects
 			// When searching for a material code, the stack is read from top of the stack to bottom
 			// Each material library is an object map keyed by colour codes.
@@ -516,1292 +541,1291 @@
 
 			this.smoothNormals = true;
 
-		} // Special surface finish tag types.
-		// Note: "MATERIAL" tag (e.g. GLITTER, SPECKLE) is not implemented
+		}
 
+		load( url, onLoad, onProgress, onError ) {
 
-		LDrawLoader.FINISH_TYPE_DEFAULT = 0;
-		LDrawLoader.FINISH_TYPE_CHROME = 1;
-		LDrawLoader.FINISH_TYPE_PEARLESCENT = 2;
-		LDrawLoader.FINISH_TYPE_RUBBER = 3;
-		LDrawLoader.FINISH_TYPE_MATTE_METALLIC = 4;
-		LDrawLoader.FINISH_TYPE_METAL = 5; // State machine to search a subobject path.
-		// The LDraw standard establishes these various possible subfolders.
+			if ( ! this.fileMap ) {
 
-		LDrawLoader.FILE_LOCATION_AS_IS = 0;
-		LDrawLoader.FILE_LOCATION_TRY_PARTS = 1;
-		LDrawLoader.FILE_LOCATION_TRY_P = 2;
-		LDrawLoader.FILE_LOCATION_TRY_MODELS = 3;
-		LDrawLoader.FILE_LOCATION_TRY_RELATIVE = 4;
-		LDrawLoader.FILE_LOCATION_TRY_ABSOLUTE = 5;
-		LDrawLoader.FILE_LOCATION_NOT_FOUND = 6;
-		LDrawLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-			constructor: LDrawLoader,
-			load: function ( url, onLoad, onProgress, onError ) {
+				this.fileMap = {};
 
-				if ( ! this.fileMap ) {
+			}
 
-					this.fileMap = {};
+			const scope = this;
+			const fileLoader = new THREE.FileLoader( this.manager );
+			fileLoader.setPath( this.path );
+			fileLoader.setRequestHeader( this.requestHeader );
+			fileLoader.setWithCredentials( this.withCredentials );
+			fileLoader.load( url, function ( text ) {
 
-				}
+				scope.processObject( text, onLoad, null, url );
 
-				var scope = this;
-				var fileLoader = new THREE.FileLoader( this.manager );
-				fileLoader.setPath( this.path );
-				fileLoader.setRequestHeader( this.requestHeader );
-				fileLoader.setWithCredentials( this.withCredentials );
-				fileLoader.load( url, function ( text ) {
+			}, onProgress, onError );
 
-					scope.processObject( text, onLoad, null, url );
+		}
 
-				}, onProgress, onError );
+		parse( text, path, onLoad ) {
 
-			},
-			parse: function ( text, path, onLoad ) {
+			// Async parse.	This function calls onParse with the parsed THREE.Object3D as parameter
+			this.processObject( text, onLoad, null, path );
 
-				// Async parse.	This function calls onParse with the parsed THREE.Object3D as parameter
-				this.processObject( text, onLoad, null, path );
+		}
 
-			},
-			setMaterials: function ( materials ) {
+		setMaterials( materials ) {
 
-				// Clears parse scopes stack, adds new scope with material library
-				this.parseScopesStack = [];
-				this.newParseScopeLevel( materials );
-				this.getCurrentParseScope().isFromParse = false;
-				this.materials = materials;
-				return this;
+			// Clears parse scopes stack, adds new scope with material library
+			this.parseScopesStack = [];
+			this.newParseScopeLevel( materials );
+			this.getCurrentParseScope().isFromParse = false;
+			this.materials = materials;
+			return this;
 
-			},
-			setFileMap: function ( fileMap ) {
+		}
 
-				this.fileMap = fileMap;
-				return this;
+		setFileMap( fileMap ) {
 
-			},
-			newParseScopeLevel: function ( materials ) {
+			this.fileMap = fileMap;
+			return this;
 
-				// Adds a new scope level, assign materials to it and returns it
-				var matLib = {};
+		}
 
-				if ( materials ) {
+		newParseScopeLevel( materials ) {
 
-					for ( var i = 0, n = materials.length; i < n; i ++ ) {
+			// Adds a new scope level, assign materials to it and returns it
+			const matLib = {};
 
-						var material = materials[ i ];
-						matLib[ material.userData.code ] = material;
+			if ( materials ) {
 
-					}
+				for ( let i = 0, n = materials.length; i < n; i ++ ) {
+
+					const material = materials[ i ];
+					matLib[ material.userData.code ] = material;
 
 				}
 
-				var topParseScope = this.getCurrentParseScope();
-				var newParseScope = {
-					lib: matLib,
-					url: null,
-					// Subobjects
-					subobjects: null,
-					numSubobjects: 0,
-					subobjectIndex: 0,
-					inverted: false,
-					category: null,
-					keywords: null,
-					// Current subobject
-					currentFileName: null,
-					mainColourCode: topParseScope ? topParseScope.mainColourCode : '16',
-					mainEdgeColourCode: topParseScope ? topParseScope.mainEdgeColourCode : '24',
-					currentMatrix: new THREE.Matrix4(),
-					matrix: new THREE.Matrix4(),
-					// If false, it is a root material scope previous to parse
-					isFromParse: true,
-					triangles: null,
-					lineSegments: null,
-					conditionalSegments: null,
-					// If true, this object is the start of a construction step
-					startingConstructionStep: false
-				};
-				this.parseScopesStack.push( newParseScope );
-				return newParseScope;
+			}
 
-			},
-			removeScopeLevel: function () {
+			const topParseScope = this.getCurrentParseScope();
+			const newParseScope = {
+				lib: matLib,
+				url: null,
+				// Subobjects
+				subobjects: null,
+				numSubobjects: 0,
+				subobjectIndex: 0,
+				inverted: false,
+				category: null,
+				keywords: null,
+				// Current subobject
+				currentFileName: null,
+				mainColourCode: topParseScope ? topParseScope.mainColourCode : '16',
+				mainEdgeColourCode: topParseScope ? topParseScope.mainEdgeColourCode : '24',
+				currentMatrix: new THREE.Matrix4(),
+				matrix: new THREE.Matrix4(),
+				// If false, it is a root material scope previous to parse
+				isFromParse: true,
+				triangles: null,
+				lineSegments: null,
+				conditionalSegments: null,
+				// If true, this object is the start of a construction step
+				startingConstructionStep: false
+			};
+			this.parseScopesStack.push( newParseScope );
+			return newParseScope;
 
-				this.parseScopesStack.pop();
-				return this;
+		}
 
-			},
-			addMaterial: function ( material ) {
+		removeScopeLevel() {
 
-				// Adds a material to the material library which is on top of the parse scopes stack. And also to the materials array
-				var matLib = this.getCurrentParseScope().lib;
+			this.parseScopesStack.pop();
+			return this;
 
-				if ( ! matLib[ material.userData.code ] ) {
+		}
 
-					this.materials.push( material );
+		addMaterial( material ) {
 
-				}
+			// Adds a material to the material library which is on top of the parse scopes stack. And also to the materials array
+			const matLib = this.getCurrentParseScope().lib;
 
-				matLib[ material.userData.code ] = material;
-				return this;
+			if ( ! matLib[ material.userData.code ] ) {
 
-			},
-			getMaterial: function ( colourCode ) {
+				this.materials.push( material );
 
-				// Given a colour code search its material in the parse scopes stack
-				if ( colourCode.startsWith( '0x2' ) ) {
+			}
 
-					// Special 'direct' material value (RGB colour)
-					var colour = colourCode.substring( 3 );
-					return this.parseColourMetaDirective( new LineParser( 'Direct_Color_' + colour + ' CODE -1 VALUE #' + colour + ' EDGE #' + colour + '' ) );
+			matLib[ material.userData.code ] = material;
+			return this;
 
-				}
+		}
 
-				for ( var i = this.parseScopesStack.length - 1; i >= 0; i -- ) {
+		getMaterial( colourCode ) {
 
-					var material = this.parseScopesStack[ i ].lib[ colourCode ];
+			// Given a colour code search its material in the parse scopes stack
+			if ( colourCode.startsWith( '0x2' ) ) {
 
-					if ( material ) {
+				// Special 'direct' material value (RGB colour)
+				const colour = colourCode.substring( 3 );
+				return this.parseColourMetaDirective( new LineParser( 'Direct_Color_' + colour + ' CODE -1 VALUE #' + colour + ' EDGE #' + colour + '' ) );
 
-						return material;
+			}
 
-					}
+			for ( let i = this.parseScopesStack.length - 1; i >= 0; i -- ) {
 
-				} // Material was not found
+				const material = this.parseScopesStack[ i ].lib[ colourCode ];
 
-
-				return null;
-
-			},
-			getParentParseScope: function () {
-
-				if ( this.parseScopesStack.length > 1 ) {
-
-					return this.parseScopesStack[ this.parseScopesStack.length - 2 ];
-
-				}
-
-				return null;
-
-			},
-			getCurrentParseScope: function () {
-
-				if ( this.parseScopesStack.length > 0 ) {
-
-					return this.parseScopesStack[ this.parseScopesStack.length - 1 ];
-
-				}
-
-				return null;
-
-			},
-			parseColourMetaDirective: function ( lineParser ) {
-
-				// Parses a colour definition and returns a THREE.Material or null if error
-				var code = null; // Triangle and line colours
-
-				var colour = 0xFF00FF;
-				var edgeColour = 0xFF00FF; // Transparency
-
-				var alpha = 1;
-				var isTransparent = false; // Self-illumination:
-
-				var luminance = 0;
-				var finishType = LDrawLoader.FINISH_TYPE_DEFAULT;
-				var canHaveEnvMap = true;
-				var edgeMaterial = null;
-				var name = lineParser.getToken();
-
-				if ( ! name ) {
-
-					throw 'LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.';
-
-				} // Parse tag tokens and their parameters
-
-
-				var token = null;
-
-				while ( true ) {
-
-					token = lineParser.getToken();
-
-					if ( ! token ) {
-
-						break;
-
-					}
-
-					switch ( token.toUpperCase() ) {
-
-						case 'CODE':
-							code = lineParser.getToken();
-							break;
-
-						case 'VALUE':
-							colour = lineParser.getToken();
-
-							if ( colour.startsWith( '0x' ) ) {
-
-								colour = '#' + colour.substring( 2 );
-
-							} else if ( ! colour.startsWith( '#' ) ) {
-
-								throw 'LDrawLoader: Invalid colour while parsing material' + lineParser.getLineNumberString() + '.';
-
-							}
-
-							break;
-
-						case 'EDGE':
-							edgeColour = lineParser.getToken();
-
-							if ( edgeColour.startsWith( '0x' ) ) {
-
-								edgeColour = '#' + edgeColour.substring( 2 );
-
-							} else if ( ! edgeColour.startsWith( '#' ) ) {
-
-								// Try to see if edge colour is a colour code
-								edgeMaterial = this.getMaterial( edgeColour );
-
-								if ( ! edgeMaterial ) {
-
-									throw 'LDrawLoader: Invalid edge colour while parsing material' + lineParser.getLineNumberString() + '.';
-
-								} // Get the edge material for this triangle material
-
-
-								edgeMaterial = edgeMaterial.userData.edgeMaterial;
-
-							}
-
-							break;
-
-						case 'ALPHA':
-							alpha = parseInt( lineParser.getToken() );
-
-							if ( isNaN( alpha ) ) {
-
-								throw 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.';
-
-							}
-
-							alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
-
-							if ( alpha < 1 ) {
-
-								isTransparent = true;
-
-							}
-
-							break;
-
-						case 'LUMINANCE':
-							luminance = parseInt( lineParser.getToken() );
-
-							if ( isNaN( luminance ) ) {
-
-								throw 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.';
-
-							}
-
-							luminance = Math.max( 0, Math.min( 1, luminance / 255 ) );
-							break;
-
-						case 'CHROME':
-							finishType = LDrawLoader.FINISH_TYPE_CHROME;
-							break;
-
-						case 'PEARLESCENT':
-							finishType = LDrawLoader.FINISH_TYPE_PEARLESCENT;
-							break;
-
-						case 'RUBBER':
-							finishType = LDrawLoader.FINISH_TYPE_RUBBER;
-							break;
-
-						case 'MATTE_METALLIC':
-							finishType = LDrawLoader.FINISH_TYPE_MATTE_METALLIC;
-							break;
-
-						case 'METAL':
-							finishType = LDrawLoader.FINISH_TYPE_METAL;
-							break;
-
-						case 'MATERIAL':
-						// Not implemented
-							lineParser.setToEnd();
-							break;
-
-						default:
-							throw 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.';
-							break;
-
-					}
-
-				}
-
-				var material = null;
-
-				switch ( finishType ) {
-
-					case LDrawLoader.FINISH_TYPE_DEFAULT:
-						material = new THREE.MeshStandardMaterial( {
-							color: colour,
-							roughness: 0.3,
-							envMapIntensity: 0.3,
-							metalness: 0
-						} );
-						break;
-
-					case LDrawLoader.FINISH_TYPE_PEARLESCENT:
-					// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
-						var specular = new THREE.Color( colour );
-						var hsl = specular.getHSL( {
-							h: 0,
-							s: 0,
-							l: 0
-						} );
-						hsl.h = ( hsl.h + 0.5 ) % 1;
-						hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
-						specular.setHSL( hsl.h, hsl.s, hsl.l );
-						material = new THREE.MeshPhongMaterial( {
-							color: colour,
-							specular: specular,
-							shininess: 10,
-							reflectivity: 0.3
-						} );
-						break;
-
-					case LDrawLoader.FINISH_TYPE_CHROME:
-					// Mirror finish surface
-						material = new THREE.MeshStandardMaterial( {
-							color: colour,
-							roughness: 0,
-							metalness: 1
-						} );
-						break;
-
-					case LDrawLoader.FINISH_TYPE_RUBBER:
-					// Rubber finish
-						material = new THREE.MeshStandardMaterial( {
-							color: colour,
-							roughness: 0.9,
-							metalness: 0
-						} );
-						canHaveEnvMap = false;
-						break;
-
-					case LDrawLoader.FINISH_TYPE_MATTE_METALLIC:
-					// Brushed metal finish
-						material = new THREE.MeshStandardMaterial( {
-							color: colour,
-							roughness: 0.8,
-							metalness: 0.4
-						} );
-						break;
-
-					case LDrawLoader.FINISH_TYPE_METAL:
-					// Average metal finish
-						material = new THREE.MeshStandardMaterial( {
-							color: colour,
-							roughness: 0.2,
-							metalness: 0.85
-						} );
-						break;
-
-					default:
-					// Should not happen
-						break;
-
-				}
-
-				material.transparent = isTransparent;
-				material.premultipliedAlpha = true;
-				material.opacity = alpha;
-				material.depthWrite = ! isTransparent;
-				material.polygonOffset = true;
-				material.polygonOffsetFactor = 1;
-				material.userData.canHaveEnvMap = canHaveEnvMap;
-
-				if ( luminance !== 0 ) {
-
-					material.emissive.set( material.color ).multiplyScalar( luminance );
-
-				}
-
-				if ( ! edgeMaterial ) {
-
-					// This is the material used for edges
-					edgeMaterial = new THREE.LineBasicMaterial( {
-						color: edgeColour,
-						transparent: isTransparent,
-						opacity: alpha,
-						depthWrite: ! isTransparent
-					} );
-					edgeMaterial.userData.code = code;
-					edgeMaterial.name = name + ' - Edge';
-					edgeMaterial.userData.canHaveEnvMap = false; // This is the material used for conditional edges
-
-					edgeMaterial.userData.conditionalEdgeMaterial = new THREE.ShaderMaterial( {
-						vertexShader: conditionalLineVertShader,
-						fragmentShader: conditionalLineFragShader,
-						uniforms: THREE.UniformsUtils.merge( [ THREE.UniformsLib.fog, {
-							diffuse: {
-								value: new THREE.Color( edgeColour )
-							},
-							opacity: {
-								value: alpha
-							}
-						} ] ),
-						fog: true,
-						transparent: isTransparent,
-						depthWrite: ! isTransparent
-					} );
-					edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
-
-				}
-
-				material.userData.code = code;
-				material.name = name;
-				material.userData.edgeMaterial = edgeMaterial;
-				return material;
-
-			},
-			//
-			objectParse: function ( text ) {
-
-				// Retrieve data from the parent parse scope
-				var parentParseScope = this.getParentParseScope(); // Main colour codes passed to this subobject (or default codes 16 and 24 if it is the root object)
-
-				var mainColourCode = parentParseScope.mainColourCode;
-				var mainEdgeColourCode = parentParseScope.mainEdgeColourCode;
-				var currentParseScope = this.getCurrentParseScope(); // Parse result variables
-
-				var triangles;
-				var lineSegments;
-				var conditionalSegments;
-				var subobjects = [];
-				var category = null;
-				var keywords = null;
-
-				if ( text.indexOf( '\r\n' ) !== - 1 ) {
-
-					// This is faster than String.split with regex that splits on both
-					text = text.replace( /\r\n/g, '\n' );
-
-				}
-
-				var lines = text.split( '\n' );
-				var numLines = lines.length;
-				var lineIndex = 0;
-				var parsingEmbeddedFiles = false;
-				var currentEmbeddedFileName = null;
-				var currentEmbeddedText = null;
-				var bfcCertified = false;
-				var bfcCCW = true;
-				var bfcInverted = false;
-				var bfcCull = true;
-				var type = '';
-				var startingConstructionStep = false;
-				var scope = this;
-
-				function parseColourCode( lineParser, forEdge ) {
-
-					// Parses next colour code and returns a THREE.Material
-					var colourCode = lineParser.getToken();
-
-					if ( ! forEdge && colourCode === '16' ) {
-
-						colourCode = mainColourCode;
-
-					}
-
-					if ( forEdge && colourCode === '24' ) {
-
-						colourCode = mainEdgeColourCode;
-
-					}
-
-					var material = scope.getMaterial( colourCode );
-
-					if ( ! material ) {
-
-						throw 'LDrawLoader: Unknown colour code "' + colourCode + '" is used' + lineParser.getLineNumberString() + ' but it was not defined previously.';
-
-					}
+				if ( material ) {
 
 					return material;
 
 				}
 
-				function parseVector( lp ) {
-
-					var v = new THREE.Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
-
-					if ( ! scope.separateObjects ) {
-
-						v.applyMatrix4( currentParseScope.currentMatrix );
-
-					}
-
-					return v;
-
-				} // Parse all line commands
+			} // Material was not found
 
 
-				for ( lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
+			return null;
 
-					var line = lines[ lineIndex ];
-					if ( line.length === 0 ) continue;
+		}
 
-					if ( parsingEmbeddedFiles ) {
+		getParentParseScope() {
 
-						if ( line.startsWith( '0 FILE ' ) ) {
+			if ( this.parseScopesStack.length > 1 ) {
 
-							// Save previous embedded file in the cache
-							this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText; // New embedded text file
+				return this.parseScopesStack[ this.parseScopesStack.length - 2 ];
 
-							currentEmbeddedFileName = line.substring( 7 );
-							currentEmbeddedText = '';
+			}
 
-						} else {
+			return null;
 
-							currentEmbeddedText += line + '\n';
+		}
+
+		getCurrentParseScope() {
+
+			if ( this.parseScopesStack.length > 0 ) {
+
+				return this.parseScopesStack[ this.parseScopesStack.length - 1 ];
+
+			}
+
+			return null;
+
+		}
+
+		parseColourMetaDirective( lineParser ) {
+
+			// Parses a colour definition and returns a THREE.Material or null if error
+			var code = null; // Triangle and line colours
+
+			var colour = 0xFF00FF;
+			var edgeColour = 0xFF00FF; // Transparency
+
+			var alpha = 1;
+			var isTransparent = false; // Self-illumination:
+
+			var luminance = 0;
+			var finishType = FINISH_TYPE_DEFAULT;
+			var canHaveEnvMap = true;
+			var edgeMaterial = null;
+			var name = lineParser.getToken();
+
+			if ( ! name ) {
+
+				throw 'LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.';
+
+			} // Parse tag tokens and their parameters
+
+
+			var token = null;
+
+			while ( true ) {
+
+				token = lineParser.getToken();
+
+				if ( ! token ) {
+
+					break;
+
+				}
+
+				switch ( token.toUpperCase() ) {
+
+					case 'CODE':
+						code = lineParser.getToken();
+						break;
+
+					case 'VALUE':
+						colour = lineParser.getToken();
+
+						if ( colour.startsWith( '0x' ) ) {
+
+							colour = '#' + colour.substring( 2 );
+
+						} else if ( ! colour.startsWith( '#' ) ) {
+
+							throw 'LDrawLoader: Invalid colour while parsing material' + lineParser.getLineNumberString() + '.';
 
 						}
 
-						continue;
+						break;
+
+					case 'EDGE':
+						edgeColour = lineParser.getToken();
+
+						if ( edgeColour.startsWith( '0x' ) ) {
+
+							edgeColour = '#' + edgeColour.substring( 2 );
+
+						} else if ( ! edgeColour.startsWith( '#' ) ) {
+
+							// Try to see if edge colour is a colour code
+							edgeMaterial = this.getMaterial( edgeColour );
+
+							if ( ! edgeMaterial ) {
+
+								throw 'LDrawLoader: Invalid edge colour while parsing material' + lineParser.getLineNumberString() + '.';
+
+							} // Get the edge material for this triangle material
+
+
+							edgeMaterial = edgeMaterial.userData.edgeMaterial;
+
+						}
+
+						break;
+
+					case 'ALPHA':
+						alpha = parseInt( lineParser.getToken() );
+
+						if ( isNaN( alpha ) ) {
+
+							throw 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.';
+
+						}
+
+						alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
+
+						if ( alpha < 1 ) {
+
+							isTransparent = true;
+
+						}
+
+						break;
+
+					case 'LUMINANCE':
+						luminance = parseInt( lineParser.getToken() );
+
+						if ( isNaN( luminance ) ) {
+
+							throw 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.';
+
+						}
+
+						luminance = Math.max( 0, Math.min( 1, luminance / 255 ) );
+						break;
+
+					case 'CHROME':
+						finishType = FINISH_TYPE_CHROME;
+						break;
+
+					case 'PEARLESCENT':
+						finishType = FINISH_TYPE_PEARLESCENT;
+						break;
+
+					case 'RUBBER':
+						finishType = FINISH_TYPE_RUBBER;
+						break;
+
+					case 'MATTE_METALLIC':
+						finishType = FINISH_TYPE_MATTE_METALLIC;
+						break;
+
+					case 'METAL':
+						finishType = FINISH_TYPE_METAL;
+						break;
+
+					case 'MATERIAL':
+					// Not implemented
+						lineParser.setToEnd();
+						break;
+
+					default:
+						throw 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.';
+						break;
+
+				}
+
+			}
+
+			var material = null;
+
+			switch ( finishType ) {
+
+				case FINISH_TYPE_DEFAULT:
+					material = new THREE.MeshStandardMaterial( {
+						color: colour,
+						roughness: 0.3,
+						envMapIntensity: 0.3,
+						metalness: 0
+					} );
+					break;
+
+				case FINISH_TYPE_PEARLESCENT:
+				// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
+					var specular = new THREE.Color( colour );
+					var hsl = specular.getHSL( {
+						h: 0,
+						s: 0,
+						l: 0
+					} );
+					hsl.h = ( hsl.h + 0.5 ) % 1;
+					hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
+					specular.setHSL( hsl.h, hsl.s, hsl.l );
+					material = new THREE.MeshPhongMaterial( {
+						color: colour,
+						specular: specular,
+						shininess: 10,
+						reflectivity: 0.3
+					} );
+					break;
+
+				case FINISH_TYPE_CHROME:
+				// Mirror finish surface
+					material = new THREE.MeshStandardMaterial( {
+						color: colour,
+						roughness: 0,
+						metalness: 1
+					} );
+					break;
+
+				case FINISH_TYPE_RUBBER:
+				// Rubber finish
+					material = new THREE.MeshStandardMaterial( {
+						color: colour,
+						roughness: 0.9,
+						metalness: 0
+					} );
+					canHaveEnvMap = false;
+					break;
+
+				case FINISH_TYPE_MATTE_METALLIC:
+				// Brushed metal finish
+					material = new THREE.MeshStandardMaterial( {
+						color: colour,
+						roughness: 0.8,
+						metalness: 0.4
+					} );
+					break;
+
+				case FINISH_TYPE_METAL:
+				// Average metal finish
+					material = new THREE.MeshStandardMaterial( {
+						color: colour,
+						roughness: 0.2,
+						metalness: 0.85
+					} );
+					break;
+
+				default:
+				// Should not happen
+					break;
+
+			}
+
+			material.transparent = isTransparent;
+			material.premultipliedAlpha = true;
+			material.opacity = alpha;
+			material.depthWrite = ! isTransparent;
+			material.polygonOffset = true;
+			material.polygonOffsetFactor = 1;
+			material.userData.canHaveEnvMap = canHaveEnvMap;
+
+			if ( luminance !== 0 ) {
+
+				material.emissive.set( material.color ).multiplyScalar( luminance );
+
+			}
+
+			if ( ! edgeMaterial ) {
+
+				// This is the material used for edges
+				edgeMaterial = new THREE.LineBasicMaterial( {
+					color: edgeColour,
+					transparent: isTransparent,
+					opacity: alpha,
+					depthWrite: ! isTransparent
+				} );
+				edgeMaterial.userData.code = code;
+				edgeMaterial.name = name + ' - Edge';
+				edgeMaterial.userData.canHaveEnvMap = false; // This is the material used for conditional edges
+
+				edgeMaterial.userData.conditionalEdgeMaterial = new THREE.ShaderMaterial( {
+					vertexShader: conditionalLineVertShader,
+					fragmentShader: conditionalLineFragShader,
+					uniforms: THREE.UniformsUtils.merge( [ THREE.UniformsLib.fog, {
+						diffuse: {
+							value: new THREE.Color( edgeColour )
+						},
+						opacity: {
+							value: alpha
+						}
+					} ] ),
+					fog: true,
+					transparent: isTransparent,
+					depthWrite: ! isTransparent
+				} );
+				edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
+
+			}
+
+			material.userData.code = code;
+			material.name = name;
+			material.userData.edgeMaterial = edgeMaterial;
+			return material;
+
+		} //
+
+
+		objectParse( text ) {
+
+			// Retrieve data from the parent parse scope
+			var parentParseScope = this.getParentParseScope(); // Main colour codes passed to this subobject (or default codes 16 and 24 if it is the root object)
+
+			var mainColourCode = parentParseScope.mainColourCode;
+			var mainEdgeColourCode = parentParseScope.mainEdgeColourCode;
+			var currentParseScope = this.getCurrentParseScope(); // Parse result variables
+
+			var triangles;
+			var lineSegments;
+			var conditionalSegments;
+			var subobjects = [];
+			var category = null;
+			var keywords = null;
+
+			if ( text.indexOf( '\r\n' ) !== - 1 ) {
+
+				// This is faster than String.split with regex that splits on both
+				text = text.replace( /\r\n/g, '\n' );
+
+			}
+
+			var lines = text.split( '\n' );
+			var numLines = lines.length;
+			var lineIndex = 0;
+			var parsingEmbeddedFiles = false;
+			var currentEmbeddedFileName = null;
+			var currentEmbeddedText = null;
+			var bfcCertified = false;
+			var bfcCCW = true;
+			var bfcInverted = false;
+			var bfcCull = true;
+			var type = '';
+			var startingConstructionStep = false;
+			var scope = this;
+
+			function parseColourCode( lineParser, forEdge ) {
+
+				// Parses next colour code and returns a THREE.Material
+				var colourCode = lineParser.getToken();
+
+				if ( ! forEdge && colourCode === '16' ) {
+
+					colourCode = mainColourCode;
+
+				}
+
+				if ( forEdge && colourCode === '24' ) {
+
+					colourCode = mainEdgeColourCode;
+
+				}
+
+				var material = scope.getMaterial( colourCode );
+
+				if ( ! material ) {
+
+					throw 'LDrawLoader: Unknown colour code "' + colourCode + '" is used' + lineParser.getLineNumberString() + ' but it was not defined previously.';
+
+				}
+
+				return material;
+
+			}
+
+			function parseVector( lp ) {
+
+				var v = new THREE.Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
+
+				if ( ! scope.separateObjects ) {
+
+					v.applyMatrix4( currentParseScope.currentMatrix );
+
+				}
+
+				return v;
+
+			} // Parse all line commands
+
+
+			for ( lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
+
+				var line = lines[ lineIndex ];
+				if ( line.length === 0 ) continue;
+
+				if ( parsingEmbeddedFiles ) {
+
+					if ( line.startsWith( '0 FILE ' ) ) {
+
+						// Save previous embedded file in the cache
+						this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText; // New embedded text file
+
+						currentEmbeddedFileName = line.substring( 7 );
+						currentEmbeddedText = '';
+
+					} else {
+
+						currentEmbeddedText += line + '\n';
 
 					}
 
-					var lp = new LineParser( line, lineIndex + 1 );
-					lp.seekNonSpace();
+					continue;
 
-					if ( lp.isAtTheEnd() ) {
+				}
 
-						// Empty line
-						continue;
+				var lp = new LineParser( line, lineIndex + 1 );
+				lp.seekNonSpace();
 
-					} // Parse the line type
+				if ( lp.isAtTheEnd() ) {
 
+					// Empty line
+					continue;
 
-					var lineType = lp.getToken();
-
-					switch ( lineType ) {
-
-						// Line type 0: Comment or META
-						case '0':
-						// Parse meta directive
-							var meta = lp.getToken();
-
-							if ( meta ) {
-
-								switch ( meta ) {
-
-									case '!LDRAW_ORG':
-										type = lp.getToken();
-										currentParseScope.triangles = [];
-										currentParseScope.lineSegments = [];
-										currentParseScope.conditionalSegments = [];
-										currentParseScope.type = type;
-										var isRoot = ! parentParseScope.isFromParse;
-
-										if ( isRoot || scope.separateObjects && ! isPrimitiveType( type ) ) {
-
-											currentParseScope.groupObject = new THREE.Group();
-											currentParseScope.groupObject.userData.startingConstructionStep = currentParseScope.startingConstructionStep;
-
-										} // If the scale of the object is negated then the triangle winding order
-										// needs to be flipped.
+				} // Parse the line type
 
 
-										var matrix = currentParseScope.matrix;
+				var lineType = lp.getToken();
 
-										if ( matrix.determinant() < 0 && ( scope.separateObjects && isPrimitiveType( type ) || ! scope.separateObjects ) ) {
+				switch ( lineType ) {
 
-											currentParseScope.inverted = ! currentParseScope.inverted;
+					// Line type 0: Comment or META
+					case '0':
+					// Parse meta directive
+						var meta = lp.getToken();
 
-										}
+						if ( meta ) {
 
-										triangles = currentParseScope.triangles;
-										lineSegments = currentParseScope.lineSegments;
-										conditionalSegments = currentParseScope.conditionalSegments;
-										break;
+							switch ( meta ) {
 
-									case '!COLOUR':
-										var material = this.parseColourMetaDirective( lp );
+								case '!LDRAW_ORG':
+									type = lp.getToken();
+									currentParseScope.triangles = [];
+									currentParseScope.lineSegments = [];
+									currentParseScope.conditionalSegments = [];
+									currentParseScope.type = type;
+									var isRoot = ! parentParseScope.isFromParse;
 
-										if ( material ) {
+									if ( isRoot || scope.separateObjects && ! isPrimitiveType( type ) ) {
 
-											this.addMaterial( material );
+										currentParseScope.groupObject = new THREE.Group();
+										currentParseScope.groupObject.userData.startingConstructionStep = currentParseScope.startingConstructionStep;
 
-										} else {
+									} // If the scale of the object is negated then the triangle winding order
+									// needs to be flipped.
 
-											console.warn( 'LDrawLoader: Error parsing material' + lp.getLineNumberString() );
 
-										}
+									var matrix = currentParseScope.matrix;
 
-										break;
+									if ( matrix.determinant() < 0 && ( scope.separateObjects && isPrimitiveType( type ) || ! scope.separateObjects ) ) {
 
-									case '!CATEGORY':
-										category = lp.getToken();
-										break;
+										currentParseScope.inverted = ! currentParseScope.inverted;
 
-									case '!KEYWORDS':
-										var newKeywords = lp.getRemainingString().split( ',' );
+									}
 
-										if ( newKeywords.length > 0 ) {
+									triangles = currentParseScope.triangles;
+									lineSegments = currentParseScope.lineSegments;
+									conditionalSegments = currentParseScope.conditionalSegments;
+									break;
 
-											if ( ! keywords ) {
+								case '!COLOUR':
+									var material = this.parseColourMetaDirective( lp );
 
-												keywords = [];
+									if ( material ) {
 
-											}
+										this.addMaterial( material );
 
-											newKeywords.forEach( function ( keyword ) {
+									} else {
 
-												keywords.push( keyword.trim() );
+										console.warn( 'LDrawLoader: Error parsing material' + lp.getLineNumberString() );
 
-											} );
+									}
+
+									break;
+
+								case '!CATEGORY':
+									category = lp.getToken();
+									break;
+
+								case '!KEYWORDS':
+									var newKeywords = lp.getRemainingString().split( ',' );
+
+									if ( newKeywords.length > 0 ) {
+
+										if ( ! keywords ) {
+
+											keywords = [];
 
 										}
 
-										break;
+										newKeywords.forEach( function ( keyword ) {
 
-									case 'FILE':
-										if ( lineIndex > 0 ) {
+											keywords.push( keyword.trim() );
 
-											// Start embedded text files parsing
-											parsingEmbeddedFiles = true;
-											currentEmbeddedFileName = lp.getRemainingString();
-											currentEmbeddedText = '';
-											bfcCertified = false;
-											bfcCCW = true;
+										} );
+
+									}
+
+									break;
+
+								case 'FILE':
+									if ( lineIndex > 0 ) {
+
+										// Start embedded text files parsing
+										parsingEmbeddedFiles = true;
+										currentEmbeddedFileName = lp.getRemainingString();
+										currentEmbeddedText = '';
+										bfcCertified = false;
+										bfcCCW = true;
+
+									}
+
+									break;
+
+								case 'BFC':
+								// Changes to the backface culling state
+									while ( ! lp.isAtTheEnd() ) {
+
+										var token = lp.getToken();
+
+										switch ( token ) {
+
+											case 'CERTIFY':
+											case 'NOCERTIFY':
+												bfcCertified = token === 'CERTIFY';
+												bfcCCW = true;
+												break;
+
+											case 'CW':
+											case 'CCW':
+												bfcCCW = token === 'CCW';
+												break;
+
+											case 'INVERTNEXT':
+												bfcInverted = true;
+												break;
+
+											case 'CLIP':
+											case 'NOCLIP':
+												bfcCull = token === 'CLIP';
+												break;
+
+											default:
+												console.warn( 'THREE.LDrawLoader: BFC directive "' + token + '" is unknown.' );
+												break;
 
 										}
 
-										break;
+									}
 
-									case 'BFC':
-									// Changes to the backface culling state
-										while ( ! lp.isAtTheEnd() ) {
+									break;
 
-											var token = lp.getToken();
+								case 'STEP':
+									startingConstructionStep = true;
+									break;
 
-											switch ( token ) {
-
-												case 'CERTIFY':
-												case 'NOCERTIFY':
-													bfcCertified = token === 'CERTIFY';
-													bfcCCW = true;
-													break;
-
-												case 'CW':
-												case 'CCW':
-													bfcCCW = token === 'CCW';
-													break;
-
-												case 'INVERTNEXT':
-													bfcInverted = true;
-													break;
-
-												case 'CLIP':
-												case 'NOCLIP':
-													bfcCull = token === 'CLIP';
-													break;
-
-												default:
-													console.warn( 'THREE.LDrawLoader: BFC directive "' + token + '" is unknown.' );
-													break;
-
-											}
-
-										}
-
-										break;
-
-									case 'STEP':
-										startingConstructionStep = true;
-										break;
-
-									default:
-									// Other meta directives are not implemented
-										break;
-
-								}
+								default:
+								// Other meta directives are not implemented
+									break;
 
 							}
 
-							break;
-							// Line type 1: Sub-object file
+						}
 
-						case '1':
-							var material = parseColourCode( lp );
-							var posX = parseFloat( lp.getToken() );
-							var posY = parseFloat( lp.getToken() );
-							var posZ = parseFloat( lp.getToken() );
-							var m0 = parseFloat( lp.getToken() );
-							var m1 = parseFloat( lp.getToken() );
-							var m2 = parseFloat( lp.getToken() );
-							var m3 = parseFloat( lp.getToken() );
-							var m4 = parseFloat( lp.getToken() );
-							var m5 = parseFloat( lp.getToken() );
-							var m6 = parseFloat( lp.getToken() );
-							var m7 = parseFloat( lp.getToken() );
-							var m8 = parseFloat( lp.getToken() );
-							var matrix = new THREE.Matrix4().set( m0, m1, m2, posX, m3, m4, m5, posY, m6, m7, m8, posZ, 0, 0, 0, 1 );
-							var fileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
+						break;
+						// Line type 1: Sub-object file
 
-							if ( scope.fileMap[ fileName ] ) {
+					case '1':
+						var material = parseColourCode( lp );
+						var posX = parseFloat( lp.getToken() );
+						var posY = parseFloat( lp.getToken() );
+						var posZ = parseFloat( lp.getToken() );
+						var m0 = parseFloat( lp.getToken() );
+						var m1 = parseFloat( lp.getToken() );
+						var m2 = parseFloat( lp.getToken() );
+						var m3 = parseFloat( lp.getToken() );
+						var m4 = parseFloat( lp.getToken() );
+						var m5 = parseFloat( lp.getToken() );
+						var m6 = parseFloat( lp.getToken() );
+						var m7 = parseFloat( lp.getToken() );
+						var m8 = parseFloat( lp.getToken() );
+						var matrix = new THREE.Matrix4().set( m0, m1, m2, posX, m3, m4, m5, posY, m6, m7, m8, posZ, 0, 0, 0, 1 );
+						var fileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
 
-								// Found the subobject path in the preloaded file path map
-								fileName = scope.fileMap[ fileName ];
+						if ( scope.fileMap[ fileName ] ) {
 
-							} else {
+							// Found the subobject path in the preloaded file path map
+							fileName = scope.fileMap[ fileName ];
 
-								// Standardized subfolders
-								if ( fileName.startsWith( 's/' ) ) {
+						} else {
 
-									fileName = 'parts/' + fileName;
+							// Standardized subfolders
+							if ( fileName.startsWith( 's/' ) ) {
 
-								} else if ( fileName.startsWith( '48/' ) ) {
+								fileName = 'parts/' + fileName;
 
-									fileName = 'p/' + fileName;
+							} else if ( fileName.startsWith( '48/' ) ) {
 
-								}
-
-							}
-
-							subobjects.push( {
-								material: material,
-								matrix: matrix,
-								fileName: fileName,
-								originalFileName: fileName,
-								locationState: LDrawLoader.FILE_LOCATION_AS_IS,
-								url: null,
-								triedLowerCase: false,
-								inverted: bfcInverted !== currentParseScope.inverted,
-								startingConstructionStep: startingConstructionStep
-							} );
-							bfcInverted = false;
-							break;
-							// Line type 2: Line segment
-
-						case '2':
-							var material = parseColourCode( lp, true );
-							var segment = {
-								material: material.userData.edgeMaterial,
-								colourCode: material.userData.code,
-								v0: parseVector( lp ),
-								v1: parseVector( lp )
-							};
-							lineSegments.push( segment );
-							break;
-							// Line type 5: Conditional Line segment
-
-						case '5':
-							var material = parseColourCode( lp, true );
-							var segment = {
-								material: material.userData.edgeMaterial.userData.conditionalEdgeMaterial,
-								colourCode: material.userData.code,
-								v0: parseVector( lp ),
-								v1: parseVector( lp ),
-								c0: parseVector( lp ),
-								c1: parseVector( lp )
-							};
-							conditionalSegments.push( segment );
-							break;
-							// Line type 3: Triangle
-
-						case '3':
-							var material = parseColourCode( lp );
-							var inverted = currentParseScope.inverted;
-							var ccw = bfcCCW !== inverted;
-							var doubleSided = ! bfcCertified || ! bfcCull;
-							var v0, v1, v2, faceNormal;
-
-							if ( ccw === true ) {
-
-								v0 = parseVector( lp );
-								v1 = parseVector( lp );
-								v2 = parseVector( lp );
-
-							} else {
-
-								v2 = parseVector( lp );
-								v1 = parseVector( lp );
-								v0 = parseVector( lp );
+								fileName = 'p/' + fileName;
 
 							}
 
-							tempVec0.subVectors( v1, v0 );
-							tempVec1.subVectors( v2, v1 );
-							faceNormal = new THREE.Vector3().crossVectors( tempVec0, tempVec1 ).normalize();
-							triangles.push( {
-								material: material,
-								colourCode: material.userData.code,
-								v0: v0,
-								v1: v1,
-								v2: v2,
-								faceNormal: faceNormal,
-								n0: null,
-								n1: null,
-								n2: null
-							} );
+						}
 
-							if ( doubleSided === true ) {
+						subobjects.push( {
+							material: material,
+							matrix: matrix,
+							fileName: fileName,
+							originalFileName: fileName,
+							locationState: FILE_LOCATION_AS_IS,
+							url: null,
+							triedLowerCase: false,
+							inverted: bfcInverted !== currentParseScope.inverted,
+							startingConstructionStep: startingConstructionStep
+						} );
+						bfcInverted = false;
+						break;
+						// Line type 2: Line segment
 
-								triangles.push( {
-									material: material,
-									colourCode: material.userData.code,
-									v0: v0,
-									v1: v2,
-									v2: v1,
-									faceNormal: faceNormal,
-									n0: null,
-									n1: null,
-									n2: null
-								} );
+					case '2':
+						var material = parseColourCode( lp, true );
+						var segment = {
+							material: material.userData.edgeMaterial,
+							colourCode: material.userData.code,
+							v0: parseVector( lp ),
+							v1: parseVector( lp )
+						};
+						lineSegments.push( segment );
+						break;
+						// Line type 5: Conditional Line segment
 
-							}
+					case '5':
+						var material = parseColourCode( lp, true );
+						var segment = {
+							material: material.userData.edgeMaterial.userData.conditionalEdgeMaterial,
+							colourCode: material.userData.code,
+							v0: parseVector( lp ),
+							v1: parseVector( lp ),
+							c0: parseVector( lp ),
+							c1: parseVector( lp )
+						};
+						conditionalSegments.push( segment );
+						break;
+						// Line type 3: Triangle
 
-							break;
-							// Line type 4: Quadrilateral
+					case '3':
+						var material = parseColourCode( lp );
+						var inverted = currentParseScope.inverted;
+						var ccw = bfcCCW !== inverted;
+						var doubleSided = ! bfcCertified || ! bfcCull;
+						var v0, v1, v2, faceNormal;
 
-						case '4':
-							var material = parseColourCode( lp );
-							var inverted = currentParseScope.inverted;
-							var ccw = bfcCCW !== inverted;
-							var doubleSided = ! bfcCertified || ! bfcCull;
-							var v0, v1, v2, v3, faceNormal;
+						if ( ccw === true ) {
 
-							if ( ccw === true ) {
+							v0 = parseVector( lp );
+							v1 = parseVector( lp );
+							v2 = parseVector( lp );
 
-								v0 = parseVector( lp );
-								v1 = parseVector( lp );
-								v2 = parseVector( lp );
-								v3 = parseVector( lp );
+						} else {
 
-							} else {
+							v2 = parseVector( lp );
+							v1 = parseVector( lp );
+							v0 = parseVector( lp );
 
-								v3 = parseVector( lp );
-								v2 = parseVector( lp );
-								v1 = parseVector( lp );
-								v0 = parseVector( lp );
+						}
 
-							}
+						_tempVec0.subVectors( v1, v0 );
 
-							tempVec0.subVectors( v1, v0 );
-							tempVec1.subVectors( v2, v1 );
-							faceNormal = new THREE.Vector3().crossVectors( tempVec0, tempVec1 ).normalize();
-							triangles.push( {
-								material: material,
-								colourCode: material.userData.code,
-								v0: v0,
-								v1: v1,
-								v2: v2,
-								faceNormal: faceNormal,
-								n0: null,
-								n1: null,
-								n2: null
-							} );
+						_tempVec1.subVectors( v2, v1 );
+
+						faceNormal = new THREE.Vector3().crossVectors( _tempVec0, _tempVec1 ).normalize();
+						triangles.push( {
+							material: material,
+							colourCode: material.userData.code,
+							v0: v0,
+							v1: v1,
+							v2: v2,
+							faceNormal: faceNormal,
+							n0: null,
+							n1: null,
+							n2: null
+						} );
+
+						if ( doubleSided === true ) {
+
 							triangles.push( {
 								material: material,
 								colourCode: material.userData.code,
 								v0: v0,
 								v1: v2,
-								v2: v3,
+								v2: v1,
 								faceNormal: faceNormal,
 								n0: null,
 								n1: null,
 								n2: null
 							} );
 
-							if ( doubleSided === true ) {
+						}
 
-								triangles.push( {
-									material: material,
-									colourCode: material.userData.code,
-									v0: v0,
-									v1: v2,
-									v2: v1,
-									faceNormal: faceNormal,
-									n0: null,
-									n1: null,
-									n2: null
-								} );
-								triangles.push( {
-									material: material,
-									colourCode: material.userData.code,
-									v0: v0,
-									v1: v3,
-									v2: v2,
-									faceNormal: faceNormal,
-									n0: null,
-									n1: null,
-									n2: null
-								} );
+						break;
+						// Line type 4: Quadrilateral
 
-							}
+					case '4':
+						var material = parseColourCode( lp );
+						var inverted = currentParseScope.inverted;
+						var ccw = bfcCCW !== inverted;
+						var doubleSided = ! bfcCertified || ! bfcCull;
+						var v0, v1, v2, v3, faceNormal;
 
-							break;
+						if ( ccw === true ) {
 
-						default:
-							throw 'LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.';
-							break;
+							v0 = parseVector( lp );
+							v1 = parseVector( lp );
+							v2 = parseVector( lp );
+							v3 = parseVector( lp );
 
-					}
+						} else {
 
-				}
-
-				if ( parsingEmbeddedFiles ) {
-
-					this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
-
-				}
-
-				currentParseScope.category = category;
-				currentParseScope.keywords = keywords;
-				currentParseScope.subobjects = subobjects;
-				currentParseScope.numSubobjects = subobjects.length;
-				currentParseScope.subobjectIndex = 0;
-
-			},
-			computeConstructionSteps: function ( model ) {
-
-				// Sets userdata.constructionStep number in THREE.Group objects and userData.numConstructionSteps number in the root THREE.Group object.
-				var stepNumber = 0;
-				model.traverse( c => {
-
-					if ( c.isGroup ) {
-
-						if ( c.userData.startingConstructionStep ) {
-
-							stepNumber ++;
+							v3 = parseVector( lp );
+							v2 = parseVector( lp );
+							v1 = parseVector( lp );
+							v0 = parseVector( lp );
 
 						}
 
-						c.userData.constructionStep = stepNumber;
+						_tempVec0.subVectors( v1, v0 );
 
-					}
+						_tempVec1.subVectors( v2, v1 );
 
-				} );
-				model.userData.numConstructionSteps = stepNumber + 1;
-
-			},
-			processObject: function ( text, onProcessed, subobject, url ) {
-
-				var scope = this;
-				var parseScope = scope.newParseScopeLevel();
-				parseScope.url = url;
-				var parentParseScope = scope.getParentParseScope(); // Set current matrix
-
-				if ( subobject ) {
-
-					parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
-					parseScope.matrix.copy( subobject.matrix );
-					parseScope.inverted = subobject.inverted;
-					parseScope.startingConstructionStep = subobject.startingConstructionStep;
-
-				} // Add to cache
-
-
-				var currentFileName = parentParseScope.currentFileName;
-
-				if ( currentFileName !== null ) {
-
-					currentFileName = parentParseScope.currentFileName.toLowerCase();
-
-				}
-
-				if ( scope.subobjectCache[ currentFileName ] === undefined ) {
-
-					scope.subobjectCache[ currentFileName ] = text;
-
-				} // Parse the object (returns a THREE.Group)
-
-
-				scope.objectParse( text );
-				var finishedCount = 0;
-				onSubobjectFinish();
-
-				function onSubobjectFinish() {
-
-					finishedCount ++;
-
-					if ( finishedCount === parseScope.subobjects.length + 1 ) {
-
-						finalizeObject();
-
-					} else {
-
-						// Once the previous subobject has finished we can start processing the next one in the list.
-						// The subobject processing shares scope in processing so it's important that they be loaded serially
-						// to avoid race conditions.
-						// Promise.resolve is used as an approach to asynchronously schedule a task _before_ this frame ends to
-						// avoid stack overflow exceptions when loading many subobjects from the cache. RequestAnimationFrame
-						// will work but causes the load to happen after the next frame which causes the load to take significantly longer.
-						var subobject = parseScope.subobjects[ parseScope.subobjectIndex ];
-						Promise.resolve().then( function () {
-
-							loadSubobject( subobject );
-
+						faceNormal = new THREE.Vector3().crossVectors( _tempVec0, _tempVec1 ).normalize();
+						triangles.push( {
+							material: material,
+							colourCode: material.userData.code,
+							v0: v0,
+							v1: v1,
+							v2: v2,
+							faceNormal: faceNormal,
+							n0: null,
+							n1: null,
+							n2: null
 						} );
-						parseScope.subobjectIndex ++;
+						triangles.push( {
+							material: material,
+							colourCode: material.userData.code,
+							v0: v0,
+							v1: v2,
+							v2: v3,
+							faceNormal: faceNormal,
+							n0: null,
+							n1: null,
+							n2: null
+						} );
 
-					}
+						if ( doubleSided === true ) {
 
-				}
-
-				function finalizeObject() {
-
-					if ( scope.smoothNormals && parseScope.type === 'Part' ) {
-
-						smoothNormals( parseScope.triangles, parseScope.lineSegments );
-
-					}
-
-					var isRoot = ! parentParseScope.isFromParse;
-
-					if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || isRoot ) {
-
-						const objGroup = parseScope.groupObject;
-
-						if ( parseScope.triangles.length > 0 ) {
-
-							objGroup.add( createObject( parseScope.triangles, 3 ) );
-
-						}
-
-						if ( parseScope.lineSegments.length > 0 ) {
-
-							objGroup.add( createObject( parseScope.lineSegments, 2 ) );
-
-						}
-
-						if ( parseScope.conditionalSegments.length > 0 ) {
-
-							objGroup.add( createObject( parseScope.conditionalSegments, 2, true ) );
-
-						}
-
-						if ( parentParseScope.groupObject ) {
-
-							objGroup.name = parseScope.fileName;
-							objGroup.userData.category = parseScope.category;
-							objGroup.userData.keywords = parseScope.keywords;
-							parseScope.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
-							parentParseScope.groupObject.add( objGroup );
+							triangles.push( {
+								material: material,
+								colourCode: material.userData.code,
+								v0: v0,
+								v1: v2,
+								v2: v1,
+								faceNormal: faceNormal,
+								n0: null,
+								n1: null,
+								n2: null
+							} );
+							triangles.push( {
+								material: material,
+								colourCode: material.userData.code,
+								v0: v0,
+								v1: v3,
+								v2: v2,
+								faceNormal: faceNormal,
+								n0: null,
+								n1: null,
+								n2: null
+							} );
 
 						}
 
-					} else {
-
-						var separateObjects = scope.separateObjects;
-						var parentLineSegments = parentParseScope.lineSegments;
-						var parentConditionalSegments = parentParseScope.conditionalSegments;
-						var parentTriangles = parentParseScope.triangles;
-						var lineSegments = parseScope.lineSegments;
-						var conditionalSegments = parseScope.conditionalSegments;
-						var triangles = parseScope.triangles;
-
-						for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
-
-							var ls = lineSegments[ i ];
-
-							if ( separateObjects ) {
-
-								ls.v0.applyMatrix4( parseScope.matrix );
-								ls.v1.applyMatrix4( parseScope.matrix );
-
-							}
-
-							parentLineSegments.push( ls );
-
-						}
-
-						for ( var i = 0, l = conditionalSegments.length; i < l; i ++ ) {
-
-							var os = conditionalSegments[ i ];
-
-							if ( separateObjects ) {
-
-								os.v0.applyMatrix4( parseScope.matrix );
-								os.v1.applyMatrix4( parseScope.matrix );
-								os.c0.applyMatrix4( parseScope.matrix );
-								os.c1.applyMatrix4( parseScope.matrix );
-
-							}
-
-							parentConditionalSegments.push( os );
-
-						}
-
-						for ( var i = 0, l = triangles.length; i < l; i ++ ) {
-
-							var tri = triangles[ i ];
-
-							if ( separateObjects ) {
-
-								tri.v0 = tri.v0.clone().applyMatrix4( parseScope.matrix );
-								tri.v1 = tri.v1.clone().applyMatrix4( parseScope.matrix );
-								tri.v2 = tri.v2.clone().applyMatrix4( parseScope.matrix );
-								tempVec0.subVectors( tri.v1, tri.v0 );
-								tempVec1.subVectors( tri.v2, tri.v1 );
-								tri.faceNormal.crossVectors( tempVec0, tempVec1 ).normalize();
-
-							}
-
-							parentTriangles.push( tri );
-
-						}
-
-					}
-
-					scope.removeScopeLevel(); // If it is root object, compute construction steps
-
-					if ( ! parentParseScope.isFromParse ) {
-
-						scope.computeConstructionSteps( parseScope.groupObject );
-
-					}
-
-					if ( onProcessed ) {
-
-						onProcessed( parseScope.groupObject );
-
-					}
-
-				}
-
-				function loadSubobject( subobject ) {
-
-					parseScope.mainColourCode = subobject.material.userData.code;
-					parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
-					parseScope.currentFileName = subobject.originalFileName; // If subobject was cached previously, use the cached one
-
-					var cached = scope.subobjectCache[ subobject.originalFileName.toLowerCase() ];
-
-					if ( cached ) {
-
-						scope.processObject( cached, function ( subobjectGroup ) {
-
-							onSubobjectLoaded( subobjectGroup, subobject );
-							onSubobjectFinish();
-
-						}, subobject, url );
-						return;
-
-					} // Adjust file name to locate the subobject file path in standard locations (always under directory scope.path)
-					// Update also subobject.locationState for the next try if this load fails.
-
-
-					var subobjectURL = subobject.fileName;
-					var newLocationState = LDrawLoader.FILE_LOCATION_NOT_FOUND;
-
-					switch ( subobject.locationState ) {
-
-						case LDrawLoader.FILE_LOCATION_AS_IS:
-							newLocationState = subobject.locationState + 1;
-							break;
-
-						case LDrawLoader.FILE_LOCATION_TRY_PARTS:
-							subobjectURL = 'parts/' + subobjectURL;
-							newLocationState = subobject.locationState + 1;
-							break;
-
-						case LDrawLoader.FILE_LOCATION_TRY_P:
-							subobjectURL = 'p/' + subobjectURL;
-							newLocationState = subobject.locationState + 1;
-							break;
-
-						case LDrawLoader.FILE_LOCATION_TRY_MODELS:
-							subobjectURL = 'models/' + subobjectURL;
-							newLocationState = subobject.locationState + 1;
-							break;
-
-						case LDrawLoader.FILE_LOCATION_TRY_RELATIVE:
-							subobjectURL = url.substring( 0, url.lastIndexOf( '/' ) + 1 ) + subobjectURL;
-							newLocationState = subobject.locationState + 1;
-							break;
-
-						case LDrawLoader.FILE_LOCATION_TRY_ABSOLUTE:
-							if ( subobject.triedLowerCase ) {
-
-								// Try absolute path
-								newLocationState = LDrawLoader.FILE_LOCATION_NOT_FOUND;
-
-							} else {
-
-								// Next attempt is lower case
-								subobject.fileName = subobject.fileName.toLowerCase();
-								subobjectURL = subobject.fileName;
-								subobject.triedLowerCase = true;
-								newLocationState = LDrawLoader.FILE_LOCATION_AS_IS;
-
-							}
-
-							break;
-
-						case LDrawLoader.FILE_LOCATION_NOT_FOUND:
-						// All location possibilities have been tried, give up loading this object
-							console.warn( 'LDrawLoader: Subobject "' + subobject.originalFileName + '" could not be found.' );
-							return;
-
-					}
-
-					subobject.locationState = newLocationState;
-					subobject.url = subobjectURL; // Load the subobject
-					// Use another file loader here so we can keep track of the subobject information
-					// and use it when processing the next model.
-
-					var fileLoader = new THREE.FileLoader( scope.manager );
-					fileLoader.setPath( scope.path );
-					fileLoader.setRequestHeader( scope.requestHeader );
-					fileLoader.setWithCredentials( scope.withCredentials );
-					fileLoader.load( subobjectURL, function ( text ) {
-
-						scope.processObject( text, function ( subobjectGroup ) {
-
-							onSubobjectLoaded( subobjectGroup, subobject );
-							onSubobjectFinish();
-
-						}, subobject, url );
-
-					}, undefined, function ( err ) {
-
-						onSubobjectError( err, subobject );
-
-					}, subobject );
-
-				}
-
-				function onSubobjectLoaded( subobjectGroup, subobject ) {
-
-					if ( subobjectGroup === null ) {
-
-						// Try to reload
-						loadSubobject( subobject );
-						return;
-
-					}
-
-					scope.fileMap[ subobject.originalFileName ] = subobject.url;
-
-				}
-
-				function onSubobjectError( err, subobject ) {
-
-					// Retry download from a different default possible location
-					loadSubobject( subobject );
+						break;
+
+					default:
+						throw 'LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.';
+						break;
 
 				}
 
 			}
-		} );
-		return LDrawLoader;
 
-	}();
+			if ( parsingEmbeddedFiles ) {
+
+				this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
+
+			}
+
+			currentParseScope.category = category;
+			currentParseScope.keywords = keywords;
+			currentParseScope.subobjects = subobjects;
+			currentParseScope.numSubobjects = subobjects.length;
+			currentParseScope.subobjectIndex = 0;
+
+		}
+
+		computeConstructionSteps( model ) {
+
+			// Sets userdata.constructionStep number in THREE.Group objects and userData.numConstructionSteps number in the root THREE.Group object.
+			var stepNumber = 0;
+			model.traverse( c => {
+
+				if ( c.isGroup ) {
+
+					if ( c.userData.startingConstructionStep ) {
+
+						stepNumber ++;
+
+					}
+
+					c.userData.constructionStep = stepNumber;
+
+				}
+
+			} );
+			model.userData.numConstructionSteps = stepNumber + 1;
+
+		}
+
+		processObject( text, onProcessed, subobject, url ) {
+
+			var scope = this;
+			var parseScope = scope.newParseScopeLevel();
+			parseScope.url = url;
+			var parentParseScope = scope.getParentParseScope(); // Set current matrix
+
+			if ( subobject ) {
+
+				parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
+				parseScope.matrix.copy( subobject.matrix );
+				parseScope.inverted = subobject.inverted;
+				parseScope.startingConstructionStep = subobject.startingConstructionStep;
+
+			} // Add to cache
+
+
+			var currentFileName = parentParseScope.currentFileName;
+
+			if ( currentFileName !== null ) {
+
+				currentFileName = parentParseScope.currentFileName.toLowerCase();
+
+			}
+
+			if ( scope.subobjectCache[ currentFileName ] === undefined ) {
+
+				scope.subobjectCache[ currentFileName ] = text;
+
+			} // Parse the object (returns a THREE.Group)
+
+
+			scope.objectParse( text );
+			var finishedCount = 0;
+			onSubobjectFinish();
+
+			function onSubobjectFinish() {
+
+				finishedCount ++;
+
+				if ( finishedCount === parseScope.subobjects.length + 1 ) {
+
+					finalizeObject();
+
+				} else {
+
+					// Once the previous subobject has finished we can start processing the next one in the list.
+					// The subobject processing shares scope in processing so it's important that they be loaded serially
+					// to avoid race conditions.
+					// Promise.resolve is used as an approach to asynchronously schedule a task _before_ this frame ends to
+					// avoid stack overflow exceptions when loading many subobjects from the cache. RequestAnimationFrame
+					// will work but causes the load to happen after the next frame which causes the load to take significantly longer.
+					var subobject = parseScope.subobjects[ parseScope.subobjectIndex ];
+					Promise.resolve().then( function () {
+
+						loadSubobject( subobject );
+
+					} );
+					parseScope.subobjectIndex ++;
+
+				}
+
+			}
+
+			function finalizeObject() {
+
+				if ( scope.smoothNormals && parseScope.type === 'Part' ) {
+
+					smoothNormals( parseScope.triangles, parseScope.lineSegments );
+
+				}
+
+				var isRoot = ! parentParseScope.isFromParse;
+
+				if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || isRoot ) {
+
+					const objGroup = parseScope.groupObject;
+
+					if ( parseScope.triangles.length > 0 ) {
+
+						objGroup.add( createObject( parseScope.triangles, 3 ) );
+
+					}
+
+					if ( parseScope.lineSegments.length > 0 ) {
+
+						objGroup.add( createObject( parseScope.lineSegments, 2 ) );
+
+					}
+
+					if ( parseScope.conditionalSegments.length > 0 ) {
+
+						objGroup.add( createObject( parseScope.conditionalSegments, 2, true ) );
+
+					}
+
+					if ( parentParseScope.groupObject ) {
+
+						objGroup.name = parseScope.fileName;
+						objGroup.userData.category = parseScope.category;
+						objGroup.userData.keywords = parseScope.keywords;
+						parseScope.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
+						parentParseScope.groupObject.add( objGroup );
+
+					}
+
+				} else {
+
+					var separateObjects = scope.separateObjects;
+					var parentLineSegments = parentParseScope.lineSegments;
+					var parentConditionalSegments = parentParseScope.conditionalSegments;
+					var parentTriangles = parentParseScope.triangles;
+					var lineSegments = parseScope.lineSegments;
+					var conditionalSegments = parseScope.conditionalSegments;
+					var triangles = parseScope.triangles;
+
+					for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
+
+						var ls = lineSegments[ i ];
+
+						if ( separateObjects ) {
+
+							ls.v0.applyMatrix4( parseScope.matrix );
+							ls.v1.applyMatrix4( parseScope.matrix );
+
+						}
+
+						parentLineSegments.push( ls );
+
+					}
+
+					for ( var i = 0, l = conditionalSegments.length; i < l; i ++ ) {
+
+						var os = conditionalSegments[ i ];
+
+						if ( separateObjects ) {
+
+							os.v0.applyMatrix4( parseScope.matrix );
+							os.v1.applyMatrix4( parseScope.matrix );
+							os.c0.applyMatrix4( parseScope.matrix );
+							os.c1.applyMatrix4( parseScope.matrix );
+
+						}
+
+						parentConditionalSegments.push( os );
+
+					}
+
+					for ( var i = 0, l = triangles.length; i < l; i ++ ) {
+
+						var tri = triangles[ i ];
+
+						if ( separateObjects ) {
+
+							tri.v0 = tri.v0.clone().applyMatrix4( parseScope.matrix );
+							tri.v1 = tri.v1.clone().applyMatrix4( parseScope.matrix );
+							tri.v2 = tri.v2.clone().applyMatrix4( parseScope.matrix );
+
+							_tempVec0.subVectors( tri.v1, tri.v0 );
+
+							_tempVec1.subVectors( tri.v2, tri.v1 );
+
+							tri.faceNormal.crossVectors( _tempVec0, _tempVec1 ).normalize();
+
+						}
+
+						parentTriangles.push( tri );
+
+					}
+
+				}
+
+				scope.removeScopeLevel(); // If it is root object, compute construction steps
+
+				if ( ! parentParseScope.isFromParse ) {
+
+					scope.computeConstructionSteps( parseScope.groupObject );
+
+				}
+
+				if ( onProcessed ) {
+
+					onProcessed( parseScope.groupObject );
+
+				}
+
+			}
+
+			function loadSubobject( subobject ) {
+
+				parseScope.mainColourCode = subobject.material.userData.code;
+				parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
+				parseScope.currentFileName = subobject.originalFileName; // If subobject was cached previously, use the cached one
+
+				var cached = scope.subobjectCache[ subobject.originalFileName.toLowerCase() ];
+
+				if ( cached ) {
+
+					scope.processObject( cached, function ( subobjectGroup ) {
+
+						onSubobjectLoaded( subobjectGroup, subobject );
+						onSubobjectFinish();
+
+					}, subobject, url );
+					return;
+
+				} // Adjust file name to locate the subobject file path in standard locations (always under directory scope.path)
+				// Update also subobject.locationState for the next try if this load fails.
+
+
+				var subobjectURL = subobject.fileName;
+				var newLocationState = FILE_LOCATION_NOT_FOUND;
+
+				switch ( subobject.locationState ) {
+
+					case FILE_LOCATION_AS_IS:
+						newLocationState = subobject.locationState + 1;
+						break;
+
+					case FILE_LOCATION_TRY_PARTS:
+						subobjectURL = 'parts/' + subobjectURL;
+						newLocationState = subobject.locationState + 1;
+						break;
+
+					case FILE_LOCATION_TRY_P:
+						subobjectURL = 'p/' + subobjectURL;
+						newLocationState = subobject.locationState + 1;
+						break;
+
+					case FILE_LOCATION_TRY_MODELS:
+						subobjectURL = 'models/' + subobjectURL;
+						newLocationState = subobject.locationState + 1;
+						break;
+
+					case FILE_LOCATION_TRY_RELATIVE:
+						subobjectURL = url.substring( 0, url.lastIndexOf( '/' ) + 1 ) + subobjectURL;
+						newLocationState = subobject.locationState + 1;
+						break;
+
+					case FILE_LOCATION_TRY_ABSOLUTE:
+						if ( subobject.triedLowerCase ) {
+
+							// Try absolute path
+							newLocationState = FILE_LOCATION_NOT_FOUND;
+
+						} else {
+
+							// Next attempt is lower case
+							subobject.fileName = subobject.fileName.toLowerCase();
+							subobjectURL = subobject.fileName;
+							subobject.triedLowerCase = true;
+							newLocationState = FILE_LOCATION_AS_IS;
+
+						}
+
+						break;
+
+					case FILE_LOCATION_NOT_FOUND:
+					// All location possibilities have been tried, give up loading this object
+						console.warn( 'LDrawLoader: Subobject "' + subobject.originalFileName + '" could not be found.' );
+						return;
+
+				}
+
+				subobject.locationState = newLocationState;
+				subobject.url = subobjectURL; // Load the subobject
+				// Use another file loader here so we can keep track of the subobject information
+				// and use it when processing the next model.
+
+				var fileLoader = new THREE.FileLoader( scope.manager );
+				fileLoader.setPath( scope.path );
+				fileLoader.setRequestHeader( scope.requestHeader );
+				fileLoader.setWithCredentials( scope.withCredentials );
+				fileLoader.load( subobjectURL, function ( text ) {
+
+					scope.processObject( text, function ( subobjectGroup ) {
+
+						onSubobjectLoaded( subobjectGroup, subobject );
+						onSubobjectFinish();
+
+					}, subobject, url );
+
+				}, undefined, function ( err ) {
+
+					onSubobjectError( err, subobject );
+
+				}, subobject );
+
+			}
+
+			function onSubobjectLoaded( subobjectGroup, subobject ) {
+
+				if ( subobjectGroup === null ) {
+
+					// Try to reload
+					loadSubobject( subobject );
+					return;
+
+				}
+
+				scope.fileMap[ subobject.originalFileName ] = subobject.url;
+
+			}
+
+			function onSubobjectError( err, subobject ) {
+
+				// Retry download from a different default possible location
+				loadSubobject( subobject );
+
+			}
+
+		}
+
+	}
 
 	THREE.LDrawLoader = LDrawLoader;
 

--- a/examples/js/loaders/MMDLoader.js
+++ b/examples/js/loaders/MMDLoader.js
@@ -29,14 +29,15 @@
  *	- shadow support.
  */
 
-	var MMDLoader = function () {
+	/**
+ * @param {THREE.LoadingManager} manager
+ */
 
-		/**
-	 * @param {THREE.LoadingManager} manager
-	 */
-		function MMDLoader( manager ) {
+	class MMDLoader extends THREE.Loader {
 
-			THREE.Loader.call( this, manager );
+		constructor( manager ) {
+
+			super( manager );
 			this.loader = new THREE.FileLoader( this.manager );
 			this.parser = null; // lazy generation
 
@@ -44,890 +45,901 @@
 			this.animationBuilder = new AnimationBuilder();
 
 		}
+		/**
+	 * @param {string} animationPath
+	 * @return {MMDLoader}
+	 */
 
-		MMDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-			constructor: MMDLoader,
 
-			/**
-		 * @param {string} animationPath
-		 * @return {MMDLoader}
-		 */
-			setAnimationPath: function ( animationPath ) {
+		setAnimationPath( animationPath ) {
 
-				this.animationPath = animationPath;
-				return this;
+			this.animationPath = animationPath;
+			return this;
 
-			},
-			// Load MMD assets as Three.js Object
+		} // Load MMD assets as Three.js Object
 
-			/**
-		 * Loads Model file (.pmd or .pmx) as a THREE.SkinnedMesh.
-		 *
-		 * @param {string} url - url to Model(.pmd or .pmx) file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			load: function ( url, onLoad, onProgress, onError ) {
+		/**
+	 * Loads Model file (.pmd or .pmx) as a THREE.SkinnedMesh.
+	 *
+	 * @param {string} url - url to Model(.pmd or .pmx) file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
 
-				var builder = this.meshBuilder.setCrossOrigin( this.crossOrigin ); // resource path
 
-				var resourcePath;
+		load( url, onLoad, onProgress, onError ) {
 
-				if ( this.resourcePath !== '' ) {
+			const builder = this.meshBuilder.setCrossOrigin( this.crossOrigin ); // resource path
 
-					resourcePath = this.resourcePath;
+			let resourcePath;
 
-				} else if ( this.path !== '' ) {
+			if ( this.resourcePath !== '' ) {
 
-					resourcePath = this.path;
+				resourcePath = this.resourcePath;
 
-				} else {
+			} else if ( this.path !== '' ) {
 
-					resourcePath = THREE.LoaderUtils.extractUrlBase( url );
+				resourcePath = this.path;
 
-				}
+			} else {
 
-				var modelExtension = this._extractExtension( url ).toLowerCase(); // Should I detect by seeing header?
-
-
-				if ( modelExtension !== 'pmd' && modelExtension !== 'pmx' ) {
-
-					if ( onError ) onError( new Error( 'THREE.MMDLoader: Unknown model file extension .' + modelExtension + '.' ) );
-					return;
-
-				}
-
-				this[ modelExtension === 'pmd' ? 'loadPMD' : 'loadPMX' ]( url, function ( data ) {
-
-					onLoad( builder.build( data, resourcePath, onProgress, onError ) );
-
-				}, onProgress, onError );
-
-			},
-
-			/**
-		 * Loads Motion file(s) (.vmd) as a THREE.AnimationClip.
-		 * If two or more files are specified, they'll be merged.
-		 *
-		 * @param {string|Array<string>} url - url(s) to animation(.vmd) file(s)
-		 * @param {SkinnedMesh|THREE.Camera} object - tracks will be fitting to this object
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadAnimation: function ( url, object, onLoad, onProgress, onError ) {
-
-				var builder = this.animationBuilder;
-				this.loadVMD( url, function ( vmd ) {
-
-					onLoad( object.isCamera ? builder.buildCameraAnimation( vmd ) : builder.build( vmd, object ) );
-
-				}, onProgress, onError );
-
-			},
-
-			/**
-		 * Loads mode file and motion file(s) as an object containing
-		 * a THREE.SkinnedMesh and a THREE.AnimationClip.
-		 * Tracks of THREE.AnimationClip are fitting to the model.
-		 *
-		 * @param {string} modelUrl - url to Model(.pmd or .pmx) file
-		 * @param {string|Array{string}} vmdUrl - url(s) to animation(.vmd) file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadWithAnimation: function ( modelUrl, vmdUrl, onLoad, onProgress, onError ) {
-
-				var scope = this;
-				this.load( modelUrl, function ( mesh ) {
-
-					scope.loadAnimation( vmdUrl, mesh, function ( animation ) {
-
-						onLoad( {
-							mesh: mesh,
-							animation: animation
-						} );
-
-					}, onProgress, onError );
-
-				}, onProgress, onError );
-
-			},
-			// Load MMD assets as Object data parsed by MMDParser
-
-			/**
-		 * Loads .pmd file as an Object.
-		 *
-		 * @param {string} url - url to .pmd file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadPMD: function ( url, onLoad, onProgress, onError ) {
-
-				var parser = this._getParser();
-
-				this.loader.setMimeType( undefined ).setPath( this.path ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( buffer ) {
-
-					onLoad( parser.parsePmd( buffer, true ) );
-
-				}, onProgress, onError );
-
-			},
-
-			/**
-		 * Loads .pmx file as an Object.
-		 *
-		 * @param {string} url - url to .pmx file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadPMX: function ( url, onLoad, onProgress, onError ) {
-
-				var parser = this._getParser();
-
-				this.loader.setMimeType( undefined ).setPath( this.path ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( buffer ) {
-
-					onLoad( parser.parsePmx( buffer, true ) );
-
-				}, onProgress, onError );
-
-			},
-
-			/**
-		 * Loads .vmd file as an Object. If two or more files are specified
-		 * they'll be merged.
-		 *
-		 * @param {string|Array<string>} url - url(s) to .vmd file(s)
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadVMD: function ( url, onLoad, onProgress, onError ) {
-
-				var urls = Array.isArray( url ) ? url : [ url ];
-				var vmds = [];
-				var vmdNum = urls.length;
-
-				var parser = this._getParser();
-
-				this.loader.setMimeType( undefined ).setPath( this.animationPath ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials );
-
-				for ( var i = 0, il = urls.length; i < il; i ++ ) {
-
-					this.loader.load( urls[ i ], function ( buffer ) {
-
-						vmds.push( parser.parseVmd( buffer, true ) );
-						if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
-
-					}, onProgress, onError );
-
-				}
-
-			},
-
-			/**
-		 * Loads .vpd file as an Object.
-		 *
-		 * @param {string} url - url to .vpd file
-		 * @param {boolean} isUnicode
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-			loadVPD: function ( url, isUnicode, onLoad, onProgress, onError ) {
-
-				var parser = this._getParser();
-
-				this.loader.setMimeType( isUnicode ? undefined : 'text/plain; charset=shift_jis' ).setPath( this.animationPath ).setResponseType( 'text' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( text ) {
-
-					onLoad( parser.parseVpd( text, true ) );
-
-				}, onProgress, onError );
-
-			},
-			// private methods
-			_extractExtension: function ( url ) {
-
-				var index = url.lastIndexOf( '.' );
-				return index < 0 ? '' : url.slice( index + 1 );
-
-			},
-			_getParser: function () {
-
-				if ( this.parser === null ) {
-
-					if ( typeof MMDParser === 'undefined' ) {
-
-						throw new Error( 'THREE.MMDLoader: Import MMDParser https://github.com/takahirox/mmd-parser' );
-
-					}
-
-					this.parser = new MMDParser.Parser(); // eslint-disable-line no-undef
-
-				}
-
-				return this.parser;
+				resourcePath = THREE.LoaderUtils.extractUrlBase( url );
 
 			}
-		} ); // Utilities
 
-		/*
+			const modelExtension = this._extractExtension( url ).toLowerCase(); // Should I detect by seeing header?
+
+
+			if ( modelExtension !== 'pmd' && modelExtension !== 'pmx' ) {
+
+				if ( onError ) onError( new Error( 'THREE.MMDLoader: Unknown model file extension .' + modelExtension + '.' ) );
+				return;
+
+			}
+
+			this[ modelExtension === 'pmd' ? 'loadPMD' : 'loadPMX' ]( url, function ( data ) {
+
+				onLoad( builder.build( data, resourcePath, onProgress, onError ) );
+
+			}, onProgress, onError );
+
+		}
+		/**
+	 * Loads Motion file(s) (.vmd) as a THREE.AnimationClip.
+	 * If two or more files are specified, they'll be merged.
+	 *
+	 * @param {string|Array<string>} url - url(s) to animation(.vmd) file(s)
+	 * @param {SkinnedMesh|THREE.Camera} object - tracks will be fitting to this object
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadAnimation( url, object, onLoad, onProgress, onError ) {
+
+			const builder = this.animationBuilder;
+			this.loadVMD( url, function ( vmd ) {
+
+				onLoad( object.isCamera ? builder.buildCameraAnimation( vmd ) : builder.build( vmd, object ) );
+
+			}, onProgress, onError );
+
+		}
+		/**
+	 * Loads mode file and motion file(s) as an object containing
+	 * a THREE.SkinnedMesh and a THREE.AnimationClip.
+	 * Tracks of THREE.AnimationClip are fitting to the model.
+	 *
+	 * @param {string} modelUrl - url to Model(.pmd or .pmx) file
+	 * @param {string|Array{string}} vmdUrl - url(s) to animation(.vmd) file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadWithAnimation( modelUrl, vmdUrl, onLoad, onProgress, onError ) {
+
+			const scope = this;
+			this.load( modelUrl, function ( mesh ) {
+
+				scope.loadAnimation( vmdUrl, mesh, function ( animation ) {
+
+					onLoad( {
+						mesh: mesh,
+						animation: animation
+					} );
+
+				}, onProgress, onError );
+
+			}, onProgress, onError );
+
+		} // Load MMD assets as Object data parsed by MMDParser
+
+		/**
+	 * Loads .pmd file as an Object.
+	 *
+	 * @param {string} url - url to .pmd file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadPMD( url, onLoad, onProgress, onError ) {
+
+			const parser = this._getParser();
+
+			this.loader.setMimeType( undefined ).setPath( this.path ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( buffer ) {
+
+				onLoad( parser.parsePmd( buffer, true ) );
+
+			}, onProgress, onError );
+
+		}
+		/**
+	 * Loads .pmx file as an Object.
+	 *
+	 * @param {string} url - url to .pmx file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadPMX( url, onLoad, onProgress, onError ) {
+
+			const parser = this._getParser();
+
+			this.loader.setMimeType( undefined ).setPath( this.path ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( buffer ) {
+
+				onLoad( parser.parsePmx( buffer, true ) );
+
+			}, onProgress, onError );
+
+		}
+		/**
+	 * Loads .vmd file as an Object. If two or more files are specified
+	 * they'll be merged.
+	 *
+	 * @param {string|Array<string>} url - url(s) to .vmd file(s)
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadVMD( url, onLoad, onProgress, onError ) {
+
+			const urls = Array.isArray( url ) ? url : [ url ];
+			const vmds = [];
+			const vmdNum = urls.length;
+
+			const parser = this._getParser();
+
+			this.loader.setMimeType( undefined ).setPath( this.animationPath ).setResponseType( 'arraybuffer' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials );
+
+			for ( let i = 0, il = urls.length; i < il; i ++ ) {
+
+				this.loader.load( urls[ i ], function ( buffer ) {
+
+					vmds.push( parser.parseVmd( buffer, true ) );
+					if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
+
+				}, onProgress, onError );
+
+			}
+
+		}
+		/**
+	 * Loads .vpd file as an Object.
+	 *
+	 * @param {string} url - url to .vpd file
+	 * @param {boolean} isUnicode
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+
+
+		loadVPD( url, isUnicode, onLoad, onProgress, onError ) {
+
+			const parser = this._getParser();
+
+			this.loader.setMimeType( isUnicode ? undefined : 'text/plain; charset=shift_jis' ).setPath( this.animationPath ).setResponseType( 'text' ).setRequestHeader( this.requestHeader ).setWithCredentials( this.withCredentials ).load( url, function ( text ) {
+
+				onLoad( parser.parseVpd( text, true ) );
+
+			}, onProgress, onError );
+
+		} // private methods
+
+
+		_extractExtension( url ) {
+
+			const index = url.lastIndexOf( '.' );
+			return index < 0 ? '' : url.slice( index + 1 );
+
+		}
+
+		_getParser() {
+
+			if ( this.parser === null ) {
+
+				if ( typeof MMDParser === 'undefined' ) {
+
+					throw new Error( 'THREE.MMDLoader: Import MMDParser https://github.com/takahirox/mmd-parser' );
+
+				}
+
+				this.parser = new MMDParser.Parser(); // eslint-disable-line no-undef
+
+			}
+
+			return this.parser;
+
+		}
+
+	} // Utilities
+
+	/*
 	 * base64 encoded defalut toon textures toon00.bmp - toon10.bmp.
 	 * We don't need to request external toon image files.
 	 * This idea is from http://www20.atpages.jp/katwat/three.js_r58/examples/mytest37/mmd.three.js
 	 */
 
-		var DEFAULT_TOON_TEXTURES = [ 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/bWiiMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh8aBHZBl14e8wAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOUlEQVRYR+3WMREAMAwDsYY/yoDI7MLwIiP40+RJklfcCCBAgAABAgTqArfb/QMCCBAgQIAAgbbAB3z/e0F3js2cAAAAAElFTkSuQmCC', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/B5ilMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh81dWyx0gFwKAAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOklEQVRYR+3WoREAMAwDsWb/UQtCy9wxTOQJ/oQ8SXKKGwEECBAgQIBAXeDt7f4BAQQIECBAgEBb4AOz8Hzx7WLY4wAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABPUlEQVRYR+1XwW7CMAy1+f9fZOMysSEOEweEOPRNdm3HbdOyIhAcklPrOs/PLy9RygBALxzcCDQFmgJNgaZAU6Ap0BR4PwX8gsRMVLssMRH5HcpzJEaWL7EVg9F1IHRlyqQohgVr4FGUlUcMJSjcUlDw0zvjeun70cLWmneoyf7NgBTQSniBTQQSuJAZsOnnaczjIMb5hCiuHKxokCrJfVnrctyZL0PkJAJe1HMil4nxeyi3Ypfn1kX51jpPvo/JeCNC4PhVdHdJw2XjBR8brF8PEIhNVn12AgP7uHsTBguBn53MUZCqv7Lp07Pn5k1Ro+uWmUNn7D+M57rtk7aG0Vo73xyF/fbFf0bPJjDXngnGocDTdFhygZjwUQrMNrDcmZlQT50VJ/g/UwNyHpu778+yW+/ksOz/BFo54P4AsUXMfRq7XWsAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACMElEQVRYR+2Xv4pTQRTGf2dubhLdICiii2KnYKHVolhauKWPoGAnNr6BD6CvIVaihYuI2i1ia0BY0MZGRHQXjZj/mSPnnskfNWiWZUlzJ5k7M2cm833nO5Mziej2DWWJRUoCpQKlAntSQCqgw39/iUWAGmh37jrRnVsKlgpiqmkoGVABA7E57fvY+pJDdgKqF6HzFCSADkDq+F6AHABtQ+UMVE5D7zXod7fFNhTEckTbj5XQgHzNN+5tQvc5NG7C6BNkp6D3EmpXHDR+dQAjFLchW3VS9rlw3JBh+B7ys5Cf9z0GW1C/7P32AyBAOAz1q4jGliIH3YPuBnSfQX4OGreTIgEYQb/pBDtPnEQ4CivXYPAWBk13oHrB54yA9QuSn2H4AcKRpEILDt0BUzj+RLR1V5EqjD66NPRBVpLcQwjHoHYJOhsQv6U4mnzmrIXJCFr4LDwm/xBUoboG9XX4cc9VKdYoSA2yk5NQLJaKDUjTBoveG3Z2TElTxwjNK4M3LEZgUdDdruvcXzKBpStgp2NPiWi3ks9ZXxIoFVi+AvHLdc9TqtjL3/aYjpPlrzOcEnK62Szhimdd7xX232zFDTgtxezOu3WNMRLjiKgjtOhHVMd1loynVHvOgjuIIJMaELEqhJAV/RCSLbWTcfPFakFgFlALTRRvx+ok6Hlp/Q+v3fmx90bMyUzaEAhmM3KvHlXTL5DxnbGf/1M8RNNACLL5MNtPxP/mypJAqcDSFfgFhpYqWUzhTEAAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=' ]; // Builders. They build Three.js object from Object data parsed by MMDParser.
 
-		/**
-	 * @param {THREE.LoadingManager} manager
-	 */
+	const DEFAULT_TOON_TEXTURES = [ 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/bWiiMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh8aBHZBl14e8wAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOUlEQVRYR+3WMREAMAwDsYY/yoDI7MLwIiP40+RJklfcCCBAgAABAgTqArfb/QMCCBAgQIAAgbbAB3z/e0F3js2cAAAAAElFTkSuQmCC', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/B5ilMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh81dWyx0gFwKAAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOklEQVRYR+3WoREAMAwDsWb/UQtCy9wxTOQJ/oQ8SXKKGwEECBAgQIBAXeDt7f4BAQQIECBAgEBb4AOz8Hzx7WLY4wAAAABJRU5ErkJggg==', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABPUlEQVRYR+1XwW7CMAy1+f9fZOMysSEOEweEOPRNdm3HbdOyIhAcklPrOs/PLy9RygBALxzcCDQFmgJNgaZAU6Ap0BR4PwX8gsRMVLssMRH5HcpzJEaWL7EVg9F1IHRlyqQohgVr4FGUlUcMJSjcUlDw0zvjeun70cLWmneoyf7NgBTQSniBTQQSuJAZsOnnaczjIMb5hCiuHKxokCrJfVnrctyZL0PkJAJe1HMil4nxeyi3Ypfn1kX51jpPvo/JeCNC4PhVdHdJw2XjBR8brF8PEIhNVn12AgP7uHsTBguBn53MUZCqv7Lp07Pn5k1Ro+uWmUNn7D+M57rtk7aG0Vo73xyF/fbFf0bPJjDXngnGocDTdFhygZjwUQrMNrDcmZlQT50VJ/g/UwNyHpu778+yW+/ksOz/BFo54P4AsUXMfRq7XWsAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACMElEQVRYR+2Xv4pTQRTGf2dubhLdICiii2KnYKHVolhauKWPoGAnNr6BD6CvIVaihYuI2i1ia0BY0MZGRHQXjZj/mSPnnskfNWiWZUlzJ5k7M2cm833nO5Mziej2DWWJRUoCpQKlAntSQCqgw39/iUWAGmh37jrRnVsKlgpiqmkoGVABA7E57fvY+pJDdgKqF6HzFCSADkDq+F6AHABtQ+UMVE5D7zXod7fFNhTEckTbj5XQgHzNN+5tQvc5NG7C6BNkp6D3EmpXHDR+dQAjFLchW3VS9rlw3JBh+B7ys5Cf9z0GW1C/7P32AyBAOAz1q4jGliIH3YPuBnSfQX4OGreTIgEYQb/pBDtPnEQ4CivXYPAWBk13oHrB54yA9QuSn2H4AcKRpEILDt0BUzj+RLR1V5EqjD66NPRBVpLcQwjHoHYJOhsQv6U4mnzmrIXJCFr4LDwm/xBUoboG9XX4cc9VKdYoSA2yk5NQLJaKDUjTBoveG3Z2TElTxwjNK4M3LEZgUdDdruvcXzKBpStgp2NPiWi3ks9ZXxIoFVi+AvHLdc9TqtjL3/aYjpPlrzOcEnK62Szhimdd7xX232zFDTgtxezOu3WNMRLjiKgjtOhHVMd1loynVHvOgjuIIJMaELEqhJAV/RCSLbWTcfPFakFgFlALTRRvx+ok6Hlp/Q+v3fmx90bMyUzaEAhmM3KvHlXTL5DxnbGf/1M8RNNACLL5MNtPxP/mypJAqcDSFfgFhpYqWUzhTEAAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=' ]; // Builders. They build Three.js object from Object data parsed by MMDParser.
 
-		function MeshBuilder( manager ) {
+	/**
+ * @param {THREE.LoadingManager} manager
+ */
 
+	class MeshBuilder {
+
+		constructor( manager ) {
+
+			this.crossOrigin = 'anonymous';
 			this.geometryBuilder = new GeometryBuilder();
 			this.materialBuilder = new MaterialBuilder( manager );
 
 		}
+		/**
+	 * @param {string} crossOrigin
+	 * @return {MeshBuilder}
+	 */
 
-		MeshBuilder.prototype = {
-			constructor: MeshBuilder,
-			crossOrigin: 'anonymous',
 
-			/**
-		 * @param {string} crossOrigin
-		 * @return {MeshBuilder}
-		 */
-			setCrossOrigin: function ( crossOrigin ) {
+		setCrossOrigin( crossOrigin ) {
 
-				this.crossOrigin = crossOrigin;
-				return this;
+			this.crossOrigin = crossOrigin;
+			return this;
 
-			},
+		}
+		/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @param {string} resourcePath
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 * @return {SkinnedMesh}
+	 */
 
-			/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @param {string} resourcePath
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 * @return {SkinnedMesh}
-		 */
-			build: function ( data, resourcePath, onProgress, onError ) {
 
-				var geometry = this.geometryBuilder.build( data );
-				var material = this.materialBuilder.setCrossOrigin( this.crossOrigin ).setResourcePath( resourcePath ).build( data, geometry, onProgress, onError );
-				var mesh = new THREE.SkinnedMesh( geometry, material );
-				var skeleton = new THREE.Skeleton( initBones( mesh ) );
-				mesh.bind( skeleton ); // console.log( mesh ); // for console debug
+		build( data, resourcePath, onProgress, onError ) {
 
-				return mesh;
+			const geometry = this.geometryBuilder.build( data );
+			const material = this.materialBuilder.setCrossOrigin( this.crossOrigin ).setResourcePath( resourcePath ).build( data, geometry, onProgress, onError );
+			const mesh = new THREE.SkinnedMesh( geometry, material );
+			const skeleton = new THREE.Skeleton( initBones( mesh ) );
+			mesh.bind( skeleton ); // console.log( mesh ); // for console debug
+
+			return mesh;
+
+		}
+
+	} // TODO: Try to remove this function
+
+
+	function initBones( mesh ) {
+
+		const geometry = mesh.geometry;
+		const bones = [];
+
+		if ( geometry && geometry.bones !== undefined ) {
+
+			// first, create array of 'Bone' objects from geometry data
+			for ( let i = 0, il = geometry.bones.length; i < il; i ++ ) {
+
+				const gbone = geometry.bones[ i ]; // create new 'Bone' object
+
+				const bone = new THREE.Bone();
+				bones.push( bone ); // apply values
+
+				bone.name = gbone.name;
+				bone.position.fromArray( gbone.pos );
+				bone.quaternion.fromArray( gbone.rotq );
+				if ( gbone.scl !== undefined ) bone.scale.fromArray( gbone.scl );
+
+			} // second, create bone hierarchy
+
+
+			for ( let i = 0, il = geometry.bones.length; i < il; i ++ ) {
+
+				const gbone = geometry.bones[ i ];
+
+				if ( gbone.parent !== - 1 && gbone.parent !== null && bones[ gbone.parent ] !== undefined ) {
+
+					// subsequent bones in the hierarchy
+					bones[ gbone.parent ].add( bones[ i ] );
+
+				} else {
+
+					// topmost bone, immediate child of the skinned mesh
+					mesh.add( bones[ i ] );
+
+				}
 
 			}
-		}; // TODO: Try to remove this function
 
-		function initBones( mesh ) {
-
-			var geometry = mesh.geometry;
-			var bones = [],
-				bone,
-				gbone;
-			var i, il;
-
-			if ( geometry && geometry.bones !== undefined ) {
-
-				// first, create array of 'Bone' objects from geometry data
-				for ( i = 0, il = geometry.bones.length; i < il; i ++ ) {
-
-					gbone = geometry.bones[ i ]; // create new 'Bone' object
-
-					bone = new THREE.Bone();
-					bones.push( bone ); // apply values
-
-					bone.name = gbone.name;
-					bone.position.fromArray( gbone.pos );
-					bone.quaternion.fromArray( gbone.rotq );
-					if ( gbone.scl !== undefined ) bone.scale.fromArray( gbone.scl );
-
-				} // second, create bone hierarchy
+		} // now the bones are part of the scene graph and children of the skinned mesh.
+		// let's update the corresponding matrices
 
 
-				for ( i = 0, il = geometry.bones.length; i < il; i ++ ) {
+		mesh.updateMatrixWorld( true );
+		return bones;
 
-					gbone = geometry.bones[ i ];
-
-					if ( gbone.parent !== - 1 && gbone.parent !== null && bones[ gbone.parent ] !== undefined ) {
-
-						// subsequent bones in the hierarchy
-						bones[ gbone.parent ].add( bones[ i ] );
-
-					} else {
-
-						// topmost bone, immediate child of the skinned mesh
-						mesh.add( bones[ i ] );
-
-					}
-
-				}
-
-			} // now the bones are part of the scene graph and children of the skinned mesh.
-			// let's update the corresponding matrices
+	} //
 
 
-			mesh.updateMatrixWorld( true );
-			return bones;
+	class GeometryBuilder {
 
-		} //
+		/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @return {BufferGeometry}
+	 */
+		build( data ) {
 
+			// for geometry
+			const positions = [];
+			const uvs = [];
+			const normals = [];
+			const indices = [];
+			const groups = [];
+			const bones = [];
+			const skinIndices = [];
+			const skinWeights = [];
+			const morphTargets = [];
+			const morphPositions = [];
+			const iks = [];
+			const grants = [];
+			const rigidBodies = [];
+			const constraints = []; // for work
 
-		function GeometryBuilder() {}
+			let offset = 0;
+			const boneTypeTable = {}; // positions, normals, uvs, skinIndices, skinWeights
 
-		GeometryBuilder.prototype = {
-			constructor: GeometryBuilder,
+			for ( let i = 0; i < data.metadata.vertexCount; i ++ ) {
 
-			/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @return {BufferGeometry}
-		 */
-			build: function ( data ) {
+				const v = data.vertices[ i ];
 
-				// for geometry
-				var positions = [];
-				var uvs = [];
-				var normals = [];
-				var indices = [];
-				var groups = [];
-				var bones = [];
-				var skinIndices = [];
-				var skinWeights = [];
-				var morphTargets = [];
-				var morphPositions = [];
-				var iks = [];
-				var grants = [];
-				var rigidBodies = [];
-				var constraints = []; // for work
+				for ( let j = 0, jl = v.position.length; j < jl; j ++ ) {
 
-				var offset = 0;
-				var boneTypeTable = {}; // positions, normals, uvs, skinIndices, skinWeights
-
-				for ( var i = 0; i < data.metadata.vertexCount; i ++ ) {
-
-					var v = data.vertices[ i ];
-
-					for ( var j = 0, jl = v.position.length; j < jl; j ++ ) {
-
-						positions.push( v.position[ j ] );
-
-					}
-
-					for ( var j = 0, jl = v.normal.length; j < jl; j ++ ) {
-
-						normals.push( v.normal[ j ] );
-
-					}
-
-					for ( var j = 0, jl = v.uv.length; j < jl; j ++ ) {
-
-						uvs.push( v.uv[ j ] );
-
-					}
-
-					for ( var j = 0; j < 4; j ++ ) {
-
-						skinIndices.push( v.skinIndices.length - 1 >= j ? v.skinIndices[ j ] : 0.0 );
-
-					}
-
-					for ( var j = 0; j < 4; j ++ ) {
-
-						skinWeights.push( v.skinWeights.length - 1 >= j ? v.skinWeights[ j ] : 0.0 );
-
-					}
-
-				} // indices
-
-
-				for ( var i = 0; i < data.metadata.faceCount; i ++ ) {
-
-					var face = data.faces[ i ];
-
-					for ( var j = 0, jl = face.indices.length; j < jl; j ++ ) {
-
-						indices.push( face.indices[ j ] );
-
-					}
-
-				} // groups
-
-
-				for ( var i = 0; i < data.metadata.materialCount; i ++ ) {
-
-					var material = data.materials[ i ];
-					groups.push( {
-						offset: offset * 3,
-						count: material.faceCount * 3
-					} );
-					offset += material.faceCount;
-
-				} // bones
-
-
-				for ( var i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
-
-					var body = data.rigidBodies[ i ];
-					var value = boneTypeTable[ body.boneIndex ]; // keeps greater number if already value is set without any special reasons
-
-					value = value === undefined ? body.type : Math.max( body.type, value );
-					boneTypeTable[ body.boneIndex ] = value;
+					positions.push( v.position[ j ] );
 
 				}
 
-				for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
+				for ( let j = 0, jl = v.normal.length; j < jl; j ++ ) {
 
-					var boneData = data.bones[ i ];
-					var bone = {
-						index: i,
-						transformationClass: boneData.transformationClass,
-						parent: boneData.parentIndex,
-						name: boneData.name,
-						pos: boneData.position.slice( 0, 3 ),
-						rotq: [ 0, 0, 0, 1 ],
-						scl: [ 1, 1, 1 ],
-						rigidBodyType: boneTypeTable[ i ] !== undefined ? boneTypeTable[ i ] : - 1
+					normals.push( v.normal[ j ] );
+
+				}
+
+				for ( let j = 0, jl = v.uv.length; j < jl; j ++ ) {
+
+					uvs.push( v.uv[ j ] );
+
+				}
+
+				for ( let j = 0; j < 4; j ++ ) {
+
+					skinIndices.push( v.skinIndices.length - 1 >= j ? v.skinIndices[ j ] : 0.0 );
+
+				}
+
+				for ( let j = 0; j < 4; j ++ ) {
+
+					skinWeights.push( v.skinWeights.length - 1 >= j ? v.skinWeights[ j ] : 0.0 );
+
+				}
+
+			} // indices
+
+
+			for ( let i = 0; i < data.metadata.faceCount; i ++ ) {
+
+				const face = data.faces[ i ];
+
+				for ( let j = 0, jl = face.indices.length; j < jl; j ++ ) {
+
+					indices.push( face.indices[ j ] );
+
+				}
+
+			} // groups
+
+
+			for ( let i = 0; i < data.metadata.materialCount; i ++ ) {
+
+				const material = data.materials[ i ];
+				groups.push( {
+					offset: offset * 3,
+					count: material.faceCount * 3
+				} );
+				offset += material.faceCount;
+
+			} // bones
+
+
+			for ( let i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
+
+				const body = data.rigidBodies[ i ];
+				let value = boneTypeTable[ body.boneIndex ]; // keeps greater number if already value is set without any special reasons
+
+				value = value === undefined ? body.type : Math.max( body.type, value );
+				boneTypeTable[ body.boneIndex ] = value;
+
+			}
+
+			for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+				const boneData = data.bones[ i ];
+				const bone = {
+					index: i,
+					transformationClass: boneData.transformationClass,
+					parent: boneData.parentIndex,
+					name: boneData.name,
+					pos: boneData.position.slice( 0, 3 ),
+					rotq: [ 0, 0, 0, 1 ],
+					scl: [ 1, 1, 1 ],
+					rigidBodyType: boneTypeTable[ i ] !== undefined ? boneTypeTable[ i ] : - 1
+				};
+
+				if ( bone.parent !== - 1 ) {
+
+					bone.pos[ 0 ] -= data.bones[ bone.parent ].position[ 0 ];
+					bone.pos[ 1 ] -= data.bones[ bone.parent ].position[ 1 ];
+					bone.pos[ 2 ] -= data.bones[ bone.parent ].position[ 2 ];
+
+				}
+
+				bones.push( bone );
+
+			} // iks
+			// TODO: remove duplicated codes between PMD and PMX
+
+
+			if ( data.metadata.format === 'pmd' ) {
+
+				for ( let i = 0; i < data.metadata.ikCount; i ++ ) {
+
+					const ik = data.iks[ i ];
+					const param = {
+						target: ik.target,
+						effector: ik.effector,
+						iteration: ik.iteration,
+						maxAngle: ik.maxAngle * 4,
+						links: []
 					};
 
-					if ( bone.parent !== - 1 ) {
+					for ( let j = 0, jl = ik.links.length; j < jl; j ++ ) {
 
-						bone.pos[ 0 ] -= data.bones[ bone.parent ].position[ 0 ];
-						bone.pos[ 1 ] -= data.bones[ bone.parent ].position[ 1 ];
-						bone.pos[ 2 ] -= data.bones[ bone.parent ].position[ 2 ];
+						const link = {};
+						link.index = ik.links[ j ].index;
+						link.enabled = true;
 
-					}
+						if ( data.bones[ link.index ].name.indexOf( 'ひざ' ) >= 0 ) {
 
-					bones.push( bone );
-
-				} // iks
-				// TODO: remove duplicated codes between PMD and PMX
-
-
-				if ( data.metadata.format === 'pmd' ) {
-
-					for ( var i = 0; i < data.metadata.ikCount; i ++ ) {
-
-						var ik = data.iks[ i ];
-						var param = {
-							target: ik.target,
-							effector: ik.effector,
-							iteration: ik.iteration,
-							maxAngle: ik.maxAngle * 4,
-							links: []
-						};
-
-						for ( var j = 0, jl = ik.links.length; j < jl; j ++ ) {
-
-							var link = {};
-							link.index = ik.links[ j ].index;
-							link.enabled = true;
-
-							if ( data.bones[ link.index ].name.indexOf( 'ひざ' ) >= 0 ) {
-
-								link.limitation = new THREE.Vector3( 1.0, 0.0, 0.0 );
-
-							}
-
-							param.links.push( link );
+							link.limitation = new THREE.Vector3( 1.0, 0.0, 0.0 );
 
 						}
 
-						iks.push( param );
+						param.links.push( link );
+
+					}
+
+					iks.push( param );
+
+				}
+
+			} else {
+
+				for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+					const ik = data.bones[ i ].ik;
+					if ( ik === undefined ) continue;
+					const param = {
+						target: i,
+						effector: ik.effector,
+						iteration: ik.iteration,
+						maxAngle: ik.maxAngle,
+						links: []
+					};
+
+					for ( let j = 0, jl = ik.links.length; j < jl; j ++ ) {
+
+						const link = {};
+						link.index = ik.links[ j ].index;
+						link.enabled = true;
+
+						if ( ik.links[ j ].angleLimitation === 1 ) {
+
+							// Revert if rotationMin/Max doesn't work well
+							// link.limitation = new THREE.Vector3( 1.0, 0.0, 0.0 );
+							const rotationMin = ik.links[ j ].lowerLimitationAngle;
+							const rotationMax = ik.links[ j ].upperLimitationAngle; // Convert Left to Right coordinate by myself because
+							// MMDParser doesn't convert. It's a MMDParser's bug
+
+							const tmp1 = - rotationMax[ 0 ];
+							const tmp2 = - rotationMax[ 1 ];
+							rotationMax[ 0 ] = - rotationMin[ 0 ];
+							rotationMax[ 1 ] = - rotationMin[ 1 ];
+							rotationMin[ 0 ] = tmp1;
+							rotationMin[ 1 ] = tmp2;
+							link.rotationMin = new THREE.Vector3().fromArray( rotationMin );
+							link.rotationMax = new THREE.Vector3().fromArray( rotationMax );
+
+						}
+
+						param.links.push( link );
+
+					}
+
+					iks.push( param ); // Save the reference even from bone data for efficiently
+					// simulating PMX animation system
+
+					bones[ i ].ik = param;
+
+				}
+
+			} // grants
+
+
+			if ( data.metadata.format === 'pmx' ) {
+
+				// bone index -> grant entry map
+				const grantEntryMap = {};
+
+				for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+					const boneData = data.bones[ i ];
+					const grant = boneData.grant;
+					if ( grant === undefined ) continue;
+					const param = {
+						index: i,
+						parentIndex: grant.parentIndex,
+						ratio: grant.ratio,
+						isLocal: grant.isLocal,
+						affectRotation: grant.affectRotation,
+						affectPosition: grant.affectPosition,
+						transformationClass: boneData.transformationClass
+					};
+					grantEntryMap[ i ] = {
+						parent: null,
+						children: [],
+						param: param,
+						visited: false
+					};
+
+				}
+
+				const rootEntry = {
+					parent: null,
+					children: [],
+					param: null,
+					visited: false
+				}; // Build a tree representing grant hierarchy
+
+				for ( const boneIndex in grantEntryMap ) {
+
+					const grantEntry = grantEntryMap[ boneIndex ];
+					const parentGrantEntry = grantEntryMap[ grantEntry.parentIndex ] || rootEntry;
+					grantEntry.parent = parentGrantEntry;
+					parentGrantEntry.children.push( grantEntry );
+
+				} // Sort grant parameters from parents to children because
+				// grant uses parent's transform that parent's grant is already applied
+				// so grant should be applied in order from parents to children
+
+
+				function traverse( entry ) {
+
+					if ( entry.param ) {
+
+						grants.push( entry.param ); // Save the reference even from bone data for efficiently
+						// simulating PMX animation system
+
+						bones[ entry.param.index ].grant = entry.param;
+
+					}
+
+					entry.visited = true;
+
+					for ( let i = 0, il = entry.children.length; i < il; i ++ ) {
+
+						const child = entry.children[ i ]; // Cut off a loop if exists. (Is a grant loop invalid?)
+
+						if ( ! child.visited ) traverse( child );
+
+					}
+
+				}
+
+				traverse( rootEntry );
+
+			} // morph
+
+
+			function updateAttributes( attribute, morph, ratio ) {
+
+				for ( let i = 0; i < morph.elementCount; i ++ ) {
+
+					const element = morph.elements[ i ];
+					let index;
+
+					if ( data.metadata.format === 'pmd' ) {
+
+						index = data.morphs[ 0 ].elements[ element.index ].index;
+
+					} else {
+
+						index = element.index;
+
+					}
+
+					attribute.array[ index * 3 + 0 ] += element.position[ 0 ] * ratio;
+					attribute.array[ index * 3 + 1 ] += element.position[ 1 ] * ratio;
+					attribute.array[ index * 3 + 2 ] += element.position[ 2 ] * ratio;
+
+				}
+
+			}
+
+			for ( let i = 0; i < data.metadata.morphCount; i ++ ) {
+
+				const morph = data.morphs[ i ];
+				const params = {
+					name: morph.name
+				};
+				const attribute = new THREE.Float32BufferAttribute( data.metadata.vertexCount * 3, 3 );
+				attribute.name = morph.name;
+
+				for ( let j = 0; j < data.metadata.vertexCount * 3; j ++ ) {
+
+					attribute.array[ j ] = positions[ j ];
+
+				}
+
+				if ( data.metadata.format === 'pmd' ) {
+
+					if ( i !== 0 ) {
+
+						updateAttributes( attribute, morph, 1.0 );
 
 					}
 
 				} else {
 
-					for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
+					if ( morph.type === 0 ) {
 
-						var ik = data.bones[ i ].ik;
-						if ( ik === undefined ) continue;
-						var param = {
-							target: i,
-							effector: ik.effector,
-							iteration: ik.iteration,
-							maxAngle: ik.maxAngle,
-							links: []
-						};
+						// group
+						for ( let j = 0; j < morph.elementCount; j ++ ) {
 
-						for ( var j = 0, jl = ik.links.length; j < jl; j ++ ) {
+							const morph2 = data.morphs[ morph.elements[ j ].index ];
+							const ratio = morph.elements[ j ].ratio;
 
-							var link = {};
-							link.index = ik.links[ j ].index;
-							link.enabled = true;
+							if ( morph2.type === 1 ) {
 
-							if ( ik.links[ j ].angleLimitation === 1 ) {
+								updateAttributes( attribute, morph2, ratio );
 
-								// Revert if rotationMin/Max doesn't work well
-								// link.limitation = new THREE.Vector3( 1.0, 0.0, 0.0 );
-								var rotationMin = ik.links[ j ].lowerLimitationAngle;
-								var rotationMax = ik.links[ j ].upperLimitationAngle; // Convert Left to Right coordinate by myself because
-								// MMDParser doesn't convert. It's a MMDParser's bug
-
-								var tmp1 = - rotationMax[ 0 ];
-								var tmp2 = - rotationMax[ 1 ];
-								rotationMax[ 0 ] = - rotationMin[ 0 ];
-								rotationMax[ 1 ] = - rotationMin[ 1 ];
-								rotationMin[ 0 ] = tmp1;
-								rotationMin[ 1 ] = tmp2;
-								link.rotationMin = new THREE.Vector3().fromArray( rotationMin );
-								link.rotationMax = new THREE.Vector3().fromArray( rotationMax );
-
+							} else { // TODO: implement
 							}
 
-							param.links.push( link );
-
 						}
 
-						iks.push( param ); // Save the reference even from bone data for efficiently
-						// simulating PMX animation system
+					} else if ( morph.type === 1 ) {
 
-						bones[ i ].ik = param;
+						// vertex
+						updateAttributes( attribute, morph, 1.0 );
 
-					}
-
-				} // grants
-
-
-				if ( data.metadata.format === 'pmx' ) {
-
-					// bone index -> grant entry map
-					var grantEntryMap = {};
-
-					for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
-
-						var boneData = data.bones[ i ];
-						var grant = boneData.grant;
-						if ( grant === undefined ) continue;
-						var param = {
-							index: i,
-							parentIndex: grant.parentIndex,
-							ratio: grant.ratio,
-							isLocal: grant.isLocal,
-							affectRotation: grant.affectRotation,
-							affectPosition: grant.affectPosition,
-							transformationClass: boneData.transformationClass
-						};
-						grantEntryMap[ i ] = {
-							parent: null,
-							children: [],
-							param: param,
-							visited: false
-						};
-
-					}
-
-					var rootEntry = {
-						parent: null,
-						children: [],
-						param: null,
-						visited: false
-					}; // Build a tree representing grant hierarchy
-
-					for ( var boneIndex in grantEntryMap ) {
-
-						var grantEntry = grantEntryMap[ boneIndex ];
-						var parentGrantEntry = grantEntryMap[ grantEntry.parentIndex ] || rootEntry;
-						grantEntry.parent = parentGrantEntry;
-						parentGrantEntry.children.push( grantEntry );
-
-					} // Sort grant parameters from parents to children because
-					// grant uses parent's transform that parent's grant is already applied
-					// so grant should be applied in order from parents to children
-
-
-					function traverse( entry ) {
-
-						if ( entry.param ) {
-
-							grants.push( entry.param ); // Save the reference even from bone data for efficiently
-							// simulating PMX animation system
-
-							bones[ entry.param.index ].grant = entry.param;
-
-						}
-
-						entry.visited = true;
-
-						for ( var i = 0, il = entry.children.length; i < il; i ++ ) {
-
-							var child = entry.children[ i ]; // Cut off a loop if exists. (Is a grant loop invalid?)
-
-							if ( ! child.visited ) traverse( child );
-
-						}
-
-					}
-
-					traverse( rootEntry );
-
-				} // morph
-
-
-				function updateAttributes( attribute, morph, ratio ) {
-
-					for ( var i = 0; i < morph.elementCount; i ++ ) {
-
-						var element = morph.elements[ i ];
-						var index;
-
-						if ( data.metadata.format === 'pmd' ) {
-
-							index = data.morphs[ 0 ].elements[ element.index ].index;
-
-						} else {
-
-							index = element.index;
-
-						}
-
-						attribute.array[ index * 3 + 0 ] += element.position[ 0 ] * ratio;
-						attribute.array[ index * 3 + 1 ] += element.position[ 1 ] * ratio;
-						attribute.array[ index * 3 + 2 ] += element.position[ 2 ] * ratio;
-
+					} else if ( morph.type === 2 ) { // bone
+					// TODO: implement
+					} else if ( morph.type === 3 ) { // uv
+					// TODO: implement
+					} else if ( morph.type === 4 ) { // additional uv1
+					// TODO: implement
+					} else if ( morph.type === 5 ) { // additional uv2
+					// TODO: implement
+					} else if ( morph.type === 6 ) { // additional uv3
+					// TODO: implement
+					} else if ( morph.type === 7 ) { // additional uv4
+					// TODO: implement
+					} else if ( morph.type === 8 ) { // material
+					// TODO: implement
 					}
 
 				}
 
-				for ( var i = 0; i < data.metadata.morphCount; i ++ ) {
+				morphTargets.push( params );
+				morphPositions.push( attribute );
 
-					var morph = data.morphs[ i ];
-					var params = {
-						name: morph.name
-					};
-					var attribute = new THREE.Float32BufferAttribute( data.metadata.vertexCount * 3, 3 );
-					attribute.name = morph.name;
-
-					for ( var j = 0; j < data.metadata.vertexCount * 3; j ++ ) {
-
-						attribute.array[ j ] = positions[ j ];
-
-					}
-
-					if ( data.metadata.format === 'pmd' ) {
-
-						if ( i !== 0 ) {
-
-							updateAttributes( attribute, morph, 1.0 );
-
-						}
-
-					} else {
-
-						if ( morph.type === 0 ) {
-
-							// group
-							for ( var j = 0; j < morph.elementCount; j ++ ) {
-
-								var morph2 = data.morphs[ morph.elements[ j ].index ];
-								var ratio = morph.elements[ j ].ratio;
-
-								if ( morph2.type === 1 ) {
-
-									updateAttributes( attribute, morph2, ratio );
-
-								} else { // TODO: implement
-								}
-
-							}
-
-						} else if ( morph.type === 1 ) {
-
-							// vertex
-							updateAttributes( attribute, morph, 1.0 );
-
-						} else if ( morph.type === 2 ) { // bone
-						// TODO: implement
-						} else if ( morph.type === 3 ) { // uv
-						// TODO: implement
-						} else if ( morph.type === 4 ) { // additional uv1
-						// TODO: implement
-						} else if ( morph.type === 5 ) { // additional uv2
-						// TODO: implement
-						} else if ( morph.type === 6 ) { // additional uv3
-						// TODO: implement
-						} else if ( morph.type === 7 ) { // additional uv4
-						// TODO: implement
-						} else if ( morph.type === 8 ) { // material
-						// TODO: implement
-						}
-
-					}
-
-					morphTargets.push( params );
-					morphPositions.push( attribute );
-
-				} // rigid bodies from rigidBodies field.
+			} // rigid bodies from rigidBodies field.
 
 
-				for ( var i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
+			for ( let i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
 
-					var rigidBody = data.rigidBodies[ i ];
-					var params = {};
+				const rigidBody = data.rigidBodies[ i ];
+				const params = {};
 
-					for ( var key in rigidBody ) {
+				for ( const key in rigidBody ) {
 
-						params[ key ] = rigidBody[ key ];
+					params[ key ] = rigidBody[ key ];
 
-					}
-					/*
+				}
+				/*
 				 * RigidBody position parameter in PMX seems global position
 				 * while the one in PMD seems offset from corresponding bone.
 				 * So unify being offset.
 				 */
 
 
-					if ( data.metadata.format === 'pmx' ) {
+				if ( data.metadata.format === 'pmx' ) {
 
-						if ( params.boneIndex !== - 1 ) {
+					if ( params.boneIndex !== - 1 ) {
 
-							var bone = data.bones[ params.boneIndex ];
-							params.position[ 0 ] -= bone.position[ 0 ];
-							params.position[ 1 ] -= bone.position[ 1 ];
-							params.position[ 2 ] -= bone.position[ 2 ];
-
-						}
+						const bone = data.bones[ params.boneIndex ];
+						params.position[ 0 ] -= bone.position[ 0 ];
+						params.position[ 1 ] -= bone.position[ 1 ];
+						params.position[ 2 ] -= bone.position[ 2 ];
 
 					}
-
-					rigidBodies.push( params );
-
-				} // constraints from constraints field.
-
-
-				for ( var i = 0; i < data.metadata.constraintCount; i ++ ) {
-
-					var constraint = data.constraints[ i ];
-					var params = {};
-
-					for ( var key in constraint ) {
-
-						params[ key ] = constraint[ key ];
-
-					}
-
-					var bodyA = rigidBodies[ params.rigidBodyIndex1 ];
-					var bodyB = rigidBodies[ params.rigidBodyIndex2 ]; // Refer to http://www20.atpages.jp/katwat/wp/?p=4135
-
-					if ( bodyA.type !== 0 && bodyB.type === 2 ) {
-
-						if ( bodyA.boneIndex !== - 1 && bodyB.boneIndex !== - 1 && data.bones[ bodyB.boneIndex ].parentIndex === bodyA.boneIndex ) {
-
-							bodyB.type = 1;
-
-						}
-
-					}
-
-					constraints.push( params );
-
-				} // build THREE.BufferGeometry.
-
-
-				var geometry = new THREE.BufferGeometry();
-				geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
-				geometry.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
-				geometry.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
-				geometry.setAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( skinIndices, 4 ) );
-				geometry.setAttribute( 'skinWeight', new THREE.Float32BufferAttribute( skinWeights, 4 ) );
-				geometry.setIndex( indices );
-
-				for ( var i = 0, il = groups.length; i < il; i ++ ) {
-
-					geometry.addGroup( groups[ i ].offset, groups[ i ].count, i );
 
 				}
 
-				geometry.bones = bones;
-				geometry.morphTargets = morphTargets;
-				geometry.morphAttributes.position = morphPositions;
-				geometry.morphTargetsRelative = false;
-				geometry.userData.MMD = {
-					bones: bones,
-					iks: iks,
-					grants: grants,
-					rigidBodies: rigidBodies,
-					constraints: constraints,
-					format: data.metadata.format
-				};
-				geometry.computeBoundingSphere();
-				return geometry;
+				rigidBodies.push( params );
+
+			} // constraints from constraints field.
+
+
+			for ( let i = 0; i < data.metadata.constraintCount; i ++ ) {
+
+				const constraint = data.constraints[ i ];
+				const params = {};
+
+				for ( const key in constraint ) {
+
+					params[ key ] = constraint[ key ];
+
+				}
+
+				const bodyA = rigidBodies[ params.rigidBodyIndex1 ];
+				const bodyB = rigidBodies[ params.rigidBodyIndex2 ]; // Refer to http://www20.atpages.jp/katwat/wp/?p=4135
+
+				if ( bodyA.type !== 0 && bodyB.type === 2 ) {
+
+					if ( bodyA.boneIndex !== - 1 && bodyB.boneIndex !== - 1 && data.bones[ bodyB.boneIndex ].parentIndex === bodyA.boneIndex ) {
+
+						bodyB.type = 1;
+
+					}
+
+				}
+
+				constraints.push( params );
+
+			} // build THREE.BufferGeometry.
+
+
+			const geometry = new THREE.BufferGeometry();
+			geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
+			geometry.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+			geometry.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
+			geometry.setAttribute( 'skinIndex', new THREE.Uint16BufferAttribute( skinIndices, 4 ) );
+			geometry.setAttribute( 'skinWeight', new THREE.Float32BufferAttribute( skinWeights, 4 ) );
+			geometry.setIndex( indices );
+
+			for ( let i = 0, il = groups.length; i < il; i ++ ) {
+
+				geometry.addGroup( groups[ i ].offset, groups[ i ].count, i );
 
 			}
-		}; //
 
-		/**
-	 * @param {THREE.LoadingManager} manager
-	 */
+			geometry.bones = bones;
+			geometry.morphTargets = morphTargets;
+			geometry.morphAttributes.position = morphPositions;
+			geometry.morphTargetsRelative = false;
+			geometry.userData.MMD = {
+				bones: bones,
+				iks: iks,
+				grants: grants,
+				rigidBodies: rigidBodies,
+				constraints: constraints,
+				format: data.metadata.format
+			};
+			geometry.computeBoundingSphere();
+			return geometry;
 
-		function MaterialBuilder( manager ) {
+		}
+
+	} //
+
+	/**
+ * @param {THREE.LoadingManager} manager
+ */
+
+
+	class MaterialBuilder {
+
+		constructor( manager ) {
 
 			this.manager = manager;
 			this.textureLoader = new THREE.TextureLoader( this.manager );
 			this.tgaLoader = null; // lazy generation
 
+			this.crossOrigin = 'anonymous';
+			this.resourcePath = undefined;
+
 		}
+		/**
+	 * @param {string} crossOrigin
+	 * @return {MaterialBuilder}
+	 */
 
-		MaterialBuilder.prototype = {
-			constructor: MaterialBuilder,
-			crossOrigin: 'anonymous',
-			resourcePath: undefined,
 
-			/**
-		 * @param {string} crossOrigin
-		 * @return {MaterialBuilder}
-		 */
-			setCrossOrigin: function ( crossOrigin ) {
+		setCrossOrigin( crossOrigin ) {
 
-				this.crossOrigin = crossOrigin;
-				return this;
+			this.crossOrigin = crossOrigin;
+			return this;
 
-			},
+		}
+		/**
+	 * @param {string} resourcePath
+	 * @return {MaterialBuilder}
+	 */
 
-			/**
-		 * @param {string} resourcePath
-		 * @return {MaterialBuilder}
-		 */
-			setResourcePath: function ( resourcePath ) {
 
-				this.resourcePath = resourcePath;
-				return this;
+		setResourcePath( resourcePath ) {
 
-			},
+			this.resourcePath = resourcePath;
+			return this;
 
-			/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @param {BufferGeometry} geometry - some properties are dependend on geometry
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 * @return {Array<MeshToonMaterial>}
-		 */
-			build: function ( data, geometry
-				/*, onProgress, onError */
-			) {
+		}
+		/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @param {BufferGeometry} geometry - some properties are dependend on geometry
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 * @return {Array<MeshToonMaterial>}
+	 */
 
-				var materials = [];
-				var textures = {};
-				this.textureLoader.setCrossOrigin( this.crossOrigin ); // materials
 
-				for ( var i = 0; i < data.metadata.materialCount; i ++ ) {
+		build( data, geometry
+			/*, onProgress, onError */
+		) {
 
-					var material = data.materials[ i ];
-					var params = {
-						userData: {}
-					};
-					if ( material.name !== undefined ) params.name = material.name;
-					/*
+			const materials = [];
+			const textures = {};
+			this.textureLoader.setCrossOrigin( this.crossOrigin ); // materials
+
+			for ( let i = 0; i < data.metadata.materialCount; i ++ ) {
+
+				const material = data.materials[ i ];
+				const params = {
+					userData: {}
+				};
+				if ( material.name !== undefined ) params.name = material.name;
+				/*
 				 * THREE.Color
 				 *
 				 * MMD				 THREE.MeshToonMaterial
@@ -939,343 +951,348 @@
 				 * It'll be too bright if material has map texture so using coef 0.2.
 				 */
 
-					params.color = new THREE.Color().fromArray( material.diffuse );
-					params.opacity = material.diffuse[ 3 ];
-					params.emissive = new THREE.Color().fromArray( material.ambient );
-					params.transparent = params.opacity !== 1.0; //
-
-					params.skinning = geometry.bones.length > 0 ? true : false;
-					params.morphTargets = geometry.morphTargets.length > 0 ? true : false;
-					params.fog = true; // blend
-
-					params.blending = THREE.CustomBlending;
-					params.blendSrc = THREE.SrcAlphaFactor;
-					params.blendDst = THREE.OneMinusSrcAlphaFactor;
-					params.blendSrcAlpha = THREE.SrcAlphaFactor;
-					params.blendDstAlpha = THREE.DstAlphaFactor; // side
-
-					if ( data.metadata.format === 'pmx' && ( material.flag & 0x1 ) === 1 ) {
-
-						params.side = THREE.DoubleSide;
-
-					} else {
-
-						params.side = params.opacity === 1.0 ? THREE.FrontSide : THREE.DoubleSide;
-
-					}
-
-					if ( data.metadata.format === 'pmd' ) {
-
-						// map, envMap
-						if ( material.fileName ) {
-
-							var fileName = material.fileName;
-							var fileNames = fileName.split( '*' ); // fileNames[ 0 ]: mapFileName
-							// fileNames[ 1 ]: envMapFileName( optional )
-
-							params.map = this._loadTexture( fileNames[ 0 ], textures );
-
-							if ( fileNames.length > 1 ) {
-
-								var extension = fileNames[ 1 ].slice( - 4 ).toLowerCase();
-								params.envMap = this._loadTexture( fileNames[ 1 ], textures );
-								params.combine = extension === '.sph' ? THREE.MultiplyOperation : THREE.AddOperation;
-
-							}
-
-						} // gradientMap
-
-
-						var toonFileName = material.toonIndex === - 1 ? 'toon00.bmp' : data.toonTextures[ material.toonIndex ].fileName;
-						params.gradientMap = this._loadTexture( toonFileName, textures, {
-							isToonTexture: true,
-							isDefaultToonTexture: this._isDefaultToonTexture( toonFileName )
-						} ); // parameters for OutlineEffect
-
-						params.userData.outlineParameters = {
-							thickness: material.edgeFlag === 1 ? 0.003 : 0.0,
-							color: [ 0, 0, 0 ],
-							alpha: 1.0,
-							visible: material.edgeFlag === 1
-						};
-
-					} else {
-
-						// map
-						if ( material.textureIndex !== - 1 ) {
-
-							params.map = this._loadTexture( data.textures[ material.textureIndex ], textures );
-
-						} // envMap TODO: support m.envFlag === 3
-
-
-						if ( material.envTextureIndex !== - 1 && ( material.envFlag === 1 || material.envFlag == 2 ) ) {
-
-							params.envMap = this._loadTexture( data.textures[ material.envTextureIndex ], textures );
-							params.combine = material.envFlag === 1 ? THREE.MultiplyOperation : THREE.AddOperation;
-
-						} // gradientMap
-
-
-						var toonFileName, isDefaultToon;
-
-						if ( material.toonIndex === - 1 || material.toonFlag !== 0 ) {
-
-							toonFileName = 'toon' + ( '0' + ( material.toonIndex + 1 ) ).slice( - 2 ) + '.bmp';
-							isDefaultToon = true;
-
-						} else {
-
-							toonFileName = data.textures[ material.toonIndex ];
-							isDefaultToon = false;
-
-						}
-
-						params.gradientMap = this._loadTexture( toonFileName, textures, {
-							isToonTexture: true,
-							isDefaultToonTexture: isDefaultToon
-						} ); // parameters for OutlineEffect
-
-						params.userData.outlineParameters = {
-							thickness: material.edgeSize / 300,
-							// TODO: better calculation?
-							color: material.edgeColor.slice( 0, 3 ),
-							alpha: material.edgeColor[ 3 ],
-							visible: ( material.flag & 0x10 ) !== 0 && material.edgeSize > 0.0
-						};
-
-					}
-
-					if ( params.map !== undefined ) {
-
-						if ( ! params.transparent ) {
-
-							this._checkImageTransparency( params.map, geometry, i );
-
-						}
-
-						params.emissive.multiplyScalar( 0.2 );
-
-					}
-
-					materials.push( new THREE.MeshToonMaterial( params ) );
-
-				}
-
-				if ( data.metadata.format === 'pmx' ) {
-
-					// set transparent true if alpha morph is defined.
-					function checkAlphaMorph( elements, materials ) {
-
-						for ( var i = 0, il = elements.length; i < il; i ++ ) {
-
-							var element = elements[ i ];
-							if ( element.index === - 1 ) continue;
-							var material = materials[ element.index ];
-
-							if ( material.opacity !== element.diffuse[ 3 ] ) {
-
-								material.transparent = true;
-
-							}
-
-						}
-
-					}
-
-					for ( var i = 0, il = data.morphs.length; i < il; i ++ ) {
-
-						var morph = data.morphs[ i ];
-						var elements = morph.elements;
-
-						if ( morph.type === 0 ) {
-
-							for ( var j = 0, jl = elements.length; j < jl; j ++ ) {
-
-								var morph2 = data.morphs[ elements[ j ].index ];
-								if ( morph2.type !== 8 ) continue;
-								checkAlphaMorph( morph2.elements, materials );
-
-							}
-
-						} else if ( morph.type === 8 ) {
-
-							checkAlphaMorph( elements, materials );
-
-						}
-
-					}
-
-				}
-
-				return materials;
-
-			},
-			// private methods
-			_getTGALoader: function () {
-
-				if ( this.tgaLoader === null ) {
-
-					if ( THREE.TGALoader === undefined ) {
-
-						throw new Error( 'THREE.MMDLoader: Import THREE.TGALoader' );
-
-					}
-
-					this.tgaLoader = new THREE.TGALoader( this.manager );
-
-				}
-
-				return this.tgaLoader;
-
-			},
-			_isDefaultToonTexture: function ( name ) {
-
-				if ( name.length !== 10 ) return false;
-				return /toon(10|0[0-9])\.bmp/.test( name );
-
-			},
-			_loadTexture: function ( filePath, textures, params, onProgress, onError ) {
-
-				params = params || {};
-				var scope = this;
-				var fullPath;
-
-				if ( params.isDefaultToonTexture === true ) {
-
-					var index;
-
-					try {
-
-						index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
-
-					} catch ( e ) {
-
-						console.warn( 'THREE.MMDLoader: ' + filePath + ' seems like a ' + 'not right default texture path. Using toon00.bmp instead.' );
-						index = 0;
-
-					}
-
-					fullPath = DEFAULT_TOON_TEXTURES[ index ];
+				params.color = new THREE.Color().fromArray( material.diffuse );
+				params.opacity = material.diffuse[ 3 ];
+				params.emissive = new THREE.Color().fromArray( material.ambient );
+				params.transparent = params.opacity !== 1.0; //
+
+				params.skinning = geometry.bones.length > 0 ? true : false;
+				params.morphTargets = geometry.morphTargets.length > 0 ? true : false;
+				params.fog = true; // blend
+
+				params.blending = THREE.CustomBlending;
+				params.blendSrc = THREE.SrcAlphaFactor;
+				params.blendDst = THREE.OneMinusSrcAlphaFactor;
+				params.blendSrcAlpha = THREE.SrcAlphaFactor;
+				params.blendDstAlpha = THREE.DstAlphaFactor; // side
+
+				if ( data.metadata.format === 'pmx' && ( material.flag & 0x1 ) === 1 ) {
+
+					params.side = THREE.DoubleSide;
 
 				} else {
 
-					fullPath = this.resourcePath + filePath;
+					params.side = params.opacity === 1.0 ? THREE.FrontSide : THREE.DoubleSide;
 
 				}
 
-				if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
-				var loader = this.manager.getHandler( fullPath );
+				if ( data.metadata.format === 'pmd' ) {
 
-				if ( loader === null ) {
+					// map, envMap
+					if ( material.fileName ) {
 
-					loader = filePath.slice( - 4 ).toLowerCase() === '.tga' ? this._getTGALoader() : this.textureLoader;
+						const fileName = material.fileName;
+						const fileNames = fileName.split( '*' ); // fileNames[ 0 ]: mapFileName
+						// fileNames[ 1 ]: envMapFileName( optional )
 
-				}
+						params.map = this._loadTexture( fileNames[ 0 ], textures );
 
-				var texture = loader.load( fullPath, function ( t ) {
+						if ( fileNames.length > 1 ) {
 
-					// MMD toon texture is Axis-Y oriented
-					// but Three.js gradient map is Axis-X oriented.
-					// So here replaces the toon texture image with the rotated one.
-					if ( params.isToonTexture === true ) {
-
-						t.image = scope._getRotatedImage( t.image );
-						t.magFilter = THREE.NearestFilter;
-						t.minFilter = THREE.NearestFilter;
-
-					}
-
-					t.flipY = false;
-					t.wrapS = THREE.RepeatWrapping;
-					t.wrapT = THREE.RepeatWrapping;
-
-					for ( var i = 0; i < texture.readyCallbacks.length; i ++ ) {
-
-						texture.readyCallbacks[ i ]( texture );
-
-					}
-
-					delete texture.readyCallbacks;
-
-				}, onProgress, onError );
-				texture.readyCallbacks = [];
-				textures[ fullPath ] = texture;
-				return texture;
-
-			},
-			_getRotatedImage: function ( image ) {
-
-				var canvas = document.createElement( 'canvas' );
-				var context = canvas.getContext( '2d' );
-				var width = image.width;
-				var height = image.height;
-				canvas.width = width;
-				canvas.height = height;
-				context.clearRect( 0, 0, width, height );
-				context.translate( width / 2.0, height / 2.0 );
-				context.rotate( 0.5 * Math.PI ); // 90.0 * Math.PI / 180.0
-
-				context.translate( - width / 2.0, - height / 2.0 );
-				context.drawImage( image, 0, 0 );
-				return context.getImageData( 0, 0, width, height );
-
-			},
-			// Check if the partial image area used by the texture is transparent.
-			_checkImageTransparency: function ( map, geometry, groupIndex ) {
-
-				map.readyCallbacks.push( function ( texture ) {
-
-					// Is there any efficient ways?
-					function createImageData( image ) {
-
-						var canvas = document.createElement( 'canvas' );
-						canvas.width = image.width;
-						canvas.height = image.height;
-						var context = canvas.getContext( '2d' );
-						context.drawImage( image, 0, 0 );
-						return context.getImageData( 0, 0, canvas.width, canvas.height );
-
-					}
-
-					function detectImageTransparency( image, uvs, indices ) {
-
-						var width = image.width;
-						var height = image.height;
-						var data = image.data;
-						var threshold = 253;
-						if ( data.length / ( width * height ) !== 4 ) return false;
-
-						for ( var i = 0; i < indices.length; i += 3 ) {
-
-							var centerUV = {
-								x: 0.0,
-								y: 0.0
-							};
-
-							for ( var j = 0; j < 3; j ++ ) {
-
-								var index = indices[ i * 3 + j ];
-								var uv = {
-									x: uvs[ index * 2 + 0 ],
-									y: uvs[ index * 2 + 1 ]
-								};
-								if ( getAlphaByUv( image, uv ) < threshold ) return true;
-								centerUV.x += uv.x;
-								centerUV.y += uv.y;
-
-							}
-
-							centerUV.x /= 3;
-							centerUV.y /= 3;
-							if ( getAlphaByUv( image, centerUV ) < threshold ) return true;
+							const extension = fileNames[ 1 ].slice( - 4 ).toLowerCase();
+							params.envMap = this._loadTexture( fileNames[ 1 ], textures );
+							params.combine = extension === '.sph' ? THREE.MultiplyOperation : THREE.AddOperation;
 
 						}
 
-						return false;
+					} // gradientMap
+
+
+					const toonFileName = material.toonIndex === - 1 ? 'toon00.bmp' : data.toonTextures[ material.toonIndex ].fileName;
+					params.gradientMap = this._loadTexture( toonFileName, textures, {
+						isToonTexture: true,
+						isDefaultToonTexture: this._isDefaultToonTexture( toonFileName )
+					} ); // parameters for OutlineEffect
+
+					params.userData.outlineParameters = {
+						thickness: material.edgeFlag === 1 ? 0.003 : 0.0,
+						color: [ 0, 0, 0 ],
+						alpha: 1.0,
+						visible: material.edgeFlag === 1
+					};
+
+				} else {
+
+					// map
+					if ( material.textureIndex !== - 1 ) {
+
+						params.map = this._loadTexture( data.textures[ material.textureIndex ], textures );
+
+					} // envMap TODO: support m.envFlag === 3
+
+
+					if ( material.envTextureIndex !== - 1 && ( material.envFlag === 1 || material.envFlag == 2 ) ) {
+
+						params.envMap = this._loadTexture( data.textures[ material.envTextureIndex ], textures );
+						params.combine = material.envFlag === 1 ? THREE.MultiplyOperation : THREE.AddOperation;
+
+					} // gradientMap
+
+
+					let toonFileName, isDefaultToon;
+
+					if ( material.toonIndex === - 1 || material.toonFlag !== 0 ) {
+
+						toonFileName = 'toon' + ( '0' + ( material.toonIndex + 1 ) ).slice( - 2 ) + '.bmp';
+						isDefaultToon = true;
+
+					} else {
+
+						toonFileName = data.textures[ material.toonIndex ];
+						isDefaultToon = false;
 
 					}
-					/*
+
+					params.gradientMap = this._loadTexture( toonFileName, textures, {
+						isToonTexture: true,
+						isDefaultToonTexture: isDefaultToon
+					} ); // parameters for OutlineEffect
+
+					params.userData.outlineParameters = {
+						thickness: material.edgeSize / 300,
+						// TODO: better calculation?
+						color: material.edgeColor.slice( 0, 3 ),
+						alpha: material.edgeColor[ 3 ],
+						visible: ( material.flag & 0x10 ) !== 0 && material.edgeSize > 0.0
+					};
+
+				}
+
+				if ( params.map !== undefined ) {
+
+					if ( ! params.transparent ) {
+
+						this._checkImageTransparency( params.map, geometry, i );
+
+					}
+
+					params.emissive.multiplyScalar( 0.2 );
+
+				}
+
+				materials.push( new THREE.MeshToonMaterial( params ) );
+
+			}
+
+			if ( data.metadata.format === 'pmx' ) {
+
+				// set transparent true if alpha morph is defined.
+				function checkAlphaMorph( elements, materials ) {
+
+					for ( let i = 0, il = elements.length; i < il; i ++ ) {
+
+						const element = elements[ i ];
+						if ( element.index === - 1 ) continue;
+						const material = materials[ element.index ];
+
+						if ( material.opacity !== element.diffuse[ 3 ] ) {
+
+							material.transparent = true;
+
+						}
+
+					}
+
+				}
+
+				for ( let i = 0, il = data.morphs.length; i < il; i ++ ) {
+
+					const morph = data.morphs[ i ];
+					const elements = morph.elements;
+
+					if ( morph.type === 0 ) {
+
+						for ( let j = 0, jl = elements.length; j < jl; j ++ ) {
+
+							const morph2 = data.morphs[ elements[ j ].index ];
+							if ( morph2.type !== 8 ) continue;
+							checkAlphaMorph( morph2.elements, materials );
+
+						}
+
+					} else if ( morph.type === 8 ) {
+
+						checkAlphaMorph( elements, materials );
+
+					}
+
+				}
+
+			}
+
+			return materials;
+
+		} // private methods
+
+
+		_getTGALoader() {
+
+			if ( this.tgaLoader === null ) {
+
+				if ( THREE.TGALoader === undefined ) {
+
+					throw new Error( 'THREE.MMDLoader: Import THREE.TGALoader' );
+
+				}
+
+				this.tgaLoader = new THREE.TGALoader( this.manager );
+
+			}
+
+			return this.tgaLoader;
+
+		}
+
+		_isDefaultToonTexture( name ) {
+
+			if ( name.length !== 10 ) return false;
+			return /toon(10|0[0-9])\.bmp/.test( name );
+
+		}
+
+		_loadTexture( filePath, textures, params, onProgress, onError ) {
+
+			params = params || {};
+			const scope = this;
+			let fullPath;
+
+			if ( params.isDefaultToonTexture === true ) {
+
+				let index;
+
+				try {
+
+					index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
+
+				} catch ( e ) {
+
+					console.warn( 'THREE.MMDLoader: ' + filePath + ' seems like a ' + 'not right default texture path. Using toon00.bmp instead.' );
+					index = 0;
+
+				}
+
+				fullPath = DEFAULT_TOON_TEXTURES[ index ];
+
+			} else {
+
+				fullPath = this.resourcePath + filePath;
+
+			}
+
+			if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
+			let loader = this.manager.getHandler( fullPath );
+
+			if ( loader === null ) {
+
+				loader = filePath.slice( - 4 ).toLowerCase() === '.tga' ? this._getTGALoader() : this.textureLoader;
+
+			}
+
+			const texture = loader.load( fullPath, function ( t ) {
+
+				// MMD toon texture is Axis-Y oriented
+				// but Three.js gradient map is Axis-X oriented.
+				// So here replaces the toon texture image with the rotated one.
+				if ( params.isToonTexture === true ) {
+
+					t.image = scope._getRotatedImage( t.image );
+					t.magFilter = THREE.NearestFilter;
+					t.minFilter = THREE.NearestFilter;
+
+				}
+
+				t.flipY = false;
+				t.wrapS = THREE.RepeatWrapping;
+				t.wrapT = THREE.RepeatWrapping;
+
+				for ( let i = 0; i < texture.readyCallbacks.length; i ++ ) {
+
+					texture.readyCallbacks[ i ]( texture );
+
+				}
+
+				delete texture.readyCallbacks;
+
+			}, onProgress, onError );
+			texture.readyCallbacks = [];
+			textures[ fullPath ] = texture;
+			return texture;
+
+		}
+
+		_getRotatedImage( image ) {
+
+			const canvas = document.createElement( 'canvas' );
+			const context = canvas.getContext( '2d' );
+			const width = image.width;
+			const height = image.height;
+			canvas.width = width;
+			canvas.height = height;
+			context.clearRect( 0, 0, width, height );
+			context.translate( width / 2.0, height / 2.0 );
+			context.rotate( 0.5 * Math.PI ); // 90.0 * Math.PI / 180.0
+
+			context.translate( - width / 2.0, - height / 2.0 );
+			context.drawImage( image, 0, 0 );
+			return context.getImageData( 0, 0, width, height );
+
+		} // Check if the partial image area used by the texture is transparent.
+
+
+		_checkImageTransparency( map, geometry, groupIndex ) {
+
+			map.readyCallbacks.push( function ( texture ) {
+
+				// Is there any efficient ways?
+				function createImageData( image ) {
+
+					const canvas = document.createElement( 'canvas' );
+					canvas.width = image.width;
+					canvas.height = image.height;
+					const context = canvas.getContext( '2d' );
+					context.drawImage( image, 0, 0 );
+					return context.getImageData( 0, 0, canvas.width, canvas.height );
+
+				}
+
+				function detectImageTransparency( image, uvs, indices ) {
+
+					const width = image.width;
+					const height = image.height;
+					const data = image.data;
+					const threshold = 253;
+					if ( data.length / ( width * height ) !== 4 ) return false;
+
+					for ( let i = 0; i < indices.length; i += 3 ) {
+
+						const centerUV = {
+							x: 0.0,
+							y: 0.0
+						};
+
+						for ( let j = 0; j < 3; j ++ ) {
+
+							const index = indices[ i * 3 + j ];
+							const uv = {
+								x: uvs[ index * 2 + 0 ],
+								y: uvs[ index * 2 + 1 ]
+							};
+							if ( getAlphaByUv( image, uv ) < threshold ) return true;
+							centerUV.x += uv.x;
+							centerUV.y += uv.y;
+
+						}
+
+						centerUV.x /= 3;
+						centerUV.y /= 3;
+						if ( getAlphaByUv( image, centerUV ) < threshold ) return true;
+
+					}
+
+					return false;
+
+				}
+				/*
 				 * This method expects
 				 *	 texture.flipY = false
 				 *	 texture.wrapS = THREE.RepeatWrapping
@@ -1284,432 +1301,437 @@
 				 */
 
 
-					function getAlphaByUv( image, uv ) {
+				function getAlphaByUv( image, uv ) {
 
-						var width = image.width;
-						var height = image.height;
-						var x = Math.round( uv.x * width ) % width;
-						var y = Math.round( uv.y * height ) % height;
-						if ( x < 0 ) x += width;
-						if ( y < 0 ) y += height;
-						var index = y * width + x;
-						return image.data[ index * 4 + 3 ];
+					const width = image.width;
+					const height = image.height;
+					let x = Math.round( uv.x * width ) % width;
+					let y = Math.round( uv.y * height ) % height;
+					if ( x < 0 ) x += width;
+					if ( y < 0 ) y += height;
+					const index = y * width + x;
+					return image.data[ index * 4 + 3 ];
 
-					}
+				}
 
-					var imageData = texture.image.data !== undefined ? texture.image : createImageData( texture.image );
-					var group = geometry.groups[ groupIndex ];
+				const imageData = texture.image.data !== undefined ? texture.image : createImageData( texture.image );
+				const group = geometry.groups[ groupIndex ];
 
-					if ( detectImageTransparency( imageData, geometry.attributes.uv.array, geometry.index.array.slice( group.start, group.start + group.count ) ) ) {
+				if ( detectImageTransparency( imageData, geometry.attributes.uv.array, geometry.index.array.slice( group.start, group.start + group.count ) ) ) {
 
-						map.transparent = true;
+					map.transparent = true;
 
-					}
+				}
 
-				} );
+			} );
+
+		}
+
+	} //
+
+
+	class AnimationBuilder {
+
+		/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
+		build( vmd, mesh ) {
+
+			// combine skeletal and morph animations
+			const tracks = this.buildSkeletalAnimation( vmd, mesh ).tracks;
+			const tracks2 = this.buildMorphAnimation( vmd, mesh ).tracks;
+
+			for ( let i = 0, il = tracks2.length; i < il; i ++ ) {
+
+				tracks.push( tracks2[ i ] );
 
 			}
-		}; //
 
-		function AnimationBuilder() {}
+			return new THREE.AnimationClip( '', - 1, tracks );
 
-		AnimationBuilder.prototype = {
-			constructor: AnimationBuilder,
+		}
+		/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
 
-			/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-			build: function ( vmd, mesh ) {
 
-				// combine skeletal and morph animations
-				var tracks = this.buildSkeletalAnimation( vmd, mesh ).tracks;
-				var tracks2 = this.buildMorphAnimation( vmd, mesh ).tracks;
+		buildSkeletalAnimation( vmd, mesh ) {
 
-				for ( var i = 0, il = tracks2.length; i < il; i ++ ) {
+			function pushInterpolation( array, interpolation, index ) {
 
-					tracks.push( tracks2[ i ] );
+				array.push( interpolation[ index + 0 ] / 127 ); // x1
 
-				}
+				array.push( interpolation[ index + 8 ] / 127 ); // x2
 
-				return new THREE.AnimationClip( '', - 1, tracks );
+				array.push( interpolation[ index + 4 ] / 127 ); // y1
 
-			},
+				array.push( interpolation[ index + 12 ] / 127 ); // y2
 
-			/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-			buildSkeletalAnimation: function ( vmd, mesh ) {
+			}
 
-				function pushInterpolation( array, interpolation, index ) {
+			const tracks = [];
+			const motions = {};
+			const bones = mesh.skeleton.bones;
+			const boneNameDictionary = {};
 
-					array.push( interpolation[ index + 0 ] / 127 ); // x1
+			for ( let i = 0, il = bones.length; i < il; i ++ ) {
 
-					array.push( interpolation[ index + 8 ] / 127 ); // x2
+				boneNameDictionary[ bones[ i ].name ] = true;
 
-					array.push( interpolation[ index + 4 ] / 127 ); // y1
+			}
 
-					array.push( interpolation[ index + 12 ] / 127 ); // y2
+			for ( let i = 0; i < vmd.metadata.motionCount; i ++ ) {
 
-				}
+				const motion = vmd.motions[ i ];
+				const boneName = motion.boneName;
+				if ( boneNameDictionary[ boneName ] === undefined ) continue;
+				motions[ boneName ] = motions[ boneName ] || [];
+				motions[ boneName ].push( motion );
 
-				var tracks = [];
-				var motions = {};
-				var bones = mesh.skeleton.bones;
-				var boneNameDictionary = {};
+			}
 
-				for ( var i = 0, il = bones.length; i < il; i ++ ) {
+			for ( const key in motions ) {
 
-					boneNameDictionary[ bones[ i ].name ] = true;
-
-				}
-
-				for ( var i = 0; i < vmd.metadata.motionCount; i ++ ) {
-
-					var motion = vmd.motions[ i ];
-					var boneName = motion.boneName;
-					if ( boneNameDictionary[ boneName ] === undefined ) continue;
-					motions[ boneName ] = motions[ boneName ] || [];
-					motions[ boneName ].push( motion );
-
-				}
-
-				for ( var key in motions ) {
-
-					var array = motions[ key ];
-					array.sort( function ( a, b ) {
-
-						return a.frameNum - b.frameNum;
-
-					} );
-					var times = [];
-					var positions = [];
-					var rotations = [];
-					var pInterpolations = [];
-					var rInterpolations = [];
-					var basePosition = mesh.skeleton.getBoneByName( key ).position.toArray();
-
-					for ( var i = 0, il = array.length; i < il; i ++ ) {
-
-						var time = array[ i ].frameNum / 30;
-						var position = array[ i ].position;
-						var rotation = array[ i ].rotation;
-						var interpolation = array[ i ].interpolation;
-						times.push( time );
-
-						for ( var j = 0; j < 3; j ++ ) positions.push( basePosition[ j ] + position[ j ] );
-
-						for ( var j = 0; j < 4; j ++ ) rotations.push( rotation[ j ] );
-
-						for ( var j = 0; j < 3; j ++ ) pushInterpolation( pInterpolations, interpolation, j );
-
-						pushInterpolation( rInterpolations, interpolation, 3 );
-
-					}
-
-					var targetName = '.bones[' + key + ']';
-					tracks.push( this._createTrack( targetName + '.position', THREE.VectorKeyframeTrack, times, positions, pInterpolations ) );
-					tracks.push( this._createTrack( targetName + '.quaternion', THREE.QuaternionKeyframeTrack, times, rotations, rInterpolations ) );
-
-				}
-
-				return new THREE.AnimationClip( '', - 1, tracks );
-
-			},
-
-			/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-			buildMorphAnimation: function ( vmd, mesh ) {
-
-				var tracks = [];
-				var morphs = {};
-				var morphTargetDictionary = mesh.morphTargetDictionary;
-
-				for ( var i = 0; i < vmd.metadata.morphCount; i ++ ) {
-
-					var morph = vmd.morphs[ i ];
-					var morphName = morph.morphName;
-					if ( morphTargetDictionary[ morphName ] === undefined ) continue;
-					morphs[ morphName ] = morphs[ morphName ] || [];
-					morphs[ morphName ].push( morph );
-
-				}
-
-				for ( var key in morphs ) {
-
-					var array = morphs[ key ];
-					array.sort( function ( a, b ) {
-
-						return a.frameNum - b.frameNum;
-
-					} );
-					var times = [];
-					var values = [];
-
-					for ( var i = 0, il = array.length; i < il; i ++ ) {
-
-						times.push( array[ i ].frameNum / 30 );
-						values.push( array[ i ].weight );
-
-					}
-
-					tracks.push( new THREE.NumberKeyframeTrack( '.morphTargetInfluences[' + morphTargetDictionary[ key ] + ']', times, values ) );
-
-				}
-
-				return new THREE.AnimationClip( '', - 1, tracks );
-
-			},
-
-			/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @return {AnimationClip}
-		 */
-			buildCameraAnimation: function ( vmd ) {
-
-				function pushVector3( array, vec ) {
-
-					array.push( vec.x );
-					array.push( vec.y );
-					array.push( vec.z );
-
-				}
-
-				function pushQuaternion( array, q ) {
-
-					array.push( q.x );
-					array.push( q.y );
-					array.push( q.z );
-					array.push( q.w );
-
-				}
-
-				function pushInterpolation( array, interpolation, index ) {
-
-					array.push( interpolation[ index * 4 + 0 ] / 127 ); // x1
-
-					array.push( interpolation[ index * 4 + 1 ] / 127 ); // x2
-
-					array.push( interpolation[ index * 4 + 2 ] / 127 ); // y1
-
-					array.push( interpolation[ index * 4 + 3 ] / 127 ); // y2
-
-				}
-
-				var tracks = [];
-				var cameras = vmd.cameras === undefined ? [] : vmd.cameras.slice();
-				cameras.sort( function ( a, b ) {
+				const array = motions[ key ];
+				array.sort( function ( a, b ) {
 
 					return a.frameNum - b.frameNum;
 
 				} );
-				var times = [];
-				var centers = [];
-				var quaternions = [];
-				var positions = [];
-				var fovs = [];
-				var cInterpolations = [];
-				var qInterpolations = [];
-				var pInterpolations = [];
-				var fInterpolations = [];
-				var quaternion = new THREE.Quaternion();
-				var euler = new THREE.Euler();
-				var position = new THREE.Vector3();
-				var center = new THREE.Vector3();
+				const times = [];
+				const positions = [];
+				const rotations = [];
+				const pInterpolations = [];
+				const rInterpolations = [];
+				const basePosition = mesh.skeleton.getBoneByName( key ).position.toArray();
 
-				for ( var i = 0, il = cameras.length; i < il; i ++ ) {
+				for ( let i = 0, il = array.length; i < il; i ++ ) {
 
-					var motion = cameras[ i ];
-					var time = motion.frameNum / 30;
-					var pos = motion.position;
-					var rot = motion.rotation;
-					var distance = motion.distance;
-					var fov = motion.fov;
-					var interpolation = motion.interpolation;
+					const time = array[ i ].frameNum / 30;
+					const position = array[ i ].position;
+					const rotation = array[ i ].rotation;
+					const interpolation = array[ i ].interpolation;
 					times.push( time );
-					position.set( 0, 0, - distance );
-					center.set( pos[ 0 ], pos[ 1 ], pos[ 2 ] );
-					euler.set( - rot[ 0 ], - rot[ 1 ], - rot[ 2 ] );
-					quaternion.setFromEuler( euler );
-					position.add( center );
-					position.applyQuaternion( quaternion );
-					pushVector3( centers, center );
-					pushQuaternion( quaternions, quaternion );
-					pushVector3( positions, position );
-					fovs.push( fov );
 
-					for ( var j = 0; j < 3; j ++ ) {
+					for ( let j = 0; j < 3; j ++ ) positions.push( basePosition[ j ] + position[ j ] );
 
-						pushInterpolation( cInterpolations, interpolation, j );
+					for ( let j = 0; j < 4; j ++ ) rotations.push( rotation[ j ] );
 
-					}
+					for ( let j = 0; j < 3; j ++ ) pushInterpolation( pInterpolations, interpolation, j );
 
-					pushInterpolation( qInterpolations, interpolation, 3 ); // use the same parameter for x, y, z axis.
-
-					for ( var j = 0; j < 3; j ++ ) {
-
-						pushInterpolation( pInterpolations, interpolation, 4 );
-
-					}
-
-					pushInterpolation( fInterpolations, interpolation, 5 );
+					pushInterpolation( rInterpolations, interpolation, 3 );
 
 				}
 
-				var tracks = []; // I expect an object whose name 'target' exists under THREE.Camera
+				const targetName = '.bones[' + key + ']';
+				tracks.push( this._createTrack( targetName + '.position', THREE.VectorKeyframeTrack, times, positions, pInterpolations ) );
+				tracks.push( this._createTrack( targetName + '.quaternion', THREE.QuaternionKeyframeTrack, times, rotations, rInterpolations ) );
 
-				tracks.push( this._createTrack( 'target.position', THREE.VectorKeyframeTrack, times, centers, cInterpolations ) );
-				tracks.push( this._createTrack( '.quaternion', THREE.QuaternionKeyframeTrack, times, quaternions, qInterpolations ) );
-				tracks.push( this._createTrack( '.position', THREE.VectorKeyframeTrack, times, positions, pInterpolations ) );
-				tracks.push( this._createTrack( '.fov', THREE.NumberKeyframeTrack, times, fovs, fInterpolations ) );
-				return new THREE.AnimationClip( '', - 1, tracks );
+			}
 
-			},
-			// private method
-			_createTrack: function ( node, typedKeyframeTrack, times, values, interpolations ) {
+			return new THREE.AnimationClip( '', - 1, tracks );
 
-				/*
+		}
+		/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
+
+
+		buildMorphAnimation( vmd, mesh ) {
+
+			const tracks = [];
+			const morphs = {};
+			const morphTargetDictionary = mesh.morphTargetDictionary;
+
+			for ( let i = 0; i < vmd.metadata.morphCount; i ++ ) {
+
+				const morph = vmd.morphs[ i ];
+				const morphName = morph.morphName;
+				if ( morphTargetDictionary[ morphName ] === undefined ) continue;
+				morphs[ morphName ] = morphs[ morphName ] || [];
+				morphs[ morphName ].push( morph );
+
+			}
+
+			for ( const key in morphs ) {
+
+				const array = morphs[ key ];
+				array.sort( function ( a, b ) {
+
+					return a.frameNum - b.frameNum;
+
+				} );
+				const times = [];
+				const values = [];
+
+				for ( let i = 0, il = array.length; i < il; i ++ ) {
+
+					times.push( array[ i ].frameNum / 30 );
+					values.push( array[ i ].weight );
+
+				}
+
+				tracks.push( new THREE.NumberKeyframeTrack( '.morphTargetInfluences[' + morphTargetDictionary[ key ] + ']', times, values ) );
+
+			}
+
+			return new THREE.AnimationClip( '', - 1, tracks );
+
+		}
+		/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @return {AnimationClip}
+	 */
+
+
+		buildCameraAnimation( vmd ) {
+
+			function pushVector3( array, vec ) {
+
+				array.push( vec.x );
+				array.push( vec.y );
+				array.push( vec.z );
+
+			}
+
+			function pushQuaternion( array, q ) {
+
+				array.push( q.x );
+				array.push( q.y );
+				array.push( q.z );
+				array.push( q.w );
+
+			}
+
+			function pushInterpolation( array, interpolation, index ) {
+
+				array.push( interpolation[ index * 4 + 0 ] / 127 ); // x1
+
+				array.push( interpolation[ index * 4 + 1 ] / 127 ); // x2
+
+				array.push( interpolation[ index * 4 + 2 ] / 127 ); // y1
+
+				array.push( interpolation[ index * 4 + 3 ] / 127 ); // y2
+
+			}
+
+			const cameras = vmd.cameras === undefined ? [] : vmd.cameras.slice();
+			cameras.sort( function ( a, b ) {
+
+				return a.frameNum - b.frameNum;
+
+			} );
+			const times = [];
+			const centers = [];
+			const quaternions = [];
+			const positions = [];
+			const fovs = [];
+			const cInterpolations = [];
+			const qInterpolations = [];
+			const pInterpolations = [];
+			const fInterpolations = [];
+			const quaternion = new THREE.Quaternion();
+			const euler = new THREE.Euler();
+			const position = new THREE.Vector3();
+			const center = new THREE.Vector3();
+
+			for ( let i = 0, il = cameras.length; i < il; i ++ ) {
+
+				const motion = cameras[ i ];
+				const time = motion.frameNum / 30;
+				const pos = motion.position;
+				const rot = motion.rotation;
+				const distance = motion.distance;
+				const fov = motion.fov;
+				const interpolation = motion.interpolation;
+				times.push( time );
+				position.set( 0, 0, - distance );
+				center.set( pos[ 0 ], pos[ 1 ], pos[ 2 ] );
+				euler.set( - rot[ 0 ], - rot[ 1 ], - rot[ 2 ] );
+				quaternion.setFromEuler( euler );
+				position.add( center );
+				position.applyQuaternion( quaternion );
+				pushVector3( centers, center );
+				pushQuaternion( quaternions, quaternion );
+				pushVector3( positions, position );
+				fovs.push( fov );
+
+				for ( let j = 0; j < 3; j ++ ) {
+
+					pushInterpolation( cInterpolations, interpolation, j );
+
+				}
+
+				pushInterpolation( qInterpolations, interpolation, 3 ); // use the same parameter for x, y, z axis.
+
+				for ( let j = 0; j < 3; j ++ ) {
+
+					pushInterpolation( pInterpolations, interpolation, 4 );
+
+				}
+
+				pushInterpolation( fInterpolations, interpolation, 5 );
+
+			}
+
+			const tracks = []; // I expect an object whose name 'target' exists under THREE.Camera
+
+			tracks.push( this._createTrack( 'target.position', THREE.VectorKeyframeTrack, times, centers, cInterpolations ) );
+			tracks.push( this._createTrack( '.quaternion', THREE.QuaternionKeyframeTrack, times, quaternions, qInterpolations ) );
+			tracks.push( this._createTrack( '.position', THREE.VectorKeyframeTrack, times, positions, pInterpolations ) );
+			tracks.push( this._createTrack( '.fov', THREE.NumberKeyframeTrack, times, fovs, fInterpolations ) );
+			return new THREE.AnimationClip( '', - 1, tracks );
+
+		} // private method
+
+
+		_createTrack( node, typedKeyframeTrack, times, values, interpolations ) {
+
+			/*
 			 * optimizes here not to let KeyframeTrackPrototype optimize
 			 * because KeyframeTrackPrototype optimizes times and values but
 			 * doesn't optimize interpolations.
 			 */
-				if ( times.length > 2 ) {
+			if ( times.length > 2 ) {
 
-					times = times.slice();
-					values = values.slice();
-					interpolations = interpolations.slice();
-					var stride = values.length / times.length;
-					var interpolateStride = interpolations.length / times.length;
-					var index = 1;
+				times = times.slice();
+				values = values.slice();
+				interpolations = interpolations.slice();
+				const stride = values.length / times.length;
+				const interpolateStride = interpolations.length / times.length;
+				let index = 1;
 
-					for ( var aheadIndex = 2, endIndex = times.length; aheadIndex < endIndex; aheadIndex ++ ) {
+				for ( let aheadIndex = 2, endIndex = times.length; aheadIndex < endIndex; aheadIndex ++ ) {
 
-						for ( var i = 0; i < stride; i ++ ) {
+					for ( let i = 0; i < stride; i ++ ) {
 
-							if ( values[ index * stride + i ] !== values[ ( index - 1 ) * stride + i ] || values[ index * stride + i ] !== values[ aheadIndex * stride + i ] ) {
+						if ( values[ index * stride + i ] !== values[ ( index - 1 ) * stride + i ] || values[ index * stride + i ] !== values[ aheadIndex * stride + i ] ) {
 
-								index ++;
-								break;
-
-							}
-
-						}
-
-						if ( aheadIndex > index ) {
-
-							times[ index ] = times[ aheadIndex ];
-
-							for ( var i = 0; i < stride; i ++ ) {
-
-								values[ index * stride + i ] = values[ aheadIndex * stride + i ];
-
-							}
-
-							for ( var i = 0; i < interpolateStride; i ++ ) {
-
-								interpolations[ index * interpolateStride + i ] = interpolations[ aheadIndex * interpolateStride + i ];
-
-							}
+							index ++;
+							break;
 
 						}
 
 					}
 
-					times.length = index + 1;
-					values.length = ( index + 1 ) * stride;
-					interpolations.length = ( index + 1 ) * interpolateStride;
+					if ( aheadIndex > index ) {
+
+						times[ index ] = times[ aheadIndex ];
+
+						for ( let i = 0; i < stride; i ++ ) {
+
+							values[ index * stride + i ] = values[ aheadIndex * stride + i ];
+
+						}
+
+						for ( let i = 0; i < interpolateStride; i ++ ) {
+
+							interpolations[ index * interpolateStride + i ] = interpolations[ aheadIndex * interpolateStride + i ];
+
+						}
+
+					}
 
 				}
 
-				var track = new typedKeyframeTrack( node, times, values );
-
-				track.createInterpolant = function InterpolantFactoryMethodCubicBezier( result ) {
-
-					return new CubicBezierInterpolation( this.times, this.values, this.getValueSize(), result, new Float32Array( interpolations ) );
-
-				};
-
-				return track;
+				times.length = index + 1;
+				values.length = ( index + 1 ) * stride;
+				interpolations.length = ( index + 1 ) * interpolateStride;
 
 			}
-		}; // interpolation
 
-		function CubicBezierInterpolation( parameterPositions, sampleValues, sampleSize, resultBuffer, params ) {
+			const track = new typedKeyframeTrack( node, times, values );
 
-			THREE.Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+			track.createInterpolant = function InterpolantFactoryMethodCubicBezier( result ) {
+
+				return new CubicBezierInterpolation( this.times, this.values, this.getValueSize(), result, new Float32Array( interpolations ) );
+
+			};
+
+			return track;
+
+		}
+
+	} // interpolation
+
+
+	class CubicBezierInterpolation extends THREE.Interpolant {
+
+		constructor( parameterPositions, sampleValues, sampleSize, resultBuffer, params ) {
+
+			super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 			this.interpolationParams = params;
 
 		}
 
-		CubicBezierInterpolation.prototype = Object.assign( Object.create( THREE.Interpolant.prototype ), {
-			constructor: CubicBezierInterpolation,
-			interpolate_: function ( i1, t0, t, t1 ) {
+		interpolate_( i1, t0, t, t1 ) {
 
-				var result = this.resultBuffer;
-				var values = this.sampleValues;
-				var stride = this.valueSize;
-				var params = this.interpolationParams;
-				var offset1 = i1 * stride;
-				var offset0 = offset1 - stride; // No interpolation if next key frame is in one frame in 30fps.
-				// This is from MMD animation spec.
-				// '1.5' is for precision loss. times are Float32 in Three.js Animation system.
+			const result = this.resultBuffer;
+			const values = this.sampleValues;
+			const stride = this.valueSize;
+			const params = this.interpolationParams;
+			const offset1 = i1 * stride;
+			const offset0 = offset1 - stride; // No interpolation if next key frame is in one frame in 30fps.
+			// This is from MMD animation spec.
+			// '1.5' is for precision loss. times are Float32 in Three.js Animation system.
 
-				var weight1 = t1 - t0 < 1 / 30 * 1.5 ? 0.0 : ( t - t0 ) / ( t1 - t0 );
+			const weight1 = t1 - t0 < 1 / 30 * 1.5 ? 0.0 : ( t - t0 ) / ( t1 - t0 );
 
-				if ( stride === 4 ) {
+			if ( stride === 4 ) {
 
-					// THREE.Quaternion
-					var x1 = params[ i1 * 4 + 0 ];
-					var x2 = params[ i1 * 4 + 1 ];
-					var y1 = params[ i1 * 4 + 2 ];
-					var y2 = params[ i1 * 4 + 3 ];
+				// THREE.Quaternion
+				const x1 = params[ i1 * 4 + 0 ];
+				const x2 = params[ i1 * 4 + 1 ];
+				const y1 = params[ i1 * 4 + 2 ];
+				const y2 = params[ i1 * 4 + 3 ];
 
-					var ratio = this._calculate( x1, x2, y1, y2, weight1 );
+				const ratio = this._calculate( x1, x2, y1, y2, weight1 );
 
-					THREE.Quaternion.slerpFlat( result, 0, values, offset0, values, offset1, ratio );
+				THREE.Quaternion.slerpFlat( result, 0, values, offset0, values, offset1, ratio );
 
-				} else if ( stride === 3 ) {
+			} else if ( stride === 3 ) {
 
-					// THREE.Vector3
-					for ( var i = 0; i !== stride; ++ i ) {
+				// THREE.Vector3
+				for ( let i = 0; i !== stride; ++ i ) {
 
-						var x1 = params[ i1 * 12 + i * 4 + 0 ];
-						var x2 = params[ i1 * 12 + i * 4 + 1 ];
-						var y1 = params[ i1 * 12 + i * 4 + 2 ];
-						var y2 = params[ i1 * 12 + i * 4 + 3 ];
+					const x1 = params[ i1 * 12 + i * 4 + 0 ];
+					const x2 = params[ i1 * 12 + i * 4 + 1 ];
+					const y1 = params[ i1 * 12 + i * 4 + 2 ];
+					const y2 = params[ i1 * 12 + i * 4 + 3 ];
 
-						var ratio = this._calculate( x1, x2, y1, y2, weight1 );
+					const ratio = this._calculate( x1, x2, y1, y2, weight1 );
 
-						result[ i ] = values[ offset0 + i ] * ( 1 - ratio ) + values[ offset1 + i ] * ratio;
-
-					}
-
-				} else {
-
-					// Number
-					var x1 = params[ i1 * 4 + 0 ];
-					var x2 = params[ i1 * 4 + 1 ];
-					var y1 = params[ i1 * 4 + 2 ];
-					var y2 = params[ i1 * 4 + 3 ];
-
-					var ratio = this._calculate( x1, x2, y1, y2, weight1 );
-
-					result[ 0 ] = values[ offset0 ] * ( 1 - ratio ) + values[ offset1 ] * ratio;
+					result[ i ] = values[ offset0 + i ] * ( 1 - ratio ) + values[ offset1 + i ] * ratio;
 
 				}
 
-				return result;
+			} else {
 
-			},
-			_calculate: function ( x1, x2, y1, y2, x ) {
+				// Number
+				const x1 = params[ i1 * 4 + 0 ];
+				const x2 = params[ i1 * 4 + 1 ];
+				const y1 = params[ i1 * 4 + 2 ];
+				const y2 = params[ i1 * 4 + 3 ];
 
-				/*
+				const ratio = this._calculate( x1, x2, y1, y2, weight1 );
+
+				result[ 0 ] = values[ offset0 ] * ( 1 - ratio ) + values[ offset1 ] * ratio;
+
+			}
+
+			return result;
+
+		}
+
+		_calculate( x1, x2, y1, y2, x ) {
+
+			/*
 			 * Cubic Bezier curves
 			 *	 https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves
 			 *
@@ -1745,34 +1767,32 @@
 			 * (Another option: Newton's method
 			 *		https://en.wikipedia.org/wiki/Newton%27s_method)
 			 */
-				var c = 0.5;
-				var t = c;
-				var s = 1.0 - t;
-				var loop = 15;
-				var eps = 1e-5;
-				var math = Math;
-				var sst3, stt3, ttt;
+			let c = 0.5;
+			let t = c;
+			let s = 1.0 - t;
+			const loop = 15;
+			const eps = 1e-5;
+			const math = Math;
+			let sst3, stt3, ttt;
 
-				for ( var i = 0; i < loop; i ++ ) {
+			for ( let i = 0; i < loop; i ++ ) {
 
-					sst3 = 3.0 * s * s * t;
-					stt3 = 3.0 * s * t * t;
-					ttt = t * t * t;
-					var ft = sst3 * x1 + stt3 * x2 + ttt - x;
-					if ( math.abs( ft ) < eps ) break;
-					c /= 2.0;
-					t += ft < 0 ? c : - c;
-					s = 1.0 - t;
-
-				}
-
-				return sst3 * y1 + stt3 * y2 + ttt;
+				sst3 = 3.0 * s * s * t;
+				stt3 = 3.0 * s * t * t;
+				ttt = t * t * t;
+				const ft = sst3 * x1 + stt3 * x2 + ttt - x;
+				if ( math.abs( ft ) < eps ) break;
+				c /= 2.0;
+				t += ft < 0 ? c : - c;
+				s = 1.0 - t;
 
 			}
-		} );
-		return MMDLoader;
 
-	}();
+			return sst3 * y1 + stt3 * y2 + ttt;
+
+		}
+
+	}
 
 	THREE.MMDLoader = MMDLoader;
 

--- a/examples/js/loaders/NRRDLoader.js
+++ b/examples/js/loaders/NRRDLoader.js
@@ -1,17 +1,17 @@
 ( function () {
 
-	var NRRDLoader = function ( manager ) {
+	class NRRDLoader extends THREE.Loader {
 
-		THREE.Loader.call( this, manager );
+		constructor( manager ) {
 
-	};
+			super( manager );
 
-	NRRDLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-		constructor: NRRDLoader,
-		load: function ( url, onLoad, onProgress, onError ) {
+		}
 
-			var scope = this;
-			var loader = new THREE.FileLoader( scope.manager );
+		load( url, onLoad, onProgress, onError ) {
+
+			const scope = this;
+			const loader = new THREE.FileLoader( scope.manager );
 			loader.setPath( scope.path );
 			loader.setResponseType( 'arraybuffer' );
 			loader.setRequestHeader( scope.requestHeader );
@@ -40,17 +40,18 @@
 
 			}, onProgress, onError );
 
-		},
-		parse: function ( data ) {
+		}
+
+		parse( data ) {
 
 			// this parser is largely inspired from the XTK NRRD parser : https://github.com/xtk/X
-			var _data = data;
-			var _dataPointer = 0;
+			let _data = data;
+			let _dataPointer = 0;
 
-			var _nativeLittleEndian = new Int8Array( new Int16Array( [ 1 ] ).buffer )[ 0 ] > 0;
+			const _nativeLittleEndian = new Int8Array( new Int16Array( [ 1 ] ).buffer )[ 0 ] > 0;
 
-			var _littleEndian = true;
-			var headerObject = {};
+			const _littleEndian = true;
+			const headerObject = {};
 
 			function scan( type, chunks ) {
 
@@ -60,8 +61,8 @@
 
 				}
 
-				var _chunkSize = 1;
-				var _array_type = Uint8Array;
+				let _chunkSize = 1;
+				let _array_type = Uint8Array;
 
 				switch ( type ) {
 
@@ -113,7 +114,7 @@
 				} // increase the data pointer in-place
 
 
-				var _bytes = new _array_type( _data.slice( _dataPointer, _dataPointer += chunks * _chunkSize ) ); // if required, flip the endianness of the bytes
+				let _bytes = new _array_type( _data.slice( _dataPointer, _dataPointer += chunks * _chunkSize ) ); // if required, flip the endianness of the bytes
 
 
 				if ( _nativeLittleEndian != _littleEndian ) {
@@ -138,13 +139,13 @@
 
 			function flipEndianness( array, chunkSize ) {
 
-				var u8 = new Uint8Array( array.buffer, array.byteOffset, array.byteLength );
+				const u8 = new Uint8Array( array.buffer, array.byteOffset, array.byteLength );
 
-				for ( var i = 0; i < array.byteLength; i += chunkSize ) {
+				for ( let i = 0; i < array.byteLength; i += chunkSize ) {
 
-					for ( var j = i + chunkSize - 1, k = i; j > k; j --, k ++ ) {
+					for ( let j = i + chunkSize - 1, k = i; j > k; j --, k ++ ) {
 
-						var tmp = u8[ k ];
+						const tmp = u8[ k ];
 						u8[ k ] = u8[ j ];
 						u8[ j ] = tmp;
 
@@ -159,9 +160,9 @@
 
 			function parseHeader( header ) {
 
-				var data, field, fn, i, l, lines, m, _i, _len;
+				let data, field, fn, i, l, m, _i, _len;
 
-				lines = header.split( /\r?\n/ );
+				const lines = header.split( /\r?\n/ );
 
 				for ( _i = 0, _len = lines.length; _i < _len; _i ++ ) {
 
@@ -175,7 +176,7 @@
 
 						field = m[ 1 ].trim();
 						data = m[ 2 ].trim();
-						fn = NRRDLoader.prototype.fieldFunctions[ field ];
+						fn = _fieldFunctions[ field ];
 
 						if ( fn ) {
 
@@ -229,17 +230,17 @@
 
 			function parseDataAsText( data, start, end ) {
 
-				var number = '';
+				let number = '';
 				start = start || 0;
 				end = end || data.length;
-				var value; //length of the result is the product of the sizes
+				let value; //length of the result is the product of the sizes
 
-				var lengthOfTheResult = headerObject.sizes.reduce( function ( previous, current ) {
+				const lengthOfTheResult = headerObject.sizes.reduce( function ( previous, current ) {
 
 					return previous * current;
 
 				}, 1 );
-				var base = 10;
+				let base = 10;
 
 				if ( headerObject.encoding === 'hex' ) {
 
@@ -247,9 +248,9 @@
 
 				}
 
-				var result = new headerObject.__array( lengthOfTheResult );
-				var resultIndex = 0;
-				var parsingFunction = parseInt;
+				const result = new headerObject.__array( lengthOfTheResult );
+				let resultIndex = 0;
+				let parsingFunction = parseInt;
 
 				if ( headerObject.__array === Float32Array || headerObject.__array === Float64Array ) {
 
@@ -257,7 +258,7 @@
 
 				}
 
-				for ( var i = start; i < end; i ++ ) {
+				for ( let i = start; i < end; i ++ ) {
 
 					value = data[ i ]; //if value is not a space
 
@@ -291,12 +292,12 @@
 
 			}
 
-			var _bytes = scan( 'uchar', data.byteLength );
+			const _bytes = scan( 'uchar', data.byteLength );
 
-			var _length = _bytes.length;
-			var _header = null;
-			var _data_start = 0;
-			var i;
+			const _length = _bytes.length;
+			let _header = null;
+			let _data_start = 0;
+			let i;
 
 			for ( i = 1; i < _length; i ++ ) {
 
@@ -315,9 +316,7 @@
 
 
 			parseHeader( _header );
-
-			var _data = _bytes.subarray( _data_start ); // the data without header
-
+			_data = _bytes.subarray( _data_start ); // the data without header
 
 			if ( headerObject.encoding.substring( 0, 2 ) === 'gz' ) {
 
@@ -332,9 +331,9 @@
 			} else if ( headerObject.encoding === 'raw' ) {
 
 				//we need to copy the array to create a new array buffer, else we retrieve the original arraybuffer with the header
-				var _copy = new Uint8Array( _data.length );
+				const _copy = new Uint8Array( _data.length );
 
-				for ( var i = 0; i < _data.length; i ++ ) {
+				for ( let i = 0; i < _data.length; i ++ ) {
 
 					_copy[ i ] = _data[ i ];
 
@@ -346,16 +345,16 @@
 
 
 			_data = _data.buffer;
-			var volume = new THREE.Volume();
+			const volume = new THREE.Volume();
 			volume.header = headerObject; //
 			// parse the (unzipped) data to a datastream of the correct type
 			//
 
 			volume.data = new headerObject.__array( _data ); // get the min and max intensities
 
-			var min_max = volume.computeMinMax();
-			var min = min_max[ 0 ];
-			var max = min_max[ 1 ]; // attach the scalar range to the volume
+			const min_max = volume.computeMinMax();
+			const min = min_max[ 0 ];
+			const max = min_max[ 1 ]; // attach the scalar range to the volume
 
 			volume.windowLow = min;
 			volume.windowHigh = max; // get the image dimensions
@@ -365,15 +364,15 @@
 			volume.yLength = volume.dimensions[ 1 ];
 			volume.zLength = volume.dimensions[ 2 ]; // spacing
 
-			var spacingX = new THREE.Vector3( headerObject.vectors[ 0 ][ 0 ], headerObject.vectors[ 0 ][ 1 ], headerObject.vectors[ 0 ][ 2 ] ).length();
-			var spacingY = new THREE.Vector3( headerObject.vectors[ 1 ][ 0 ], headerObject.vectors[ 1 ][ 1 ], headerObject.vectors[ 1 ][ 2 ] ).length();
-			var spacingZ = new THREE.Vector3( headerObject.vectors[ 2 ][ 0 ], headerObject.vectors[ 2 ][ 1 ], headerObject.vectors[ 2 ][ 2 ] ).length();
+			const spacingX = new THREE.Vector3( headerObject.vectors[ 0 ][ 0 ], headerObject.vectors[ 0 ][ 1 ], headerObject.vectors[ 0 ][ 2 ] ).length();
+			const spacingY = new THREE.Vector3( headerObject.vectors[ 1 ][ 0 ], headerObject.vectors[ 1 ][ 1 ], headerObject.vectors[ 1 ][ 2 ] ).length();
+			const spacingZ = new THREE.Vector3( headerObject.vectors[ 2 ][ 0 ], headerObject.vectors[ 2 ][ 1 ], headerObject.vectors[ 2 ][ 2 ] ).length();
 			volume.spacing = [ spacingX, spacingY, spacingZ ]; // Create IJKtoRAS matrix
 
 			volume.matrix = new THREE.Matrix4();
-			var _spaceX = 1;
-			var _spaceY = 1;
-			var _spaceZ = 1;
+			let _spaceX = 1;
+			let _spaceY = 1;
+			const _spaceZ = 1;
 
 			if ( headerObject.space == 'left-posterior-superior' ) {
 
@@ -392,7 +391,7 @@
 
 			} else {
 
-				var v = headerObject.vectors;
+				const v = headerObject.vectors;
 				volume.matrix.set( _spaceX * v[ 0 ][ 0 ], _spaceX * v[ 1 ][ 0 ], _spaceX * v[ 2 ][ 0 ], 0, _spaceY * v[ 0 ][ 1 ], _spaceY * v[ 1 ][ 1 ], _spaceY * v[ 2 ][ 1 ], 0, _spaceZ * v[ 0 ][ 2 ], _spaceZ * v[ 1 ][ 2 ], _spaceZ * v[ 2 ][ 2 ], 0, 0, 0, 0, 1 );
 
 			}
@@ -416,8 +415,9 @@
 
 			return volume;
 
-		},
-		parseChars: function ( array, start, end ) {
+		}
+
+		parseChars( array, start, end ) {
 
 			// without borders, use the whole array
 			if ( start === undefined ) {
@@ -432,9 +432,9 @@
 
 			}
 
-			var output = ''; // create and append the chars
+			let output = ''; // create and append the chars
 
-			var i = 0;
+			let i = 0;
 
 			for ( i = start; i < end; ++ i ) {
 
@@ -444,185 +444,181 @@
 
 			return output;
 
+		}
+
+	}
+
+	const _fieldFunctions = {
+		type: function ( data ) {
+
+			switch ( data ) {
+
+				case 'uchar':
+				case 'unsigned char':
+				case 'uint8':
+				case 'uint8_t':
+					this.__array = Uint8Array;
+					break;
+
+				case 'signed char':
+				case 'int8':
+				case 'int8_t':
+					this.__array = Int8Array;
+					break;
+
+				case 'short':
+				case 'short int':
+				case 'signed short':
+				case 'signed short int':
+				case 'int16':
+				case 'int16_t':
+					this.__array = Int16Array;
+					break;
+
+				case 'ushort':
+				case 'unsigned short':
+				case 'unsigned short int':
+				case 'uint16':
+				case 'uint16_t':
+					this.__array = Uint16Array;
+					break;
+
+				case 'int':
+				case 'signed int':
+				case 'int32':
+				case 'int32_t':
+					this.__array = Int32Array;
+					break;
+
+				case 'uint':
+				case 'unsigned int':
+				case 'uint32':
+				case 'uint32_t':
+					this.__array = Uint32Array;
+					break;
+
+				case 'float':
+					this.__array = Float32Array;
+					break;
+
+				case 'double':
+					this.__array = Float64Array;
+					break;
+
+				default:
+					throw new Error( 'Unsupported NRRD data type: ' + data );
+
+			}
+
+			return this.type = data;
+
 		},
-		fieldFunctions: {
-			type: function ( data ) {
+		endian: function ( data ) {
 
-				switch ( data ) {
+			return this.endian = data;
 
-					case 'uchar':
-					case 'unsigned char':
-					case 'uint8':
-					case 'uint8_t':
-						this.__array = Uint8Array;
-						break;
+		},
+		encoding: function ( data ) {
 
-					case 'signed char':
-					case 'int8':
-					case 'int8_t':
-						this.__array = Int8Array;
-						break;
+			return this.encoding = data;
 
-					case 'short':
-					case 'short int':
-					case 'signed short':
-					case 'signed short int':
-					case 'int16':
-					case 'int16_t':
-						this.__array = Int16Array;
-						break;
+		},
+		dimension: function ( data ) {
 
-					case 'ushort':
-					case 'unsigned short':
-					case 'unsigned short int':
-					case 'uint16':
-					case 'uint16_t':
-						this.__array = Uint16Array;
-						break;
+			return this.dim = parseInt( data, 10 );
 
-					case 'int':
-					case 'signed int':
-					case 'int32':
-					case 'int32_t':
-						this.__array = Int32Array;
-						break;
+		},
+		sizes: function ( data ) {
 
-					case 'uint':
-					case 'unsigned int':
-					case 'uint32':
-					case 'uint32_t':
-						this.__array = Uint32Array;
-						break;
+			let i;
+			return this.sizes = function () {
 
-					case 'float':
-						this.__array = Float32Array;
-						break;
+				const _ref = data.split( /\s+/ );
 
-					case 'double':
-						this.__array = Float64Array;
-						break;
+				const _results = [];
 
-					default:
-						throw new Error( 'Unsupported NRRD data type: ' + data );
+				for ( let _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
+
+					i = _ref[ _i ];
+
+					_results.push( parseInt( i, 10 ) );
 
 				}
 
-				return this.type = data;
+				return _results;
 
-			},
-			endian: function ( data ) {
+			}();
 
-				return this.endian = data;
+		},
+		space: function ( data ) {
 
-			},
-			encoding: function ( data ) {
+			return this.space = data;
 
-				return this.encoding = data;
+		},
+		'space origin': function ( data ) {
 
-			},
-			dimension: function ( data ) {
+			return this.space_origin = data.split( '(' )[ 1 ].split( ')' )[ 0 ].split( ',' );
 
-				return this.dim = parseInt( data, 10 );
+		},
+		'space directions': function ( data ) {
 
-			},
-			sizes: function ( data ) {
+			let f, v;
+			const parts = data.match( /\(.*?\)/g );
+			return this.vectors = function () {
 
-				var i;
-				return this.sizes = function () {
+				const _results = [];
 
-					var _i, _len, _ref, _results;
+				for ( let _i = 0, _len = parts.length; _i < _len; _i ++ ) {
 
-					_ref = data.split( /\s+/ );
-					_results = [];
+					v = parts[ _i ];
 
-					for ( _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
+					_results.push( function () {
 
-						i = _ref[ _i ];
+						const _ref = v.slice( 1, - 1 ).split( /,/ );
 
-						_results.push( parseInt( i, 10 ) );
+						const _results2 = [];
 
-					}
+						for ( let _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
 
-					return _results;
+							f = _ref[ _j ];
 
-				}();
+							_results2.push( parseFloat( f ) );
 
-			},
-			space: function ( data ) {
+						}
 
-				return this.space = data;
+						return _results2;
 
-			},
-			'space origin': function ( data ) {
+					}() );
 
-				return this.space_origin = data.split( '(' )[ 1 ].split( ')' )[ 0 ].split( ',' );
+				}
 
-			},
-			'space directions': function ( data ) {
+				return _results;
 
-				var f, parts, v;
-				parts = data.match( /\(.*?\)/g );
-				return this.vectors = function () {
+			}();
 
-					var _i, _len, _results;
+		},
+		spacings: function ( data ) {
 
-					_results = [];
+			let f;
+			const parts = data.split( /\s+/ );
+			return this.spacings = function () {
 
-					for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
+				const _results = [];
 
-						v = parts[ _i ];
+				for ( let _i = 0, _len = parts.length; _i < _len; _i ++ ) {
 
-						_results.push( function () {
+					f = parts[ _i ];
 
-							var _j, _len2, _ref, _results2;
+					_results.push( parseFloat( f ) );
 
-							_ref = v.slice( 1, - 1 ).split( /,/ );
-							_results2 = [];
+				}
 
-							for ( _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
+				return _results;
 
-								f = _ref[ _j ];
+			}();
 
-								_results2.push( parseFloat( f ) );
-
-							}
-
-							return _results2;
-
-						}() );
-
-					}
-
-					return _results;
-
-				}();
-
-			},
-			spacings: function ( data ) {
-
-				var f, parts;
-				parts = data.split( /\s+/ );
-				return this.spacings = function () {
-
-					var _i,
-						_len,
-						_results = [];
-
-					for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
-
-						f = parts[ _i ];
-
-						_results.push( parseFloat( f ) );
-
-					}
-
-					return _results;
-
-				}();
-
-			}
 		}
-	} );
+	};
 
 	THREE.NRRDLoader = NRRDLoader;
 

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -1,17 +1,17 @@
 ( function () {
 
-	var VTKLoader = function ( manager ) {
+	class VTKLoader extends THREE.Loader {
 
-		THREE.Loader.call( this, manager );
+		constructor( manager ) {
 
-	};
+			super( manager );
 
-	VTKLoader.prototype = Object.assign( Object.create( THREE.Loader.prototype ), {
-		constructor: VTKLoader,
-		load: function ( url, onLoad, onProgress, onError ) {
+		}
 
-			var scope = this;
-			var loader = new THREE.FileLoader( scope.manager );
+		load( url, onLoad, onProgress, onError ) {
+
+			const scope = this;
+			const loader = new THREE.FileLoader( scope.manager );
 			loader.setPath( scope.path );
 			loader.setResponseType( 'arraybuffer' );
 			loader.setRequestHeader( scope.requestHeader );
@@ -40,8 +40,9 @@
 
 			}, onProgress, onError );
 
-		},
-		parse: function ( data ) {
+		}
+
+		parse( data ) {
 
 			function parseASCII( data ) {
 
@@ -511,7 +512,7 @@
 
 			function Float32Concat( first, second ) {
 
-				var firstLength = first.length,
+				const firstLength = first.length,
 					result = new Float32Array( firstLength + second.length );
 				result.set( first );
 				result.set( second, firstLength );
@@ -1121,7 +1122,8 @@
 			}
 
 		}
-	} );
+
+	}
 
 	THREE.VTKLoader = VTKLoader;
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -87,19 +87,17 @@ import * as fflate from '../libs/fflate.module.min.js';
 
 // // End of OpenEXR license -------------------------------------------------
 
-var EXRLoader = function ( manager ) {
+class EXRLoader extends DataTextureLoader {
 
-	DataTextureLoader.call( this, manager );
+	constructor( manager ) {
 
-	this.type = FloatType;
+		super( manager );
 
-};
+		this.type = FloatType;
 
-EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype ), {
+	}
 
-	constructor: EXRLoader,
-
-	parse: function ( buffer ) {
+	parse( buffer ) {
 
 		const USHORT_RANGE = ( 1 << 16 );
 		const BITMAP_SIZE = ( USHORT_RANGE >> 3 );
@@ -2366,16 +2364,16 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 			type: this.type
 		};
 
-	},
+	}
 
-	setDataType: function ( value ) {
+	setDataType( value ) {
 
 		this.type = value;
 		return this;
 
-	},
+	}
 
-	load: function ( url, onLoad, onProgress, onError ) {
+	load( url, onLoad, onProgress, onError ) {
 
 		function onLoadCallback( texture, texData ) {
 
@@ -2406,10 +2404,10 @@ EXRLoader.prototype = Object.assign( Object.create( DataTextureLoader.prototype 
 
 		}
 
-		return DataTextureLoader.prototype.load.call( this, url, onLoadCallback, onProgress, onError );
+		return super.load( url, onLoadCallback, onProgress, onError );
 
 	}
 
-} );
+}
 
 export { EXRLoader };

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -62,205 +62,197 @@ import { NURBSCurve } from '../curves/NURBSCurve.js';
  */
 
 
-var FBXLoader = ( function () {
+let fbxTree;
+let connections;
+let sceneGraph;
 
-	var fbxTree;
-	var connections;
-	var sceneGraph;
+class FBXLoader extends Loader {
 
-	function FBXLoader( manager ) {
+	constructor( manager ) {
 
-		Loader.call( this, manager );
+		super( manager );
 
 	}
 
-	FBXLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	load( url, onLoad, onProgress, onError ) {
 
-		constructor: FBXLoader,
+		const scope = this;
 
-		load: function ( url, onLoad, onProgress, onError ) {
+		const path = ( scope.path === '' ) ? LoaderUtils.extractUrlBase( url ) : scope.path;
 
-			var scope = this;
+		const loader = new FileLoader( this.manager );
+		loader.setPath( scope.path );
+		loader.setResponseType( 'arraybuffer' );
+		loader.setRequestHeader( scope.requestHeader );
+		loader.setWithCredentials( scope.withCredentials );
 
-			var path = ( scope.path === '' ) ? LoaderUtils.extractUrlBase( url ) : scope.path;
+		loader.load( url, function ( buffer ) {
 
-			var loader = new FileLoader( this.manager );
-			loader.setPath( scope.path );
-			loader.setResponseType( 'arraybuffer' );
-			loader.setRequestHeader( scope.requestHeader );
-			loader.setWithCredentials( scope.withCredentials );
+			try {
 
-			loader.load( url, function ( buffer ) {
+				onLoad( scope.parse( buffer, path ) );
 
-				try {
+			} catch ( e ) {
 
-					onLoad( scope.parse( buffer, path ) );
+				if ( onError ) {
 
-				} catch ( e ) {
+					onError( e );
 
-					if ( onError ) {
+				} else {
 
-						onError( e );
-
-					} else {
-
-						console.error( e );
-
-					}
-
-					scope.manager.itemError( url );
+					console.error( e );
 
 				}
 
-			}, onProgress, onError );
-
-		},
-
-		parse: function ( FBXBuffer, path ) {
-
-			if ( isFbxFormatBinary( FBXBuffer ) ) {
-
-				fbxTree = new BinaryParser().parse( FBXBuffer );
-
-			} else {
-
-				var FBXText = convertArrayBufferToString( FBXBuffer );
-
-				if ( ! isFbxFormatASCII( FBXText ) ) {
-
-					throw new Error( 'THREE.FBXLoader: Unknown format.' );
-
-				}
-
-				if ( getFbxVersion( FBXText ) < 7000 ) {
-
-					throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + getFbxVersion( FBXText ) );
-
-				}
-
-				fbxTree = new TextParser().parse( FBXText );
+				scope.manager.itemError( url );
 
 			}
 
-			// console.log( fbxTree );
+		}, onProgress, onError );
 
-			var textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+	}
 
-			return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
+	parse( FBXBuffer, path ) {
+
+		if ( isFbxFormatBinary( FBXBuffer ) ) {
+
+			fbxTree = new BinaryParser().parse( FBXBuffer );
+
+		} else {
+
+			const FBXText = convertArrayBufferToString( FBXBuffer );
+
+			if ( ! isFbxFormatASCII( FBXText ) ) {
+
+				throw new Error( 'THREE.FBXLoader: Unknown format.' );
+
+			}
+
+			if ( getFbxVersion( FBXText ) < 7000 ) {
+
+				throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + getFbxVersion( FBXText ) );
+
+			}
+
+			fbxTree = new TextParser().parse( FBXText );
 
 		}
 
-	} );
+		// console.log( fbxTree );
 
-	// Parse the FBXTree object returned by the BinaryParser or TextParser and return a Group
-	function FBXTreeParser( textureLoader, manager ) {
+		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+
+		return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
+
+	}
+
+}
+
+// Parse the FBXTree object returned by the BinaryParser or TextParser and return a Group
+class FBXTreeParser {
+
+	constructor( textureLoader, manager ) {
 
 		this.textureLoader = textureLoader;
 		this.manager = manager;
 
 	}
 
-	FBXTreeParser.prototype = {
+	parse() {
 
-		constructor: FBXTreeParser,
+		connections = this.parseConnections();
 
-		parse: function () {
+		const images = this.parseImages();
+		const textures = this.parseTextures( images );
+		const materials = this.parseMaterials( textures );
+		const deformers = this.parseDeformers();
+		const geometryMap = new GeometryParser().parse( deformers );
 
-			connections = this.parseConnections();
+		this.parseScene( deformers, geometryMap, materials );
 
-			var images = this.parseImages();
-			var textures = this.parseTextures( images );
-			var materials = this.parseMaterials( textures );
-			var deformers = this.parseDeformers();
-			var geometryMap = new GeometryParser().parse( deformers );
+		return sceneGraph;
 
-			this.parseScene( deformers, geometryMap, materials );
+	}
 
-			return sceneGraph;
+	// Parses FBXTree.Connections which holds parent-child connections between objects (e.g. material -> texture, model->geometry )
+	// and details the connection type
+	parseConnections() {
 
-		},
+		const connectionMap = new Map();
 
-		// Parses FBXTree.Connections which holds parent-child connections between objects (e.g. material -> texture, model->geometry )
-		// and details the connection type
-		parseConnections: function () {
+		if ( 'Connections' in fbxTree ) {
 
-			var connectionMap = new Map();
+			const rawConnections = fbxTree.Connections.connections;
 
-			if ( 'Connections' in fbxTree ) {
+			rawConnections.forEach( function ( rawConnection ) {
 
-				var rawConnections = fbxTree.Connections.connections;
+				const fromID = rawConnection[ 0 ];
+				const toID = rawConnection[ 1 ];
+				const relationship = rawConnection[ 2 ];
 
-				rawConnections.forEach( function ( rawConnection ) {
+				if ( ! connectionMap.has( fromID ) ) {
 
-					var fromID = rawConnection[ 0 ];
-					var toID = rawConnection[ 1 ];
-					var relationship = rawConnection[ 2 ];
+					connectionMap.set( fromID, {
+						parents: [],
+						children: []
+					} );
 
-					if ( ! connectionMap.has( fromID ) ) {
+				}
 
-						connectionMap.set( fromID, {
-							parents: [],
-							children: []
-						} );
+				const parentRelationship = { ID: toID, relationship: relationship };
+				connectionMap.get( fromID ).parents.push( parentRelationship );
 
-					}
+				if ( ! connectionMap.has( toID ) ) {
 
-					var parentRelationship = { ID: toID, relationship: relationship };
-					connectionMap.get( fromID ).parents.push( parentRelationship );
+					connectionMap.set( toID, {
+						parents: [],
+						children: []
+					} );
 
-					if ( ! connectionMap.has( toID ) ) {
+				}
 
-						connectionMap.set( toID, {
-							parents: [],
-							children: []
-						} );
+				const childRelationship = { ID: fromID, relationship: relationship };
+				connectionMap.get( toID ).children.push( childRelationship );
 
-					}
+			} );
 
-					var childRelationship = { ID: fromID, relationship: relationship };
-					connectionMap.get( toID ).children.push( childRelationship );
+		}
 
-				} );
+		return connectionMap;
 
-			}
+	}
 
-			return connectionMap;
+	// Parse FBXTree.Objects.Video for embedded image data
+	// These images are connected to textures in FBXTree.Objects.Textures
+	// via FBXTree.Connections.
+	parseImages() {
 
-		},
+		const images = {};
+		const blobs = {};
 
-		// Parse FBXTree.Objects.Video for embedded image data
-		// These images are connected to textures in FBXTree.Objects.Textures
-		// via FBXTree.Connections.
-		parseImages: function () {
+		if ( 'Video' in fbxTree.Objects ) {
 
-			var images = {};
-			var blobs = {};
+			const videoNodes = fbxTree.Objects.Video;
 
-			if ( 'Video' in fbxTree.Objects ) {
+			for ( const nodeID in videoNodes ) {
 
-				var videoNodes = fbxTree.Objects.Video;
+				const videoNode = videoNodes[ nodeID ];
 
-				for ( var nodeID in videoNodes ) {
+				const id = parseInt( nodeID );
 
-					var videoNode = videoNodes[ nodeID ];
+				images[ id ] = videoNode.RelativeFilename || videoNode.Filename;
 
-					var id = parseInt( nodeID );
+				// raw image data is in videoNode.Content
+				if ( 'Content' in videoNode ) {
 
-					images[ id ] = videoNode.RelativeFilename || videoNode.Filename;
+					const arrayBufferContent = ( videoNode.Content instanceof ArrayBuffer ) && ( videoNode.Content.byteLength > 0 );
+					const base64Content = ( typeof videoNode.Content === 'string' ) && ( videoNode.Content !== '' );
 
-					// raw image data is in videoNode.Content
-					if ( 'Content' in videoNode ) {
+					if ( arrayBufferContent || base64Content ) {
 
-						var arrayBufferContent = ( videoNode.Content instanceof ArrayBuffer ) && ( videoNode.Content.byteLength > 0 );
-						var base64Content = ( typeof videoNode.Content === 'string' ) && ( videoNode.Content !== '' );
+						const image = this.parseImage( videoNodes[ nodeID ] );
 
-						if ( arrayBufferContent || base64Content ) {
-
-							var image = this.parseImage( videoNodes[ nodeID ] );
-
-							blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
-
-						}
+						blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
 
 					}
 
@@ -268,3046 +260,3230 @@ var FBXLoader = ( function () {
 
 			}
 
-			for ( var id in images ) {
+		}
 
-				var filename = images[ id ];
+		for ( const id in images ) {
 
-				if ( blobs[ filename ] !== undefined ) images[ id ] = blobs[ filename ];
-				else images[ id ] = images[ id ].split( '\\' ).pop();
+			const filename = images[ id ];
 
-			}
+			if ( blobs[ filename ] !== undefined ) images[ id ] = blobs[ filename ];
+			else images[ id ] = images[ id ].split( '\\' ).pop();
 
-			return images;
+		}
 
-		},
+		return images;
 
-		// Parse embedded image data in FBXTree.Video.Content
-		parseImage: function ( videoNode ) {
+	}
 
-			var content = videoNode.Content;
-			var fileName = videoNode.RelativeFilename || videoNode.Filename;
-			var extension = fileName.slice( fileName.lastIndexOf( '.' ) + 1 ).toLowerCase();
+	// Parse embedded image data in FBXTree.Video.Content
+	parseImage( videoNode ) {
 
-			var type;
+		const content = videoNode.Content;
+		const fileName = videoNode.RelativeFilename || videoNode.Filename;
+		const extension = fileName.slice( fileName.lastIndexOf( '.' ) + 1 ).toLowerCase();
 
-			switch ( extension ) {
+		let type;
 
-				case 'bmp':
+		switch ( extension ) {
 
-					type = 'image/bmp';
-					break;
+			case 'bmp':
 
-				case 'jpg':
-				case 'jpeg':
+				type = 'image/bmp';
+				break;
 
-					type = 'image/jpeg';
-					break;
+			case 'jpg':
+			case 'jpeg':
 
-				case 'png':
+				type = 'image/jpeg';
+				break;
 
-					type = 'image/png';
-					break;
+			case 'png':
 
-				case 'tif':
+				type = 'image/png';
+				break;
 
-					type = 'image/tiff';
-					break;
+			case 'tif':
 
-				case 'tga':
+				type = 'image/tiff';
+				break;
 
-					if ( this.manager.getHandler( '.tga' ) === null ) {
+			case 'tga':
 
-						console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
+				if ( this.manager.getHandler( '.tga' ) === null ) {
 
-					}
-
-					type = 'image/tga';
-					break;
-
-				default:
-
-					console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
-					return;
-
-			}
-
-			if ( typeof content === 'string' ) { // ASCII format
-
-				return 'data:' + type + ';base64,' + content;
-
-			} else { // Binary Format
-
-				var array = new Uint8Array( content );
-				return window.URL.createObjectURL( new Blob( [ array ], { type: type } ) );
-
-			}
-
-		},
-
-		// Parse nodes in FBXTree.Objects.Texture
-		// These contain details such as UV scaling, cropping, rotation etc and are connected
-		// to images in FBXTree.Objects.Video
-		parseTextures: function ( images ) {
-
-			var textureMap = new Map();
-
-			if ( 'Texture' in fbxTree.Objects ) {
-
-				var textureNodes = fbxTree.Objects.Texture;
-				for ( var nodeID in textureNodes ) {
-
-					var texture = this.parseTexture( textureNodes[ nodeID ], images );
-					textureMap.set( parseInt( nodeID ), texture );
+					console.warn( 'FBXLoader: TGA loader not found, skipping ', fileName );
 
 				}
 
-			}
+				type = 'image/tga';
+				break;
 
-			return textureMap;
+			default:
 
-		},
+				console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );
+				return;
 
-		// Parse individual node in FBXTree.Objects.Texture
-		parseTexture: function ( textureNode, images ) {
+		}
 
-			var texture = this.loadTexture( textureNode, images );
+		if ( typeof content === 'string' ) { // ASCII format
 
-			texture.ID = textureNode.id;
+			return 'data:' + type + ';base64,' + content;
 
-			texture.name = textureNode.attrName;
+		} else { // Binary Format
 
-			var wrapModeU = textureNode.WrapModeU;
-			var wrapModeV = textureNode.WrapModeV;
+			const array = new Uint8Array( content );
+			return window.URL.createObjectURL( new Blob( [ array ], { type: type } ) );
 
-			var valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
-			var valueV = wrapModeV !== undefined ? wrapModeV.value : 0;
+		}
 
-			// http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
-			// 0: repeat(default), 1: clamp
+	}
 
-			texture.wrapS = valueU === 0 ? RepeatWrapping : ClampToEdgeWrapping;
-			texture.wrapT = valueV === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+	// Parse nodes in FBXTree.Objects.Texture
+	// These contain details such as UV scaling, cropping, rotation etc and are connected
+	// to images in FBXTree.Objects.Video
+	parseTextures( images ) {
 
-			if ( 'Scaling' in textureNode ) {
+		const textureMap = new Map();
 
-				var values = textureNode.Scaling.value;
+		if ( 'Texture' in fbxTree.Objects ) {
 
-				texture.repeat.x = values[ 0 ];
-				texture.repeat.y = values[ 1 ];
+			const textureNodes = fbxTree.Objects.Texture;
+			for ( const nodeID in textureNodes ) {
 
-			}
-
-			return texture;
-
-		},
-
-		// load a texture specified as a blob or data URI, or via an external URL using TextureLoader
-		loadTexture: function ( textureNode, images ) {
-
-			var fileName;
-
-			var currentPath = this.textureLoader.path;
-
-			var children = connections.get( textureNode.id ).children;
-
-			if ( children !== undefined && children.length > 0 && images[ children[ 0 ].ID ] !== undefined ) {
-
-				fileName = images[ children[ 0 ].ID ];
-
-				if ( fileName.indexOf( 'blob:' ) === 0 || fileName.indexOf( 'data:' ) === 0 ) {
-
-					this.textureLoader.setPath( undefined );
-
-				}
+				const texture = this.parseTexture( textureNodes[ nodeID ], images );
+				textureMap.set( parseInt( nodeID ), texture );
 
 			}
 
-			var texture;
+		}
 
-			var extension = textureNode.FileName.slice( - 3 ).toLowerCase();
+		return textureMap;
 
-			if ( extension === 'tga' ) {
+	}
 
-				var loader = this.manager.getHandler( '.tga' );
+	// Parse individual node in FBXTree.Objects.Texture
+	parseTexture( textureNode, images ) {
 
-				if ( loader === null ) {
+		const texture = this.loadTexture( textureNode, images );
 
-					console.warn( 'FBXLoader: TGA loader not found, creating placeholder texture for', textureNode.RelativeFilename );
-					texture = new Texture();
+		texture.ID = textureNode.id;
 
-				} else {
+		texture.name = textureNode.attrName;
 
-					texture = loader.load( fileName );
+		const wrapModeU = textureNode.WrapModeU;
+		const wrapModeV = textureNode.WrapModeV;
 
-				}
+		const valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
+		const valueV = wrapModeV !== undefined ? wrapModeV.value : 0;
 
-			} else if ( extension === 'psd' ) {
+		// http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
+		// 0: repeat(default), 1: clamp
 
-				console.warn( 'FBXLoader: PSD textures are not supported, creating placeholder texture for', textureNode.RelativeFilename );
+		texture.wrapS = valueU === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+		texture.wrapT = valueV === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+
+		if ( 'Scaling' in textureNode ) {
+
+			const values = textureNode.Scaling.value;
+
+			texture.repeat.x = values[ 0 ];
+			texture.repeat.y = values[ 1 ];
+
+		}
+
+		return texture;
+
+	}
+
+	// load a texture specified as a blob or data URI, or via an external URL using TextureLoader
+	loadTexture( textureNode, images ) {
+
+		let fileName;
+
+		const currentPath = this.textureLoader.path;
+
+		const children = connections.get( textureNode.id ).children;
+
+		if ( children !== undefined && children.length > 0 && images[ children[ 0 ].ID ] !== undefined ) {
+
+			fileName = images[ children[ 0 ].ID ];
+
+			if ( fileName.indexOf( 'blob:' ) === 0 || fileName.indexOf( 'data:' ) === 0 ) {
+
+				this.textureLoader.setPath( undefined );
+
+			}
+
+		}
+
+		let texture;
+
+		const extension = textureNode.FileName.slice( - 3 ).toLowerCase();
+
+		if ( extension === 'tga' ) {
+
+			const loader = this.manager.getHandler( '.tga' );
+
+			if ( loader === null ) {
+
+				console.warn( 'FBXLoader: TGA loader not found, creating placeholder texture for', textureNode.RelativeFilename );
 				texture = new Texture();
 
 			} else {
 
-				texture = this.textureLoader.load( fileName );
+				texture = loader.load( fileName );
 
 			}
 
-			this.textureLoader.setPath( currentPath );
+		} else if ( extension === 'psd' ) {
 
-			return texture;
+			console.warn( 'FBXLoader: PSD textures are not supported, creating placeholder texture for', textureNode.RelativeFilename );
+			texture = new Texture();
 
-		},
+		} else {
 
-		// Parse nodes in FBXTree.Objects.Material
-		parseMaterials: function ( textureMap ) {
-
-			var materialMap = new Map();
-
-			if ( 'Material' in fbxTree.Objects ) {
-
-				var materialNodes = fbxTree.Objects.Material;
-
-				for ( var nodeID in materialNodes ) {
-
-					var material = this.parseMaterial( materialNodes[ nodeID ], textureMap );
-
-					if ( material !== null ) materialMap.set( parseInt( nodeID ), material );
-
-				}
-
-			}
-
-			return materialMap;
-
-		},
-
-		// Parse single node in FBXTree.Objects.Material
-		// Materials are connected to texture maps in FBXTree.Objects.Textures
-		// FBX format currently only supports Lambert and Phong shading models
-		parseMaterial: function ( materialNode, textureMap ) {
-
-			var ID = materialNode.id;
-			var name = materialNode.attrName;
-			var type = materialNode.ShadingModel;
-
-			// Case where FBX wraps shading model in property object.
-			if ( typeof type === 'object' ) {
-
-				type = type.value;
-
-			}
-
-			// Ignore unused materials which don't have any connections.
-			if ( ! connections.has( ID ) ) return null;
-
-			var parameters = this.parseParameters( materialNode, textureMap, ID );
-
-			var material;
-
-			switch ( type.toLowerCase() ) {
-
-				case 'phong':
-					material = new MeshPhongMaterial();
-					break;
-				case 'lambert':
-					material = new MeshLambertMaterial();
-					break;
-				default:
-					console.warn( 'THREE.FBXLoader: unknown material type "%s". Defaulting to MeshPhongMaterial.', type );
-					material = new MeshPhongMaterial();
-					break;
-
-			}
-
-			material.setValues( parameters );
-			material.name = name;
-
-			return material;
-
-		},
-
-		// Parse FBX material and return parameters suitable for a three.js material
-		// Also parse the texture map and return any textures associated with the material
-		parseParameters: function ( materialNode, textureMap, ID ) {
-
-			var parameters = {};
-
-			if ( materialNode.BumpFactor ) {
-
-				parameters.bumpScale = materialNode.BumpFactor.value;
-
-			}
-
-			if ( materialNode.Diffuse ) {
-
-				parameters.color = new Color().fromArray( materialNode.Diffuse.value );
-
-			} else if ( materialNode.DiffuseColor && ( materialNode.DiffuseColor.type === 'Color' || materialNode.DiffuseColor.type === 'ColorRGB' ) ) {
-
-				// The blender exporter exports diffuse here instead of in materialNode.Diffuse
-				parameters.color = new Color().fromArray( materialNode.DiffuseColor.value );
-
-			}
-
-			if ( materialNode.DisplacementFactor ) {
-
-				parameters.displacementScale = materialNode.DisplacementFactor.value;
-
-			}
-
-			if ( materialNode.Emissive ) {
-
-				parameters.emissive = new Color().fromArray( materialNode.Emissive.value );
-
-			} else if ( materialNode.EmissiveColor && ( materialNode.EmissiveColor.type === 'Color' || materialNode.EmissiveColor.type === 'ColorRGB' ) ) {
-
-				// The blender exporter exports emissive color here instead of in materialNode.Emissive
-				parameters.emissive = new Color().fromArray( materialNode.EmissiveColor.value );
-
-			}
-
-			if ( materialNode.EmissiveFactor ) {
-
-				parameters.emissiveIntensity = parseFloat( materialNode.EmissiveFactor.value );
-
-			}
-
-			if ( materialNode.Opacity ) {
-
-				parameters.opacity = parseFloat( materialNode.Opacity.value );
-
-			}
-
-			if ( parameters.opacity < 1.0 ) {
-
-				parameters.transparent = true;
-
-			}
-
-			if ( materialNode.ReflectionFactor ) {
-
-				parameters.reflectivity = materialNode.ReflectionFactor.value;
-
-			}
-
-			if ( materialNode.Shininess ) {
-
-				parameters.shininess = materialNode.Shininess.value;
-
-			}
-
-			if ( materialNode.Specular ) {
-
-				parameters.specular = new Color().fromArray( materialNode.Specular.value );
-
-			} else if ( materialNode.SpecularColor && materialNode.SpecularColor.type === 'Color' ) {
-
-				// The blender exporter exports specular color here instead of in materialNode.Specular
-				parameters.specular = new Color().fromArray( materialNode.SpecularColor.value );
-
-			}
-
-			var scope = this;
-			connections.get( ID ).children.forEach( function ( child ) {
-
-				var type = child.relationship;
-
-				switch ( type ) {
-
-					case 'Bump':
-						parameters.bumpMap = scope.getTexture( textureMap, child.ID );
-						break;
-
-					case 'Maya|TEX_ao_map':
-						parameters.aoMap = scope.getTexture( textureMap, child.ID );
-						break;
-
-					case 'DiffuseColor':
-					case 'Maya|TEX_color_map':
-						parameters.map = scope.getTexture( textureMap, child.ID );
-						parameters.map.encoding = sRGBEncoding;
-						break;
-
-					case 'DisplacementColor':
-						parameters.displacementMap = scope.getTexture( textureMap, child.ID );
-						break;
-
-					case 'EmissiveColor':
-						parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
-						parameters.emissiveMap.encoding = sRGBEncoding;
-						break;
-
-					case 'NormalMap':
-					case 'Maya|TEX_normal_map':
-						parameters.normalMap = scope.getTexture( textureMap, child.ID );
-						break;
-
-					case 'ReflectionColor':
-						parameters.envMap = scope.getTexture( textureMap, child.ID );
-						parameters.envMap.mapping = EquirectangularReflectionMapping;
-						parameters.envMap.encoding = sRGBEncoding;
-						break;
-
-					case 'SpecularColor':
-						parameters.specularMap = scope.getTexture( textureMap, child.ID );
-						parameters.specularMap.encoding = sRGBEncoding;
-						break;
-
-					case 'TransparentColor':
-					case 'TransparencyFactor':
-						parameters.alphaMap = scope.getTexture( textureMap, child.ID );
-						parameters.transparent = true;
-						break;
-
-					case 'AmbientColor':
-					case 'ShininessExponent': // AKA glossiness map
-					case 'SpecularFactor': // AKA specularLevel
-					case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
-					default:
-						console.warn( 'THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type );
-						break;
-
-				}
-
-			} );
-
-			return parameters;
-
-		},
-
-		// get a texture from the textureMap for use by a material.
-		getTexture: function ( textureMap, id ) {
-
-			// if the texture is a layered texture, just use the first layer and issue a warning
-			if ( 'LayeredTexture' in fbxTree.Objects && id in fbxTree.Objects.LayeredTexture ) {
-
-				console.warn( 'THREE.FBXLoader: layered textures are not supported in three.js. Discarding all but first layer.' );
-				id = connections.get( id ).children[ 0 ].ID;
-
-			}
-
-			return textureMap.get( id );
-
-		},
-
-		// Parse nodes in FBXTree.Objects.Deformer
-		// Deformer node can contain skinning or Vertex Cache animation data, however only skinning is supported here
-		// Generates map of Skeleton-like objects for use later when generating and binding skeletons.
-		parseDeformers: function () {
-
-			var skeletons = {};
-			var morphTargets = {};
-
-			if ( 'Deformer' in fbxTree.Objects ) {
-
-				var DeformerNodes = fbxTree.Objects.Deformer;
-
-				for ( var nodeID in DeformerNodes ) {
-
-					var deformerNode = DeformerNodes[ nodeID ];
-
-					var relationships = connections.get( parseInt( nodeID ) );
-
-					if ( deformerNode.attrType === 'Skin' ) {
-
-						var skeleton = this.parseSkeleton( relationships, DeformerNodes );
-						skeleton.ID = nodeID;
-
-						if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: skeleton attached to more than one geometry is not supported.' );
-						skeleton.geometryID = relationships.parents[ 0 ].ID;
-
-						skeletons[ nodeID ] = skeleton;
-
-					} else if ( deformerNode.attrType === 'BlendShape' ) {
-
-						var morphTarget = {
-							id: nodeID,
-						};
-
-						morphTarget.rawTargets = this.parseMorphTargets( relationships, DeformerNodes );
-						morphTarget.id = nodeID;
-
-						if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: morph target attached to more than one geometry is not supported.' );
-
-						morphTargets[ nodeID ] = morphTarget;
-
-					}
-
-				}
-
-			}
-
-			return {
-
-				skeletons: skeletons,
-				morphTargets: morphTargets,
-
-			};
-
-		},
-
-		// Parse single nodes in FBXTree.Objects.Deformer
-		// The top level skeleton node has type 'Skin' and sub nodes have type 'Cluster'
-		// Each skin node represents a skeleton and each cluster node represents a bone
-		parseSkeleton: function ( relationships, deformerNodes ) {
-
-			var rawBones = [];
-
-			relationships.children.forEach( function ( child ) {
-
-				var boneNode = deformerNodes[ child.ID ];
-
-				if ( boneNode.attrType !== 'Cluster' ) return;
-
-				var rawBone = {
-
-					ID: child.ID,
-					indices: [],
-					weights: [],
-					transformLink: new Matrix4().fromArray( boneNode.TransformLink.a ),
-					// transform: new Matrix4().fromArray( boneNode.Transform.a ),
-					// linkMode: boneNode.Mode,
-
-				};
-
-				if ( 'Indexes' in boneNode ) {
-
-					rawBone.indices = boneNode.Indexes.a;
-					rawBone.weights = boneNode.Weights.a;
-
-				}
-
-				rawBones.push( rawBone );
-
-			} );
-
-			return {
-
-				rawBones: rawBones,
-				bones: []
-
-			};
-
-		},
-
-		// The top level morph deformer node has type "BlendShape" and sub nodes have type "BlendShapeChannel"
-		parseMorphTargets: function ( relationships, deformerNodes ) {
-
-			var rawMorphTargets = [];
-
-			for ( var i = 0; i < relationships.children.length; i ++ ) {
-
-				var child = relationships.children[ i ];
-
-				var morphTargetNode = deformerNodes[ child.ID ];
-
-				var rawMorphTarget = {
-
-					name: morphTargetNode.attrName,
-					initialWeight: morphTargetNode.DeformPercent,
-					id: morphTargetNode.id,
-					fullWeights: morphTargetNode.FullWeights.a
-
-				};
-
-				if ( morphTargetNode.attrType !== 'BlendShapeChannel' ) return;
-
-				rawMorphTarget.geoID = connections.get( parseInt( child.ID ) ).children.filter( function ( child ) {
-
-					return child.relationship === undefined;
-
-				} )[ 0 ].ID;
-
-				rawMorphTargets.push( rawMorphTarget );
-
-			}
-
-			return rawMorphTargets;
-
-		},
-
-		// create the main Group() to be returned by the loader
-		parseScene: function ( deformers, geometryMap, materialMap ) {
-
-			sceneGraph = new Group();
-
-			var modelMap = this.parseModels( deformers.skeletons, geometryMap, materialMap );
-
-			var modelNodes = fbxTree.Objects.Model;
-
-			var scope = this;
-			modelMap.forEach( function ( model ) {
-
-				var modelNode = modelNodes[ model.ID ];
-				scope.setLookAtProperties( model, modelNode );
-
-				var parentConnections = connections.get( model.ID ).parents;
-
-				parentConnections.forEach( function ( connection ) {
-
-					var parent = modelMap.get( connection.ID );
-					if ( parent !== undefined ) parent.add( model );
-
-				} );
-
-				if ( model.parent === null ) {
-
-					sceneGraph.add( model );
-
-				}
-
-
-			} );
-
-			this.bindSkeleton( deformers.skeletons, geometryMap, modelMap );
-
-			this.createAmbientLight();
-
-			this.setupMorphMaterials();
-
-			sceneGraph.traverse( function ( node ) {
-
-				if ( node.userData.transformData ) {
-
-					if ( node.parent ) {
-
-						node.userData.transformData.parentMatrix = node.parent.matrix;
-						node.userData.transformData.parentMatrixWorld = node.parent.matrixWorld;
-
-					}
-
-					var transform = generateTransform( node.userData.transformData );
-
-					node.applyMatrix4( transform );
-					node.updateWorldMatrix();
-
-				}
-
-			} );
-
-			var animations = new AnimationParser().parse();
-
-			// if all the models where already combined in a single group, just return that
-			if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
-
-				sceneGraph.children[ 0 ].animations = animations;
-				sceneGraph = sceneGraph.children[ 0 ];
-
-			}
-
-			sceneGraph.animations = animations;
-
-		},
-
-		// parse nodes in FBXTree.Objects.Model
-		parseModels: function ( skeletons, geometryMap, materialMap ) {
-
-			var modelMap = new Map();
-			var modelNodes = fbxTree.Objects.Model;
-
-			for ( var nodeID in modelNodes ) {
-
-				var id = parseInt( nodeID );
-				var node = modelNodes[ nodeID ];
-				var relationships = connections.get( id );
-
-				var model = this.buildSkeleton( relationships, skeletons, id, node.attrName );
-
-				if ( ! model ) {
-
-					switch ( node.attrType ) {
-
-						case 'Camera':
-							model = this.createCamera( relationships );
-							break;
-						case 'Light':
-							model = this.createLight( relationships );
-							break;
-						case 'Mesh':
-							model = this.createMesh( relationships, geometryMap, materialMap );
-							break;
-						case 'NurbsCurve':
-							model = this.createCurve( relationships, geometryMap );
-							break;
-						case 'LimbNode':
-						case 'Root':
-							model = new Bone();
-							break;
-						case 'Null':
-						default:
-							model = new Group();
-							break;
-
-					}
-
-					model.name = node.attrName ? PropertyBinding.sanitizeNodeName( node.attrName ) : '';
-
-					model.ID = id;
-
-				}
-
-				this.getTransformData( model, node );
-				modelMap.set( id, model );
-
-			}
-
-			return modelMap;
-
-		},
-
-		buildSkeleton: function ( relationships, skeletons, id, name ) {
-
-			var bone = null;
-
-			relationships.parents.forEach( function ( parent ) {
-
-				for ( var ID in skeletons ) {
-
-					var skeleton = skeletons[ ID ];
-
-					skeleton.rawBones.forEach( function ( rawBone, i ) {
-
-						if ( rawBone.ID === parent.ID ) {
-
-							var subBone = bone;
-							bone = new Bone();
-
-							bone.matrixWorld.copy( rawBone.transformLink );
-
-							// set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
-
-							bone.name = name ? PropertyBinding.sanitizeNodeName( name ) : '';
-							bone.ID = id;
-
-							skeleton.bones[ i ] = bone;
-
-							// In cases where a bone is shared between multiple meshes
-							// duplicate the bone here and and it as a child of the first bone
-							if ( subBone !== null ) {
-
-								bone.add( subBone );
-
-							}
-
-						}
-
-					} );
-
-				}
-
-			} );
-
-			return bone;
-
-		},
-
-		// create a PerspectiveCamera or OrthographicCamera
-		createCamera: function ( relationships ) {
-
-			var model;
-			var cameraAttribute;
-
-			relationships.children.forEach( function ( child ) {
-
-				var attr = fbxTree.Objects.NodeAttribute[ child.ID ];
-
-				if ( attr !== undefined ) {
-
-					cameraAttribute = attr;
-
-				}
-
-			} );
-
-			if ( cameraAttribute === undefined ) {
-
-				model = new Object3D();
-
-			} else {
-
-				var type = 0;
-				if ( cameraAttribute.CameraProjectionType !== undefined && cameraAttribute.CameraProjectionType.value === 1 ) {
-
-					type = 1;
-
-				}
-
-				var nearClippingPlane = 1;
-				if ( cameraAttribute.NearPlane !== undefined ) {
-
-					nearClippingPlane = cameraAttribute.NearPlane.value / 1000;
-
-				}
-
-				var farClippingPlane = 1000;
-				if ( cameraAttribute.FarPlane !== undefined ) {
-
-					farClippingPlane = cameraAttribute.FarPlane.value / 1000;
-
-				}
-
-
-				var width = window.innerWidth;
-				var height = window.innerHeight;
-
-				if ( cameraAttribute.AspectWidth !== undefined && cameraAttribute.AspectHeight !== undefined ) {
-
-					width = cameraAttribute.AspectWidth.value;
-					height = cameraAttribute.AspectHeight.value;
-
-				}
-
-				var aspect = width / height;
-
-				var fov = 45;
-				if ( cameraAttribute.FieldOfView !== undefined ) {
-
-					fov = cameraAttribute.FieldOfView.value;
-
-				}
-
-				var focalLength = cameraAttribute.FocalLength ? cameraAttribute.FocalLength.value : null;
-
-				switch ( type ) {
-
-					case 0: // Perspective
-						model = new PerspectiveCamera( fov, aspect, nearClippingPlane, farClippingPlane );
-						if ( focalLength !== null ) model.setFocalLength( focalLength );
-						break;
-
-					case 1: // Orthographic
-						model = new OrthographicCamera( - width / 2, width / 2, height / 2, - height / 2, nearClippingPlane, farClippingPlane );
-						break;
-
-					default:
-						console.warn( 'THREE.FBXLoader: Unknown camera type ' + type + '.' );
-						model = new Object3D();
-						break;
-
-				}
-
-			}
-
-			return model;
-
-		},
-
-		// Create a DirectionalLight, PointLight or SpotLight
-		createLight: function ( relationships ) {
-
-			var model;
-			var lightAttribute;
-
-			relationships.children.forEach( function ( child ) {
-
-				var attr = fbxTree.Objects.NodeAttribute[ child.ID ];
-
-				if ( attr !== undefined ) {
-
-					lightAttribute = attr;
-
-				}
-
-			} );
-
-			if ( lightAttribute === undefined ) {
-
-				model = new Object3D();
-
-			} else {
-
-				var type;
-
-				// LightType can be undefined for Point lights
-				if ( lightAttribute.LightType === undefined ) {
-
-					type = 0;
-
-				} else {
-
-					type = lightAttribute.LightType.value;
-
-				}
-
-				var color = 0xffffff;
-
-				if ( lightAttribute.Color !== undefined ) {
-
-					color = new Color().fromArray( lightAttribute.Color.value );
-
-				}
-
-				var intensity = ( lightAttribute.Intensity === undefined ) ? 1 : lightAttribute.Intensity.value / 100;
-
-				// light disabled
-				if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0 ) {
-
-					intensity = 0;
-
-				}
-
-				var distance = 0;
-				if ( lightAttribute.FarAttenuationEnd !== undefined ) {
-
-					if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === 0 ) {
-
-						distance = 0;
-
-					} else {
-
-						distance = lightAttribute.FarAttenuationEnd.value;
-
-					}
-
-				}
-
-				// TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
-				var decay = 1;
-
-				switch ( type ) {
-
-					case 0: // Point
-						model = new PointLight( color, intensity, distance, decay );
-						break;
-
-					case 1: // Directional
-						model = new DirectionalLight( color, intensity );
-						break;
-
-					case 2: // Spot
-						var angle = Math.PI / 3;
-
-						if ( lightAttribute.InnerAngle !== undefined ) {
-
-							angle = MathUtils.degToRad( lightAttribute.InnerAngle.value );
-
-						}
-
-						var penumbra = 0;
-						if ( lightAttribute.OuterAngle !== undefined ) {
-
-							// TODO: this is not correct - FBX calculates outer and inner angle in degrees
-							// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
-							// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
-							penumbra = MathUtils.degToRad( lightAttribute.OuterAngle.value );
-							penumbra = Math.max( penumbra, 1 );
-
-						}
-
-						model = new SpotLight( color, intensity, distance, angle, penumbra, decay );
-						break;
-
-					default:
-						console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType.value + ', defaulting to a PointLight.' );
-						model = new PointLight( color, intensity );
-						break;
-
-				}
-
-				if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === 1 ) {
-
-					model.castShadow = true;
-
-				}
-
-			}
-
-			return model;
-
-		},
-
-		createMesh: function ( relationships, geometryMap, materialMap ) {
-
-			var model;
-			var geometry = null;
-			var material = null;
-			var materials = [];
-
-			// get geometry and materials(s) from connections
-			relationships.children.forEach( function ( child ) {
-
-				if ( geometryMap.has( child.ID ) ) {
-
-					geometry = geometryMap.get( child.ID );
-
-				}
-
-				if ( materialMap.has( child.ID ) ) {
-
-					materials.push( materialMap.get( child.ID ) );
-
-				}
-
-			} );
-
-			if ( materials.length > 1 ) {
-
-				material = materials;
-
-			} else if ( materials.length > 0 ) {
-
-				material = materials[ 0 ];
-
-			} else {
-
-				material = new MeshPhongMaterial( { color: 0xcccccc } );
-				materials.push( material );
-
-			}
-
-			if ( 'color' in geometry.attributes ) {
-
-				materials.forEach( function ( material ) {
-
-					material.vertexColors = true;
-
-				} );
-
-			}
-
-			if ( geometry.FBX_Deformer ) {
-
-				materials.forEach( function ( material ) {
-
-					material.skinning = true;
-
-				} );
-
-				model = new SkinnedMesh( geometry, material );
-				model.normalizeSkinWeights();
-
-			} else {
-
-				model = new Mesh( geometry, material );
-
-			}
-
-			return model;
-
-		},
-
-		createCurve: function ( relationships, geometryMap ) {
-
-			var geometry = relationships.children.reduce( function ( geo, child ) {
-
-				if ( geometryMap.has( child.ID ) ) geo = geometryMap.get( child.ID );
-
-				return geo;
-
-			}, null );
-
-			// FBX does not list materials for Nurbs lines, so we'll just put our own in here.
-			var material = new LineBasicMaterial( { color: 0x3300ff, linewidth: 1 } );
-			return new Line( geometry, material );
-
-		},
-
-		// parse the model node for transform data
-		getTransformData: function ( model, modelNode ) {
-
-			var transformData = {};
-
-			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-
-			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
-			else transformData.eulerOrder = 'ZYX';
-
-			if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
-
-			if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
-			if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
-			if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
-
-			if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
-
-			if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
-			if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
-
-			if ( 'RotationOffset' in modelNode ) transformData.rotationOffset = modelNode.RotationOffset.value;
-			if ( 'RotationPivot' in modelNode ) transformData.rotationPivot = modelNode.RotationPivot.value;
-
-			model.userData.transformData = transformData;
-
-		},
-
-		setLookAtProperties: function ( model, modelNode ) {
-
-			if ( 'LookAtProperty' in modelNode ) {
-
-				var children = connections.get( model.ID ).children;
-
-				children.forEach( function ( child ) {
-
-					if ( child.relationship === 'LookAtProperty' ) {
-
-						var lookAtTarget = fbxTree.Objects.Model[ child.ID ];
-
-						if ( 'Lcl_Translation' in lookAtTarget ) {
-
-							var pos = lookAtTarget.Lcl_Translation.value;
-
-							// DirectionalLight, SpotLight
-							if ( model.target !== undefined ) {
-
-								model.target.position.fromArray( pos );
-								sceneGraph.add( model.target );
-
-							} else { // Cameras and other Object3Ds
-
-								model.lookAt( new Vector3().fromArray( pos ) );
-
-							}
-
-						}
-
-					}
-
-				} );
-
-			}
-
-		},
-
-		bindSkeleton: function ( skeletons, geometryMap, modelMap ) {
-
-			var bindMatrices = this.parsePoseNodes();
-
-			for ( var ID in skeletons ) {
-
-				var skeleton = skeletons[ ID ];
-
-				var parents = connections.get( parseInt( skeleton.ID ) ).parents;
-
-				parents.forEach( function ( parent ) {
-
-					if ( geometryMap.has( parent.ID ) ) {
-
-						var geoID = parent.ID;
-						var geoRelationships = connections.get( geoID );
-
-						geoRelationships.parents.forEach( function ( geoConnParent ) {
-
-							if ( modelMap.has( geoConnParent.ID ) ) {
-
-								var model = modelMap.get( geoConnParent.ID );
-
-								model.bind( new Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
-
-							}
-
-						} );
-
-					}
-
-				} );
-
-			}
-
-		},
-
-		parsePoseNodes: function () {
-
-			var bindMatrices = {};
-
-			if ( 'Pose' in fbxTree.Objects ) {
-
-				var BindPoseNode = fbxTree.Objects.Pose;
-
-				for ( var nodeID in BindPoseNode ) {
-
-					if ( BindPoseNode[ nodeID ].attrType === 'BindPose' ) {
-
-						var poseNodes = BindPoseNode[ nodeID ].PoseNode;
-
-						if ( Array.isArray( poseNodes ) ) {
-
-							poseNodes.forEach( function ( poseNode ) {
-
-								bindMatrices[ poseNode.Node ] = new Matrix4().fromArray( poseNode.Matrix.a );
-
-							} );
-
-						} else {
-
-							bindMatrices[ poseNodes.Node ] = new Matrix4().fromArray( poseNodes.Matrix.a );
-
-						}
-
-					}
-
-				}
-
-			}
-
-			return bindMatrices;
-
-		},
-
-		// Parse ambient color in FBXTree.GlobalSettings - if it's not set to black (default), create an ambient light
-		createAmbientLight: function () {
-
-			if ( 'GlobalSettings' in fbxTree && 'AmbientColor' in fbxTree.GlobalSettings ) {
-
-				var ambientColor = fbxTree.GlobalSettings.AmbientColor.value;
-				var r = ambientColor[ 0 ];
-				var g = ambientColor[ 1 ];
-				var b = ambientColor[ 2 ];
-
-				if ( r !== 0 || g !== 0 || b !== 0 ) {
-
-					var color = new Color( r, g, b );
-					sceneGraph.add( new AmbientLight( color, 1 ) );
-
-				}
-
-			}
-
-		},
-
-		setupMorphMaterials: function () {
-
-			var scope = this;
-			sceneGraph.traverse( function ( child ) {
-
-				if ( child.isMesh ) {
-
-					if ( child.geometry.morphAttributes.position && child.geometry.morphAttributes.position.length ) {
-
-						if ( Array.isArray( child.material ) ) {
-
-							child.material.forEach( function ( material, i ) {
-
-								scope.setupMorphMaterial( child, material, i );
-
-							} );
-
-						} else {
-
-							scope.setupMorphMaterial( child, child.material );
-
-						}
-
-					}
-
-				}
-
-			} );
-
-		},
-
-		setupMorphMaterial: function ( child, material, index ) {
-
-			var uuid = child.uuid;
-			var matUuid = material.uuid;
-
-			// if a geometry has morph targets, it cannot share the material with other geometries
-			var sharedMat = false;
-
-			sceneGraph.traverse( function ( node ) {
-
-				if ( node.isMesh ) {
-
-					if ( Array.isArray( node.material ) ) {
-
-						node.material.forEach( function ( mat ) {
-
-							if ( mat.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-						} );
-
-					} else if ( node.material.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-				}
-
-			} );
-
-			if ( sharedMat === true ) {
-
-				var clonedMat = material.clone();
-				clonedMat.morphTargets = true;
-
-				if ( index === undefined ) child.material = clonedMat;
-				else child.material[ index ] = clonedMat;
-
-			} else material.morphTargets = true;
+			texture = this.textureLoader.load( fileName );
 
 		}
 
-	};
+		this.textureLoader.setPath( currentPath );
 
-	// parse Geometry data from FBXTree and return map of BufferGeometries
-	function GeometryParser() {}
+		return texture;
 
-	GeometryParser.prototype = {
+	}
 
-		constructor: GeometryParser,
+	// Parse nodes in FBXTree.Objects.Material
+	parseMaterials( textureMap ) {
 
-		// Parse nodes in FBXTree.Objects.Geometry
-		parse: function ( deformers ) {
+		const materialMap = new Map();
 
-			var geometryMap = new Map();
+		if ( 'Material' in fbxTree.Objects ) {
 
-			if ( 'Geometry' in fbxTree.Objects ) {
+			const materialNodes = fbxTree.Objects.Material;
 
-				var geoNodes = fbxTree.Objects.Geometry;
+			for ( const nodeID in materialNodes ) {
 
-				for ( var nodeID in geoNodes ) {
+				const material = this.parseMaterial( materialNodes[ nodeID ], textureMap );
 
-					var relationships = connections.get( parseInt( nodeID ) );
-					var geo = this.parseGeometry( relationships, geoNodes[ nodeID ], deformers );
-
-					geometryMap.set( parseInt( nodeID ), geo );
-
-				}
+				if ( material !== null ) materialMap.set( parseInt( nodeID ), material );
 
 			}
 
-			return geometryMap;
+		}
 
-		},
+		return materialMap;
 
-		// Parse single node in FBXTree.Objects.Geometry
-		parseGeometry: function ( relationships, geoNode, deformers ) {
+	}
 
-			switch ( geoNode.attrType ) {
+	// Parse single node in FBXTree.Objects.Material
+	// Materials are connected to texture maps in FBXTree.Objects.Textures
+	// FBX format currently only supports Lambert and Phong shading models
+	parseMaterial( materialNode, textureMap ) {
 
-				case 'Mesh':
-					return this.parseMeshGeometry( relationships, geoNode, deformers );
+		const ID = materialNode.id;
+		const name = materialNode.attrName;
+		let type = materialNode.ShadingModel;
+
+		// Case where FBX wraps shading model in property object.
+		if ( typeof type === 'object' ) {
+
+			type = type.value;
+
+		}
+
+		// Ignore unused materials which don't have any connections.
+		if ( ! connections.has( ID ) ) return null;
+
+		const parameters = this.parseParameters( materialNode, textureMap, ID );
+
+		let material;
+
+		switch ( type.toLowerCase() ) {
+
+			case 'phong':
+				material = new MeshPhongMaterial();
+				break;
+			case 'lambert':
+				material = new MeshLambertMaterial();
+				break;
+			default:
+				console.warn( 'THREE.FBXLoader: unknown material type "%s". Defaulting to MeshPhongMaterial.', type );
+				material = new MeshPhongMaterial();
+				break;
+
+		}
+
+		material.setValues( parameters );
+		material.name = name;
+
+		return material;
+
+	}
+
+	// Parse FBX material and return parameters suitable for a three.js material
+	// Also parse the texture map and return any textures associated with the material
+	parseParameters( materialNode, textureMap, ID ) {
+
+		const parameters = {};
+
+		if ( materialNode.BumpFactor ) {
+
+			parameters.bumpScale = materialNode.BumpFactor.value;
+
+		}
+
+		if ( materialNode.Diffuse ) {
+
+			parameters.color = new Color().fromArray( materialNode.Diffuse.value );
+
+		} else if ( materialNode.DiffuseColor && ( materialNode.DiffuseColor.type === 'Color' || materialNode.DiffuseColor.type === 'ColorRGB' ) ) {
+
+			// The blender exporter exports diffuse here instead of in materialNode.Diffuse
+			parameters.color = new Color().fromArray( materialNode.DiffuseColor.value );
+
+		}
+
+		if ( materialNode.DisplacementFactor ) {
+
+			parameters.displacementScale = materialNode.DisplacementFactor.value;
+
+		}
+
+		if ( materialNode.Emissive ) {
+
+			parameters.emissive = new Color().fromArray( materialNode.Emissive.value );
+
+		} else if ( materialNode.EmissiveColor && ( materialNode.EmissiveColor.type === 'Color' || materialNode.EmissiveColor.type === 'ColorRGB' ) ) {
+
+			// The blender exporter exports emissive color here instead of in materialNode.Emissive
+			parameters.emissive = new Color().fromArray( materialNode.EmissiveColor.value );
+
+		}
+
+		if ( materialNode.EmissiveFactor ) {
+
+			parameters.emissiveIntensity = parseFloat( materialNode.EmissiveFactor.value );
+
+		}
+
+		if ( materialNode.Opacity ) {
+
+			parameters.opacity = parseFloat( materialNode.Opacity.value );
+
+		}
+
+		if ( parameters.opacity < 1.0 ) {
+
+			parameters.transparent = true;
+
+		}
+
+		if ( materialNode.ReflectionFactor ) {
+
+			parameters.reflectivity = materialNode.ReflectionFactor.value;
+
+		}
+
+		if ( materialNode.Shininess ) {
+
+			parameters.shininess = materialNode.Shininess.value;
+
+		}
+
+		if ( materialNode.Specular ) {
+
+			parameters.specular = new Color().fromArray( materialNode.Specular.value );
+
+		} else if ( materialNode.SpecularColor && materialNode.SpecularColor.type === 'Color' ) {
+
+			// The blender exporter exports specular color here instead of in materialNode.Specular
+			parameters.specular = new Color().fromArray( materialNode.SpecularColor.value );
+
+		}
+
+		const scope = this;
+		connections.get( ID ).children.forEach( function ( child ) {
+
+			const type = child.relationship;
+
+			switch ( type ) {
+
+				case 'Bump':
+					parameters.bumpMap = scope.getTexture( textureMap, child.ID );
 					break;
 
-				case 'NurbsCurve':
-					return this.parseNurbsGeometry( geoNode );
+				case 'Maya|TEX_ao_map':
+					parameters.aoMap = scope.getTexture( textureMap, child.ID );
+					break;
+
+				case 'DiffuseColor':
+				case 'Maya|TEX_color_map':
+					parameters.map = scope.getTexture( textureMap, child.ID );
+					parameters.map.encoding = sRGBEncoding;
+					break;
+
+				case 'DisplacementColor':
+					parameters.displacementMap = scope.getTexture( textureMap, child.ID );
+					break;
+
+				case 'EmissiveColor':
+					parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
+					parameters.emissiveMap.encoding = sRGBEncoding;
+					break;
+
+				case 'NormalMap':
+				case 'Maya|TEX_normal_map':
+					parameters.normalMap = scope.getTexture( textureMap, child.ID );
+					break;
+
+				case 'ReflectionColor':
+					parameters.envMap = scope.getTexture( textureMap, child.ID );
+					parameters.envMap.mapping = EquirectangularReflectionMapping;
+					parameters.envMap.encoding = sRGBEncoding;
+					break;
+
+				case 'SpecularColor':
+					parameters.specularMap = scope.getTexture( textureMap, child.ID );
+					parameters.specularMap.encoding = sRGBEncoding;
+					break;
+
+				case 'TransparentColor':
+				case 'TransparencyFactor':
+					parameters.alphaMap = scope.getTexture( textureMap, child.ID );
+					parameters.transparent = true;
+					break;
+
+				case 'AmbientColor':
+				case 'ShininessExponent': // AKA glossiness map
+				case 'SpecularFactor': // AKA specularLevel
+				case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
+				default:
+					console.warn( 'THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type );
 					break;
 
 			}
 
-		},
+		} );
 
+		return parameters;
 
-		// Parse single node mesh geometry in FBXTree.Objects.Geometry
-		parseMeshGeometry: function ( relationships, geoNode, deformers ) {
+	}
 
-			var skeletons = deformers.skeletons;
-			var morphTargets = [];
+	// get a texture from the textureMap for use by a material.
+	getTexture( textureMap, id ) {
 
-			var modelNodes = relationships.parents.map( function ( parent ) {
+		// if the texture is a layered texture, just use the first layer and issue a warning
+		if ( 'LayeredTexture' in fbxTree.Objects && id in fbxTree.Objects.LayeredTexture ) {
 
-				return fbxTree.Objects.Model[ parent.ID ];
+			console.warn( 'THREE.FBXLoader: layered textures are not supported in three.js. Discarding all but first layer.' );
+			id = connections.get( id ).children[ 0 ].ID;
+
+		}
+
+		return textureMap.get( id );
+
+	}
+
+	// Parse nodes in FBXTree.Objects.Deformer
+	// Deformer node can contain skinning or Vertex Cache animation data, however only skinning is supported here
+	// Generates map of Skeleton-like objects for use later when generating and binding skeletons.
+	parseDeformers() {
+
+		const skeletons = {};
+		const morphTargets = {};
+
+		if ( 'Deformer' in fbxTree.Objects ) {
+
+			const DeformerNodes = fbxTree.Objects.Deformer;
+
+			for ( const nodeID in DeformerNodes ) {
+
+				const deformerNode = DeformerNodes[ nodeID ];
+
+				const relationships = connections.get( parseInt( nodeID ) );
+
+				if ( deformerNode.attrType === 'Skin' ) {
+
+					const skeleton = this.parseSkeleton( relationships, DeformerNodes );
+					skeleton.ID = nodeID;
+
+					if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: skeleton attached to more than one geometry is not supported.' );
+					skeleton.geometryID = relationships.parents[ 0 ].ID;
+
+					skeletons[ nodeID ] = skeleton;
+
+				} else if ( deformerNode.attrType === 'BlendShape' ) {
+
+					const morphTarget = {
+						id: nodeID,
+					};
+
+					morphTarget.rawTargets = this.parseMorphTargets( relationships, DeformerNodes );
+					morphTarget.id = nodeID;
+
+					if ( relationships.parents.length > 1 ) console.warn( 'THREE.FBXLoader: morph target attached to more than one geometry is not supported.' );
+
+					morphTargets[ nodeID ] = morphTarget;
+
+				}
+
+			}
+
+		}
+
+		return {
+
+			skeletons: skeletons,
+			morphTargets: morphTargets,
+
+		};
+
+	}
+
+	// Parse single nodes in FBXTree.Objects.Deformer
+	// The top level skeleton node has type 'Skin' and sub nodes have type 'Cluster'
+	// Each skin node represents a skeleton and each cluster node represents a bone
+	parseSkeleton( relationships, deformerNodes ) {
+
+		const rawBones = [];
+
+		relationships.children.forEach( function ( child ) {
+
+			const boneNode = deformerNodes[ child.ID ];
+
+			if ( boneNode.attrType !== 'Cluster' ) return;
+
+			const rawBone = {
+
+				ID: child.ID,
+				indices: [],
+				weights: [],
+				transformLink: new Matrix4().fromArray( boneNode.TransformLink.a ),
+				// transform: new Matrix4().fromArray( boneNode.Transform.a ),
+				// linkMode: boneNode.Mode,
+
+			};
+
+			if ( 'Indexes' in boneNode ) {
+
+				rawBone.indices = boneNode.Indexes.a;
+				rawBone.weights = boneNode.Weights.a;
+
+			}
+
+			rawBones.push( rawBone );
+
+		} );
+
+		return {
+
+			rawBones: rawBones,
+			bones: []
+
+		};
+
+	}
+
+	// The top level morph deformer node has type "BlendShape" and sub nodes have type "BlendShapeChannel"
+	parseMorphTargets( relationships, deformerNodes ) {
+
+		const rawMorphTargets = [];
+
+		for ( let i = 0; i < relationships.children.length; i ++ ) {
+
+			const child = relationships.children[ i ];
+
+			const morphTargetNode = deformerNodes[ child.ID ];
+
+			const rawMorphTarget = {
+
+				name: morphTargetNode.attrName,
+				initialWeight: morphTargetNode.DeformPercent,
+				id: morphTargetNode.id,
+				fullWeights: morphTargetNode.FullWeights.a
+
+			};
+
+			if ( morphTargetNode.attrType !== 'BlendShapeChannel' ) return;
+
+			rawMorphTarget.geoID = connections.get( parseInt( child.ID ) ).children.filter( function ( child ) {
+
+				return child.relationship === undefined;
+
+			} )[ 0 ].ID;
+
+			rawMorphTargets.push( rawMorphTarget );
+
+		}
+
+		return rawMorphTargets;
+
+	}
+
+	// create the main Group() to be returned by the loader
+	parseScene( deformers, geometryMap, materialMap ) {
+
+		sceneGraph = new Group();
+
+		const modelMap = this.parseModels( deformers.skeletons, geometryMap, materialMap );
+
+		const modelNodes = fbxTree.Objects.Model;
+
+		const scope = this;
+		modelMap.forEach( function ( model ) {
+
+			const modelNode = modelNodes[ model.ID ];
+			scope.setLookAtProperties( model, modelNode );
+
+			const parentConnections = connections.get( model.ID ).parents;
+
+			parentConnections.forEach( function ( connection ) {
+
+				const parent = modelMap.get( connection.ID );
+				if ( parent !== undefined ) parent.add( model );
 
 			} );
 
-			// don't create geometry if it is not associated with any models
-			if ( modelNodes.length === 0 ) return;
+			if ( model.parent === null ) {
 
-			var skeleton = relationships.children.reduce( function ( skeleton, child ) {
+				sceneGraph.add( model );
 
-				if ( skeletons[ child.ID ] !== undefined ) skeleton = skeletons[ child.ID ];
+			}
 
-				return skeleton;
 
-			}, null );
+		} );
 
-			relationships.children.forEach( function ( child ) {
+		this.bindSkeleton( deformers.skeletons, geometryMap, modelMap );
 
-				if ( deformers.morphTargets[ child.ID ] !== undefined ) {
+		this.createAmbientLight();
 
-					morphTargets.push( deformers.morphTargets[ child.ID ] );
+		this.setupMorphMaterials();
+
+		sceneGraph.traverse( function ( node ) {
+
+			if ( node.userData.transformData ) {
+
+				if ( node.parent ) {
+
+					node.userData.transformData.parentMatrix = node.parent.matrix;
+					node.userData.transformData.parentMatrixWorld = node.parent.matrixWorld;
 
 				}
 
-			} );
+				const transform = generateTransform( node.userData.transformData );
 
-			// Assume one model and get the preRotation from that
-			// if there is more than one model associated with the geometry this may cause problems
-			var modelNode = modelNodes[ 0 ];
-
-			var transformData = {};
-
-			if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
-			if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
-
-			if ( 'GeometricTranslation' in modelNode ) transformData.translation = modelNode.GeometricTranslation.value;
-			if ( 'GeometricRotation' in modelNode ) transformData.rotation = modelNode.GeometricRotation.value;
-			if ( 'GeometricScaling' in modelNode ) transformData.scale = modelNode.GeometricScaling.value;
-
-			var transform = generateTransform( transformData );
-
-			return this.genGeometry( geoNode, skeleton, morphTargets, transform );
-
-		},
-
-		// Generate a BufferGeometry from a node in FBXTree.Objects.Geometry
-		genGeometry: function ( geoNode, skeleton, morphTargets, preTransform ) {
-
-			var geo = new BufferGeometry();
-			if ( geoNode.attrName ) geo.name = geoNode.attrName;
-
-			var geoInfo = this.parseGeoNode( geoNode, skeleton );
-			var buffers = this.genBuffers( geoInfo );
-
-			var positionAttribute = new Float32BufferAttribute( buffers.vertex, 3 );
-
-			positionAttribute.applyMatrix4( preTransform );
-
-			geo.setAttribute( 'position', positionAttribute );
-
-			if ( buffers.colors.length > 0 ) {
-
-				geo.setAttribute( 'color', new Float32BufferAttribute( buffers.colors, 3 ) );
+				node.applyMatrix4( transform );
+				node.updateWorldMatrix();
 
 			}
 
-			if ( skeleton ) {
+		} );
 
-				geo.setAttribute( 'skinIndex', new Uint16BufferAttribute( buffers.weightsIndices, 4 ) );
+		const animations = new AnimationParser().parse();
 
-				geo.setAttribute( 'skinWeight', new Float32BufferAttribute( buffers.vertexWeights, 4 ) );
+		// if all the models where already combined in a single group, just return that
+		if ( sceneGraph.children.length === 1 && sceneGraph.children[ 0 ].isGroup ) {
 
-				// used later to bind the skeleton to the model
-				geo.FBX_Deformer = skeleton;
+			sceneGraph.children[ 0 ].animations = animations;
+			sceneGraph = sceneGraph.children[ 0 ];
 
-			}
+		}
 
-			if ( buffers.normal.length > 0 ) {
+		sceneGraph.animations = animations;
 
-				var normalMatrix = new Matrix3().getNormalMatrix( preTransform );
+	}
 
-				var normalAttribute = new Float32BufferAttribute( buffers.normal, 3 );
-				normalAttribute.applyNormalMatrix( normalMatrix );
+	// parse nodes in FBXTree.Objects.Model
+	parseModels( skeletons, geometryMap, materialMap ) {
 
-				geo.setAttribute( 'normal', normalAttribute );
+		const modelMap = new Map();
+		const modelNodes = fbxTree.Objects.Model;
 
-			}
+		for ( const nodeID in modelNodes ) {
 
-			buffers.uvs.forEach( function ( uvBuffer, i ) {
+			const id = parseInt( nodeID );
+			const node = modelNodes[ nodeID ];
+			const relationships = connections.get( id );
 
-				// subsequent uv buffers are called 'uv1', 'uv2', ...
-				var name = 'uv' + ( i + 1 ).toString();
+			let model = this.buildSkeleton( relationships, skeletons, id, node.attrName );
 
-				// the first uv buffer is just called 'uv'
-				if ( i === 0 ) {
+			if ( ! model ) {
 
-					name = 'uv';
+				switch ( node.attrType ) {
+
+					case 'Camera':
+						model = this.createCamera( relationships );
+						break;
+					case 'Light':
+						model = this.createLight( relationships );
+						break;
+					case 'Mesh':
+						model = this.createMesh( relationships, geometryMap, materialMap );
+						break;
+					case 'NurbsCurve':
+						model = this.createCurve( relationships, geometryMap );
+						break;
+					case 'LimbNode':
+					case 'Root':
+						model = new Bone();
+						break;
+					case 'Null':
+					default:
+						model = new Group();
+						break;
 
 				}
 
-				geo.setAttribute( name, new Float32BufferAttribute( buffers.uvs[ i ], 2 ) );
+				model.name = node.attrName ? PropertyBinding.sanitizeNodeName( node.attrName ) : '';
 
-			} );
-
-			if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
-
-				// Convert the material indices of each vertex into rendering groups on the geometry.
-				var prevMaterialIndex = buffers.materialIndex[ 0 ];
-				var startIndex = 0;
-
-				buffers.materialIndex.forEach( function ( currentIndex, i ) {
-
-					if ( currentIndex !== prevMaterialIndex ) {
-
-						geo.addGroup( startIndex, i - startIndex, prevMaterialIndex );
-
-						prevMaterialIndex = currentIndex;
-						startIndex = i;
-
-					}
-
-				} );
-
-				// the loop above doesn't add the last group, do that here.
-				if ( geo.groups.length > 0 ) {
-
-					var lastGroup = geo.groups[ geo.groups.length - 1 ];
-					var lastIndex = lastGroup.start + lastGroup.count;
-
-					if ( lastIndex !== buffers.materialIndex.length ) {
-
-						geo.addGroup( lastIndex, buffers.materialIndex.length - lastIndex, prevMaterialIndex );
-
-					}
-
-				}
-
-				// case where there are multiple materials but the whole geometry is only
-				// using one of them
-				if ( geo.groups.length === 0 ) {
-
-					geo.addGroup( 0, buffers.materialIndex.length, buffers.materialIndex[ 0 ] );
-
-				}
+				model.ID = id;
 
 			}
 
-			this.addMorphTargets( geo, geoNode, morphTargets, preTransform );
+			this.getTransformData( model, node );
+			modelMap.set( id, model );
 
-			return geo;
+		}
 
-		},
+		return modelMap;
 
-		parseGeoNode: function ( geoNode, skeleton ) {
+	}
 
-			var geoInfo = {};
+	buildSkeleton( relationships, skeletons, id, name ) {
 
-			geoInfo.vertexPositions = ( geoNode.Vertices !== undefined ) ? geoNode.Vertices.a : [];
-			geoInfo.vertexIndices = ( geoNode.PolygonVertexIndex !== undefined ) ? geoNode.PolygonVertexIndex.a : [];
+		let bone = null;
 
-			if ( geoNode.LayerElementColor ) {
+		relationships.parents.forEach( function ( parent ) {
 
-				geoInfo.color = this.parseVertexColors( geoNode.LayerElementColor[ 0 ] );
+			for ( const ID in skeletons ) {
 
-			}
-
-			if ( geoNode.LayerElementMaterial ) {
-
-				geoInfo.material = this.parseMaterialIndices( geoNode.LayerElementMaterial[ 0 ] );
-
-			}
-
-			if ( geoNode.LayerElementNormal ) {
-
-				geoInfo.normal = this.parseNormals( geoNode.LayerElementNormal[ 0 ] );
-
-			}
-
-			if ( geoNode.LayerElementUV ) {
-
-				geoInfo.uv = [];
-
-				var i = 0;
-				while ( geoNode.LayerElementUV[ i ] ) {
-
-					if ( geoNode.LayerElementUV[ i ].UV ) {
-
-						geoInfo.uv.push( this.parseUVs( geoNode.LayerElementUV[ i ] ) );
-
-					}
-
-					i ++;
-
-				}
-
-			}
-
-			geoInfo.weightTable = {};
-
-			if ( skeleton !== null ) {
-
-				geoInfo.skeleton = skeleton;
+				const skeleton = skeletons[ ID ];
 
 				skeleton.rawBones.forEach( function ( rawBone, i ) {
 
-					// loop over the bone's vertex indices and weights
-					rawBone.indices.forEach( function ( index, j ) {
+					if ( rawBone.ID === parent.ID ) {
 
-						if ( geoInfo.weightTable[ index ] === undefined ) geoInfo.weightTable[ index ] = [];
+						const subBone = bone;
+						bone = new Bone();
 
-						geoInfo.weightTable[ index ].push( {
+						bone.matrixWorld.copy( rawBone.transformLink );
 
-							id: i,
-							weight: rawBone.weights[ j ],
+						// set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
 
-						} );
+						bone.name = name ? PropertyBinding.sanitizeNodeName( name ) : '';
+						bone.ID = id;
 
-					} );
+						skeleton.bones[ i ] = bone;
+
+						// In cases where a bone is shared between multiple meshes
+						// duplicate the bone here and and it as a child of the first bone
+						if ( subBone !== null ) {
+
+							bone.add( subBone );
+
+						}
+
+					}
 
 				} );
 
 			}
 
-			return geoInfo;
+		} );
 
-		},
+		return bone;
 
-		genBuffers: function ( geoInfo ) {
+	}
 
-			var buffers = {
-				vertex: [],
-				normal: [],
-				colors: [],
-				uvs: [],
-				materialIndex: [],
-				vertexWeights: [],
-				weightsIndices: [],
-			};
+	// create a PerspectiveCamera or OrthographicCamera
+	createCamera( relationships ) {
 
-			var polygonIndex = 0;
-			var faceLength = 0;
-			var displayedWeightsWarning = false;
+		let model;
+		let cameraAttribute;
 
-			// these will hold data for a single face
-			var facePositionIndexes = [];
-			var faceNormals = [];
-			var faceColors = [];
-			var faceUVs = [];
-			var faceWeights = [];
-			var faceWeightIndices = [];
+		relationships.children.forEach( function ( child ) {
 
-			var scope = this;
-			geoInfo.vertexIndices.forEach( function ( vertexIndex, polygonVertexIndex ) {
+			const attr = fbxTree.Objects.NodeAttribute[ child.ID ];
 
-				var endOfFace = false;
+			if ( attr !== undefined ) {
 
-				// Face index and vertex index arrays are combined in a single array
-				// A cube with quad faces looks like this:
-				// PolygonVertexIndex: *24 {
-				//  a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
-				//  }
-				// Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
-				// to find index of last vertex bit shift the index: ^ - 1
-				if ( vertexIndex < 0 ) {
+				cameraAttribute = attr;
 
-					vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
-					endOfFace = true;
+			}
 
-				}
+		} );
 
-				var weightIndices = [];
-				var weights = [];
+		if ( cameraAttribute === undefined ) {
 
-				facePositionIndexes.push( vertexIndex * 3, vertexIndex * 3 + 1, vertexIndex * 3 + 2 );
+			model = new Object3D();
 
-				if ( geoInfo.color ) {
+		} else {
 
-					var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.color );
+			let type = 0;
+			if ( cameraAttribute.CameraProjectionType !== undefined && cameraAttribute.CameraProjectionType.value === 1 ) {
 
-					faceColors.push( data[ 0 ], data[ 1 ], data[ 2 ] );
+				type = 1;
 
-				}
+			}
 
-				if ( geoInfo.skeleton ) {
+			let nearClippingPlane = 1;
+			if ( cameraAttribute.NearPlane !== undefined ) {
 
-					if ( geoInfo.weightTable[ vertexIndex ] !== undefined ) {
+				nearClippingPlane = cameraAttribute.NearPlane.value / 1000;
 
-						geoInfo.weightTable[ vertexIndex ].forEach( function ( wt ) {
+			}
 
-							weights.push( wt.weight );
-							weightIndices.push( wt.id );
+			let farClippingPlane = 1000;
+			if ( cameraAttribute.FarPlane !== undefined ) {
 
-						} );
+				farClippingPlane = cameraAttribute.FarPlane.value / 1000;
 
+			}
 
-					}
 
-					if ( weights.length > 4 ) {
+			let width = window.innerWidth;
+			let height = window.innerHeight;
 
-						if ( ! displayedWeightsWarning ) {
+			if ( cameraAttribute.AspectWidth !== undefined && cameraAttribute.AspectHeight !== undefined ) {
 
-							console.warn( 'THREE.FBXLoader: Vertex has more than 4 skinning weights assigned to vertex. Deleting additional weights.' );
-							displayedWeightsWarning = true;
+				width = cameraAttribute.AspectWidth.value;
+				height = cameraAttribute.AspectHeight.value;
 
-						}
+			}
 
-						var wIndex = [ 0, 0, 0, 0 ];
-						var Weight = [ 0, 0, 0, 0 ];
+			const aspect = width / height;
 
-						weights.forEach( function ( weight, weightIndex ) {
+			let fov = 45;
+			if ( cameraAttribute.FieldOfView !== undefined ) {
 
-							var currentWeight = weight;
-							var currentIndex = weightIndices[ weightIndex ];
+				fov = cameraAttribute.FieldOfView.value;
 
-							Weight.forEach( function ( comparedWeight, comparedWeightIndex, comparedWeightArray ) {
+			}
 
-								if ( currentWeight > comparedWeight ) {
+			const focalLength = cameraAttribute.FocalLength ? cameraAttribute.FocalLength.value : null;
 
-									comparedWeightArray[ comparedWeightIndex ] = currentWeight;
-									currentWeight = comparedWeight;
+			switch ( type ) {
 
-									var tmp = wIndex[ comparedWeightIndex ];
-									wIndex[ comparedWeightIndex ] = currentIndex;
-									currentIndex = tmp;
+				case 0: // Perspective
+					model = new PerspectiveCamera( fov, aspect, nearClippingPlane, farClippingPlane );
+					if ( focalLength !== null ) model.setFocalLength( focalLength );
+					break;
 
-								}
+				case 1: // Orthographic
+					model = new OrthographicCamera( - width / 2, width / 2, height / 2, - height / 2, nearClippingPlane, farClippingPlane );
+					break;
 
-							} );
+				default:
+					console.warn( 'THREE.FBXLoader: Unknown camera type ' + type + '.' );
+					model = new Object3D();
+					break;
 
-						} );
+			}
 
-						weightIndices = wIndex;
-						weights = Weight;
+		}
 
-					}
+		return model;
 
-					// if the weight array is shorter than 4 pad with 0s
-					while ( weights.length < 4 ) {
+	}
 
-						weights.push( 0 );
-						weightIndices.push( 0 );
+	// Create a DirectionalLight, PointLight or SpotLight
+	createLight( relationships ) {
 
-					}
+		let model;
+		let lightAttribute;
 
-					for ( var i = 0; i < 4; ++ i ) {
+		relationships.children.forEach( function ( child ) {
 
-						faceWeights.push( weights[ i ] );
-						faceWeightIndices.push( weightIndices[ i ] );
+			const attr = fbxTree.Objects.NodeAttribute[ child.ID ];
 
-					}
+			if ( attr !== undefined ) {
 
-				}
+				lightAttribute = attr;
 
-				if ( geoInfo.normal ) {
+			}
 
-					var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.normal );
+		} );
 
-					faceNormals.push( data[ 0 ], data[ 1 ], data[ 2 ] );
+		if ( lightAttribute === undefined ) {
 
-				}
+			model = new Object3D();
 
-				if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
+		} else {
 
-					var materialIndex = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material )[ 0 ];
+			let type;
 
-				}
+			// LightType can be undefined for Point lights
+			if ( lightAttribute.LightType === undefined ) {
 
-				if ( geoInfo.uv ) {
+				type = 0;
 
-					geoInfo.uv.forEach( function ( uv, i ) {
+			} else {
 
-						var data = getData( polygonVertexIndex, polygonIndex, vertexIndex, uv );
+				type = lightAttribute.LightType.value;
 
-						if ( faceUVs[ i ] === undefined ) {
+			}
 
-							faceUVs[ i ] = [];
+			let color = 0xffffff;
 
-						}
+			if ( lightAttribute.Color !== undefined ) {
 
-						faceUVs[ i ].push( data[ 0 ] );
-						faceUVs[ i ].push( data[ 1 ] );
+				color = new Color().fromArray( lightAttribute.Color.value );
 
-					} );
+			}
 
-				}
+			let intensity = ( lightAttribute.Intensity === undefined ) ? 1 : lightAttribute.Intensity.value / 100;
 
-				faceLength ++;
+			// light disabled
+			if ( lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0 ) {
 
-				if ( endOfFace ) {
+				intensity = 0;
 
-					scope.genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength );
+			}
 
-					polygonIndex ++;
-					faceLength = 0;
+			let distance = 0;
+			if ( lightAttribute.FarAttenuationEnd !== undefined ) {
 
-					// reset arrays for the next face
-					facePositionIndexes = [];
-					faceNormals = [];
-					faceColors = [];
-					faceUVs = [];
-					faceWeights = [];
-					faceWeightIndices = [];
+				if ( lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === 0 ) {
 
-				}
+					distance = 0;
 
-			} );
+				} else {
 
-			return buffers;
-
-		},
-
-		// Generate data for a single face in a geometry. If the face is a quad then split it into 2 tris
-		genFace: function ( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength ) {
-
-			for ( var i = 2; i < faceLength; i ++ ) {
-
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 0 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 1 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 2 ] ] );
-
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
-
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 1 ] ] );
-				buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 2 ] ] );
-
-				if ( geoInfo.skeleton ) {
-
-					buffers.vertexWeights.push( faceWeights[ 0 ] );
-					buffers.vertexWeights.push( faceWeights[ 1 ] );
-					buffers.vertexWeights.push( faceWeights[ 2 ] );
-					buffers.vertexWeights.push( faceWeights[ 3 ] );
-
-					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 ] );
-					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
-					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
-					buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
-
-					buffers.vertexWeights.push( faceWeights[ i * 4 ] );
-					buffers.vertexWeights.push( faceWeights[ i * 4 + 1 ] );
-					buffers.vertexWeights.push( faceWeights[ i * 4 + 2 ] );
-					buffers.vertexWeights.push( faceWeights[ i * 4 + 3 ] );
-
-					buffers.weightsIndices.push( faceWeightIndices[ 0 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ 1 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ 2 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ 3 ] );
-
-					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
-
-					buffers.weightsIndices.push( faceWeightIndices[ i * 4 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 1 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 2 ] );
-					buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 3 ] );
-
-				}
-
-				if ( geoInfo.color ) {
-
-					buffers.colors.push( faceColors[ 0 ] );
-					buffers.colors.push( faceColors[ 1 ] );
-					buffers.colors.push( faceColors[ 2 ] );
-
-					buffers.colors.push( faceColors[ ( i - 1 ) * 3 ] );
-					buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 1 ] );
-					buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 2 ] );
-
-					buffers.colors.push( faceColors[ i * 3 ] );
-					buffers.colors.push( faceColors[ i * 3 + 1 ] );
-					buffers.colors.push( faceColors[ i * 3 + 2 ] );
-
-				}
-
-				if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
-
-					buffers.materialIndex.push( materialIndex );
-					buffers.materialIndex.push( materialIndex );
-					buffers.materialIndex.push( materialIndex );
-
-				}
-
-				if ( geoInfo.normal ) {
-
-					buffers.normal.push( faceNormals[ 0 ] );
-					buffers.normal.push( faceNormals[ 1 ] );
-					buffers.normal.push( faceNormals[ 2 ] );
-
-					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 ] );
-					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 1 ] );
-					buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 2 ] );
-
-					buffers.normal.push( faceNormals[ i * 3 ] );
-					buffers.normal.push( faceNormals[ i * 3 + 1 ] );
-					buffers.normal.push( faceNormals[ i * 3 + 2 ] );
-
-				}
-
-				if ( geoInfo.uv ) {
-
-					geoInfo.uv.forEach( function ( uv, j ) {
-
-						if ( buffers.uvs[ j ] === undefined ) buffers.uvs[ j ] = [];
-
-						buffers.uvs[ j ].push( faceUVs[ j ][ 0 ] );
-						buffers.uvs[ j ].push( faceUVs[ j ][ 1 ] );
-
-						buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 ] );
-						buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
-
-						buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 ] );
-						buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 + 1 ] );
-
-					} );
+					distance = lightAttribute.FarAttenuationEnd.value;
 
 				}
 
 			}
 
-		},
+			// TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
+			const decay = 1;
 
-		addMorphTargets: function ( parentGeo, parentGeoNode, morphTargets, preTransform ) {
+			switch ( type ) {
 
-			if ( morphTargets.length === 0 ) return;
+				case 0: // Point
+					model = new PointLight( color, intensity, distance, decay );
+					break;
 
-			parentGeo.morphTargetsRelative = true;
+				case 1: // Directional
+					model = new DirectionalLight( color, intensity );
+					break;
 
-			parentGeo.morphAttributes.position = [];
-			// parentGeo.morphAttributes.normal = []; // not implemented
+				case 2: // Spot
+					let angle = Math.PI / 3;
 
-			var scope = this;
-			morphTargets.forEach( function ( morphTarget ) {
+					if ( lightAttribute.InnerAngle !== undefined ) {
 
-				morphTarget.rawTargets.forEach( function ( rawTarget ) {
-
-					var morphGeoNode = fbxTree.Objects.Geometry[ rawTarget.geoID ];
-
-					if ( morphGeoNode !== undefined ) {
-
-						scope.genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, rawTarget.name );
+						angle = MathUtils.degToRad( lightAttribute.InnerAngle.value );
 
 					}
+
+					let penumbra = 0;
+					if ( lightAttribute.OuterAngle !== undefined ) {
+
+						// TODO: this is not correct - FBX calculates outer and inner angle in degrees
+						// with OuterAngle > InnerAngle && OuterAngle <= Math.PI
+						// while three.js uses a penumbra between (0, 1) to attenuate the inner angle
+						penumbra = MathUtils.degToRad( lightAttribute.OuterAngle.value );
+						penumbra = Math.max( penumbra, 1 );
+
+					}
+
+					model = new SpotLight( color, intensity, distance, angle, penumbra, decay );
+					break;
+
+				default:
+					console.warn( 'THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType.value + ', defaulting to a PointLight.' );
+					model = new PointLight( color, intensity );
+					break;
+
+			}
+
+			if ( lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === 1 ) {
+
+				model.castShadow = true;
+
+			}
+
+		}
+
+		return model;
+
+	}
+
+	createMesh( relationships, geometryMap, materialMap ) {
+
+		let model;
+		let geometry = null;
+		let material = null;
+		const materials = [];
+
+		// get geometry and materials(s) from connections
+		relationships.children.forEach( function ( child ) {
+
+			if ( geometryMap.has( child.ID ) ) {
+
+				geometry = geometryMap.get( child.ID );
+
+			}
+
+			if ( materialMap.has( child.ID ) ) {
+
+				materials.push( materialMap.get( child.ID ) );
+
+			}
+
+		} );
+
+		if ( materials.length > 1 ) {
+
+			material = materials;
+
+		} else if ( materials.length > 0 ) {
+
+			material = materials[ 0 ];
+
+		} else {
+
+			material = new MeshPhongMaterial( { color: 0xcccccc } );
+			materials.push( material );
+
+		}
+
+		if ( 'color' in geometry.attributes ) {
+
+			materials.forEach( function ( material ) {
+
+				material.vertexColors = true;
+
+			} );
+
+		}
+
+		if ( geometry.FBX_Deformer ) {
+
+			materials.forEach( function ( material ) {
+
+				material.skinning = true;
+
+			} );
+
+			model = new SkinnedMesh( geometry, material );
+			model.normalizeSkinWeights();
+
+		} else {
+
+			model = new Mesh( geometry, material );
+
+		}
+
+		return model;
+
+	}
+
+	createCurve( relationships, geometryMap ) {
+
+		const geometry = relationships.children.reduce( function ( geo, child ) {
+
+			if ( geometryMap.has( child.ID ) ) geo = geometryMap.get( child.ID );
+
+			return geo;
+
+		}, null );
+
+		// FBX does not list materials for Nurbs lines, so we'll just put our own in here.
+		const material = new LineBasicMaterial( { color: 0x3300ff, linewidth: 1 } );
+		return new Line( geometry, material );
+
+	}
+
+	// parse the model node for transform data
+	getTransformData( model, modelNode ) {
+
+		const transformData = {};
+
+		if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
+
+		if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
+		else transformData.eulerOrder = 'ZYX';
+
+		if ( 'Lcl_Translation' in modelNode ) transformData.translation = modelNode.Lcl_Translation.value;
+
+		if ( 'PreRotation' in modelNode ) transformData.preRotation = modelNode.PreRotation.value;
+		if ( 'Lcl_Rotation' in modelNode ) transformData.rotation = modelNode.Lcl_Rotation.value;
+		if ( 'PostRotation' in modelNode ) transformData.postRotation = modelNode.PostRotation.value;
+
+		if ( 'Lcl_Scaling' in modelNode ) transformData.scale = modelNode.Lcl_Scaling.value;
+
+		if ( 'ScalingOffset' in modelNode ) transformData.scalingOffset = modelNode.ScalingOffset.value;
+		if ( 'ScalingPivot' in modelNode ) transformData.scalingPivot = modelNode.ScalingPivot.value;
+
+		if ( 'RotationOffset' in modelNode ) transformData.rotationOffset = modelNode.RotationOffset.value;
+		if ( 'RotationPivot' in modelNode ) transformData.rotationPivot = modelNode.RotationPivot.value;
+
+		model.userData.transformData = transformData;
+
+	}
+
+	setLookAtProperties( model, modelNode ) {
+
+		if ( 'LookAtProperty' in modelNode ) {
+
+			const children = connections.get( model.ID ).children;
+
+			children.forEach( function ( child ) {
+
+				if ( child.relationship === 'LookAtProperty' ) {
+
+					const lookAtTarget = fbxTree.Objects.Model[ child.ID ];
+
+					if ( 'Lcl_Translation' in lookAtTarget ) {
+
+						const pos = lookAtTarget.Lcl_Translation.value;
+
+						// DirectionalLight, SpotLight
+						if ( model.target !== undefined ) {
+
+							model.target.position.fromArray( pos );
+							sceneGraph.add( model.target );
+
+						} else { // Cameras and other Object3Ds
+
+							model.lookAt( new Vector3().fromArray( pos ) );
+
+						}
+
+					}
+
+				}
+
+			} );
+
+		}
+
+	}
+
+	bindSkeleton( skeletons, geometryMap, modelMap ) {
+
+		const bindMatrices = this.parsePoseNodes();
+
+		for ( const ID in skeletons ) {
+
+			const skeleton = skeletons[ ID ];
+
+			const parents = connections.get( parseInt( skeleton.ID ) ).parents;
+
+			parents.forEach( function ( parent ) {
+
+				if ( geometryMap.has( parent.ID ) ) {
+
+					const geoID = parent.ID;
+					const geoRelationships = connections.get( geoID );
+
+					geoRelationships.parents.forEach( function ( geoConnParent ) {
+
+						if ( modelMap.has( geoConnParent.ID ) ) {
+
+							const model = modelMap.get( geoConnParent.ID );
+
+							model.bind( new Skeleton( skeleton.bones ), bindMatrices[ geoConnParent.ID ] );
+
+						}
+
+					} );
+
+				}
+
+			} );
+
+		}
+
+	}
+
+	parsePoseNodes() {
+
+		const bindMatrices = {};
+
+		if ( 'Pose' in fbxTree.Objects ) {
+
+			const BindPoseNode = fbxTree.Objects.Pose;
+
+			for ( const nodeID in BindPoseNode ) {
+
+				if ( BindPoseNode[ nodeID ].attrType === 'BindPose' ) {
+
+					const poseNodes = BindPoseNode[ nodeID ].PoseNode;
+
+					if ( Array.isArray( poseNodes ) ) {
+
+						poseNodes.forEach( function ( poseNode ) {
+
+							bindMatrices[ poseNode.Node ] = new Matrix4().fromArray( poseNode.Matrix.a );
+
+						} );
+
+					} else {
+
+						bindMatrices[ poseNodes.Node ] = new Matrix4().fromArray( poseNodes.Matrix.a );
+
+					}
+
+				}
+
+			}
+
+		}
+
+		return bindMatrices;
+
+	}
+
+	// Parse ambient color in FBXTree.GlobalSettings - if it's not set to black (default), create an ambient light
+	createAmbientLight() {
+
+		if ( 'GlobalSettings' in fbxTree && 'AmbientColor' in fbxTree.GlobalSettings ) {
+
+			const ambientColor = fbxTree.GlobalSettings.AmbientColor.value;
+			const r = ambientColor[ 0 ];
+			const g = ambientColor[ 1 ];
+			const b = ambientColor[ 2 ];
+
+			if ( r !== 0 || g !== 0 || b !== 0 ) {
+
+				const color = new Color( r, g, b );
+				sceneGraph.add( new AmbientLight( color, 1 ) );
+
+			}
+
+		}
+
+	}
+
+	setupMorphMaterials() {
+
+		const scope = this;
+		sceneGraph.traverse( function ( child ) {
+
+			if ( child.isMesh ) {
+
+				if ( child.geometry.morphAttributes.position && child.geometry.morphAttributes.position.length ) {
+
+					if ( Array.isArray( child.material ) ) {
+
+						child.material.forEach( function ( material, i ) {
+
+							scope.setupMorphMaterial( child, material, i );
+
+						} );
+
+					} else {
+
+						scope.setupMorphMaterial( child, child.material );
+
+					}
+
+				}
+
+			}
+
+		} );
+
+	}
+
+	setupMorphMaterial( child, material, index ) {
+
+		const uuid = child.uuid;
+		const matUuid = material.uuid;
+
+		// if a geometry has morph targets, it cannot share the material with other geometries
+		let sharedMat = false;
+
+		sceneGraph.traverse( function ( node ) {
+
+			if ( node.isMesh ) {
+
+				if ( Array.isArray( node.material ) ) {
+
+					node.material.forEach( function ( mat ) {
+
+						if ( mat.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
+
+					} );
+
+				} else if ( node.material.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
+
+			}
+
+		} );
+
+		if ( sharedMat === true ) {
+
+			const clonedMat = material.clone();
+			clonedMat.morphTargets = true;
+
+			if ( index === undefined ) child.material = clonedMat;
+			else child.material[ index ] = clonedMat;
+
+		} else material.morphTargets = true;
+
+	}
+
+}
+
+// parse Geometry data from FBXTree and return map of BufferGeometries
+class GeometryParser {
+
+	// Parse nodes in FBXTree.Objects.Geometry
+	parse( deformers ) {
+
+		const geometryMap = new Map();
+
+		if ( 'Geometry' in fbxTree.Objects ) {
+
+			const geoNodes = fbxTree.Objects.Geometry;
+
+			for ( const nodeID in geoNodes ) {
+
+				const relationships = connections.get( parseInt( nodeID ) );
+				const geo = this.parseGeometry( relationships, geoNodes[ nodeID ], deformers );
+
+				geometryMap.set( parseInt( nodeID ), geo );
+
+			}
+
+		}
+
+		return geometryMap;
+
+	}
+
+	// Parse single node in FBXTree.Objects.Geometry
+	parseGeometry( relationships, geoNode, deformers ) {
+
+		switch ( geoNode.attrType ) {
+
+			case 'Mesh':
+				return this.parseMeshGeometry( relationships, geoNode, deformers );
+				break;
+
+			case 'NurbsCurve':
+				return this.parseNurbsGeometry( geoNode );
+				break;
+
+		}
+
+	}
+
+	// Parse single node mesh geometry in FBXTree.Objects.Geometry
+	parseMeshGeometry( relationships, geoNode, deformers ) {
+
+		const skeletons = deformers.skeletons;
+		const morphTargets = [];
+
+		const modelNodes = relationships.parents.map( function ( parent ) {
+
+			return fbxTree.Objects.Model[ parent.ID ];
+
+		} );
+
+		// don't create geometry if it is not associated with any models
+		if ( modelNodes.length === 0 ) return;
+
+		const skeleton = relationships.children.reduce( function ( skeleton, child ) {
+
+			if ( skeletons[ child.ID ] !== undefined ) skeleton = skeletons[ child.ID ];
+
+			return skeleton;
+
+		}, null );
+
+		relationships.children.forEach( function ( child ) {
+
+			if ( deformers.morphTargets[ child.ID ] !== undefined ) {
+
+				morphTargets.push( deformers.morphTargets[ child.ID ] );
+
+			}
+
+		} );
+
+		// Assume one model and get the preRotation from that
+		// if there is more than one model associated with the geometry this may cause problems
+		const modelNode = modelNodes[ 0 ];
+
+		const transformData = {};
+
+		if ( 'RotationOrder' in modelNode ) transformData.eulerOrder = getEulerOrder( modelNode.RotationOrder.value );
+		if ( 'InheritType' in modelNode ) transformData.inheritType = parseInt( modelNode.InheritType.value );
+
+		if ( 'GeometricTranslation' in modelNode ) transformData.translation = modelNode.GeometricTranslation.value;
+		if ( 'GeometricRotation' in modelNode ) transformData.rotation = modelNode.GeometricRotation.value;
+		if ( 'GeometricScaling' in modelNode ) transformData.scale = modelNode.GeometricScaling.value;
+
+		const transform = generateTransform( transformData );
+
+		return this.genGeometry( geoNode, skeleton, morphTargets, transform );
+
+	}
+
+	// Generate a BufferGeometry from a node in FBXTree.Objects.Geometry
+	genGeometry( geoNode, skeleton, morphTargets, preTransform ) {
+
+		const geo = new BufferGeometry();
+		if ( geoNode.attrName ) geo.name = geoNode.attrName;
+
+		const geoInfo = this.parseGeoNode( geoNode, skeleton );
+		const buffers = this.genBuffers( geoInfo );
+
+		const positionAttribute = new Float32BufferAttribute( buffers.vertex, 3 );
+
+		positionAttribute.applyMatrix4( preTransform );
+
+		geo.setAttribute( 'position', positionAttribute );
+
+		if ( buffers.colors.length > 0 ) {
+
+			geo.setAttribute( 'color', new Float32BufferAttribute( buffers.colors, 3 ) );
+
+		}
+
+		if ( skeleton ) {
+
+			geo.setAttribute( 'skinIndex', new Uint16BufferAttribute( buffers.weightsIndices, 4 ) );
+
+			geo.setAttribute( 'skinWeight', new Float32BufferAttribute( buffers.vertexWeights, 4 ) );
+
+			// used later to bind the skeleton to the model
+			geo.FBX_Deformer = skeleton;
+
+		}
+
+		if ( buffers.normal.length > 0 ) {
+
+			const normalMatrix = new Matrix3().getNormalMatrix( preTransform );
+
+			const normalAttribute = new Float32BufferAttribute( buffers.normal, 3 );
+			normalAttribute.applyNormalMatrix( normalMatrix );
+
+			geo.setAttribute( 'normal', normalAttribute );
+
+		}
+
+		buffers.uvs.forEach( function ( uvBuffer, i ) {
+
+			// subsequent uv buffers are called 'uv1', 'uv2', ...
+			let name = 'uv' + ( i + 1 ).toString();
+
+			// the first uv buffer is just called 'uv'
+			if ( i === 0 ) {
+
+				name = 'uv';
+
+			}
+
+			geo.setAttribute( name, new Float32BufferAttribute( buffers.uvs[ i ], 2 ) );
+
+		} );
+
+		if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
+
+			// Convert the material indices of each vertex into rendering groups on the geometry.
+			let prevMaterialIndex = buffers.materialIndex[ 0 ];
+			let startIndex = 0;
+
+			buffers.materialIndex.forEach( function ( currentIndex, i ) {
+
+				if ( currentIndex !== prevMaterialIndex ) {
+
+					geo.addGroup( startIndex, i - startIndex, prevMaterialIndex );
+
+					prevMaterialIndex = currentIndex;
+					startIndex = i;
+
+				}
+
+			} );
+
+			// the loop above doesn't add the last group, do that here.
+			if ( geo.groups.length > 0 ) {
+
+				const lastGroup = geo.groups[ geo.groups.length - 1 ];
+				const lastIndex = lastGroup.start + lastGroup.count;
+
+				if ( lastIndex !== buffers.materialIndex.length ) {
+
+					geo.addGroup( lastIndex, buffers.materialIndex.length - lastIndex, prevMaterialIndex );
+
+				}
+
+			}
+
+			// case where there are multiple materials but the whole geometry is only
+			// using one of them
+			if ( geo.groups.length === 0 ) {
+
+				geo.addGroup( 0, buffers.materialIndex.length, buffers.materialIndex[ 0 ] );
+
+			}
+
+		}
+
+		this.addMorphTargets( geo, geoNode, morphTargets, preTransform );
+
+		return geo;
+
+	}
+
+	parseGeoNode( geoNode, skeleton ) {
+
+		const geoInfo = {};
+
+		geoInfo.vertexPositions = ( geoNode.Vertices !== undefined ) ? geoNode.Vertices.a : [];
+		geoInfo.vertexIndices = ( geoNode.PolygonVertexIndex !== undefined ) ? geoNode.PolygonVertexIndex.a : [];
+
+		if ( geoNode.LayerElementColor ) {
+
+			geoInfo.color = this.parseVertexColors( geoNode.LayerElementColor[ 0 ] );
+
+		}
+
+		if ( geoNode.LayerElementMaterial ) {
+
+			geoInfo.material = this.parseMaterialIndices( geoNode.LayerElementMaterial[ 0 ] );
+
+		}
+
+		if ( geoNode.LayerElementNormal ) {
+
+			geoInfo.normal = this.parseNormals( geoNode.LayerElementNormal[ 0 ] );
+
+		}
+
+		if ( geoNode.LayerElementUV ) {
+
+			geoInfo.uv = [];
+
+			let i = 0;
+			while ( geoNode.LayerElementUV[ i ] ) {
+
+				if ( geoNode.LayerElementUV[ i ].UV ) {
+
+					geoInfo.uv.push( this.parseUVs( geoNode.LayerElementUV[ i ] ) );
+
+				}
+
+				i ++;
+
+			}
+
+		}
+
+		geoInfo.weightTable = {};
+
+		if ( skeleton !== null ) {
+
+			geoInfo.skeleton = skeleton;
+
+			skeleton.rawBones.forEach( function ( rawBone, i ) {
+
+				// loop over the bone's vertex indices and weights
+				rawBone.indices.forEach( function ( index, j ) {
+
+					if ( geoInfo.weightTable[ index ] === undefined ) geoInfo.weightTable[ index ] = [];
+
+					geoInfo.weightTable[ index ].push( {
+
+						id: i,
+						weight: rawBone.weights[ j ],
+
+					} );
 
 				} );
 
 			} );
 
-		},
+		}
 
-		// a morph geometry node is similar to a standard  node, and the node is also contained
-		// in FBXTree.Objects.Geometry, however it can only have attributes for position, normal
-		// and a special attribute Index defining which vertices of the original geometry are affected
-		// Normal and position attributes only have data for the vertices that are affected by the morph
-		genMorphGeometry: function ( parentGeo, parentGeoNode, morphGeoNode, preTransform, name ) {
+		return geoInfo;
 
-			var vertexIndices = ( parentGeoNode.PolygonVertexIndex !== undefined ) ? parentGeoNode.PolygonVertexIndex.a : [];
+	}
 
-			var morphPositionsSparse = ( morphGeoNode.Vertices !== undefined ) ? morphGeoNode.Vertices.a : [];
-			var indices = ( morphGeoNode.Indexes !== undefined ) ? morphGeoNode.Indexes.a : [];
+	genBuffers( geoInfo ) {
 
-			var length = parentGeo.attributes.position.count * 3;
-			var morphPositions = new Float32Array( length );
+		const buffers = {
+			vertex: [],
+			normal: [],
+			colors: [],
+			uvs: [],
+			materialIndex: [],
+			vertexWeights: [],
+			weightsIndices: [],
+		};
 
-			for ( var i = 0; i < indices.length; i ++ ) {
+		let polygonIndex = 0;
+		let faceLength = 0;
+		let displayedWeightsWarning = false;
 
-				var morphIndex = indices[ i ] * 3;
+		// these will hold data for a single face
+		let facePositionIndexes = [];
+		let faceNormals = [];
+		let faceColors = [];
+		let faceUVs = [];
+		let faceWeights = [];
+		let faceWeightIndices = [];
 
-				morphPositions[ morphIndex ] = morphPositionsSparse[ i * 3 ];
-				morphPositions[ morphIndex + 1 ] = morphPositionsSparse[ i * 3 + 1 ];
-				morphPositions[ morphIndex + 2 ] = morphPositionsSparse[ i * 3 + 2 ];
+		const scope = this;
+		geoInfo.vertexIndices.forEach( function ( vertexIndex, polygonVertexIndex ) {
+
+			let materialIndex;
+			let endOfFace = false;
+
+			// Face index and vertex index arrays are combined in a single array
+			// A cube with quad faces looks like this:
+			// PolygonVertexIndex: *24 {
+			//  a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
+			//  }
+			// Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
+			// to find index of last vertex bit shift the index: ^ - 1
+			if ( vertexIndex < 0 ) {
+
+				vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
+				endOfFace = true;
 
 			}
 
-			// TODO: add morph normal support
-			var morphGeoInfo = {
-				vertexIndices: vertexIndices,
-				vertexPositions: morphPositions,
+			let weightIndices = [];
+			let weights = [];
 
-			};
+			facePositionIndexes.push( vertexIndex * 3, vertexIndex * 3 + 1, vertexIndex * 3 + 2 );
 
-			var morphBuffers = this.genBuffers( morphGeoInfo );
+			if ( geoInfo.color ) {
 
-			var positionAttribute = new Float32BufferAttribute( morphBuffers.vertex, 3 );
-			positionAttribute.name = name || morphGeoNode.attrName;
+				const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.color );
 
-			positionAttribute.applyMatrix4( preTransform );
+				faceColors.push( data[ 0 ], data[ 1 ], data[ 2 ] );
 
-			parentGeo.morphAttributes.position.push( positionAttribute );
+			}
 
-		},
+			if ( geoInfo.skeleton ) {
 
-		// Parse normal from FBXTree.Objects.Geometry.LayerElementNormal if it exists
-		parseNormals: function ( NormalNode ) {
+				if ( geoInfo.weightTable[ vertexIndex ] !== undefined ) {
 
-			var mappingType = NormalNode.MappingInformationType;
-			var referenceType = NormalNode.ReferenceInformationType;
-			var buffer = NormalNode.Normals.a;
-			var indexBuffer = [];
-			if ( referenceType === 'IndexToDirect' ) {
+					geoInfo.weightTable[ vertexIndex ].forEach( function ( wt ) {
 
-				if ( 'NormalIndex' in NormalNode ) {
+						weights.push( wt.weight );
+						weightIndices.push( wt.id );
 
-					indexBuffer = NormalNode.NormalIndex.a;
+					} );
 
-				} else if ( 'NormalsIndex' in NormalNode ) {
 
-					indexBuffer = NormalNode.NormalsIndex.a;
+				}
+
+				if ( weights.length > 4 ) {
+
+					if ( ! displayedWeightsWarning ) {
+
+						console.warn( 'THREE.FBXLoader: Vertex has more than 4 skinning weights assigned to vertex. Deleting additional weights.' );
+						displayedWeightsWarning = true;
+
+					}
+
+					const wIndex = [ 0, 0, 0, 0 ];
+					const Weight = [ 0, 0, 0, 0 ];
+
+					weights.forEach( function ( weight, weightIndex ) {
+
+						let currentWeight = weight;
+						let currentIndex = weightIndices[ weightIndex ];
+
+						Weight.forEach( function ( comparedWeight, comparedWeightIndex, comparedWeightArray ) {
+
+							if ( currentWeight > comparedWeight ) {
+
+								comparedWeightArray[ comparedWeightIndex ] = currentWeight;
+								currentWeight = comparedWeight;
+
+								const tmp = wIndex[ comparedWeightIndex ];
+								wIndex[ comparedWeightIndex ] = currentIndex;
+								currentIndex = tmp;
+
+							}
+
+						} );
+
+					} );
+
+					weightIndices = wIndex;
+					weights = Weight;
+
+				}
+
+				// if the weight array is shorter than 4 pad with 0s
+				while ( weights.length < 4 ) {
+
+					weights.push( 0 );
+					weightIndices.push( 0 );
+
+				}
+
+				for ( let i = 0; i < 4; ++ i ) {
+
+					faceWeights.push( weights[ i ] );
+					faceWeightIndices.push( weightIndices[ i ] );
 
 				}
 
 			}
 
-			return {
-				dataSize: 3,
-				buffer: buffer,
-				indices: indexBuffer,
-				mappingType: mappingType,
-				referenceType: referenceType
-			};
+			if ( geoInfo.normal ) {
 
-		},
+				const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.normal );
 
-		// Parse UVs from FBXTree.Objects.Geometry.LayerElementUV if it exists
-		parseUVs: function ( UVNode ) {
-
-			var mappingType = UVNode.MappingInformationType;
-			var referenceType = UVNode.ReferenceInformationType;
-			var buffer = UVNode.UV.a;
-			var indexBuffer = [];
-			if ( referenceType === 'IndexToDirect' ) {
-
-				indexBuffer = UVNode.UVIndex.a;
+				faceNormals.push( data[ 0 ], data[ 1 ], data[ 2 ] );
 
 			}
 
-			return {
-				dataSize: 2,
-				buffer: buffer,
-				indices: indexBuffer,
-				mappingType: mappingType,
-				referenceType: referenceType
-			};
+			if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
 
-		},
-
-		// Parse Vertex Colors from FBXTree.Objects.Geometry.LayerElementColor if it exists
-		parseVertexColors: function ( ColorNode ) {
-
-			var mappingType = ColorNode.MappingInformationType;
-			var referenceType = ColorNode.ReferenceInformationType;
-			var buffer = ColorNode.Colors.a;
-			var indexBuffer = [];
-			if ( referenceType === 'IndexToDirect' ) {
-
-				indexBuffer = ColorNode.ColorIndex.a;
+				materialIndex = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material )[ 0 ];
 
 			}
 
-			return {
-				dataSize: 4,
-				buffer: buffer,
-				indices: indexBuffer,
-				mappingType: mappingType,
-				referenceType: referenceType
-			};
+			if ( geoInfo.uv ) {
 
-		},
+				geoInfo.uv.forEach( function ( uv, i ) {
 
-		// Parse mapping and material data in FBXTree.Objects.Geometry.LayerElementMaterial if it exists
-		parseMaterialIndices: function ( MaterialNode ) {
+					const data = getData( polygonVertexIndex, polygonIndex, vertexIndex, uv );
 
-			var mappingType = MaterialNode.MappingInformationType;
-			var referenceType = MaterialNode.ReferenceInformationType;
+					if ( faceUVs[ i ] === undefined ) {
 
-			if ( mappingType === 'NoMappingInformation' ) {
+						faceUVs[ i ] = [];
 
-				return {
-					dataSize: 1,
-					buffer: [ 0 ],
-					indices: [ 0 ],
-					mappingType: 'AllSame',
-					referenceType: referenceType
-				};
+					}
+
+					faceUVs[ i ].push( data[ 0 ] );
+					faceUVs[ i ].push( data[ 1 ] );
+
+				} );
 
 			}
 
-			var materialIndexBuffer = MaterialNode.Materials.a;
+			faceLength ++;
 
-			// Since materials are stored as indices, there's a bit of a mismatch between FBX and what
-			// we expect.So we create an intermediate buffer that points to the index in the buffer,
-			// for conforming with the other functions we've written for other data.
-			var materialIndices = [];
+			if ( endOfFace ) {
 
-			for ( var i = 0; i < materialIndexBuffer.length; ++ i ) {
+				scope.genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength );
 
-				materialIndices.push( i );
+				polygonIndex ++;
+				faceLength = 0;
+
+				// reset arrays for the next face
+				facePositionIndexes = [];
+				faceNormals = [];
+				faceColors = [];
+				faceUVs = [];
+				faceWeights = [];
+				faceWeightIndices = [];
 
 			}
+
+		} );
+
+		return buffers;
+
+	}
+
+	// Generate data for a single face in a geometry. If the face is a quad then split it into 2 tris
+	genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength ) {
+
+		for ( let i = 2; i < faceLength; i ++ ) {
+
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 0 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 1 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ 2 ] ] );
+
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 1 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ ( i - 1 ) * 3 + 2 ] ] );
+
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 1 ] ] );
+			buffers.vertex.push( geoInfo.vertexPositions[ facePositionIndexes[ i * 3 + 2 ] ] );
+
+			if ( geoInfo.skeleton ) {
+
+				buffers.vertexWeights.push( faceWeights[ 0 ] );
+				buffers.vertexWeights.push( faceWeights[ 1 ] );
+				buffers.vertexWeights.push( faceWeights[ 2 ] );
+				buffers.vertexWeights.push( faceWeights[ 3 ] );
+
+				buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 ] );
+				buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 1 ] );
+				buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 2 ] );
+				buffers.vertexWeights.push( faceWeights[ ( i - 1 ) * 4 + 3 ] );
+
+				buffers.vertexWeights.push( faceWeights[ i * 4 ] );
+				buffers.vertexWeights.push( faceWeights[ i * 4 + 1 ] );
+				buffers.vertexWeights.push( faceWeights[ i * 4 + 2 ] );
+				buffers.vertexWeights.push( faceWeights[ i * 4 + 3 ] );
+
+				buffers.weightsIndices.push( faceWeightIndices[ 0 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ 1 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ 2 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ 3 ] );
+
+				buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 1 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 2 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ ( i - 1 ) * 4 + 3 ] );
+
+				buffers.weightsIndices.push( faceWeightIndices[ i * 4 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 1 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 2 ] );
+				buffers.weightsIndices.push( faceWeightIndices[ i * 4 + 3 ] );
+
+			}
+
+			if ( geoInfo.color ) {
+
+				buffers.colors.push( faceColors[ 0 ] );
+				buffers.colors.push( faceColors[ 1 ] );
+				buffers.colors.push( faceColors[ 2 ] );
+
+				buffers.colors.push( faceColors[ ( i - 1 ) * 3 ] );
+				buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 1 ] );
+				buffers.colors.push( faceColors[ ( i - 1 ) * 3 + 2 ] );
+
+				buffers.colors.push( faceColors[ i * 3 ] );
+				buffers.colors.push( faceColors[ i * 3 + 1 ] );
+				buffers.colors.push( faceColors[ i * 3 + 2 ] );
+
+			}
+
+			if ( geoInfo.material && geoInfo.material.mappingType !== 'AllSame' ) {
+
+				buffers.materialIndex.push( materialIndex );
+				buffers.materialIndex.push( materialIndex );
+				buffers.materialIndex.push( materialIndex );
+
+			}
+
+			if ( geoInfo.normal ) {
+
+				buffers.normal.push( faceNormals[ 0 ] );
+				buffers.normal.push( faceNormals[ 1 ] );
+				buffers.normal.push( faceNormals[ 2 ] );
+
+				buffers.normal.push( faceNormals[ ( i - 1 ) * 3 ] );
+				buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 1 ] );
+				buffers.normal.push( faceNormals[ ( i - 1 ) * 3 + 2 ] );
+
+				buffers.normal.push( faceNormals[ i * 3 ] );
+				buffers.normal.push( faceNormals[ i * 3 + 1 ] );
+				buffers.normal.push( faceNormals[ i * 3 + 2 ] );
+
+			}
+
+			if ( geoInfo.uv ) {
+
+				geoInfo.uv.forEach( function ( uv, j ) {
+
+					if ( buffers.uvs[ j ] === undefined ) buffers.uvs[ j ] = [];
+
+					buffers.uvs[ j ].push( faceUVs[ j ][ 0 ] );
+					buffers.uvs[ j ].push( faceUVs[ j ][ 1 ] );
+
+					buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 ] );
+					buffers.uvs[ j ].push( faceUVs[ j ][ ( i - 1 ) * 2 + 1 ] );
+
+					buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 ] );
+					buffers.uvs[ j ].push( faceUVs[ j ][ i * 2 + 1 ] );
+
+				} );
+
+			}
+
+		}
+
+	}
+
+	addMorphTargets( parentGeo, parentGeoNode, morphTargets, preTransform ) {
+
+		if ( morphTargets.length === 0 ) return;
+
+		parentGeo.morphTargetsRelative = true;
+
+		parentGeo.morphAttributes.position = [];
+		// parentGeo.morphAttributes.normal = []; // not implemented
+
+		const scope = this;
+		morphTargets.forEach( function ( morphTarget ) {
+
+			morphTarget.rawTargets.forEach( function ( rawTarget ) {
+
+				const morphGeoNode = fbxTree.Objects.Geometry[ rawTarget.geoID ];
+
+				if ( morphGeoNode !== undefined ) {
+
+					scope.genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, rawTarget.name );
+
+				}
+
+			} );
+
+		} );
+
+	}
+
+	// a morph geometry node is similar to a standard  node, and the node is also contained
+	// in FBXTree.Objects.Geometry, however it can only have attributes for position, normal
+	// and a special attribute Index defining which vertices of the original geometry are affected
+	// Normal and position attributes only have data for the vertices that are affected by the morph
+	genMorphGeometry( parentGeo, parentGeoNode, morphGeoNode, preTransform, name ) {
+
+		const vertexIndices = ( parentGeoNode.PolygonVertexIndex !== undefined ) ? parentGeoNode.PolygonVertexIndex.a : [];
+
+		const morphPositionsSparse = ( morphGeoNode.Vertices !== undefined ) ? morphGeoNode.Vertices.a : [];
+		const indices = ( morphGeoNode.Indexes !== undefined ) ? morphGeoNode.Indexes.a : [];
+
+		const length = parentGeo.attributes.position.count * 3;
+		const morphPositions = new Float32Array( length );
+
+		for ( let i = 0; i < indices.length; i ++ ) {
+
+			const morphIndex = indices[ i ] * 3;
+
+			morphPositions[ morphIndex ] = morphPositionsSparse[ i * 3 ];
+			morphPositions[ morphIndex + 1 ] = morphPositionsSparse[ i * 3 + 1 ];
+			morphPositions[ morphIndex + 2 ] = morphPositionsSparse[ i * 3 + 2 ];
+
+		}
+
+		// TODO: add morph normal support
+		const morphGeoInfo = {
+			vertexIndices: vertexIndices,
+			vertexPositions: morphPositions,
+
+		};
+
+		const morphBuffers = this.genBuffers( morphGeoInfo );
+
+		const positionAttribute = new Float32BufferAttribute( morphBuffers.vertex, 3 );
+		positionAttribute.name = name || morphGeoNode.attrName;
+
+		positionAttribute.applyMatrix4( preTransform );
+
+		parentGeo.morphAttributes.position.push( positionAttribute );
+
+	}
+
+	// Parse normal from FBXTree.Objects.Geometry.LayerElementNormal if it exists
+	parseNormals( NormalNode ) {
+
+		const mappingType = NormalNode.MappingInformationType;
+		const referenceType = NormalNode.ReferenceInformationType;
+		const buffer = NormalNode.Normals.a;
+		let indexBuffer = [];
+		if ( referenceType === 'IndexToDirect' ) {
+
+			if ( 'NormalIndex' in NormalNode ) {
+
+				indexBuffer = NormalNode.NormalIndex.a;
+
+			} else if ( 'NormalsIndex' in NormalNode ) {
+
+				indexBuffer = NormalNode.NormalsIndex.a;
+
+			}
+
+		}
+
+		return {
+			dataSize: 3,
+			buffer: buffer,
+			indices: indexBuffer,
+			mappingType: mappingType,
+			referenceType: referenceType
+		};
+
+	}
+
+	// Parse UVs from FBXTree.Objects.Geometry.LayerElementUV if it exists
+	parseUVs( UVNode ) {
+
+		const mappingType = UVNode.MappingInformationType;
+		const referenceType = UVNode.ReferenceInformationType;
+		const buffer = UVNode.UV.a;
+		let indexBuffer = [];
+		if ( referenceType === 'IndexToDirect' ) {
+
+			indexBuffer = UVNode.UVIndex.a;
+
+		}
+
+		return {
+			dataSize: 2,
+			buffer: buffer,
+			indices: indexBuffer,
+			mappingType: mappingType,
+			referenceType: referenceType
+		};
+
+	}
+
+	// Parse Vertex Colors from FBXTree.Objects.Geometry.LayerElementColor if it exists
+	parseVertexColors( ColorNode ) {
+
+		const mappingType = ColorNode.MappingInformationType;
+		const referenceType = ColorNode.ReferenceInformationType;
+		const buffer = ColorNode.Colors.a;
+		let indexBuffer = [];
+		if ( referenceType === 'IndexToDirect' ) {
+
+			indexBuffer = ColorNode.ColorIndex.a;
+
+		}
+
+		return {
+			dataSize: 4,
+			buffer: buffer,
+			indices: indexBuffer,
+			mappingType: mappingType,
+			referenceType: referenceType
+		};
+
+	}
+
+	// Parse mapping and material data in FBXTree.Objects.Geometry.LayerElementMaterial if it exists
+	parseMaterialIndices( MaterialNode ) {
+
+		const mappingType = MaterialNode.MappingInformationType;
+		const referenceType = MaterialNode.ReferenceInformationType;
+
+		if ( mappingType === 'NoMappingInformation' ) {
 
 			return {
 				dataSize: 1,
-				buffer: materialIndexBuffer,
-				indices: materialIndices,
-				mappingType: mappingType,
+				buffer: [ 0 ],
+				indices: [ 0 ],
+				mappingType: 'AllSame',
 				referenceType: referenceType
 			};
 
-		},
+		}
 
-		// Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
-		parseNurbsGeometry: function ( geoNode ) {
+		const materialIndexBuffer = MaterialNode.Materials.a;
 
-			if ( NURBSCurve === undefined ) {
+		// Since materials are stored as indices, there's a bit of a mismatch between FBX and what
+		// we expect.So we create an intermediate buffer that points to the index in the buffer,
+		// for conforming with the other functions we've written for other data.
+		const materialIndices = [];
 
-				console.error( 'THREE.FBXLoader: The loader relies on NURBSCurve for any nurbs present in the model. Nurbs will show up as empty geometry.' );
-				return new BufferGeometry();
+		for ( let i = 0; i < materialIndexBuffer.length; ++ i ) {
 
-			}
+			materialIndices.push( i );
 
-			var order = parseInt( geoNode.Order );
+		}
 
-			if ( isNaN( order ) ) {
+		return {
+			dataSize: 1,
+			buffer: materialIndexBuffer,
+			indices: materialIndices,
+			mappingType: mappingType,
+			referenceType: referenceType
+		};
 
-				console.error( 'THREE.FBXLoader: Invalid Order %s given for geometry ID: %s', geoNode.Order, geoNode.id );
-				return new BufferGeometry();
+	}
 
-			}
+	// Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
+	parseNurbsGeometry( geoNode ) {
 
-			var degree = order - 1;
+		if ( NURBSCurve === undefined ) {
 
-			var knots = geoNode.KnotVector.a;
-			var controlPoints = [];
-			var pointsValues = geoNode.Points.a;
+			console.error( 'THREE.FBXLoader: The loader relies on NURBSCurve for any nurbs present in the model. Nurbs will show up as empty geometry.' );
+			return new BufferGeometry();
 
-			for ( var i = 0, l = pointsValues.length; i < l; i += 4 ) {
+		}
 
-				controlPoints.push( new Vector4().fromArray( pointsValues, i ) );
+		const order = parseInt( geoNode.Order );
 
-			}
+		if ( isNaN( order ) ) {
 
-			var startKnot, endKnot;
+			console.error( 'THREE.FBXLoader: Invalid Order %s given for geometry ID: %s', geoNode.Order, geoNode.id );
+			return new BufferGeometry();
 
-			if ( geoNode.Form === 'Closed' ) {
+		}
 
-				controlPoints.push( controlPoints[ 0 ] );
+		const degree = order - 1;
 
-			} else if ( geoNode.Form === 'Periodic' ) {
+		const knots = geoNode.KnotVector.a;
+		const controlPoints = [];
+		const pointsValues = geoNode.Points.a;
 
-				startKnot = degree;
-				endKnot = knots.length - 1 - startKnot;
+		for ( let i = 0, l = pointsValues.length; i < l; i += 4 ) {
 
-				for ( var i = 0; i < degree; ++ i ) {
+			controlPoints.push( new Vector4().fromArray( pointsValues, i ) );
 
-					controlPoints.push( controlPoints[ i ] );
+		}
 
-				}
+		let startKnot, endKnot;
 
-			}
+		if ( geoNode.Form === 'Closed' ) {
 
-			var curve = new NURBSCurve( degree, knots, controlPoints, startKnot, endKnot );
-			var vertices = curve.getPoints( controlPoints.length * 7 );
+			controlPoints.push( controlPoints[ 0 ] );
 
-			var positions = new Float32Array( vertices.length * 3 );
+		} else if ( geoNode.Form === 'Periodic' ) {
 
-			vertices.forEach( function ( vertex, i ) {
+			startKnot = degree;
+			endKnot = knots.length - 1 - startKnot;
 
-				vertex.toArray( positions, i * 3 );
+			for ( let i = 0; i < degree; ++ i ) {
 
-			} );
-
-			var geometry = new BufferGeometry();
-			geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
-
-			return geometry;
-
-		},
-
-	};
-
-	// parse animation data from FBXTree
-	function AnimationParser() {}
-
-	AnimationParser.prototype = {
-
-		constructor: AnimationParser,
-
-		// take raw animation clips and turn them into three.js animation clips
-		parse: function () {
-
-			var animationClips = [];
-
-			var rawClips = this.parseClips();
-
-			if ( rawClips !== undefined ) {
-
-				for ( var key in rawClips ) {
-
-					var rawClip = rawClips[ key ];
-
-					var clip = this.addClip( rawClip );
-
-					animationClips.push( clip );
-
-				}
+				controlPoints.push( controlPoints[ i ] );
 
 			}
 
-			return animationClips;
+		}
 
-		},
+		const curve = new NURBSCurve( degree, knots, controlPoints, startKnot, endKnot );
+		const vertices = curve.getPoints( controlPoints.length * 7 );
 
-		parseClips: function () {
+		const positions = new Float32Array( vertices.length * 3 );
 
-			// since the actual transformation data is stored in FBXTree.Objects.AnimationCurve,
-			// if this is undefined we can safely assume there are no animations
-			if ( fbxTree.Objects.AnimationCurve === undefined ) return undefined;
+		vertices.forEach( function ( vertex, i ) {
 
-			var curveNodesMap = this.parseAnimationCurveNodes();
+			vertex.toArray( positions, i * 3 );
 
-			this.parseAnimationCurves( curveNodesMap );
+		} );
 
-			var layersMap = this.parseAnimationLayers( curveNodesMap );
-			var rawClips = this.parseAnimStacks( layersMap );
+		const geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
-			return rawClips;
+		return geometry;
 
-		},
+	}
 
-		// parse nodes in FBXTree.Objects.AnimationCurveNode
-		// each AnimationCurveNode holds data for an animation transform for a model (e.g. left arm rotation )
-		// and is referenced by an AnimationLayer
-		parseAnimationCurveNodes: function () {
+}
 
-			var rawCurveNodes = fbxTree.Objects.AnimationCurveNode;
+// parse animation data from FBXTree
+class AnimationParser {
 
-			var curveNodesMap = new Map();
+	// take raw animation clips and turn them into three.js animation clips
+	parse() {
 
-			for ( var nodeID in rawCurveNodes ) {
+		const animationClips = [];
 
-				var rawCurveNode = rawCurveNodes[ nodeID ];
+		const rawClips = this.parseClips();
 
-				if ( rawCurveNode.attrName.match( /S|R|T|DeformPercent/ ) !== null ) {
+		if ( rawClips !== undefined ) {
 
-					var curveNode = {
+			for ( const key in rawClips ) {
 
-						id: rawCurveNode.id,
-						attr: rawCurveNode.attrName,
-						curves: {},
+				const rawClip = rawClips[ key ];
 
-					};
+				const clip = this.addClip( rawClip );
 
-					curveNodesMap.set( curveNode.id, curveNode );
-
-				}
+				animationClips.push( clip );
 
 			}
 
-			return curveNodesMap;
+		}
 
-		},
+		return animationClips;
 
-		// parse nodes in FBXTree.Objects.AnimationCurve and connect them up to
-		// previously parsed AnimationCurveNodes. Each AnimationCurve holds data for a single animated
-		// axis ( e.g. times and values of x rotation)
-		parseAnimationCurves: function ( curveNodesMap ) {
+	}
 
-			var rawCurves = fbxTree.Objects.AnimationCurve;
+	parseClips() {
 
-			// TODO: Many values are identical up to roundoff error, but won't be optimised
-			// e.g. position times: [0, 0.4, 0. 8]
-			// position values: [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.235384487103147e-7, 93.67520904541016, -0.9982695579528809]
-			// clearly, this should be optimised to
-			// times: [0], positions [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809]
-			// this shows up in nearly every FBX file, and generally time array is length > 100
+		// since the actual transformation data is stored in FBXTree.Objects.AnimationCurve,
+		// if this is undefined we can safely assume there are no animations
+		if ( fbxTree.Objects.AnimationCurve === undefined ) return undefined;
 
-			for ( var nodeID in rawCurves ) {
+		const curveNodesMap = this.parseAnimationCurveNodes();
 
-				var animationCurve = {
+		this.parseAnimationCurves( curveNodesMap );
 
-					id: rawCurves[ nodeID ].id,
-					times: rawCurves[ nodeID ].KeyTime.a.map( convertFBXTimeToSeconds ),
-					values: rawCurves[ nodeID ].KeyValueFloat.a,
+		const layersMap = this.parseAnimationLayers( curveNodesMap );
+		const rawClips = this.parseAnimStacks( layersMap );
+
+		return rawClips;
+
+	}
+
+	// parse nodes in FBXTree.Objects.AnimationCurveNode
+	// each AnimationCurveNode holds data for an animation transform for a model (e.g. left arm rotation )
+	// and is referenced by an AnimationLayer
+	parseAnimationCurveNodes() {
+
+		const rawCurveNodes = fbxTree.Objects.AnimationCurveNode;
+
+		const curveNodesMap = new Map();
+
+		for ( const nodeID in rawCurveNodes ) {
+
+			const rawCurveNode = rawCurveNodes[ nodeID ];
+
+			if ( rawCurveNode.attrName.match( /S|R|T|DeformPercent/ ) !== null ) {
+
+				const curveNode = {
+
+					id: rawCurveNode.id,
+					attr: rawCurveNode.attrName,
+					curves: {},
 
 				};
 
-				var relationships = connections.get( animationCurve.id );
+				curveNodesMap.set( curveNode.id, curveNode );
 
-				if ( relationships !== undefined ) {
+			}
 
-					var animationCurveID = relationships.parents[ 0 ].ID;
-					var animationCurveRelationship = relationships.parents[ 0 ].relationship;
+		}
 
-					if ( animationCurveRelationship.match( /X/ ) ) {
+		return curveNodesMap;
 
-						curveNodesMap.get( animationCurveID ).curves[ 'x' ] = animationCurve;
+	}
 
-					} else if ( animationCurveRelationship.match( /Y/ ) ) {
+	// parse nodes in FBXTree.Objects.AnimationCurve and connect them up to
+	// previously parsed AnimationCurveNodes. Each AnimationCurve holds data for a single animated
+	// axis ( e.g. times and values of x rotation)
+	parseAnimationCurves( curveNodesMap ) {
 
-						curveNodesMap.get( animationCurveID ).curves[ 'y' ] = animationCurve;
+		const rawCurves = fbxTree.Objects.AnimationCurve;
 
-					} else if ( animationCurveRelationship.match( /Z/ ) ) {
+		// TODO: Many values are identical up to roundoff error, but won't be optimised
+		// e.g. position times: [0, 0.4, 0. 8]
+		// position values: [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.235384487103147e-7, 93.67520904541016, -0.9982695579528809]
+		// clearly, this should be optimised to
+		// times: [0], positions [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809]
+		// this shows up in nearly every FBX file, and generally time array is length > 100
 
-						curveNodesMap.get( animationCurveID ).curves[ 'z' ] = animationCurve;
+		for ( const nodeID in rawCurves ) {
 
-					} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) && curveNodesMap.has( animationCurveID ) ) {
+			const animationCurve = {
 
-						curveNodesMap.get( animationCurveID ).curves[ 'morph' ] = animationCurve;
+				id: rawCurves[ nodeID ].id,
+				times: rawCurves[ nodeID ].KeyTime.a.map( convertFBXTimeToSeconds ),
+				values: rawCurves[ nodeID ].KeyValueFloat.a,
 
-					}
+			};
+
+			const relationships = connections.get( animationCurve.id );
+
+			if ( relationships !== undefined ) {
+
+				const animationCurveID = relationships.parents[ 0 ].ID;
+				const animationCurveRelationship = relationships.parents[ 0 ].relationship;
+
+				if ( animationCurveRelationship.match( /X/ ) ) {
+
+					curveNodesMap.get( animationCurveID ).curves[ 'x' ] = animationCurve;
+
+				} else if ( animationCurveRelationship.match( /Y/ ) ) {
+
+					curveNodesMap.get( animationCurveID ).curves[ 'y' ] = animationCurve;
+
+				} else if ( animationCurveRelationship.match( /Z/ ) ) {
+
+					curveNodesMap.get( animationCurveID ).curves[ 'z' ] = animationCurve;
+
+				} else if ( animationCurveRelationship.match( /d|DeformPercent/ ) && curveNodesMap.has( animationCurveID ) ) {
+
+					curveNodesMap.get( animationCurveID ).curves[ 'morph' ] = animationCurve;
 
 				}
 
 			}
 
-		},
+		}
 
-		// parse nodes in FBXTree.Objects.AnimationLayer. Each layers holds references
-		// to various AnimationCurveNodes and is referenced by an AnimationStack node
-		// note: theoretically a stack can have multiple layers, however in practice there always seems to be one per stack
-		parseAnimationLayers: function ( curveNodesMap ) {
+	}
 
-			var rawLayers = fbxTree.Objects.AnimationLayer;
+	// parse nodes in FBXTree.Objects.AnimationLayer. Each layers holds references
+	// to various AnimationCurveNodes and is referenced by an AnimationStack node
+	// note: theoretically a stack can have multiple layers, however in practice there always seems to be one per stack
+	parseAnimationLayers( curveNodesMap ) {
 
-			var layersMap = new Map();
+		const rawLayers = fbxTree.Objects.AnimationLayer;
 
-			for ( var nodeID in rawLayers ) {
+		const layersMap = new Map();
 
-				var layerCurveNodes = [];
+		for ( const nodeID in rawLayers ) {
 
-				var connection = connections.get( parseInt( nodeID ) );
+			const layerCurveNodes = [];
 
-				if ( connection !== undefined ) {
+			const connection = connections.get( parseInt( nodeID ) );
 
-					// all the animationCurveNodes used in the layer
-					var children = connection.children;
+			if ( connection !== undefined ) {
 
-					children.forEach( function ( child, i ) {
+				// all the animationCurveNodes used in the layer
+				const children = connection.children;
 
-						if ( curveNodesMap.has( child.ID ) ) {
+				children.forEach( function ( child, i ) {
 
-							var curveNode = curveNodesMap.get( child.ID );
+					if ( curveNodesMap.has( child.ID ) ) {
 
-							// check that the curves are defined for at least one axis, otherwise ignore the curveNode
-							if ( curveNode.curves.x !== undefined || curveNode.curves.y !== undefined || curveNode.curves.z !== undefined ) {
+						const curveNode = curveNodesMap.get( child.ID );
 
-								if ( layerCurveNodes[ i ] === undefined ) {
+						// check that the curves are defined for at least one axis, otherwise ignore the curveNode
+						if ( curveNode.curves.x !== undefined || curveNode.curves.y !== undefined || curveNode.curves.z !== undefined ) {
 
-									var modelID = connections.get( child.ID ).parents.filter( function ( parent ) {
+							if ( layerCurveNodes[ i ] === undefined ) {
 
-										return parent.relationship !== undefined;
+								const modelID = connections.get( child.ID ).parents.filter( function ( parent ) {
 
-									} )[ 0 ].ID;
+									return parent.relationship !== undefined;
 
-									if ( modelID !== undefined ) {
+								} )[ 0 ].ID;
 
-										var rawModel = fbxTree.Objects.Model[ modelID.toString() ];
+								if ( modelID !== undefined ) {
 
-										if ( rawModel === undefined ) {
+									const rawModel = fbxTree.Objects.Model[ modelID.toString() ];
 
-											console.warn( 'THREE.FBXLoader: Encountered a unused curve.', child );
-											return;
+									if ( rawModel === undefined ) {
 
-										}
-
-										var node = {
-
-											modelName: rawModel.attrName ? PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
-											ID: rawModel.id,
-											initialPosition: [ 0, 0, 0 ],
-											initialRotation: [ 0, 0, 0 ],
-											initialScale: [ 1, 1, 1 ],
-
-										};
-
-										sceneGraph.traverse( function ( child ) {
-
-											if ( child.ID === rawModel.id ) {
-
-												node.transform = child.matrix;
-
-												if ( child.userData.transformData ) node.eulerOrder = child.userData.transformData.eulerOrder;
-
-											}
-
-										} );
-
-										if ( ! node.transform ) node.transform = new Matrix4();
-
-										// if the animated model is pre rotated, we'll have to apply the pre rotations to every
-										// animation value as well
-										if ( 'PreRotation' in rawModel ) node.preRotation = rawModel.PreRotation.value;
-										if ( 'PostRotation' in rawModel ) node.postRotation = rawModel.PostRotation.value;
-
-										layerCurveNodes[ i ] = node;
+										console.warn( 'THREE.FBXLoader: Encountered a unused curve.', child );
+										return;
 
 									}
 
-								}
-
-								if ( layerCurveNodes[ i ] ) layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
-
-							} else if ( curveNode.curves.morph !== undefined ) {
-
-								if ( layerCurveNodes[ i ] === undefined ) {
-
-									var deformerID = connections.get( child.ID ).parents.filter( function ( parent ) {
-
-										return parent.relationship !== undefined;
-
-									} )[ 0 ].ID;
-
-									var morpherID = connections.get( deformerID ).parents[ 0 ].ID;
-									var geoID = connections.get( morpherID ).parents[ 0 ].ID;
-
-									// assuming geometry is not used in more than one model
-									var modelID = connections.get( geoID ).parents[ 0 ].ID;
-
-									var rawModel = fbxTree.Objects.Model[ modelID ];
-
-									var node = {
+									const node = {
 
 										modelName: rawModel.attrName ? PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
-										morphName: fbxTree.Objects.Deformer[ deformerID ].attrName,
+										ID: rawModel.id,
+										initialPosition: [ 0, 0, 0 ],
+										initialRotation: [ 0, 0, 0 ],
+										initialScale: [ 1, 1, 1 ],
 
 									};
+
+									sceneGraph.traverse( function ( child ) {
+
+										if ( child.ID === rawModel.id ) {
+
+											node.transform = child.matrix;
+
+											if ( child.userData.transformData ) node.eulerOrder = child.userData.transformData.eulerOrder;
+
+										}
+
+									} );
+
+									if ( ! node.transform ) node.transform = new Matrix4();
+
+									// if the animated model is pre rotated, we'll have to apply the pre rotations to every
+									// animation value as well
+									if ( 'PreRotation' in rawModel ) node.preRotation = rawModel.PreRotation.value;
+									if ( 'PostRotation' in rawModel ) node.postRotation = rawModel.PostRotation.value;
 
 									layerCurveNodes[ i ] = node;
 
 								}
 
-								layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+							}
+
+							if ( layerCurveNodes[ i ] ) layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+
+						} else if ( curveNode.curves.morph !== undefined ) {
+
+							if ( layerCurveNodes[ i ] === undefined ) {
+
+								const deformerID = connections.get( child.ID ).parents.filter( function ( parent ) {
+
+									return parent.relationship !== undefined;
+
+								} )[ 0 ].ID;
+
+								const morpherID = connections.get( deformerID ).parents[ 0 ].ID;
+								const geoID = connections.get( morpherID ).parents[ 0 ].ID;
+
+								// assuming geometry is not used in more than one model
+								const modelID = connections.get( geoID ).parents[ 0 ].ID;
+
+								const rawModel = fbxTree.Objects.Model[ modelID ];
+
+								const node = {
+
+									modelName: rawModel.attrName ? PropertyBinding.sanitizeNodeName( rawModel.attrName ) : '',
+									morphName: fbxTree.Objects.Deformer[ deformerID ].attrName,
+
+								};
+
+								layerCurveNodes[ i ] = node;
 
 							}
 
+							layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+
 						}
 
-					} );
-
-					layersMap.set( parseInt( nodeID ), layerCurveNodes );
-
-				}
-
-			}
-
-			return layersMap;
-
-		},
-
-		// parse nodes in FBXTree.Objects.AnimationStack. These are the top level node in the animation
-		// hierarchy. Each Stack node will be used to create a AnimationClip
-		parseAnimStacks: function ( layersMap ) {
-
-			var rawStacks = fbxTree.Objects.AnimationStack;
-
-			// connect the stacks (clips) up to the layers
-			var rawClips = {};
-
-			for ( var nodeID in rawStacks ) {
-
-				var children = connections.get( parseInt( nodeID ) ).children;
-
-				if ( children.length > 1 ) {
-
-					// it seems like stacks will always be associated with a single layer. But just in case there are files
-					// where there are multiple layers per stack, we'll display a warning
-					console.warn( 'THREE.FBXLoader: Encountered an animation stack with multiple layers, this is currently not supported. Ignoring subsequent layers.' );
-
-				}
-
-				var layer = layersMap.get( children[ 0 ].ID );
-
-				rawClips[ nodeID ] = {
-
-					name: rawStacks[ nodeID ].attrName,
-					layer: layer,
-
-				};
-
-			}
-
-			return rawClips;
-
-		},
-
-		addClip: function ( rawClip ) {
-
-			var tracks = [];
-
-			var scope = this;
-			rawClip.layer.forEach( function ( rawTracks ) {
-
-				tracks = tracks.concat( scope.generateTracks( rawTracks ) );
-
-			} );
-
-			return new AnimationClip( rawClip.name, - 1, tracks );
-
-		},
-
-		generateTracks: function ( rawTracks ) {
-
-			var tracks = [];
-
-			var initialPosition = new Vector3();
-			var initialRotation = new Quaternion();
-			var initialScale = new Vector3();
-
-			if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
-
-			initialPosition = initialPosition.toArray();
-			initialRotation = new Euler().setFromQuaternion( initialRotation, rawTracks.eulerOrder ).toArray();
-			initialScale = initialScale.toArray();
-
-			if ( rawTracks.T !== undefined && Object.keys( rawTracks.T.curves ).length > 0 ) {
-
-				var positionTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position' );
-				if ( positionTrack !== undefined ) tracks.push( positionTrack );
-
-			}
-
-			if ( rawTracks.R !== undefined && Object.keys( rawTracks.R.curves ).length > 0 ) {
-
-				var rotationTrack = this.generateRotationTrack( rawTracks.modelName, rawTracks.R.curves, initialRotation, rawTracks.preRotation, rawTracks.postRotation, rawTracks.eulerOrder );
-				if ( rotationTrack !== undefined ) tracks.push( rotationTrack );
-
-			}
-
-			if ( rawTracks.S !== undefined && Object.keys( rawTracks.S.curves ).length > 0 ) {
-
-				var scaleTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.S.curves, initialScale, 'scale' );
-				if ( scaleTrack !== undefined ) tracks.push( scaleTrack );
-
-			}
-
-			if ( rawTracks.DeformPercent !== undefined ) {
-
-				var morphTrack = this.generateMorphTrack( rawTracks );
-				if ( morphTrack !== undefined ) tracks.push( morphTrack );
-
-			}
-
-			return tracks;
-
-		},
-
-		generateVectorTrack: function ( modelName, curves, initialValue, type ) {
-
-			var times = this.getTimesForAllAxes( curves );
-			var values = this.getKeyframeTrackValues( times, curves, initialValue );
-
-			return new VectorKeyframeTrack( modelName + '.' + type, times, values );
-
-		},
-
-		generateRotationTrack: function ( modelName, curves, initialValue, preRotation, postRotation, eulerOrder ) {
-
-			if ( curves.x !== undefined ) {
-
-				this.interpolateRotations( curves.x );
-				curves.x.values = curves.x.values.map( MathUtils.degToRad );
-
-			}
-
-			if ( curves.y !== undefined ) {
-
-				this.interpolateRotations( curves.y );
-				curves.y.values = curves.y.values.map( MathUtils.degToRad );
-
-			}
-
-			if ( curves.z !== undefined ) {
-
-				this.interpolateRotations( curves.z );
-				curves.z.values = curves.z.values.map( MathUtils.degToRad );
-
-			}
-
-			var times = this.getTimesForAllAxes( curves );
-			var values = this.getKeyframeTrackValues( times, curves, initialValue );
-
-			if ( preRotation !== undefined ) {
-
-				preRotation = preRotation.map( MathUtils.degToRad );
-				preRotation.push( eulerOrder );
-
-				preRotation = new Euler().fromArray( preRotation );
-				preRotation = new Quaternion().setFromEuler( preRotation );
-
-			}
-
-			if ( postRotation !== undefined ) {
-
-				postRotation = postRotation.map( MathUtils.degToRad );
-				postRotation.push( eulerOrder );
-
-				postRotation = new Euler().fromArray( postRotation );
-				postRotation = new Quaternion().setFromEuler( postRotation ).invert();
-
-			}
-
-			var quaternion = new Quaternion();
-			var euler = new Euler();
-
-			var quaternionValues = [];
-
-			for ( var i = 0; i < values.length; i += 3 ) {
-
-				euler.set( values[ i ], values[ i + 1 ], values[ i + 2 ], eulerOrder );
-
-				quaternion.setFromEuler( euler );
-
-				if ( preRotation !== undefined ) quaternion.premultiply( preRotation );
-				if ( postRotation !== undefined ) quaternion.multiply( postRotation );
-
-				quaternion.toArray( quaternionValues, ( i / 3 ) * 4 );
-
-			}
-
-			return new QuaternionKeyframeTrack( modelName + '.quaternion', times, quaternionValues );
-
-		},
-
-		generateMorphTrack: function ( rawTracks ) {
-
-			var curves = rawTracks.DeformPercent.curves.morph;
-			var values = curves.values.map( function ( val ) {
-
-				return val / 100;
-
-			} );
-
-			var morphNum = sceneGraph.getObjectByName( rawTracks.modelName ).morphTargetDictionary[ rawTracks.morphName ];
-
-			return new NumberKeyframeTrack( rawTracks.modelName + '.morphTargetInfluences[' + morphNum + ']', curves.times, values );
-
-		},
-
-		// For all animated objects, times are defined separately for each axis
-		// Here we'll combine the times into one sorted array without duplicates
-		getTimesForAllAxes: function ( curves ) {
-
-			var times = [];
-
-			// first join together the times for each axis, if defined
-			if ( curves.x !== undefined ) times = times.concat( curves.x.times );
-			if ( curves.y !== undefined ) times = times.concat( curves.y.times );
-			if ( curves.z !== undefined ) times = times.concat( curves.z.times );
-
-			// then sort them
-			times = times.sort( function ( a, b ) {
-
-				return a - b;
-
-			} );
-
-			// and remove duplicates
-			if ( times.length > 1 ) {
-
-				var targetIndex = 1;
-				var lastValue = times[ 0 ];
-				for ( var i = 1; i < times.length; i ++ ) {
-
-					var currentValue = times[ i ];
-					if ( currentValue !== lastValue ) {
-
-						times[ targetIndex ] = currentValue;
-						lastValue = currentValue;
-						targetIndex ++;
-
 					}
-
-				}
-
-				times = times.slice( 0, targetIndex );
-
-			}
-
-			return times;
-
-		},
-
-		getKeyframeTrackValues: function ( times, curves, initialValue ) {
-
-			var prevValue = initialValue;
-
-			var values = [];
-
-			var xIndex = - 1;
-			var yIndex = - 1;
-			var zIndex = - 1;
-
-			times.forEach( function ( time ) {
-
-				if ( curves.x ) xIndex = curves.x.times.indexOf( time );
-				if ( curves.y ) yIndex = curves.y.times.indexOf( time );
-				if ( curves.z ) zIndex = curves.z.times.indexOf( time );
-
-				// if there is an x value defined for this frame, use that
-				if ( xIndex !== - 1 ) {
-
-					var xValue = curves.x.values[ xIndex ];
-					values.push( xValue );
-					prevValue[ 0 ] = xValue;
-
-				} else {
-
-					// otherwise use the x value from the previous frame
-					values.push( prevValue[ 0 ] );
-
-				}
-
-				if ( yIndex !== - 1 ) {
-
-					var yValue = curves.y.values[ yIndex ];
-					values.push( yValue );
-					prevValue[ 1 ] = yValue;
-
-				} else {
-
-					values.push( prevValue[ 1 ] );
-
-				}
-
-				if ( zIndex !== - 1 ) {
-
-					var zValue = curves.z.values[ zIndex ];
-					values.push( zValue );
-					prevValue[ 2 ] = zValue;
-
-				} else {
-
-					values.push( prevValue[ 2 ] );
-
-				}
-
-			} );
-
-			return values;
-
-		},
-
-		// Rotations are defined as Euler angles which can have values  of any size
-		// These will be converted to quaternions which don't support values greater than
-		// PI, so we'll interpolate large rotations
-		interpolateRotations: function ( curve ) {
-
-			for ( var i = 1; i < curve.values.length; i ++ ) {
-
-				var initialValue = curve.values[ i - 1 ];
-				var valuesSpan = curve.values[ i ] - initialValue;
-
-				var absoluteSpan = Math.abs( valuesSpan );
-
-				if ( absoluteSpan >= 180 ) {
-
-					var numSubIntervals = absoluteSpan / 180;
-
-					var step = valuesSpan / numSubIntervals;
-					var nextValue = initialValue + step;
-
-					var initialTime = curve.times[ i - 1 ];
-					var timeSpan = curve.times[ i ] - initialTime;
-					var interval = timeSpan / numSubIntervals;
-					var nextTime = initialTime + interval;
-
-					var interpolatedTimes = [];
-					var interpolatedValues = [];
-
-					while ( nextTime < curve.times[ i ] ) {
-
-						interpolatedTimes.push( nextTime );
-						nextTime += interval;
-
-						interpolatedValues.push( nextValue );
-						nextValue += step;
-
-					}
-
-					curve.times = inject( curve.times, i, interpolatedTimes );
-					curve.values = inject( curve.values, i, interpolatedValues );
-
-				}
-
-			}
-
-		},
-
-	};
-
-	// parse an FBX file in ASCII format
-	function TextParser() {}
-
-	TextParser.prototype = {
-
-		constructor: TextParser,
-
-		getPrevNode: function () {
-
-			return this.nodeStack[ this.currentIndent - 2 ];
-
-		},
-
-		getCurrentNode: function () {
-
-			return this.nodeStack[ this.currentIndent - 1 ];
-
-		},
-
-		getCurrentProp: function () {
-
-			return this.currentProp;
-
-		},
-
-		pushStack: function ( node ) {
-
-			this.nodeStack.push( node );
-			this.currentIndent += 1;
-
-		},
-
-		popStack: function () {
-
-			this.nodeStack.pop();
-			this.currentIndent -= 1;
-
-		},
-
-		setCurrentProp: function ( val, name ) {
-
-			this.currentProp = val;
-			this.currentPropName = name;
-
-		},
-
-		parse: function ( text ) {
-
-			this.currentIndent = 0;
-
-			this.allNodes = new FBXTree();
-			this.nodeStack = [];
-			this.currentProp = [];
-			this.currentPropName = '';
-
-			var scope = this;
-
-			var split = text.split( /[\r\n]+/ );
-
-			split.forEach( function ( line, i ) {
-
-				var matchComment = line.match( /^[\s\t]*;/ );
-				var matchEmpty = line.match( /^[\s\t]*$/ );
-
-				if ( matchComment || matchEmpty ) return;
-
-				var matchBeginning = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):(.*){', '' );
-				var matchProperty = line.match( '^\\t{' + ( scope.currentIndent ) + '}(\\w+):[\\s\\t\\r\\n](.*)' );
-				var matchEnd = line.match( '^\\t{' + ( scope.currentIndent - 1 ) + '}}' );
-
-				if ( matchBeginning ) {
-
-					scope.parseNodeBegin( line, matchBeginning );
-
-				} else if ( matchProperty ) {
-
-					scope.parseNodeProperty( line, matchProperty, split[ ++ i ] );
-
-				} else if ( matchEnd ) {
-
-					scope.popStack();
-
-				} else if ( line.match( /^[^\s\t}]/ ) ) {
-
-					// large arrays are split over multiple lines terminated with a ',' character
-					// if this is encountered the line needs to be joined to the previous line
-					scope.parseNodePropertyContinued( line );
-
-				}
-
-			} );
-
-			return this.allNodes;
-
-		},
-
-		parseNodeBegin: function ( line, property ) {
-
-			var nodeName = property[ 1 ].trim().replace( /^"/, '' ).replace( /"$/, '' );
-
-			var nodeAttrs = property[ 2 ].split( ',' ).map( function ( attr ) {
-
-				return attr.trim().replace( /^"/, '' ).replace( /"$/, '' );
-
-			} );
-
-			var node = { name: nodeName };
-			var attrs = this.parseNodeAttr( nodeAttrs );
-
-			var currentNode = this.getCurrentNode();
-
-			// a top node
-			if ( this.currentIndent === 0 ) {
-
-				this.allNodes.add( nodeName, node );
-
-			} else { // a subnode
-
-				// if the subnode already exists, append it
-				if ( nodeName in currentNode ) {
-
-					// special case Pose needs PoseNodes as an array
-					if ( nodeName === 'PoseNode' ) {
-
-						currentNode.PoseNode.push( node );
-
-					} else if ( currentNode[ nodeName ].id !== undefined ) {
-
-						currentNode[ nodeName ] = {};
-						currentNode[ nodeName ][ currentNode[ nodeName ].id ] = currentNode[ nodeName ];
-
-					}
-
-					if ( attrs.id !== '' ) currentNode[ nodeName ][ attrs.id ] = node;
-
-				} else if ( typeof attrs.id === 'number' ) {
-
-					currentNode[ nodeName ] = {};
-					currentNode[ nodeName ][ attrs.id ] = node;
-
-				} else if ( nodeName !== 'Properties70' ) {
-
-					if ( nodeName === 'PoseNode' )	currentNode[ nodeName ] = [ node ];
-					else currentNode[ nodeName ] = node;
-
-				}
-
-			}
-
-			if ( typeof attrs.id === 'number' ) node.id = attrs.id;
-			if ( attrs.name !== '' ) node.attrName = attrs.name;
-			if ( attrs.type !== '' ) node.attrType = attrs.type;
-
-			this.pushStack( node );
-
-		},
-
-		parseNodeAttr: function ( attrs ) {
-
-			var id = attrs[ 0 ];
-
-			if ( attrs[ 0 ] !== '' ) {
-
-				id = parseInt( attrs[ 0 ] );
-
-				if ( isNaN( id ) ) {
-
-					id = attrs[ 0 ];
-
-				}
-
-			}
-
-			var name = '', type = '';
-
-			if ( attrs.length > 1 ) {
-
-				name = attrs[ 1 ].replace( /^(\w+)::/, '' );
-				type = attrs[ 2 ];
-
-			}
-
-			return { id: id, name: name, type: type };
-
-		},
-
-		parseNodeProperty: function ( line, property, contentLine ) {
-
-			var propName = property[ 1 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
-			var propValue = property[ 2 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
-
-			// for special case: base64 image data follows "Content: ," line
-			//	Content: ,
-			//	 "/9j/4RDaRXhpZgAATU0A..."
-			if ( propName === 'Content' && propValue === ',' ) {
-
-				propValue = contentLine.replace( /"/g, '' ).replace( /,$/, '' ).trim();
-
-			}
-
-			var currentNode = this.getCurrentNode();
-			var parentName = currentNode.name;
-
-			if ( parentName === 'Properties70' ) {
-
-				this.parseNodeSpecialProperty( line, propName, propValue );
-				return;
-
-			}
-
-			// Connections
-			if ( propName === 'C' ) {
-
-				var connProps = propValue.split( ',' ).slice( 1 );
-				var from = parseInt( connProps[ 0 ] );
-				var to = parseInt( connProps[ 1 ] );
-
-				var rest = propValue.split( ',' ).slice( 3 );
-
-				rest = rest.map( function ( elem ) {
-
-					return elem.trim().replace( /^"/, '' );
 
 				} );
 
-				propName = 'connections';
-				propValue = [ from, to ];
-				append( propValue, rest );
+				layersMap.set( parseInt( nodeID ), layerCurveNodes );
 
-				if ( currentNode[ propName ] === undefined ) {
+			}
 
-					currentNode[ propName ] = [];
+		}
+
+		return layersMap;
+
+	}
+
+	// parse nodes in FBXTree.Objects.AnimationStack. These are the top level node in the animation
+	// hierarchy. Each Stack node will be used to create a AnimationClip
+	parseAnimStacks( layersMap ) {
+
+		const rawStacks = fbxTree.Objects.AnimationStack;
+
+		// connect the stacks (clips) up to the layers
+		const rawClips = {};
+
+		for ( const nodeID in rawStacks ) {
+
+			const children = connections.get( parseInt( nodeID ) ).children;
+
+			if ( children.length > 1 ) {
+
+				// it seems like stacks will always be associated with a single layer. But just in case there are files
+				// where there are multiple layers per stack, we'll display a warning
+				console.warn( 'THREE.FBXLoader: Encountered an animation stack with multiple layers, this is currently not supported. Ignoring subsequent layers.' );
+
+			}
+
+			const layer = layersMap.get( children[ 0 ].ID );
+
+			rawClips[ nodeID ] = {
+
+				name: rawStacks[ nodeID ].attrName,
+				layer: layer,
+
+			};
+
+		}
+
+		return rawClips;
+
+	}
+
+	addClip( rawClip ) {
+
+		let tracks = [];
+
+		const scope = this;
+		rawClip.layer.forEach( function ( rawTracks ) {
+
+			tracks = tracks.concat( scope.generateTracks( rawTracks ) );
+
+		} );
+
+		return new AnimationClip( rawClip.name, - 1, tracks );
+
+	}
+
+	generateTracks( rawTracks ) {
+
+		const tracks = [];
+
+		let initialPosition = new Vector3();
+		let initialRotation = new Quaternion();
+		let initialScale = new Vector3();
+
+		if ( rawTracks.transform ) rawTracks.transform.decompose( initialPosition, initialRotation, initialScale );
+
+		initialPosition = initialPosition.toArray();
+		initialRotation = new Euler().setFromQuaternion( initialRotation, rawTracks.eulerOrder ).toArray();
+		initialScale = initialScale.toArray();
+
+		if ( rawTracks.T !== undefined && Object.keys( rawTracks.T.curves ).length > 0 ) {
+
+			const positionTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position' );
+			if ( positionTrack !== undefined ) tracks.push( positionTrack );
+
+		}
+
+		if ( rawTracks.R !== undefined && Object.keys( rawTracks.R.curves ).length > 0 ) {
+
+			const rotationTrack = this.generateRotationTrack( rawTracks.modelName, rawTracks.R.curves, initialRotation, rawTracks.preRotation, rawTracks.postRotation, rawTracks.eulerOrder );
+			if ( rotationTrack !== undefined ) tracks.push( rotationTrack );
+
+		}
+
+		if ( rawTracks.S !== undefined && Object.keys( rawTracks.S.curves ).length > 0 ) {
+
+			const scaleTrack = this.generateVectorTrack( rawTracks.modelName, rawTracks.S.curves, initialScale, 'scale' );
+			if ( scaleTrack !== undefined ) tracks.push( scaleTrack );
+
+		}
+
+		if ( rawTracks.DeformPercent !== undefined ) {
+
+			const morphTrack = this.generateMorphTrack( rawTracks );
+			if ( morphTrack !== undefined ) tracks.push( morphTrack );
+
+		}
+
+		return tracks;
+
+	}
+
+	generateVectorTrack( modelName, curves, initialValue, type ) {
+
+		const times = this.getTimesForAllAxes( curves );
+		const values = this.getKeyframeTrackValues( times, curves, initialValue );
+
+		return new VectorKeyframeTrack( modelName + '.' + type, times, values );
+
+	}
+
+	generateRotationTrack( modelName, curves, initialValue, preRotation, postRotation, eulerOrder ) {
+
+		if ( curves.x !== undefined ) {
+
+			this.interpolateRotations( curves.x );
+			curves.x.values = curves.x.values.map( MathUtils.degToRad );
+
+		}
+
+		if ( curves.y !== undefined ) {
+
+			this.interpolateRotations( curves.y );
+			curves.y.values = curves.y.values.map( MathUtils.degToRad );
+
+		}
+
+		if ( curves.z !== undefined ) {
+
+			this.interpolateRotations( curves.z );
+			curves.z.values = curves.z.values.map( MathUtils.degToRad );
+
+		}
+
+		const times = this.getTimesForAllAxes( curves );
+		const values = this.getKeyframeTrackValues( times, curves, initialValue );
+
+		if ( preRotation !== undefined ) {
+
+			preRotation = preRotation.map( MathUtils.degToRad );
+			preRotation.push( eulerOrder );
+
+			preRotation = new Euler().fromArray( preRotation );
+			preRotation = new Quaternion().setFromEuler( preRotation );
+
+		}
+
+		if ( postRotation !== undefined ) {
+
+			postRotation = postRotation.map( MathUtils.degToRad );
+			postRotation.push( eulerOrder );
+
+			postRotation = new Euler().fromArray( postRotation );
+			postRotation = new Quaternion().setFromEuler( postRotation ).invert();
+
+		}
+
+		const quaternion = new Quaternion();
+		const euler = new Euler();
+
+		const quaternionValues = [];
+
+		for ( let i = 0; i < values.length; i += 3 ) {
+
+			euler.set( values[ i ], values[ i + 1 ], values[ i + 2 ], eulerOrder );
+
+			quaternion.setFromEuler( euler );
+
+			if ( preRotation !== undefined ) quaternion.premultiply( preRotation );
+			if ( postRotation !== undefined ) quaternion.multiply( postRotation );
+
+			quaternion.toArray( quaternionValues, ( i / 3 ) * 4 );
+
+		}
+
+		return new QuaternionKeyframeTrack( modelName + '.quaternion', times, quaternionValues );
+
+	}
+
+	generateMorphTrack( rawTracks ) {
+
+		const curves = rawTracks.DeformPercent.curves.morph;
+		const values = curves.values.map( function ( val ) {
+
+			return val / 100;
+
+		} );
+
+		const morphNum = sceneGraph.getObjectByName( rawTracks.modelName ).morphTargetDictionary[ rawTracks.morphName ];
+
+		return new NumberKeyframeTrack( rawTracks.modelName + '.morphTargetInfluences[' + morphNum + ']', curves.times, values );
+
+	}
+
+	// For all animated objects, times are defined separately for each axis
+	// Here we'll combine the times into one sorted array without duplicates
+	getTimesForAllAxes( curves ) {
+
+		let times = [];
+
+		// first join together the times for each axis, if defined
+		if ( curves.x !== undefined ) times = times.concat( curves.x.times );
+		if ( curves.y !== undefined ) times = times.concat( curves.y.times );
+		if ( curves.z !== undefined ) times = times.concat( curves.z.times );
+
+		// then sort them
+		times = times.sort( function ( a, b ) {
+
+			return a - b;
+
+		} );
+
+		// and remove duplicates
+		if ( times.length > 1 ) {
+
+			let targetIndex = 1;
+			let lastValue = times[ 0 ];
+			for ( let i = 1; i < times.length; i ++ ) {
+
+				const currentValue = times[ i ];
+				if ( currentValue !== lastValue ) {
+
+					times[ targetIndex ] = currentValue;
+					lastValue = currentValue;
+					targetIndex ++;
 
 				}
 
 			}
 
-			// Node
-			if ( propName === 'Node' ) currentNode.id = propValue;
+			times = times.slice( 0, targetIndex );
 
-			// connections
-			if ( propName in currentNode && Array.isArray( currentNode[ propName ] ) ) {
+		}
 
-				currentNode[ propName ].push( propValue );
+		return times;
+
+	}
+
+	getKeyframeTrackValues( times, curves, initialValue ) {
+
+		const prevValue = initialValue;
+
+		const values = [];
+
+		let xIndex = - 1;
+		let yIndex = - 1;
+		let zIndex = - 1;
+
+		times.forEach( function ( time ) {
+
+			if ( curves.x ) xIndex = curves.x.times.indexOf( time );
+			if ( curves.y ) yIndex = curves.y.times.indexOf( time );
+			if ( curves.z ) zIndex = curves.z.times.indexOf( time );
+
+			// if there is an x value defined for this frame, use that
+			if ( xIndex !== - 1 ) {
+
+				const xValue = curves.x.values[ xIndex ];
+				values.push( xValue );
+				prevValue[ 0 ] = xValue;
 
 			} else {
 
-				if ( propName !== 'a' ) currentNode[ propName ] = propValue;
-				else currentNode.a = propValue;
+				// otherwise use the x value from the previous frame
+				values.push( prevValue[ 0 ] );
 
 			}
 
-			this.setCurrentProp( currentNode, propName );
+			if ( yIndex !== - 1 ) {
 
-			// convert string to array, unless it ends in ',' in which case more will be added to it
-			if ( propName === 'a' && propValue.slice( - 1 ) !== ',' ) {
+				const yValue = curves.y.values[ yIndex ];
+				values.push( yValue );
+				prevValue[ 1 ] = yValue;
 
-				currentNode.a = parseNumberArray( propValue );
+			} else {
 
-			}
-
-		},
-
-		parseNodePropertyContinued: function ( line ) {
-
-			var currentNode = this.getCurrentNode();
-
-			currentNode.a += line;
-
-			// if the line doesn't end in ',' we have reached the end of the property value
-			// so convert the string to an array
-			if ( line.slice( - 1 ) !== ',' ) {
-
-				currentNode.a = parseNumberArray( currentNode.a );
+				values.push( prevValue[ 1 ] );
 
 			}
 
-		},
+			if ( zIndex !== - 1 ) {
 
-		// parse "Property70"
-		parseNodeSpecialProperty: function ( line, propName, propValue ) {
+				const zValue = curves.z.values[ zIndex ];
+				values.push( zValue );
+				prevValue[ 2 ] = zValue;
 
-			// split this
-			// P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
-			// into array like below
-			// ["Lcl Scaling", "Lcl Scaling", "", "A", "1,1,1" ]
-			var props = propValue.split( '",' ).map( function ( prop ) {
+			} else {
 
-				return prop.trim().replace( /^\"/, '' ).replace( /\s/, '_' );
+				values.push( prevValue[ 2 ] );
+
+			}
+
+		} );
+
+		return values;
+
+	}
+
+	// Rotations are defined as Euler angles which can have values  of any size
+	// These will be converted to quaternions which don't support values greater than
+	// PI, so we'll interpolate large rotations
+	interpolateRotations( curve ) {
+
+		for ( let i = 1; i < curve.values.length; i ++ ) {
+
+			const initialValue = curve.values[ i - 1 ];
+			const valuesSpan = curve.values[ i ] - initialValue;
+
+			const absoluteSpan = Math.abs( valuesSpan );
+
+			if ( absoluteSpan >= 180 ) {
+
+				const numSubIntervals = absoluteSpan / 180;
+
+				const step = valuesSpan / numSubIntervals;
+				let nextValue = initialValue + step;
+
+				const initialTime = curve.times[ i - 1 ];
+				const timeSpan = curve.times[ i ] - initialTime;
+				const interval = timeSpan / numSubIntervals;
+				let nextTime = initialTime + interval;
+
+				const interpolatedTimes = [];
+				const interpolatedValues = [];
+
+				while ( nextTime < curve.times[ i ] ) {
+
+					interpolatedTimes.push( nextTime );
+					nextTime += interval;
+
+					interpolatedValues.push( nextValue );
+					nextValue += step;
+
+				}
+
+				curve.times = inject( curve.times, i, interpolatedTimes );
+				curve.values = inject( curve.values, i, interpolatedValues );
+
+			}
+
+		}
+
+	}
+
+}
+
+// parse an FBX file in ASCII format
+class TextParser {
+
+	getPrevNode() {
+
+		return this.nodeStack[ this.currentIndent - 2 ];
+
+	}
+
+	getCurrentNode() {
+
+		return this.nodeStack[ this.currentIndent - 1 ];
+
+	}
+
+	getCurrentProp() {
+
+		return this.currentProp;
+
+	}
+
+	pushStack( node ) {
+
+		this.nodeStack.push( node );
+		this.currentIndent += 1;
+
+	}
+
+	popStack() {
+
+		this.nodeStack.pop();
+		this.currentIndent -= 1;
+
+	}
+
+	setCurrentProp( val, name ) {
+
+		this.currentProp = val;
+		this.currentPropName = name;
+
+	}
+
+	parse( text ) {
+
+		this.currentIndent = 0;
+
+		this.allNodes = new FBXTree();
+		this.nodeStack = [];
+		this.currentProp = [];
+		this.currentPropName = '';
+
+		const scope = this;
+
+		const split = text.split( /[\r\n]+/ );
+
+		split.forEach( function ( line, i ) {
+
+			const matchComment = line.match( /^[\s\t]*;/ );
+			const matchEmpty = line.match( /^[\s\t]*$/ );
+
+			if ( matchComment || matchEmpty ) return;
+
+			const matchBeginning = line.match( '^\\t{' + scope.currentIndent + '}(\\w+):(.*){', '' );
+			const matchProperty = line.match( '^\\t{' + ( scope.currentIndent ) + '}(\\w+):[\\s\\t\\r\\n](.*)' );
+			const matchEnd = line.match( '^\\t{' + ( scope.currentIndent - 1 ) + '}}' );
+
+			if ( matchBeginning ) {
+
+				scope.parseNodeBegin( line, matchBeginning );
+
+			} else if ( matchProperty ) {
+
+				scope.parseNodeProperty( line, matchProperty, split[ ++ i ] );
+
+			} else if ( matchEnd ) {
+
+				scope.popStack();
+
+			} else if ( line.match( /^[^\s\t}]/ ) ) {
+
+				// large arrays are split over multiple lines terminated with a ',' character
+				// if this is encountered the line needs to be joined to the previous line
+				scope.parseNodePropertyContinued( line );
+
+			}
+
+		} );
+
+		return this.allNodes;
+
+	}
+
+	parseNodeBegin( line, property ) {
+
+		const nodeName = property[ 1 ].trim().replace( /^"/, '' ).replace( /"$/, '' );
+
+		const nodeAttrs = property[ 2 ].split( ',' ).map( function ( attr ) {
+
+			return attr.trim().replace( /^"/, '' ).replace( /"$/, '' );
+
+		} );
+
+		const node = { name: nodeName };
+		const attrs = this.parseNodeAttr( nodeAttrs );
+
+		const currentNode = this.getCurrentNode();
+
+		// a top node
+		if ( this.currentIndent === 0 ) {
+
+			this.allNodes.add( nodeName, node );
+
+		} else { // a subnode
+
+			// if the subnode already exists, append it
+			if ( nodeName in currentNode ) {
+
+				// special case Pose needs PoseNodes as an array
+				if ( nodeName === 'PoseNode' ) {
+
+					currentNode.PoseNode.push( node );
+
+				} else if ( currentNode[ nodeName ].id !== undefined ) {
+
+					currentNode[ nodeName ] = {};
+					currentNode[ nodeName ][ currentNode[ nodeName ].id ] = currentNode[ nodeName ];
+
+				}
+
+				if ( attrs.id !== '' ) currentNode[ nodeName ][ attrs.id ] = node;
+
+			} else if ( typeof attrs.id === 'number' ) {
+
+				currentNode[ nodeName ] = {};
+				currentNode[ nodeName ][ attrs.id ] = node;
+
+			} else if ( nodeName !== 'Properties70' ) {
+
+				if ( nodeName === 'PoseNode' )	currentNode[ nodeName ] = [ node ];
+				else currentNode[ nodeName ] = node;
+
+			}
+
+		}
+
+		if ( typeof attrs.id === 'number' ) node.id = attrs.id;
+		if ( attrs.name !== '' ) node.attrName = attrs.name;
+		if ( attrs.type !== '' ) node.attrType = attrs.type;
+
+		this.pushStack( node );
+
+	}
+
+	parseNodeAttr( attrs ) {
+
+		let id = attrs[ 0 ];
+
+		if ( attrs[ 0 ] !== '' ) {
+
+			id = parseInt( attrs[ 0 ] );
+
+			if ( isNaN( id ) ) {
+
+				id = attrs[ 0 ];
+
+			}
+
+		}
+
+		let name = '', type = '';
+
+		if ( attrs.length > 1 ) {
+
+			name = attrs[ 1 ].replace( /^(\w+)::/, '' );
+			type = attrs[ 2 ];
+
+		}
+
+		return { id: id, name: name, type: type };
+
+	}
+
+	parseNodeProperty( line, property, contentLine ) {
+
+		let propName = property[ 1 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
+		let propValue = property[ 2 ].replace( /^"/, '' ).replace( /"$/, '' ).trim();
+
+		// for special case: base64 image data follows "Content: ," line
+		//	Content: ,
+		//	 "/9j/4RDaRXhpZgAATU0A..."
+		if ( propName === 'Content' && propValue === ',' ) {
+
+			propValue = contentLine.replace( /"/g, '' ).replace( /,$/, '' ).trim();
+
+		}
+
+		const currentNode = this.getCurrentNode();
+		const parentName = currentNode.name;
+
+		if ( parentName === 'Properties70' ) {
+
+			this.parseNodeSpecialProperty( line, propName, propValue );
+			return;
+
+		}
+
+		// Connections
+		if ( propName === 'C' ) {
+
+			const connProps = propValue.split( ',' ).slice( 1 );
+			const from = parseInt( connProps[ 0 ] );
+			const to = parseInt( connProps[ 1 ] );
+
+			let rest = propValue.split( ',' ).slice( 3 );
+
+			rest = rest.map( function ( elem ) {
+
+				return elem.trim().replace( /^"/, '' );
 
 			} );
 
-			var innerPropName = props[ 0 ];
-			var innerPropType1 = props[ 1 ];
-			var innerPropType2 = props[ 2 ];
-			var innerPropFlag = props[ 3 ];
-			var innerPropValue = props[ 4 ];
+			propName = 'connections';
+			propValue = [ from, to ];
+			append( propValue, rest );
 
-			// cast values where needed, otherwise leave as strings
-			switch ( innerPropType1 ) {
+			if ( currentNode[ propName ] === undefined ) {
 
-				case 'int':
-				case 'enum':
-				case 'bool':
-				case 'ULongLong':
-				case 'double':
-				case 'Number':
-				case 'FieldOfView':
-					innerPropValue = parseFloat( innerPropValue );
-					break;
-
-				case 'Color':
-				case 'ColorRGB':
-				case 'Vector3D':
-				case 'Lcl_Translation':
-				case 'Lcl_Rotation':
-				case 'Lcl_Scaling':
-					innerPropValue = parseNumberArray( innerPropValue );
-					break;
+				currentNode[ propName ] = [];
 
 			}
 
-			// CAUTION: these props must append to parent's parent
-			this.getPrevNode()[ innerPropName ] = {
+		}
+
+		// Node
+		if ( propName === 'Node' ) currentNode.id = propValue;
+
+		// connections
+		if ( propName in currentNode && Array.isArray( currentNode[ propName ] ) ) {
+
+			currentNode[ propName ].push( propValue );
+
+		} else {
+
+			if ( propName !== 'a' ) currentNode[ propName ] = propValue;
+			else currentNode.a = propValue;
+
+		}
+
+		this.setCurrentProp( currentNode, propName );
+
+		// convert string to array, unless it ends in ',' in which case more will be added to it
+		if ( propName === 'a' && propValue.slice( - 1 ) !== ',' ) {
+
+			currentNode.a = parseNumberArray( propValue );
+
+		}
+
+	}
+
+	parseNodePropertyContinued( line ) {
+
+		const currentNode = this.getCurrentNode();
+
+		currentNode.a += line;
+
+		// if the line doesn't end in ',' we have reached the end of the property value
+		// so convert the string to an array
+		if ( line.slice( - 1 ) !== ',' ) {
+
+			currentNode.a = parseNumberArray( currentNode.a );
+
+		}
+
+	}
+
+	// parse "Property70"
+	parseNodeSpecialProperty( line, propName, propValue ) {
+
+		// split this
+		// P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+		// into array like below
+		// ["Lcl Scaling", "Lcl Scaling", "", "A", "1,1,1" ]
+		const props = propValue.split( '",' ).map( function ( prop ) {
+
+			return prop.trim().replace( /^\"/, '' ).replace( /\s/, '_' );
+
+		} );
+
+		const innerPropName = props[ 0 ];
+		const innerPropType1 = props[ 1 ];
+		const innerPropType2 = props[ 2 ];
+		const innerPropFlag = props[ 3 ];
+		let innerPropValue = props[ 4 ];
+
+		// cast values where needed, otherwise leave as strings
+		switch ( innerPropType1 ) {
+
+			case 'int':
+			case 'enum':
+			case 'bool':
+			case 'ULongLong':
+			case 'double':
+			case 'Number':
+			case 'FieldOfView':
+				innerPropValue = parseFloat( innerPropValue );
+				break;
+
+			case 'Color':
+			case 'ColorRGB':
+			case 'Vector3D':
+			case 'Lcl_Translation':
+			case 'Lcl_Rotation':
+			case 'Lcl_Scaling':
+				innerPropValue = parseNumberArray( innerPropValue );
+				break;
+
+		}
+
+		// CAUTION: these props must append to parent's parent
+		this.getPrevNode()[ innerPropName ] = {
+
+			'type': innerPropType1,
+			'type2': innerPropType2,
+			'flag': innerPropFlag,
+			'value': innerPropValue
+
+		};
+
+		this.setCurrentProp( this.getPrevNode(), innerPropName );
+
+	}
+
+}
+
+// Parse an FBX file in Binary format
+class BinaryParser {
+
+	parse( buffer ) {
+
+		const reader = new BinaryReader( buffer );
+		reader.skip( 23 ); // skip magic 23 bytes
+
+		const version = reader.getUint32();
+
+		if ( version < 6400 ) {
+
+			throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + version );
+
+		}
+
+		const allNodes = new FBXTree();
+
+		while ( ! this.endOfContent( reader ) ) {
+
+			const node = this.parseNode( reader, version );
+			if ( node !== null ) allNodes.add( node.name, node );
+
+		}
+
+		return allNodes;
+
+	}
+
+	// Check if reader has reached the end of content.
+	endOfContent( reader ) {
+
+		// footer size: 160bytes + 16-byte alignment padding
+		// - 16bytes: magic
+		// - padding til 16-byte alignment (at least 1byte?)
+		//	(seems like some exporters embed fixed 15 or 16bytes?)
+		// - 4bytes: magic
+		// - 4bytes: version
+		// - 120bytes: zero
+		// - 16bytes: magic
+		if ( reader.size() % 16 === 0 ) {
+
+			return ( ( reader.getOffset() + 160 + 16 ) & ~ 0xf ) >= reader.size();
+
+		} else {
+
+			return reader.getOffset() + 160 + 16 >= reader.size();
+
+		}
+
+	}
+
+	// recursively parse nodes until the end of the file is reached
+	parseNode( reader, version ) {
+
+		const node = {};
+
+		// The first three data sizes depends on version.
+		const endOffset = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
+		const numProperties = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
+
+		( version >= 7500 ) ? reader.getUint64() : reader.getUint32(); // the returned propertyListLen is not used
+
+		const nameLen = reader.getUint8();
+		const name = reader.getString( nameLen );
+
+		// Regards this node as NULL-record if endOffset is zero
+		if ( endOffset === 0 ) return null;
+
+		const propertyList = [];
+
+		for ( let i = 0; i < numProperties; i ++ ) {
+
+			propertyList.push( this.parseProperty( reader ) );
+
+		}
+
+		// Regards the first three elements in propertyList as id, attrName, and attrType
+		const id = propertyList.length > 0 ? propertyList[ 0 ] : '';
+		const attrName = propertyList.length > 1 ? propertyList[ 1 ] : '';
+		const attrType = propertyList.length > 2 ? propertyList[ 2 ] : '';
+
+		// check if this node represents just a single property
+		// like (name, 0) set or (name2, [0, 1, 2]) set of {name: 0, name2: [0, 1, 2]}
+		node.singleProperty = ( numProperties === 1 && reader.getOffset() === endOffset ) ? true : false;
+
+		while ( endOffset > reader.getOffset() ) {
+
+			const subNode = this.parseNode( reader, version );
+
+			if ( subNode !== null ) this.parseSubNode( name, node, subNode );
+
+		}
+
+		node.propertyList = propertyList; // raw property list used by parent
+
+		if ( typeof id === 'number' ) node.id = id;
+		if ( attrName !== '' ) node.attrName = attrName;
+		if ( attrType !== '' ) node.attrType = attrType;
+		if ( name !== '' ) node.name = name;
+
+		return node;
+
+	}
+
+	parseSubNode( name, node, subNode ) {
+
+		// special case: child node is single property
+		if ( subNode.singleProperty === true ) {
+
+			const value = subNode.propertyList[ 0 ];
+
+			if ( Array.isArray( value ) ) {
+
+				node[ subNode.name ] = subNode;
+
+				subNode.a = value;
+
+			} else {
+
+				node[ subNode.name ] = value;
+
+			}
+
+		} else if ( name === 'Connections' && subNode.name === 'C' ) {
+
+			const array = [];
+
+			subNode.propertyList.forEach( function ( property, i ) {
+
+				// first Connection is FBX type (OO, OP, etc.). We'll discard these
+				if ( i !== 0 ) array.push( property );
+
+			} );
+
+			if ( node.connections === undefined ) {
+
+				node.connections = [];
+
+			}
+
+			node.connections.push( array );
+
+		} else if ( subNode.name === 'Properties70' ) {
+
+			const keys = Object.keys( subNode );
+
+			keys.forEach( function ( key ) {
+
+				node[ key ] = subNode[ key ];
+
+			} );
+
+		} else if ( name === 'Properties70' && subNode.name === 'P' ) {
+
+			let innerPropName = subNode.propertyList[ 0 ];
+			let innerPropType1 = subNode.propertyList[ 1 ];
+			const innerPropType2 = subNode.propertyList[ 2 ];
+			const innerPropFlag = subNode.propertyList[ 3 ];
+			let innerPropValue;
+
+			if ( innerPropName.indexOf( 'Lcl ' ) === 0 ) innerPropName = innerPropName.replace( 'Lcl ', 'Lcl_' );
+			if ( innerPropType1.indexOf( 'Lcl ' ) === 0 ) innerPropType1 = innerPropType1.replace( 'Lcl ', 'Lcl_' );
+
+			if ( innerPropType1 === 'Color' || innerPropType1 === 'ColorRGB' || innerPropType1 === 'Vector' || innerPropType1 === 'Vector3D' || innerPropType1.indexOf( 'Lcl_' ) === 0 ) {
+
+				innerPropValue = [
+					subNode.propertyList[ 4 ],
+					subNode.propertyList[ 5 ],
+					subNode.propertyList[ 6 ]
+				];
+
+			} else {
+
+				innerPropValue = subNode.propertyList[ 4 ];
+
+			}
+
+			// this will be copied to parent, see above
+			node[ innerPropName ] = {
 
 				'type': innerPropType1,
 				'type2': innerPropType2,
@@ -3316,345 +3492,150 @@ var FBXLoader = ( function () {
 
 			};
 
-			this.setCurrentProp( this.getPrevNode(), innerPropName );
+		} else if ( node[ subNode.name ] === undefined ) {
 
-		},
+			if ( typeof subNode.id === 'number' ) {
 
-	};
-
-	// Parse an FBX file in Binary format
-	function BinaryParser() {}
-
-	BinaryParser.prototype = {
-
-		constructor: BinaryParser,
-
-		parse: function ( buffer ) {
-
-			var reader = new BinaryReader( buffer );
-			reader.skip( 23 ); // skip magic 23 bytes
-
-			var version = reader.getUint32();
-
-			if ( version < 6400 ) {
-
-				throw new Error( 'THREE.FBXLoader: FBX version not supported, FileVersion: ' + version );
-
-			}
-
-			var allNodes = new FBXTree();
-
-			while ( ! this.endOfContent( reader ) ) {
-
-				var node = this.parseNode( reader, version );
-				if ( node !== null ) allNodes.add( node.name, node );
-
-			}
-
-			return allNodes;
-
-		},
-
-		// Check if reader has reached the end of content.
-		endOfContent: function ( reader ) {
-
-			// footer size: 160bytes + 16-byte alignment padding
-			// - 16bytes: magic
-			// - padding til 16-byte alignment (at least 1byte?)
-			//	(seems like some exporters embed fixed 15 or 16bytes?)
-			// - 4bytes: magic
-			// - 4bytes: version
-			// - 120bytes: zero
-			// - 16bytes: magic
-			if ( reader.size() % 16 === 0 ) {
-
-				return ( ( reader.getOffset() + 160 + 16 ) & ~ 0xf ) >= reader.size();
+				node[ subNode.name ] = {};
+				node[ subNode.name ][ subNode.id ] = subNode;
 
 			} else {
 
-				return reader.getOffset() + 160 + 16 >= reader.size();
+				node[ subNode.name ] = subNode;
 
 			}
 
-		},
+		} else {
 
-		// recursively parse nodes until the end of the file is reached
-		parseNode: function ( reader, version ) {
+			if ( subNode.name === 'PoseNode' ) {
 
-			var node = {};
+				if ( ! Array.isArray( node[ subNode.name ] ) ) {
 
-			// The first three data sizes depends on version.
-			var endOffset = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
-			var numProperties = ( version >= 7500 ) ? reader.getUint64() : reader.getUint32();
-
-			( version >= 7500 ) ? reader.getUint64() : reader.getUint32(); // the returned propertyListLen is not used
-
-			var nameLen = reader.getUint8();
-			var name = reader.getString( nameLen );
-
-			// Regards this node as NULL-record if endOffset is zero
-			if ( endOffset === 0 ) return null;
-
-			var propertyList = [];
-
-			for ( var i = 0; i < numProperties; i ++ ) {
-
-				propertyList.push( this.parseProperty( reader ) );
-
-			}
-
-			// Regards the first three elements in propertyList as id, attrName, and attrType
-			var id = propertyList.length > 0 ? propertyList[ 0 ] : '';
-			var attrName = propertyList.length > 1 ? propertyList[ 1 ] : '';
-			var attrType = propertyList.length > 2 ? propertyList[ 2 ] : '';
-
-			// check if this node represents just a single property
-			// like (name, 0) set or (name2, [0, 1, 2]) set of {name: 0, name2: [0, 1, 2]}
-			node.singleProperty = ( numProperties === 1 && reader.getOffset() === endOffset ) ? true : false;
-
-			while ( endOffset > reader.getOffset() ) {
-
-				var subNode = this.parseNode( reader, version );
-
-				if ( subNode !== null ) this.parseSubNode( name, node, subNode );
-
-			}
-
-			node.propertyList = propertyList; // raw property list used by parent
-
-			if ( typeof id === 'number' ) node.id = id;
-			if ( attrName !== '' ) node.attrName = attrName;
-			if ( attrType !== '' ) node.attrType = attrType;
-			if ( name !== '' ) node.name = name;
-
-			return node;
-
-		},
-
-		parseSubNode: function ( name, node, subNode ) {
-
-			// special case: child node is single property
-			if ( subNode.singleProperty === true ) {
-
-				var value = subNode.propertyList[ 0 ];
-
-				if ( Array.isArray( value ) ) {
-
-					node[ subNode.name ] = subNode;
-
-					subNode.a = value;
-
-				} else {
-
-					node[ subNode.name ] = value;
+					node[ subNode.name ] = [ node[ subNode.name ] ];
 
 				}
 
-			} else if ( name === 'Connections' && subNode.name === 'C' ) {
+				node[ subNode.name ].push( subNode );
 
-				var array = [];
+			} else if ( node[ subNode.name ][ subNode.id ] === undefined ) {
 
-				subNode.propertyList.forEach( function ( property, i ) {
-
-					// first Connection is FBX type (OO, OP, etc.). We'll discard these
-					if ( i !== 0 ) array.push( property );
-
-				} );
-
-				if ( node.connections === undefined ) {
-
-					node.connections = [];
-
-				}
-
-				node.connections.push( array );
-
-			} else if ( subNode.name === 'Properties70' ) {
-
-				var keys = Object.keys( subNode );
-
-				keys.forEach( function ( key ) {
-
-					node[ key ] = subNode[ key ];
-
-				} );
-
-			} else if ( name === 'Properties70' && subNode.name === 'P' ) {
-
-				var innerPropName = subNode.propertyList[ 0 ];
-				var innerPropType1 = subNode.propertyList[ 1 ];
-				var innerPropType2 = subNode.propertyList[ 2 ];
-				var innerPropFlag = subNode.propertyList[ 3 ];
-				var innerPropValue;
-
-				if ( innerPropName.indexOf( 'Lcl ' ) === 0 ) innerPropName = innerPropName.replace( 'Lcl ', 'Lcl_' );
-				if ( innerPropType1.indexOf( 'Lcl ' ) === 0 ) innerPropType1 = innerPropType1.replace( 'Lcl ', 'Lcl_' );
-
-				if ( innerPropType1 === 'Color' || innerPropType1 === 'ColorRGB' || innerPropType1 === 'Vector' || innerPropType1 === 'Vector3D' || innerPropType1.indexOf( 'Lcl_' ) === 0 ) {
-
-					innerPropValue = [
-						subNode.propertyList[ 4 ],
-						subNode.propertyList[ 5 ],
-						subNode.propertyList[ 6 ]
-					];
-
-				} else {
-
-					innerPropValue = subNode.propertyList[ 4 ];
-
-				}
-
-				// this will be copied to parent, see above
-				node[ innerPropName ] = {
-
-					'type': innerPropType1,
-					'type2': innerPropType2,
-					'flag': innerPropFlag,
-					'value': innerPropValue
-
-				};
-
-			} else if ( node[ subNode.name ] === undefined ) {
-
-				if ( typeof subNode.id === 'number' ) {
-
-					node[ subNode.name ] = {};
-					node[ subNode.name ][ subNode.id ] = subNode;
-
-				} else {
-
-					node[ subNode.name ] = subNode;
-
-				}
-
-			} else {
-
-				if ( subNode.name === 'PoseNode' ) {
-
-					if ( ! Array.isArray( node[ subNode.name ] ) ) {
-
-						node[ subNode.name ] = [ node[ subNode.name ] ];
-
-					}
-
-					node[ subNode.name ].push( subNode );
-
-				} else if ( node[ subNode.name ][ subNode.id ] === undefined ) {
-
-					node[ subNode.name ][ subNode.id ] = subNode;
-
-				}
-
-			}
-
-		},
-
-		parseProperty: function ( reader ) {
-
-			var type = reader.getString( 1 );
-
-			switch ( type ) {
-
-				case 'C':
-					return reader.getBoolean();
-
-				case 'D':
-					return reader.getFloat64();
-
-				case 'F':
-					return reader.getFloat32();
-
-				case 'I':
-					return reader.getInt32();
-
-				case 'L':
-					return reader.getInt64();
-
-				case 'R':
-					var length = reader.getUint32();
-					return reader.getArrayBuffer( length );
-
-				case 'S':
-					var length = reader.getUint32();
-					return reader.getString( length );
-
-				case 'Y':
-					return reader.getInt16();
-
-				case 'b':
-				case 'c':
-				case 'd':
-				case 'f':
-				case 'i':
-				case 'l':
-
-					var arrayLength = reader.getUint32();
-					var encoding = reader.getUint32(); // 0: non-compressed, 1: compressed
-					var compressedLength = reader.getUint32();
-
-					if ( encoding === 0 ) {
-
-						switch ( type ) {
-
-							case 'b':
-							case 'c':
-								return reader.getBooleanArray( arrayLength );
-
-							case 'd':
-								return reader.getFloat64Array( arrayLength );
-
-							case 'f':
-								return reader.getFloat32Array( arrayLength );
-
-							case 'i':
-								return reader.getInt32Array( arrayLength );
-
-							case 'l':
-								return reader.getInt64Array( arrayLength );
-
-						}
-
-					}
-
-					if ( typeof fflate === 'undefined' ) {
-
-						console.error( 'THREE.FBXLoader: External library fflate.min.js required.' );
-
-					}
-
-					var data = fflate.unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) ); // eslint-disable-line no-undef
-					var reader2 = new BinaryReader( data.buffer );
-
-					switch ( type ) {
-
-						case 'b':
-						case 'c':
-							return reader2.getBooleanArray( arrayLength );
-
-						case 'd':
-							return reader2.getFloat64Array( arrayLength );
-
-						case 'f':
-							return reader2.getFloat32Array( arrayLength );
-
-						case 'i':
-							return reader2.getInt32Array( arrayLength );
-
-						case 'l':
-							return reader2.getInt64Array( arrayLength );
-
-					}
-
-				default:
-					throw new Error( 'THREE.FBXLoader: Unknown property type ' + type );
+				node[ subNode.name ][ subNode.id ] = subNode;
 
 			}
 
 		}
 
-	};
+	}
 
-	function BinaryReader( buffer, littleEndian ) {
+	parseProperty( reader ) {
+
+		const type = reader.getString( 1 );
+		let length;
+
+		switch ( type ) {
+
+			case 'C':
+				return reader.getBoolean();
+
+			case 'D':
+				return reader.getFloat64();
+
+			case 'F':
+				return reader.getFloat32();
+
+			case 'I':
+				return reader.getInt32();
+
+			case 'L':
+				return reader.getInt64();
+
+			case 'R':
+				length = reader.getUint32();
+				return reader.getArrayBuffer( length );
+
+			case 'S':
+				length = reader.getUint32();
+				return reader.getString( length );
+
+			case 'Y':
+				return reader.getInt16();
+
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'f':
+			case 'i':
+			case 'l':
+
+				const arrayLength = reader.getUint32();
+				const encoding = reader.getUint32(); // 0: non-compressed, 1: compressed
+				const compressedLength = reader.getUint32();
+
+				if ( encoding === 0 ) {
+
+					switch ( type ) {
+
+						case 'b':
+						case 'c':
+							return reader.getBooleanArray( arrayLength );
+
+						case 'd':
+							return reader.getFloat64Array( arrayLength );
+
+						case 'f':
+							return reader.getFloat32Array( arrayLength );
+
+						case 'i':
+							return reader.getInt32Array( arrayLength );
+
+						case 'l':
+							return reader.getInt64Array( arrayLength );
+
+					}
+
+				}
+
+				if ( typeof fflate === 'undefined' ) {
+
+					console.error( 'THREE.FBXLoader: External library fflate.min.js required.' );
+
+				}
+
+				const data = fflate.unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) ); // eslint-disable-line no-undef
+				const reader2 = new BinaryReader( data.buffer );
+
+				switch ( type ) {
+
+					case 'b':
+					case 'c':
+						return reader2.getBooleanArray( arrayLength );
+
+					case 'd':
+						return reader2.getFloat64Array( arrayLength );
+
+					case 'f':
+						return reader2.getFloat32Array( arrayLength );
+
+					case 'i':
+						return reader2.getInt32Array( arrayLength );
+
+					case 'l':
+						return reader2.getInt64Array( arrayLength );
+
+				}
+
+			default:
+				throw new Error( 'THREE.FBXLoader: Unknown property type ' + type );
+
+		}
+
+	}
+
+}
+
+class BinaryReader {
+
+	constructor( buffer, littleEndian ) {
 
 		this.dv = new DataView( buffer );
 		this.offset = 0;
@@ -3662,546 +3643,40 @@ var FBXLoader = ( function () {
 
 	}
 
-	BinaryReader.prototype = {
+	getOffset() {
 
-		constructor: BinaryReader,
-
-		getOffset: function () {
-
-			return this.offset;
-
-		},
-
-		size: function () {
-
-			return this.dv.buffer.byteLength;
-
-		},
-
-		skip: function ( length ) {
-
-			this.offset += length;
-
-		},
-
-		// seems like true/false representation depends on exporter.
-		// true: 1 or 'Y'(=0x59), false: 0 or 'T'(=0x54)
-		// then sees LSB.
-		getBoolean: function () {
-
-			return ( this.getUint8() & 1 ) === 1;
-
-		},
-
-		getBooleanArray: function ( size ) {
-
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getBoolean() );
-
-			}
-
-			return a;
-
-		},
-
-		getUint8: function () {
-
-			var value = this.dv.getUint8( this.offset );
-			this.offset += 1;
-			return value;
-
-		},
-
-		getInt16: function () {
-
-			var value = this.dv.getInt16( this.offset, this.littleEndian );
-			this.offset += 2;
-			return value;
-
-		},
-
-		getInt32: function () {
-
-			var value = this.dv.getInt32( this.offset, this.littleEndian );
-			this.offset += 4;
-			return value;
-
-		},
-
-		getInt32Array: function ( size ) {
-
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getInt32() );
-
-			}
-
-			return a;
-
-		},
-
-		getUint32: function () {
-
-			var value = this.dv.getUint32( this.offset, this.littleEndian );
-			this.offset += 4;
-			return value;
-
-		},
-
-		// JavaScript doesn't support 64-bit integer so calculate this here
-		// 1 << 32 will return 1 so using multiply operation instead here.
-		// There's a possibility that this method returns wrong value if the value
-		// is out of the range between Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER.
-		// TODO: safely handle 64-bit integer
-		getInt64: function () {
-
-			var low, high;
-
-			if ( this.littleEndian ) {
-
-				low = this.getUint32();
-				high = this.getUint32();
-
-			} else {
-
-				high = this.getUint32();
-				low = this.getUint32();
-
-			}
-
-			// calculate negative value
-			if ( high & 0x80000000 ) {
-
-				high = ~ high & 0xFFFFFFFF;
-				low = ~ low & 0xFFFFFFFF;
-
-				if ( low === 0xFFFFFFFF ) high = ( high + 1 ) & 0xFFFFFFFF;
-
-				low = ( low + 1 ) & 0xFFFFFFFF;
-
-				return - ( high * 0x100000000 + low );
-
-			}
-
-			return high * 0x100000000 + low;
-
-		},
-
-		getInt64Array: function ( size ) {
-
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getInt64() );
-
-			}
-
-			return a;
-
-		},
-
-		// Note: see getInt64() comment
-		getUint64: function () {
-
-			var low, high;
-
-			if ( this.littleEndian ) {
-
-				low = this.getUint32();
-				high = this.getUint32();
-
-			} else {
-
-				high = this.getUint32();
-				low = this.getUint32();
-
-			}
-
-			return high * 0x100000000 + low;
-
-		},
-
-		getFloat32: function () {
-
-			var value = this.dv.getFloat32( this.offset, this.littleEndian );
-			this.offset += 4;
-			return value;
-
-		},
-
-		getFloat32Array: function ( size ) {
-
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getFloat32() );
-
-			}
-
-			return a;
-
-		},
-
-		getFloat64: function () {
-
-			var value = this.dv.getFloat64( this.offset, this.littleEndian );
-			this.offset += 8;
-			return value;
-
-		},
-
-		getFloat64Array: function ( size ) {
-
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a.push( this.getFloat64() );
-
-			}
-
-			return a;
-
-		},
-
-		getArrayBuffer: function ( size ) {
-
-			var value = this.dv.buffer.slice( this.offset, this.offset + size );
-			this.offset += size;
-			return value;
-
-		},
-
-		getString: function ( size ) {
-
-			// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
-			var a = [];
-
-			for ( var i = 0; i < size; i ++ ) {
-
-				a[ i ] = this.getUint8();
-
-			}
-
-			var nullByte = a.indexOf( 0 );
-			if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
-
-			return LoaderUtils.decodeText( new Uint8Array( a ) );
-
-		}
-
-	};
-
-	// FBXTree holds a representation of the FBX data, returned by the TextParser ( FBX ASCII format)
-	// and BinaryParser( FBX Binary format)
-	function FBXTree() {}
-
-	FBXTree.prototype = {
-
-		constructor: FBXTree,
-
-		add: function ( key, val ) {
-
-			this[ key ] = val;
-
-		},
-
-	};
-
-	// ************** UTILITY FUNCTIONS **************
-
-	function isFbxFormatBinary( buffer ) {
-
-		var CORRECT = 'Kaydara FBX Binary  \0';
-
-		return buffer.byteLength >= CORRECT.length && CORRECT === convertArrayBufferToString( buffer, 0, CORRECT.length );
+		return this.offset;
 
 	}
 
-	function isFbxFormatASCII( text ) {
+	size() {
 
-		var CORRECT = [ 'K', 'a', 'y', 'd', 'a', 'r', 'a', '\\', 'F', 'B', 'X', '\\', 'B', 'i', 'n', 'a', 'r', 'y', '\\', '\\' ];
-
-		var cursor = 0;
-
-		function read( offset ) {
-
-			var result = text[ offset - 1 ];
-			text = text.slice( cursor + offset );
-			cursor ++;
-			return result;
-
-		}
-
-		for ( var i = 0; i < CORRECT.length; ++ i ) {
-
-			var num = read( 1 );
-			if ( num === CORRECT[ i ] ) {
-
-				return false;
-
-			}
-
-		}
-
-		return true;
+		return this.dv.buffer.byteLength;
 
 	}
 
-	function getFbxVersion( text ) {
+	skip( length ) {
 
-		var versionRegExp = /FBXVersion: (\d+)/;
-		var match = text.match( versionRegExp );
-
-		if ( match ) {
-
-			var version = parseInt( match[ 1 ] );
-			return version;
-
-		}
-
-		throw new Error( 'THREE.FBXLoader: Cannot find the version number for the file given.' );
+		this.offset += length;
 
 	}
 
-	// Converts FBX ticks into real time seconds.
-	function convertFBXTimeToSeconds( time ) {
+	// seems like true/false representation depends on exporter.
+	// true: 1 or 'Y'(=0x59), false: 0 or 'T'(=0x54)
+	// then sees LSB.
+	getBoolean() {
 
-		return time / 46186158000;
-
-	}
-
-	var dataArray = [];
-
-	// extracts the data from the correct position in the FBX array based on indexing type
-	function getData( polygonVertexIndex, polygonIndex, vertexIndex, infoObject ) {
-
-		var index;
-
-		switch ( infoObject.mappingType ) {
-
-			case 'ByPolygonVertex' :
-				index = polygonVertexIndex;
-				break;
-			case 'ByPolygon' :
-				index = polygonIndex;
-				break;
-			case 'ByVertice' :
-				index = vertexIndex;
-				break;
-			case 'AllSame' :
-				index = infoObject.indices[ 0 ];
-				break;
-			default :
-				console.warn( 'THREE.FBXLoader: unknown attribute mapping type ' + infoObject.mappingType );
-
-		}
-
-		if ( infoObject.referenceType === 'IndexToDirect' ) index = infoObject.indices[ index ];
-
-		var from = index * infoObject.dataSize;
-		var to = from + infoObject.dataSize;
-
-		return slice( dataArray, infoObject.buffer, from, to );
+		return ( this.getUint8() & 1 ) === 1;
 
 	}
 
-	var tempEuler = new Euler();
-	var tempVec = new Vector3();
+	getBooleanArray( size ) {
 
-	// generate transformation from FBX transform data
-	// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
-	// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
-	function generateTransform( transformData ) {
+		const a = [];
 
-		var lTranslationM = new Matrix4();
-		var lPreRotationM = new Matrix4();
-		var lRotationM = new Matrix4();
-		var lPostRotationM = new Matrix4();
+		for ( let i = 0; i < size; i ++ ) {
 
-		var lScalingM = new Matrix4();
-		var lScalingPivotM = new Matrix4();
-		var lScalingOffsetM = new Matrix4();
-		var lRotationOffsetM = new Matrix4();
-		var lRotationPivotM = new Matrix4();
-
-		var lParentGX = new Matrix4();
-		var lParentLX = new Matrix4();
-		var lGlobalT = new Matrix4();
-
-		var inheritType = ( transformData.inheritType ) ? transformData.inheritType : 0;
-
-		if ( transformData.translation ) lTranslationM.setPosition( tempVec.fromArray( transformData.translation ) );
-
-		if ( transformData.preRotation ) {
-
-			var array = transformData.preRotation.map( MathUtils.degToRad );
-			array.push( transformData.eulerOrder );
-			lPreRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-
-		}
-
-		if ( transformData.rotation ) {
-
-			var array = transformData.rotation.map( MathUtils.degToRad );
-			array.push( transformData.eulerOrder );
-			lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-
-		}
-
-		if ( transformData.postRotation ) {
-
-			var array = transformData.postRotation.map( MathUtils.degToRad );
-			array.push( transformData.eulerOrder );
-			lPostRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
-			lPostRotationM.invert();
-
-		}
-
-		if ( transformData.scale ) lScalingM.scale( tempVec.fromArray( transformData.scale ) );
-
-		// Pivots and offsets
-		if ( transformData.scalingOffset ) lScalingOffsetM.setPosition( tempVec.fromArray( transformData.scalingOffset ) );
-		if ( transformData.scalingPivot ) lScalingPivotM.setPosition( tempVec.fromArray( transformData.scalingPivot ) );
-		if ( transformData.rotationOffset ) lRotationOffsetM.setPosition( tempVec.fromArray( transformData.rotationOffset ) );
-		if ( transformData.rotationPivot ) lRotationPivotM.setPosition( tempVec.fromArray( transformData.rotationPivot ) );
-
-		// parent transform
-		if ( transformData.parentMatrixWorld ) {
-
-			lParentLX.copy( transformData.parentMatrix );
-			lParentGX.copy( transformData.parentMatrixWorld );
-
-		}
-
-		var lLRM = new Matrix4().copy( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM );
-		// Global Rotation
-		var lParentGRM = new Matrix4();
-		lParentGRM.extractRotation( lParentGX );
-
-		// Global Shear*Scaling
-		var lParentTM = new Matrix4();
-		lParentTM.copyPosition( lParentGX );
-
-		var lParentGSM = new Matrix4();
-		var lParentGRSM = new Matrix4().copy( lParentTM ).invert().multiply( lParentGX );
-		lParentGSM.copy( lParentGRM ).invert().multiply( lParentGRSM );
-		var lLSM = lScalingM;
-
-		var lGlobalRS = new Matrix4();
-
-		if ( inheritType === 0 ) {
-
-			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
-
-		} else if ( inheritType === 1 ) {
-
-			lGlobalRS.copy( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
-
-		} else {
-
-			var lParentLSM = new Matrix4().scale( new Vector3().setFromMatrixScale( lParentLX ) );
-			var lParentLSM_inv = new Matrix4().copy( lParentLSM ).invert();
-			var lParentGSM_noLocal = new Matrix4().copy( lParentGSM ).multiply( lParentLSM_inv );
-
-			lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
-
-		}
-
-		var lRotationPivotM_inv = new Matrix4();
-		lRotationPivotM_inv.copy( lRotationPivotM ).invert();
-		var lScalingPivotM_inv = new Matrix4();
-		lScalingPivotM_inv.copy( lScalingPivotM ).invert();
-		// Calculate the local transform matrix
-		var lTransform = new Matrix4();
-		lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
-
-		var lLocalTWithAllPivotAndOffsetInfo = new Matrix4().copyPosition( lTransform );
-
-		var lGlobalTranslation = new Matrix4().copy( lParentGX ).multiply( lLocalTWithAllPivotAndOffsetInfo );
-		lGlobalT.copyPosition( lGlobalTranslation );
-
-		lTransform = new Matrix4().copy( lGlobalT ).multiply( lGlobalRS );
-
-		// from global to local
-		lTransform.premultiply( lParentGX.invert() );
-
-		return lTransform;
-
-	}
-
-	// Returns the three.js intrinsic Euler order corresponding to FBX extrinsic Euler order
-	// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
-	function getEulerOrder( order ) {
-
-		order = order || 0;
-
-		var enums = [
-			'ZYX', // -> XYZ extrinsic
-			'YZX', // -> XZY extrinsic
-			'XZY', // -> YZX extrinsic
-			'ZXY', // -> YXZ extrinsic
-			'YXZ', // -> ZXY extrinsic
-			'XYZ', // -> ZYX extrinsic
-			//'SphericXYZ', // not possible to support
-		];
-
-		if ( order === 6 ) {
-
-			console.warn( 'THREE.FBXLoader: unsupported Euler Order: Spherical XYZ. Animations and rotations may be incorrect.' );
-			return enums[ 0 ];
-
-		}
-
-		return enums[ order ];
-
-	}
-
-	// Parses comma separated list of numbers and returns them an array.
-	// Used internally by the TextParser
-	function parseNumberArray( value ) {
-
-		var array = value.split( ',' ).map( function ( val ) {
-
-			return parseFloat( val );
-
-		} );
-
-		return array;
-
-	}
-
-	function convertArrayBufferToString( buffer, from, to ) {
-
-		if ( from === undefined ) from = 0;
-		if ( to === undefined ) to = buffer.byteLength;
-
-		return LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) );
-
-	}
-
-	function append( a, b ) {
-
-		for ( var i = 0, j = a.length, l = b.length; i < l; i ++, j ++ ) {
-
-			a[ j ] = b[ i ];
-
-		}
-
-	}
-
-	function slice( a, b, from, to ) {
-
-		for ( var i = from, j = 0; i < to; i ++, j ++ ) {
-
-			a[ j ] = b[ i ];
+			a.push( this.getBoolean() );
 
 		}
 
@@ -4209,15 +3684,509 @@ var FBXLoader = ( function () {
 
 	}
 
-	// inject array a2 into array a1 at index
-	function inject( a1, index, a2 ) {
+	getUint8() {
 
-		return a1.slice( 0, index ).concat( a2 ).concat( a1.slice( index ) );
+		const value = this.dv.getUint8( this.offset );
+		this.offset += 1;
+		return value;
 
 	}
 
-	return FBXLoader;
+	getInt16() {
 
-} )();
+		const value = this.dv.getInt16( this.offset, this.littleEndian );
+		this.offset += 2;
+		return value;
+
+	}
+
+	getInt32() {
+
+		const value = this.dv.getInt32( this.offset, this.littleEndian );
+		this.offset += 4;
+		return value;
+
+	}
+
+	getInt32Array( size ) {
+
+		const a = [];
+
+		for ( let i = 0; i < size; i ++ ) {
+
+			a.push( this.getInt32() );
+
+		}
+
+		return a;
+
+	}
+
+	getUint32() {
+
+		const value = this.dv.getUint32( this.offset, this.littleEndian );
+		this.offset += 4;
+		return value;
+
+	}
+
+	// JavaScript doesn't support 64-bit integer so calculate this here
+	// 1 << 32 will return 1 so using multiply operation instead here.
+	// There's a possibility that this method returns wrong value if the value
+	// is out of the range between Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER.
+	// TODO: safely handle 64-bit integer
+	getInt64() {
+
+		let low, high;
+
+		if ( this.littleEndian ) {
+
+			low = this.getUint32();
+			high = this.getUint32();
+
+		} else {
+
+			high = this.getUint32();
+			low = this.getUint32();
+
+		}
+
+		// calculate negative value
+		if ( high & 0x80000000 ) {
+
+			high = ~ high & 0xFFFFFFFF;
+			low = ~ low & 0xFFFFFFFF;
+
+			if ( low === 0xFFFFFFFF ) high = ( high + 1 ) & 0xFFFFFFFF;
+
+			low = ( low + 1 ) & 0xFFFFFFFF;
+
+			return - ( high * 0x100000000 + low );
+
+		}
+
+		return high * 0x100000000 + low;
+
+	}
+
+	getInt64Array( size ) {
+
+		const a = [];
+
+		for ( let i = 0; i < size; i ++ ) {
+
+			a.push( this.getInt64() );
+
+		}
+
+		return a;
+
+	}
+
+	// Note: see getInt64() comment
+	getUint64() {
+
+		let low, high;
+
+		if ( this.littleEndian ) {
+
+			low = this.getUint32();
+			high = this.getUint32();
+
+		} else {
+
+			high = this.getUint32();
+			low = this.getUint32();
+
+		}
+
+		return high * 0x100000000 + low;
+
+	}
+
+	getFloat32() {
+
+		const value = this.dv.getFloat32( this.offset, this.littleEndian );
+		this.offset += 4;
+		return value;
+
+	}
+
+	getFloat32Array( size ) {
+
+		const a = [];
+
+		for ( let i = 0; i < size; i ++ ) {
+
+			a.push( this.getFloat32() );
+
+		}
+
+		return a;
+
+	}
+
+	getFloat64() {
+
+		const value = this.dv.getFloat64( this.offset, this.littleEndian );
+		this.offset += 8;
+		return value;
+
+	}
+
+	getFloat64Array( size ) {
+
+		const a = [];
+
+		for ( let i = 0; i < size; i ++ ) {
+
+			a.push( this.getFloat64() );
+
+		}
+
+		return a;
+
+	}
+
+	getArrayBuffer( size ) {
+
+		const value = this.dv.buffer.slice( this.offset, this.offset + size );
+		this.offset += size;
+		return value;
+
+	}
+
+	getString( size ) {
+
+		// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
+		let a = [];
+
+		for ( let i = 0; i < size; i ++ ) {
+
+			a[ i ] = this.getUint8();
+
+		}
+
+		const nullByte = a.indexOf( 0 );
+		if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
+
+		return LoaderUtils.decodeText( new Uint8Array( a ) );
+
+	}
+
+}
+
+// FBXTree holds a representation of the FBX data, returned by the TextParser ( FBX ASCII format)
+// and BinaryParser( FBX Binary format)
+class FBXTree {
+
+	add( key, val ) {
+
+		this[ key ] = val;
+
+	}
+
+}
+
+// ************** UTILITY FUNCTIONS **************
+
+function isFbxFormatBinary( buffer ) {
+
+	const CORRECT = 'Kaydara FBX Binary  \0';
+
+	return buffer.byteLength >= CORRECT.length && CORRECT === convertArrayBufferToString( buffer, 0, CORRECT.length );
+
+}
+
+function isFbxFormatASCII( text ) {
+
+	const CORRECT = [ 'K', 'a', 'y', 'd', 'a', 'r', 'a', '\\', 'F', 'B', 'X', '\\', 'B', 'i', 'n', 'a', 'r', 'y', '\\', '\\' ];
+
+	let cursor = 0;
+
+	function read( offset ) {
+
+		const result = text[ offset - 1 ];
+		text = text.slice( cursor + offset );
+		cursor ++;
+		return result;
+
+	}
+
+	for ( let i = 0; i < CORRECT.length; ++ i ) {
+
+		const num = read( 1 );
+		if ( num === CORRECT[ i ] ) {
+
+			return false;
+
+		}
+
+	}
+
+	return true;
+
+}
+
+function getFbxVersion( text ) {
+
+	const versionRegExp = /FBXVersion: (\d+)/;
+	const match = text.match( versionRegExp );
+
+	if ( match ) {
+
+		const version = parseInt( match[ 1 ] );
+		return version;
+
+	}
+
+	throw new Error( 'THREE.FBXLoader: Cannot find the version number for the file given.' );
+
+}
+
+// Converts FBX ticks into real time seconds.
+function convertFBXTimeToSeconds( time ) {
+
+	return time / 46186158000;
+
+}
+
+const dataArray = [];
+
+// extracts the data from the correct position in the FBX array based on indexing type
+function getData( polygonVertexIndex, polygonIndex, vertexIndex, infoObject ) {
+
+	let index;
+
+	switch ( infoObject.mappingType ) {
+
+		case 'ByPolygonVertex' :
+			index = polygonVertexIndex;
+			break;
+		case 'ByPolygon' :
+			index = polygonIndex;
+			break;
+		case 'ByVertice' :
+			index = vertexIndex;
+			break;
+		case 'AllSame' :
+			index = infoObject.indices[ 0 ];
+			break;
+		default :
+			console.warn( 'THREE.FBXLoader: unknown attribute mapping type ' + infoObject.mappingType );
+
+	}
+
+	if ( infoObject.referenceType === 'IndexToDirect' ) index = infoObject.indices[ index ];
+
+	const from = index * infoObject.dataSize;
+	const to = from + infoObject.dataSize;
+
+	return slice( dataArray, infoObject.buffer, from, to );
+
+}
+
+const tempEuler = new Euler();
+const tempVec = new Vector3();
+
+// generate transformation from FBX transform data
+// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
+// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
+function generateTransform( transformData ) {
+
+	const lTranslationM = new Matrix4();
+	const lPreRotationM = new Matrix4();
+	const lRotationM = new Matrix4();
+	const lPostRotationM = new Matrix4();
+
+	const lScalingM = new Matrix4();
+	const lScalingPivotM = new Matrix4();
+	const lScalingOffsetM = new Matrix4();
+	const lRotationOffsetM = new Matrix4();
+	const lRotationPivotM = new Matrix4();
+
+	const lParentGX = new Matrix4();
+	const lParentLX = new Matrix4();
+	const lGlobalT = new Matrix4();
+
+	const inheritType = ( transformData.inheritType ) ? transformData.inheritType : 0;
+
+	if ( transformData.translation ) lTranslationM.setPosition( tempVec.fromArray( transformData.translation ) );
+
+	if ( transformData.preRotation ) {
+
+		const array = transformData.preRotation.map( MathUtils.degToRad );
+		array.push( transformData.eulerOrder );
+		lPreRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+
+	}
+
+	if ( transformData.rotation ) {
+
+		const array = transformData.rotation.map( MathUtils.degToRad );
+		array.push( transformData.eulerOrder );
+		lRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+
+	}
+
+	if ( transformData.postRotation ) {
+
+		const array = transformData.postRotation.map( MathUtils.degToRad );
+		array.push( transformData.eulerOrder );
+		lPostRotationM.makeRotationFromEuler( tempEuler.fromArray( array ) );
+		lPostRotationM.invert();
+
+	}
+
+	if ( transformData.scale ) lScalingM.scale( tempVec.fromArray( transformData.scale ) );
+
+	// Pivots and offsets
+	if ( transformData.scalingOffset ) lScalingOffsetM.setPosition( tempVec.fromArray( transformData.scalingOffset ) );
+	if ( transformData.scalingPivot ) lScalingPivotM.setPosition( tempVec.fromArray( transformData.scalingPivot ) );
+	if ( transformData.rotationOffset ) lRotationOffsetM.setPosition( tempVec.fromArray( transformData.rotationOffset ) );
+	if ( transformData.rotationPivot ) lRotationPivotM.setPosition( tempVec.fromArray( transformData.rotationPivot ) );
+
+	// parent transform
+	if ( transformData.parentMatrixWorld ) {
+
+		lParentLX.copy( transformData.parentMatrix );
+		lParentGX.copy( transformData.parentMatrixWorld );
+
+	}
+
+	const lLRM = new Matrix4().copy( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM );
+	// Global Rotation
+	const lParentGRM = new Matrix4();
+	lParentGRM.extractRotation( lParentGX );
+
+	// Global Shear*Scaling
+	const lParentTM = new Matrix4();
+	lParentTM.copyPosition( lParentGX );
+
+	const lParentGSM = new Matrix4();
+	const lParentGRSM = new Matrix4().copy( lParentTM ).invert().multiply( lParentGX );
+	lParentGSM.copy( lParentGRM ).invert().multiply( lParentGRSM );
+	const lLSM = lScalingM;
+
+	const lGlobalRS = new Matrix4();
+
+	if ( inheritType === 0 ) {
+
+		lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM ).multiply( lLSM );
+
+	} else if ( inheritType === 1 ) {
+
+		lGlobalRS.copy( lParentGRM ).multiply( lParentGSM ).multiply( lLRM ).multiply( lLSM );
+
+	} else {
+
+		const lParentLSM = new Matrix4().scale( new Vector3().setFromMatrixScale( lParentLX ) );
+		const lParentLSM_inv = new Matrix4().copy( lParentLSM ).invert();
+		const lParentGSM_noLocal = new Matrix4().copy( lParentGSM ).multiply( lParentLSM_inv );
+
+		lGlobalRS.copy( lParentGRM ).multiply( lLRM ).multiply( lParentGSM_noLocal ).multiply( lLSM );
+
+	}
+
+	const lRotationPivotM_inv = new Matrix4();
+	lRotationPivotM_inv.copy( lRotationPivotM ).invert();
+	const lScalingPivotM_inv = new Matrix4();
+	lScalingPivotM_inv.copy( lScalingPivotM ).invert();
+	// Calculate the local transform matrix
+	let lTransform = new Matrix4();
+	lTransform.copy( lTranslationM ).multiply( lRotationOffsetM ).multiply( lRotationPivotM ).multiply( lPreRotationM ).multiply( lRotationM ).multiply( lPostRotationM ).multiply( lRotationPivotM_inv ).multiply( lScalingOffsetM ).multiply( lScalingPivotM ).multiply( lScalingM ).multiply( lScalingPivotM_inv );
+
+	const lLocalTWithAllPivotAndOffsetInfo = new Matrix4().copyPosition( lTransform );
+
+	const lGlobalTranslation = new Matrix4().copy( lParentGX ).multiply( lLocalTWithAllPivotAndOffsetInfo );
+	lGlobalT.copyPosition( lGlobalTranslation );
+
+	lTransform = new Matrix4().copy( lGlobalT ).multiply( lGlobalRS );
+
+	// from global to local
+	lTransform.premultiply( lParentGX.invert() );
+
+	return lTransform;
+
+}
+
+// Returns the three.js intrinsic Euler order corresponding to FBX extrinsic Euler order
+// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
+function getEulerOrder( order ) {
+
+	order = order || 0;
+
+	const enums = [
+		'ZYX', // -> XYZ extrinsic
+		'YZX', // -> XZY extrinsic
+		'XZY', // -> YZX extrinsic
+		'ZXY', // -> YXZ extrinsic
+		'YXZ', // -> ZXY extrinsic
+		'XYZ', // -> ZYX extrinsic
+		//'SphericXYZ', // not possible to support
+	];
+
+	if ( order === 6 ) {
+
+		console.warn( 'THREE.FBXLoader: unsupported Euler Order: Spherical XYZ. Animations and rotations may be incorrect.' );
+		return enums[ 0 ];
+
+	}
+
+	return enums[ order ];
+
+}
+
+// Parses comma separated list of numbers and returns them an array.
+// Used internally by the TextParser
+function parseNumberArray( value ) {
+
+	const array = value.split( ',' ).map( function ( val ) {
+
+		return parseFloat( val );
+
+	} );
+
+	return array;
+
+}
+
+function convertArrayBufferToString( buffer, from, to ) {
+
+	if ( from === undefined ) from = 0;
+	if ( to === undefined ) to = buffer.byteLength;
+
+	return LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) );
+
+}
+
+function append( a, b ) {
+
+	for ( let i = 0, j = a.length, l = b.length; i < l; i ++, j ++ ) {
+
+		a[ j ] = b[ i ];
+
+	}
+
+}
+
+function slice( a, b, from, to ) {
+
+	for ( let i = from, j = 0; i < to; i ++, j ++ ) {
+
+		a[ j ] = b[ i ];
+
+	}
+
+	return a;
+
+}
+
+// inject array a2 into array a1 at index
+function inject( a1, index, a2 ) {
+
+	return a1.slice( 0, index ).concat( a2 ).concat( a1.slice( index ) );
+
+}
 
 export { FBXLoader };

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -18,23 +18,21 @@ import {
  * @param {Manager} manager Loading manager.
  */
 
-var GCodeLoader = function ( manager ) {
+class GCodeLoader extends Loader {
 
-	Loader.call( this, manager );
+	constructor( manager ) {
 
-	this.splitLayer = false;
+		super( manager );
 
-};
+		this.splitLayer = false;
 
-GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	}
 
-	constructor: GCodeLoader,
+	load( url, onLoad, onProgress, onError ) {
 
-	load: function ( url, onLoad, onProgress, onError ) {
+		const scope = this;
 
-		var scope = this;
-
-		var loader = new FileLoader( scope.manager );
+		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
@@ -62,9 +60,9 @@ GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		var state = { x: 0, y: 0, z: 0, e: 0, f: 0, extruding: false, relative: false };
 		var layers = [];
@@ -260,6 +258,6 @@ GCodeLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	}
 
-} );
+}
 
 export { GCodeLoader };

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -18,9 +18,26 @@ import {
 	Vector3
 } from '../../../build/three.module.js';
 
-var LDrawLoader = ( function () {
+// Special surface finish tag types.
+// Note: "MATERIAL" tag (e.g. GLITTER, SPECKLE) is not implemented
+const FINISH_TYPE_DEFAULT = 0;
+const FINISH_TYPE_CHROME = 1;
+const FINISH_TYPE_PEARLESCENT = 2;
+const FINISH_TYPE_RUBBER = 3;
+const FINISH_TYPE_MATTE_METALLIC = 4;
+const FINISH_TYPE_METAL = 5;
 
-	var conditionalLineVertShader = /* glsl */`
+// State machine to search a subobject path.
+// The LDraw standard establishes these various possible subfolders.
+const FILE_LOCATION_AS_IS = 0;
+const FILE_LOCATION_TRY_PARTS = 1;
+const FILE_LOCATION_TRY_P = 2;
+const FILE_LOCATION_TRY_MODELS = 3;
+const FILE_LOCATION_TRY_RELATIVE = 4;
+const FILE_LOCATION_TRY_ABSOLUTE = 5;
+const FILE_LOCATION_NOT_FOUND = 6;
+
+const conditionalLineVertShader = /* glsl */`
 	attribute vec3 control0;
 	attribute vec3 control1;
 	attribute vec3 direction;
@@ -68,7 +85,7 @@ var LDrawLoader = ( function () {
 	}
 	`;
 
-	var conditionalLineFragShader = /* glsl */`
+const conditionalLineFragShader = /* glsl */`
 	uniform vec3 diffuse;
 	uniform float opacity;
 	varying float discardFlag;
@@ -96,177 +113,174 @@ var LDrawLoader = ( function () {
 	}
 	`;
 
+const _tempVec0 = new Vector3();
+const _tempVec1 = new Vector3();
 
+function smoothNormals( triangles, lineSegments ) {
 
-	var tempVec0 = new Vector3();
-	var tempVec1 = new Vector3();
-	function smoothNormals( triangles, lineSegments ) {
+	function hashVertex( v ) {
 
-		function hashVertex( v ) {
+		// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
+		// to be smoothed as expected (see minifig arms). The errors between edges
+		// could be due to matrix multiplication.
+		const x = ~ ~ ( v.x * 1e2 );
+		const y = ~ ~ ( v.y * 1e2 );
+		const z = ~ ~ ( v.z * 1e2 );
+		return `${ x },${ y },${ z }`;
 
-			// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
-			// to be smoothed as expected (see minifig arms). The errors between edges
-			// could be due to matrix multiplication.
-			var x = ~ ~ ( v.x * 1e2 );
-			var y = ~ ~ ( v.y * 1e2 );
-			var z = ~ ~ ( v.z * 1e2 );
-			return `${ x },${ y },${ z }`;
+	}
+
+	function hashEdge( v0, v1 ) {
+
+		return `${ hashVertex( v0 ) }_${ hashVertex( v1 ) }`;
+
+	}
+
+	const hardEdges = new Set();
+	const halfEdgeList = {};
+	const fullHalfEdgeList = {};
+	const normals = [];
+
+	// Save the list of hard edges by hash
+	for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
+
+		const ls = lineSegments[ i ];
+		const v0 = ls.v0;
+		const v1 = ls.v1;
+		hardEdges.add( hashEdge( v0, v1 ) );
+		hardEdges.add( hashEdge( v1, v0 ) );
+
+	}
+
+	// track the half edges associated with each triangle
+	for ( let i = 0, l = triangles.length; i < l; i ++ ) {
+
+		const tri = triangles[ i ];
+		for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+
+			const index = i2;
+			const next = ( i2 + 1 ) % 3;
+			const v0 = tri[ `v${ index }` ];
+			const v1 = tri[ `v${ next }` ];
+			const hash = hashEdge( v0, v1 );
+
+			// don't add the triangle if the edge is supposed to be hard
+			if ( hardEdges.has( hash ) ) continue;
+			halfEdgeList[ hash ] = tri;
+			fullHalfEdgeList[ hash ] = tri;
 
 		}
 
-		function hashEdge( v0, v1 ) {
+	}
 
-			return `${ hashVertex( v0 ) }_${ hashVertex( v1 ) }`;
+	// NOTE: Some of the normals wind up being skewed in an unexpected way because
+	// quads provide more "influence" to some vertex normals than a triangle due to
+	// the fact that a quad is made up of two triangles and all triangles are weighted
+	// equally. To fix this quads could be tracked separately so their vertex normals
+	// are weighted appropriately or we could try only adding a normal direction
+	// once per normal.
 
-		}
+	// Iterate until we've tried to connect all triangles to share normals
+	while ( true ) {
 
-		var hardEdges = new Set();
-		var halfEdgeList = {};
-		var fullHalfEdgeList = {};
-		var normals = [];
+		// Stop if there are no more triangles left
+		const halfEdges = Object.keys( halfEdgeList );
+		if ( halfEdges.length === 0 ) break;
 
-		// Save the list of hard edges by hash
-		for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
+		// Exhaustively find all connected triangles
+		let i = 0;
+		const queue = [ fullHalfEdgeList[ halfEdges[ 0 ] ] ];
+		while ( i < queue.length ) {
 
-			var ls = lineSegments[ i ];
-			var v0 = ls.v0;
-			var v1 = ls.v1;
-			hardEdges.add( hashEdge( v0, v1 ) );
-			hardEdges.add( hashEdge( v1, v0 ) );
+			// initialize all vertex normals in this triangle
+			const tri = queue[ i ];
+			i ++;
 
-		}
+			const faceNormal = tri.faceNormal;
+			if ( tri.n0 === null ) {
 
-		// track the half edges associated with each triangle
-		for ( var i = 0, l = triangles.length; i < l; i ++ ) {
-
-			var tri = triangles[ i ];
-			for ( var i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
-
-				var index = i2;
-				var next = ( i2 + 1 ) % 3;
-				var v0 = tri[ `v${ index }` ];
-				var v1 = tri[ `v${ next }` ];
-				var hash = hashEdge( v0, v1 );
-
-				// don't add the triangle if the edge is supposed to be hard
-				if ( hardEdges.has( hash ) ) continue;
-				halfEdgeList[ hash ] = tri;
-				fullHalfEdgeList[ hash ] = tri;
+				tri.n0 = faceNormal.clone();
+				normals.push( tri.n0 );
 
 			}
 
-		}
+			if ( tri.n1 === null ) {
 
-		// NOTE: Some of the normals wind up being skewed in an unexpected way because
-		// quads provide more "influence" to some vertex normals than a triangle due to
-		// the fact that a quad is made up of two triangles and all triangles are weighted
-		// equally. To fix this quads could be tracked separately so their vertex normals
-		// are weighted appropriately or we could try only adding a normal direction
-		// once per normal.
+				tri.n1 = faceNormal.clone();
+				normals.push( tri.n1 );
 
-		// Iterate until we've tried to connect all triangles to share normals
-		while ( true ) {
+			}
 
-			// Stop if there are no more triangles left
-			var halfEdges = Object.keys( halfEdgeList );
-			if ( halfEdges.length === 0 ) break;
+			if ( tri.n2 === null ) {
 
-			// Exhaustively find all connected triangles
-			var i = 0;
-			var queue = [ fullHalfEdgeList[ halfEdges[ 0 ] ] ];
-			while ( i < queue.length ) {
+				tri.n2 = faceNormal.clone();
+				normals.push( tri.n2 );
 
-				// initialize all vertex normals in this triangle
-				var tri = queue[ i ];
-				i ++;
+			}
 
-				var faceNormal = tri.faceNormal;
-				if ( tri.n0 === null ) {
+			// Check if any edge is connected to another triangle edge
+			for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
 
-					tri.n0 = faceNormal.clone();
-					normals.push( tri.n0 );
+				const index = i2;
+				const next = ( i2 + 1 ) % 3;
+				const v0 = tri[ `v${ index }` ];
+				const v1 = tri[ `v${ next }` ];
 
-				}
+				// delete this triangle from the list so it won't be found again
+				const hash = hashEdge( v0, v1 );
+				delete halfEdgeList[ hash ];
 
-				if ( tri.n1 === null ) {
+				const reverseHash = hashEdge( v1, v0 );
+				const otherTri = fullHalfEdgeList[ reverseHash ];
+				if ( otherTri ) {
 
-					tri.n1 = faceNormal.clone();
-					normals.push( tri.n1 );
+					// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
+					// hard edge. There are some cases where the line segments do not line up exactly
+					// with or span multiple triangle edges (see Lunar Vehicle wheels).
+					if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
 
-				}
+						continue;
 
-				if ( tri.n2 === null ) {
+					}
 
-					tri.n2 = faceNormal.clone();
-					normals.push( tri.n2 );
+					// if this triangle has already been traversed then it won't be in
+					// the halfEdgeList. If it has not then add it to the queue and delete
+					// it so it won't be found again.
+					if ( reverseHash in halfEdgeList ) {
 
-				}
+						queue.push( otherTri );
+						delete halfEdgeList[ reverseHash ];
 
-				// Check if any edge is connected to another triangle edge
-				for ( var i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+					}
 
-					var index = i2;
-					var next = ( i2 + 1 ) % 3;
-					var v0 = tri[ `v${ index }` ];
-					var v1 = tri[ `v${ next }` ];
+					// Find the matching edge in this triangle and copy the normal vector over
+					for ( let i3 = 0, l3 = 3; i3 < l3; i3 ++ ) {
 
-					// delete this triangle from the list so it won't be found again
-					var hash = hashEdge( v0, v1 );
-					delete halfEdgeList[ hash ];
+						const otherIndex = i3;
+						const otherNext = ( i3 + 1 ) % 3;
+						const otherV0 = otherTri[ `v${ otherIndex }` ];
+						const otherV1 = otherTri[ `v${ otherNext }` ];
 
-					var reverseHash = hashEdge( v1, v0 );
-					var otherTri = fullHalfEdgeList[ reverseHash ];
-					if ( otherTri ) {
+						const otherHash = hashEdge( otherV0, otherV1 );
+						if ( otherHash === reverseHash ) {
 
-						// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
-						// hard edge. There are some cases where the line segments do not line up exactly
-						// with or span multiple triangle edges (see Lunar Vehicle wheels).
-						if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
+							if ( otherTri[ `n${ otherIndex }` ] === null ) {
 
-							continue;
-
-						}
-
-						// if this triangle has already been traversed then it won't be in
-						// the halfEdgeList. If it has not then add it to the queue and delete
-						// it so it won't be found again.
-						if ( reverseHash in halfEdgeList ) {
-
-							queue.push( otherTri );
-							delete halfEdgeList[ reverseHash ];
-
-						}
-
-						// Find the matching edge in this triangle and copy the normal vector over
-						for ( var i3 = 0, l3 = 3; i3 < l3; i3 ++ ) {
-
-							var otherIndex = i3;
-							var otherNext = ( i3 + 1 ) % 3;
-							var otherV0 = otherTri[ `v${ otherIndex }` ];
-							var otherV1 = otherTri[ `v${ otherNext }` ];
-
-							var otherHash = hashEdge( otherV0, otherV1 );
-							if ( otherHash === reverseHash ) {
-
-								if ( otherTri[ `n${ otherIndex }` ] === null ) {
-
-									var norm = tri[ `n${ next }` ];
-									otherTri[ `n${ otherIndex }` ] = norm;
-									norm.add( otherTri.faceNormal );
-
-								}
-
-								if ( otherTri[ `n${ otherNext }` ] === null ) {
-
-									var norm = tri[ `n${ index }` ];
-									otherTri[ `n${ otherNext }` ] = norm;
-									norm.add( otherTri.faceNormal );
-
-								}
-
-								break;
+								const norm = tri[ `n${ next }` ];
+								otherTri[ `n${ otherIndex }` ] = norm;
+								norm.add( otherTri.faceNormal );
 
 							}
+
+							if ( otherTri[ `n${ otherNext }` ] === null ) {
+
+								const norm = tri[ `n${ index }` ];
+								otherTri[ `n${ otherNext }` ] = norm;
+								norm.add( otherTri.faceNormal );
+
+							}
+
+							break;
 
 						}
 
@@ -278,22 +292,26 @@ var LDrawLoader = ( function () {
 
 		}
 
-		// The normals of each face have been added up so now we average them by normalizing the vector.
-		for ( var i = 0, l = normals.length; i < l; i ++ ) {
+	}
 
-			normals[ i ].normalize();
+	// The normals of each face have been added up so now we average them by normalizing the vector.
+	for ( let i = 0, l = normals.length; i < l; i ++ ) {
 
-		}
+		normals[ i ].normalize();
 
 	}
 
-	function isPrimitiveType( type ) {
+}
 
-		return /primitive/i.test( type ) || type === 'Subpart';
+function isPrimitiveType( type ) {
 
-	}
+	return /primitive/i.test( type ) || type === 'Subpart';
 
-	function LineParser( line, lineNumber ) {
+}
+
+class LineParser {
+
+	constructor( line, lineNumber ) {
 
 		this.line = line;
 		this.lineLength = line.length;
@@ -303,238 +321,235 @@ var LDrawLoader = ( function () {
 
 	}
 
-	LineParser.prototype = {
+	seekNonSpace() {
 
-		constructor: LineParser,
+		while ( this.currentCharIndex < this.lineLength ) {
 
-		seekNonSpace: function () {
+			this.currentChar = this.line.charAt( this.currentCharIndex );
 
-			while ( this.currentCharIndex < this.lineLength ) {
+			if ( this.currentChar !== ' ' && this.currentChar !== '\t' ) {
 
-				this.currentChar = this.line.charAt( this.currentCharIndex );
-
-				if ( this.currentChar !== ' ' && this.currentChar !== '\t' ) {
-
-					return;
-
-				}
-
-				this.currentCharIndex ++;
+				return;
 
 			}
 
-		},
-
-		getToken: function () {
-
-			var pos0 = this.currentCharIndex ++;
-
-			// Seek space
-			while ( this.currentCharIndex < this.lineLength ) {
-
-				this.currentChar = this.line.charAt( this.currentCharIndex );
-
-				if ( this.currentChar === ' ' || this.currentChar === '\t' ) {
-
-					break;
-
-				}
-
-				this.currentCharIndex ++;
-
-			}
-
-			var pos1 = this.currentCharIndex;
-
-			this.seekNonSpace();
-
-			return this.line.substring( pos0, pos1 );
-
-		},
-
-		getRemainingString: function () {
-
-			return this.line.substring( this.currentCharIndex, this.lineLength );
-
-		},
-
-		isAtTheEnd: function () {
-
-			return this.currentCharIndex >= this.lineLength;
-
-		},
-
-		setToEnd: function () {
-
-			this.currentCharIndex = this.lineLength;
-
-		},
-
-		getLineNumberString: function () {
-
-			return this.lineNumber >= 0 ? ' at line ' + this.lineNumber : '';
+			this.currentCharIndex ++;
 
 		}
-
-
-	};
-
-	function sortByMaterial( a, b ) {
-
-		if ( a.colourCode === b.colourCode ) {
-
-			return 0;
-
-		}
-
-		if ( a.colourCode < b.colourCode ) {
-
-			return - 1;
-
-		}
-
-		return 1;
 
 	}
 
-	function createObject( elements, elementSize, isConditionalSegments ) {
+	getToken() {
 
-		// Creates a LineSegments (elementSize = 2) or a Mesh (elementSize = 3 )
-		// With per face / segment material, implemented with mesh groups and materials array
+		const pos0 = this.currentCharIndex ++;
 
-		// Sort the triangles or line segments by colour code to make later the mesh groups
-		elements.sort( sortByMaterial );
+		// Seek space
+		while ( this.currentCharIndex < this.lineLength ) {
 
-		var positions = [];
-		var normals = [];
-		var materials = [];
+			this.currentChar = this.line.charAt( this.currentCharIndex );
 
-		var bufferGeometry = new BufferGeometry();
-		var prevMaterial = null;
-		var index0 = 0;
-		var numGroupVerts = 0;
+			if ( this.currentChar === ' ' || this.currentChar === '\t' ) {
 
-		for ( var iElem = 0, nElem = elements.length; iElem < nElem; iElem ++ ) {
-
-			var elem = elements[ iElem ];
-			var v0 = elem.v0;
-			var v1 = elem.v1;
-			// Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
-			positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
-			if ( elementSize === 3 ) {
-
-				positions.push( elem.v2.x, elem.v2.y, elem.v2.z );
-
-				var n0 = elem.n0 || elem.faceNormal;
-				var n1 = elem.n1 || elem.faceNormal;
-				var n2 = elem.n2 || elem.faceNormal;
-				normals.push( n0.x, n0.y, n0.z );
-				normals.push( n1.x, n1.y, n1.z );
-				normals.push( n2.x, n2.y, n2.z );
+				break;
 
 			}
 
-			if ( prevMaterial !== elem.material ) {
-
-				if ( prevMaterial !== null ) {
-
-					bufferGeometry.addGroup( index0, numGroupVerts, materials.length - 1 );
-
-				}
-
-				materials.push( elem.material );
-
-				prevMaterial = elem.material;
-				index0 = iElem * elementSize;
-				numGroupVerts = elementSize;
-
-			} else {
-
-				numGroupVerts += elementSize;
-
-			}
+			this.currentCharIndex ++;
 
 		}
 
-		if ( numGroupVerts > 0 ) {
+		const pos1 = this.currentCharIndex;
 
-			bufferGeometry.addGroup( index0, Infinity, materials.length - 1 );
+		this.seekNonSpace();
 
-		}
+		return this.line.substring( pos0, pos1 );
 
-		bufferGeometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+	}
 
+	getRemainingString() {
+
+		return this.line.substring( this.currentCharIndex, this.lineLength );
+
+	}
+
+	isAtTheEnd() {
+
+		return this.currentCharIndex >= this.lineLength;
+
+	}
+
+	setToEnd() {
+
+		this.currentCharIndex = this.lineLength;
+
+	}
+
+	getLineNumberString() {
+
+		return this.lineNumber >= 0 ? ' at line ' + this.lineNumber : '';
+
+	}
+
+}
+
+function sortByMaterial( a, b ) {
+
+	if ( a.colourCode === b.colourCode ) {
+
+		return 0;
+
+	}
+
+	if ( a.colourCode < b.colourCode ) {
+
+		return - 1;
+
+	}
+
+	return 1;
+
+}
+
+function createObject( elements, elementSize, isConditionalSegments ) {
+
+	// Creates a LineSegments (elementSize = 2) or a Mesh (elementSize = 3 )
+	// With per face / segment material, implemented with mesh groups and materials array
+
+	// Sort the triangles or line segments by colour code to make later the mesh groups
+	elements.sort( sortByMaterial );
+
+	const positions = [];
+	const normals = [];
+	const materials = [];
+
+	const bufferGeometry = new BufferGeometry();
+	let prevMaterial = null;
+	let index0 = 0;
+	let numGroupVerts = 0;
+
+	for ( let iElem = 0, nElem = elements.length; iElem < nElem; iElem ++ ) {
+
+		const elem = elements[ iElem ];
+		const v0 = elem.v0;
+		const v1 = elem.v1;
+		// Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
+		positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
 		if ( elementSize === 3 ) {
 
-			bufferGeometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+			positions.push( elem.v2.x, elem.v2.y, elem.v2.z );
+
+			const n0 = elem.n0 || elem.faceNormal;
+			const n1 = elem.n1 || elem.faceNormal;
+			const n2 = elem.n2 || elem.faceNormal;
+			normals.push( n0.x, n0.y, n0.z );
+			normals.push( n1.x, n1.y, n1.z );
+			normals.push( n2.x, n2.y, n2.z );
 
 		}
 
-		var object3d = null;
+		if ( prevMaterial !== elem.material ) {
 
-		if ( elementSize === 2 ) {
+			if ( prevMaterial !== null ) {
 
-			object3d = new LineSegments( bufferGeometry, materials );
-
-		} else if ( elementSize === 3 ) {
-
-			object3d = new Mesh( bufferGeometry, materials );
-
-		}
-
-		if ( isConditionalSegments ) {
-
-			object3d.isConditionalLine = true;
-
-			var controlArray0 = new Float32Array( elements.length * 3 * 2 );
-			var controlArray1 = new Float32Array( elements.length * 3 * 2 );
-			var directionArray = new Float32Array( elements.length * 3 * 2 );
-			for ( var i = 0, l = elements.length; i < l; i ++ ) {
-
-				var os = elements[ i ];
-				var c0 = os.c0;
-				var c1 = os.c1;
-				var v0 = os.v0;
-				var v1 = os.v1;
-				var index = i * 3 * 2;
-				controlArray0[ index + 0 ] = c0.x;
-				controlArray0[ index + 1 ] = c0.y;
-				controlArray0[ index + 2 ] = c0.z;
-				controlArray0[ index + 3 ] = c0.x;
-				controlArray0[ index + 4 ] = c0.y;
-				controlArray0[ index + 5 ] = c0.z;
-
-				controlArray1[ index + 0 ] = c1.x;
-				controlArray1[ index + 1 ] = c1.y;
-				controlArray1[ index + 2 ] = c1.z;
-				controlArray1[ index + 3 ] = c1.x;
-				controlArray1[ index + 4 ] = c1.y;
-				controlArray1[ index + 5 ] = c1.z;
-
-				directionArray[ index + 0 ] = v1.x - v0.x;
-				directionArray[ index + 1 ] = v1.y - v0.y;
-				directionArray[ index + 2 ] = v1.z - v0.z;
-				directionArray[ index + 3 ] = v1.x - v0.x;
-				directionArray[ index + 4 ] = v1.y - v0.y;
-				directionArray[ index + 5 ] = v1.z - v0.z;
+				bufferGeometry.addGroup( index0, numGroupVerts, materials.length - 1 );
 
 			}
 
-			bufferGeometry.setAttribute( 'control0', new BufferAttribute( controlArray0, 3, false ) );
-			bufferGeometry.setAttribute( 'control1', new BufferAttribute( controlArray1, 3, false ) );
-			bufferGeometry.setAttribute( 'direction', new BufferAttribute( directionArray, 3, false ) );
+			materials.push( elem.material );
+
+			prevMaterial = elem.material;
+			index0 = iElem * elementSize;
+			numGroupVerts = elementSize;
+
+		} else {
+
+			numGroupVerts += elementSize;
 
 		}
 
-		return object3d;
+	}
+
+	if ( numGroupVerts > 0 ) {
+
+		bufferGeometry.addGroup( index0, Infinity, materials.length - 1 );
 
 	}
 
-	//
+	bufferGeometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-	function LDrawLoader( manager ) {
+	if ( elementSize === 3 ) {
 
-		Loader.call( this, manager );
+		bufferGeometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+
+	}
+
+	let object3d = null;
+
+	if ( elementSize === 2 ) {
+
+		object3d = new LineSegments( bufferGeometry, materials );
+
+	} else if ( elementSize === 3 ) {
+
+		object3d = new Mesh( bufferGeometry, materials );
+
+	}
+
+	if ( isConditionalSegments ) {
+
+		object3d.isConditionalLine = true;
+
+		const controlArray0 = new Float32Array( elements.length * 3 * 2 );
+		const controlArray1 = new Float32Array( elements.length * 3 * 2 );
+		const directionArray = new Float32Array( elements.length * 3 * 2 );
+		for ( let i = 0, l = elements.length; i < l; i ++ ) {
+
+			const os = elements[ i ];
+			const c0 = os.c0;
+			const c1 = os.c1;
+			const v0 = os.v0;
+			const v1 = os.v1;
+			const index = i * 3 * 2;
+			controlArray0[ index + 0 ] = c0.x;
+			controlArray0[ index + 1 ] = c0.y;
+			controlArray0[ index + 2 ] = c0.z;
+			controlArray0[ index + 3 ] = c0.x;
+			controlArray0[ index + 4 ] = c0.y;
+			controlArray0[ index + 5 ] = c0.z;
+
+			controlArray1[ index + 0 ] = c1.x;
+			controlArray1[ index + 1 ] = c1.y;
+			controlArray1[ index + 2 ] = c1.z;
+			controlArray1[ index + 3 ] = c1.x;
+			controlArray1[ index + 4 ] = c1.y;
+			controlArray1[ index + 5 ] = c1.z;
+
+			directionArray[ index + 0 ] = v1.x - v0.x;
+			directionArray[ index + 1 ] = v1.y - v0.y;
+			directionArray[ index + 2 ] = v1.z - v0.z;
+			directionArray[ index + 3 ] = v1.x - v0.x;
+			directionArray[ index + 4 ] = v1.y - v0.y;
+			directionArray[ index + 5 ] = v1.z - v0.z;
+
+		}
+
+		bufferGeometry.setAttribute( 'control0', new BufferAttribute( controlArray0, 3, false ) );
+		bufferGeometry.setAttribute( 'control1', new BufferAttribute( controlArray1, 3, false ) );
+		bufferGeometry.setAttribute( 'direction', new BufferAttribute( directionArray, 3, false ) );
+
+	}
+
+	return object3d;
+
+}
+
+//
+
+class LDrawLoader extends Loader {
+
+	constructor( manager ) {
+
+		super( manager );
 
 		// This is a stack of 'parse scopes' with one level per subobject loaded file.
 		// Each level contains a material lib and also other runtime variables passed between parent and child subobjects
@@ -567,1406 +582,1379 @@ var LDrawLoader = ( function () {
 
 	}
 
-	// Special surface finish tag types.
-	// Note: "MATERIAL" tag (e.g. GLITTER, SPECKLE) is not implemented
-	LDrawLoader.FINISH_TYPE_DEFAULT = 0;
-	LDrawLoader.FINISH_TYPE_CHROME = 1;
-	LDrawLoader.FINISH_TYPE_PEARLESCENT = 2;
-	LDrawLoader.FINISH_TYPE_RUBBER = 3;
-	LDrawLoader.FINISH_TYPE_MATTE_METALLIC = 4;
-	LDrawLoader.FINISH_TYPE_METAL = 5;
+	load( url, onLoad, onProgress, onError ) {
 
-	// State machine to search a subobject path.
-	// The LDraw standard establishes these various possible subfolders.
-	LDrawLoader.FILE_LOCATION_AS_IS = 0;
-	LDrawLoader.FILE_LOCATION_TRY_PARTS = 1;
-	LDrawLoader.FILE_LOCATION_TRY_P = 2;
-	LDrawLoader.FILE_LOCATION_TRY_MODELS = 3;
-	LDrawLoader.FILE_LOCATION_TRY_RELATIVE = 4;
-	LDrawLoader.FILE_LOCATION_TRY_ABSOLUTE = 5;
-	LDrawLoader.FILE_LOCATION_NOT_FOUND = 6;
+		if ( ! this.fileMap ) {
 
-	LDrawLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+			this.fileMap = {};
 
-		constructor: LDrawLoader,
+		}
 
-		load: function ( url, onLoad, onProgress, onError ) {
+		const scope = this;
 
-			if ( ! this.fileMap ) {
+		const fileLoader = new FileLoader( this.manager );
+		fileLoader.setPath( this.path );
+		fileLoader.setRequestHeader( this.requestHeader );
+		fileLoader.setWithCredentials( this.withCredentials );
+		fileLoader.load( url, function ( text ) {
 
-				this.fileMap = {};
+			scope.processObject( text, onLoad, null, url );
 
-			}
+		}, onProgress, onError );
 
-			var scope = this;
+	}
 
-			var fileLoader = new FileLoader( this.manager );
-			fileLoader.setPath( this.path );
-			fileLoader.setRequestHeader( this.requestHeader );
-			fileLoader.setWithCredentials( this.withCredentials );
-			fileLoader.load( url, function ( text ) {
+	parse( text, path, onLoad ) {
 
-				scope.processObject( text, onLoad, null, url );
+		// Async parse.  This function calls onParse with the parsed THREE.Object3D as parameter
 
-			}, onProgress, onError );
+		this.processObject( text, onLoad, null, path );
 
-		},
+	}
 
-		parse: function ( text, path, onLoad ) {
+	setMaterials( materials ) {
 
-			// Async parse.  This function calls onParse with the parsed THREE.Object3D as parameter
+		// Clears parse scopes stack, adds new scope with material library
 
-			this.processObject( text, onLoad, null, path );
+		this.parseScopesStack = [];
 
-		},
+		this.newParseScopeLevel( materials );
 
-		setMaterials: function ( materials ) {
+		this.getCurrentParseScope().isFromParse = false;
 
-			// Clears parse scopes stack, adds new scope with material library
+		this.materials = materials;
 
-			this.parseScopesStack = [];
+		return this;
 
-			this.newParseScopeLevel( materials );
+	}
 
-			this.getCurrentParseScope().isFromParse = false;
+	setFileMap( fileMap ) {
 
-			this.materials = materials;
+		this.fileMap = fileMap;
 
-			return this;
+		return this;
 
-		},
+	}
 
-		setFileMap: function ( fileMap ) {
+	newParseScopeLevel( materials ) {
 
-			this.fileMap = fileMap;
+		// Adds a new scope level, assign materials to it and returns it
 
-			return this;
+		const matLib = {};
 
-		},
+		if ( materials ) {
 
-		newParseScopeLevel: function ( materials ) {
+			for ( let i = 0, n = materials.length; i < n; i ++ ) {
 
-			// Adds a new scope level, assign materials to it and returns it
-
-			var matLib = {};
-
-			if ( materials ) {
-
-				for ( var i = 0, n = materials.length; i < n; i ++ ) {
-
-					var material = materials[ i ];
-					matLib[ material.userData.code ] = material;
-
-				}
+				const material = materials[ i ];
+				matLib[ material.userData.code ] = material;
 
 			}
 
-			var topParseScope = this.getCurrentParseScope();
-			var newParseScope = {
+		}
 
-				lib: matLib,
-				url: null,
+		const topParseScope = this.getCurrentParseScope();
+		const newParseScope = {
 
-				// Subobjects
-				subobjects: null,
-				numSubobjects: 0,
-				subobjectIndex: 0,
-				inverted: false,
-				category: null,
-				keywords: null,
+			lib: matLib,
+			url: null,
 
-				// Current subobject
-				currentFileName: null,
-				mainColourCode: topParseScope ? topParseScope.mainColourCode : '16',
-				mainEdgeColourCode: topParseScope ? topParseScope.mainEdgeColourCode : '24',
-				currentMatrix: new Matrix4(),
-				matrix: new Matrix4(),
+			// Subobjects
+			subobjects: null,
+			numSubobjects: 0,
+			subobjectIndex: 0,
+			inverted: false,
+			category: null,
+			keywords: null,
 
-				// If false, it is a root material scope previous to parse
-				isFromParse: true,
+			// Current subobject
+			currentFileName: null,
+			mainColourCode: topParseScope ? topParseScope.mainColourCode : '16',
+			mainEdgeColourCode: topParseScope ? topParseScope.mainEdgeColourCode : '24',
+			currentMatrix: new Matrix4(),
+			matrix: new Matrix4(),
 
-				triangles: null,
-				lineSegments: null,
-				conditionalSegments: null,
+			// If false, it is a root material scope previous to parse
+			isFromParse: true,
 
-				// If true, this object is the start of a construction step
-				startingConstructionStep: false
-			};
+			triangles: null,
+			lineSegments: null,
+			conditionalSegments: null,
 
-			this.parseScopesStack.push( newParseScope );
+			// If true, this object is the start of a construction step
+			startingConstructionStep: false
+		};
 
-			return newParseScope;
+		this.parseScopesStack.push( newParseScope );
 
-		},
+		return newParseScope;
 
-		removeScopeLevel: function () {
+	}
 
-			this.parseScopesStack.pop();
+	removeScopeLevel() {
 
-			return this;
+		this.parseScopesStack.pop();
 
-		},
+		return this;
 
-		addMaterial: function ( material ) {
+	}
 
-			// Adds a material to the material library which is on top of the parse scopes stack. And also to the materials array
+	addMaterial( material ) {
 
-			var matLib = this.getCurrentParseScope().lib;
+		// Adds a material to the material library which is on top of the parse scopes stack. And also to the materials array
 
-			if ( ! matLib[ material.userData.code ] ) {
+		const matLib = this.getCurrentParseScope().lib;
 
-				this.materials.push( material );
+		if ( ! matLib[ material.userData.code ] ) {
 
-			}
+			this.materials.push( material );
 
-			matLib[ material.userData.code ] = material;
+		}
 
-			return this;
+		matLib[ material.userData.code ] = material;
 
-		},
+		return this;
 
-		getMaterial: function ( colourCode ) {
+	}
 
-			// Given a colour code search its material in the parse scopes stack
+	getMaterial( colourCode ) {
 
-			if ( colourCode.startsWith( '0x2' ) ) {
+		// Given a colour code search its material in the parse scopes stack
 
-				// Special 'direct' material value (RGB colour)
+		if ( colourCode.startsWith( '0x2' ) ) {
 
-				var colour = colourCode.substring( 3 );
+			// Special 'direct' material value (RGB colour)
 
-				return this.parseColourMetaDirective( new LineParser( 'Direct_Color_' + colour + ' CODE -1 VALUE #' + colour + ' EDGE #' + colour + '' ) );
+			const colour = colourCode.substring( 3 );
 
-			}
+			return this.parseColourMetaDirective( new LineParser( 'Direct_Color_' + colour + ' CODE -1 VALUE #' + colour + ' EDGE #' + colour + '' ) );
 
-			for ( var i = this.parseScopesStack.length - 1; i >= 0; i -- ) {
+		}
 
-				var material = this.parseScopesStack[ i ].lib[ colourCode ];
+		for ( let i = this.parseScopesStack.length - 1; i >= 0; i -- ) {
 
-				if ( material ) {
+			const material = this.parseScopesStack[ i ].lib[ colourCode ];
 
-					return material;
-
-				}
-
-			}
-
-			// Material was not found
-			return null;
-
-		},
-
-		getParentParseScope: function () {
-
-			if ( this.parseScopesStack.length > 1 ) {
-
-				return this.parseScopesStack[ this.parseScopesStack.length - 2 ];
-
-			}
-
-			return null;
-
-		},
-
-		getCurrentParseScope: function () {
-
-			if ( this.parseScopesStack.length > 0 ) {
-
-				return this.parseScopesStack[ this.parseScopesStack.length - 1 ];
-
-			}
-
-			return null;
-
-		},
-
-		parseColourMetaDirective: function ( lineParser ) {
-
-			// Parses a colour definition and returns a THREE.Material or null if error
-
-			var code = null;
-
-			// Triangle and line colours
-			var colour = 0xFF00FF;
-			var edgeColour = 0xFF00FF;
-
-			// Transparency
-			var alpha = 1;
-			var isTransparent = false;
-			// Self-illumination:
-			var luminance = 0;
-
-			var finishType = LDrawLoader.FINISH_TYPE_DEFAULT;
-			var canHaveEnvMap = true;
-
-			var edgeMaterial = null;
-
-			var name = lineParser.getToken();
-			if ( ! name ) {
-
-				throw 'LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.';
-
-			}
-
-			// Parse tag tokens and their parameters
-			var token = null;
-			while ( true ) {
-
-				token = lineParser.getToken();
-
-				if ( ! token ) {
-
-					break;
-
-				}
-
-				switch ( token.toUpperCase() ) {
-
-					case 'CODE':
-
-						code = lineParser.getToken();
-						break;
-
-					case 'VALUE':
-
-						colour = lineParser.getToken();
-						if ( colour.startsWith( '0x' ) ) {
-
-							colour = '#' + colour.substring( 2 );
-
-						} else if ( ! colour.startsWith( '#' ) ) {
-
-							throw 'LDrawLoader: Invalid colour while parsing material' + lineParser.getLineNumberString() + '.';
-
-						}
-
-						break;
-
-					case 'EDGE':
-
-						edgeColour = lineParser.getToken();
-						if ( edgeColour.startsWith( '0x' ) ) {
-
-							edgeColour = '#' + edgeColour.substring( 2 );
-
-						} else if ( ! edgeColour.startsWith( '#' ) ) {
-
-							// Try to see if edge colour is a colour code
-							edgeMaterial = this.getMaterial( edgeColour );
-							if ( ! edgeMaterial ) {
-
-								throw 'LDrawLoader: Invalid edge colour while parsing material' + lineParser.getLineNumberString() + '.';
-
-							}
-
-							// Get the edge material for this triangle material
-							edgeMaterial = edgeMaterial.userData.edgeMaterial;
-
-						}
-
-						break;
-
-					case 'ALPHA':
-
-						alpha = parseInt( lineParser.getToken() );
-
-						if ( isNaN( alpha ) ) {
-
-							throw 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.';
-
-						}
-
-						alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
-
-						if ( alpha < 1 ) {
-
-							isTransparent = true;
-
-						}
-
-						break;
-
-					case 'LUMINANCE':
-
-						luminance = parseInt( lineParser.getToken() );
-
-						if ( isNaN( luminance ) ) {
-
-							throw 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.';
-
-						}
-
-						luminance = Math.max( 0, Math.min( 1, luminance / 255 ) );
-
-						break;
-
-					case 'CHROME':
-						finishType = LDrawLoader.FINISH_TYPE_CHROME;
-						break;
-
-					case 'PEARLESCENT':
-						finishType = LDrawLoader.FINISH_TYPE_PEARLESCENT;
-						break;
-
-					case 'RUBBER':
-						finishType = LDrawLoader.FINISH_TYPE_RUBBER;
-						break;
-
-					case 'MATTE_METALLIC':
-						finishType = LDrawLoader.FINISH_TYPE_MATTE_METALLIC;
-						break;
-
-					case 'METAL':
-						finishType = LDrawLoader.FINISH_TYPE_METAL;
-						break;
-
-					case 'MATERIAL':
-						// Not implemented
-						lineParser.setToEnd();
-						break;
-
-					default:
-						throw 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.';
-						break;
-
-				}
-
-			}
-
-			var material = null;
-
-			switch ( finishType ) {
-
-				case LDrawLoader.FINISH_TYPE_DEFAULT:
-
-					material = new MeshStandardMaterial( { color: colour, roughness: 0.3, envMapIntensity: 0.3, metalness: 0 } );
-					break;
-
-				case LDrawLoader.FINISH_TYPE_PEARLESCENT:
-
-					// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
-					var specular = new Color( colour );
-					var hsl = specular.getHSL( { h: 0, s: 0, l: 0 } );
-					hsl.h = ( hsl.h + 0.5 ) % 1;
-					hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
-					specular.setHSL( hsl.h, hsl.s, hsl.l );
-
-					material = new MeshPhongMaterial( { color: colour, specular: specular, shininess: 10, reflectivity: 0.3 } );
-					break;
-
-				case LDrawLoader.FINISH_TYPE_CHROME:
-
-					// Mirror finish surface
-					material = new MeshStandardMaterial( { color: colour, roughness: 0, metalness: 1 } );
-					break;
-
-				case LDrawLoader.FINISH_TYPE_RUBBER:
-
-					// Rubber finish
-					material = new MeshStandardMaterial( { color: colour, roughness: 0.9, metalness: 0 } );
-					canHaveEnvMap = false;
-					break;
-
-				case LDrawLoader.FINISH_TYPE_MATTE_METALLIC:
-
-					// Brushed metal finish
-					material = new MeshStandardMaterial( { color: colour, roughness: 0.8, metalness: 0.4 } );
-					break;
-
-				case LDrawLoader.FINISH_TYPE_METAL:
-
-					// Average metal finish
-					material = new MeshStandardMaterial( { color: colour, roughness: 0.2, metalness: 0.85 } );
-					break;
-
-				default:
-					// Should not happen
-					break;
-
-			}
-
-			material.transparent = isTransparent;
-			material.premultipliedAlpha = true;
-			material.opacity = alpha;
-			material.depthWrite = ! isTransparent;
-
-			material.polygonOffset = true;
-			material.polygonOffsetFactor = 1;
-
-			material.userData.canHaveEnvMap = canHaveEnvMap;
-
-			if ( luminance !== 0 ) {
-
-				material.emissive.set( material.color ).multiplyScalar( luminance );
-
-			}
-
-			if ( ! edgeMaterial ) {
-
-				// This is the material used for edges
-				edgeMaterial = new LineBasicMaterial( {
-					color: edgeColour,
-					transparent: isTransparent,
-					opacity: alpha,
-					depthWrite: ! isTransparent
-				} );
-				edgeMaterial.userData.code = code;
-				edgeMaterial.name = name + ' - Edge';
-				edgeMaterial.userData.canHaveEnvMap = false;
-
-				// This is the material used for conditional edges
-				edgeMaterial.userData.conditionalEdgeMaterial = new ShaderMaterial( {
-					vertexShader: conditionalLineVertShader,
-					fragmentShader: conditionalLineFragShader,
-					uniforms: UniformsUtils.merge( [
-						UniformsLib.fog,
-						{
-							diffuse: {
-								value: new Color( edgeColour )
-							},
-							opacity: {
-								value: alpha
-							}
-						}
-					] ),
-					fog: true,
-					transparent: isTransparent,
-					depthWrite: ! isTransparent
-				} );
-				edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
-
-			}
-
-			material.userData.code = code;
-			material.name = name;
-
-			material.userData.edgeMaterial = edgeMaterial;
-
-			return material;
-
-		},
-
-		//
-
-		objectParse: function ( text ) {
-
-			// Retrieve data from the parent parse scope
-			var parentParseScope = this.getParentParseScope();
-
-			// Main colour codes passed to this subobject (or default codes 16 and 24 if it is the root object)
-			var mainColourCode = parentParseScope.mainColourCode;
-			var mainEdgeColourCode = parentParseScope.mainEdgeColourCode;
-
-			var currentParseScope = this.getCurrentParseScope();
-
-			// Parse result variables
-			var triangles;
-			var lineSegments;
-			var conditionalSegments;
-
-			var subobjects = [];
-
-			var category = null;
-			var keywords = null;
-
-			if ( text.indexOf( '\r\n' ) !== - 1 ) {
-
-				// This is faster than String.split with regex that splits on both
-				text = text.replace( /\r\n/g, '\n' );
-
-			}
-
-			var lines = text.split( '\n' );
-			var numLines = lines.length;
-			var lineIndex = 0;
-
-			var parsingEmbeddedFiles = false;
-			var currentEmbeddedFileName = null;
-			var currentEmbeddedText = null;
-
-			var bfcCertified = false;
-			var bfcCCW = true;
-			var bfcInverted = false;
-			var bfcCull = true;
-			var type = '';
-
-			var startingConstructionStep = false;
-
-			var scope = this;
-			function parseColourCode( lineParser, forEdge ) {
-
-				// Parses next colour code and returns a THREE.Material
-
-				var colourCode = lineParser.getToken();
-
-				if ( ! forEdge && colourCode === '16' ) {
-
-					colourCode = mainColourCode;
-
-				}
-
-				if ( forEdge && colourCode === '24' ) {
-
-					colourCode = mainEdgeColourCode;
-
-				}
-
-				var material = scope.getMaterial( colourCode );
-
-				if ( ! material ) {
-
-					throw 'LDrawLoader: Unknown colour code "' + colourCode + '" is used' + lineParser.getLineNumberString() + ' but it was not defined previously.';
-
-				}
+			if ( material ) {
 
 				return material;
 
 			}
 
-			function parseVector( lp ) {
+		}
 
-				var v = new Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
+		// Material was not found
+		return null;
 
-				if ( ! scope.separateObjects ) {
+	}
 
-					v.applyMatrix4( currentParseScope.currentMatrix );
+	getParentParseScope() {
 
-				}
+		if ( this.parseScopesStack.length > 1 ) {
 
-				return v;
+			return this.parseScopesStack[ this.parseScopesStack.length - 2 ];
+
+		}
+
+		return null;
+
+	}
+
+	getCurrentParseScope() {
+
+		if ( this.parseScopesStack.length > 0 ) {
+
+			return this.parseScopesStack[ this.parseScopesStack.length - 1 ];
+
+		}
+
+		return null;
+
+	}
+
+	parseColourMetaDirective( lineParser ) {
+
+		// Parses a colour definition and returns a THREE.Material or null if error
+
+		var code = null;
+
+		// Triangle and line colours
+		var colour = 0xFF00FF;
+		var edgeColour = 0xFF00FF;
+
+		// Transparency
+		var alpha = 1;
+		var isTransparent = false;
+		// Self-illumination:
+		var luminance = 0;
+
+		var finishType = FINISH_TYPE_DEFAULT;
+		var canHaveEnvMap = true;
+
+		var edgeMaterial = null;
+
+		var name = lineParser.getToken();
+		if ( ! name ) {
+
+			throw 'LDrawLoader: Material name was expected after "!COLOUR tag' + lineParser.getLineNumberString() + '.';
+
+		}
+
+		// Parse tag tokens and their parameters
+		var token = null;
+		while ( true ) {
+
+			token = lineParser.getToken();
+
+			if ( ! token ) {
+
+				break;
 
 			}
 
-			// Parse all line commands
-			for ( lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
+			switch ( token.toUpperCase() ) {
 
-				var line = lines[ lineIndex ];
+				case 'CODE':
 
-				if ( line.length === 0 ) continue;
+					code = lineParser.getToken();
+					break;
 
-				if ( parsingEmbeddedFiles ) {
+				case 'VALUE':
 
-					if ( line.startsWith( '0 FILE ' ) ) {
+					colour = lineParser.getToken();
+					if ( colour.startsWith( '0x' ) ) {
 
-						// Save previous embedded file in the cache
-						this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
+						colour = '#' + colour.substring( 2 );
 
-						// New embedded text file
-						currentEmbeddedFileName = line.substring( 7 );
-						currentEmbeddedText = '';
+					} else if ( ! colour.startsWith( '#' ) ) {
 
-					} else {
-
-						currentEmbeddedText += line + '\n';
+						throw 'LDrawLoader: Invalid colour while parsing material' + lineParser.getLineNumberString() + '.';
 
 					}
 
-					continue;
+					break;
+
+				case 'EDGE':
+
+					edgeColour = lineParser.getToken();
+					if ( edgeColour.startsWith( '0x' ) ) {
+
+						edgeColour = '#' + edgeColour.substring( 2 );
+
+					} else if ( ! edgeColour.startsWith( '#' ) ) {
+
+						// Try to see if edge colour is a colour code
+						edgeMaterial = this.getMaterial( edgeColour );
+						if ( ! edgeMaterial ) {
+
+							throw 'LDrawLoader: Invalid edge colour while parsing material' + lineParser.getLineNumberString() + '.';
+
+						}
+
+						// Get the edge material for this triangle material
+						edgeMaterial = edgeMaterial.userData.edgeMaterial;
+
+					}
+
+					break;
+
+				case 'ALPHA':
+
+					alpha = parseInt( lineParser.getToken() );
+
+					if ( isNaN( alpha ) ) {
+
+						throw 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.';
+
+					}
+
+					alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
+
+					if ( alpha < 1 ) {
+
+						isTransparent = true;
+
+					}
+
+					break;
+
+				case 'LUMINANCE':
+
+					luminance = parseInt( lineParser.getToken() );
+
+					if ( isNaN( luminance ) ) {
+
+						throw 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.';
+
+					}
+
+					luminance = Math.max( 0, Math.min( 1, luminance / 255 ) );
+
+					break;
+
+				case 'CHROME':
+					finishType = FINISH_TYPE_CHROME;
+					break;
+
+				case 'PEARLESCENT':
+					finishType = FINISH_TYPE_PEARLESCENT;
+					break;
+
+				case 'RUBBER':
+					finishType = FINISH_TYPE_RUBBER;
+					break;
+
+				case 'MATTE_METALLIC':
+					finishType = FINISH_TYPE_MATTE_METALLIC;
+					break;
+
+				case 'METAL':
+					finishType = FINISH_TYPE_METAL;
+					break;
+
+				case 'MATERIAL':
+					// Not implemented
+					lineParser.setToEnd();
+					break;
+
+				default:
+					throw 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.';
+					break;
+
+			}
+
+		}
+
+		var material = null;
+
+		switch ( finishType ) {
+
+			case FINISH_TYPE_DEFAULT:
+
+				material = new MeshStandardMaterial( { color: colour, roughness: 0.3, envMapIntensity: 0.3, metalness: 0 } );
+				break;
+
+			case FINISH_TYPE_PEARLESCENT:
+
+				// Try to imitate pearlescency by setting the specular to the complementary of the color, and low shininess
+				var specular = new Color( colour );
+				var hsl = specular.getHSL( { h: 0, s: 0, l: 0 } );
+				hsl.h = ( hsl.h + 0.5 ) % 1;
+				hsl.l = Math.min( 1, hsl.l + ( 1 - hsl.l ) * 0.7 );
+				specular.setHSL( hsl.h, hsl.s, hsl.l );
+
+				material = new MeshPhongMaterial( { color: colour, specular: specular, shininess: 10, reflectivity: 0.3 } );
+				break;
+
+			case FINISH_TYPE_CHROME:
+
+				// Mirror finish surface
+				material = new MeshStandardMaterial( { color: colour, roughness: 0, metalness: 1 } );
+				break;
+
+			case FINISH_TYPE_RUBBER:
+
+				// Rubber finish
+				material = new MeshStandardMaterial( { color: colour, roughness: 0.9, metalness: 0 } );
+				canHaveEnvMap = false;
+				break;
+
+			case FINISH_TYPE_MATTE_METALLIC:
+
+				// Brushed metal finish
+				material = new MeshStandardMaterial( { color: colour, roughness: 0.8, metalness: 0.4 } );
+				break;
+
+			case FINISH_TYPE_METAL:
+
+				// Average metal finish
+				material = new MeshStandardMaterial( { color: colour, roughness: 0.2, metalness: 0.85 } );
+				break;
+
+			default:
+				// Should not happen
+				break;
+
+		}
+
+		material.transparent = isTransparent;
+		material.premultipliedAlpha = true;
+		material.opacity = alpha;
+		material.depthWrite = ! isTransparent;
+
+		material.polygonOffset = true;
+		material.polygonOffsetFactor = 1;
+
+		material.userData.canHaveEnvMap = canHaveEnvMap;
+
+		if ( luminance !== 0 ) {
+
+			material.emissive.set( material.color ).multiplyScalar( luminance );
+
+		}
+
+		if ( ! edgeMaterial ) {
+
+			// This is the material used for edges
+			edgeMaterial = new LineBasicMaterial( {
+				color: edgeColour,
+				transparent: isTransparent,
+				opacity: alpha,
+				depthWrite: ! isTransparent
+			} );
+			edgeMaterial.userData.code = code;
+			edgeMaterial.name = name + ' - Edge';
+			edgeMaterial.userData.canHaveEnvMap = false;
+
+			// This is the material used for conditional edges
+			edgeMaterial.userData.conditionalEdgeMaterial = new ShaderMaterial( {
+				vertexShader: conditionalLineVertShader,
+				fragmentShader: conditionalLineFragShader,
+				uniforms: UniformsUtils.merge( [
+					UniformsLib.fog,
+					{
+						diffuse: {
+							value: new Color( edgeColour )
+						},
+						opacity: {
+							value: alpha
+						}
+					}
+				] ),
+				fog: true,
+				transparent: isTransparent,
+				depthWrite: ! isTransparent
+			} );
+			edgeMaterial.userData.conditionalEdgeMaterial.userData.canHaveEnvMap = false;
+
+		}
+
+		material.userData.code = code;
+		material.name = name;
+
+		material.userData.edgeMaterial = edgeMaterial;
+
+		return material;
+
+	}
+
+	//
+
+	objectParse( text ) {
+
+		// Retrieve data from the parent parse scope
+		var parentParseScope = this.getParentParseScope();
+
+		// Main colour codes passed to this subobject (or default codes 16 and 24 if it is the root object)
+		var mainColourCode = parentParseScope.mainColourCode;
+		var mainEdgeColourCode = parentParseScope.mainEdgeColourCode;
+
+		var currentParseScope = this.getCurrentParseScope();
+
+		// Parse result variables
+		var triangles;
+		var lineSegments;
+		var conditionalSegments;
+
+		var subobjects = [];
+
+		var category = null;
+		var keywords = null;
+
+		if ( text.indexOf( '\r\n' ) !== - 1 ) {
+
+			// This is faster than String.split with regex that splits on both
+			text = text.replace( /\r\n/g, '\n' );
+
+		}
+
+		var lines = text.split( '\n' );
+		var numLines = lines.length;
+		var lineIndex = 0;
+
+		var parsingEmbeddedFiles = false;
+		var currentEmbeddedFileName = null;
+		var currentEmbeddedText = null;
+
+		var bfcCertified = false;
+		var bfcCCW = true;
+		var bfcInverted = false;
+		var bfcCull = true;
+		var type = '';
+
+		var startingConstructionStep = false;
+
+		var scope = this;
+		function parseColourCode( lineParser, forEdge ) {
+
+			// Parses next colour code and returns a THREE.Material
+
+			var colourCode = lineParser.getToken();
+
+			if ( ! forEdge && colourCode === '16' ) {
+
+				colourCode = mainColourCode;
+
+			}
+
+			if ( forEdge && colourCode === '24' ) {
+
+				colourCode = mainEdgeColourCode;
+
+			}
+
+			var material = scope.getMaterial( colourCode );
+
+			if ( ! material ) {
+
+				throw 'LDrawLoader: Unknown colour code "' + colourCode + '" is used' + lineParser.getLineNumberString() + ' but it was not defined previously.';
+
+			}
+
+			return material;
+
+		}
+
+		function parseVector( lp ) {
+
+			var v = new Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
+
+			if ( ! scope.separateObjects ) {
+
+				v.applyMatrix4( currentParseScope.currentMatrix );
+
+			}
+
+			return v;
+
+		}
+
+		// Parse all line commands
+		for ( lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
+
+			var line = lines[ lineIndex ];
+
+			if ( line.length === 0 ) continue;
+
+			if ( parsingEmbeddedFiles ) {
+
+				if ( line.startsWith( '0 FILE ' ) ) {
+
+					// Save previous embedded file in the cache
+					this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
+
+					// New embedded text file
+					currentEmbeddedFileName = line.substring( 7 );
+					currentEmbeddedText = '';
+
+				} else {
+
+					currentEmbeddedText += line + '\n';
 
 				}
 
-				var lp = new LineParser( line, lineIndex + 1 );
+				continue;
 
-				lp.seekNonSpace();
+			}
 
-				if ( lp.isAtTheEnd() ) {
+			var lp = new LineParser( line, lineIndex + 1 );
 
-					// Empty line
-					continue;
+			lp.seekNonSpace();
 
-				}
+			if ( lp.isAtTheEnd() ) {
 
-				// Parse the line type
-				var lineType = lp.getToken();
+				// Empty line
+				continue;
 
-				switch ( lineType ) {
+			}
 
-					// Line type 0: Comment or META
-					case '0':
+			// Parse the line type
+			var lineType = lp.getToken();
 
-						// Parse meta directive
-						var meta = lp.getToken();
+			switch ( lineType ) {
 
-						if ( meta ) {
+				// Line type 0: Comment or META
+				case '0':
 
-							switch ( meta ) {
+					// Parse meta directive
+					var meta = lp.getToken();
 
-								case '!LDRAW_ORG':
+					if ( meta ) {
 
-									type = lp.getToken();
+						switch ( meta ) {
 
-									currentParseScope.triangles = [];
-									currentParseScope.lineSegments = [];
-									currentParseScope.conditionalSegments = [];
-									currentParseScope.type = type;
+							case '!LDRAW_ORG':
 
-									var isRoot = ! parentParseScope.isFromParse;
-									if ( isRoot || scope.separateObjects && ! isPrimitiveType( type ) ) {
+								type = lp.getToken();
 
-										currentParseScope.groupObject = new Group();
+								currentParseScope.triangles = [];
+								currentParseScope.lineSegments = [];
+								currentParseScope.conditionalSegments = [];
+								currentParseScope.type = type;
 
-										currentParseScope.groupObject.userData.startingConstructionStep = currentParseScope.startingConstructionStep;
+								var isRoot = ! parentParseScope.isFromParse;
+								if ( isRoot || scope.separateObjects && ! isPrimitiveType( type ) ) {
 
-									}
+									currentParseScope.groupObject = new Group();
 
-									// If the scale of the object is negated then the triangle winding order
-									// needs to be flipped.
-									var matrix = currentParseScope.matrix;
-									if (
-										matrix.determinant() < 0 && (
-											scope.separateObjects && isPrimitiveType( type ) ||
+									currentParseScope.groupObject.userData.startingConstructionStep = currentParseScope.startingConstructionStep;
+
+								}
+
+								// If the scale of the object is negated then the triangle winding order
+								// needs to be flipped.
+								var matrix = currentParseScope.matrix;
+								if (
+									matrix.determinant() < 0 && (
+										scope.separateObjects && isPrimitiveType( type ) ||
 											! scope.separateObjects
-										) ) {
+									) ) {
 
-										currentParseScope.inverted = ! currentParseScope.inverted;
+									currentParseScope.inverted = ! currentParseScope.inverted;
 
-									}
+								}
 
-									triangles = currentParseScope.triangles;
-									lineSegments = currentParseScope.lineSegments;
-									conditionalSegments = currentParseScope.conditionalSegments;
+								triangles = currentParseScope.triangles;
+								lineSegments = currentParseScope.lineSegments;
+								conditionalSegments = currentParseScope.conditionalSegments;
 
-									break;
+								break;
 
-								case '!COLOUR':
+							case '!COLOUR':
 
-									var material = this.parseColourMetaDirective( lp );
-									if ( material ) {
+								var material = this.parseColourMetaDirective( lp );
+								if ( material ) {
 
-										this.addMaterial( material );
+									this.addMaterial( material );
 
-									}	else {
+								}	else {
 
-										console.warn( 'LDrawLoader: Error parsing material' + lp.getLineNumberString() );
+									console.warn( 'LDrawLoader: Error parsing material' + lp.getLineNumberString() );
 
-									}
+								}
 
-									break;
+								break;
 
-								case '!CATEGORY':
+							case '!CATEGORY':
 
-									category = lp.getToken();
-									break;
+								category = lp.getToken();
+								break;
 
-								case '!KEYWORDS':
+							case '!KEYWORDS':
 
-									var newKeywords = lp.getRemainingString().split( ',' );
-									if ( newKeywords.length > 0 ) {
+								var newKeywords = lp.getRemainingString().split( ',' );
+								if ( newKeywords.length > 0 ) {
 
-										if ( ! keywords ) {
+									if ( ! keywords ) {
 
-											keywords = [];
-
-										}
-
-										newKeywords.forEach( function ( keyword ) {
-
-											keywords.push( keyword.trim() );
-
-										} );
+										keywords = [];
 
 									}
 
-									break;
+									newKeywords.forEach( function ( keyword ) {
 
-								case 'FILE':
+										keywords.push( keyword.trim() );
 
-									if ( lineIndex > 0 ) {
+									} );
 
-										// Start embedded text files parsing
-										parsingEmbeddedFiles = true;
-										currentEmbeddedFileName = lp.getRemainingString();
-										currentEmbeddedText = '';
+								}
 
-										bfcCertified = false;
-										bfcCCW = true;
+								break;
 
-									}
+							case 'FILE':
 
-									break;
+								if ( lineIndex > 0 ) {
 
-								case 'BFC':
+									// Start embedded text files parsing
+									parsingEmbeddedFiles = true;
+									currentEmbeddedFileName = lp.getRemainingString();
+									currentEmbeddedText = '';
 
-									// Changes to the backface culling state
-									while ( ! lp.isAtTheEnd() ) {
+									bfcCertified = false;
+									bfcCCW = true;
 
-										var token = lp.getToken();
+								}
 
-										switch ( token ) {
+								break;
 
-											case 'CERTIFY':
-											case 'NOCERTIFY':
+							case 'BFC':
 
-												bfcCertified = token === 'CERTIFY';
-												bfcCCW = true;
+								// Changes to the backface culling state
+								while ( ! lp.isAtTheEnd() ) {
 
-												break;
+									var token = lp.getToken();
 
-											case 'CW':
-											case 'CCW':
+									switch ( token ) {
 
-												bfcCCW = token === 'CCW';
+										case 'CERTIFY':
+										case 'NOCERTIFY':
 
-												break;
+											bfcCertified = token === 'CERTIFY';
+											bfcCCW = true;
 
-											case 'INVERTNEXT':
+											break;
 
-												bfcInverted = true;
+										case 'CW':
+										case 'CCW':
 
-												break;
+											bfcCCW = token === 'CCW';
 
-											case 'CLIP':
-											case 'NOCLIP':
+											break;
+
+										case 'INVERTNEXT':
+
+											bfcInverted = true;
+
+											break;
+
+										case 'CLIP':
+										case 'NOCLIP':
 
 											  bfcCull = token === 'CLIP';
 
-												break;
+											break;
 
-											default:
+										default:
 
-												console.warn( 'THREE.LDrawLoader: BFC directive "' + token + '" is unknown.' );
+											console.warn( 'THREE.LDrawLoader: BFC directive "' + token + '" is unknown.' );
 
-												break;
-
-										}
+											break;
 
 									}
 
-									break;
+								}
 
-								case 'STEP':
+								break;
 
-									startingConstructionStep = true;
+							case 'STEP':
 
-									break;
+								startingConstructionStep = true;
 
-								default:
-									// Other meta directives are not implemented
-									break;
+								break;
 
-							}
+							default:
+								// Other meta directives are not implemented
+								break;
 
 						}
 
-						break;
+					}
+
+					break;
 
 					// Line type 1: Sub-object file
-					case '1':
+				case '1':
 
-						var material = parseColourCode( lp );
+					var material = parseColourCode( lp );
 
-						var posX = parseFloat( lp.getToken() );
-						var posY = parseFloat( lp.getToken() );
-						var posZ = parseFloat( lp.getToken() );
-						var m0 = parseFloat( lp.getToken() );
-						var m1 = parseFloat( lp.getToken() );
-						var m2 = parseFloat( lp.getToken() );
-						var m3 = parseFloat( lp.getToken() );
-						var m4 = parseFloat( lp.getToken() );
-						var m5 = parseFloat( lp.getToken() );
-						var m6 = parseFloat( lp.getToken() );
-						var m7 = parseFloat( lp.getToken() );
-						var m8 = parseFloat( lp.getToken() );
+					var posX = parseFloat( lp.getToken() );
+					var posY = parseFloat( lp.getToken() );
+					var posZ = parseFloat( lp.getToken() );
+					var m0 = parseFloat( lp.getToken() );
+					var m1 = parseFloat( lp.getToken() );
+					var m2 = parseFloat( lp.getToken() );
+					var m3 = parseFloat( lp.getToken() );
+					var m4 = parseFloat( lp.getToken() );
+					var m5 = parseFloat( lp.getToken() );
+					var m6 = parseFloat( lp.getToken() );
+					var m7 = parseFloat( lp.getToken() );
+					var m8 = parseFloat( lp.getToken() );
 
-						var matrix = new Matrix4().set(
-							m0, m1, m2, posX,
-							m3, m4, m5, posY,
-							m6, m7, m8, posZ,
-							0, 0, 0, 1
-						);
+					var matrix = new Matrix4().set(
+						m0, m1, m2, posX,
+						m3, m4, m5, posY,
+						m6, m7, m8, posZ,
+						0, 0, 0, 1
+					);
 
-						var fileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
+					var fileName = lp.getRemainingString().trim().replace( /\\/g, '/' );
 
-						if ( scope.fileMap[ fileName ] ) {
+					if ( scope.fileMap[ fileName ] ) {
 
-							// Found the subobject path in the preloaded file path map
-							fileName = scope.fileMap[ fileName ];
+						// Found the subobject path in the preloaded file path map
+						fileName = scope.fileMap[ fileName ];
 
-						}	else {
+					}	else {
 
-							// Standardized subfolders
-							if ( fileName.startsWith( 's/' ) ) {
+						// Standardized subfolders
+						if ( fileName.startsWith( 's/' ) ) {
 
-								fileName = 'parts/' + fileName;
+							fileName = 'parts/' + fileName;
 
-							} else if ( fileName.startsWith( '48/' ) ) {
+						} else if ( fileName.startsWith( '48/' ) ) {
 
-								fileName = 'p/' + fileName;
-
-							}
+							fileName = 'p/' + fileName;
 
 						}
 
-						subobjects.push( {
-							material: material,
-							matrix: matrix,
-							fileName: fileName,
-							originalFileName: fileName,
-							locationState: LDrawLoader.FILE_LOCATION_AS_IS,
-							url: null,
-							triedLowerCase: false,
-							inverted: bfcInverted !== currentParseScope.inverted,
-							startingConstructionStep: startingConstructionStep
-						} );
+					}
 
-						bfcInverted = false;
+					subobjects.push( {
+						material: material,
+						matrix: matrix,
+						fileName: fileName,
+						originalFileName: fileName,
+						locationState: FILE_LOCATION_AS_IS,
+						url: null,
+						triedLowerCase: false,
+						inverted: bfcInverted !== currentParseScope.inverted,
+						startingConstructionStep: startingConstructionStep
+					} );
 
-						break;
+					bfcInverted = false;
+
+					break;
 
 					// Line type 2: Line segment
-					case '2':
+				case '2':
 
-						var material = parseColourCode( lp, true );
+					var material = parseColourCode( lp, true );
 
-						var segment = {
-							material: material.userData.edgeMaterial,
-							colourCode: material.userData.code,
-							v0: parseVector( lp ),
-							v1: parseVector( lp )
-						};
+					var segment = {
+						material: material.userData.edgeMaterial,
+						colourCode: material.userData.code,
+						v0: parseVector( lp ),
+						v1: parseVector( lp )
+					};
 
-						lineSegments.push( segment );
+					lineSegments.push( segment );
 
-						break;
+					break;
 
 					// Line type 5: Conditional Line segment
-					case '5':
+				case '5':
 
-						var material = parseColourCode( lp, true );
+					var material = parseColourCode( lp, true );
 
-						var segment = {
-							material: material.userData.edgeMaterial.userData.conditionalEdgeMaterial,
-							colourCode: material.userData.code,
-							v0: parseVector( lp ),
-							v1: parseVector( lp ),
-							c0: parseVector( lp ),
-							c1: parseVector( lp )
-						};
+					var segment = {
+						material: material.userData.edgeMaterial.userData.conditionalEdgeMaterial,
+						colourCode: material.userData.code,
+						v0: parseVector( lp ),
+						v1: parseVector( lp ),
+						c0: parseVector( lp ),
+						c1: parseVector( lp )
+					};
 
-						conditionalSegments.push( segment );
+					conditionalSegments.push( segment );
 
-						break;
+					break;
 
 					// Line type 3: Triangle
-					case '3':
+				case '3':
 
-						var material = parseColourCode( lp );
+					var material = parseColourCode( lp );
 
-						var inverted = currentParseScope.inverted;
-						var ccw = bfcCCW !== inverted;
-						var doubleSided = ! bfcCertified || ! bfcCull;
-						var v0, v1, v2, faceNormal;
+					var inverted = currentParseScope.inverted;
+					var ccw = bfcCCW !== inverted;
+					var doubleSided = ! bfcCertified || ! bfcCull;
+					var v0, v1, v2, faceNormal;
 
-						if ( ccw === true ) {
+					if ( ccw === true ) {
 
-							v0 = parseVector( lp );
-							v1 = parseVector( lp );
-							v2 = parseVector( lp );
+						v0 = parseVector( lp );
+						v1 = parseVector( lp );
+						v2 = parseVector( lp );
 
-						} else {
+					} else {
 
-							v2 = parseVector( lp );
-							v1 = parseVector( lp );
-							v0 = parseVector( lp );
+						v2 = parseVector( lp );
+						v1 = parseVector( lp );
+						v0 = parseVector( lp );
 
-						}
+					}
 
-						tempVec0.subVectors( v1, v0 );
-						tempVec1.subVectors( v2, v1 );
-						faceNormal = new Vector3()
-							.crossVectors( tempVec0, tempVec1 )
-							.normalize();
+					_tempVec0.subVectors( v1, v0 );
+					_tempVec1.subVectors( v2, v1 );
+					faceNormal = new Vector3()
+						.crossVectors( _tempVec0, _tempVec1 )
+						.normalize();
 
-						triangles.push( {
-							material: material,
-							colourCode: material.userData.code,
-							v0: v0,
-							v1: v1,
-							v2: v2,
-							faceNormal: faceNormal,
-							n0: null,
-							n1: null,
-							n2: null
-						} );
+					triangles.push( {
+						material: material,
+						colourCode: material.userData.code,
+						v0: v0,
+						v1: v1,
+						v2: v2,
+						faceNormal: faceNormal,
+						n0: null,
+						n1: null,
+						n2: null
+					} );
 
-						if ( doubleSided === true ) {
-
-							triangles.push( {
-								material: material,
-								colourCode: material.userData.code,
-								v0: v0,
-								v1: v2,
-								v2: v1,
-								faceNormal: faceNormal,
-								n0: null,
-								n1: null,
-								n2: null
-							} );
-
-						}
-
-						break;
-
-					// Line type 4: Quadrilateral
-					case '4':
-
-						var material = parseColourCode( lp );
-
-						var inverted = currentParseScope.inverted;
-						var ccw = bfcCCW !== inverted;
-						var doubleSided = ! bfcCertified || ! bfcCull;
-						var v0, v1, v2, v3, faceNormal;
-
-						if ( ccw === true ) {
-
-							v0 = parseVector( lp );
-							v1 = parseVector( lp );
-							v2 = parseVector( lp );
-							v3 = parseVector( lp );
-
-						} else {
-
-							v3 = parseVector( lp );
-							v2 = parseVector( lp );
-							v1 = parseVector( lp );
-							v0 = parseVector( lp );
-
-						}
-
-						tempVec0.subVectors( v1, v0 );
-						tempVec1.subVectors( v2, v1 );
-						faceNormal = new Vector3()
-							.crossVectors( tempVec0, tempVec1 )
-							.normalize();
-
-						triangles.push( {
-							material: material,
-							colourCode: material.userData.code,
-							v0: v0,
-							v1: v1,
-							v2: v2,
-							faceNormal: faceNormal,
-							n0: null,
-							n1: null,
-							n2: null
-						} );
+					if ( doubleSided === true ) {
 
 						triangles.push( {
 							material: material,
 							colourCode: material.userData.code,
 							v0: v0,
 							v1: v2,
-							v2: v3,
+							v2: v1,
 							faceNormal: faceNormal,
 							n0: null,
 							n1: null,
 							n2: null
 						} );
 
-						if ( doubleSided === true ) {
+					}
 
-							triangles.push( {
-								material: material,
-								colourCode: material.userData.code,
-								v0: v0,
-								v1: v2,
-								v2: v1,
-								faceNormal: faceNormal,
-								n0: null,
-								n1: null,
-								n2: null
-							} );
+					break;
 
-							triangles.push( {
-								material: material,
-								colourCode: material.userData.code,
-								v0: v0,
-								v1: v3,
-								v2: v2,
-								faceNormal: faceNormal,
-								n0: null,
-								n1: null,
-								n2: null
-							} );
+					// Line type 4: Quadrilateral
+				case '4':
 
-						}
+					var material = parseColourCode( lp );
 
-						break;
+					var inverted = currentParseScope.inverted;
+					var ccw = bfcCCW !== inverted;
+					var doubleSided = ! bfcCertified || ! bfcCull;
+					var v0, v1, v2, v3, faceNormal;
 
-					default:
-						throw 'LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.';
-						break;
+					if ( ccw === true ) {
 
-				}
+						v0 = parseVector( lp );
+						v1 = parseVector( lp );
+						v2 = parseVector( lp );
+						v3 = parseVector( lp );
 
-			}
+					} else {
 
-			if ( parsingEmbeddedFiles ) {
-
-				this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
-
-			}
-
-			currentParseScope.category = category;
-			currentParseScope.keywords = keywords;
-			currentParseScope.subobjects = subobjects;
-			currentParseScope.numSubobjects = subobjects.length;
-			currentParseScope.subobjectIndex = 0;
-
-		},
-
-		computeConstructionSteps: function ( model ) {
-
-			// Sets userdata.constructionStep number in Group objects and userData.numConstructionSteps number in the root Group object.
-
-			var stepNumber = 0;
-
-			model.traverse( c => {
-
-				if ( c.isGroup ) {
-
-					if ( c.userData.startingConstructionStep ) {
-
-						stepNumber ++;
+						v3 = parseVector( lp );
+						v2 = parseVector( lp );
+						v1 = parseVector( lp );
+						v0 = parseVector( lp );
 
 					}
 
-					c.userData.constructionStep = stepNumber;
+					_tempVec0.subVectors( v1, v0 );
+					_tempVec1.subVectors( v2, v1 );
+					faceNormal = new Vector3()
+						.crossVectors( _tempVec0, _tempVec1 )
+						.normalize();
 
-				}
-
-			} );
-
-			model.userData.numConstructionSteps = stepNumber + 1;
-
-		},
-
-		processObject: function ( text, onProcessed, subobject, url ) {
-
-			var scope = this;
-
-			var parseScope = scope.newParseScopeLevel();
-			parseScope.url = url;
-
-			var parentParseScope = scope.getParentParseScope();
-
-			// Set current matrix
-			if ( subobject ) {
-
-				parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
-				parseScope.matrix.copy( subobject.matrix );
-				parseScope.inverted = subobject.inverted;
-				parseScope.startingConstructionStep = subobject.startingConstructionStep;
-
-			}
-
-			// Add to cache
-			var currentFileName = parentParseScope.currentFileName;
-			if ( currentFileName !== null ) {
-
-				currentFileName = parentParseScope.currentFileName.toLowerCase();
-
-			}
-
-			if ( scope.subobjectCache[ currentFileName ] === undefined ) {
-
-				scope.subobjectCache[ currentFileName ] = text;
-
-			}
-
-
-			// Parse the object (returns a Group)
-			scope.objectParse( text );
-			var finishedCount = 0;
-			onSubobjectFinish();
-
-			function onSubobjectFinish() {
-
-				finishedCount ++;
-
-				if ( finishedCount === parseScope.subobjects.length + 1 ) {
-
-					finalizeObject();
-
-				} else {
-
-					// Once the previous subobject has finished we can start processing the next one in the list.
-					// The subobject processing shares scope in processing so it's important that they be loaded serially
-					// to avoid race conditions.
-					// Promise.resolve is used as an approach to asynchronously schedule a task _before_ this frame ends to
-					// avoid stack overflow exceptions when loading many subobjects from the cache. RequestAnimationFrame
-					// will work but causes the load to happen after the next frame which causes the load to take significantly longer.
-					var subobject = parseScope.subobjects[ parseScope.subobjectIndex ];
-					Promise.resolve().then( function () {
-
-						loadSubobject( subobject );
-
+					triangles.push( {
+						material: material,
+						colourCode: material.userData.code,
+						v0: v0,
+						v1: v1,
+						v2: v2,
+						faceNormal: faceNormal,
+						n0: null,
+						n1: null,
+						n2: null
 					} );
-					parseScope.subobjectIndex ++;
 
-				}
+					triangles.push( {
+						material: material,
+						colourCode: material.userData.code,
+						v0: v0,
+						v1: v2,
+						v2: v3,
+						faceNormal: faceNormal,
+						n0: null,
+						n1: null,
+						n2: null
+					} );
 
-			}
+					if ( doubleSided === true ) {
 
-			function finalizeObject() {
+						triangles.push( {
+							material: material,
+							colourCode: material.userData.code,
+							v0: v0,
+							v1: v2,
+							v2: v1,
+							faceNormal: faceNormal,
+							n0: null,
+							n1: null,
+							n2: null
+						} );
 
-				if ( scope.smoothNormals && parseScope.type === 'Part' ) {
-
-					smoothNormals( parseScope.triangles, parseScope.lineSegments );
-
-				}
-
-				var isRoot = ! parentParseScope.isFromParse;
-				if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || isRoot ) {
-
-					const objGroup = parseScope.groupObject;
-
-					if ( parseScope.triangles.length > 0 ) {
-
-						objGroup.add( createObject( parseScope.triangles, 3 ) );
-
-					}
-
-					if ( parseScope.lineSegments.length > 0 ) {
-
-						objGroup.add( createObject( parseScope.lineSegments, 2 ) );
-
-					}
-
-					if ( parseScope.conditionalSegments.length > 0 ) {
-
-						objGroup.add( createObject( parseScope.conditionalSegments, 2, true ) );
-
-					}
-
-					if ( parentParseScope.groupObject ) {
-
-						objGroup.name = parseScope.fileName;
-						objGroup.userData.category = parseScope.category;
-						objGroup.userData.keywords = parseScope.keywords;
-						parseScope.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
-
-						parentParseScope.groupObject.add( objGroup );
+						triangles.push( {
+							material: material,
+							colourCode: material.userData.code,
+							v0: v0,
+							v1: v3,
+							v2: v2,
+							faceNormal: faceNormal,
+							n0: null,
+							n1: null,
+							n2: null
+						} );
 
 					}
 
-				} else {
-
-					var separateObjects = scope.separateObjects;
-					var parentLineSegments = parentParseScope.lineSegments;
-					var parentConditionalSegments = parentParseScope.conditionalSegments;
-					var parentTriangles = parentParseScope.triangles;
-
-					var lineSegments = parseScope.lineSegments;
-					var conditionalSegments = parseScope.conditionalSegments;
-					var triangles = parseScope.triangles;
-
-					for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
-
-						var ls = lineSegments[ i ];
-
-						if ( separateObjects ) {
-
-							ls.v0.applyMatrix4( parseScope.matrix );
-							ls.v1.applyMatrix4( parseScope.matrix );
-
-						}
-
-						parentLineSegments.push( ls );
-
-					}
-
-					for ( var i = 0, l = conditionalSegments.length; i < l; i ++ ) {
-
-						var os = conditionalSegments[ i ];
-
-						if ( separateObjects ) {
-
-							os.v0.applyMatrix4( parseScope.matrix );
-							os.v1.applyMatrix4( parseScope.matrix );
-							os.c0.applyMatrix4( parseScope.matrix );
-							os.c1.applyMatrix4( parseScope.matrix );
-
-						}
-
-						parentConditionalSegments.push( os );
-
-					}
-
-					for ( var i = 0, l = triangles.length; i < l; i ++ ) {
-
-						var tri = triangles[ i ];
-
-						if ( separateObjects ) {
-
-							tri.v0 = tri.v0.clone().applyMatrix4( parseScope.matrix );
-							tri.v1 = tri.v1.clone().applyMatrix4( parseScope.matrix );
-							tri.v2 = tri.v2.clone().applyMatrix4( parseScope.matrix );
-
-							tempVec0.subVectors( tri.v1, tri.v0 );
-							tempVec1.subVectors( tri.v2, tri.v1 );
-							tri.faceNormal.crossVectors( tempVec0, tempVec1 ).normalize();
-
-						}
-
-						parentTriangles.push( tri );
-
-					}
-
-				}
-
-				scope.removeScopeLevel();
-
-				// If it is root object, compute construction steps
-				if ( ! parentParseScope.isFromParse ) {
-
-					scope.computeConstructionSteps( parseScope.groupObject );
-
-				}
-
-				if ( onProcessed ) {
-
-					onProcessed( parseScope.groupObject );
-
-				}
-
-			}
-
-			function loadSubobject( subobject ) {
-
-				parseScope.mainColourCode = subobject.material.userData.code;
-				parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
-				parseScope.currentFileName = subobject.originalFileName;
-
-
-				// If subobject was cached previously, use the cached one
-				var cached = scope.subobjectCache[ subobject.originalFileName.toLowerCase() ];
-				if ( cached ) {
-
-					scope.processObject( cached, function ( subobjectGroup ) {
-
-						onSubobjectLoaded( subobjectGroup, subobject );
-						onSubobjectFinish();
-
-					}, subobject, url );
-
-					return;
-
-				}
-
-				// Adjust file name to locate the subobject file path in standard locations (always under directory scope.path)
-				// Update also subobject.locationState for the next try if this load fails.
-				var subobjectURL = subobject.fileName;
-				var newLocationState = LDrawLoader.FILE_LOCATION_NOT_FOUND;
-
-				switch ( subobject.locationState ) {
-
-					case LDrawLoader.FILE_LOCATION_AS_IS:
-						newLocationState = subobject.locationState + 1;
-						break;
-
-					case LDrawLoader.FILE_LOCATION_TRY_PARTS:
-						subobjectURL = 'parts/' + subobjectURL;
-						newLocationState = subobject.locationState + 1;
-						break;
-
-					case LDrawLoader.FILE_LOCATION_TRY_P:
-						subobjectURL = 'p/' + subobjectURL;
-						newLocationState = subobject.locationState + 1;
-						break;
-
-					case LDrawLoader.FILE_LOCATION_TRY_MODELS:
-						subobjectURL = 'models/' + subobjectURL;
-						newLocationState = subobject.locationState + 1;
-						break;
-
-					case LDrawLoader.FILE_LOCATION_TRY_RELATIVE:
-						subobjectURL = url.substring( 0, url.lastIndexOf( '/' ) + 1 ) + subobjectURL;
-						newLocationState = subobject.locationState + 1;
-						break;
-
-					case LDrawLoader.FILE_LOCATION_TRY_ABSOLUTE:
-
-						if ( subobject.triedLowerCase ) {
-
-							// Try absolute path
-							newLocationState = LDrawLoader.FILE_LOCATION_NOT_FOUND;
-
-						} else {
-
-							// Next attempt is lower case
-							subobject.fileName = subobject.fileName.toLowerCase();
-							subobjectURL = subobject.fileName;
-							subobject.triedLowerCase = true;
-							newLocationState = LDrawLoader.FILE_LOCATION_AS_IS;
-
-						}
-
-						break;
-
-					case LDrawLoader.FILE_LOCATION_NOT_FOUND:
-
-						// All location possibilities have been tried, give up loading this object
-						console.warn( 'LDrawLoader: Subobject "' + subobject.originalFileName + '" could not be found.' );
-
-						return;
-
-				}
-
-				subobject.locationState = newLocationState;
-				subobject.url = subobjectURL;
-
-				// Load the subobject
-				// Use another file loader here so we can keep track of the subobject information
-				// and use it when processing the next model.
-				var fileLoader = new FileLoader( scope.manager );
-				fileLoader.setPath( scope.path );
-				fileLoader.setRequestHeader( scope.requestHeader );
-				fileLoader.setWithCredentials( scope.withCredentials );
-				fileLoader.load( subobjectURL, function ( text ) {
-
-					scope.processObject( text, function ( subobjectGroup ) {
-
-						onSubobjectLoaded( subobjectGroup, subobject );
-						onSubobjectFinish();
-
-					}, subobject, url );
-
-				}, undefined, function ( err ) {
-
-					onSubobjectError( err, subobject );
-
-				}, subobject );
-
-			}
-
-			function onSubobjectLoaded( subobjectGroup, subobject ) {
-
-				if ( subobjectGroup === null ) {
-
-					// Try to reload
-					loadSubobject( subobject );
-					return;
-
-				}
-
-				scope.fileMap[ subobject.originalFileName ] = subobject.url;
-
-			}
-
-			function onSubobjectError( err, subobject ) {
-
-				// Retry download from a different default possible location
-				loadSubobject( subobject );
+					break;
+
+				default:
+					throw 'LDrawLoader: Unknown line type "' + lineType + '"' + lp.getLineNumberString() + '.';
+					break;
 
 			}
 
 		}
 
-	} );
+		if ( parsingEmbeddedFiles ) {
 
-	return LDrawLoader;
+			this.subobjectCache[ currentEmbeddedFileName.toLowerCase() ] = currentEmbeddedText;
 
-} )();
+		}
+
+		currentParseScope.category = category;
+		currentParseScope.keywords = keywords;
+		currentParseScope.subobjects = subobjects;
+		currentParseScope.numSubobjects = subobjects.length;
+		currentParseScope.subobjectIndex = 0;
+
+	}
+
+	computeConstructionSteps( model ) {
+
+		// Sets userdata.constructionStep number in Group objects and userData.numConstructionSteps number in the root Group object.
+
+		var stepNumber = 0;
+
+		model.traverse( c => {
+
+			if ( c.isGroup ) {
+
+				if ( c.userData.startingConstructionStep ) {
+
+					stepNumber ++;
+
+				}
+
+				c.userData.constructionStep = stepNumber;
+
+			}
+
+		} );
+
+		model.userData.numConstructionSteps = stepNumber + 1;
+
+	}
+
+	processObject( text, onProcessed, subobject, url ) {
+
+		var scope = this;
+
+		var parseScope = scope.newParseScopeLevel();
+		parseScope.url = url;
+
+		var parentParseScope = scope.getParentParseScope();
+
+		// Set current matrix
+		if ( subobject ) {
+
+			parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
+			parseScope.matrix.copy( subobject.matrix );
+			parseScope.inverted = subobject.inverted;
+			parseScope.startingConstructionStep = subobject.startingConstructionStep;
+
+		}
+
+		// Add to cache
+		var currentFileName = parentParseScope.currentFileName;
+		if ( currentFileName !== null ) {
+
+			currentFileName = parentParseScope.currentFileName.toLowerCase();
+
+		}
+
+		if ( scope.subobjectCache[ currentFileName ] === undefined ) {
+
+			scope.subobjectCache[ currentFileName ] = text;
+
+		}
+
+
+		// Parse the object (returns a Group)
+		scope.objectParse( text );
+		var finishedCount = 0;
+		onSubobjectFinish();
+
+		function onSubobjectFinish() {
+
+			finishedCount ++;
+
+			if ( finishedCount === parseScope.subobjects.length + 1 ) {
+
+				finalizeObject();
+
+			} else {
+
+				// Once the previous subobject has finished we can start processing the next one in the list.
+				// The subobject processing shares scope in processing so it's important that they be loaded serially
+				// to avoid race conditions.
+				// Promise.resolve is used as an approach to asynchronously schedule a task _before_ this frame ends to
+				// avoid stack overflow exceptions when loading many subobjects from the cache. RequestAnimationFrame
+				// will work but causes the load to happen after the next frame which causes the load to take significantly longer.
+				var subobject = parseScope.subobjects[ parseScope.subobjectIndex ];
+				Promise.resolve().then( function () {
+
+					loadSubobject( subobject );
+
+				} );
+				parseScope.subobjectIndex ++;
+
+			}
+
+		}
+
+		function finalizeObject() {
+
+			if ( scope.smoothNormals && parseScope.type === 'Part' ) {
+
+				smoothNormals( parseScope.triangles, parseScope.lineSegments );
+
+			}
+
+			var isRoot = ! parentParseScope.isFromParse;
+			if ( scope.separateObjects && ! isPrimitiveType( parseScope.type ) || isRoot ) {
+
+				const objGroup = parseScope.groupObject;
+
+				if ( parseScope.triangles.length > 0 ) {
+
+					objGroup.add( createObject( parseScope.triangles, 3 ) );
+
+				}
+
+				if ( parseScope.lineSegments.length > 0 ) {
+
+					objGroup.add( createObject( parseScope.lineSegments, 2 ) );
+
+				}
+
+				if ( parseScope.conditionalSegments.length > 0 ) {
+
+					objGroup.add( createObject( parseScope.conditionalSegments, 2, true ) );
+
+				}
+
+				if ( parentParseScope.groupObject ) {
+
+					objGroup.name = parseScope.fileName;
+					objGroup.userData.category = parseScope.category;
+					objGroup.userData.keywords = parseScope.keywords;
+					parseScope.matrix.decompose( objGroup.position, objGroup.quaternion, objGroup.scale );
+
+					parentParseScope.groupObject.add( objGroup );
+
+				}
+
+			} else {
+
+				var separateObjects = scope.separateObjects;
+				var parentLineSegments = parentParseScope.lineSegments;
+				var parentConditionalSegments = parentParseScope.conditionalSegments;
+				var parentTriangles = parentParseScope.triangles;
+
+				var lineSegments = parseScope.lineSegments;
+				var conditionalSegments = parseScope.conditionalSegments;
+				var triangles = parseScope.triangles;
+
+				for ( var i = 0, l = lineSegments.length; i < l; i ++ ) {
+
+					var ls = lineSegments[ i ];
+
+					if ( separateObjects ) {
+
+						ls.v0.applyMatrix4( parseScope.matrix );
+						ls.v1.applyMatrix4( parseScope.matrix );
+
+					}
+
+					parentLineSegments.push( ls );
+
+				}
+
+				for ( var i = 0, l = conditionalSegments.length; i < l; i ++ ) {
+
+					var os = conditionalSegments[ i ];
+
+					if ( separateObjects ) {
+
+						os.v0.applyMatrix4( parseScope.matrix );
+						os.v1.applyMatrix4( parseScope.matrix );
+						os.c0.applyMatrix4( parseScope.matrix );
+						os.c1.applyMatrix4( parseScope.matrix );
+
+					}
+
+					parentConditionalSegments.push( os );
+
+				}
+
+				for ( var i = 0, l = triangles.length; i < l; i ++ ) {
+
+					var tri = triangles[ i ];
+
+					if ( separateObjects ) {
+
+						tri.v0 = tri.v0.clone().applyMatrix4( parseScope.matrix );
+						tri.v1 = tri.v1.clone().applyMatrix4( parseScope.matrix );
+						tri.v2 = tri.v2.clone().applyMatrix4( parseScope.matrix );
+
+						_tempVec0.subVectors( tri.v1, tri.v0 );
+						_tempVec1.subVectors( tri.v2, tri.v1 );
+						tri.faceNormal.crossVectors( _tempVec0, _tempVec1 ).normalize();
+
+					}
+
+					parentTriangles.push( tri );
+
+				}
+
+			}
+
+			scope.removeScopeLevel();
+
+			// If it is root object, compute construction steps
+			if ( ! parentParseScope.isFromParse ) {
+
+				scope.computeConstructionSteps( parseScope.groupObject );
+
+			}
+
+			if ( onProcessed ) {
+
+				onProcessed( parseScope.groupObject );
+
+			}
+
+		}
+
+		function loadSubobject( subobject ) {
+
+			parseScope.mainColourCode = subobject.material.userData.code;
+			parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
+			parseScope.currentFileName = subobject.originalFileName;
+
+
+			// If subobject was cached previously, use the cached one
+			var cached = scope.subobjectCache[ subobject.originalFileName.toLowerCase() ];
+			if ( cached ) {
+
+				scope.processObject( cached, function ( subobjectGroup ) {
+
+					onSubobjectLoaded( subobjectGroup, subobject );
+					onSubobjectFinish();
+
+				}, subobject, url );
+
+				return;
+
+			}
+
+			// Adjust file name to locate the subobject file path in standard locations (always under directory scope.path)
+			// Update also subobject.locationState for the next try if this load fails.
+			var subobjectURL = subobject.fileName;
+			var newLocationState = FILE_LOCATION_NOT_FOUND;
+
+			switch ( subobject.locationState ) {
+
+				case FILE_LOCATION_AS_IS:
+					newLocationState = subobject.locationState + 1;
+					break;
+
+				case FILE_LOCATION_TRY_PARTS:
+					subobjectURL = 'parts/' + subobjectURL;
+					newLocationState = subobject.locationState + 1;
+					break;
+
+				case FILE_LOCATION_TRY_P:
+					subobjectURL = 'p/' + subobjectURL;
+					newLocationState = subobject.locationState + 1;
+					break;
+
+				case FILE_LOCATION_TRY_MODELS:
+					subobjectURL = 'models/' + subobjectURL;
+					newLocationState = subobject.locationState + 1;
+					break;
+
+				case FILE_LOCATION_TRY_RELATIVE:
+					subobjectURL = url.substring( 0, url.lastIndexOf( '/' ) + 1 ) + subobjectURL;
+					newLocationState = subobject.locationState + 1;
+					break;
+
+				case FILE_LOCATION_TRY_ABSOLUTE:
+
+					if ( subobject.triedLowerCase ) {
+
+						// Try absolute path
+						newLocationState = FILE_LOCATION_NOT_FOUND;
+
+					} else {
+
+						// Next attempt is lower case
+						subobject.fileName = subobject.fileName.toLowerCase();
+						subobjectURL = subobject.fileName;
+						subobject.triedLowerCase = true;
+						newLocationState = FILE_LOCATION_AS_IS;
+
+					}
+
+					break;
+
+				case FILE_LOCATION_NOT_FOUND:
+
+					// All location possibilities have been tried, give up loading this object
+					console.warn( 'LDrawLoader: Subobject "' + subobject.originalFileName + '" could not be found.' );
+
+					return;
+
+			}
+
+			subobject.locationState = newLocationState;
+			subobject.url = subobjectURL;
+
+			// Load the subobject
+			// Use another file loader here so we can keep track of the subobject information
+			// and use it when processing the next model.
+			var fileLoader = new FileLoader( scope.manager );
+			fileLoader.setPath( scope.path );
+			fileLoader.setRequestHeader( scope.requestHeader );
+			fileLoader.setWithCredentials( scope.withCredentials );
+			fileLoader.load( subobjectURL, function ( text ) {
+
+				scope.processObject( text, function ( subobjectGroup ) {
+
+					onSubobjectLoaded( subobjectGroup, subobject );
+					onSubobjectFinish();
+
+				}, subobject, url );
+
+			}, undefined, function ( err ) {
+
+				onSubobjectError( err, subobject );
+
+			}, subobject );
+
+		}
+
+		function onSubobjectLoaded( subobjectGroup, subobject ) {
+
+			if ( subobjectGroup === null ) {
+
+				// Try to reload
+				loadSubobject( subobject );
+				return;
+
+			}
+
+			scope.fileMap[ subobject.originalFileName ] = subobject.url;
+
+		}
+
+		function onSubobjectError( err, subobject ) {
+
+			// Retry download from a different default possible location
+			loadSubobject( subobject );
+
+		}
+
+	}
+
+}
 
 export { LDrawLoader };

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -62,14 +62,14 @@ import { MMDParser } from '../libs/mmdparser.module.js';
  *  - shadow support.
  */
 
-var MMDLoader = ( function () {
+/**
+ * @param {THREE.LoadingManager} manager
+ */
+class MMDLoader extends Loader {
 
-	/**
-	 * @param {THREE.LoadingManager} manager
-	 */
-	function MMDLoader( manager ) {
+	constructor( manager ) {
 
-		Loader.call( this, manager );
+		super( manager );
 
 		this.loader = new FileLoader( this.manager );
 
@@ -79,1027 +79,1010 @@ var MMDLoader = ( function () {
 
 	}
 
-	MMDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	/**
+	 * @param {string} animationPath
+	 * @return {MMDLoader}
+	 */
+	setAnimationPath( animationPath ) {
 
-		constructor: MMDLoader,
+		this.animationPath = animationPath;
+		return this;
 
-		/**
-		 * @param {string} animationPath
-		 * @return {MMDLoader}
-		 */
-		setAnimationPath: function ( animationPath ) {
+	}
 
-			this.animationPath = animationPath;
-			return this;
+	// Load MMD assets as Three.js Object
 
-		},
+	/**
+	 * Loads Model file (.pmd or .pmx) as a SkinnedMesh.
+	 *
+	 * @param {string} url - url to Model(.pmd or .pmx) file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	load( url, onLoad, onProgress, onError ) {
 
-		// Load MMD assets as Three.js Object
+		const builder = this.meshBuilder.setCrossOrigin( this.crossOrigin );
 
-		/**
-		 * Loads Model file (.pmd or .pmx) as a SkinnedMesh.
-		 *
-		 * @param {string} url - url to Model(.pmd or .pmx) file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		load: function ( url, onLoad, onProgress, onError ) {
+		// resource path
 
-			var builder = this.meshBuilder.setCrossOrigin( this.crossOrigin );
+		let resourcePath;
 
-			// resource path
+		if ( this.resourcePath !== '' ) {
 
-			var resourcePath;
+			resourcePath = this.resourcePath;
 
-			if ( this.resourcePath !== '' ) {
+		} else if ( this.path !== '' ) {
 
-				resourcePath = this.resourcePath;
+			resourcePath = this.path;
 
-			} else if ( this.path !== '' ) {
+		} else {
 
-				resourcePath = this.path;
-
-			} else {
-
-				resourcePath = LoaderUtils.extractUrlBase( url );
-
-			}
-
-			var modelExtension = this._extractExtension( url ).toLowerCase();
-
-			// Should I detect by seeing header?
-			if ( modelExtension !== 'pmd' && modelExtension !== 'pmx' ) {
-
-				if ( onError ) onError( new Error( 'THREE.MMDLoader: Unknown model file extension .' + modelExtension + '.' ) );
-
-				return;
-
-			}
-
-			this[ modelExtension === 'pmd' ? 'loadPMD' : 'loadPMX' ]( url, function ( data ) {
-
-				onLoad(	builder.build( data, resourcePath, onProgress, onError )	);
-
-			}, onProgress, onError );
-
-		},
-
-		/**
-		 * Loads Motion file(s) (.vmd) as a AnimationClip.
-		 * If two or more files are specified, they'll be merged.
-		 *
-		 * @param {string|Array<string>} url - url(s) to animation(.vmd) file(s)
-		 * @param {SkinnedMesh|THREE.Camera} object - tracks will be fitting to this object
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadAnimation: function ( url, object, onLoad, onProgress, onError ) {
-
-			var builder = this.animationBuilder;
-
-			this.loadVMD( url, function ( vmd ) {
-
-				onLoad( object.isCamera
-					? builder.buildCameraAnimation( vmd )
-					: builder.build( vmd, object ) );
-
-			}, onProgress, onError );
-
-		},
-
-		/**
-		 * Loads mode file and motion file(s) as an object containing
-		 * a SkinnedMesh and a AnimationClip.
-		 * Tracks of AnimationClip are fitting to the model.
-		 *
-		 * @param {string} modelUrl - url to Model(.pmd or .pmx) file
-		 * @param {string|Array{string}} vmdUrl - url(s) to animation(.vmd) file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadWithAnimation: function ( modelUrl, vmdUrl, onLoad, onProgress, onError ) {
-
-			var scope = this;
-
-			this.load( modelUrl, function ( mesh ) {
-
-				scope.loadAnimation( vmdUrl, mesh, function ( animation ) {
-
-					onLoad( {
-						mesh: mesh,
-						animation: animation
-					} );
-
-				}, onProgress, onError );
-
-			}, onProgress, onError );
-
-		},
-
-		// Load MMD assets as Object data parsed by MMDParser
-
-		/**
-		 * Loads .pmd file as an Object.
-		 *
-		 * @param {string} url - url to .pmd file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadPMD: function ( url, onLoad, onProgress, onError ) {
-
-			var parser = this._getParser();
-
-			this.loader
-				.setMimeType( undefined )
-				.setPath( this.path )
-				.setResponseType( 'arraybuffer' )
-				.setRequestHeader( this.requestHeader )
-				.setWithCredentials( this.withCredentials )
-				.load( url, function ( buffer ) {
-
-					onLoad( parser.parsePmd( buffer, true ) );
-
-				}, onProgress, onError );
-
-		},
-
-		/**
-		 * Loads .pmx file as an Object.
-		 *
-		 * @param {string} url - url to .pmx file
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadPMX: function ( url, onLoad, onProgress, onError ) {
-
-			var parser = this._getParser();
-
-			this.loader
-				.setMimeType( undefined )
-				.setPath( this.path )
-				.setResponseType( 'arraybuffer' )
-				.setRequestHeader( this.requestHeader )
-				.setWithCredentials( this.withCredentials )
-				.load( url, function ( buffer ) {
-
-					onLoad( parser.parsePmx( buffer, true ) );
-
-				}, onProgress, onError );
-
-		},
-
-		/**
-		 * Loads .vmd file as an Object. If two or more files are specified
-		 * they'll be merged.
-		 *
-		 * @param {string|Array<string>} url - url(s) to .vmd file(s)
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadVMD: function ( url, onLoad, onProgress, onError ) {
-
-			var urls = Array.isArray( url ) ? url : [ url ];
-
-			var vmds = [];
-			var vmdNum = urls.length;
-
-			var parser = this._getParser();
-
-			this.loader
-				.setMimeType( undefined )
-				.setPath( this.animationPath )
-				.setResponseType( 'arraybuffer' )
-				.setRequestHeader( this.requestHeader )
-				.setWithCredentials( this.withCredentials );
-
-			for ( var i = 0, il = urls.length; i < il; i ++ ) {
-
-				this.loader.load( urls[ i ], function ( buffer ) {
-
-					vmds.push( parser.parseVmd( buffer, true ) );
-
-					if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
-
-				}, onProgress, onError );
-
-			}
-
-		},
-
-		/**
-		 * Loads .vpd file as an Object.
-		 *
-		 * @param {string} url - url to .vpd file
-		 * @param {boolean} isUnicode
-		 * @param {function} onLoad
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 */
-		loadVPD: function ( url, isUnicode, onLoad, onProgress, onError ) {
-
-			var parser = this._getParser();
-
-			this.loader
-				.setMimeType( isUnicode ? undefined : 'text/plain; charset=shift_jis' )
-				.setPath( this.animationPath )
-				.setResponseType( 'text' )
-				.setRequestHeader( this.requestHeader )
-				.setWithCredentials( this.withCredentials )
-				.load( url, function ( text ) {
-
-					onLoad( parser.parseVpd( text, true ) );
-
-				}, onProgress, onError );
-
-		},
-
-		// private methods
-
-		_extractExtension: function ( url ) {
-
-			var index = url.lastIndexOf( '.' );
-			return index < 0 ? '' : url.slice( index + 1 );
-
-		},
-
-		_getParser: function () {
-
-			if ( this.parser === null ) {
-
-				if ( typeof MMDParser === 'undefined' ) {
-
-					throw new Error( 'THREE.MMDLoader: Import MMDParser https://github.com/takahirox/mmd-parser' );
-
-				}
-
-				this.parser = new MMDParser.Parser(); // eslint-disable-line no-undef
-
-			}
-
-			return this.parser;
+			resourcePath = LoaderUtils.extractUrlBase( url );
 
 		}
 
-	} );
+		const modelExtension = this._extractExtension( url ).toLowerCase();
 
-	// Utilities
+		// Should I detect by seeing header?
+		if ( modelExtension !== 'pmd' && modelExtension !== 'pmx' ) {
 
-	/*
+			if ( onError ) onError( new Error( 'THREE.MMDLoader: Unknown model file extension .' + modelExtension + '.' ) );
+
+			return;
+
+		}
+
+		this[ modelExtension === 'pmd' ? 'loadPMD' : 'loadPMX' ]( url, function ( data ) {
+
+			onLoad(	builder.build( data, resourcePath, onProgress, onError )	);
+
+		}, onProgress, onError );
+
+	}
+
+	/**
+	 * Loads Motion file(s) (.vmd) as a AnimationClip.
+	 * If two or more files are specified, they'll be merged.
+	 *
+	 * @param {string|Array<string>} url - url(s) to animation(.vmd) file(s)
+	 * @param {SkinnedMesh|THREE.Camera} object - tracks will be fitting to this object
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadAnimation( url, object, onLoad, onProgress, onError ) {
+
+		const builder = this.animationBuilder;
+
+		this.loadVMD( url, function ( vmd ) {
+
+			onLoad( object.isCamera
+				? builder.buildCameraAnimation( vmd )
+				: builder.build( vmd, object ) );
+
+		}, onProgress, onError );
+
+	}
+
+	/**
+	 * Loads mode file and motion file(s) as an object containing
+	 * a SkinnedMesh and a AnimationClip.
+	 * Tracks of AnimationClip are fitting to the model.
+	 *
+	 * @param {string} modelUrl - url to Model(.pmd or .pmx) file
+	 * @param {string|Array{string}} vmdUrl - url(s) to animation(.vmd) file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadWithAnimation( modelUrl, vmdUrl, onLoad, onProgress, onError ) {
+
+		const scope = this;
+
+		this.load( modelUrl, function ( mesh ) {
+
+			scope.loadAnimation( vmdUrl, mesh, function ( animation ) {
+
+				onLoad( {
+					mesh: mesh,
+					animation: animation
+				} );
+
+			}, onProgress, onError );
+
+		}, onProgress, onError );
+
+	}
+
+	// Load MMD assets as Object data parsed by MMDParser
+
+	/**
+	 * Loads .pmd file as an Object.
+	 *
+	 * @param {string} url - url to .pmd file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadPMD( url, onLoad, onProgress, onError ) {
+
+		const parser = this._getParser();
+
+		this.loader
+			.setMimeType( undefined )
+			.setPath( this.path )
+			.setResponseType( 'arraybuffer' )
+			.setRequestHeader( this.requestHeader )
+			.setWithCredentials( this.withCredentials )
+			.load( url, function ( buffer ) {
+
+				onLoad( parser.parsePmd( buffer, true ) );
+
+			}, onProgress, onError );
+
+	}
+
+	/**
+	 * Loads .pmx file as an Object.
+	 *
+	 * @param {string} url - url to .pmx file
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadPMX( url, onLoad, onProgress, onError ) {
+
+		const parser = this._getParser();
+
+		this.loader
+			.setMimeType( undefined )
+			.setPath( this.path )
+			.setResponseType( 'arraybuffer' )
+			.setRequestHeader( this.requestHeader )
+			.setWithCredentials( this.withCredentials )
+			.load( url, function ( buffer ) {
+
+				onLoad( parser.parsePmx( buffer, true ) );
+
+			}, onProgress, onError );
+
+	}
+
+	/**
+	 * Loads .vmd file as an Object. If two or more files are specified
+	 * they'll be merged.
+	 *
+	 * @param {string|Array<string>} url - url(s) to .vmd file(s)
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadVMD( url, onLoad, onProgress, onError ) {
+
+		const urls = Array.isArray( url ) ? url : [ url ];
+
+		const vmds = [];
+		const vmdNum = urls.length;
+
+		const parser = this._getParser();
+
+		this.loader
+			.setMimeType( undefined )
+			.setPath( this.animationPath )
+			.setResponseType( 'arraybuffer' )
+			.setRequestHeader( this.requestHeader )
+			.setWithCredentials( this.withCredentials );
+
+		for ( let i = 0, il = urls.length; i < il; i ++ ) {
+
+			this.loader.load( urls[ i ], function ( buffer ) {
+
+				vmds.push( parser.parseVmd( buffer, true ) );
+
+				if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
+
+			}, onProgress, onError );
+
+		}
+
+	}
+
+	/**
+	 * Loads .vpd file as an Object.
+	 *
+	 * @param {string} url - url to .vpd file
+	 * @param {boolean} isUnicode
+	 * @param {function} onLoad
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 */
+	loadVPD( url, isUnicode, onLoad, onProgress, onError ) {
+
+		const parser = this._getParser();
+
+		this.loader
+			.setMimeType( isUnicode ? undefined : 'text/plain; charset=shift_jis' )
+			.setPath( this.animationPath )
+			.setResponseType( 'text' )
+			.setRequestHeader( this.requestHeader )
+			.setWithCredentials( this.withCredentials )
+			.load( url, function ( text ) {
+
+				onLoad( parser.parseVpd( text, true ) );
+
+			}, onProgress, onError );
+
+	}
+
+	// private methods
+
+	_extractExtension( url ) {
+
+		const index = url.lastIndexOf( '.' );
+		return index < 0 ? '' : url.slice( index + 1 );
+
+	}
+
+	_getParser() {
+
+		if ( this.parser === null ) {
+
+			if ( typeof MMDParser === 'undefined' ) {
+
+				throw new Error( 'THREE.MMDLoader: Import MMDParser https://github.com/takahirox/mmd-parser' );
+
+			}
+
+			this.parser = new MMDParser.Parser(); // eslint-disable-line no-undef
+
+		}
+
+		return this.parser;
+
+	}
+
+}
+
+// Utilities
+
+/*
 	 * base64 encoded defalut toon textures toon00.bmp - toon10.bmp.
 	 * We don't need to request external toon image files.
 	 * This idea is from http://www20.atpages.jp/katwat/three.js_r58/examples/mytest37/mmd.three.js
 	 */
-	var DEFAULT_TOON_TEXTURES = [
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/bWiiMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh8aBHZBl14e8wAAAABJRU5ErkJggg==',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOUlEQVRYR+3WMREAMAwDsYY/yoDI7MLwIiP40+RJklfcCCBAgAABAgTqArfb/QMCCBAgQIAAgbbAB3z/e0F3js2cAAAAAElFTkSuQmCC',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/B5ilMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh81dWyx0gFwKAAAAABJRU5ErkJggg==',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOklEQVRYR+3WoREAMAwDsWb/UQtCy9wxTOQJ/oQ8SXKKGwEECBAgQIBAXeDt7f4BAQQIECBAgEBb4AOz8Hzx7WLY4wAAAABJRU5ErkJggg==',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABPUlEQVRYR+1XwW7CMAy1+f9fZOMysSEOEweEOPRNdm3HbdOyIhAcklPrOs/PLy9RygBALxzcCDQFmgJNgaZAU6Ap0BR4PwX8gsRMVLssMRH5HcpzJEaWL7EVg9F1IHRlyqQohgVr4FGUlUcMJSjcUlDw0zvjeun70cLWmneoyf7NgBTQSniBTQQSuJAZsOnnaczjIMb5hCiuHKxokCrJfVnrctyZL0PkJAJe1HMil4nxeyi3Ypfn1kX51jpPvo/JeCNC4PhVdHdJw2XjBR8brF8PEIhNVn12AgP7uHsTBguBn53MUZCqv7Lp07Pn5k1Ro+uWmUNn7D+M57rtk7aG0Vo73xyF/fbFf0bPJjDXngnGocDTdFhygZjwUQrMNrDcmZlQT50VJ/g/UwNyHpu778+yW+/ksOz/BFo54P4AsUXMfRq7XWsAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACMElEQVRYR+2Xv4pTQRTGf2dubhLdICiii2KnYKHVolhauKWPoGAnNr6BD6CvIVaihYuI2i1ia0BY0MZGRHQXjZj/mSPnnskfNWiWZUlzJ5k7M2cm833nO5Mziej2DWWJRUoCpQKlAntSQCqgw39/iUWAGmh37jrRnVsKlgpiqmkoGVABA7E57fvY+pJDdgKqF6HzFCSADkDq+F6AHABtQ+UMVE5D7zXod7fFNhTEckTbj5XQgHzNN+5tQvc5NG7C6BNkp6D3EmpXHDR+dQAjFLchW3VS9rlw3JBh+B7ys5Cf9z0GW1C/7P32AyBAOAz1q4jGliIH3YPuBnSfQX4OGreTIgEYQb/pBDtPnEQ4CivXYPAWBk13oHrB54yA9QuSn2H4AcKRpEILDt0BUzj+RLR1V5EqjD66NPRBVpLcQwjHoHYJOhsQv6U4mnzmrIXJCFr4LDwm/xBUoboG9XX4cc9VKdYoSA2yk5NQLJaKDUjTBoveG3Z2TElTxwjNK4M3LEZgUdDdruvcXzKBpStgp2NPiWi3ks9ZXxIoFVi+AvHLdc9TqtjL3/aYjpPlrzOcEnK62Szhimdd7xX232zFDTgtxezOu3WNMRLjiKgjtOhHVMd1loynVHvOgjuIIJMaELEqhJAV/RCSLbWTcfPFakFgFlALTRRvx+ok6Hlp/Q+v3fmx90bMyUzaEAhmM3KvHlXTL5DxnbGf/1M8RNNACLL5MNtPxP/mypJAqcDSFfgFhpYqWUzhTEAAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
-		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII='
-	];
+const DEFAULT_TOON_TEXTURES = [
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/bWiiMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh8aBHZBl14e8wAAAABJRU5ErkJggg==',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOUlEQVRYR+3WMREAMAwDsYY/yoDI7MLwIiP40+RJklfcCCBAgAABAgTqArfb/QMCCBAgQIAAgbbAB3z/e0F3js2cAAAAAElFTkSuQmCC',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVRYR+3WQREAMBACsZ5/B5ilMvgEBTt5cW37hjsBBAgQIECAwFwgyfYPCCBAgAABAgTWAh81dWyx0gFwKAAAAABJRU5ErkJggg==',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAOklEQVRYR+3WoREAMAwDsWb/UQtCy9wxTOQJ/oQ8SXKKGwEECBAgQIBAXeDt7f4BAQQIECBAgEBb4AOz8Hzx7WLY4wAAAABJRU5ErkJggg==',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABPUlEQVRYR+1XwW7CMAy1+f9fZOMysSEOEweEOPRNdm3HbdOyIhAcklPrOs/PLy9RygBALxzcCDQFmgJNgaZAU6Ap0BR4PwX8gsRMVLssMRH5HcpzJEaWL7EVg9F1IHRlyqQohgVr4FGUlUcMJSjcUlDw0zvjeun70cLWmneoyf7NgBTQSniBTQQSuJAZsOnnaczjIMb5hCiuHKxokCrJfVnrctyZL0PkJAJe1HMil4nxeyi3Ypfn1kX51jpPvo/JeCNC4PhVdHdJw2XjBR8brF8PEIhNVn12AgP7uHsTBguBn53MUZCqv7Lp07Pn5k1Ro+uWmUNn7D+M57rtk7aG0Vo73xyF/fbFf0bPJjDXngnGocDTdFhygZjwUQrMNrDcmZlQT50VJ/g/UwNyHpu778+yW+/ksOz/BFo54P4AsUXMfRq7XWsAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACMElEQVRYR+2Xv4pTQRTGf2dubhLdICiii2KnYKHVolhauKWPoGAnNr6BD6CvIVaihYuI2i1ia0BY0MZGRHQXjZj/mSPnnskfNWiWZUlzJ5k7M2cm833nO5Mziej2DWWJRUoCpQKlAntSQCqgw39/iUWAGmh37jrRnVsKlgpiqmkoGVABA7E57fvY+pJDdgKqF6HzFCSADkDq+F6AHABtQ+UMVE5D7zXod7fFNhTEckTbj5XQgHzNN+5tQvc5NG7C6BNkp6D3EmpXHDR+dQAjFLchW3VS9rlw3JBh+B7ys5Cf9z0GW1C/7P32AyBAOAz1q4jGliIH3YPuBnSfQX4OGreTIgEYQb/pBDtPnEQ4CivXYPAWBk13oHrB54yA9QuSn2H4AcKRpEILDt0BUzj+RLR1V5EqjD66NPRBVpLcQwjHoHYJOhsQv6U4mnzmrIXJCFr4LDwm/xBUoboG9XX4cc9VKdYoSA2yk5NQLJaKDUjTBoveG3Z2TElTxwjNK4M3LEZgUdDdruvcXzKBpStgp2NPiWi3ks9ZXxIoFVi+AvHLdc9TqtjL3/aYjpPlrzOcEnK62Szhimdd7xX232zFDTgtxezOu3WNMRLjiKgjtOhHVMd1loynVHvOgjuIIJMaELEqhJAV/RCSLbWTcfPFakFgFlALTRRvx+ok6Hlp/Q+v3fmx90bMyUzaEAhmM3KvHlXTL5DxnbGf/1M8RNNACLL5MNtPxP/mypJAqcDSFfgFhpYqWUzhTEAAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII=',
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAL0lEQVRYR+3QQREAAAzCsOFfNJPBJ1XQS9r2hsUAAQIECBAgQIAAAQIECBAgsBZ4MUx/ofm2I/kAAAAASUVORK5CYII='
+];
 
-	// Builders. They build Three.js object from Object data parsed by MMDParser.
+// Builders. They build Three.js object from Object data parsed by MMDParser.
 
-	/**
-	 * @param {THREE.LoadingManager} manager
-	 */
-	function MeshBuilder( manager ) {
+/**
+ * @param {THREE.LoadingManager} manager
+ */
+class MeshBuilder {
 
+	constructor( manager ) {
+
+		this.crossOrigin = 'anonymous';
 		this.geometryBuilder = new GeometryBuilder();
 		this.materialBuilder = new MaterialBuilder( manager );
 
 	}
 
-	MeshBuilder.prototype = {
+	/**
+	 * @param {string} crossOrigin
+	 * @return {MeshBuilder}
+	 */
+	setCrossOrigin( crossOrigin ) {
 
-		constructor: MeshBuilder,
+		this.crossOrigin = crossOrigin;
+		return this;
 
-		crossOrigin: 'anonymous',
+	}
 
-		/**
-		 * @param {string} crossOrigin
-		 * @return {MeshBuilder}
-		 */
-		setCrossOrigin: function ( crossOrigin ) {
+	/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @param {string} resourcePath
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 * @return {SkinnedMesh}
+	 */
+	build( data, resourcePath, onProgress, onError ) {
 
-			this.crossOrigin = crossOrigin;
-			return this;
+		const geometry = this.geometryBuilder.build( data );
+		const material = this.materialBuilder
+			.setCrossOrigin( this.crossOrigin )
+			.setResourcePath( resourcePath )
+			.build( data, geometry, onProgress, onError );
 
-		},
+		const mesh = new SkinnedMesh( geometry, material );
 
-		/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @param {string} resourcePath
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 * @return {SkinnedMesh}
-		 */
-		build: function ( data, resourcePath, onProgress, onError ) {
+		const skeleton = new Skeleton( initBones( mesh ) );
+		mesh.bind( skeleton );
 
-			var geometry = this.geometryBuilder.build( data );
-			var material = this.materialBuilder
-				.setCrossOrigin( this.crossOrigin )
-				.setResourcePath( resourcePath )
-				.build( data, geometry, onProgress, onError );
+		// console.log( mesh ); // for console debug
 
-			var mesh = new SkinnedMesh( geometry, material );
+		return mesh;
 
-			var skeleton = new Skeleton( initBones( mesh ) );
-			mesh.bind( skeleton );
+	}
 
-			// console.log( mesh ); // for console debug
+}
 
-			return mesh;
+// TODO: Try to remove this function
+
+function initBones( mesh ) {
+
+	const geometry = mesh.geometry;
+
+	const bones = [];
+
+	if ( geometry && geometry.bones !== undefined ) {
+
+		// first, create array of 'Bone' objects from geometry data
+
+		for ( let i = 0, il = geometry.bones.length; i < il; i ++ ) {
+
+			const gbone = geometry.bones[ i ];
+
+			// create new 'Bone' object
+
+			const bone = new Bone();
+			bones.push( bone );
+
+			// apply values
+
+			bone.name = gbone.name;
+			bone.position.fromArray( gbone.pos );
+			bone.quaternion.fromArray( gbone.rotq );
+			if ( gbone.scl !== undefined ) bone.scale.fromArray( gbone.scl );
 
 		}
 
-	};
+		// second, create bone hierarchy
 
-	// TODO: Try to remove this function
+		for ( let i = 0, il = geometry.bones.length; i < il; i ++ ) {
 
-	function initBones( mesh ) {
+			const gbone = geometry.bones[ i ];
 
-		var geometry = mesh.geometry;
+			if ( ( gbone.parent !== - 1 ) && ( gbone.parent !== null ) && ( bones[ gbone.parent ] !== undefined ) ) {
 
-		var bones = [], bone, gbone;
-		var i, il;
+				// subsequent bones in the hierarchy
 
-		if ( geometry && geometry.bones !== undefined ) {
+				bones[ gbone.parent ].add( bones[ i ] );
 
-			// first, create array of 'Bone' objects from geometry data
+			} else {
 
-			for ( i = 0, il = geometry.bones.length; i < il; i ++ ) {
+				// topmost bone, immediate child of the skinned mesh
 
-				gbone = geometry.bones[ i ];
-
-				// create new 'Bone' object
-
-				bone = new Bone();
-				bones.push( bone );
-
-				// apply values
-
-				bone.name = gbone.name;
-				bone.position.fromArray( gbone.pos );
-				bone.quaternion.fromArray( gbone.rotq );
-				if ( gbone.scl !== undefined ) bone.scale.fromArray( gbone.scl );
-
-			}
-
-			// second, create bone hierarchy
-
-			for ( i = 0, il = geometry.bones.length; i < il; i ++ ) {
-
-				gbone = geometry.bones[ i ];
-
-				if ( ( gbone.parent !== - 1 ) && ( gbone.parent !== null ) && ( bones[ gbone.parent ] !== undefined ) ) {
-
-					// subsequent bones in the hierarchy
-
-					bones[ gbone.parent ].add( bones[ i ] );
-
-				} else {
-
-					// topmost bone, immediate child of the skinned mesh
-
-					mesh.add( bones[ i ] );
-
-				}
+				mesh.add( bones[ i ] );
 
 			}
 
 		}
 
-		// now the bones are part of the scene graph and children of the skinned mesh.
-		// let's update the corresponding matrices
-
-		mesh.updateMatrixWorld( true );
-
-		return bones;
-
 	}
 
-	//
+	// now the bones are part of the scene graph and children of the skinned mesh.
+	// let's update the corresponding matrices
 
-	function GeometryBuilder() {
+	mesh.updateMatrixWorld( true );
 
-	}
+	return bones;
 
-	GeometryBuilder.prototype = {
+}
 
-		constructor: GeometryBuilder,
+//
 
-		/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @return {BufferGeometry}
-		 */
-		build: function ( data ) {
+class GeometryBuilder {
 
-			// for geometry
-			var positions = [];
-			var uvs = [];
-			var normals = [];
+	/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @return {BufferGeometry}
+	 */
+	build( data ) {
 
-			var indices = [];
+		// for geometry
+		const positions = [];
+		const uvs = [];
+		const normals = [];
 
-			var groups = [];
+		const indices = [];
 
-			var bones = [];
-			var skinIndices = [];
-			var skinWeights = [];
+		const groups = [];
 
-			var morphTargets = [];
-			var morphPositions = [];
+		const bones = [];
+		const skinIndices = [];
+		const skinWeights = [];
 
-			var iks = [];
-			var grants = [];
+		const morphTargets = [];
+		const morphPositions = [];
 
-			var rigidBodies = [];
-			var constraints = [];
+		const iks = [];
+		const grants = [];
 
-			// for work
-			var offset = 0;
-			var boneTypeTable = {};
+		const rigidBodies = [];
+		const constraints = [];
 
-			// positions, normals, uvs, skinIndices, skinWeights
+		// for work
+		let offset = 0;
+		const boneTypeTable = {};
 
-			for ( var i = 0; i < data.metadata.vertexCount; i ++ ) {
+		// positions, normals, uvs, skinIndices, skinWeights
 
-				var v = data.vertices[ i ];
+		for ( let i = 0; i < data.metadata.vertexCount; i ++ ) {
 
-				for ( var j = 0, jl = v.position.length; j < jl; j ++ ) {
+			const v = data.vertices[ i ];
 
-					positions.push( v.position[ j ] );
+			for ( let j = 0, jl = v.position.length; j < jl; j ++ ) {
 
-				}
-
-				for ( var j = 0, jl = v.normal.length; j < jl; j ++ ) {
-
-					normals.push( v.normal[ j ] );
-
-				}
-
-				for ( var j = 0, jl = v.uv.length; j < jl; j ++ ) {
-
-					uvs.push( v.uv[ j ] );
-
-				}
-
-				for ( var j = 0; j < 4; j ++ ) {
-
-					skinIndices.push( v.skinIndices.length - 1 >= j ? v.skinIndices[ j ] : 0.0 );
-
-				}
-
-				for ( var j = 0; j < 4; j ++ ) {
-
-					skinWeights.push( v.skinWeights.length - 1 >= j ? v.skinWeights[ j ] : 0.0 );
-
-				}
+				positions.push( v.position[ j ] );
 
 			}
 
-			// indices
+			for ( let j = 0, jl = v.normal.length; j < jl; j ++ ) {
 
-			for ( var i = 0; i < data.metadata.faceCount; i ++ ) {
-
-				var face = data.faces[ i ];
-
-				for ( var j = 0, jl = face.indices.length; j < jl; j ++ ) {
-
-					indices.push( face.indices[ j ] );
-
-				}
+				normals.push( v.normal[ j ] );
 
 			}
 
-			// groups
+			for ( let j = 0, jl = v.uv.length; j < jl; j ++ ) {
 
-			for ( var i = 0; i < data.metadata.materialCount; i ++ ) {
-
-				var material = data.materials[ i ];
-
-				groups.push( {
-					offset: offset * 3,
-					count: material.faceCount * 3
-				} );
-
-				offset += material.faceCount;
+				uvs.push( v.uv[ j ] );
 
 			}
 
-			// bones
+			for ( let j = 0; j < 4; j ++ ) {
 
-			for ( var i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
-
-				var body = data.rigidBodies[ i ];
-				var value = boneTypeTable[ body.boneIndex ];
-
-				// keeps greater number if already value is set without any special reasons
-				value = value === undefined ? body.type : Math.max( body.type, value );
-
-				boneTypeTable[ body.boneIndex ] = value;
+				skinIndices.push( v.skinIndices.length - 1 >= j ? v.skinIndices[ j ] : 0.0 );
 
 			}
 
-			for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
+			for ( let j = 0; j < 4; j ++ ) {
 
-				var boneData = data.bones[ i ];
+				skinWeights.push( v.skinWeights.length - 1 >= j ? v.skinWeights[ j ] : 0.0 );
 
-				var bone = {
-					index: i,
-					transformationClass: boneData.transformationClass,
-					parent: boneData.parentIndex,
-					name: boneData.name,
-					pos: boneData.position.slice( 0, 3 ),
-					rotq: [ 0, 0, 0, 1 ],
-					scl: [ 1, 1, 1 ],
-					rigidBodyType: boneTypeTable[ i ] !== undefined ? boneTypeTable[ i ] : - 1
+			}
+
+		}
+
+		// indices
+
+		for ( let i = 0; i < data.metadata.faceCount; i ++ ) {
+
+			const face = data.faces[ i ];
+
+			for ( let j = 0, jl = face.indices.length; j < jl; j ++ ) {
+
+				indices.push( face.indices[ j ] );
+
+			}
+
+		}
+
+		// groups
+
+		for ( let i = 0; i < data.metadata.materialCount; i ++ ) {
+
+			const material = data.materials[ i ];
+
+			groups.push( {
+				offset: offset * 3,
+				count: material.faceCount * 3
+			} );
+
+			offset += material.faceCount;
+
+		}
+
+		// bones
+
+		for ( let i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
+
+			const body = data.rigidBodies[ i ];
+			let value = boneTypeTable[ body.boneIndex ];
+
+			// keeps greater number if already value is set without any special reasons
+			value = value === undefined ? body.type : Math.max( body.type, value );
+
+			boneTypeTable[ body.boneIndex ] = value;
+
+		}
+
+		for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+			const boneData = data.bones[ i ];
+
+			const bone = {
+				index: i,
+				transformationClass: boneData.transformationClass,
+				parent: boneData.parentIndex,
+				name: boneData.name,
+				pos: boneData.position.slice( 0, 3 ),
+				rotq: [ 0, 0, 0, 1 ],
+				scl: [ 1, 1, 1 ],
+				rigidBodyType: boneTypeTable[ i ] !== undefined ? boneTypeTable[ i ] : - 1
+			};
+
+			if ( bone.parent !== - 1 ) {
+
+				bone.pos[ 0 ] -= data.bones[ bone.parent ].position[ 0 ];
+				bone.pos[ 1 ] -= data.bones[ bone.parent ].position[ 1 ];
+				bone.pos[ 2 ] -= data.bones[ bone.parent ].position[ 2 ];
+
+			}
+
+			bones.push( bone );
+
+		}
+
+		// iks
+
+		// TODO: remove duplicated codes between PMD and PMX
+		if ( data.metadata.format === 'pmd' ) {
+
+			for ( let i = 0; i < data.metadata.ikCount; i ++ ) {
+
+				const ik = data.iks[ i ];
+
+				const param = {
+					target: ik.target,
+					effector: ik.effector,
+					iteration: ik.iteration,
+					maxAngle: ik.maxAngle * 4,
+					links: []
 				};
 
-				if ( bone.parent !== - 1 ) {
+				for ( let j = 0, jl = ik.links.length; j < jl; j ++ ) {
 
-					bone.pos[ 0 ] -= data.bones[ bone.parent ].position[ 0 ];
-					bone.pos[ 1 ] -= data.bones[ bone.parent ].position[ 1 ];
-					bone.pos[ 2 ] -= data.bones[ bone.parent ].position[ 2 ];
+					const link = {};
+					link.index = ik.links[ j ].index;
+					link.enabled = true;
 
-				}
+					if ( data.bones[ link.index ].name.indexOf( 'ひざ' ) >= 0 ) {
 
-				bones.push( bone );
-
-			}
-
-			// iks
-
-			// TODO: remove duplicated codes between PMD and PMX
-			if ( data.metadata.format === 'pmd' ) {
-
-				for ( var i = 0; i < data.metadata.ikCount; i ++ ) {
-
-					var ik = data.iks[ i ];
-
-					var param = {
-						target: ik.target,
-						effector: ik.effector,
-						iteration: ik.iteration,
-						maxAngle: ik.maxAngle * 4,
-						links: []
-					};
-
-					for ( var j = 0, jl = ik.links.length; j < jl; j ++ ) {
-
-						var link = {};
-						link.index = ik.links[ j ].index;
-						link.enabled = true;
-
-						if ( data.bones[ link.index ].name.indexOf( 'ひざ' ) >= 0 ) {
-
-							link.limitation = new Vector3( 1.0, 0.0, 0.0 );
-
-						}
-
-						param.links.push( link );
+						link.limitation = new Vector3( 1.0, 0.0, 0.0 );
 
 					}
 
-					iks.push( param );
+					param.links.push( link );
+
+				}
+
+				iks.push( param );
+
+			}
+
+		} else {
+
+			for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+				const ik = data.bones[ i ].ik;
+
+				if ( ik === undefined ) continue;
+
+				const param = {
+					target: i,
+					effector: ik.effector,
+					iteration: ik.iteration,
+					maxAngle: ik.maxAngle,
+					links: []
+				};
+
+				for ( let j = 0, jl = ik.links.length; j < jl; j ++ ) {
+
+					const link = {};
+					link.index = ik.links[ j ].index;
+					link.enabled = true;
+
+					if ( ik.links[ j ].angleLimitation === 1 ) {
+
+						// Revert if rotationMin/Max doesn't work well
+						// link.limitation = new Vector3( 1.0, 0.0, 0.0 );
+
+						const rotationMin = ik.links[ j ].lowerLimitationAngle;
+						const rotationMax = ik.links[ j ].upperLimitationAngle;
+
+						// Convert Left to Right coordinate by myself because
+						// MMDParser doesn't convert. It's a MMDParser's bug
+
+						const tmp1 = - rotationMax[ 0 ];
+						const tmp2 = - rotationMax[ 1 ];
+						rotationMax[ 0 ] = - rotationMin[ 0 ];
+						rotationMax[ 1 ] = - rotationMin[ 1 ];
+						rotationMin[ 0 ] = tmp1;
+						rotationMin[ 1 ] = tmp2;
+
+						link.rotationMin = new Vector3().fromArray( rotationMin );
+						link.rotationMax = new Vector3().fromArray( rotationMax );
+
+					}
+
+					param.links.push( link );
+
+				}
+
+				iks.push( param );
+
+				// Save the reference even from bone data for efficiently
+				// simulating PMX animation system
+				bones[ i ].ik = param;
+
+			}
+
+		}
+
+		// grants
+
+		if ( data.metadata.format === 'pmx' ) {
+
+			// bone index -> grant entry map
+			const grantEntryMap = {};
+
+			for ( let i = 0; i < data.metadata.boneCount; i ++ ) {
+
+				const boneData = data.bones[ i ];
+				const grant = boneData.grant;
+
+				if ( grant === undefined ) continue;
+
+				const param = {
+					index: i,
+					parentIndex: grant.parentIndex,
+					ratio: grant.ratio,
+					isLocal: grant.isLocal,
+					affectRotation: grant.affectRotation,
+					affectPosition: grant.affectPosition,
+					transformationClass: boneData.transformationClass
+				};
+
+				grantEntryMap[ i ] = { parent: null, children: [], param: param, visited: false };
+
+			}
+
+			const rootEntry = { parent: null, children: [], param: null, visited: false };
+
+			// Build a tree representing grant hierarchy
+
+			for ( const boneIndex in grantEntryMap ) {
+
+				const grantEntry = grantEntryMap[ boneIndex ];
+				const parentGrantEntry = grantEntryMap[ grantEntry.parentIndex ] || rootEntry;
+
+				grantEntry.parent = parentGrantEntry;
+				parentGrantEntry.children.push( grantEntry );
+
+			}
+
+			// Sort grant parameters from parents to children because
+			// grant uses parent's transform that parent's grant is already applied
+			// so grant should be applied in order from parents to children
+
+			function traverse( entry ) {
+
+				if ( entry.param ) {
+
+					grants.push( entry.param );
+
+					// Save the reference even from bone data for efficiently
+					// simulating PMX animation system
+					bones[ entry.param.index ].grant = entry.param;
+
+				}
+
+				entry.visited = true;
+
+				for ( let i = 0, il = entry.children.length; i < il; i ++ ) {
+
+					const child = entry.children[ i ];
+
+					// Cut off a loop if exists. (Is a grant loop invalid?)
+					if ( ! child.visited ) traverse( child );
+
+				}
+
+			}
+
+			traverse( rootEntry );
+
+		}
+
+		// morph
+
+		function updateAttributes( attribute, morph, ratio ) {
+
+			for ( let i = 0; i < morph.elementCount; i ++ ) {
+
+				const element = morph.elements[ i ];
+
+				let index;
+
+				if ( data.metadata.format === 'pmd' ) {
+
+					index = data.morphs[ 0 ].elements[ element.index ].index;
+
+				} else {
+
+					index = element.index;
+
+				}
+
+				attribute.array[ index * 3 + 0 ] += element.position[ 0 ] * ratio;
+				attribute.array[ index * 3 + 1 ] += element.position[ 1 ] * ratio;
+				attribute.array[ index * 3 + 2 ] += element.position[ 2 ] * ratio;
+
+			}
+
+		}
+
+		for ( let i = 0; i < data.metadata.morphCount; i ++ ) {
+
+			const morph = data.morphs[ i ];
+			const params = { name: morph.name };
+
+			const attribute = new Float32BufferAttribute( data.metadata.vertexCount * 3, 3 );
+			attribute.name = morph.name;
+
+			for ( let j = 0; j < data.metadata.vertexCount * 3; j ++ ) {
+
+				attribute.array[ j ] = positions[ j ];
+
+			}
+
+			if ( data.metadata.format === 'pmd' ) {
+
+				if ( i !== 0 ) {
+
+					updateAttributes( attribute, morph, 1.0 );
 
 				}
 
 			} else {
 
-				for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
+				if ( morph.type === 0 ) { // group
 
-					var ik = data.bones[ i ].ik;
+					for ( let j = 0; j < morph.elementCount; j ++ ) {
 
-					if ( ik === undefined ) continue;
+						const morph2 = data.morphs[ morph.elements[ j ].index ];
+						const ratio = morph.elements[ j ].ratio;
 
-					var param = {
-						target: i,
-						effector: ik.effector,
-						iteration: ik.iteration,
-						maxAngle: ik.maxAngle,
-						links: []
-					};
+						if ( morph2.type === 1 ) {
 
-					for ( var j = 0, jl = ik.links.length; j < jl; j ++ ) {
+							updateAttributes( attribute, morph2, ratio );
 
-						var link = {};
-						link.index = ik.links[ j ].index;
-						link.enabled = true;
+						} else {
 
-						if ( ik.links[ j ].angleLimitation === 1 ) {
-
-							// Revert if rotationMin/Max doesn't work well
-							// link.limitation = new Vector3( 1.0, 0.0, 0.0 );
-
-							var rotationMin = ik.links[ j ].lowerLimitationAngle;
-							var rotationMax = ik.links[ j ].upperLimitationAngle;
-
-							// Convert Left to Right coordinate by myself because
-							// MMDParser doesn't convert. It's a MMDParser's bug
-
-							var tmp1 = - rotationMax[ 0 ];
-							var tmp2 = - rotationMax[ 1 ];
-							rotationMax[ 0 ] = - rotationMin[ 0 ];
-							rotationMax[ 1 ] = - rotationMin[ 1 ];
-							rotationMin[ 0 ] = tmp1;
-							rotationMin[ 1 ] = tmp2;
-
-							link.rotationMin = new Vector3().fromArray( rotationMin );
-							link.rotationMax = new Vector3().fromArray( rotationMax );
+							// TODO: implement
 
 						}
 
-						param.links.push( link );
-
 					}
 
-					iks.push( param );
+				} else if ( morph.type === 1 ) { // vertex
 
-					// Save the reference even from bone data for efficiently
-					// simulating PMX animation system
-					bones[ i ].ik = param;
+					updateAttributes( attribute, morph, 1.0 );
+
+				} else if ( morph.type === 2 ) { // bone
+
+					// TODO: implement
+
+				} else if ( morph.type === 3 ) { // uv
+
+					// TODO: implement
+
+				} else if ( morph.type === 4 ) { // additional uv1
+
+					// TODO: implement
+
+				} else if ( morph.type === 5 ) { // additional uv2
+
+					// TODO: implement
+
+				} else if ( morph.type === 6 ) { // additional uv3
+
+					// TODO: implement
+
+				} else if ( morph.type === 7 ) { // additional uv4
+
+					// TODO: implement
+
+				} else if ( morph.type === 8 ) { // material
+
+					// TODO: implement
 
 				}
 
 			}
 
-			// grants
+			morphTargets.push( params );
+			morphPositions.push( attribute );
 
-			if ( data.metadata.format === 'pmx' ) {
+		}
 
-				// bone index -> grant entry map
-				var grantEntryMap = {};
+		// rigid bodies from rigidBodies field.
 
-				for ( var i = 0; i < data.metadata.boneCount; i ++ ) {
+		for ( let i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
 
-					var boneData = data.bones[ i ];
-					var grant = boneData.grant;
+			const rigidBody = data.rigidBodies[ i ];
+			const params = {};
 
-					if ( grant === undefined ) continue;
+			for ( const key in rigidBody ) {
 
-					var param = {
-						index: i,
-						parentIndex: grant.parentIndex,
-						ratio: grant.ratio,
-						isLocal: grant.isLocal,
-						affectRotation: grant.affectRotation,
-						affectPosition: grant.affectPosition,
-						transformationClass: boneData.transformationClass
-					};
-
-					grantEntryMap[ i ] = { parent: null, children: [], param: param, visited: false };
-
-				}
-
-				var rootEntry = { parent: null, children: [], param: null, visited: false };
-
-				// Build a tree representing grant hierarchy
-
-				for ( var boneIndex in grantEntryMap ) {
-
-					var grantEntry = grantEntryMap[ boneIndex ];
-					var parentGrantEntry = grantEntryMap[ grantEntry.parentIndex ] || rootEntry;
-
-					grantEntry.parent = parentGrantEntry;
-					parentGrantEntry.children.push( grantEntry );
-
-				}
-
-				// Sort grant parameters from parents to children because
-				// grant uses parent's transform that parent's grant is already applied
-				// so grant should be applied in order from parents to children
-
-				function traverse( entry ) {
-
-					if ( entry.param ) {
-
-						grants.push( entry.param );
-
-						// Save the reference even from bone data for efficiently
-						// simulating PMX animation system
-						bones[ entry.param.index ].grant = entry.param;
-
-					}
-
-					entry.visited = true;
-
-					for ( var i = 0, il = entry.children.length; i < il; i ++ ) {
-
-						var child = entry.children[ i ];
-
-						// Cut off a loop if exists. (Is a grant loop invalid?)
-						if ( ! child.visited ) traverse( child );
-
-					}
-
-				}
-
-				traverse( rootEntry );
+				params[ key ] = rigidBody[ key ];
 
 			}
 
-			// morph
-
-			function updateAttributes( attribute, morph, ratio ) {
-
-				for ( var i = 0; i < morph.elementCount; i ++ ) {
-
-					var element = morph.elements[ i ];
-
-					var index;
-
-					if ( data.metadata.format === 'pmd' ) {
-
-						index = data.morphs[ 0 ].elements[ element.index ].index;
-
-					} else {
-
-						index = element.index;
-
-					}
-
-					attribute.array[ index * 3 + 0 ] += element.position[ 0 ] * ratio;
-					attribute.array[ index * 3 + 1 ] += element.position[ 1 ] * ratio;
-					attribute.array[ index * 3 + 2 ] += element.position[ 2 ] * ratio;
-
-				}
-
-			}
-
-			for ( var i = 0; i < data.metadata.morphCount; i ++ ) {
-
-				var morph = data.morphs[ i ];
-				var params = { name: morph.name };
-
-				var attribute = new Float32BufferAttribute( data.metadata.vertexCount * 3, 3 );
-				attribute.name = morph.name;
-
-				for ( var j = 0; j < data.metadata.vertexCount * 3; j ++ ) {
-
-					attribute.array[ j ] = positions[ j ];
-
-				}
-
-				if ( data.metadata.format === 'pmd' ) {
-
-					if ( i !== 0 ) {
-
-						updateAttributes( attribute, morph, 1.0 );
-
-					}
-
-				} else {
-
-					if ( morph.type === 0 ) { // group
-
-						for ( var j = 0; j < morph.elementCount; j ++ ) {
-
-							var morph2 = data.morphs[ morph.elements[ j ].index ];
-							var ratio = morph.elements[ j ].ratio;
-
-							if ( morph2.type === 1 ) {
-
-								updateAttributes( attribute, morph2, ratio );
-
-							} else {
-
-								// TODO: implement
-
-							}
-
-						}
-
-					} else if ( morph.type === 1 ) { // vertex
-
-						updateAttributes( attribute, morph, 1.0 );
-
-					} else if ( morph.type === 2 ) { // bone
-
-						// TODO: implement
-
-					} else if ( morph.type === 3 ) { // uv
-
-						// TODO: implement
-
-					} else if ( morph.type === 4 ) { // additional uv1
-
-						// TODO: implement
-
-					} else if ( morph.type === 5 ) { // additional uv2
-
-						// TODO: implement
-
-					} else if ( morph.type === 6 ) { // additional uv3
-
-						// TODO: implement
-
-					} else if ( morph.type === 7 ) { // additional uv4
-
-						// TODO: implement
-
-					} else if ( morph.type === 8 ) { // material
-
-						// TODO: implement
-
-					}
-
-				}
-
-				morphTargets.push( params );
-				morphPositions.push( attribute );
-
-			}
-
-			// rigid bodies from rigidBodies field.
-
-			for ( var i = 0; i < data.metadata.rigidBodyCount; i ++ ) {
-
-				var rigidBody = data.rigidBodies[ i ];
-				var params = {};
-
-				for ( var key in rigidBody ) {
-
-					params[ key ] = rigidBody[ key ];
-
-				}
-
-				/*
+			/*
 				 * RigidBody position parameter in PMX seems global position
 				 * while the one in PMD seems offset from corresponding bone.
 				 * So unify being offset.
 				 */
-				if ( data.metadata.format === 'pmx' ) {
+			if ( data.metadata.format === 'pmx' ) {
 
-					if ( params.boneIndex !== - 1 ) {
+				if ( params.boneIndex !== - 1 ) {
 
-						var bone = data.bones[ params.boneIndex ];
-						params.position[ 0 ] -= bone.position[ 0 ];
-						params.position[ 1 ] -= bone.position[ 1 ];
-						params.position[ 2 ] -= bone.position[ 2 ];
-
-					}
+					const bone = data.bones[ params.boneIndex ];
+					params.position[ 0 ] -= bone.position[ 0 ];
+					params.position[ 1 ] -= bone.position[ 1 ];
+					params.position[ 2 ] -= bone.position[ 2 ];
 
 				}
 
-				rigidBodies.push( params );
-
 			}
 
-			// constraints from constraints field.
-
-			for ( var i = 0; i < data.metadata.constraintCount; i ++ ) {
-
-				var constraint = data.constraints[ i ];
-				var params = {};
-
-				for ( var key in constraint ) {
-
-					params[ key ] = constraint[ key ];
-
-				}
-
-				var bodyA = rigidBodies[ params.rigidBodyIndex1 ];
-				var bodyB = rigidBodies[ params.rigidBodyIndex2 ];
-
-				// Refer to http://www20.atpages.jp/katwat/wp/?p=4135
-				if ( bodyA.type !== 0 && bodyB.type === 2 ) {
-
-					if ( bodyA.boneIndex !== - 1 && bodyB.boneIndex !== - 1 &&
-					     data.bones[ bodyB.boneIndex ].parentIndex === bodyA.boneIndex ) {
-
-						bodyB.type = 1;
-
-					}
-
-				}
-
-				constraints.push( params );
-
-			}
-
-			// build BufferGeometry.
-
-			var geometry = new BufferGeometry();
-
-			geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-			geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-			geometry.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
-			geometry.setAttribute( 'skinIndex', new Uint16BufferAttribute( skinIndices, 4 ) );
-			geometry.setAttribute( 'skinWeight', new Float32BufferAttribute( skinWeights, 4 ) );
-			geometry.setIndex( indices );
-
-			for ( var i = 0, il = groups.length; i < il; i ++ ) {
-
-				geometry.addGroup( groups[ i ].offset, groups[ i ].count, i );
-
-			}
-
-			geometry.bones = bones;
-
-			geometry.morphTargets = morphTargets;
-			geometry.morphAttributes.position = morphPositions;
-			geometry.morphTargetsRelative = false;
-
-			geometry.userData.MMD = {
-				bones: bones,
-				iks: iks,
-				grants: grants,
-				rigidBodies: rigidBodies,
-				constraints: constraints,
-				format: data.metadata.format
-			};
-
-			geometry.computeBoundingSphere();
-
-			return geometry;
+			rigidBodies.push( params );
 
 		}
 
-	};
+		// constraints from constraints field.
 
-	//
+		for ( let i = 0; i < data.metadata.constraintCount; i ++ ) {
 
-	/**
-	 * @param {THREE.LoadingManager} manager
-	 */
-	function MaterialBuilder( manager ) {
+			const constraint = data.constraints[ i ];
+			const params = {};
+
+			for ( const key in constraint ) {
+
+				params[ key ] = constraint[ key ];
+
+			}
+
+			const bodyA = rigidBodies[ params.rigidBodyIndex1 ];
+			const bodyB = rigidBodies[ params.rigidBodyIndex2 ];
+
+			// Refer to http://www20.atpages.jp/katwat/wp/?p=4135
+			if ( bodyA.type !== 0 && bodyB.type === 2 ) {
+
+				if ( bodyA.boneIndex !== - 1 && bodyB.boneIndex !== - 1 &&
+					     data.bones[ bodyB.boneIndex ].parentIndex === bodyA.boneIndex ) {
+
+					bodyB.type = 1;
+
+				}
+
+			}
+
+			constraints.push( params );
+
+		}
+
+		// build BufferGeometry.
+
+		const geometry = new BufferGeometry();
+
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		geometry.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		geometry.setAttribute( 'skinIndex', new Uint16BufferAttribute( skinIndices, 4 ) );
+		geometry.setAttribute( 'skinWeight', new Float32BufferAttribute( skinWeights, 4 ) );
+		geometry.setIndex( indices );
+
+		for ( let i = 0, il = groups.length; i < il; i ++ ) {
+
+			geometry.addGroup( groups[ i ].offset, groups[ i ].count, i );
+
+		}
+
+		geometry.bones = bones;
+
+		geometry.morphTargets = morphTargets;
+		geometry.morphAttributes.position = morphPositions;
+		geometry.morphTargetsRelative = false;
+
+		geometry.userData.MMD = {
+			bones: bones,
+			iks: iks,
+			grants: grants,
+			rigidBodies: rigidBodies,
+			constraints: constraints,
+			format: data.metadata.format
+		};
+
+		geometry.computeBoundingSphere();
+
+		return geometry;
+
+	}
+
+}
+
+//
+
+/**
+ * @param {THREE.LoadingManager} manager
+ */
+class MaterialBuilder {
+
+	constructor( manager ) {
 
 		this.manager = manager;
 
 		this.textureLoader = new TextureLoader( this.manager );
 		this.tgaLoader = null; // lazy generation
 
+		this.crossOrigin = 'anonymous';
+		this.resourcePath = undefined;
+
 	}
 
-	MaterialBuilder.prototype = {
+	/**
+	 * @param {string} crossOrigin
+	 * @return {MaterialBuilder}
+	 */
+	setCrossOrigin( crossOrigin ) {
 
-		constructor: MaterialBuilder,
+		this.crossOrigin = crossOrigin;
+		return this;
 
-		crossOrigin: 'anonymous',
+	}
 
-		resourcePath: undefined,
+	/**
+	 * @param {string} resourcePath
+	 * @return {MaterialBuilder}
+	 */
+	setResourcePath( resourcePath ) {
 
-		/**
-		 * @param {string} crossOrigin
-		 * @return {MaterialBuilder}
-		 */
-		setCrossOrigin: function ( crossOrigin ) {
+		this.resourcePath = resourcePath;
+		return this;
 
-			this.crossOrigin = crossOrigin;
-			return this;
+	}
 
-		},
+	/**
+	 * @param {Object} data - parsed PMD/PMX data
+	 * @param {BufferGeometry} geometry - some properties are dependend on geometry
+	 * @param {function} onProgress
+	 * @param {function} onError
+	 * @return {Array<MeshToonMaterial>}
+	 */
+	build( data, geometry /*, onProgress, onError */ ) {
 
-		/**
-		 * @param {string} resourcePath
-		 * @return {MaterialBuilder}
-		 */
-		setResourcePath: function ( resourcePath ) {
+		const materials = [];
 
-			this.resourcePath = resourcePath;
-			return this;
+		const textures = {};
 
-		},
+		this.textureLoader.setCrossOrigin( this.crossOrigin );
 
-		/**
-		 * @param {Object} data - parsed PMD/PMX data
-		 * @param {BufferGeometry} geometry - some properties are dependend on geometry
-		 * @param {function} onProgress
-		 * @param {function} onError
-		 * @return {Array<MeshToonMaterial>}
-		 */
-		build: function ( data, geometry /*, onProgress, onError */ ) {
+		// materials
 
-			var materials = [];
+		for ( let i = 0; i < data.metadata.materialCount; i ++ ) {
 
-			var textures = {};
+			const material = data.materials[ i ];
 
-			this.textureLoader.setCrossOrigin( this.crossOrigin );
+			const params = { userData: {} };
 
-			// materials
+			if ( material.name !== undefined ) params.name = material.name;
 
-			for ( var i = 0; i < data.metadata.materialCount; i ++ ) {
-
-				var material = data.materials[ i ];
-
-				var params = { userData: {} };
-
-				if ( material.name !== undefined ) params.name = material.name;
-
-				/*
+			/*
 				 * Color
 				 *
 				 * MMD         MeshToonMaterial
@@ -1110,890 +1093,880 @@ var MMDLoader = ( function () {
 				 * MeshToonMaterial doesn't have ambient. Set it to emissive instead.
 				 * It'll be too bright if material has map texture so using coef 0.2.
 				 */
-				params.color = new Color().fromArray( material.diffuse );
-				params.opacity = material.diffuse[ 3 ];
-				params.emissive = new Color().fromArray( material.ambient );
-				params.transparent = params.opacity !== 1.0;
+			params.color = new Color().fromArray( material.diffuse );
+			params.opacity = material.diffuse[ 3 ];
+			params.emissive = new Color().fromArray( material.ambient );
+			params.transparent = params.opacity !== 1.0;
 
-				//
+			//
 
-				params.skinning = geometry.bones.length > 0 ? true : false;
-				params.morphTargets = geometry.morphTargets.length > 0 ? true : false;
-				params.fog = true;
+			params.skinning = geometry.bones.length > 0 ? true : false;
+			params.morphTargets = geometry.morphTargets.length > 0 ? true : false;
+			params.fog = true;
 
-				// blend
+			// blend
 
-				params.blending = CustomBlending;
-				params.blendSrc = SrcAlphaFactor;
-				params.blendDst = OneMinusSrcAlphaFactor;
-				params.blendSrcAlpha = SrcAlphaFactor;
-				params.blendDstAlpha = DstAlphaFactor;
+			params.blending = CustomBlending;
+			params.blendSrc = SrcAlphaFactor;
+			params.blendDst = OneMinusSrcAlphaFactor;
+			params.blendSrcAlpha = SrcAlphaFactor;
+			params.blendDstAlpha = DstAlphaFactor;
 
-				// side
+			// side
 
-				if ( data.metadata.format === 'pmx' && ( material.flag & 0x1 ) === 1 ) {
+			if ( data.metadata.format === 'pmx' && ( material.flag & 0x1 ) === 1 ) {
 
-					params.side = DoubleSide;
+				params.side = DoubleSide;
 
-				} else {
+			} else {
 
-					params.side = params.opacity === 1.0 ? FrontSide : DoubleSide;
+				params.side = params.opacity === 1.0 ? FrontSide : DoubleSide;
 
-				}
+			}
 
-				if ( data.metadata.format === 'pmd' ) {
+			if ( data.metadata.format === 'pmd' ) {
 
-					// map, envMap
+				// map, envMap
 
-					if ( material.fileName ) {
+				if ( material.fileName ) {
 
-						var fileName = material.fileName;
-						var fileNames = fileName.split( '*' );
+					const fileName = material.fileName;
+					const fileNames = fileName.split( '*' );
 
-						// fileNames[ 0 ]: mapFileName
-						// fileNames[ 1 ]: envMapFileName( optional )
+					// fileNames[ 0 ]: mapFileName
+					// fileNames[ 1 ]: envMapFileName( optional )
 
-						params.map = this._loadTexture( fileNames[ 0 ], textures );
+					params.map = this._loadTexture( fileNames[ 0 ], textures );
 
-						if ( fileNames.length > 1 ) {
+					if ( fileNames.length > 1 ) {
 
-							var extension = fileNames[ 1 ].slice( - 4 ).toLowerCase();
-
-							params.envMap = this._loadTexture(
-								fileNames[ 1 ],
-								textures
-							);
-
-							params.combine = extension === '.sph'
-								? MultiplyOperation
-								: AddOperation;
-
-						}
-
-					}
-
-					// gradientMap
-
-					var toonFileName = ( material.toonIndex === - 1 )
-						? 'toon00.bmp'
-						: data.toonTextures[ material.toonIndex ].fileName;
-
-					params.gradientMap = this._loadTexture(
-						toonFileName,
-						textures,
-						{
-							isToonTexture: true,
-							isDefaultToonTexture: this._isDefaultToonTexture( toonFileName )
-						}
-					);
-
-					// parameters for OutlineEffect
-
-					params.userData.outlineParameters = {
-						thickness: material.edgeFlag === 1 ? 0.003 : 0.0,
-						color: [ 0, 0, 0 ],
-						alpha: 1.0,
-						visible: material.edgeFlag === 1
-					};
-
-				} else {
-
-					// map
-
-					if ( material.textureIndex !== - 1 ) {
-
-						params.map = this._loadTexture( data.textures[ material.textureIndex ], textures );
-
-					}
-
-					// envMap TODO: support m.envFlag === 3
-
-					if ( material.envTextureIndex !== - 1 && ( material.envFlag === 1 || material.envFlag == 2 ) ) {
+						const extension = fileNames[ 1 ].slice( - 4 ).toLowerCase();
 
 						params.envMap = this._loadTexture(
-							data.textures[ material.envTextureIndex ],
+							fileNames[ 1 ],
 							textures
 						);
 
-						params.combine = material.envFlag === 1
+						params.combine = extension === '.sph'
 							? MultiplyOperation
 							: AddOperation;
 
 					}
 
-					// gradientMap
+				}
 
-					var toonFileName, isDefaultToon;
+				// gradientMap
 
-					if ( material.toonIndex === - 1 || material.toonFlag !== 0 ) {
+				const toonFileName = ( material.toonIndex === - 1 )
+					? 'toon00.bmp'
+					: data.toonTextures[ material.toonIndex ].fileName;
 
-						toonFileName = 'toon' + ( '0' + ( material.toonIndex + 1 ) ).slice( - 2 ) + '.bmp';
-						isDefaultToon = true;
-
-					} else {
-
-						toonFileName = data.textures[ material.toonIndex ];
-						isDefaultToon = false;
-
+				params.gradientMap = this._loadTexture(
+					toonFileName,
+					textures,
+					{
+						isToonTexture: true,
+						isDefaultToonTexture: this._isDefaultToonTexture( toonFileName )
 					}
-
-					params.gradientMap = this._loadTexture(
-						toonFileName,
-						textures,
-						{
-							isToonTexture: true,
-							isDefaultToonTexture: isDefaultToon
-						}
-					);
-
-					// parameters for OutlineEffect
-					params.userData.outlineParameters = {
-						thickness: material.edgeSize / 300, // TODO: better calculation?
-						color: material.edgeColor.slice( 0, 3 ),
-						alpha: material.edgeColor[ 3 ],
-						visible: ( material.flag & 0x10 ) !== 0 && material.edgeSize > 0.0
-					};
-
-				}
-
-				if ( params.map !== undefined ) {
-
-					if ( ! params.transparent ) {
-
-						this._checkImageTransparency( params.map, geometry, i );
-
-					}
-
-					params.emissive.multiplyScalar( 0.2 );
-
-				}
-
-				materials.push( new MeshToonMaterial( params ) );
-
-			}
-
-			if ( data.metadata.format === 'pmx' ) {
-
-				// set transparent true if alpha morph is defined.
-
-				function checkAlphaMorph( elements, materials ) {
-
-					for ( var i = 0, il = elements.length; i < il; i ++ ) {
-
-						var element = elements[ i ];
-
-						if ( element.index === - 1 ) continue;
-
-						var material = materials[ element.index ];
-
-						if ( material.opacity !== element.diffuse[ 3 ] ) {
-
-							material.transparent = true;
-
-						}
-
-					}
-
-				}
-
-				for ( var i = 0, il = data.morphs.length; i < il; i ++ ) {
-
-					var morph = data.morphs[ i ];
-					var elements = morph.elements;
-
-					if ( morph.type === 0 ) {
-
-						for ( var j = 0, jl = elements.length; j < jl; j ++ ) {
-
-							var morph2 = data.morphs[ elements[ j ].index ];
-
-							if ( morph2.type !== 8 ) continue;
-
-							checkAlphaMorph( morph2.elements, materials );
-
-						}
-
-					} else if ( morph.type === 8 ) {
-
-						checkAlphaMorph( elements, materials );
-
-					}
-
-				}
-
-			}
-
-			return materials;
-
-		},
-
-		// private methods
-
-		_getTGALoader: function () {
-
-			if ( this.tgaLoader === null ) {
-
-				if ( TGALoader === undefined ) {
-
-					throw new Error( 'THREE.MMDLoader: Import TGALoader' );
-
-				}
-
-				this.tgaLoader = new TGALoader( this.manager );
-
-			}
-
-			return this.tgaLoader;
-
-		},
-
-		_isDefaultToonTexture: function ( name ) {
-
-			if ( name.length !== 10 ) return false;
-
-			return /toon(10|0[0-9])\.bmp/.test( name );
-
-		},
-
-		_loadTexture: function ( filePath, textures, params, onProgress, onError ) {
-
-			params = params || {};
-
-			var scope = this;
-
-			var fullPath;
-
-			if ( params.isDefaultToonTexture === true ) {
-
-				var index;
-
-				try {
-
-					index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
-
-				} catch ( e ) {
-
-					console.warn( 'THREE.MMDLoader: ' + filePath + ' seems like a '
-						+ 'not right default texture path. Using toon00.bmp instead.' );
-
-					index = 0;
-
-				}
-
-				fullPath = DEFAULT_TOON_TEXTURES[ index ];
+				);
+
+				// parameters for OutlineEffect
+
+				params.userData.outlineParameters = {
+					thickness: material.edgeFlag === 1 ? 0.003 : 0.0,
+					color: [ 0, 0, 0 ],
+					alpha: 1.0,
+					visible: material.edgeFlag === 1
+				};
 
 			} else {
 
-				fullPath = this.resourcePath + filePath;
+				// map
+
+				if ( material.textureIndex !== - 1 ) {
+
+					params.map = this._loadTexture( data.textures[ material.textureIndex ], textures );
+
+				}
+
+				// envMap TODO: support m.envFlag === 3
+
+				if ( material.envTextureIndex !== - 1 && ( material.envFlag === 1 || material.envFlag == 2 ) ) {
+
+					params.envMap = this._loadTexture(
+						data.textures[ material.envTextureIndex ],
+						textures
+					);
+
+					params.combine = material.envFlag === 1
+						? MultiplyOperation
+						: AddOperation;
+
+				}
+
+				// gradientMap
+
+				let toonFileName, isDefaultToon;
+
+				if ( material.toonIndex === - 1 || material.toonFlag !== 0 ) {
+
+					toonFileName = 'toon' + ( '0' + ( material.toonIndex + 1 ) ).slice( - 2 ) + '.bmp';
+					isDefaultToon = true;
+
+				} else {
+
+					toonFileName = data.textures[ material.toonIndex ];
+					isDefaultToon = false;
+
+				}
+
+				params.gradientMap = this._loadTexture(
+					toonFileName,
+					textures,
+					{
+						isToonTexture: true,
+						isDefaultToonTexture: isDefaultToon
+					}
+				);
+
+				// parameters for OutlineEffect
+				params.userData.outlineParameters = {
+					thickness: material.edgeSize / 300, // TODO: better calculation?
+					color: material.edgeColor.slice( 0, 3 ),
+					alpha: material.edgeColor[ 3 ],
+					visible: ( material.flag & 0x10 ) !== 0 && material.edgeSize > 0.0
+				};
 
 			}
 
-			if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
+			if ( params.map !== undefined ) {
 
-			var loader = this.manager.getHandler( fullPath );
+				if ( ! params.transparent ) {
 
-			if ( loader === null ) {
+					this._checkImageTransparency( params.map, geometry, i );
 
-				loader = ( filePath.slice( - 4 ).toLowerCase() === '.tga' )
-					? this._getTGALoader()
-					: this.textureLoader;
+				}
+
+				params.emissive.multiplyScalar( 0.2 );
 
 			}
 
-			var texture = loader.load( fullPath, function ( t ) {
+			materials.push( new MeshToonMaterial( params ) );
 
-				// MMD toon texture is Axis-Y oriented
-				// but Three.js gradient map is Axis-X oriented.
-				// So here replaces the toon texture image with the rotated one.
-				if ( params.isToonTexture === true ) {
+		}
 
-					t.image = scope._getRotatedImage( t.image );
+		if ( data.metadata.format === 'pmx' ) {
 
-					t.magFilter = NearestFilter;
-					t.minFilter = NearestFilter;
+			// set transparent true if alpha morph is defined.
 
-				}
+			function checkAlphaMorph( elements, materials ) {
 
-				t.flipY = false;
-				t.wrapS = RepeatWrapping;
-				t.wrapT = RepeatWrapping;
+				for ( let i = 0, il = elements.length; i < il; i ++ ) {
 
-				for ( var i = 0; i < texture.readyCallbacks.length; i ++ ) {
+					const element = elements[ i ];
 
-					texture.readyCallbacks[ i ]( texture );
+					if ( element.index === - 1 ) continue;
 
-				}
+					const material = materials[ element.index ];
 
-				delete texture.readyCallbacks;
+					if ( material.opacity !== element.diffuse[ 3 ] ) {
 
-			}, onProgress, onError );
-
-			texture.readyCallbacks = [];
-
-			textures[ fullPath ] = texture;
-
-			return texture;
-
-		},
-
-		_getRotatedImage: function ( image ) {
-
-			var canvas = document.createElement( 'canvas' );
-			var context = canvas.getContext( '2d' );
-
-			var width = image.width;
-			var height = image.height;
-
-			canvas.width = width;
-			canvas.height = height;
-
-			context.clearRect( 0, 0, width, height );
-			context.translate( width / 2.0, height / 2.0 );
-			context.rotate( 0.5 * Math.PI ); // 90.0 * Math.PI / 180.0
-			context.translate( - width / 2.0, - height / 2.0 );
-			context.drawImage( image, 0, 0 );
-
-			return context.getImageData( 0, 0, width, height );
-
-		},
-
-		// Check if the partial image area used by the texture is transparent.
-		_checkImageTransparency: function ( map, geometry, groupIndex ) {
-
-			map.readyCallbacks.push( function ( texture ) {
-
-				// Is there any efficient ways?
-				function createImageData( image ) {
-
-					var canvas = document.createElement( 'canvas' );
-					canvas.width = image.width;
-					canvas.height = image.height;
-
-					var context = canvas.getContext( '2d' );
-					context.drawImage( image, 0, 0 );
-
-					return context.getImageData( 0, 0, canvas.width, canvas.height );
-
-				}
-
-				function detectImageTransparency( image, uvs, indices ) {
-
-					var width = image.width;
-					var height = image.height;
-					var data = image.data;
-					var threshold = 253;
-
-					if ( data.length / ( width * height ) !== 4 ) return false;
-
-					for ( var i = 0; i < indices.length; i += 3 ) {
-
-						var centerUV = { x: 0.0, y: 0.0 };
-
-						for ( var j = 0; j < 3; j ++ ) {
-
-							var index = indices[ i * 3 + j ];
-							var uv = { x: uvs[ index * 2 + 0 ], y: uvs[ index * 2 + 1 ] };
-
-							if ( getAlphaByUv( image, uv ) < threshold ) return true;
-
-							centerUV.x += uv.x;
-							centerUV.y += uv.y;
-
-						}
-
-						centerUV.x /= 3;
-						centerUV.y /= 3;
-
-						if ( getAlphaByUv( image, centerUV ) < threshold ) return true;
+						material.transparent = true;
 
 					}
 
-					return false;
+				}
+
+			}
+
+			for ( let i = 0, il = data.morphs.length; i < il; i ++ ) {
+
+				const morph = data.morphs[ i ];
+				const elements = morph.elements;
+
+				if ( morph.type === 0 ) {
+
+					for ( let j = 0, jl = elements.length; j < jl; j ++ ) {
+
+						const morph2 = data.morphs[ elements[ j ].index ];
+
+						if ( morph2.type !== 8 ) continue;
+
+						checkAlphaMorph( morph2.elements, materials );
+
+					}
+
+				} else if ( morph.type === 8 ) {
+
+					checkAlphaMorph( elements, materials );
 
 				}
 
-				/*
+			}
+
+		}
+
+		return materials;
+
+	}
+
+	// private methods
+
+	_getTGALoader() {
+
+		if ( this.tgaLoader === null ) {
+
+			if ( TGALoader === undefined ) {
+
+				throw new Error( 'THREE.MMDLoader: Import TGALoader' );
+
+			}
+
+			this.tgaLoader = new TGALoader( this.manager );
+
+		}
+
+		return this.tgaLoader;
+
+	}
+
+	_isDefaultToonTexture( name ) {
+
+		if ( name.length !== 10 ) return false;
+
+		return /toon(10|0[0-9])\.bmp/.test( name );
+
+	}
+
+	_loadTexture( filePath, textures, params, onProgress, onError ) {
+
+		params = params || {};
+
+		const scope = this;
+
+		let fullPath;
+
+		if ( params.isDefaultToonTexture === true ) {
+
+			let index;
+
+			try {
+
+				index = parseInt( filePath.match( /toon([0-9]{2})\.bmp$/ )[ 1 ] );
+
+			} catch ( e ) {
+
+				console.warn( 'THREE.MMDLoader: ' + filePath + ' seems like a '
+						+ 'not right default texture path. Using toon00.bmp instead.' );
+
+				index = 0;
+
+			}
+
+			fullPath = DEFAULT_TOON_TEXTURES[ index ];
+
+		} else {
+
+			fullPath = this.resourcePath + filePath;
+
+		}
+
+		if ( textures[ fullPath ] !== undefined ) return textures[ fullPath ];
+
+		let loader = this.manager.getHandler( fullPath );
+
+		if ( loader === null ) {
+
+			loader = ( filePath.slice( - 4 ).toLowerCase() === '.tga' )
+				? this._getTGALoader()
+				: this.textureLoader;
+
+		}
+
+		const texture = loader.load( fullPath, function ( t ) {
+
+			// MMD toon texture is Axis-Y oriented
+			// but Three.js gradient map is Axis-X oriented.
+			// So here replaces the toon texture image with the rotated one.
+			if ( params.isToonTexture === true ) {
+
+				t.image = scope._getRotatedImage( t.image );
+
+				t.magFilter = NearestFilter;
+				t.minFilter = NearestFilter;
+
+			}
+
+			t.flipY = false;
+			t.wrapS = RepeatWrapping;
+			t.wrapT = RepeatWrapping;
+
+			for ( let i = 0; i < texture.readyCallbacks.length; i ++ ) {
+
+				texture.readyCallbacks[ i ]( texture );
+
+			}
+
+			delete texture.readyCallbacks;
+
+		}, onProgress, onError );
+
+		texture.readyCallbacks = [];
+
+		textures[ fullPath ] = texture;
+
+		return texture;
+
+	}
+
+	_getRotatedImage( image ) {
+
+		const canvas = document.createElement( 'canvas' );
+		const context = canvas.getContext( '2d' );
+
+		const width = image.width;
+		const height = image.height;
+
+		canvas.width = width;
+		canvas.height = height;
+
+		context.clearRect( 0, 0, width, height );
+		context.translate( width / 2.0, height / 2.0 );
+		context.rotate( 0.5 * Math.PI ); // 90.0 * Math.PI / 180.0
+		context.translate( - width / 2.0, - height / 2.0 );
+		context.drawImage( image, 0, 0 );
+
+		return context.getImageData( 0, 0, width, height );
+
+	}
+
+	// Check if the partial image area used by the texture is transparent.
+	_checkImageTransparency( map, geometry, groupIndex ) {
+
+		map.readyCallbacks.push( function ( texture ) {
+
+			// Is there any efficient ways?
+			function createImageData( image ) {
+
+				const canvas = document.createElement( 'canvas' );
+				canvas.width = image.width;
+				canvas.height = image.height;
+
+				const context = canvas.getContext( '2d' );
+				context.drawImage( image, 0, 0 );
+
+				return context.getImageData( 0, 0, canvas.width, canvas.height );
+
+			}
+
+			function detectImageTransparency( image, uvs, indices ) {
+
+				const width = image.width;
+				const height = image.height;
+				const data = image.data;
+				const threshold = 253;
+
+				if ( data.length / ( width * height ) !== 4 ) return false;
+
+				for ( let i = 0; i < indices.length; i += 3 ) {
+
+					const centerUV = { x: 0.0, y: 0.0 };
+
+					for ( let j = 0; j < 3; j ++ ) {
+
+						const index = indices[ i * 3 + j ];
+						const uv = { x: uvs[ index * 2 + 0 ], y: uvs[ index * 2 + 1 ] };
+
+						if ( getAlphaByUv( image, uv ) < threshold ) return true;
+
+						centerUV.x += uv.x;
+						centerUV.y += uv.y;
+
+					}
+
+					centerUV.x /= 3;
+					centerUV.y /= 3;
+
+					if ( getAlphaByUv( image, centerUV ) < threshold ) return true;
+
+				}
+
+				return false;
+
+			}
+
+			/*
 				 * This method expects
 				 *   texture.flipY = false
 				 *   texture.wrapS = RepeatWrapping
 				 *   texture.wrapT = RepeatWrapping
 				 * TODO: more precise
 				 */
-				function getAlphaByUv( image, uv ) {
+			function getAlphaByUv( image, uv ) {
 
-					var width = image.width;
-					var height = image.height;
+				const width = image.width;
+				const height = image.height;
 
-					var x = Math.round( uv.x * width ) % width;
-					var y = Math.round( uv.y * height ) % height;
+				let x = Math.round( uv.x * width ) % width;
+				let y = Math.round( uv.y * height ) % height;
 
-					if ( x < 0 ) x += width;
-					if ( y < 0 ) y += height;
+				if ( x < 0 ) x += width;
+				if ( y < 0 ) y += height;
 
-					var index = y * width + x;
+				const index = y * width + x;
 
-					return image.data[ index * 4 + 3 ];
+				return image.data[ index * 4 + 3 ];
 
-				}
+			}
 
-				var imageData = texture.image.data !== undefined
-					? texture.image
-					: createImageData( texture.image );
+			const imageData = texture.image.data !== undefined
+				? texture.image
+				: createImageData( texture.image );
 
-				var group = geometry.groups[ groupIndex ];
+			const group = geometry.groups[ groupIndex ];
 
-				if ( detectImageTransparency(
-					imageData,
-					geometry.attributes.uv.array,
-					geometry.index.array.slice( group.start, group.start + group.count ) ) ) {
+			if ( detectImageTransparency(
+				imageData,
+				geometry.attributes.uv.array,
+				geometry.index.array.slice( group.start, group.start + group.count ) ) ) {
 
-					map.transparent = true;
+				map.transparent = true;
 
-				}
+			}
 
-			} );
-
-		}
-
-	};
-
-	//
-
-	function AnimationBuilder() {
+		} );
 
 	}
 
-	AnimationBuilder.prototype = {
+}
 
-		constructor: AnimationBuilder,
+//
 
-		/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-		build: function ( vmd, mesh ) {
+class AnimationBuilder {
 
-			// combine skeletal and morph animations
+	/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
+	build( vmd, mesh ) {
 
-			var tracks = this.buildSkeletalAnimation( vmd, mesh ).tracks;
-			var tracks2 = this.buildMorphAnimation( vmd, mesh ).tracks;
+		// combine skeletal and morph animations
 
-			for ( var i = 0, il = tracks2.length; i < il; i ++ ) {
+		const tracks = this.buildSkeletalAnimation( vmd, mesh ).tracks;
+		const tracks2 = this.buildMorphAnimation( vmd, mesh ).tracks;
 
-				tracks.push( tracks2[ i ] );
+		for ( let i = 0, il = tracks2.length; i < il; i ++ ) {
 
-			}
+			tracks.push( tracks2[ i ] );
 
-			return new AnimationClip( '', - 1, tracks );
+		}
 
-		},
+		return new AnimationClip( '', - 1, tracks );
 
-		/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-		buildSkeletalAnimation: function ( vmd, mesh ) {
+	}
 
-			function pushInterpolation( array, interpolation, index ) {
+	/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
+	buildSkeletalAnimation( vmd, mesh ) {
 
-				array.push( interpolation[ index + 0 ] / 127 ); // x1
-				array.push( interpolation[ index + 8 ] / 127 ); // x2
-				array.push( interpolation[ index + 4 ] / 127 ); // y1
-				array.push( interpolation[ index + 12 ] / 127 ); // y2
+		function pushInterpolation( array, interpolation, index ) {
 
-			}
+			array.push( interpolation[ index + 0 ] / 127 ); // x1
+			array.push( interpolation[ index + 8 ] / 127 ); // x2
+			array.push( interpolation[ index + 4 ] / 127 ); // y1
+			array.push( interpolation[ index + 12 ] / 127 ); // y2
 
-			var tracks = [];
+		}
 
-			var motions = {};
-			var bones = mesh.skeleton.bones;
-			var boneNameDictionary = {};
+		const tracks = [];
 
-			for ( var i = 0, il = bones.length; i < il; i ++ ) {
+		const motions = {};
+		const bones = mesh.skeleton.bones;
+		const boneNameDictionary = {};
 
-				boneNameDictionary[ bones[ i ].name ] = true;
+		for ( let i = 0, il = bones.length; i < il; i ++ ) {
 
-			}
+			boneNameDictionary[ bones[ i ].name ] = true;
 
-			for ( var i = 0; i < vmd.metadata.motionCount; i ++ ) {
+		}
 
-				var motion = vmd.motions[ i ];
-				var boneName = motion.boneName;
+		for ( let i = 0; i < vmd.metadata.motionCount; i ++ ) {
 
-				if ( boneNameDictionary[ boneName ] === undefined ) continue;
+			const motion = vmd.motions[ i ];
+			const boneName = motion.boneName;
 
-				motions[ boneName ] = motions[ boneName ] || [];
-				motions[ boneName ].push( motion );
+			if ( boneNameDictionary[ boneName ] === undefined ) continue;
 
-			}
+			motions[ boneName ] = motions[ boneName ] || [];
+			motions[ boneName ].push( motion );
 
-			for ( var key in motions ) {
+		}
 
-				var array = motions[ key ];
+		for ( const key in motions ) {
 
-				array.sort( function ( a, b ) {
+			const array = motions[ key ];
 
-					return a.frameNum - b.frameNum;
-
-				} );
-
-				var times = [];
-				var positions = [];
-				var rotations = [];
-				var pInterpolations = [];
-				var rInterpolations = [];
-
-				var basePosition = mesh.skeleton.getBoneByName( key ).position.toArray();
-
-				for ( var i = 0, il = array.length; i < il; i ++ ) {
-
-					var time = array[ i ].frameNum / 30;
-					var position = array[ i ].position;
-					var rotation = array[ i ].rotation;
-					var interpolation = array[ i ].interpolation;
-
-					times.push( time );
-
-					for ( var j = 0; j < 3; j ++ ) positions.push( basePosition[ j ] + position[ j ] );
-					for ( var j = 0; j < 4; j ++ ) rotations.push( rotation[ j ] );
-					for ( var j = 0; j < 3; j ++ ) pushInterpolation( pInterpolations, interpolation, j );
-
-					pushInterpolation( rInterpolations, interpolation, 3 );
-
-				}
-
-				var targetName = '.bones[' + key + ']';
-
-				tracks.push( this._createTrack( targetName + '.position', VectorKeyframeTrack, times, positions, pInterpolations ) );
-				tracks.push( this._createTrack( targetName + '.quaternion', QuaternionKeyframeTrack, times, rotations, rInterpolations ) );
-
-			}
-
-			return new AnimationClip( '', - 1, tracks );
-
-		},
-
-		/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
-		 * @return {AnimationClip}
-		 */
-		buildMorphAnimation: function ( vmd, mesh ) {
-
-			var tracks = [];
-
-			var morphs = {};
-			var morphTargetDictionary = mesh.morphTargetDictionary;
-
-			for ( var i = 0; i < vmd.metadata.morphCount; i ++ ) {
-
-				var morph = vmd.morphs[ i ];
-				var morphName = morph.morphName;
-
-				if ( morphTargetDictionary[ morphName ] === undefined ) continue;
-
-				morphs[ morphName ] = morphs[ morphName ] || [];
-				morphs[ morphName ].push( morph );
-
-			}
-
-			for ( var key in morphs ) {
-
-				var array = morphs[ key ];
-
-				array.sort( function ( a, b ) {
-
-					return a.frameNum - b.frameNum;
-
-				} );
-
-				var times = [];
-				var values = [];
-
-				for ( var i = 0, il = array.length; i < il; i ++ ) {
-
-					times.push( array[ i ].frameNum / 30 );
-					values.push( array[ i ].weight );
-
-				}
-
-				tracks.push( new NumberKeyframeTrack( '.morphTargetInfluences[' + morphTargetDictionary[ key ] + ']', times, values ) );
-
-			}
-
-			return new AnimationClip( '', - 1, tracks );
-
-		},
-
-		/**
-		 * @param {Object} vmd - parsed VMD data
-		 * @return {AnimationClip}
-		 */
-		buildCameraAnimation: function ( vmd ) {
-
-			function pushVector3( array, vec ) {
-
-				array.push( vec.x );
-				array.push( vec.y );
-				array.push( vec.z );
-
-			}
-
-			function pushQuaternion( array, q ) {
-
-				array.push( q.x );
-				array.push( q.y );
-				array.push( q.z );
-				array.push( q.w );
-
-			}
-
-			function pushInterpolation( array, interpolation, index ) {
-
-				array.push( interpolation[ index * 4 + 0 ] / 127 ); // x1
-				array.push( interpolation[ index * 4 + 1 ] / 127 ); // x2
-				array.push( interpolation[ index * 4 + 2 ] / 127 ); // y1
-				array.push( interpolation[ index * 4 + 3 ] / 127 ); // y2
-
-			}
-
-			var tracks = [];
-
-			var cameras = vmd.cameras === undefined ? [] : vmd.cameras.slice();
-
-			cameras.sort( function ( a, b ) {
+			array.sort( function ( a, b ) {
 
 				return a.frameNum - b.frameNum;
 
 			} );
 
-			var times = [];
-			var centers = [];
-			var quaternions = [];
-			var positions = [];
-			var fovs = [];
+			const times = [];
+			const positions = [];
+			const rotations = [];
+			const pInterpolations = [];
+			const rInterpolations = [];
 
-			var cInterpolations = [];
-			var qInterpolations = [];
-			var pInterpolations = [];
-			var fInterpolations = [];
+			const basePosition = mesh.skeleton.getBoneByName( key ).position.toArray();
 
-			var quaternion = new Quaternion();
-			var euler = new Euler();
-			var position = new Vector3();
-			var center = new Vector3();
+			for ( let i = 0, il = array.length; i < il; i ++ ) {
 
-			for ( var i = 0, il = cameras.length; i < il; i ++ ) {
-
-				var motion = cameras[ i ];
-
-				var time = motion.frameNum / 30;
-				var pos = motion.position;
-				var rot = motion.rotation;
-				var distance = motion.distance;
-				var fov = motion.fov;
-				var interpolation = motion.interpolation;
+				const time = array[ i ].frameNum / 30;
+				const position = array[ i ].position;
+				const rotation = array[ i ].rotation;
+				const interpolation = array[ i ].interpolation;
 
 				times.push( time );
 
-				position.set( 0, 0, - distance );
-				center.set( pos[ 0 ], pos[ 1 ], pos[ 2 ] );
+				for ( let j = 0; j < 3; j ++ ) positions.push( basePosition[ j ] + position[ j ] );
+				for ( let j = 0; j < 4; j ++ ) rotations.push( rotation[ j ] );
+				for ( let j = 0; j < 3; j ++ ) pushInterpolation( pInterpolations, interpolation, j );
 
-				euler.set( - rot[ 0 ], - rot[ 1 ], - rot[ 2 ] );
-				quaternion.setFromEuler( euler );
-
-				position.add( center );
-				position.applyQuaternion( quaternion );
-
-				pushVector3( centers, center );
-				pushQuaternion( quaternions, quaternion );
-				pushVector3( positions, position );
-
-				fovs.push( fov );
-
-				for ( var j = 0; j < 3; j ++ ) {
-
-					pushInterpolation( cInterpolations, interpolation, j );
-
-				}
-
-				pushInterpolation( qInterpolations, interpolation, 3 );
-
-				// use the same parameter for x, y, z axis.
-				for ( var j = 0; j < 3; j ++ ) {
-
-					pushInterpolation( pInterpolations, interpolation, 4 );
-
-				}
-
-				pushInterpolation( fInterpolations, interpolation, 5 );
+				pushInterpolation( rInterpolations, interpolation, 3 );
 
 			}
 
-			var tracks = [];
+			const targetName = '.bones[' + key + ']';
 
-			// I expect an object whose name 'target' exists under THREE.Camera
-			tracks.push( this._createTrack( 'target.position', VectorKeyframeTrack, times, centers, cInterpolations ) );
+			tracks.push( this._createTrack( targetName + '.position', VectorKeyframeTrack, times, positions, pInterpolations ) );
+			tracks.push( this._createTrack( targetName + '.quaternion', QuaternionKeyframeTrack, times, rotations, rInterpolations ) );
 
-			tracks.push( this._createTrack( '.quaternion', QuaternionKeyframeTrack, times, quaternions, qInterpolations ) );
-			tracks.push( this._createTrack( '.position', VectorKeyframeTrack, times, positions, pInterpolations ) );
-			tracks.push( this._createTrack( '.fov', NumberKeyframeTrack, times, fovs, fInterpolations ) );
+		}
 
-			return new AnimationClip( '', - 1, tracks );
+		return new AnimationClip( '', - 1, tracks );
 
-		},
+	}
 
-		// private method
+	/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @param {SkinnedMesh} mesh - tracks will be fitting to mesh
+	 * @return {AnimationClip}
+	 */
+	buildMorphAnimation( vmd, mesh ) {
 
-		_createTrack: function ( node, typedKeyframeTrack, times, values, interpolations ) {
+		const tracks = [];
 
-			/*
+		const morphs = {};
+		const morphTargetDictionary = mesh.morphTargetDictionary;
+
+		for ( let i = 0; i < vmd.metadata.morphCount; i ++ ) {
+
+			const morph = vmd.morphs[ i ];
+			const morphName = morph.morphName;
+
+			if ( morphTargetDictionary[ morphName ] === undefined ) continue;
+
+			morphs[ morphName ] = morphs[ morphName ] || [];
+			morphs[ morphName ].push( morph );
+
+		}
+
+		for ( const key in morphs ) {
+
+			const array = morphs[ key ];
+
+			array.sort( function ( a, b ) {
+
+				return a.frameNum - b.frameNum;
+
+			} );
+
+			const times = [];
+			const values = [];
+
+			for ( let i = 0, il = array.length; i < il; i ++ ) {
+
+				times.push( array[ i ].frameNum / 30 );
+				values.push( array[ i ].weight );
+
+			}
+
+			tracks.push( new NumberKeyframeTrack( '.morphTargetInfluences[' + morphTargetDictionary[ key ] + ']', times, values ) );
+
+		}
+
+		return new AnimationClip( '', - 1, tracks );
+
+	}
+
+	/**
+	 * @param {Object} vmd - parsed VMD data
+	 * @return {AnimationClip}
+	 */
+	buildCameraAnimation( vmd ) {
+
+		function pushVector3( array, vec ) {
+
+			array.push( vec.x );
+			array.push( vec.y );
+			array.push( vec.z );
+
+		}
+
+		function pushQuaternion( array, q ) {
+
+			array.push( q.x );
+			array.push( q.y );
+			array.push( q.z );
+			array.push( q.w );
+
+		}
+
+		function pushInterpolation( array, interpolation, index ) {
+
+			array.push( interpolation[ index * 4 + 0 ] / 127 ); // x1
+			array.push( interpolation[ index * 4 + 1 ] / 127 ); // x2
+			array.push( interpolation[ index * 4 + 2 ] / 127 ); // y1
+			array.push( interpolation[ index * 4 + 3 ] / 127 ); // y2
+
+		}
+
+		const cameras = vmd.cameras === undefined ? [] : vmd.cameras.slice();
+
+		cameras.sort( function ( a, b ) {
+
+			return a.frameNum - b.frameNum;
+
+		} );
+
+		const times = [];
+		const centers = [];
+		const quaternions = [];
+		const positions = [];
+		const fovs = [];
+
+		const cInterpolations = [];
+		const qInterpolations = [];
+		const pInterpolations = [];
+		const fInterpolations = [];
+
+		const quaternion = new Quaternion();
+		const euler = new Euler();
+		const position = new Vector3();
+		const center = new Vector3();
+
+		for ( let i = 0, il = cameras.length; i < il; i ++ ) {
+
+			const motion = cameras[ i ];
+
+			const time = motion.frameNum / 30;
+			const pos = motion.position;
+			const rot = motion.rotation;
+			const distance = motion.distance;
+			const fov = motion.fov;
+			const interpolation = motion.interpolation;
+
+			times.push( time );
+
+			position.set( 0, 0, - distance );
+			center.set( pos[ 0 ], pos[ 1 ], pos[ 2 ] );
+
+			euler.set( - rot[ 0 ], - rot[ 1 ], - rot[ 2 ] );
+			quaternion.setFromEuler( euler );
+
+			position.add( center );
+			position.applyQuaternion( quaternion );
+
+			pushVector3( centers, center );
+			pushQuaternion( quaternions, quaternion );
+			pushVector3( positions, position );
+
+			fovs.push( fov );
+
+			for ( let j = 0; j < 3; j ++ ) {
+
+				pushInterpolation( cInterpolations, interpolation, j );
+
+			}
+
+			pushInterpolation( qInterpolations, interpolation, 3 );
+
+			// use the same parameter for x, y, z axis.
+			for ( let j = 0; j < 3; j ++ ) {
+
+				pushInterpolation( pInterpolations, interpolation, 4 );
+
+			}
+
+			pushInterpolation( fInterpolations, interpolation, 5 );
+
+		}
+
+		const tracks = [];
+
+		// I expect an object whose name 'target' exists under THREE.Camera
+		tracks.push( this._createTrack( 'target.position', VectorKeyframeTrack, times, centers, cInterpolations ) );
+
+		tracks.push( this._createTrack( '.quaternion', QuaternionKeyframeTrack, times, quaternions, qInterpolations ) );
+		tracks.push( this._createTrack( '.position', VectorKeyframeTrack, times, positions, pInterpolations ) );
+		tracks.push( this._createTrack( '.fov', NumberKeyframeTrack, times, fovs, fInterpolations ) );
+
+		return new AnimationClip( '', - 1, tracks );
+
+	}
+
+	// private method
+
+	_createTrack( node, typedKeyframeTrack, times, values, interpolations ) {
+
+		/*
 			 * optimizes here not to let KeyframeTrackPrototype optimize
 			 * because KeyframeTrackPrototype optimizes times and values but
 			 * doesn't optimize interpolations.
 			 */
-			if ( times.length > 2 ) {
+		if ( times.length > 2 ) {
 
-				times = times.slice();
-				values = values.slice();
-				interpolations = interpolations.slice();
+			times = times.slice();
+			values = values.slice();
+			interpolations = interpolations.slice();
 
-				var stride = values.length / times.length;
-				var interpolateStride = interpolations.length / times.length;
+			const stride = values.length / times.length;
+			const interpolateStride = interpolations.length / times.length;
 
-				var index = 1;
+			let index = 1;
 
-				for ( var aheadIndex = 2, endIndex = times.length; aheadIndex < endIndex; aheadIndex ++ ) {
+			for ( let aheadIndex = 2, endIndex = times.length; aheadIndex < endIndex; aheadIndex ++ ) {
 
-					for ( var i = 0; i < stride; i ++ ) {
+				for ( let i = 0; i < stride; i ++ ) {
 
-						if ( values[ index * stride + i ] !== values[ ( index - 1 ) * stride + i ] ||
+					if ( values[ index * stride + i ] !== values[ ( index - 1 ) * stride + i ] ||
 							values[ index * stride + i ] !== values[ aheadIndex * stride + i ] ) {
 
-							index ++;
-							break;
-
-						}
-
-					}
-
-					if ( aheadIndex > index ) {
-
-						times[ index ] = times[ aheadIndex ];
-
-						for ( var i = 0; i < stride; i ++ ) {
-
-							values[ index * stride + i ] = values[ aheadIndex * stride + i ];
-
-						}
-
-						for ( var i = 0; i < interpolateStride; i ++ ) {
-
-							interpolations[ index * interpolateStride + i ] = interpolations[ aheadIndex * interpolateStride + i ];
-
-						}
+						index ++;
+						break;
 
 					}
 
 				}
 
-				times.length = index + 1;
-				values.length = ( index + 1 ) * stride;
-				interpolations.length = ( index + 1 ) * interpolateStride;
+				if ( aheadIndex > index ) {
+
+					times[ index ] = times[ aheadIndex ];
+
+					for ( let i = 0; i < stride; i ++ ) {
+
+						values[ index * stride + i ] = values[ aheadIndex * stride + i ];
+
+					}
+
+					for ( let i = 0; i < interpolateStride; i ++ ) {
+
+						interpolations[ index * interpolateStride + i ] = interpolations[ aheadIndex * interpolateStride + i ];
+
+					}
+
+				}
 
 			}
 
-			var track = new typedKeyframeTrack( node, times, values );
-
-			track.createInterpolant = function InterpolantFactoryMethodCubicBezier( result ) {
-
-				return new CubicBezierInterpolation( this.times, this.values, this.getValueSize(), result, new Float32Array( interpolations ) );
-
-			};
-
-			return track;
+			times.length = index + 1;
+			values.length = ( index + 1 ) * stride;
+			interpolations.length = ( index + 1 ) * interpolateStride;
 
 		}
 
-	};
+		const track = new typedKeyframeTrack( node, times, values );
 
-	// interpolation
+		track.createInterpolant = function InterpolantFactoryMethodCubicBezier( result ) {
 
-	function CubicBezierInterpolation( parameterPositions, sampleValues, sampleSize, resultBuffer, params ) {
+			return new CubicBezierInterpolation( this.times, this.values, this.getValueSize(), result, new Float32Array( interpolations ) );
 
-		Interpolant.call( this, parameterPositions, sampleValues, sampleSize, resultBuffer );
+		};
+
+		return track;
+
+	}
+
+}
+
+// interpolation
+
+class CubicBezierInterpolation extends Interpolant {
+
+	constructor( parameterPositions, sampleValues, sampleSize, resultBuffer, params ) {
+
+		super( parameterPositions, sampleValues, sampleSize, resultBuffer );
 
 		this.interpolationParams = params;
 
 	}
 
-	CubicBezierInterpolation.prototype = Object.assign( Object.create( Interpolant.prototype ), {
+	interpolate_( i1, t0, t, t1 ) {
 
-		constructor: CubicBezierInterpolation,
+		const result = this.resultBuffer;
+		const values = this.sampleValues;
+		const stride = this.valueSize;
+		const params = this.interpolationParams;
 
-		interpolate_: function ( i1, t0, t, t1 ) {
+		const offset1 = i1 * stride;
+		const offset0 = offset1 - stride;
 
-			var result = this.resultBuffer;
-			var values = this.sampleValues;
-			var stride = this.valueSize;
-			var params = this.interpolationParams;
+		// No interpolation if next key frame is in one frame in 30fps.
+		// This is from MMD animation spec.
+		// '1.5' is for precision loss. times are Float32 in Three.js Animation system.
+		const weight1 = ( ( t1 - t0 ) < 1 / 30 * 1.5 ) ? 0.0 : ( t - t0 ) / ( t1 - t0 );
 
-			var offset1 = i1 * stride;
-			var offset0 = offset1 - stride;
+		if ( stride === 4 ) { // Quaternion
 
-			// No interpolation if next key frame is in one frame in 30fps.
-			// This is from MMD animation spec.
-			// '1.5' is for precision loss. times are Float32 in Three.js Animation system.
-			var weight1 = ( ( t1 - t0 ) < 1 / 30 * 1.5 ) ? 0.0 : ( t - t0 ) / ( t1 - t0 );
+			const x1 = params[ i1 * 4 + 0 ];
+			const x2 = params[ i1 * 4 + 1 ];
+			const y1 = params[ i1 * 4 + 2 ];
+			const y2 = params[ i1 * 4 + 3 ];
 
-			if ( stride === 4 ) { // Quaternion
+			const ratio = this._calculate( x1, x2, y1, y2, weight1 );
 
-				var x1 = params[ i1 * 4 + 0 ];
-				var x2 = params[ i1 * 4 + 1 ];
-				var y1 = params[ i1 * 4 + 2 ];
-				var y2 = params[ i1 * 4 + 3 ];
+			Quaternion.slerpFlat( result, 0, values, offset0, values, offset1, ratio );
 
-				var ratio = this._calculate( x1, x2, y1, y2, weight1 );
+		} else if ( stride === 3 ) { // Vector3
 
-				Quaternion.slerpFlat( result, 0, values, offset0, values, offset1, ratio );
+			for ( let i = 0; i !== stride; ++ i ) {
 
-			} else if ( stride === 3 ) { // Vector3
+				const x1 = params[ i1 * 12 + i * 4 + 0 ];
+				const x2 = params[ i1 * 12 + i * 4 + 1 ];
+				const y1 = params[ i1 * 12 + i * 4 + 2 ];
+				const y2 = params[ i1 * 12 + i * 4 + 3 ];
 
-				for ( var i = 0; i !== stride; ++ i ) {
+				const ratio = this._calculate( x1, x2, y1, y2, weight1 );
 
-					var x1 = params[ i1 * 12 + i * 4 + 0 ];
-					var x2 = params[ i1 * 12 + i * 4 + 1 ];
-					var y1 = params[ i1 * 12 + i * 4 + 2 ];
-					var y2 = params[ i1 * 12 + i * 4 + 3 ];
-
-					var ratio = this._calculate( x1, x2, y1, y2, weight1 );
-
-					result[ i ] = values[ offset0 + i ] * ( 1 - ratio ) + values[ offset1 + i ] * ratio;
-
-				}
-
-			} else { // Number
-
-				var x1 = params[ i1 * 4 + 0 ];
-				var x2 = params[ i1 * 4 + 1 ];
-				var y1 = params[ i1 * 4 + 2 ];
-				var y2 = params[ i1 * 4 + 3 ];
-
-				var ratio = this._calculate( x1, x2, y1, y2, weight1 );
-
-				result[ 0 ] = values[ offset0 ] * ( 1 - ratio ) + values[ offset1 ] * ratio;
+				result[ i ] = values[ offset0 + i ] * ( 1 - ratio ) + values[ offset1 + i ] * ratio;
 
 			}
 
-			return result;
+		} else { // Number
 
-		},
+			const x1 = params[ i1 * 4 + 0 ];
+			const x2 = params[ i1 * 4 + 1 ];
+			const y1 = params[ i1 * 4 + 2 ];
+			const y2 = params[ i1 * 4 + 3 ];
 
-		_calculate: function ( x1, x2, y1, y2, x ) {
+			const ratio = this._calculate( x1, x2, y1, y2, weight1 );
 
-			/*
+			result[ 0 ] = values[ offset0 ] * ( 1 - ratio ) + values[ offset1 ] * ratio;
+
+		}
+
+		return result;
+
+	}
+
+	_calculate( x1, x2, y1, y2, x ) {
+
+		/*
 			 * Cubic Bezier curves
 			 *   https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B.C3.A9zier_curves
 			 *
@@ -2030,40 +2003,36 @@ var MMDLoader = ( function () {
 			 *    https://en.wikipedia.org/wiki/Newton%27s_method)
 			 */
 
-			var c = 0.5;
-			var t = c;
-			var s = 1.0 - t;
-			var loop = 15;
-			var eps = 1e-5;
-			var math = Math;
+		let c = 0.5;
+		let t = c;
+		let s = 1.0 - t;
+		const loop = 15;
+		const eps = 1e-5;
+		const math = Math;
 
-			var sst3, stt3, ttt;
+		let sst3, stt3, ttt;
 
-			for ( var i = 0; i < loop; i ++ ) {
+		for ( let i = 0; i < loop; i ++ ) {
 
-				sst3 = 3.0 * s * s * t;
-				stt3 = 3.0 * s * t * t;
-				ttt = t * t * t;
+			sst3 = 3.0 * s * s * t;
+			stt3 = 3.0 * s * t * t;
+			ttt = t * t * t;
 
-				var ft = ( sst3 * x1 ) + ( stt3 * x2 ) + ( ttt ) - x;
+			const ft = ( sst3 * x1 ) + ( stt3 * x2 ) + ( ttt ) - x;
 
-				if ( math.abs( ft ) < eps ) break;
+			if ( math.abs( ft ) < eps ) break;
 
-				c /= 2.0;
+			c /= 2.0;
 
-				t += ( ft < 0 ) ? c : - c;
-				s = 1.0 - t;
-
-			}
-
-			return ( sst3 * y1 ) + ( stt3 * y2 ) + ttt;
+			t += ( ft < 0 ) ? c : - c;
+			s = 1.0 - t;
 
 		}
 
-	} );
+		return ( sst3 * y1 ) + ( stt3 * y2 ) + ttt;
 
-	return MMDLoader;
+	}
 
-} )();
+}
 
 export { MMDLoader };

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -7,21 +7,19 @@ import {
 import * as fflate from '../libs/fflate.module.min.js';
 import { Volume } from '../misc/Volume.js';
 
-var NRRDLoader = function ( manager ) {
+class NRRDLoader extends Loader {
 
-	Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	}
 
-	constructor: NRRDLoader,
+	load( url, onLoad, onProgress, onError ) {
 
-	load: function ( url, onLoad, onProgress, onError ) {
+		const scope = this;
 
-		var scope = this;
-
-		var loader = new FileLoader( scope.manager );
+		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
@@ -50,21 +48,21 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		// this parser is largely inspired from the XTK NRRD parser : https://github.com/xtk/X
 
-		var _data = data;
+		let _data = data;
 
-		var _dataPointer = 0;
+		let _dataPointer = 0;
 
-		var _nativeLittleEndian = new Int8Array( new Int16Array( [ 1 ] ).buffer )[ 0 ] > 0;
+		const _nativeLittleEndian = new Int8Array( new Int16Array( [ 1 ] ).buffer )[ 0 ] > 0;
 
-		var _littleEndian = true;
+		const _littleEndian = true;
 
-		var headerObject = {};
+		const headerObject = {};
 
 		function scan( type, chunks ) {
 
@@ -74,8 +72,8 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			}
 
-			var _chunkSize = 1;
-			var _array_type = Uint8Array;
+			let _chunkSize = 1;
+			let _array_type = Uint8Array;
 
 			switch ( type ) {
 
@@ -119,7 +117,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 			}
 
 			// increase the data pointer in-place
-			var _bytes = new _array_type( _data.slice( _dataPointer,
+			let _bytes = new _array_type( _data.slice( _dataPointer,
 				_dataPointer += chunks * _chunkSize ) );
 
 			// if required, flip the endianness of the bytes
@@ -146,12 +144,12 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		function flipEndianness( array, chunkSize ) {
 
-			var u8 = new Uint8Array( array.buffer, array.byteOffset, array.byteLength );
-			for ( var i = 0; i < array.byteLength; i += chunkSize ) {
+			const u8 = new Uint8Array( array.buffer, array.byteOffset, array.byteLength );
+			for ( let i = 0; i < array.byteLength; i += chunkSize ) {
 
-				for ( var j = i + chunkSize - 1, k = i; j > k; j --, k ++ ) {
+				for ( let j = i + chunkSize - 1, k = i; j > k; j --, k ++ ) {
 
-					var tmp = u8[ k ];
+					const tmp = u8[ k ];
 					u8[ k ] = u8[ j ];
 					u8[ j ] = tmp;
 
@@ -166,8 +164,8 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		//parse the header
 		function parseHeader( header ) {
 
-			var data, field, fn, i, l, lines, m, _i, _len;
-			lines = header.split( /\r?\n/ );
+			let data, field, fn, i, l, m, _i, _len;
+			const lines = header.split( /\r?\n/ );
 			for ( _i = 0, _len = lines.length; _i < _len; _i ++ ) {
 
 				l = lines[ _i ];
@@ -180,7 +178,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 					field = m[ 1 ].trim();
 					data = m[ 2 ].trim();
-					fn = NRRDLoader.prototype.fieldFunctions[ field ];
+					fn = _fieldFunctions[ field ];
 					if ( fn ) {
 
 						fn.call( headerObject, data );
@@ -233,34 +231,34 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		//parse the data when registred as one of this type : 'text', 'ascii', 'txt'
 		function parseDataAsText( data, start, end ) {
 
-			var number = '';
+			let number = '';
 			start = start || 0;
 			end = end || data.length;
-			var value;
+			let value;
 			//length of the result is the product of the sizes
-			var lengthOfTheResult = headerObject.sizes.reduce( function ( previous, current ) {
+			const lengthOfTheResult = headerObject.sizes.reduce( function ( previous, current ) {
 
 				return previous * current;
 
 			}, 1 );
 
-			var base = 10;
+			let base = 10;
 			if ( headerObject.encoding === 'hex' ) {
 
 				base = 16;
 
 			}
 
-			var result = new headerObject.__array( lengthOfTheResult );
-			var resultIndex = 0;
-			var parsingFunction = parseInt;
+			const result = new headerObject.__array( lengthOfTheResult );
+			let resultIndex = 0;
+			let parsingFunction = parseInt;
 			if ( headerObject.__array === Float32Array || headerObject.__array === Float64Array ) {
 
 				parsingFunction = parseFloat;
 
 			}
 
-			for ( var i = start; i < end; i ++ ) {
+			for ( let i = start; i < end; i ++ ) {
 
 				value = data[ i ];
 				//if value is not a space
@@ -294,11 +292,11 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}
 
-		var _bytes = scan( 'uchar', data.byteLength );
-		var _length = _bytes.length;
-		var _header = null;
-		var _data_start = 0;
-		var i;
+		const _bytes = scan( 'uchar', data.byteLength );
+		const _length = _bytes.length;
+		let _header = null;
+		let _data_start = 0;
+		let i;
 		for ( i = 1; i < _length; i ++ ) {
 
 			if ( _bytes[ i - 1 ] == 10 && _bytes[ i ] == 10 ) {
@@ -317,7 +315,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		// parse the header
 		parseHeader( _header );
 
-		var _data = _bytes.subarray( _data_start ); // the data without header
+		_data = _bytes.subarray( _data_start ); // the data without header
 		if ( headerObject.encoding.substring( 0, 2 ) === 'gz' ) {
 
 			// we need to decompress the datastream
@@ -331,9 +329,9 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		} else if ( headerObject.encoding === 'raw' ) {
 
 			//we need to copy the array to create a new array buffer, else we retrieve the original arraybuffer with the header
-			var _copy = new Uint8Array( _data.length );
+			const _copy = new Uint8Array( _data.length );
 
-			for ( var i = 0; i < _data.length; i ++ ) {
+			for ( let i = 0; i < _data.length; i ++ ) {
 
 				_copy[ i ] = _data[ i ];
 
@@ -346,16 +344,16 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		// .. let's use the underlying array buffer
 		_data = _data.buffer;
 
-		var volume = new Volume();
+		const volume = new Volume();
 		volume.header = headerObject;
 		//
 		// parse the (unzipped) data to a datastream of the correct type
 		//
 		volume.data = new headerObject.__array( _data );
 		// get the min and max intensities
-		var min_max = volume.computeMinMax();
-		var min = min_max[ 0 ];
-		var max = min_max[ 1 ];
+		const min_max = volume.computeMinMax();
+		const min = min_max[ 0 ];
+		const max = min_max[ 1 ];
 		// attach the scalar range to the volume
 		volume.windowLow = min;
 		volume.windowHigh = max;
@@ -366,11 +364,11 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		volume.yLength = volume.dimensions[ 1 ];
 		volume.zLength = volume.dimensions[ 2 ];
 		// spacing
-		var spacingX = ( new Vector3( headerObject.vectors[ 0 ][ 0 ], headerObject.vectors[ 0 ][ 1 ],
+		const spacingX = ( new Vector3( headerObject.vectors[ 0 ][ 0 ], headerObject.vectors[ 0 ][ 1 ],
 			headerObject.vectors[ 0 ][ 2 ] ) ).length();
-		var spacingY = ( new Vector3( headerObject.vectors[ 1 ][ 0 ], headerObject.vectors[ 1 ][ 1 ],
+		const spacingY = ( new Vector3( headerObject.vectors[ 1 ][ 0 ], headerObject.vectors[ 1 ][ 1 ],
 			headerObject.vectors[ 1 ][ 2 ] ) ).length();
-		var spacingZ = ( new Vector3( headerObject.vectors[ 2 ][ 0 ], headerObject.vectors[ 2 ][ 1 ],
+		const spacingZ = ( new Vector3( headerObject.vectors[ 2 ][ 0 ], headerObject.vectors[ 2 ][ 1 ],
 			headerObject.vectors[ 2 ][ 2 ] ) ).length();
 		volume.spacing = [ spacingX, spacingY, spacingZ ];
 
@@ -378,9 +376,9 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		// Create IJKtoRAS matrix
 		volume.matrix = new Matrix4();
 
-		var _spaceX = 1;
-		var _spaceY = 1;
-		var _spaceZ = 1;
+		let _spaceX = 1;
+		let _spaceY = 1;
+		const _spaceZ = 1;
 
 		if ( headerObject.space == 'left-posterior-superior' ) {
 
@@ -404,7 +402,7 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		} else {
 
-			var v = headerObject.vectors;
+			const v = headerObject.vectors;
 
 			volume.matrix.set(
 				_spaceX * v[ 0 ][ 0 ], _spaceX * v[ 1 ][ 0 ], _spaceX * v[ 2 ][ 0 ], 0,
@@ -434,9 +432,9 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		return volume;
 
-	},
+	}
 
-	parseChars: function ( array, start, end ) {
+	parseChars( array, start, end ) {
 
 		// without borders, use the whole array
 		if ( start === undefined ) {
@@ -451,9 +449,9 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}
 
-		var output = '';
+		let output = '';
 		// create and append the chars
-		var i = 0;
+		let i = 0;
 		for ( i = start; i < end; ++ i ) {
 
 			output += String.fromCharCode( array[ i ] );
@@ -462,178 +460,176 @@ NRRDLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		return output;
 
+	}
+
+}
+
+const _fieldFunctions = {
+
+	type: function ( data ) {
+
+		switch ( data ) {
+
+			case 'uchar':
+			case 'unsigned char':
+			case 'uint8':
+			case 'uint8_t':
+				this.__array = Uint8Array;
+				break;
+			case 'signed char':
+			case 'int8':
+			case 'int8_t':
+				this.__array = Int8Array;
+				break;
+			case 'short':
+			case 'short int':
+			case 'signed short':
+			case 'signed short int':
+			case 'int16':
+			case 'int16_t':
+				this.__array = Int16Array;
+				break;
+			case 'ushort':
+			case 'unsigned short':
+			case 'unsigned short int':
+			case 'uint16':
+			case 'uint16_t':
+				this.__array = Uint16Array;
+				break;
+			case 'int':
+			case 'signed int':
+			case 'int32':
+			case 'int32_t':
+				this.__array = Int32Array;
+				break;
+			case 'uint':
+			case 'unsigned int':
+			case 'uint32':
+			case 'uint32_t':
+				this.__array = Uint32Array;
+				break;
+			case 'float':
+				this.__array = Float32Array;
+				break;
+			case 'double':
+				this.__array = Float64Array;
+				break;
+			default:
+				throw new Error( 'Unsupported NRRD data type: ' + data );
+
+		}
+
+		return this.type = data;
+
 	},
 
-	fieldFunctions: {
+	endian: function ( data ) {
 
-		type: function ( data ) {
+		return this.endian = data;
 
-			switch ( data ) {
+	},
 
-				case 'uchar':
-				case 'unsigned char':
-				case 'uint8':
-				case 'uint8_t':
-					this.__array = Uint8Array;
-					break;
-				case 'signed char':
-				case 'int8':
-				case 'int8_t':
-					this.__array = Int8Array;
-					break;
-				case 'short':
-				case 'short int':
-				case 'signed short':
-				case 'signed short int':
-				case 'int16':
-				case 'int16_t':
-					this.__array = Int16Array;
-					break;
-				case 'ushort':
-				case 'unsigned short':
-				case 'unsigned short int':
-				case 'uint16':
-				case 'uint16_t':
-					this.__array = Uint16Array;
-					break;
-				case 'int':
-				case 'signed int':
-				case 'int32':
-				case 'int32_t':
-					this.__array = Int32Array;
-					break;
-				case 'uint':
-				case 'unsigned int':
-				case 'uint32':
-				case 'uint32_t':
-					this.__array = Uint32Array;
-					break;
-				case 'float':
-					this.__array = Float32Array;
-					break;
-				case 'double':
-					this.__array = Float64Array;
-					break;
-				default:
-					throw new Error( 'Unsupported NRRD data type: ' + data );
+	encoding: function ( data ) {
+
+		return this.encoding = data;
+
+	},
+
+	dimension: function ( data ) {
+
+		return this.dim = parseInt( data, 10 );
+
+	},
+
+	sizes: function ( data ) {
+
+		let i;
+		return this.sizes = ( function () {
+
+			const _ref = data.split( /\s+/ );
+			const _results = [];
+
+			for ( let _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
+
+				i = _ref[ _i ];
+				_results.push( parseInt( i, 10 ) );
 
 			}
 
-			return this.type = data;
+			return _results;
 
-		},
+		} )();
 
-		endian: function ( data ) {
+	},
 
-			return this.endian = data;
+	space: function ( data ) {
 
-		},
+		return this.space = data;
 
-		encoding: function ( data ) {
+	},
 
-			return this.encoding = data;
+	'space origin': function ( data ) {
 
-		},
+		return this.space_origin = data.split( '(' )[ 1 ].split( ')' )[ 0 ].split( ',' );
 
-		dimension: function ( data ) {
+	},
 
-			return this.dim = parseInt( data, 10 );
+	'space directions': function ( data ) {
 
-		},
+		let f, v;
+		const parts = data.match( /\(.*?\)/g );
+		return this.vectors = ( function () {
 
-		sizes: function ( data ) {
+			const _results = [];
 
-			var i;
-			return this.sizes = ( function () {
+			for ( let _i = 0, _len = parts.length; _i < _len; _i ++ ) {
 
-				var _i, _len, _ref, _results;
-				_ref = data.split( /\s+/ );
-				_results = [];
+				v = parts[ _i ];
+				_results.push( ( function () {
 
-				for ( _i = 0, _len = _ref.length; _i < _len; _i ++ ) {
+					const _ref = v.slice( 1, - 1 ).split( /,/ );
+					const _results2 = [];
 
-					i = _ref[ _i ];
-					_results.push( parseInt( i, 10 ) );
+					for ( let _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
 
-				}
+						f = _ref[ _j ];
+						_results2.push( parseFloat( f ) );
 
-				return _results;
+					}
 
-			} )();
+					return _results2;
 
-		},
+				} )() );
 
-		space: function ( data ) {
+			}
 
-			return this.space = data;
+			return _results;
 
-		},
+		} )();
 
-		'space origin': function ( data ) {
+	},
 
-			return this.space_origin = data.split( '(' )[ 1 ].split( ')' )[ 0 ].split( ',' );
+	spacings: function ( data ) {
 
-		},
+		let f;
+		const parts = data.split( /\s+/ );
+		return this.spacings = ( function () {
 
-		'space directions': function ( data ) {
+			const _results = [];
 
-			var f, parts, v;
-			parts = data.match( /\(.*?\)/g );
-			return this.vectors = ( function () {
+			for ( let _i = 0, _len = parts.length; _i < _len; _i ++ ) {
 
-				var _i, _len, _results;
-				_results = [];
+				f = parts[ _i ];
+				_results.push( parseFloat( f ) );
 
-				for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
+			}
 
-					v = parts[ _i ];
-					_results.push( ( function () {
+			return _results;
 
-						var _j, _len2, _ref, _results2;
-						_ref = v.slice( 1, - 1 ).split( /,/ );
-						_results2 = [];
+		} )();
 
-						for ( _j = 0, _len2 = _ref.length; _j < _len2; _j ++ ) {
-
-							f = _ref[ _j ];
-							_results2.push( parseFloat( f ) );
-
-						}
-
-						return _results2;
-
-					} )() );
-
-				}
-
-				return _results;
-
-			} )();
-
-		},
-
-		spacings: function ( data ) {
-
-			var f, parts;
-			parts = data.split( /\s+/ );
-			return this.spacings = ( function () {
-
-				var _i, _len, _results = [];
-
-				for ( _i = 0, _len = parts.length; _i < _len; _i ++ ) {
-
-					f = parts[ _i ];
-					_results.push( parseFloat( f ) );
-
-				}
-
-				return _results;
-
-			} )();
-
-		}
 	}
 
-} );
+};
 
 export { NRRDLoader };

--- a/examples/jsm/loaders/NodeMaterialLoader.js
+++ b/examples/jsm/loaders/NodeMaterialLoader.js
@@ -1,81 +1,29 @@
 import {
-	DefaultLoadingManager,
+	Loader,
 	FileLoader
 } from '../../../build/three.module.js';
 
 import * as Nodes from '../nodes/Nodes.js';
 
-var NodeMaterialLoader = function ( manager, library ) {
+class NodeMaterialLoader extends Loader {
 
-	this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+	constructor( manager, library = {} ) {
 
-	this.nodes = {};
-	this.materials = {};
-	this.passes = {};
-	this.names = {};
-	this.library = library || {};
+		super( manager );
 
-};
-
-var NodeMaterialLoaderUtils = {
-
-	replaceUUIDObject: function ( object, uuid, value, recursive ) {
-
-		recursive = recursive !== undefined ? recursive : true;
-
-		if ( typeof uuid === 'object' ) uuid = uuid.uuid;
-
-		if ( typeof object === 'object' ) {
-
-			var keys = Object.keys( object );
-
-			for ( var i = 0; i < keys.length; i ++ ) {
-
-				var key = keys[ i ];
-
-				if ( recursive ) {
-
-					object[ key ] = this.replaceUUIDObject( object[ key ], uuid, value );
-
-				}
-
-				if ( key === uuid ) {
-
-					object[ uuid ] = object[ key ];
-
-					delete object[ key ];
-
-				}
-
-			}
-
-		}
-
-		return object === uuid ? value : object;
-
-	},
-
-	replaceUUID: function ( json, uuid, value ) {
-
-		this.replaceUUIDObject( json, uuid, value, false );
-		this.replaceUUIDObject( json.nodes, uuid, value );
-		this.replaceUUIDObject( json.materials, uuid, value );
-		this.replaceUUIDObject( json.passes, uuid, value );
-		this.replaceUUIDObject( json.library, uuid, value, false );
-
-		return json;
+		this.nodes = {};
+		this.materials = {};
+		this.passes = {};
+		this.names = {};
+		this.library = library;
 
 	}
 
-};
+	load( url, onLoad, onProgress, onError ) {
 
-Object.assign( NodeMaterialLoader.prototype, {
+		const scope = this;
 
-	load: function ( url, onLoad, onProgress, onError ) {
-
-		var scope = this;
-
-		var loader = new FileLoader( scope.manager );
+		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
 		loader.load( url, function ( text ) {
 
@@ -85,22 +33,15 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 		return this;
 
-	},
+	}
 
-	setPath: function ( value ) {
-
-		this.path = value;
-		return this;
-
-	},
-
-	getObjectByName: function ( uuid ) {
+	getObjectByName( uuid ) {
 
 		return this.names[ uuid ];
 
-	},
+	}
 
-	getObjectById: function ( uuid ) {
+	getObjectById( uuid ) {
 
 		return this.library[ uuid ] ||
 			this.nodes[ uuid ] ||
@@ -108,11 +49,11 @@ Object.assign( NodeMaterialLoader.prototype, {
 			this.passes[ uuid ] ||
 			this.names[ uuid ];
 
-	},
+	}
 
-	getNode: function ( uuid ) {
+	getNode( uuid ) {
 
-		var object = this.getObjectById( uuid );
+		const object = this.getObjectById( uuid );
 
 		if ( ! object ) {
 
@@ -122,9 +63,9 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 		return object;
 
-	},
+	}
 
-	resolve: function ( json ) {
+	resolve( json ) {
 
 		switch ( typeof json ) {
 
@@ -147,7 +88,7 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 				if ( Array.isArray( json ) ) {
 
-					for ( var i = 0; i < json.length; i ++ ) {
+					for ( let i = 0; i < json.length; i ++ ) {
 
 						json[ i ] = this.resolve( json[ i ] );
 
@@ -155,7 +96,7 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 				} else {
 
-					for ( var prop in json ) {
+					for ( const prop in json ) {
 
 						if ( prop === 'uuid' ) continue;
 
@@ -169,11 +110,11 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 		return json;
 
-	},
+	}
 
-	declare: function ( json ) {
+	declare( json ) {
 
-		var uuid, node, object;
+		let uuid, node, object;
 
 		for ( uuid in json.nodes ) {
 
@@ -235,11 +176,11 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 		return json;
 
-	},
+	}
 
-	parse: function ( json ) {
+	parse( json ) {
 
-		var uuid;
+		let uuid;
 
 		json = this.resolve( this.declare( json ) );
 
@@ -265,6 +206,58 @@ Object.assign( NodeMaterialLoader.prototype, {
 
 	}
 
-} );
+}
+
+class NodeMaterialLoaderUtils {
+
+	static replaceUUIDObject( object, uuid, value, recursive ) {
+
+		recursive = recursive !== undefined ? recursive : true;
+
+		if ( typeof uuid === 'object' ) uuid = uuid.uuid;
+
+		if ( typeof object === 'object' ) {
+
+			const keys = Object.keys( object );
+
+			for ( let i = 0; i < keys.length; i ++ ) {
+
+				const key = keys[ i ];
+
+				if ( recursive ) {
+
+					object[ key ] = this.replaceUUIDObject( object[ key ], uuid, value );
+
+				}
+
+				if ( key === uuid ) {
+
+					object[ uuid ] = object[ key ];
+
+					delete object[ key ];
+
+				}
+
+			}
+
+		}
+
+		return object === uuid ? value : object;
+
+	}
+
+	static replaceUUID( json, uuid, value ) {
+
+		this.replaceUUIDObject( json, uuid, value, false );
+		this.replaceUUIDObject( json.nodes, uuid, value );
+		this.replaceUUIDObject( json.materials, uuid, value );
+		this.replaceUUIDObject( json.passes, uuid, value );
+		this.replaceUUIDObject( json.library, uuid, value, false );
+
+		return json;
+
+	}
+
+}
 
 export { NodeMaterialLoader, NodeMaterialLoaderUtils };

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -8,21 +8,19 @@ import {
 } from '../../../build/three.module.js';
 import * as fflate from '../libs/fflate.module.min.js';
 
-var VTKLoader = function ( manager ) {
+class VTKLoader extends Loader {
 
-	Loader.call( this, manager );
+	constructor( manager ) {
 
-};
+		super( manager );
 
-VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	}
 
-	constructor: VTKLoader,
+	load( url, onLoad, onProgress, onError ) {
 
-	load: function ( url, onLoad, onProgress, onError ) {
+		const scope = this;
 
-		var scope = this;
-
-		var loader = new FileLoader( scope.manager );
+		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
@@ -51,9 +49,9 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		}, onProgress, onError );
 
-	},
+	}
 
-	parse: function ( data ) {
+	parse( data ) {
 
 		function parseASCII( data ) {
 
@@ -553,23 +551,23 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		function Float32Concat( first, second ) {
 
-		    var firstLength = first.length, result = new Float32Array( firstLength + second.length );
+			const firstLength = first.length, result = new Float32Array( firstLength + second.length );
 
-		    result.set( first );
-		    result.set( second, firstLength );
+			result.set( first );
+			result.set( second, firstLength );
 
-		    return result;
+			return result;
 
 		}
 
 		function Int32Concat( first, second ) {
 
-		    var firstLength = first.length, result = new Int32Array( firstLength + second.length );
+			var firstLength = first.length, result = new Int32Array( firstLength + second.length );
 
-		    result.set( first );
-		    result.set( second, firstLength );
+			result.set( first );
+			result.set( second, firstLength );
 
-		    return result;
+			return result;
 
 		}
 
@@ -1179,6 +1177,6 @@ VTKLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 	}
 
-} );
+}
 
 export { VTKLoader };


### PR DESCRIPTION
Related issue: -

**Description**

More loader conversions.

I did not convert all loader to code to `let/const` since some code depends on the specific scoping of `var`. Since I'm not 100% familiar with the format of the following loaders, I would like to ask other devs for help and remove the remaining usage of `var` in `3DMLoader`, `EXRLoader`, `GCodeLoader`, `VTKLoader` and `LDrawLoader`.

/ping @tentone, @yomboprime, @fraguada, @sciecode 
