### PR TITLE
Examples: Fix alignment issue in LUTCubeLoader

### DIFF
--- a/examples/js/loaders/LUTCubeLoader.js
+++ b/examples/js/loaders/LUTCubeLoader.js
@@ -108,6 +108,7 @@
 			texture.wrapS = THREE.ClampToEdgeWrapping;
 			texture.wrapT = THREE.ClampToEdgeWrapping;
 			texture.generateMipmaps = false;
+			texture.unpackAlignment = 1;
 			const texture3D = new THREE.DataTexture3D();
 			texture3D.image.data = data;
 			texture3D.image.width = size;
@@ -121,6 +122,7 @@
 			texture3D.wrapT = THREE.ClampToEdgeWrapping;
 			texture3D.wrapR = THREE.ClampToEdgeWrapping;
 			texture3D.generateMipmaps = false;
+			texture3D.unpackAlignment = 1;
 			return {
 				title,
 				size,

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -124,6 +124,7 @@ export class LUTCubeLoader extends Loader {
 		texture.wrapS = ClampToEdgeWrapping;
 		texture.wrapT = ClampToEdgeWrapping;
 		texture.generateMipmaps = false;
+		texture.unpackAlignment = 1;
 
 		const texture3D = new DataTexture3D();
 		texture3D.image.data = data;
@@ -138,6 +139,7 @@ export class LUTCubeLoader extends Loader {
 		texture3D.wrapT = ClampToEdgeWrapping;
 		texture3D.wrapR = ClampToEdgeWrapping;
 		texture3D.generateMipmaps = false;
+		texture3D.unpackAlignment = 1;
 
 		return {
 			title,


### PR DESCRIPTION
This patch sets to 1 the unpackAlignment of the DataTexture3D generated by LUTCubeLoader.

There was an issue when LUTCubeLoader is used to load valid 3D .cube files with specific table sizes, the call to gl.texImage3D would fail with the following error: _WebGL: INVALID_OPERATION: texImage3D: ArrayBufferView not big enough for request_. I specifically noticed the issue with 2x2x2 and 3x3x3 LUT tables.

It should be noted that the issue didn't happen when using the DataTexture (2D) generated by LUTCubeLoader because that class has a default unpackAlignment of 1, unlike DataTexture3D which has a default unpackAlignment of 4. For the sake of clarity, I explicitely set the unpackAlignment to 1 for both the DataTexture and the DataTexture3D in this patch.

/fyi @gkjohnson

Thanks to twitter user KimiruHamiru for the [help](https://twitter.com/KimiruHamiru/status/1380683992391806979) btw.

Example of a valid 3D .cube file which would trigger the issue :

```
# Header
TITLE "WhiteToYellow"

LUT_3D_SIZE 3

DOMAIN_MIN 0.0 0.0 0.0
DOMAIN_MAX 1.0 1.0 1.0

# Data table
0 0 0
0.5 0 0
1 0 0

0 0.5 0
0.5 0.5 0
1 0.5 0

0 1 0
0.5 1 0
1 1 0

0 0 0.5
0.5 0 0.5
1 0 0.5

0 0.5 0.5
0.5 0.5 0.5
1 0.5 0.5

0 1 0.5
0.5 1 0.5
1 1 0.5

0 0 1
0.5 0 1
1 0 1

0 0.5 1
0.5 0.5 1
1 0.5 1

0 1 1
0.5 1 1
1 1 0
```