### PR TITLE
GCodeLoader ES6 variables (let/const)

### DIFF
--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -53,7 +53,7 @@
 
 		parse( data ) {
 
-			var state = {
+			let state = {
 				x: 0,
 				y: 0,
 				z: 0,
@@ -62,13 +62,13 @@
 				extruding: false,
 				relative: false
 			};
-			var layers = [];
-			var currentLayer = undefined;
-			var pathMaterial = new THREE.LineBasicMaterial( {
+			let layers = [];
+			let currentLayer = undefined;
+			let pathMaterial = new THREE.LineBasicMaterial( {
 				color: 0xFF0000
 			} );
 			pathMaterial.name = 'path';
-			var extrudingMaterial = new THREE.LineBasicMaterial( {
+			let extrudingMaterial = new THREE.LineBasicMaterial( {
 				color: 0x00FF00
 			} );
 			extrudingMaterial.name = 'extruded';
@@ -119,20 +119,20 @@
 
 			}
 
-			var lines = data.replace( /;.+/g, '' ).split( '\n' );
+			let lines = data.replace( /;.+/g, '' ).split( '\n' );
 
-			for ( var i = 0; i < lines.length; i ++ ) {
+			for ( let i = 0; i < lines.length; i ++ ) {
 
-				var tokens = lines[ i ].split( ' ' );
-				var cmd = tokens[ 0 ].toUpperCase(); //Argumments
+				let tokens = lines[ i ].split( ' ' );
+				let cmd = tokens[ 0 ].toUpperCase(); //Argumments
 
-				var args = {};
+				let args = {};
 				tokens.splice( 1 ).forEach( function ( token ) {
 
 					if ( token[ 0 ] !== undefined ) {
 
-						var key = token[ 0 ].toLowerCase();
-						var value = parseFloat( token.substring( 1 ) );
+						let key = token[ 0 ].toLowerCase();
+						let value = parseFloat( token.substring( 1 ) );
 						args[ key ] = value;
 
 					}
@@ -142,7 +142,7 @@
 
 				if ( cmd === 'G0' || cmd === 'G1' ) {
 
-					var line = {
+					let line = {
 						x: args.x !== undefined ? absolute( state.x, args.x ) : state.x,
 						y: args.y !== undefined ? absolute( state.y, args.y ) : state.y,
 						z: args.z !== undefined ? absolute( state.z, args.z ) : state.z,
@@ -180,7 +180,7 @@
 				} else if ( cmd === 'G92' ) {
 
 					//G92: Set Position
-					var line = state;
+					let line = state;
 					line.x = args.x !== undefined ? args.x : line.x;
 					line.y = args.y !== undefined ? args.y : line.y;
 					line.z = args.z !== undefined ? args.z : line.z;
@@ -192,47 +192,47 @@
 
 			}
 
-			function addObject( vertex, extruding ) {
+			function addObject( vertex, extruding, i ) {
 
-				var geometry = new THREE.BufferGeometry();
+				let geometry = new THREE.BufferGeometry();
 				geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( vertex, 3 ) );
-				var segments = new THREE.LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
+				let segments = new THREE.LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
 				segments.name = 'layer' + i;
 				object.add( segments );
 
 			}
 
-			var object = new THREE.Group();
+			let object = new THREE.Group();
 			object.name = 'gcode';
 
 			if ( this.splitLayer ) {
 
-				for ( var i = 0; i < layers.length; i ++ ) {
+				for ( let i = 0; i < layers.length; i ++ ) {
 
-					var layer = layers[ i ];
-					addObject( layer.vertex, true );
-					addObject( layer.pathVertex, false );
+					let layer = layers[ i ];
+					addObject( layer.vertex, true, i );
+					addObject( layer.pathVertex, false, i );
 
 				}
 
 			} else {
 
-				var vertex = [],
+				let vertex = [],
 					pathVertex = [];
 
-				for ( var i = 0; i < layers.length; i ++ ) {
+				for ( let i = 0; i < layers.length; i ++ ) {
 
-					var layer = layers[ i ];
-					var layerVertex = layer.vertex;
-					var layerPathVertex = layer.pathVertex;
+					let layer = layers[ i ];
+					let layerVertex = layer.vertex;
+					let layerPathVertex = layer.pathVertex;
 
-					for ( var j = 0; j < layerVertex.length; j ++ ) {
+					for ( let j = 0; j < layerVertex.length; j ++ ) {
 
 						vertex.push( layerVertex[ j ] );
 
 					}
 
-					for ( var j = 0; j < layerPathVertex.length; j ++ ) {
+					for ( let j = 0; j < layerPathVertex.length; j ++ ) {
 
 						pathVertex.push( layerPathVertex[ j ] );
 
@@ -240,8 +240,8 @@
 
 				}
 
-				addObject( vertex, true );
-				addObject( pathVertex, false );
+				addObject( vertex, true, i );
+				addObject( pathVertex, false, i );
 
 			}
 

--- a/examples/js/loaders/GCodeLoader.js
+++ b/examples/js/loaders/GCodeLoader.js
@@ -64,14 +64,17 @@
 			};
 			let layers = [];
 			let currentLayer = undefined;
-			let pathMaterial = new THREE.LineBasicMaterial( {
+
+			const pathMaterial = new THREE.LineBasicMaterial( {
 				color: 0xFF0000
 			} );
 			pathMaterial.name = 'path';
-			let extrudingMaterial = new THREE.LineBasicMaterial( {
+
+			const extrudingMaterial = new THREE.LineBasicMaterial( {
 				color: 0x00FF00
 			} );
 			extrudingMaterial.name = 'extruded';
+			
 
 			function newLayer( line ) {
 
@@ -93,7 +96,7 @@
 
 				}
 
-				if ( line.extruding ) {
+				if ( state.extruding ) {
 
 					currentLayer.vertex.push( p1.x, p1.y, p1.z );
 					currentLayer.vertex.push( p2.x, p2.y, p2.z );
@@ -202,7 +205,7 @@
 
 			}
 
-			let object = new THREE.Group();
+			const object = new THREE.Group();
 			object.name = 'gcode';
 
 			if ( this.splitLayer ) {
@@ -217,7 +220,7 @@
 
 			} else {
 
-				let vertex = [],
+				const vertex = [],
 					pathVertex = [];
 
 				for ( let i = 0; i < layers.length; i ++ ) {
@@ -240,8 +243,8 @@
 
 				}
 
-				addObject( vertex, true, i );
-				addObject( pathVertex, false, i );
+				addObject( vertex, true, layers.length );
+				addObject( pathVertex, false, layers.length );
 
 			}
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -64,15 +64,15 @@ class GCodeLoader extends Loader {
 
 	parse( data ) {
 
-		var state = { x: 0, y: 0, z: 0, e: 0, f: 0, extruding: false, relative: false };
-		var layers = [];
+		let state = { x: 0, y: 0, z: 0, e: 0, f: 0, extruding: false, relative: false };
+		let layers = [];
 
-		var currentLayer = undefined;
+		let currentLayer = undefined;
 
-		var pathMaterial = new LineBasicMaterial( { color: 0xFF0000 } );
+		let pathMaterial = new LineBasicMaterial( { color: 0xFF0000 } );
 		pathMaterial.name = 'path';
 
-		var extrudingMaterial = new LineBasicMaterial( { color: 0x00FF00 } );
+		let extrudingMaterial = new LineBasicMaterial( { color: 0x00FF00 } );
 		extrudingMaterial.name = 'extruded';
 
 		function newLayer( line ) {
@@ -117,21 +117,21 @@ class GCodeLoader extends Loader {
 
 		}
 
-		var lines = data.replace( /;.+/g, '' ).split( '\n' );
+		let lines = data.replace( /;.+/g, '' ).split( '\n' );
 
-		for ( var i = 0; i < lines.length; i ++ ) {
+		for ( let i = 0; i < lines.length; i ++ ) {
 
-			var tokens = lines[ i ].split( ' ' );
-			var cmd = tokens[ 0 ].toUpperCase();
+			let tokens = lines[ i ].split( ' ' );
+			let cmd = tokens[ 0 ].toUpperCase();
 
 			//Argumments
-			var args = {};
+			let args = {};
 			tokens.splice( 1 ).forEach( function ( token ) {
 
 				if ( token[ 0 ] !== undefined ) {
 
-					var key = token[ 0 ].toLowerCase();
-					var value = parseFloat( token.substring( 1 ) );
+					let key = token[ 0 ].toLowerCase();
+					let value = parseFloat( token.substring( 1 ) );
 					args[ key ] = value;
 
 				}
@@ -142,7 +142,7 @@ class GCodeLoader extends Loader {
 			//G0/G1 – Linear Movement
 			if ( cmd === 'G0' || cmd === 'G1' ) {
 
-				var line = {
+				let line = {
 					x: args.x !== undefined ? absolute( state.x, args.x ) : state.x,
 					y: args.y !== undefined ? absolute( state.y, args.y ) : state.y,
 					z: args.z !== undefined ? absolute( state.z, args.z ) : state.z,
@@ -184,7 +184,7 @@ class GCodeLoader extends Loader {
 			} else if ( cmd === 'G92' ) {
 
 				//G92: Set Position
-				var line = state;
+				let line = state;
 				line.x = args.x !== undefined ? args.x : line.x;
 				line.y = args.y !== undefined ? args.y : line.y;
 				line.z = args.z !== undefined ? args.z : line.z;
@@ -199,47 +199,47 @@ class GCodeLoader extends Loader {
 
 		}
 
-		function addObject( vertex, extruding ) {
+		function addObject( vertex, extruding, i ) {
 
-			var geometry = new BufferGeometry();
-			geometry.setAttribute( 'position', new Float32BufferAttribute( vertex, 3 ) );
-
-			var segments = new LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
+			let geometry = new THREE.BufferGeometry();
+			geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( vertex, 3 ) );
+			let segments = new THREE.LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
 			segments.name = 'layer' + i;
 			object.add( segments );
 
 		}
 
-		var object = new Group();
+		let object = new THREE.Group();
 		object.name = 'gcode';
 
 		if ( this.splitLayer ) {
 
-			for ( var i = 0; i < layers.length; i ++ ) {
+			for ( let i = 0; i < layers.length; i ++ ) {
 
-				var layer = layers[ i ];
-				addObject( layer.vertex, true );
-				addObject( layer.pathVertex, false );
+				let layer = layers[ i ];
+				addObject( layer.vertex, true, i );
+				addObject( layer.pathVertex, false, i );
 
 			}
 
 		} else {
 
-			var vertex = [], pathVertex = [];
+			let vertex = [],
+				pathVertex = [];
 
-			for ( var i = 0; i < layers.length; i ++ ) {
+			for ( let i = 0; i < layers.length; i ++ ) {
 
-				var layer = layers[ i ];
-				var layerVertex = layer.vertex;
-				var layerPathVertex = layer.pathVertex;
+				let layer = layers[ i ];
+				let layerVertex = layer.vertex;
+				let layerPathVertex = layer.pathVertex;
 
-				for ( var j = 0; j < layerVertex.length; j ++ ) {
+				for ( let j = 0; j < layerVertex.length; j ++ ) {
 
 					vertex.push( layerVertex[ j ] );
 
 				}
 
-				for ( var j = 0; j < layerPathVertex.length; j ++ ) {
+				for ( let j = 0; j < layerPathVertex.length; j ++ ) {
 
 					pathVertex.push( layerPathVertex[ j ] );
 
@@ -247,8 +247,8 @@ class GCodeLoader extends Loader {
 
 			}
 
-			addObject( vertex, true );
-			addObject( pathVertex, false );
+			addObject( vertex, true, i );
+			addObject( pathVertex, false, i );
 
 		}
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -69,10 +69,10 @@ class GCodeLoader extends Loader {
 
 		let currentLayer = undefined;
 
-		let pathMaterial = new LineBasicMaterial( { color: 0xFF0000 } );
+		const pathMaterial = new LineBasicMaterial( { color: 0xFF0000 } );
 		pathMaterial.name = 'path';
 
-		let extrudingMaterial = new LineBasicMaterial( { color: 0x00FF00 } );
+		const extrudingMaterial = new LineBasicMaterial( { color: 0x00FF00 } );
 		extrudingMaterial.name = 'extruded';
 
 		function newLayer( line ) {
@@ -91,7 +91,7 @@ class GCodeLoader extends Loader {
 
 			}
 
-			if ( line.extruding ) {
+			if ( state.extruding ) {
 
 				currentLayer.vertex.push( p1.x, p1.y, p1.z );
 				currentLayer.vertex.push( p2.x, p2.y, p2.z );
@@ -201,15 +201,15 @@ class GCodeLoader extends Loader {
 
 		function addObject( vertex, extruding, i ) {
 
-			let geometry = new THREE.BufferGeometry();
-			geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( vertex, 3 ) );
-			let segments = new THREE.LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
+			let geometry = new BufferGeometry();
+			geometry.setAttribute( 'position', new Float32BufferAttribute( vertex, 3 ) );
+			let segments = new LineSegments( geometry, extruding ? extrudingMaterial : pathMaterial );
 			segments.name = 'layer' + i;
 			object.add( segments );
 
 		}
 
-		let object = new THREE.Group();
+		const object = new Group();
 		object.name = 'gcode';
 
 		if ( this.splitLayer ) {
@@ -224,7 +224,7 @@ class GCodeLoader extends Loader {
 
 		} else {
 
-			let vertex = [],
+			const vertex = [],
 				pathVertex = [];
 
 			for ( let i = 0; i < layers.length; i ++ ) {
@@ -247,8 +247,8 @@ class GCodeLoader extends Loader {
 
 			}
 
-			addObject( vertex, true, i );
-			addObject( pathVertex, false, i );
+			addObject( vertex, true, layers.length );
+			addObject( pathVertex, false, layers.length );
 
 		}
 


### PR DESCRIPTION
Related issue: #21616

 - Implemented the usage of let/const in the `GCodeLoader`.
 - Fixed a small typo in the code that was reading the extruding `state` from `line` instead of using the `state` object.
 - Mino reorganization of code to ensure access to all vars.
