### PR TITLE
[examples/index.html]: remove onmousewheel

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -173,12 +173,6 @@
 				content.classList.toggle( 'minimal' );
 
 			};
-			
-			viewer.addEventListener( 'wheel', function ( event ) {
-
-				event.preventDefault();
-
-			}, { passive: false } );
 
 			// iOS iframe auto-resize workaround
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,7 +38,7 @@
 
 		</div>
 
-		<iframe id="viewer" name="viewer" allowfullscreen allowvr onmousewheel=""></iframe>
+		<iframe id="viewer" name="viewer" allowfullscreen allowvr></iframe>
 
 		<a id="button" target="_blank"><img src="../files/ic_code_black_24dp.svg"></a>
 
@@ -173,6 +173,12 @@
 				content.classList.toggle( 'minimal' );
 
 			};
+			
+			viewer.addEventListener( 'wheel', function ( event ) {
+
+				event.preventDefault();
+
+			}, { passive: false } );
 
 			// iOS iframe auto-resize workaround
 


### PR DESCRIPTION
### The first reason

**mousewheel**

https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event

>This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards ...

> **Important:** Instead of this obsolete event, use the standard [`wheel`](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event) event.



<br>

### Second reason

oh...

![onmousewheel](https://puxiao.com/temp/test-passive/onmousewheel.jpg)



<br>

### So

```diff
-	<iframe id="viewer" name="viewer" allowfullscreen allowvr onmousewheel=""></iframe>
+	<iframe id="viewer" name="viewer" allowfullscreen allowvr></iframe>

...

// Events

+	viewer.addEventListener( 'wheel', function ( event ) {
+
+		event.preventDefault();
+
+	}, { passive: false } );
```



<br>

This contribution is funded by Example: https://raw.githack.com/puxiao/three.js/dev/examples/index.html