### PR TITLE
Legacy: Remove more deprercated methods to improve tree-shaking

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -22,11 +22,9 @@ import {
 	BufferAttribute
 } from './core/BufferAttribute.js';
 import { BufferGeometry } from './core/BufferGeometry.js';
-import { InstancedBufferGeometry } from './core/InstancedBufferGeometry.js';
 import { InterleavedBuffer } from './core/InterleavedBuffer.js';
 import { Object3D } from './core/Object3D.js';
 import { Uniform } from './core/Uniform.js';
-import { Raycaster } from './core/Raycaster.js';
 import { Curve } from './extras/core/Curve.js';
 import { Path } from './extras/core/Path.js';
 import { AxesHelper } from './helpers/AxesHelper.js';
@@ -47,7 +45,6 @@ import { DataTextureLoader } from './loaders/DataTextureLoader.js';
 import { TextureLoader } from './loaders/TextureLoader.js';
 import { Material } from './materials/Material.js';
 import { LineBasicMaterial } from './materials/LineBasicMaterial.js';
-import { MeshPhysicalMaterial } from './materials/MeshPhysicalMaterial.js';
 import { PointsMaterial } from './materials/PointsMaterial.js';
 import { ShaderMaterial } from './materials/ShaderMaterial.js';
 import { Box2 } from './math/Box2.js';

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1325,25 +1325,6 @@ Object.defineProperties( Material.prototype, {
 
 } );
 
-Object.defineProperties( MeshPhysicalMaterial.prototype, {
-
-	transparency: {
-		get: function () {
-
-			console.warn( 'THREE.MeshPhysicalMaterial: .transparency has been renamed to .transmission.' );
-			return this.transmission;
-
-		},
-		set: function ( value ) {
-
-			console.warn( 'THREE.MeshPhysicalMaterial: .transparency has been renamed to .transmission.' );
-			this.transmission = value;
-
-		}
-	}
-
-} );
-
 Object.defineProperties( ShaderMaterial.prototype, {
 
 	derivatives: {

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -941,23 +941,6 @@ SkinnedMesh.prototype.initBones = function () {
 
 };
 
-Object.defineProperty( Curve.prototype, '__arcLengthDivisions', {
-
-	get: function () {
-
-		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
-		return this.arcLengthDivisions;
-
-	},
-	set: function ( value ) {
-
-		console.warn( 'THREE.Curve: .__arcLengthDivisions is now .arcLengthDivisions.' );
-		this.arcLengthDivisions = value;
-
-	}
-
-} );
-
 //
 
 PerspectiveCamera.prototype.setLens = function ( focalLength, filmGauge ) {
@@ -1215,63 +1198,6 @@ Object.defineProperties( BufferGeometry.prototype, {
 
 			console.warn( 'THREE.BufferGeometry: .offsets has been renamed to .groups.' );
 			return this.groups;
-
-		}
-	}
-
-} );
-
-Object.defineProperties( InstancedBufferGeometry.prototype, {
-
-	maxInstancedCount: {
-		get: function () {
-
-			console.warn( 'THREE.InstancedBufferGeometry: .maxInstancedCount has been renamed to .instanceCount.' );
-			return this.instanceCount;
-
-		},
-		set: function ( value ) {
-
-			console.warn( 'THREE.InstancedBufferGeometry: .maxInstancedCount has been renamed to .instanceCount.' );
-			this.instanceCount = value;
-
-		}
-	}
-
-} );
-
-Object.defineProperties( Raycaster.prototype, {
-
-	linePrecision: {
-		get: function () {
-
-			console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
-			return this.params.Line.threshold;
-
-		},
-		set: function ( value ) {
-
-			console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
-			this.params.Line.threshold = value;
-
-		}
-	}
-
-} );
-
-Object.defineProperties( InterleavedBuffer.prototype, {
-
-	dynamic: {
-		get: function () {
-
-			console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
-			return this.usage === DynamicDrawUsage;
-
-		},
-		set: function ( value ) {
-
-			console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
-			this.setUsage( value );
 
 		}
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/21437#issuecomment-819016592

**Description**

Now that the core has been mostly converted to classes, let's remove the remaining deprecated methods that are preventing some classes from being tree-shaken.

In detail:

- [x] remove `InstancedBufferGeometry.maxInstancedCount` saving `~0.8kb`
- [x] remove `Curve.__arcLengthDivisions` saving `~3.1kb`
- [x] remove `Raycaster.linePrecision` saving `~1.42kb`
- [x] remove `InterleavedBuffer.dynamic` saving `~2.17kb`
- [x] remove `MeshPhysicalMaterial.transparency` saving `~3.5kb`

This brings down the tree-shaken bundle to `~402kb`


| Before this PR | After this PR |
|----------------|------------|
| <img width="257" alt="" src="https://user-images.githubusercontent.com/7217420/114677197-5c609780-9d0a-11eb-9c5a-b6e4b5e0516a.png"> | <img width="269" alt="" src="https://user-images.githubusercontent.com/7217420/114677210-5ff41e80-9d0a-11eb-89ee-8dc471cdcb77.png"> |


