### PR TITLE
Test-treeshake: use terser for minification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ test/*
 test/*.cmd
 test/unit/build
 test/treeshake/index.bundle.js
+test/treeshake/index.bundle.min.js
 
 
 **/node_modules

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -1,17 +1,33 @@
 import resolve from '@rollup/plugin-node-resolve';
 import filesize from 'rollup-plugin-filesize';
+import { terser } from 'rollup-plugin-terser';
 
 export default [
 	{
 		input: 'test/treeshake/index.js',
 		plugins: [
 			resolve(),
-			filesize(),
 		],
 		output: [
 			{
 				format: 'esm',
 				file: 'test/treeshake/index.bundle.js'
+			}
+		]
+	},
+	{
+		input: 'test/treeshake/index.js',
+		plugins: [
+			resolve(),
+			terser(),
+			filesize( {
+				showMinifiedSize: false,
+			} ),
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'test/treeshake/index.bundle.min.js'
 			}
 		]
 	}


### PR DESCRIPTION
Related issue: -

**Description**

We were using [rollup-plugin-filesize](https://github.com/ritz078/rollup-plugin-filesize) to show the minified size in the `test-treeshake` script. However the minified sized were skewed because it was calculating them internally.

I've updated the script to use [terser](https://github.com/terser/terser) to compute the minified size. Terser is what most people use nowadays to minify, so it's more accurate.

The script now produces `index.bundle.min.js` and an unminified `index.bundle.js` for human inspection, this is the new output:

<img src="https://user-images.githubusercontent.com/7217420/114686971-908c8600-9d13-11eb-91ea-a188b9b71c7e.png" width="450" />