### PR TITLE
MathUtils: convert to esmodules to allow for tree-shaking

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -53,7 +53,7 @@ import { Sphere } from './math/Sphere.js';
 import { Color } from './math/Color.js';
 import { Frustum } from './math/Frustum.js';
 import { Line3 } from './math/Line3.js';
-import { MathUtils } from './math/MathUtils.js';
+import * as MathUtils from './math/MathUtils.js';
 import { Matrix3 } from './math/Matrix3.js';
 import { Matrix4 } from './math/Matrix4.js';
 import { Plane } from './math/Plane.js';
@@ -423,29 +423,6 @@ Line3.prototype.center = function ( optionalTarget ) {
 
 	console.warn( 'THREE.Line3: .center() has been renamed to .getCenter().' );
 	return this.getCenter( optionalTarget );
-
-};
-
-//
-
-MathUtils.random16 = function () {
-
-	console.warn( 'THREE.Math: .random16() has been deprecated. Use Math.random() instead.' );
-	return Math.random();
-
-};
-
-MathUtils.nearestPowerOfTwo = function ( value ) {
-
-	console.warn( 'THREE.Math: .nearestPowerOfTwo() has been renamed to .floorPowerOfTwo().' );
-	return MathUtils.floorPowerOfTwo( value );
-
-};
-
-MathUtils.nextPowerOfTwo = function ( value ) {
-
-	console.warn( 'THREE.Math: .nextPowerOfTwo() has been renamed to .ceilPowerOfTwo().' );
-	return MathUtils.ceilPowerOfTwo( value );
 
 };
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -106,7 +106,7 @@ export { DiscreteInterpolant } from './math/interpolants/DiscreteInterpolant.js'
 export { CubicInterpolant } from './math/interpolants/CubicInterpolant.js';
 export { Interpolant } from './math/Interpolant.js';
 export { Triangle } from './math/Triangle.js';
-export { MathUtils } from './math/MathUtils.js';
+export * as MathUtils from './math/MathUtils.js';
 export { Spherical } from './math/Spherical.js';
 export { Cylindrical } from './math/Cylindrical.js';
 export { Plane } from './math/Plane.js';

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -6,7 +6,7 @@ import { NumberKeyframeTrack } from './tracks/NumberKeyframeTrack.js';
 import { QuaternionKeyframeTrack } from './tracks/QuaternionKeyframeTrack.js';
 import { StringKeyframeTrack } from './tracks/StringKeyframeTrack.js';
 import { VectorKeyframeTrack } from './tracks/VectorKeyframeTrack.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { NormalAnimationBlendMode } from '../constants.js';
 
 class AnimationClip {

--- a/src/animation/AnimationObjectGroup.js
+++ b/src/animation/AnimationObjectGroup.js
@@ -1,5 +1,5 @@
 import { PropertyBinding } from './PropertyBinding.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 /**
  *

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -1,5 +1,5 @@
 import { Camera } from './Camera.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 class PerspectiveCamera extends Camera {
 

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -1,5 +1,5 @@
 import { Matrix4 } from '../math/Matrix4.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { PerspectiveCamera } from './PerspectiveCamera.js';
 
 const _eyeRight = /*@__PURE__*/ new Matrix4();

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -7,7 +7,7 @@ import { Sphere } from '../math/Sphere.js';
 import { Object3D } from './Object3D.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Matrix3 } from '../math/Matrix3.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { arrayMax } from '../utils.js';
 
 let _id = 0;

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -1,4 +1,4 @@
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { StaticDrawUsage } from '../constants.js';
 
 class InterleavedBuffer {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -5,7 +5,7 @@ import { EventDispatcher } from './EventDispatcher.js';
 import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 let _object3DId = 0;
 

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -1,4 +1,4 @@
-import { MathUtils } from '../../math/MathUtils.js';
+import * as MathUtils from '../../math/MathUtils.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { Matrix4 } from '../../math/Matrix4.js';

--- a/src/extras/core/Shape.js
+++ b/src/extras/core/Shape.js
@@ -1,5 +1,5 @@
 import { Path } from './Path.js';
-import { MathUtils } from '../../math/MathUtils.js';
+import * as MathUtils from '../../math/MathUtils.js';
 
 class Shape extends Path {
 

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -1,6 +1,6 @@
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { Triangle } from '../math/Triangle.js';
 import { Vector3 } from '../math/Vector3.js';
 

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -2,7 +2,7 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector2 } from '../math/Vector2.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 class LatheGeometry extends BufferGeometry {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -1,5 +1,5 @@
 import { LightShadow } from './LightShadow.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 
 class SpotLightShadow extends LightShadow {

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,6 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
 import { FrontSide, FlatShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 let materialId = 0;
 

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -1,7 +1,7 @@
 import { Vector2 } from '../math/Vector2.js';
 import { MeshStandardMaterial } from './MeshStandardMaterial.js';
 import { Color } from '../math/Color.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 /**
  * parameters = {

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -1,4 +1,4 @@
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 
 const _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
 	'beige': 0xF5F5DC, 'bisque': 0xFFE4C4, 'black': 0x000000, 'blanchedalmond': 0xFFEBCD, 'blue': 0x0000FF, 'blueviolet': 0x8A2BE2,

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -1,7 +1,7 @@
 import { Quaternion } from './Quaternion.js';
 import { Vector3 } from './Vector3.js';
 import { Matrix4 } from './Matrix4.js';
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 
 const _matrix = /*@__PURE__*/ new Matrix4();
 const _quaternion = /*@__PURE__*/ new Quaternion();

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -1,5 +1,5 @@
 import { Vector3 } from './Vector3.js';
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 
 const _startP = /*@__PURE__*/ new Vector3();
 const _startEnd = /*@__PURE__*/ new Vector3();

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -8,241 +8,251 @@ for ( let i = 0; i < 256; i ++ ) {
 
 let _seed = 1234567;
 
-const MathUtils = {
 
-	DEG2RAD: Math.PI / 180,
-	RAD2DEG: 180 / Math.PI,
+const DEG2RAD = Math.PI / 180;
+const RAD2DEG = 180 / Math.PI;
 
-	generateUUID: function () {
+// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
+function generateUUID() {
 
-		// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
-
-		const d0 = Math.random() * 0xffffffff | 0;
-		const d1 = Math.random() * 0xffffffff | 0;
-		const d2 = Math.random() * 0xffffffff | 0;
-		const d3 = Math.random() * 0xffffffff | 0;
-		const uuid = _lut[ d0 & 0xff ] + _lut[ d0 >> 8 & 0xff ] + _lut[ d0 >> 16 & 0xff ] + _lut[ d0 >> 24 & 0xff ] + '-' +
+	const d0 = Math.random() * 0xffffffff | 0;
+	const d1 = Math.random() * 0xffffffff | 0;
+	const d2 = Math.random() * 0xffffffff | 0;
+	const d3 = Math.random() * 0xffffffff | 0;
+	const uuid = _lut[ d0 & 0xff ] + _lut[ d0 >> 8 & 0xff ] + _lut[ d0 >> 16 & 0xff ] + _lut[ d0 >> 24 & 0xff ] + '-' +
 			_lut[ d1 & 0xff ] + _lut[ d1 >> 8 & 0xff ] + '-' + _lut[ d1 >> 16 & 0x0f | 0x40 ] + _lut[ d1 >> 24 & 0xff ] + '-' +
 			_lut[ d2 & 0x3f | 0x80 ] + _lut[ d2 >> 8 & 0xff ] + '-' + _lut[ d2 >> 16 & 0xff ] + _lut[ d2 >> 24 & 0xff ] +
 			_lut[ d3 & 0xff ] + _lut[ d3 >> 8 & 0xff ] + _lut[ d3 >> 16 & 0xff ] + _lut[ d3 >> 24 & 0xff ];
 
-		// .toUpperCase() here flattens concatenated strings to save heap memory space.
-		return uuid.toUpperCase();
+	// .toUpperCase() here flattens concatenated strings to save heap memory space.
+	return uuid.toUpperCase();
 
-	},
+}
 
-	clamp: function ( value, min, max ) {
+function clamp( value, min, max ) {
 
-		return Math.max( min, Math.min( max, value ) );
+	return Math.max( min, Math.min( max, value ) );
 
-	},
+}
 
-	// compute euclidian modulo of m % n
-	// https://en.wikipedia.org/wiki/Modulo_operation
+// compute euclidian modulo of m % n
+// https://en.wikipedia.org/wiki/Modulo_operation
+function euclideanModulo( n, m ) {
 
-	euclideanModulo: function ( n, m ) {
+	return ( ( n % m ) + m ) % m;
 
-		return ( ( n % m ) + m ) % m;
+}
 
-	},
+// Linear mapping from range <a1, a2> to range <b1, b2>
+function mapLinear( x, a1, a2, b1, b2 ) {
 
-	// Linear mapping from range <a1, a2> to range <b1, b2>
+	return b1 + ( x - a1 ) * ( b2 - b1 ) / ( a2 - a1 );
 
-	mapLinear: function ( x, a1, a2, b1, b2 ) {
+}
 
-		return b1 + ( x - a1 ) * ( b2 - b1 ) / ( a2 - a1 );
+// https://www.gamedev.net/tutorials/programming/general-and-gameplay-programming/inverse-lerp-a-super-useful-yet-often-overlooked-function-r5230/
+function inverseLerp( x, y, value ) {
 
-	},
+	if ( x !== y ) {
 
-	// https://www.gamedev.net/tutorials/programming/general-and-gameplay-programming/inverse-lerp-a-super-useful-yet-often-overlooked-function-r5230/
-
-	inverseLerp: function ( x, y, value ) {
-
-		if ( x !== y ) {
-
-			return ( value - x ) / ( y - x );
+		return ( value - x ) / ( y - x );
 
 		 } else {
 
-			return 0;
+		return 0;
 
 		 }
 
-	},
+}
 
-	// https://en.wikipedia.org/wiki/Linear_interpolation
+// https://en.wikipedia.org/wiki/Linear_interpolation
+function lerp( x, y, t ) {
 
-	lerp: function ( x, y, t ) {
+	return ( 1 - t ) * x + t * y;
 
-		return ( 1 - t ) * x + t * y;
+}
 
-	},
+// http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
+function damp( x, y, lambda, dt ) {
 
-	// http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
+	return lerp( x, y, 1 - Math.exp( - lambda * dt ) );
 
-	damp: function ( x, y, lambda, dt ) {
+}
 
-		return MathUtils.lerp( x, y, 1 - Math.exp( - lambda * dt ) );
+// https://www.desmos.com/calculator/vcsjnyz7x4
+function pingpong( x, length = 1 ) {
 
-	},
+	return length - Math.abs( euclideanModulo( x, length * 2 ) - length );
 
-	// https://www.desmos.com/calculator/vcsjnyz7x4
+}
 
-	pingpong: function ( x, length = 1 ) {
+// http://en.wikipedia.org/wiki/Smoothstep
+function smoothstep( x, min, max ) {
 
-		return length - Math.abs( MathUtils.euclideanModulo( x, length * 2 ) - length );
+	if ( x <= min ) return 0;
+	if ( x >= max ) return 1;
 
-	},
+	x = ( x - min ) / ( max - min );
 
-	// http://en.wikipedia.org/wiki/Smoothstep
+	return x * x * ( 3 - 2 * x );
 
-	smoothstep: function ( x, min, max ) {
+}
 
-		if ( x <= min ) return 0;
-		if ( x >= max ) return 1;
+function smootherstep( x, min, max ) {
 
-		x = ( x - min ) / ( max - min );
+	if ( x <= min ) return 0;
+	if ( x >= max ) return 1;
 
-		return x * x * ( 3 - 2 * x );
+	x = ( x - min ) / ( max - min );
 
-	},
+	return x * x * x * ( x * ( x * 6 - 15 ) + 10 );
 
-	smootherstep: function ( x, min, max ) {
+}
 
-		if ( x <= min ) return 0;
-		if ( x >= max ) return 1;
+// Random integer from <low, high> interval
+function randInt( low, high ) {
 
-		x = ( x - min ) / ( max - min );
+	return low + Math.floor( Math.random() * ( high - low + 1 ) );
 
-		return x * x * x * ( x * ( x * 6 - 15 ) + 10 );
+}
 
-	},
+// Random float from <low, high> interval
+function randFloat( low, high ) {
 
-	// Random integer from <low, high> interval
+	return low + Math.random() * ( high - low );
 
-	randInt: function ( low, high ) {
+}
 
-		return low + Math.floor( Math.random() * ( high - low + 1 ) );
+// Random float from <-range/2, range/2> interval
+function randFloatSpread( range ) {
 
-	},
+	return range * ( 0.5 - Math.random() );
 
-	// Random float from <low, high> interval
+}
 
-	randFloat: function ( low, high ) {
+// Deterministic pseudo-random float in the interval [ 0, 1 ]
+function seededRandom( s ) {
 
-		return low + Math.random() * ( high - low );
+	if ( s !== undefined ) _seed = s % 2147483647;
 
-	},
+	// Park-Miller algorithm
 
-	// Random float from <-range/2, range/2> interval
+	_seed = _seed * 16807 % 2147483647;
 
-	randFloatSpread: function ( range ) {
+	return ( _seed - 1 ) / 2147483646;
 
-		return range * ( 0.5 - Math.random() );
+}
 
-	},
+function degToRad( degrees ) {
 
-	// Deterministic pseudo-random float in the interval [ 0, 1 ]
+	return degrees * DEG2RAD;
 
-	seededRandom: function ( s ) {
+}
 
-		if ( s !== undefined ) _seed = s % 2147483647;
+function radToDeg( radians ) {
 
-		// Park-Miller algorithm
+	return radians * RAD2DEG;
 
-		_seed = _seed * 16807 % 2147483647;
+}
 
-		return ( _seed - 1 ) / 2147483646;
+function isPowerOfTwo( value ) {
 
-	},
+	return ( value & ( value - 1 ) ) === 0 && value !== 0;
 
-	degToRad: function ( degrees ) {
+}
 
-		return degrees * MathUtils.DEG2RAD;
+function ceilPowerOfTwo( value ) {
 
-	},
+	return Math.pow( 2, Math.ceil( Math.log( value ) / Math.LN2 ) );
 
-	radToDeg: function ( radians ) {
+}
 
-		return radians * MathUtils.RAD2DEG;
+function floorPowerOfTwo( value ) {
 
-	},
+	return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
 
-	isPowerOfTwo: function ( value ) {
+}
 
-		return ( value & ( value - 1 ) ) === 0 && value !== 0;
+function setQuaternionFromProperEuler( q, a, b, c, order ) {
 
-	},
+	// Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
 
-	ceilPowerOfTwo: function ( value ) {
+	// rotations are applied to the axes in the order specified by 'order'
+	// rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
+	// angles are in radians
 
-		return Math.pow( 2, Math.ceil( Math.log( value ) / Math.LN2 ) );
+	const cos = Math.cos;
+	const sin = Math.sin;
 
-	},
+	const c2 = cos( b / 2 );
+	const s2 = sin( b / 2 );
 
-	floorPowerOfTwo: function ( value ) {
+	const c13 = cos( ( a + c ) / 2 );
+	const s13 = sin( ( a + c ) / 2 );
 
-		return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
+	const c1_3 = cos( ( a - c ) / 2 );
+	const s1_3 = sin( ( a - c ) / 2 );
 
-	},
+	const c3_1 = cos( ( c - a ) / 2 );
+	const s3_1 = sin( ( c - a ) / 2 );
 
-	setQuaternionFromProperEuler: function ( q, a, b, c, order ) {
+	switch ( order ) {
 
-		// Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
+		case 'XYX':
+			q.set( c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13 );
+			break;
 
-		// rotations are applied to the axes in the order specified by 'order'
-		// rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
-		// angles are in radians
+		case 'YZY':
+			q.set( s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13 );
+			break;
 
-		const cos = Math.cos;
-		const sin = Math.sin;
+		case 'ZXZ':
+			q.set( s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13 );
+			break;
 
-		const c2 = cos( b / 2 );
-		const s2 = sin( b / 2 );
+		case 'XZX':
+			q.set( c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13 );
+			break;
 
-		const c13 = cos( ( a + c ) / 2 );
-		const s13 = sin( ( a + c ) / 2 );
+		case 'YXY':
+			q.set( s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13 );
+			break;
 
-		const c1_3 = cos( ( a - c ) / 2 );
-		const s1_3 = sin( ( a - c ) / 2 );
+		case 'ZYZ':
+			q.set( s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13 );
+			break;
 
-		const c3_1 = cos( ( c - a ) / 2 );
-		const s3_1 = sin( ( c - a ) / 2 );
-
-		switch ( order ) {
-
-			case 'XYX':
-				q.set( c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13 );
-				break;
-
-			case 'YZY':
-				q.set( s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13 );
-				break;
-
-			case 'ZXZ':
-				q.set( s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13 );
-				break;
-
-			case 'XZX':
-				q.set( c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13 );
-				break;
-
-			case 'YXY':
-				q.set( s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13 );
-				break;
-
-			case 'ZYZ':
-				q.set( s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13 );
-				break;
-
-			default:
-				console.warn( 'THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order: ' + order );
-
-		}
+		default:
+			console.warn( 'THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order: ' + order );
 
 	}
 
+}
+
+
+
+
+export {
+	DEG2RAD,
+	RAD2DEG,
+	generateUUID,
+	clamp,
+	euclideanModulo,
+	mapLinear,
+	inverseLerp,
+	lerp,
+	damp,
+	pingpong,
+	smoothstep,
+	smootherstep,
+	randInt,
+	randFloat,
+	randFloatSpread,
+	seededRandom,
+	degToRad,
+	radToDeg,
+	isPowerOfTwo,
+	ceilPowerOfTwo,
+	floorPowerOfTwo,
+	setQuaternionFromProperEuler,
 };
-
-
-export { MathUtils };

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -1,4 +1,4 @@
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 
 class Quaternion {
 

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -5,7 +5,7 @@
  * The azimuthal angle (theta) is measured from the positive z-axis.
  */
 
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 
 class Spherical {
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -1,4 +1,4 @@
-import { MathUtils } from './MathUtils.js';
+import * as MathUtils from './MathUtils.js';
 import { Quaternion } from './Quaternion.js';
 
 class Vector3 {

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -1,6 +1,6 @@
 import { Bone } from './Bone.js';
 import { Matrix4 } from '../math/Matrix4.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 
 const _offsetMatrix = /*@__PURE__*/ new Matrix4();
 const _identityMatrix = /*@__PURE__*/ new Matrix4();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6,7 +6,7 @@ import {
 	LinearEncoding,
 	NoToneMapping
 } from '../constants.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { DataTexture } from '../textures/DataTexture.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,5 +1,5 @@
 import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping } from '../../constants.js';
-import { MathUtils } from '../../math/MathUtils.js';
+import * as MathUtils from '../../math/MathUtils.js';
 
 function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -10,7 +10,7 @@ import {
 	LinearFilter,
 	UVMapping
 } from '../constants.js';
-import { MathUtils } from '../math/MathUtils.js';
+import * as MathUtils from '../math/MathUtils.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { ImageUtils } from '../extras/ImageUtils.js';

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 
-import { MathUtils } from '../../../../src/math/MathUtils';
+import * as MathUtils from '../../../../src/math/MathUtils';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -5,7 +5,7 @@ import { Matrix4 } from '../../../../src/math/Matrix4';
 import { Vector3 } from '../../../../src/math/Vector3';
 import { Euler } from '../../../../src/math/Euler';
 import { Quaternion } from '../../../../src/math/Quaternion';
-import { MathUtils } from '../../../../src/math/MathUtils';
+import * as MathUtils from '../../../../src/math/MathUtils';
 import { eps } from './Constants.tests';
 
 


### PR DESCRIPTION
Related issue: -

**Description**

This is the pattern to use if we want to allow for tree-shaking for the util-functions files. The API of `MathUtils` does not change, just the import internally changes.

The downside is: you can't add methods dynamically from outside the file. It was being done in `Three.Legacy.js`, and I had to remove the methods there.