### PR TITLE
Examples: Convert jsm files to use bare three import before npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
     "test-treeshake": "rollup -c test/rollup.treeshake.config.js",
-    "make-screenshot": "node test/e2e/puppeteer.js --make"
+    "make-screenshot": "node test/e2e/puppeteer.js --make",
+    "prepublishOnly": "node utils/prepublish.js"
   },
   "keywords": [
     "three",

--- a/utils/prepublish.js
+++ b/utils/prepublish.js
@@ -1,0 +1,12 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+const glob = require( 'glob' );
+
+const paths = glob.sync( path.resolve( __dirname, '../examples/jsm/**/*.js' ) );
+paths.forEach( p => {
+
+	const content = fs.readFileSync( p, { encoding: 'utf8' } );
+	const bareContent = content.replace( /(\.\.\/){2,}build\/three.module.js/g, 'three' );
+	fs.writeFileSync( p, bareContent, { encoding: 'utf8' } );
+
+} );


### PR DESCRIPTION
Related issue: #17482

**Description**

Adds a "prepublishOnly" npm script that will convert the jsm examples to import from "three" rather than "three.module.js" before publish. The changes will not be committed but will but will be published to NPM.

After publish there will be modified files in git but we can add a postpublish script of something like "git checkout ./examples/jsm/" if desired.

cc @donmccurdy @Mugen87 