### PR TITLE
TransformControls.js: Added stop() and cancel() methods

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -154,10 +154,10 @@
 		<h3>[method:null cancel] ( [param:Boolean continueTransform] )</h3>
 		<p>
 			<p>
-				[page:Boolean continueTransform]: (optional) Keep transforming the object after resetting its position, rotation and scale. Default is false.
+				[page:Boolean continueTransform]: (optional) Keep transforming the object after resetting its position, rotation and scale. Default is *false*.
 			</p>
 			<p>
-				Cancels the current transform action and resets the object's position, rotation and scale to when the transform dragging began.
+				Resets the object's position, rotation and scale to when the current dragging's transform action began and calls [page:.stop stop()] if [param:Boolean continueTransform] evaluates to false.
 			</p>
 		</p>
 
@@ -228,7 +228,7 @@
 
 		<h3>[method:null stop] ()</h3>
 		<p>
-			Can be called to stop the dragging action without releasing the mouse button.
+			Stops the current transform action and does the same as mouse up.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -151,6 +151,16 @@
 			</p>
 		</p>
 
+		<h3>[method:null cancel] ( [param:Boolean continueTransform] )</h3>
+		<p>
+			<p>
+				[page:Boolean continueTransform]: (optional) Keep transforming the object after resetting its position, rotation and scale. Default is false.
+			</p>
+			<p>
+				Cancels the current transform action and resets the object's position, rotation and scale to when the transform dragging began.
+			</p>
+		</p>
+
 		<h3>[method:TransformControls detach] ()</h3>
 		<p>
 			Removes the current 3D object from the controls and makes the helper UI is invisible.
@@ -214,6 +224,11 @@
 			<p>
 				Sets the translation snap.
 			</p>
+		</p>
+
+		<h3>[method:null stop] ()</h3>
+		<p>
+			Can be called to stop the dragging action without releasing the mouse button.
 		</p>
 
 		<h2>Source</h2>

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -52,6 +52,7 @@ class TransformControls extends Object3D {
 
 		this.visible = false;
 		this.domElement = domElement;
+		this.previousState = null;
 
 		const _gizmo = new TransformControlsGizmo();
 		this._gizmo = _gizmo;
@@ -232,6 +233,12 @@ class TransformControls extends Object3D {
 	pointerDown( pointer ) {
 
 		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
+
+		this.previousState = {
+			position: this.object.position.clone(),
+			quaternion: this.object.quaternion.clone(),
+			scale: this.object.scale.clone()
+		};
 
 		if ( this.axis !== null ) {
 
@@ -546,6 +553,7 @@ class TransformControls extends Object3D {
 
 		this.dragging = false;
 		this.axis = null;
+		this.previousState = null;
 
 	}
 
@@ -581,6 +589,7 @@ class TransformControls extends Object3D {
 		this.object = undefined;
 		this.visible = false;
 		this.axis = null;
+		this.previousState = null;
 
 		return this;
 
@@ -633,6 +642,39 @@ class TransformControls extends Object3D {
 	update() {
 
 		console.warn( 'THREE.TransformControls: update function has no more functionality and therefore has been deprecated.' );
+
+	}
+
+	stop() {
+
+		if ( ! this.enabled ) return;
+
+		this.domElement.style.touchAction = '';
+		this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
+
+		this.pointerUp( {
+			x: 0,
+			y: 0,
+			button: 0
+		} );
+
+	}
+
+	cancel( continueTransform ) {
+
+		if ( this.previousState !== null ) {
+
+			this.object.position.copy( this.previousState.position );
+			this.object.quaternion.copy( this.previousState.quaternion );
+			this.object.scale.copy( this.previousState.scale );
+
+		}
+
+		if ( ! continueTransform ) {
+
+			this.stop();
+
+		}
 
 	}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -52,7 +52,7 @@ class TransformControls extends Object3D {
 
 		this.visible = false;
 		this.domElement = domElement;
-		this.previousState = {
+		this.previousObjectState = {
 			isActive: false,
 			position: new Vector3(),
 			quaternion: new Quaternion(),
@@ -239,10 +239,10 @@ class TransformControls extends Object3D {
 
 		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
 
-		this.previousState.position.copy( this.object.position );
-		this.previousState.quaternion.copy( this.object.quaternion );
-		this.previousState.scale.copy( this.object.scale );
-		this.previousState.isActive = true;
+		this.previousObjectState.position.copy( this.object.position );
+		this.previousObjectState.quaternion.copy( this.object.quaternion );
+		this.previousObjectState.scale.copy( this.object.scale );
+		this.previousObjectState.isActive = true;
 
 		if ( this.axis !== null ) {
 
@@ -557,7 +557,7 @@ class TransformControls extends Object3D {
 
 		this.dragging = false;
 		this.axis = null;
-		this.previousState.isActive = false;
+		this.previousObjectState.isActive = false;
 
 	}
 
@@ -593,7 +593,7 @@ class TransformControls extends Object3D {
 		this.object = undefined;
 		this.visible = false;
 		this.axis = null;
-		this.previousState.isActive = false;
+		this.previousObjectState.isActive = false;
 
 		return this;
 
@@ -666,11 +666,11 @@ class TransformControls extends Object3D {
 
 	cancel( continueTransform ) {
 
-		if ( this.previousState.isActive ) {
+		if ( this.previousObjectState.isActive ) {
 
-			this.object.position.copy( this.previousState.position );
-			this.object.quaternion.copy( this.previousState.quaternion );
-			this.object.scale.copy( this.previousState.scale );
+			this.object.position.copy( this.previousObjectState.position );
+			this.object.quaternion.copy( this.previousObjectState.quaternion );
+			this.object.scale.copy( this.previousObjectState.scale );
 
 		}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -52,7 +52,12 @@ class TransformControls extends Object3D {
 
 		this.visible = false;
 		this.domElement = domElement;
-		this.previousState = null;
+		this.previousState = {
+			isActive: false,
+			position: new Vector3(),
+			quaternion: new Quaternion(),
+			scale: new Vector3()
+		};
 
 		const _gizmo = new TransformControlsGizmo();
 		this._gizmo = _gizmo;
@@ -234,11 +239,10 @@ class TransformControls extends Object3D {
 
 		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
 
-		this.previousState = {
-			position: this.object.position.clone(),
-			quaternion: this.object.quaternion.clone(),
-			scale: this.object.scale.clone()
-		};
+		this.previousState.position.copy( this.object.position );
+		this.previousState.quaternion.copy( this.object.quaternion );
+		this.previousState.scale.copy( this.object.scale );
+		this.previousState.isActive = true;
 
 		if ( this.axis !== null ) {
 
@@ -553,7 +557,7 @@ class TransformControls extends Object3D {
 
 		this.dragging = false;
 		this.axis = null;
-		this.previousState = null;
+		this.previousState.isActive = false;
 
 	}
 
@@ -589,7 +593,7 @@ class TransformControls extends Object3D {
 		this.object = undefined;
 		this.visible = false;
 		this.axis = null;
-		this.previousState = null;
+		this.previousState.isActive = false;
 
 		return this;
 
@@ -662,7 +666,7 @@ class TransformControls extends Object3D {
 
 	cancel( continueTransform ) {
 
-		if ( this.previousState !== null ) {
+		if ( this.previousState.isActive ) {
 
 			this.object.position.copy( this.previousState.position );
 			this.object.quaternion.copy( this.previousState.quaternion );


### PR DESCRIPTION
Related issue: #21655

**Description**

There was no (easy) way to cancel/abort a transform action. The pull request adds that functionality.
- `stop()` does the same as a regular mouse up event.
- `cancel()` restores the current object to its state when the dragging/transformation started and fires `stop()`. The optional `continueTransform` boolean parameter can prevent the firing of `stop()` to let the user continue with the transform action.

Resolves #21655