### PR TITLE
Build-examples: use eslint indentation

### DIFF
--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -8,14 +8,9 @@ const EOL = os.EOL;
 
 function babelCleanup() {
 
-	const doubleSpaces = / {2}/g;
-
 	return {
 
 		transform( code ) {
-
-			code = code.replace( doubleSpaces, '\t' );
-
 
 			// remove comments messed up by babel that break eslint
 			// example:
@@ -25,7 +20,6 @@ function babelCleanup() {
 			//             ↓
 			// 	  setSize: function () {
 			code = code.replace( new RegExp( `\\(\\)${EOL}\\s*\\/\\*([a-zA-Z0-9_, ]+)\\*\\/${EOL}\\s*{`, 'g' ), '( ) {' );
-
 
 			return {
 				code: code,
@@ -103,7 +97,7 @@ function unmodularize() {
 			// fix for BasisTextureLoader.js
 			imports.forEach( imp => {
 
-				code = code.replace( new RegExp( `${EOL}(\\s)THREE\\.${imp}:`, 'g' ), ( match, p1 ) => {
+				code = code.replace( new RegExp( `${EOL}(\\s)*THREE\\.${imp}:`, 'g' ), ( match, p1 ) => {
 
 					return `${EOL}${p1}${imp}:`;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/21669#issuecomment-821976928

**Description**

The string replace of double spaces into tabs was breaking some strings that contained spaces.

This PR makes the `build-examples` script use the eslint's [indent-rule](https://eslint.org/docs/rules/indent) to replace spaces with tabs, already present in [mdcs](https://github.com/zz85/mrdoobapproves/blob/4b681fb6a4607bf6905f3f55eec5fda6858133dc/mdcs_eslint.js#L36).