### PR TITLE
WebGLNodes: Fix expected behavior .colorNode (WebGPU based)

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodes.js
@@ -35,7 +35,7 @@ Material.prototype.onBuild = function ( parameters, renderer ) {
 	fragmentShader = addCodeAfterSnippet( fragmentShader, '#include <color_fragment>',
 		`#ifdef NODE_COLOR
 
-			diffuseColor *= NODE_COLOR;
+			diffuseColor = NODE_COLOR;
 
 		#endif` );
 


### PR DESCRIPTION
**Description**

If defined `Material.colorNode` should override the `Material.map` and `Material.color` values as defined in `WebGPU`.

**Related**

https://github.com/mrdoob/three.js/pull/21322#discussion_r603114723