### PR TITLE
WebGPURenderer: Update to latest API.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUComputePipelines.js
+++ b/examples/jsm/renderers/webgpu/WebGPUComputePipelines.js
@@ -41,13 +41,13 @@ class WebGPUComputePipelines {
 
 			//
 
-			const computeStage = {
+			const compute = {
 				module: moduleCompute,
 				entryPoint: 'main'
 			};
 
 			pipeline = device.createComputePipeline( {
-				computeStage: computeStage
+				compute: compute
 			} );
 
 			this.pipelines.set( param, pipeline );

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -189,10 +189,10 @@ class WebGPURenderer {
 
 		this._renderPassDescriptor = {
 			colorAttachments: [ {
-				attachment: null
+				view: null
 			} ],
 			 depthStencilAttachment: {
-				attachment: null,
+				view: null,
 				depthStoreOp: GPUStoreOp.Store,
 				stencilStoreOp: GPUStoreOp.Store
 			}
@@ -246,24 +246,24 @@ class WebGPURenderer {
 
 			const renderTargetProperties = this._properties.get( renderTarget );
 
-			colorAttachment.attachment = renderTargetProperties.colorTextureGPU.createView();
-			depthStencilAttachment.attachment = renderTargetProperties.depthTextureGPU.createView();
+			colorAttachment.view = renderTargetProperties.colorTextureGPU.createView();
+			depthStencilAttachment.view = renderTargetProperties.depthTextureGPU.createView();
 
 		} else {
 
 			if ( this._parameters.antialias === true ) {
 
-				colorAttachment.attachment = this._colorBuffer.createView();
+				colorAttachment.view = this._colorBuffer.createView();
 				colorAttachment.resolveTarget = this._swapChain.getCurrentTexture().createView();
 
 			} else {
 
-				colorAttachment.attachment = this._swapChain.getCurrentTexture().createView();
+				colorAttachment.view = this._swapChain.getCurrentTexture().createView();
 				colorAttachment.resolveTarget = undefined;
 
 			}
 
-			depthStencilAttachment.attachment = this._depthBuffer.createView();
+			depthStencilAttachment.view = this._depthBuffer.createView();
 
 		}
 

--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -111,7 +111,7 @@ class WebGPUTextureUtils {
 
 			const passEncoder = commandEncoder.beginRenderPass( {
 				colorAttachments: [ {
-					attachment: dstView,
+					view: dstView,
 					loadValue: [ 0, 0, 0, 0 ],
 				} ],
 			} );


### PR DESCRIPTION
Related issue: -

**Description**

`GPUComputePipelineDescriptor`, `GPURenderPassColorAttachment` and `GPURenderPassDepthStencilAttachment` have changed. 
