### PR TITLE
Move envMapIntensity, envMapIntensity, refractionRatio outside of env…

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -249,13 +249,14 @@ Material.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 		if ( this.envMap && this.envMap.isTexture ) {
 
 			data.envMap = this.envMap.toJSON( meta ).uuid;
-			data.reflectivity = this.reflectivity; // Scale behind envMap
-			data.refractionRatio = this.refractionRatio;
 
 			if ( this.combine !== undefined ) data.combine = this.combine;
-			if ( this.envMapIntensity !== undefined ) data.envMapIntensity = this.envMapIntensity;
 
 		}
+
+		if ( this.envMapIntensity !== undefined ) data.envMapIntensity = this.envMapIntensity;
+		if ( this.reflectivity !== undefined ) data.reflectivity = this.reflectivity;
+		if ( this.refractionRatio !== undefined ) data.refractionRatio = this.refractionRatio;
 
 		if ( this.gradientMap && this.gradientMap.isTexture ) {
 


### PR DESCRIPTION
**Description**

After the implementation of `scene.environment` #18218 it is possible for a material to use parameters from an envMap without having to have a specific envMap assigned to it.

This PR move `envMapIntensity`, `reflectivity` & `refractionRatio` in `Material.toJSON()` outside of the conditional that check for an existence of explicit `envMap` in the material 
