### PR TITLE
Typo in panSpeed description

### DIFF
--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -126,7 +126,7 @@
 
 		<h3>[property:Number panSpeed]</h3>
 		<p>
-			The zoom speed. Default is *0.3*.
+			The pan speed. Default is *0.3*.
 		</p>
 
 		<h3>[property:Number rotateSpeed]</h3>


### PR DESCRIPTION
says "zoom" instead of "pan"

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Example](https://example.com).
