### PR TITLE
WebGLNodeBuilder: Fix warns

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -77,6 +77,14 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 	}
 
+	getVarsHeaderSnippet( /*shaderStage*/ ) {
+
+	}
+
+	getVarsBodySnippet( /*shaderStage*/ ) {
+
+	}
+
 	getVarysHeaderSnippet( /*shaderStage*/ ) {
 
 	}


### PR DESCRIPTION
Fix warnings generate from that PR (https://github.com/mrdoob/three.js/pull/21322) for now.
I will add support to `vars` too in nexts PR.