### PR TITLE
Docs: Mention troika-three-text on Creating Text page

### DIFF
--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -115,6 +115,17 @@
 		</div>
 
 
+		<h2>6. Troika Text</h2>
+		<div>
+			<p>The <a href="https://www.npmjs.com/package/troika-three-text">troika-three-text</a> package renders quality antialiased text using a similar technique as BMFonts, but works directly with any .TTF or .WOFF font file so you don't have to pregenerate a glyph texture offline. It also adds capabilities including:</p>
+			<ul>
+				<li>Effects like strokes, drop shadows, and curvature</li>
+				<li>The ability to apply any three.js Material, even a custom ShaderMaterial</li>
+				<li>Support for font ligatures, scripts with joined letters, and right-to-left/bidirectional layout</li>
+				<li>Optimization for large amounts of dynamic text, performing most work off the main thread in a web worker</li>
+			</ul>
+		</div>
+
 
 	</body>
 </html>


### PR DESCRIPTION
**Description**

This adds a reference to [troika-three-text](https://www.npmjs.com/package/troika-three-text) on the ["Creating Text"](https://threejs.org/docs/#manual/en/introduction/Creating-text) manual page. While I'm uncomfortable with self-promotion in Three.js docs, this addition has been suggested to me by several community members as something that would benefit many people, and mrdoob has voiced agreement.

I'm completely open to any edits on this. I made it a sixth top-level section but it could also be a "5a" since it sort of falls into the same general family of SDF rendering.
