### PR TITLE
Docs: Update 'Installation' guide to use cdn.skypack.dev

### DIFF
--- a/docs/manual/ar/introduction/Installation.html
+++ b/docs/manual/ar/introduction/Installation.html
@@ -87,9 +87,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/build/three.module.js';
+		  import * as THREE from 'https://cdn.skypack.dev/three@&lt;version&gt;';
 
 		  const scene = new THREE.Scene();
 
@@ -125,9 +125,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import { OrbitControls } from 'https://unpkg.com/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
+		  import { OrbitControls } from 'https://cdn.skypack.dev/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
 
 		  const controls = new OrbitControls();
 

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -69,9 +69,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/build/three.module.js';
+		  import * as THREE from 'https://cdn.skypack.dev/three@&lt;version&gt;';
 
 		  const scene = new THREE.Scene();
 
@@ -79,7 +79,7 @@
 		</code>
 
 		<p>
-			Not all features are accessed through the <em>build/three.module.js</em> module. Other popular parts of the library — such as controls, loaders, and post-processing effects — must be imported from the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] subfolder. To learn more, see <em>Examples</em> below.
+			Not all features are accessed through the <em>three</em> entrypoint. Other popular parts of the library — such as controls, loaders, and post-processing effects — must be imported from the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] subfolder. To learn more, see <em>Examples</em> below.
 		</p>
 
 
@@ -107,9 +107,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import { OrbitControls } from 'https://unpkg.com/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
+		  import { OrbitControls } from 'https://cdn.skypack.dev/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
 
 		  const controls = new OrbitControls();
 

--- a/docs/manual/ja/introduction/Installation.html
+++ b/docs/manual/ja/introduction/Installation.html
@@ -71,9 +71,9 @@
     <code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three. The URL will
-		  // redirect to the newest stable release.
-		  import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
+
+		  import * as THREE from 'https://cdn.skypack.dev/three@&lt;version&gt;';
 
 		  const scene = new THREE.Scene();
 
@@ -109,9 +109,9 @@
     <code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three. The URL will
+		  // Find the latest version by visiting https://cdn.skypack.dev/three. The URL will
 		  // redirect to the newest stable release.
-		  import { OrbitControls } from 'https://unpkg.com/three/examples/jsm/controls/OrbitControls.js';
+		  import { OrbitControls } from 'https://cdn.skypack.dev/three/examples/jsm/controls/OrbitControls.js';
 
 		  const controls = new OrbitControls();
 

--- a/docs/manual/ko/introduction/Installation.html
+++ b/docs/manual/ko/introduction/Installation.html
@@ -79,9 +79,9 @@
     <code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/build/three.module.js';
+		  import * as THREE from 'https://cdn.skypack.dev/three@&lt;version&gt;';
 
 		  const scene = new THREE.Scene();
 
@@ -122,9 +122,9 @@
     <code>
 		&lt;script type="module">
 
-		  // Find the latest version by visiting https://unpkg.com/three.
+		  // Find the latest version by visiting https://cdn.skypack.dev/three.
 
-		  import { OrbitControls } from 'https://unpkg.com/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
+		  import { OrbitControls } from 'https://cdn.skypack.dev/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
 
 		  const controls = new OrbitControls();
 

--- a/docs/manual/zh/introduction/Installation.html
+++ b/docs/manual/zh/introduction/Installation.html
@@ -69,9 +69,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // 通过访问 https://unpkg.com/three 来查找最新版本。
+		  // 通过访问 https://cdn.skypack.dev/three 来查找最新版本。
 
-		  import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/build/three.module.js';
+		  import * as THREE from 'https://cdn.skypack.dev/three@&lt;version&gt;';
 
 		  const scene = new THREE.Scene();
 
@@ -107,9 +107,9 @@
 		<code>
 		&lt;script type="module">
 
-		  // 通过访问 https://unpkg.com/three 来查找最新版本。
+		  // 通过访问 https://cdn.skypack.dev/three 来查找最新版本。
 
-		  import { OrbitControls } from 'https://unpkg.com/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
+		  import { OrbitControls } from 'https://cdn.skypack.dev/three@&lt;version&gt;/examples/jsm/controls/OrbitControls.js';
 
 		  const controls = new OrbitControls();
 


### PR DESCRIPTION
Context: https://github.com/mrdoob/three.js/pull/21654.