### PR TITLE
WebGLRenderTarget: clone texture image data when cloning render target

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -88,7 +88,10 @@ class WebGLRenderTarget extends EventDispatcher {
 
 		this.viewport.copy( source.viewport );
 
+		// By default texture.clone retains a reference to the original image data which
+		// isn't correct for WebGLRenderTarget. See issue #20328.
 		this.texture = source.texture.clone();
+		this.texture.image = { ...this.texture.image };
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -88,10 +88,8 @@ class WebGLRenderTarget extends EventDispatcher {
 
 		this.viewport.copy( source.viewport );
 
-		// By default texture.clone retains a reference to the original image data which
-		// isn't correct for WebGLRenderTarget. See issue #20328.
 		this.texture = source.texture.clone();
-		this.texture.image = { ...this.texture.image };
+		this.texture.image = { ...this.texture.image }; // See #20328.
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;


### PR DESCRIPTION
Related issue: #20328

**Description**

Clone the `WebGLRenderTarget.texture` image data object when cloning the render target. If it's not cloned then modifying the cloned render target will modify the original render targets image object causing it to be out of sync. See this case:

```js
const x = new THREE.WebGLRenderTarget( 10, 10 );
const y = new THREE.WebGLRenderTarget( 20, 20 );
console.log( x.texture.image.width, x.texture.image.height, x.width, x.height ); // 10, 10, 10, 10

y.copy( x );
y.setSize( 100, 100 );

console.log( x.texture.image.width, x.texture.image.height, x.width, x.height ); // 100, 100, 10, 10
```

This shouldn't be a breaking change because I can't see how you'd be relying on this behavior.