### PR TITLE
Docs: Fix link to troika-three-text

### DIFF
--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -117,7 +117,12 @@
 
 		<h2>6. Troika Text</h2>
 		<div>
-			<p>The <a href="https://www.npmjs.com/package/troika-three-text">troika-three-text</a> package renders quality antialiased text using a similar technique as BMFonts, but works directly with any .TTF or .WOFF font file so you don't have to pregenerate a glyph texture offline. It also adds capabilities including:</p>
+			<p>
+				The [link:https://www.npmjs.com/package/troika-three-text troika-three-text] package renders 
+				quality antialiased text using a similar technique as BMFonts, but works directly with any .TTF 
+				or .WOFF font file so you don't have to pregenerate a glyph texture offline. It also adds 
+				capabilities including:
+			</p>
 			<ul>
 				<li>Effects like strokes, drop shadows, and curvature</li>
 				<li>The ability to apply any three.js Material, even a custom ShaderMaterial</li>


### PR DESCRIPTION
**Description**

My sincere apologies for the noise, but I had somehow missed the special `[link: ...]` format in my original PR #21708. This fixes that so the link works properly, and adjusts the formatting of that line to match the rest of the doc.