### PR TITLE
LineSegmentsGeometry: Fix typo.

### DIFF
--- a/examples/js/lines/LineSegmentsGeometry.js
+++ b/examples/js/lines/LineSegmentsGeometry.js
@@ -121,7 +121,7 @@
 
 		}
 
-		romLineSegments( lineSegments ) {
+		fromLineSegments( lineSegments ) {
 
 			const geometry = lineSegments.geometry;
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -138,7 +138,7 @@ class LineSegmentsGeometry extends InstancedBufferGeometry {
 
 	}
 
-	romLineSegments( lineSegments ) {
+	fromLineSegments( lineSegments ) {
 
 		const geometry = lineSegments.geometry;
 


### PR DESCRIPTION
Related issue: Fixed #21724

**Description**

Fixed a typo in the method name of `fromLineSegments()`.
