### PR TITLE
Tests: Fix GLTFExporter Unit test

### DIFF
--- a/test/unit/example/exporters/GLTFExporter.tests.js
+++ b/test/unit/example/exporters/GLTFExporter.tests.js
@@ -395,7 +395,7 @@ export default QUnit.module( 'Exporters', () => {
 
 			const scene = new Scene();
 			const mesh = new Mesh(
-				new BoxBufferGeometry( 1, 1, 1 ),
+				new BoxGeometry( 1, 1, 1 ),
 				new MeshBasicMaterial()
 			);
 			scene.add( mesh );


### PR DESCRIPTION
**Description**

This PR fixes `GLTFExporter` Unit test.

`BoxGeometry` is imported as `BoxGeometry` in the test

https://github.com/mrdoob/three.js/blob/r128/test/unit/example/exporters/GLTFExporter.tests.js#L6

But this line refers it as `BoxBufferGeometry`.

https://github.com/mrdoob/three.js/blob/r128/test/unit/example/exporters/GLTFExporter.tests.js#L398

This PR fixes the line by renaming `BoxBufferGeometry` to `BoxGeometry`.