### PR TITLE
TransformControls: Fix gizmo transform.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -958,7 +958,7 @@
 
 		updateMatrixWorld( force ) {
 
-			const space = this.mode === 'scale' ? this.space : 'local'; // scale always oriented to local rotation
+			const space = this.mode === 'scale' ? 'local' : this.space; // scale always oriented to local rotation
 
 			const quaternion = space === 'local' ? this.worldQuaternion : _identityQuaternion; // Show only gizmos for current transform mode
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1175,7 +1175,7 @@ class TransformControlsGizmo extends Object3D {
 
 	updateMatrixWorld( force ) {
 
-		const space = ( this.mode === 'scale' ) ? this.space : 'local'; // scale always oriented to local rotation
+		const space = ( this.mode === 'scale' ) ? 'local' : this.space; // scale always oriented to local rotation
 
 		const quaternion = ( space === 'local' ) ? this.worldQuaternion : _identityQuaternion;
 


### PR DESCRIPTION
Related issue: Fixed #21731.

**Description**

Fixed the usage of the ternary operator at one place in order to fix wrong transforms of gizmos.