### PR TITLE
WebGLRenderer: add copyFramebufferToTexture3D()

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -295,6 +295,9 @@
 		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<p>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
+		<h3>[method:null copyFramebufferToTexture3D]( [param:Vector2 position], [param:Vector2 dstPosition] , [param:Texture texture], [param:Number level] )</h3>
+		<p>Copies pixels from the current WebGLFramebuffer into a 2D texture at the given offset. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexSubImage3D WebGLRenderingContext.copyTexSubImage3D].</p>
+
 		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
 		<p>Copies all pixels of a texture to an existing texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
 

--- a/examples/files.json
+++ b/examples/files.json
@@ -311,6 +311,7 @@
 		"webgl2_materials_texture3d_partialupdate",
 		"webgl2_multisampled_renderbuffers",
 		"webgl2_rendertarget_texture2darray",
+		"webgl2_framebuffer_texture3d",
 		"webgl2_volume_cloud",
 		"webgl2_volume_instancing",
 		"webgl2_volume_perlin"

--- a/examples/webgl2_framebuffer_texture3d.html
+++ b/examples/webgl2_framebuffer_texture3d.html
@@ -27,8 +27,12 @@
 
 			}
 
+			const _minusZ = new THREE.Vector3(0.0, 0.0, -1.0);
+
 			const _vector2 = new THREE.Vector2();
 			const _vector3 = new THREE.Vector3();
+			const _pointA = new THREE.Vector3();
+			const _pointB = new THREE.Vector3();
 
 			const SHADOW_PASS_CLEAR_COLOR = new THREE.Color(0xFFFFFF);
 			const INITIAL_CLOUD_SIZE = 128;
@@ -47,14 +51,18 @@
 
 				vec4 attenuation(vec3 localPosition)
 				{
-
+					// @todo: use step size.
+					vec4 prev = texture(shadowVolume, vec3(localPosition.xy, localPosition.z - 1.0));
+					if (slice <= 0.00001) {
+						prev = vec4(1.0);
+					}
+					return prev * 0.9;
 				}
 
 				void main()
 				{
 					vec3 localPosition = vec3(vUv, slice);
-
-
+					color = attenuation(localPosition);
 
 					// if (lightDirectionVolume.y < - 0.5) {
 					// 	color = vec4(1.0, 0.0, 0.0, 1.0);
@@ -81,10 +89,60 @@
 
 			`;
 
-			let renderer, scene, camera;
+			class ShadowVolume extends THREE.Object3D {
+
+				constructor(volume) {
+
+					super();
+
+					this.texture = null;
+
+					if (volume) {
+
+						this._init(volume)
+
+					}
+
+				}
+
+				render(light) {
+
+					const direction = light.target.getWorldPosition(_pointA);
+					direction
+						.sub(light.target.getWorldPosition(_pointB))
+						.normalize();
+
+					this.quaternion.setFromUnitVectors(_minusZ, direction);
+					this.updateMatrix();
+
+				}
+
+				_init(volume) {
+
+					// Assumes the volume is a cube. For non-uniform volume, we need
+					// to compute the appropriate x, y, z basis.
+					// Diagonal of a cube: a * sqrt(3).
+					//
+					// This is a bit wasteful in terms of texture memory but it
+					// avoids to re-upload the texture and is easier to manage for an example.
+					const diagonal = volume.image.width * Math.sqrt(3);
+					const texture = new THREE.DataTexture3D(null, diagonal, diagonal, diagonal);
+					texture.format = THREE.RGBAFormat;
+					texture.internalFormat = 'RGBA16F';
+					texture.type = THREE.HalfFloatType;
+					texture.unpackAlignment = 1;
+					texture.minFilter = THREE.LinearFilter;
+					texture.magFilter = THREE.LinearFilter;
+					this.texture = texture;
+
+				}
+
+			}
+
+			let renderer, scene, camera, light;
 			let mesh;
 			
-			let shadowScene, shadowTexture, shadowRenderTarget, shadowMaterial;
+			let shadowScene, shadowRenderTarget, shadowMaterial, shadowVolume;
 
 			let prevTime = performance.now();
 
@@ -122,25 +180,6 @@
 
 			}
 
-			function generateShadowTexture(volume) {
-				// Assumes the volume is a cube. For non-uniform volume, we need
-				// to compute the appropriate x, y, z basis.
-				// Diagonal of a cube: a * sqrt(3).
-				//
-				// This is a bit wasteful in terms of texture memory but it
-				// avoids to re-upload the texture and is easier to manage for an example.
-				const diagonal = volume.image.width * sqrt(3);
-
-				const texture = new THREE.DataTexture3D(null, diagonal, diagonal, diagonal);
-				texture.format = THREE.RGBAFormat;
-				texture.internalFormat = 'RGBA16F';
-				texture.type = THREE.HalfFloatType;
-				texture.unpackAlignment = 1;
-				texture.minFilter = THREE.LinearFilter;
-				texture.magFilter = THREE.LinearFilter;
-				return texture;
-			}
-
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
@@ -165,13 +204,13 @@
 
 				// Shadow Pass
 
-				shadowTexture = generateShadowTexture(texture);
+				shadowVolume = new ShadowVolume(texture);
 
 				shadowMaterial = new THREE.RawShaderMaterial( {
 					glslVersion: THREE.GLSL3,
 					uniforms: {
 						volume: { value: texture },
-						shadowVolume: { value: shadowTexture },
+						shadowVolume: { value: shadowVolume.texture },
 						lightDirectionVolume: { value: new THREE.Vector3() },
 						slice: { value: 0.0 }
 					},
@@ -198,7 +237,7 @@
 					// format: THREE.RedFormat,
 					// internalFormat: 'R16F',
 					format: THREE.RGBAFormat,
-      		internalFormat: 'RGBA16F',
+					internalFormat: 'RGBA16F',
 					type: THREE.HalfFloatType,
 					stencilBuffer: false,
 					depthBuffer: false
@@ -223,6 +262,12 @@
 					new THREE.MeshBasicMaterial( { map: new THREE.CanvasTexture( canvas ), side: THREE.BackSide } )
 				);
 				scene.add( sky );
+
+				// Light
+
+				light = new THREE.DirectionalLight();
+				light.target.position.set(0.0, -1.0, 0.0);
+				light.target.updateMatrix();
 
 				// Material
 
@@ -402,7 +447,7 @@
 						// base: { value: new THREE.Color( 0x798aa0 ) },
 						base: { value: new THREE.Color( 0x111111 ) },
 						map: { value: texture },
-						shadowTexture: { value: shadowTexture },
+						shadowTexture: { value: shadowVolume.texture },
 						cameraPos: { value: new THREE.Vector3() },
 						threshold: { value: 0.25 },
 						opacity: { value: 0.25 },
@@ -447,6 +492,11 @@
 
 			}
 
+			function updateShadow() {
+				const light = new THREE.Vector3(0.0, -1.0, 0.0);
+
+			}
+
 			function onWindowResize() {
 
 				camera.aspect = window.innerWidth / window.innerHeight;
@@ -476,21 +526,20 @@
 				renderer.autoClear = false;
 				renderer.setClearColor(SHADOW_PASS_CLEAR_COLOR, 1.0);
 				renderer.clearColor();
-				for (let i = 1; i < INITIAL_CLOUD_SIZE; ++i) {
+				for (let i = 0; i < INITIAL_CLOUD_SIZE; ++i) {
 					shadowMaterial.uniforms.slice.value = i / INITIAL_CLOUD_SIZE;
 					shadowScene.render(renderer);
 
 					// Copies slice from framebuffer into 3D texture.
 					const srcPos = _vector2.set(0, 0);
 					const dstPos = _vector3.set(0, 0, i);
-					renderer.copyFramebufferToTexture3D(srcPos, dstPos, shadowTexture);
+					renderer.copyFramebufferToTexture3D(srcPos, dstPos, shadowVolume.texture);
 				}
 
 				renderer.autoClear = true;
 				renderer.setRenderTarget( null );
 
 				// Renders volume and uses shadow texture.
-
 			
 				mesh.material.uniforms.cameraPos.value.copy( camera.position );
 				mesh.material.uniforms.frame.value ++;

--- a/examples/webgl2_framebuffer_texture3d.html
+++ b/examples/webgl2_framebuffer_texture3d.html
@@ -30,22 +30,62 @@
 			const _vector2 = new THREE.Vector2();
 			const _vector3 = new THREE.Vector3();
 
+			const SHADOW_PASS_CLEAR_COLOR = new THREE.Color(0xFFFFFF);
 			const INITIAL_CLOUD_SIZE = 128;
 
 			const fragmentShadowing = `
 				precision highp float;
+				precision highp sampler3D;
 
+				in vec2 vUv;
 				out vec4 color;
 
-				void main() {
-					color.r = 1.0;
+				uniform sampler3D volume;
+				uniform sampler3D shadowVolume;
+				uniform vec3 			lightDirectionVolume;
+				uniform float 		slice;
+
+				vec4 attenuation(vec3 localPosition)
+				{
+
+				}
+
+				void main()
+				{
+					vec3 localPosition = vec3(vUv, slice);
+
+
+
+					// if (lightDirectionVolume.y < - 0.5) {
+					// 	color = vec4(1.0, 0.0, 0.0, 1.0);
+					// } else {
+					// 	color = vec4(1.0);
+					// }
+
+					// if (slice > 0.0 && slice <= 1.0 / 128.0 + 0.000001)
+					// {
+					// 	color =	vec4(1.0, 0.0, 0.0, 0.0);
+					// } else if (slice > 0.0 && slice <= 2.0 / 128.0 + 0.000001)
+					// {
+					// 	color =	vec4(0.0, 1.0, 0.0, 0.0);
+					// }
+					// else if (slice > 0.0 && slice <= 3.0 / 128.0 + 0.000001)
+					// {
+					// 	color =	vec4(0.0, 0.0, 0.0, 1.0);
+					// }
+					// else
+					// {
+					// 	color = vec4(1.0);
+					// }
 				}
 
 			`;
 
 			let renderer, scene, camera;
 			let mesh;
-			let shadowScene, shadowTexture, shadowRenderTarget;
+			
+			let shadowScene, shadowTexture, shadowRenderTarget, shadowMaterial;
+
 			let prevTime = performance.now();
 
 			init();
@@ -82,6 +122,25 @@
 
 			}
 
+			function generateShadowTexture(volume) {
+				// Assumes the volume is a cube. For non-uniform volume, we need
+				// to compute the appropriate x, y, z basis.
+				// Diagonal of a cube: a * sqrt(3).
+				//
+				// This is a bit wasteful in terms of texture memory but it
+				// avoids to re-upload the texture and is easier to manage for an example.
+				const diagonal = volume.image.width * sqrt(3);
+
+				const texture = new THREE.DataTexture3D(null, diagonal, diagonal, diagonal);
+				texture.format = THREE.RGBAFormat;
+				texture.internalFormat = 'RGBA16F';
+				texture.type = THREE.HalfFloatType;
+				texture.unpackAlignment = 1;
+				texture.minFilter = THREE.LinearFilter;
+				texture.magFilter = THREE.LinearFilter;
+				return texture;
+			}
+
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
@@ -96,11 +155,25 @@
 
 				new OrbitControls( camera, renderer.domElement );
 
+				// Volume texture
+
+				const texture = generateCloudTexture(INITIAL_CLOUD_SIZE);
+				texture.format = THREE.RedFormat;
+				texture.minFilter = THREE.LinearFilter;
+				texture.magFilter = THREE.LinearFilter;
+				texture.unpackAlignment = 1;
+
 				// Shadow Pass
 
-				const shadowMaterial = new THREE.RawShaderMaterial( {
+				shadowTexture = generateShadowTexture(texture);
+
+				shadowMaterial = new THREE.RawShaderMaterial( {
 					glslVersion: THREE.GLSL3,
 					uniforms: {
+						volume: { value: texture },
+						shadowVolume: { value: shadowTexture },
+						lightDirectionVolume: { value: new THREE.Vector3() },
+						slice: { value: 0.0 }
 					},
 					vertexShader: `
 						in vec3 position;
@@ -108,7 +181,6 @@
 						out vec2 vUv;
 
 						uniform mat4 projectionMatrix;
-
 						void main() {
 							vUv = uv;
 							gl_Position = projectionMatrix * vec4( position, 1.0 );
@@ -123,19 +195,14 @@
 				shadowRenderTarget = new THREE.WebGLRenderTarget( INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE, {
 					minFilter: THREE.NearestFilter,
 					magFilter: THREE.NearestFilter,
-					format: THREE.RedFormat,
-					internalFormat: 'R16F',
+					// format: THREE.RedFormat,
+					// internalFormat: 'R16F',
+					format: THREE.RGBAFormat,
+      		internalFormat: 'RGBA16F',
 					type: THREE.HalfFloatType,
 					stencilBuffer: false,
 					depthBuffer: false
 				} );
-
-				shadowTexture = new THREE.DataTexture3D(null, INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE);
-				shadowTexture.format = THREE.RedFormat;
-				shadowTexture.type = THREE.HalfFloatType;
-				shadowTexture.unpackAlignment = 1;
-				shadowTexture.minFilter = THREE.LinearFilter;
-				shadowTexture.magFilter = THREE.LinearFilter;
 
 				// Sky
 
@@ -156,14 +223,6 @@
 					new THREE.MeshBasicMaterial( { map: new THREE.CanvasTexture( canvas ), side: THREE.BackSide } )
 				);
 				scene.add( sky );
-
-				// Texture
-
-				const texture = generateCloudTexture(INITIAL_CLOUD_SIZE);
-				texture.format = THREE.RedFormat;
-				texture.minFilter = THREE.LinearFilter;
-				texture.magFilter = THREE.LinearFilter;
-				texture.unpackAlignment = 1;
 
 				// Material
 
@@ -194,6 +253,7 @@
 
 					uniform mat4 modelViewMatrix;
 					uniform mat4 projectionMatrix;
+					uniform mat4 volumeToShadowVolume;
 
 					in vec3 vOrigin;
 					in vec3 vDirection;
@@ -242,6 +302,11 @@
 
 					float sample1( vec3 p ) {
 						return texture( map, p ).r;
+					}
+
+					vec3 sampleShadow( vec3 p )
+					{
+						return texture( shadowTexture, p + 0.5 ).rgb;
 					}
 
 					vec3
@@ -310,11 +375,7 @@
 
 							d = smoothstep( threshold - range, threshold + range, d ) * opacity;
 
-							// float col = shading( p + 0.5 ) * 3.0 + ( ( p.x + p.y ) * 0.25 ) + 0.2;
-							// vec3 col = vec3(shading( p + 0.5 ) * 3.0 + ( ( p.x + p.y ) * 0.25 ) + 0.2);
-							// vec3 col = localShading( p + 0.5 );
-
-							vec3 col = vec3(1.0) * texture( shadowTexture, p ).r;
+							vec3 col = vec3(1.0) * sampleShadow( p );
 
 							ac.rgb += ( 1.0 - ac.a ) * d * col;
 
@@ -338,7 +399,8 @@
 				const material = new THREE.RawShaderMaterial( {
 					glslVersion: THREE.GLSL3,
 					uniforms: {
-						base: { value: new THREE.Color( 0x798aa0 ) },
+						// base: { value: new THREE.Color( 0x798aa0 ) },
+						base: { value: new THREE.Color( 0x111111 ) },
 						map: { value: texture },
 						shadowTexture: { value: shadowTexture },
 						cameraPos: { value: new THREE.Vector3() },
@@ -394,42 +456,43 @@
 
 			}
 
-			let curr = 0;
-			const countPerRow = 4;
-			const countPerSlice = countPerRow * countPerRow;
-			const sliceCount = 4;
-			const totalCount = sliceCount * countPerSlice;
-			const margins = 8;
-
-			const perElementPaddedSize = ( INITIAL_CLOUD_SIZE - margins ) / countPerRow;
-			const perElementSize = Math.floor( ( INITIAL_CLOUD_SIZE - 1 ) / countPerRow );
-
 			function animate() {
 
 				requestAnimationFrame( animate );
 
-				// Renders shadow volume first.
+				// mesh.rotation.y = - performance.now() / 7500;
+				mesh.updateMatrixWorld();
+
+				/** Step 1: Renders shadow volume first. */
+
+				// Update light.
+
+				const m = new THREE.Matrix4();
+				m.copy(mesh.matrixWorld).invert();
+				shadowMaterial.uniforms.lightDirectionVolume.value.set(0.0, -1.0, 0.0);
+				shadowMaterial.uniforms.lightDirectionVolume.value.applyMatrix4(m);
 
 				renderer.setRenderTarget( shadowRenderTarget );
-
-				for (let i = 0; i < INITIAL_CLOUD_SIZE; ++i) {
-
+				renderer.autoClear = false;
+				renderer.setClearColor(SHADOW_PASS_CLEAR_COLOR, 1.0);
+				renderer.clearColor();
+				for (let i = 1; i < INITIAL_CLOUD_SIZE; ++i) {
+					shadowMaterial.uniforms.slice.value = i / INITIAL_CLOUD_SIZE;
 					shadowScene.render(renderer);
 
 					// Copies slice from framebuffer into 3D texture.
 					const srcPos = _vector2.set(0, 0);
-					const dstPos = _vector2.set(0, 0, i);
+					const dstPos = _vector3.set(0, 0, i);
 					renderer.copyFramebufferToTexture3D(srcPos, dstPos, shadowTexture);
-
 				}
 
+				renderer.autoClear = true;
 				renderer.setRenderTarget( null );
 
 				// Renders volume and uses shadow texture.
 
+			
 				mesh.material.uniforms.cameraPos.value.copy( camera.position );
-				// mesh.rotation.y = - performance.now() / 7500;
-
 				mesh.material.uniforms.frame.value ++;
 
 				renderer.render( scene, camera );

--- a/examples/webgl2_framebuffer_texture3d.html
+++ b/examples/webgl2_framebuffer_texture3d.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl2 - volume - cloud</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+
+	<body>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl2 - volume - cloud
+		</div>
+
+		<script type="module">
+			import * as THREE from '../build/three.module.js';
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { ImprovedNoise } from './jsm/math/ImprovedNoise.js';
+			import { FullScreenQuad } from './jsm/postprocessing/Pass.js';
+
+			import { GUI } from './jsm/libs/dat.gui.module.js';
+			import { WEBGL } from './jsm/WebGL.js';
+
+			if ( WEBGL.isWebGL2Available() === false ) {
+
+				document.body.appendChild( WEBGL.getWebGL2ErrorMessage() );
+
+			}
+
+			const _vector2 = new THREE.Vector2();
+			const _vector3 = new THREE.Vector3();
+
+			const INITIAL_CLOUD_SIZE = 128;
+
+			const fragmentShadowing = `
+				precision highp float;
+
+				out vec4 color;
+
+				void main() {
+					color.r = 1.0;
+				}
+
+			`;
+
+			let renderer, scene, camera;
+			let mesh;
+			let shadowScene, shadowTexture, shadowRenderTarget;
+			let prevTime = performance.now();
+
+			init();
+			animate();
+
+			function generateCloudTexture( size, scaleFactor = 1.0 ) {
+
+				const data = new Uint8Array( size * size * size );
+				const scale = scaleFactor * 10.0 / size;
+
+				let i = 0;
+				const perlin = new ImprovedNoise();
+				const vector = new THREE.Vector3();
+
+				for ( let z = 0; z < size; z ++ ) {
+
+					for ( let y = 0; y < size; y ++ ) {
+
+						for ( let x = 0; x < size; x ++ ) {
+
+							const dist = vector.set( x, y, z ).subScalar( size / 2 ).divideScalar( size ).length();
+							const fadingFactor = ( 1.0 - dist ) * ( 1.0 - dist );
+							data[ i ] = ( 128 + 128 * perlin.noise( x * scale / 1.5, y * scale, z * scale / 1.5 ) ) * fadingFactor;
+
+							i ++;
+
+						}
+
+					}
+
+				}
+
+				return new THREE.DataTexture3D( data, size, size, size );
+
+			}
+
+			function init() {
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
+
+				scene = new THREE.Scene();
+
+				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.1, 100 );
+				camera.position.set( 0, 0, 1.5 );
+
+				new OrbitControls( camera, renderer.domElement );
+
+				// Shadow Pass
+
+				const shadowMaterial = new THREE.RawShaderMaterial( {
+					glslVersion: THREE.GLSL3,
+					uniforms: {
+					},
+					vertexShader: `
+						in vec3 position;
+						in vec2 uv;
+						out vec2 vUv;
+
+						uniform mat4 projectionMatrix;
+
+						void main() {
+							vUv = uv;
+							gl_Position = projectionMatrix * vec4( position, 1.0 );
+						}`,
+					fragmentShader: fragmentShadowing,
+					side: THREE.FrontSide,
+					transparent: false
+				} );
+
+				shadowScene = new FullScreenQuad(shadowMaterial);
+
+				shadowRenderTarget = new THREE.WebGLRenderTarget( INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE, {
+					minFilter: THREE.NearestFilter,
+					magFilter: THREE.NearestFilter,
+					format: THREE.RedFormat,
+					internalFormat: 'R16F',
+					type: THREE.HalfFloatType,
+					stencilBuffer: false,
+					depthBuffer: false
+				} );
+
+				shadowTexture = new THREE.DataTexture3D(null, INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE, INITIAL_CLOUD_SIZE);
+				shadowTexture.format = THREE.RedFormat;
+				shadowTexture.type = THREE.HalfFloatType;
+				shadowTexture.unpackAlignment = 1;
+				shadowTexture.minFilter = THREE.LinearFilter;
+				shadowTexture.magFilter = THREE.LinearFilter;
+
+				// Sky
+
+				const canvas = document.createElement( 'canvas' );
+				canvas.width = 1;
+				canvas.height = 32;
+
+				const context = canvas.getContext( '2d' );
+				const gradient = context.createLinearGradient( 0, 0, 0, 32 );
+				gradient.addColorStop( 0.0, '#014a84' );
+				gradient.addColorStop( 0.5, '#0561a0' );
+				gradient.addColorStop( 1.0, '#437ab6' );
+				context.fillStyle = gradient;
+				context.fillRect( 0, 0, 1, 32 );
+
+				const sky = new THREE.Mesh(
+					new THREE.SphereGeometry( 10 ),
+					new THREE.MeshBasicMaterial( { map: new THREE.CanvasTexture( canvas ), side: THREE.BackSide } )
+				);
+				scene.add( sky );
+
+				// Texture
+
+				const texture = generateCloudTexture(INITIAL_CLOUD_SIZE);
+				texture.format = THREE.RedFormat;
+				texture.minFilter = THREE.LinearFilter;
+				texture.magFilter = THREE.LinearFilter;
+				texture.unpackAlignment = 1;
+
+				// Material
+
+				const vertexShader = /* glsl */`
+					in vec3 position;
+
+					uniform mat4 modelMatrix;
+					uniform mat4 modelViewMatrix;
+					uniform mat4 projectionMatrix;
+					uniform vec3 cameraPos;
+
+					out vec3 vOrigin;
+					out vec3 vDirection;
+
+					void main() {
+						vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+
+						vOrigin = vec3( inverse( modelMatrix ) * vec4( cameraPos, 1.0 ) ).xyz;
+						vDirection = position - vOrigin;
+
+						gl_Position = projectionMatrix * mvPosition;
+					}
+				`;
+
+				const fragmentShader = /* glsl */`
+					precision highp float;
+					precision highp sampler3D;
+
+					uniform mat4 modelViewMatrix;
+					uniform mat4 projectionMatrix;
+
+					in vec3 vOrigin;
+					in vec3 vDirection;
+
+					out vec4 color;
+
+					uniform vec3 base;
+					uniform sampler3D map;
+					uniform sampler3D shadowTexture;
+
+					uniform float threshold;
+					uniform float range;
+					uniform float opacity;
+					uniform float steps;
+					uniform float frame;
+
+					#include <tonemapping_pars_fragment>
+
+					uint wang_hash(uint seed)
+					{
+							seed = (seed ^ 61u) ^ (seed >> 16u);
+							seed *= 9u;
+							seed = seed ^ (seed >> 4u);
+							seed *= 0x27d4eb2du;
+							seed = seed ^ (seed >> 15u);
+							return seed;
+					}
+
+					float randomFloat(inout uint seed)
+					{
+							return float(wang_hash(seed)) / 4294967296.;
+					}
+
+					vec2 hitBox( vec3 orig, vec3 dir ) {
+						const vec3 box_min = vec3( - 0.5 );
+						const vec3 box_max = vec3( 0.5 );
+						vec3 inv_dir = 1.0 / dir;
+						vec3 tmin_tmp = ( box_min - orig ) * inv_dir;
+						vec3 tmax_tmp = ( box_max - orig ) * inv_dir;
+						vec3 tmin = min( tmin_tmp, tmax_tmp );
+						vec3 tmax = max( tmin_tmp, tmax_tmp );
+						float t0 = max( tmin.x, max( tmin.y, tmin.z ) );
+						float t1 = min( tmax.x, min( tmax.y, tmax.z ) );
+						return vec2( t0, t1 );
+					}
+
+					float sample1( vec3 p ) {
+						return texture( map, p ).r;
+					}
+
+					vec3
+					computeGradient(vec3 position, float step)
+					{
+						return normalize(vec3(
+							sample1(vec3(position.x + step, position.y, position.z))
+							- sample1(vec3(position.x - step, position.y, position.z)),
+							sample1(vec3(position.x, position.y + step, position.z))
+							- sample1(vec3(position.x, position.y - step, position.z)),
+							sample1(vec3(position.x, position.y, position.z + step))
+							- sample1(vec3(position.x, position.y, position.z - step))
+						));
+					}
+
+					float shading( vec3 coord ) {
+						float step = 0.01;
+						vec3 gradient = computeGradient(coord, step);
+						float ambient = 0.075;
+						return dot(gradient, vec3(1.0, 0.0, 0.0)) + ambient;
+						// return dot(gradient, vec3(1.0, 0.0, 0.0)) * (sample1( coord + vec3( - step ) ) - sample1( coord + vec3( step ) ));
+						// return sample1( coord + vec3( - step ) ) - sample1( coord + vec3( step ) );
+					}
+
+					vec3 localShading(vec3 pos)
+					{
+						float step = 0.01;
+						vec3 gradient = computeGradient(pos, step);
+
+						vec3 diffuseColor = vec3(0.8);
+						vec3 ambient = vec3(0.075);
+						vec3 diffuse = diffuseColor * dot(gradient, vec3(1.0, 0.0, 0.0));
+
+						return diffuse + ambient;
+					}
+
+					void main(){
+						vec3 rayDir = normalize( vDirection );
+						vec2 bounds = hitBox( vOrigin, rayDir );
+
+						if ( bounds.x > bounds.y ) discard;
+
+						bounds.x = max( bounds.x, 0.0 );
+
+						vec3 p = vOrigin + bounds.x * rayDir;
+						vec3 inc = 1.0 / abs( rayDir );
+						float delta = min( inc.x, min( inc.y, inc.z ) );
+						delta /= steps;
+
+						// Jitter
+
+						// Nice little seed from
+						// https://blog.demofox.org/2020/05/25/casual-shadertoy-path-tracing-1-basic-camera-diffuse-emissive/
+						uint seed = uint( gl_FragCoord.x ) * uint( 1973 ) + uint( gl_FragCoord.y ) * uint( 9277 ) + uint( frame ) * uint( 26699 );
+						vec3 size = vec3( textureSize( map, 0 ) );
+						float randNum = randomFloat( seed ) * 2.0 - 1.0;
+						p += rayDir * randNum * ( 1.0 / size );
+
+						//
+
+						vec4 ac = vec4( base, 0.0 );
+
+						for ( float t = bounds.x; t < bounds.y; t += delta ) {
+
+							float d = sample1( p + 0.5 );
+
+							d = smoothstep( threshold - range, threshold + range, d ) * opacity;
+
+							// float col = shading( p + 0.5 ) * 3.0 + ( ( p.x + p.y ) * 0.25 ) + 0.2;
+							// vec3 col = vec3(shading( p + 0.5 ) * 3.0 + ( ( p.x + p.y ) * 0.25 ) + 0.2);
+							// vec3 col = localShading( p + 0.5 );
+
+							vec3 col = vec3(1.0) * texture( shadowTexture, p ).r;
+
+							ac.rgb += ( 1.0 - ac.a ) * d * col;
+
+							ac.a += ( 1.0 - ac.a ) * d;
+
+							if ( ac.a >= 0.95 ) break;
+
+							p += rayDir * delta;
+
+						}
+
+						ac.rgb = ACESFilmicToneMapping(ac.rgb);
+						color = ac;
+
+						if ( color.a == 0.0 ) discard;
+
+					}
+				`;
+
+				const geometry = new THREE.BoxGeometry( 1, 1, 1 );
+				const material = new THREE.RawShaderMaterial( {
+					glslVersion: THREE.GLSL3,
+					uniforms: {
+						base: { value: new THREE.Color( 0x798aa0 ) },
+						map: { value: texture },
+						shadowTexture: { value: shadowTexture },
+						cameraPos: { value: new THREE.Vector3() },
+						threshold: { value: 0.25 },
+						opacity: { value: 0.25 },
+						range: { value: 0.1 },
+						steps: { value: 100 },
+						frame: { value: 0 }
+					},
+					vertexShader,
+					fragmentShader,
+					side: THREE.BackSide,
+					transparent: true
+				} );
+
+				mesh = new THREE.Mesh( geometry, material );
+				scene.add( mesh );
+
+				//
+
+				const parameters = {
+					threshold: 0.25,
+					opacity: 0.25,
+					range: 0.1,
+					steps: 100
+				};
+
+				function update() {
+
+					material.uniforms.threshold.value = parameters.threshold;
+					material.uniforms.opacity.value = parameters.opacity;
+					material.uniforms.range.value = parameters.range;
+					material.uniforms.steps.value = parameters.steps;
+
+				}
+
+				const gui = new GUI();
+				gui.add( parameters, 'threshold', 0, 1, 0.01 ).onChange( update );
+				gui.add( parameters, 'opacity', 0, 1, 0.01 ).onChange( update );
+				gui.add( parameters, 'range', 0, 1, 0.01 ).onChange( update );
+				gui.add( parameters, 'steps', 0, 200, 1 ).onChange( update );
+
+				window.addEventListener( 'resize', onWindowResize );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			let curr = 0;
+			const countPerRow = 4;
+			const countPerSlice = countPerRow * countPerRow;
+			const sliceCount = 4;
+			const totalCount = sliceCount * countPerSlice;
+			const margins = 8;
+
+			const perElementPaddedSize = ( INITIAL_CLOUD_SIZE - margins ) / countPerRow;
+			const perElementSize = Math.floor( ( INITIAL_CLOUD_SIZE - 1 ) / countPerRow );
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				// Renders shadow volume first.
+
+				renderer.setRenderTarget( shadowRenderTarget );
+
+				for (let i = 0; i < INITIAL_CLOUD_SIZE; ++i) {
+
+					shadowScene.render(renderer);
+
+					// Copies slice from framebuffer into 3D texture.
+					const srcPos = _vector2.set(0, 0);
+					const dstPos = _vector2.set(0, 0, i);
+					renderer.copyFramebufferToTexture3D(srcPos, dstPos, shadowTexture);
+
+				}
+
+				renderer.setRenderTarget( null );
+
+				// Renders volume and uses shadow texture.
+
+				mesh.material.uniforms.cameraPos.value.copy( camera.position );
+				// mesh.rotation.y = - performance.now() / 7500;
+
+				mesh.material.uniforms.frame.value ++;
+
+				renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1974,9 +1974,6 @@ function WebGLRenderer( parameters ) {
 		const levelScale = Math.pow( 2, - level );
 		const width = Math.floor( texture.image.width * levelScale );
 		const height = Math.floor( texture.image.height * levelScale );
-		const glFormat = utils.convert( texture.format );
-
-		// textures.setTexture2D( texture, 0 );
 
 		let glTarget;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1969,6 +1969,40 @@ function WebGLRenderer( parameters ) {
 
 	};
 
+	this.copyFramebufferToTexture3D = function ( position, dstPosition, texture, level = 0 ) {
+
+		const levelScale = Math.pow( 2, - level );
+		const width = Math.floor( texture.image.width * levelScale );
+		const height = Math.floor( texture.image.height * levelScale );
+		const glFormat = utils.convert( texture.format );
+
+		// textures.setTexture2D( texture, 0 );
+
+		let glTarget;
+
+		if ( texture.isDataTexture3D ) {
+
+			textures.setTexture3D( texture, 0 );
+			glTarget = _gl.TEXTURE_3D;
+
+		} else if ( texture.isDataTexture2DArray ) {
+
+			textures.setTexture2DArray( texture, 0 );
+			glTarget = _gl.TEXTURE_2D_ARRAY;
+
+		} else {
+
+			console.warn( 'THREE.WebGLRenderer.copyFramebufferToTexture3D: only supports THREE.DataTexture3D and THREE.DataTexture2DArray.' );
+			return;
+
+		}
+
+		_gl.copyTexSubImage3D( glTarget, level, dstPosition.x, dstPosition.y, dstPosition.z, position.x, position.y, width, height );
+
+		state.unbindTexture();
+
+	};
+
 	this.copyTextureToTexture = function ( position, srcTexture, dstTexture, level = 0 ) {
 
 		const width = srcTexture.image.width;


### PR DESCRIPTION
**Description**

This PR adds support to copy from the framebuffer to a 3D texture at a given offset. This is similar to the already existing `copyFramebufferToTexture`.