### PR TITLE
GLTFLoader: Allow multiple associations

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2614,10 +2614,7 @@ class GLTFParser {
 			texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || RepeatWrapping;
 			texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || RepeatWrapping;
 
-			parser.associations.set( texture, {
-				type: 'textures',
-				index: textureIndex
-			} );
+			parser.associations.set( texture, { textures: textureIndex } );
 
 			return texture;
 
@@ -2956,7 +2953,7 @@ class GLTFParser {
 
 			assignExtrasToUserData( material, materialDef );
 
-			parser.associations.set( material, { type: 'materials', index: materialIndex } );
+			parser.associations.set( material, { materials: materialIndex } );
 
 			if ( materialDef.extensions ) addUnknownExtensionsToUserData( extensions, material, materialDef );
 
@@ -3169,6 +3166,15 @@ class GLTFParser {
 
 			}
 
+			for ( let i = 0, il = meshes.length; i < il; i ++ ) {
+
+				parser.associations.set( meshes[ i ], {
+					meshes: meshIndex,
+					primitives: i
+				} );
+
+			}
+
 			if ( meshes.length === 1 ) {
 
 				return meshes[ 0 ];
@@ -3176,6 +3182,8 @@ class GLTFParser {
 			}
 
 			const group = new Group();
+
+			parser.associations.set( group, { meshes: meshIndex } );
 
 			for ( let i = 0, il = meshes.length; i < il; i ++ ) {
 
@@ -3584,7 +3592,13 @@ class GLTFParser {
 
 			}
 
-			parser.associations.set( node, { type: 'nodes', index: nodeIndex } );
+			if ( ! parser.associations.has( node ) ) {
+
+				parser.associations.set( node, {} );
+
+			}
+
+			parser.associations.get( node ).nodes = nodeIndex;
 
 			return node;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/19359#issuecomment-776413917

**Description**

This PR allows `GLTFLoader` to save multiple associations by changing from

```
{
  types: 'nodes',
  index: nodeIndex
}
```

to

```
{
  nodes: nodeIndex,
  meshes: meshIndex,
  primitives: primitiveIndex
}
```

and newly saves mesh and primitive indices.

Regarding adding mesh and primitive indices, from @donmccurdy comment https://github.com/mrdoob/three.js/pull/19359#issuecomment-775677101

> I'm OK with adding that if we have clear use cases to help us design it usefully.

My use case is I want to get mesh and primitive definitions for `KHR_materials_variants` extension from Three.js Mesh object because the extension definition is under primitive

https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_materials_variants/README.md#example

and different variants can be selected after the loader parses glTF.

And a Three.js Mesh can be associated to both a node definition and mesh definition so I would like to suggest to allow multiple associations.

This change requires users who already use `parser.associations` to update their code because of `associations` data structure change. Is it ok? @cdata

BTW who should run `npm run build-examples`? Me and I should add `examples/js/loaders/GLTFLoader.js` change in this PR?