### PR TITLE
Respect the original camera view offset inside SSAARenderPass.

### DIFF
--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -95,25 +95,25 @@ class SSAARenderPass extends Pass {
 		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
-    const view = {
-      
-      enabled: false,
-      
-      fullWidth: readBuffer.width,
-      
-      fullHeight: readBuffer.height,
-      
-      offsetX: 0,
-      
-      offsetY: 0,
-      
-      width: readBuffer.width,
-      
-      height: readBuffer.height
-    
-    };
+		const view = {
+			
+			enabled: false,
+			
+			fullWidth: readBuffer.width,
+			
+			fullHeight: readBuffer.height,
+			
+			offsetX: 0,
+			
+			offsetY: 0,
+			
+			width: readBuffer.width,
+			
+			height: readBuffer.height
+		
+		};
 
-    if ( this.camera.view !== null && this.camera.view.enabled ) Object.assign( view, this.camera.view );
+		if ( this.camera.view !== null && this.camera.view.enabled ) Object.assign( view, this.camera.view );
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
@@ -161,12 +161,12 @@ class SSAARenderPass extends Pass {
 		}
 
 		if ( this.camera.clearViewOffset ) {
-      
-      if ( view.enabled ) this.camera.view = Object.assign( {}, view );
-      
-      else this.camera.clearViewOffset();
-      
-    }
+			
+			if ( view.enabled ) this.camera.view = Object.assign( {}, view );
+			
+			else this.camera.clearViewOffset();
+			
+		}
 
 		renderer.autoClear = autoClear;
 		renderer.setClearColor( this._oldClearColor, oldClearAlpha );

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -111,15 +111,9 @@ class SSAARenderPass extends Pass {
 		
 		};
 
-		let originalViewOffset = null;
-
-		if ( this.camera.setViewOffset ) {
-
-			originalViewOffset = this.camera.view === null ? null : Object.assign( {}, this.camera.view );
+		let originalViewOffset = this.camera.view === null ? null : Object.assign( {}, this.camera.view );
 	
-			if ( originalViewOffset !== null && originalViewOffset.enabled ) Object.assign( viewOffset, originalViewOffset );
-			
-		}
+		if ( originalViewOffset !== null && originalViewOffset.enabled ) Object.assign( viewOffset, originalViewOffset );
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -95,19 +95,25 @@ class SSAARenderPass extends Pass {
 		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
-    const view = this.camera.view !== null && this.camera.view.enabled ? Object.assign( {}, this.camera.view ) : null;
+    const view = {
+      
+      enabled: false,
+      
+      fullWidth: readBuffer.width,
+      
+      fullHeight: readBuffer.height,
+      
+      offsetX: 0,
+      
+      offsetY: 0,
+      
+      width: readBuffer.width,
+      
+      height: readBuffer.height
+    
+    };
 
-		const fullWidth = view ? view.fullWidth : readBuffer.width;
-    
-    const fullHeight = view ? view.fullHeight : readBuffer.height;
-    
-    const offsetX = view ? view.offsetX : 0;
-    
-    const offsetY = view ? view.offsetY : 0;
-    
-    const width = view ? view.width : readBuffer.width;
-    
-    const height = view ? view.height : readBuffer.height;
+    if ( this.camera.view !== null && this.camera.view.enabled ) Object.assign( view, this.camera.view );
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
@@ -116,9 +122,9 @@ class SSAARenderPass extends Pass {
 
 			if ( this.camera.setViewOffset ) {
 
-				this.camera.setViewOffset( fullWidth, fullHeight,
-					offsetX + jitterOffset[ 0 ] * 0.0625, offsetY + jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
-					width, height );
+				this.camera.setViewOffset( view.fullWidth, view.fullHeight,
+					view.offsetX + jitterOffset[ 0 ] * 0.0625, view.offsetY + jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
+					view.width, view.height );
 
 			}
 
@@ -156,7 +162,7 @@ class SSAARenderPass extends Pass {
 
 		if ( this.camera.clearViewOffset ) {
       
-      if ( view ) this.camera.setViewOffset( fullWidth, fullHeight, offsetX, offsetY, width, height );
+      if ( view.enabled ) this.camera.view = Object.assign( {}, view );
       
       else this.camera.clearViewOffset();
       

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -95,7 +95,19 @@ class SSAARenderPass extends Pass {
 		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
-		const width = readBuffer.width, height = readBuffer.height;
+    const view = this.camera.view !== null && this.camera.view.enabled ? Object.assign( {}, this.camera.view ) : null;
+
+		const fullWidth = view ? view.fullWidth : readBuffer.width;
+    
+    const fullHeight = view ? view.fullHeight : readBuffer.height;
+    
+    const offsetX = view ? view.offsetX : 0;
+    
+    const offsetY = view ? view.offsetY : 0;
+    
+    const width = view ? view.width : readBuffer.width;
+    
+    const height = view ? view.height : readBuffer.height;
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
@@ -104,8 +116,8 @@ class SSAARenderPass extends Pass {
 
 			if ( this.camera.setViewOffset ) {
 
-				this.camera.setViewOffset( width, height,
-					jitterOffset[ 0 ] * 0.0625, jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
+				this.camera.setViewOffset( fullWidth, fullHeight,
+					offsetX + jitterOffset[ 0 ] * 0.0625, offsetY + jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
 					width, height );
 
 			}
@@ -142,7 +154,13 @@ class SSAARenderPass extends Pass {
 
 		}
 
-		if ( this.camera.clearViewOffset ) this.camera.clearViewOffset();
+		if ( this.camera.clearViewOffset ) {
+      
+      if ( view ) this.camera.setViewOffset( fullWidth, fullHeight, offsetX, offsetY, width, height );
+      
+      else this.camera.clearViewOffset();
+      
+    }
 
 		renderer.autoClear = autoClear;
 		renderer.setClearColor( this._oldClearColor, oldClearAlpha );

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -111,9 +111,9 @@ class SSAARenderPass extends Pass {
 		
 		};
 
-		let originalViewOffset = this.camera.view === null ? null : Object.assign( {}, this.camera.view );
+		let originalViewOffset = Object.assign( {}, this.camera.view );
 	
-		if ( originalViewOffset !== null && originalViewOffset.enabled ) Object.assign( viewOffset, originalViewOffset );
+		if ( originalViewOffset.enabled ) Object.assign( viewOffset, originalViewOffset );
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
@@ -166,7 +166,7 @@ class SSAARenderPass extends Pass {
 
 		}
 			
-		if ( this.camera.setViewOffset && originalViewOffset !== null && originalViewOffset.enabled ) {
+		if ( this.camera.setViewOffset && originalViewOffset.enabled ) {
 			
 			this.camera.setViewOffset(
 				

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -95,9 +95,9 @@ class SSAARenderPass extends Pass {
 		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
+		const originalView = Object.assign( {}, this.camera.view );
+
 		const view = {
-			
-			enabled: false,
 			
 			fullWidth: readBuffer.width,
 			
@@ -113,7 +113,7 @@ class SSAARenderPass extends Pass {
 		
 		};
 
-		if ( this.camera.view !== null && this.camera.view.enabled ) Object.assign( view, this.camera.view );
+		if ( originalView !== null && originalView.enabled ) Object.assign( view, originalView );
 
 		// render the scene multiple times, each slightly jitter offset from the last and accumulate the results.
 		for ( let i = 0; i < jitterOffsets.length; i ++ ) {
@@ -160,13 +160,7 @@ class SSAARenderPass extends Pass {
 
 		}
 
-		if ( this.camera.clearViewOffset ) {
-			
-			if ( view.enabled ) this.camera.view = Object.assign( {}, view );
-			
-			else this.camera.clearViewOffset();
-			
-		}
+		if ( this.camera.clearViewOffset ) this.camera.view = Object.assign( {}, originalView );
 
 		renderer.autoClear = autoClear;
 		renderer.setClearColor( this._oldClearColor, oldClearAlpha );

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -94,7 +94,7 @@
 
 				cameraP = new THREE.PerspectiveCamera( 65, aspect, 3, 10 );
 				cameraP.position.z = 7;
-        cameraP.setViewOffset( width, height, params.viewOffset, 0, width, height );
+        cameraP.setViewOffset( width, height, params.viewOffsetX, 0, width, height );
 
 				cameraO = new THREE.OrthographicCamera( width / - 2, width / 2, height / 2, height / - 2, 3, 10 );
 				cameraO.position.z = 7;

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -39,6 +39,7 @@
 				camera: 'perspective',
 				clearColor: 'black',
 				clearAlpha: 1.0,
+        viewOffsetX: 0,
 				autoRotate: true
 
 			};
@@ -67,6 +68,7 @@
 				gui.add( params, 'camera', [ 'perspective', 'orthographic' ] );
 				gui.add( params, "clearColor", [ 'black', 'white', 'blue', 'green', 'red' ] );
 				gui.add( params, "clearAlpha", 0, 1 );
+        gui.add( params, "viewOffsetX", -100, 100 );
 				gui.add( params, "autoRotate" );
 
 				gui.open();
@@ -92,6 +94,7 @@
 
 				cameraP = new THREE.PerspectiveCamera( 65, aspect, 3, 10 );
 				cameraP.position.z = 7;
+        cameraP.setViewOffset( width, height, params.viewOffset, 0, width, height );
 
 				cameraO = new THREE.OrthographicCamera( width / - 2, width / 2, height / 2, height / - 2, 3, 10 );
 				cameraO.position.z = 7;
@@ -172,6 +175,7 @@
 				const aspect = width / height;
 
 				cameraP.aspect = aspect;
+        cameraP.setViewOffset( width, height, params.viewOffset, 0, width, height );
 				cameraO.updateProjectionMatrix();
 
 				cameraO.left = - height * aspect;
@@ -226,6 +230,8 @@
 				ssaaRenderPassO.enabled = ( params.camera === 'orthographic' );
 
 				copyPass.enabled = ! params.renderToScreen;
+        
+        cameraP.view.offsetX = params.viewOffsetX;
 
 				composer.render();
 

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -39,7 +39,7 @@
 				camera: 'perspective',
 				clearColor: 'black',
 				clearAlpha: 1.0,
-        viewOffsetX: 0,
+				viewOffsetX: 0,
 				autoRotate: true
 
 			};
@@ -68,7 +68,7 @@
 				gui.add( params, 'camera', [ 'perspective', 'orthographic' ] );
 				gui.add( params, "clearColor", [ 'black', 'white', 'blue', 'green', 'red' ] );
 				gui.add( params, "clearAlpha", 0, 1 );
-        gui.add( params, "viewOffsetX", -100, 100 );
+				gui.add( params, "viewOffsetX", -100, 100 );
 				gui.add( params, "autoRotate" );
 
 				gui.open();
@@ -94,7 +94,7 @@
 
 				cameraP = new THREE.PerspectiveCamera( 65, aspect, 3, 10 );
 				cameraP.position.z = 7;
-        cameraP.setViewOffset( width, height, params.viewOffsetX, 0, width, height );
+				cameraP.setViewOffset( width, height, params.viewOffsetX, 0, width, height );
 
 				cameraO = new THREE.OrthographicCamera( width / - 2, width / 2, height / 2, height / - 2, 3, 10 );
 				cameraO.position.z = 7;
@@ -175,7 +175,7 @@
 				const aspect = width / height;
 
 				cameraP.aspect = aspect;
-        cameraP.setViewOffset( width, height, params.viewOffset, 0, width, height );
+				cameraP.setViewOffset( width, height, params.viewOffset, 0, width, height );
 				cameraO.updateProjectionMatrix();
 
 				cameraO.left = - height * aspect;
@@ -230,8 +230,8 @@
 				ssaaRenderPassO.enabled = ( params.camera === 'orthographic' );
 
 				copyPass.enabled = ! params.renderToScreen;
-        
-        cameraP.view.offsetX = params.viewOffsetX;
+				
+				cameraP.view.offsetX = params.viewOffsetX;
 
 				composer.render();
 


### PR DESCRIPTION
Respect the original camera view offset inside SSAARenderPass.

Add a viewOffsetX GUI param to the webgl_postprocessing_ssaa example.

Fixes #21735.