### PR TITLE
Update VideoTexture doc with note about using RGBA format to avoid Firefox performance issue.

### DIFF
--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -49,8 +49,9 @@
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
 		The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
-		[page:Constant format] -- The format used in the texture.
-		See [page:Textures format constants] for other choices.<br />
+		[page:Constant format] -- The default is [page:Textures THREE.RGBFormat].
+		See [page:Textures format constants] for other choices.
+		Note that a bug has been reported with Firefox's WebGL implementation where use of [page:Textures THREE.RGBFormat] on a VideoTexture can result in a significant performance penalty, if you encounter this issue it is recommended to pass in [page:Textures THREE.RGBAFormat] instead.<br />
 
 		[page:Constant type] -- Default is [page:Textures THREE.UnsignedByteType].
 		See [page:Textures type constants] for other choices.<br />

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -1,4 +1,4 @@
-import { RGBFormat, LinearFilter } from '../constants.js';
+import { RGBAFormat, LinearFilter } from '../constants.js';
 import { Texture } from './Texture.js';
 
 class VideoTexture extends Texture {
@@ -7,7 +7,7 @@ class VideoTexture extends Texture {
 
 		super( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
 
-		this.format = format !== undefined ? format : RGBFormat;
+		this.format = format !== undefined ? format : RGBAFormat;
 
 		this.minFilter = minFilter !== undefined ? minFilter : LinearFilter;
 		this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -1,4 +1,4 @@
-import { RGBAFormat, LinearFilter } from '../constants.js';
+import { RGBFormat, LinearFilter } from '../constants.js';
 import { Texture } from './Texture.js';
 
 class VideoTexture extends Texture {
@@ -7,7 +7,7 @@ class VideoTexture extends Texture {
 
 		super( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
 
-		this.format = format !== undefined ? format : RGBAFormat;
+		this.format = format !== undefined ? format : RGBFormat;
 
 		this.minFilter = minFilter !== undefined ? minFilter : LinearFilter;
 		this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;


### PR DESCRIPTION
There's an issue with Firefox desktop that causes RGBFormat on a video texture to destroy performance.  When testing with a single 4K 360 video, frame times on Firefox with RGBFormat were ~200x RGBAFormat.  (62ms vs .32ms)  

I propose defaulting to RGBAFormat to avoid this.
