### PR TITLE
USDZExporter: Support transparency

### DIFF
--- a/examples/js/exporters/USDZExporter.js
+++ b/examples/js/exporters/USDZExporter.js
@@ -320,6 +320,7 @@ ${array.join( '' )}
 
 		}
 
+		parameters.push( `${pad}float inputs:opacity = ${material.opacity}` );
 		return `
     def Material "Material_${material.id}"
     {

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -338,6 +338,8 @@ function buildMaterial( material ) {
 
 	}
 
+	parameters.push( `${ pad }float inputs:opacity = ${ material.opacity }` );
+
 	return `
     def Material "Material_${ material.id }"
     {


### PR DESCRIPTION
Fixed #21594

Transparency parameter is [supported by USDZ format](https://graphics.pixar.com/usd/docs/UsdPreviewSurface-Proposal.html#UsdPreviewSurfaceProposal-addOpacityThreshold).

Tested with Mac and iOS AR QuickLook, works!
