### PR TITLE
fixed some triangles not being found in Octree due to small floating point inaccuracies

### DIFF
--- a/examples/js/math/Octree.js
+++ b/examples/js/math/Octree.js
@@ -14,6 +14,8 @@
 
 	const _capsule = new THREE.Capsule();
 
+	const epsilon = new THREE.Vector3( 0.01, 0.01, 0.01 );
+
 	class Octree {
 
 		constructor( box ) {
@@ -66,8 +68,8 @@
 
 						const v = _v1.set( x, y, z );
 
-						box.min.copy( this.box.min ).add( v.multiply( halfsize ) );
-						box.max.copy( box.min ).add( halfsize );
+						box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( epsilon );
+						box.max.copy( box.min ).add( halfsize ).addScaledVector( epsilon, 2 );
 						subTrees.push( new Octree( box ) );
 
 					}

--- a/examples/js/math/Octree.js
+++ b/examples/js/math/Octree.js
@@ -14,7 +14,7 @@
 
 	const _capsule = new THREE.Capsule();
 
-	const epsilon = new THREE.Vector3( 0.01, 0.01, 0.01 );
+	const _epsilon = new THREE.Vector3( 0.01, 0.01, 0.01 );
 
 	class Octree {
 
@@ -68,8 +68,8 @@
 
 						const v = _v1.set( x, y, z );
 
-						box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( epsilon );
-						box.max.copy( box.min ).add( halfsize ).addScaledVector( epsilon, 2 );
+						box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( _epsilon );
+						box.max.copy( box.min ).add( halfsize ).addScaledVector( _epsilon, 2 );
 						subTrees.push( new Octree( box ) );
 
 					}

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -16,7 +16,7 @@ const _line1 = new Line3();
 const _line2 = new Line3();
 const _sphere = new Sphere();
 const _capsule = new Capsule();
-const epsilon = new Vector3( 0.01, 0.01, 0.01 );
+const _epsilon = new Vector3( 0.01, 0.01, 0.01 );
 
 class Octree {
 
@@ -75,8 +75,8 @@ class Octree {
 					const box = new Box3();
 					const v = _v1.set( x, y, z );
 
-					box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( epsilon );
-					box.max.copy( box.min ).add( halfsize ).addScaledVector( epsilon, 2 );
+					box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( _epsilon );
+					box.max.copy( box.min ).add( halfsize ).addScaledVector( _epsilon, 2 );
 
 					subTrees.push( new Octree( box ) );
 

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -16,6 +16,7 @@ const _line1 = new Line3();
 const _line2 = new Line3();
 const _sphere = new Sphere();
 const _capsule = new Capsule();
+const epsilon = new Vector3( 0.01, 0.01, 0.01 );
 
 class Octree {
 
@@ -74,8 +75,8 @@ class Octree {
 					const box = new Box3();
 					const v = _v1.set( x, y, z );
 
-					box.min.copy( this.box.min ).add( v.multiply( halfsize ) );
-					box.max.copy( box.min ).add( halfsize );
+					box.min.copy( this.box.min ).add( v.multiply( halfsize ) ).sub( epsilon );
+					box.max.copy( box.min ).add( halfsize ).addScaledVector( epsilon, 2 );
 
 					subTrees.push( new Octree( box ) );
 


### PR DESCRIPTION
Fixed: #21755 
Due to small floating point inaccuracies in the order of one millionth of a millimeter, in practice some triangles would not be found for some of the subtrees. This could result moving through faces of Axis Aligned 3d objects. To fix this, make each subtree slightly larger to make sure that all relevant triangles are found.