### PR TITLE
LineSegments2: Fix typo in raycast

### DIFF
--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -178,8 +178,8 @@
 
 				_end4.fromBufferAttribute( instanceEnd, i );
 
-				_start.w = 1;
-				_end.w = 1; // camera space
+				_start4.w = 1;
+				_end4.w = 1; // camera space
 
 				_start4.applyMatrix4( _mvMatrix );
 

--- a/examples/js/lines/LineSegments2.js
+++ b/examples/js/lines/LineSegments2.js
@@ -178,8 +178,8 @@
 
 				_end4.fromBufferAttribute( instanceEnd, i );
 
-				_start4.w = 1;
-				_end4.w = 1; // camera space
+				_start.w = 1;
+				_end.w = 1; // camera space
 
 				_start4.applyMatrix4( _mvMatrix );
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -184,8 +184,8 @@ class LineSegments2 extends Mesh {
 			_start4.fromBufferAttribute( instanceStart, i );
 			_end4.fromBufferAttribute( instanceEnd, i );
 
-			_start.w = 1;
-			_end.w = 1;
+			_start4.w = 1;
+			_end4.w = 1;
 
 			// camera space
 			_start4.applyMatrix4( _mvMatrix );


### PR DESCRIPTION
**Description**

Raycast code for `LineSegment2` was broken in my project when updating to r128. Taking a look it seems like there was a mix-up between `_start` and `_start4` as well as `_end` and `_end4`.

The following commit should fix the bug and raycasting with `LineSegment2` should work again! 