### PR TITLE
MD2Loader: Clear previous frame's name.

### DIFF
--- a/examples/jsm/loaders/MD2Loader.js
+++ b/examples/jsm/loaders/MD2Loader.js
@@ -218,7 +218,6 @@ class MD2Loader extends Loader {
 
 		const translation = new Vector3();
 		const scale = new Vector3();
-		const string = [];
 
 		const frames = [];
 
@@ -239,6 +238,8 @@ class MD2Loader extends Loader {
 			);
 
 			offset += 24;
+			
+			const string = [];
 
 			for ( let j = 0; j < 16; j ++ ) {
 


### PR DESCRIPTION
Previous frames' names are not cleared resulting in frame names like:
stand40
stand41
run1d41
run2d41
