### PR TITLE
Move onUploadCallback back to prototype scope

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -29,9 +29,9 @@ class BufferAttribute {
 
 		this.version = 0;
 
-		this.onUploadCallback = function () {};
-
 	}
+
+	onUploadCallback() {}
 
 	set needsUpdate( value ) {
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -16,9 +16,9 @@ class InterleavedBuffer {
 
 		this.uuid = MathUtils.generateUUID();
 
-		this.onUploadCallback = function () {};
-
 	}
+
+	onUploadCallback() {}
 
 	set needsUpdate( value ) {
 


### PR DESCRIPTION
Fixed #21769

**Description**

As suggested in linked issue this PR moves back `onUploadCallback` to the prototype scope in `BufferAttribute` and `InterleavedBuffer`. Tests executed locally are ok with the change.
