### PR TITLE
WebGLRenderer: Allow overrideMaterial to be changed on a per-object b…

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1264,15 +1264,13 @@ function WebGLRenderer( parameters ) {
 
 	function renderObjects( renderList, scene, camera ) {
 
-		const overrideMaterial = scene.isScene === true ? scene.overrideMaterial : null;
-
 		for ( let i = 0, l = renderList.length; i < l; i ++ ) {
 
 			const renderItem = renderList[ i ];
 
 			const object = renderItem.object;
 			const geometry = renderItem.geometry;
-			const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
+			const material = renderItem.material;
 			const group = renderItem.group;
 
 			if ( camera.isArrayCamera ) {
@@ -1308,6 +1306,12 @@ function WebGLRenderer( parameters ) {
 	function renderObject( object, scene, camera, geometry, material, group ) {
 
 		object.onBeforeRender( _this, scene, camera, geometry, material, group );
+
+		if ( scene.isScene === true && scene.overrideMaterial !== null ) {
+
+			material = scene.overrideMaterial;
+
+		}
 
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );


### PR DESCRIPTION
**Description**

Right now when rendering a scene its override material will only be read once at the start of `renderObjects()`, which means that it cannot be changed e.g. in `onBeforeRender()` on a per-render-object basis. But for our G-buffer implementation we wanted to be able to pick an override material based on mesh/material variables like `morphTargets`/`morphNormals` or `skinning` which would be a bit expensive to enable for all render objects.

This patch moves the override material logic into the `renderObject()` method, after the call to `onBeforeRender()`, which faciliated us to do this. As a side effect onBeforeRender() now receives the original mesh material as parameter instead of the override material, which is desirable in my opinion.
