### PR TITLE
InstancedInterleavedBuffer: Fix incorrect clone result

### DIFF
--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -90,7 +90,7 @@ class InterleavedBuffer {
 
 		const array = new this.array.constructor( data.arrayBuffers[ this.array.buffer._uuid ] );
 
-		const ib = new InterleavedBuffer( array, this.stride );
+		const ib = new this.constructor( array, this.stride );
 		ib.setUsage( this.usage );
 
 		return ib;


### PR DESCRIPTION
Related issue: --

**Description**

When calling `InstancedInterleavedBuffer.clone()` an `InterleavedBuffer` was returned:

```js
instanceBuffer = new THREE.InstancedInterleavedBuffer( new Float32Array( [ 1, 2, 3 ] ), 3, 1 );
a = new THREE.InstancedBufferGeometry()
a.setAttribute( 'test', new THREE.InterleavedBufferAttribute( instanceBuffer, 3, 0 ) );

b = a.clone()

console.log( a.attributes.test.data.isInstancedInterleavedBuffer, b.attributes.test.data.isInstancedInterleavedBuffer );

// BEFORE: true, undefined
// AFTER: true, true
```