### PR TITLE
LineGeometry: Remove "copy" function override

### DIFF
--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -80,14 +80,6 @@ class LineGeometry extends LineSegmentsGeometry {
 
 	}
 
-	copy( /* source */ ) {
-
-		// todo
-
-		return this;
-
-	}
-
 }
 
 LineGeometry.prototype.isLineGeometry = true;


### PR DESCRIPTION
Related issue: --

**Description**

Removes the unimplemented `LineGeometry.copy` override which prevented the function from working. Related to #21781.

cc @WestLangley is there a reason you expected this to require a custom implementation?

