### PR TITLE
NodeMaterial: Add RemapNode.

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -71,6 +71,7 @@ export { BumpMapNode } from './misc/BumpMapNode.js';
 export { BypassNode } from './utils/BypassNode.js';
 export { JoinNode } from './utils/JoinNode.js';
 export { SwitchNode } from './utils/SwitchNode.js';
+export { RemapNode } from './utils/RemapNode.js';
 export { TimerNode } from './utils/TimerNode.js';
 export { VelocityNode } from './utils/VelocityNode.js';
 export { UVTransformNode } from './utils/UVTransformNode.js';

--- a/examples/jsm/nodes/utils/RemapNode.js
+++ b/examples/jsm/nodes/utils/RemapNode.js
@@ -1,0 +1,153 @@
+import { TempNode } from '../core/TempNode.js';
+import { FunctionNode } from '../core/FunctionNode.js';
+
+const REMAP_SRC = `
+float remap( float value, float inLow, float inHigh, float outLow, float outHigh ) {
+
+	float x = ( value - inLow ) / ( inHigh - inLow );
+	return outLow + ( outHigh - outLow ) * x;
+
+}
+
+vec2 remap( vec2 value, vec2 inLow, vec2 inHigh, vec2 outLow, vec2 outHigh ) {
+
+	return vec2(
+		remap( value.x, inLow.x, inHigh.x, outLow.x, outHigh.x ),
+		remap( value.y, inLow.y, inHigh.y, outLow.y, outHigh.y )
+	);
+
+}
+
+vec2 remap( vec2 value, float inLow, float inHigh, float outLow, float outHigh ) {
+
+	return vec2(
+		remap( value.x, inLow, inHigh, outLow, outHigh ),
+		remap( value.y, inLow, inHigh, outLow, outHigh )
+	);
+
+}
+
+vec3 remap( vec3 value, vec3 inLow, vec3 inHigh, vec3 outLow, vec3 outHigh ) {
+
+	return vec3(
+		remap( value.x, inLow.x, inHigh.x, outLow.x, outHigh.x ),
+		remap( value.y, inLow.y, inHigh.y, outLow.y, outHigh.y ),
+		remap( value.z, inLow.z, inHigh.z, outLow.z, outHigh.z )
+	);
+
+}
+
+vec3 remap( vec3 value, float inLow, float inHigh, float outLow, float outHigh ) {
+
+	return vec3(
+		remap( value.x, inLow, inHigh, outLow, outHigh ),
+		remap( value.y, inLow, inHigh, outLow, outHigh ),
+		remap( value.z, inLow, inHigh, outLow, outHigh )
+	);
+
+}
+
+vec4 remap( vec4 value, vec4 inLow, vec4 inHigh, vec4 outLow, vec4 outHigh ) {
+
+	return vec4(
+		remap( value.x, inLow.x, inHigh.x, outLow.x, outHigh.x ),
+		remap( value.y, inLow.y, inHigh.y, outLow.y, outHigh.y ),
+		remap( value.z, inLow.z, inHigh.z, outLow.z, outHigh.z ),
+		remap( value.w, inLow.w, inHigh.w, outLow.w, outHigh.w )
+	);
+
+}
+
+vec4 remap( vec4 value, float inLow, float inHigh, float outLow, float outHigh ) {
+
+	return vec4(
+		remap( value.x, inLow, inHigh, outLow, outHigh ),
+		remap( value.y, inLow, inHigh, outLow, outHigh ),
+		remap( value.z, inLow, inHigh, outLow, outHigh ),
+		remap( value.w, inLow, inHigh, outLow, outHigh )
+	);
+
+}
+`.trim();
+
+function RemapNode( value, inLow, inHigh, outLow, outHigh ) {
+
+	TempNode.call( this, 'f' );
+
+	this.value = value;
+	this.inLow = inLow;
+	this.inHigh = inHigh;
+	this.outLow = outLow;
+	this.outHigh = outHigh;
+
+}
+
+RemapNode.prototype = Object.create( TempNode.prototype );
+RemapNode.prototype.constructor = RemapNode;
+RemapNode.prototype.nodeType = 'Remap';
+
+RemapNode.Nodes = (function () {
+
+	return {
+
+		remap: new FunctionNode( REMAP_SRC )
+
+	};
+
+})();
+
+RemapNode.prototype.generate = function (builder, output) {
+
+	const remap = builder.include( RemapNode.Nodes.remap );
+
+	return builder.format( remap + '( ' + [
+
+		this.value.build( builder ),
+		this.inLow.build( builder ),
+		this.inHigh.build( builder ),
+		this.outLow.build( builder ),
+		this.outHigh.build( builder ),
+
+	].join( ', ' ) + ' )', this.getType( builder ), output );
+
+};
+
+RemapNode.prototype.getType = function ( builder ) {
+
+	return this.value.getType( builder );
+
+};
+
+RemapNode.prototype.copy = function ( source ) {
+
+	TempNode.prototype.copy.call( this, source );
+
+	this.value = source.value;
+	this.inLow = source.inLow;
+	this.inHigh = source.inHigh;
+	this.outLow = source.outLow;
+	this.outHigh = source.outHigh;
+
+};
+
+RemapNode.prototype.toJSON = function ( meta ) {
+
+	const data = this.getJSONNode( meta );
+
+	if ( ! data ) {
+
+		data = this.createJSONNode( meta );
+
+		data.value = this.value.toJSON( meta ).uuid;
+		data.inLow = this.inLow.toJSON( meta ).uuid;
+		data.inHigh = this.inHigh.toJSON( meta ).uuid;
+		data.outLow = this.outLow.toJSON( meta ).uuid;
+		data.outHigh = this.outHigh.toJSON( meta ).uuid;
+
+	}
+
+	return data;
+
+};
+
+export { RemapNode };


### PR DESCRIPTION
Related issues: https://github.com/mrdoob/three.js/issues/20541, https://github.com/mrdoob/three.js/issues/15666

**RemapNode:**  Linearly remap incoming values from one range of float/color/vector values to another.

Based on [MaterialX OSL implementation (Apache 2.0)](https://github.com/materialx/MaterialX/blob/4ca33a1b7033106d9c7f3cb378267867b60e1bd8/libraries/stdlib/osl/mx_funcs.h#L137-L147). Omits the `doClamp` option, which doesn't appear to be required by the MaterialX specification. Presumably there's a clever way to generate the appropriate overloads without hard-coding them all, but I wasn't sure how to go about that.

/cc @sunag