### PR TITLE
LineMaterial: Automatically adjust the USE_DASH define when setting "dashed"

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -284,8 +284,6 @@ class LineMaterial extends ShaderMaterial {
 
 		} );
 
-		this.dashed = false;
-
 		Object.defineProperties( this, {
 
 			color: {
@@ -319,6 +317,38 @@ class LineMaterial extends ShaderMaterial {
 				set: function ( value ) {
 
 					this.uniforms.linewidth.value = value;
+
+				}
+
+			},
+
+			dashed: {
+
+				enumerable: true,
+
+				get: function () {
+
+					return Boolean( 'USE_DASH' in this.defines );
+
+				},
+
+				set( value ) {
+
+					if ( Boolean( value ) !== Boolean( 'USE_DASH' in this.defines ) ) {
+
+						this.needsUpdate = true;
+
+					}
+
+					if ( value ) {
+
+						this.defines.USE_DASH = '';
+
+					} else {
+
+						delete this.defines.USE_DASH;
+
+					}
 
 				}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -340,7 +340,7 @@ class LineMaterial extends ShaderMaterial {
 
 					}
 
-					if ( value ) {
+					if ( value === true ) {
 
 						this.defines.USE_DASH = '';
 
@@ -480,7 +480,7 @@ class LineMaterial extends ShaderMaterial {
 
 					}
 
-					if ( value ) {
+					if ( value === true ) {
 
 						this.defines.ALPHA_TO_COVERAGE = '';
 						this.extensions.derivatives = true;

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -242,13 +242,6 @@
 				gui.add( param, 'dashed' ).onChange( function ( val ) {
 
 					matLine.dashed = val;
-
-					// dashed is implemented as a defines -- not as a uniform. this could be changed.
-					// ... or THREE.LineDashedMaterial could be implemented as a separate material
-					// temporary hack - renderer should do this eventually
-					if ( val ) matLine.defines.USE_DASH = ""; else delete matLine.defines.USE_DASH;
-					matLine.needsUpdate = true;
-
 					line1.material = val ? matLineDashed : matLineBasic;
 
 				} );


### PR DESCRIPTION
Related issue: --

**Description**

Adjust the `LineMaterial.dashed` field behavior to automatically change the material `USE_DASH` define and set `needsUpdate` to true. I found it confusing when using this that adjusting `dashed` seemed to do nothing (and from looking at the code it wasn't being used at all).

Live demo here:

https://raw.githack.com/gkjohnson/three.js/improve-dash-field/examples/webgl_lines_fat.html

cc @WestLangley 