### PR TITLE
UniformsLib: default color uniforms to white

### DIFF
--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -10,7 +10,7 @@ const UniformsLib = {
 
 	common: {
 
-		diffuse: { value: new Color( 0xeeeeee ) },
+		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
 
 		map: { value: null },
@@ -187,7 +187,7 @@ const UniformsLib = {
 
 	points: {
 
-		diffuse: { value: new Color( 0xeeeeee ) },
+		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
 		size: { value: 1.0 },
 		scale: { value: 1.0 },
@@ -199,7 +199,7 @@ const UniformsLib = {
 
 	sprite: {
 
-		diffuse: { value: new Color( 0xeeeeee ) },
+		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
 		center: { value: new Vector2( 0.5, 0.5 ) },
 		rotation: { value: 0.0 },


### PR DESCRIPTION
Related issue: --

**Description**

Perhaps there's a reason for this but if so it wasn't clear to me. The three "diffuse" color uniforms were defaulting to `0xeeeeee` rather than white as I expected, at least. This isn't an issue with any of the built in materials because they all seem to explicitly set their initial value to `0xffffff`. `examples/jsm/lines/LineMaterial` does not, though, and uses the set of "line" uniforms from "UniformsLib" meaning the color is defaulting to the _slightly_ off white color.