### PR TITLE
Docs: Add page for WebGLMultipleRenderTargets.

### DIFF
--- a/docs/api/en/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/en/renderers/WebGLMultipleRenderTargets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />
@@ -12,34 +12,35 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A special render target that can be used to utilize multi-sampled renderbuffers.
+			A special render target that enables a fragment shader to write to several textures.
+			This approach is useful for advanced rendering techniques like post-processing or deferred rendering.
+
 			Heads up: [name] can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl2_multisampled_renderbuffers webgl2 / multisampled / renderbuffers ]
+			[example:webgl2_multiple_rendertargets webgl2 / multiple / rendertargets ]
 		</p>
 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
+		<h3>[name]([param:Number width], [param:Number height], [param:Number count])</h3>
 
 		<p>
-		[page:Float width] - The width of the render target. <br />
-		[page:Float height] - The height of the render target.<br />
-		[page:Object options] - (optional) object that holds texture parameters for an auto-generated target
-		texture and depthBuffer/stencilBuffer booleans.
+		[page:Number width] - The width of the render target. <br />
+		[page:Number height] - The height of the render target.<br />
+		[page:Number count] - The number of render targets.
 		</p>
 
 		<h2>Properties</h2>
 
-		<h3>[property:number samples]</h3>
+		<h3>[property:Array texture]</h3>
 		<p>
-		Specifies the number of samples to be used for the renderbuffer storage. However, the maximum supported
-		size for multisampling is platform dependent and defined via *gl.MAX_SAMPLES*.
+		The texture property is overwritten in [name] and replaced with an array. This array holds the [page:WebGLRenderTarget.texture texture]
+		references of the respective render targets.
 		</p>
 
 		<p>[page:WebGLRenderTarget WebGLRenderTarget] properties are available on this class.</p>

--- a/docs/api/en/renderers/WebGLMultisampleRenderTarget.html
+++ b/docs/api/en/renderers/WebGLMultisampleRenderTarget.html
@@ -7,6 +7,8 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
+		[page:WebGLRenderTarget] &rarr;
+
 		<h1>[name]</h1>
 
 		<p class="desc">
@@ -14,6 +16,11 @@
 			Heads up: [name] can only be used with a WebGL 2 rendering context.
 		</p>
 
+		<h2>Examples</h2>
+
+		<p>
+			[example:webgl2_multisampled_renderbuffers webgl2 / multisampled / renderbuffers ]
+		</p>
 
 		<h2>Constructor</h2>
 

--- a/docs/api/zh/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/zh/renderers/WebGLMultipleRenderTargets.html
@@ -12,34 +12,35 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A special render target that can be used to utilize multi-sampled renderbuffers.
+			A special render target that enables a fragment shader to write to several textures.
+			This approach is useful for advanced rendering techniques like post-processing or deferred rendering.
+
 			Heads up: [name] can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl2_multisampled_renderbuffers webgl2 / multisampled / renderbuffers ]
+			[example:webgl2_multiple_rendertargets webgl2 / multiple / rendertargets ]
 		</p>
 
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
+		<h3>[name]([param:Number width], [param:Number height], [param:Number count])</h3>
 
 		<p>
-		[page:Float width] - The width of the render target. <br />
-		[page:Float height] - The height of the render target.<br />
-		[page:Object options] - (optional) object that holds texture parameters for an auto-generated target
-		texture and depthBuffer/stencilBuffer booleans.
+		[page:Number width] - The width of the render target. <br />
+		[page:Number height] - The height of the render target.<br />
+		[page:Number count] - The number of render targets.
 		</p>
 
 		<h2>Properties</h2>
 
-		<h3>[property:number samples]</h3>
+		<h3>[property:Array texture]</h3>
 		<p>
-		Specifies the number of samples to be used for the renderbuffer storage. However, the maximum supported
-		size for multisampling is platform dependent and defined via *gl.MAX_SAMPLES*.
+		The texture property is overwritten in [name] and replaced with an array. This array holds the [page:WebGLRenderTarget.texture texture]
+		references of the respective render targets.
 		</p>
 
 		<p>[page:WebGLRenderTarget WebGLRenderTarget] properties are available on this class.</p>

--- a/docs/list.json
+++ b/docs/list.json
@@ -290,6 +290,7 @@
 			},
 
 			"Renderers": {
+				"WebGLMultipleRenderTargets": "api/en/renderers/WebGLMultipleRenderTargets",
 				"WebGLMultisampleRenderTarget": "api/en/renderers/WebGLMultisampleRenderTarget",
 				"WebGLRenderer": "api/en/renderers/WebGLRenderer",
 				"WebGL1Renderer": "api/en/renderers/WebGL1Renderer",
@@ -799,6 +800,7 @@
 			},
 
 			"渲染器": {
+				"WebGLMultipleRenderTargets": "api/zh/renderers/WebGLMultipleRenderTargets",
 				"WebGLMultisampleRenderTarget": "api/zh/renderers/WebGLMultisampleRenderTarget",
 				"WebGLRenderer": "api/zh/renderers/WebGLRenderer",
 				"WebGL1Renderer": "api/zh/renderers/WebGL1Renderer",


### PR DESCRIPTION
Related issue: #16390

**Description**

Adds the doc page for `WebGLMultipleRenderTargets`.
