### PR TITLE
Editor:  MoveObjectCommand should dispatch 'added' event

### DIFF
--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -49,6 +49,7 @@ class MoveObjectCommand extends Command {
 		children.splice( this.newIndex, 0, this.object );
 		this.object.parent = this.newParent;
 
+		this.object.dispatchEvent( { type: 'added' } );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
 	}
@@ -61,6 +62,7 @@ class MoveObjectCommand extends Command {
 		children.splice( this.oldIndex, 0, this.object );
 		this.object.parent = this.oldParent;
 
+		this.object.dispatchEvent( { type: 'added' } );
 		this.editor.signals.sceneGraphChanged.dispatch();
 
 	}


### PR DESCRIPTION
Changing the parent of an object by moving it in the scene hierarchy in the Editor works by calling `parent.remove(child)` and splicing in the child manually to respect the insertion point. Calling `.add()` instead would push the child at the end of the children array. However, without a call to `.add()` there is no dispatch for the `added` event and only a `removed` event is triggered.

This PR adds a dispatch for the `added` event so both events are triggered.