### PR TITLE
Add 'getControllers' method to WebXRManager

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -52,6 +52,10 @@ class WebXRManager extends EventDispatcher {
 
 		this.isPresenting = false;
 
+		this.getControllers = function () {
+			return controllers
+		}
+
 		this.getController = function ( index ) {
 
 			let controller = controllers[ index ];


### PR DESCRIPTION
Allow direct access to the 'controllers' array / WebXRController instances.