### PR TITLE
GLTFLoader: Ignore redundant 'KHR_texture_transform' extensions and 'textures' entries.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1115,6 +1115,19 @@ class GLTFTextureTransformExtension {
 
 	extendTexture( texture, transform ) {
 
+		if ( transform.texCoord !== undefined ) {
+
+			console.warn( 'THREE.GLTFLoader: Custom UV sets in "' + this.name + '" extension not yet supported.' );
+
+		}
+
+		if ( transform.offset === undefined && transform.rotation === undefined && transform.scale === undefined ) {
+
+			// See https://github.com/mrdoob/three.js/issues/21819.
+			return texture;
+
+		}
+
 		texture = texture.clone();
 
 		if ( transform.offset !== undefined ) {
@@ -1132,12 +1145,6 @@ class GLTFTextureTransformExtension {
 		if ( transform.scale !== undefined ) {
 
 			texture.repeat.fromArray( transform.scale );
-
-		}
-
-		if ( transform.texCoord !== undefined ) {
-
-			console.warn( 'THREE.GLTFLoader: Custom UV sets in "' + this.name + '" extension not yet supported.' );
 
 		}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2538,7 +2538,7 @@ class GLTFParser {
 
 		const textureDef = json.textures[ textureIndex ];
 
-		const cacheKey = textureDef.source  + ':' + textureDef.sampler;
+		const cacheKey = ( source.uri || source.bufferView ) + ':' + textureDef.sampler;
 
 		if ( this.textureCache[ cacheKey ] ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1972,6 +1972,8 @@ class GLTFParser {
 		this.cameraCache = { refs: {}, uses: {} };
 		this.lightCache = { refs: {}, uses: {} };
 
+		this.textureCache = {};
+
 		// Track node names, to ensure no duplicates
 		this.nodeNamesUsed = {};
 
@@ -2536,6 +2538,15 @@ class GLTFParser {
 
 		const textureDef = json.textures[ textureIndex ];
 
+		const cacheKey = textureDef.source  + ':' + textureDef.sampler;
+
+		if ( this.textureCache[ cacheKey ] ) {
+
+			// See https://github.com/mrdoob/three.js/issues/21559.
+			return this.textureCache[ cacheKey ];
+
+		}
+
 		const URL = self.URL || self.webkitURL;
 
 		let sourceURI = source.uri;
@@ -2576,7 +2587,7 @@ class GLTFParser {
 
 		}
 
-		return Promise.resolve( sourceURI ).then( function ( sourceURI ) {
+		const promise = Promise.resolve( sourceURI ).then( function ( sourceURI ) {
 
 			return new Promise( function ( resolve, reject ) {
 
@@ -2629,6 +2640,10 @@ class GLTFParser {
 			return texture;
 
 		} );
+
+		this.textureCache[ cacheKey ] = promise;
+
+		return promise;
 
 	}
 


### PR DESCRIPTION
Fixes #21819. Fixes #21559.