### PR TITLE
Matrix4: generalize .makeShear() method

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -317,18 +317,21 @@ x, 0, 0, 0,
 			</code>
 		</p>
 
-		<h3>[method:this makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeShear]( [param:Float xy], [param:Float xz], [param:Float yx], [param:Float yz], [param:Float zx], [param:Float zy] )</h3>
 		<p>
-		[page:Float x] - the amount to shear in the X axis.<br />
-		[page:Float y] - the amount to shear in the Y axis.<br />
-		[page:Float z] - the amount to shear in the Z axis.<br /><br />
+			[page:Float x] - the amount to shear X by Y.<br />
+			[page:Float x] - the amount to shear X by Z.<br />
+			[page:Float x] - the amount to shear Y by X.<br />
+			[page:Float x] - the amount to shear Y by Z.<br />
+			[page:Float y] - the amount to shear Z by X.<br />
+			[page:Float z] - the amount to shear Z by Y.<br /><br />
 
 		Sets this matrix as a shear transform:
 <code>
-1, y, z, 0,
-x, 1, z, 0,
-x, y, 1, 0,
-0, 0, 0, 1
+1,   yx,  zx,  0,
+xy,   1,  zy,  0,
+xz,  yz,   1,  0,
+0,    0,   0,  1
 </code>
 		</p>
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -677,10 +677,10 @@ class Matrix4 {
 
 		this.set(
 
-			1,   yx,  zx,  0,
-			xy,   1,  zy,  0,
-			xz,  yz,   1,  0,
-			0,    0,   0,  1
+			1, yx, zx, 0,
+			xy, 1, zy, 0,
+			xz, yz, 1, 0,
+			0, 0, 0, 1
 
 		);
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -673,14 +673,14 @@ class Matrix4 {
 
 	}
 
-	makeShear( x, y, z ) {
+	makeShear( xy, xz, yx, yz, zx, zy ) {
 
 		this.set(
 
-			1, y, z, 0,
-			x, 1, z, 0,
-			x, y, 1, 0,
-			0, 0, 0, 1
+			1,   yx,  zx,  0,
+			xy,   1,  zy,  0,
+			xz,  yz,   1,  0,
+			0,    0,   0,  1
 
 		);
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -621,9 +621,9 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( "makeShear", ( assert ) => {
 
 			var a = new Matrix4();
-			var c = new Matrix4().set( 1, 3, 4, 0, 2, 1, 4, 0, 2, 3, 1, 0, 0, 0, 0, 1 );
+			var c = new Matrix4().set( 1, 3, 5, 0, 1, 1, 6, 0, 2, 4, 1, 0, 0, 0, 0, 1 );
 
-			a.makeShear( 2, 3, 4 );
+			a.makeShear( 1, 2, 3, 4, 5, 6 );
 			assert.ok( matrixEquals4( a, c ), "Passed!" );
 
 		} );


### PR DESCRIPTION
The current `.makeShear()` method is too restrictive to be useful.

Even the most trivial shear matrix
```
1,   0.5,  0,   1
0,   1,    0,   1
0,   0,    1,   1
0,   0,    0,   1
```
is not supported.

This PR supports a generalized shear matrix.