### PR TITLE
Octree: Fix and optimize fromGraphNode().

### DIFF
--- a/examples/js/math/Octree.js
+++ b/examples/js/math/Octree.js
@@ -411,19 +411,18 @@
 
 		fromGraphNode( group ) {
 
+			group.updateWorldMatrix( true, true );
 			group.traverse( obj => {
 
-				if ( obj.type === 'Mesh' ) {
+				if ( obj.isMesh === true ) {
 
-					obj.updateMatrix();
-					obj.updateWorldMatrix();
 					let geometry,
 						isTemp = false;
 
-					if ( obj.geometry.index ) {
+					if ( obj.geometry.index !== null ) {
 
 						isTemp = true;
-						geometry = obj.geometry.clone().toNonIndexed();
+						geometry = obj.geometry.toNonIndexed();
 
 					} else {
 
@@ -431,17 +430,16 @@
 
 					}
 
-					const positions = geometry.attributes.position.array;
-					const transform = obj.matrixWorld;
+					const positionAttribute = geometry.getAttribute( 'position' );
 
-					for ( let i = 0; i < positions.length; i += 9 ) {
+					for ( let i = 0; i < positionAttribute.count; i += 3 ) {
 
-						const v1 = new THREE.Vector3( positions[ i ], positions[ i + 1 ], positions[ i + 2 ] );
-						const v2 = new THREE.Vector3( positions[ i + 3 ], positions[ i + 4 ], positions[ i + 5 ] );
-						const v3 = new THREE.Vector3( positions[ i + 6 ], positions[ i + 7 ], positions[ i + 8 ] );
-						v1.applyMatrix4( transform );
-						v2.applyMatrix4( transform );
-						v3.applyMatrix4( transform );
+						const v1 = new THREE.Vector3().fromBufferAttribute( positionAttribute, i );
+						const v2 = new THREE.Vector3().fromBufferAttribute( positionAttribute, i + 1 );
+						const v3 = new THREE.Vector3().fromBufferAttribute( positionAttribute, i + 2 );
+						v1.applyMatrix4( obj.matrixWorld );
+						v2.applyMatrix4( obj.matrixWorld );
+						v3.applyMatrix4( obj.matrixWorld );
 						this.addTriangle( new THREE.Triangle( v1, v2, v3 ) );
 
 					}

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -406,19 +406,18 @@ class Octree {
 
 	fromGraphNode( group ) {
 
+		group.updateWorldMatrix( true, true );
+
 		group.traverse( ( obj ) => {
 
-			if ( obj.type === 'Mesh' ) {
-
-				obj.updateMatrix();
-				obj.updateWorldMatrix();
+			if ( obj.isMesh === true ) {
 
 				let geometry, isTemp = false;
 
-				if ( obj.geometry.index ) {
+				if ( obj.geometry.index !== null ) {
 
 					isTemp = true;
-					geometry = obj.geometry.clone().toNonIndexed();
+					geometry = obj.geometry.toNonIndexed();
 
 				} else {
 
@@ -426,18 +425,17 @@ class Octree {
 
 				}
 
-				const positions = geometry.attributes.position.array;
-				const transform = obj.matrixWorld;
+				const positionAttribute = geometry.getAttribute( 'position' );
 
-				for ( let i = 0; i < positions.length; i += 9 ) {
+				for ( let i = 0; i < positionAttribute.count; i += 3 ) {
 
-					const v1 = new Vector3( positions[ i ], positions[ i + 1 ], positions[ i + 2 ] );
-					const v2 = new Vector3( positions[ i + 3 ], positions[ i + 4 ], positions[ i + 5 ] );
-					const v3 = new Vector3( positions[ i + 6 ], positions[ i + 7 ], positions[ i + 8 ] );
+					const v1 = new Vector3().fromBufferAttribute( positionAttribute, i );
+					const v2 = new Vector3().fromBufferAttribute( positionAttribute, i + 1 );
+					const v3 = new Vector3().fromBufferAttribute( positionAttribute, i + 2 );
 
-					v1.applyMatrix4( transform );
-					v2.applyMatrix4( transform );
-					v3.applyMatrix4( transform );
+					v1.applyMatrix4( obj.matrixWorld );
+					v2.applyMatrix4( obj.matrixWorld );
+					v3.applyMatrix4( obj.matrixWorld );
 
 					this.addTriangle( new Triangle( v1, v2, v3 ) );
 


### PR DESCRIPTION
Related issue: Fixed #21439.

**Description**

`Octree.fromGraphNode()` has several issues right now. It does not compute the world matrices of 3D object correctly and also performs too many redundant computations. Besides, geometries are cloned before `toNonIndexed()` is used although this is not necessary (since the method already creates a new geometry). And `fromGraphNode()` directly accesses the `array` property of buffer attributes which should never be done (since interleaved data are not supported that way). 