### PR TITLE
Respect morph targets in OutlinePass

### DIFF
--- a/examples/js/postprocessing/OutlinePass.js
+++ b/examples/js/postprocessing/OutlinePass.js
@@ -395,7 +395,7 @@
 					#include <project_vertex>
 
 					vPosition = mvPosition;
-					vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+					vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
 					projTexCoord = textureMatrix * worldPosition;
 
 				}`,

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -453,7 +453,7 @@ class OutlinePass extends Pass {
 					#include <project_vertex>
 
 					vPosition = mvPosition;
-					vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+					vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
 					projTexCoord = textureMatrix * worldPosition;
 
 				}`,


### PR DESCRIPTION
Fixed #21790

**Description**

Prior to this pull request, the texture coordinates used to access the depth texture used to make the mask representing occluded vs non-occluded sections of selected objects were constructed using raw model vertex positions. The result of this was that models animated with morph targets would have outlines statically colored based on the positions of the pre-morphed vertices.

This pull request replaces the use of the unmodified vertex positions with the morphed vertex positions. As a result, the outline is correctly colored based on whether the current animated positions are occluded.

Linked examples of before and after (from the linked issue, where there are also static images):
Before: https://jsfiddle.net/Centipede5dev/q9kwpf4L/3
After: https://jsfiddle.net/yd6wo18z/9/