### PR TITLE
Examples: Add package.json indicating jsm examples are modules

### DIFF
--- a/examples/jsm/package.json
+++ b/examples/jsm/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/19575#issuecomment-838834358

**Description**

As @donmccurdy suggested this adds a package.json file in `examples/jsm` to indicate that the contained files are es6 modules so they can be loaded correctly in node. In current master node will try (and fail) to load the `examples/jsm` files as commonjs because "type: module" is not present in the root package.json. Tested by making a test node project with npm and adding the file to the `node_modules/three/examples/jsm` folder.

The true end of an era? Hopefully 🤞 