### PR TITLE
Docs: Improve `MeshPhysicalMaterial` page.

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -82,14 +82,14 @@
 
 		<h3>[property:Float clearcoat]</h3>
 		<p>
-		Represents the thickness of the clear coat layer, from *0.0* to *1.0*. Use clear coat related properties to enable multilayer
+		Represents the intensity of the clear coat layer, from *0.0* to *1.0*. Use clear coat related properties to enable multilayer
 		materials that have a thin translucent layer over the base layer. Default is *0.0*.
 		</p>
 
 		<h3>[property:Texture clearcoatMap]</h3>
 		<p>
 		The red channel of this texture is multiplied against [page:.clearcoat], for per-pixel control
-		over a coating's thickness. Default is *null*.
+		over a coating's intensity. Default is *null*.
 		</p>
 
 		<h3>[property:Texture clearcoatNormalMap]</h3>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -80,14 +80,14 @@
 
 		<h3>[property:Float clearcoat]</h3>
 		<p>
-		Represents the thickness of the clear coat layer, from *0.0* to *1.0*. Use clear coat related properties to enable multilayer
+		Represents the intensity of the clear coat layer, from *0.0* to *1.0*. Use clear coat related properties to enable multilayer
 		materials that have a thin translucent layer over the base layer. Default is *0.0*.
 		</p>
 
 		<h3>[property:Texture clearcoatMap]</h3>
 		<p>
 		The red channel of this texture is multiplied against [page:.clearcoat], for per-pixel control
-		over a coating's thickness. Default is *null*.
+		over a coating's intensity. Default is *null*.
 		</p>
 
 		<h3>[property:Texture clearcoatNormalMap]</h3>


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/commit/d70dd11ac5a901dff34ee9cb0032699cf86fd3f7#r50925111

**Description**

Uses the term `intensity` in the `MeshPhysicalMaterial` page.
