### PR TITLE
USDZExporter: Store only objects with PBR Materials

### DIFF
--- a/examples/js/exporters/USDZExporter.js
+++ b/examples/js/exporters/USDZExporter.js
@@ -13,7 +13,7 @@
 			const textures = {};
 			scene.traverseVisible( object => {
 
-				if ( object.isMesh ) {
+				if ( object.isMesh && object.material.isMeshStandardMaterial ) {
 
 					const geometry = object.geometry;
 					const material = object.material;

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -17,7 +17,7 @@ class USDZExporter {
 
 		scene.traverseVisible( ( object ) => {
 
-			if ( object.isMesh ) {
+			if ( object.isMesh && object.material.isMeshStandardMaterial ) {
 
 				const geometry = object.geometry;
 				const material = object.material;


### PR DESCRIPTION
**Description**

In rare case when material do not have roughness / metallic defined we'll have problems with loading of USDZ. Apple's AR viewer couldn't read such files.
`float inputs:roughness = undefined` - this one prevents whole USDZ loading

As a workaround we could remove undefined fields at all. 
So our material will be loading with some default values.
