### PR TITLE
RectAreaLightHelper: Ignore inherited scale factors

### DIFF
--- a/examples/js/helpers/RectAreaLightHelper.js
+++ b/examples/js/helpers/RectAreaLightHelper.js
@@ -50,9 +50,10 @@
 				if ( max > 1 ) c.multiplyScalar( 1 / max );
 				this.children[ 0 ].material.color.copy( this.material.color );
 
-			}
+			} // ignore world scale on light
 
-			this.matrixWorld.copy( this.light.matrixWorld ).scale( this.scale );
+
+			this.matrixWorld.extractRotation( this.light.matrixWorld ).scale( this.scale ).copyPosition( this.light.matrixWorld );
 			this.children[ 0 ].matrixWorld.copy( this.matrixWorld );
 
 		}

--- a/examples/jsm/helpers/RectAreaLightHelper.js
+++ b/examples/jsm/helpers/RectAreaLightHelper.js
@@ -64,7 +64,9 @@ class RectAreaLightHelper extends Line {
 
 		}
 
-		this.matrixWorld.copy( this.light.matrixWorld ).scale( this.scale );
+		// ignore world scale on light
+		this.matrixWorld.extractRotation( this.light.matrixWorld ).scale( this.scale ).copyPosition( this.light.matrixWorld );
+
 		this.children[ 0 ].matrixWorld.copy( this.matrixWorld );
 
 	}


### PR DESCRIPTION
`RectAreaLights` are sized by `light.width` and `light.height`, and ignore any inherited scaling from the scene graph.

Typically, lights are not scaled, but a light could be a child of a scaled object. 

This PR ensures that `RectAreaLightHelper` ignores inherited scaling, too, and renders the area light in its specified size.
