### PR TITLE
GLTFExporter: Fix value of emissiveFactor.

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1081,7 +1081,7 @@
 			if ( material.emissive ) {
 
 				// emissiveFactor
-				const emissive = material.emissive.clone().multiplyScalar( material.emissiveIntensity ).toArray();
+				const emissive = material.emissive.toArray();
 
 				if ( ! equalArray( emissive, [ 0, 0, 0 ] ) ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1177,7 +1177,7 @@ class GLTFWriter {
 		if ( material.emissive ) {
 
 			// emissiveFactor
-			const emissive = material.emissive.clone().multiplyScalar( material.emissiveIntensity ).toArray();
+			const emissive = material.emissive.toArray();
 
 			if ( ! equalArray( emissive, [ 0, 0, 0 ] ) ) {
 


### PR DESCRIPTION
Related issue: Fixed #21849.

**Description**

Ensures `emissiveFactor` is in the correct range `[0,1]`.
