### PR TITLE
FBXLoader: Configure TGALoader with the correct path.

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -364,6 +364,7 @@
 
 				} else {
 
+					loader.setPath( this.textureLoader.path );
 					texture = loader.load( fileName );
 
 				}

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -431,6 +431,7 @@ class FBXTreeParser {
 
 			} else {
 
+				loader.setPath( this.textureLoader.path );
 				texture = loader.load( fileName );
 
 			}


### PR DESCRIPTION
Related issue: see https://discourse.threejs.org/t/how-to-load-multiple-textures-in-a-model/26445/

**Description**

The instance of `TGALoader` was never configured with the correct resource path in `FBXLoader`.
