### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 		Creates a texture for use with a video texture.<br /><br />
 
-		This is almost the same as the base [page:Texture Texture] class, except that it continuosly sets [page:Texture.needsUpdate needsUpdate] to *true* so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
+		This is almost the same as the base [page:Texture Texture] class, except that it continuously sets [page:Texture.needsUpdate needsUpdate] to *true* so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
 		</p>
 
 		<h2>Code Example</h2>


### PR DESCRIPTION
**Description**

While looking through the docs i found a typo: ```continuosly``` which i corrected to ```continuously```. That's all.

Note: This is actually my second pull request, since i accidentally closed the first one due to my inexperience with github, I apologize for that.
