### PR TITLE
ExtrudeGeometry: Improve Default UV Generator

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -731,7 +731,7 @@ const WorldUVGenerator = {
 		const d_y = vertices[ indexD * 3 + 1 ];
 		const d_z = vertices[ indexD * 3 + 2 ];
 
-		if ( Math.abs( a_y - b_y ) < 0.01 ) {
+		if ( Math.abs( a_y - b_y ) < Math.abs( a_x - b_x ) ) {
 
 			return [
 				new Vector2( a_x, 1 - a_z ),


### PR DESCRIPTION
Related issue: #4994

**Description**

Per the linked issue, some surfaces in extruded geometry would have default generated uv coordinates such that their textures were stretched. This was a result of having two uv mapping schemes—one for surfaces close to vertical, one for surfaces close to horizontal—and using the vertical mapping for all but the most horizontal of surfaces.

This change increases the quality of the default mapping by using the horizontal mapping scheme in more cases. We determine whether to use the vertical scheme or the horizontal scheme by taking the angle between the up vector and a segment in the generated extrusion surface. When the angle is less than 45 degrees, we treat it as mostly vertical; when it is greater, we treat it as mostly horizontal. We then apply the matching scheme.

Borrowing the images that @WestLangley kindly submitted to illustrate the difference, we have the before:

<img width="450" alt="Screen Shot 2021-05-21 at 10 54 30 PM" src="https://user-images.githubusercontent.com/1000017/119223649-96bb1280-bac8-11eb-9cd3-bada8484d1a9.png">

And the after:

<img width="450" alt="Screen Shot 2021-05-21 at 10 54 30 PM" src="https://user-images.githubusercontent.com/1000017/119223683-c0743980-bac8-11eb-906f-9b021ac4c345.png">