### PR TITLE
WebGL: gl.UNSIGNED_BYTE type for Uint8ClampedArray

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -66,6 +66,10 @@ function WebGLAttributes( gl, capabilities ) {
 
 			type = gl.UNSIGNED_BYTE;
 
+		} else if ( array instanceof Uint8ClampedArray ) {
+			
+			type = gl.UNSIGNED_BYTE;
+			
 		}
 
 		return {


### PR DESCRIPTION
**Description**

In the WebGLAttributes function, Uint8ClampedArray buffers were being treated as Float32Array. 
The wrong type code was then being sent when uploading to the GPU.
Added line to check on buffer data creation.