### PR TITLE
Build examples: Make the libs import replace more generalized

### DIFF
--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -110,12 +110,7 @@ function unmodularize() {
 
 			// Remove library imports that are exposed as
 			// global variables in the non-module world
-			code = code.replace( 'import * as fflate from \'../libs/fflate.module.js\';', '' );
-			code = code.replace( 'import { MMDParser } from \'../libs/mmdparser.module.js\';', '' );
-			code = code.replace( 'import { potpack } from \'../libs/potpack.module.js\';', '' );
-			code = code.replace( 'import { opentype } from \'../libs/opentype.module.min.js\';', '' );
-			code = code.replace( 'import chevrotain from \'../libs/chevrotain.module.min.js\';', '' );
-			code = code.replace( 'import { ZSTDDecoder } from \'../libs/zstddec.module.js\';', '' );
+			code = code.replace( /import (.*) from '(.*)\/libs\/(.*)';/g, '' );
 
 			// remove newline at the start of file
 			code = code.trimStart();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/commit/55f98ce4938b652d082d13f536217352a6f1adc6#r51139097

**Description**

In the `build-examples` script, remove automatically every import coming from the `libs/` folder instead of specifying the libraries manually.

This won't need to be changed for eventual future libraries added.