### PR TITLE
GLTFLoader: Set RGBFormat for jpg with no mimeType.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2291,11 +2291,11 @@
 			}
 
 			const URL = self.URL || self.webkitURL;
-			let sourceURI = source.uri;
+			let sourceURI = source.uri || '';
 			let isObjectURL = false;
 			let hasAlpha = true;
-			if ( source.mimeType === 'image/jpeg' ) hasAlpha = false;
-			if ( source.uri && source.uri.search( /\.jpe?g($|\?)/i ) > 0 ) hasAlpha = false;
+			const isJPEG = sourceURI.search( /\.jpe?g($|\?)/i ) > 0 || sourceURI.search( /^data\:image\/jpeg/ ) === 0;
+			if ( source.mimeType === 'image/jpeg' || isJPEG ) hasAlpha = false;
 
 			if ( source.bufferView !== undefined ) {
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2295,6 +2295,7 @@
 			let isObjectURL = false;
 			let hasAlpha = true;
 			if ( source.mimeType === 'image/jpeg' ) hasAlpha = false;
+			if ( source.uri && source.uri.search( /\.jpe?g($|\?)/i ) > 0 ) hasAlpha = false;
 
 			if ( source.bufferView !== undefined ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2553,6 +2553,7 @@ class GLTFParser {
 		let hasAlpha = true;
 
 		if ( source.mimeType === 'image/jpeg' ) hasAlpha = false;
+		if ( source.uri && source.uri.search( /\.jpe?g($|\?)/i ) > 0 ) hasAlpha = false;
 
 		if ( source.bufferView !== undefined ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2548,12 +2548,13 @@ class GLTFParser {
 
 		const URL = self.URL || self.webkitURL;
 
-		let sourceURI = source.uri;
+		let sourceURI = source.uri || '';
 		let isObjectURL = false;
 		let hasAlpha = true;
 
-		if ( source.mimeType === 'image/jpeg' ) hasAlpha = false;
-		if ( source.uri && source.uri.search( /\.jpe?g($|\?)/i ) > 0 ) hasAlpha = false;
+		const isJPEG = sourceURI.search( /\.jpe?g($|\?)/i ) > 0 || sourceURI.search( /^data\:image\/jpeg/ ) === 0;
+
+		if ( source.mimeType === 'image/jpeg' || isJPEG ) hasAlpha = false;
 
 		if ( source.bufferView !== undefined ) {
 


### PR DESCRIPTION
**Description**

It seems like it can be the case that an image source has `uri` but not `mimeType`. 
`TextureLoader` automatically sets `RGBFormat` based on the `url` but `ImageBitmapLoader` doesn't do that.

An example of a model is `DamagedHelmet`:
https://github.com/mrdoob/three.js/blob/c3dd48275815708284d4007c5bac3278fcf667b6/examples/models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf#L98-L114

@donmccurdy @takahirox does this make sense to you?