### PR TITLE
ShaderChunk: Fixed transmission crash when using flat shading

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -16,7 +16,6 @@ export default /* glsl */`
 	vec3 pos = vWorldPosition.xyz / vWorldPosition.w;
 	vec3 v = normalize( cameraPosition - pos );
 	vec3 viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
-	vec3 n = normalize( vNormal );
 	float ior = ( 1.0 + 0.4 * reflectivity ) / ( 1.0 - 0.4 * reflectivity );
 
 	// From https://google.github.io/filament/Filament.html#materialsystem/parameterization/remapping
@@ -24,7 +23,7 @@ export default /* glsl */`
 	vec3 f90 = vec3( 1.0 );
 
 	vec3 f_transmission = totalTransmission * getIBLVolumeRefraction(
-		n, v, viewDir, roughnessFactor, diffuseColor.rgb, f0, f90,
+		normal, v, viewDir, roughnessFactor, diffuseColor.rgb, f0, f90,
 		pos, modelMatrix, viewMatrix, projectionMatrix, ior, thicknessFactor,
 		attenuationColor, attenuationDistance);
 


### PR DESCRIPTION
Related issue: #21884

**Description**

The material wouldn't compile when enabling flat shading because `vNormal` was nor available.

<img width="1231" alt="Screen Shot 2021-05-27 at 9 34 35 AM" src="https://user-images.githubusercontent.com/97088/119794987-f1d97480-becf-11eb-8bc6-e21e7ca63709.png">

@takahirox FYI