### PR TITLE
TextGeometry: Added serialization/deserialization.

### DIFF
--- a/docs/api/en/geometries/TextGeometry.html
+++ b/docs/api/en/geometries/TextGeometry.html
@@ -64,10 +64,10 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([param:String text], [param:Object parameters])</h3>
+		<h3>[name]([param:String text], [param:Object options])</h3>
 		<p>
 		text — The text that needs to be shown. <br />
-		parameters — Object that can contains the following parameters.
+		options — Object that can contains the following options.
 		<ul>
 			<li>font — an instance of THREE.Font.</li>
 			<li>size — Float. Size of the text. Default is 100.</li>

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -94,9 +94,11 @@
 		This is used internally by [page:.load]() but can also be used directly to parse a previously loaded JSON structure.
 		</p>
 
-		<h3>[method:Object3D parseGeometries]( [param:Object json] )</h3>
+		<h3>[method:Object3D parseGeometries]( [param:Object json], [param:Object shapes], [param:Object fonts] )</h3>
 		<p>
-		[page:Object json] — required. The JSON source to parse.<br /><br />
+		[page:Object json] — required. The JSON source to parse.<br />
+		[page:Object shape] — required. A dictionary holding shapes.<br />
+		[page:Object fonts] — required. A dictionary holding fonts.<br /><br />
 
 		This is used by [page:.parse]() to parse any [page:BufferGeometry geometries] in the JSON structure.
 		</p>

--- a/docs/api/zh/geometries/TextGeometry.html
+++ b/docs/api/zh/geometries/TextGeometry.html
@@ -50,6 +50,7 @@
 				bevelEnabled: true,
 				bevelThickness: 10,
 				bevelSize: 8,
+				bevelOffset: 0,
 				bevelSegments: 5
 			} );
 		} );
@@ -63,10 +64,10 @@
 
 		<h2>构造器</h2>
 
-		<h3>[name]([param:String text], [param:Object parameters])</h3>
+		<h3>[name]([param:String text], [param:Object options])</h3>
 		<p>
 		text — 将要显示的文本。<br />
-		parameters — 包含有下列参数的对象：
+		options — 包含有下列参数的对象：
 		<ul>
 			<li>font — THREE.Font的实例。</li>
 			<li>size — Float。字体大小，默认值为100。</li>

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -94,9 +94,11 @@
 		内部使用[page:.load]()进行加载, 但也可以直接用于解析先前加载的JSON结构。
 		</p>
 
-		<h3>[method:Object3D parseGeometries]( [param:Object json] )</h3>
+		<h3>[method:Object3D parseGeometries]( [param:Object json], [param:Object shapes], [param:Object fonts] )</h3>
 		<p>
-		[page:Object json] — 必选参数，需要被解析的JSON源。<br /><br />
+		[page:Object json] — 必选参数，需要被解析的JSON源。<br />
+		[page:Object shape] — required. A dictionary holding shapes.<br />
+		[page:Object fonts] — required. A dictionary holding fonts.<br /><br />
 
 			此函数以JSON结构，用[page:.parse]()去解析[page:BufferGeometry geometries]。
 		</p>

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -670,6 +670,7 @@ class Object3D extends EventDispatcher {
 				textures: {},
 				images: {},
 				shapes: {},
+				fonts: {},
 				skeletons: {},
 				animations: {}
 			};
@@ -733,23 +734,37 @@ class Object3D extends EventDispatcher {
 
 			const parameters = this.geometry.parameters;
 
-			if ( parameters !== undefined && parameters.shapes !== undefined ) {
+			if ( parameters !== undefined ) {
 
-				const shapes = parameters.shapes;
+				// shapes
 
-				if ( Array.isArray( shapes ) ) {
+				if ( parameters.shapes !== undefined ) {
 
-					for ( let i = 0, l = shapes.length; i < l; i ++ ) {
+					const shapes = parameters.shapes;
 
-						const shape = shapes[ i ];
+					if ( Array.isArray( shapes ) ) {
 
-						serialize( meta.shapes, shape );
+						for ( let i = 0, l = shapes.length; i < l; i ++ ) {
+
+							const shape = shapes[ i ];
+
+							serialize( meta.shapes, shape );
+
+						}
+
+					} else {
+
+						serialize( meta.shapes, shapes );
 
 					}
 
-				} else {
+				}
 
-					serialize( meta.shapes, shapes );
+				// fonts
+
+				if ( parameters.font !== undefined ) {
+
+					serialize( meta.fonts, parameters.font );
 
 				}
 
@@ -831,6 +846,7 @@ class Object3D extends EventDispatcher {
 			const textures = extractFromCache( meta.textures );
 			const images = extractFromCache( meta.images );
 			const shapes = extractFromCache( meta.shapes );
+			const fonts = extractFromCache( meta.fonts );
 			const skeletons = extractFromCache( meta.skeletons );
 			const animations = extractFromCache( meta.animations );
 
@@ -839,6 +855,7 @@ class Object3D extends EventDispatcher {
 			if ( textures.length > 0 ) output.textures = textures;
 			if ( images.length > 0 ) output.images = images;
 			if ( shapes.length > 0 ) output.shapes = shapes;
+			if ( fonts.length > 0 ) output.fonts = fonts;
 			if ( skeletons.length > 0 ) output.skeletons = skeletons;
 			if ( animations.length > 0 ) output.animations = animations;
 

--- a/src/extras/core/Font.js
+++ b/src/extras/core/Font.js
@@ -1,8 +1,11 @@
 import { ShapePath } from './ShapePath.js';
+import * as MathUtils from '../../math/MathUtils.js';
 
 class Font {
 
 	constructor( data ) {
+
+		this.uuid = MathUtils.generateUUID();
 
 		this.type = 'Font';
 
@@ -22,6 +25,24 @@ class Font {
 		}
 
 		return shapes;
+
+	}
+
+	fromJSON( json ) {
+
+		this.uuid = json.uuid;
+		this.data = json.data;
+
+		return this;
+
+	}
+
+	toJSON() {
+
+		return {
+			uuid: this.uuid,
+			data: this.data
+		};
 
 	}
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -757,21 +757,25 @@ const WorldUVGenerator = {
 
 function toJSON( shapes, options, data ) {
 
-	data.shapes = [];
+	if ( shapes !== undefined ) {
 
-	if ( Array.isArray( shapes ) ) {
+		data.shapes = [];
 
-		for ( let i = 0, l = shapes.length; i < l; i ++ ) {
+		if ( Array.isArray( shapes ) ) {
 
-			const shape = shapes[ i ];
+			for ( let i = 0, l = shapes.length; i < l; i ++ ) {
 
-			data.shapes.push( shape.uuid );
+				const shape = shapes[ i ];
+
+				data.shapes.push( shape.uuid );
+
+			}
+
+		} else {
+
+			data.shapes.push( shapes.uuid );
 
 		}
-
-	} else {
-
-		data.shapes.push( shapes.uuid );
 
 	}
 

--- a/src/geometries/TextGeometry.js
+++ b/src/geometries/TextGeometry.js
@@ -20,9 +20,9 @@ import { ExtrudeGeometry } from './ExtrudeGeometry.js';
 
 class TextGeometry extends ExtrudeGeometry {
 
-	constructor( text, parameters = {} ) {
+	constructor( text, options = {} ) {
 
-		const font = parameters.font;
+		const font = options.font;
 
 		if ( ! ( font && font.isFont ) ) {
 
@@ -31,21 +31,38 @@ class TextGeometry extends ExtrudeGeometry {
 
 		}
 
-		const shapes = font.generateShapes( text, parameters.size );
+		const shapes = font.generateShapes( text, options.size );
 
 		// translate parameters to ExtrudeGeometry API
 
-		parameters.depth = parameters.height !== undefined ? parameters.height : 50;
+		options.depth = options.height !== undefined ? options.height : 50;
 
 		// defaults
 
-		if ( parameters.bevelThickness === undefined ) parameters.bevelThickness = 10;
-		if ( parameters.bevelSize === undefined ) parameters.bevelSize = 8;
-		if ( parameters.bevelEnabled === undefined ) parameters.bevelEnabled = false;
+		if ( options.bevelThickness === undefined ) options.bevelThickness = 10;
+		if ( options.bevelSize === undefined ) options.bevelSize = 8;
+		if ( options.bevelEnabled === undefined ) options.bevelEnabled = false;
 
-		super( shapes, parameters );
+		super( shapes, options );
 
 		this.type = 'TextGeometry';
+
+		this.parameters = {
+			text: text,
+			font: font, // store font in parameters so it can be easier processed in Object3D.toJSON() (need to remove it in TextGeometry.toJSON() again)
+			options: options
+		};
+
+	}
+
+	toJSON() {
+
+		const data = super.toJSON();
+
+		delete data.font;
+		data.options.font = this.parameters.font.uuid;
+
+		return data;
 
 	}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -34,6 +34,7 @@ import { SkinnedMesh } from '../objects/SkinnedMesh.js';
 import { Bone } from '../objects/Bone.js';
 import { Skeleton } from '../objects/Skeleton.js';
 import { Shape } from '../extras/core/Shape.js';
+import { Font } from '../extras/core/Font.js';
 import { Fog } from '../scenes/Fog.js';
 import { FogExp2 } from '../scenes/FogExp2.js';
 import { HemisphereLight } from '../lights/HemisphereLight.js';
@@ -117,7 +118,8 @@ class ObjectLoader extends Loader {
 
 		const animations = this.parseAnimations( json.animations );
 		const shapes = this.parseShapes( json.shapes );
-		const geometries = this.parseGeometries( json.geometries, shapes );
+		const fonts = this.parseFonts( json.fonts );
+		const geometries = this.parseGeometries( json.geometries, shapes, fonts );
 
 		const images = this.parseImages( json.images, function () {
 
@@ -178,6 +180,26 @@ class ObjectLoader extends Loader {
 
 	}
 
+	parseFonts( json ) {
+
+		const fonts = {};
+
+		if ( json !== undefined ) {
+
+			for ( let i = 0, l = json.length; i < l; i ++ ) {
+
+				const font = new Font().fromJSON( json[ i ] );
+
+				fonts[ font.uuid ] = font;
+
+			}
+
+		}
+
+		return fonts;
+
+	}
+
 	parseSkeletons( json, object ) {
 
 		const skeletons = {};
@@ -209,7 +231,7 @@ class ObjectLoader extends Loader {
 
 	}
 
-	parseGeometries( json, shapes ) {
+	parseGeometries( json, shapes, fonts ) {
 
 		const geometries = {};
 		let geometryShapes;
@@ -449,6 +471,18 @@ class ObjectLoader extends Loader {
 
 						geometry = new Geometries[ data.type ](
 							geometryShapes,
+							data.options
+						);
+
+						break;
+
+					case 'TextGeometry':
+					case 'TextBufferGeometry':
+
+						data.options.font = fonts[ data.options.font ];
+
+						geometry = new Geometries[ data.type ](
+							data.text,
 							data.options
 						);
 


### PR DESCRIPTION
Related issue: Fixed #9905.

**Description**

Ensures `TextGeometry` can be serialized/deserialized. Fonts are handled similar to shapes in a dictionary to save space.

BTW: The PR could be simplified if the signature of `TextGeometry` would be: `new TextGeometry( text, font, options )`. Meaning the font is no part of `options` anymore but the second parameter. 
