### PR TITLE
Example Tags: Add tags for example with GPU stats panel

### DIFF
--- a/examples/tags.json
+++ b/examples/tags.json
@@ -27,6 +27,7 @@
 	"webgl_layers": [ "groups" ],
 	"webgl_lights_hemisphere": [ "directional" ],
 	"webgl_lights_pointlights": [ "multiple" ],
+	"webgl_lines_fat": [ "gpu", "stats", "panel" ],
 	"webgl_loader_ttf": [ "text", "font" ],
 	"webgl_loader_pdb": [ "molecules", "css2d" ],
 	"webgl_lod": [ "level", "details" ],


### PR DESCRIPTION
Related issue: #21509

**Description**

Add tags related to the GPU stats panel for the webgl_lines_fat example to make it more discoverable.