### PR TITLE
better light angle in PointLightShadow docs

### DIFF
--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -24,7 +24,7 @@
 
 		//Create a PointLight and turn on shadows for the light
 		const light = new THREE.PointLight( 0xffffff, 1, 100 );
-		light.position.set( 0, 10, 0 );
+		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );
 

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -25,7 +25,7 @@
 
 		//Create a PointLight and turn on shadows for the light
 		const light = new THREE.PointLight( 0xffffff, 1, 100 );
-		light.position.set( 0, 10, 0 );
+		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );
 


### PR DESCRIPTION
So I was trying to copy-paste this code into [sfiddle](https://jsfiddle.net/90pvqa4m/) and discovered that it does not actually produce shadow :D Because the light is inside the plane,

before:
![Screen Shot 2021-05-29 at 1 30 33 ](https://user-images.githubusercontent.com/242577/120051100-9c13e200-c01f-11eb-9563-cc6546b36232.png)

after:
![Screen Shot 2021-05-29 at 1 30 14 ](https://user-images.githubusercontent.com/242577/120051109-a504b380-c01f-11eb-9a21-462b3787216a.png)
