### PR TITLE
Antialias MeshPhysicalMaterial transmission support

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -28,6 +28,7 @@ import { WebGLGeometries } from './webgl/WebGLGeometries.js';
 import { WebGLIndexedBufferRenderer } from './webgl/WebGLIndexedBufferRenderer.js';
 import { WebGLInfo } from './webgl/WebGLInfo.js';
 import { WebGLMorphtargets } from './webgl/WebGLMorphtargets.js';
+import { WebGLMultisampleRenderTarget } from './WebGLMultisampleRenderTarget.js';
 import { WebGLObjects } from './webgl/WebGLObjects.js';
 import { WebGLPrograms } from './webgl/WebGLPrograms.js';
 import { WebGLProperties } from './webgl/WebGLProperties.js';
@@ -1267,7 +1268,8 @@ function WebGLRenderer( parameters ) {
 
 		if ( _transmissionRenderTarget === null ) {
 
-			_transmissionRenderTarget = new WebGLRenderTarget( 1024, 1024, {
+			const renderTargetType = _antialias && capabilities.isWebGL2 && false ? WebGLMultisampleRenderTarget : WebGLRenderTarget;
+			_transmissionRenderTarget = new renderTargetType( 1024, 1024, {
 				generateMipmaps: true,
 				minFilter: LinearMipmapLinearFilter,
 				magFilter: NearestFilter,
@@ -1283,6 +1285,7 @@ function WebGLRenderer( parameters ) {
 
 		renderObjects( opaqueObjects, scene, camera );
 
+		textures.updateMultisampleRenderTarget( _transmissionRenderTarget );
 		textures.updateRenderTargetMipmap( _transmissionRenderTarget );
 
 		_this.setRenderTarget( currentRenderTarget );


### PR DESCRIPTION
Fixes: #21913

**Description**

This PR adds antialias `MeshPhysicalMaterial` transmission support with `WebGLMultisampleRenderTarget`.

**Screenshot problem**

A problem is that it works correctly on web browser but `WebGLMultisampleRenderTarget` doesn't seem to work correctly on Puppeteer.

I made screenshots of `webgl_materials_physical_transmission` and `webgl_loader_gltf_transmission` but `transmissionSamplerMap` looks black.

![webgl_materials_physical_transmission](https://user-images.githubusercontent.com/7637832/120058628-1719d000-c001-11eb-900c-a2a36e702259.jpg)

![webgl_loader_gltf_transmission](https://user-images.githubusercontent.com/7637832/120058637-3284db00-c001-11eb-8f7d-9cf647f1f77c.jpg)

I also noticed that the existing `webgl2_multisampled_renderbuffers` screenshot right side (using `WebGLMultisampleRenderTarget`) is black.

![webgl2_multisampled_renderbuffers](https://user-images.githubusercontent.com/7637832/120059030-a32cf700-c003-11eb-8028-86c605406ea6.jpg)

Any ideas to resolve the problem?