### PR TITLE
fps example: collision detection in substeps

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -77,6 +77,8 @@
 			const NUM_SPHERES = 20;
 			const SPHERE_RADIUS = 0.2;
 
+			const STEPS_PER_FRAME = 5;
+
 			const sphereGeometry = new THREE.SphereGeometry( SPHERE_RADIUS, 32, 32 );
 			const sphereMaterial = new THREE.MeshStandardMaterial( { color: 0x888855, roughness: 0.8, metalness: 0.5 } );
 
@@ -360,13 +362,19 @@
 
 			function animate() {
 
-				const deltaTime = Math.min( 0.1, clock.getDelta() );
+				const deltaTime = Math.min( 0.05, clock.getDelta() ) / STEPS_PER_FRAME;
 
-				controls( deltaTime );
+				// we look for collisions in substeps to mitigate the risk of
+				// an object traversing another too quickly for detection.
+				for ( let i=0 ; i<STEPS_PER_FRAME ; i++ ) {
 
-				updatePlayer( deltaTime );
+					controls( deltaTime );
 
-				updateSpheres( deltaTime );
+					updatePlayer( deltaTime );
+
+					updateSpheres( deltaTime );
+
+				}
 
 				renderer.render( scene, camera );
 

--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -366,7 +366,8 @@
 
 				// we look for collisions in substeps to mitigate the risk of
 				// an object traversing another too quickly for detection.
-				for ( let i=0 ; i<STEPS_PER_FRAME ; i++ ) {
+
+				for ( let i = 0 ; i < STEPS_PER_FRAME ; i ++ ) {
 
 					controls( deltaTime );
 


### PR DESCRIPTION
Related issue: Fixed #21921.

In the [fps example](https://threejs.org/examples/?q=fps#games_fps), objects could traverse the walls when running at a low framerate ( eg: 30fps ).

This PR updates the example to run the collision detection un smaller substeps, which greatly reduce the risk of an object traversing too quickly.

As @Mugen87 pointed out, this is hacky and a cleaner solution could be found.