### PR TITLE
F_Schlick, dotLH -> dotVH

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
@@ -56,14 +56,14 @@ vec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {
 
 } // validated
 
-vec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {
+vec3 F_Schlick( const in vec3 specularColor, const in float dotVH ) {
 
 	// Original approximation by Christophe Schlick '94
-	// float fresnel = pow( 1.0 - dotLH, 5.0 );
+	// float fresnel = pow( 1.0 - dotVH, 5.0 );
 
 	// Optimized variant (presented by Epic at SIGGRAPH '13)
 	// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-	float fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );
+	float fresnel = exp2( ( -5.55473 * dotVH - 6.98316 ) * dotVH );
 
 	return ( 1.0 - specularColor ) * fresnel + specularColor;
 


### PR DESCRIPTION
I don't know why `dotLH` was used to F_Schlick, according to paper, here is dotVH.
