### PR TITLE
doc: fix dark theme on empty location hash

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -478,11 +478,13 @@
 
 				iframe.src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
 				subtitle = titles[ splitHash[ 0 ] ] + splitHash[ 1 ] + ' – ';
+				iframe.style.display = 'unset';
 
 			} else {
 
 				iframe.src = '';
 				subtitle = '';
+				iframe.style.display = 'none';
 
 			}
 


### PR DESCRIPTION

When accessing https://threejs.org/docs/ with a browser with dark theme preference, this is what shows up : 

![Screenshot_2](https://user-images.githubusercontent.com/46470486/120197707-8f5edc00-c221-11eb-8030-b2aba395b9dd.jpg)

Tested on Chrome and Opera.

It seems that the iframe with an empty `src` has an opaque white background overlapping the body background.

Original dark mode support PR by @mrdoob for reference : #17729

After the commit : 

![Screenshot_3](https://user-images.githubusercontent.com/46470486/120198767-caadda80-c222-11eb-8a29-97f758f7b025.jpg)
