### PR TITLE
examples: fix dark theme on empty location hash

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -105,6 +105,7 @@
 
 					selectFile( file );
 					viewer.src = validRedirects.get( file );
+					viewer.style.display = 'unset';
 
 				}
 
@@ -221,6 +222,7 @@
 
 			window.location.hash = file;
 			viewer.focus();
+			viewer.style.display = 'unset';
 
 			panel.classList.remove( 'open' );
 

--- a/files/main.css
+++ b/files/main.css
@@ -383,6 +383,7 @@ iframe {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
+	display: none;
 }
 
 #viewer {


### PR DESCRIPTION
following #21929

Accessing https://threejs.org/examples with a browser with dark theme preference lead to the following output, whereas the body behind the empty iframe has a nice dark theme.

![120200460-a521d080-c224-11eb-8f5c-718111a092a5](https://user-images.githubusercontent.com/46470486/120241566-4cbdf380-c263-11eb-8c06-0391abd248c7.png)

Commit demo ( depends on your browser settings ) : https://raw.githack.com/felixmariotto/three.js/dark_examples/examples/

@Mugen87 I have not been able to understand why the iframe was transparent when testing locally... most susprinsing.