### PR TITLE
Controls: Remove preventDefault() from mouse handlers.

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -81,8 +81,6 @@
 
 			function onPointerMove( event ) {
 
-				event.preventDefault();
-
 				switch ( event.pointerType ) {
 
 					case 'mouse':
@@ -173,8 +171,6 @@
 
 			function onPointerDown( event ) {
 
-				event.preventDefault();
-
 				switch ( event.pointerType ) {
 
 					case 'mouse':
@@ -187,9 +183,8 @@
 
 			}
 
-			function onMouseDown( event ) {
+			function onMouseDown() {
 
-				event.preventDefault();
 				_intersections.length = 0;
 
 				_raycaster.setFromCamera( _mouse, _camera );
@@ -220,8 +215,6 @@
 
 			function onPointerCancel( event ) {
 
-				event.preventDefault();
-
 				switch ( event.pointerType ) {
 
 					case 'mouse':
@@ -234,9 +227,7 @@
 
 			}
 
-			function onMouseCancel( event ) {
-
-				event.preventDefault();
+			function onMouseCancel() {
 
 				if ( _selected ) {
 

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -72,8 +72,6 @@
 
 				}
 
-				event.preventDefault();
-
 				if ( this.activeLook ) {
 
 					switch ( event.button ) {
@@ -95,8 +93,6 @@
 			};
 
 			this.onMouseUp = function ( event ) {
-
-				event.preventDefault();
 
 				if ( this.activeLook ) {
 
@@ -136,7 +132,6 @@
 
 			this.onKeyDown = function ( event ) {
 
-				//event.preventDefault();
 				switch ( event.code ) {
 
 					case 'ArrowUp':

--- a/examples/js/controls/FlyControls.js
+++ b/examples/js/controls/FlyControls.js
@@ -55,8 +55,7 @@
 
 					return;
 
-				} //event.preventDefault();
-
+				}
 
 				switch ( event.code ) {
 
@@ -186,14 +185,6 @@
 
 			this.mousedown = function ( event ) {
 
-				if ( this.domElement !== document ) {
-
-					this.domElement.focus();
-
-				}
-
-				event.preventDefault();
-
 				if ( this.dragToLook ) {
 
 					this.mouseStatus ++;
@@ -234,8 +225,6 @@
 			};
 
 			this.mouseup = function ( event ) {
-
-				event.preventDefault();
 
 				if ( this.dragToLook ) {
 

--- a/examples/js/controls/OrbitControls.js
+++ b/examples/js/controls/OrbitControls.js
@@ -741,11 +741,6 @@
 
 			function onMouseDown( event ) {
 
-				// Prevent the browser from scrolling.
-				event.preventDefault(); // Manually set the focus since calling preventDefault above
-				// prevents the browser from setting it automatically.
-
-				scope.domElement.focus ? scope.domElement.focus() : window.focus();
 				let mouseAction;
 
 				switch ( event.button ) {
@@ -827,7 +822,6 @@
 			function onMouseMove( event ) {
 
 				if ( scope.enabled === false ) return;
-				event.preventDefault();
 
 				switch ( state ) {
 

--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -462,8 +462,6 @@
 
 			function onMouseDown( event ) {
 
-				event.preventDefault();
-
 				if ( _state === STATE.NONE ) {
 
 					switch ( event.button ) {
@@ -518,7 +516,6 @@
 			function onMouseMove( event ) {
 
 				if ( scope.enabled === false ) return;
-				event.preventDefault();
 				const state = _keyState !== STATE.NONE ? _keyState : _state;
 
 				if ( state === STATE.ROTATE && ! scope.noRotate ) {
@@ -539,10 +536,9 @@
 
 			}
 
-			function onMouseUp( event ) {
+			function onMouseUp() {
 
 				if ( scope.enabled === false ) return;
-				event.preventDefault();
 				_state = STATE.NONE;
 				scope.domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove );
 				scope.domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -70,8 +70,6 @@ class DragControls extends EventDispatcher {
 
 		function onPointerMove( event ) {
 
-			event.preventDefault();
-
 			switch ( event.pointerType ) {
 
 				case 'mouse':
@@ -154,8 +152,6 @@ class DragControls extends EventDispatcher {
 
 		function onPointerDown( event ) {
 
-			event.preventDefault();
-
 			switch ( event.pointerType ) {
 
 				case 'mouse':
@@ -169,9 +165,7 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function onMouseDown( event ) {
-
-			event.preventDefault();
+		function onMouseDown() {
 
 			_intersections.length = 0;
 
@@ -200,8 +194,6 @@ class DragControls extends EventDispatcher {
 
 		function onPointerCancel( event ) {
 
-			event.preventDefault();
-
 			switch ( event.pointerType ) {
 
 				case 'mouse':
@@ -215,9 +207,7 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function onMouseCancel( event ) {
-
-			event.preventDefault();
+		function onMouseCancel() {
 
 			if ( _selected ) {
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -91,8 +91,6 @@ class FirstPersonControls {
 
 			}
 
-			event.preventDefault();
-
 			if ( this.activeLook ) {
 
 				switch ( event.button ) {
@@ -109,8 +107,6 @@ class FirstPersonControls {
 		};
 
 		this.onMouseUp = function ( event ) {
-
-			event.preventDefault();
 
 			if ( this.activeLook ) {
 
@@ -144,8 +140,6 @@ class FirstPersonControls {
 		};
 
 		this.onKeyDown = function ( event ) {
-
-			//event.preventDefault();
 
 			switch ( event.code ) {
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -57,8 +57,6 @@ class FlyControls extends EventDispatcher {
 
 			}
 
-			//event.preventDefault();
-
 			switch ( event.code ) {
 
 				case 'ShiftLeft':
@@ -123,14 +121,6 @@ class FlyControls extends EventDispatcher {
 
 		this.mousedown = function ( event ) {
 
-			if ( this.domElement !== document ) {
-
-				this.domElement.focus();
-
-			}
-
-			event.preventDefault();
-
 			if ( this.dragToLook ) {
 
 				this.mouseStatus ++;
@@ -168,8 +158,6 @@ class FlyControls extends EventDispatcher {
 		};
 
 		this.mouseup = function ( event ) {
-
-			event.preventDefault();
 
 			if ( this.dragToLook ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -841,14 +841,6 @@ class OrbitControls extends EventDispatcher {
 
 		function onMouseDown( event ) {
 
-			// Prevent the browser from scrolling.
-			event.preventDefault();
-
-			// Manually set the focus since calling preventDefault above
-			// prevents the browser from setting it automatically.
-
-			scope.domElement.focus ? scope.domElement.focus() : window.focus();
-
 			let mouseAction;
 
 			switch ( event.button ) {
@@ -950,8 +942,6 @@ class OrbitControls extends EventDispatcher {
 		function onMouseMove( event ) {
 
 			if ( scope.enabled === false ) return;
-
-			event.preventDefault();
 
 			switch ( state ) {
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -491,8 +491,6 @@ class TrackballControls extends EventDispatcher {
 
 		function onMouseDown( event ) {
 
-			event.preventDefault();
-
 			if ( _state === STATE.NONE ) {
 
 				switch ( event.button ) {
@@ -546,8 +544,6 @@ class TrackballControls extends EventDispatcher {
 
 			if ( scope.enabled === false ) return;
 
-			event.preventDefault();
-
 			const state = ( _keyState !== STATE.NONE ) ? _keyState : _state;
 
 			if ( state === STATE.ROTATE && ! scope.noRotate ) {
@@ -567,11 +563,9 @@ class TrackballControls extends EventDispatcher {
 
 		}
 
-		function onMouseUp( event ) {
+		function onMouseUp() {
 
 			if ( scope.enabled === false ) return;
-
-			event.preventDefault();
 
 			_state = STATE.NONE;
 


### PR DESCRIPTION
Related issue: #21889

**Description**

This PR removes all calls of `preventDefault()` in mouse handlers from all controls classes to avoid side-effects mentioned in #21889. During my local testing with the examples I was not able to spot a different behavior.
