### PR TITLE
WebGLRenderer.copyTextureToTexture3D() support Texture and CompressedTexture

### DIFF
--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -110,13 +110,6 @@
 							glslVersion: THREE.GLSL3
 						} );
 
-						new THREE.TextureLoader().load( 'textures/uv_grid_opengl.jpg', function(tex) {
-							const position = new THREE.Vector3(0,0,0);
-							const box = new THREE.Box3( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 255, 255, 0 ) );
-							// tex.image.data = tex.image; // workaround to mascarade a THREE.Texture as a THREE.DataTexture
-							renderer.copyTextureToTexture3D( box, position, tex, texture );
-						} );
-
 						const geometry = new THREE.PlaneGeometry( planeWidth, planeHeight );
 
 						mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -110,6 +110,13 @@
 							glslVersion: THREE.GLSL3
 						} );
 
+						new THREE.TextureLoader().load( 'textures/uv_grid_opengl.jpg', function(tex) {
+							const position = new THREE.Vector3(0,0,0);
+							const box = new THREE.Box3( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 255, 255, 0 ) );
+							// tex.image.data = tex.image; // workaround to mascarade a THREE.Texture as a THREE.DataTexture
+							renderer.copyTextureToTexture3D( box, position, tex, texture );
+						} );
+
 						const geometry = new THREE.PlaneGeometry( planeWidth, planeHeight );
 
 						mesh = new THREE.Mesh( geometry, material );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2107,7 +2107,9 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		const { width, height, data } = srcTexture.image;
+		const width = sourceBox.max.x - sourceBox.min.x + 1;
+		const height = sourceBox.max.y - sourceBox.min.y + 1;
+		const depth = sourceBox.max.z - sourceBox.min.z + 1;
 		const glFormat = utils.convert( dstTexture.format );
 		const glType = utils.convert( dstTexture.type );
 		let glTarget;
@@ -2139,25 +2141,32 @@ function WebGLRenderer( parameters ) {
 		const unpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
 		const unpackSkipImages = _gl.getParameter( _gl.UNPACK_SKIP_IMAGES );
 
-		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, width );
-		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, height );
+		const image = srcTexture.isCompressedTexture ? srcTexture.mipmaps[ 0 ] : srcTexture.image;
+
+		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
+		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, image.height );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, sourceBox.min.x );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, sourceBox.min.y );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_IMAGES, sourceBox.min.z );
 
-		_gl.texSubImage3D(
-			glTarget,
-			level,
-			position.x,
-			position.y,
-			position.z,
-			sourceBox.max.x - sourceBox.min.x + 1,
-			sourceBox.max.y - sourceBox.min.y + 1,
-			sourceBox.max.z - sourceBox.min.z + 1,
-			glFormat,
-			glType,
-			data
-		);
+		if ( srcTexture.isDataTexture || srcTexture.isDataTexture3D ) {
+
+			_gl.texSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, glType, image.data );
+
+		} else {
+
+			if ( srcTexture.isCompressedTexture ) {
+
+				console.warn( 'THREE.WebGLRenderer.copyTextureToTexture3D: untested support for compressed srcTexture.' );
+				_gl.compressedTexSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, image.data );
+
+			} else {
+
+				_gl.texSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, glType, image );
+
+			}
+
+		}
 
 		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, unpackRowLen );
 		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, unpackImageHeight );


### PR DESCRIPTION
**Description**

[copyTextureToTexture3D ](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.copyTextureToTexture3D)  currently assumes that `srcTexture` is a `THREE.DataTexture`.

**Bug**

The bug may be reproduced using the [webgl2_materials_texture2darray.html example of this PR](https://github.com/mbredif/three.js/blob/a7cc089e368d406bdca837530ee64c260eef831b/examples/webgl2_materials_texture2darray.html#L113-L118) against r128 or dev.
It fails because `srcTexture.image` is `undefined`.

**Workaround**

Without this PR, a `THREE.Texture` may be passed to [copyTextureToTexture3D ](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.copyTextureToTexture3D) after the following workaround (so that it mimicks a `THREE.DataTexture`)
`texture.image.data = texture.image;`

**Fix**
This PR enables passing a `THREE.Texture` or a `THREE.CompressedTexture` as a source to [copyTextureToTexture3D](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.copyTextureToTexture3D) using an approach similar to the implementation of [copyTextureToTexture](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.copyTextureToTexture) .
It has not been thoroughly tested on compressed textures though.

**Alternative/temporary fix**
Change the docs to state that srcTexture should be a DataTexture rather than a Texture.

<!-- Remove the line below if is not relevant -->

This contribution is funded by the [ALEGORIA ANR project](http://alegoria.ign.fr/).
