### PR TITLE
examples: fix dark theme on empty location hash ( fix )

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -105,6 +105,7 @@
 
 					selectFile( file );
 					viewer.src = validRedirects.get( file );
+					viewer.style.display = 'unset';
 
 				}
 
@@ -221,6 +222,7 @@
 
 			window.location.hash = file;
 			viewer.focus();
+			viewer.style.display = 'unset';
 
 			panel.classList.remove( 'open' );
 

--- a/files/main.css
+++ b/files/main.css
@@ -383,6 +383,7 @@ iframe {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
+	display: none;
 }
 
 #viewer {

--- a/files/main.css
+++ b/files/main.css
@@ -383,6 +383,9 @@ iframe {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
+}
+
+iframe#viewer {
 	display: none;
 }
 


### PR DESCRIPTION
following : #21932

This PR fixes a bug caused by the last PR on the home page.

Make https://threejs.org/examples background dark if browser theme preference is dark.