### PR TITLE
fix broken link in VertexTangentsHelper docs

### DIFF
--- a/docs/examples/en/helpers/VertexTangentsHelper.html
+++ b/docs/examples/en/helpers/VertexTangentsHelper.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 			Renders arrows to visualize an object's vertex tangent vectors.
 			Requires that tangents have been specified in a [page:BufferAttribute custom attribute] or
-			have been calculated using [page:BufferGeometryUtils.computeTangents computeTangents].<br /><br />
+			have been calculated using [page:BufferGeometry.computeTangents computeTangents].<br /><br />
 
 			This helper supports [page:BufferGeometry] only.
 		</p>

--- a/docs/examples/zh/helpers/VertexTangentsHelper.html
+++ b/docs/examples/zh/helpers/VertexTangentsHelper.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 			Renders arrows to visualize an object's vertex tangent vectors.
 			Requires that tangents have been specified in a [page:BufferAttribute custom attribute] or
-			have been calculated using [page:BufferGeometryUtils.computeTangents computeTangents].<br /><br />
+			have been calculated using [page:BufferGeometry.computeTangents computeTangents].<br /><br />
 
 			This helper supports [page:BufferGeometry] only.
 		</p>


### PR DESCRIPTION
so I changed the link to BufferGometry where the method actually is? I think.