### PR TITLE
DragControls: Fully migrate to pointer events.

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -4,7 +4,7 @@
 
 	const _raycaster = new THREE.Raycaster();
 
-	const _mouse = new THREE.Vector2();
+	const _pointer = new THREE.Vector2();
 
 	const _offset = new THREE.Vector3();
 
@@ -35,16 +35,6 @@
 
 				_domElement.addEventListener( 'pointerleave', onPointerCancel );
 
-				_domElement.addEventListener( 'touchmove', onTouchMove, {
-					passive: false
-				} );
-
-				_domElement.addEventListener( 'touchstart', onTouchStart, {
-					passive: false
-				} );
-
-				_domElement.addEventListener( 'touchend', onTouchEnd );
-
 			}
 
 			function deactivate() {
@@ -56,12 +46,6 @@
 				_domElement.removeEventListener( 'pointerup', onPointerCancel );
 
 				_domElement.removeEventListener( 'pointerleave', onPointerCancel );
-
-				_domElement.removeEventListener( 'touchmove', onTouchMove );
-
-				_domElement.removeEventListener( 'touchstart', onTouchStart );
-
-				_domElement.removeEventListener( 'touchend', onTouchEnd );
 
 				_domElement.style.cursor = '';
 
@@ -81,26 +65,9 @@
 
 			function onPointerMove( event ) {
 
-				switch ( event.pointerType ) {
+				updatePointer( event );
 
-					case 'mouse':
-					case 'pen':
-						onMouseMove( event );
-						break;
-        // TODO touch
-
-				}
-
-			}
-
-			function onMouseMove( event ) {
-
-				const rect = _domElement.getBoundingClientRect();
-
-				_mouse.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
-				_mouse.y = - ( ( event.clientY - rect.top ) / rect.height ) * 2 + 1;
-
-				_raycaster.setFromCamera( _mouse, _camera );
+				_raycaster.setFromCamera( _pointer, _camera );
 
 				if ( _selected && scope.enabled ) {
 
@@ -116,175 +83,71 @@
 					} );
 					return;
 
+				} // hover support
+
+
+				if ( event.pointerType === 'mouse' || event.pointerType === 'pen' ) {
+
+					_intersections.length = 0;
+
+					_raycaster.setFromCamera( _pointer, _camera );
+
+					_raycaster.intersectObjects( _objects, true, _intersections );
+
+					if ( _intersections.length > 0 ) {
+
+						const object = _intersections[ 0 ].object;
+
+						_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
+
+						if ( _hovered !== object && _hovered !== null ) {
+
+							scope.dispatchEvent( {
+								type: 'hoveroff',
+								object: _hovered
+							} );
+							_domElement.style.cursor = 'auto';
+							_hovered = null;
+
+						}
+
+						if ( _hovered !== object ) {
+
+							scope.dispatchEvent( {
+								type: 'hoveron',
+								object: object
+							} );
+							_domElement.style.cursor = 'pointer';
+							_hovered = object;
+
+						}
+
+					} else {
+
+						if ( _hovered !== null ) {
+
+							scope.dispatchEvent( {
+								type: 'hoveroff',
+								object: _hovered
+							} );
+							_domElement.style.cursor = 'auto';
+							_hovered = null;
+
+						}
+
+					}
+
 				}
 
+			}
+
+			function onPointerDown() {
+
+				_domElement.style.touchAction = 'none';
+				updatePointer( event );
 				_intersections.length = 0;
 
-				_raycaster.setFromCamera( _mouse, _camera );
-
-				_raycaster.intersectObjects( _objects, true, _intersections );
-
-				if ( _intersections.length > 0 ) {
-
-					const object = _intersections[ 0 ].object;
-
-					_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
-
-					if ( _hovered !== object && _hovered !== null ) {
-
-						scope.dispatchEvent( {
-							type: 'hoveroff',
-							object: _hovered
-						} );
-						_domElement.style.cursor = 'auto';
-						_hovered = null;
-
-					}
-
-					if ( _hovered !== object ) {
-
-						scope.dispatchEvent( {
-							type: 'hoveron',
-							object: object
-						} );
-						_domElement.style.cursor = 'pointer';
-						_hovered = object;
-
-					}
-
-				} else {
-
-					if ( _hovered !== null ) {
-
-						scope.dispatchEvent( {
-							type: 'hoveroff',
-							object: _hovered
-						} );
-						_domElement.style.cursor = 'auto';
-						_hovered = null;
-
-					}
-
-				}
-
-			}
-
-			function onPointerDown( event ) {
-
-				switch ( event.pointerType ) {
-
-					case 'mouse':
-					case 'pen':
-						onMouseDown();
-						break;
-        // TODO touch
-
-				}
-
-			}
-
-			function onMouseDown() {
-
-				_intersections.length = 0;
-
-				_raycaster.setFromCamera( _mouse, _camera );
-
-				_raycaster.intersectObjects( _objects, true, _intersections );
-
-				if ( _intersections.length > 0 ) {
-
-					_selected = scope.transformGroup === true ? _objects[ 0 ] : _intersections[ 0 ].object;
-
-					if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
-
-						_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
-
-						_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
-
-					}
-
-					_domElement.style.cursor = 'move';
-					scope.dispatchEvent( {
-						type: 'dragstart',
-						object: _selected
-					} );
-
-				}
-
-			}
-
-			function onPointerCancel( event ) {
-
-				switch ( event.pointerType ) {
-
-					case 'mouse':
-					case 'pen':
-						onMouseCancel();
-						break;
-        // TODO touch
-
-				}
-
-			}
-
-			function onMouseCancel() {
-
-				if ( _selected ) {
-
-					scope.dispatchEvent( {
-						type: 'dragend',
-						object: _selected
-					} );
-					_selected = null;
-
-				}
-
-				_domElement.style.cursor = _hovered ? 'pointer' : 'auto';
-
-			}
-
-			function onTouchMove( event ) {
-
-				event.preventDefault();
-				event = event.changedTouches[ 0 ];
-
-				const rect = _domElement.getBoundingClientRect();
-
-				_mouse.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
-				_mouse.y = - ( ( event.clientY - rect.top ) / rect.height ) * 2 + 1;
-
-				_raycaster.setFromCamera( _mouse, _camera );
-
-				if ( _selected && scope.enabled ) {
-
-					if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
-
-						_selected.position.copy( _intersection.sub( _offset ).applyMatrix4( _inverseMatrix ) );
-
-					}
-
-					scope.dispatchEvent( {
-						type: 'drag',
-						object: _selected
-					} );
-					return;
-
-				}
-
-			}
-
-			function onTouchStart( event ) {
-
-				event.preventDefault();
-				event = event.changedTouches[ 0 ];
-
-				const rect = _domElement.getBoundingClientRect();
-
-				_mouse.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
-				_mouse.y = - ( ( event.clientY - rect.top ) / rect.height ) * 2 + 1;
-				_intersections.length = 0;
-
-				_raycaster.setFromCamera( _mouse, _camera );
+				_raycaster.setFromCamera( _pointer, _camera );
 
 				_raycaster.intersectObjects( _objects, true, _intersections );
 
@@ -312,9 +175,7 @@
 
 			}
 
-			function onTouchEnd( event ) {
-
-				event.preventDefault();
+			function onPointerCancel() {
 
 				if ( _selected ) {
 
@@ -326,7 +187,19 @@
 
 				}
 
-				_domElement.style.cursor = 'auto';
+				_domElement.style.cursor = _hovered ? 'pointer' : 'auto';
+				_domElement.style.touchAction = '';
+
+			}
+
+			function updatePointer( event ) {
+
+				const e = event.changedTouches ? event.changedTouches[ 0 ] : event;
+
+				const rect = _domElement.getBoundingClientRect();
+
+				_pointer.x = ( e.clientX - rect.left ) / rect.width * 2 - 1;
+				_pointer.y = - ( e.clientY - rect.top ) / rect.height * 2 + 1;
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes the usage of all touch event listeners. Touch input is now processed by refactored pointer event listeners.

The PR also removes the usage of `preventDefault()`. The implementation is now similar to how `TransformControls` works.
