### PR TITLE
Controls: Remove usage of changedTouches.

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -65,11 +65,12 @@
 
 			function onPointerMove( event ) {
 
+				if ( scope.enabled === false ) return;
 				updatePointer( event );
 
 				_raycaster.setFromCamera( _pointer, _camera );
 
-				if ( _selected && scope.enabled ) {
+				if ( _selected ) {
 
 					if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
@@ -143,6 +144,7 @@
 
 			function onPointerDown() {
 
+				if ( scope.enabled === false ) return;
 				_domElement.style.touchAction = 'none';
 				updatePointer( event );
 				_intersections.length = 0;
@@ -177,6 +179,8 @@
 
 			function onPointerCancel() {
 
+				if ( scope.enabled === false ) return;
+
 				if ( _selected ) {
 
 					scope.dispatchEvent( {
@@ -194,12 +198,10 @@
 
 			function updatePointer( event ) {
 
-				const e = event.changedTouches ? event.changedTouches[ 0 ] : event;
-
 				const rect = _domElement.getBoundingClientRect();
 
-				_pointer.x = ( e.clientX - rect.left ) / rect.width * 2 - 1;
-				_pointer.y = - ( e.clientY - rect.top ) / rect.height * 2 + 1;
+				_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
+				_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;
 
 			}
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -617,11 +617,10 @@
 
 		} else {
 
-			const pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
 			const rect = this.domElement.getBoundingClientRect();
 			return {
-				x: ( pointer.clientX - rect.left ) / rect.width * 2 - 1,
-				y: - ( pointer.clientY - rect.top ) / rect.height * 2 + 1,
+				x: ( event.clientX - rect.left ) / rect.width * 2 - 1,
+				y: - ( event.clientY - rect.top ) / rect.height * 2 + 1,
 				button: event.button
 			};
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -188,12 +188,10 @@ class DragControls extends EventDispatcher {
 
 		function updatePointer( event ) {
 
-			const e = event.changedTouches ? event.changedTouches[ 0 ] : event;
-
 			const rect = _domElement.getBoundingClientRect();
 
-			_pointer.x = ( e.clientX - rect.left ) / rect.width * 2 - 1;
-			_pointer.y = - ( e.clientY - rect.top ) / rect.height * 2 + 1;
+			_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
+			_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;
 
 		}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -654,13 +654,11 @@ function getPointer( event ) {
 
 	} else {
 
-		const pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
-
 		const rect = this.domElement.getBoundingClientRect();
 
 		return {
-			x: ( pointer.clientX - rect.left ) / rect.width * 2 - 1,
-			y: - ( pointer.clientY - rect.top ) / rect.height * 2 + 1,
+			x: ( event.clientX - rect.left ) / rect.width * 2 - 1,
+			y: - ( event.clientY - rect.top ) / rect.height * 2 + 1,
 			button: event.button
 		};
 


### PR DESCRIPTION
Related issue: -

**Description**

Removes the usage of `changedTouches` from `TransformControls` and `DragControls`. The property is a member of [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches) which are not processed by both controls anymore. They only work with pointer events.