### PR TITLE
seamless computeTangents() for SphereGeometry

### DIFF
--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -122,11 +122,11 @@ class SphereGeometry extends BufferGeometry {
 			const normal = this.attributes.normal;
 			const tangent = normal.clone();
 			const vector = new THREE.Vector3();
-      
-			for ( let i = 0; i < tangent.count; i++ ) {
+
+			for ( let i = 0; i < tangent.count; i ++ ) {
 
 				vector.fromBufferAttribute( normal, i );
-				vector.set( vector.z, 0, -vector.x ).normalize();
+				vector.set( vector.z, 0, - vector.x ).normalize();
 				tangent.setXYZ( i, vector.x, vector.y, vector.z );
 
 			}

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -115,6 +115,28 @@ class SphereGeometry extends BufferGeometry {
 
 	}
 
+	computeTangents() {
+
+		if ( this.attributes.tangent === undefined ) {
+
+			const normal = this.attributes.normal;
+			const tangent = normal.clone();
+			const vector = new THREE.Vector3();
+      
+			for ( let i = 0; i < tangent.count; i++ ) {
+
+				vector.fromBufferAttribute( normal, i );
+				vector.set( vector.z, 0, -vector.x ).normalize();
+				tangent.setXYZ( i, vector.x, vector.y, vector.z );
+
+			}
+
+			this.setAttribute( 'tangent', tangent );
+
+		}
+
+	}
+
 }
 
 export { SphereGeometry, SphereGeometry as SphereBufferGeometry };


### PR DESCRIPTION
The issue was reported on discord a day ago, generic computeTangents() called on SphereGeometry creates a seam. An implementation that is aware of SphereGeometry geometry could easily fix it:
![Screen Shot 2021-06-09 at 2 13 38 ](https://user-images.githubusercontent.com/242577/121274421-bd4fba80-c8ca-11eb-9d1c-83b66e51db01.png)
https://jsfiddle.net/1xucLyq8/ (current sphere at the bottom, fixed sphere at the top)