### PR TITLE
Compressed texture 3d

### DIFF
--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -110,6 +110,13 @@
 							glslVersion: THREE.GLSL3
 						} );
 
+						new THREE.TextureLoader().load( 'textures/uv_grid_opengl.jpg', function(tex) {
+							const position = new THREE.Vector3(0,0,0);
+							const box = new THREE.Box3( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 255, 255, 0 ) );
+							// tex.image.data = tex.image; // workaround to mascarade a THREE.Texture as a THREE.DataTexture
+							renderer.copyTextureToTexture3D( box, position, tex, texture );
+						} );
+
 						const geometry = new THREE.PlaneGeometry( planeWidth, planeHeight );
 
 						mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -59,6 +59,7 @@
 			import { unzipSync } from './jsm/libs/fflate.module.js';
 
 			import { WEBGL } from './jsm/WebGL.js';
+			import { DDSLoader } from './jsm/loaders/DDSLoader.js';
 
 			if ( WEBGL.isWebGL2Available() === false ) {
 
@@ -71,7 +72,7 @@
 			const planeWidth = 50;
 			const planeHeight = 50;
 
-			let depthStep = 0.4;
+			let depthStep = 0.05;
 
 			init();
 			animate();
@@ -84,46 +85,6 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.1, 2000 );
 				camera.position.z = 70;
 
-				scene = new THREE.Scene();
-
-				// width 256, height 256, depth 109, 8-bit, zip archived raw data
-
-				new THREE.FileLoader()
-					.setResponseType( 'arraybuffer' )
-					.load( 'textures/3d/head256x256x109.zip', function ( data ) {
-
-						const zip = unzipSync( new Uint8Array( data ) );
-						const array = new Uint8Array( zip[ 'head256x256x109' ].buffer );
-
-						const texture = new THREE.DataTexture2DArray( array, 256, 256, 109 );
-						texture.format = THREE.RedFormat;
-						texture.type = THREE.UnsignedByteType;
-
-						const material = new THREE.ShaderMaterial( {
-							uniforms: {
-								diffuse: { value: texture },
-								depth: { value: 55 },
-								size: { value: new THREE.Vector2( planeWidth, planeHeight ) }
-							},
-							vertexShader: document.getElementById( 'vs' ).textContent.trim(),
-							fragmentShader: document.getElementById( 'fs' ).textContent.trim(),
-							glslVersion: THREE.GLSL3
-						} );
-
-						new THREE.TextureLoader().load( 'textures/uv_grid_opengl.jpg', function(tex) {
-							const position = new THREE.Vector3(0,0,0);
-							const box = new THREE.Box3( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 255, 255, 0 ) );
-							// tex.image.data = tex.image; // workaround to mascarade a THREE.Texture as a THREE.DataTexture
-							renderer.copyTextureToTexture3D( box, position, tex, texture );
-						} );
-
-						const geometry = new THREE.PlaneGeometry( planeWidth, planeHeight );
-
-						mesh = new THREE.Mesh( geometry, material );
-
-						scene.add( mesh );
-
-					} );
 
 				// 2D Texture array is available on WebGL 2.0
 
@@ -132,6 +93,52 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
+
+												const loader = new DDSLoader();
+					scene = new THREE.Scene();
+				loader.load('textures/compressed/Mountains.dds', tex => {
+					const image =tex.image[0].mipmaps[0] || tex.mipmaps[0];
+					const texture = new THREE.DataTexture2DArray( image.data, image.width, image.height, 1);
+					texture.format = tex.format;
+					texture.type = tex.type;
+					texture.unpackAlignment = tex.unpackAlignment;
+					console.log("tex",tex);
+					console.log("array",texture);
+
+					const material = new THREE.ShaderMaterial( {
+						uniforms: {
+							diffuse: { value: texture },
+							depth: { value: 0 },
+							size: { value: new THREE.Vector2( planeWidth, planeHeight ) }
+						},
+						vertexShader: document.getElementById( 'vs' ).textContent.trim(),
+						fragmentShader: document.getElementById( 'fs' ).textContent.trim(),
+						glslVersion: THREE.GLSL3
+					} );
+
+					const geometry = new THREE.PlaneGeometry( planeWidth, planeHeight );
+
+					mesh = new THREE.Mesh( geometry, material );
+
+					scene.add( mesh );
+
+
+					function copyTextureToTexture3D(z, anisotropy, filter) {
+						return tex => {
+							if (filter) tex.minFilter = tex.magFilter = filter;
+							tex.anisotropy = anisotropy;
+							const box = new THREE.Box3( new THREE.Vector3( 0, 0, 0 ), new THREE.Vector3( 511, 511, 0 ) );
+							const position = new THREE.Vector3(0,0,z);
+							renderer.copyTextureToTexture3D( box, position, tex, texture );
+						};
+					}
+					//loader.load( 'textures/compressed/Mountains.dds', copyTextureToTexture3D(0, 4, THREE.LinearFilter));
+					//loader.load( 'textures/compressed/disturb_dxt1_mip.dds', copyTextureToTexture3D(0, 4));
+					//loader.load( 'textures/compressed/hepatica_dxt3_mip.dds', copyTextureToTexture3D(0, 4));
+					//loader.load( 'textures/compressed/explosion_dxt5_mip.dds', copyTextureToTexture3D(0, 4));
+					//loader.load( 'textures/compressed/disturb_argb_nomip.dds', copyTextureToTexture3D(0, 4, THREE.LinearFilter));
+					//loader.load( 'textures/compressed/disturb_argb_mip.dds', copyTextureToTexture3D(0, 4));
+				});
 				stats = new Stats();
 				container.appendChild( stats.dom );
 
@@ -158,12 +165,9 @@
 
 					value += depthStep;
 
-					if ( value > 109.0 || value < 0.0 ) {
+					if ( value > 2.0 ) {
 
-						if ( value > 1.0 ) value = 109.0 * 2.0 - value;
-						if ( value < 0.0 ) value = - value;
-
-						depthStep = - depthStep;
+						value = value % 2;
 
 					}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2157,7 +2157,12 @@ function WebGLRenderer( parameters ) {
 
 			if ( srcTexture.isCompressedTexture ) {
 
-				console.warn( 'THREE.WebGLRenderer.copyTextureToTexture3D: untested support for compressed srcTexture.' );
+				if ( glFormat !== utils.convert( srcTexture.format ) ) {
+
+					console.warn( 'THREE.WebGLRenderer.copyTextureToTexture3D: non matching formats.' );
+
+				}
+
 				_gl.compressedTexSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, image.data );
 
 			} else {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2107,7 +2107,9 @@ function WebGLRenderer( parameters ) {
 
 		}
 
-		const { width, height, data } = srcTexture.image;
+		const width = sourceBox.max.x - sourceBox.min.x + 1;
+		const height = sourceBox.max.y - sourceBox.min.y + 1;
+		const depth = sourceBox.max.z - sourceBox.min.z + 1;
 		const glFormat = utils.convert( dstTexture.format );
 		const glType = utils.convert( dstTexture.type );
 		let glTarget;
@@ -2139,25 +2141,32 @@ function WebGLRenderer( parameters ) {
 		const unpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
 		const unpackSkipImages = _gl.getParameter( _gl.UNPACK_SKIP_IMAGES );
 
-		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, width );
-		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, height );
+		const image = srcTexture.isCompressedTexture ? srcTexture.mipmaps[ 0 ] : srcTexture.image;
+
+		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
+		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, image.height );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, sourceBox.min.x );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, sourceBox.min.y );
 		_gl.pixelStorei( _gl.UNPACK_SKIP_IMAGES, sourceBox.min.z );
 
-		_gl.texSubImage3D(
-			glTarget,
-			level,
-			position.x,
-			position.y,
-			position.z,
-			sourceBox.max.x - sourceBox.min.x + 1,
-			sourceBox.max.y - sourceBox.min.y + 1,
-			sourceBox.max.z - sourceBox.min.z + 1,
-			glFormat,
-			glType,
-			data
-		);
+		if ( srcTexture.isDataTexture || srcTexture.isDataTexture3D ) {
+
+			_gl.texSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, glType, image.data );
+
+		} else {
+
+			if ( srcTexture.isCompressedTexture ) {
+
+				console.warn( 'THREE.WebGLRenderer.copyTextureToTexture3D: untested support for compressed srcTexture.' );
+				_gl.compressedTexSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, image.data );
+
+			} else {
+
+				_gl.texSubImage3D( glTarget, level, position.x, position.y, position.z, width, height, depth, glFormat, glType, image );
+
+			}
+
+		}
 
 		_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, unpackRowLen );
 		_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, unpackImageHeight );

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -879,6 +879,20 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
+	function compressedTexImage3D() {
+
+		try {
+
+			gl.compressedTexImage3D.apply( gl, arguments );
+
+		} catch ( error ) {
+
+			console.error( 'THREE.WebGLState:', error );
+
+		}
+
+	}
+
 	function texImage2D() {
 
 		try {
@@ -1054,6 +1068,7 @@ function WebGLState( gl, extensions, capabilities ) {
 		bindTexture: bindTexture,
 		unbindTexture: unbindTexture,
 		compressedTexImage2D: compressedTexImage2D,
+		compressedTexImage3D: compressedTexImage2D,
 		texImage2D: texImage2D,
 		texImage3D: texImage3D,
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -1068,7 +1068,7 @@ function WebGLState( gl, extensions, capabilities ) {
 		bindTexture: bindTexture,
 		unbindTexture: unbindTexture,
 		compressedTexImage2D: compressedTexImage2D,
-		compressedTexImage3D: compressedTexImage2D,
+		compressedTexImage3D: compressedTexImage3D,
 		texImage2D: texImage2D,
 		texImage3D: texImage3D,
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -672,7 +672,16 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		} else if ( texture.isDataTexture2DArray ) {
 
-			state.texImage3D( _gl.TEXTURE_2D_ARRAY, 0, glInternalFormat, image.width, image.height, image.depth, 0, glFormat, glType, image.data );
+			if ( utils.isCompressed( glInternalFormat ) ) {
+
+				state.compressedTexImage3D( _gl.TEXTURE_2D_ARRAY, 0, glInternalFormat, image.width, image.height, image.depth, 0, image.data );
+
+			} else {
+
+				state.texImage3D( _gl.TEXTURE_2D_ARRAY, 0, glInternalFormat, image.width, image.height, image.depth, 0, glFormat, glType, image.data );
+
+			}
+
 			textureProperties.__maxMipLevel = 0;
 
 		} else if ( texture.isDataTexture3D ) {

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -189,7 +189,32 @@ function WebGLUtils( gl, extensions, capabilities ) {
 
 	}
 
-	return { convert: convert };
+
+	function isCompressed( p ) {
+
+		return (
+			p === RGB_S3TC_DXT1_Format || p === RGBA_S3TC_DXT1_Format ||
+			p === RGBA_S3TC_DXT3_Format || p === RGBA_S3TC_DXT5_Format ||
+			p === RGB_PVRTC_4BPPV1_Format || p === RGB_PVRTC_2BPPV1_Format ||
+			p === RGBA_PVRTC_4BPPV1_Format || p === RGBA_PVRTC_2BPPV1_Format ||
+			p === RGB_ETC1_Format ||	p === RGB_ETC2_Format || p === RGBA_ETC2_EAC_Format ||
+			p === RGBA_ASTC_4x4_Format || p === RGBA_ASTC_5x4_Format || p === RGBA_ASTC_5x5_Format ||
+			p === RGBA_ASTC_6x5_Format || p === RGBA_ASTC_6x6_Format || p === RGBA_ASTC_8x5_Format ||
+			p === RGBA_ASTC_8x6_Format || p === RGBA_ASTC_8x8_Format || p === RGBA_ASTC_10x5_Format ||
+			p === RGBA_ASTC_10x6_Format || p === RGBA_ASTC_10x8_Format || p === RGBA_ASTC_10x10_Format ||
+			p === RGBA_ASTC_12x10_Format || p === RGBA_ASTC_12x12_Format ||
+			p === SRGB8_ALPHA8_ASTC_4x4_Format || p === SRGB8_ALPHA8_ASTC_5x4_Format || p === SRGB8_ALPHA8_ASTC_5x5_Format ||
+			p === SRGB8_ALPHA8_ASTC_6x5_Format || p === SRGB8_ALPHA8_ASTC_6x6_Format || p === SRGB8_ALPHA8_ASTC_8x5_Format ||
+			p === SRGB8_ALPHA8_ASTC_8x6_Format || p === SRGB8_ALPHA8_ASTC_8x8_Format || p === SRGB8_ALPHA8_ASTC_10x5_Format ||
+			p === SRGB8_ALPHA8_ASTC_10x6_Format || p === SRGB8_ALPHA8_ASTC_10x8_Format || p === SRGB8_ALPHA8_ASTC_10x10_Format ||
+			p === SRGB8_ALPHA8_ASTC_12x10_Format || p === SRGB8_ALPHA8_ASTC_12x12_Format ||
+			p === RGBA_BPTC_Format
+		);
+
+	}
+
+
+	return { convert: convert, isCompressed: isCompressed };
 
 }
 


### PR DESCRIPTION
Related issue: #21942 (follow up)

**Description**

This is a work in progress to enable better support for compressed 3D textures and compressed 2D texture arrays.
I leave it here so that anybody interested in these features could start from this preliminary work.

As an alternative to a utils.isCompressed(internalformat) function, a simpler alternative could be to add a texture.isCompressed property, giving the responsability to set it up to the user.