### PR TITLE
GLTFLoader: Use Texture instead of CanvasTexture for ImageBitmaps

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4,7 +4,6 @@ import {
 	Box3,
 	BufferAttribute,
 	BufferGeometry,
-	CanvasTexture,
 	ClampToEdgeWrapping,
 	Color,
 	DirectionalLight,
@@ -54,6 +53,7 @@ import {
 	Sphere,
 	SpotLight,
 	TangentSpaceNormalMap,
+	Texture,
 	TextureLoader,
 	TriangleFanDrawMode,
 	TriangleStripDrawMode,
@@ -2598,7 +2598,10 @@ class GLTFParser {
 
 					onLoad = function ( imageBitmap ) {
 
-						resolve( new CanvasTexture( imageBitmap ) );
+						const texture = new Texture( imageBitmap );
+						texture.needsUpdate = true;
+
+						resolve( texture );
 
 					};
 


### PR DESCRIPTION
**Description**

`GLTFLoader` was using `CanvasTexture` when dealing with `ImageBitmap` but people were finding confusing.

https://twitter.com/mrdoob/status/1402387056379138050

/cc @takahirox 