### PR TITLE
GLTFLoader: Return null when failing to load textures

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2645,6 +2645,7 @@ class GLTFParser {
 
 		} ).catch( function () {
 
+			console.error( 'THREE.GLTFLoader: Couldn\'t load texture', sourceURI );
 			return null;
 
 		} );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2643,6 +2643,10 @@ class GLTFParser {
 
 			return texture;
 
+		} ).catch( function () {
+
+			return null;
+
 		} );
 
 		this.textureCache[ cacheKey ] = promise;


### PR DESCRIPTION
**Description**

`GLTFLoader` currently fails to load a model when it's unable to load its textures.
I think it's friendlier to load the model whenever possible.