### PR TITLE
Reflector: Add support for logarithmic depth buffer.

### DIFF
--- a/examples/js/objects/Reflector.js
+++ b/examples/js/objects/Reflector.js
@@ -158,11 +158,16 @@
 		uniform mat4 textureMatrix;
 		varying vec4 vUv;
 
+		#include <common>
+		#include <logdepthbuf_pars_vertex>
+
 		void main() {
 
 			vUv = textureMatrix * vec4( position, 1.0 );
 
 			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+			#include <logdepthbuf_vertex>
 
 		}`,
 		fragmentShader:
@@ -171,6 +176,8 @@
 		uniform vec3 color;
 		uniform sampler2D tDiffuse;
 		varying vec4 vUv;
+
+		#include <logdepthbuf_pars_fragment>
 
 		float blendOverlay( float base, float blend ) {
 
@@ -185,6 +192,8 @@
 		}
 
 		void main() {
+
+			#include <logdepthbuf_fragment>
 
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -221,11 +221,16 @@ Reflector.ReflectorShader = {
 		uniform mat4 textureMatrix;
 		varying vec4 vUv;
 
+		#include <common>
+		#include <logdepthbuf_pars_vertex>
+
 		void main() {
 
 			vUv = textureMatrix * vec4( position, 1.0 );
 
 			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+			#include <logdepthbuf_vertex>
 
 		}`,
 
@@ -233,6 +238,8 @@ Reflector.ReflectorShader = {
 		uniform vec3 color;
 		uniform sampler2D tDiffuse;
 		varying vec4 vUv;
+
+		#include <logdepthbuf_pars_fragment>
 
 		float blendOverlay( float base, float blend ) {
 
@@ -247,6 +254,8 @@ Reflector.ReflectorShader = {
 		}
 
 		void main() {
+
+			#include <logdepthbuf_fragment>
 
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );


### PR DESCRIPTION
Related issue: Fixed #21980.

**Description**

Using `logarithmicDepthBuffer = true` does not break mirrors anymore.