### PR TITLE
copyTextureToTexture sourcebox, flipY from source

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -295,11 +295,11 @@
 		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<p>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
-		<p>Copies all pixels of a texture to an existing texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
+		<h3>[method:null copyTextureToTexture]( [param:Texture srcTexture], [param:Texture dstTexture], [param:Vector2 dstPosition], [param:Box2 srcBox], [param:Number dstLevel], [param:Number srcLevel] )</h3>
+		<p>Copies the pixels of a source texture in the bounds '[page:Box2 srcBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture3D]( [param:Box3 sourceBox], [param:Vector3 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
-		<p>Copies the pixels of a texture in the bounds '[page:Box3 sourceBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D WebGL2RenderingContext.texSubImage3D].</p>
+		<h3>[method:null copyTextureToTexture3D]( [param:Texture srcTexture], [param:Texture dstTexture], [param:Vector3 dstPosition], [param:Box3 srcBox], [param:Number dstLevel], [param:Number srcLevel] )</h3>
+		<p>Copies the pixels of a source texture in the bounds '[page:Box3 srcBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D WebGL2RenderingContext.texSubImage3D].</p>
 
 		<h3>[method:null dispose]( )</h3>
 		<p>Dispose of the current rendering context.</p>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -282,8 +282,11 @@
 		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<p>将当前WebGLFramebuffer中的像素复制到2D纹理中。可访问[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
-		<p>将纹理的所有像素复制到一个已有的从给定位置开始的纹理中。可访问[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
+    <h3>[method:null copyTextureToTexture]( [param:Texture srcTexture], [param:Texture dstTexture], [param:Vector2 dstPosition], [param:Box2 srcBox], [param:Number dstLevel], [param:Number srcLevel] )</h3>
+		<p>Copies the pixels of a source texture in the bounds '[page:Box2 srcBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
+
+		<h3>[method:null copyTextureToTexture3D]( [param:Texture srcTexture], [param:Texture dstTexture], [param:Vector3 dstPosition], [param:Box3 srcBox], [param:Number dstLevel], [param:Number srcLevel] )</h3>
+		<p>Copies the pixels of a source texture in the bounds '[page:Box3 srcBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D WebGL2RenderingContext.texSubImage3D].</p>
 
 		<h3>[method:null dispose]( )</h3>
 		<p>处理当前的渲染环境</p>

--- a/examples/webgl2_materials_texture3d_partialupdate.html
+++ b/examples/webgl2_materials_texture3d_partialupdate.html
@@ -335,7 +335,8 @@
 					const scaleFactor = ( Math.random() + 0.5 ) * 0.5;
 					const source = generateCloudTexture( perElementPaddedSize, scaleFactor );
 
-					renderer.copyTextureToTexture3D( box, position, source, cloudTexture );
+					renderer.copyTextureToTexture3D( box, position, source, cloudTexture ); // old api
+					// renderer.copyTextureToTexture3D( source, cloudTexture, position, box ); // new api
 
 					prevTime = time;
 

--- a/examples/webgl_materials_texture_partialupdate.html
+++ b/examples/webgl_materials_texture_partialupdate.html
@@ -17,7 +17,7 @@
 
 			import * as THREE from '../build/three.module.js';
 
-			let camera, scene, renderer, clock, dataTexture, diffuseMap;
+			let camera, scene, renderer, clock, dataTexture, diffuseMap, lavaMap;
 
 			let last = 0;
 			const position = new THREE.Vector2();
@@ -36,6 +36,7 @@
 
 				const loader = new THREE.TextureLoader();
 				diffuseMap = loader.load( 'textures/floors/FloorsCheckerboard_S_Diffuse.jpg', animate );
+				lavaMap = loader.load( 'textures/lava/lavatile.jpg', animate );
 				diffuseMap.minFilter = THREE.LinearFilter;
 				diffuseMap.generateMipmaps = false;
 
@@ -85,16 +86,35 @@
 
 					last = elapsedTime;
 
-					position.x = ( 32 * THREE.MathUtils.randInt( 1, 16 ) ) - 32;
-					position.y = ( 32 * THREE.MathUtils.randInt( 1, 16 ) ) - 32;
+					position.x = ( 32 * THREE.MathUtils.randInt( 0, 15 ) );
+					position.y = ( 32 * THREE.MathUtils.randInt( 0, 15 ) );
 
-					// generate new color data
+					if (THREE.MathUtils.randInt(0,1)) {
 
-					updateDataTexture( dataTexture );
+						// generate new color data
+						updateDataTexture( dataTexture );
 
-					// perform copy from src to dest texture to a random position
+						// perform copy from src to dest texture to a random position
+						renderer.copyTextureToTexture( position, dataTexture, diffuseMap ); // old api
+						// renderer.copyTextureToTexture( dataTexture, diffuseMap, position ); // new api
 
-					renderer.copyTextureToTexture( position, dataTexture, diffuseMap );
+					} else {
+
+						const srcBox = new THREE.Box2();
+						srcBox.min.copy(position);
+						srcBox.max.x = srcBox.min.x + 31;
+						srcBox.max.y = srcBox.min.y + 31;
+
+						// if image is loaded, perform copy from src to dest texture to a random position
+						if (lavaMap.image) {
+
+							// impossible with old api (no srcBox parameter)
+							renderer.copyTextureToTexture( lavaMap, diffuseMap, position, srcBox ); // new api
+
+
+						}
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: #21942 

**Description**

This PR aligns the apis of copyTextureToTexture and copyTextureToTexture3D in the WebGLRenderer : 
- copyTextureToTexture was missing a source box parameter (only full images could be copied)
- a source level is added to enable copying a higher level than 0 from the source image for advanced uses.
- the parameters are reordered in both functions as `( srcTexture, dstTexture, dstPosition = undefined, srcBox = undefined, dstLevel = 0, srcLevel = 0 )` as all parameters but textures have sensible defaults (destination position at origin, full source box and levels at 0).
- usage of the previous api is detected by checking if the first argument is a texture, to reorder the parameters and print a deprecation warning.

examples/webgl_materials_texture_partialupdate.html 
- it now demonstrates copying sub parts of an input 2D texture
![image](https://user-images.githubusercontent.com/7373521/121910571-40d83400-cd2f-11eb-9d69-bd3e8a953547.png)

The box is reduced so that it points to valid pixels in both the source and destination textures. As an alternative, this code could be simplified if this burden is given to the user (big boxes will trigger webgl error).

finally, the UNPACK parameters are now taken from the source texture rather than the destination texture. It makes more sense in my use cases (otherwise I always end up at least copying flipY and unpackAlignment from the srcTexture to the dstTexture before the copy as a workaround)

