### PR TITLE
Editor: Added vertex colors support to draco export

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -228,8 +228,18 @@ function MenubarFile( editor ) {
 
 		var exporter = new DRACOExporter();
 
+		const options = {
+			decodeSpeed: 5,
+			encodeSpeed: 5,
+			encoderMethod: DRACOExporter.MESH_EDGEBREAKER_ENCODING,
+			quantization: [ 16, 8, 8, 8, 8 ],
+			exportUvs: true,
+			exportNormals: true,
+			exportColor: object.geometry.hasAttribute( 'color' )
+		};
+
 		// TODO: Change to DRACOExporter's parse( geometry, onParse )?
-		var result = exporter.parse( object );
+		var result = exporter.parse( object, options );
 		saveArrayBuffer( result, 'model.drc' );
 
 	} );


### PR DESCRIPTION
**Description**

Pass `exportColor: true` to `DRACOExporter`'s `parse()` when `geometry.hasAttribute( 'color' )`.
