### PR TITLE
PCDLoader: fixed some problems with reading RGB

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -122,7 +122,7 @@ class PCDLoader extends Loader {
 
 			// remove comments
 
-			PCDheader.str = PCDheader.str.replace( /\#.*/gi, '' );
+			PCDheader.str = PCDheader.str.replace( /#.*/gi, '' );
 
 			// parse
 
@@ -290,30 +290,35 @@ class PCDLoader extends Loader {
 			const dataview = new DataView( decompressed.buffer );
 
 			const offset = PCDheader.offset;
+			
+			const fieldsSize = {};
+			PCDheader.fields.forEach( ( value, index ) => {
+				fieldsSize[ value ] = PCDheader.size[ index ];
+			} )
 
 			for ( let i = 0; i < PCDheader.points; i ++ ) {
 
 				if ( offset.x !== undefined ) {
 
-					position.push( dataview.getFloat32( ( PCDheader.points * offset.x ) + PCDheader.size[ 0 ] * i, this.littleEndian ) );
-					position.push( dataview.getFloat32( ( PCDheader.points * offset.y ) + PCDheader.size[ 1 ] * i, this.littleEndian ) );
-					position.push( dataview.getFloat32( ( PCDheader.points * offset.z ) + PCDheader.size[ 2 ] * i, this.littleEndian ) );
+					position.push( dataview.getFloat32( ( PCDheader.points * offset.x ) + fieldsSize.x * i, this.littleEndian ) );
+					position.push( dataview.getFloat32( ( PCDheader.points * offset.y ) + fieldsSize.y * i, this.littleEndian ) );
+					position.push( dataview.getFloat32( ( PCDheader.points * offset.z ) + fieldsSize.z * i, this.littleEndian ) );
 
 				}
 
 				if ( offset.rgb !== undefined ) {
 
-					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + PCDheader.size[ 3 ] * i + 0 ) / 255.0 );
-					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + PCDheader.size[ 3 ] * i + 1 ) / 255.0 );
-					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + PCDheader.size[ 3 ] * i + 2 ) / 255.0 );
+					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + fieldsSize.rgb * i + 0 ) / 255.0 );
+					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + fieldsSize.rgb * i + 1 ) / 255.0 );
+					color.push( dataview.getUint8( ( PCDheader.points * offset.rgb ) + fieldsSize.rgb * i + 2 ) / 255.0 );
 
 				}
 
 				if ( offset.normal_x !== undefined ) {
 
-					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_x ) + PCDheader.size[ 4 ] * i, this.littleEndian ) );
-					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_y ) + PCDheader.size[ 5 ] * i, this.littleEndian ) );
-					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_z ) + PCDheader.size[ 6 ] * i, this.littleEndian ) );
+					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_x ) + fieldsSize.normal_x * i, this.littleEndian ) );
+					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_y ) + fieldsSize.normal_y * i, this.littleEndian ) );
+					normal.push( dataview.getFloat32( ( PCDheader.points * offset.normal_z ) + fieldsSize.normal_z * i, this.littleEndian ) );
 
 				}
 
@@ -340,9 +345,9 @@ class PCDLoader extends Loader {
 
 				if ( offset.rgb !== undefined ) {
 
-					color.push( dataview.getUint8( row + offset.rgb + 2 ) / 255.0 );
-					color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
 					color.push( dataview.getUint8( row + offset.rgb + 0 ) / 255.0 );
+					color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
+					color.push( dataview.getUint8( row + offset.rgb + 2 ) / 255.0 );
 
 				}
 
@@ -386,7 +391,7 @@ class PCDLoader extends Loader {
 
 		const mesh = new Points( geometry, material );
 		let name = url.split( '' ).reverse().join( '' );
-		name = /([^\/]*)/.exec( name );
+		name = /([^/]*)/.exec( name );
 		name = name[ 1 ].split( '' ).reverse().join( '' );
 		mesh.name = name;
 


### PR DESCRIPTION
Related issue: null



#### Description

When I used PCDLoader to load point cloud file (xxx.pcd), I found some problems.



**1. Unnecessary escape character (eslint)**

```diff
- /\#.*/gi
+ /#.*/gi

- /([^\/]*)/
+ /([^/]*)/
```



<br>

**2. I think the read order is reversed** 

```diff
- color.push( dataview.getUint8( row + offset.rgb + 2 ) / 255.0 );
- color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
- color.push( dataview.getUint8( row + offset.rgb + 0 ) / 255.0 );

+ color.push( dataview.getUint8( row + offset.rgb + 0 ) / 255.0 );
+ color.push( dataview.getUint8( row + offset.rgb + 1 ) / 255.0 );
+ color.push( dataview.getUint8( row + offset.rgb + 2 ) / 255.0 );
```



<br>

**3. "fields" and "size"**

I don't think index numbers can be written as fixed values.

You can't be completely sure of their order.

*Although in practice, we almost all comply with it.*



<br>

> https://vml.sakura.ne.jp/koeda/PCL/tutorials/html/pcd_file_format.html
>
> As of version 0.7, the PCD header contains the following entries:
>
> **FIELDS** - specifies the name of each dimension/field that a point can have. Examples:
>
> ```
> FIELDS x y z                                # XYZ data
> FIELDS x y z rgb                            # XYZ + colors
> FIELDS x y z normal_x normal_y normal_z     # XYZ + surface normals
> FIELDS j1 j2 j3                             # moment invariants
> ...
> ```



<br>

```diff
+ const fieldsSize = {};
+ PCDheader.fields.forEach( ( value, index ) => {
+    fieldsSize[ value ] = PCDheader.size[ index ];
+ } )

- PCDheader.size[ 0 ]
- PCDheader.size[ 1 ]
- PCDheader.size[ 2 ]
+ fieldsSize.x
+ fieldsSize.y
+ fieldsSize.z

- PCDheader.size[ 3 ]
+ fieldsSize.rgb

...
```



<br>

-----

<br>

#### There remained one significant problem.

But I don't know how to modify it properly.

In the current code, we don't read and set the `intensity`.

More frustrating is that for every .pcd file, we can not know the value range of `intensity`.

I didn't find the value range specification of reflectance in [PCL](https://en.wikipedia.org/wiki/Point_Cloud_Library).



<br>

**I try to convert different intensity into different colors**

<br>

```
const color = [];

const maxIntensity = 250 // assume the intensity range is 0-250
//Maybe we should go through all the intensity and find the maximum value.

const pointColor = new Three.Color()
const pushColorByIntensity = function (intensity) {
    pointColor.setHSL(intensity, intensity, intensity);
    color.push(pointColor.r, pointColor.g, pointColor.b, intensity);
}

//...
for (let i = 0; i < PCDheader.points; i++) {

    if (offset.x !== undefined) { ... }
    if (offset.rgb !== undefined) { ... }
    if (offset.normal_x !== undefined) { ... }
    
    if (offset.intensity !== undefined) {
    
        // HACK
        if (offset.rgb !== undefined) continue
		
        const intensity = dataview.getUint8((PCDheader.points * offset.intensity) + fieldsSize.intensity * i)
        pushColorByIntensity( intensity / maxIntensity)
        
    }
}

//
if (color.length > 0)
geometry.setAttribute('color', new Float32BufferAttribute(color, PCDheader.offset.rgb !== undefined ? 3 : 4));
```

<br>

It looks very complicated, so I won't submit the relevant code for the time being, I haven't figured out how to do it myself.

But, you can see the results running on my machine.



![color-by-intensity](https://puxiao.com/temp/color_pcd2.jpg)



<br>

I am using online translation tools, some sentences may cause trouble to you, I am sorry.