### PR TITLE
docs: update slack invite-link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The aim of the project is to create an easy to use, lightweight, cross-browser, 
 [Migrating](https://github.com/mrdoob/three.js/wiki/Migration-Guide) &mdash;
 [Questions](http://stackoverflow.com/questions/tagged/three.js) &mdash;
 [Forum](https://discourse.threejs.org/) &mdash;
-[Slack](https://join.slack.com/t/threejs/shared_invite/enQtMzYxMzczODM2OTgxLTQ1YmY4YTQxOTFjNDAzYmQ4NjU2YzRhNzliY2RiNDEyYjU2MjhhODgyYWQ5Y2MyZTU3MWNkOGVmOGRhOTQzYTk) &mdash;
+[Slack](https://join.slack.com/t/threejs/shared_invite/zt-rnuegz5e-FQpc6YboDVW~5idlp7GfDw) &mdash;
 [Discord](https://discordapp.com/invite/HF4UdyF)
 
 ### Usage ###


### PR DESCRIPTION
**Description**

The invite link for our slack community expired so I made a new one.