### PR TITLE
homepage: update slack invite-link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 						<li><a href="https://stackoverflow.com/questions/tagged/three.js">questions</a></li>
 						<li><a href="https://discord.gg/HF4UdyF">discord</a></li>
 						<li><a href="https://discourse.threejs.org/">forum</a></li>
-						<li><a href="https://join.slack.com/t/threejs/shared_invite/enQtMzYxMzczODM2OTgxLTQ1YmY4YTQxOTFjNDAzYmQ4NjU2YzRhNzliY2RiNDEyYjU2MjhhODgyYWQ5Y2MyZTU3MWNkOGVmOGRhOTQzYTk">slack</a></li>
+						<li><a href="https://join.slack.com/t/threejs/shared_invite/zt-rnuegz5e-FQpc6YboDVW~5idlp7GfDw">slack</a></li>
 						<li><a href="https://twitter.com/threejs">twitter</a></li>
 					</ul>
 


### PR DESCRIPTION
**Description**

Update the invite link to the slack community since the old one expired.