### PR TITLE
[Docs] add vertexAlphas in Material, supported since r127

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -292,6 +292,12 @@
 		<p>
 		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
 		</p>
+	
+		<h3>[property:Boolean vertexAlphas]</h3>
+		<p>
+		Defines whether vertex coloring support alpha value. Default is *false*.
+		Only applies when using .vertexColors property.
+		</p>
 
 		<h3>[property:Boolean vertexColors]</h3>
 		<p>


### PR DESCRIPTION
Related issue: no-issue

**Description**

Add missing property `vertexAlphas` in Material

release r127 changes: https://github.com/mrdoob/three.js/releases/tag/r127
PR with change and discussion https://github.com/mrdoob/three.js/pull/20975

