### PR TITLE
ObjectLoader: Ensure onLoad() is not fired twice.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -141,10 +141,25 @@ class ObjectLoader extends Loader {
 
 			for ( const uuid in images ) {
 
-				if ( images[ uuid ] instanceof HTMLImageElement ) {
+				const image = images[ uuid ];
+
+				if ( image instanceof HTMLImageElement ) {
 
 					hasImages = true;
 					break;
+
+				} else if ( Array.isArray( image ) ) {
+
+					for ( let i = 0; i < image.length; i ++ ) {
+
+						if ( image[ i ] instanceof HTMLImageElement ) {
+
+							hasImages = true;
+							break;
+
+						}
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: Follow-up of #18834.

**Description**

Ensures `onLoad()` is not fired twice when array of images (for cube textures) are used.