### PR TITLE
ObjectLoader: Add async API.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -640,12 +640,10 @@ Editor.prototype = {
 
 	//
 
-	fromJSON: function ( json ) {
-
-		var scope = this;
+	fromJSON: async function ( json ) {
 
 		var loader = new THREE.ObjectLoader();
-		var camera = loader.parse( json.camera );
+		var camera = await loader.parseAsync( json.camera );
 
 		this.camera.copy( camera );
 		this.signals.cameraResetted.dispatch();
@@ -653,11 +651,7 @@ Editor.prototype = {
 		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
-		loader.parse( json.scene, function ( scene ) {
-
-			scope.setScene( scene );
-
-		} );
+		this.setScene( await loader.parseAsync( json.scene ) );
 
 	},
 

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -56,10 +56,10 @@
 			let container, stats;
 			let camera, scene, renderer;
 
-			init();
+			await init();
 			animate();
 
-			function init() {
+			async function init() {
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
@@ -126,11 +126,8 @@
 				// MODEL
 
 				const loader = new THREE.ObjectLoader();
-				loader.load( "models/json/lightmap/lightmap.json", function ( object ) {
-
-					scene.add( object );
-
-				} );
+				const object = await loader.loadAsync( "models/json/lightmap/lightmap.json" );
+				scene.add( object );
 
 				//
 


### PR DESCRIPTION
Related issue: see #22026.

**Description**

This PR adds `parseAsync()`, `loadAsync()` and `parseImagesAsync()` to `ObjectLoader`. This resolves a hack during the image loading process which also closes #13177.

The previous usage of the loader still works. At some point in the future, we might want to add a deprecation message two `load()` and `parse()` and then remove both methods.