### PR TITLE
fix: #22037 enable texutre with extensions can be cache

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2212,7 +2212,7 @@ class GLTFParser {
 
 		if ( type == 'texture' ) {
 
-			const textureDef = this.json.textures[index];
+			const textureDef = this.json.textures[ index ];
 			cacheKey = type + ':' + textureDef.sampler + ':' + textureDef.source + ':' + JSON.stringify( textureDef.extensions );
 
 		}

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2208,7 +2208,15 @@ class GLTFParser {
 	 */
 	getDependency( type, index ) {
 
-		const cacheKey = type + ':' + index;
+		let cacheKey = type + ':' + index;
+
+		if ( type == 'texture' ) {
+
+			const textureDef = this.json.textures[index];
+			cacheKey = type + ':' + textureDef.sampler + ':' + textureDef.source + ':' + JSON.stringify( textureDef.extensions );
+
+		}
+
 		let dependency = this.cache.get( cacheKey );
 
 		if ( ! dependency ) {


### PR DESCRIPTION
Related issue: #22037 #21559

**Description**

enable texutre with extensions can be cache

https://deepkolos.github.io/lazy-gltf-loader/examples/texture-test.html

![图片](https://user-images.githubusercontent.com/12824616/123118874-98844700-d475-11eb-8be4-82e3fe956cf6.png)