### PR TITLE
AxesHelper: added setColors()

### DIFF
--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -44,7 +44,12 @@ scene.add( axesHelper );
 		<h2>Methods</h2>
 		<p>See the base [page:LineSegments] class for common methods.</p>
 
-		<h3>[method:AxesHelper dispose]()</h3>
+		<h3>[method:this setColors]( [param:Color xAxisColor], [param:Color yAxisColor], [param:Color zAxisColor] )</h3>
+		<p>
+		Sets the axes colors to [page:Color xAxisColor], [page:Color yAxisColor], [page:Color zAxisColor].
+		</p>
+
+		<h3>[method:null dispose]()</h3>
 		<p>
 		Disposes of the internally-created [page:Line.material material] and [page:Line.geometry geometry] used by this helper.
 		</p>

--- a/src/helpers/AxesHelper.js
+++ b/src/helpers/AxesHelper.js
@@ -2,6 +2,7 @@ import { LineSegments } from '../objects/LineSegments.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
+import { Color } from '../math/Color.js';
 
 class AxesHelper extends LineSegments {
 
@@ -28,6 +29,29 @@ class AxesHelper extends LineSegments {
 		super( geometry, material );
 
 		this.type = 'AxesHelper';
+
+	}
+
+	setColors( xAxisColor, yAxisColor, zAxisColor ) {
+
+		const color = new Color();
+		const array = this.geometry.attributes.color.array;
+
+		color.set( xAxisColor );
+		color.toArray( array, 0 );
+		color.toArray( array, 3 );
+
+		color.set( yAxisColor );
+		color.toArray( array, 6 );
+		color.toArray( array, 9 );
+
+		color.set( zAxisColor );
+		color.toArray( array, 12 );
+		color.toArray( array, 15 );
+
+		this.geometry.attributes.color.needsUpdate = true;
+
+		return this;
 
 	}
 


### PR DESCRIPTION
Implementation of this method is a bit tedious for the user.

We allow users to set the colors of other helpers -- although (primarily) in the constructor only.

