### PR TITLE
docs: fix link to THREE.Matrix4

### DIFF
--- a/docs/api/en/core/Uniform.html
+++ b/docs/api/en/core/Uniform.html
@@ -133,7 +133,7 @@
 				</tr>
 				<tr>
 					<td>mat4</td>
-					<td>[page:Matrix3 THREE.Matrix4]</td>
+					<td>[page:Matrix4 THREE.Matrix4]</td>
 				</tr>
 				<tr>
 					<td>mat4</td>


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Fix wrong link to THREE.Matrix4.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Example](https://example.com).
