### PR TITLE
Docs: Ensure navigation links are properly selected.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -279,6 +279,16 @@
 						const linkElement = createLink( pageName, pageURL );
 						listElement.appendChild( linkElement );
 
+						// select current page
+
+						const selectedPage = window.location.hash.substring( 1 );
+
+						if ( pageURL === selectedPage ) {
+
+							linkElement.classList.add( 'selected' );
+
+						}
+
 						// Gather the main properties for the current subpage
 
 						pageProperties[ pageName ] = {

--- a/docs/index.html
+++ b/docs/index.html
@@ -238,6 +238,7 @@
 			}
 
 			const localList = list[ language ];
+			const selectedPage = window.location.hash.substring( 1 );
 
 			for ( const section in localList ) {
 
@@ -280,8 +281,6 @@
 						listElement.appendChild( linkElement );
 
 						// select current page
-
-						const selectedPage = window.location.hash.substring( 1 );
 
 						if ( pageURL === selectedPage ) {
 


### PR DESCRIPTION
Related issue: Fixed #22055.

**Description**

Ensures the navigation bar's links are properly selected after a page refresh.
