### PR TITLE
Mesh: Prevent infinite loop in raycast().

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -170,7 +170,7 @@ class Mesh extends Object3D {
 						const groupMaterial = material[ group.materialIndex ];
 
 						const start = Math.max( group.start, drawRange.start );
-						const end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+						const end = Math.min( index.count, Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) ) );
 
 						for ( let j = start, jl = end; j < jl; j += 3 ) {
 
@@ -228,7 +228,7 @@ class Mesh extends Object3D {
 						const groupMaterial = material[ group.materialIndex ];
 
 						const start = Math.max( group.start, drawRange.start );
-						const end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+						const end = Math.min( position.count, Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) ) );
 
 						for ( let j = start, jl = end; j < jl; j += 3 ) {
 


### PR DESCRIPTION
**Description**

If you raycast at a Mesh with multiple materials, you end up in an infinite loop if both group.count and drawRange.count are set to Infinity.  (Which seems to me to be a common case.)  The single material cases check against the minimum of index.count or position.count (depending on if the Geometry is indexed or not).  It seems to me that this same check should be included in the array of materials case as well.