### PR TITLE
Expose Raycaster object in TransformControls

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -161,6 +161,14 @@
 			Should be called if the controls is no longer required.
 		</p>
 
+		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<p>
+			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of
+			TransformControls. If you set the [page:Object3D.layers .layers] property of the [name], you will also want to
+			set the [page:Raycaster.layers .layers] property on the [page:Raycaster] with a matching value, or else the [name]
+			won't work as expected.
+		</p>
+
 		<h3>[method:String getMode] ()</h3>
 		<p>
 			Returns the transformation mode.

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -161,7 +161,7 @@
 			Should be called if the controls is no longer required.
 		</p>
 
-		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of
 			TransformControls. If you set the [page:Object3D.layers .layers] property of the [name], you will also want to

--- a/docs/examples/ko/controls/TransformControls.html
+++ b/docs/examples/ko/controls/TransformControls.html
@@ -159,6 +159,13 @@
 			컨트롤을 더이상 필요하지 않을 경우 호출해야 합니다.
 		</p>
 
+		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<p>
+			사용자 상호 작용에 사용되는 [page:Raycaster] 객체를 반환합니다. 이 개체는의 모든 인스턴스간에 공유됩니다. TransformControls. [name] 의
+			[page:Object3D.layers .layers] 속성을 설정하면 [page:Raycaster] 의 [page:Raycaster.layers .layers] 속성을 일치하는
+			값으로 설정하거나 그렇지 않으면 [name] 예상대로 작동하지 않습니다.
+		</p>
+
 		<h3>[method:String getMode] ()</h3>
 		<p>
 			변환 모드를 반환합니다.

--- a/docs/examples/ko/controls/TransformControls.html
+++ b/docs/examples/ko/controls/TransformControls.html
@@ -159,7 +159,7 @@
 			컨트롤을 더이상 필요하지 않을 경우 호출해야 합니다.
 		</p>
 
-		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			사용자 상호 작용에 사용되는 [page:Raycaster] 객체를 반환합니다. 이 개체는의 모든 인스턴스간에 공유됩니다. TransformControls. [name] 의
 			[page:Object3D.layers .layers] 속성을 설정하면 [page:Raycaster] 의 [page:Raycaster.layers .layers] 속성을 일치하는

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -160,6 +160,13 @@
 			若不再需要该控制器，则应当调用此函数。
 		</p>
 
+		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<p>
+			返回用于用户交互的 [page:Raycaster] 对象。 此对象在所有实例之间共享 变换控件。 如果您设置 [name] 的
+			[page:Object3D.layers .layers] 属性，您还需要 使用匹配值设置 [page:Raycaster] 上的
+			[page:Raycaster.layers .layers] 属性，否则设置 [name] 不会按预期工作。
+		</p>
+
 		<h3>[method:String getMode] ()</h3>
 		<p>
 			返回变换模式。

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -160,7 +160,7 @@
 			若不再需要该控制器，则应当调用此函数。
 		</p>
 
-		<h3>[method:Raycaster getSharedRaycaster] ()</h3>
+		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			返回用于用户交互的 [page:Raycaster] 对象。 此对象在所有实例之间共享 变换控件。 如果您设置 [name] 的
 			[page:Object3D.layers .layers] 属性，您还需要 使用匹配值设置 [page:Raycaster] 上的

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -553,7 +553,7 @@
 
 		}
 
-		getSharedRaycaster() {
+		getRaycaster() {
 
 			return _raycaster;
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -551,6 +551,12 @@
 			this.axis = null;
 			return this;
 
+		}
+
+		getSharedRaycaster() {
+
+			return _raycaster;
+
 		} // TODO: deprecate
 
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -586,7 +586,7 @@ class TransformControls extends Object3D {
 
 	}
 
-	getSharedRaycaster() {
+	getRaycaster() {
 
 		return _raycaster;
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -586,6 +586,12 @@ class TransformControls extends Object3D {
 
 	}
 
+	getSharedRaycaster() {
+
+		return _raycaster;
+
+	}
+
 	// TODO: deprecate
 
 	getMode() {


### PR DESCRIPTION
Related issue: #21933

I noticed that in #21933 @mrdoob suggested to make this a getter instead of exposing the variable as a property. This also directly exposes the shared Raycaster to limit the code changes.