### PR TITLE
Fix regression in WebXR

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -496,7 +496,7 @@ class WebXRManager extends EventDispatcher {
 
 						const glSubImage = glBinding.getViewSubImage( glProjLayer, view );
 
-						gl.bindFramebuffer( gl.FRAMEBUFFER, glFramebuffer );
+						state.bindXRFramebuffer( glFramebuffer );
 
 						gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glSubImage.colorTexture, 0 );
 
@@ -505,8 +505,6 @@ class WebXRManager extends EventDispatcher {
 							gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glSubImage.depthStencilTexture, 0 );
 
 						}
-
-						state.bindXRFramebuffer( glFramebuffer );
 
 						viewport = glSubImage.viewport;
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -506,8 +506,6 @@ class WebXRManager extends EventDispatcher {
 
 						}
 
-						gl.bindFramebuffer( gl.FRAMEBUFFER, null );
-
 						state.bindXRFramebuffer( glFramebuffer );
 
 						viewport = glSubImage.viewport;


### PR DESCRIPTION
Related issue: #22069

**Description**

The code that unbinds the framebuffer broke some examples.
Closes #22069 

This contribution is funded by [Oculus](https://oculus.com).
