### PR TITLE
WebGLRenderer: Add logarithmicDepthBufferFragment parameter

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -69,10 +69,10 @@
 		optimization and can cause a decrease in performance.
 		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.<br />
 
-		{page:Boolean logarithmicDepthBufferFragment] - whether to apply logarithmic depth to individual fragments in the fragment shader (true),
+		[page:Boolean logarithmicDepthBufferFragment] - whether to apply logarithmic depth to individual fragments in the fragment shader (true),
 		or to emulate logarithmic depth per vertex in the vertex shader (false).
 		Default value is *false* which uses emulated logarithmic depth in the vertex shader.
-		There are benefits and drawbacks to both approaches, most notably:
+		There are benefits and drawbacks to both approaches, most notably:<br />
 		Fragment logarithmic depth will
 		<ul>
 			<li>Disable MSAA on some webgl implementations</li>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -67,7 +67,22 @@
 		be neccesary to use this if dealing with huge differences in scale in a single scene. Note that this setting
 		uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
 		optimization and can cause a decrease in performance.
-		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
+		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.<br />
+
+		{page:Boolean logarithmicDepthBufferFragment] - whether to apply logarithmic depth to individual fragments in the fragment shader (true),
+		or to emulate logarithmic depth per vertex in the vertex shader (false).
+		Default value is *false* which uses emulated logarithmic depth in the vertex shader.
+		There are benefits and drawbacks to both approaches, most notably:
+		Fragment logarithmic depth will
+		<ul>
+			<li>Disable MSAA on some webgl implementations</li>
+			<li>Disable some z-test optimisations as the fragment shader writes to gl_FragDepth</li>
+		</ul>
+		Emulated vertex logarithmic depth may
+		<ul>
+			<li>Cause z-fighting or artifacts, especially on large triangles</li>
+		</ul>
+		It is recommended to choose a mode based on the requirements of your application.
 		</p>
 
 		<h2>Properties</h2>

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -70,6 +70,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 	const drawBuffers = isWebGL2 || extensions.has( 'WEBGL_draw_buffers' );
 
 	const logarithmicDepthBuffer = parameters.logarithmicDepthBuffer === true;
+	const logarithmicDepthBufferFragment = parameters.logarithmicDepthBufferFragment === true;
 
 	const maxTextures = gl.getParameter( gl.MAX_TEXTURE_IMAGE_UNITS );
 	const maxVertexTextures = gl.getParameter( gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS );
@@ -98,6 +99,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 		precision: precision,
 		logarithmicDepthBuffer: logarithmicDepthBuffer,
+		logarithmicDepthBufferFragment: logarithmicDepthBufferFragment,
 
 		maxTextures: maxTextures,
 		maxVertexTextures: maxVertexTextures,

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -117,7 +117,7 @@ function generateExtensions( parameters ) {
 
 	const chunks = [
 		( parameters.extensionDerivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
-		( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
+		( parameters.extensionFragDepth || ( parameters.logarithmicDepthBuffer && parameters.logarithmicDepthBufferFragment ) ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
 		( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
 		( parameters.extensionShaderTextureLOD || parameters.envMap || parameters.transmission > 0.0 ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 	];
@@ -494,7 +494,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+			( parameters.logarithmicDepthBuffer && parameters.logarithmicDepthBufferFragment && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 			'uniform mat4 modelMatrix;',
 			'uniform mat4 modelViewMatrix;',
@@ -636,7 +636,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
 			parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-			( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+			( parameters.logarithmicDepthBuffer && parameters.logarithmicDepthBufferFragment && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 			( ( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ) ? '#define TEXTURE_LOD_EXT' : '',
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -9,6 +9,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 
 	const isWebGL2 = capabilities.isWebGL2;
 	const logarithmicDepthBuffer = capabilities.logarithmicDepthBuffer;
+	const logarithmicDepthBufferFragment = capabilities.logarithmicDepthBufferFragment;
 	const floatVertexTextures = capabilities.floatVertexTextures;
 	const maxVertexUniforms = capabilities.maxVertexUniforms;
 	const vertexTextures = capabilities.vertexTextures;
@@ -39,7 +40,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 		'lightMap', 'lightMapEncoding', 'aoMap', 'emissiveMap', 'emissiveMapEncoding', 'bumpMap', 'normalMap', 'objectSpaceNormalMap', 'tangentSpaceNormalMap', 'clearcoatMap', 'clearcoatRoughnessMap', 'clearcoatNormalMap', 'displacementMap', 'specularMap',
 		'roughnessMap', 'metalnessMap', 'gradientMap',
 		'alphaMap', 'combine', 'vertexColors', 'vertexAlphas', 'vertexTangents', 'vertexUvs', 'uvsVertexOnly', 'fog', 'useFog', 'fogExp2',
-		'flatShading', 'sizeAttenuation', 'logarithmicDepthBuffer', 'skinning',
+		'flatShading', 'sizeAttenuation', 'logarithmicDepthBuffer', 'logarithmicDepthBufferFragment', 'skinning',
 		'maxBones', 'useVertexTexture', 'morphTargets', 'morphNormals', 'premultipliedAlpha',
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
 		'numDirLightShadows', 'numPointLightShadows', 'numSpotLightShadows',
@@ -222,6 +223,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 
 			sizeAttenuation: material.sizeAttenuation,
 			logarithmicDepthBuffer: logarithmicDepthBuffer,
+			logarithmicDepthBufferFragment: logarithmicDepthBufferFragment,
 
 			skinning: object.isSkinnedMesh === true && maxBones > 0,
 			maxBones: maxBones,


### PR DESCRIPTION

Related issue: #22017

**Description**

Added logarithmicDepthBufferFragment parameter to allow the user to choose between vertex shader emulated logarithmic depth and fragment shader logarithmic depth.

This is an alternative option to https://github.com/mrdoob/three.js/pull/22041 which removes fragment shader logarithmic depth entirely.
