### PR TITLE
DragControls: added onPointerDown parameters

### DIFF
--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -136,7 +136,7 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function onPointerDown() {
+		function onPointerDown( event ) {
 
 			if ( scope.enabled === false ) return;
 


### PR DESCRIPTION
Related issue: null

**Description**

emm....
Even if you don’t add this parameter, it can still be executed normally.
