### PR TITLE
WireframeGeometry: Prevent duplicate edges.

### DIFF
--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -19,12 +19,12 @@ class WireframeGeometry extends BufferGeometry {
 		// buffer
 
 		const vertices = [];
+		const edges = new Set();
 
 		// helper variables
 
-		const edge = [ 0, 0 ], edges = {};
-
-		const vertex = new Vector3();
+		const start = new Vector3();
+		const end = new Vector3();
 
 		if ( geometry.index !== null ) {
 
@@ -46,43 +46,29 @@ class WireframeGeometry extends BufferGeometry {
 
 				const group = groups[ o ];
 
-				const start = group.start;
-				const count = group.count;
+				const groupStart = group.start;
+				const groupCount = group.count;
 
-				for ( let i = start, l = ( start + count ); i < l; i += 3 ) {
+				for ( let i = groupStart, l = ( groupStart + groupCount ); i < l; i += 3 ) {
 
 					for ( let j = 0; j < 3; j ++ ) {
 
-						const edge1 = indices.getX( i + j );
-						const edge2 = indices.getX( i + ( j + 1 ) % 3 );
-						edge[ 0 ] = Math.min( edge1, edge2 ); // sorting prevents duplicates
-						edge[ 1 ] = Math.max( edge1, edge2 );
+						const index1 = indices.getX( i + j );
+						const index2 = indices.getX( i + ( j + 1 ) % 3 );
 
-						const key = edge[ 0 ] + ',' + edge[ 1 ];
+						start.fromBufferAttribute( position, index1 );
+						end.fromBufferAttribute( position, index2 );
 
-						if ( edges[ key ] === undefined ) {
+						if ( isUniqueEdge( start, end, edges ) === true ) {
 
-							edges[ key ] = { index1: edge[ 0 ], index2: edge[ 1 ] };
+							vertices.push( start.x, start.y, start.z );
+							vertices.push( end.x, end.y, end.z );
 
 						}
 
 					}
 
 				}
-
-			}
-
-			// generate vertices
-
-			for ( const key in edges ) {
-
-				const e = edges[ key ];
-
-				vertex.fromBufferAttribute( position, e.index1 );
-				vertices.push( vertex.x, vertex.y, vertex.z );
-
-				vertex.fromBufferAttribute( position, e.index2 );
-				vertices.push( vertex.x, vertex.y, vertex.z );
 
 			}
 
@@ -100,12 +86,17 @@ class WireframeGeometry extends BufferGeometry {
 					// e.g. the first triangle has the following edges: (0,1),(1,2),(2,0)
 
 					const index1 = 3 * i + j;
-					vertex.fromBufferAttribute( position, index1 );
-					vertices.push( vertex.x, vertex.y, vertex.z );
-
 					const index2 = 3 * i + ( ( j + 1 ) % 3 );
-					vertex.fromBufferAttribute( position, index2 );
-					vertices.push( vertex.x, vertex.y, vertex.z );
+
+					start.fromBufferAttribute( position, index1 );
+					end.fromBufferAttribute( position, index2 );
+
+					if ( isUniqueEdge( start, end, edges ) === true ) {
+
+						vertices.push( start.x, start.y, start.z );
+						vertices.push( end.x, end.y, end.z );
+
+					}
 
 				}
 
@@ -116,6 +107,24 @@ class WireframeGeometry extends BufferGeometry {
 		// build geometry
 
 		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+
+	}
+
+}
+
+function isUniqueEdge( start, end, edges ) {
+
+	const hash1 = `${start.x},${start.y},${start.z}-${end.x},${end.y},${end.z}`;
+	const hash2 = `${end.x},${end.y},${end.z}-${start.x},${start.y},${start.z}`; // opposing edge
+
+	if ( edges.has( hash1 ) === true || edges.has( hash2 ) === true ) {
+
+		return false;
+
+	} else {
+
+		edges.add( hash1, hash2 );
+		return true;
 
 	}
 

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -115,7 +115,7 @@ class WireframeGeometry extends BufferGeometry {
 function isUniqueEdge( start, end, edges ) {
 
 	const hash1 = `${start.x},${start.y},${start.z}-${end.x},${end.y},${end.z}`;
-	const hash2 = `${end.x},${end.y},${end.z}-${start.x},${start.y},${start.z}`; // opposing edge
+	const hash2 = `${end.x},${end.y},${end.z}-${start.x},${start.y},${start.z}`; // coincident edge
 
 	if ( edges.has( hash1 ) === true || edges.has( hash2 ) === true ) {
 


### PR DESCRIPTION
Related issue: Fixed #22094.

**Description**

`WireframeGeometry` checks now for unique edges by comparing vertex data.
