### PR TITLE
HTMLMesh: Reuse <canvas> instance

### DIFF
--- a/examples/js/interactive/HTMLMesh.js
+++ b/examples/js/interactive/HTMLMesh.js
@@ -57,6 +57,8 @@
 	} //
 
 
+	const canvases = new WeakMap();
+
 	function html2canvas( element ) {
 
 		var range = document.createRange();
@@ -233,14 +235,25 @@
 
 		}
 
-		var offset = element.getBoundingClientRect();
-		var canvas = document.createElement( 'canvas' );
-		canvas.width = offset.width;
-		canvas.height = offset.height;
-		var context = canvas.getContext( '2d'
+		const offset = element.getBoundingClientRect();
+		let canvas;
+
+		if ( canvases.has( element ) ) {
+
+			canvas = canvases.get( element );
+
+		} else {
+
+			canvas = document.createElement( 'canvas' );
+			canvas.width = offset.width;
+			canvas.height = offset.height;
+
+		}
+
+		const context = canvas.getContext( '2d'
 			/*, { alpha: false }*/
 		);
-		var clipper = new Clipper( context ); // console.time( 'drawElement' );
+		const clipper = new Clipper( context ); // console.time( 'drawElement' );
 
 		drawElement( element ); // console.timeEnd( 'drawElement' );
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -67,6 +67,8 @@ class HTMLTexture extends CanvasTexture {
 
 //
 
+const canvases = new WeakMap();
+
 function html2canvas( element ) {
 
 	var range = document.createRange();
@@ -245,15 +247,25 @@ function html2canvas( element ) {
 
 	}
 
-	var offset = element.getBoundingClientRect();
+	const offset = element.getBoundingClientRect();
 
-	var canvas = document.createElement( 'canvas' );
-	canvas.width = offset.width;
-	canvas.height = offset.height;
+	let canvas;
 
-	var context = canvas.getContext( '2d'/*, { alpha: false }*/ );
+	if ( canvases.has( element ) ) {
 
-	var clipper = new Clipper( context );
+		canvas = canvases.get( element );
+
+	} else {
+
+		canvas = document.createElement( 'canvas' );
+		canvas.width = offset.width;
+		canvas.height = offset.height;
+
+	}
+
+	const context = canvas.getContext( '2d'/*, { alpha: false }*/ );
+
+	const clipper = new Clipper( context );
 
 	// console.time( 'drawElement' );
 


### PR DESCRIPTION
Fixes: #22093

**Description**

Avoid instantiating new `<canvas>` elements every interacting frame 😬