### PR TITLE
Docs: fix links in OrbitControls

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -216,7 +216,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 position0]</h3>
 		<p>
-			Used internally by the [method:saveState] and [method:reset] methods.
+			Used internally by the [page:.saveState] and [page:.reset] methods.
 		</p>
 
 		<h3>[property:Float rotateSpeed]</h3>
@@ -233,7 +233,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 target0]</h3>
 		<p>
-			Used internally by the [method:saveState] and [method:reset] methods.
+			Used internally by the [page:.saveState] and [page:.reset] methods.
 		</p>
 
 		<h3>[property:Vector3 target]</h3>
@@ -255,7 +255,7 @@ controls.touches = {
 
 		<h3>[property:Float zoom0]</h3>
 		<p>
-			Used internally by the [method:saveState] and [method:reset] methods.
+			Used internally by the [page:.saveState] and [page:.reset] methods.
 		</p>
 
 		<h3>[property:Float zoomSpeed]</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -290,7 +290,7 @@ controls.touches = {
 
 		<h3>[method:null saveState] ()</h3>
 		<p>
-			컨트롤의 현재 상태를 저장합니다. 나중에 [page:.rest]을 이용하여 현재 상태로 복구할 수 있습니다.
+			컨트롤의 현재 상태를 저장합니다. 나중에 [page:.reset]을 이용하여 현재 상태로 복구할 수 있습니다.
 		</p>
 
 		<h3>[method:Boolean update] ()</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -212,7 +212,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 position0]</h3>
 		<p>
-			해당 프로퍼티는 [method:saveState] 및 [method:reset] 메서드에서 내부적으로 사용합니다.
+			해당 프로퍼티는 [page:.saveState] 및 [page:.reset] 메서드에서 내부적으로 사용합니다.
 		</p>
 
 		<h3>[property:Float rotateSpeed]</h3>
@@ -229,7 +229,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 target0]</h3>
 		<p>
-			[method:saveState] 및 [method:rest] 메서드에서 내부적으로 사용합니다.
+			[page:.saveState] 및 [method:rest] 메서드에서 내부적으로 사용합니다.
 		</p>
 
 		<h3>[property:Vector3 target]</h3>
@@ -250,7 +250,7 @@ controls.touches = {
 
 		<h3>[property:Float zoom0]</h3>
 		<p>
-			[method:saveState] 및 [method:reset] 메서드에서 내부적으로 사용합니다.
+			[page:.saveState] 및 [page:.reset] 메서드에서 내부적으로 사용합니다.
 		</p>
 
 		<h3>[property:Float zoomSpeed]</h3>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -214,7 +214,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 position0]</h3>
 		<p>
-			由[method:saveState]和[method:reset]方法在内部使用。
+			由[page:.saveState]和[page:.reset]方法在内部使用。
 		</p>
 
 		<h3>[property:Float rotateSpeed]</h3>
@@ -231,7 +231,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 target0]</h3>
 		<p>
-			由[method:saveState]和[method:reset]方法在内部使用。
+			由[page:.saveState]和[page:.reset]方法在内部使用。
 		</p>
 
 		<h3>[property:Vector3 target]</h3>
@@ -253,7 +253,7 @@ controls.touches = {
 
 		<h3>[property:Float zoom0]</h3>
 		<p>
-			由[method:saveState]和[method:reset]方法在内部使用。
+			由[page:.saveState]和[page:.reset]方法在内部使用。
 		</p>
 
 		<h3>[property:Float zoomSpeed]</h3>


### PR DESCRIPTION
References to methods saveState & reset used `method` instead of `page`
Leading to broken sections
![image](https://user-images.githubusercontent.com/55801/124893711-96cf8d00-dff8-11eb-88b9-b9e5755f8f09.png)
