### PR TITLE
CSSRenderers: Prevent selection and dragging of CSS objects.

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -13,6 +13,9 @@ class CSS2DObject extends Object3D {
 		this.element = element || document.createElement( 'div' );
 
 		this.element.style.position = 'absolute';
+		this.element.style.userSelect = 'none';
+
+		this.element.setAttribute( 'draggable', false );
 
 		this.addEventListener( 'removed', function () {
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -16,6 +16,9 @@ class CSS3DObject extends Object3D {
 		this.element = element || document.createElement( 'div' );
 		this.element.style.position = 'absolute';
 		this.element.style.pointerEvents = 'auto';
+		this.element.style.userSelect = 'none';
+
+		this.element.setAttribute( 'draggable', false );
 
 		this.addEventListener( 'removed', function () {
 


### PR DESCRIPTION
Related issue: Fixed #22104.

**Description**

Prevents the text selection of CSS objects as well as unexpected dragging.
