### PR TITLE
Docs: Fix tags in filter result.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -367,21 +367,9 @@
 				const categoryClassList = linkElement.parentElement.classList;
 				const filterResults = pageName.match( regExp );
 
-				if ( filterResults && filterResults.length > 0 ) {
+				if ( filterResults !== null && filterResults.length > 0 ) {
 
-					// Accentuate matching characters
-
-					for ( let i = 0; i < filterResults.length; i ++ ) {
-
-						const result = filterResults[ i ];
-
-						if ( result !== '' ) {
-
-							pageName = pageName.replace( result, '<b>' + result + '</b>' );
-
-						}
-
-					}
+					pageName = pageName.replaceAll( regExp, '<b>$&</b>' );
 
 					categoryClassList.remove( 'hidden' );
 					linkElement.innerHTML = pageName;


### PR DESCRIPTION
Related issue: Fixed #22107

**Description**

The code uses now `replaceAll()` to highlight search results. This fixes #22107 and also simplifies the code.