### PR TITLE
FBXLoader: Check null textures before assignment

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -610,55 +610,63 @@ class FBXTreeParser {
 			switch ( type ) {
 
 				case 'Bump':
-					parameters.bumpMap = scope.getTexture(textureMap, child.ID);
+					parameters.bumpMap = scope.getTexture( textureMap, child.ID );
 					break;
 
 				case 'Maya|TEX_ao_map':
-					parameters.aoMap = scope.getTexture(textureMap, child.ID);
+					parameters.aoMap = scope.getTexture( textureMap, child.ID );
 					break;
 
 				case 'DiffuseColor':
 				case 'Maya|TEX_color_map':
-					parameters.map = scope.getTexture(textureMap, child.ID);
-					if (parameters.map !== undefined) {
+					parameters.map = scope.getTexture( textureMap, child.ID );
+					if ( parameters.map !== undefined ) {
+
 						parameters.map.encoding = sRGBEncoding;
+
 					}
 					break;
 
 				case 'DisplacementColor':
-					parameters.displacementMap = scope.getTexture(textureMap, child.ID);
+					parameters.displacementMap = scope.getTexture( textureMap, child.ID );
 					break;
 
 				case 'EmissiveColor':
-					parameters.emissiveMap = scope.getTexture(textureMap, child.ID);
-					if (parameters.emissiveMap !== undefined) {
+					parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
+					if ( parameters.emissiveMap !== undefined ) {
+
 						parameters.emissiveMap.encoding = sRGBEncoding;
+
 					}
 					break;
 					
 				case 'NormalMap':
 				case 'Maya|TEX_normal_map':
-					parameters.normalMap = scope.getTexture(textureMap, child.ID);
+					parameters.normalMap = scope.getTexture( textureMap, child.ID );
 					break;
 
 				case 'ReflectionColor':
-					parameters.envMap = scope.getTexture(textureMap, child.ID);
-					if (parameters.envMap !== undefined) {
+					parameters.envMap = scope.getTexture( textureMap, child.ID );
+					if ( parameters.envMap !== undefined ) {
+
 						parameters.envMap.mapping = EquirectangularReflectionMapping;
 						parameters.envMap.encoding = sRGBEncoding;
+
 					}
 					break;
 
 				case 'SpecularColor':
-					parameters.specularMap = scope.getTexture(textureMap, child.ID);
-					if (parameters.specularMap !== undefined) {
+					parameters.specularMap = scope.getTexture( textureMap, child.ID );
+					if ( parameters.specularMap !== undefined ) {
+
 						parameters.specularMap.encoding = sRGBEncoding;
+
 					}
 					break;
 
 				case 'TransparentColor':
 				case 'TransparencyFactor':
-					parameters.alphaMap = scope.getTexture(textureMap, child.ID);
+					parameters.alphaMap = scope.getTexture( textureMap, child.ID );
 					parameters.transparent = true;
 					break;
 
@@ -691,11 +699,16 @@ class FBXTreeParser {
 
 		const texture = textureMap.get( id );
 
-		if (texture.image !== undefined) {
+		if ( texture.image !== undefined ) {
+
 			return texture;
+
 		} else {
+
 			return undefined;
+
 		}
+
 	}
 
 	// Parse nodes in FBXTree.Objects.Deformer

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -610,47 +610,55 @@ class FBXTreeParser {
 			switch ( type ) {
 
 				case 'Bump':
-					parameters.bumpMap = scope.getTexture( textureMap, child.ID );
+					parameters.bumpMap = scope.getTexture(textureMap, child.ID);
 					break;
 
 				case 'Maya|TEX_ao_map':
-					parameters.aoMap = scope.getTexture( textureMap, child.ID );
+					parameters.aoMap = scope.getTexture(textureMap, child.ID);
 					break;
 
 				case 'DiffuseColor':
 				case 'Maya|TEX_color_map':
-					parameters.map = scope.getTexture( textureMap, child.ID );
-					parameters.map.encoding = sRGBEncoding;
+					parameters.map = scope.getTexture(textureMap, child.ID);
+					if (parameters.map !== undefined) {
+						parameters.map.encoding = sRGBEncoding;
+					}
 					break;
 
 				case 'DisplacementColor':
-					parameters.displacementMap = scope.getTexture( textureMap, child.ID );
+					parameters.displacementMap = scope.getTexture(textureMap, child.ID);
 					break;
 
 				case 'EmissiveColor':
-					parameters.emissiveMap = scope.getTexture( textureMap, child.ID );
-					parameters.emissiveMap.encoding = sRGBEncoding;
+					parameters.emissiveMap = scope.getTexture(textureMap, child.ID);
+					if (parameters.emissiveMap !== undefined) {
+						parameters.emissiveMap.encoding = sRGBEncoding;
+					}
 					break;
-
+					
 				case 'NormalMap':
 				case 'Maya|TEX_normal_map':
-					parameters.normalMap = scope.getTexture( textureMap, child.ID );
+					parameters.normalMap = scope.getTexture(textureMap, child.ID);
 					break;
 
 				case 'ReflectionColor':
-					parameters.envMap = scope.getTexture( textureMap, child.ID );
-					parameters.envMap.mapping = EquirectangularReflectionMapping;
-					parameters.envMap.encoding = sRGBEncoding;
+					parameters.envMap = scope.getTexture(textureMap, child.ID);
+					if (parameters.envMap !== undefined) {
+						parameters.envMap.mapping = EquirectangularReflectionMapping;
+						parameters.envMap.encoding = sRGBEncoding;
+					}
 					break;
 
 				case 'SpecularColor':
-					parameters.specularMap = scope.getTexture( textureMap, child.ID );
-					parameters.specularMap.encoding = sRGBEncoding;
+					parameters.specularMap = scope.getTexture(textureMap, child.ID);
+					if (parameters.specularMap !== undefined) {
+						parameters.specularMap.encoding = sRGBEncoding;
+					}
 					break;
 
 				case 'TransparentColor':
 				case 'TransparencyFactor':
-					parameters.alphaMap = scope.getTexture( textureMap, child.ID );
+					parameters.alphaMap = scope.getTexture(textureMap, child.ID);
 					parameters.transparent = true;
 					break;
 
@@ -681,8 +689,13 @@ class FBXTreeParser {
 
 		}
 
-		return textureMap.get( id );
+		const texture = textureMap.get( id );
 
+		if (texture.image !== undefined) {
+			return texture;
+		} else {
+			return undefined;
+		}
 	}
 
 	// Parse nodes in FBXTree.Objects.Deformer


### PR DESCRIPTION
**Description**

We've found that a variety of FBX exporters from CAD software fail to correctly create/assign textures. As a result, `scope.getTexture` returns null/undefined, but the code fails when attempting to assign an encoding or other property immediately after.

As such, the preferred behaviour would be to load what is possible from the model (sans textures if they are not able to load) rather than throw and exception.