### PR TITLE
Fix a bug that thicknessMap is not loaded correctly in the shader

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -10,7 +10,7 @@ export default /* glsl */`
 
 	#endif
 
-	#ifdef USE_THICKNESSNMAP
+	#ifdef USE_THICKNESSMAP
 
 		thicknessFactor *= texture2D( thicknessMap, vUv ).g;
 


### PR DESCRIPTION
**Description**

This PR fixes a bug that `thicknessMap` is not loaded correctly in the shader
