### PR TITLE
Editor: Re-enabled Materials pane in Project Sidebar

### DIFF
--- a/editor/js/Sidebar.Project.js
+++ b/editor/js/Sidebar.Project.js
@@ -1,6 +1,6 @@
 import { UIPanel, UIRow, UIInput, UICheckbox, UIText, UISpan } from './libs/ui.js';
 
-/* import { SidebarProjectMaterials } from './Sidebar.Project.Materials.js'; */
+import { SidebarProjectMaterials } from './Sidebar.Project.Materials.js';
 import { SidebarProjectRenderer } from './Sidebar.Project.Renderer.js';
 import { SidebarProjectVideo } from './Sidebar.Project.Video.js';
 
@@ -61,7 +61,7 @@ function SidebarProject( editor ) {
 
 	//
 
-	/* container.add( new SidebarProjectMaterials( editor ) ); */
+	container.add( new SidebarProjectMaterials( editor ) );
 	container.add( new SidebarProjectRenderer( editor ) );
 
 	if ( 'SharedArrayBuffer' in window ) {

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1174,7 +1174,7 @@ class UIListbox extends UIDiv {
 
 			const item = this.items[ i ];
 
-			const listitem = new UIListbox.ListboxItem( this );
+			const listitem = new ListboxItem( this );
 			listitem.setId( item.id || `Listbox-${i}` );
 			listitem.setTextContent( item.name || item.type );
 			this.add( listitem );


### PR DESCRIPTION

Related issue: 

**Description**

In ui.js,  `UIListbox.render(...)`  is trying to use the `new UIListbox.ListboxItem( this );` constructor which is no longer valid.  
Changing it to use the `new ListboxItem( this );`   fixes the exception and allows the Project.Materials pane to be used again.

