### PR TITLE
WebGLRenderer: Rearrange logic in renderObjects to reduce CPU-side draw cost for multi-camera setups.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1275,28 +1275,28 @@ function WebGLRenderer( parameters = {} ) {
 
 		const overrideMaterial = scene.isScene === true ? scene.overrideMaterial : null;
 
-		for ( let i = 0, l = renderList.length; i < l; i ++ ) {
+		if ( camera.isArrayCamera ) {
 
-			const renderItem = renderList[ i ];
+			const cameras = camera.cameras;
 
-			const object = renderItem.object;
-			const geometry = renderItem.geometry;
-			const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
-			const group = renderItem.group;
+			for ( let i = 0, l = cameras.length; i < l; i ++ ) {
 
-			if ( camera.isArrayCamera ) {
+				const camera2 = cameras[ i ];
 
-				const cameras = camera.cameras;
+				state.viewport( _currentViewport.copy( camera2.viewport ) );
 
-				for ( let j = 0, jl = cameras.length; j < jl; j ++ ) {
+				currentRenderState.setupLightsView( camera2 );
 
-					const camera2 = cameras[ j ];
+				for ( let j = 0, jl = renderList.length; j < jl; j ++ ) {
+
+					const renderItem = renderList[ j ];
+
+					const object = renderItem.object;
+					const geometry = renderItem.geometry;
+					const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
+					const group = renderItem.group;
 
 					if ( object.layers.test( camera2.layers ) ) {
-
-						state.viewport( _currentViewport.copy( camera2.viewport ) );
-
-						currentRenderState.setupLightsView( camera2 );
 
 						renderObject( object, scene, camera2, geometry, material, group );
 
@@ -1304,7 +1304,18 @@ function WebGLRenderer( parameters = {} ) {
 
 				}
 
-			} else {
+			}
+
+		} else {
+
+			for ( let j = 0, jl = renderList.length; j < jl; j ++ ) {
+
+				const renderItem = renderList[ j ];
+
+				const object = renderItem.object;
+				const geometry = renderItem.geometry;
+				const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
+				const group = renderItem.group;
 
 				renderObject( object, scene, camera, geometry, material, group );
 


### PR DESCRIPTION
**Description**

Rendering all objects for one camera at a time (vs. rendering each object for all cameras before moving to the next object) reduces the CPU cost of rendering fairly significantly. Specifically, reduces needing to recompute a bunch of stuff per-camera for each object, and also reduces the number of GL state changes made when rendering objects with similar materials.

You can see a before/after example in this sample - [link](https://davehill00.github.io/dist/three-objcount.html). By default, it renders with the current Three.js behavior for WebGLRenderer::renderObjects. If you tap the right grip button, it will switch to the proposed renderObjects order. Tapping the left grip button will revert to the default behavior again. To most effectively evaluate this, run OVR Metrics HUD and keep an eye on framerate. On Quest 2, I see an initial framerate of ~60fps. Toggling to the proposed renderObjects order, I get a solid 90fps.

A note on the sample -- it is focused on stressing CPU draw calls. It draws a bunch of individual cubes as unique draw calls, and it's intentionally rendering headlocked and to low-resolution eye buffers to provide consistent perf results and to focus the timing results on CPU perf.