### PR TITLE
SVGLoader: fix round rects when only rx or ry is specified

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -758,8 +758,8 @@ class SVGLoader extends Loader {
 
 			const x = parseFloatWithUnits( node.getAttribute( 'x' ) || 0 );
 			const y = parseFloatWithUnits( node.getAttribute( 'y' ) || 0 );
-			const rx = parseFloatWithUnits( node.getAttribute( 'rx' ) || 0 );
-			const ry = parseFloatWithUnits( node.getAttribute( 'ry' ) || 0 );
+			const rx = parseFloatWithUnits( node.getAttribute( 'rx' ) || node.getAttribute( 'ry' ) || 0 );
+			const ry = parseFloatWithUnits( node.getAttribute( 'ry' ) || node.getAttribute( 'rx' ) || 0 );
 			const w = parseFloatWithUnits( node.getAttribute( 'width' ) );
 			const h = parseFloatWithUnits( node.getAttribute( 'height' ) );
 


### PR DESCRIPTION
The current implementation handles `rect` rounded corners incorrectly when either `rx` or `ry` attr is omitted.

Here’s a SVG made in Inkscape where only `rx` is specified:

![image](https://user-images.githubusercontent.com/146383/125435883-a5fda026-89ce-4102-af82-d0bf16f38c4d.png)

[round-rect.svg.zip](https://github.com/mrdoob/three.js/files/6808105/round-rect.svg.zip)

```xml
    <rect
       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:round"
       id="rect846"
       width="161.13248"
       height="78.283867"
       x="20.170506"
       y="27.046577"
       rx="10" />
```

Here’s how a browser renders it:

![image](https://user-images.githubusercontent.com/146383/125436406-c06cde19-143f-4b29-b02d-965e87c0f36c.png)

Here’s how THREE.js loads it without the fix:

![image](https://user-images.githubusercontent.com/146383/125436528-b3291e2f-7160-4495-829b-40d5a10b24ef.png)

And here’s how THREE.js loads it with the fix:

![image](https://user-images.githubusercontent.com/146383/125436483-56392690-07bb-486a-80f4-674bbc448367.png)

---

Indeed, [the standard says](https://www.w3.org/TR/SVG/geometry.html#RxProperty):

> When the computed value of ‘rx’ is auto, the used radius is equal to the absolute length used for ry, creating a circular arc.

The same applies to `ry`
