### PR TITLE
ShaderChunk: Fixed overblown color in transmission_fragment

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -21,7 +21,7 @@ export default /* glsl */`
 	float ior = ( 1.0 + 0.4 * reflectivity ) / ( 1.0 - 0.4 * reflectivity );
 
 	vec3 transmission = transmissionFactor * getIBLVolumeRefraction(
-		normal, v, roughnessFactor, material.diffuseColor, totalSpecular,
+		normal, v, roughnessFactor, material.diffuseColor, material.specularColor,
 		pos, modelMatrix, viewMatrix, projectionMatrix, ior, thicknessFactor,
 		attenuationColor, attenuationDistance );
 


### PR DESCRIPTION
Related issue: #22009

**Description**

Before:

<img width="923" alt="Screenshot 2021-07-13 at 15 15 09" src="https://user-images.githubusercontent.com/97088/125468386-83e61268-0076-4b91-ab6c-1d5b4d36f5a2.png">

After:

<img width="923" alt="Screenshot 2021-07-13 at 15 15 27" src="https://user-images.githubusercontent.com/97088/125468434-34609930-a775-4091-a168-22ab4478f009.png">

Before:

<img width="924" alt="Screenshot 2021-07-13 at 15 17 13" src="https://user-images.githubusercontent.com/97088/125468470-2476606d-efbe-4e91-906b-2b6f9f801a22.png">

After:

<img width="925" alt="Screenshot 2021-07-13 at 15 17 33" src="https://user-images.githubusercontent.com/97088/125468500-68d26b23-609d-4a02-ab35-f5ea5930c372.png">

