### PR TITLE
OrbitControls: add getDistance()

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -282,6 +282,11 @@ controls.touches = {
 			Get the current vertical rotation, in radians.
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -282,9 +282,9 @@ controls.touches = {
 			Get the current vertical rotation, in radians.
 		</p>
 
-		<h3>[method:radians getDistance] ()</h3>
+		<h3>[method:Float getDistance] ()</h3>
 		<p>
-			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+			Returns the distance from the camera to the target.
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -278,9 +278,9 @@ controls.touches = {
 			라디안 단위로 현재 수직 회전값을 가져옵니다.
 		</p>
 
-		<h3>[method:radians getDistance] ()</h3>
+		<h3>[method:Float getDistance] ()</h3>
 		<p>
-			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+			Returns the distance from the camera to the target.
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -278,6 +278,11 @@ controls.touches = {
 			라디안 단위로 현재 수직 회전값을 가져옵니다.
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -280,6 +280,11 @@ controls.touches = {
 			获得当前的垂直旋转，单位为弧度。
 		</p>
 
+		<h3>[method:radians getDistance] ()</h3>
+		<p>
+			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+		</p>
+
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			为指定的DOM元素添加按键监听。推荐将window作为指定的DOM元素。

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -280,9 +280,9 @@ controls.touches = {
 			获得当前的垂直旋转，单位为弧度。
 		</p>
 
-		<h3>[method:radians getDistance] ()</h3>
+		<h3>[method:Float getDistance] ()</h3>
 		<p>
-			Get the current dolly distance ( [page:PerspectiveCamera] only ).
+			Returns the distance from the camera to the target.
 		</p>
 
 		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -114,6 +114,12 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
+		this.getDistance = function () {
+
+			return spherical.radius;
+
+		};
+
 		this.listenToKeyEvents = function ( domElement ) {
 
 			domElement.addEventListener( 'keydown', onKeyDown );

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -116,6 +116,13 @@ class OrbitControls extends EventDispatcher {
 
 		this.getDistance = function () {
 
+			// compute the distance manually if the camera is orthographic
+			if ( this.object.isOrthographicCamera ) {
+
+				return this.object.position.distanceTo( this.target );
+
+			}
+
 			return spherical.radius;
 
 		};

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -116,14 +116,7 @@ class OrbitControls extends EventDispatcher {
 
 		this.getDistance = function () {
 
-			// compute the distance manually if the camera is orthographic
-			if ( this.object.isOrthographicCamera ) {
-
-				return this.object.position.distanceTo( this.target );
-
-			}
-
-			return spherical.radius;
+			return this.object.position.distanceTo( this.target );
 
 		};
 


### PR DESCRIPTION
Related issue: remake of #21162

**Description**

Add `OrbitControls.getDistance()` which exposes `spherical.radius`.

This is useful for example if you want to enable zooming in but disable zooming out from the start position:

```js
const controls = new OrbitControls(camera, renderer.domElement);
const currentDistance = controls.getDistance();
controls.maxDistance = currentDistance;
```