### PR TITLE
SVGLoader: Improve round rect corners approximation

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -763,25 +763,65 @@ class SVGLoader extends Loader {
 			const w = parseFloatWithUnits( node.getAttribute( 'width' ) );
 			const h = parseFloatWithUnits( node.getAttribute( 'height' ) );
 
-			const path = new ShapePath();
-			path.moveTo( x + 2 * rx, y );
-			path.lineTo( x + w - 2 * rx, y );
-			if ( rx !== 0 || ry !== 0 ) path.bezierCurveTo( x + w, y, x + w, y, x + w, y + 2 * ry );
-			path.lineTo( x + w, y + h - 2 * ry );
-			if ( rx !== 0 || ry !== 0 ) path.bezierCurveTo( x + w, y + h, x + w, y + h, x + w - 2 * rx, y + h );
-			path.lineTo( x + 2 * rx, y + h );
+			// Ellipse arc to Bezier approximation Coefficient (Inversed). See:
+			// https://spencermortensen.com/articles/bezier-circle/
+			const bci = 1 - 0.551915024494;
 
+			const path = new ShapePath();
+
+			// top left
+			path.moveTo( x + rx, y );
+
+			// top right
+			path.lineTo( x + w - rx, y );
 			if ( rx !== 0 || ry !== 0 ) {
 
-				path.bezierCurveTo( x, y + h, x, y + h, x, y + h - 2 * ry );
+				path.bezierCurveTo(
+					x + w - rx * bci,
+					y,
+					x + w,
+					y + ry * bci,
+					x + w,
+					y + ry
+				);
 
 			}
 
-			path.lineTo( x, y + 2 * ry );
-
+			// bottom right
+			path.lineTo( x + w, y + h - ry );
 			if ( rx !== 0 || ry !== 0 ) {
 
-				path.bezierCurveTo( x, y, x, y, x + 2 * rx, y );
+				path.bezierCurveTo(
+					x + w,
+					y + h - ry * bci,
+					x + w - rx * bci,
+					y + h,
+					x + w - rx,
+					y + h
+				);
+
+			}
+
+			// bottom left
+			path.lineTo( x + rx, y + h );
+			if ( rx !== 0 || ry !== 0 ) {
+
+				path.bezierCurveTo(
+					x + rx * bci,
+					y + h,
+					x,
+					y + h - ry * bci,
+					x,
+					y + h - ry
+				);
+
+			}
+
+			// back to top left
+			path.lineTo( x, y + ry );
+			if ( rx !== 0 || ry !== 0 ) {
+
+				path.bezierCurveTo( x, y + ry * bci, x + rx * bci, y, x + rx, y );
 
 			}
 


### PR DESCRIPTION
Hello!

The current approximation of SVG round rects with Bezier curves is too rough when corner radii are large enough and comparable to the dimensions. Here’s a simple Inkscape example where border-radius is almost ½ of the rect height:

[round-rect.svg.zip](https://github.com/mrdoob/three.js/files/6817016/round-rect.svg.zip)

It renders in a browser like this:

![image](https://user-images.githubusercontent.com/146383/125645180-a4571080-b956-4314-ae8a-4fb3c9e620c2.png)

And loads by THREE.js like this:

![image](https://user-images.githubusercontent.com/146383/125645435-5a2d55ea-3191-4eb7-80e4-e4cd55945a3c.png)

Note the curve “overruns”. I tried to follow the current algorithm on paper and it flaws in several ways:

- The `2 * rx` and `2 * ry` offsets is a mistake. They should not be doubled. That’s the reason for overrun
- The control points of Bezier curve are trivially placed in corners. There are better ways to arrange them to approximate an ellipse, i.e. to minimize the approximation error (referred in comment).

I’ve adjusted the implementation and the rect now looks like:

![image](https://user-images.githubusercontent.com/146383/125645276-f3d507ab-b395-4a79-a707-6ec48a82202e.png)

---

BTW, is there any reason why `ShapePath` does not provide methods like `arc` and `ellipse`? I see they can be trivially implemented as a proxy to `Path` like `lineTo` or `bezierCurveTo`. It would allow avoiding approximation so that the corners may be implemented as true ellipse arcs. I suspect though there’s a reason, some dependency which does not allow to do it easily. Could you clarify this point? If it just “no time to bother”, I could try to do it.