### PR TITLE
Fat Lines: fixed alpha-to-coverage bug

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -218,7 +218,7 @@ ShaderLib[ 'line' ] = {
 
 			#endif
 
-			float alpha = opacity;
+			float alpha = 1.0;
 
 			#ifdef ALPHA_TO_COVERAGE
 
@@ -248,12 +248,12 @@ ShaderLib[ 'line' ] = {
 
 			#endif
 
-			vec4 diffuseColor = vec4( diffuse, alpha );
+			vec4 diffuseColor = vec4( diffuse, opacity * alpha );
 
 			#include <logdepthbuf_fragment>
 			#include <color_fragment>
 
-			gl_FragColor = vec4( diffuseColor.rgb, alpha );
+			gl_FragColor = diffuseColor;
 
 			#include <tonemapping_fragment>
 			#include <encodings_fragment>


### PR DESCRIPTION
The shader code was incorrect when opacity was less than 1.

/ping @gkjohnson for a second opinion.