### PR TITLE
SphereGeometry: Increased default widthSegments 32 and heightSegment 16

### DIFF
--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -205,7 +205,7 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/sphere' ) );
 	option.onClick( function () {
 
-		var geometry = new THREE.SphereGeometry( 1, 8, 6, 0, Math.PI * 2, 0, Math.PI );
+		var geometry = new THREE.SphereGeometry( 1, 32, 16, 0, Math.PI * 2, 0, Math.PI );
 		var mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Sphere';
 

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -4,7 +4,7 @@ import { Vector3 } from '../math/Vector3.js';
 
 class SphereGeometry extends BufferGeometry {
 
-	constructor( radius = 1, widthSegments = 8, heightSegments = 6, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI ) {
+	constructor( radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI ) {
 
 		super();
 		this.type = 'SphereGeometry';


### PR DESCRIPTION
**Description**

The default values were set in the `CanvasRenderer` days.
I think we can increase them today and align them to Blender's default values.

Before:

<img width="230" alt="Screenshot 2021-07-16 at 13 05 06" src="https://user-images.githubusercontent.com/97088/125944804-0da7a33e-9529-48bd-ae78-66bf47ac36f4.png">

After:

<img width="225" alt="Screenshot 2021-07-16 at 13 05 12" src="https://user-images.githubusercontent.com/97088/125944812-cb520520-6f34-4966-8db4-93898dcd9678.png">
