### PR TITLE
Support setting up axis and unit in Collada exporter

### DIFF
--- a/docs/examples/en/exporters/ColladaExporter.html
+++ b/docs/examples/en/exporters/ColladaExporter.html
@@ -48,6 +48,9 @@
 			<li>version - string. Which version of Collada to export. The options are "1.4.1" or "1.5.0". Defaults to "1.4.1".</li>
 			<li>author - string. The name to include in the author field. Author field is excluded by default.</li>
 			<li>textureDirectory - string. The directory relative to the Collada file to save the textures to.</li>
+			<li>upAxis - string. Either Y_UP (default), Z_UP or X_UP.</li>
+			<li>unitName - string. Name of the unit. Can be any string, but could be for example "meter", "inch", or "parsec".</li>
+			<li>unitMeter - number. Length of the unit in meters.</li>
 		</ul>
 		</p>
 		<p>

--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -25,7 +25,35 @@ class ColladaExporter {
 			version: '1.4.1',
 			author: null,
 			textureDirectory: '',
+			upAxis: 'Y_UP',
+			unitName: null,
+			unitMeter: null,
 		}, options );
+
+		if (options.upAxis.match(/^[XYZ]_UP$/) === null) {
+
+			console.error('ColladaExporter: Invalid upAxis: valid values are X_UP, Y_UP or Z_UP.');
+			return null;
+
+		}
+
+		if ( (options.unitName === null) !== (options.unitMeter === null) ) {
+
+			if ( options.unitMeter === null ) {
+
+				console.error('ColladaExporter: unitMeter needs to be specified if unitName is specified.');
+
+			}
+
+			if ( options.unitName === null ) {
+
+				console.error('ColladaExporter: unitName needs to be specified if unitMeter is specified.');
+
+			}
+
+			return null;
+
+		}
 
 		if ( options.textureDirectory !== '' ) {
 
@@ -633,7 +661,8 @@ class ColladaExporter {
 				'</contributor>' +
 				`<created>${ ( new Date() ).toISOString() }</created>` +
 				`<modified>${ ( new Date() ).toISOString() }</modified>` +
-				'<up_axis>Y_UP</up_axis>'
+				( options.unitName !== null ? `<unit name="${ options.unitName }" meter="${ options.unitMeter }" />` : "" ) +
+				`<up_axis>${ options.upAxis }</up_axis>`
 			) +
 			'</asset>';
 

--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -61,7 +61,7 @@
 
 				// CAMERA
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 20000 );
-				camera.position.set( - 150, 130, 350 );
+				camera.position.set( - 150, 137.5, 325 );
 
 				// LIGHTS
 				ambientLight = new THREE.AmbientLight( 0x333333 );	// 0.2

--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -30,7 +30,7 @@
 			let camera, scene, renderer;
 			let cameraControls;
 			let effectController;
-			const teapotSize = 400;
+			const teapotSize = 100; // vertical height of the teapot is about 2x this, we scale it to millimeters.
 			let ambientLight, light;
 
 			let tess = - 1;	// force initialization
@@ -60,8 +60,8 @@
 				const canvasHeight = window.innerHeight;
 
 				// CAMERA
-				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 80000 );
-				camera.position.set( - 600, 550, 1300 );
+				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 20000 );
+				camera.position.set( - 150, 130, 350 );
 
 				// LIGHTS
 				ambientLight = new THREE.AmbientLight( 0x333333 );	// 0.2
@@ -352,7 +352,7 @@
 
 			function exportCollada() {
 
-				const result = exporter.parse( teapot );
+				const result = exporter.parse( teapot, undefined, { upAxis: 'Y_UP', unitName: 'millimeter', unitMeter: 0.001 } );
 				let materialType = "Phong";
 
 				if ( shading === "wireframe" ) {


### PR DESCRIPTION
The Collada standard includes support for setting the unit used as well as the up axis used, so that elements can be transferred between applications in consistent real-world scale and orientation. For example Blender's Collada importer supports the unit tag.

This contribution is funded by [Higharc](https://higharc.com).
