### PR TITLE
Avoid console warnings when using WebXR Layers

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1922,10 +1922,14 @@ function WebGLRenderer( parameters = {} ) {
 
 				if ( _currentDrawBuffers.length !== 1 || _currentDrawBuffers[ 0 ] !== _gl.BACK ) {
 
-					_currentDrawBuffers[ 0 ] = _gl.BACK;
-					_currentDrawBuffers.length = 1;
+					if ( !xr || !xr.getSession() || !xr.getSession().renderState || !xr.getSession().renderState.layers ) {
 
-					needsUpdate = true;
+						_currentDrawBuffers[ 0 ] = _gl.BACK;
+						_currentDrawBuffers.length = 1;
+
+						needsUpdate = true;
+
+					} // else avoid https://github.com/mrdoob/three.js/issues/22079 when using XR layers.
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1922,7 +1922,7 @@ function WebGLRenderer( parameters = {} ) {
 
 				if ( _currentDrawBuffers.length !== 1 || _currentDrawBuffers[ 0 ] !== _gl.BACK ) {
 
-					if ( !xr || !xr.getSession() || !xr.getSession().renderState || !xr.getSession().renderState.layers ) {
+					if ( ! xr || ! xr.getSession() || ! xr.getSession().renderState || ! xr.getSession().renderState.layers ) {
 
 						_currentDrawBuffers[ 0 ] = _gl.BACK;
 						_currentDrawBuffers.length = 1;


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/22079

Tested:
* webxr_vr_layers.html has no warnings on Quest 2
* Other webxr_vr_* examples are working without issues.