### PR TITLE
Docs: Improve InstancedBufferGeometry page.

### DIFF
--- a/docs/api/en/core/InstancedBufferGeometry.html
+++ b/docs/api/en/core/InstancedBufferGeometry.html
@@ -31,6 +31,9 @@
 		<h2>Methods</h2>
 		<p>See [page:BufferGeometry] for inherited methods.</p>
 
+		<h3>[method:InstancedBufferGeometry copy]( [param:InstancedBufferGeometry source] )</h3>
+		<p>Copies the given [name] to this instance.</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/zh/core/InstancedBufferGeometry.html
+++ b/docs/api/zh/core/InstancedBufferGeometry.html
@@ -31,6 +31,9 @@
 		<h2>方法</h2>
 		<p>继承方法详见 [page:BufferGeometry]。</p>
 
+		<h3>[method:InstancedBufferGeometry copy]( [param:InstancedBufferGeometry source] )</h3>
+		<p>Copies the given [name] to this instance.</p>
+
 		<h2>源代码</h2>
 
 		<p>


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/22151#issuecomment-882478145

**Description**

Adds a `copy()` method to clarify only instances of `InstancedBufferGeometry` can be passed to the method.