### PR TITLE
Docs: Fix redirect for geometry generators.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
 
 			// *BufferGeometry to *Geometry
 
-			if ( /([\w]+)BufferGeometry$/.exec( window.location.hash ) ) {
+			if ( /^(?!.*(Instanced)).*BufferGeometry/.exec( window.location.hash ) ) {
 
 				window.location.hash = window.location.hash.replace( 'BufferGeometry', 'Geometry' );
 


### PR DESCRIPTION
Related issue: -

**Description**

There is currently a redirect in place that ensures the doc page URL for e.g. [BoxBufferGeometry](https://threejs.org/docs/index.html#api/en/geometries/BoxBufferGeometry) is redirected to `BoxGeometry`. However, the implementation also affects `InstancedBufferGeometry` which is redirected to `InstancedGeometry`.

I've updated the regex to avoid the resulting 404.