### PR TITLE
Editor: Turn off autocomplete of input elements.

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -267,6 +267,8 @@ class UIInput extends UIElement {
 		this.dom.style.padding = '2px';
 		this.dom.style.border = '1px solid transparent';
 
+		this.dom.setAttribute( 'autocomplete', 'off' );
+
 		this.dom.addEventListener( 'keydown', function ( event ) {
 
 			event.stopPropagation();
@@ -302,6 +304,8 @@ class UITextArea extends UIElement {
 		this.dom.className = 'TextArea';
 		this.dom.style.padding = '2px';
 		this.dom.spellcheck = false;
+
+		this.dom.setAttribute( 'autocomplete', 'off' );
 
 		this.dom.addEventListener( 'keydown', function ( event ) {
 
@@ -347,6 +351,8 @@ class UISelect extends UIElement {
 
 		this.dom.className = 'Select';
 		this.dom.style.padding = '2px';
+
+		this.dom.setAttribute( 'autocomplete', 'off' );
 
 	}
 
@@ -452,6 +458,8 @@ class UIColor extends UIElement {
 		this.dom.style.padding = '2px';
 		this.dom.style.backgroundColor = 'transparent';
 
+		this.dom.setAttribute( 'autocomplete', 'off' );
+
 		try {
 
 			this.dom.type = 'color';
@@ -500,6 +508,8 @@ class UINumber extends UIElement {
 		this.dom.style.cursor = 'ns-resize';
 		this.dom.className = 'Number';
 		this.dom.value = '0.00';
+
+		this.dom.setAttribute( 'autocomplete', 'off' );
 
 		this.value = 0;
 
@@ -766,6 +776,8 @@ class UIInteger extends UIElement {
 		this.dom.style.cursor = 'ns-resize';
 		this.dom.className = 'Number';
 		this.dom.value = '0';
+
+		this.dom.setAttribute( 'autocomplete', 'off' );
 
 		this.value = 0;
 


### PR DESCRIPTION
Related issue: Fixed #22131.

**Description**

This resolved all runtime errors mentioned in #22131 and also fixed the corrupted UI state. 

The only bit that does not work is the camera select element. It still has no value selected after the clone. But only in Chrome, not in Firefox. Seems to be a browser issue.
