### PR TITLE
E2E: remove installation checking

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -1,15 +1,3 @@
-
-try {
-
-	require( 'puppeteer' );
-
-} catch {
-
-	console.log( 'Error: Can\'t find Puppeteer. Run `npm install --prefix test`.' );
-	process.exit( 0 );
-
-}
-
 const puppeteer = require( 'puppeteer' );
 const handler = require( 'serve-handler' );
 const http = require( 'http' );


### PR DESCRIPTION
This was added to simplify e2e adoption and checking useless right now.

P.S.
I am just revisited current e2e implementation after reading this tweet https://twitter.com/RReverser/status/1417800541133058050
Basically we doing almost the same, but we also controlling time. Each frame is rendered in 16ms in our virtual time to make pictures exactly the same, we rendering 2 frames and making screenshot after that.

Ways to improve current e2e implementation (without recreating all screenshots):
* to use some fancy test framework
* remove progressive attempts to simplify script but testing pipeline will be little bit slower
* try to take benefits from parallel pages https://github.com/checkly/puppeteer-examples/blob/master/5.%20parallel-pages/screenshots_parallel.js
* change puppeteer to playwright they have almost the same API but playwright supports Safari and Firefox.
