### PR TITLE
Material: Remove morphTargets and morphNormals properties.

### DIFF
--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -87,9 +87,6 @@
 			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
 		</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h2>Methods</h2>
 		<p>See the base [page:Material] class for common methods.</p>
 

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -92,10 +92,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
-
 		<h3>[property:Float reflectivity]</h3>
 		<p>
 			How much the environment map affects the surface; also see [page:.combine].

--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -84,9 +84,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Boolean wireframe]</h3>
 		<p>Render geometry as wireframe. Default is false (i.e. render as smooth shaded).</p>
 

--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -95,9 +95,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Float nearDistance]</h3>
 		<p>
 			The near value of the point light's internal shadow camera.

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -119,15 +119,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is  null.</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Float reflectivity]</h3>
 		<p>How much the environment map affects the surface; also see [page:.combine].</p>
 

--- a/docs/api/en/materials/MeshMatcapMaterial.html
+++ b/docs/api/en/materials/MeshMatcapMaterial.html
@@ -106,15 +106,6 @@
 		<h3>[property:Texture matcap]</h3>
 		<p>The matcap map. Default is null.</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -83,15 +83,6 @@
 		<h3>[property:Boolean fog]</h3>
 		<p>Whether the material is affected by fog. Default is *false*.</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -156,15 +156,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -196,15 +196,6 @@
 		<h3>[property:Texture metalnessMap]</h3>
 		<p>The blue channel of this texture is used to alter the metalness of the material.</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -133,15 +133,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -82,11 +82,7 @@
 		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
 
 		<h3>[property:Texture map]</h3>
-
 		<p>Sets the color of the points using data from a [page:Texture].</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
 
 		<h3>[property:Number size]</h3>
 		<p>Sets the size of the points. Default is 1.0.<br/>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -367,17 +367,6 @@ this.extensions = {
 		always be 1 regardless of the set value.
 		</p>
 
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>
-		When set to true, morph target attributes are available in the vertex shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-		When set to true, morph normal attributes are available in the vertex shader. Default is *false*.
-		</p>
-
 		<h3>[property:Boolean flatShading]</h3>
 		<p>
 		Define whether the material is rendered with flat shading. Default is false.

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -76,9 +76,6 @@
 			并且会被[page:WebGLRenderer WebGL]渲染器忽略。
 		</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h2>方法(Methods)</h2>
 		<p>共有方法请参见其基类[page:Material]。</p>
 

--- a/docs/api/zh/materials/MeshBasicMaterial.html
+++ b/docs/api/zh/materials/MeshBasicMaterial.html
@@ -82,10 +82,6 @@
 		<h3>[property:Texture map]</h3>
 		<p> 颜色贴图。默认为null。</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>材质是否使用morphTargets。默认值为false。</p>
-
-
 		<h3>[property:Float reflectivity]</h3>
 		<p> 环境贴图对表面的影响程度; 见[page:.combine]。默认值为1，有效范围介于0（无反射）和1（完全反射）之间。
 		</p>

--- a/docs/api/zh/materials/MeshDepthMaterial.html
+++ b/docs/api/zh/materials/MeshDepthMaterial.html
@@ -73,9 +73,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Boolean wireframe]</h3>
 		<p> 将几何体渲染为线框。默认值为*false*（即渲染为平滑着色）。</p>
 

--- a/docs/api/zh/materials/MeshDistanceMaterial.html
+++ b/docs/api/zh/materials/MeshDistanceMaterial.html
@@ -84,9 +84,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Float nearDistance]</h3>
 		<p>
 			The near value of the point light's internal shadow camera.

--- a/docs/api/zh/materials/MeshLambertMaterial.html
+++ b/docs/api/zh/materials/MeshLambertMaterial.html
@@ -101,13 +101,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> 定义是否使用morphNormals。设置为true可将morphNormal属性从geometry传递到shader。默认值为*false*。
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>定义材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Float reflectivity]</h3>
 		<p> 环境贴图对表面的影响程度; 见[page:.combine]。默认值为1，有效范围介于0（无反射）和1（完全反射）之间。</p>
 

--- a/docs/api/zh/materials/MeshMatcapMaterial.html
+++ b/docs/api/zh/materials/MeshMatcapMaterial.html
@@ -90,13 +90,6 @@
 		<h3>[property:Texture matcap]</h3>
 		<p>matcap贴图，默认为null。</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> 定义是否使用morphNormals。设置为true可将morphNormal属性从geometry传递到shader。默认值为*false*。
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>定义材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p> 用于创建法线贴图的纹理。RGB值会影响每个像素片段的曲面法线，并更改颜色照亮的方式。法线贴图不会改变曲面的实际形状，只会改变光照。
 			In case the material has a normal map authored using the left handed convention, the y component of normalScale

--- a/docs/api/zh/materials/MeshNormalMaterial.html
+++ b/docs/api/zh/materials/MeshNormalMaterial.html
@@ -69,13 +69,6 @@
 		<h3>[property:Boolean fog]</h3>
 		<p>材质是否受雾影响。默认值为*false*。</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> 定义是否使用morphNormals。设置为true可将morphNormal属性从geometry传递到shader。默认值为*false*。
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>定义材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p> 用于创建法线贴图的纹理。RGB值会影响每个像素片段的曲面法线，并更改颜色照亮的方式。法线贴图不会改变曲面的实际形状，只会改变光照。
 			In case the material has a normal map authored using the left handed convention, the y component of normalScale

--- a/docs/api/zh/materials/MeshPhongMaterial.html
+++ b/docs/api/zh/materials/MeshPhongMaterial.html
@@ -125,13 +125,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。纹理贴图颜色由漫反射颜色[page:.color]调节。</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> 定义是否使用morphNormals。设置为true可将morphNormal属性从geometry传递到shader。默认值为*false*。
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>定义材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p> 用于创建法线贴图的纹理。RGB值会影响每个像素片段的曲面法线，并更改颜色照亮的方式。法线贴图不会改变曲面的实际形状，只会改变光照。
 			In case the material has a normal map authored using the left handed convention, the y component of normalScale

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -161,13 +161,6 @@
 		<h3>[property:Texture metalnessMap]</h3>
 		<p> 该纹理的蓝色通道用于改变材质的金属度。</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> 定义是否使用morphNormals。设置为true可将morphNormal属性从geometry传递到shader。默认值为*false*。
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>定义材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>用于创建法线贴图的纹理。RGB值会影响每个像素片段的曲面法线，并更改颜色照亮的方式。法线贴图不会改变曲面的实际形状，只会改变光照。
 			In case the material has a normal map authored using the left handed convention, the y component of normalScale

--- a/docs/api/zh/materials/MeshToonMaterial.html
+++ b/docs/api/zh/materials/MeshToonMaterial.html
@@ -133,15 +133,6 @@
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</p>
 
-		<h3>[property:Boolean morphNormals]</h3>
-		<p>
-			Defines whether the material uses morphNormals. Set as true to pass morphNormal
-			attributes from the geometry to the shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>Define whether the material uses morphTargets. Default is false.</p>
-
 		<h3>[property:Texture normalMap]</h3>
 		<p>
 			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change

--- a/docs/api/zh/materials/PointsMaterial.html
+++ b/docs/api/zh/materials/PointsMaterial.html
@@ -82,9 +82,6 @@
 
 		<p>使用[page:Texture]中的数据设置点的颜色。</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p>材质是否使用morphTargets。默认值为false。</p>
-
 		<h3>[property:Number size]</h3>
 		<p>设置点的大小。默认值为1.0。<br/>
 			Will be capped if it exceeds the hardware dependent parameter [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParameter gl.ALIASED_POINT_SIZE_RANGE].</p>

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -325,14 +325,6 @@ this.extensions = {
 			由于[link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]与大多数平台上[page:WebGLRenderer WebGL]渲染器的限制，无论如何设置该值，线宽始终为1。
 		</p>
 
-		<h3>[property:Boolean morphTargets]</h3>
-		<p> When set to true, morph target attributes are available in the vertex shader. Default is *false*.
-		</p>
-
-		<h3>[property:Boolean morphNormals]</h3>
-		<p> When set to true, morph normal attributes are available in the vertex shader. Default is *false*.
-		</p>
-
 		<h3>[property:Boolean flatShading]</h3>
 		<p> 定义材质是否使用平面着色进行渲染。默认值为false。
 		</p>

--- a/docs/manual/ja/introduction/How-to-update-things.html
+++ b/docs/manual/ja/introduction/How-to-update-things.html
@@ -126,33 +126,6 @@ line.geometry.computeBoundingSphere();
 
     </div>
 
-    <h2>Geometry</h2>
-    <div>
-        <p>
-            下記に示してあるフラグはさまざまなジオメトリの要素の更新をコントロールします。 更新にはコストがかかるので、更新が必要な要素のみを、更新するように設定してください。 バッファが変化すると、自動的にこれらのフラグはflaseにリセットされます。 バッファを更新し続けたいのであれば、このフラグをtrueに設定し続ける必要があります。 これは[page:Geometry]にのみ適用されて、[page:BufferGeometry]には適用されないことに注意してください。
-        </p>
-        <code>
-const geometry = new THREE.Geometry();
-geometry.verticesNeedUpdate = true;
-geometry.elementsNeedUpdate = true;
-geometry.morphTargetsNeedUpdate = true;
-geometry.uvsNeedUpdate = true;
-geometry.normalsNeedUpdate = true;
-geometry.colorsNeedUpdate = true;
-geometry.tangentsNeedUpdate = true;
-			</code>
-
-        <p>
-            [link:https://github.com/mrdoob/three.js/releases/tag/r66 r66]以前のバージョンでは、メッシュは<em>dynamic</em>フラグを有効にする必要があります。これは内部で型付き配列を保持するために必要になります。
-        </p>
-
-        <code>
-// removed after r66
-geometry.dynamic = true;
-			</code>
-
-    </div>
-
     <h2>Materials</h2>
     <div>
         <p>

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -417,10 +417,7 @@ function Loader( editor ) {
 					var { MD2Loader } = await import( '../../examples/jsm/loaders/MD2Loader.js' );
 
 					var geometry = new MD2Loader().parse( contents );
-					var material = new THREE.MeshStandardMaterial( {
-						morphTargets: true,
-						morphNormals: true
-					} );
+					var material = new THREE.MeshStandardMaterial();
 
 					var mesh = new THREE.Mesh( geometry, material );
 					mesh.mixer = new THREE.AnimationMixer( mesh );

--- a/examples/jsm/effects/OutlineEffect.js
+++ b/examples/jsm/effects/OutlineEffect.js
@@ -333,8 +333,6 @@ class OutlineEffect {
 
 			const outlineParameters = originalMaterial.userData.outlineParameters;
 
-			material.morphTargets = originalMaterial.morphTargets;
-			material.morphNormals = originalMaterial.morphNormals;
 			material.fog = originalMaterial.fog;
 			material.toneMapped = originalMaterial.toneMapped;
 			material.premultipliedAlpha = originalMaterial.premultipliedAlpha;

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -858,8 +858,6 @@ class FBXTreeParser {
 
 		this.createAmbientLight();
 
-		this.setupMorphMaterials();
-
 		sceneGraph.traverse( function ( node ) {
 
 			if ( node.userData.transformData ) {
@@ -1450,75 +1448,6 @@ class FBXTreeParser {
 			}
 
 		}
-
-	}
-
-	setupMorphMaterials() {
-
-		const scope = this;
-		sceneGraph.traverse( function ( child ) {
-
-			if ( child.isMesh ) {
-
-				if ( child.geometry.morphAttributes.position && child.geometry.morphAttributes.position.length ) {
-
-					if ( Array.isArray( child.material ) ) {
-
-						child.material.forEach( function ( material, i ) {
-
-							scope.setupMorphMaterial( child, material, i );
-
-						} );
-
-					} else {
-
-						scope.setupMorphMaterial( child, child.material );
-
-					}
-
-				}
-
-			}
-
-		} );
-
-	}
-
-	setupMorphMaterial( child, material, index ) {
-
-		const uuid = child.uuid;
-		const matUuid = material.uuid;
-
-		// if a geometry has morph targets, it cannot share the material with other geometries
-		let sharedMat = false;
-
-		sceneGraph.traverse( function ( node ) {
-
-			if ( node.isMesh ) {
-
-				if ( Array.isArray( node.material ) ) {
-
-					node.material.forEach( function ( mat ) {
-
-						if ( mat.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-					} );
-
-				} else if ( node.material.uuid === matUuid && node.uuid !== uuid ) sharedMat = true;
-
-			}
-
-		} );
-
-		if ( sharedMat === true ) {
-
-			const clonedMat = material.clone();
-			clonedMat.morphTargets = true;
-
-			if ( index === undefined ) child.material = clonedMat;
-			else child.material[ index ] = clonedMat;
-
-		} else material.morphTargets = true;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2832,8 +2832,6 @@ class GLTFParser {
 		const useVertexTangents = geometry.attributes.tangent !== undefined;
 		const useVertexColors = geometry.attributes.color !== undefined;
 		const useFlatShading = geometry.attributes.normal === undefined;
-		const useMorphTargets = Object.keys( geometry.morphAttributes ).length > 0;
-		const useMorphNormals = useMorphTargets && geometry.morphAttributes.normal !== undefined;
 
 		if ( mesh.isPoints ) {
 
@@ -2876,7 +2874,7 @@ class GLTFParser {
 		}
 
 		// Clone the material if it will be modified
-		if ( useVertexTangents || useVertexColors || useFlatShading || useMorphTargets ) {
+		if ( useVertexTangents || useVertexColors || useFlatShading ) {
 
 			let cacheKey = 'ClonedMaterial:' + material.uuid + ':';
 
@@ -2884,8 +2882,6 @@ class GLTFParser {
 			if ( useVertexTangents ) cacheKey += 'vertex-tangents:';
 			if ( useVertexColors ) cacheKey += 'vertex-colors:';
 			if ( useFlatShading ) cacheKey += 'flat-shading:';
-			if ( useMorphTargets ) cacheKey += 'morph-targets:';
-			if ( useMorphNormals ) cacheKey += 'morph-normals:';
 
 			let cachedMaterial = this.cache.get( cacheKey );
 
@@ -2895,8 +2891,6 @@ class GLTFParser {
 
 				if ( useVertexColors ) cachedMaterial.vertexColors = true;
 				if ( useFlatShading ) cachedMaterial.flatShading = true;
-				if ( useMorphTargets ) cachedMaterial.morphTargets = true;
-				if ( useMorphNormals ) cachedMaterial.morphNormals = true;
 
 				if ( useVertexTangents ) {
 

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -239,7 +239,6 @@ class LWOTreeParser {
 
 					spec.size = 0.1;
 					spec.map = mat.map;
-					spec.morphTargets = mat.morphTargets;
 					materials[ i ] = new PointsMaterial( spec );
 
 				} else if ( type === 'lines' ) {

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -1117,7 +1117,6 @@ class MaterialBuilder {
 
 			//
 
-			params.morphTargets = geometry.morphTargets.length > 0 ? true : false;
 			params.fog = true;
 
 			// blend

--- a/examples/jsm/misc/MD2Character.js
+++ b/examples/jsm/misc/MD2Character.js
@@ -43,8 +43,8 @@ class MD2Character {
 
 		function createPart( geometry, skinMap ) {
 
-			const materialWireframe = new MeshLambertMaterial( { color: 0xffaa00, wireframe: true, morphTargets: true, morphNormals: true } );
-			const materialTexture = new MeshLambertMaterial( { color: 0xffffff, wireframe: false, map: skinMap, morphTargets: true, morphNormals: true } );
+			const materialWireframe = new MeshLambertMaterial( { color: 0xffaa00, wireframe: true } );
+			const materialTexture = new MeshLambertMaterial( { color: 0xffffff, wireframe: false, map: skinMap } );
 
 			//
 

--- a/examples/jsm/misc/MD2CharacterComplex.js
+++ b/examples/jsm/misc/MD2CharacterComplex.js
@@ -550,8 +550,8 @@ class MD2CharacterComplex {
 
 	_createPart( geometry, skinMap ) {
 
-		const materialWireframe = new MeshLambertMaterial( { color: 0xffaa00, wireframe: true, morphTargets: true, morphNormals: true } );
-		const materialTexture = new MeshLambertMaterial( { color: 0xffffff, wireframe: false, map: skinMap, morphTargets: true, morphNormals: true } );
+		const materialWireframe = new MeshLambertMaterial( { color: 0xffaa00, wireframe: true } );
+		const materialTexture = new MeshLambertMaterial( { color: 0xffffff, wireframe: false, map: skinMap } );
 
 		//
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -190,8 +190,6 @@ class NodeMaterial extends ShaderMaterial {
 			if ( this.alphaTest > 0 ) data.alphaTest = this.alphaTest;
 			if ( this.premultipliedAlpha === true ) data.premultipliedAlpha = this.premultipliedAlpha;
 
-			if ( this.morphTargets === true ) data.morphTargets = true;
-
 			if ( this.visible === false ) data.visible = false;
 			if ( JSON.stringify( this.userData ) !== '{}' ) data.userData = this.userData;
 

--- a/examples/jsm/postprocessing/SSRPass.js
+++ b/examples/jsm/postprocessing/SSRPass.js
@@ -24,7 +24,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
 
 class SSRPass extends Pass {
 
-	constructor( { renderer, scene, camera, width, height, selects, encoding, bouncing = false, morphTargets = false, groundReflector } ) {
+	constructor( { renderer, scene, camera, width, height, selects, encoding, bouncing = false, groundReflector } ) {
 
 		super();
 
@@ -241,7 +241,7 @@ class SSRPass extends Pass {
 
 		// normal material
 
-		this.normalMaterial = new MeshNormalMaterial( { morphTargets } );
+		this.normalMaterial = new MeshNormalMaterial();
 		this.normalMaterial.blending = NoBlending;
 
 		// metalnessOn material

--- a/examples/jsm/postprocessing/SSRrPass.js
+++ b/examples/jsm/postprocessing/SSRrPass.js
@@ -24,7 +24,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
 
 class SSRrPass extends Pass {
 
-	constructor( { renderer, scene, camera, width, height, selects, encoding, morphTargets = false } ) {
+	constructor( { renderer, scene, camera, width, height, selects, encoding } ) {
 
 		super();
 
@@ -187,7 +187,7 @@ class SSRrPass extends Pass {
 
 		// normal material
 
-		this.normalMaterial = new MeshNormalMaterial( { morphTargets } );
+		this.normalMaterial = new MeshNormalMaterial();
 		this.normalMaterial.blending = NoBlending;
 
 		// refractiveOn material

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -492,9 +492,10 @@ class Projector {
 							let y = positions[ i + 1 ];
 							let z = positions[ i + 2 ];
 
-							if ( material.morphTargets === true ) {
+							const morphTargets = geometry.morphAttributes.position;
 
-								const morphTargets = geometry.morphAttributes.position;
+							if ( morphTargets !== undefined ) {
+
 								const morphTargetsRelative = geometry.morphTargetsRelative;
 								const morphInfluences = object.morphTargetInfluences;
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -16,7 +16,6 @@
 			import * as THREE from '../build/three.module.js';
 
 			import Stats from './jsm/libs/stats.module.js';
-			import { GUI } from './jsm/libs/dat.gui.module.js';
 
 			let container, stats, clock;
 
@@ -27,10 +26,6 @@
 			const segments = 10000;
 			const r = 800;
 			let t = 0;
-
-			const params = {
-				morphTargets: false
-			};
 
 			init();
 			animate();
@@ -49,7 +44,7 @@
 				clock = new THREE.Clock();
 
 				const geometry = new THREE.BufferGeometry();
-				const material = new THREE.LineBasicMaterial( { vertexColors: true, morphTargets: true } );
+				const material = new THREE.LineBasicMaterial( { vertexColors: true } );
 
 				const positions = [];
 				const colors = [];
@@ -97,13 +92,6 @@
 
 				//
 
-				const gui = new GUI();
-				gui.add( params, 'morphTargets' );
-				gui.open();
-
-
-				//
-
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -136,12 +124,8 @@
 				line.rotation.x = time * 0.25;
 				line.rotation.y = time * 0.5;
 
-				if ( params.morphTargets ) {
-
-					t += delta * 0.5;
-					line.morphTargetInfluences[ 0 ] = Math.abs( Math.sin( t ) );
-
-				}
+				t += delta * 0.5;
+				line.morphTargetInfluences[ 0 ] = Math.abs( Math.sin( t ) );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_mdd.html
+++ b/examples/webgl_loader_mdd.html
@@ -44,7 +44,7 @@
 					const geometry = new THREE.BoxGeometry();
 					geometry.morphAttributes.position = morphTargets; // apply morph targets
 
-					const material = new THREE.MeshNormalMaterial( { morphTargets: true } );
+					const material = new THREE.MeshNormalMaterial();
 
 					const mesh = new THREE.Mesh( geometry, material );
 					scene.add( mesh );

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -136,7 +136,7 @@
 
 				} );
 
-				const vtkmaterial = new THREE.MeshLambertMaterial( { wireframe: false, morphTargets: false, side: THREE.DoubleSide, color: 0xff0000 } );
+				const vtkmaterial = new THREE.MeshLambertMaterial( { wireframe: false, side: THREE.DoubleSide, color: 0xff0000 } );
 
 				const vtkloader = new VTKLoader();
 				vtkloader.load( "models/vtk/liver.vtk", function ( geometry ) {

--- a/examples/webgl_loader_vrm.html
+++ b/examples/webgl_loader_vrm.html
@@ -62,8 +62,6 @@
 									THREE.Material.prototype.copy.call( material, object.material[ i ] );
 									material.color.copy( object.material[ i ].color );
 									material.map = object.material[ i ].map;
-									material.morphTargets = object.material[ i ].morphTargets;
-									material.morphNormals = object.material[ i ].morphNormals;
 									object.material[ i ] = material;
 
 								}
@@ -74,8 +72,6 @@
 								THREE.Material.prototype.copy.call( material, object.material );
 								material.color.copy( object.material.color );
 								material.map = object.material.map;
-								material.morphTargets = object.material.morphTargets;
-								material.morphNormals = object.material.morphNormals;
 								object.material = material;
 
 							}

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -45,8 +45,7 @@
 
 				const material = new THREE.MeshPhongMaterial( {
 					color: 0xff0000,
-					flatShading: true,
-					morphTargets: true
+					flatShading: true
 				} );
 
 				mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -55,7 +55,6 @@
 				loader.load( 'models/gltf/AnimatedMorphSphere/glTF/AnimatedMorphSphere.gltf', function ( gltf ) {
 
 					mesh = gltf.scene.getObjectByName( 'AnimatedMorphSphere' );
-					mesh.material.morphTargets = true;
 					mesh.rotation.z = Math.PI / 2;
 					scene.add( mesh );
 
@@ -65,8 +64,7 @@
 						size: 10,
 						sizeAttenuation: false,
 						map: new THREE.TextureLoader().load( 'textures/sprites/disc.png' ),
-						alphaTest: 0.5,
-						morphTargets: true
+						alphaTest: 0.5
 					} );
 
 					const points = new THREE.Points( mesh.geometry, pointsMaterial );

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -122,8 +122,6 @@ class MaterialLoader extends Loader {
 		if ( json.polygonOffsetFactor !== undefined ) material.polygonOffsetFactor = json.polygonOffsetFactor;
 		if ( json.polygonOffsetUnits !== undefined ) material.polygonOffsetUnits = json.polygonOffsetUnits;
 
-		if ( json.morphTargets !== undefined ) material.morphTargets = json.morphTargets;
-		if ( json.morphNormals !== undefined ) material.morphNormals = json.morphNormals;
 		if ( json.dithering !== undefined ) material.dithering = json.dithering;
 
 		if ( json.alphaToCoverage !== undefined ) material.alphaToCoverage = json.alphaToCoverage;

--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -26,8 +26,6 @@ class LineBasicMaterial extends Material {
 		this.linecap = 'round';
 		this.linejoin = 'round';
 
-		this.morphTargets = false;
-
 		this.setValues( parameters );
 
 	}
@@ -42,8 +40,6 @@ class LineBasicMaterial extends Material {
 		this.linewidth = source.linewidth;
 		this.linecap = source.linecap;
 		this.linejoin = source.linejoin;
-
-		this.morphTargets = source.morphTargets;
 
 		return this;
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -317,9 +317,6 @@ class Material extends EventDispatcher {
 		if ( this.wireframeLinecap !== 'round' ) data.wireframeLinecap = this.wireframeLinecap;
 		if ( this.wireframeLinejoin !== 'round' ) data.wireframeLinejoin = this.wireframeLinejoin;
 
-		if ( this.morphTargets === true ) data.morphTargets = true;
-		if ( this.morphNormals === true ) data.morphNormals = true;
-
 		if ( this.flatShading === true ) data.flatShading = this.flatShading;
 
 		if ( this.visible === false ) data.visible = false;

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -28,8 +28,6 @@ import { Color } from '../math/Color.js';
  *
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
- *
- *  morphTargets: <bool>
  * }
  */
 
@@ -65,8 +63,6 @@ class MeshBasicMaterial extends Material {
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
 
-		this.morphTargets = false;
-
 		this.setValues( parameters );
 
 	}
@@ -98,8 +94,6 @@ class MeshBasicMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.morphTargets = source.morphTargets;
 
 		return this;
 

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -29,8 +29,6 @@ class MeshDepthMaterial extends Material {
 
 		this.depthPacking = BasicDepthPacking;
 
-		this.morphTargets = false;
-
 		this.map = null;
 
 		this.alphaMap = null;
@@ -53,8 +51,6 @@ class MeshDepthMaterial extends Material {
 		super.copy( source );
 
 		this.depthPacking = source.depthPacking;
-
-		this.morphTargets = source.morphTargets;
 
 		this.map = source.map;
 

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -8,8 +8,6 @@ import { Vector3 } from '../math/Vector3.js';
  *  nearDistance: <float>,
  *  farDistance: <float>,
  *
- *  morphTargets: <bool>,
- *
  *  map: new THREE.Texture( <Image> ),
  *
  *  alphaMap: new THREE.Texture( <Image> ),
@@ -33,8 +31,6 @@ class MeshDistanceMaterial extends Material {
 		this.nearDistance = 1;
 		this.farDistance = 1000;
 
-		this.morphTargets = false;
-
 		this.map = null;
 
 		this.alphaMap = null;
@@ -56,8 +52,6 @@ class MeshDistanceMaterial extends Material {
 		this.referencePosition.copy( source.referencePosition );
 		this.nearDistance = source.nearDistance;
 		this.farDistance = source.farDistance;
-
-		this.morphTargets = source.morphTargets;
 
 		this.map = source.map;
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -31,8 +31,6 @@ import { Color } from '../math/Color.js';
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>
  * }
  */
 
@@ -72,9 +70,6 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.setValues( parameters );
 
 	}
@@ -110,9 +105,6 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		return this;
 

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -25,9 +25,6 @@ import { Color } from '../math/Color.js';
  *
  *  alphaMap: new THREE.Texture( <Image> ),
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>
- *
  *  flatShading: <bool>
  * }
  */
@@ -61,9 +58,6 @@ class MeshMatcapMaterial extends Material {
 
 		this.alphaMap = null;
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.flatShading = false;
 
 		this.setValues( parameters );
@@ -95,9 +89,6 @@ class MeshMatcapMaterial extends Material {
 		this.displacementBias = source.displacementBias;
 
 		this.alphaMap = source.alphaMap;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		this.flatShading = source.flatShading;
 

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -20,9 +20,6 @@ import { Vector2 } from '../math/Vector2.js';
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>,
- *
  *  flatShading: <bool>
  * }
  */
@@ -51,9 +48,6 @@ class MeshNormalMaterial extends Material {
 
 		this.fog = false;
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.flatShading = false;
 
 		this.setValues( parameters );
@@ -77,9 +71,6 @@ class MeshNormalMaterial extends Material {
 
 		this.wireframe = source.wireframe;
 		this.wireframeLinewidth = source.wireframeLinewidth;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		this.flatShading = source.flatShading;
 

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -45,9 +45,6 @@ import { Color } from '../math/Color.js';
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>,
- *
  *  flatShading: <bool>
  * }
  */
@@ -101,9 +98,6 @@ class MeshPhongMaterial extends Material {
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.flatShading = false;
 
 		this.setValues( parameters );
@@ -154,9 +148,6 @@ class MeshPhongMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		this.flatShading = source.flatShading;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -47,9 +47,6 @@ import { Color } from '../math/Color.js';
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>,
- *
  *  flatShading: <bool>
  * }
  */
@@ -107,9 +104,6 @@ class MeshStandardMaterial extends Material {
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.flatShading = false;
 
 		this.vertexTangents = false;
@@ -166,9 +160,6 @@ class MeshStandardMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		this.flatShading = source.flatShading;
 

--- a/src/materials/MeshToonMaterial.js
+++ b/src/materials/MeshToonMaterial.js
@@ -36,8 +36,6 @@ import { Color } from '../math/Color.js';
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
  *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>
  * }
  */
 
@@ -84,9 +82,6 @@ class MeshToonMaterial extends Material {
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
 
-		this.morphTargets = false;
-		this.morphNormals = false;
-
 		this.setValues( parameters );
 
 	}
@@ -127,9 +122,6 @@ class MeshToonMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		return this;
 

--- a/src/materials/PointsMaterial.js
+++ b/src/materials/PointsMaterial.js
@@ -11,7 +11,6 @@ import { Color } from '../math/Color.js';
  *  size: <float>,
  *  sizeAttenuation: <bool>
  *
- *  morphTargets: <bool>
  * }
  */
 
@@ -32,8 +31,6 @@ class PointsMaterial extends Material {
 		this.size = 1;
 		this.sizeAttenuation = true;
 
-		this.morphTargets = false;
-
 		this.setValues( parameters );
 
 	}
@@ -50,8 +47,6 @@ class PointsMaterial extends Material {
 
 		this.size = source.size;
 		this.sizeAttenuation = source.sizeAttenuation;
-
-		this.morphTargets = source.morphTargets;
 
 		return this;
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -15,10 +15,7 @@ import default_fragment from '../renderers/shaders/ShaderChunk/default_fragment.
  *  wireframe: <boolean>,
  *  wireframeLinewidth: <float>,
  *
- *  lights: <bool>,
- *
- *  morphTargets: <bool>,
- *  morphNormals: <bool>
+ *  lights: <bool>
  * }
  */
 
@@ -44,9 +41,6 @@ class ShaderMaterial extends Material {
 		this.fog = false; // set to use scene fog
 		this.lights = false; // set to use scene lights
 		this.clipping = false; // set to use user-defined clipping planes
-
-		this.morphTargets = false; // set to use morph targets
-		this.morphNormals = false; // set to use morph normals
 
 		this.extensions = {
 			derivatives: false, // set to use derivatives
@@ -98,9 +92,6 @@ class ShaderMaterial extends Material {
 
 		this.lights = source.lights;
 		this.clipping = source.clipping;
-
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		this.extensions = Object.assign( {}, source.extensions );
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -327,7 +327,7 @@ function checkBufferGeometryIntersection( object, material, raycaster, ray, posi
 
 	const morphInfluences = object.morphTargetInfluences;
 
-	if ( material.morphTargets && morphPosition && morphInfluences ) {
+	if ( morphPosition && morphInfluences ) {
 
 		_morphA.set( 0, 0, 0 );
 		_morphB.set( 0, 0, 0 );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -765,7 +765,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		if ( material.morphTargets || material.morphNormals ) {
+		if ( geometry.morphAttributes.position !== undefined || geometry.morphAttributes.normal !== undefined ) {
 
 			morphtargets.update( object, geometry, material, program );
 
@@ -1489,6 +1489,8 @@ function WebGLRenderer( parameters = {} ) {
 		materialProperties.outputEncoding = parameters.outputEncoding;
 		materialProperties.instancing = parameters.instancing;
 		materialProperties.skinning = parameters.skinning;
+		materialProperties.morphTargets = parameters.morphTargets;
+		materialProperties.morphNormals = parameters.morphNormals;
 		materialProperties.numClippingPlanes = parameters.numClippingPlanes;
 		materialProperties.numIntersection = parameters.numClipIntersection;
 		materialProperties.vertexAlphas = parameters.vertexAlphas;
@@ -1506,6 +1508,8 @@ function WebGLRenderer( parameters = {} ) {
 		const encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
 		const envMap = cubemaps.get( material.envMap || environment );
 		const vertexAlphas = material.vertexColors === true && object.geometry && object.geometry.attributes.color && object.geometry.attributes.color.itemSize === 4;
+		const morphTargets = object.geometry && object.geometry.morphAttributes.position;
+		const morphNormals = object.geometry && object.geometry.morphAttributes.normal;
 
 		const materialProperties = properties.get( material );
 		const lights = currentRenderState.state.lights;
@@ -1572,6 +1576,14 @@ function WebGLRenderer( parameters = {} ) {
 				needsProgramChange = true;
 
 			} else if ( materialProperties.vertexAlphas !== vertexAlphas ) {
+
+				needsProgramChange = true;
+
+			} else if ( materialProperties.morphTargets !== morphTargets ) {
+
+				needsProgramChange = true;
+
+			} else if ( materialProperties.morphNormals !== morphNormals ) {
 
 				needsProgramChange = true;
 

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -81,8 +81,8 @@ function WebGLMorphtargets( gl ) {
 
 		workInfluences.sort( numericalSort );
 
-		const morphTargets = material.morphTargets && geometry.morphAttributes.position;
-		const morphNormals = material.morphNormals && geometry.morphAttributes.normal;
+		const morphTargets = geometry.morphAttributes.position;
+		const morphNormals = geometry.morphAttributes.normal;
 
 		let morphInfluencesSum = 0;
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -227,8 +227,8 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 			maxBones: maxBones,
 			useVertexTexture: floatVertexTextures,
 
-			morphTargets: material.morphTargets,
-			morphNormals: material.morphNormals,
+			morphTargets: object.geometry && object.geometry.morphAttributes.position !== undefined,
+			morphNormals: object.geometry && object.geometry.morphAttributes.normal !== undefined,
 
 			numDirLights: lights.directional.length,
 			numPointLights: lights.point.length,

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -22,8 +22,8 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		_viewport = new Vector4(),
 
-		_depthMaterials = [],
-		_distanceMaterials = [],
+		_depthMaterial = new MeshDepthMaterial( { depthPacking: RGBADepthPacking } ),
+		_distanceMaterial = new MeshDistanceMaterial(),
 
 		_materialCache = {},
 
@@ -228,81 +228,19 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 	}
 
-	function getDepthMaterialVariant( useMorphing ) {
-
-		const index = useMorphing << 0;
-
-		let material = _depthMaterials[ index ];
-
-		if ( material === undefined ) {
-
-			material = new MeshDepthMaterial( {
-
-				depthPacking: RGBADepthPacking,
-
-				morphTargets: useMorphing
-
-			} );
-
-			_depthMaterials[ index ] = material;
-
-		}
-
-		return material;
-
-	}
-
-	function getDistanceMaterialVariant( useMorphing ) {
-
-		const index = useMorphing << 0;
-
-		let material = _distanceMaterials[ index ];
-
-		if ( material === undefined ) {
-
-			material = new MeshDistanceMaterial( {
-
-				morphTargets: useMorphing
-
-			} );
-
-			_distanceMaterials[ index ] = material;
-
-		}
-
-		return material;
-
-	}
-
 	function getDepthMaterial( object, geometry, material, light, shadowCameraNear, shadowCameraFar, type ) {
 
 		let result = null;
 
-		let getMaterialVariant = getDepthMaterialVariant;
-		let customMaterial = object.customDepthMaterial;
+		const customMaterial = ( light.isPointLight === true ) ? object.customDistanceMaterial : object.customDepthMaterial;
 
-		if ( light.isPointLight === true ) {
+		if ( customMaterial !== undefined ) {
 
-			getMaterialVariant = getDistanceMaterialVariant;
-			customMaterial = object.customDistanceMaterial;
-
-		}
-
-		if ( customMaterial === undefined ) {
-
-			let useMorphing = false;
-
-			if ( material.morphTargets === true ) {
-
-				useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
-
-			}
-
-			result = getMaterialVariant( useMorphing );
+			result = customMaterial;
 
 		} else {
 
-			result = customMaterial;
+			result = ( light.isPointLight === true ) ? _distanceMaterial : _depthMaterial;
 
 		}
 


### PR DESCRIPTION
Related issue: Fixed #22166. Fixed #12844.

**Description**

Removes `morphTargets` and `morphNormals` from all materials. Whether a shader program uses morph targets or not not depends on the geometry data.
