### PR TITLE
LDrawLoader: Fix slanted normals

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -262,7 +262,8 @@ function smoothNormals( triangles, lineSegments ) {
 								const norm = tri[ `n${ next }` ];
 								otherTri[ `n${ otherIndex }` ] = norm;
 
-								norm.addScaledVector( otherTri.faceNormal, otherTri.fromQuad && otherIndex !== 2 ? 0.5 : 1.0 );
+								const isDoubledVert = otherTri.fromQuad && otherIndex !== 2;
+								norm.addScaledVector( otherTri.faceNormal, isDoubledVert ? 0.5 : 1.0 );
 
 							}
 
@@ -270,7 +271,9 @@ function smoothNormals( triangles, lineSegments ) {
 
 								const norm = tri[ `n${ index }` ];
 								otherTri[ `n${ otherNext }` ] = norm;
-								norm.addScaledVector( otherTri.faceNormal, otherTri.fromQuad && otherNext !== 2 ? 0.5 : 1.0 );
+
+								const isDoubledVert = otherTri.fromQuad && otherNext !== 2;
+								norm.addScaledVector( otherTri.faceNormal, isDoubledVert ? 0.5 : 1.0 );
 
 							}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -173,13 +173,6 @@ function smoothNormals( triangles, lineSegments ) {
 
 	}
 
-	// NOTE: Some of the normals wind up being skewed in an unexpected way because
-	// quads provide more "influence" to some vertex normals than a triangle due to
-	// the fact that a quad is made up of two triangles and all triangles are weighted
-	// equally. To fix this quads could be tracked separately so their vertex normals
-	// are weighted appropriately or we could try only adding a normal direction
-	// once per normal.
-
 	// Iterate until we've tried to connect all triangles to share normals
 	while ( true ) {
 
@@ -199,14 +192,14 @@ function smoothNormals( triangles, lineSegments ) {
 			const faceNormal = tri.faceNormal;
 			if ( tri.n0 === null ) {
 
-				tri.n0 = faceNormal.clone();
+				tri.n0 = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
 				normals.push( tri.n0 );
 
 			}
 
 			if ( tri.n1 === null ) {
 
-				tri.n1 = faceNormal.clone();
+				tri.n1 = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
 				normals.push( tri.n1 );
 
 			}
@@ -268,7 +261,8 @@ function smoothNormals( triangles, lineSegments ) {
 
 								const norm = tri[ `n${ next }` ];
 								otherTri[ `n${ otherIndex }` ] = norm;
-								norm.add( otherTri.faceNormal );
+
+								norm.addScaledVector( otherTri.faceNormal, otherTri.fromQuad && otherIndex !== 2 ? 0.5 : 1.0 );
 
 							}
 
@@ -276,7 +270,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 								const norm = tri[ `n${ index }` ];
 								otherTri[ `n${ otherNext }` ] = norm;
-								norm.add( otherTri.faceNormal );
+								norm.addScaledVector( otherTri.faceNormal, otherTri.fromQuad && otherNext !== 2 ? 0.5 : 1.0 );
 
 							}
 
@@ -1482,7 +1476,8 @@ class LDrawLoader extends Loader {
 						faceNormal: faceNormal,
 						n0: null,
 						n1: null,
-						n2: null
+						n2: null,
+						fromQuad: false,
 					} );
 
 					if ( doubleSided === true ) {
@@ -1496,7 +1491,8 @@ class LDrawLoader extends Loader {
 							faceNormal: faceNormal,
 							n0: null,
 							n1: null,
-							n2: null
+							n2: null,
+							fromQuad: false,
 						} );
 
 					}
@@ -1534,16 +1530,19 @@ class LDrawLoader extends Loader {
 						.crossVectors( _tempVec0, _tempVec1 )
 						.normalize();
 
+					// specifically place the triangle diagonal in the v0 and v1 slots so we can
+					// account for the doubling of vertices later when smoothing normals.
 					triangles.push( {
 						material: material,
 						colourCode: material.userData.code,
-						v0: v0,
-						v1: v1,
-						v2: v2,
+						v0: v2,
+						v1: v0,
+						v2: v1,
 						faceNormal: faceNormal,
 						n0: null,
 						n1: null,
-						n2: null
+						n2: null,
+						fromQuad: true,
 					} );
 
 					triangles.push( {
@@ -1555,7 +1554,8 @@ class LDrawLoader extends Loader {
 						faceNormal: faceNormal,
 						n0: null,
 						n1: null,
-						n2: null
+						n2: null,
+						fromQuad: true,
 					} );
 
 					if ( doubleSided === true ) {
@@ -1569,19 +1569,21 @@ class LDrawLoader extends Loader {
 							faceNormal: faceNormal,
 							n0: null,
 							n1: null,
-							n2: null
+							n2: null,
+							fromQuad: true,
 						} );
 
 						triangles.push( {
 							material: material,
 							colourCode: material.userData.code,
-							v0: v0,
-							v1: v3,
-							v2: v2,
+							v0: v2,
+							v1: v0,
+							v2: v3,
 							faceNormal: faceNormal,
 							n0: null,
 							n1: null,
-							n2: null
+							n2: null,
+							fromQuad: true,
 						} );
 
 					}


### PR DESCRIPTION
Related issue: --

**Description**

Fixes skewed normals from redundant quad vertices when generating smooth normals that were particularly noticeable on the studs. Here's a gif of the before and after fix:

![ldraw-normal-diff](https://user-images.githubusercontent.com/734200/126910162-f49b4d38-dc8a-4147-ab87-792ad43829f5.gif)

And screenshots:

| **BEFORE** | **AFTER** |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/126910192-ace8d180-7580-46c3-8c70-086434a05ae9.png) | ![image](https://user-images.githubusercontent.com/734200/126910197-15d91ca3-06e3-4b19-9d71-3fd97c125d07.png) |

Also semi-related I notice that after 2f09982f44bd613a9478ab3bb1ff210db27d92d2 the LDraw example page looks very washed out and the lego models don't look bright and vibrant the way I expect them to. Was this intentional? I'm not sure I feel an environment map is the best way to demonstrate the models.

cc @yomboprime 
