### PR TITLE
WebGLRenderer, GLTFLoader: Clean up .vertexTangents removal.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1219,14 +1219,10 @@ class GLTFWriter {
 
 			const normalMapDef = { index: this.processTexture( material.normalMap ) };
 
-			if ( material.normalScale && material.normalScale.x !== - 1 ) {
+			if ( material.normalScale && material.normalScale.x !== 1 ) {
 
-				if ( material.normalScale.x !== material.normalScale.y ) {
-
-					console.warn( 'THREE.GLTFExporter: Normal scale components are different, ignoring Y and exporting X.' );
-
-				}
-
+				// glTF normal scale is univariate. Ignore `y`, which may be flipped.
+				// Context: https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
 				normalMapDef.scale = material.normalScale.x;
 
 			}

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -684,7 +684,8 @@ class GLTFMaterialsClearcoatExtension {
 
 				const scale = extension.clearcoatNormalTexture.scale;
 
-				materialParams.clearcoatNormalScale = new Vector2( scale, scale );
+				// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
+				materialParams.clearcoatNormalScale = new Vector2( scale, - scale );
 
 			}
 
@@ -2891,6 +2892,14 @@ class GLTFParser {
 				if ( useVertexColors ) cachedMaterial.vertexColors = true;
 				if ( useFlatShading ) cachedMaterial.flatShading = true;
 
+				if ( useVertexTangents ) {
+
+					// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
+					if ( cachedMaterial.normalScale ) cachedMaterial.normalScale.y *= - 1;
+					if ( cachedMaterial.clearcoatNormalScale ) cachedMaterial.clearcoatNormalScale.y *= - 1;
+
+				}
+
 				this.cache.add( cacheKey, cachedMaterial );
 
 				this.associations.set( cachedMaterial, this.associations.get( material ) );
@@ -3029,9 +3038,12 @@ class GLTFParser {
 
 			pending.push( parser.assignTexture( materialParams, 'normalMap', materialDef.normalTexture ) );
 
+			// https://github.com/mrdoob/three.js/issues/11438#issuecomment-507003995
+			materialParams.normalScale = new Vector2( 1, - 1 );
+
 			if ( materialDef.normalTexture.scale !== undefined ) {
 
-				materialParams.normalScale = new Vector2( materialDef.normalTexture.scale, materialDef.normalTexture.scale );
+				materialParams.normalScale.set( materialDef.normalTexture.scale, - materialDef.normalTexture.scale );
 
 			}
 

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_maps.glsl.js
@@ -4,12 +4,6 @@ export default /* glsl */`
 	vec3 clearcoatMapN = texture2D( clearcoatNormalMap, vUv ).xyz * 2.0 - 1.0;
 	clearcoatMapN.xy *= clearcoatNormalScale;
 
-	#ifdef FLIP_NORMAL_SCALE_Y
-
-		clearcoatMapN.y *= -1.0;
-
-	#endif
-
 	#ifdef USE_TANGENT
 
 		clearcoatNormal = normalize( vTBN * clearcoatMapN );

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_maps.glsl.js
@@ -23,12 +23,6 @@ export default /* glsl */`
 	vec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;
 	mapN.xy *= normalScale;
 
-	#ifdef FLIP_NORMAL_SCALE_Y
-
-		mapN.y *= -1.0;
-
-	#endif
-
 	#ifdef USE_TANGENT
 
 		normal = normalize( vTBN * mapN );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -477,7 +477,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.vertexAlphas ? '#define USE_COLOR_ALPHA' : '',
 			parameters.vertexUvs ? '#define USE_UV' : '',
 			parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
-			parameters.flipNormalScaleY ? '#define FLIP_NORMAL_SCALE_Y' : '',
 
 			parameters.flatShading ? '#define FLAT_SHADED' : '',
 
@@ -621,7 +620,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.vertexAlphas ? '#define USE_COLOR_ALPHA' : '',
 			parameters.vertexUvs ? '#define USE_UV' : '',
 			parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
-			parameters.flipNormalScaleY ? '#define FLIP_NORMAL_SCALE_Y' : '',
 
 			parameters.gradientMap ? '#define USE_GRADIENTMAP' : '',
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -38,7 +38,7 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 		'map', 'mapEncoding', 'matcap', 'matcapEncoding', 'envMap', 'envMapMode', 'envMapEncoding', 'envMapCubeUV',
 		'lightMap', 'lightMapEncoding', 'aoMap', 'emissiveMap', 'emissiveMapEncoding', 'bumpMap', 'normalMap', 'objectSpaceNormalMap', 'tangentSpaceNormalMap', 'clearcoatMap', 'clearcoatRoughnessMap', 'clearcoatNormalMap', 'displacementMap', 'specularMap',
 		'roughnessMap', 'metalnessMap', 'gradientMap',
-		'alphaMap', 'combine', 'vertexColors', 'vertexAlphas', 'vertexTangents', 'vertexUvs', 'uvsVertexOnly', 'flipNormalScaleY', 'fog', 'useFog', 'fogExp2',
+		'alphaMap', 'combine', 'vertexColors', 'vertexAlphas', 'vertexTangents', 'vertexUvs', 'uvsVertexOnly', 'fog', 'useFog', 'fogExp2',
 		'flatShading', 'sizeAttenuation', 'logarithmicDepthBuffer', 'skinning',
 		'maxBones', 'useVertexTexture', 'morphTargets', 'morphNormals', 'premultipliedAlpha',
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
@@ -213,7 +213,6 @@ function WebGLPrograms( renderer, cubemaps, extensions, capabilities, bindingSta
 			vertexAlphas: material.vertexColors === true && object.geometry && object.geometry.attributes.color && object.geometry.attributes.color.itemSize === 4,
 			vertexUvs: !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatMap || !! material.clearcoatRoughnessMap || !! material.clearcoatNormalMap || !! material.displacementMap || !! material.transmissionMap || !! material.thicknessMap,
 			uvsVertexOnly: ! ( !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatNormalMap || !! material.transmission || !! material.transmissionMap || !! material.thicknessMap ) && !! material.displacementMap,
-			flipNormalScaleY: ( ( material.normalMap && material.normalMap.flipY === false || material.clearcoatNormalMap && material.clearcoatNormalMap.flipY === false ) && ! ( object.geometry && object.geometry.attributes.tangent ) ),
 
 			fog: !! fog,
 			useFog: material.fog,


### PR DESCRIPTION
- Context: #22146

My change in #22146 did a bit too much, in trying to detect DirectX and OpenGL normal maps. I think it would be better to keep the `1, -1` normalScale setting in GLTFLoader, since that is a better indicator of the normal map convention than `.flipY`. For glTF models, there should be no rendering differences between:

1. r130
2. current `dev` branch
3. after this PR

But for anyone using `.flipY=false` (e.g. anything with Basis textures) for normal maps, but _not_ using the OpenGL-style normal map convention, the `dev` branch has a change that probably isn't desirable. This PR addresses that problem.

I think it would be best to include this in r131 — if that's an issue, we can revert #22146 for now.

/cc @mrdoob @WestLangley 