### PR TITLE
RGBELoader: Use FloatType as default texture type.

### DIFF
--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -22,7 +22,7 @@ class HDRCubeTextureLoader extends Loader {
 		super( manager );
 
 		this.hdrLoader = new RGBELoader();
-		this.type = UnsignedByteType;
+		this.type = FloatType;
 
 	}
 

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -21,7 +21,7 @@ class RGBELoader extends DataTextureLoader {
 
 		super( manager );
 
-		this.type = UnsignedByteType;
+		this.type = FloatType;
 
 	}
 


### PR DESCRIPTION
Related issue: see #22178

**Description**

Sets `FloatType` as the default texture type of `RGBELoader`. Also updated `HDRCubeTextureLoader`.
