### PR TITLE
ShaderChunk: Add opacity support to transmission shader

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -20,11 +20,13 @@ export default /* glsl */`
 	vec3 v = normalize( cameraPosition - pos );
 	float ior = ( 1.0 + 0.4 * reflectivity ) / ( 1.0 - 0.4 * reflectivity );
 
-	vec3 transmission = transmissionFactor * getIBLVolumeRefraction(
+	vec4 transmission = getIBLVolumeRefraction(
 		normal, v, roughnessFactor, material.diffuseColor, material.specularColor,
 		pos, modelMatrix, viewMatrix, projectionMatrix, ior, thicknessFactor,
 		attenuationColor, attenuationDistance );
 
-	totalDiffuse = mix( totalDiffuse, transmission, transmissionFactor );
+	totalDiffuse = mix( totalDiffuse, transmissionFactor * transmission.rgb, transmissionFactor );
+	diffuseColor.a *= transmission.a;
+
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -44,9 +44,9 @@ export default /* glsl */`
 		return roughness * clamp(ior * 2.0 - 2.0, 0.0, 1.0);
 	}
 
-	vec3 getTransmissionSample(vec2 fragCoord, float roughness, float ior) {
+	vec4 getTransmissionSample(vec2 fragCoord, float roughness, float ior) {
 		float framebufferLod = log2(transmissionSamplerSize.x) * applyIorToRoughness(roughness, ior);
-		return texture2DLodEXT(transmissionSamplerMap, fragCoord.xy, framebufferLod).rgb;
+		return texture2DLodEXT(transmissionSamplerMap, fragCoord.xy, framebufferLod);
 	}
 
 	vec3 applyVolumeAttenuation(vec3 radiance, float transmissionDistance, vec3 attenuationColor, float attenuationDistance) {
@@ -61,7 +61,7 @@ export default /* glsl */`
 		}
 	}
 
-	vec3 getIBLVolumeRefraction(vec3 n, vec3 v, float perceptualRoughness, vec3 baseColor, vec3 specularColor,
+	vec4 getIBLVolumeRefraction(vec3 n, vec3 v, float perceptualRoughness, vec3 baseColor, vec3 specularColor,
 		vec3 position, mat4 modelMatrix, mat4 viewMatrix, mat4 projMatrix, float ior, float thickness,
 		vec3 attenuationColor, float attenuationDistance) {
 		vec3 transmissionRay = getVolumeTransmissionRay(n, v, thickness, ior, modelMatrix);
@@ -74,11 +74,11 @@ export default /* glsl */`
 		refractionCoords /= 2.0;
 
 		// Sample framebuffer to get pixel the refracted ray hits.
-		vec3 transmittedLight = getTransmissionSample(refractionCoords, perceptualRoughness, ior);
+		vec4 transmittedLight = getTransmissionSample(refractionCoords, perceptualRoughness, ior);
 
-		vec3 attenuatedColor = applyVolumeAttenuation(transmittedLight, length(transmissionRay), attenuationColor, attenuationDistance);
+		vec3 attenuatedColor = applyVolumeAttenuation(transmittedLight.rgb, length(transmissionRay), attenuationColor, attenuationDistance);
 
-		return (1.0 - specularColor) * attenuatedColor * baseColor;
+		return vec4( ( 1.0 - specularColor ) * attenuatedColor * baseColor, transmittedLight.a );
 	}
 #endif
 `;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/22009#issuecomment-867038046

**Description**

<img width="953" alt="Screenshot 2021-07-27 at 17 27 24" src="https://user-images.githubusercontent.com/97088/127191949-d63240cc-8aac-4618-93c7-68a2a1ad588f.png">

/cc @elalish 