### PR TITLE
USDZExporter: Only include metalnessMap/roughnessMap when metalness/roughness is 1

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -425,7 +425,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.roughnessMap !== null ) {
+	if ( material.roughnessMap !== null && material.roughness === 1 ) {
 
 		inputs.push( `${ pad }float inputs:roughness.connect = </Materials/Material_${ material.id }/Texture_${ material.roughnessMap.id }_roughness.outputs:g>` );
 
@@ -437,7 +437,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.metalnessMap !== null ) {
+	if ( material.metalnessMap !== null && material.metalness === 1 ) {
 
 		inputs.push( `${ pad }float inputs:metallic.connect = </Materials/Material_${ material.id }/Texture_${ material.metalnessMap.id }_metallic.outputs:b>` );
 


### PR DESCRIPTION
Related issue: #21928

**Description**

Ideally we would multiply the factor into the texture, but I think this workaround is all is needed for now to solve the workflow in #21928.