### PR TITLE
WebGPURenderer: Replace outdated context type argument.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -162,7 +162,7 @@ class WebGPURenderer {
 
 		const compiler = await glslang();
 
-		const context = ( parameters.context !== undefined ) ? parameters.context : this.domElement.getContext( 'gpupresent' );
+		const context = ( parameters.context !== undefined ) ? parameters.context : this.domElement.getContext( 'webgpu' );
 
 		const swapChain = context.configure( {
 			device: device,


### PR DESCRIPTION
Related issue: -

**Description**

Replace `gpupresent` with `webgpu`.
