### PR TITLE
WebGLRenderer: Fix render state management in compile().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -877,6 +877,8 @@ function WebGLRenderer( parameters = {} ) {
 		currentRenderState = renderStates.get( scene );
 		currentRenderState.init();
 
+		renderStateStack.push( currentRenderState );
+
 		scene.traverseVisible( function ( object ) {
 
 			if ( object.isLight && object.layers.test( camera.layers ) ) {
@@ -920,6 +922,9 @@ function WebGLRenderer( parameters = {} ) {
 			}
 
 		} );
+
+		renderStateStack.pop();
+		currentRenderState = null;
 
 	};
 


### PR DESCRIPTION
Related issue: Fixed #22217.

**Description**

The integration of `PMREMGenerator` actually revealed a bug in `WebGLRenderer.compile()`. The current render state was not correctly added to the internal stack which breaks nested calls of `render()`.
