### PR TITLE
GLTFExporter: add support for draco compression

### DIFF
--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -44,7 +44,7 @@ class DRACOExporter {
 		const encoder = new dracoEncoder.Encoder();
 		let builder;
 		let dracoObject;
-
+		const attributeIDs = {};
 
 		if ( geometry.isBufferGeometry !== true ) {
 
@@ -58,7 +58,13 @@ class DRACOExporter {
 			dracoObject = new dracoEncoder.Mesh();
 
 			const vertices = geometry.getAttribute( 'position' );
-			builder.AddFloatAttributeToMesh( dracoObject, dracoEncoder.POSITION, vertices.count, vertices.itemSize, vertices.array );
+			attributeIDs[ 'POSITION' ] = builder.AddFloatAttributeToMesh(
+				dracoObject,
+				dracoEncoder.POSITION,
+				vertices.count,
+				vertices.itemSize,
+				vertices.array
+			);
 
 			const faces = geometry.getIndex();
 
@@ -86,7 +92,13 @@ class DRACOExporter {
 
 				if ( normals !== undefined ) {
 
-					builder.AddFloatAttributeToMesh( dracoObject, dracoEncoder.NORMAL, normals.count, normals.itemSize, normals.array );
+					attributeIDs[ 'NORMAL' ] = builder.AddFloatAttributeToMesh(
+						dracoObject,
+						dracoEncoder.NORMAL,
+						normals.count,
+						normals.itemSize,
+						normals.array
+					);
 
 				}
 
@@ -98,7 +110,13 @@ class DRACOExporter {
 
 				if ( uvs !== undefined ) {
 
-					builder.AddFloatAttributeToMesh( dracoObject, dracoEncoder.TEX_COORD, uvs.count, uvs.itemSize, uvs.array );
+					attributeIDs[ 'TEXCOORD_0' ] = builder.AddFloatAttributeToMesh(
+						dracoObject,
+						dracoEncoder.TEX_COORD,
+						uvs.count,
+						uvs.itemSize,
+						uvs.array
+					);
 
 				}
 
@@ -110,7 +128,13 @@ class DRACOExporter {
 
 				if ( colors !== undefined ) {
 
-					builder.AddFloatAttributeToMesh( dracoObject, dracoEncoder.COLOR, colors.count, colors.itemSize, colors.array );
+					attributeIDs[ 'COLOR_0' ] = builder.AddFloatAttributeToMesh(
+						dracoObject,
+						dracoEncoder.COLOR,
+						colors.count,
+						colors.itemSize,
+						colors.array
+					);
 
 				}
 
@@ -122,7 +146,13 @@ class DRACOExporter {
 			dracoObject = new dracoEncoder.PointCloud();
 
 			const vertices = geometry.getAttribute( 'position' );
-			builder.AddFloatAttribute( dracoObject, dracoEncoder.POSITION, vertices.count, vertices.itemSize, vertices.array );
+			builder.AddFloatAttribute(
+				dracoObject,
+				dracoEncoder.POSITION,
+				vertices.count,
+				vertices.itemSize,
+				vertices.array
+			);
 
 			if ( options.exportColor === true ) {
 
@@ -130,7 +160,13 @@ class DRACOExporter {
 
 				if ( colors !== undefined ) {
 
-					builder.AddFloatAttribute( dracoObject, dracoEncoder.COLOR, colors.count, colors.itemSize, colors.array );
+					builder.AddFloatAttribute(
+						dracoObject,
+						dracoEncoder.COLOR,
+						colors.count,
+						colors.itemSize,
+						colors.array
+					);
 
 				}
 
@@ -138,15 +174,15 @@ class DRACOExporter {
 
 		} else {
 
-			throw new Error( 'DRACOExporter: Unsupported object type.' );
+			throw new Error( 'DRACOExporter: Unsupported object type: ' + object.type );
 
 		}
 
-		//Compress using draco encoder
+		// Compress using draco encoder
 
 		const encodedData = new dracoEncoder.DracoInt8Array();
 
-		//Sets the desired encoding and decoding speed for the given options from 0 (slowest speed, but the best compression) to 10 (fastest, but the worst compression).
+		// Sets the desired encoding and decoding speed for the given options from 0 (slowest speed, but the best compression) to 10 (fastest, but the worst compression).
 
 		const encodeSpeed = ( options.encodeSpeed !== undefined ) ? options.encodeSpeed : 5;
 		const decodeSpeed = ( options.decodeSpeed !== undefined ) ? options.decodeSpeed : 5;
@@ -197,7 +233,7 @@ class DRACOExporter {
 
 		}
 
-		//Copy encoded data to buffer.
+		// Copy encoded data to buffer.
 		const outputData = new Int8Array( new ArrayBuffer( length ) );
 
 		for ( let i = 0; i < length; i ++ ) {
@@ -210,7 +246,10 @@ class DRACOExporter {
 		dracoEncoder.destroy( encoder );
 		dracoEncoder.destroy( builder );
 
-		return outputData;
+		return {
+			buffer: outputData,
+			attributeIDs,
+		};
 
 	}
 

--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -146,7 +146,7 @@ class DRACOExporter {
 			dracoObject = new dracoEncoder.PointCloud();
 
 			const vertices = geometry.getAttribute( 'position' );
-			builder.AddFloatAttribute(
+			attributeIDs[ 'POSITION' ] = builder.AddFloatAttribute(
 				dracoObject,
 				dracoEncoder.POSITION,
 				vertices.count,
@@ -160,7 +160,7 @@ class DRACOExporter {
 
 				if ( colors !== undefined ) {
 
-					builder.AddFloatAttribute(
+					attributeIDs[ 'COLOR_0' ] = builder.AddFloatAttribute(
 						dracoObject,
 						dracoEncoder.COLOR,
 						colors.count,

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -120,7 +120,7 @@
 			function exportFile() {
 
 				const result = exporter.parse( mesh );
-				saveArrayBuffer( result, 'file.drc' );
+				saveArrayBuffer( result.buffer, 'file.drc' );
 
 			}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -20,8 +20,11 @@
 			<label><input id="option_visible" name="visible" type="checkbox" checked="checked"/>Only Visible</label>
 			<label><input id="option_drawrange" name="visible" type="checkbox" checked="checked"/>Truncate drawRange</label><br/>
 			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
+			<label><input id="option_draco" name="visible" type="checkbox">Draco compression</label>
 			<label><input id="option_maxsize" name="maxSize" type="number" value="4096" min="2" max="8192" step="1"> Max texture size</label>
 		</div>
+
+		<script src="js/libs/draco/draco_encoder.js"></script>
 
 		<script type="module">
 
@@ -29,16 +32,21 @@
 
 			import { OBJLoader } from './jsm/loaders/OBJLoader.js';
 			import { GLTFExporter } from './jsm/exporters/GLTFExporter.js';
+			import { DRACOExporter } from './jsm/exporters/DRACOExporter.js';
+
+			const gltfExporter = new GLTFExporter();
+			const dracoExporter = new DRACOExporter();
+			gltfExporter.setDRACOExporter( dracoExporter );
+
 
 			function exportGLTF( input ) {
-
-				const gltfExporter = new GLTFExporter();
 
 				const options = {
 					trs: document.getElementById( 'option_trs' ).checked,
 					onlyVisible: document.getElementById( 'option_visible' ).checked,
 					truncateDrawRange: document.getElementById( 'option_drawrange' ).checked,
 					binary: document.getElementById( 'option_binary' ).checked,
+					draco: document.getElementById( 'option_draco' ).checked,
 					maxTextureSize: Number( document.getElementById( 'option_maxsize' ).value ) || Infinity // To prevent NaN value
 				};
 				gltfExporter.parse( input, function ( result ) {
@@ -162,7 +170,7 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
 				camera.position.set( 600, 400, 0 );
 
-				camera.name = "PerspectiveCamera";
+				camera.name = 'PerspectiveCamera';
 				scene1.add( camera );
 
 				// ---------------------------------------------------------------------
@@ -187,14 +195,14 @@
 				// ---------------------------------------------------------------------
 				gridHelper = new THREE.GridHelper( 2000, 20, 0x888888, 0x444444 );
 				gridHelper.position.y = - 50;
-				gridHelper.name = "Grid";
+				gridHelper.name = 'Grid';
 				scene1.add( gridHelper );
 
 				// ---------------------------------------------------------------------
 				// Axes
 				// ---------------------------------------------------------------------
 				const axes = new THREE.AxesHelper( 500 );
-				axes.name = "AxesHelper";
+				axes.name = 'AxesHelper';
 				scene1.add( axes );
 
 				// ---------------------------------------------------------------------
@@ -248,7 +256,7 @@
 				material.map = gradientTexture;
 				sphere = new THREE.Mesh( new THREE.SphereGeometry( 70, 10, 10 ), material );
 				sphere.position.set( 0, 0, 0 );
-				sphere.name = "Sphere";
+				sphere.name = 'Sphere';
 				scene1.add( sphere );
 
 				// Cylinder
@@ -258,7 +266,7 @@
 				} );
 				object = new THREE.Mesh( new THREE.CylinderGeometry( 10, 80, 100 ), material );
 				object.position.set( 200, 0, 0 );
-				object.name = "Cylinder";
+				object.name = 'Cylinder';
 				scene1.add( object );
 
 				// TorusKnot
@@ -268,7 +276,7 @@
 				} );
 				object = new THREE.Mesh( new THREE.TorusKnotGeometry( 50, 15, 40, 10 ), material );
 				object.position.set( - 200, 0, 0 );
-				object.name = "Cylinder";
+				object.name = 'Cylinder';
 				scene1.add( object );
 
 
@@ -280,13 +288,13 @@
 
 				object = new THREE.Mesh( new THREE.BoxGeometry( 40, 100, 100 ), material );
 				object.position.set( - 200, 0, 400 );
-				object.name = "Cube";
+				object.name = 'Cube';
 				scene1.add( object );
 
 				object2 = new THREE.Mesh( new THREE.BoxGeometry( 40, 40, 40, 2, 2, 2 ), material );
 				object2.position.set( 0, 0, 50 );
 				object2.rotation.set( 0, 45, 0 );
-				object2.name = "SubCube";
+				object2.name = 'SubCube';
 				object.add( object2 );
 
 
@@ -294,16 +302,16 @@
 				// Groups
 				// ---------------------------------------------------------------------
 				const group1 = new THREE.Group();
-				group1.name = "Group";
+				group1.name = 'Group';
 				scene1.add( group1 );
 
 				const group2 = new THREE.Group();
-				group2.name = "subGroup";
+				group2.name = 'subGroup';
 				group2.position.set( 0, 50, 0 );
 				group1.add( group2 );
 
 				object2 = new THREE.Mesh( new THREE.BoxGeometry( 30, 30, 30 ), material );
-				object2.name = "Cube in group";
+				object2.name = 'Cube in group';
 				object2.position.set( 0, 0, 400 );
 				group2.add( object2 );
 
@@ -406,7 +414,7 @@
 
 				const pointsMaterial = new THREE.PointsMaterial( { color: 0xffff00, size: 5 } );
 				const pointCloud = new THREE.Points( pointsGeo, pointsMaterial );
-				pointCloud.name = "Points";
+				pointCloud.name = 'Points';
 				pointCloud.position.set( - 200, 0, - 200 );
 				scene1.add( pointCloud );
 
@@ -455,7 +463,7 @@
 				} );
 				object = new THREE.Mesh( new THREE.BoxGeometry( 200, 200, 200 ), material );
 				object.position.set( 0, 0, 0 );
-				object.name = "CubeHidden";
+				object.name = 'CubeHidden';
 				object.visible = false;
 				scene1.add( object );
 
@@ -479,7 +487,7 @@
 				scene2 = new THREE.Scene();
 				object = new THREE.Mesh( new THREE.BoxGeometry( 100, 100, 100 ), material );
 				object.position.set( 0, 0, 0 );
-				object.name = "Cube2ndScene";
+				object.name = 'Cube2ndScene';
 				scene2.name = 'Scene2';
 				scene2.add( object );
 


### PR DESCRIPTION
Related issue: Fixes #21492

**Description**

We did this at Spline and wanted to give back to three.js as well.

You can try the draco option here, enable the checkbox and click on `Export walthead`.
https://raw.githack.com/marcofugaro/three.js/gltf-draco-exporter/examples/misc_exporter_gltf.html

<img width="500" alt="Screenshot 2021-07-30 at 16 56 33" src="https://user-images.githubusercontent.com/7217420/127674417-56169a97-daa6-4a89-a3e6-291889214c20.png">

Currently I made it use the existing `draco_encoder.js`. In a future PR, I'll add the option to use `draco_encoder.wasm` which is way faster!

/cc @donmccurdy 

This contribution is funded by [Spline](http://spline.design/).
