### PR TITLE
LDrawLoader: Improve smooth normal generation performance a bit

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -258,28 +258,28 @@ function smoothNormals( triangles, lineSegments ) {
 			// initialize all vertex normals in this triangle
 			const tri = queue[ i ].tri;
 			const vertices = tri.vertices;
-			const normals = tri.normals;
+			const triNormals = tri.normals;
 			i ++;
 
 			const faceNormal = tri.faceNormal;
-			if ( normals[ 0 ] === null ) {
+			if ( triNormals[ 0 ] === null ) {
 
-				normals[ 0 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
-				normals.push( normals[ 0 ] );
-
-			}
-
-			if ( normals[ 1 ] === null ) {
-
-				normals[ 1 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
-				normals.push( normals[ 1 ] );
+				triNormals[ 0 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
+				normals.push( triNormals[ 0 ] );
 
 			}
 
-			if ( normals[ 2 ] === null ) {
+			if ( triNormals[ 1 ] === null ) {
 
-				normals[ 2 ] = faceNormal.clone();
-				normals.push( normals[ 2 ] );
+				triNormals[ 1 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
+				normals.push( triNormals[ 1 ] );
+
+			}
+
+			if ( triNormals[ 2 ] === null ) {
+
+				triNormals[ 2 ] = faceNormal.clone();
+				normals.push( triNormals[ 2 ] );
 
 			}
 
@@ -325,7 +325,7 @@ function smoothNormals( triangles, lineSegments ) {
 					const otherNext = ( otherIndex + 1 ) % 3;
 					if ( otherNormals[ otherIndex ] === null ) {
 
-						const norm = normals[ next ];
+						const norm = triNormals[ next ];
 						otherNormals[ otherIndex ] = norm;
 
 						const isDoubledVert = otherTri.fromQuad && otherIndex !== 2;
@@ -335,7 +335,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 					if ( otherNormals[ otherNext ] === null ) {
 
-						const norm = normals[ index ];
+						const norm = triNormals[ index ];
 						otherNormals[ otherNext ] = norm;
 
 						const isDoubledVert = otherTri.fromQuad && otherNext !== 2;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -3,7 +3,6 @@ import {
 	BufferGeometry,
 	Color,
 	FileLoader,
-	Float32BufferAttribute,
 	Group,
 	LineBasicMaterial,
 	LineSegments,

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1595,7 +1595,6 @@ class LDrawLoader extends Loader {
 
 						vertices: [ v2, v0, v1 ],
 						normals: [ null, null, null ],
-
 					} );
 
 					triangles.push( {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -476,8 +476,8 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 	// Sort the triangles or line segments by colour code to make later the mesh groups
 	elements.sort( sortByMaterial );
 
-	const positions = [];
-	const normals = [];
+	const positions = new Float32Array( elementSize * elements.length * 3 );
+	const normals = new Float32Array( elementSize * elements.length * 3 );
 	const materials = [];
 
 	const bufferGeometry = new BufferGeometry();
@@ -494,18 +494,33 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 		const v1 = vertices[ 1 ];
 
 		// Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
-		positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
+		const index = iElem * elementSize * 3;
+		positions[ index + 0 ] = v0.x;
+		positions[ index + 1 ] = v0.y;
+		positions[ index + 2 ] = v0.z;
+		positions[ index + 3 ] = v1.x;
+		positions[ index + 4 ] = v1.y;
+		positions[ index + 5 ] = v1.z;
+
 		if ( elementSize === 3 ) {
 
 			const v2 = vertices[ 2 ];
-			positions.push( v2.x, v2.y, v2.z );
+			positions[ index + 6 ] = v2.x;
+			positions[ index + 7 ] = v2.y;
+			positions[ index + 8 ] = v2.z;
 
 			const n0 = elemNormals[ 0 ] || elem.faceNormal;
 			const n1 = elemNormals[ 1 ] || elem.faceNormal;
 			const n2 = elemNormals[ 2 ] || elem.faceNormal;
-			normals.push( n0.x, n0.y, n0.z );
-			normals.push( n1.x, n1.y, n1.z );
-			normals.push( n2.x, n2.y, n2.z );
+			normals[ index + 0 ] = n0.x;
+			normals[ index + 1 ] = n0.y;
+			normals[ index + 2 ] = n0.z;
+			normals[ index + 3 ] = n1.x;
+			normals[ index + 4 ] = n1.y;
+			normals[ index + 5 ] = n1.z;
+			normals[ index + 6 ] = n2.x;
+			normals[ index + 7 ] = n2.y;
+			normals[ index + 8 ] = n2.z;
 
 		}
 
@@ -537,11 +552,11 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 
 	}
 
-	bufferGeometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+	bufferGeometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
 	if ( elementSize === 3 ) {
 
-		bufferGeometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		bufferGeometry.setAttribute( 'normal', new BufferAttribute( normals, 3 ) );
 
 	}
 


### PR DESCRIPTION
Related issue: --

**Description**

Improves the generation time of smooth normals a bit by doing the following:

- Avoid using `Object.keys` to get a single element from an object and instead use an immediately terminating for loop.
- Cache index for half edge so we don't have to iterate over the other triangle edges to find a match.
- Convert element vertex / normal storage to use arrays rather than dictionary keys.

With these changes the time to generate smooth normals goes from ~18.25 seconds to ~16 seconds when loading the AT-ST model. Nothing earth shattering but it is an improvement. I also switched to using typed arrays when generating geometry which saves another ~0.5 seconds on the AT-ST total processing time.

Next up I'm planning to bookkeep quads as 4 vertices so we can cut down on trying the smooth the plane diagonal as well as some other performance improvements. I also want to improve the ergonomics of the loader specifically relating to loading models with the LDraw parts library.

cc @yomboprime 
