### PR TITLE
LDrawLoader: Further improve smooth normal generation performance

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -190,7 +190,6 @@ function smoothNormals( faces, lineSegments ) {
 
 	const hardEdges = new Set();
 	const halfEdgeList = {};
-	const fullHalfEdgeList = {};
 	const normals = [];
 
 	// Save the list of hard edges by hash
@@ -227,7 +226,6 @@ function smoothNormals( faces, lineSegments ) {
 				tri: tri
 			};
 			halfEdgeList[ hash ] = info;
-			fullHalfEdgeList[ hash ] = info;
 
 		}
 
@@ -252,16 +250,14 @@ function smoothNormals( faces, lineSegments ) {
 		}
 
 		// Exhaustively find all connected faces
-		let i = 0;
 		const queue = [ halfEdge ];
-		while ( i < queue.length ) {
+		while ( queue.length > 0 ) {
 
 			// initialize all vertex normals in this triangle
-			const tri = queue[ i ].tri;
+			const tri = queue.pop().tri;
 			const vertices = tri.vertices;
 			const vertNormals = tri.normals;
 			const faceNormal = tri.faceNormal;
-			i ++;
 
 			// Check if any edge is connected to another triangle edge
 			const vertCount = vertices.length;
@@ -277,7 +273,7 @@ function smoothNormals( faces, lineSegments ) {
 				delete halfEdgeList[ hash ];
 
 				const reverseHash = hashEdge( v1, v0 );
-				const otherInfo = fullHalfEdgeList[ reverseHash ];
+				const otherInfo = halfEdgeList[ reverseHash ];
 				if ( otherInfo ) {
 
 					const otherTri = otherInfo.tri;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -476,52 +476,46 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 	elements.sort( sortByMaterial );
 
 	const positions = new Float32Array( elementSize * elements.length * 3 );
-	const normals = new Float32Array( elementSize * elements.length * 3 );
+	const normals = elementSize === 3 ? new Float32Array( elementSize * elements.length * 3 ) : null;
 	const materials = [];
 
 	const bufferGeometry = new BufferGeometry();
 	let prevMaterial = null;
 	let index0 = 0;
 	let numGroupVerts = 0;
+	let offset = 0;
 
 	for ( let iElem = 0, nElem = elements.length; iElem < nElem; iElem ++ ) {
 
 		const elem = elements[ iElem ];
 		const vertices = elem.vertices;
-		const elemNormals = elem.normals;
-		const v0 = vertices[ 0 ];
-		const v1 = vertices[ 1 ];
 
-		// Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
-		const index = iElem * elementSize * 3;
-		positions[ index + 0 ] = v0.x;
-		positions[ index + 1 ] = v0.y;
-		positions[ index + 2 ] = v0.z;
-		positions[ index + 3 ] = v1.x;
-		positions[ index + 4 ] = v1.y;
-		positions[ index + 5 ] = v1.z;
+		for ( let j = 0, l = vertices.length; j < l; j ++ ) {
+
+			const v = vertices[ j ];
+			const index = offset + j * 3;
+			positions[ index + 0 ] = v.x;
+			positions[ index + 1 ] = v.y;
+			positions[ index + 2 ] = v.z;
+
+		}
 
 		if ( elementSize === 3 ) {
 
-			const v2 = vertices[ 2 ];
-			positions[ index + 6 ] = v2.x;
-			positions[ index + 7 ] = v2.y;
-			positions[ index + 8 ] = v2.z;
+			const elemNormals = elem.normals;
+			for ( let j = 0, l = vertices.length; j < l; j ++ ) {
 
-			const n0 = elemNormals[ 0 ] || elem.faceNormal;
-			const n1 = elemNormals[ 1 ] || elem.faceNormal;
-			const n2 = elemNormals[ 2 ] || elem.faceNormal;
-			normals[ index + 0 ] = n0.x;
-			normals[ index + 1 ] = n0.y;
-			normals[ index + 2 ] = n0.z;
-			normals[ index + 3 ] = n1.x;
-			normals[ index + 4 ] = n1.y;
-			normals[ index + 5 ] = n1.z;
-			normals[ index + 6 ] = n2.x;
-			normals[ index + 7 ] = n2.y;
-			normals[ index + 8 ] = n2.z;
+				const n = elemNormals[ j ];
+				const index = offset + j * 3;
+				normals[ index + 0 ] = n.x;
+				normals[ index + 1 ] = n.y;
+				normals[ index + 2 ] = n.z;
+
+			}
 
 		}
+
+		offset += 3 * vertices.length;
 
 		if ( prevMaterial !== elem.material ) {
 
@@ -553,7 +547,7 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 
 	bufferGeometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
-	if ( elementSize === 3 ) {
+	if ( normals !== null ) {
 
 		bufferGeometry.setAttribute( 'normal', new BufferAttribute( normals, 3 ) );
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -209,11 +209,12 @@ function smoothNormals( triangles, lineSegments ) {
 	for ( let i = 0, l = triangles.length; i < l; i ++ ) {
 
 		const tri = triangles[ i ];
-		for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+		const vertices = tri.vertices;
+		const vertCount = vertices.length;
+		for ( let i2 = 0; i2 < vertCount; i2 ++ ) {
 
 			const index = i2;
-			const next = ( i2 + 1 ) % 3;
-			const vertices = tri.vertices;
+			const next = ( i2 + 1 ) % vertCount;
 			const v0 = vertices[ index ];
 			const v1 = vertices[ next ];
 			const hash = hashEdge( v0, v1 );
@@ -284,10 +285,11 @@ function smoothNormals( triangles, lineSegments ) {
 			}
 
 			// Check if any edge is connected to another triangle edge
-			for ( let i2 = 0, l2 = 3; i2 < l2; i2 ++ ) {
+			const vertCount = vertices.length;
+			for ( let i2 = 0; i2 < vertCount; i2 ++ ) {
 
 				const index = i2;
-				const next = ( i2 + 1 ) % 3;
+				const next = ( i2 + 1 ) % vertCount;
 				const v0 = vertices[ index ];
 				const v1 = vertices[ next ];
 
@@ -302,6 +304,7 @@ function smoothNormals( triangles, lineSegments ) {
 					const otherTri = otherInfo.tri;
 					const otherIndex = otherInfo.index;
 					const otherNormals = otherTri.normals;
+					const otherVertCount = otherNormals.length;
 
 					// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
 					// hard edge. There are some cases where the line segments do not line up exactly
@@ -322,7 +325,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 					}
 
-					const otherNext = ( otherIndex + 1 ) % 3;
+					const otherNext = ( otherIndex + 1 ) % otherVertCount;
 					if ( otherNormals[ otherIndex ] === null ) {
 
 						const norm = normals[ next ];
@@ -505,7 +508,7 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 			const elemNormals = elem.normals;
 			for ( let j = 0, l = vertices.length; j < l; j ++ ) {
 
-				const n = elemNormals[ j ];
+				const n = elemNormals[ j ] || elem.faceNormal;
 				const index = offset + j * 3;
 				normals[ index + 0 ] = n.x;
 				normals[ index + 1 ] = n.y;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -258,28 +258,28 @@ function smoothNormals( triangles, lineSegments ) {
 			// initialize all vertex normals in this triangle
 			const tri = queue[ i ].tri;
 			const vertices = tri.vertices;
-			const normals = tri.normals;
+			const triNormals = tri.normals;
 			i ++;
 
 			const faceNormal = tri.faceNormal;
-			if ( normals[ 0 ] === null ) {
+			if ( triNormals[ 0 ] === null ) {
 
-				normals[ 0 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
-				normals.push( normals[ 0 ] );
-
-			}
-
-			if ( normals[ 1 ] === null ) {
-
-				normals[ 1 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
-				normals.push( normals[ 1 ] );
+				triNormals[ 0 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
+				normals.push( triNormals[ 0 ] );
 
 			}
 
-			if ( normals[ 2 ] === null ) {
+			if ( triNormals[ 1 ] === null ) {
 
-				normals[ 2 ] = faceNormal.clone();
-				normals.push( normals[ 2 ] );
+				triNormals[ 1 ] = faceNormal.clone().multiplyScalar( tri.fromQuad ? 0.5 : 1.0 );
+				normals.push( triNormals[ 1 ] );
+
+			}
+
+			if ( triNormals[ 2 ] === null ) {
+
+				triNormals[ 2 ] = faceNormal.clone();
+				normals.push( triNormals[ 2 ] );
 
 			}
 
@@ -325,7 +325,7 @@ function smoothNormals( triangles, lineSegments ) {
 					const otherNext = ( otherIndex + 1 ) % 3;
 					if ( otherNormals[ otherIndex ] === null ) {
 
-						const norm = normals[ next ];
+						const norm = triNormals[ next ];
 						otherNormals[ otherIndex ] = norm;
 
 						const isDoubledVert = otherTri.fromQuad && otherIndex !== 2;
@@ -335,7 +335,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 					if ( otherNormals[ otherNext ] === null ) {
 
-						const norm = normals[ index ];
+						const norm = triNormals[ index ];
 						otherNormals[ otherNext ] = norm;
 
 						const isDoubledVert = otherTri.fromQuad && otherNext !== 2;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -3,7 +3,6 @@ import {
 	BufferGeometry,
 	Color,
 	FileLoader,
-	Float32BufferAttribute,
 	Group,
 	LineBasicMaterial,
 	LineSegments,

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -168,7 +168,7 @@ class LDrawConditionalLineMaterial extends ShaderMaterial {
 
 }
 
-function smoothNormals( triangles, lineSegments ) {
+function smoothNormals( faces, lineSegments ) {
 
 	function hashVertex( v ) {
 
@@ -206,9 +206,9 @@ function smoothNormals( triangles, lineSegments ) {
 	}
 
 	// track the half edges associated with each triangle
-	for ( let i = 0, l = triangles.length; i < l; i ++ ) {
+	for ( let i = 0, l = faces.length; i < l; i ++ ) {
 
-		const tri = triangles[ i ];
+		const tri = faces[ i ];
 		const vertices = tri.vertices;
 		const vertCount = vertices.length;
 		for ( let i2 = 0; i2 < vertCount; i2 ++ ) {
@@ -233,10 +233,10 @@ function smoothNormals( triangles, lineSegments ) {
 
 	}
 
-	// Iterate until we've tried to connect all triangles to share normals
+	// Iterate until we've tried to connect all faces to share normals
 	while ( true ) {
 
-		// Stop if there are no more triangles left
+		// Stop if there are no more faces left
 		let halfEdge = null;
 		for ( const key in halfEdgeList ) {
 
@@ -251,7 +251,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 		}
 
-		// Exhaustively find all connected triangles
+		// Exhaustively find all connected faces
 		let i = 0;
 		const queue = [ halfEdge ];
 		while ( i < queue.length ) {
@@ -286,7 +286,7 @@ function smoothNormals( triangles, lineSegments ) {
 					const otherVertCount = otherNormals.length;
 					const otherFaceNormal = otherTri.faceNormal;
 
-					// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
+					// NOTE: If the angle between faces is > 67.5 degrees then assume it's
 					// hard edge. There are some cases where the line segments do not line up exactly
 					// with or span multiple triangle edges (see Lunar Vehicle wheels).
 					if ( Math.abs( otherTri.faceNormal.dot( tri.faceNormal ) ) < 0.25 ) {
@@ -481,7 +481,7 @@ function createObject( elements, elementSize, isConditionalSegments = false, tot
 	// Creates a LineSegments (elementSize = 2) or a Mesh (elementSize = 3 )
 	// With per face / segment material, implemented with mesh groups and materials array
 
-	// Sort the triangles or line segments by colour code to make later the mesh groups
+	// Sort the faces or line segments by colour code to make later the mesh groups
 	elements.sort( sortByMaterial );
 
 	if ( totalElements === null ) {
@@ -788,7 +788,7 @@ class LDrawLoader extends Loader {
 			// If false, it is a root material scope previous to parse
 			isFromParse: true,
 
-			triangles: null,
+			faces: null,
 			lineSegments: null,
 			conditionalSegments: null,
 			totalFaces: 0,
@@ -1149,7 +1149,7 @@ class LDrawLoader extends Loader {
 		const currentParseScope = this.getCurrentParseScope();
 
 		// Parse result variables
-		let triangles;
+		let faces;
 		let lineSegments;
 		let conditionalSegments;
 
@@ -1290,7 +1290,7 @@ class LDrawLoader extends Loader {
 
 								type = lp.getToken();
 
-								currentParseScope.triangles = [];
+								currentParseScope.faces = [];
 								currentParseScope.lineSegments = [];
 								currentParseScope.conditionalSegments = [];
 								currentParseScope.type = type;
@@ -1316,7 +1316,7 @@ class LDrawLoader extends Loader {
 
 								}
 
-								triangles = currentParseScope.triangles;
+								faces = currentParseScope.faces;
 								lineSegments = currentParseScope.lineSegments;
 								conditionalSegments = currentParseScope.conditionalSegments;
 
@@ -1576,7 +1576,7 @@ class LDrawLoader extends Loader {
 						.crossVectors( _tempVec0, _tempVec1 )
 						.normalize();
 
-					triangles.push( {
+					faces.push( {
 						material: material,
 						colourCode: material.userData.code,
 						faceNormal: faceNormal,
@@ -1587,7 +1587,7 @@ class LDrawLoader extends Loader {
 
 					if ( doubleSided === true ) {
 
-						triangles.push( {
+						faces.push( {
 							material: material,
 							colourCode: material.userData.code,
 							faceNormal: faceNormal,
@@ -1633,7 +1633,7 @@ class LDrawLoader extends Loader {
 
 					// specifically place the triangle diagonal in the v0 and v1 slots so we can
 					// account for the doubling of vertices later when smoothing normals.
-					triangles.push( {
+					faces.push( {
 						material: material,
 						colourCode: material.userData.code,
 						faceNormal: faceNormal,
@@ -1644,7 +1644,7 @@ class LDrawLoader extends Loader {
 
 					if ( doubleSided === true ) {
 
-						triangles.push( {
+						faces.push( {
 							material: material,
 							colourCode: material.userData.code,
 							faceNormal: faceNormal,
@@ -1776,7 +1776,7 @@ class LDrawLoader extends Loader {
 
 			if ( scope.smoothNormals && parseScope.type === 'Part' ) {
 
-				smoothNormals( parseScope.triangles, parseScope.lineSegments );
+				smoothNormals( parseScope.faces, parseScope.lineSegments );
 
 			}
 
@@ -1785,9 +1785,9 @@ class LDrawLoader extends Loader {
 
 				const objGroup = parseScope.groupObject;
 
-				if ( parseScope.triangles.length > 0 ) {
+				if ( parseScope.faces.length > 0 ) {
 
-					objGroup.add( createObject( parseScope.triangles, 3, false, parseScope.totalFaces ) );
+					objGroup.add( createObject( parseScope.faces, 3, false, parseScope.totalFaces ) );
 
 				}
 
@@ -1819,11 +1819,11 @@ class LDrawLoader extends Loader {
 				const separateObjects = scope.separateObjects;
 				const parentLineSegments = parentParseScope.lineSegments;
 				const parentConditionalSegments = parentParseScope.conditionalSegments;
-				const parentTriangles = parentParseScope.triangles;
+				const parentFaces = parentParseScope.faces;
 
 				const lineSegments = parseScope.lineSegments;
 				const conditionalSegments = parseScope.conditionalSegments;
-				const triangles = parseScope.triangles;
+				const faces = parseScope.faces;
 
 				for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
 
@@ -1860,9 +1860,9 @@ class LDrawLoader extends Loader {
 
 				}
 
-				for ( let i = 0, l = triangles.length; i < l; i ++ ) {
+				for ( let i = 0, l = faces.length; i < l; i ++ ) {
 
-					const tri = triangles[ i ];
+					const tri = faces[ i ];
 
 					if ( separateObjects ) {
 
@@ -1879,7 +1879,7 @@ class LDrawLoader extends Loader {
 
 					}
 
-					parentTriangles.push( tri );
+					parentFaces.push( tri );
 
 				}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1595,7 +1595,6 @@ class LDrawLoader extends Loader {
 
 						vertices: [ v2, v0, v1 ],
 						normals: [ null, null, null ],
-
 					} );
 
 					triangles.push( {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -476,8 +476,8 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 	// Sort the triangles or line segments by colour code to make later the mesh groups
 	elements.sort( sortByMaterial );
 
-	const positions = [];
-	const normals = [];
+	const positions = new Float32Array( elementSize * elements.length * 3 );
+	const normals = new Float32Array( elementSize * elements.length * 3 );
 	const materials = [];
 
 	const bufferGeometry = new BufferGeometry();
@@ -494,18 +494,33 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 		const v1 = vertices[ 1 ];
 
 		// Note that LDraw coordinate system is rotated 180 deg. in the X axis w.r.t. Three.js's one
-		positions.push( v0.x, v0.y, v0.z, v1.x, v1.y, v1.z );
+		const index = iElem * elementSize * 3;
+		positions[ index + 0 ] = v0.x;
+		positions[ index + 1 ] = v0.y;
+		positions[ index + 2 ] = v0.z;
+		positions[ index + 3 ] = v1.x;
+		positions[ index + 4 ] = v1.y;
+		positions[ index + 5 ] = v1.z;
+
 		if ( elementSize === 3 ) {
 
 			const v2 = vertices[ 2 ];
-			positions.push( v2.x, v2.y, v2.z );
+			positions[ index + 6 ] = v2.x;
+			positions[ index + 7 ] = v2.y;
+			positions[ index + 8 ] = v2.z;
 
 			const n0 = elemNormals[ 0 ] || elem.faceNormal;
 			const n1 = elemNormals[ 1 ] || elem.faceNormal;
 			const n2 = elemNormals[ 2 ] || elem.faceNormal;
-			normals.push( n0.x, n0.y, n0.z );
-			normals.push( n1.x, n1.y, n1.z );
-			normals.push( n2.x, n2.y, n2.z );
+			normals[ index + 0 ] = n0.x;
+			normals[ index + 1 ] = n0.y;
+			normals[ index + 2 ] = n0.z;
+			normals[ index + 3 ] = n1.x;
+			normals[ index + 4 ] = n1.y;
+			normals[ index + 5 ] = n1.z;
+			normals[ index + 6 ] = n2.x;
+			normals[ index + 7 ] = n2.y;
+			normals[ index + 8 ] = n2.z;
 
 		}
 
@@ -537,11 +552,11 @@ function createObject( elements, elementSize, isConditionalSegments ) {
 
 	}
 
-	bufferGeometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+	bufferGeometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
 	if ( elementSize === 3 ) {
 
-		bufferGeometry.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		bufferGeometry.setAttribute( 'normal', new BufferAttribute( normals, 3 ) );
 
 	}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -265,8 +265,12 @@ function smoothNormals( triangles, lineSegments ) {
 			const faceNormal = tri.faceNormal;
 			for ( let j = 0, lj = triNormals.length; j < lj; j ++ ) {
 
-				triNormals[ j ] = faceNormal.clone();
-				normals.push( triNormals[ j ] );
+				if ( triNormals[ j ] === null ) {
+
+					triNormals[ j ] = faceNormal.clone();
+					normals.push( triNormals[ j ] );
+
+				}
 
 			}
 
@@ -311,6 +315,7 @@ function smoothNormals( triangles, lineSegments ) {
 
 					}
 
+					// TODO: there are cases where the other tri already has a different normal??
 					const otherNext = ( otherIndex + 1 ) % otherVertCount;
 					if ( otherNormals[ otherIndex ] === null ) {
 
@@ -506,7 +511,7 @@ function createObject( elements, elementSize, isConditionalSegments = false, tot
 		if ( elementSize === 3 ) {
 
 			let elemNormals = elem.normals;
-			if ( vertices.length === 4 ) {
+			if ( elemNormals.length === 4 ) {
 
 				quadArray[ 0 ] = elemNormals[ 0 ];
 				quadArray[ 1 ] = elemNormals[ 1 ];
@@ -518,7 +523,7 @@ function createObject( elements, elementSize, isConditionalSegments = false, tot
 
 			}
 
-			for ( let j = 0, l = vertices.length; j < l; j ++ ) {
+			for ( let j = 0, l = elemNormals.length; j < l; j ++ ) {
 
 				const n = elemNormals[ j ] || elem.faceNormal;
 				const index = offset + j * 3;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1851,9 +1851,11 @@ class LDrawLoader extends Loader {
 					if ( separateObjects ) {
 
 						const vertices = tri.vertices;
-						vertices[ 0 ] = vertices[ 0 ].clone().applyMatrix4( parseScope.matrix );
-						vertices[ 1 ] = vertices[ 1 ].clone().applyMatrix4( parseScope.matrix );
-						vertices[ 2 ] = vertices[ 2 ].clone().applyMatrix4( parseScope.matrix );
+						for ( let i = 0, l = vertices.length; i < l; i ++ ) {
+
+							vertices[ i ] = vertices[ i ].clone().applyMatrix4( parseScope.matrix );
+
+						}
 
 						_tempVec0.subVectors( vertices[ 1 ], vertices[ 0 ] );
 						_tempVec1.subVectors( vertices[ 2 ], vertices[ 1 ] );

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -259,20 +259,9 @@ function smoothNormals( triangles, lineSegments ) {
 			// initialize all vertex normals in this triangle
 			const tri = queue[ i ].tri;
 			const vertices = tri.vertices;
-			const triNormals = tri.normals;
-			i ++;
-
+			const vertNormals = tri.normals;
 			const faceNormal = tri.faceNormal;
-			for ( let j = 0, lj = triNormals.length; j < lj; j ++ ) {
-
-				if ( triNormals[ j ] === null ) {
-
-					triNormals[ j ] = faceNormal.clone();
-					normals.push( triNormals[ j ] );
-
-				}
-
-			}
+			i ++;
 
 			// Check if any edge is connected to another triangle edge
 			const vertCount = vertices.length;
@@ -295,6 +284,7 @@ function smoothNormals( triangles, lineSegments ) {
 					const otherIndex = otherInfo.index;
 					const otherNormals = otherTri.normals;
 					const otherVertCount = otherNormals.length;
+					const otherFaceNormal = otherTri.faceNormal;
 
 					// NOTE: If the angle between triangles is > 67.5 degrees then assume it's
 					// hard edge. There are some cases where the line segments do not line up exactly
@@ -315,21 +305,50 @@ function smoothNormals( triangles, lineSegments ) {
 
 					}
 
-					// TODO: there are cases where the other tri already has a different normal??
+					// share the first normal
 					const otherNext = ( otherIndex + 1 ) % otherVertCount;
-					if ( otherNormals[ otherIndex ] === null ) {
+					let sharedNormal1 = vertNormals[ index ] || otherNormals[ otherNext ];
+					if ( sharedNormal1 === null ) {
 
-						const norm = triNormals[ next ];
-						otherNormals[ otherIndex ] = norm;
-						norm.add( otherTri.faceNormal );
+						sharedNormal1 = new Vector3();
+						normals.push( sharedNormal1 );
+
+					}
+
+					if ( vertNormals[ index ] === null ) {
+
+						vertNormals[ index ] = sharedNormal1;
+						sharedNormal1.add( faceNormal );
 
 					}
 
 					if ( otherNormals[ otherNext ] === null ) {
 
-						const norm = triNormals[ index ];
-						otherNormals[ otherNext ] = norm;
-						norm.add( otherTri.faceNormal );
+						otherNormals[ otherNext ] = sharedNormal1;
+						sharedNormal1.add( otherFaceNormal );
+
+					}
+
+					// share the second normal
+					let sharedNormal2 = vertNormals[ next ] || otherNormals[ otherIndex ];
+					if ( sharedNormal2 === null ) {
+
+						sharedNormal2 = new Vector3();
+						normals.push( sharedNormal2 );
+
+					}
+
+					if ( vertNormals[ next ] === null ) {
+
+						vertNormals[ next ] = sharedNormal2;
+						sharedNormal2.add( faceNormal );
+
+					}
+
+					if ( otherNormals[ otherIndex ] === null ) {
+
+						otherNormals[ otherIndex ] = sharedNormal2;
+						sharedNormal2.add( otherFaceNormal );
 
 					}
 


### PR DESCRIPTION
Merge #22228 first

**Description**

- Adjust the bookkeeping of faces to retain whether the original face was a quad or triangle and change normal smoothing and geometry generation accordingly.
- Rename `scope.triangles` array to `scope.faces`

With this change the total load time for the AT-ST model comes down from ~21 seconds to ~15 seconds compared to #22228.

There's a normal smoothing issue I found (not new) that I'll fix in another PR and I'll add `preloadMaterials` and `setPartsLibraryPath` functions so the loader is easier to use with the full LDraw parts library.

cc @yomboprime 