### PR TITLE
CSS3DSprite with parent scale

### DIFF
--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -246,7 +246,12 @@ class CSS3DRenderer {
 					if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
 
 					_matrix.copyPosition( object.matrixWorld );
-					_matrix.scale( object.scale );
+					
+					let curr = object;
+					while(curr) {
+						_matrix.scale( curr.scale )
+						curr = curr.parent;
+					}
 
 					_matrix.elements[ 3 ] = 0;
 					_matrix.elements[ 7 ] = 0;

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -246,12 +246,7 @@ class CSS3DRenderer {
 					if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
 
 					_matrix.copyPosition( object.matrixWorld );
-					
-					let curr = object;
-					while(curr) {
-						_matrix.scale( curr.scale )
-						curr = curr.parent;
-					}
+					_matrix.scale( object.getWorldScale() );
 
 					_matrix.elements[ 3 ] = 0;
 					_matrix.elements[ 7 ] = 0;

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -9,7 +9,7 @@ import {
  * Based on http://www.emagix.net/academic/mscs-project/item/camera-sync-with-css3-and-webgl-threejs
  */
 
-const _vector = new Vector3();
+const _position = new Vector3();
 const _quaternion = new Quaternion();
 const _scale = new Vector3();
 
@@ -251,10 +251,9 @@ class CSS3DRenderer {
 
 					if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
 
-					_matrix.copyPosition( object.matrixWorld);
-					
-					object.matrixWorld.decompose( _vector, _quaternion, _scale );
-					_matrix.scale( _scale )
+					object.matrixWorld.decompose( _position, _quaternion, _scale );
+					_matrix.setPosition( _position );
+					_matrix.scale( _scale );
 
 					_matrix.elements[ 3 ] = 0;
 					_matrix.elements[ 7 ] = 0;

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -1,12 +1,17 @@
 import {
 	Matrix4,
 	Object3D,
+	Quaternion,
 	Vector3
 } from '../../../build/three.module.js';
 
 /**
  * Based on http://www.emagix.net/academic/mscs-project/item/camera-sync-with-css3-and-webgl-threejs
  */
+
+const _vector = new Vector3();
+const _quaternion = new Quaternion();
+const _scale = new Vector3();
 
 class CSS3DObject extends Object3D {
 
@@ -246,10 +251,10 @@ class CSS3DRenderer {
 
 					if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
 
-					_matrix.copyPosition( object.matrixWorld );
-					const objectWorldScale = new Vector3();
-					object.getWorldScale( objectWorldScale )
-					matrix.scale( objectWorldScale )
+					_matrix.copyPosition( object.matrixWorld);
+					
+					object.matrixWorld.decompose( _vector, _quaternion, _scale );
+					_matrix.scale( _scale )
 
 					_matrix.elements[ 3 ] = 0;
 					_matrix.elements[ 7 ] = 0;

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -1,6 +1,7 @@
 import {
 	Matrix4,
-	Object3D
+	Object3D,
+	Vector3
 } from '../../../build/three.module.js';
 
 /**
@@ -246,7 +247,9 @@ class CSS3DRenderer {
 					if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
 
 					_matrix.copyPosition( object.matrixWorld );
-					_matrix.scale( object.getWorldScale() );
+					const objectWorldScale = new Vector3();
+					object.getWorldScale( objectWorldScale )
+					matrix.scale( objectWorldScale )
 
 					_matrix.elements[ 3 ] = 0;
 					_matrix.elements[ 7 ] = 0;


### PR DESCRIPTION
CSS3DSprite seems to ignore parent scale completely; this seems to fix it, but I don't know if there are better / cleaner solutions