### PR TITLE
ShaderChunk: Removed unused MAXIMUM_SPECULAR_COEFFICIENT  constant

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -16,7 +16,6 @@ struct PhysicalMaterial {
 
 };
 
-#define MAXIMUM_SPECULAR_COEFFICIENT 0.16
 #define DEFAULT_SPECULAR_COEFFICIENT 0.04
 
 // Clear coat directional hemishperical reflectance (this approximation should be improved)


### PR DESCRIPTION
Related issue: #22238

**Description**

@WestLangley Seems like this constant is no longer needed?