### PR TITLE
[bugfix] Fix issue when light.distance is zero

### DIFF
--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -9,11 +9,14 @@ const _projScreenMatrix = /*@__PURE__*/ new Matrix4();
 const _lightPositionWorld = /*@__PURE__*/ new Vector3();
 const _lookTarget = /*@__PURE__*/ new Vector3();
 
+/** Define default shadow distance. */
+const DEF_DISTANCE = 500;
+
 class PointLightShadow extends LightShadow {
 
 	constructor() {
 
-		super( new PerspectiveCamera( 90, 1, 0.5, 500 ) );
+		super( new PerspectiveCamera( 90, 1, 0.5, DEF_DISTANCE ) );
 
 		this._frameExtents = new Vector2( 4, 2 );
 
@@ -64,7 +67,7 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
-		const far = light.distance || camera.far;
+		const far = light.distance != null ? light.distance : DEF_DISTANCE;
 
 		if ( far !== camera.far ) {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -2,11 +2,14 @@ import { LightShadow } from './LightShadow.js';
 import * as MathUtils from '../math/MathUtils.js';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 
+/** Define default shadow distance. */
+const DEF_DISTANCE = 500;
+
 class SpotLightShadow extends LightShadow {
 
 	constructor() {
 
-		super( new PerspectiveCamera( 50, 1, 0.5, 500 ) );
+		super( new PerspectiveCamera( 50, 1, 0.5, DEF_DISTANCE ) );
 
 		this.focus = 1;
 
@@ -18,7 +21,7 @@ class SpotLightShadow extends LightShadow {
 
 		const fov = MathUtils.RAD2DEG * 2 * light.angle * this.focus;
 		const aspect = this.mapSize.width / this.mapSize.height;
-		const far = light.distance || camera.far;
+		const far = light.distance != null ? light.distance : DEF_DISTANCE;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
 


### PR DESCRIPTION
**Description**

`shadow.camera.far` are not updated correctly when light.intensity set to zero.

`SpotLightShadow` and `PointLightShadow` have the same issue.

**Example**
```
// Create SpotLight
const light = new THREE.SpotLight();

// Set distance to 1
light.distance = 1;

// Set distance back to zero.
light.distance = 0;

// [ISSUE] shadow.camera.far is still 1, cannot render shadow correctly.
```

**How to fix it**

Using `light.intensity != null ? light.intensity: default` instead of `light.intensity || camera.far`