### PR TITLE
LDrawLoader: Improve parts library ergonomics, improve normal smoothing functionality

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -699,6 +699,34 @@ class LDrawLoader extends Loader {
 
 	}
 
+	async preloadMaterials( url ) {
+
+		const fileLoader = new FileLoader( this.manager );
+		fileLoader.setPath( this.path );
+		fileLoader.setRequestHeader( this.requestHeader );
+		fileLoader.setWithCredentials( this.withCredentials );
+
+		const text = await fileLoader.loadAsync( url );
+		const colorLineRegex = /^0 !COLOUR/;
+		const lines = text.split( /[\n\r]/g );
+		const materials = [];
+		for ( let i = 0, l = lines.length; i < l; i ++ ) {
+
+			const line = lines[ i ];
+			if ( colorLineRegex.test( line ) ) {
+
+				const directive = line.replace( colorLineRegex, '' );
+				const material = this.parseColourMetaDirective( new LineParser( directive ) );
+				materials.push( material );
+
+			}
+
+		}
+
+		this.setMaterials( materials );
+
+	}
+
 	load( url, onLoad, onProgress, onError ) {
 
 		if ( ! this.fileMap ) {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -687,6 +687,16 @@ class LDrawLoader extends Loader {
 		// If this flag is set to true the vertex normals will be smoothed.
 		this.smoothNormals = true;
 
+		// The path to load parts from the LDraw parts library from.
+		this.partsLibraryPath = '';
+
+	}
+
+	setPartsLibraryPath( path ) {
+
+		this.partsLibraryPath = path;
+		return this;
+
 	}
 
 	load( url, onLoad, onProgress, onError ) {
@@ -1988,7 +1998,7 @@ class LDrawLoader extends Loader {
 			// Use another file loader here so we can keep track of the subobject information
 			// and use it when processing the next model.
 			const fileLoader = new FileLoader( scope.manager );
-			fileLoader.setPath( scope.path );
+			fileLoader.setPath( scope.partsLibraryPath );
 			fileLoader.setRequestHeader( scope.requestHeader );
 			fileLoader.setWithCredentials( scope.withCredentials );
 			fileLoader.load( subobjectURL, function ( text ) {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -303,48 +303,71 @@ function smoothNormals( faces, lineSegments ) {
 
 					// share the first normal
 					const otherNext = ( otherIndex + 1 ) % otherVertCount;
+					if (
+						vertNormals[ index ] && otherNormals[ otherNext ] &&
+						vertNormals[ index ] !== otherNormals[ otherNext ]
+					) {
+
+						otherNormals[ otherNext ].norm.add( vertNormals[ index ].norm );
+						vertNormals[ index ].norm = otherNormals[ otherNext ].norm;
+
+					}
+
 					let sharedNormal1 = vertNormals[ index ] || otherNormals[ otherNext ];
 					if ( sharedNormal1 === null ) {
 
-						sharedNormal1 = new Vector3();
-						normals.push( sharedNormal1 );
+						// it's possible to encounter an edge of a triangle that has already been traversed meaning
+						// both edges already have different normals defined and shared. To work around this we create
+						// a wrapper object so when those edges are merged the normals can be updated everywhere.
+						sharedNormal1 = { norm: new Vector3() };
+						normals.push( sharedNormal1.norm );
 
 					}
 
 					if ( vertNormals[ index ] === null ) {
 
 						vertNormals[ index ] = sharedNormal1;
-						sharedNormal1.add( faceNormal );
+						sharedNormal1.norm.add( faceNormal );
 
 					}
 
 					if ( otherNormals[ otherNext ] === null ) {
 
 						otherNormals[ otherNext ] = sharedNormal1;
-						sharedNormal1.add( otherFaceNormal );
+						sharedNormal1.norm.add( otherFaceNormal );
 
 					}
 
 					// share the second normal
+					if (
+						vertNormals[ next ] && otherNormals[ otherIndex ] &&
+						vertNormals[ next ] !== otherNormals[ otherIndex ]
+					) {
+
+						otherNormals[ otherIndex ].norm.add( vertNormals[ next ].norm );
+						vertNormals[ next ].norm = otherNormals[ otherIndex ].norm;
+
+					}
+
 					let sharedNormal2 = vertNormals[ next ] || otherNormals[ otherIndex ];
 					if ( sharedNormal2 === null ) {
 
-						sharedNormal2 = new Vector3();
-						normals.push( sharedNormal2 );
+						sharedNormal2 = { norm: new Vector3() };
+						normals.push( sharedNormal2.norm );
 
 					}
 
 					if ( vertNormals[ next ] === null ) {
 
 						vertNormals[ next ] = sharedNormal2;
-						sharedNormal2.add( faceNormal );
+						sharedNormal2.norm.add( faceNormal );
 
 					}
 
 					if ( otherNormals[ otherIndex ] === null ) {
 
 						otherNormals[ otherIndex ] = sharedNormal2;
-						sharedNormal2.add( otherFaceNormal );
+						sharedNormal2.norm.add( otherFaceNormal );
 
 					}
 
@@ -540,7 +563,13 @@ function createObject( elements, elementSize, isConditionalSegments = false, tot
 
 			for ( let j = 0, l = elemNormals.length; j < l; j ++ ) {
 
-				const n = elemNormals[ j ] || elem.faceNormal;
+				let n = elem.faceNormal;
+				if ( elemNormals[ j ] ) {
+
+					n = elemNormals[ j ].norm;
+
+				}
+
 				const index = offset + j * 3;
 				normals[ index + 0 ] = n.x;
 				normals[ index + 1 ] = n.y;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -592,11 +592,11 @@ function createObject( elements, elementSize, isConditionalSegments = false, tot
 
 	if ( elementSize === 2 ) {
 
-		object3d = new LineSegments( bufferGeometry, materials );
+		object3d = new LineSegments( bufferGeometry, materials.length === 1 ? materials[ 0 ] : materials );
 
 	} else if ( elementSize === 3 ) {
 
-		object3d = new Mesh( bufferGeometry, materials );
+		object3d = new Mesh( bufferGeometry, materials.length === 1 ? materials[ 0 ] : materials );
 
 	}
 


### PR DESCRIPTION
Related issue: --

**Description**

- Change the loader so meshes only receive a single material instead of an array if only one material is present.
- Add "setPartsLibraryPath" function (see [here](https://github.com/mrdoob/three.js/pull/22231#issuecomment-890544653))
- Add async "preloadMaterials" function so color files can be preloaded and color codes seeded before loading a model. Without preloading color codes most "unpacked" models don't seem to load.
- Improve the normal smoothing to handle cases where common edges were not getting normals merged by using a "reference"-like structure with the normals wrapped in an object.

Here are the types of normal issues that have been fixed:

| BEFORE | AFTER |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/127913950-d1c51b6f-0600-47da-bd5f-dfa926abd467.png) | ![image](https://user-images.githubusercontent.com/734200/127913988-6de6c4a3-a0ce-4567-b2fb-d04604588b93.png) |
| ![image](https://user-images.githubusercontent.com/734200/127914070-b010954b-f64d-4188-bde2-c10eb8747151.png) | ![image](https://user-images.githubusercontent.com/734200/127914118-a456877a-f8f8-4654-b147-31e996764ab4.png) |
| ![image](https://user-images.githubusercontent.com/734200/127914211-335fc374-022e-45e4-9947-9777bfe6d4e4.png) | ![image](https://user-images.githubusercontent.com/734200/127914230-4335af56-f811-4958-adb5-546478576ea6.png) |

cc @yomboprime 

In the next PR I'll be working to parallelize the downloads when using the parts library to improve load times.