### PR TITLE
[BugFix] Set correct 'shadow.camera.far' when light.distance set to zero

### DIFF
--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -67,7 +67,7 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
-		const far = light.distance != null ? light.distance : DEF_DISTANCE;
+		const far = light.distance === 0 ? DEF_DISTANCE : light.distance || camera.far;
 
 		if ( far !== camera.far ) {
 

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -9,11 +9,14 @@ const _projScreenMatrix = /*@__PURE__*/ new Matrix4();
 const _lightPositionWorld = /*@__PURE__*/ new Vector3();
 const _lookTarget = /*@__PURE__*/ new Vector3();
 
+/** Define default shadow distance. */
+const DEF_DISTANCE = 500;
+
 class PointLightShadow extends LightShadow {
 
 	constructor() {
 
-		super( new PerspectiveCamera( 90, 1, 0.5, 500 ) );
+		super( new PerspectiveCamera( 90, 1, 0.5, DEF_DISTANCE ) );
 
 		this._frameExtents = new Vector2( 4, 2 );
 
@@ -64,7 +67,7 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
-		const far = light.distance || camera.far;
+		const far = light.distance != null ? light.distance : DEF_DISTANCE;
 
 		if ( far !== camera.far ) {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -2,11 +2,14 @@ import { LightShadow } from './LightShadow.js';
 import * as MathUtils from '../math/MathUtils.js';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 
+/** Define default shadow distance. */
+const DEF_DISTANCE = 500;
+
 class SpotLightShadow extends LightShadow {
 
 	constructor() {
 
-		super( new PerspectiveCamera( 50, 1, 0.5, 500 ) );
+		super( new PerspectiveCamera( 50, 1, 0.5, DEF_DISTANCE ) );
 
 		this.focus = 1;
 
@@ -18,7 +21,7 @@ class SpotLightShadow extends LightShadow {
 
 		const fov = MathUtils.RAD2DEG * 2 * light.angle * this.focus;
 		const aspect = this.mapSize.width / this.mapSize.height;
-		const far = light.distance || camera.far;
+		const far = light.distance != null ? light.distance : DEF_DISTANCE;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -21,7 +21,7 @@ class SpotLightShadow extends LightShadow {
 
 		const fov = MathUtils.RAD2DEG * 2 * light.angle * this.focus;
 		const aspect = this.mapSize.width / this.mapSize.height;
-		const far = light.distance != null ? light.distance : DEF_DISTANCE;
+		const far = light.distance === 0 ? DEF_DISTANCE : light.distance || camera.far;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
 


### PR DESCRIPTION
**Issue Description**

![image](https://user-images.githubusercontent.com/29571300/127946015-c2601119-248d-458c-a684-d8b0e72b81a8.png)
![image](https://user-images.githubusercontent.com/29571300/127946089-4959c39c-a3e2-4928-bb89-8e3cbaaf8403.png)
![image](https://user-images.githubusercontent.com/29571300/127946191-6bc89b0b-b0b1-4242-8d65-db0fc8f383c5.png)

**Code Analysis**

In `SpotLightShadow.updateMatrices`:

```
const far = light.distance || camera.far;
```

`shadow.camera.far` will be set to `camera.far` when `light.distance` set to zero.
`light.distance = 0` means infinite, but `camera.far` is set to 1 for now.

**How to fix it**

Reset `camera.far` to default value when `light.distance` set to zero.