### PR TITLE
LDrawLoader: Fix scenario where geometry was not getting smoothed

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1979,6 +1979,7 @@ class LDrawLoader extends Loader {
 			parseScope.startingConstructionStep = subobject.startingConstructionStep;
 			parseScope.mainColourCode = subobject.material.userData.code;
 			parseScope.mainEdgeColourCode = subobject.material.userData.edgeMaterial.userData.code;
+			parseScope.fileName = subobject.fileName;
 
 		}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1857,6 +1857,10 @@ class LDrawLoader extends Loader {
 	finalizeObject( subobjectParseScope ) {
 
 		const parentParseScope = subobjectParseScope.parentScope;
+
+		// Smooth the normals if this is a part or if this is a case where the subpart
+		// is added directly into the parent model (meaning it will never get smoothed by
+		// being added to a part)
 		const doSmooth =
 			isPartType( subobjectParseScope.type ) ||
 			(

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -869,15 +869,13 @@ class LDrawLoader extends Loader {
 
 		}
 
-		const scope = this;
-
 		const fileLoader = new FileLoader( this.manager );
 		fileLoader.setPath( this.path );
 		fileLoader.setRequestHeader( this.requestHeader );
 		fileLoader.setWithCredentials( this.withCredentials );
-		fileLoader.load( url, function ( text ) {
+		fileLoader.load( url, text => {
 
-			scope.processObject( text, null, url, scope.rootParseScope )
+			this.processObject( text, null, url, this.rootParseScope )
 				.then( function ( result ) {
 
 					onLoad( result.groupObject );
@@ -1967,7 +1965,7 @@ class LDrawLoader extends Loader {
 
 		const scope = this;
 
-		const parseScope = scope.newParseScopeLevel( null, parentScope );
+		const parseScope = this.newParseScopeLevel( null, parentScope );
 		parseScope.url = url;
 
 		const parentParseScope = parseScope.parentScope;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -388,6 +388,18 @@ function smoothNormals( faces, lineSegments ) {
 
 }
 
+function isPartType( type ) {
+
+	return type === 'Part';
+
+}
+
+function isModelType( type ) {
+
+	return type === 'Model' || type === 'Unofficial_Model';
+
+}
+
 function isPrimitiveType( type ) {
 
 	return /primitive/i.test( type ) || type === 'Subpart';
@@ -1845,8 +1857,15 @@ class LDrawLoader extends Loader {
 	finalizeObject( subobjectParseScope ) {
 
 		const parentParseScope = subobjectParseScope.parentScope;
+		const doSmooth =
+			isPartType( subobjectParseScope.type ) ||
+			(
+				! isPartType( subobjectParseScope.type ) &&
+				! isModelType( subobjectParseScope.type ) &&
+				isModelType( subobjectParseScope.parentScope.type )
+			);
 
-		if ( this.smoothNormals && subobjectParseScope.type === 'Part' ) {
+		if ( this.smoothNormals && doSmooth ) {
 
 			smoothNormals( subobjectParseScope.faces, subobjectParseScope.lineSegments );
 


### PR DESCRIPTION
Related issue: --

**Description**

- Fixes a scenario where subparts / primitives were direct children of a Model type file meaning they would never get smoothed.
- Ensure the part name is made available to the parseScope for subobjects so parts are named correctly.
- Remove some use of class functions in favor of arrow functions.

This will probably be my last LDrawLoader PR for a bit but I think there are still a few things that could be done to improve load times. Specifically I think we could cache the parsed versions of the parts files and clone it when needed rather than the original text to avoid parsing all the same content over and over again. And once that's done you could cache the smoothed normals per parsed file to avoid smoothing some edges over and over which I think would give a nice boost. But that's for another time!

| | BEFORE | AFTER |
|---|---|---|
| AT-ST Tubes | ![image](https://user-images.githubusercontent.com/734200/128073225-668641ae-7977-4cfd-960e-7ff0d16de5ee.png) | ![image](https://user-images.githubusercontent.com/734200/128073148-184e9ad5-29c6-40c7-bd35-b2f0cbca611c.png) |
| AT-ST "Neck" | ![image](https://user-images.githubusercontent.com/734200/128073360-765a9b33-dd7c-4f8e-bfb3-b9dc727f6b07.png) | ![image](https://user-images.githubusercontent.com/734200/128073387-550d43d8-0210-4f26-9ff7-a4c08f9fd22a.png) |
| AT-ST Rubberband | ![image](https://user-images.githubusercontent.com/734200/128073481-3047f3eb-3120-4efc-9e66-fc8720a126cb.png) | ![image](https://user-images.githubusercontent.com/734200/128073778-b1890b88-5737-45bb-aa53-d1b5fd0eaccf.png) |

cc @yomboprime 


