### PR TITLE
Shaders: Adhere to three.js nomenclature conventions

### DIFF
--- a/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_fragment.glsl.js
@@ -3,11 +3,11 @@ export default /* glsl */`
 
 	#ifdef FOG_EXP2
 
-		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth );
+		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * vFogDepth * vFogDepth );
 
 	#else
 
-		float fogFactor = smoothstep( fogNear, fogFar, fogDepth );
+		float fogFactor = smoothstep( fogNear, fogFar, vFogDepth );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_fragment.glsl.js
@@ -2,7 +2,7 @@ export default /* glsl */`
 #ifdef USE_FOG
 
 	uniform vec3 fogColor;
-	varying float fogDepth;
+	varying float vFogDepth;
 
 	#ifdef FOG_EXP2
 

--- a/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_pars_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_FOG
 
-	varying float fogDepth;
+	varying float vFogDepth;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/fog_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/fog_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_FOG
 
-	fogDepth = - mvPosition.z;
+	vFogDepth = - mvPosition.z;
 
 #endif
 `;


### PR DESCRIPTION
Minor fix: `fogDepth` -> `vFogDepth`
