### PR TITLE
MeshPhongMaterial: Added vertex tangent support

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -5,8 +5,14 @@ varying vec3 vViewPosition;
 
 	varying vec3 vNormal;
 
-#endif
+	#ifdef USE_TANGENT
 
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
+#endif
 
 struct BlinnPhongMaterial {
 

--- a/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
@@ -5,8 +5,14 @@ varying vec3 vViewPosition;
 
 	varying vec3 vNormal;
 
-#endif
+	#ifdef USE_TANGENT
 
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
+#endif
 
 struct ToonMaterial {
 

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
@@ -7,6 +7,13 @@ varying vec3 vViewPosition;
 
 	varying vec3 vNormal;
 
+	#ifdef USE_TANGENT
+
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
 #endif
 
 #include <common>
@@ -34,11 +41,18 @@ void main() {
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
 
-#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
+	#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
 
-	vNormal = normalize( transformedNormal );
+		vNormal = normalize( transformedNormal );
 
-#endif
+		#ifdef USE_TANGENT
+
+			vTangent = normalize( transformedTangent );
+			vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
+
+		#endif
+
+	#endif
 
 	#include <begin_vertex>
 	#include <morphtarget_vertex>

--- a/src/renderers/shaders/ShaderLib/meshtoon_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_vert.glsl.js
@@ -7,6 +7,13 @@ varying vec3 vViewPosition;
 
 	varying vec3 vNormal;
 
+	#ifdef USE_TANGENT
+
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
 #endif
 
 #include <common>
@@ -33,11 +40,18 @@ void main() {
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
 
-#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
+	#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
 
-	vNormal = normalize( transformedNormal );
+		vNormal = normalize( transformedNormal );
 
-#endif
+		#ifdef USE_TANGENT
+
+			vTangent = normalize( transformedTangent );
+			vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
+
+		#endif
+
+	#endif
 
 	#include <begin_vertex>
 	#include <morphtarget_vertex>


### PR DESCRIPTION
Added support for vertex tangents to `MeshPhongMaterial`. `MeshToonMaterial`, likewise.



