### PR TITLE
Loaders: Use HalfFloatType as default texture type.

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -93,7 +93,7 @@ class EXRLoader extends DataTextureLoader {
 
 		super( manager );
 
-		this.type = FloatType;
+		this.type = HalfFloatType;
 
 	}
 

--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -22,7 +22,7 @@ class HDRCubeTextureLoader extends Loader {
 		super( manager );
 
 		this.hdrLoader = new RGBELoader();
-		this.type = FloatType;
+		this.type = HalfFloatType;
 
 	}
 

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -21,7 +21,7 @@ class RGBELoader extends DataTextureLoader {
 
 		super( manager );
 
-		this.type = FloatType;
+		this.type = HalfFloatType;
 
 	}
 

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -40,7 +40,6 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'royal_esplanade_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_gltf_extensions.html
+++ b/examples/webgl_loader_gltf_extensions.html
@@ -158,7 +158,6 @@
 				// Load background and generate envMap
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'venice_sunset_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -42,7 +42,6 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'royal_esplanade_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_gltf_variants.html
+++ b/examples/webgl_loader_gltf_variants.html
@@ -43,7 +43,6 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'quarry_01_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -48,7 +48,6 @@
 				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 1 );
 
 				new EXRLoader()
-					.setDataType( THREE.FloatType )
 					.load( 'textures/memorial.exr', function ( texture, textureData ) {
 
 						// memorial.exr is NPOT

--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -46,7 +46,6 @@
 				scene.add( group );
 
 				new HDRCubeTextureLoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/cube/pisaHDR/' )
 					.load( [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ],
 						function ( texture ) {

--- a/examples/webgl_materials_physical_reflectivity.html
+++ b/examples/webgl_materials_physical_reflectivity.html
@@ -113,7 +113,6 @@
 				} );
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'royal_esplanade_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_materials_physical_transmission.html
+++ b/examples/webgl_materials_physical_transmission.html
@@ -39,7 +39,6 @@
 			let mesh;
 
 			const hdrEquirect = new RGBELoader()
-				.setDataType( THREE.FloatType )
 				.setPath( 'textures/equirectangular/' )
 				.load( 'royal_esplanade_1k.hdr', function () {
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -121,7 +121,6 @@
 
 					const filename = environments[ name ].filename;
 					new RGBELoader()
-						.setDataType( THREE.FloatType )
 						.setPath( 'textures/equirectangular/' )
 						.load( filename, function ( hdrEquirect ) {
 

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -47,7 +47,6 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'pedestrian_overpass_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -52,7 +52,6 @@
 				imgTexture = null;
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'pedestrian_overpass_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -63,7 +63,6 @@
 				scene = new THREE.Scene();
 
 				new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' )
 					.load( 'royal_esplanade_1k.hdr', function ( texture ) {
 

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -85,7 +85,6 @@
 				controls.update();
 
 				const rgbeLoader = new RGBELoader()
-					.setDataType( THREE.FloatType )
 					.setPath( 'textures/equirectangular/' );
 
 				const gltfLoader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );


### PR DESCRIPTION
Related issue: Fixed #22226.

**Description**

Use `THREE.HalfFloatType` in `RGBELoader`, `HDRCubeTextureLoader` and `EXRLoader` for better device compatibilty.
