### PR TITLE
Shaders: Added new shader chunks for tangent support

### DIFF
--- a/examples/jsm/nodes/materials/nodes/PhongNode.js
+++ b/examples/jsm/nodes/materials/nodes/PhongNode.js
@@ -41,14 +41,9 @@ class PhongNode extends Node {
 			builder.addParsCode( /* glsl */`
 				varying vec3 vViewPosition;
 
-				#ifndef FLAT_SHADED
-
-					varying vec3 vNormal;
-
-				#endif
-
 				//"#include <encodings_pars_fragment> // encoding functions
 				#include <fog_pars_vertex>
+				#include <normal_pars_vertex>
 				#include <morphtarget_pars_vertex>
 				#include <skinning_pars_vertex>
 				#include <shadowmap_pars_vertex>
@@ -62,12 +57,7 @@ class PhongNode extends Node {
 				'#include <skinbase_vertex>',
 				'#include <skinnormal_vertex>',
 				'#include <defaultnormal_vertex>',
-
-				'#ifndef FLAT_SHADED', // normal computed with derivatives when FLAT_SHADED
-
-				'	vNormal = normalize( transformedNormal );',
-
-				'#endif',
+				'#include <normal_vertex>',
 
 				'#include <begin_vertex>'
 			];
@@ -150,6 +140,7 @@ class PhongNode extends Node {
 				#include <fog_pars_fragment>
 				#include <bsdfs>
 				#include <lights_pars_begin>
+				#include <normal_pars_fragment>
 				#include <lights_phong_pars_fragment>
 				#include <shadowmap_pars_fragment>
 				#include <logdepthbuf_pars_fragment>`

--- a/examples/jsm/shaders/MMDToonShader.js
+++ b/examples/jsm/shaders/MMDToonShader.js
@@ -18,13 +18,6 @@ import { UniformsUtils, ShaderLib } from '../../../build/three.module.js';
 const lights_mmd_toon_pars_fragment = `
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-
-	varying vec3 vNormal;
-
-#endif
-
-
 struct BlinnPhongMaterial {
 
 	vec3 diffuseColor;

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -156,6 +156,7 @@
 						THREE.ShaderChunk[ "common" ],
 						THREE.ShaderChunk[ "bsdfs" ],
 						THREE.ShaderChunk[ "lights_pars_begin" ],
+						THREE.ShaderChunk[ "normal_pars_fragment" ],
 						THREE.ShaderChunk[ "lights_phong_pars_fragment" ],
 
 						"void main() {",

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -63,6 +63,9 @@ import morphtarget_pars_vertex from './ShaderChunk/morphtarget_pars_vertex.glsl.
 import morphtarget_vertex from './ShaderChunk/morphtarget_vertex.glsl.js';
 import normal_fragment_begin from './ShaderChunk/normal_fragment_begin.glsl.js';
 import normal_fragment_maps from './ShaderChunk/normal_fragment_maps.glsl.js';
+import normal_pars_fragment from './ShaderChunk/normal_pars_fragment.glsl.js';
+import normal_pars_vertex from './ShaderChunk/normal_pars_vertex.glsl.js';
+import normal_vertex from './ShaderChunk/normal_vertex.glsl.js';
 import normalmap_pars_fragment from './ShaderChunk/normalmap_pars_fragment.glsl.js';
 import clearcoat_normal_fragment_begin from './ShaderChunk/clearcoat_normal_fragment_begin.glsl.js';
 import clearcoat_normal_fragment_maps from './ShaderChunk/clearcoat_normal_fragment_maps.glsl.js';
@@ -195,6 +198,9 @@ export const ShaderChunk = {
 	morphtarget_vertex: morphtarget_vertex,
 	normal_fragment_begin: normal_fragment_begin,
 	normal_fragment_maps: normal_fragment_maps,
+	normal_pars_fragment: normal_pars_fragment,
+	normal_pars_vertex: normal_pars_vertex,
+	normal_vertex: normal_vertex,
 	normalmap_pars_fragment: normalmap_pars_fragment,
 	clearcoat_normal_fragment_begin: clearcoat_normal_fragment_begin,
 	clearcoat_normal_fragment_maps: clearcoat_normal_fragment_maps,

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -1,19 +1,6 @@
 export default /* glsl */`
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-
-	varying vec3 vNormal;
-
-	#ifdef USE_TANGENT
-
-		varying vec3 vTangent;
-		varying vec3 vBitangent;
-
-	#endif
-
-#endif
-
 struct BlinnPhongMaterial {
 
 	vec3 diffuseColor;

--- a/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
@@ -1,19 +1,6 @@
 export default /* glsl */`
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-
-	varying vec3 vNormal;
-
-	#ifdef USE_TANGENT
-
-		varying vec3 vTangent;
-		varying vec3 vBitangent;
-
-	#endif
-
-#endif
-
 struct ToonMaterial {
 
 	vec3 diffuseColor;

--- a/src/renderers/shaders/ShaderChunk/normal_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_pars_fragment.glsl.js
@@ -1,0 +1,14 @@
+export default /* glsl */`
+#ifndef FLAT_SHADED
+
+	varying vec3 vNormal;
+
+	#ifdef USE_TANGENT
+
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
+#endif
+`;

--- a/src/renderers/shaders/ShaderChunk/normal_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_pars_vertex.glsl.js
@@ -1,0 +1,14 @@
+export default /* glsl */`
+#ifndef FLAT_SHADED
+
+	varying vec3 vNormal;
+
+	#ifdef USE_TANGENT
+
+		varying vec3 vTangent;
+		varying vec3 vBitangent;
+
+	#endif
+
+#endif
+`;

--- a/src/renderers/shaders/ShaderChunk/normal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_vertex.glsl.js
@@ -1,0 +1,14 @@
+export default /* glsl */`
+#ifndef FLAT_SHADED // normal is computed with derivatives when FLAT_SHADED
+
+	vNormal = normalize( transformedNormal );
+
+	#ifdef USE_TANGENT
+
+		vTangent = normalize( transformedTangent );
+		vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
+
+	#endif
+
+#endif
+`;

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -24,6 +24,7 @@ uniform float opacity;
 #include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
+#include <normal_pars_fragment>
 #include <lights_phong_pars_fragment>
 #include <shadowmap_pars_fragment>
 #include <bumpmap_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
@@ -3,19 +3,6 @@ export default /* glsl */`
 
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-
-	varying vec3 vNormal;
-
-	#ifdef USE_TANGENT
-
-		varying vec3 vTangent;
-		varying vec3 vBitangent;
-
-	#endif
-
-#endif
-
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
@@ -23,6 +10,7 @@ varying vec3 vViewPosition;
 #include <envmap_pars_vertex>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
+#include <normal_pars_vertex>
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
 #include <shadowmap_pars_vertex>
@@ -40,19 +28,7 @@ void main() {
 	#include <skinbase_vertex>
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
-
-	#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
-
-		vNormal = normalize( transformedNormal );
-
-		#ifdef USE_TANGENT
-
-			vTangent = normalize( transformedTangent );
-			vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
-
-		#endif
-
-	#endif
+	#include <normal_vertex>
 
 	#include <begin_vertex>
 	#include <morphtarget_vertex>

--- a/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
@@ -20,6 +20,7 @@ uniform float opacity;
 #include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
+#include <normal_pars_fragment>
 #include <lights_toon_pars_fragment>
 #include <shadowmap_pars_fragment>
 #include <bumpmap_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshtoon_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_vert.glsl.js
@@ -3,25 +3,13 @@ export default /* glsl */`
 
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-
-	varying vec3 vNormal;
-
-	#ifdef USE_TANGENT
-
-		varying vec3 vTangent;
-		varying vec3 vBitangent;
-
-	#endif
-
-#endif
-
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
+#include <normal_pars_vertex>
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
 #include <shadowmap_pars_vertex>
@@ -39,19 +27,7 @@ void main() {
 	#include <skinbase_vertex>
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
-
-	#ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
-
-		vNormal = normalize( transformedNormal );
-
-		#ifdef USE_TANGENT
-
-			vTangent = normalize( transformedTangent );
-			vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );
-
-		#endif
-
-	#endif
+	#include <normal_vertex>
 
 	#include <begin_vertex>
 	#include <morphtarget_vertex>


### PR DESCRIPTION
This PR adds three new shader chunks to consolidate some frequently-used code patterns.

These shader chunks are required for universal tangent support.

The new shader chunks have been applied to `MeshPhongMaterial` and `MeshToonMaterial` as a start.