### PR TITLE
build-examples: Support namespaced modules

### DIFF
--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -43,13 +43,9 @@ function unmodularize() {
 
 		renderChunk( code, { fileName } ) {
 
-			// the modules that need to be namespaced
-			const namespaces = [ 'BufferGeometryUtils' ];
-
-
+			// Namespace the modules that end with Utils
 			const fileNameNoExtension = fileName.slice( 0, fileName.indexOf( '.' ) );
-			const namespace = namespaces.includes( fileNameNoExtension ) ? fileNameNoExtension : '';
-
+			const namespace = fileNameNoExtension.endsWith( 'Utils' ) ? fileNameNoExtension : undefined;
 
 			// export { Example };
 			// ↓

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -41,7 +41,15 @@ function unmodularize() {
 	return {
 
 
-		renderChunk( code ) {
+		renderChunk( code, { fileName } ) {
+
+			// the modules that need to be namespaced
+			const namespaces = [ 'BufferGeometryUtils' ];
+
+
+			const fileNameNoExtension = fileName.slice( 0, fileName.indexOf( '.' ) );
+			const namespace = namespaces.includes( fileNameNoExtension ) ? fileNameNoExtension : '';
+
 
 			// export { Example };
 			// ↓
@@ -49,7 +57,22 @@ function unmodularize() {
 			code = code.replace( /export { ([a-zA-Z0-9_, ]+) };/g, ( match, p1 ) => {
 
 				const exps = p1.split( ', ' );
-				return exps.map( exp => `THREE.${exp} = ${exp};` ).join( EOL );
+
+				let output = '';
+
+				if ( namespace ) {
+
+					output += `THREE.${namespace} = {};${ EOL }`;
+					output += exps.map( exp => `THREE.${namespace}.${exp} = ${exp};` ).join( EOL );
+
+				} else {
+
+					output += exps.map( exp => `THREE.${exp} = ${exp};` ).join( EOL );
+
+				}
+
+
+				return output;
 
 			} );
 
@@ -65,6 +88,18 @@ function unmodularize() {
 				return '';
 
 			} );
+
+			// import * as Example from '...';
+			// but excluding imports importing from the libs/ folder
+			code = code.replace( /import \* as ([a-zA-Z0-9_, ]+) from '((?!libs).)*';/g, ( match, p1 ) => {
+
+				const imp = p1;
+				imports.push( imp );
+
+				return '';
+
+			} );
+
 
 			// new Example()
 			// (Example)


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/pull/22267#issuecomment-892696528

**Description**

Add support for namespaced modules in the `build-examples` script.

Basically this

```js
export {
	computeTangents,
	mergeBufferGeometries,
	mergeBufferAttributes,
	interleaveAttributes,
	estimateBytesUsed,
	mergeVertices,
	toTrianglesDrawMode,
	computeMorphedAttributes,
};
``` 

becomes this

```js
THREE.BufferGeometryUtils = {};
THREE.BufferGeometryUtils.computeMorphedAttributes = computeMorphedAttributes;
THREE.BufferGeometryUtils.computeTangents = computeTangents;
THREE.BufferGeometryUtils.estimateBytesUsed = estimateBytesUsed;
THREE.BufferGeometryUtils.interleaveAttributes = interleaveAttributes;
THREE.BufferGeometryUtils.mergeBufferAttributes = mergeBufferAttributes;
THREE.BufferGeometryUtils.mergeBufferGeometries = mergeBufferGeometries;
THREE.BufferGeometryUtils.mergeVertices = mergeVertices;
THREE.BufferGeometryUtils.toTrianglesDrawMode = toTrianglesDrawMode;
```

I had to add an array to keep track of modules that need to be namespaced, otherwise, there is no way to tell.