### PR TITLE
VSM Shadows: Add support for setting the number of blur samples

### DIFF
--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -42,7 +42,12 @@
 		<h3>[property:Float bias]</h3>
 		<p>
 			Shadow map bias, how much to add or subtract from the normalized depth when deciding whether a surface is in shadow.<br />
-			The default is 0. Very tiny adjustments here (in the order of 0.0001) may help reduce artefacts in shadows
+			The default is 0. Very tiny adjustments here (in the order of 0.0001) may help reduce artifacts in shadows
+		</p>
+
+		<h3>[property:Float blurSamples]</h3>
+		<p>
+			The amount of samples to use when blurring a VSM shadow map.
 		</p>
 
 		<h3>[property:WebGLRenderTarget map]</h3>

--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -45,7 +45,7 @@
 			The default is 0. Very tiny adjustments here (in the order of 0.0001) may help reduce artifacts in shadows
 		</p>
 
-		<h3>[property:Float blurSamples]</h3>
+		<h3>[property:Integer blurSamples]</h3>
 		<p>
 			The amount of samples to use when blurring a VSM shadow map.
 		</p>

--- a/docs/api/zh/lights/shadows/LightShadow.html
+++ b/docs/api/zh/lights/shadows/LightShadow.html
@@ -42,8 +42,8 @@
 			阴影贴图偏差，在确定曲面是否在阴影中时，从标准化深度添加或减去多少。<br />
 			默认值为0.此处非常小的调整（大约0.0001）可能有助于减少阴影中的伪影
 		</p>
-		
-		<h3>[property:Float blurSamples]</h3>
+
+		<h3>[property:Integer blurSamples]</h3>
 		<p>
 			The amount of samples to use when blurring a VSM shadow map.
 		</p>

--- a/docs/api/zh/lights/shadows/LightShadow.html
+++ b/docs/api/zh/lights/shadows/LightShadow.html
@@ -42,6 +42,11 @@
 			阴影贴图偏差，在确定曲面是否在阴影中时，从标准化深度添加或减去多少。<br />
 			默认值为0.此处非常小的调整（大约0.0001）可能有助于减少阴影中的伪影
 		</p>
+		
+		<h3>[property:Float blurSamples]</h3>
+		<p>
+			The amount of samples to use when blurring a VSM shadow map.
+		</p>
 
 		<h3>[property:WebGLRenderTarget map]</h3>
 		<p>

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -43,13 +43,13 @@
 				};
 
 				const spotlightFolder = gui.addFolder( 'Spotlight' );
-				spotlightFolder.add( config, 'spotlightRadius' ).name( 'radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
+				spotlightFolder.add( config, 'spotlightRadius' ).name( 'radius' ).min( 0 ).max( 25 ).onChange( function ( value ) {
 
 					spotLight.shadow.radius = value;
 
 				} );
 
-				spotlightFolder.add( config, 'spotlightSamples', 1, 50, 1 ).name( 'samples' ).onChange( function ( value ) {
+				spotlightFolder.add( config, 'spotlightSamples', 1, 25, 1 ).name( 'samples' ).onChange( function ( value ) {
 
 					spotLight.shadow.blurSamples = value;
 
@@ -57,13 +57,13 @@
 				spotlightFolder.open();
 
 				const dirlightFolder = gui.addFolder( 'Directional Light' );
-				dirlightFolder.add( config, 'dirlightRadius' ).name( 'radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
+				dirlightFolder.add( config, 'dirlightRadius' ).name( 'radius' ).min( 0 ).max( 25 ).onChange( function ( value ) {
 
 					dirLight.shadow.radius = value;
 
 				} );
 
-				dirlightFolder.add( config, 'dirlightSamples', 1, 50, 1 ).name( 'samples' ).onChange( function ( value ) {
+				dirlightFolder.add( config, 'dirlightSamples', 1, 25, 1 ).name( 'samples' ).onChange( function ( value ) {
 
 					dirLight.shadow.blurSamples = value;
 

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -98,7 +98,6 @@
 				dirLight.shadow.mapSize.height = 512;
 				dirLight.shadow.radius = 4;
 				dirLight.shadow.bias = - 0.0005;
-				scene.add( dirLight );
 
 				dirGroup = new THREE.Group();
 				dirGroup.add( dirLight );

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -37,18 +37,32 @@
 
 				const config = {
 					'Spotlight Radius': 4,
-					'Directional light Radius': 4,
+					'Spotlight Samples': 8,
+					'Dirlight Radius': 4,
+					'Dirlight Samples': 8
 				};
 
-				gui.add( config, 'Spotlight Radius' ).min( 2 ).max( 8 ).onChange( function ( value ) {
+				gui.add( config, 'Spotlight Radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
 
 					spotLight.shadow.radius = value;
 
 				} );
+				
+				gui.add( config, 'Spotlight Samples', 1, 50, 1 ).onChange( function ( value ) {
 
-				gui.add( config, 'Directional light Radius' ).min( 2 ).max( 8 ).onChange( function ( value ) {
+					spotLight.shadow.blurSamples = value;
+
+				} );
+
+				gui.add( config, 'Dirlight Radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
 
 					dirLight.shadow.radius = value;
+
+				} );
+
+				gui.add( config, 'Dirlight Samples', 1, 50, 1 ).onChange( function ( value ) {
+
+					dirLight.shadow.blurSamples = value;
 
 				} );
 

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -36,35 +36,39 @@
 				const gui = new GUI();
 
 				const config = {
-					'Spotlight Radius': 4,
-					'Spotlight Samples': 8,
-					'Dirlight Radius': 4,
-					'Dirlight Samples': 8
+					spotlightRadius: 4,
+					spotlightSamples: 8,
+					dirlightRadius: 4,
+					dirlightSamples: 8
 				};
 
-				gui.add( config, 'Spotlight Radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
+				const spotlightFolder = gui.addFolder( 'Spotlight' );
+				spotlightFolder.add( config, 'spotlightRadius' ).name( 'radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
 
 					spotLight.shadow.radius = value;
 
 				} );
-				
-				gui.add( config, 'Spotlight Samples', 1, 50, 1 ).onChange( function ( value ) {
+
+				spotlightFolder.add( config, 'spotlightSamples', 1, 50, 1 ).name( 'samples' ).onChange( function ( value ) {
 
 					spotLight.shadow.blurSamples = value;
 
 				} );
+				spotlightFolder.open();
 
-				gui.add( config, 'Dirlight Radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
+				const dirlightFolder = gui.addFolder( 'Directional Light' );
+				dirlightFolder.add( config, 'dirlightRadius' ).name( 'radius' ).min( 0 ).max( 58 ).onChange( function ( value ) {
 
 					dirLight.shadow.radius = value;
 
 				} );
 
-				gui.add( config, 'Dirlight Samples', 1, 50, 1 ).onChange( function ( value ) {
+				dirlightFolder.add( config, 'dirlightSamples', 1, 50, 1 ).name( 'samples' ).onChange( function ( value ) {
 
 					dirLight.shadow.blurSamples = value;
 
 				} );
+				dirlightFolder.open();
 
 				document.body.appendChild( renderer.domElement );
 				window.addEventListener( 'resize', onWindowResize );

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -17,6 +17,7 @@ class LightShadow {
 		this.bias = 0;
 		this.normalBias = 0;
 		this.radius = 1;
+		this.blurSamples = 8;
 
 		this.mapSize = new Vector2( 512, 512 );
 

--- a/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
@@ -14,10 +14,11 @@ void main() {
 	// This seems totally useless but it's a crazy work around for a Adreno compiler bug
 	// float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy ) / resolution ) );
 
-	float uvMultiplier = 2.0 / ( samples - 1.0 );
+	float uvStride = samples <= 1.0 ? 0.0 : 2.0 / ( samples - 1.0 );
+	float uvStart = samples <= 1.0 ? 0.0 : - 1.0;
 	for ( float i = 0.0; i < samples; i ++ ) {
 
-		float uvOffset = - 1.0 + float( i ) * uvMultiplier;
+		float uvOffset = uvStart + i * uvStride;
 
 		#ifdef HORIZONTAL_PASS
 

--- a/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm_frag.glsl.js
@@ -2,6 +2,7 @@ export default /* glsl */`
 uniform sampler2D shadow_pass;
 uniform vec2 resolution;
 uniform float radius;
+uniform float samples;
 
 #include <packing>
 
@@ -11,19 +12,22 @@ void main() {
 	float squared_mean = 0.0;
 
 	// This seems totally useless but it's a crazy work around for a Adreno compiler bug
-	float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy ) / resolution ) );
+	// float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy ) / resolution ) );
 
-	for ( float i = -1.0; i < 1.0 ; i += SAMPLE_RATE) {
+	float uvMultiplier = 2.0 / ( samples - 1.0 );
+	for ( float i = 0.0; i < samples; i ++ ) {
+
+		float uvOffset = - 1.0 + float( i ) * uvMultiplier;
 
 		#ifdef HORIZONTAL_PASS
 
-			vec2 distribution = unpackRGBATo2Half( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );
+			vec2 distribution = unpackRGBATo2Half( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( uvOffset, 0.0 ) * radius ) / resolution ) );
 			mean += distribution.x;
 			squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;
 
 		#else
 
-			float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0, i ) * radius ) / resolution ) );
+			float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0, uvOffset ) * radius ) / resolution ) );
 			mean += depth;
 			squared_mean += depth * depth;
 
@@ -31,8 +35,8 @@ void main() {
 
 	}
 
-	mean = mean * HALF_SAMPLE_RATE;
-	squared_mean = squared_mean * HALF_SAMPLE_RATE;
+	mean = mean / samples;
+	squared_mean = squared_mean / samples;
 
 	float std_dev = sqrt( squared_mean - mean * mean );
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -33,15 +33,11 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 	const shadowMaterialVertical = new ShaderMaterial( {
 
-		defines: {
-			SAMPLE_RATE: 2.0 / 8.0,
-			HALF_SAMPLE_RATE: 1.0 / 8.0
-		},
-
 		uniforms: {
 			shadow_pass: { value: null },
 			resolution: { value: new Vector2() },
-			radius: { value: 4.0 }
+			radius: { value: 4.0 },
+			samples: { value: 8.0 }
 		},
 
 		vertexShader: vsm_vert,
@@ -213,6 +209,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		shadowMaterialVertical.uniforms.shadow_pass.value = shadow.map.texture;
 		shadowMaterialVertical.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialVertical.uniforms.radius.value = shadow.radius;
+		shadowMaterialVertical.uniforms.samples.value = shadow.blurSamples;
 		_renderer.setRenderTarget( shadow.mapPass );
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
@@ -222,6 +219,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		shadowMaterialHorizontal.uniforms.shadow_pass.value = shadow.mapPass.texture;
 		shadowMaterialHorizontal.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialHorizontal.uniforms.radius.value = shadow.radius;
+		shadowMaterialHorizontal.uniforms.samples.value = shadow.blurSamples;
 		_renderer.setRenderTarget( shadow.map );
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialHorizontal, fullScreenMesh, null );

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -214,6 +214,12 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
 
+		if ( shadow.blurSamples <= 1.0 ) {
+
+			return;
+
+		}
+
 		// horizontal pass
 
 		shadowMaterialHorizontal.uniforms.shadow_pass.value = shadow.mapPass.texture;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -214,12 +214,6 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
 
-		if ( shadow.blurSamples <= 1.0 ) {
-
-			return;
-
-		}
-
 		// horizontal pass
 
 		shadowMaterialHorizontal.uniforms.shadow_pass.value = shadow.mapPass.texture;


### PR DESCRIPTION
Related issue: --

**Description**

Adds support for setting the number of blur samples in the separable blur passes when using VSM shadow maps. Previously a fixed count of 8 samples was being used which is more than needed to get a good blur in some cases and a lot less than needed in others.

With this PR the user can set the amount of blur samples using the `blurSamples` field:

```js
directionalLight.shadow.blurSamples = 10;
```

| radius | DEV | 4 samples | 8 samples | 16 samples |
|---|---|---|---|---|
| 2 | ![image](https://user-images.githubusercontent.com/734200/128273129-879e51bd-60af-49dc-9779-b33ea84bfbc7.png) | ![image](https://user-images.githubusercontent.com/734200/128272763-b84374cc-ba8c-4d34-9d41-32f008743fb4.png) | ![image](https://user-images.githubusercontent.com/734200/128272787-4f3f632f-9fa7-4571-ae37-ce7b88583bd4.png) | ![image](https://user-images.githubusercontent.com/734200/128272822-527f4c0a-621d-4a28-8145-d9b2e18c8e3d.png) |
| 16 | ![image](https://user-images.githubusercontent.com/734200/128273187-f78da1f4-d9c8-43f1-a29c-1091b6e609a0.png) | ![image](https://user-images.githubusercontent.com/734200/128272933-2fac1c93-1178-446a-9264-033bb8557ccd.png) | ![image](https://user-images.githubusercontent.com/734200/128272944-b4e482f0-57fb-434d-ab9c-c256d8a40784.png) | ![image](https://user-images.githubusercontent.com/734200/128272958-3ff6615b-8de7-418d-9bae-cef0d3e401ad.png) |




