### PR TITLE
WebGLRenderer: Set sRGBEncoding outputEncoding by default

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -6,7 +6,7 @@ import {
 	HalfFloatType,
 	FloatType,
 	UnsignedByteType,
-	LinearEncoding,
+	sRGBEncoding,
 	NoToneMapping,
 	LinearMipmapLinearFilter,
 	NearestFilter,
@@ -109,7 +109,7 @@ function WebGLRenderer( parameters = {} ) {
 	// physically based shading
 
 	this.gammaFactor = 2.0;	// for backwards compatibility
-	this.outputEncoding = LinearEncoding;
+	this.outputEncoding = sRGBEncoding;
 
 	// physical lights
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Test Pull Request to see how many things this change would break...
