### PR TITLE
MeshPhysicalMaterial: remove duplicated varying

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -16,7 +16,7 @@ export default /* glsl */`
 
 	#endif
 
-	vec3 pos = vWorldPosition.xyz / vWorldPosition.w;
+	vec3 pos = vWorldPosition;
 	vec3 v = normalize( cameraPosition - pos );
 	vec3 n = inverseTransformDirection( normal, viewMatrix );
 

--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -27,7 +27,7 @@ export default /* glsl */`
 	uniform mat4 modelMatrix;
 	uniform mat4 projectionMatrix;
 
-	varying vec4 vWorldPosition;
+	varying vec3 vWorldPosition;
 
 	vec3 getVolumeTransmissionRay(vec3 n, vec3 v, float thickness, float ior, mat4 modelMatrix) {
 		// Direction of refracted light.

--- a/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_vert.glsl.js
@@ -5,7 +5,7 @@ varying vec3 vViewPosition;
 
 #ifdef USE_TRANSMISSION
 
-	varying vec4 vWorldPosition;
+	varying vec3 vWorldPosition;
 
 #endif
 
@@ -51,7 +51,7 @@ void main() {
 
 #ifdef USE_TRANSMISSION
 
-	vWorldPosition = worldPosition;
+	vWorldPosition = worldPosition.xyz;
 
 #endif
 }


### PR DESCRIPTION
`vWorldPosition` already exists as a varying and it is a `vec3`.
