### PR TITLE
Examples: convert Utils files to esmodules

### DIFF
--- a/examples/jsm/curves/NURBSCurve.js
+++ b/examples/jsm/curves/NURBSCurve.js
@@ -3,7 +3,7 @@ import {
 	Vector3,
 	Vector4
 } from '../../../build/three.module.js';
-import { NURBSUtils } from '../curves/NURBSUtils.js';
+import * as NURBSUtils from '../curves/NURBSUtils.js';
 
 /**
  * NURBS curve object

--- a/examples/jsm/curves/NURBSSurface.js
+++ b/examples/jsm/curves/NURBSSurface.js
@@ -1,7 +1,7 @@
 import {
 	Vector4
 } from '../../../build/three.module.js';
-import { NURBSUtils } from '../curves/NURBSUtils.js';
+import * as NURBSUtils from '../curves/NURBSUtils.js';
 
 /**
  * NURBS surface object

--- a/examples/jsm/curves/NURBSUtils.js
+++ b/examples/jsm/curves/NURBSUtils.js
@@ -14,466 +14,474 @@ import {
  *	NURBS Utils
  **************************************************************/
 
-class NURBSUtils {
+/*
+Finds knot vector span.
 
-	/*
-	Finds knot vector span.
+p : degree
+u : parametric value
+U : knot vector
 
-	p : degree
-	u : parametric value
-	U : knot vector
+returns the span
+*/
+function findSpan( p, u, U ) {
 
-	returns the span
-	*/
-	static findSpan( p, u, U ) {
+	const n = U.length - p - 1;
 
-		const n = U.length - p - 1;
+	if ( u >= U[ n ] ) {
 
-		if ( u >= U[ n ] ) {
-
-			return n - 1;
-
-		}
-
-		if ( u <= U[ p ] ) {
-
-			return p;
-
-		}
-
-		let low = p;
-		let high = n;
-		let mid = Math.floor( ( low + high ) / 2 );
-
-		while ( u < U[ mid ] || u >= U[ mid + 1 ] ) {
-
-			if ( u < U[ mid ] ) {
-
-				high = mid;
-
-			} else {
-
-				low = mid;
-
-			}
-
-			mid = Math.floor( ( low + high ) / 2 );
-
-		}
-
-		return mid;
+		return n - 1;
 
 	}
 
+	if ( u <= U[ p ] ) {
 
-	/*
-	Calculate basis functions. See The NURBS Book, page 70, algorithm A2.2
-
-	span : span in which u lies
-	u    : parametric point
-	p    : degree
-	U    : knot vector
-
-	returns array[p+1] with basis functions values.
-	*/
-	static calcBasisFunctions( span, u, p, U ) {
-
-		const N = [];
-		const left = [];
-		const right = [];
-		N[ 0 ] = 1.0;
-
-		for ( let j = 1; j <= p; ++ j ) {
-
-			left[ j ] = u - U[ span + 1 - j ];
-			right[ j ] = U[ span + j ] - u;
-
-			let saved = 0.0;
-
-			for ( let r = 0; r < j; ++ r ) {
-
-				const rv = right[ r + 1 ];
-				const lv = left[ j - r ];
-				const temp = N[ r ] / ( rv + lv );
-				N[ r ] = saved + rv * temp;
-				saved = lv * temp;
-
-			 }
-
-			 N[ j ] = saved;
-
-		 }
-
-		 return N;
+		return p;
 
 	}
 
+	let low = p;
+	let high = n;
+	let mid = Math.floor( ( low + high ) / 2 );
 
-	/*
-	Calculate B-Spline curve points. See The NURBS Book, page 82, algorithm A3.1.
+	while ( u < U[ mid ] || u >= U[ mid + 1 ] ) {
 
-	p : degree of B-Spline
-	U : knot vector
-	P : control points (x, y, z, w)
-	u : parametric point
+		if ( u < U[ mid ] ) {
 
-	returns point for given u
-	*/
-	static calcBSplinePoint( p, U, P, u ) {
+			high = mid;
 
-		const span = this.findSpan( p, u, U );
-		const N = this.calcBasisFunctions( span, u, p, U );
-		const C = new Vector4( 0, 0, 0, 0 );
+		} else {
 
-		for ( let j = 0; j <= p; ++ j ) {
-
-			const point = P[ span - p + j ];
-			const Nj = N[ j ];
-			const wNj = point.w * Nj;
-			C.x += point.x * wNj;
-			C.y += point.y * wNj;
-			C.z += point.z * wNj;
-			C.w += point.w * Nj;
+			low = mid;
 
 		}
 
-		return C;
+		mid = Math.floor( ( low + high ) / 2 );
 
 	}
 
-
-	/*
-	Calculate basis functions derivatives. See The NURBS Book, page 72, algorithm A2.3.
-
-	span : span in which u lies
-	u    : parametric point
-	p    : degree
-	n    : number of derivatives to calculate
-	U    : knot vector
-
-	returns array[n+1][p+1] with basis functions derivatives
-	*/
-	static calcBasisFunctionDerivatives( span, u, p, n, U ) {
-
-		const zeroArr = [];
-		for ( let i = 0; i <= p; ++ i )
-			zeroArr[ i ] = 0.0;
-
-		const ders = [];
-
-		for ( let i = 0; i <= n; ++ i )
-			ders[ i ] = zeroArr.slice( 0 );
-
-		const ndu = [];
-
-		for ( let i = 0; i <= p; ++ i )
-			ndu[ i ] = zeroArr.slice( 0 );
-
-		ndu[ 0 ][ 0 ] = 1.0;
-
-		const left = zeroArr.slice( 0 );
-		const right = zeroArr.slice( 0 );
-
-		for ( let j = 1; j <= p; ++ j ) {
-
-			left[ j ] = u - U[ span + 1 - j ];
-			right[ j ] = U[ span + j ] - u;
-
-			let saved = 0.0;
-
-			for ( let r = 0; r < j; ++ r ) {
-
-				const rv = right[ r + 1 ];
-				const lv = left[ j - r ];
-				ndu[ j ][ r ] = rv + lv;
-
-				const temp = ndu[ r ][ j - 1 ] / ndu[ j ][ r ];
-				ndu[ r ][ j ] = saved + rv * temp;
-				saved = lv * temp;
-
-			}
-
-			ndu[ j ][ j ] = saved;
-
-		}
-
-		for ( let j = 0; j <= p; ++ j ) {
-
-			ders[ 0 ][ j ] = ndu[ j ][ p ];
-
-		}
-
-		for ( let r = 0; r <= p; ++ r ) {
-
-			let s1 = 0;
-			let s2 = 1;
-
-			const a = [];
-			for ( let i = 0; i <= p; ++ i ) {
-
-				a[ i ] = zeroArr.slice( 0 );
-
-			}
-
-			a[ 0 ][ 0 ] = 1.0;
-
-			for ( let k = 1; k <= n; ++ k ) {
-
-				let d = 0.0;
-				const rk = r - k;
-				const pk = p - k;
-
-				if ( r >= k ) {
-
-					a[ s2 ][ 0 ] = a[ s1 ][ 0 ] / ndu[ pk + 1 ][ rk ];
-					d = a[ s2 ][ 0 ] * ndu[ rk ][ pk ];
-
-				}
-
-				const j1 = ( rk >= - 1 ) ? 1 : - rk;
-				const j2 = ( r - 1 <= pk ) ? k - 1 : p - r;
-
-				for ( let j = j1; j <= j2; ++ j ) {
-
-					a[ s2 ][ j ] = ( a[ s1 ][ j ] - a[ s1 ][ j - 1 ] ) / ndu[ pk + 1 ][ rk + j ];
-					d += a[ s2 ][ j ] * ndu[ rk + j ][ pk ];
-
-				}
-
-				if ( r <= pk ) {
-
-					a[ s2 ][ k ] = - a[ s1 ][ k - 1 ] / ndu[ pk + 1 ][ r ];
-					d += a[ s2 ][ k ] * ndu[ r ][ pk ];
-
-				}
-
-				ders[ k ][ r ] = d;
-
-				const j = s1;
-				s1 = s2;
-				s2 = j;
-
-			}
-
-		}
-
-		let r = p;
-
-		for ( let k = 1; k <= n; ++ k ) {
-
-			for ( let j = 0; j <= p; ++ j ) {
-
-				ders[ k ][ j ] *= r;
-
-			}
-
-			r *= p - k;
-
-		}
-
-		return ders;
-
-	}
-
-
-	/*
-		Calculate derivatives of a B-Spline. See The NURBS Book, page 93, algorithm A3.2.
-
-		p  : degree
-		U  : knot vector
-		P  : control points
-		u  : Parametric points
-		nd : number of derivatives
-
-		returns array[d+1] with derivatives
-		*/
-	static calcBSplineDerivatives( p, U, P, u, nd ) {
-
-		const du = nd < p ? nd : p;
-		const CK = [];
-		const span = this.findSpan( p, u, U );
-		const nders = this.calcBasisFunctionDerivatives( span, u, p, du, U );
-		const Pw = [];
-
-		for ( let i = 0; i < P.length; ++ i ) {
-
-			const point = P[ i ].clone();
-			const w = point.w;
-
-			point.x *= w;
-			point.y *= w;
-			point.z *= w;
-
-			Pw[ i ] = point;
-
-		}
-
-		for ( let k = 0; k <= du; ++ k ) {
-
-			const point = Pw[ span - p ].clone().multiplyScalar( nders[ k ][ 0 ] );
-
-			for ( let j = 1; j <= p; ++ j ) {
-
-				point.add( Pw[ span - p + j ].clone().multiplyScalar( nders[ k ][ j ] ) );
-
-			}
-
-			CK[ k ] = point;
-
-		}
-
-		for ( let k = du + 1; k <= nd + 1; ++ k ) {
-
-			CK[ k ] = new Vector4( 0, 0, 0 );
-
-		}
-
-		return CK;
-
-	}
-
-
-	/*
-	Calculate "K over I"
-
-	returns k!/(i!(k-i)!)
-	*/
-	static calcKoverI( k, i ) {
-
-		let nom = 1;
-
-		for ( let j = 2; j <= k; ++ j ) {
-
-			nom *= j;
-
-		}
-
-		let denom = 1;
-
-		for ( let j = 2; j <= i; ++ j ) {
-
-			denom *= j;
-
-		}
-
-		for ( let j = 2; j <= k - i; ++ j ) {
-
-			denom *= j;
-
-		}
-
-		return nom / denom;
-
-	}
-
-
-	/*
-	Calculate derivatives (0-nd) of rational curve. See The NURBS Book, page 127, algorithm A4.2.
-
-	Pders : result of function calcBSplineDerivatives
-
-	returns array with derivatives for rational curve.
-	*/
-	static calcRationalCurveDerivatives( Pders ) {
-
-		const nd = Pders.length;
-		const Aders = [];
-		const wders = [];
-
-		for ( let i = 0; i < nd; ++ i ) {
-
-			const point = Pders[ i ];
-			Aders[ i ] = new Vector3( point.x, point.y, point.z );
-			wders[ i ] = point.w;
-
-		}
-
-		const CK = [];
-
-		for ( let k = 0; k < nd; ++ k ) {
-
-			const v = Aders[ k ].clone();
-
-			for ( let i = 1; i <= k; ++ i ) {
-
-				v.sub( CK[ k - i ].clone().multiplyScalar( this.calcKoverI( k, i ) * wders[ i ] ) );
-
-			}
-
-			CK[ k ] = v.divideScalar( wders[ 0 ] );
-
-		}
-
-		return CK;
-
-	}
-
-
-	/*
-	Calculate NURBS curve derivatives. See The NURBS Book, page 127, algorithm A4.2.
-
-	p  : degree
-	U  : knot vector
-	P  : control points in homogeneous space
-	u  : parametric points
-	nd : number of derivatives
-
-	returns array with derivatives.
-	*/
-	static calcNURBSDerivatives( p, U, P, u, nd ) {
-
-		const Pders = this.calcBSplineDerivatives( p, U, P, u, nd );
-		return this.calcRationalCurveDerivatives( Pders );
-
-	}
-
-
-	/*
-	Calculate rational B-Spline surface point. See The NURBS Book, page 134, algorithm A4.3.
-
-	p1, p2 : degrees of B-Spline surface
-	U1, U2 : knot vectors
-	P      : control points (x, y, z, w)
-	u, v   : parametric values
-
-	returns point for given (u, v)
-	*/
-	static calcSurfacePoint( p, q, U, V, P, u, v, target ) {
-
-		const uspan = this.findSpan( p, u, U );
-		const vspan = this.findSpan( q, v, V );
-		const Nu = this.calcBasisFunctions( uspan, u, p, U );
-		const Nv = this.calcBasisFunctions( vspan, v, q, V );
-		const temp = [];
-
-		for ( let l = 0; l <= q; ++ l ) {
-
-			temp[ l ] = new Vector4( 0, 0, 0, 0 );
-			for ( let k = 0; k <= p; ++ k ) {
-
-				const point = P[ uspan - p + k ][ vspan - q + l ].clone();
-				const w = point.w;
-				point.x *= w;
-				point.y *= w;
-				point.z *= w;
-				temp[ l ].add( point.multiplyScalar( Nu[ k ] ) );
-
-			}
-
-		}
-
-		const Sw = new Vector4( 0, 0, 0, 0 );
-		for ( let l = 0; l <= q; ++ l ) {
-
-			Sw.add( temp[ l ].multiplyScalar( Nv[ l ] ) );
-
-		}
-
-		Sw.divideScalar( Sw.w );
-		target.set( Sw.x, Sw.y, Sw.z );
-
-	}
+	return mid;
 
 }
 
-export { NURBSUtils };
+
+/*
+Calculate basis functions. See The NURBS Book, page 70, algorithm A2.2
+
+span : span in which u lies
+u    : parametric point
+p    : degree
+U    : knot vector
+
+returns array[p+1] with basis functions values.
+*/
+function calcBasisFunctions( span, u, p, U ) {
+
+	const N = [];
+	const left = [];
+	const right = [];
+	N[ 0 ] = 1.0;
+
+	for ( let j = 1; j <= p; ++ j ) {
+
+		left[ j ] = u - U[ span + 1 - j ];
+		right[ j ] = U[ span + j ] - u;
+
+		let saved = 0.0;
+
+		for ( let r = 0; r < j; ++ r ) {
+
+			const rv = right[ r + 1 ];
+			const lv = left[ j - r ];
+			const temp = N[ r ] / ( rv + lv );
+			N[ r ] = saved + rv * temp;
+			saved = lv * temp;
+
+		}
+
+		N[ j ] = saved;
+
+	}
+
+	return N;
+
+}
+
+
+/*
+Calculate B-Spline curve points. See The NURBS Book, page 82, algorithm A3.1.
+
+p : degree of B-Spline
+U : knot vector
+P : control points (x, y, z, w)
+u : parametric point
+
+returns point for given u
+*/
+function calcBSplinePoint( p, U, P, u ) {
+
+	const span = this.findSpan( p, u, U );
+	const N = this.calcBasisFunctions( span, u, p, U );
+	const C = new Vector4( 0, 0, 0, 0 );
+
+	for ( let j = 0; j <= p; ++ j ) {
+
+		const point = P[ span - p + j ];
+		const Nj = N[ j ];
+		const wNj = point.w * Nj;
+		C.x += point.x * wNj;
+		C.y += point.y * wNj;
+		C.z += point.z * wNj;
+		C.w += point.w * Nj;
+
+	}
+
+	return C;
+
+}
+
+
+/*
+Calculate basis functions derivatives. See The NURBS Book, page 72, algorithm A2.3.
+
+span : span in which u lies
+u    : parametric point
+p    : degree
+n    : number of derivatives to calculate
+U    : knot vector
+
+returns array[n+1][p+1] with basis functions derivatives
+*/
+function calcBasisFunctionDerivatives( span, u, p, n, U ) {
+
+	const zeroArr = [];
+	for ( let i = 0; i <= p; ++ i )
+		zeroArr[ i ] = 0.0;
+
+	const ders = [];
+
+	for ( let i = 0; i <= n; ++ i )
+		ders[ i ] = zeroArr.slice( 0 );
+
+	const ndu = [];
+
+	for ( let i = 0; i <= p; ++ i )
+		ndu[ i ] = zeroArr.slice( 0 );
+
+	ndu[ 0 ][ 0 ] = 1.0;
+
+	const left = zeroArr.slice( 0 );
+	const right = zeroArr.slice( 0 );
+
+	for ( let j = 1; j <= p; ++ j ) {
+
+		left[ j ] = u - U[ span + 1 - j ];
+		right[ j ] = U[ span + j ] - u;
+
+		let saved = 0.0;
+
+		for ( let r = 0; r < j; ++ r ) {
+
+			const rv = right[ r + 1 ];
+			const lv = left[ j - r ];
+			ndu[ j ][ r ] = rv + lv;
+
+			const temp = ndu[ r ][ j - 1 ] / ndu[ j ][ r ];
+			ndu[ r ][ j ] = saved + rv * temp;
+			saved = lv * temp;
+
+		}
+
+		ndu[ j ][ j ] = saved;
+
+	}
+
+	for ( let j = 0; j <= p; ++ j ) {
+
+		ders[ 0 ][ j ] = ndu[ j ][ p ];
+
+	}
+
+	for ( let r = 0; r <= p; ++ r ) {
+
+		let s1 = 0;
+		let s2 = 1;
+
+		const a = [];
+		for ( let i = 0; i <= p; ++ i ) {
+
+			a[ i ] = zeroArr.slice( 0 );
+
+		}
+
+		a[ 0 ][ 0 ] = 1.0;
+
+		for ( let k = 1; k <= n; ++ k ) {
+
+			let d = 0.0;
+			const rk = r - k;
+			const pk = p - k;
+
+			if ( r >= k ) {
+
+				a[ s2 ][ 0 ] = a[ s1 ][ 0 ] / ndu[ pk + 1 ][ rk ];
+				d = a[ s2 ][ 0 ] * ndu[ rk ][ pk ];
+
+			}
+
+			const j1 = ( rk >= - 1 ) ? 1 : - rk;
+			const j2 = ( r - 1 <= pk ) ? k - 1 : p - r;
+
+			for ( let j = j1; j <= j2; ++ j ) {
+
+				a[ s2 ][ j ] = ( a[ s1 ][ j ] - a[ s1 ][ j - 1 ] ) / ndu[ pk + 1 ][ rk + j ];
+				d += a[ s2 ][ j ] * ndu[ rk + j ][ pk ];
+
+			}
+
+			if ( r <= pk ) {
+
+				a[ s2 ][ k ] = - a[ s1 ][ k - 1 ] / ndu[ pk + 1 ][ r ];
+				d += a[ s2 ][ k ] * ndu[ r ][ pk ];
+
+			}
+
+			ders[ k ][ r ] = d;
+
+			const j = s1;
+			s1 = s2;
+			s2 = j;
+
+		}
+
+	}
+
+	let r = p;
+
+	for ( let k = 1; k <= n; ++ k ) {
+
+		for ( let j = 0; j <= p; ++ j ) {
+
+			ders[ k ][ j ] *= r;
+
+		}
+
+		r *= p - k;
+
+	}
+
+	return ders;
+
+}
+
+
+/*
+	Calculate derivatives of a B-Spline. See The NURBS Book, page 93, algorithm A3.2.
+
+	p  : degree
+	U  : knot vector
+	P  : control points
+	u  : Parametric points
+	nd : number of derivatives
+
+	returns array[d+1] with derivatives
+	*/
+function calcBSplineDerivatives( p, U, P, u, nd ) {
+
+	const du = nd < p ? nd : p;
+	const CK = [];
+	const span = this.findSpan( p, u, U );
+	const nders = this.calcBasisFunctionDerivatives( span, u, p, du, U );
+	const Pw = [];
+
+	for ( let i = 0; i < P.length; ++ i ) {
+
+		const point = P[ i ].clone();
+		const w = point.w;
+
+		point.x *= w;
+		point.y *= w;
+		point.z *= w;
+
+		Pw[ i ] = point;
+
+	}
+
+	for ( let k = 0; k <= du; ++ k ) {
+
+		const point = Pw[ span - p ].clone().multiplyScalar( nders[ k ][ 0 ] );
+
+		for ( let j = 1; j <= p; ++ j ) {
+
+			point.add( Pw[ span - p + j ].clone().multiplyScalar( nders[ k ][ j ] ) );
+
+		}
+
+		CK[ k ] = point;
+
+	}
+
+	for ( let k = du + 1; k <= nd + 1; ++ k ) {
+
+		CK[ k ] = new Vector4( 0, 0, 0 );
+
+	}
+
+	return CK;
+
+}
+
+
+/*
+Calculate "K over I"
+
+returns k!/(i!(k-i)!)
+*/
+function calcKoverI( k, i ) {
+
+	let nom = 1;
+
+	for ( let j = 2; j <= k; ++ j ) {
+
+		nom *= j;
+
+	}
+
+	let denom = 1;
+
+	for ( let j = 2; j <= i; ++ j ) {
+
+		denom *= j;
+
+	}
+
+	for ( let j = 2; j <= k - i; ++ j ) {
+
+		denom *= j;
+
+	}
+
+	return nom / denom;
+
+}
+
+
+/*
+Calculate derivatives (0-nd) of rational curve. See The NURBS Book, page 127, algorithm A4.2.
+
+Pders : result of function calcBSplineDerivatives
+
+returns array with derivatives for rational curve.
+*/
+function calcRationalCurveDerivatives( Pders ) {
+
+	const nd = Pders.length;
+	const Aders = [];
+	const wders = [];
+
+	for ( let i = 0; i < nd; ++ i ) {
+
+		const point = Pders[ i ];
+		Aders[ i ] = new Vector3( point.x, point.y, point.z );
+		wders[ i ] = point.w;
+
+	}
+
+	const CK = [];
+
+	for ( let k = 0; k < nd; ++ k ) {
+
+		const v = Aders[ k ].clone();
+
+		for ( let i = 1; i <= k; ++ i ) {
+
+			v.sub( CK[ k - i ].clone().multiplyScalar( this.calcKoverI( k, i ) * wders[ i ] ) );
+
+		}
+
+		CK[ k ] = v.divideScalar( wders[ 0 ] );
+
+	}
+
+	return CK;
+
+}
+
+
+/*
+Calculate NURBS curve derivatives. See The NURBS Book, page 127, algorithm A4.2.
+
+p  : degree
+U  : knot vector
+P  : control points in homogeneous space
+u  : parametric points
+nd : number of derivatives
+
+returns array with derivatives.
+*/
+function calcNURBSDerivatives( p, U, P, u, nd ) {
+
+	const Pders = this.calcBSplineDerivatives( p, U, P, u, nd );
+	return this.calcRationalCurveDerivatives( Pders );
+
+}
+
+
+/*
+Calculate rational B-Spline surface point. See The NURBS Book, page 134, algorithm A4.3.
+
+p1, p2 : degrees of B-Spline surface
+U1, U2 : knot vectors
+P      : control points (x, y, z, w)
+u, v   : parametric values
+
+returns point for given (u, v)
+*/
+function calcSurfacePoint( p, q, U, V, P, u, v, target ) {
+
+	const uspan = this.findSpan( p, u, U );
+	const vspan = this.findSpan( q, v, V );
+	const Nu = this.calcBasisFunctions( uspan, u, p, U );
+	const Nv = this.calcBasisFunctions( vspan, v, q, V );
+	const temp = [];
+
+	for ( let l = 0; l <= q; ++ l ) {
+
+		temp[ l ] = new Vector4( 0, 0, 0, 0 );
+		for ( let k = 0; k <= p; ++ k ) {
+
+			const point = P[ uspan - p + k ][ vspan - q + l ].clone();
+			const w = point.w;
+			point.x *= w;
+			point.y *= w;
+			point.z *= w;
+			temp[ l ].add( point.multiplyScalar( Nu[ k ] ) );
+
+		}
+
+	}
+
+	const Sw = new Vector4( 0, 0, 0, 0 );
+	for ( let l = 0; l <= q; ++ l ) {
+
+		Sw.add( temp[ l ].multiplyScalar( Nv[ l ] ) );
+
+	}
+
+	Sw.divideScalar( Sw.w );
+	target.set( Sw.x, Sw.y, Sw.z );
+
+}
+
+
+
+export {
+	findSpan,
+	calcBasisFunctions,
+	calcBSplinePoint,
+	calcBasisFunctionDerivatives,
+	calcBSplineDerivatives,
+	calcKoverI,
+	calcRationalCurveDerivatives,
+	calcNURBSDerivatives,
+	calcSurfacePoint,
+};

--- a/examples/jsm/utils/CameraUtils.js
+++ b/examples/jsm/utils/CameraUtils.js
@@ -13,64 +13,61 @@ const _va = /*@__PURE__*/ new Vector3(), // from pe to pa
 	_vec = /*@__PURE__*/ new Vector3(), // temporary vector
 	_quat = /*@__PURE__*/ new Quaternion(); // temporary quaternion
 
-class CameraUtils {
 
-	/** Set a PerspectiveCamera's projectionMatrix and quaternion
-	 * to exactly frame the corners of an arbitrary rectangle.
-	 * NOTE: This function ignores the standard parameters;
-	 * do not call updateProjectionMatrix() after this!
-	 * @param {Vector3} bottomLeftCorner
-	 * @param {Vector3} bottomRightCorner
-	 * @param {Vector3} topLeftCorner
-	 * @param {boolean} estimateViewFrustum */
-	static frameCorners( camera, bottomLeftCorner, bottomRightCorner, topLeftCorner, estimateViewFrustum = false ) {
+/** Set a PerspectiveCamera's projectionMatrix and quaternion
+ * to exactly frame the corners of an arbitrary rectangle.
+ * NOTE: This function ignores the standard parameters;
+ * do not call updateProjectionMatrix() after this!
+ * @param {Vector3} bottomLeftCorner
+ * @param {Vector3} bottomRightCorner
+ * @param {Vector3} topLeftCorner
+ * @param {boolean} estimateViewFrustum */
+function frameCorners( camera, bottomLeftCorner, bottomRightCorner, topLeftCorner, estimateViewFrustum = false ) {
 
-		const pa = bottomLeftCorner, pb = bottomRightCorner, pc = topLeftCorner;
-		const pe = camera.position; // eye position
-		const n = camera.near; // distance of near clipping plane
-		const f = camera.far; //distance of far clipping plane
+	const pa = bottomLeftCorner, pb = bottomRightCorner, pc = topLeftCorner;
+	const pe = camera.position; // eye position
+	const n = camera.near; // distance of near clipping plane
+	const f = camera.far; //distance of far clipping plane
 
-		_vr.copy( pb ).sub( pa ).normalize();
-		_vu.copy( pc ).sub( pa ).normalize();
-		_vn.crossVectors( _vr, _vu ).normalize();
+	_vr.copy( pb ).sub( pa ).normalize();
+	_vu.copy( pc ).sub( pa ).normalize();
+	_vn.crossVectors( _vr, _vu ).normalize();
 
-		_va.copy( pa ).sub( pe ); // from pe to pa
-		_vb.copy( pb ).sub( pe ); // from pe to pb
-		_vc.copy( pc ).sub( pe ); // from pe to pc
+	_va.copy( pa ).sub( pe ); // from pe to pa
+	_vb.copy( pb ).sub( pe ); // from pe to pb
+	_vc.copy( pc ).sub( pe ); // from pe to pc
 
-		const d = - _va.dot( _vn );	// distance from eye to screen
-		const l = _vr.dot( _va ) * n / d; // distance to left screen edge
-		const r = _vr.dot( _vb ) * n / d; // distance to right screen edge
-		const b = _vu.dot( _va ) * n / d; // distance to bottom screen edge
-		const t = _vu.dot( _vc ) * n / d; // distance to top screen edge
+	const d = - _va.dot( _vn );	// distance from eye to screen
+	const l = _vr.dot( _va ) * n / d; // distance to left screen edge
+	const r = _vr.dot( _vb ) * n / d; // distance to right screen edge
+	const b = _vu.dot( _va ) * n / d; // distance to bottom screen edge
+	const t = _vu.dot( _vc ) * n / d; // distance to top screen edge
 
-		// Set the camera rotation to match the focal plane to the corners' plane
-		_quat.setFromUnitVectors( _vec.set( 0, 1, 0 ), _vu );
-		camera.quaternion.setFromUnitVectors( _vec.set( 0, 0, 1 ).applyQuaternion( _quat ), _vn ).multiply( _quat );
+	// Set the camera rotation to match the focal plane to the corners' plane
+	_quat.setFromUnitVectors( _vec.set( 0, 1, 0 ), _vu );
+	camera.quaternion.setFromUnitVectors( _vec.set( 0, 0, 1 ).applyQuaternion( _quat ), _vn ).multiply( _quat );
 
-		// Set the off-axis projection matrix to match the corners
-		camera.projectionMatrix.set( 2.0 * n / ( r - l ), 0.0,
-			( r + l ) / ( r - l ), 0.0, 0.0,
-			2.0 * n / ( t - b ),
-			( t + b ) / ( t - b ), 0.0, 0.0, 0.0,
-			( f + n ) / ( n - f ),
-			2.0 * f * n / ( n - f ), 0.0, 0.0, - 1.0, 0.0 );
-		camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+	// Set the off-axis projection matrix to match the corners
+	camera.projectionMatrix.set( 2.0 * n / ( r - l ), 0.0,
+		( r + l ) / ( r - l ), 0.0, 0.0,
+		2.0 * n / ( t - b ),
+		( t + b ) / ( t - b ), 0.0, 0.0, 0.0,
+		( f + n ) / ( n - f ),
+		2.0 * f * n / ( n - f ), 0.0, 0.0, - 1.0, 0.0 );
+	camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
 
-		// FoV estimation to fix frustum culling
-		if ( estimateViewFrustum ) {
+	// FoV estimation to fix frustum culling
+	if ( estimateViewFrustum ) {
 
-			// Set fieldOfView to a conservative estimate
-			// to make frustum tall/wide enough to encompass it
-			camera.fov =
-				MathUtils.RAD2DEG / Math.min( 1.0, camera.aspect ) *
-				Math.atan( ( _vec.copy( pb ).sub( pa ).length() +
-						   ( _vec.copy( pc ).sub( pa ).length() ) ) / _va.length() );
-
-		}
+		// Set fieldOfView to a conservative estimate
+		// to make frustum tall/wide enough to encompass it
+		camera.fov =
+			MathUtils.RAD2DEG / Math.min( 1.0, camera.aspect ) *
+			Math.atan( ( _vec.copy( pb ).sub( pa ).length() +
+							( _vec.copy( pc ).sub( pa ).length() ) ) / _va.length() );
 
 	}
 
 }
 
-export { CameraUtils };
+export { frameCorners };

--- a/examples/jsm/utils/GeometryCompressionUtils.js
+++ b/examples/jsm/utils/GeometryCompressionUtils.js
@@ -9,907 +9,657 @@ import {
 	BufferAttribute,
 	Matrix3,
 	Matrix4,
-	MeshPhongMaterial,
-	ShaderChunk,
-	ShaderLib,
-	UniformsUtils,
 	Vector3
 } from '../../../build/three.module.js';
-
-class GeometryCompressionUtils {
-
-	/**
-		 * Make the input mesh.geometry's normal attribute encoded and compressed by 3 different methods.
-		 * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the normal data.
-		 *
-		 * @param {THREE.Mesh} mesh
-		 * @param {String} encodeMethod		"DEFAULT" || "OCT1Byte" || "OCT2Byte" || "ANGLES"
-		 *
-		 */
-	static compressNormals( mesh, encodeMethod ) {
-
-		if ( ! mesh.geometry ) {
-
-			console.error( 'Mesh must contain geometry. ' );
-
-		}
-
-		const normal = mesh.geometry.attributes.normal;
-
-		if ( ! normal ) {
-
-			console.error( 'Geometry must contain normal attribute. ' );
-
-		}
-
-		if ( normal.isPacked ) return;
-
-		if ( normal.itemSize != 3 ) {
-
-			console.error( 'normal.itemSize is not 3, which cannot be encoded. ' );
-
-		}
-
-		const array = normal.array;
-		const count = normal.count;
-
-		let result;
-		if ( encodeMethod == 'DEFAULT' ) {
-
-			// TODO: Add 1 byte to the result, making the encoded length to be 4 bytes.
-			result = new Uint8Array( count * 3 );
-
-			for ( let idx = 0; idx < array.length; idx += 3 ) {
-
-				const encoded = EncodingFuncs.defaultEncode( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 1 );
-
-				result[ idx + 0 ] = encoded[ 0 ];
-				result[ idx + 1 ] = encoded[ 1 ];
-				result[ idx + 2 ] = encoded[ 2 ];
-
-			}
-
-			mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 3, true ) );
-			mesh.geometry.attributes.normal.bytes = result.length * 1;
-
-		} else if ( encodeMethod == 'OCT1Byte' ) {
-
-			/**
-			* It is not recommended to use 1-byte octahedron normals encoding unless you want to extremely reduce the memory usage
-			* As it makes vertex data not aligned to a 4 byte boundary which may harm some WebGL implementations and sometimes the normal distortion is visible
-			* Please refer to @zeux 's comments in https://github.com/mrdoob/three.js/pull/18208
-			*/
-
-			result = new Int8Array( count * 2 );
-
-			for ( let idx = 0; idx < array.length; idx += 3 ) {
-
-				const encoded = EncodingFuncs.octEncodeBest( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 1 );
-
-				result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
-				result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
-
-			}
-
-			mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
-			mesh.geometry.attributes.normal.bytes = result.length * 1;
-
-		} else if ( encodeMethod == 'OCT2Byte' ) {
-
-			result = new Int16Array( count * 2 );
-
-			for ( let idx = 0; idx < array.length; idx += 3 ) {
-
-				const encoded = EncodingFuncs.octEncodeBest( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 2 );
-
-				result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
-				result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
-
-			}
-
-			mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
-			mesh.geometry.attributes.normal.bytes = result.length * 2;
-
-		} else if ( encodeMethod == 'ANGLES' ) {
-
-			result = new Uint16Array( count * 2 );
-
-			for ( let idx = 0; idx < array.length; idx += 3 ) {
-
-				const encoded = EncodingFuncs.anglesEncode( array[ idx ], array[ idx + 1 ], array[ idx + 2 ] );
-
-				result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
-				result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
-
-			}
-
-			mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
-			mesh.geometry.attributes.normal.bytes = result.length * 2;
-
-		} else {
-
-			console.error( 'Unrecognized encoding method, should be `DEFAULT` or `ANGLES` or `OCT`. ' );
-
-		}
-
-		mesh.geometry.attributes.normal.needsUpdate = true;
-		mesh.geometry.attributes.normal.isPacked = true;
-		mesh.geometry.attributes.normal.packingMethod = encodeMethod;
-
-		// modify material
-		if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
-
-			mesh.material = new PackedPhongMaterial().copy( mesh.material );
-
-		}
-
-		if ( encodeMethod == 'ANGLES' ) {
-
-			mesh.material.defines.USE_PACKED_NORMAL = 0;
-
-		}
-
-		if ( encodeMethod == 'OCT1Byte' ) {
-
-			mesh.material.defines.USE_PACKED_NORMAL = 1;
-
-		}
-
-		if ( encodeMethod == 'OCT2Byte' ) {
-
-			mesh.material.defines.USE_PACKED_NORMAL = 1;
-
-		}
-
-		if ( encodeMethod == 'DEFAULT' ) {
-
-			mesh.material.defines.USE_PACKED_NORMAL = 2;
-
-		}
-
-	}
-
-
-	/**
-		 * Make the input mesh.geometry's position attribute encoded and compressed.
-		 * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the position data.
-		 *
-		 * @param {THREE.Mesh} mesh
-		 *
-		 */
-	static compressPositions( mesh ) {
-
-		if ( ! mesh.geometry ) {
-
-			console.error( 'Mesh must contain geometry. ' );
-
-		}
-
-		const position = mesh.geometry.attributes.position;
-
-		if ( ! position ) {
-
-			console.error( 'Geometry must contain position attribute. ' );
-
-		}
-
-		if ( position.isPacked ) return;
-
-		if ( position.itemSize != 3 ) {
-
-			console.error( 'position.itemSize is not 3, which cannot be packed. ' );
-
-		}
-
-		const array = position.array;
-		const encodingBytes = 2;
-
-		const result = EncodingFuncs.quantizedEncode( array, encodingBytes );
-
-		const quantized = result.quantized;
-		const decodeMat = result.decodeMat;
-
-		// IMPORTANT: calculate original geometry bounding info first, before updating packed positions
-		if ( mesh.geometry.boundingBox == null ) mesh.geometry.computeBoundingBox();
-		if ( mesh.geometry.boundingSphere == null ) mesh.geometry.computeBoundingSphere();
-
-		mesh.geometry.setAttribute( 'position', new BufferAttribute( quantized, 3 ) );
-		mesh.geometry.attributes.position.isPacked = true;
-		mesh.geometry.attributes.position.needsUpdate = true;
-		mesh.geometry.attributes.position.bytes = quantized.length * encodingBytes;
-
-		// modify material
-		if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
-
-			mesh.material = new PackedPhongMaterial().copy( mesh.material );
-
-		}
-
-		mesh.material.defines.USE_PACKED_POSITION = 0;
-
-		mesh.material.uniforms.quantizeMatPos.value = decodeMat;
-		mesh.material.uniforms.quantizeMatPos.needsUpdate = true;
-
-	}
-
-	/**
-		 * Make the input mesh.geometry's uv attribute encoded and compressed.
-		 * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the uv data.
-		 *
-		 * @param {THREE.Mesh} mesh
-		 *
-		 */
-	static compressUvs( mesh ) {
-
-		if ( ! mesh.geometry ) {
-
-			console.error( 'Mesh must contain geometry property. ' );
-
-		}
-
-		const uvs = mesh.geometry.attributes.uv;
-
-		if ( ! uvs ) {
-
-			console.error( 'Geometry must contain uv attribute. ' );
-
-		}
-
-		if ( uvs.isPacked ) return;
-
-		const range = { min: Infinity, max: - Infinity };
-
-		const array = uvs.array;
-
-		for ( let i = 0; i < array.length; i ++ ) {
-
-			range.min = Math.min( range.min, array[ i ] );
-			range.max = Math.max( range.max, array[ i ] );
-
-		}
-
-		let result;
-
-		if ( range.min >= - 1.0 && range.max <= 1.0 ) {
-
-			// use default encoding method
-			result = new Uint16Array( array.length );
-
-			for ( let i = 0; i < array.length; i += 2 ) {
-
-				const encoded = EncodingFuncs.defaultEncode( array[ i ], array[ i + 1 ], 0, 2 );
-
-				result[ i ] = encoded[ 0 ];
-				result[ i + 1 ] = encoded[ 1 ];
-
-			}
-
-			mesh.geometry.setAttribute( 'uv', new BufferAttribute( result, 2, true ) );
-			mesh.geometry.attributes.uv.isPacked = true;
-			mesh.geometry.attributes.uv.needsUpdate = true;
-			mesh.geometry.attributes.uv.bytes = result.length * 2;
-
-			if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
-
-				mesh.material = new PackedPhongMaterial().copy( mesh.material );
-
-			}
-
-			mesh.material.defines.USE_PACKED_UV = 0;
-
-		} else {
-
-			// use quantized encoding method
-			result = EncodingFuncs.quantizedEncodeUV( array, 2 );
-
-			mesh.geometry.setAttribute( 'uv', new BufferAttribute( result.quantized, 2 ) );
-			mesh.geometry.attributes.uv.isPacked = true;
-			mesh.geometry.attributes.uv.needsUpdate = true;
-			mesh.geometry.attributes.uv.bytes = result.quantized.length * 2;
-
-			if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
-
-				mesh.material = new PackedPhongMaterial().copy( mesh.material );
-
-			}
-
-			mesh.material.defines.USE_PACKED_UV = 1;
-
-			mesh.material.uniforms.quantizeMatUV.value = result.decodeMat;
-			mesh.material.uniforms.quantizeMatUV.needsUpdate = true;
-
-		}
-
-	}
-
-}
-
-class EncodingFuncs {
-
-	static defaultEncode( x, y, z, bytes ) {
-
-		if ( bytes == 1 ) {
-
-			const tmpx = Math.round( ( x + 1 ) * 0.5 * 255 );
-			const tmpy = Math.round( ( y + 1 ) * 0.5 * 255 );
-			const tmpz = Math.round( ( z + 1 ) * 0.5 * 255 );
-			return new Uint8Array( [ tmpx, tmpy, tmpz ] );
-
-		} else if ( bytes == 2 ) {
-
-			const tmpx = Math.round( ( x + 1 ) * 0.5 * 65535 );
-			const tmpy = Math.round( ( y + 1 ) * 0.5 * 65535 );
-			const tmpz = Math.round( ( z + 1 ) * 0.5 * 65535 );
-			return new Uint16Array( [ tmpx, tmpy, tmpz ] );
-
-		} else {
-
-			console.error( 'number of bytes must be 1 or 2' );
-
-		}
-
-	}
-
-	static defaultDecode( array, bytes ) {
-
-		if ( bytes == 1 ) {
-
-			return [
-				( ( array[ 0 ] / 255 ) * 2.0 ) - 1.0,
-				( ( array[ 1 ] / 255 ) * 2.0 ) - 1.0,
-				( ( array[ 2 ] / 255 ) * 2.0 ) - 1.0,
-			];
-
-		} else if ( bytes == 2 ) {
-
-			return [
-				( ( array[ 0 ] / 65535 ) * 2.0 ) - 1.0,
-				( ( array[ 1 ] / 65535 ) * 2.0 ) - 1.0,
-				( ( array[ 2 ] / 65535 ) * 2.0 ) - 1.0,
-			];
-
-		} else {
-
-			console.error( 'number of bytes must be 1 or 2' );
-
-		}
-
-	}
-
-	// for `Angles` encoding
-	static anglesEncode( x, y, z ) {
-
-		const normal0 = parseInt( 0.5 * ( 1.0 + Math.atan2( y, x ) / Math.PI ) * 65535 );
-		const normal1 = parseInt( 0.5 * ( 1.0 + z ) * 65535 );
-		return new Uint16Array( [ normal0, normal1 ] );
-
-	}
-
-	// for `Octahedron` encoding
-	static octEncodeBest( x, y, z, bytes ) {
-
-		let oct, dec, best, currentCos, bestCos;
-
-		// Test various combinations of ceil and floor
-		// to minimize rounding errors
-		best = oct = octEncodeVec3( x, y, z, 'floor', 'floor' );
-		dec = octDecodeVec2( oct );
-		bestCos = dot( x, y, z, dec );
-
-		oct = octEncodeVec3( x, y, z, 'ceil', 'floor' );
-		dec = octDecodeVec2( oct );
-		currentCos = dot( x, y, z, dec );
-
-		if ( currentCos > bestCos ) {
-
-			best = oct;
-			bestCos = currentCos;
-
-		}
-
-		oct = octEncodeVec3( x, y, z, 'floor', 'ceil' );
-		dec = octDecodeVec2( oct );
-		currentCos = dot( x, y, z, dec );
-
-		if ( currentCos > bestCos ) {
-
-			best = oct;
-			bestCos = currentCos;
-
-		}
-
-		oct = octEncodeVec3( x, y, z, 'ceil', 'ceil' );
-		dec = octDecodeVec2( oct );
-		currentCos = dot( x, y, z, dec );
-
-		if ( currentCos > bestCos ) {
-
-			best = oct;
-
-		}
-
-		return best;
-
-		function octEncodeVec3( x0, y0, z0, xfunc, yfunc ) {
-
-			let x = x0 / ( Math.abs( x0 ) + Math.abs( y0 ) + Math.abs( z0 ) );
-			let y = y0 / ( Math.abs( x0 ) + Math.abs( y0 ) + Math.abs( z0 ) );
-
-			if ( z < 0 ) {
-
-				const tempx = ( 1 - Math.abs( y ) ) * ( x >= 0 ? 1 : - 1 );
-				const tempy = ( 1 - Math.abs( x ) ) * ( y >= 0 ? 1 : - 1 );
-
-				x = tempx;
-				y = tempy;
-
-				let diff = 1 - Math.abs( x ) - Math.abs( y );
-				if ( diff > 0 ) {
-
-					diff += 0.001;
-					x += x > 0 ? diff / 2 : - diff / 2;
-					y += y > 0 ? diff / 2 : - diff / 2;
-
-				}
-
-			}
-
-			if ( bytes == 1 ) {
-
-				return new Int8Array( [
-					Math[ xfunc ]( x * 127.5 + ( x < 0 ? 1 : 0 ) ),
-					Math[ yfunc ]( y * 127.5 + ( y < 0 ? 1 : 0 ) )
-				] );
-
-			}
-
-			if ( bytes == 2 ) {
-
-				return new Int16Array( [
-					Math[ xfunc ]( x * 32767.5 + ( x < 0 ? 1 : 0 ) ),
-					Math[ yfunc ]( y * 32767.5 + ( y < 0 ? 1 : 0 ) )
-				] );
-
-			}
-
-
-		}
-
-		function octDecodeVec2( oct ) {
-
-			let x = oct[ 0 ];
-			let y = oct[ 1 ];
-
-			if ( bytes == 1 ) {
-
-				x /= x < 0 ? 127 : 128;
-				y /= y < 0 ? 127 : 128;
-
-			} else if ( bytes == 2 ) {
-
-				x /= x < 0 ? 32767 : 32768;
-				y /= y < 0 ? 32767 : 32768;
-
-			}
-
-
-			const z = 1 - Math.abs( x ) - Math.abs( y );
-
-			if ( z < 0 ) {
-
-				const tmpx = x;
-				x = ( 1 - Math.abs( y ) ) * ( x >= 0 ? 1 : - 1 );
-				y = ( 1 - Math.abs( tmpx ) ) * ( y >= 0 ? 1 : - 1 );
-
-			}
-
-			const length = Math.sqrt( x * x + y * y + z * z );
-
-			return [
-				x / length,
-				y / length,
-				z / length
-			];
-
-		}
-
-		function dot( x, y, z, vec3 ) {
-
-			return x * vec3[ 0 ] + y * vec3[ 1 ] + z * vec3[ 2 ];
-
-		}
-
-	}
-
-	static quantizedEncode( array, bytes ) {
-
-		let quantized, segments;
-
-		if ( bytes == 1 ) {
-
-			quantized = new Uint8Array( array.length );
-			segments = 255;
-
-		} else if ( bytes == 2 ) {
-
-			quantized = new Uint16Array( array.length );
-			segments = 65535;
-
-		} else {
-
-			console.error( 'number of bytes error! ' );
-
-		}
-
-		const decodeMat = new Matrix4();
-
-		const min = new Float32Array( 3 );
-		const max = new Float32Array( 3 );
-
-		min[ 0 ] = min[ 1 ] = min[ 2 ] = Number.MAX_VALUE;
-		max[ 0 ] = max[ 1 ] = max[ 2 ] = - Number.MAX_VALUE;
-
-		for ( let i = 0; i < array.length; i += 3 ) {
-
-			min[ 0 ] = Math.min( min[ 0 ], array[ i + 0 ] );
-			min[ 1 ] = Math.min( min[ 1 ], array[ i + 1 ] );
-			min[ 2 ] = Math.min( min[ 2 ], array[ i + 2 ] );
-			max[ 0 ] = Math.max( max[ 0 ], array[ i + 0 ] );
-			max[ 1 ] = Math.max( max[ 1 ], array[ i + 1 ] );
-			max[ 2 ] = Math.max( max[ 2 ], array[ i + 2 ] );
-
-		}
-
-		decodeMat.scale( new Vector3(
-			( max[ 0 ] - min[ 0 ] ) / segments,
-			( max[ 1 ] - min[ 1 ] ) / segments,
-			( max[ 2 ] - min[ 2 ] ) / segments
-		) );
-
-		decodeMat.elements[ 12 ] = min[ 0 ];
-		decodeMat.elements[ 13 ] = min[ 1 ];
-		decodeMat.elements[ 14 ] = min[ 2 ];
-
-		decodeMat.transpose();
-
-
-		const multiplier = new Float32Array( [
-			max[ 0 ] !== min[ 0 ] ? segments / ( max[ 0 ] - min[ 0 ] ) : 0,
-			max[ 1 ] !== min[ 1 ] ? segments / ( max[ 1 ] - min[ 1 ] ) : 0,
-			max[ 2 ] !== min[ 2 ] ? segments / ( max[ 2 ] - min[ 2 ] ) : 0
-		] );
-
-		for ( let i = 0; i < array.length; i += 3 ) {
-
-			quantized[ i + 0 ] = Math.floor( ( array[ i + 0 ] - min[ 0 ] ) * multiplier[ 0 ] );
-			quantized[ i + 1 ] = Math.floor( ( array[ i + 1 ] - min[ 1 ] ) * multiplier[ 1 ] );
-			quantized[ i + 2 ] = Math.floor( ( array[ i + 2 ] - min[ 2 ] ) * multiplier[ 2 ] );
-
-		}
-
-		return {
-			quantized: quantized,
-			decodeMat: decodeMat
-		};
-
-	}
-
-	static quantizedEncodeUV( array, bytes ) {
-
-		let quantized, segments;
-
-		if ( bytes == 1 ) {
-
-			quantized = new Uint8Array( array.length );
-			segments = 255;
-
-		} else if ( bytes == 2 ) {
-
-			quantized = new Uint16Array( array.length );
-			segments = 65535;
-
-		} else {
-
-			console.error( 'number of bytes error! ' );
-
-		}
-
-		const decodeMat = new Matrix3();
-
-		const min = new Float32Array( 2 );
-		const max = new Float32Array( 2 );
-
-		min[ 0 ] = min[ 1 ] = Number.MAX_VALUE;
-		max[ 0 ] = max[ 1 ] = - Number.MAX_VALUE;
-
-		for ( let i = 0; i < array.length; i += 2 ) {
-
-			min[ 0 ] = Math.min( min[ 0 ], array[ i + 0 ] );
-			min[ 1 ] = Math.min( min[ 1 ], array[ i + 1 ] );
-			max[ 0 ] = Math.max( max[ 0 ], array[ i + 0 ] );
-			max[ 1 ] = Math.max( max[ 1 ], array[ i + 1 ] );
-
-		}
-
-		decodeMat.scale(
-			( max[ 0 ] - min[ 0 ] ) / segments,
-			( max[ 1 ] - min[ 1 ] ) / segments
-		);
-
-		decodeMat.elements[ 6 ] = min[ 0 ];
-		decodeMat.elements[ 7 ] = min[ 1 ];
-
-		decodeMat.transpose();
-
-		const multiplier = new Float32Array( [
-			max[ 0 ] !== min[ 0 ] ? segments / ( max[ 0 ] - min[ 0 ] ) : 0,
-			max[ 1 ] !== min[ 1 ] ? segments / ( max[ 1 ] - min[ 1 ] ) : 0
-		] );
-
-		for ( let i = 0; i < array.length; i += 2 ) {
-
-			quantized[ i + 0 ] = Math.floor( ( array[ i + 0 ] - min[ 0 ] ) * multiplier[ 0 ] );
-			quantized[ i + 1 ] = Math.floor( ( array[ i + 1 ] - min[ 1 ] ) * multiplier[ 1 ] );
-
-		}
-
-		return {
-			quantized: quantized,
-			decodeMat: decodeMat
-		};
-
-	}
-
-}
+import { PackedPhongMaterial } from './PackedPhongMaterial.js';
 
 
 
 /**
- * `PackedPhongMaterial` inherited from THREE.MeshPhongMaterial
+ * Make the input mesh.geometry's normal attribute encoded and compressed by 3 different methods.
+ * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the normal data.
  *
- * @param {Object} parameters
+ * @param {THREE.Mesh} mesh
+ * @param {String} encodeMethod		"DEFAULT" || "OCT1Byte" || "OCT2Byte" || "ANGLES"
+ *
  */
-class PackedPhongMaterial extends MeshPhongMaterial {
+function compressNormals( mesh, encodeMethod ) {
 
-	constructor( parameters ) {
+	if ( ! mesh.geometry ) {
 
-		super();
+		console.error( 'Mesh must contain geometry. ' );
 
-		this.defines = {};
-		this.type = 'PackedPhongMaterial';
-		this.uniforms = UniformsUtils.merge( [
+	}
 
-			ShaderLib.phong.uniforms,
+	const normal = mesh.geometry.attributes.normal;
 
-			{
-				quantizeMatPos: { value: null },
-				quantizeMatUV: { value: null }
-			}
+	if ( ! normal ) {
 
-		] );
+		console.error( 'Geometry must contain normal attribute. ' );
 
-		this.vertexShader = [
-			'#define PHONG',
+	}
 
-			'varying vec3 vViewPosition;',
+	if ( normal.isPacked ) return;
 
-			'#ifndef FLAT_SHADED',
-			'varying vec3 vNormal;',
-			'#endif',
+	if ( normal.itemSize != 3 ) {
 
-			ShaderChunk.common,
-			ShaderChunk.uv_pars_vertex,
-			ShaderChunk.uv2_pars_vertex,
-			ShaderChunk.displacementmap_pars_vertex,
-			ShaderChunk.envmap_pars_vertex,
-			ShaderChunk.color_pars_vertex,
-			ShaderChunk.fog_pars_vertex,
-			ShaderChunk.morphtarget_pars_vertex,
-			ShaderChunk.skinning_pars_vertex,
-			ShaderChunk.shadowmap_pars_vertex,
-			ShaderChunk.logdepthbuf_pars_vertex,
-			ShaderChunk.clipping_planes_pars_vertex,
+		console.error( 'normal.itemSize is not 3, which cannot be encoded. ' );
 
-			`#ifdef USE_PACKED_NORMAL
-					#if USE_PACKED_NORMAL == 0
-						vec3 decodeNormal(vec3 packedNormal)
-						{
-							float x = packedNormal.x * 2.0 - 1.0;
-							float y = packedNormal.y * 2.0 - 1.0;
-							vec2 scth = vec2(sin(x * PI), cos(x * PI));
-							vec2 scphi = vec2(sqrt(1.0 - y * y), y);
-							return normalize( vec3(scth.y * scphi.x, scth.x * scphi.x, scphi.y) );
-						}
-					#endif
+	}
 
-					#if USE_PACKED_NORMAL == 1
-						vec3 decodeNormal(vec3 packedNormal)
-						{
-							vec3 v = vec3(packedNormal.xy, 1.0 - abs(packedNormal.x) - abs(packedNormal.y));
-							if (v.z < 0.0)
-							{
-								v.xy = (1.0 - abs(v.yx)) * vec2((v.x >= 0.0) ? +1.0 : -1.0, (v.y >= 0.0) ? +1.0 : -1.0);
-							}
-							return normalize(v);
-						}
-					#endif
+	const array = normal.array;
+	const count = normal.count;
 
-					#if USE_PACKED_NORMAL == 2
-						vec3 decodeNormal(vec3 packedNormal)
-						{
-							vec3 v = (packedNormal * 2.0) - 1.0;
-							return normalize(v);
-						}
-					#endif
-				#endif`,
+	let result;
+	if ( encodeMethod == 'DEFAULT' ) {
 
-			`#ifdef USE_PACKED_POSITION
-					#if USE_PACKED_POSITION == 0
-						uniform mat4 quantizeMatPos;
-					#endif
-				#endif`,
+		// TODO: Add 1 byte to the result, making the encoded length to be 4 bytes.
+		result = new Uint8Array( count * 3 );
 
-			`#ifdef USE_PACKED_UV
-					#if USE_PACKED_UV == 1
-						uniform mat3 quantizeMatUV;
-					#endif
-				#endif`,
+		for ( let idx = 0; idx < array.length; idx += 3 ) {
 
-			`#ifdef USE_PACKED_UV
-					#if USE_PACKED_UV == 0
-						vec2 decodeUV(vec2 packedUV)
-						{
-							vec2 uv = (packedUV * 2.0) - 1.0;
-							return uv;
-						}
-					#endif
+			const encoded = defaultEncode( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 1 );
 
-					#if USE_PACKED_UV == 1
-						vec2 decodeUV(vec2 packedUV)
-						{
-							vec2 uv = ( vec3(packedUV, 1.0) * quantizeMatUV ).xy;
-							return uv;
-						}
-					#endif
-				#endif`,
+			result[ idx + 0 ] = encoded[ 0 ];
+			result[ idx + 1 ] = encoded[ 1 ];
+			result[ idx + 2 ] = encoded[ 2 ];
 
-			'void main() {',
+		}
 
-			ShaderChunk.uv_vertex,
+		mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 3, true ) );
+		mesh.geometry.attributes.normal.bytes = result.length * 1;
 
-			`#ifdef USE_UV
-					#ifdef USE_PACKED_UV
-						vUv = decodeUV(vUv);
-					#endif
-				#endif`,
+	} else if ( encodeMethod == 'OCT1Byte' ) {
 
-			ShaderChunk.uv2_vertex,
-			ShaderChunk.color_vertex,
-			ShaderChunk.beginnormal_vertex,
+		/**
+		* It is not recommended to use 1-byte octahedron normals encoding unless you want to extremely reduce the memory usage
+		* As it makes vertex data not aligned to a 4 byte boundary which may harm some WebGL implementations and sometimes the normal distortion is visible
+		* Please refer to @zeux 's comments in https://github.com/mrdoob/three.js/pull/18208
+		*/
 
-			`#ifdef USE_PACKED_NORMAL
-					objectNormal = decodeNormal(objectNormal);
-				#endif
+		result = new Int8Array( count * 2 );
 
-				#ifdef USE_TANGENT
-					vec3 objectTangent = vec3( tangent.xyz );
-				#endif
-				`,
+		for ( let idx = 0; idx < array.length; idx += 3 ) {
 
-			ShaderChunk.morphnormal_vertex,
-			ShaderChunk.skinbase_vertex,
-			ShaderChunk.skinnormal_vertex,
-			ShaderChunk.defaultnormal_vertex,
+			const encoded = octEncodeBest( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 1 );
 
-			'#ifndef FLAT_SHADED',
-			'	vNormal = normalize( transformedNormal );',
-			'#endif',
+			result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
+			result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
 
-			ShaderChunk.begin_vertex,
+		}
 
-			`#ifdef USE_PACKED_POSITION
-					#if USE_PACKED_POSITION == 0
-						transformed = ( vec4(transformed, 1.0) * quantizeMatPos ).xyz;
-					#endif
-				#endif`,
+		mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
+		mesh.geometry.attributes.normal.bytes = result.length * 1;
 
-			ShaderChunk.morphtarget_vertex,
-			ShaderChunk.skinning_vertex,
-			ShaderChunk.displacementmap_vertex,
-			ShaderChunk.project_vertex,
-			ShaderChunk.logdepthbuf_vertex,
-			ShaderChunk.clipping_planes_vertex,
+	} else if ( encodeMethod == 'OCT2Byte' ) {
 
-			'vViewPosition = - mvPosition.xyz;',
+		result = new Int16Array( count * 2 );
 
-			ShaderChunk.worldpos_vertex,
-			ShaderChunk.envmap_vertex,
-			ShaderChunk.shadowmap_vertex,
-			ShaderChunk.fog_vertex,
+		for ( let idx = 0; idx < array.length; idx += 3 ) {
 
-			'}',
-		].join( '\n' );
+			const encoded = octEncodeBest( array[ idx ], array[ idx + 1 ], array[ idx + 2 ], 2 );
 
-		// Use the original MeshPhongMaterial's fragmentShader.
-		this.fragmentShader = [
-			'#define PHONG',
+			result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
+			result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
 
-			'uniform vec3 diffuse;',
-			'uniform vec3 emissive;',
-			'uniform vec3 specular;',
-			'uniform float shininess;',
-			'uniform float opacity;',
+		}
 
-			ShaderChunk.common,
-			ShaderChunk.packing,
-			ShaderChunk.dithering_pars_fragment,
-			ShaderChunk.color_pars_fragment,
-			ShaderChunk.uv_pars_fragment,
-			ShaderChunk.uv2_pars_fragment,
-			ShaderChunk.map_pars_fragment,
-			ShaderChunk.alphamap_pars_fragment,
-			ShaderChunk.aomap_pars_fragment,
-			ShaderChunk.lightmap_pars_fragment,
-			ShaderChunk.emissivemap_pars_fragment,
-			ShaderChunk.envmap_common_pars_fragment,
-			ShaderChunk.envmap_pars_fragment,
-			ShaderChunk.cube_uv_reflection_fragment,
-			ShaderChunk.fog_pars_fragment,
-			ShaderChunk.bsdfs,
-			ShaderChunk.lights_pars_begin,
-			ShaderChunk.lights_phong_pars_fragment,
-			ShaderChunk.shadowmap_pars_fragment,
-			ShaderChunk.bumpmap_pars_fragment,
-			ShaderChunk.normalmap_pars_fragment,
-			ShaderChunk.specularmap_pars_fragment,
-			ShaderChunk.logdepthbuf_pars_fragment,
-			ShaderChunk.clipping_planes_pars_fragment,
+		mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
+		mesh.geometry.attributes.normal.bytes = result.length * 2;
 
-			'void main() {',
+	} else if ( encodeMethod == 'ANGLES' ) {
 
-			ShaderChunk.clipping_planes_fragment,
+		result = new Uint16Array( count * 2 );
 
-			'vec4 diffuseColor = vec4( diffuse, opacity );',
-			'ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );',
-			'vec3 totalEmissiveRadiance = emissive;',
+		for ( let idx = 0; idx < array.length; idx += 3 ) {
 
-			ShaderChunk.logdepthbuf_fragment,
-			ShaderChunk.map_fragment,
-			ShaderChunk.color_fragment,
-			ShaderChunk.alphamap_fragment,
-			ShaderChunk.alphatest_fragment,
-			ShaderChunk.specularmap_fragment,
-			ShaderChunk.normal_fragment_begin,
-			ShaderChunk.normal_fragment_maps,
-			ShaderChunk.emissivemap_fragment,
+			const encoded = anglesEncode( array[ idx ], array[ idx + 1 ], array[ idx + 2 ] );
 
-			// accumulation
-			ShaderChunk.lights_phong_fragment,
-			ShaderChunk.lights_fragment_begin,
-			ShaderChunk.lights_fragment_maps,
-			ShaderChunk.lights_fragment_end,
+			result[ idx / 3 * 2 + 0 ] = encoded[ 0 ];
+			result[ idx / 3 * 2 + 1 ] = encoded[ 1 ];
 
-			// modulation
-			ShaderChunk.aomap_fragment,
+		}
 
-			'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;',
+		mesh.geometry.setAttribute( 'normal', new BufferAttribute( result, 2, true ) );
+		mesh.geometry.attributes.normal.bytes = result.length * 2;
 
-			ShaderChunk.envmap_fragment,
+	} else {
 
-			'gl_FragColor = vec4( outgoingLight, diffuseColor.a );',
+		console.error( 'Unrecognized encoding method, should be `DEFAULT` or `ANGLES` or `OCT`. ' );
 
-			ShaderChunk.tonemapping_fragment,
-			ShaderChunk.encodings_fragment,
-			ShaderChunk.fog_fragment,
-			ShaderChunk.premultiplied_alpha_fragment,
-			ShaderChunk.dithering_fragment,
-			'}',
-		].join( '\n' );
+	}
 
-		this.setValues( parameters );
+	mesh.geometry.attributes.normal.needsUpdate = true;
+	mesh.geometry.attributes.normal.isPacked = true;
+	mesh.geometry.attributes.normal.packingMethod = encodeMethod;
+
+	// modify material
+	if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
+
+		mesh.material = new PackedPhongMaterial().copy( mesh.material );
+
+	}
+
+	if ( encodeMethod == 'ANGLES' ) {
+
+		mesh.material.defines.USE_PACKED_NORMAL = 0;
+
+	}
+
+	if ( encodeMethod == 'OCT1Byte' ) {
+
+		mesh.material.defines.USE_PACKED_NORMAL = 1;
+
+	}
+
+	if ( encodeMethod == 'OCT2Byte' ) {
+
+		mesh.material.defines.USE_PACKED_NORMAL = 1;
+
+	}
+
+	if ( encodeMethod == 'DEFAULT' ) {
+
+		mesh.material.defines.USE_PACKED_NORMAL = 2;
 
 	}
 
 }
 
-export { GeometryCompressionUtils, PackedPhongMaterial };
+
+/**
+	 * Make the input mesh.geometry's position attribute encoded and compressed.
+	 * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the position data.
+	 *
+	 * @param {THREE.Mesh} mesh
+	 *
+	 */
+function compressPositions( mesh ) {
+
+	if ( ! mesh.geometry ) {
+
+		console.error( 'Mesh must contain geometry. ' );
+
+	}
+
+	const position = mesh.geometry.attributes.position;
+
+	if ( ! position ) {
+
+		console.error( 'Geometry must contain position attribute. ' );
+
+	}
+
+	if ( position.isPacked ) return;
+
+	if ( position.itemSize != 3 ) {
+
+		console.error( 'position.itemSize is not 3, which cannot be packed. ' );
+
+	}
+
+	const array = position.array;
+	const encodingBytes = 2;
+
+	const result = quantizedEncode( array, encodingBytes );
+
+	const quantized = result.quantized;
+	const decodeMat = result.decodeMat;
+
+	// IMPORTANT: calculate original geometry bounding info first, before updating packed positions
+	if ( mesh.geometry.boundingBox == null ) mesh.geometry.computeBoundingBox();
+	if ( mesh.geometry.boundingSphere == null ) mesh.geometry.computeBoundingSphere();
+
+	mesh.geometry.setAttribute( 'position', new BufferAttribute( quantized, 3 ) );
+	mesh.geometry.attributes.position.isPacked = true;
+	mesh.geometry.attributes.position.needsUpdate = true;
+	mesh.geometry.attributes.position.bytes = quantized.length * encodingBytes;
+
+	// modify material
+	if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
+
+		mesh.material = new PackedPhongMaterial().copy( mesh.material );
+
+	}
+
+	mesh.material.defines.USE_PACKED_POSITION = 0;
+
+	mesh.material.uniforms.quantizeMatPos.value = decodeMat;
+	mesh.material.uniforms.quantizeMatPos.needsUpdate = true;
+
+}
+
+/**
+ * Make the input mesh.geometry's uv attribute encoded and compressed.
+ * Also will change the mesh.material to `PackedPhongMaterial` which let the vertex shader program decode the uv data.
+ *
+ * @param {THREE.Mesh} mesh
+ *
+ */
+function compressUvs( mesh ) {
+
+	if ( ! mesh.geometry ) {
+
+		console.error( 'Mesh must contain geometry property. ' );
+
+	}
+
+	const uvs = mesh.geometry.attributes.uv;
+
+	if ( ! uvs ) {
+
+		console.error( 'Geometry must contain uv attribute. ' );
+
+	}
+
+	if ( uvs.isPacked ) return;
+
+	const range = { min: Infinity, max: - Infinity };
+
+	const array = uvs.array;
+
+	for ( let i = 0; i < array.length; i ++ ) {
+
+		range.min = Math.min( range.min, array[ i ] );
+		range.max = Math.max( range.max, array[ i ] );
+
+	}
+
+	let result;
+
+	if ( range.min >= - 1.0 && range.max <= 1.0 ) {
+
+		// use default encoding method
+		result = new Uint16Array( array.length );
+
+		for ( let i = 0; i < array.length; i += 2 ) {
+
+			const encoded = defaultEncode( array[ i ], array[ i + 1 ], 0, 2 );
+
+			result[ i ] = encoded[ 0 ];
+			result[ i + 1 ] = encoded[ 1 ];
+
+		}
+
+		mesh.geometry.setAttribute( 'uv', new BufferAttribute( result, 2, true ) );
+		mesh.geometry.attributes.uv.isPacked = true;
+		mesh.geometry.attributes.uv.needsUpdate = true;
+		mesh.geometry.attributes.uv.bytes = result.length * 2;
+
+		if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
+
+			mesh.material = new PackedPhongMaterial().copy( mesh.material );
+
+		}
+
+		mesh.material.defines.USE_PACKED_UV = 0;
+
+	} else {
+
+		// use quantized encoding method
+		result = quantizedEncodeUV( array, 2 );
+
+		mesh.geometry.setAttribute( 'uv', new BufferAttribute( result.quantized, 2 ) );
+		mesh.geometry.attributes.uv.isPacked = true;
+		mesh.geometry.attributes.uv.needsUpdate = true;
+		mesh.geometry.attributes.uv.bytes = result.quantized.length * 2;
+
+		if ( ! ( mesh.material instanceof PackedPhongMaterial ) ) {
+
+			mesh.material = new PackedPhongMaterial().copy( mesh.material );
+
+		}
+
+		mesh.material.defines.USE_PACKED_UV = 1;
+
+		mesh.material.uniforms.quantizeMatUV.value = result.decodeMat;
+		mesh.material.uniforms.quantizeMatUV.needsUpdate = true;
+
+	}
+
+}
+
+
+// Encoding functions
+
+function defaultEncode( x, y, z, bytes ) {
+
+	if ( bytes == 1 ) {
+
+		const tmpx = Math.round( ( x + 1 ) * 0.5 * 255 );
+		const tmpy = Math.round( ( y + 1 ) * 0.5 * 255 );
+		const tmpz = Math.round( ( z + 1 ) * 0.5 * 255 );
+		return new Uint8Array( [ tmpx, tmpy, tmpz ] );
+
+	} else if ( bytes == 2 ) {
+
+		const tmpx = Math.round( ( x + 1 ) * 0.5 * 65535 );
+		const tmpy = Math.round( ( y + 1 ) * 0.5 * 65535 );
+		const tmpz = Math.round( ( z + 1 ) * 0.5 * 65535 );
+		return new Uint16Array( [ tmpx, tmpy, tmpz ] );
+
+	} else {
+
+		console.error( 'number of bytes must be 1 or 2' );
+
+	}
+
+}
+
+function defaultDecode( array, bytes ) {
+
+	if ( bytes == 1 ) {
+
+		return [
+			( ( array[ 0 ] / 255 ) * 2.0 ) - 1.0,
+			( ( array[ 1 ] / 255 ) * 2.0 ) - 1.0,
+			( ( array[ 2 ] / 255 ) * 2.0 ) - 1.0,
+		];
+
+	} else if ( bytes == 2 ) {
+
+		return [
+			( ( array[ 0 ] / 65535 ) * 2.0 ) - 1.0,
+			( ( array[ 1 ] / 65535 ) * 2.0 ) - 1.0,
+			( ( array[ 2 ] / 65535 ) * 2.0 ) - 1.0,
+		];
+
+	} else {
+
+		console.error( 'number of bytes must be 1 or 2' );
+
+	}
+
+}
+
+// for `Angles` encoding
+function anglesEncode( x, y, z ) {
+
+	const normal0 = parseInt( 0.5 * ( 1.0 + Math.atan2( y, x ) / Math.PI ) * 65535 );
+	const normal1 = parseInt( 0.5 * ( 1.0 + z ) * 65535 );
+	return new Uint16Array( [ normal0, normal1 ] );
+
+}
+
+// for `Octahedron` encoding
+function octEncodeBest( x, y, z, bytes ) {
+
+	let oct, dec, best, currentCos, bestCos;
+
+	// Test various combinations of ceil and floor
+	// to minimize rounding errors
+	best = oct = octEncodeVec3( x, y, z, 'floor', 'floor' );
+	dec = octDecodeVec2( oct );
+	bestCos = dot( x, y, z, dec );
+
+	oct = octEncodeVec3( x, y, z, 'ceil', 'floor' );
+	dec = octDecodeVec2( oct );
+	currentCos = dot( x, y, z, dec );
+
+	if ( currentCos > bestCos ) {
+
+		best = oct;
+		bestCos = currentCos;
+
+	}
+
+	oct = octEncodeVec3( x, y, z, 'floor', 'ceil' );
+	dec = octDecodeVec2( oct );
+	currentCos = dot( x, y, z, dec );
+
+	if ( currentCos > bestCos ) {
+
+		best = oct;
+		bestCos = currentCos;
+
+	}
+
+	oct = octEncodeVec3( x, y, z, 'ceil', 'ceil' );
+	dec = octDecodeVec2( oct );
+	currentCos = dot( x, y, z, dec );
+
+	if ( currentCos > bestCos ) {
+
+		best = oct;
+
+	}
+
+	return best;
+
+	function octEncodeVec3( x0, y0, z0, xfunc, yfunc ) {
+
+		let x = x0 / ( Math.abs( x0 ) + Math.abs( y0 ) + Math.abs( z0 ) );
+		let y = y0 / ( Math.abs( x0 ) + Math.abs( y0 ) + Math.abs( z0 ) );
+
+		if ( z < 0 ) {
+
+			const tempx = ( 1 - Math.abs( y ) ) * ( x >= 0 ? 1 : - 1 );
+			const tempy = ( 1 - Math.abs( x ) ) * ( y >= 0 ? 1 : - 1 );
+
+			x = tempx;
+			y = tempy;
+
+			let diff = 1 - Math.abs( x ) - Math.abs( y );
+			if ( diff > 0 ) {
+
+				diff += 0.001;
+				x += x > 0 ? diff / 2 : - diff / 2;
+				y += y > 0 ? diff / 2 : - diff / 2;
+
+			}
+
+		}
+
+		if ( bytes == 1 ) {
+
+			return new Int8Array( [
+				Math[ xfunc ]( x * 127.5 + ( x < 0 ? 1 : 0 ) ),
+				Math[ yfunc ]( y * 127.5 + ( y < 0 ? 1 : 0 ) )
+			] );
+
+		}
+
+		if ( bytes == 2 ) {
+
+			return new Int16Array( [
+				Math[ xfunc ]( x * 32767.5 + ( x < 0 ? 1 : 0 ) ),
+				Math[ yfunc ]( y * 32767.5 + ( y < 0 ? 1 : 0 ) )
+			] );
+
+		}
+
+
+	}
+
+	function octDecodeVec2( oct ) {
+
+		let x = oct[ 0 ];
+		let y = oct[ 1 ];
+
+		if ( bytes == 1 ) {
+
+			x /= x < 0 ? 127 : 128;
+			y /= y < 0 ? 127 : 128;
+
+		} else if ( bytes == 2 ) {
+
+			x /= x < 0 ? 32767 : 32768;
+			y /= y < 0 ? 32767 : 32768;
+
+		}
+
+
+		const z = 1 - Math.abs( x ) - Math.abs( y );
+
+		if ( z < 0 ) {
+
+			const tmpx = x;
+			x = ( 1 - Math.abs( y ) ) * ( x >= 0 ? 1 : - 1 );
+			y = ( 1 - Math.abs( tmpx ) ) * ( y >= 0 ? 1 : - 1 );
+
+		}
+
+		const length = Math.sqrt( x * x + y * y + z * z );
+
+		return [
+			x / length,
+			y / length,
+			z / length
+		];
+
+	}
+
+	function dot( x, y, z, vec3 ) {
+
+		return x * vec3[ 0 ] + y * vec3[ 1 ] + z * vec3[ 2 ];
+
+	}
+
+}
+
+function quantizedEncode( array, bytes ) {
+
+	let quantized, segments;
+
+	if ( bytes == 1 ) {
+
+		quantized = new Uint8Array( array.length );
+		segments = 255;
+
+	} else if ( bytes == 2 ) {
+
+		quantized = new Uint16Array( array.length );
+		segments = 65535;
+
+	} else {
+
+		console.error( 'number of bytes error! ' );
+
+	}
+
+	const decodeMat = new Matrix4();
+
+	const min = new Float32Array( 3 );
+	const max = new Float32Array( 3 );
+
+	min[ 0 ] = min[ 1 ] = min[ 2 ] = Number.MAX_VALUE;
+	max[ 0 ] = max[ 1 ] = max[ 2 ] = - Number.MAX_VALUE;
+
+	for ( let i = 0; i < array.length; i += 3 ) {
+
+		min[ 0 ] = Math.min( min[ 0 ], array[ i + 0 ] );
+		min[ 1 ] = Math.min( min[ 1 ], array[ i + 1 ] );
+		min[ 2 ] = Math.min( min[ 2 ], array[ i + 2 ] );
+		max[ 0 ] = Math.max( max[ 0 ], array[ i + 0 ] );
+		max[ 1 ] = Math.max( max[ 1 ], array[ i + 1 ] );
+		max[ 2 ] = Math.max( max[ 2 ], array[ i + 2 ] );
+
+	}
+
+	decodeMat.scale( new Vector3(
+		( max[ 0 ] - min[ 0 ] ) / segments,
+		( max[ 1 ] - min[ 1 ] ) / segments,
+		( max[ 2 ] - min[ 2 ] ) / segments
+	) );
+
+	decodeMat.elements[ 12 ] = min[ 0 ];
+	decodeMat.elements[ 13 ] = min[ 1 ];
+	decodeMat.elements[ 14 ] = min[ 2 ];
+
+	decodeMat.transpose();
+
+
+	const multiplier = new Float32Array( [
+		max[ 0 ] !== min[ 0 ] ? segments / ( max[ 0 ] - min[ 0 ] ) : 0,
+		max[ 1 ] !== min[ 1 ] ? segments / ( max[ 1 ] - min[ 1 ] ) : 0,
+		max[ 2 ] !== min[ 2 ] ? segments / ( max[ 2 ] - min[ 2 ] ) : 0
+	] );
+
+	for ( let i = 0; i < array.length; i += 3 ) {
+
+		quantized[ i + 0 ] = Math.floor( ( array[ i + 0 ] - min[ 0 ] ) * multiplier[ 0 ] );
+		quantized[ i + 1 ] = Math.floor( ( array[ i + 1 ] - min[ 1 ] ) * multiplier[ 1 ] );
+		quantized[ i + 2 ] = Math.floor( ( array[ i + 2 ] - min[ 2 ] ) * multiplier[ 2 ] );
+
+	}
+
+	return {
+		quantized: quantized,
+		decodeMat: decodeMat
+	};
+
+}
+
+function quantizedEncodeUV( array, bytes ) {
+
+	let quantized, segments;
+
+	if ( bytes == 1 ) {
+
+		quantized = new Uint8Array( array.length );
+		segments = 255;
+
+	} else if ( bytes == 2 ) {
+
+		quantized = new Uint16Array( array.length );
+		segments = 65535;
+
+	} else {
+
+		console.error( 'number of bytes error! ' );
+
+	}
+
+	const decodeMat = new Matrix3();
+
+	const min = new Float32Array( 2 );
+	const max = new Float32Array( 2 );
+
+	min[ 0 ] = min[ 1 ] = Number.MAX_VALUE;
+	max[ 0 ] = max[ 1 ] = - Number.MAX_VALUE;
+
+	for ( let i = 0; i < array.length; i += 2 ) {
+
+		min[ 0 ] = Math.min( min[ 0 ], array[ i + 0 ] );
+		min[ 1 ] = Math.min( min[ 1 ], array[ i + 1 ] );
+		max[ 0 ] = Math.max( max[ 0 ], array[ i + 0 ] );
+		max[ 1 ] = Math.max( max[ 1 ], array[ i + 1 ] );
+
+	}
+
+	decodeMat.scale(
+		( max[ 0 ] - min[ 0 ] ) / segments,
+		( max[ 1 ] - min[ 1 ] ) / segments
+	);
+
+	decodeMat.elements[ 6 ] = min[ 0 ];
+	decodeMat.elements[ 7 ] = min[ 1 ];
+
+	decodeMat.transpose();
+
+	const multiplier = new Float32Array( [
+		max[ 0 ] !== min[ 0 ] ? segments / ( max[ 0 ] - min[ 0 ] ) : 0,
+		max[ 1 ] !== min[ 1 ] ? segments / ( max[ 1 ] - min[ 1 ] ) : 0
+	] );
+
+	for ( let i = 0; i < array.length; i += 2 ) {
+
+		quantized[ i + 0 ] = Math.floor( ( array[ i + 0 ] - min[ 0 ] ) * multiplier[ 0 ] );
+		quantized[ i + 1 ] = Math.floor( ( array[ i + 1 ] - min[ 1 ] ) * multiplier[ 1 ] );
+
+	}
+
+	return {
+		quantized: quantized,
+		decodeMat: decodeMat
+	};
+
+}
+
+
+
+export {
+	compressNormals,
+	compressPositions,
+	compressUvs,
+};

--- a/examples/jsm/utils/GeometryUtils.js
+++ b/examples/jsm/utils/GeometryUtils.js
@@ -2,225 +2,228 @@ import {
 	Vector3
 } from '../../../build/three.module.js';
 
-class GeometryUtils {
 
-	/**
-	 * Generates 2D-Coordinates in a very fast way.
-	 *
-	 * Based on work by:
-	 * @link http://www.openprocessing.org/sketch/15493
-	 *
-	 * @param center     Center of Hilbert curve.
-	 * @param size       Total width of Hilbert curve.
-	 * @param iterations Number of subdivisions.
-	 * @param v0         Corner index -X, -Z.
-	 * @param v1         Corner index -X, +Z.
-	 * @param v2         Corner index +X, +Z.
-	 * @param v3         Corner index +X, -Z.
-	 */
-	static hilbert2D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3 ) {
+/**
+ * Generates 2D-Coordinates in a very fast way.
+ *
+ * Based on work by:
+ * @link http://www.openprocessing.org/sketch/15493
+ *
+ * @param center     Center of Hilbert curve.
+ * @param size       Total width of Hilbert curve.
+ * @param iterations Number of subdivisions.
+ * @param v0         Corner index -X, -Z.
+ * @param v1         Corner index -X, +Z.
+ * @param v2         Corner index +X, +Z.
+ * @param v3         Corner index +X, -Z.
+ */
+function hilbert2D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3 ) {
 
-		const half = size / 2;
+	const half = size / 2;
 
-		const vec_s = [
-			new Vector3( center.x - half, center.y, center.z - half ),
-			new Vector3( center.x - half, center.y, center.z + half ),
-			new Vector3( center.x + half, center.y, center.z + half ),
-			new Vector3( center.x + half, center.y, center.z - half )
-		];
+	const vec_s = [
+		new Vector3( center.x - half, center.y, center.z - half ),
+		new Vector3( center.x - half, center.y, center.z + half ),
+		new Vector3( center.x + half, center.y, center.z + half ),
+		new Vector3( center.x + half, center.y, center.z - half )
+	];
 
-		const vec = [
-			vec_s[ v0 ],
-			vec_s[ v1 ],
-			vec_s[ v2 ],
-			vec_s[ v3 ]
-		];
+	const vec = [
+		vec_s[ v0 ],
+		vec_s[ v1 ],
+		vec_s[ v2 ],
+		vec_s[ v3 ]
+	];
 
-		// Recurse iterations
-		if ( 0 <= -- iterations ) {
+	// Recurse iterations
+	if ( 0 <= -- iterations ) {
 
-			const tmp = [];
+		const tmp = [];
 
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert2D( vec[ 0 ], half, iterations, v0, v3, v2, v1 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert2D( vec[ 1 ], half, iterations, v0, v1, v2, v3 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert2D( vec[ 2 ], half, iterations, v0, v1, v2, v3 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert2D( vec[ 3 ], half, iterations, v2, v1, v0, v3 ) );
+		Array.prototype.push.apply( tmp, hilbert2D( vec[ 0 ], half, iterations, v0, v3, v2, v1 ) );
+		Array.prototype.push.apply( tmp, hilbert2D( vec[ 1 ], half, iterations, v0, v1, v2, v3 ) );
+		Array.prototype.push.apply( tmp, hilbert2D( vec[ 2 ], half, iterations, v0, v1, v2, v3 ) );
+		Array.prototype.push.apply( tmp, hilbert2D( vec[ 3 ], half, iterations, v2, v1, v0, v3 ) );
 
-			// Return recursive call
-			return tmp;
-
-		}
-
-		// Return complete Hilbert Curve.
-		return vec;
+		// Return recursive call
+		return tmp;
 
 	}
 
-	/**
-	 * Generates 3D-Coordinates in a very fast way.
-	 *
-	 * Based on work by:
-	 * @link http://www.openprocessing.org/visuals/?visualID=15599
-	 *
-	 * @param center     Center of Hilbert curve.
-	 * @param size       Total width of Hilbert curve.
-	 * @param iterations Number of subdivisions.
-	 * @param v0         Corner index -X, +Y, -Z.
-	 * @param v1         Corner index -X, +Y, +Z.
-	 * @param v2         Corner index -X, -Y, +Z.
-	 * @param v3         Corner index -X, -Y, -Z.
-	 * @param v4         Corner index +X, -Y, -Z.
-	 * @param v5         Corner index +X, -Y, +Z.
-	 * @param v6         Corner index +X, +Y, +Z.
-	 * @param v7         Corner index +X, +Y, -Z.
-	 */
-	static hilbert3D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6, v7 = 7 ) {
-
-		// Default Vars
-		const half = size / 2;
-
-		const vec_s = [
-			new Vector3( center.x - half, center.y + half, center.z - half ),
-			new Vector3( center.x - half, center.y + half, center.z + half ),
-			new Vector3( center.x - half, center.y - half, center.z + half ),
-			new Vector3( center.x - half, center.y - half, center.z - half ),
-			new Vector3( center.x + half, center.y - half, center.z - half ),
-			new Vector3( center.x + half, center.y - half, center.z + half ),
-			new Vector3( center.x + half, center.y + half, center.z + half ),
-			new Vector3( center.x + half, center.y + half, center.z - half )
-		];
-
-		const vec = [
-			vec_s[ v0 ],
-			vec_s[ v1 ],
-			vec_s[ v2 ],
-			vec_s[ v3 ],
-			vec_s[ v4 ],
-			vec_s[ v5 ],
-			vec_s[ v6 ],
-			vec_s[ v7 ]
-		];
-
-		// Recurse iterations
-		if ( -- iterations >= 0 ) {
-
-			const tmp = [];
-
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 0 ], half, iterations, v0, v3, v4, v7, v6, v5, v2, v1 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 1 ], half, iterations, v0, v7, v6, v1, v2, v5, v4, v3 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 2 ], half, iterations, v0, v7, v6, v1, v2, v5, v4, v3 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 3 ], half, iterations, v2, v3, v0, v1, v6, v7, v4, v5 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 4 ], half, iterations, v2, v3, v0, v1, v6, v7, v4, v5 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 5 ], half, iterations, v4, v3, v2, v5, v6, v1, v0, v7 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 6 ], half, iterations, v4, v3, v2, v5, v6, v1, v0, v7 ) );
-			Array.prototype.push.apply( tmp, GeometryUtils.hilbert3D( vec[ 7 ], half, iterations, v6, v5, v2, v1, v0, v3, v4, v7 ) );
-
-			// Return recursive call
-			return tmp;
-
-		}
-
-		// Return complete Hilbert Curve.
-		return vec;
-
-	}
-
-	/**
-	 * Generates a Gosper curve (lying in the XY plane)
-	 *
-	 * https://gist.github.com/nitaku/6521802
-	 *
-	 * @param size The size of a single gosper island.
-	 */
-	static gosper( size = 1 ) {
-
-		function fractalize( config ) {
-
-			let output;
-			let input = config.axiom;
-
-			for ( let i = 0, il = config.steps; 0 <= il ? i < il : i > il; 0 <= il ? i ++ : i -- ) {
-
-				output = '';
-
-				for ( let j = 0, jl = input.length; j < jl; j ++ ) {
-
-					const char = input[ j ];
-
-					if ( char in config.rules ) {
-
-						output += config.rules[ char ];
-
-					} else {
-
-						output += char;
-
-					}
-
-				}
-
-				input = output;
-
-			}
-
-			return output;
-
-		}
-
-		function toPoints( config ) {
-
-			let currX = 0, currY = 0;
-			let angle = 0;
-			const path = [ 0, 0, 0 ];
-			const fractal = config.fractal;
-
-			for ( let i = 0, l = fractal.length; i < l; i ++ ) {
-
-				const char = fractal[ i ];
-
-				if ( char === '+' ) {
-
-					angle += config.angle;
-
-				} else if ( char === '-' ) {
-
-					angle -= config.angle;
-
-				} else if ( char === 'F' ) {
-
-					currX += config.size * Math.cos( angle );
-					currY += - config.size * Math.sin( angle );
-					path.push( currX, currY, 0 );
-
-				}
-
-			}
-
-			return path;
-
-		}
-
-		//
-
-		const gosper = fractalize( {
-			axiom: 'A',
-			steps: 4,
-			rules: {
-				A: 'A+BF++BF-FA--FAFA-BF+',
-				B: '-FA+BFBF++BF+FA--FA-B'
-			}
-		} );
-
-		const points = toPoints( {
-			fractal: gosper,
-			size: size,
-			angle: Math.PI / 3 // 60 degrees
-		} );
-
-		return points;
-
-	}
+	// Return complete Hilbert Curve.
+	return vec;
 
 }
 
-export { GeometryUtils };
+/**
+ * Generates 3D-Coordinates in a very fast way.
+ *
+ * Based on work by:
+ * @link http://www.openprocessing.org/visuals/?visualID=15599
+ *
+ * @param center     Center of Hilbert curve.
+ * @param size       Total width of Hilbert curve.
+ * @param iterations Number of subdivisions.
+ * @param v0         Corner index -X, +Y, -Z.
+ * @param v1         Corner index -X, +Y, +Z.
+ * @param v2         Corner index -X, -Y, +Z.
+ * @param v3         Corner index -X, -Y, -Z.
+ * @param v4         Corner index +X, -Y, -Z.
+ * @param v5         Corner index +X, -Y, +Z.
+ * @param v6         Corner index +X, +Y, +Z.
+ * @param v7         Corner index +X, +Y, -Z.
+ */
+function hilbert3D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6, v7 = 7 ) {
+
+	// Default Vars
+	const half = size / 2;
+
+	const vec_s = [
+		new Vector3( center.x - half, center.y + half, center.z - half ),
+		new Vector3( center.x - half, center.y + half, center.z + half ),
+		new Vector3( center.x - half, center.y - half, center.z + half ),
+		new Vector3( center.x - half, center.y - half, center.z - half ),
+		new Vector3( center.x + half, center.y - half, center.z - half ),
+		new Vector3( center.x + half, center.y - half, center.z + half ),
+		new Vector3( center.x + half, center.y + half, center.z + half ),
+		new Vector3( center.x + half, center.y + half, center.z - half )
+	];
+
+	const vec = [
+		vec_s[ v0 ],
+		vec_s[ v1 ],
+		vec_s[ v2 ],
+		vec_s[ v3 ],
+		vec_s[ v4 ],
+		vec_s[ v5 ],
+		vec_s[ v6 ],
+		vec_s[ v7 ]
+	];
+
+	// Recurse iterations
+	if ( -- iterations >= 0 ) {
+
+		const tmp = [];
+
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 0 ], half, iterations, v0, v3, v4, v7, v6, v5, v2, v1 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 1 ], half, iterations, v0, v7, v6, v1, v2, v5, v4, v3 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 2 ], half, iterations, v0, v7, v6, v1, v2, v5, v4, v3 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 3 ], half, iterations, v2, v3, v0, v1, v6, v7, v4, v5 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 4 ], half, iterations, v2, v3, v0, v1, v6, v7, v4, v5 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 5 ], half, iterations, v4, v3, v2, v5, v6, v1, v0, v7 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 6 ], half, iterations, v4, v3, v2, v5, v6, v1, v0, v7 ) );
+		Array.prototype.push.apply( tmp, hilbert3D( vec[ 7 ], half, iterations, v6, v5, v2, v1, v0, v3, v4, v7 ) );
+
+		// Return recursive call
+		return tmp;
+
+	}
+
+	// Return complete Hilbert Curve.
+	return vec;
+
+}
+
+/**
+ * Generates a Gosper curve (lying in the XY plane)
+ *
+ * https://gist.github.com/nitaku/6521802
+ *
+ * @param size The size of a single gosper island.
+ */
+function gosper( size = 1 ) {
+
+	function fractalize( config ) {
+
+		let output;
+		let input = config.axiom;
+
+		for ( let i = 0, il = config.steps; 0 <= il ? i < il : i > il; 0 <= il ? i ++ : i -- ) {
+
+			output = '';
+
+			for ( let j = 0, jl = input.length; j < jl; j ++ ) {
+
+				const char = input[ j ];
+
+				if ( char in config.rules ) {
+
+					output += config.rules[ char ];
+
+				} else {
+
+					output += char;
+
+				}
+
+			}
+
+			input = output;
+
+		}
+
+		return output;
+
+	}
+
+	function toPoints( config ) {
+
+		let currX = 0, currY = 0;
+		let angle = 0;
+		const path = [ 0, 0, 0 ];
+		const fractal = config.fractal;
+
+		for ( let i = 0, l = fractal.length; i < l; i ++ ) {
+
+			const char = fractal[ i ];
+
+			if ( char === '+' ) {
+
+				angle += config.angle;
+
+			} else if ( char === '-' ) {
+
+				angle -= config.angle;
+
+			} else if ( char === 'F' ) {
+
+				currX += config.size * Math.cos( angle );
+				currY += - config.size * Math.sin( angle );
+				path.push( currX, currY, 0 );
+
+			}
+
+		}
+
+		return path;
+
+	}
+
+	//
+
+	const gosper = fractalize( {
+		axiom: 'A',
+		steps: 4,
+		rules: {
+			A: 'A+BF++BF-FA--FAFA-BF+',
+			B: '-FA+BFBF++BF+FA--FA-B'
+		}
+	} );
+
+	const points = toPoints( {
+		fractal: gosper,
+		size: size,
+		angle: Math.PI / 3 // 60 degrees
+	} );
+
+	return points;
+
+}
+
+
+
+export {
+	hilbert2D,
+	hilbert3D,
+	gosper,
+};

--- a/examples/jsm/utils/PackedPhongMaterial.js
+++ b/examples/jsm/utils/PackedPhongMaterial.js
@@ -1,0 +1,257 @@
+
+/**
+ * `PackedPhongMaterial` inherited from THREE.MeshPhongMaterial
+ *
+ * @param {Object} parameters
+ */
+import {
+	MeshPhongMaterial,
+	ShaderChunk,
+	ShaderLib,
+	UniformsUtils,
+} from '../../../build/three.module.js';
+
+class PackedPhongMaterial extends MeshPhongMaterial {
+
+	constructor( parameters ) {
+
+		super();
+
+		this.defines = {};
+		this.type = 'PackedPhongMaterial';
+		this.uniforms = UniformsUtils.merge( [
+
+			ShaderLib.phong.uniforms,
+
+			{
+				quantizeMatPos: { value: null },
+				quantizeMatUV: { value: null }
+			}
+
+		] );
+
+		this.vertexShader = [
+			'#define PHONG',
+
+			'varying vec3 vViewPosition;',
+
+			'#ifndef FLAT_SHADED',
+			'varying vec3 vNormal;',
+			'#endif',
+
+			ShaderChunk.common,
+			ShaderChunk.uv_pars_vertex,
+			ShaderChunk.uv2_pars_vertex,
+			ShaderChunk.displacementmap_pars_vertex,
+			ShaderChunk.envmap_pars_vertex,
+			ShaderChunk.color_pars_vertex,
+			ShaderChunk.fog_pars_vertex,
+			ShaderChunk.morphtarget_pars_vertex,
+			ShaderChunk.skinning_pars_vertex,
+			ShaderChunk.shadowmap_pars_vertex,
+			ShaderChunk.logdepthbuf_pars_vertex,
+			ShaderChunk.clipping_planes_pars_vertex,
+
+			`#ifdef USE_PACKED_NORMAL
+					#if USE_PACKED_NORMAL == 0
+						vec3 decodeNormal(vec3 packedNormal)
+						{
+							float x = packedNormal.x * 2.0 - 1.0;
+							float y = packedNormal.y * 2.0 - 1.0;
+							vec2 scth = vec2(sin(x * PI), cos(x * PI));
+							vec2 scphi = vec2(sqrt(1.0 - y * y), y);
+							return normalize( vec3(scth.y * scphi.x, scth.x * scphi.x, scphi.y) );
+						}
+					#endif
+
+					#if USE_PACKED_NORMAL == 1
+						vec3 decodeNormal(vec3 packedNormal)
+						{
+							vec3 v = vec3(packedNormal.xy, 1.0 - abs(packedNormal.x) - abs(packedNormal.y));
+							if (v.z < 0.0)
+							{
+								v.xy = (1.0 - abs(v.yx)) * vec2((v.x >= 0.0) ? +1.0 : -1.0, (v.y >= 0.0) ? +1.0 : -1.0);
+							}
+							return normalize(v);
+						}
+					#endif
+
+					#if USE_PACKED_NORMAL == 2
+						vec3 decodeNormal(vec3 packedNormal)
+						{
+							vec3 v = (packedNormal * 2.0) - 1.0;
+							return normalize(v);
+						}
+					#endif
+				#endif`,
+
+			`#ifdef USE_PACKED_POSITION
+					#if USE_PACKED_POSITION == 0
+						uniform mat4 quantizeMatPos;
+					#endif
+				#endif`,
+
+			`#ifdef USE_PACKED_UV
+					#if USE_PACKED_UV == 1
+						uniform mat3 quantizeMatUV;
+					#endif
+				#endif`,
+
+			`#ifdef USE_PACKED_UV
+					#if USE_PACKED_UV == 0
+						vec2 decodeUV(vec2 packedUV)
+						{
+							vec2 uv = (packedUV * 2.0) - 1.0;
+							return uv;
+						}
+					#endif
+
+					#if USE_PACKED_UV == 1
+						vec2 decodeUV(vec2 packedUV)
+						{
+							vec2 uv = ( vec3(packedUV, 1.0) * quantizeMatUV ).xy;
+							return uv;
+						}
+					#endif
+				#endif`,
+
+			'void main() {',
+
+			ShaderChunk.uv_vertex,
+
+			`#ifdef USE_UV
+					#ifdef USE_PACKED_UV
+						vUv = decodeUV(vUv);
+					#endif
+				#endif`,
+
+			ShaderChunk.uv2_vertex,
+			ShaderChunk.color_vertex,
+			ShaderChunk.beginnormal_vertex,
+
+			`#ifdef USE_PACKED_NORMAL
+					objectNormal = decodeNormal(objectNormal);
+				#endif
+
+				#ifdef USE_TANGENT
+					vec3 objectTangent = vec3( tangent.xyz );
+				#endif
+				`,
+
+			ShaderChunk.morphnormal_vertex,
+			ShaderChunk.skinbase_vertex,
+			ShaderChunk.skinnormal_vertex,
+			ShaderChunk.defaultnormal_vertex,
+
+			'#ifndef FLAT_SHADED',
+			'	vNormal = normalize( transformedNormal );',
+			'#endif',
+
+			ShaderChunk.begin_vertex,
+
+			`#ifdef USE_PACKED_POSITION
+					#if USE_PACKED_POSITION == 0
+						transformed = ( vec4(transformed, 1.0) * quantizeMatPos ).xyz;
+					#endif
+				#endif`,
+
+			ShaderChunk.morphtarget_vertex,
+			ShaderChunk.skinning_vertex,
+			ShaderChunk.displacementmap_vertex,
+			ShaderChunk.project_vertex,
+			ShaderChunk.logdepthbuf_vertex,
+			ShaderChunk.clipping_planes_vertex,
+
+			'vViewPosition = - mvPosition.xyz;',
+
+			ShaderChunk.worldpos_vertex,
+			ShaderChunk.envmap_vertex,
+			ShaderChunk.shadowmap_vertex,
+			ShaderChunk.fog_vertex,
+
+			'}',
+		].join( '\n' );
+
+		// Use the original MeshPhongMaterial's fragmentShader.
+		this.fragmentShader = [
+			'#define PHONG',
+
+			'uniform vec3 diffuse;',
+			'uniform vec3 emissive;',
+			'uniform vec3 specular;',
+			'uniform float shininess;',
+			'uniform float opacity;',
+
+			ShaderChunk.common,
+			ShaderChunk.packing,
+			ShaderChunk.dithering_pars_fragment,
+			ShaderChunk.color_pars_fragment,
+			ShaderChunk.uv_pars_fragment,
+			ShaderChunk.uv2_pars_fragment,
+			ShaderChunk.map_pars_fragment,
+			ShaderChunk.alphamap_pars_fragment,
+			ShaderChunk.aomap_pars_fragment,
+			ShaderChunk.lightmap_pars_fragment,
+			ShaderChunk.emissivemap_pars_fragment,
+			ShaderChunk.envmap_common_pars_fragment,
+			ShaderChunk.envmap_pars_fragment,
+			ShaderChunk.cube_uv_reflection_fragment,
+			ShaderChunk.fog_pars_fragment,
+			ShaderChunk.bsdfs,
+			ShaderChunk.lights_pars_begin,
+			ShaderChunk.lights_phong_pars_fragment,
+			ShaderChunk.shadowmap_pars_fragment,
+			ShaderChunk.bumpmap_pars_fragment,
+			ShaderChunk.normalmap_pars_fragment,
+			ShaderChunk.specularmap_pars_fragment,
+			ShaderChunk.logdepthbuf_pars_fragment,
+			ShaderChunk.clipping_planes_pars_fragment,
+
+			'void main() {',
+
+			ShaderChunk.clipping_planes_fragment,
+
+			'vec4 diffuseColor = vec4( diffuse, opacity );',
+			'ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );',
+			'vec3 totalEmissiveRadiance = emissive;',
+
+			ShaderChunk.logdepthbuf_fragment,
+			ShaderChunk.map_fragment,
+			ShaderChunk.color_fragment,
+			ShaderChunk.alphamap_fragment,
+			ShaderChunk.alphatest_fragment,
+			ShaderChunk.specularmap_fragment,
+			ShaderChunk.normal_fragment_begin,
+			ShaderChunk.normal_fragment_maps,
+			ShaderChunk.emissivemap_fragment,
+
+			// accumulation
+			ShaderChunk.lights_phong_fragment,
+			ShaderChunk.lights_fragment_begin,
+			ShaderChunk.lights_fragment_maps,
+			ShaderChunk.lights_fragment_end,
+
+			// modulation
+			ShaderChunk.aomap_fragment,
+
+			'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;',
+
+			ShaderChunk.envmap_fragment,
+
+			'gl_FragColor = vec4( outgoingLight, diffuseColor.a );',
+
+			ShaderChunk.tonemapping_fragment,
+			ShaderChunk.encodings_fragment,
+			ShaderChunk.fog_fragment,
+			ShaderChunk.premultiplied_alpha_fragment,
+			ShaderChunk.dithering_fragment,
+			'}',
+		].join( '\n' );
+
+		this.setValues( parameters );
+
+	}
+
+}
+
+export { PackedPhongMaterial };

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -3,64 +3,69 @@ import {
 	Mesh
 } from '../../../build/three.module.js';
 
-class SceneUtils {
 
-	static createMeshesFromInstancedMesh( instancedMesh ) {
 
-		const group = new Group();
+function createMeshesFromInstancedMesh( instancedMesh ) {
 
-		const count = instancedMesh.count;
-		const geometry = instancedMesh.geometry;
-		const material = instancedMesh.material;
+	const group = new Group();
 
-		for ( let i = 0; i < count; i ++ ) {
+	const count = instancedMesh.count;
+	const geometry = instancedMesh.geometry;
+	const material = instancedMesh.material;
 
-			const mesh = new Mesh( geometry, material );
+	for ( let i = 0; i < count; i ++ ) {
 
-			instancedMesh.getMatrixAt( i, mesh.matrix );
-			mesh.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
+		const mesh = new Mesh( geometry, material );
 
-			group.add( mesh );
+		instancedMesh.getMatrixAt( i, mesh.matrix );
+		mesh.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
 
-		}
-
-		group.copy( instancedMesh );
-		group.updateMatrixWorld(); // ensure correct world matrices of meshes
-
-		return group;
+		group.add( mesh );
 
 	}
 
-	static createMultiMaterialObject( geometry, materials ) {
+	group.copy( instancedMesh );
+	group.updateMatrixWorld(); // ensure correct world matrices of meshes
 
-		const group = new Group();
-
-		for ( let i = 0, l = materials.length; i < l; i ++ ) {
-
-			group.add( new Mesh( geometry, materials[ i ] ) );
-
-		}
-
-		return group;
-
-	}
-
-	static detach( child, parent, scene ) {
-
-		console.warn( 'THREE.SceneUtils: detach() has been deprecated. Use scene.attach( child ) instead.' );
-
-		scene.attach( child );
-
-	}
-
-	static attach( child, scene, parent ) {
-
-		console.warn( 'THREE.SceneUtils: attach() has been deprecated. Use parent.attach( child ) instead.' );
-
-		parent.attach( child );
-
-	}
+	return group;
 
 }
 
-export { SceneUtils };
+function createMultiMaterialObject( geometry, materials ) {
+
+	const group = new Group();
+
+	for ( let i = 0, l = materials.length; i < l; i ++ ) {
+
+		group.add( new Mesh( geometry, materials[ i ] ) );
+
+	}
+
+	return group;
+
+}
+
+function detach( child, parent, scene ) {
+
+	console.warn( 'THREE.SceneUtils: detach() has been deprecated. Use scene.attach( child ) instead.' );
+
+	scene.attach( child );
+
+}
+
+function attach( child, scene, parent ) {
+
+	console.warn( 'THREE.SceneUtils: attach() has been deprecated. Use parent.attach( child ) instead.' );
+
+	parent.attach( child );
+
+}
+
+
+
+export {
+	createMeshesFromInstancedMesh,
+	createMultiMaterialObject,
+	detach,
+	attach,
+};

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -11,563 +11,562 @@ import {
 	VectorKeyframeTrack
 } from '../../../build/three.module.js';
 
-class SkeletonUtils {
 
-	static retarget( target, source, options = {} ) {
+function retarget( target, source, options = {} ) {
 
-		const pos = new Vector3(),
-			quat = new Quaternion(),
-			scale = new Vector3(),
-			bindBoneMatrix = new Matrix4(),
-			relativeMatrix = new Matrix4(),
-			globalMatrix = new Matrix4();
+	const pos = new Vector3(),
+		quat = new Quaternion(),
+		scale = new Vector3(),
+		bindBoneMatrix = new Matrix4(),
+		relativeMatrix = new Matrix4(),
+		globalMatrix = new Matrix4();
 
-		options.preserveMatrix = options.preserveMatrix !== undefined ? options.preserveMatrix : true;
-		options.preservePosition = options.preservePosition !== undefined ? options.preservePosition : true;
-		options.preserveHipPosition = options.preserveHipPosition !== undefined ? options.preserveHipPosition : false;
-		options.useTargetMatrix = options.useTargetMatrix !== undefined ? options.useTargetMatrix : false;
-		options.hip = options.hip !== undefined ? options.hip : 'hip';
-		options.names = options.names || {};
+	options.preserveMatrix = options.preserveMatrix !== undefined ? options.preserveMatrix : true;
+	options.preservePosition = options.preservePosition !== undefined ? options.preservePosition : true;
+	options.preserveHipPosition = options.preserveHipPosition !== undefined ? options.preserveHipPosition : false;
+	options.useTargetMatrix = options.useTargetMatrix !== undefined ? options.useTargetMatrix : false;
+	options.hip = options.hip !== undefined ? options.hip : 'hip';
+	options.names = options.names || {};
 
-		const sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
-			bones = target.isObject3D ? target.skeleton.bones : this.getBones( target );
+	const sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
+		bones = target.isObject3D ? target.skeleton.bones : this.getBones( target );
 
-		let bindBones,
-			bone, name, boneTo,
-			bonesPosition;
+	let bindBones,
+		bone, name, boneTo,
+		bonesPosition;
 
-		// reset bones
+	// reset bones
 
-		if ( target.isObject3D ) {
+	if ( target.isObject3D ) {
 
-			target.skeleton.pose();
+		target.skeleton.pose();
 
-		} else {
+	} else {
 
-			options.useTargetMatrix = true;
-			options.preserveMatrix = false;
+		options.useTargetMatrix = true;
+		options.preserveMatrix = false;
 
-		}
+	}
 
-		if ( options.preservePosition ) {
+	if ( options.preservePosition ) {
 
-			bonesPosition = [];
+		bonesPosition = [];
 
-			for ( let i = 0; i < bones.length; i ++ ) {
+		for ( let i = 0; i < bones.length; i ++ ) {
 
-				bonesPosition.push( bones[ i ].position.clone() );
-
-			}
+			bonesPosition.push( bones[ i ].position.clone() );
 
 		}
 
-		if ( options.preserveMatrix ) {
+	}
 
-			// reset matrix
+	if ( options.preserveMatrix ) {
 
-			target.updateMatrixWorld();
+		// reset matrix
 
-			target.matrixWorld.identity();
+		target.updateMatrixWorld();
 
-			// reset children matrix
+		target.matrixWorld.identity();
 
-			for ( let i = 0; i < target.children.length; ++ i ) {
+		// reset children matrix
 
-				target.children[ i ].updateMatrixWorld( true );
+		for ( let i = 0; i < target.children.length; ++ i ) {
 
-			}
-
-		}
-
-		if ( options.offsets ) {
-
-			bindBones = [];
-
-			for ( let i = 0; i < bones.length; ++ i ) {
-
-				bone = bones[ i ];
-				name = options.names[ bone.name ] || bone.name;
-
-				if ( options.offsets && options.offsets[ name ] ) {
-
-					bone.matrix.multiply( options.offsets[ name ] );
-
-					bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
-
-					bone.updateMatrixWorld();
-
-				}
-
-				bindBones.push( bone.matrixWorld.clone() );
-
-			}
+			target.children[ i ].updateMatrixWorld( true );
 
 		}
+
+	}
+
+	if ( options.offsets ) {
+
+		bindBones = [];
 
 		for ( let i = 0; i < bones.length; ++ i ) {
 
 			bone = bones[ i ];
 			name = options.names[ bone.name ] || bone.name;
 
-			boneTo = this.getBoneByName( name, sourceBones );
+			if ( options.offsets && options.offsets[ name ] ) {
 
-			globalMatrix.copy( bone.matrixWorld );
-
-			if ( boneTo ) {
-
-				boneTo.updateMatrixWorld();
-
-				if ( options.useTargetMatrix ) {
-
-					relativeMatrix.copy( boneTo.matrixWorld );
-
-				} else {
-
-					relativeMatrix.copy( target.matrixWorld ).invert();
-					relativeMatrix.multiply( boneTo.matrixWorld );
-
-				}
-
-				// ignore scale to extract rotation
-
-				scale.setFromMatrixScale( relativeMatrix );
-				relativeMatrix.scale( scale.set( 1 / scale.x, 1 / scale.y, 1 / scale.z ) );
-
-				// apply to global matrix
-
-				globalMatrix.makeRotationFromQuaternion( quat.setFromRotationMatrix( relativeMatrix ) );
-
-				if ( target.isObject3D ) {
-
-					const boneIndex = bones.indexOf( bone ),
-						wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.copy( target.skeleton.boneInverses[ boneIndex ] ).invert();
-
-					globalMatrix.multiply( wBindMatrix );
-
-				}
-
-				globalMatrix.copyPosition( relativeMatrix );
-
-			}
-
-			if ( bone.parent && bone.parent.isBone ) {
-
-				bone.matrix.copy( bone.parent.matrixWorld ).invert();
-				bone.matrix.multiply( globalMatrix );
-
-			} else {
-
-				bone.matrix.copy( globalMatrix );
-
-			}
-
-			if ( options.preserveHipPosition && name === options.hip ) {
-
-				bone.matrix.setPosition( pos.set( 0, bone.position.y, 0 ) );
-
-			}
-
-			bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
-
-			bone.updateMatrixWorld();
-
-		}
-
-		if ( options.preservePosition ) {
-
-			for ( let i = 0; i < bones.length; ++ i ) {
-
-				bone = bones[ i ];
-				name = options.names[ bone.name ] || bone.name;
-
-				if ( name !== options.hip ) {
-
-					bone.position.copy( bonesPosition[ i ] );
-
-				}
-
-			}
-
-		}
-
-		if ( options.preserveMatrix ) {
-
-			// restore matrix
-
-			target.updateMatrixWorld( true );
-
-		}
-
-	}
-
-	static retargetClip( target, source, clip, options = {} ) {
-
-		options.useFirstFramePosition = options.useFirstFramePosition !== undefined ? options.useFirstFramePosition : false;
-		options.fps = options.fps !== undefined ? options.fps : 30;
-		options.names = options.names || [];
-
-		if ( ! source.isObject3D ) {
-
-			source = this.getHelperFromSkeleton( source );
-
-		}
-
-		const numFrames = Math.round( clip.duration * ( options.fps / 1000 ) * 1000 ),
-			delta = 1 / options.fps,
-			convertedTracks = [],
-			mixer = new AnimationMixer( source ),
-			bones = this.getBones( target.skeleton ),
-			boneDatas = [];
-		let positionOffset,
-			bone, boneTo, boneData,
-			name;
-
-		mixer.clipAction( clip ).play();
-		mixer.update( 0 );
-
-		source.updateMatrixWorld();
-
-		for ( let i = 0; i < numFrames; ++ i ) {
-
-			const time = i * delta;
-
-			this.retarget( target, source, options );
-
-			for ( let j = 0; j < bones.length; ++ j ) {
-
-				name = options.names[ bones[ j ].name ] || bones[ j ].name;
-
-				boneTo = this.getBoneByName( name, source.skeleton );
-
-				if ( boneTo ) {
-
-					bone = bones[ j ];
-					boneData = boneDatas[ j ] = boneDatas[ j ] || { bone: bone };
-
-					if ( options.hip === name ) {
-
-						if ( ! boneData.pos ) {
-
-							boneData.pos = {
-								times: new Float32Array( numFrames ),
-								values: new Float32Array( numFrames * 3 )
-							};
-
-						}
-
-						if ( options.useFirstFramePosition ) {
-
-							if ( i === 0 ) {
-
-								positionOffset = bone.position.clone();
-
-							}
-
-							bone.position.sub( positionOffset );
-
-						}
-
-						boneData.pos.times[ i ] = time;
-
-						bone.position.toArray( boneData.pos.values, i * 3 );
-
-					}
-
-					if ( ! boneData.quat ) {
-
-						boneData.quat = {
-							times: new Float32Array( numFrames ),
-							values: new Float32Array( numFrames * 4 )
-						};
-
-					}
-
-					boneData.quat.times[ i ] = time;
-
-					bone.quaternion.toArray( boneData.quat.values, i * 4 );
-
-				}
-
-			}
-
-			mixer.update( delta );
-
-			source.updateMatrixWorld();
-
-		}
-
-		for ( let i = 0; i < boneDatas.length; ++ i ) {
-
-			boneData = boneDatas[ i ];
-
-			if ( boneData ) {
-
-				if ( boneData.pos ) {
-
-					convertedTracks.push( new VectorKeyframeTrack(
-						'.bones[' + boneData.bone.name + '].position',
-						boneData.pos.times,
-						boneData.pos.values
-					) );
-
-				}
-
-				convertedTracks.push( new QuaternionKeyframeTrack(
-					'.bones[' + boneData.bone.name + '].quaternion',
-					boneData.quat.times,
-					boneData.quat.values
-				) );
-
-			}
-
-		}
-
-		mixer.uncacheAction( clip );
-
-		return new AnimationClip( clip.name, - 1, convertedTracks );
-
-	}
-
-	static getHelperFromSkeleton( skeleton ) {
-
-		const source = new SkeletonHelper( skeleton.bones[ 0 ] );
-		source.skeleton = skeleton;
-
-		return source;
-
-	}
-
-	static getSkeletonOffsets( target, source, options = {} ) {
-
-		const targetParentPos = new Vector3(),
-			targetPos = new Vector3(),
-			sourceParentPos = new Vector3(),
-			sourcePos = new Vector3(),
-			targetDir = new Vector2(),
-			sourceDir = new Vector2();
-
-		options.hip = options.hip !== undefined ? options.hip : 'hip';
-		options.names = options.names || {};
-
-		if ( ! source.isObject3D ) {
-
-			source = this.getHelperFromSkeleton( source );
-
-		}
-
-		const nameKeys = Object.keys( options.names ),
-			nameValues = Object.values( options.names ),
-			sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
-			bones = target.isObject3D ? target.skeleton.bones : this.getBones( target ),
-			offsets = [];
-
-		let bone, boneTo,
-			name, i;
-
-		target.skeleton.pose();
-
-		for ( i = 0; i < bones.length; ++ i ) {
-
-			bone = bones[ i ];
-			name = options.names[ bone.name ] || bone.name;
-
-			boneTo = this.getBoneByName( name, sourceBones );
-
-			if ( boneTo && name !== options.hip ) {
-
-				const boneParent = this.getNearestBone( bone.parent, nameKeys ),
-					boneToParent = this.getNearestBone( boneTo.parent, nameValues );
-
-				boneParent.updateMatrixWorld();
-				boneToParent.updateMatrixWorld();
-
-				targetParentPos.setFromMatrixPosition( boneParent.matrixWorld );
-				targetPos.setFromMatrixPosition( bone.matrixWorld );
-
-				sourceParentPos.setFromMatrixPosition( boneToParent.matrixWorld );
-				sourcePos.setFromMatrixPosition( boneTo.matrixWorld );
-
-				targetDir.subVectors(
-					new Vector2( targetPos.x, targetPos.y ),
-					new Vector2( targetParentPos.x, targetParentPos.y )
-				).normalize();
-
-				sourceDir.subVectors(
-					new Vector2( sourcePos.x, sourcePos.y ),
-					new Vector2( sourceParentPos.x, sourceParentPos.y )
-				).normalize();
-
-				const laterialAngle = targetDir.angle() - sourceDir.angle();
-
-				const offset = new Matrix4().makeRotationFromEuler(
-					new Euler(
-						0,
-						0,
-						laterialAngle
-					)
-				);
-
-				bone.matrix.multiply( offset );
+				bone.matrix.multiply( options.offsets[ name ] );
 
 				bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
 
 				bone.updateMatrixWorld();
 
-				offsets[ name ] = offset;
-
 			}
+
+			bindBones.push( bone.matrixWorld.clone() );
 
 		}
 
-		return offsets;
+	}
+
+	for ( let i = 0; i < bones.length; ++ i ) {
+
+		bone = bones[ i ];
+		name = options.names[ bone.name ] || bone.name;
+
+		boneTo = this.getBoneByName( name, sourceBones );
+
+		globalMatrix.copy( bone.matrixWorld );
+
+		if ( boneTo ) {
+
+			boneTo.updateMatrixWorld();
+
+			if ( options.useTargetMatrix ) {
+
+				relativeMatrix.copy( boneTo.matrixWorld );
+
+			} else {
+
+				relativeMatrix.copy( target.matrixWorld ).invert();
+				relativeMatrix.multiply( boneTo.matrixWorld );
+
+			}
+
+			// ignore scale to extract rotation
+
+			scale.setFromMatrixScale( relativeMatrix );
+			relativeMatrix.scale( scale.set( 1 / scale.x, 1 / scale.y, 1 / scale.z ) );
+
+			// apply to global matrix
+
+			globalMatrix.makeRotationFromQuaternion( quat.setFromRotationMatrix( relativeMatrix ) );
+
+			if ( target.isObject3D ) {
+
+				const boneIndex = bones.indexOf( bone ),
+					wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.copy( target.skeleton.boneInverses[ boneIndex ] ).invert();
+
+				globalMatrix.multiply( wBindMatrix );
+
+			}
+
+			globalMatrix.copyPosition( relativeMatrix );
+
+		}
+
+		if ( bone.parent && bone.parent.isBone ) {
+
+			bone.matrix.copy( bone.parent.matrixWorld ).invert();
+			bone.matrix.multiply( globalMatrix );
+
+		} else {
+
+			bone.matrix.copy( globalMatrix );
+
+		}
+
+		if ( options.preserveHipPosition && name === options.hip ) {
+
+			bone.matrix.setPosition( pos.set( 0, bone.position.y, 0 ) );
+
+		}
+
+		bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
+
+		bone.updateMatrixWorld();
 
 	}
 
-	static renameBones( skeleton, names ) {
-
-		const bones = this.getBones( skeleton );
+	if ( options.preservePosition ) {
 
 		for ( let i = 0; i < bones.length; ++ i ) {
 
-			const bone = bones[ i ];
+			bone = bones[ i ];
+			name = options.names[ bone.name ] || bone.name;
 
-			if ( names[ bone.name ] ) {
+			if ( name !== options.hip ) {
 
-				bone.name = names[ bone.name ];
-
-			}
-
-		}
-
-		return this;
-
-	}
-
-	static getBones( skeleton ) {
-
-		return Array.isArray( skeleton ) ? skeleton : skeleton.bones;
-
-	}
-
-	static getBoneByName( name, skeleton ) {
-
-		for ( let i = 0, bones = this.getBones( skeleton ); i < bones.length; i ++ ) {
-
-			if ( name === bones[ i ].name )
-
-				return bones[ i ];
-
-		}
-
-	}
-
-	static getNearestBone( bone, names ) {
-
-		while ( bone.isBone ) {
-
-			if ( names.indexOf( bone.name ) !== - 1 ) {
-
-				return bone;
-
-			}
-
-			bone = bone.parent;
-
-		}
-
-	}
-
-	static findBoneTrackData( name, tracks ) {
-
-		const regexp = /\[(.*)\]\.(.*)/,
-			result = { name: name };
-
-		for ( let i = 0; i < tracks.length; ++ i ) {
-
-			// 1 is track name
-			// 2 is track type
-			const trackData = regexp.exec( tracks[ i ].name );
-
-			if ( trackData && name === trackData[ 1 ] ) {
-
-				result[ trackData[ 2 ] ] = i;
+				bone.position.copy( bonesPosition[ i ] );
 
 			}
 
 		}
 
-		return result;
-
 	}
 
-	static getEqualsBonesNames( skeleton, targetSkeleton ) {
+	if ( options.preserveMatrix ) {
 
-		const sourceBones = this.getBones( skeleton ),
-			targetBones = this.getBones( targetSkeleton ),
-			bones = [];
+		// restore matrix
 
-		search : for ( let i = 0; i < sourceBones.length; i ++ ) {
-
-			const boneName = sourceBones[ i ].name;
-
-			for ( let j = 0; j < targetBones.length; j ++ ) {
-
-				if ( boneName === targetBones[ j ].name ) {
-
-					bones.push( boneName );
-
-					continue search;
-
-				}
-
-			}
-
-		}
-
-		return bones;
-
-	}
-
-	static clone( source ) {
-
-		const sourceLookup = new Map();
-		const cloneLookup = new Map();
-
-		const clone = source.clone();
-
-		parallelTraverse( source, clone, function ( sourceNode, clonedNode ) {
-
-			sourceLookup.set( clonedNode, sourceNode );
-			cloneLookup.set( sourceNode, clonedNode );
-
-		} );
-
-		clone.traverse( function ( node ) {
-
-			if ( ! node.isSkinnedMesh ) return;
-
-			const clonedMesh = node;
-			const sourceMesh = sourceLookup.get( node );
-			const sourceBones = sourceMesh.skeleton.bones;
-
-			clonedMesh.skeleton = sourceMesh.skeleton.clone();
-			clonedMesh.bindMatrix.copy( sourceMesh.bindMatrix );
-
-			clonedMesh.skeleton.bones = sourceBones.map( function ( bone ) {
-
-				return cloneLookup.get( bone );
-
-			} );
-
-			clonedMesh.bind( clonedMesh.skeleton, clonedMesh.bindMatrix );
-
-		} );
-
-		return clone;
+		target.updateMatrixWorld( true );
 
 	}
 
 }
+
+function retargetClip( target, source, clip, options = {} ) {
+
+	options.useFirstFramePosition = options.useFirstFramePosition !== undefined ? options.useFirstFramePosition : false;
+	options.fps = options.fps !== undefined ? options.fps : 30;
+	options.names = options.names || [];
+
+	if ( ! source.isObject3D ) {
+
+		source = this.getHelperFromSkeleton( source );
+
+	}
+
+	const numFrames = Math.round( clip.duration * ( options.fps / 1000 ) * 1000 ),
+		delta = 1 / options.fps,
+		convertedTracks = [],
+		mixer = new AnimationMixer( source ),
+		bones = this.getBones( target.skeleton ),
+		boneDatas = [];
+	let positionOffset,
+		bone, boneTo, boneData,
+		name;
+
+	mixer.clipAction( clip ).play();
+	mixer.update( 0 );
+
+	source.updateMatrixWorld();
+
+	for ( let i = 0; i < numFrames; ++ i ) {
+
+		const time = i * delta;
+
+		this.retarget( target, source, options );
+
+		for ( let j = 0; j < bones.length; ++ j ) {
+
+			name = options.names[ bones[ j ].name ] || bones[ j ].name;
+
+			boneTo = this.getBoneByName( name, source.skeleton );
+
+			if ( boneTo ) {
+
+				bone = bones[ j ];
+				boneData = boneDatas[ j ] = boneDatas[ j ] || { bone: bone };
+
+				if ( options.hip === name ) {
+
+					if ( ! boneData.pos ) {
+
+						boneData.pos = {
+							times: new Float32Array( numFrames ),
+							values: new Float32Array( numFrames * 3 )
+						};
+
+					}
+
+					if ( options.useFirstFramePosition ) {
+
+						if ( i === 0 ) {
+
+							positionOffset = bone.position.clone();
+
+						}
+
+						bone.position.sub( positionOffset );
+
+					}
+
+					boneData.pos.times[ i ] = time;
+
+					bone.position.toArray( boneData.pos.values, i * 3 );
+
+				}
+
+				if ( ! boneData.quat ) {
+
+					boneData.quat = {
+						times: new Float32Array( numFrames ),
+						values: new Float32Array( numFrames * 4 )
+					};
+
+				}
+
+				boneData.quat.times[ i ] = time;
+
+				bone.quaternion.toArray( boneData.quat.values, i * 4 );
+
+			}
+
+		}
+
+		mixer.update( delta );
+
+		source.updateMatrixWorld();
+
+	}
+
+	for ( let i = 0; i < boneDatas.length; ++ i ) {
+
+		boneData = boneDatas[ i ];
+
+		if ( boneData ) {
+
+			if ( boneData.pos ) {
+
+				convertedTracks.push( new VectorKeyframeTrack(
+					'.bones[' + boneData.bone.name + '].position',
+					boneData.pos.times,
+					boneData.pos.values
+				) );
+
+			}
+
+			convertedTracks.push( new QuaternionKeyframeTrack(
+				'.bones[' + boneData.bone.name + '].quaternion',
+				boneData.quat.times,
+				boneData.quat.values
+			) );
+
+		}
+
+	}
+
+	mixer.uncacheAction( clip );
+
+	return new AnimationClip( clip.name, - 1, convertedTracks );
+
+}
+
+function getHelperFromSkeleton( skeleton ) {
+
+	const source = new SkeletonHelper( skeleton.bones[ 0 ] );
+	source.skeleton = skeleton;
+
+	return source;
+
+}
+
+function getSkeletonOffsets( target, source, options = {} ) {
+
+	const targetParentPos = new Vector3(),
+		targetPos = new Vector3(),
+		sourceParentPos = new Vector3(),
+		sourcePos = new Vector3(),
+		targetDir = new Vector2(),
+		sourceDir = new Vector2();
+
+	options.hip = options.hip !== undefined ? options.hip : 'hip';
+	options.names = options.names || {};
+
+	if ( ! source.isObject3D ) {
+
+		source = this.getHelperFromSkeleton( source );
+
+	}
+
+	const nameKeys = Object.keys( options.names ),
+		nameValues = Object.values( options.names ),
+		sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
+		bones = target.isObject3D ? target.skeleton.bones : this.getBones( target ),
+		offsets = [];
+
+	let bone, boneTo,
+		name, i;
+
+	target.skeleton.pose();
+
+	for ( i = 0; i < bones.length; ++ i ) {
+
+		bone = bones[ i ];
+		name = options.names[ bone.name ] || bone.name;
+
+		boneTo = this.getBoneByName( name, sourceBones );
+
+		if ( boneTo && name !== options.hip ) {
+
+			const boneParent = this.getNearestBone( bone.parent, nameKeys ),
+				boneToParent = this.getNearestBone( boneTo.parent, nameValues );
+
+			boneParent.updateMatrixWorld();
+			boneToParent.updateMatrixWorld();
+
+			targetParentPos.setFromMatrixPosition( boneParent.matrixWorld );
+			targetPos.setFromMatrixPosition( bone.matrixWorld );
+
+			sourceParentPos.setFromMatrixPosition( boneToParent.matrixWorld );
+			sourcePos.setFromMatrixPosition( boneTo.matrixWorld );
+
+			targetDir.subVectors(
+				new Vector2( targetPos.x, targetPos.y ),
+				new Vector2( targetParentPos.x, targetParentPos.y )
+			).normalize();
+
+			sourceDir.subVectors(
+				new Vector2( sourcePos.x, sourcePos.y ),
+				new Vector2( sourceParentPos.x, sourceParentPos.y )
+			).normalize();
+
+			const laterialAngle = targetDir.angle() - sourceDir.angle();
+
+			const offset = new Matrix4().makeRotationFromEuler(
+				new Euler(
+					0,
+					0,
+					laterialAngle
+				)
+			);
+
+			bone.matrix.multiply( offset );
+
+			bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
+
+			bone.updateMatrixWorld();
+
+			offsets[ name ] = offset;
+
+		}
+
+	}
+
+	return offsets;
+
+}
+
+function renameBones( skeleton, names ) {
+
+	const bones = this.getBones( skeleton );
+
+	for ( let i = 0; i < bones.length; ++ i ) {
+
+		const bone = bones[ i ];
+
+		if ( names[ bone.name ] ) {
+
+			bone.name = names[ bone.name ];
+
+		}
+
+	}
+
+	return this;
+
+}
+
+function getBones( skeleton ) {
+
+	return Array.isArray( skeleton ) ? skeleton : skeleton.bones;
+
+}
+
+function getBoneByName( name, skeleton ) {
+
+	for ( let i = 0, bones = this.getBones( skeleton ); i < bones.length; i ++ ) {
+
+		if ( name === bones[ i ].name )
+
+			return bones[ i ];
+
+	}
+
+}
+
+function getNearestBone( bone, names ) {
+
+	while ( bone.isBone ) {
+
+		if ( names.indexOf( bone.name ) !== - 1 ) {
+
+			return bone;
+
+		}
+
+		bone = bone.parent;
+
+	}
+
+}
+
+function findBoneTrackData( name, tracks ) {
+
+	const regexp = /\[(.*)\]\.(.*)/,
+		result = { name: name };
+
+	for ( let i = 0; i < tracks.length; ++ i ) {
+
+		// 1 is track name
+		// 2 is track type
+		const trackData = regexp.exec( tracks[ i ].name );
+
+		if ( trackData && name === trackData[ 1 ] ) {
+
+			result[ trackData[ 2 ] ] = i;
+
+		}
+
+	}
+
+	return result;
+
+}
+
+function getEqualsBonesNames( skeleton, targetSkeleton ) {
+
+	const sourceBones = this.getBones( skeleton ),
+		targetBones = this.getBones( targetSkeleton ),
+		bones = [];
+
+	search : for ( let i = 0; i < sourceBones.length; i ++ ) {
+
+		const boneName = sourceBones[ i ].name;
+
+		for ( let j = 0; j < targetBones.length; j ++ ) {
+
+			if ( boneName === targetBones[ j ].name ) {
+
+				bones.push( boneName );
+
+				continue search;
+
+			}
+
+		}
+
+	}
+
+	return bones;
+
+}
+
+function clone( source ) {
+
+	const sourceLookup = new Map();
+	const cloneLookup = new Map();
+
+	const clone = source.clone();
+
+	parallelTraverse( source, clone, function ( sourceNode, clonedNode ) {
+
+		sourceLookup.set( clonedNode, sourceNode );
+		cloneLookup.set( sourceNode, clonedNode );
+
+	} );
+
+	clone.traverse( function ( node ) {
+
+		if ( ! node.isSkinnedMesh ) return;
+
+		const clonedMesh = node;
+		const sourceMesh = sourceLookup.get( node );
+		const sourceBones = sourceMesh.skeleton.bones;
+
+		clonedMesh.skeleton = sourceMesh.skeleton.clone();
+		clonedMesh.bindMatrix.copy( sourceMesh.bindMatrix );
+
+		clonedMesh.skeleton.bones = sourceBones.map( function ( bone ) {
+
+			return cloneLookup.get( bone );
+
+		} );
+
+		clonedMesh.bind( clonedMesh.skeleton, clonedMesh.bindMatrix );
+
+	} );
+
+	return clone;
+
+}
+
+
 
 
 function parallelTraverse( a, b, callback ) {
@@ -582,4 +581,16 @@ function parallelTraverse( a, b, callback ) {
 
 }
 
-export { SkeletonUtils };
+export {
+	retarget,
+	retargetClip,
+	getHelperFromSkeleton,
+	getSkeletonOffsets,
+	renameBones,
+	getBones,
+	getBoneByName,
+	getNearestBone,
+	findBoneTrackData,
+	getEqualsBonesNames,
+	clone,
+};

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -19,7 +19,7 @@
 			import * as THREE from '../build/three.module.js';
 
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
-			import { SkeletonUtils } from './jsm/utils/SkeletonUtils.js';
+			import * as SkeletonUtils from './jsm/utils/SkeletonUtils.js';
 
 			//////////////////////////////
 			// Global objects

--- a/examples/webgl_buffergeometry_compression.html
+++ b/examples/webgl_buffergeometry_compression.html
@@ -18,7 +18,7 @@
 
 			import Stats from './jsm/libs/stats.module.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
-			import { GeometryCompressionUtils } from './jsm/utils/GeometryCompressionUtils.js';
+			import * as GeometryCompressionUtils from './jsm/utils/GeometryCompressionUtils.js';
 			import * as BufferGeometryUtils from './jsm/utils/BufferGeometryUtils.js';
 			import { TeapotGeometry } from './jsm/geometries/TeapotGeometry.js';
 			import { GUI } from './jsm/libs/dat.gui.module.js';

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -40,7 +40,7 @@
 			import * as THREE from '../build/three.module.js';
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
-			import { GeometryUtils } from './jsm/utils/GeometryUtils.js';
+			import * as GeometryUtils from './jsm/utils/GeometryUtils.js';
 
 			let camera, scene, renderer;
 			let line, sprite, texture;

--- a/examples/webgl_lines_colors.html
+++ b/examples/webgl_lines_colors.html
@@ -17,7 +17,7 @@
 
 			import * as THREE from '../build/three.module.js';
 
-			import { GeometryUtils } from './jsm/utils/GeometryUtils.js';
+			import * as GeometryUtils from './jsm/utils/GeometryUtils.js';
 
 			let mouseX = 0, mouseY = 0;
 

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -17,7 +17,7 @@
 
 			import Stats from './jsm/libs/stats.module.js';
 
-			import { GeometryUtils } from './jsm/utils/GeometryUtils.js';
+			import * as GeometryUtils from './jsm/utils/GeometryUtils.js';
 
 			let renderer, scene, camera, stats;
 			const objects = [];

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -25,7 +25,7 @@
 			import { Line2 } from './jsm/lines/Line2.js';
 			import { LineMaterial } from './jsm/lines/LineMaterial.js';
 			import { LineGeometry } from './jsm/lines/LineGeometry.js';
-			import { GeometryUtils } from './jsm/utils/GeometryUtils.js';
+			import * as GeometryUtils from './jsm/utils/GeometryUtils.js';
 
 			let line, renderer, scene, camera, camera2, controls;
 			let line1;

--- a/examples/webgl_portal.html
+++ b/examples/webgl_portal.html
@@ -24,7 +24,7 @@
 
 			import * as THREE from '../build/three.module.js';
 
-			import { CameraUtils } from './jsm/utils/CameraUtils.js';
+			import * as CameraUtils from './jsm/utils/CameraUtils.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
 			let camera, scene, renderer;


### PR DESCRIPTION
Related issue: #22267

**Description**
I converted all `*Utils` files in the examples to esmodules to allow for tree-shaking. They now need to be imported like this:

```js
import * as NURBSUtils from '../curves/NURBSUtils.js';
```


The files I touched are `NURBSUtils`, `CameraUtils`, `SceneUtils`, `GeometryCompressionUtils`, `GeometryUtils`, `SkeletonUtils`.

I had to move `PackedPhongMaterial` out of `GeometryCompressionUtils` as well.