### PR TITLE
WebGLShadowMaps: Add support for rendering shadows with displacement maps

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -244,7 +244,10 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		if ( _renderer.localClippingEnabled &&
 				material.clipShadows === true &&
-				material.clippingPlanes.length !== 0 ) {
+				material.clippingPlanes.length !== 0 ||
+				material.displacementMap &&
+				material.displacementScale !== 0
+		) {
 
 			// in this case we need a unique material instance reflecting the
 			// appropriate state
@@ -289,6 +292,9 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		result.clipShadows = material.clipShadows;
 		result.clippingPlanes = material.clippingPlanes;
 		result.clipIntersection = material.clipIntersection;
+
+		result.displacementMap = material.displacementMap;
+		result.displacementScale = material.displacementScale;
 
 		result.wireframeLinewidth = material.wireframeLinewidth;
 		result.linewidth = material.linewidth;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -295,6 +295,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		result.displacementMap = material.displacementMap;
 		result.displacementScale = material.displacementScale;
+		result.displacementBias = material.displacementBias;
 
 		result.wireframeLinewidth = material.wireframeLinewidth;
 		result.linewidth = material.linewidth;


### PR DESCRIPTION
Related issue: --

**Description**

Adds support for correctly rendering shadows for geometry with displacement maps automatically so `customDepthMaterial` and `customDistanceMaterial` are no longer needed for displacement map materials.

| BEFORE | AFTER |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/128547104-0a631d4c-3caf-4ad7-a1e8-f0382f4337d6.png) | ![image](https://user-images.githubusercontent.com/734200/128547557-1b443624-5b08-47be-a208-a08c157c364e.png) |
