### PR TITLE
FBXLoader: can't check image until loaded

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -701,16 +701,7 @@ class FBXTreeParser {
 		}
 
 		const texture = textureMap.get( id );
-
-		if ( texture !== undefined && texture.image !== undefined ) {
-
-			return texture;
-
-		} else {
-
-			return undefined;
-
-		}
+		return texture;
 
 	}
 


### PR DESCRIPTION
Resolves https://github.com/mrdoob/three.js/issues/22285

`texture.image` will always be undefined here as the textures are asynchronously loaded.
