### PR TITLE
PropertyBinding: Fix _getValue_direct().

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -261,7 +261,7 @@ class PropertyBinding {
 
 	_getValue_direct( buffer, offset ) {
 
-		buffer[ offset ] = this.node[ this.propertyName ];
+		buffer[ offset ] = this.targetObject[ this.propertyName ];
 
 	}
 


### PR DESCRIPTION
Related issue: see https://discourse.threejs.org/t/material-opacity-set-to-nan-after-animation-stops/28695

**Description**

`_getValue_direct()` used the wrong reference for accessing the target object's value. The implementation is now aligned to `_setValue_direct()`.