### PR TITLE
WebGLShadowMap: Add onDisposeCustomMaterial to prevent material memory leak

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -69,6 +69,20 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 	this.type = PCFShadowMap;
 
+	function onDisposeCustomMaterial( e ) {
+
+		const uuid = e.target.uuid;
+		const materialsForVariant = _materialCache[ uuid ];
+		for ( const key in materialsForVariant ) {
+
+			materialsForVariant[ key ].dispose();
+
+		}
+
+		delete _materialCache[ uuid ];
+
+	}
+
 	this.render = function ( lights, scene, camera ) {
 
 		if ( scope.enabled === false ) return;
@@ -257,6 +271,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 				materialsForVariant = {};
 				_materialCache[ keyA ] = materialsForVariant;
+				result.addEventListener( 'dispose', onDisposeCustomMaterial );
 
 			}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -310,6 +310,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 					material.addEventListener( 'dispose', onDisposeMaterial );
 
 				}
+
 				_reverseMaterialCache[ keyB ].add( keyA );
 
 			}


### PR DESCRIPTION
Related issue: --

**Description**

When custom materials are used with clipping planes (and soon [displacement maps](https://github.com/mrdoob/three.js/pull/22287)) clones of the material are created for every necessary mesh material but never deleted. This adds a callback to dispose of all material variant clones of a custom shadow material once it's been disposed.

There's still a memory leak for every mesh material that gets a clone in the _materialCache subobjects which aren't disposed when the original material is disposed (the `keyB` branch in `getDepthMaterial`). This case is a little more complicated to handle because it requires iterating over all material caches to delete its corresponding material. I'll propose something in another PR.