### PR TITLE
CameraControls

### DIFF
--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -6,13 +6,13 @@ import {
     Vector3
 } from '../../../build/three.module.js';
 
-// This set of controls models a movie camera.
+// This set of controls performs Rotating, dollying (zooming for OrthographicCamera), and panning.
 // Pan up / down / left / right  - right mouse, or WASD keys / touch: three finger swipe
 // Dolly forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
 // Rotate  - left mouse, or arrow keys / touch: one finger move
 
 // Compared to OrbitControls:
-// 1. It can dolly forward/backward and pan left/right/up/down.
+// 1. It can dolly forward/backward (instead of dolly in/out) and pan left/right/up/down.
 // 2. Rotation is centered on the camera itself.
 
 class CameraControls extends EventDispatcher {
@@ -62,7 +62,8 @@ class CameraControls extends EventDispatcher {
 
         // Set to false to disable rotating
         this.enableRotate = true;
-        this.rotateSpeed = 0.1;
+        this.invertRotate = false;
+        this.rotateSpeed = 0.08;
 
         // Set to false to disable panning
         this.enablePan = true;
@@ -282,8 +283,18 @@ class CameraControls extends EventDispatcher {
 
         function rotate(angleX, angleY) {
 
-            angleXDelta += angleX * 50 * scope.rotateSpeed;
-            angleYDelta -= angleY * 50 * scope.rotateSpeed;
+            if (scope.invertRotate) {
+
+                angleXDelta += angleX * 50 * scope.rotateSpeed;
+                angleYDelta -= angleY * 50 * scope.rotateSpeed;
+
+            } else {
+
+                angleXDelta -= angleX * 50 * scope.rotateSpeed;
+                angleYDelta += angleY * 50 * scope.rotateSpeed;
+
+            }
+
 
         }
 
@@ -363,7 +374,7 @@ class CameraControls extends EventDispatcher {
 
         }();
 
-        function dollyIn(dollyScale) {
+        function dollyForward(dollyScale) {
 
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
@@ -386,7 +397,7 @@ class CameraControls extends EventDispatcher {
 
         }
 
-        function dollyOut(dollyScale) {
+        function dollyBackward(dollyScale) {
 
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
@@ -455,11 +466,11 @@ class CameraControls extends EventDispatcher {
 
             if (dollyDelta.y > 0) {
 
-                dollyIn(getZoomScale());
+                dollyForward(getZoomScale());
 
             } else if (dollyDelta.y < 0) {
 
-                dollyOut(getZoomScale());
+                dollyBackward(getZoomScale());
 
             }
 
@@ -491,11 +502,11 @@ class CameraControls extends EventDispatcher {
 
             if (event.deltaY < 0) {
 
-                dollyOut(getZoomScale());
+                dollyBackward(getZoomScale());
 
             } else if (event.deltaY > 0) {
 
-                dollyIn(getZoomScale());
+                dollyForward(getZoomScale());
 
             }
 
@@ -540,12 +551,12 @@ class CameraControls extends EventDispatcher {
                 switch (event.keyCode) {
 
                     case scope.keys.FORWARD:
-                        dollyOut(getZoomScale() * scope.keyPanSpeed);;
+                        dollyBackward(getZoomScale() * scope.keyPanSpeed);;
                         scope.update();
                         break;
 
                     case scope.keys.BACKWARD:
-                        dollyIn(getZoomScale() * scope.keyPanSpeed);;
+                        dollyForward(getZoomScale() * scope.keyPanSpeed);;
                         scope.update();
                         break;
 
@@ -616,11 +627,11 @@ class CameraControls extends EventDispatcher {
 
             if (dollyDelta.y > 0) {
 
-                dollyOut(getZoomScale());
+                dollyBackward(getZoomScale());
 
             } else if (dollyDelta.y < 0) {
 
-                dollyIn(getZoomScale());
+                dollyForward(getZoomScale());
 
             }
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -9,7 +9,7 @@ import {
 // This set of controls models a movie camera.
 // Pan up / down / left / right  - right mouse, or WASD keys / touch: three finger swipe
 // Dolly forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
-// Rotate  - middle mouse, or arrow keys / touch: one finger move
+// Rotate  - left mouse, or arrow keys / touch: one finger move
 
 // Compared to OrbitControls:
 // 1. It can dolly forward/backward and pan left/right/up/down.
@@ -81,7 +81,7 @@ class CameraControls extends EventDispatcher {
         this.keys = { TURNLEFT: 37, TURNUP: 38, TURNRIGHT: 39, TURNBOTTOM: 40, FORWARD: 87, BACKWARD: 83, LEFT: 65, RIGHT: 68 };
 
         // Mouse buttons
-        this.mouseButtons = { PAN: MOUSE.RIGHT, ZOOM: false, ROTATE: MOUSE.MIDDLE };
+        this.mouseButtons = { PAN: MOUSE.RIGHT, ZOOM: false, ROTATE: MOUSE.LEFT };
 
         // for reset
         this.position0 = this.object.position.clone();
@@ -167,6 +167,11 @@ class CameraControls extends EventDispatcher {
 
                     scope.angleX += angleXDelta * scope.dampingFactor * 1.5;
                     scope.angleY = Math.max(-Math.PI / 2.001, Math.min(scope.angleY + angleYDelta * scope.dampingFactor * 1.5, Math.PI / 2.001))
+
+                } else {
+
+                    scope.angleX += angleXDelta * 1.5;
+                    scope.angleY = Math.max(-Math.PI / 2.001, Math.min(scope.angleY + angleYDelta * 1.5, Math.PI / 2.001))
 
                 }
 
@@ -337,7 +342,6 @@ class CameraControls extends EventDispatcher {
 
                 if (scope.object.isPerspectiveCamera) {
 
-                    // we actually don't use screenWidth, since perspective camera is fixed to screen height
                     panLeft(deltaX / element.clientHeight, scope.object.matrix);
                     panUp(deltaY / element.clientHeight, scope.object.matrix);
 
@@ -528,7 +532,9 @@ class CameraControls extends EventDispatcher {
                         break;
 
                 }
+
             }
+
             if (scope.enablePan === true) {
 
                 switch (event.keyCode) {
@@ -544,17 +550,19 @@ class CameraControls extends EventDispatcher {
                         break;
 
                     case scope.keys.LEFT:
-                        pan(20 * scope.keyPanSpeed, 0);
+                        pan(20 * scope.keyPanSpeed * scope.sensibility, 0);
                         scope.update();
                         break;
 
                     case scope.keys.RIGHT:
-                        pan(- 20 * scope.keyPanSpeed, 0);
+                        pan(- 20 * scope.keyPanSpeed * scope.sensibility, 0);
                         scope.update();
                         break;
 
                 }
+
             }
+
         }
 
         function handleTouchStartRotate(event) {
@@ -696,8 +704,10 @@ class CameraControls extends EventDispatcher {
         function onMouseMove(event) {
 
             if (scope.stop) {
+
                 onMouseUp(event);
                 scope.stop = false;
+
             }
 
             if (scope.enabled === false) return;

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -280,11 +280,11 @@ class CameraControls extends EventDispatcher {
 
         }();
 
-        var panUp_Distance = function () {
+        var moveForward = function () {
 
             var v = new Vector3();
 
-            return function panUp(distance) {
+            return function moveForward(distance) {
 
                 v.copy(scope.look)
 
@@ -332,7 +332,7 @@ class CameraControls extends EventDispatcher {
 
             if (scope.object.isPerspectiveCamera) {
 
-                panUp_Distance(-50 * scope.sensibility * dollyScale / element.clientHeight, scope.object.matrix);
+                moveForward(-50 * scope.sensibility * dollyScale / element.clientHeight);
 
             } else if (scope.object.isOrthographicCamera) {
 
@@ -355,7 +355,7 @@ class CameraControls extends EventDispatcher {
 
             if (scope.object.isPerspectiveCamera) {
 
-                panUp_Distance(50 * scope.sensibility * dollyScale / element.clientHeight, scope.object.matrix);
+                moveForward(50 * scope.sensibility * dollyScale / element.clientHeight);
 
             } else if (scope.object.isOrthographicCamera) {
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -63,7 +63,7 @@ class CameraControls extends EventDispatcher {
         // Set to false to disable rotating
         this.enableRotate = true;
         this.invertRotate = false;
-        this.rotateSpeed = 0.08;
+        this.rotateSpeed = 1.0;
 
         // Set to false to disable panning
         this.enablePan = true;
@@ -285,13 +285,13 @@ class CameraControls extends EventDispatcher {
 
             if (scope.invertRotate) {
 
-                angleXDelta += angleX * 100 * scope.rotateSpeed;
-                angleYDelta -= angleY * 50 * scope.rotateSpeed;
+                angleXDelta += angleX * 0.64;
+                angleYDelta -= angleY * 0.32;
 
             } else {
 
-                angleXDelta -= angleX * 100 * scope.rotateSpeed;
-                angleYDelta += angleY * 50 * scope.rotateSpeed;
+                angleXDelta -= angleX * 0.64;
+                angleYDelta += angleY * 0.32;
 
             }
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -378,15 +378,11 @@ class CameraControls extends EventDispatcher {
 
         function handleMouseDownRotate(event) {
 
-            //console.log( 'handleMouseDownRotate' );
-
             rotateStart.set(event.clientX, event.clientY);
 
         }
 
         function handleMouseDownDolly(event) {
-
-            //console.log( 'handleMouseDownDolly' );
 
             dollyStart.set(event.clientX, event.clientY);
 
@@ -394,15 +390,11 @@ class CameraControls extends EventDispatcher {
 
         function handleMouseDownPan(event) {
 
-            //console.log( 'handleMouseDownPan' );
-
             panStart.set(event.clientX, event.clientY);
 
         }
 
         function handleMouseMoveRotate(event) {
-
-            //console.log( 'handleMouseMoveRotate' );
 
             rotateEnd.set(event.clientX, event.clientY);
             rotateDelta.subVectors(rotateEnd, rotateStart);
@@ -419,8 +411,6 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleMouseMoveDolly(event) {
-
-            //console.log( 'handleMouseMoveDolly' );
 
             dollyEnd.set(event.clientX, event.clientY);
 
@@ -444,8 +434,6 @@ class CameraControls extends EventDispatcher {
 
         function handleMouseMovePan(event) {
 
-            //console.log( 'handleMouseMovePan' );
-
             panEnd.set(event.clientX, event.clientY);
 
             panDelta.subVectors(panEnd, panStart);
@@ -460,13 +448,9 @@ class CameraControls extends EventDispatcher {
 
         function handleMouseUp(event) {
 
-            // console.log( 'handleMouseUp' );
-
         }
 
         function handleMouseWheel(event) {
-
-            // console.log( 'handleMouseWheel' );
 
             if (event.deltaY < 0) {
 
@@ -483,8 +467,6 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleKeyDown(event) {
-
-            //console.log( 'handleKeyDown' );
 
             switch (event.keyCode) {
 
@@ -514,15 +496,11 @@ class CameraControls extends EventDispatcher {
 
         function handleTouchStartRotate(event) {
 
-            //console.log( 'handleTouchStartRotate' );
-
             rotateStart.set(event.touches[0].pageX, event.touches[0].pageY);
 
         }
 
         function handleTouchStartDolly(event) {
-
-            //console.log( 'handleTouchStartDolly' );
 
             var dx = event.touches[0].pageX - event.touches[1].pageX;
             var dy = event.touches[0].pageY - event.touches[1].pageY;
@@ -535,15 +513,11 @@ class CameraControls extends EventDispatcher {
 
         function handleTouchStartPan(event) {
 
-            //console.log( 'handleTouchStartPan' );
-
             panStart.set(event.touches[0].pageX, event.touches[0].pageY);
 
         }
 
         function handleTouchMoveRotate(event) {
-
-            //console.log( 'handleTouchMoveRotate' );
 
             rotateEnd.set(event.touches[0].pageX, event.touches[0].pageY);
             rotateDelta.subVectors(rotateEnd, rotateStart);
@@ -559,8 +533,6 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleTouchMoveDolly(event) {
-
-            //console.log( 'handleTouchMoveDolly' );
 
             var dx = event.touches[0].pageX - event.touches[1].pageX;
             var dy = event.touches[0].pageY - event.touches[1].pageY;
@@ -589,8 +561,6 @@ class CameraControls extends EventDispatcher {
 
         function handleTouchMovePan(event) {
 
-            //console.log( 'handleTouchMovePan' );
-
             panEnd.set(event.touches[0].pageX, event.touches[0].pageY);
 
             panDelta.subVectors(panEnd, panStart);
@@ -604,8 +574,6 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleTouchEnd(event) {
-
-            //console.log( 'handleTouchEnd' );
 
         }
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -6,12 +6,12 @@ import {
     Vector3
 } from '../../../build/three.module.js';
 
-// This set of controls performs turning, dollying (zooming), and panning. It is an update of OrbitControls
+// This set of controls models a movie camera.
 // Pan up / down / left / right  - right mouse, or WASD keys / touch: three finger swipe
 // Dolly forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
 // Rotate  - middle mouse, or arrow keys / touch: one finger move
 
-// Updates compared to OrbitControls:
+// Compared to OrbitControls:
 // 1. It can dolly forward/backward and pan left/right/up/down.
 // 2. Rotation is centered on the camera itself.
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -16,10 +16,14 @@ import {
 // 2. The turning will be conducted using the PerspectiveCamera as the center.
 
 class CameraControls extends EventDispatcher {
+
     constructor(object, domElement) {
+
         super();
+
         this.angleX = 0;
         this.angleY = 0;
+
         this.stop = false;
 
         this.o = new Vector3(0, 0, 0)
@@ -40,9 +44,6 @@ class CameraControls extends EventDispatcher {
         // If damping is enabled, you must call controls.update() in your animation loop
         this.enableDamping = false;
         this.dampingFactor = 0.1;
-
-        // "target" sets the location of focus, where the object orbits around
-        this.target = new Vector3();
 
         // "look" sets the direction of the focus
         this.look = new Vector3();
@@ -68,7 +69,7 @@ class CameraControls extends EventDispatcher {
         this.keyPanSpeed = 1.0;// pixels moved per arrow key push
         this.keyRotateSpeed = 1.0;
 
-        // Set to true to automatically rotate around the target
+        // Set to true to automatically rotate
         // If auto-rotate is enabled, you must call controls.update() in your animation loop
         this.autoRotate = false;
         this.autoRotateSpeed = 0.2;
@@ -83,7 +84,6 @@ class CameraControls extends EventDispatcher {
         this.mouseButtons = { ORBIT: MOUSE.RIGHT, ZOOM: false, PAN: MOUSE.MIDDLE };
 
         // for reset
-        this.target0 = this.target.clone();
         this.position0 = this.object.position.clone();
         this.zoom0 = this.object.zoom;
         this.look0 = this.look.clone();
@@ -96,7 +96,6 @@ class CameraControls extends EventDispatcher {
 
         this.saveState = function () {
 
-            scope.target0.copy(scope.target);
             scope.position0.copy(scope.object.position);
             scope.zoom0 = scope.object.zoom;
             scope.look0.copy(scope.look);
@@ -107,7 +106,6 @@ class CameraControls extends EventDispatcher {
 
         this.reset = function () {
 
-            scope.target.copy(scope.target0);
             scope.object.position.copy(scope.position0);
             scope.object.zoom = scope.zoom0;
             scope.look.copy(scope.look0);
@@ -126,12 +124,6 @@ class CameraControls extends EventDispatcher {
         // this method is exposed, but perhaps it would be better if we can make it private...
         this.update = function () {
 
-            var offset = new Vector3();
-
-            // so camera.up is the orbit axis
-            var quat = new Quaternion().setFromUnitVectors(object.up, new Vector3(0, 1, 0));
-            var quatInverse = quat.clone().invert();
-
             var lastPosition = new Vector3();
             var lastQuaternion = new Quaternion();
 
@@ -140,13 +132,10 @@ class CameraControls extends EventDispatcher {
                 var position = scope.object.position;
 
                 if (scope.dynamicSensibility) {
-                    scope.sensibility = Math.max(1, scope.object.position.distanceTo(scope.o))
+
+                    scope.sensibility = Math.max(1, scope.object.position.distanceTo(scope.o));
+
                 }
-
-                offset.copy(position).sub(scope.target);
-
-                // rotate offset to "y-axis-is-up" space
-                offset.applyQuaternion(quat);
 
                 if (scope.autoRotate && state === STATE.NONE) {
 
@@ -154,31 +143,33 @@ class CameraControls extends EventDispatcher {
 
                 }
 
-                // move target to panned location
+                // move position to panned location
                 if (scope.enableDamping === true) {
 
-                    scope.target.addScaledVector(panOffset, scope.dampingFactor);
+                    position.addScaledVector(panOffset, scope.dampingFactor);
 
                 } else {
 
-                    scope.target.add(panOffset);
+                    position.add(panOffset);
 
                 }
-                let distance = scope.target.distanceTo(scope.o)
+
+                let distance = position.distanceTo(scope.o);
+
                 if (distance > scope.maxDistance) {
-                    scope.target.multiplyScalar(scope.maxDistance / distance)
+
+                    position.multiplyScalar(scope.maxDistance / distance);
+
                 }
-
-                // rotate offset back to "camera-up-vector-is-up" space
-                offset.applyQuaternion(quatInverse);
-
-                position.copy(scope.target).add(offset);
 
 
                 if (scope.enableDamping) {
+
                     scope.angleX += angleXDelta * scope.dampingFactor * 1.5;
                     scope.angleY = Math.max(-Math.PI / 2.001, Math.min(scope.angleY + angleYDelta * scope.dampingFactor * 1.5, Math.PI / 2.001))
+
                 }
+
                 scope.look.x = Math.sin(scope.angleX) * (Math.PI / 2 - Math.abs(scope.angleY))
                 scope.look.z = -Math.cos(scope.angleX) * (Math.PI / 2 - Math.abs(scope.angleY))
                 scope.look.y = Math.sin(scope.angleY)
@@ -193,14 +184,12 @@ class CameraControls extends EventDispatcher {
 
                     angleXDelta *= (1 - scope.dampingFactor * 1.5);
                     angleYDelta *= (1 - scope.dampingFactor * 1.5);
-
                     panOffset.multiplyScalar(1 - scope.dampingFactor);
 
                 } else {
 
                     angleXDelta = 0;
                     angleYDelta = 0;
-
                     panOffset.set(0, 0, 0);
 
                 }
@@ -208,17 +197,12 @@ class CameraControls extends EventDispatcher {
                 // update condition is:
                 // min(camera displacement, camera rotation in radians)^2 > EPS
                 // using small-angle approximation cos(x/2) = 1 - x^2 / 8
-
-                if (zoomChanged ||
-                    lastPosition.distanceToSquared(scope.object.position) > EPS ||
-                    8 * (1 - lastQuaternion.dot(scope.object.quaternion)) > EPS) {
+                if (zoomChanged || lastPosition.distanceToSquared(scope.object.position) > EPS || 8 * (1 - lastQuaternion.dot(scope.object.quaternion)) > EPS) {
 
                     scope.dispatchEvent(changeEvent);
-
                     lastPosition.copy(scope.object.position);
                     lastQuaternion.copy(scope.object.quaternion);
                     zoomChanged = false;
-
                     return true;
 
                 }
@@ -292,8 +276,10 @@ class CameraControls extends EventDispatcher {
         }
 
         function rotate(angleX, angleY) {
+
             angleXDelta += angleX * 50 * scope.rotateSpeed;
             angleYDelta -= angleY * 50 * scope.rotateSpeed;
+
         }
 
         var panLeft = function () {
@@ -350,6 +336,7 @@ class CameraControls extends EventDispatcher {
                 var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
                 if (scope.object.isPerspectiveCamera) {
+
                     // we actually don't use screenWidth, since perspective camera is fixed to screen height
                     panLeft(deltaX / element.clientHeight, scope.object.matrix);
                     panUp(deltaY / element.clientHeight, scope.object.matrix);
@@ -373,6 +360,7 @@ class CameraControls extends EventDispatcher {
         }();
 
         function dollyIn(dollyScale) {
+
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
             if (scope.object.isPerspectiveCamera) {
@@ -395,6 +383,7 @@ class CameraControls extends EventDispatcher {
         }
 
         function dollyOut(dollyScale) {
+
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
             if (scope.object.isPerspectiveCamera) {
@@ -511,8 +500,11 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleKeyDown(event) {
+
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
             if (scope.enableRotate === true) {
+
                 switch (event.keyCode) {
 
                     case scope.keys.TURNUP:
@@ -538,6 +530,7 @@ class CameraControls extends EventDispatcher {
                 }
             }
             if (scope.enablePan === true) {
+
                 switch (event.keyCode) {
 
                     case scope.keys.FORWARD:
@@ -696,12 +689,12 @@ class CameraControls extends EventDispatcher {
                 document.addEventListener('mousemove', onMouseMove, false);
                 document.addEventListener('mouseup', onMouseUp, false);
 
-
             }
 
         }
 
         function onMouseMove(event) {
+
             if (scope.stop) {
                 onMouseUp(event);
                 scope.stop = false;
@@ -767,6 +760,7 @@ class CameraControls extends EventDispatcher {
 
             scope.dispatchEvent(startEvent); // not sure why these are here...
             scope.dispatchEvent(endEvent);
+
         }
 
         function onKeyDown(event) {
@@ -891,8 +885,6 @@ class CameraControls extends EventDispatcher {
 
         }
 
-        //
-
         scope.domElement.addEventListener('contextmenu', onContextMenu, false);
 
         scope.domElement.addEventListener('mousedown', onMouseDown, false);
@@ -905,11 +897,9 @@ class CameraControls extends EventDispatcher {
         window.addEventListener('keydown', onKeyDown, false);
 
         // force an update at start
-
         this.update();
 
     };
 }
-
 
 export { CameraControls };

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -7,13 +7,13 @@ import {
 } from '../../../build/three.module.js';
 
 // This set of controls performs turning, dollying (zooming), and panning. It is an update of OrbitControls
-// Pan up / down / left / right  - right mouse, or WASD keys / touch: one finger move
-// Move forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
-// Turn  - middle mouse, or arrow keys / touch: three finger swipe
+// Pan up / down / left / right  - right mouse, or WASD keys / touch: three finger swipe
+// Dolly forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
+// Rotate  - middle mouse, or arrow keys / touch: one finger move
 
 // Updates compared to OrbitControls:
-// 1. The dollying of PerspectiveCamera is replaced with panning forward and backward.Therefore, this component can be used to move the PerspectiveCamera to six directions including forward, backward, up, down, left and right from current perspective.
-// 2. The turning will be conducted using the PerspectiveCamera as the center.
+// 1. It can dolly forward/backward and pan left/right/up/down.
+// 2. Rotation is centered on the camera itself.
 
 class CameraControls extends EventDispatcher {
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -7,9 +7,9 @@ import {
 } from '../../../build/three.module.js';
 
 // This set of controls performs turning, dollying (zooming), and panning. It is an update of OrbitControls
-// Pan up / down / left / right  - middle mouse or WASD keys / touch: one finger move
+// Pan up / down / left / right  - right mouse, or WASD keys / touch: one finger move
 // Move forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
-// Turn  - right mouse, or arrow keys / touch: three finger swipe
+// Turn  - middle mouse, or arrow keys / touch: three finger swipe
 
 // Updates compared to OrbitControls:
 // 1. The dollying of PerspectiveCamera is replaced with panning forward and backward.Therefore, this component can be used to move the PerspectiveCamera to six directions including forward, backward, up, down, left and right from current perspective.
@@ -81,7 +81,7 @@ class CameraControls extends EventDispatcher {
         this.keys = { TURNLEFT: 37, TURNUP: 38, TURNRIGHT: 39, TURNBOTTOM: 40, FORWARD: 87, BACKWARD: 83, LEFT: 65, RIGHT: 68 };
 
         // Mouse buttons
-        this.mouseButtons = { ORBIT: MOUSE.RIGHT, ZOOM: false, PAN: MOUSE.MIDDLE };
+        this.mouseButtons = { PAN: MOUSE.RIGHT, ZOOM: false, ROTATE: MOUSE.MIDDLE };
 
         // for reset
         this.position0 = this.object.position.clone();
@@ -652,7 +652,7 @@ class CameraControls extends EventDispatcher {
 
             switch (event.button) {
 
-                case scope.mouseButtons.ORBIT:
+                case scope.mouseButtons.ROTATE:
 
                     if (scope.enableRotate === false) return;
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -285,12 +285,12 @@ class CameraControls extends EventDispatcher {
 
             if (scope.invertRotate) {
 
-                angleXDelta += angleX * 50 * scope.rotateSpeed;
+                angleXDelta += angleX * 100 * scope.rotateSpeed;
                 angleYDelta -= angleY * 50 * scope.rotateSpeed;
 
             } else {
 
-                angleXDelta -= angleX * 50 * scope.rotateSpeed;
+                angleXDelta -= angleX * 100 * scope.rotateSpeed;
                 angleYDelta += angleY * 50 * scope.rotateSpeed;
 
             }
@@ -450,7 +450,7 @@ class CameraControls extends EventDispatcher {
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
             // rotating across whole screen goes 360 degrees around
-            rotate(1.2 * (element.clientWidth / element.clientHeight) * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
+            rotate(1.2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
 
             rotateStart.copy(rotateEnd);
 
@@ -533,12 +533,12 @@ class CameraControls extends EventDispatcher {
                         break;
 
                     case scope.keys.TURNLEFT:
-                        rotate(-(element.clientWidth / element.clientHeight) * Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
+                        rotate(-Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
                         scope.update();
                         break;
 
                     case scope.keys.TURNRIGHT:
-                        rotate((element.clientWidth / element.clientHeight) * Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
+                        rotate(Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
                         scope.update();
                         break;
 
@@ -606,7 +606,7 @@ class CameraControls extends EventDispatcher {
 
             var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
-            rotate(1.2 * (element.clientWidth / element.clientHeight) * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
+            rotate(1.2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
 
             rotateStart.copy(rotateEnd);
 

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -20,7 +20,7 @@ class CameraControls extends EventDispatcher {
         super();
         this.angleX = 0;
         this.angleY = 0;
-        this.look = new Vector3(0, 0, -1);
+        this.look = new Vector3();
         this.stop = false;
 
         this.o = new Vector3(0, 0, 0)

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -113,7 +113,7 @@ class CameraControls extends EventDispatcher {
 
             // so camera.up is the orbit axis
             var quat = new Quaternion().setFromUnitVectors(object.up, new Vector3(0, 1, 0));
-            var quatInverse = quat.clone().inverse();
+            var quatInverse = quat.clone().invert();
 
             var lastPosition = new Vector3();
             var lastQuaternion = new Quaternion();

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -1,0 +1,876 @@
+import {
+    EventDispatcher,
+    MOUSE,
+    Quaternion,
+    Vector2,
+    Vector3
+} from '../../../build/three.module.js';
+
+// This set of controls performs turning, dollying (zooming), and panning. It is an update of OrbitControls
+// Pan up / down / left / right  - middle mouse / touch: one finger move
+// Move forward / backward  - mousewheel / touch: two finger spread or squish
+// Turn  - right mouse, or arrow keys / touch: three finger swipe
+
+// Updates compared to OrbitControls:
+// 1. The dollying of PerspectiveCamera is replaced with panning forward and backward.Therefore, this component can be used to move the PerspectiveCamera to six directions including forward, backward, up, down, left and right from current perspective.
+// 2. The turning will be conducted using the PerspectiveCamera as the center.
+
+class CameraControls extends EventDispatcher {
+    constructor(object, domElement) {
+        super();
+        this.angleX = 0;
+        this.angleY = 0;
+        this.look = new Vector3(0, 0, -1);
+        this.stop = false;
+
+        this.o = new Vector3(0, 0, 0)
+
+        this.object = object;
+
+        // The sensibility of panning and Dolly
+        this.sensibility = 1;
+        // Dynamically change the sensibility according to the distance between the object and center of the scene
+        this.dynamicSensibility = true;
+
+        this.domElement = (domElement !== undefined) ? domElement : document;
+
+        // Set to false to disable this control
+        this.enabled = true;
+
+        // "target" sets the location of focus, where the object orbits around
+        this.target = new Vector3();
+
+        // How far you can dolly and pan ( PerspectiveCamera only )
+        this.maxDistance = Infinity;
+
+        // How far you can zoom in and out ( OrthographicCamera only )
+        this.minZoom = 0;
+        this.maxZoom = Infinity;
+
+        // This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+        // Set to false to disable zooming
+        this.enableZoom = true;
+        this.zoomSpeed = 1.0;
+
+        // Set to false to disable rotating
+        this.enableRotate = true;
+        this.rotateSpeed = 0.1;
+
+        // Set to false to disable panning
+        this.enablePan = true;
+        this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+        // Set to true to automatically rotate around the target
+        // If auto-rotate is enabled, you must call controls.update() in your animation loop
+        this.autoRotate = false;
+        this.autoRotateSpeed = 0.2;
+
+        // Set to false to disable use of the keys
+        this.enableKeys = true;
+
+        // The four arrow keys
+        this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+
+        // Mouse buttons
+        this.mouseButtons = { ORBIT: MOUSE.RIGHT, ZOOM: false, PAN: MOUSE.MIDDLE };
+
+        // for reset
+        this.target0 = this.target.clone();
+        this.position0 = this.object.position.clone();
+        this.zoom0 = this.object.zoom;
+
+        //
+        // public methods
+        //
+
+        this.saveState = function () {
+
+            scope.target0.copy(scope.target);
+            scope.position0.copy(scope.object.position);
+            scope.zoom0 = scope.object.zoom;
+
+        };
+
+        this.reset = function () {
+
+            scope.target.copy(scope.target0);
+            scope.object.position.copy(scope.position0);
+            scope.object.zoom = scope.zoom0;
+
+            scope.object.updateProjectionMatrix();
+            scope.dispatchEvent(changeEvent);
+
+            scope.update();
+
+            state = STATE.NONE;
+
+        };
+
+        // this method is exposed, but perhaps it would be better if we can make it private...
+        this.update = function () {
+
+            var offset = new Vector3();
+
+            // so camera.up is the orbit axis
+            var quat = new Quaternion().setFromUnitVectors(object.up, new Vector3(0, 1, 0));
+            var quatInverse = quat.clone().inverse();
+
+            var lastPosition = new Vector3();
+            var lastQuaternion = new Quaternion();
+
+            return function update() {
+
+                var position = scope.object.position;
+
+                if (scope.dynamicSensibility) {
+                    scope.sensibility = Math.max(1, scope.object.position.distanceTo(scope.o))
+                }
+
+                offset.copy(position).sub(scope.target);
+
+                // rotate offset to "y-axis-is-up" space
+                offset.applyQuaternion(quat);
+
+                if (scope.autoRotate && state === STATE.NONE) {
+
+                    rotate(getAutoRotationAngle(), 0);
+
+                }
+
+                // move target to panned location
+                scope.target.add(panOffset);
+                let distance = scope.target.distanceTo(scope.o)
+                if (distance > scope.maxDistance) {
+                    scope.target.multiplyScalar(scope.maxDistance / distance)
+                }
+
+                // rotate offset back to "camera-up-vector-is-up" space
+                offset.applyQuaternion(quatInverse);
+
+                position.copy(scope.target).add(offset);
+
+
+                let look = position.clone()
+                look.add(scope.look)
+                scope.object.lookAt(look);
+
+                panOffset.set(0, 0, 0);
+
+                // update condition is:
+                // min(camera displacement, camera rotation in radians)^2 > EPS
+                // using small-angle approximation cos(x/2) = 1 - x^2 / 8
+
+                if (zoomChanged ||
+                    lastPosition.distanceToSquared(scope.object.position) > EPS ||
+                    8 * (1 - lastQuaternion.dot(scope.object.quaternion)) > EPS) {
+
+                    scope.dispatchEvent(changeEvent);
+
+                    lastPosition.copy(scope.object.position);
+                    lastQuaternion.copy(scope.object.quaternion);
+                    zoomChanged = false;
+
+                    return true;
+
+                }
+
+                return false;
+
+            };
+
+        }();
+
+        this.dispose = function () {
+
+            scope.domElement.removeEventListener('contextmenu', onContextMenu, false);
+            scope.domElement.removeEventListener('mousedown', onMouseDown, false);
+            scope.domElement.removeEventListener('wheel', onMouseWheel, false);
+
+            scope.domElement.removeEventListener('touchstart', onTouchStart, false);
+            scope.domElement.removeEventListener('touchend', onTouchEnd, false);
+            scope.domElement.removeEventListener('touchmove', onTouchMove, false);
+
+            document.removeEventListener('mousemove', onMouseMove, false);
+            document.removeEventListener('mouseup', onMouseUp, false);
+
+            window.removeEventListener('keydown', onKeyDown, false);
+
+        };
+
+        //
+        // internals
+        //
+
+        var scope = this;
+
+        var changeEvent = { type: 'change' };
+        var startEvent = { type: 'start' };
+        var endEvent = { type: 'end' };
+
+        var STATE = { NONE: - 1, ROTATE: 0, DOLLY: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_DOLLY: 4, TOUCH_PAN: 5 };
+
+        var state = STATE.NONE;
+
+        var EPS = 0.000001;
+
+
+        var panOffset = new Vector3();
+        var zoomChanged = false;
+
+        var rotateStart = new Vector2();
+        var rotateEnd = new Vector2();
+        var rotateDelta = new Vector2();
+
+        var panStart = new Vector2();
+        var panEnd = new Vector2();
+        var panDelta = new Vector2();
+
+        var dollyStart = new Vector2();
+        var dollyEnd = new Vector2();
+        var dollyDelta = new Vector2();
+
+        function getAutoRotationAngle() {
+
+            return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+
+        }
+
+        function getZoomScale() {
+
+            return Math.pow(0.95, scope.zoomSpeed);
+
+        }
+
+        function rotate(angleX, angleY) {
+            scope.angleX += angleX * 50 * scope.rotateSpeed
+            scope.angleY = Math.max(-Math.PI / 2.001, Math.min(scope.angleY - angleY * 50 * scope.rotateSpeed, Math.PI / 2.001))
+            scope.look.x = Math.sin(scope.angleX) * (Math.PI / 2 - Math.abs(scope.angleY))
+            scope.look.z = -Math.cos(scope.angleX) * (Math.PI / 2 - Math.abs(scope.angleY))
+            scope.look.y = Math.sin(scope.angleY)
+            scope.look.setLength(1)
+        }
+
+        var panLeft = function () {
+
+            var v = new Vector3();
+
+            return function panLeft(distance, objectMatrix) {
+
+                v.setFromMatrixColumn(objectMatrix, 0); // get X column of objectMatrix
+                v.multiplyScalar(- distance);
+
+                panOffset.add(v);
+
+            };
+
+        }();
+
+        var panUp = function () {
+
+            var v = new Vector3();
+
+            return function panUp(distance, objectMatrix) {
+
+                v.setFromMatrixColumn(objectMatrix, 1); // get Y column of objectMatrix
+                v.multiplyScalar(distance);
+
+                panOffset.add(v);
+
+            };
+
+        }();
+
+        var panUp_Distance = function () {
+
+            var v = new Vector3();
+
+            return function panUp(distance) {
+
+                v.copy(scope.look)
+
+
+                v.multiplyScalar(distance);
+
+                panOffset.add(v);
+
+            };
+
+        }();
+
+        // deltaX and deltaY are in pixels; right and down are positive
+        var pan = function () {
+
+            return function pan(deltaX, deltaY) {
+
+                var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+                if (scope.object.isPerspectiveCamera) {
+                    // we actually don't use screenWidth, since perspective camera is fixed to screen height
+                    panLeft(deltaX / element.clientHeight, scope.object.matrix);
+                    panUp(deltaY / element.clientHeight, scope.object.matrix);
+
+                } else if (scope.object.isOrthographicCamera) {
+
+                    // orthographic
+                    panLeft(deltaX * (scope.object.right - scope.object.left) / scope.object.zoom / element.clientWidth, scope.object.matrix);
+                    panUp(deltaY * (scope.object.top - scope.object.bottom) / scope.object.zoom / element.clientHeight, scope.object.matrix);
+
+                } else {
+
+                    // camera neither orthographic nor perspective
+                    console.warn('WARNING: CameraControls.js encountered an unknown camera type - pan disabled.');
+                    scope.enablePan = false;
+
+                }
+
+            };
+
+        }();
+
+        function dollyIn(dollyScale) {
+            var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+            if (scope.object.isPerspectiveCamera) {
+
+                panUp_Distance(-50 * scope.sensibility * dollyScale / element.clientHeight, scope.object.matrix);
+
+            } else if (scope.object.isOrthographicCamera) {
+
+                scope.object.zoom = Math.max(scope.minZoom, Math.min(scope.maxZoom, scope.object.zoom * dollyScale));
+                scope.object.updateProjectionMatrix();
+                zoomChanged = true;
+
+            } else {
+
+                console.warn('WARNING: CameraControls.js encountered an unknown camera type - dolly/zoom disabled.');
+                scope.enableZoom = false;
+
+            }
+
+        }
+
+        function dollyOut(dollyScale) {
+            if (scope.object.position.z < scope.minZ) return
+            var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+            if (scope.object.isPerspectiveCamera) {
+
+                panUp_Distance(50 * scope.sensibility * dollyScale / element.clientHeight, scope.object.matrix);
+
+            } else if (scope.object.isOrthographicCamera) {
+
+                scope.object.zoom = Math.max(scope.minZoom, Math.min(scope.maxZoom, scope.object.zoom / dollyScale));
+                scope.object.updateProjectionMatrix();
+                zoomChanged = true;
+
+            } else {
+
+                console.warn('WARNING: CameraControls.js encountered an unknown camera type - dolly/zoom disabled.');
+                scope.enableZoom = false;
+
+            }
+
+        }
+
+        //
+        // event callbacks - update the object state
+        //
+
+        function handleMouseDownRotate(event) {
+
+            //console.log( 'handleMouseDownRotate' );
+
+            rotateStart.set(event.clientX, event.clientY);
+
+        }
+
+        function handleMouseDownDolly(event) {
+
+            //console.log( 'handleMouseDownDolly' );
+
+            dollyStart.set(event.clientX, event.clientY);
+
+        }
+
+        function handleMouseDownPan(event) {
+
+            //console.log( 'handleMouseDownPan' );
+
+            panStart.set(event.clientX, event.clientY);
+
+        }
+
+        function handleMouseMoveRotate(event) {
+
+            //console.log( 'handleMouseMoveRotate' );
+
+            rotateEnd.set(event.clientX, event.clientY);
+            rotateDelta.subVectors(rotateEnd, rotateStart);
+
+            var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+            // rotating across whole screen goes 360 degrees around
+            rotate(1.2 * (element.clientWidth / element.clientHeight) * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
+
+            rotateStart.copy(rotateEnd);
+
+            scope.update();
+
+        }
+
+        function handleMouseMoveDolly(event) {
+
+            //console.log( 'handleMouseMoveDolly' );
+
+            dollyEnd.set(event.clientX, event.clientY);
+
+            dollyDelta.subVectors(dollyEnd, dollyStart);
+
+            if (dollyDelta.y > 0) {
+
+                dollyIn(getZoomScale());
+
+            } else if (dollyDelta.y < 0) {
+
+                dollyOut(getZoomScale());
+
+            }
+
+            dollyStart.copy(dollyEnd);
+
+            scope.update();
+
+        }
+
+        function handleMouseMovePan(event) {
+
+            //console.log( 'handleMouseMovePan' );
+
+            panEnd.set(event.clientX, event.clientY);
+
+            panDelta.subVectors(panEnd, panStart);
+
+            pan(panDelta.x * scope.sensibility, panDelta.y * scope.sensibility);
+
+            panStart.copy(panEnd);
+
+            scope.update();
+
+        }
+
+        function handleMouseUp(event) {
+
+            // console.log( 'handleMouseUp' );
+
+        }
+
+        function handleMouseWheel(event) {
+
+            // console.log( 'handleMouseWheel' );
+
+            if (event.deltaY < 0) {
+
+                dollyOut(getZoomScale());
+
+            } else if (event.deltaY > 0) {
+
+                dollyIn(getZoomScale());
+
+            }
+
+            scope.update();
+
+        }
+
+        function handleKeyDown(event) {
+
+            //console.log( 'handleKeyDown' );
+
+            switch (event.keyCode) {
+
+                case scope.keys.UP:
+                    pan(0, scope.keyPanSpeed);
+                    scope.update();
+                    break;
+
+                case scope.keys.BOTTOM:
+                    pan(0, - scope.keyPanSpeed);
+                    scope.update();
+                    break;
+
+                case scope.keys.LEFT:
+                    pan(scope.keyPanSpeed, 0);
+                    scope.update();
+                    break;
+
+                case scope.keys.RIGHT:
+                    pan(- scope.keyPanSpeed, 0);
+                    scope.update();
+                    break;
+
+            }
+
+        }
+
+        function handleTouchStartRotate(event) {
+
+            //console.log( 'handleTouchStartRotate' );
+
+            rotateStart.set(event.touches[0].pageX, event.touches[0].pageY);
+
+        }
+
+        function handleTouchStartDolly(event) {
+
+            //console.log( 'handleTouchStartDolly' );
+
+            var dx = event.touches[0].pageX - event.touches[1].pageX;
+            var dy = event.touches[0].pageY - event.touches[1].pageY;
+
+            var distance = Math.sqrt(dx * dx + dy * dy);
+
+            dollyStart.set(0, distance);
+
+        }
+
+        function handleTouchStartPan(event) {
+
+            //console.log( 'handleTouchStartPan' );
+
+            panStart.set(event.touches[0].pageX, event.touches[0].pageY);
+
+        }
+
+        function handleTouchMoveRotate(event) {
+
+            //console.log( 'handleTouchMoveRotate' );
+
+            rotateEnd.set(event.touches[0].pageX, event.touches[0].pageY);
+            rotateDelta.subVectors(rotateEnd, rotateStart);
+
+            var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+            rotate(1.2 * (element.clientWidth / element.clientHeight) * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed, 1.2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed);
+
+            rotateStart.copy(rotateEnd);
+
+            scope.update();
+
+        }
+
+        function handleTouchMoveDolly(event) {
+
+            //console.log( 'handleTouchMoveDolly' );
+
+            var dx = event.touches[0].pageX - event.touches[1].pageX;
+            var dy = event.touches[0].pageY - event.touches[1].pageY;
+
+            var distance = Math.sqrt(dx * dx + dy * dy);
+
+            dollyEnd.set(0, distance);
+
+            dollyDelta.subVectors(dollyEnd, dollyStart);
+
+            if (dollyDelta.y > 0) {
+
+                dollyOut(getZoomScale());
+
+            } else if (dollyDelta.y < 0) {
+
+                dollyIn(getZoomScale());
+
+            }
+
+            dollyStart.copy(dollyEnd);
+
+            scope.update();
+
+        }
+
+        function handleTouchMovePan(event) {
+
+            //console.log( 'handleTouchMovePan' );
+
+            panEnd.set(event.touches[0].pageX, event.touches[0].pageY);
+
+            panDelta.subVectors(panEnd, panStart);
+
+            pan(panDelta.x * scope.sensibility, panDelta.y * scope.sensibility);
+
+            panStart.copy(panEnd);
+
+            scope.update();
+
+        }
+
+        function handleTouchEnd(event) {
+
+            //console.log( 'handleTouchEnd' );
+
+        }
+
+        //
+        // event handlers - FSM: listen for events and reset state
+        //
+
+        function onMouseDown(event) {
+
+            if (scope.enabled === false) return;
+
+            event.preventDefault();
+
+            switch (event.button) {
+
+                case scope.mouseButtons.ORBIT:
+
+                    if (scope.enableRotate === false) return;
+
+                    handleMouseDownRotate(event);
+
+                    state = STATE.ROTATE;
+
+                    break;
+
+                case scope.mouseButtons.ZOOM:
+
+                    if (scope.enableZoom === false) return;
+
+                    handleMouseDownDolly(event);
+
+                    state = STATE.DOLLY;
+
+                    break;
+
+                case scope.mouseButtons.PAN:
+
+                    if (scope.enablePan === false) return;
+
+                    handleMouseDownPan(event);
+
+                    state = STATE.PAN;
+
+                    break;
+
+            }
+
+            if (state !== STATE.NONE) {
+
+                document.addEventListener('mousemove', onMouseMove, false);
+                document.addEventListener('mouseup', onMouseUp, false);
+
+
+            }
+
+        }
+
+        function onMouseMove(event) {
+            if (scope.stop) {
+                onMouseUp(event);
+                scope.stop = false;
+            }
+
+            if (scope.enabled === false) return;
+
+            event.preventDefault();
+
+            switch (state) {
+
+                case STATE.ROTATE:
+
+                    if (scope.enableRotate === false) return;
+
+                    handleMouseMoveRotate(event);
+
+                    break;
+
+                case STATE.DOLLY:
+
+                    if (scope.enableZoom === false) return;
+
+                    handleMouseMoveDolly(event);
+
+                    break;
+
+                case STATE.PAN:
+
+                    if (scope.enablePan === false) return;
+
+                    handleMouseMovePan(event);
+
+                    break;
+
+            }
+
+        }
+
+        function onMouseUp(event) {
+
+            if (scope.enabled === false) return;
+
+            handleMouseUp(event);
+
+            document.removeEventListener('mousemove', onMouseMove, false);
+            document.removeEventListener('mouseup', onMouseUp, false);
+
+            scope.dispatchEvent(endEvent);
+
+            state = STATE.NONE;
+
+        }
+
+        function onMouseWheel(event) {
+
+            if (scope.enabled === false || scope.enableZoom === false || (state !== STATE.NONE && state !== STATE.ROTATE)) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            handleMouseWheel(event);
+
+            scope.dispatchEvent(startEvent); // not sure why these are here...
+            scope.dispatchEvent(endEvent);
+        }
+
+        function onKeyDown(event) {
+
+            if (scope.enabled === false || scope.enableKeys === false || scope.enablePan === false) return;
+
+            handleKeyDown(event);
+
+        }
+
+        function onTouchStart(event) {
+
+            if (scope.enabled === false) return;
+
+            switch (event.touches.length) {
+
+                case 1:	// one-fingered touch: rotate
+
+                    if (scope.enableRotate === false) return;
+
+                    handleTouchStartRotate(event);
+
+                    state = STATE.TOUCH_ROTATE;
+
+                    break;
+
+                case 2:	// two-fingered touch: dolly
+
+                    if (scope.enableZoom === false) return;
+
+                    handleTouchStartDolly(event);
+
+                    state = STATE.TOUCH_DOLLY;
+
+                    break;
+
+                case 3: // three-fingered touch: pan
+
+                    if (scope.enablePan === false) return;
+
+                    handleTouchStartPan(event);
+
+                    state = STATE.TOUCH_PAN;
+
+                    break;
+
+                default:
+
+                    state = STATE.NONE;
+
+            }
+
+            if (state !== STATE.NONE) {
+
+                scope.dispatchEvent(startEvent);
+
+            }
+
+        }
+
+        function onTouchMove(event) {
+
+            if (scope.enabled === false) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            switch (event.touches.length) {
+
+                case 1: // one-fingered touch: rotate
+
+                    if (scope.enableRotate === false) return;
+                    if (state !== STATE.TOUCH_ROTATE) return; // is this needed?...
+
+                    handleTouchMoveRotate(event);
+
+                    break;
+
+                case 2: // two-fingered touch: dolly
+
+                    if (scope.enableZoom === false) return;
+                    if (state !== STATE.TOUCH_DOLLY) return; // is this needed?...
+
+                    handleTouchMoveDolly(event);
+
+                    break;
+
+                case 3: // three-fingered touch: pan
+
+                    if (scope.enablePan === false) return;
+                    if (state !== STATE.TOUCH_PAN) return; // is this needed?...
+
+                    handleTouchMovePan(event);
+
+                    break;
+
+                default:
+
+                    state = STATE.NONE;
+
+            }
+
+        }
+
+        function onTouchEnd(event) {
+
+            if (scope.enabled === false) return;
+
+            handleTouchEnd(event);
+
+            scope.dispatchEvent(endEvent);
+
+            state = STATE.NONE;
+
+        }
+
+        function onContextMenu(event) {
+
+            if (scope.enabled === false) return;
+
+            event.preventDefault();
+
+        }
+
+        //
+
+        scope.domElement.addEventListener('contextmenu', onContextMenu, false);
+
+        scope.domElement.addEventListener('mousedown', onMouseDown, false);
+        scope.domElement.addEventListener('wheel', onMouseWheel, false);
+
+        scope.domElement.addEventListener('touchstart', onTouchStart, false);
+        scope.domElement.addEventListener('touchend', onTouchEnd, false);
+        scope.domElement.addEventListener('touchmove', onTouchMove, false);
+
+        window.addEventListener('keydown', onKeyDown, false);
+
+        // force an update at start
+
+        this.update();
+
+    };
+}
+
+export { CameraControls };

--- a/examples/jsm/controls/CameraControls.js
+++ b/examples/jsm/controls/CameraControls.js
@@ -7,8 +7,8 @@ import {
 } from '../../../build/three.module.js';
 
 // This set of controls performs turning, dollying (zooming), and panning. It is an update of OrbitControls
-// Pan up / down / left / right  - middle mouse / touch: one finger move
-// Move forward / backward  - mousewheel / touch: two finger spread or squish
+// Pan up / down / left / right  - middle mouse or WASD keys / touch: one finger move
+// Move forward / backward  - mousewheel or WASD keys / touch: two finger spread or squish
 // Turn  - right mouse, or arrow keys / touch: three finger swipe
 
 // Updates compared to OrbitControls:
@@ -65,7 +65,8 @@ class CameraControls extends EventDispatcher {
 
         // Set to false to disable panning
         this.enablePan = true;
-        this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+        this.keyPanSpeed = 1.0;// pixels moved per arrow key push
+        this.keyRotateSpeed = 1.0;
 
         // Set to true to automatically rotate around the target
         // If auto-rotate is enabled, you must call controls.update() in your animation loop
@@ -76,7 +77,7 @@ class CameraControls extends EventDispatcher {
         this.enableKeys = true;
 
         // The four arrow keys
-        this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+        this.keys = { TURNLEFT: 37, TURNUP: 38, TURNRIGHT: 39, TURNBOTTOM: 40, FORWARD: 87, BACKWARD: 83, LEFT: 65, RIGHT: 68 };
 
         // Mouse buttons
         this.mouseButtons = { ORBIT: MOUSE.RIGHT, ZOOM: false, PAN: MOUSE.MIDDLE };
@@ -510,31 +511,57 @@ class CameraControls extends EventDispatcher {
         }
 
         function handleKeyDown(event) {
+            var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+            if (scope.enableRotate === true) {
+                switch (event.keyCode) {
 
-            switch (event.keyCode) {
+                    case scope.keys.TURNUP:
+                        rotate(0, -Math.PI / element.clientHeight * scope.keyRotateSpeed);
+                        scope.update();
+                        break;
 
-                case scope.keys.UP:
-                    pan(0, scope.keyPanSpeed);
-                    scope.update();
-                    break;
+                    case scope.keys.TURNBOTTOM:
+                        rotate(0, Math.PI / element.clientHeight * scope.keyRotateSpeed);
+                        scope.update();
+                        break;
 
-                case scope.keys.BOTTOM:
-                    pan(0, - scope.keyPanSpeed);
-                    scope.update();
-                    break;
+                    case scope.keys.TURNLEFT:
+                        rotate(-(element.clientWidth / element.clientHeight) * Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
+                        scope.update();
+                        break;
 
-                case scope.keys.LEFT:
-                    pan(scope.keyPanSpeed, 0);
-                    scope.update();
-                    break;
+                    case scope.keys.TURNRIGHT:
+                        rotate((element.clientWidth / element.clientHeight) * Math.PI / element.clientWidth * scope.keyRotateSpeed, 0);
+                        scope.update();
+                        break;
 
-                case scope.keys.RIGHT:
-                    pan(- scope.keyPanSpeed, 0);
-                    scope.update();
-                    break;
-
+                }
             }
+            if (scope.enablePan === true) {
+                switch (event.keyCode) {
 
+                    case scope.keys.FORWARD:
+                        dollyOut(getZoomScale() * scope.keyPanSpeed);;
+                        scope.update();
+                        break;
+
+                    case scope.keys.BACKWARD:
+                        dollyIn(getZoomScale() * scope.keyPanSpeed);;
+                        scope.update();
+                        break;
+
+                    case scope.keys.LEFT:
+                        pan(20 * scope.keyPanSpeed, 0);
+                        scope.update();
+                        break;
+
+                    case scope.keys.RIGHT:
+                        pan(- 20 * scope.keyPanSpeed, 0);
+                        scope.update();
+                        break;
+
+                }
+            }
         }
 
         function handleTouchStartRotate(event) {
@@ -744,7 +771,7 @@ class CameraControls extends EventDispatcher {
 
         function onKeyDown(event) {
 
-            if (scope.enabled === false || scope.enableKeys === false || scope.enablePan === false) return;
+            if (scope.enabled === false || scope.enableKeys === false) return;
 
             handleKeyDown(event);
 

--- a/examples/misc_controls_cameracontrols.html
+++ b/examples/misc_controls_cameracontrols.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - CameraControls</title>
+		<meta charset="utf-8" />
+		<meta
+			name="viewport"
+			content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"
+		/>
+		<link type="text/css" rel="stylesheet" href="main.css" />
+		<style>
+			body {
+				background-color: #ccc;
+				color: rgb(255, 255, 255);
+			}
+
+			a {
+				color: #f00;
+			}
+		</style>
+	</head>
+
+	<body>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
+			- CameraControls
+		</div>
+
+		<script type="module">
+			import * as THREE from "../build/three.module.js";
+
+			import { GUI } from "./jsm/libs/dat.gui.module.js";
+
+			import { CameraControls } from "./jsm/controls/CameraControls.js";
+
+			let camera, controls, scene, renderer, gui;
+
+			init();
+			//render(); // remove when using next line for animation loop (requestAnimationFrame)
+			animate();
+
+			function init() {
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color(0x333333);
+
+				renderer = new THREE.WebGLRenderer({ antialias: true });
+				renderer.setPixelRatio(window.devicePixelRatio);
+				renderer.setSize(window.innerWidth, window.innerHeight);
+				document.body.appendChild(renderer.domElement);
+
+				camera = new THREE.PerspectiveCamera(
+					60,
+					window.innerWidth / window.innerHeight,
+					0.1,
+					3000
+				);
+				camera.position.set(0, 200, 1000);
+
+				// controls
+
+				controls = new CameraControls(camera, renderer.domElement);
+				controls.enableDamping = true;
+				controls.maxDistance = 1500;
+
+				// world
+
+				const geometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 32);
+				geometry.translate(0, 0.5, 0);
+				const material = new THREE.MeshPhongMaterial({
+					color: 0xffffff,
+					flatShading: true,
+				});
+
+				for (let i = 0; i < 500; i++) {
+					const mesh = new THREE.Mesh(geometry, material);
+					mesh.position.x = Math.random() * 1600 - 800;
+					mesh.position.y = 0;
+					mesh.position.z = Math.random() * 1600 - 800;
+					mesh.scale.x = 20;
+					mesh.scale.y = Math.random() * 80 + 10;
+					mesh.scale.z = 20;
+					mesh.updateMatrix();
+					mesh.matrixAutoUpdate = false;
+					scene.add(mesh);
+				}
+
+				var helper = new THREE.GridHelper(2000, 100);
+				helper.material.opacity = 0.25;
+				helper.material.transparent = true;
+				scene.add(helper);
+
+				// lights
+
+				const dirLight1 = new THREE.DirectionalLight(0xffffff);
+				dirLight1.position.set(1, 1, 1);
+				scene.add(dirLight1);
+
+				const dirLight2 = new THREE.DirectionalLight(0xffffff * Math.random());
+				dirLight2.position.set(-1, -1, -1);
+				scene.add(dirLight2);
+
+				const ambientLight = new THREE.AmbientLight(0x222222);
+				scene.add(ambientLight);
+
+				//
+
+				window.addEventListener("resize", onWindowResize);
+
+				gui = new GUI();
+				gui.add(controls, "dynamicSensibility");
+				gui.add(controls, "sensibility", 1, 1500);
+			}
+
+			function onWindowResize() {
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize(window.innerWidth, window.innerHeight);
+			}
+
+			function animate() {
+				requestAnimationFrame(animate);
+
+				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
+
+				gui.updateDisplay();
+
+				render();
+			}
+
+			function render() {
+				renderer.render(scene, camera);
+			}
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Related issue: #CameraControls

**Description**
This set of controls performs turning, moving(zooming on OrthographicCamera), and panning.
Pan up/down/left/right - middle mouse / touch: one finger move
Move forward/backward - mousewheel / touch: two finger spread or squish
Turn - right mouse, or arrow keys / touch: three finger swipe

The CameraControls is updated from OrbitControls.
Updates compared to OrbitControls:
1. The dollying of PerspectiveCamera is replaced with panning forward and backward. The controlling will be more free as there will no limit by mindistance.
2. The turning will be conducted using the position of PerspectiveCamera as the center.

This contribution is funded by [William](https://github.com/WilliamLiu-1997/CameraControls).
