### PR TITLE
Allow to create multiple XR projection layers

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -1,6 +1,6 @@
 class VRButton {
 
-	static createButton( renderer, options ) {
+	static createButton( rendererOrCallback, options ) {
 
 		if ( options ) {
 
@@ -18,7 +18,11 @@ class VRButton {
 
 				session.addEventListener( 'end', onSessionEnded );
 
-				await renderer.xr.setSession( session );
+				if (typeof rendererOrCallback === 'function') {
+					await rendererOrCallback( session );
+				} else {
+					await renderer.xr.setSession( session );
+				}
 				button.textContent = 'EXIT VR';
 
 				currentSession = session;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -270,6 +270,8 @@ class WebXRManager extends EventDispatcher {
 
 				scope.dispatchEvent( { type: 'sessionstart' } );
 
+				return glProjLayer || glBaseLayer;
+
 			}
 
 		};

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -179,6 +179,12 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
+		this.getWebGLLayer = function() {
+
+			return glProjLayer || glBaseLayer;
+
+		};
+
 		this.setSession = async function ( value ) {
 
 			session = value;
@@ -269,8 +275,6 @@ class WebXRManager extends EventDispatcher {
 				scope.isPresenting = true;
 
 				scope.dispatchEvent( { type: 'sessionstart' } );
-
-				return glProjLayer || glBaseLayer;
 
 			}
 


### PR DESCRIPTION
**Description**

Since the recent XRLayers spec was made available, it's been technically possible to create immersive media player web apps with complex user interfaces, like for example for a scenario where the user is inside a VR cinema room with several 3D assets (not possible to convincingly recreate using a simple cube map or equirect  layer) rendered on a background layer, followed by a video layer, and on top, an user interface layer with controllers/hands and simple UI for player control.

This change exposes the newly created XR layer to the app, through a new method  `getWebGLLayer` on the renderer's XR manager, that can be called after the manager's `setSession` method resolves, providing a way to create complex multi layer media apps.

Here's an example app I made to demo this feature:
https://github.com/hmiguellima/cinema-room

I've ran the above demo on a Quest 2 with acceptable frame rates using the new fixedFoveation option of the XRLayer.