### PR TITLE
BufferGeometryUtils: update outdated reference to this

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -166,7 +166,7 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 	for ( const name in attributes ) {
 
-		const mergedAttribute = this.mergeBufferAttributes( attributes[ name ] );
+		const mergedAttribute = mergeBufferAttributes( attributes[ name ] );
 
 		if ( ! mergedAttribute ) {
 
@@ -200,7 +200,7 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 			}
 
-			const mergedMorphAttribute = this.mergeBufferAttributes( morphAttributesToMerge );
+			const mergedMorphAttribute = mergeBufferAttributes( morphAttributesToMerge );
 
 			if ( ! mergedMorphAttribute ) {
 


### PR DESCRIPTION
Related issue: #22297

**Description**

In #22267 I forgot to update the `this.` references in the file, resulting in the error described in #22297. This fixes it.