### PR TITLE
build-examples: Fix problem with import * as THREE

### DIFF
--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -90,7 +90,11 @@ function unmodularize() {
 			code = code.replace( /import \* as ([a-zA-Z0-9_, ]+) from '((?!libs).)*';/g, ( match, p1 ) => {
 
 				const imp = p1;
-				imports.push( imp );
+				if ( imp !== 'THREE' ) {
+
+					imports.push( imp );
+
+				}
 
 				return '';
 


### PR DESCRIPTION
Related issue:  https://github.com/mrdoob/three.js/pull/22267#issuecomment-896059632

**Description**

Prevents adding the THREE namespace.