### PR TITLE
ShaderChunk: Fixed transmission shader crash in WebGL1 and no EXT_shader_texture_lod

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -57,7 +57,15 @@ export default /* glsl */`
 
 		float framebufferLod = log2( transmissionSamplerSize.x ) * applyIorToRoughness( roughness, ior );
 
-		return texture2DLodEXT( transmissionSamplerMap, fragCoord.xy, framebufferLod ).rgb;
+		#ifdef TEXTURE_LOD_EXT
+
+			return texture2DLodEXT( transmissionSamplerMap, fragCoord.xy, framebufferLod ).rgb;
+
+		#else
+
+			return texture2D( transmissionSamplerMap, fragCoord.xy, framebufferLod ).rgb;
+
+		#endif
 
 	}
 


### PR DESCRIPTION
**Description**

On my system the transmission shader was crashing in Safari (WebGL1, no EXT_shader_texture_lod).

/cc @elalish 