### PR TITLE
PMREMGenerator: Correctly reset the background

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -353,6 +353,7 @@ class PMREMGenerator {
 		renderer.toneMapping = toneMapping;
 		renderer.outputEncoding = outputEncoding;
 		renderer.autoClear = originalAutoClear;
+		scene.background = background;
 
 	}
 


### PR DESCRIPTION
Related issue: Fixed #22286

**Description**

Correctly resets the scene.background color which seems to have accidentally been lost in #21034

cc @WestLangley @Mugen87 