### PR TITLE
KTX2Loader: Warn on outdated Basis library

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -355,6 +355,12 @@ KTX2Loader.BasisWorker = function () {
 
 			BasisModule.initializeBasis();
 
+			if ( BasisModule.KTX2File === undefined ) {
+
+				console.warn( 'THREE.KTX2Loader: Please update Basis Universal transcoder.' );
+
+			}
+
 		} );
 
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/21984
