### PR TITLE
Shaders: Update the Schlick formula signature

### DIFF
--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
@@ -5,6 +5,7 @@ export default /* glsl */`
 // via 'environmentBRDF' from "Physically Based Shading on Mobile"
 // https://www.unrealengine.com/blog/physically-based-shading-on-mobile - environmentBRDF for GGX on mobile
 vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {
+
 	const vec4 c0 = vec4( - 1, - 0.0275, - 0.572, 0.022 );
 
 	const vec4 c1 = vec4( 1, 0.0425, 1.04, - 0.04 );
@@ -13,7 +14,7 @@ vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {
 
 	float a004 = min( r.x * r.x, exp2( - 9.28 * dotNV ) ) * r.x + r.y;
 
-	return vec2( -1.04, 1.04 ) * a004 + r.zw;
+	return vec2( - 1.04, 1.04 ) * a004 + r.zw;
 
 }
 
@@ -40,7 +41,7 @@ float punctualLightIntensityToIrradianceFactor( const in float lightDistance, co
 
 	if( cutoffDistance > 0.0 && decayExponent > 0.0 ) {
 
-		return pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );
+		return pow( saturate( - lightDistance / cutoffDistance + 1.0 ), decayExponent );
 
 	}
 
@@ -56,16 +57,16 @@ vec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {
 
 } // validated
 
-vec3 F_Schlick( const in vec3 f0, const in vec3 f90, const in float dotVH ) {
+vec3 F_Schlick( const in vec3 f0, const in float f90, const in float dotVH ) {
 
 	// Original approximation by Christophe Schlick '94
 	// float fresnel = pow( 1.0 - dotVH, 5.0 );
 
 	// Optimized variant (presented by Epic at SIGGRAPH '13)
 	// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-	float fresnel = exp2( ( -5.55473 * dotVH - 6.98316 ) * dotVH );
+	float fresnel = exp2( ( - 5.55473 * dotVH - 6.98316 ) * dotVH );
 
-	return ( f90 - f0 ) * fresnel + f0;
+	return f0 * ( 1.0 - fresnel ) + ( f90 * fresnel );
 
 } // validated
 
@@ -95,8 +96,8 @@ float D_GGX( const in float alpha, const in float dotNH ) {
 
 }
 
-// GGX Distribution, Schlick Fresnel, GGX-Smith Visibility
-vec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 f0, const in vec3 f90, const in float roughness ) {
+// GGX Distribution, Schlick Fresnel, GGX_SmithCorrelated Visibility
+vec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 f0, const in float f90, const in float roughness ) {
 
 	float alpha = pow2( roughness ); // UE4's roughness
 
@@ -287,7 +288,7 @@ vec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in Ge
 	float dotNH = saturate( dot( geometry.normal, halfDir ) );
 	float dotVH = saturate( dot( geometry.viewDir, halfDir ) );
 
-	vec3 F = F_Schlick( specularColor, vec3( 1.0 ), dotVH );
+	vec3 F = F_Schlick( specularColor, 1.0, dotVH );
 
 	float G = G_BlinnPhong_Implicit( /* dotNL, dotNV */ );
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -13,7 +13,7 @@ material.specularRoughness = min( material.specularRoughness, 1.0 );
 
 	#ifdef SPECULAR
 
-		vec3 specularIntensityFactor = vec3( specularIntensity );
+		float specularIntensityFactor = specularIntensity;
 		vec3 specularTintFactor = specularTint;
 
 		#ifdef USE_SPECULARINTENSITYMAP
@@ -28,13 +28,13 @@ material.specularRoughness = min( material.specularRoughness, 1.0 );
 
 		#endif
 
-		material.specularColorF90 = mix( specularIntensityFactor, vec3( 1.0 ), metalnessFactor );
+		material.specularF90 = mix( specularIntensityFactor, 1.0, metalnessFactor );
 
 	#else
 
-		vec3 specularIntensityFactor = vec3( 1.0 );
+		float specularIntensityFactor = 1.0;
 		vec3 specularTintFactor = vec3( 1.0 );
-		material.specularColorF90 = vec3( 1.0 );
+		material.specularF90 = 1.0;
 
 	#endif
 
@@ -43,7 +43,7 @@ material.specularRoughness = min( material.specularRoughness, 1.0 );
 #else
 
 	material.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor.rgb, metalnessFactor );
-	material.specularColorF90 = vec3( 1.0 );
+	material.specularF90 = 1.0;
 
 #endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -4,7 +4,7 @@ struct PhysicalMaterial {
 	vec3 diffuseColor;
 	float specularRoughness;
 	vec3 specularColor;
-	vec3 specularColorF90;
+	float specularF90;
 
 #ifdef CLEARCOAT
 	float clearcoat;
@@ -93,7 +93,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 		float clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, ccDotNL );
 
-		reflectedLight.directSpecular += ccIrradiance * material.clearcoat * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), vec3( 1.0 ), material.clearcoatRoughness );
+		reflectedLight.directSpecular += ccIrradiance * material.clearcoat * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), 1.0, material.clearcoatRoughness );
 
 	#else
 
@@ -102,14 +102,18 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 	#endif
 
 	#ifdef USE_SHEEN
+
 		reflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_Sheen(
 			material.specularRoughness,
 			directLight.direction,
 			geometry,
 			material.sheenColor
 		);
+
 	#else
-		reflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularColorF90, material.specularRoughness);
+
+		reflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularF90, material.specularRoughness );
+
 	#endif
 
 	reflectedLight.directDiffuse += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );


### PR DESCRIPTION
This PR reverts a change made in #22156, which introduced F90 as a `vec3`. We only support monochromatic F90, so that variable is changed to a `float`.

This also avoids having to instantiate a `vec3` when the Schlick method is called.

Unity and Filament also consider F0 as a `vec3` and F90 as a `float`.
