### PR TITLE
[Doc/en]: fix some description errors in box3.html and sphere.html

### DIFF
--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -175,7 +175,7 @@
 		[page:Vector3 point] - [page:Vector3].<br/>
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
-		Returns a point as a proportion of this box's width and height.
+		Returns a point as a proportion of this box's width, height and depth.
 		</p>
 
 		<h3>[method:Vector3 getSize]( [param:Vector3 target] )</h3>

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -29,7 +29,7 @@
 		<p>A [page:Vector3] defining the center of the sphere. Default is (0, 0, 0).</p>
 
 		<h3>[property:Float radius]</h3>
-		<p>The radius of the sphere. Default is 0.</p>
+		<p>The radius of the sphere. Default is -1.</p>
 
 		<h2>Methods</h2>
 


### PR DESCRIPTION
Related issue: null

**Description**

*box3.html - .getParameter()*

```diff
- Returns a point as a proportion of this box's width and height.
+ Returns a point as a proportion of this box's width, height and depth.
```

<br>

*sphere.html - .radius*

```diff
- The radius of the sphere. Default is 0.
+ The radius of the sphere. Default is -1.
```
