### PR TITLE
PMREMGenerator: Remove extra conversion to RGBE color

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -99,17 +99,6 @@ const _axisDirections = [
  * https://drive.google.com/file/d/15y8r_UpKlU9SvV4ILb0C3qCPecS8pvLz/view
 */
 
-function convertLinearToRGBE( color ) {
-
-	const maxComponent = Math.max( color.r, color.g, color.b );
-	const fExp = Math.min( Math.max( Math.ceil( Math.log2( maxComponent ) ), - 128.0 ), 127.0 );
-	color.multiplyScalar( Math.pow( 2.0, - fExp ) );
-
-	const alpha = ( fExp + 128.0 ) / 255.0;
-	return alpha;
-
-}
-
 class PMREMGenerator {
 
 	constructor( renderer ) {
@@ -298,9 +287,6 @@ class PMREMGenerator {
 
 				backgroundMaterial.color.copy( background );
 				scene.background = null;
-
-				const alpha = convertLinearToRGBE( backgroundMaterial.color );
-				backgroundMaterial.opacity = alpha;
 				useSolidColor = true;
 
 			}
@@ -308,9 +294,6 @@ class PMREMGenerator {
 		} else {
 
 			backgroundMaterial.color.copy( _clearColor );
-
-			const alpha = convertLinearToRGBE( backgroundMaterial.color );
-			backgroundMaterial.opacity = alpha;
 			useSolidColor = true;
 
 		}


### PR DESCRIPTION
Related issue: Fixed #22326

**Description**

Remove unnecessary conversion to RGBE because it already implicitly happens in the shader. See https://github.com/mrdoob/three.js/issues/22326#issuecomment-898616675

I'll likely need to update the screenshot but I'll have to do that later today.

cc @WestLangley @Mugen87 