### PR TITLE
MeshPhysicalMaterial: fix double application of transmission factor

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -20,7 +20,7 @@ export default /* glsl */`
 	vec3 v = normalize( cameraPosition - pos );
 	vec3 n = inverseTransformDirection( normal, viewMatrix );
 
-	vec3 transmission = transmissionFactor * getIBLVolumeRefraction(
+	vec3 transmission = getIBLVolumeRefraction(
 		n, v, roughnessFactor, material.diffuseColor, material.specularColor,
 		pos, modelMatrix, viewMatrix, projectionMatrix, ior, thicknessFactor,
 		attenuationTint, attenuationDistance );


### PR DESCRIPTION
Related: Issue (6) in #22009.

`transmission` factor was applied twice. Below is the result of a furnace test with `material.transmisson` set to 0.5. **

<img width="542" alt="Screen Shot 2021-08-14 at 10 25 57 AM" src="https://user-images.githubusercontent.com/1000017/129451542-c2dc79e4-cea4-4db3-9b48-035ead88eed0.png">

In a furnace test, the sphere slices should render the same color as the background -- for all values of `transmission`.

With this PR, they do.

//

** `specularIntensity` was set to zero in this test. There are specular energy-conserving issues which need to be addressed separately.