### PR TITLE
WebGLRenderTarget: ensure internalFormat is set on texture

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -25,6 +25,11 @@ class WebGLRenderTarget extends EventDispatcher {
 
 		this.texture = new Texture( undefined, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 		this.texture.isRenderTargetTexture = true;
+		if ( 'internalFormat' in options ) {
+
+			this.texture.internalFormat = options.internalFormat;
+
+		}
 
 		this.texture.image = { width: width, height: height, depth: 1 };
 


### PR DESCRIPTION
Related issue: --

**Description**

Previously when creating a `WebGLRenderTarget` with an internalFormat option it was not being set on the created texture.