### PR TITLE
WebGLBackground: Background does not clear depth and stencil anymore.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -21,7 +21,6 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 	function render( renderList, scene ) {
 
-		let forceClear = false;
 		let background = scene.isScene === true ? scene.background : null;
 
 		if ( background && background.isTexture ) {
@@ -42,24 +41,19 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 		}
 
-		if ( background === null ) {
-
-			setClear( clearColor, clearAlpha );
-
-		} else if ( background && background.isColor ) {
-
-			setClear( background, 1 );
-			forceClear = true;
-
-		}
-
-		if ( renderer.autoClear || forceClear ) {
+		if ( renderer.autoClear ) {
 
 			renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 
 		}
 
-		if ( background && ( background.isCubeTexture || background.mapping === CubeUVReflectionMapping ) ) {
+		if ( background && background.isColor ) {
+
+			setClear( background, 1 );
+			renderer.clear( true, false, false );
+			setClear( clearColor, clearAlpha ); // restore clear color/alpha
+
+		} else if ( background && ( background.isCubeTexture || background.mapping === CubeUVReflectionMapping ) ) {
 
 			if ( boxMesh === undefined ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -6,6 +6,7 @@ import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
 import { BufferAttribute } from '../../core/BufferAttribute.js';
 import { BufferGeometry } from '../../core/BufferGeometry.js';
 import { Mesh } from '../../objects/Mesh.js';
+import { Color } from '../../math/Color.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Frustum } from '../../math/Frustum.js';
@@ -21,6 +22,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		_viewportSize = new Vector2(),
 
 		_viewport = new Vector4(),
+		_clearColor = new Color(),
 
 		_depthMaterial = new MeshDepthMaterial( { depthPacking: RGBADepthPacking } ),
 		_distanceMaterial = new MeshDistanceMaterial(),
@@ -79,12 +81,15 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		const currentRenderTarget = _renderer.getRenderTarget();
 		const activeCubeFace = _renderer.getActiveCubeFace();
 		const activeMipmapLevel = _renderer.getActiveMipmapLevel();
+		_renderer.getClearColor( _clearColor );
+		const alpha = _renderer.getClearAlpha();
 
 		const _state = _renderer.state;
 
 		// Set GL state for depth map.
+		_renderer.setClearColor( 0xffffff, 1 );
+
 		_state.setBlending( NoBlending );
-		_state.buffers.color.setClear( 1, 1, 1, 1 );
 		_state.buffers.depth.setTest( true );
 		_state.setScissorTest( false );
 
@@ -197,6 +202,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		scope.needsUpdate = false;
 
 		_renderer.setRenderTarget( currentRenderTarget, activeCubeFace, activeMipmapLevel );
+		_renderer.setClearColor( _clearColor, alpha );
 
 	};
 


### PR DESCRIPTION
Related issue: Fixed #22340.

**Description**

When a color is assigned to `Scene.background`, depth and stencil buffers are not cleared anymore.