### PR TITLE
TGALoader: fix blue component handling for 16-bit (RGBA5551) images

### DIFF
--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -199,10 +199,10 @@ class TGALoader extends DataTextureLoader {
 
 				for ( x = x_start; x !== x_end; x += x_step, i += 2 ) {
 
-					color = image[ i + 0 ] + ( image[ i + 1 ] << 8 ); // Inversed ?
+					color = image[ i + 0 ] + ( image[ i + 1 ] << 8 );
 					imageData[ ( x + width * y ) * 4 + 0 ] = ( color & 0x7C00 ) >> 7;
 					imageData[ ( x + width * y ) * 4 + 1 ] = ( color & 0x03E0 ) >> 2;
-					imageData[ ( x + width * y ) * 4 + 2 ] = ( color & 0x001F ) >> 3;
+					imageData[ ( x + width * y ) * 4 + 2 ] = ( color & 0x001F ) << 3;
 					imageData[ ( x + width * y ) * 4 + 3 ] = ( color & 0x8000 ) ? 0 : 255;
 
 				}


### PR DESCRIPTION
For 16 bit (RGBA5551) TGA images, the loader gets the bit shifting wrong and ruins the blue channel of the images.

This pull fixes this small error, and also removes the `// Inversed?` comment since I can confirm with this fix in place (16-bit) images are loaded perfectly.