### PR TITLE
WebXRManager: Fix XRCamera Local Space Behavior by Reverting #21964

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -503,11 +503,8 @@ class WebXRManager extends EventDispatcher {
 
 			// update user camera and its children
 
-			camera.position.copy( cameraVR.position );
-			camera.quaternion.copy( cameraVR.quaternion );
-			camera.scale.copy( cameraVR.scale );
 			camera.matrix.copy( cameraVR.matrix );
-			camera.matrixWorld.copy( cameraVR.matrixWorld );
+			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 
 			const children = camera.children;
 


### PR DESCRIPTION
Fixed #23597.
Fixed #22884.

This PR fixes a bug introduced in r130 by reverting how XR Camera calculations handle local space (by partially undoing #21964 (which appears to conflate `matrixWorld` and `matrix`)).

This enables the XR camera to be parented to another moving object without odd behavior once again.

If this isn't the correct fix; I'd be happy to test alternatives in the context of my application.

Related issues: #21964 , https://github.com/google/model-viewer/pull/2464/files#r647866462
