### PR TITLE
Add uv transform support for transmission and thickness maps

### DIFF
--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -190,6 +190,8 @@ function WebGLMaterials( properties ) {
 		// 12. clearcoat roughnessMap map
 		// 13. specular intensity map
 		// 14. specular tint map
+		// 15. transmission map
+		// 16. thickness map
 
 		let uvScaleMap;
 
@@ -248,6 +250,14 @@ function WebGLMaterials( properties ) {
 		} else if ( material.specularTintMap ) {
 
 			uvScaleMap = material.specularTintMap;
+
+		} else if ( material.transmissionMap ) {
+
+			uvScaleMap = material.transmissionMap;
+
+		} else if ( material.thicknessMap ) {
+
+			uvScaleMap = material.thicknessMap;
 
 		}
 


### PR DESCRIPTION
Before this change, when a material contained a transmission or thickness map with no other maps, UV transform on that map was implicitly disabled. This change hooks up these maps to the same first UV matrix we use for most textures since it would most often be mapped using the same layout as other material textures. Among other things this fixes thickness textures when using quantized coordinates outside of [0..1] range.

Before:
![image](https://user-images.githubusercontent.com/1106629/130001131-c4a08c29-ab17-4e30-8d88-260933c33cf3.png)

After:
![image](https://user-images.githubusercontent.com/1106629/130001143-aa693436-4d8d-481b-bb97-d52b8ee9f3b8.png)

cc @donmccurdy 