### PR TITLE
BufferGeometry: Remove computeFaceNormals() stub.

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -467,12 +467,6 @@ class BufferGeometry extends EventDispatcher {
 
 	}
 
-	computeFaceNormals() {
-
-		// backwards compatibility
-
-	}
-
 	computeTangents() {
 
 		const index = this.index;


### PR DESCRIPTION
Related issue: -

**Description**

The existence of `BufferGeometry.computeFaceNormals()` is a recurring source of confusion especially for beginners. It's better to remove it from the API.
