### PR TITLE
Shaders: renamed some functions

### DIFF
--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -7,7 +7,7 @@ export default /* glsl */`
 
 	#endif
 
-	vec3 getLightProbeIndirectIrradiance( const in GeometricContext geometry ) {
+	vec3 getIBLIrradiance( const in GeometricContext geometry ) {
 
 		#if defined( ENVMAP_TYPE_CUBE_UV )
 
@@ -25,7 +25,7 @@ export default /* glsl */`
 
 	}
 
-	vec3 getLightProbeIndirectRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness ) {
+	vec3 getIBLRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness ) {
 
 		#if defined( ENVMAP_TYPE_CUBE_UV )
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -18,7 +18,7 @@ export default /* glsl */`
 
 	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
 
-		iblIrradiance += getLightProbeIndirectIrradiance( /*lightProbe,*/ geometry );
+		iblIrradiance += getIBLIrradiance( geometry );
 
 	#endif
 
@@ -26,11 +26,11 @@ export default /* glsl */`
 
 #if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )
 
-	radiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.normal, material.specularRoughness );
+	radiance += getIBLRadiance( geometry.viewDir, geometry.normal, material.specularRoughness );
 
 	#ifdef CLEARCOAT
 
-		clearcoatRadiance += getLightProbeIndirectRadiance( /*specularLightProbe,*/ geometry.viewDir, geometry.clearcoatNormal, material.clearcoatRoughness );
+		clearcoatRadiance += getIBLRadiance( geometry.viewDir, geometry.clearcoatNormal, material.clearcoatRoughness );
 
 	#endif
 


### PR DESCRIPTION
Having the similarly-name functions `getLightProbeIrradiance()` and `getLightProbeIndirectIrradiance()` was too confusing.

The first applies to a `LightProbe` and the second to an IBL (i.e., environment map).
