### PR TITLE
Build ESM target first.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -279,6 +279,21 @@ export default [
 		input: 'src/Three.js',
 		plugins: [
 			addons(),
+			glconstants(),
+			glsl(),
+			header()
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'build/three.module.js'
+			}
+		]
+	},
+	{
+		input: 'src/Three.js',
+		plugins: [
+			addons(),
 			glsl(),
 			babel( {
 				babelHelpers: 'bundled',
@@ -318,21 +333,6 @@ export default [
 				format: 'umd',
 				name: 'THREE',
 				file: 'build/three.min.js'
-			}
-		]
-	},
-	{
-		input: 'src/Three.js',
-		plugins: [
-			addons(),
-			glconstants(),
-			glsl(),
-			header()
-		],
-		output: [
-			{
-				format: 'esm',
-				file: 'build/three.module.js'
 			}
 		]
 	}


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/22368#issuecomment-901943234

**Description**

When developing it's better when `three.module.js` is build first since it is used in the examples. `three.js` and `three.min.js` also take more time.