### PR TITLE
Shaders: renaming more functions 2

### DIFF
--- a/examples/js/shaders/MMDToonShader.js
+++ b/examples/js/shaders/MMDToonShader.js
@@ -36,15 +36,15 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 
 	#endif
 
-	reflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
-	reflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
+	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
 
 }
 
 void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
-	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 

--- a/examples/jsm/renderers/nodes/functions/BSDFs.js
+++ b/examples/jsm/renderers/nodes/functions/BSDFs.js
@@ -31,15 +31,15 @@ float D_BlinnPhong( const in float shininess, const in float dotNH ) {
 
 }` ); // validated
 
-export const BRDF_Diffuse_Lambert = new FunctionNode( `
-vec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {
+export const BRDF_Lambert = new FunctionNode( `
+vec3 BRDF_Lambert( const in vec3 diffuseColor ) {
 
 	return RECIPROCAL_PI * diffuseColor;
 
 }` ); // validated
 
-export const BRDF_Specular_BlinnPhong = new FunctionNode( `
-vec3 BRDF_Specular_BlinnPhong( vec3 lightDirection, vec3 specularColor, float shininess ) {
+export const BRDF_BlinnPhong = new FunctionNode( `
+vec3 BRDF_BlinnPhong( vec3 lightDirection, vec3 specularColor, float shininess ) {
 
 	vec3 halfDir = normalize( lightDirection + PositionViewDirection );
 
@@ -102,15 +102,15 @@ void RE_Direct_BlinnPhong( vec3 lightDirection, vec3 lightColor ) {
 
 #endif
 
-	ReflectedLightDirectDiffuse += irradiance * BRDF_Diffuse_Lambert( MaterialDiffuseColor.rgb );
+	ReflectedLightDirectDiffuse += irradiance * BRDF_Lambert( MaterialDiffuseColor.rgb );
 
-	ReflectedLightDirectSpecular += irradiance * BRDF_Specular_BlinnPhong( lightDirection, MaterialSpecularColor, MaterialSpecularShininess );
+	ReflectedLightDirectSpecular += irradiance * BRDF_BlinnPhong( lightDirection, MaterialSpecularColor, MaterialSpecularShininess );
 
-}` ).setIncludes( [ BRDF_Diffuse_Lambert, BRDF_Specular_BlinnPhong ] );
+}` ).setIncludes( [ BRDF_Lambert, BRDF_BlinnPhong ] );
 
 export const RE_IndirectDiffuse_BlinnPhong = new FunctionNode( `
 void RE_IndirectDiffuse_BlinnPhong( ) {
 
-	ReflectedLightIndirectDiffuse += Irradiance * BRDF_Diffuse_Lambert( MaterialDiffuseColor.rgb );
+	ReflectedLightIndirectDiffuse += Irradiance * BRDF_Lambert( MaterialDiffuseColor.rgb );
 
-}` ).setIncludes( [ BRDF_Diffuse_Lambert ] );
+}` ).setIncludes( [ BRDF_Lambert ] );

--- a/examples/jsm/shaders/MMDToonShader.js
+++ b/examples/jsm/shaders/MMDToonShader.js
@@ -37,15 +37,15 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 
 	#endif
 
-	reflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
-	reflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
+	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
 
 }
 
 void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
-	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js
@@ -33,7 +33,7 @@ float punctualLightIntensityToIrradianceFactor( const in float lightDistance, co
 
 }
 
-vec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {
+vec3 BRDF_Lambert( const in vec3 diffuseColor ) {
 
 	return RECIPROCAL_PI * diffuseColor;
 
@@ -79,7 +79,7 @@ float D_GGX( const in float alpha, const in float dotNH ) {
 }
 
 // GGX Distribution, Schlick Fresnel, GGX_SmithCorrelated Visibility
-vec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 f0, const in float f90, const in float roughness ) {
+vec3 BRDF_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 f0, const in float f90, const in float roughness ) {
 
 	float alpha = pow2( roughness ); // UE4's roughness
 
@@ -231,7 +231,7 @@ float D_BlinnPhong( const in float shininess, const in float dotNH ) {
 
 }
 
-vec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {
+vec3 BRDF_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {
 
 	vec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );
 
@@ -270,7 +270,7 @@ float V_Neubelt( float NoV, float NoL ) {
 
 }
 
-vec3 BRDF_Specular_Sheen( const in float roughness, const in vec3 L, const in GeometricContext geometry, vec3 specularColor ) {
+vec3 BRDF_Sheen( const in float roughness, const in vec3 L, const in GeometricContext geometry, vec3 specularColor ) {
 
 	vec3 N = geometry.normal;
 	vec3 V = geometry.viewDir;

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -21,15 +21,15 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 
 	#endif
 
-	reflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
-	reflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
+	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;
 
 }
 
 void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
-	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
@@ -17,13 +17,13 @@ void RE_Direct_Toon( const in IncidentLight directLight, const in GeometricConte
 
 	#endif
 
-	reflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 
 void RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {
 
-	reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -106,7 +106,7 @@ export default /* glsl */`
 		vec3 attenuatedColor = applyVolumeAttenuation( transmittedLight, length( transmissionRay ), attenuationColor, attenuationDistance );
 
 		// Get the specular component.
-		vec3 F = BRDF_Specular_GGX_Environment( n, v, specularColor, specularF90, roughness );
+		vec3 F = EnvironmentBRDF( n, v, specularColor, specularF90, roughness );
 
 		return ( 1.0 - F ) * attenuatedColor * diffuseColor;
 

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -65,7 +65,7 @@ void main() {
 
 	#include <lightmap_fragment>
 
-	reflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );
+	reflectedLight.indirectDiffuse *= BRDF_Lambert( diffuseColor.rgb );
 
 	#ifdef DOUBLE_SIDED
 
@@ -77,7 +77,7 @@ void main() {
 
 	#endif
 
-	reflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();
+	reflectedLight.directDiffuse *= BRDF_Lambert( diffuseColor.rgb ) * getShadowMask();
 
 	// modulation
 


### PR DESCRIPTION
To be a bit less verbose...

Part A
```
BRDF_Diffuse_Lambert() -> BRDF_Lambert()

BRDF_Specular_BlinnPhong() -> BRDF_BlinnPhong()

BRDF_Specular_GGX() -> BRDF_GGX()

BRDF_Specular_Sheen() -> BRDF_Sheen()
```
Part B
```
BRDF_Specular_Multiscattering_Environment() -> computeMultiscattering()
```
The above function is not a brdf. It computes two reflectance quantities. So renaming it to `computeMultiscattering` for now.

```
BRDF_Specular_GGX_Environment -> EnvironmentBRDF
```
This is not a brdf either. It returns a reflectance, but "EnvironmentBRDF" is a commonly-used term, so using that for now.
