### PR TITLE
MeshPhysicalMaterial: Update version for certain transmission changes.

### DIFF
--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -34,6 +34,8 @@ import * as MathUtils from '../math/MathUtils.js';
 
 class MeshPhysicalMaterial extends MeshStandardMaterial {
 
+	#transmission = 0;
+
 	constructor( parameters ) {
 
 		super();
@@ -87,6 +89,25 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.setValues( parameters );
 
 	}
+
+	get transmission() {
+
+		return this.#transmission;
+
+	}
+
+	set transmission( value ) {
+
+		if ( this.#transmission > 0 !== value > 0 ) {
+
+			this.version ++;
+
+		}
+
+		this.#transmission = value;
+
+	}
+
 
 	copy( source ) {
 


### PR DESCRIPTION
Related issue: Fixed #22365.

**Description**

If you setup a material with zero transmission and increase it at a later point, nothing will happen. That's because the transmission code path of `MeshPhysicalMaterial` is only used when `transmission > 0`. A recompile is required when `USE_TRANSMISSION` should be defined in the shader (or removed).

The only way to detect this with the current transmission implementation is to check each frame the transmission value in `setProgram()` and then set `needsProgramChange` if necessary.

If we don't want this code section for performance reasons, it's up to the user to set `Material.needsUpdate` to `true`. However, I think the behavior reported in #22365 is buggy and should be fixed.