### PR TITLE
Object3D: Added applyMatrix4OnOrigin( matrix, origin )

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -219,6 +219,11 @@
 		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale.</p>
 
+		<h3>[method:null applyMatrix4OnWorldOrigin]( [param:Matrix4 matrix], [param:Vector3 origin] )</h3>
+		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale with a origin.</p>
+		<p>The origin as a vector3 as an axis of rotation when rotating.</p>
+		<p>The (origin.x,origin.y,origin.z) as a point when scaling.</p>
+
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>Applies the rotation represented by the quaternion to the object.</p>
 

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -209,6 +209,11 @@
 		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>매트릭스 변환을 객체에 적용하고 객체의 위치, 회전 및 스케일을 업데이트합니다.</p>
 
+		<h3>[method:null applyMatrix4OnWorldOrigin]( [param:Matrix4 matrix], [param:Vector3 origin] )</h3>
+		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale with a origin.</p>
+		<p>The origin as a vector3 as an axis of rotation when rotating.</p>
+		<p>The (origin.x,origin.y,origin.z) as a point when scaling.</p>
+
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>쿼터니언으로 표시된 회전을 객체에 적용합니다</p>
 

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -208,6 +208,11 @@
 	<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
 	<p>对当前物体应用这个变换矩阵，并更新物体的位置、旋转和缩放。</p>
 
+	<h3>[method:null applyMatrix4OnWorldOrigin]( [param:Matrix4 matrix], [param:Vector3 origin] )</h3>
+	<p>对当前物体设置变换原点，应用变换矩阵，并更新物体的位置、旋转和缩放。</p>
+	<p>旋转时，origin当作向量，作为旋转轴</p>
+	<p>缩放时，origin的(x,y,z) 作为缩放原点</p>
+
 	<h3>[method:Object3D applyQuaternion]( [param:Quaternion quaternion] )</h3>
 	<p>对当前物体应用由四元数所表示的变换。</p>
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -126,23 +126,24 @@ class Object3D extends EventDispatcher {
 
 	}
 
-	applyMatrix4OnOrigin( matrix, origin ) {      
+	applyMatrix4OnOrigin( matrix, origin ) {
 
 		// Origin as a vector3 as an axis of rotation when rotating
 
 		// Origin as a point when scaling
 
-		const translation = new THREE.Matrix4()
+		const translation = new THREE.Matrix4();
 		translation.set(
 			1, 0, 0, origin.x,
 			0, 1, 0, origin.y,
 			0, 0, 1, origin.z,
 			0, 0, 0, 1
-		)
+		);
 		// M' = T⁻¹ M T
-		matrix.premultiply(translation).multiply(translation.invert());
-		this.applyMatrix4(matrix);
-	};
+		matrix.premultiply( translation ).multiply( translation.invert() );
+		this.applyMatrix4( matrix );
+
+	}
 
 	applyQuaternion( q ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -126,7 +126,7 @@ class Object3D extends EventDispatcher {
 
 	}
 
-	applyMatrix4OnWorldOrigin( matrix, origin ) {      
+	applyMatrix4OnOrigin( matrix, origin ) {      
 
 		// Origin as a vector3 as an axis of rotation when rotating
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -132,16 +132,16 @@ class Object3D extends EventDispatcher {
 
 		// Origin as a point when scaling
 
-    const translation = new THREE.Matrix4()
-    translation.set(
-      1, 0, 0, origin.x,
-      0, 1, 0, origin.y,
-      0, 0, 1, origin.z,
-      0, 0, 0, 1
-    )
-    // M' = T⁻¹ M T
-    matrix.premultiply(translation).multiply(translation.invert());
-    this.applyMatrix4(matrix);
+		const translation = new THREE.Matrix4()
+		translation.set(
+			1, 0, 0, origin.x,
+			0, 1, 0, origin.y,
+			0, 0, 1, origin.z,
+			0, 0, 0, 1
+		)
+		// M' = T⁻¹ M T
+		matrix.premultiply(translation).multiply(translation.invert());
+		this.applyMatrix4(matrix);
 	};
 
 	applyQuaternion( q ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -126,6 +126,24 @@ class Object3D extends EventDispatcher {
 
 	}
 
+	applyMatrix4OnWorldOrigin( matrix, origin ) {      
+
+		// Origin as a vector3 as an axis of rotation when rotating
+
+		// Origin as a point when scaling
+
+    const translation = new THREE.Matrix4()
+    translation.set(
+      1, 0, 0, origin.x,
+      0, 1, 0, origin.y,
+      0, 0, 1, origin.z,
+      0, 0, 0, 1
+    )
+    // M' = T⁻¹ M T
+    matrix.premultiply(translation).multiply(translation.invert());
+    this.applyMatrix4(matrix);
+	};
+
 	applyQuaternion( q ) {
 
 		this.quaternion.premultiply( q );


### PR DESCRIPTION
Related issue: #15965 

**Description**
Added a method applyMatrix4OnOrigin. This method can be used when the matrix transformation needs to scale the origin or rotation axis.

