### PR TITLE
Fix: wrong member name WebGLCubeUVMaps.onTextureDispose

### DIFF
--- a/src/renderers/webgl/WebGLCubeUVMaps.js
+++ b/src/renderers/webgl/WebGLCubeUVMaps.js
@@ -87,7 +87,7 @@ function WebGLCubeUVMaps( renderer ) {
 
 		if ( cubemapUV !== undefined ) {
 
-			cubemapUV.delete( texture );
+			cubeUVmaps.delete( texture );
 			cubemapUV.dispose();
 
 		}


### PR DESCRIPTION
The member name used in `WebGLCubeUVMaps.onTextureDispose` is wrong. It should be `cubeUVmaps.delete(texture)`, not `cubemapUV.delete(texture)`, which calls who knows what (if anything at all).

This is also confirmed by looking at similar `WebGLCubeMaps.onTextureDispose`:

```
			cubemaps.delete( texture );
			cubemap.dispose();
```