### PR TITLE
Core: Remove artist-friendly factor of PI from shaders

### DIFF
--- a/examples/js/shaders/MMDToonShader.js
+++ b/examples/js/shaders/MMDToonShader.js
@@ -30,12 +30,6 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 
 	vec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-	#endif
-
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;

--- a/examples/jsm/renderers/nodes/functions/BSDFs.js
+++ b/examples/jsm/renderers/nodes/functions/BSDFs.js
@@ -96,12 +96,6 @@ void RE_Direct_BlinnPhong( vec3 lightDirection, vec3 lightColor ) {
 	float dotNL = saturate( dot( NormalView, lightDirection ) );
 	vec3 irradiance = dotNL * lightColor;
 
-#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-#endif
-
 	ReflectedLightDirectDiffuse += irradiance * BRDF_Lambert( MaterialDiffuseColor.rgb );
 
 	ReflectedLightDirectSpecular += irradiance * BRDF_BlinnPhong( lightDirection, MaterialSpecularColor, MaterialSpecularShininess );

--- a/examples/jsm/shaders/MMDToonShader.js
+++ b/examples/jsm/shaders/MMDToonShader.js
@@ -31,12 +31,6 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 
 	vec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-	#endif
-
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -895,7 +895,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		} );
 
-		currentRenderState.setupLights();
+		currentRenderState.setupLights( _this.physicallyCorrectLights );
 
 		scene.traverse( function ( object ) {
 
@@ -1033,7 +1033,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		shadowMap.render( shadowsArray, scene, camera );
 
-		currentRenderState.setupLights();
+		currentRenderState.setupLights( _this.physicallyCorrectLights );
 		currentRenderState.setupLightsView( camera );
 
 		if ( _clippingEnabled === true ) clipping.endShadows();

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_vertex.glsl.js
@@ -42,13 +42,13 @@ vIndirectFront += getLightProbeIrradiance( lightProbe, geometry );
 		getPointLightInfo( pointLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
-		directLightColor_Diffuse = PI * directLight.color;
+		directLightColor_Diffuse = directLight.color;
 
 		vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
 
 		#ifdef DOUBLE_SIDED
 
-			vLightBack += saturate( -dotNL ) * directLightColor_Diffuse;
+			vLightBack += saturate( - dotNL ) * directLightColor_Diffuse;
 
 		#endif
 
@@ -65,13 +65,13 @@ vIndirectFront += getLightProbeIrradiance( lightProbe, geometry );
 		getSpotLightInfo( spotLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
-		directLightColor_Diffuse = PI * directLight.color;
+		directLightColor_Diffuse = directLight.color;
 
 		vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
 
 		#ifdef DOUBLE_SIDED
 
-			vLightBack += saturate( -dotNL ) * directLightColor_Diffuse;
+			vLightBack += saturate( - dotNL ) * directLightColor_Diffuse;
 
 		#endif
 	}
@@ -87,13 +87,13 @@ vIndirectFront += getLightProbeIrradiance( lightProbe, geometry );
 		getDirectionalLightInfo( directionalLights[ i ], geometry, directLight );
 
 		dotNL = dot( geometry.normal, directLight.direction );
-		directLightColor_Diffuse = PI * directLight.color;
+		directLightColor_Diffuse = directLight.color;
 
 		vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
 
 		#ifdef DOUBLE_SIDED
 
-			vLightBack += saturate( -dotNL ) * directLightColor_Diffuse;
+			vLightBack += saturate( - dotNL ) * directLightColor_Diffuse;
 
 		#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
@@ -44,12 +44,6 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 
 	vec3 irradiance = ambientLightColor;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI;
-
-	#endif
-
 	return irradiance;
 
 }
@@ -179,12 +173,6 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 		float hemiDiffuseWeight = 0.5 * dotNL + 0.5;
 
 		vec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );
-
-		#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-			irradiance *= PI;
-
-		#endif
 
 		return irradiance;
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -15,12 +15,6 @@ void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in Geometri
 	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
 	vec3 irradiance = dotNL * directLight.color;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-	#endif
-
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -120,23 +120,11 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 	vec3 irradiance = dotNL * directLight.color;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-	#endif
-
 	#ifdef CLEARCOAT
 
 		float dotNLcc = saturate( dot( geometry.clearcoatNormal, directLight.direction ) );
 
 		vec3 ccIrradiance = dotNLcc * directLight.color;
-
-		#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-			ccIrradiance *= PI; // punctual light
-
-		#endif
 
 		clearcoatSpecular += ccIrradiance * BRDF_GGX( directLight, geometry.viewDir, geometry.clearcoatNormal, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
 

--- a/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
@@ -11,12 +11,6 @@ void RE_Direct_Toon( const in IncidentLight directLight, const in GeometricConte
 
 	vec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		irradiance *= PI; // punctual light
-
-	#endif
-
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -199,7 +199,7 @@ function WebGLLights( extensions, capabilities ) {
 	const matrix4 = new Matrix4();
 	const matrix42 = new Matrix4();
 
-	function setup( lights ) {
+	function setup( lights, physicallyCorrectLights ) {
 
 		let r = 0, g = 0, b = 0;
 
@@ -217,6 +217,9 @@ function WebGLLights( extensions, capabilities ) {
 
 		lights.sort( shadowCastingLightsFirst );
 
+		// artist-friendly light intensity scaling factor
+		const scaleFactor = ( physicallyCorrectLights !== true ) ? Math.PI : 1;
+
 		for ( let i = 0, l = lights.length; i < l; i ++ ) {
 
 			const light = lights[ i ];
@@ -229,9 +232,9 @@ function WebGLLights( extensions, capabilities ) {
 
 			if ( light.isAmbientLight ) {
 
-				r += color.r * intensity;
-				g += color.g * intensity;
-				b += color.b * intensity;
+				r += color.r * intensity * scaleFactor;
+				g += color.g * intensity * scaleFactor;
+				b += color.b * intensity * scaleFactor;
 
 			} else if ( light.isLightProbe ) {
 
@@ -245,7 +248,7 @@ function WebGLLights( extensions, capabilities ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.color.copy( light.color ).multiplyScalar( light.intensity );
+				uniforms.color.copy( light.color ).multiplyScalar( light.intensity * scaleFactor );
 
 				if ( light.castShadow ) {
 
@@ -276,7 +279,7 @@ function WebGLLights( extensions, capabilities ) {
 
 				uniforms.position.setFromMatrixPosition( light.matrixWorld );
 
-				uniforms.color.copy( color ).multiplyScalar( intensity );
+				uniforms.color.copy( color ).multiplyScalar( intensity * scaleFactor );
 				uniforms.distance = distance;
 
 				uniforms.coneCos = Math.cos( light.angle );
@@ -327,7 +330,7 @@ function WebGLLights( extensions, capabilities ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.color.copy( light.color ).multiplyScalar( light.intensity );
+				uniforms.color.copy( light.color ).multiplyScalar( light.intensity * scaleFactor );
 				uniforms.distance = light.distance;
 				uniforms.decay = light.decay;
 
@@ -360,8 +363,8 @@ function WebGLLights( extensions, capabilities ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.skyColor.copy( light.color ).multiplyScalar( intensity );
-				uniforms.groundColor.copy( light.groundColor ).multiplyScalar( intensity );
+				uniforms.skyColor.copy( light.color ).multiplyScalar( intensity * scaleFactor );
+				uniforms.groundColor.copy( light.groundColor ).multiplyScalar( intensity * scaleFactor );
 
 				state.hemi[ hemiLength ] = uniforms;
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -26,9 +26,9 @@ function WebGLRenderState( extensions, capabilities ) {
 
 	}
 
-	function setupLights() {
+	function setupLights( physicallyCorrectLights ) {
 
-		lights.setup( lightsArray );
+		lights.setup( lightsArray, physicallyCorrectLights );
 
 	}
 


### PR DESCRIPTION
This PR removes the artist-friendly factor of `PI` from the shaders, and moves it into the renderer, instead.

Now, the factor is computed once per frame instead of once per fragment.

Previously, `MeshLambertMaterial` ignored the `.physicallyCorrectLights` flag, so when the flag was set,  `MeshLambertMaterial ` rendered more brightly than `MeshPhongMaterial ` by a factor of `PI`.

Only users who use `MeshLambertMaterial` while setting the `.physicallyCorrectLights` flag to `true` will see a change.

