### PR TITLE
WebGLRenderer: Reset current material in setRenderTarget().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1990,6 +1990,8 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
+		_currentMaterialId = - 1; // reset current material to ensure correct uniform bindings
+
 	};
 
 	this.readRenderTargetPixels = function ( renderTarget, x, y, width, height, buffer, activeCubeFaceIndex ) {


### PR DESCRIPTION
Related issue: Fixed https://github.com/mrdoob/three.js/pull/22335#issuecomment-899847233

**Description**

When the opaque render list is processed in `renderTransmissiveObjects()`, it's necessary to reset the cached material since texture bindings are potentially overwritten by a render target definition. This only happens when render targets are prepared in `WebGLTextures.setupRenderTarget()` (which is the first frame in the issues's test case).

Since this is a general problem, the fix is added at the end of `setRenderTarget()`.