### PR TITLE
MeshLambertMaterial: honor the physicallyCorrectLights flag when using a light map

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
@@ -1,8 +1,16 @@
 export default /* glsl */`
 #ifdef USE_LIGHTMAP
 
-	vec4 lightMapTexel= texture2D( lightMap, vUv2 );
-	reflectedLight.indirectDiffuse += PI * lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity; // factor of PI should not be present; included here to prevent breakage
+	vec4 lightMapTexel = texture2D( lightMap, vUv2 );
+	vec3 lightMapIrradiance = lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;
+
+	#ifndef PHYSICALLY_CORRECT_LIGHTS
+
+		lightMapIrradiance *= PI;
+
+	#endif
+
+	reflectedLight.indirectDiffuse += lightMapIrradiance;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -3,12 +3,12 @@ export default /* glsl */`
 
 	#ifdef USE_LIGHTMAP
 
-		vec4 lightMapTexel= texture2D( lightMap, vUv2 );
+		vec4 lightMapTexel = texture2D( lightMap, vUv2 );
 		vec3 lightMapIrradiance = lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;
 
 		#ifndef PHYSICALLY_CORRECT_LIGHTS
 
-			lightMapIrradiance *= PI; // factor of PI should not be present; included here to prevent breakage
+			lightMapIrradiance *= PI;
 
 		#endif
 


### PR DESCRIPTION
Follow-on to #22393.

For `MeshLambertMaterial`, the light map intensity is no longer scaled by the artist-friendly factor of PI when `.physicallyCorrectLights` is `true`.



