### PR TITLE
SelectionBox: Add support for InstancedMesh.

### DIFF
--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -192,19 +192,17 @@ class SelectionBox {
 
 					}
 
-				} else {
+				} 
 
-					if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
+				if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
 
-					_center.copy( object.geometry.boundingSphere.center );
+				_center.copy( object.geometry.boundingSphere.center );
 
-					_center.applyMatrix4( object.matrixWorld );
+				_center.applyMatrix4( object.matrixWorld );
 
-					if ( frustum.containsPoint( _center ) ) {
+				if ( frustum.containsPoint( _center ) ) {
 
-						this.collection.push( object );
-
-					}
+					this.collection.push( object );
 
 				}
 

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -192,21 +192,21 @@ class SelectionBox {
 
 					}
 
-				} 
+				} else {
 
-				if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
+					if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
 
-				_center.copy( object.geometry.boundingSphere.center );
+					_center.copy( object.geometry.boundingSphere.center );
 
-				_center.applyMatrix4( object.matrixWorld );
+					_center.applyMatrix4( object.matrixWorld );
 
-				if ( frustum.containsPoint( _center ) ) {
+					if ( frustum.containsPoint( _center ) ) {
 
-					this.collection.push( object );
+						this.collection.push( object );
+
+					}
 
 				}
-
-			}
 
 		}
 

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -1,6 +1,9 @@
 import {
 	Frustum,
-	Vector3
+	Vector3,
+	InstancedMesh,
+	Matrix4,
+	Quaternion,
 } from '../../../build/three.module.js';
 
 /**
@@ -27,6 +30,10 @@ const _vectemp1 = new Vector3();
 const _vectemp2 = new Vector3();
 const _vectemp3 = new Vector3();
 
+const _matrix = new Matrix4();
+const _quaternion = new Quaternion();
+const _scale = new Vector3();
+
 class SelectionBox {
 
 	constructor( camera, scene, deep = Number.MAX_VALUE ) {
@@ -37,6 +44,7 @@ class SelectionBox {
 		this.endPoint = new Vector3();
 		this.collection = [];
 		this.deep = deep;
+		this.instanceDetection = {};
 
 	}
 
@@ -167,17 +175,36 @@ class SelectionBox {
 
 		if ( object.isMesh || object.isLine || object.isPoints ) {
 
-			if ( object.material !== undefined ) {
+				if ( object instanceof InstancedMesh ) {
 
-				if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
+					this.instanceDetection[ object.uuid ] = [];
 
-				_center.copy( object.geometry.boundingSphere.center );
+					for ( let instanceId = 0; instanceId < object.count; instanceId ++ ) {
 
-				_center.applyMatrix4( object.matrixWorld );
+						object.getMatrixAt( instanceId, _matrix );
+						_matrix.decompose( _center, _quaternion, _scale );
 
-				if ( frustum.containsPoint( _center ) ) {
+						if ( frustum.containsPoint( _center ) ) {
 
-					this.collection.push( object );
+							this.instanceDetection[ object.uuid ].push( instanceId );
+
+						}
+
+					}
+
+				} else {
+
+					if ( object.geometry.boundingSphere === null ) object.geometry.computeBoundingSphere();
+
+					_center.copy( object.geometry.boundingSphere.center );
+
+					_center.applyMatrix4( object.matrixWorld );
+
+					if ( frustum.containsPoint( _center ) ) {
+
+						this.collection.push( object );
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-to-select-objects-with-a-selection-rectangle/4772/14

**Description**

SelectionBox.js does not give information about which instances in an InstanceMesh are in the frustum. This change adds a property called `instanceDetection` to the `SelectionBox` class.

When the `searchChildInFrustum` method is called, the `instanceDetection` property will update with information about which instances of an InstanceMesh are in the frustum.

An example of `this.instanceDetection` when the selection includes the instance at index 12 is below. The InstanceMesh `uuid` gets added to the object with a value of an array which includes all `instanceId`s that are in the frustum.

```
{
    "460A8174-2AD7-4F0B-96B1-3DD4CA57AE3A": [12]
}
```
![ezgif com-gif-maker](https://user-images.githubusercontent.com/16717394/130547549-6c7f8255-71c8-452c-9b81-db5fa45d6294.gif)
