### PR TITLE
ShaderChunks: Ignore alpha in output_fragment when transparent = false

### DIFF
--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -71,6 +71,7 @@ import normalmap_pars_fragment from './ShaderChunk/normalmap_pars_fragment.glsl.
 import clearcoat_normal_fragment_begin from './ShaderChunk/clearcoat_normal_fragment_begin.glsl.js';
 import clearcoat_normal_fragment_maps from './ShaderChunk/clearcoat_normal_fragment_maps.glsl.js';
 import clearcoat_pars_fragment from './ShaderChunk/clearcoat_pars_fragment.glsl.js';
+import output_fragment from './ShaderChunk/output_fragment.glsl.js';
 import packing from './ShaderChunk/packing.glsl.js';
 import premultiplied_alpha_fragment from './ShaderChunk/premultiplied_alpha_fragment.glsl.js';
 import project_vertex from './ShaderChunk/project_vertex.glsl.js';
@@ -207,6 +208,7 @@ export const ShaderChunk = {
 	clearcoat_normal_fragment_begin: clearcoat_normal_fragment_begin,
 	clearcoat_normal_fragment_maps: clearcoat_normal_fragment_maps,
 	clearcoat_pars_fragment: clearcoat_pars_fragment,
+	output_fragment: output_fragment,
 	packing: packing,
 	premultiplied_alpha_fragment: premultiplied_alpha_fragment,
 	project_vertex: project_vertex,

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifndef TRANSPARENT
+#ifdef OPAQUE
 diffuseColor.a = 1.0;
 #endif
 

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+#ifndef TRANSPARENT
+diffuseColor.a = 1.0;
+#endif
+
+gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+`;

--- a/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
@@ -31,8 +31,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb; // simple shader
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -62,8 +62,7 @@ void main() {
 
 	#include <envmap_fragment>
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -88,8 +88,7 @@ void main() {
 
 	#include <envmap_fragment>
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -53,8 +53,7 @@ void main() {
 
 	vec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -64,9 +64,7 @@ void main() {
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
 
 	#include <envmap_fragment>
-
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -117,8 +117,7 @@ void main() {
 
 	#endif
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
@@ -57,8 +57,7 @@ void main() {
 
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl.js
@@ -24,8 +24,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
@@ -25,8 +25,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -670,7 +670,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
-			parameters.transparent ? '#define TRANSPARENT' : '',
+			parameters.transparent === false ? '#define OPAQUE' : '',
 
 			ShaderChunk[ 'encodings_pars_fragment' ], // this code is required here because it is used by the various encoding/decoding function defined below
 			parameters.map ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -670,6 +670,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
+			parameters.transparent ? '#define TRANSPARENT' : '',
 
 			ShaderChunk[ 'encodings_pars_fragment' ], // this code is required here because it is used by the various encoding/decoding function defined below
 			parameters.map ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -47,7 +47,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
 		'numDirLightShadows', 'numPointLightShadows', 'numSpotLightShadows',
 		'shadowMapEnabled', 'shadowMapType', 'toneMapping', 'physicallyCorrectLights',
-		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering',
+		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering', 'transparent',
 		'sheenTint', 'transmission', 'transmissionMap', 'thicknessMap'
 	];
 
@@ -208,6 +208,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			specularIntensityMap: !! material.specularIntensityMap,
 			specularTintMap: !! material.specularTintMap,
 			specularTintMapEncoding: getTextureEncodingFromMap( material.specularTintMap ),
+
 			alphaMap: !! material.alphaMap,
 			alphaTest: useAlphaTest,
 
@@ -257,6 +258,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			numClipIntersection: clipping.numIntersection,
 
 			dithering: material.dithering,
+			transparent: material.transparent,
 
 			shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,


### PR DESCRIPTION
Related issue: #15483 #18631 #21744 #22196

**Description**

When rendering with `alpha: true` opaque materials with textures with alpha channel were "carving out" pixels from the output render.

| Before | After |
| --- | --- |
| <img width="833" alt="Screen Shot 2021-08-25 at 1 57 31 AM" src="https://user-images.githubusercontent.com/97088/130704949-b12f65fe-13f5-4d0d-85a9-b4f98fce20ac.png"> | <img width="830" alt="Screen Shot 2021-08-25 at 1 57 01 AM" src="https://user-images.githubusercontent.com/97088/130705012-45b1c46d-cc8f-45dd-a861-292875bc5382.png"> |

/cc @elalish