### PR TITLE
ShaderChunks: Ignore alpha in output_fragment when using NoBlending

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -37,6 +37,7 @@ import {
 	NearestFilter,
 	NearestMipmapLinearFilter,
 	NearestMipmapNearestFilter,
+	NoBlending,
 	NumberKeyframeTrack,
 	Object3D,
 	OrthographicCamera,
@@ -3118,6 +3119,7 @@ class GLTFParser {
 
 		} else {
 
+			materialParams.blending = NoBlending;
 			materialParams.transparent = false;
 
 			if ( alphaMode === ALPHA_MODES.MASK ) {

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -71,6 +71,7 @@ import normalmap_pars_fragment from './ShaderChunk/normalmap_pars_fragment.glsl.
 import clearcoat_normal_fragment_begin from './ShaderChunk/clearcoat_normal_fragment_begin.glsl.js';
 import clearcoat_normal_fragment_maps from './ShaderChunk/clearcoat_normal_fragment_maps.glsl.js';
 import clearcoat_pars_fragment from './ShaderChunk/clearcoat_pars_fragment.glsl.js';
+import output_fragment from './ShaderChunk/output_fragment.glsl.js';
 import packing from './ShaderChunk/packing.glsl.js';
 import premultiplied_alpha_fragment from './ShaderChunk/premultiplied_alpha_fragment.glsl.js';
 import project_vertex from './ShaderChunk/project_vertex.glsl.js';
@@ -207,6 +208,7 @@ export const ShaderChunk = {
 	clearcoat_normal_fragment_begin: clearcoat_normal_fragment_begin,
 	clearcoat_normal_fragment_maps: clearcoat_normal_fragment_maps,
 	clearcoat_pars_fragment: clearcoat_pars_fragment,
+	output_fragment: output_fragment,
 	packing: packing,
 	premultiplied_alpha_fragment: premultiplied_alpha_fragment,
 	project_vertex: project_vertex,

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifndef TRANSPARENT
+#ifdef OPAQUE
 diffuseColor.a = 1.0;
 #endif
 

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+#ifndef TRANSPARENT
+diffuseColor.a = 1.0;
+#endif
+
+gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+`;

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,7 +1,11 @@
 export default /* glsl */`
 #ifdef OPAQUE
-diffuseColor.a = 1.0;
-#endif
+
+gl_FragColor = vec4( outgoingLight, 1.0 );
+
+#else
 
 gl_FragColor = vec4( outgoingLight, diffuseColor.a );
+
+#endif
 `;

--- a/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed_frag.glsl.js
@@ -31,8 +31,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb; // simple shader
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js
@@ -62,8 +62,7 @@ void main() {
 
 	#include <envmap_fragment>
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert_frag.glsl.js
@@ -88,8 +88,7 @@ void main() {
 
 	#include <envmap_fragment>
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
@@ -53,8 +53,7 @@ void main() {
 
 	vec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
@@ -64,9 +64,7 @@ void main() {
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
 
 	#include <envmap_fragment>
-
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical_frag.glsl.js
@@ -117,8 +117,7 @@ void main() {
 
 	#endif
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon_frag.glsl.js
@@ -57,8 +57,7 @@ void main() {
 
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/points_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points_frag.glsl.js
@@ -24,8 +24,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
+++ b/src/renderers/shaders/ShaderLib/sprite_frag.glsl.js
@@ -25,8 +25,7 @@ void main() {
 
 	outgoingLight = diffuseColor.rgb;
 
-	gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-
+	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -670,7 +670,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
-			parameters.transparent ? '#define TRANSPARENT' : '',
+			parameters.transparent === false ? '#define OPAQUE' : '',
 
 			ShaderChunk[ 'encodings_pars_fragment' ], // this code is required here because it is used by the various encoding/decoding function defined below
 			parameters.map ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -670,6 +670,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
+			parameters.transparent ? '#define TRANSPARENT' : '',
 
 			ShaderChunk[ 'encodings_pars_fragment' ], // this code is required here because it is used by the various encoding/decoding function defined below
 			parameters.map ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding, LogLuvEncoding, GLSL3 } from '../../constants.js';
+import { NoBlending, NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBM16Encoding, RGBM7Encoding, RGBEEncoding, sRGBEncoding, LinearEncoding, LogLuvEncoding, GLSL3 } from '../../constants.js';
 
 let programIdCount = 0;
 
@@ -670,7 +670,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
 
 			parameters.dithering ? '#define DITHERING' : '',
-			parameters.transparent === false ? '#define OPAQUE' : '',
+			parameters.blending === NoBlending ? '#define OPAQUE' : '',
 
 			ShaderChunk[ 'encodings_pars_fragment' ], // this code is required here because it is used by the various encoding/decoding function defined below
 			parameters.map ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -47,7 +47,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
 		'numDirLightShadows', 'numPointLightShadows', 'numSpotLightShadows',
 		'shadowMapEnabled', 'shadowMapType', 'toneMapping', 'physicallyCorrectLights',
-		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering',
+		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering', 'transparent',
 		'sheenTint', 'transmission', 'transmissionMap', 'thicknessMap'
 	];
 
@@ -208,6 +208,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			specularIntensityMap: !! material.specularIntensityMap,
 			specularTintMap: !! material.specularTintMap,
 			specularTintMapEncoding: getTextureEncodingFromMap( material.specularTintMap ),
+
 			alphaMap: !! material.alphaMap,
 			alphaTest: useAlphaTest,
 
@@ -257,6 +258,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			numClipIntersection: clipping.numIntersection,
 
 			dithering: material.dithering,
+			transparent: material.transparent,
 
 			shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -47,7 +47,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		'numDirLights', 'numPointLights', 'numSpotLights', 'numHemiLights', 'numRectAreaLights',
 		'numDirLightShadows', 'numPointLightShadows', 'numSpotLightShadows',
 		'shadowMapEnabled', 'shadowMapType', 'toneMapping', 'physicallyCorrectLights',
-		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering', 'transparent',
+		'doubleSided', 'flipSided', 'numClippingPlanes', 'numClipIntersection', 'depthPacking', 'dithering', 'blending',
 		'sheenTint', 'transmission', 'transmissionMap', 'thicknessMap'
 	];
 
@@ -257,8 +257,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			numClippingPlanes: clipping.numPlanes,
 			numClipIntersection: clipping.numIntersection,
 
+			blending: material.blending,
 			dithering: material.dithering,
-			transparent: material.transparent,
 
 			shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 			shadowMapType: renderer.shadowMap.type,


### PR DESCRIPTION
Related issue: #15483 #18631 #21744 #22196 #22414

**Description**

This makes `NoBlending` behave as expected. Before this PR `NoBlending` was writing alpha pixels when the framebuffer had an alpha channel.

We can not use `NoBlending` to support GLTF's `OPAQUE` and `MASK` alpha modes which was previously broken when setting `alpha: true` in `WebGLRenderer`.

Here is an example with `alpha: true` and `renderer.domElement.style.backgroundColor = 'red'`:

| Before | After |
| --- | --- |
| <img width="833" alt="Screen Shot 2021-08-25 at 1 57 31 AM" src="https://user-images.githubusercontent.com/97088/130704949-b12f65fe-13f5-4d0d-85a9-b4f98fce20ac.png"> | <img width="830" alt="Screen Shot 2021-08-25 at 1 57 01 AM" src="https://user-images.githubusercontent.com/97088/130705012-45b1c46d-cc8f-45dd-a861-292875bc5382.png"> |

Note: I'm following a similar implementation to Khronos' GLTF Viewer:
* [ALPHAMODE_OPAQUE](https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/f38421fe27137da3b502ffa92b4ab9fe4921f549/source/Renderer/shaders/pbr.frag#L36-L38) 
* [ALPHAMODE_MASK](https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/f38421fe27137da3b502ffa92b4ab9fe4921f549/source/Renderer/shaders/pbr.frag#L245-L252)

/cc @elalish @donmccurdy 