### PR TITLE
Improve `webgl_animation_multiple` example doc

### DIFF
--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -43,7 +43,6 @@
 			const MODELS = [
 				{ name: "Soldier" },
 				{ name: "Parrot" },
-				// { name: "RiflePunch" },
 			];
 
 			// Here we define instances of the models that we want to place in the scene, their position, scale and the animations

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -10,7 +10,7 @@
 		<div id="container"></div>
 
 		<div id="info">
-			This demo shows how clone a skinned 3d model using <strong>SkeletonUtils.clone()</strong><br/>
+			This demo shows how to clone a skinned 3d model using <strong>SkeletonUtils.clone()</strong><br/>
 			Soldier model from <a href="https://www.mixamo.com" target="_blank" rel="noopener">https://www.mixamo.com</a>.
 		</div>
 


### PR DESCRIPTION
Related issue: None

**Description**

* Fix typo in `webgl_animation_multiple` example description (9deade0fd5)

* Remove unnecessary commented code (8154a0c988)

    This name isn't referenced anywhere -- looks like an original oversight.
