### PR TITLE
DRACOLoader: Avoid using `name` property of `TypedArray` to ensure compatibility when minifying and running in Safari <= 13

### DIFF
--- a/examples/js/loaders/DRACOLoader.js
+++ b/examples/js/loaders/DRACOLoader.js
@@ -94,9 +94,44 @@
 				const type = taskConfig.attributeTypes[ attribute ];
 
 				if ( type.BYTES_PER_ELEMENT !== undefined ) {
+					
+					// In certain versions of Safari (including mobile) <= 13, when aggressively minfied,
+					// the `name` property of a function can be stripped away.
+					// This leads to some `TypedArray`'s `name` property being an empty string.
+					switch ( type ) {
 
-					taskConfig.attributeTypes[ attribute ] = type.name;
+						case Float32Array:
+							taskConfig.attributeTypes[ attribute ] = "Float32Array";
+							break;
 
+						case Int8Array:
+							taskConfig.attributeTypes[ attribute ] =  "Int8Array";
+							break;
+
+						case Int16Array:
+							taskConfig.attributeTypes[ attribute ] =  "Int16Array";
+							break;
+
+						case Int32Array:
+							taskConfig.attributeTypes[ attribute ] =  "Int32Array";
+							break;
+
+						case Uint8Array:
+							taskConfig.attributeTypes[ attribute ] =  "Uint8Array";
+							break;
+
+						case Uint16Array:
+							taskConfig.attributeTypes[ attribute ] =  "Uint16Array";
+							break;
+
+						case Uint32Array:
+							taskConfig.attributeTypes[ attribute ] =  "Uint32Array";
+							break;
+
+						default:
+							throw new Error( 'THREE.DRACOLoader: Unexpected attribute type.' );
+
+					}
 				}
 
 			} //

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -111,8 +111,43 @@ class DRACOLoader extends Loader {
 
 			if ( type.BYTES_PER_ELEMENT !== undefined ) {
 
-				taskConfig.attributeTypes[ attribute ] = type.name;
+				// When aggressively minfied, certain versions of Safari (including mobile) <= 13,
+				// strip away the `name` property of a function.
+				// This leads to some `TypedArray`'s `name` property being an empty string.
+				switch ( type ) {
 
+					case Float32Array:
+						taskConfig.attributeTypes[ attribute ] = "Float32Array";
+						break;
+
+					case Int8Array:
+						taskConfig.attributeTypes[ attribute ] =  "Int8Array";
+						break;
+
+					case Int16Array:
+						taskConfig.attributeTypes[ attribute ] =  "Int16Array";
+						break;
+
+					case Int32Array:
+						taskConfig.attributeTypes[ attribute ] =  "Int32Array";
+						break;
+
+					case Uint8Array:
+						taskConfig.attributeTypes[ attribute ] =  "Uint8Array";
+						break;
+
+					case Uint16Array:
+						taskConfig.attributeTypes[ attribute ] =  "Uint16Array";
+						break;
+
+					case Uint32Array:
+						taskConfig.attributeTypes[ attribute ] =  "Uint32Array";
+						break;
+
+					default:
+						throw new Error( 'THREE.DRACOLoader: Unexpected attribute type.' );
+
+				}
 			}
 
 		}


### PR DESCRIPTION
Related issue: #18540

**Description**

This issue is only present on safari <= 13, including mobile safari, when using a minifier with core-js. This makes the code more resilient and compressable.

`decodeDracoFile` allows `attributeTypes` to be passed in with references to the `TypedArray` constructors ( like `Float32Array` ).  When using aggressive modification with both `Terser` or `esbuild` the `name` property can be stripped away. The `DRACOLoader` works when `attributeTypes` are given as strings. When the constructors of the `TypedArrays` are passed in, a conversion to strings is done using the `name` property. This change is a safer `TypedArray` to string conversion.

Below is on a site that has threejs bundled using Terser or esbuild
![image](https://user-images.githubusercontent.com/859286/130895842-7e6d423d-3630-4ce4-9d63-b3fe5e8e4eb8.png)

I do not have time now to get a minimal working example up and running, I only have a propriety example that I am unable to share.