### PR TITLE
Docs: Fix typos in docs/api/(zh),(en)

### DIFF
--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -73,9 +73,9 @@
 
 			Must be one of these constants:<br /><br />
 			[page:Animation THREE.LoopOnce] - playing the clip once,<br />
-			[page:Animation THREE.LoopRepeat] - playing the clip with the choosen number of *repetitions*,
+			[page:Animation THREE.LoopRepeat] - playing the clip with the chosen number of *repetitions*,
 			each time jumping from the end of the clip directly to its beginning,<br />
-			[page:Animation THREE.LoopPingPong] - playing the clip with the choosen number of *repetitions*,
+			[page:Animation THREE.LoopPingPong] - playing the clip with the chosen number of *repetitions*,
 			alternately playing forward and backward.
 		</p>
 
@@ -98,7 +98,7 @@
 			The local time of this action (in seconds, starting with 0).<br /><br />
 
 			The value gets clamped or wrapped to 0...clip.duration (according to the loop state). It can be
-			scaled relativly to the global mixer time by changing [page:.timeScale timeScale] (using
+			scaled relatively to the global mixer time by changing [page:.timeScale timeScale] (using
 			[page:.setEffectiveTimeScale setEffectiveTimeScale] or [page:.setDuration setDuration]).<br />
 		</p>
 

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -15,7 +15,7 @@
 			Object3Ds are a member of layer 0.<br /><br />
 
 			This can be used to control visibility - an object must share a layer with a [page:Camera camera] to be visible when that camera's
-			view is renderered.<br /><br />
+			view is rendered.<br /><br />
 
 			All classes that inherit from [page:Object3D] have an [page:Object3D.layers] property which is an instance of this class.
 		</p>

--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 		A class containing utility functions for shapes.<br /><br />
 
-		Note that these are all linear functions so it is neccessary to calculate separately for
+		Note that these are all linear functions so it is necessary to calculate separately for
 		x, y (and z, w if present) components of a vector.
 		</p>
 
@@ -30,7 +30,7 @@
 		<p>
 		pts -- points defining a 2D polygon<br /><br />
 
-		Note that this is a linear function so it is neccessary to calculate separately for
+		Note that this is a linear function so it is necessary to calculate separately for
 		x, y  components of a polygon.<br /><br />
 
 		Used internally by [page:Path Path],

--- a/docs/api/en/helpers/SkeletonHelper.html
+++ b/docs/api/en/helpers/SkeletonHelper.html
@@ -13,7 +13,7 @@
 
 		<p class="desc">
 		A helper object to assist with visualizing a [page:Skeleton Skeleton].
-		The helper is renderered using a [page:LineBasicMaterial LineBasicMaterial].
+		The helper is rendered using a [page:LineBasicMaterial LineBasicMaterial].
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/api/en/loaders/managers/DefaultLoadingManager.html
+++ b/docs/api/en/loaders/managers/DefaultLoadingManager.html
@@ -12,7 +12,7 @@
 		<p class="desc">A global instance of the [page:LoadingManager LoadingManager], used by most loaders
 			when no custom manager has been specified.<br /><br />
 
-		  This will be sufficient for most purposes, however there may be times when you desire seperate loading managers
+		  This will be sufficient for most purposes, however there may be times when you desire separate loading managers
 			for say, textures and models.
 		</p>
 

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -13,8 +13,8 @@
 			Handles and keeps track of loaded and pending data. A default global instance of this class
 			is created and used by loaders if not supplied manually - see [page:DefaultLoadingManager].<br /><br />
 
-			In general that should be sufficient, however there are times when it can be useful to have seperate loaders -
-			for example if you want to show seperate loading bars for objects and textures.
+			In general that should be sufficient, however there are times when it can be useful to have separate loaders -
+			for example if you want to show separate loading bars for objects and textures.
 
 		</p>
 

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -32,7 +32,7 @@
 		<h3>[property:Float alphaTest]</h3>
 		<p>
 		Sets the alpha value to be used when running an alpha test.
-		The material will not be renderered if the opacity is lower than this value.
+		The material will not be rendered if the opacity is lower than this value.
 		Default is *0*.
 		</p>
 

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -53,7 +53,7 @@
 						The loop variable has to be *i*.
 					</li>
 					<li>
-						The value *UNROLLED_LOOP_INDEX* will be replaced with the explicity value of *i* for the given iteration and can be used in preprocessor statements.
+						The value *UNROLLED_LOOP_INDEX* will be replaced with the explicitly value of *i* for the given iteration and can be used in preprocessor statements.
 					</li>
 				</ul>
 				<code>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -56,7 +56,7 @@
 		of GPU is suitable for this WebGL context. Can be *"high-performance"*, *"low-power"* or *"default"*. Default is *"default"*.
 		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2 WebGL spec] for details.<br />
 
-		[page:Boolean failIfMajorPerformanceCaveat] - whether the renderer creation will fail upon low perfomance is detected. Default is *false*.
+		[page:Boolean failIfMajorPerformanceCaveat] - whether the renderer creation will fail upon low performance is detected. Default is *false*.
 		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2 WebGL spec] for details.<br />
 
 		[page:Boolean depth] - whether the drawing buffer has a
@@ -64,7 +64,7 @@
 		Default is *true*.<br />
 
 		[page:Boolean logarithmicDepthBuffer] -  whether to use a logarithmic depth buffer. It may
-		be neccesary to use this if dealing with huge differences in scale in a single scene. Note that this setting
+		be necessary to use this if dealing with huge differences in scale in a single scene. Note that this setting
 		uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
 		optimization and can cause a decrease in performance.
 		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -19,7 +19,7 @@
 		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy, encoding )</h3>
 		<p>
 			The data argument must be an [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
-			Further parameters correspond to the properties inherited from [page:Texture], where both magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
+			Further parameters correspond to the properties inherited from [page:Texture], where both magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are initially set to false.
 		</p>
 		<p>
 			The interpretation of the data depends on type and format:

--- a/docs/api/en/textures/DataTexture2DArray.html
+++ b/docs/api/en/textures/DataTexture2DArray.html
@@ -19,7 +19,7 @@
 		<h3>[name]( data, width, height, depth )</h3>
 		<p>
 			The data argument must be an [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
-			The properties inherited from [page:Texture] are the default, except magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
+			The properties inherited from [page:Texture] are the default, except magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are initially set to false.
 		</p>
 		<p>
 			The interpretation of the data depends on type and format:

--- a/docs/api/zh/textures/DataTexture2DArray.html
+++ b/docs/api/zh/textures/DataTexture2DArray.html
@@ -19,7 +19,7 @@
 		<h3>[name]( data, width, height, depth )</h3>
 		<p>
 			The data argument must be an [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
-			The properties inherited from [page:Texture] are the default, except magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are intially set to false.
+			The properties inherited from [page:Texture] are the default, except magFilter and minFilter default to THREE.NearestFilter. The properties flipY and generateMipmaps are initially set to false.
 		</p>
 		<p>
 			The interpretation of the data depends on type and format:

--- a/docs/index.html
+++ b/docs/index.html
@@ -434,7 +434,7 @@
 		function setUrlFragment( pageName ) { // eslint-disable-line no-undef
 
 			// Handle navigation from the subpages (iframes):
-			// First separate the memeber (if existing) from the page name,
+			// First separate the member (if existing) from the page name,
 			// then identify the subpage's URL and set it as URL fragment (re-adding the member)
 
 			const splitPageName = decomposePageName( pageName, '.', '.' );

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -78,7 +78,7 @@
 				let sphereGeometry = new THREE.SphereGeometry( radius, segments, rings );
 				let boxGeometry = new THREE.BoxGeometry( 0.8 * radius, 0.8 * radius, 0.8 * radius, 10, 10, 10 );
 
-				// if normal and uv attributes are not removed, mergeVertices() can't consolidate indentical vertices with different normal/uv data
+				// if normal and uv attributes are not removed, mergeVertices() can't consolidate identical vertices with different normal/uv data
 
 				sphereGeometry.deleteAttribute( 'normal' );
 				sphereGeometry.deleteAttribute( 'uv' );


### PR DESCRIPTION
**Description**

Made corrections to the typos i found in the documentations.
