### PR TITLE
NodeBuilder: Fix missing LinearEncoding

### DIFF
--- a/examples/jsm/renderers/nodes/core/NodeBuilder.js
+++ b/examples/jsm/renderers/nodes/core/NodeBuilder.js
@@ -6,6 +6,8 @@ import NodeCode from './NodeCode.js';
 import NodeKeywords from './NodeKeywords.js';
 import { NodeUpdateType } from './constants.js';
 
+import { LinearEncoding } from 'three';
+
 class NodeBuilder {
 
 	constructor( material, renderer ) {


### PR DESCRIPTION
**Description**

Fix missing `include` `THREE.LinearEncoding`
