### PR TITLE
WebGPU: Fix example webgpu_compute 16-bit limit value

### DIFF
--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -55,7 +55,7 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x000000 );
 
-				const particleNum = 100000;
+				const particleNum = 50000; // 16-bit limit
 				const particleSize = 3;
 
 				const particleArray = new Float32Array( particleNum * particleSize );


### PR DESCRIPTION
**Description**

Warning to values more high than `16-bit` in `particleNum`:
![image](https://user-images.githubusercontent.com/502810/131073104-c197cc2a-1255-4393-87ee-5b96a06790e8.png)

/ping @Mugen87 
