### PR TITLE
Build: transform private class properties in the build script

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -277,6 +277,32 @@ ${ code }`;
 
 }
 
+// Transform #properties to _properties until they're supported in bundlers
+function privateProperties() {
+
+	return {
+
+		transform( code, id ) {
+
+			if ( /\.glsl.js$/.test( id ) === true ) return;
+
+			// replace `#property =` with `_property =`
+			code = code.replace( /#(\w+) =/g, ( match, p1 ) => `_${p1} =` );
+
+			// replace `this.#property` with `this._property`
+			code = code.replace( /this\.#(\w+)/g, ( match, p1 ) => `this._${p1}` );
+
+			return {
+				code: code,
+				map: null
+			};
+
+		}
+
+	};
+
+}
+
 export default [
 	{
 		input: 'src/Three.js',
@@ -284,6 +310,7 @@ export default [
 			addons(),
 			glconstants(),
 			glsl(),
+			privateProperties(),
 			header()
 		],
 		output: [

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -289,6 +289,9 @@ function privateProperties() {
 			// replace `#property =` with `_property =`
 			code = code.replace( /#(\w+) =/g, ( match, p1 ) => `_${p1} =` );
 
+			// replace `#property;` with `_property;`
+			code = code.replace( /#(\w+);/g, ( match, p1 ) => `_${p1};` );
+
 			// replace `this.#property` with `this._property`
 			code = code.replace( /this\.#(\w+)/g, ( match, p1 ) => `this._${p1}` );
 


### PR DESCRIPTION
Fixes #22434 and #22437
Alternative to #22438

**Description**

This is an alternative solution that involves transforming `#properties` to `_properties` via string replace during the rollup build phase.

We could remove the transform in a few months once the bundlers will be ready.

Your call @mrdoob, either is fine.