### PR TITLE
Material: Use pseudo private variables.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -6,8 +6,6 @@ let materialId = 0;
 
 class Material extends EventDispatcher {
 
-	#alphaTest = 0;
-
 	constructor() {
 
 		super();
@@ -76,23 +74,25 @@ class Material extends EventDispatcher {
 
 		this.version = 0;
 
+		this._alphaTest = 0;
+
 	}
 
 	get alphaTest() {
 
-		return this.#alphaTest;
+		return this._alphaTest;
 
 	}
 
 	set alphaTest( value ) {
 
-		if ( this.#alphaTest > 0 !== value > 0 ) {
+		if ( this._alphaTest > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this.#alphaTest = value;
+		this._alphaTest = value;
 
 	}
 

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -34,9 +34,6 @@ import * as MathUtils from '../math/MathUtils.js';
 
 class MeshPhysicalMaterial extends MeshStandardMaterial {
 
-	#clearcoat = 0;
-	#transmission = 0;
-
 	constructor( parameters ) {
 
 		super();
@@ -86,43 +83,47 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.specularTint = new Color( 1, 1, 1 );
 		this.specularTintMap = null;
 
+		this._clearcoat = 0;
+		this._transmission = 0;
+
+
 		this.setValues( parameters );
 
 	}
 
 	get clearcoat() {
 
-		return this.#clearcoat;
+		return this._clearcoat;
 
 	}
 
 	set clearcoat( value ) {
 
-		if ( this.#clearcoat > 0 !== value > 0 ) {
+		if ( this._clearcoat > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this.#clearcoat = value;
+		this._clearcoat = value;
 
 	}
 
 	get transmission() {
 
-		return this.#transmission;
+		return this._transmission;
 
 	}
 
 	set transmission( value ) {
 
-		if ( this.#transmission > 0 !== value > 0 ) {
+		if ( this._transmission > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this.#transmission = value;
+		this._transmission = value;
 
 	}
 

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -277,35 +277,6 @@ ${ code }`;
 
 }
 
-// Transform #properties to _properties until they're supported in bundlers
-function privateProperties() {
-
-	return {
-
-		transform( code, id ) {
-
-			if ( /\.glsl.js$/.test( id ) === true ) return;
-
-			// replace `#property =` with `_property =`
-			code = code.replace( /#(\w+) =/g, ( match, p1 ) => `_${p1} =` );
-
-			// replace `#property;` with `_property;`
-			code = code.replace( /#(\w+);/g, ( match, p1 ) => `_${p1};` );
-
-			// replace `this.#property` with `this._property`
-			code = code.replace( /this\.#(\w+)/g, ( match, p1 ) => `this._${p1}` );
-
-			return {
-				code: code,
-				map: null
-			};
-
-		}
-
-	};
-
-}
-
 let builds = [
 	{
 		input: 'src/Three.js',
@@ -313,7 +284,6 @@ let builds = [
 			addons(),
 			glconstants(),
 			glsl(),
-			privateProperties(),
 			header()
 		],
 		output: [

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -278,7 +278,6 @@ ${ code }`;
 }
 
 // Transform #properties to _properties until they're supported in bundlers
-// https://github.com/mrdoob/three.js/issues/22437
 function privateProperties() {
 
 	return {
@@ -329,7 +328,6 @@ let builds = [
 		plugins: [
 			addons(),
 			glsl(),
-			privateProperties(),
 			babel( {
 				babelHelpers: 'bundled',
 				compact: false,
@@ -354,7 +352,6 @@ let builds = [
 			addons(),
 			glconstants(),
 			glsl(),
-			privateProperties(),
 			babel( {
 				babelHelpers: 'bundled',
 				babelrc: false,


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/22437#issuecomment-907086473

**Description**

The PR reverts the last two commits regarding `rollup.config.js` and introduces pseudo private variables in the material classes.
