### PR TITLE
DataUtils: Clamp param of toHalfFloat().

### DIFF
--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -7,7 +7,13 @@ class DataUtils {
 
 	static toHalfFloat( val ) {
 
-		val = Math.min( val, 65504 ); // 65504 = maximum representable value in float16
+		if ( val > 65504 ) {
+
+			console.warn( 'THREE.DataUtils.toHalfFloat(): value exceeds 65504.' );
+
+			val = 65504; // maximum representable value in float16
+
+		}
 
 		// Source: http://gamedev.stackexchange.com/questions/17326/conversion-of-a-number-from-single-precision-floating-point-representation-to-a/17410#17410
 

--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -7,6 +7,8 @@ class DataUtils {
 
 	static toHalfFloat( val ) {
 
+		val = Math.min( val, 65504 ); // 65504 = maximum representable value in float16
+
 		// Source: http://gamedev.stackexchange.com/questions/17326/conversion-of-a-number-from-single-precision-floating-point-representation-to-a/17410#17410
 
 		/* This method is faster than the OpenEXR implementation (very often


### PR DESCRIPTION
Related issue: Fixed #22435.

**Description**

see https://github.com/mrdoob/three.js/issues/22435#issuecomment-906499629

This PR ensures that `DataUtils.toHalfFloat()` clamps the parameter to the maximum representable value in float16.

I've manually patched `RGBELoader` with this fix in the following live example to demonstrate how it resolves the rendering glitch: https://glitch.com/edit/#!/plastic-copper-hyacinth?path=index.html%3A520%3A22

@bhouston Does this change look good to you?