### PR TITLE
Docs: Clarify vector equal() methods.

### DIFF
--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -176,7 +176,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector2 v] )</h3>
-		<p>Checks for strict equality of this vector and [page:Vector2 v].</p>
+		<p>Returns *true* if the components of this vector and [page:Vector2 v] are strictly equal; *false* otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -202,7 +202,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector3 v] )</h3>
-		<p>Checks for strict equality of this vector and [page:Vector3 v].</p>
+		<p>Returns *true* if the components of this vector and [page:Vector3 v] are strictly equal; *false* otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -152,7 +152,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector4 v] )</h3>
-		<p>Checks for strict equality of this vector and [page:Vector4 v].</p>
+		<p>Returns *true* if the components of this vector and [page:Vector4 v] are strictly equal; *false* otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>


### PR DESCRIPTION
Related issue: -

**Description**

Clarifies the description of `Vector*.equals()`.
