### PR TITLE
RGBELoader: Clamp prior to converting to half float

### DIFF
--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -354,9 +354,10 @@ class RGBELoader extends DataTextureLoader {
 			const e = sourceArray[ sourceOffset + 3 ];
 			const scale = Math.pow( 2.0, e - 128.0 ) / 255.0;
 
-			destArray[ destOffset + 0 ] = DataUtils.toHalfFloat( sourceArray[ sourceOffset + 0 ] * scale );
-			destArray[ destOffset + 1 ] = DataUtils.toHalfFloat( sourceArray[ sourceOffset + 1 ] * scale );
-			destArray[ destOffset + 2 ] = DataUtils.toHalfFloat( sourceArray[ sourceOffset + 2 ] * scale );
+			// clamping to 65504, the maximum representable value in float16
+			destArray[ destOffset + 0 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 0 ] * scale, 65504 ) );
+			destArray[ destOffset + 1 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 1 ] * scale, 65504 ) );
+			destArray[ destOffset + 2 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 2 ] * scale, 65504 ) );
 
 		};
 


### PR DESCRIPTION
Fixes #22435.

In lieu of #22444. (It is the calling app's responsibility to decide _how_ to clamp large values.)

In this PR, the clamping is per-channel independently. Clamping to prevent a hue shift is also reasonable if users complain. But ACES Filmic shifts hue anyway, so for now, I think this is OK.

Below: Linear tone mapping and exposure set to _0.01_. You can see how bright the sun is compared to the rest of the sky.


<img width="779" alt="Screen Shot 2021-08-29 at 10 31 18 AM" src="https://user-images.githubusercontent.com/1000017/131254528-0d7cdd34-2ebf-4cdf-b8b6-81943530a6c0.png">
