### PR TITLE
MeshPhysicalMaterial: Implement sheen as a layer on top of the base later

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -135,11 +135,10 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 		reflectedLight.directSpecular += irradiance * BRDF_Sheen( directLight.direction, geometry.viewDir, geometry.normal, material.sheenTint, material.sheenRoughness );
 
-	#else
-
-		reflectedLight.directSpecular += irradiance * BRDF_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularF90, material.roughness );
-
 	#endif
+
+	reflectedLight.directSpecular += irradiance * BRDF_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularF90, material.roughness );
+
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 }


### PR DESCRIPTION
...as per the glTF spec.

Previously, the sheen specular lobe replaced the base specular lobe.

Energy-conservation for the sheen layer has yet to be implemented.

