### PR TITLE
ShadowMaterial: Add missing shader chunks.

### DIFF
--- a/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow_vert.glsl.js
@@ -1,13 +1,11 @@
 export default /* glsl */`
 #include <common>
 #include <fog_pars_vertex>
+#include <morphtarget_pars_vertex>
+#include <skinning_pars_vertex>
 #include <shadowmap_pars_vertex>
 
 void main() {
-
-	#include <begin_vertex>
-	#include <project_vertex>
-	#include <worldpos_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
@@ -15,6 +13,12 @@ void main() {
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
 
+	#include <begin_vertex>
+	#include <morphtarget_vertex>
+	#include <skinning_vertex>
+	#include <project_vertex>
+
+	#include <worldpos_vertex>
 	#include <shadowmap_vertex>
 	#include <fog_vertex>
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/does-shadowmaterial-work-with-skinned-mesh/29440

**Description**

Certain morph and skinning related shader chunks were missing in the vertex shader of `ShadowMaterial`.
