### PR TITLE
Frustum: Fix wrong test in split().

### DIFF
--- a/examples/jsm/csm/Frustum.js
+++ b/examples/jsm/csm/Frustum.js
@@ -109,7 +109,7 @@ class Frustum {
 
 			}
 
-			if ( i === breaks - 1 ) {
+			if ( i === breaks.length - 1 ) {
 
 				for ( let j = 0; j < 4; j ++ ) {
 


### PR DESCRIPTION
Current condition `i === breaks - 1` makes no sense. Apparently it should be breaks.length - 1, which would test for the last iteration.