### PR TITLE
NodeMaterial: Arrays of uniforms

### DIFF
--- a/examples/jsm/renderers/nodes/core/ArrayInputNode.js
+++ b/examples/jsm/renderers/nodes/core/ArrayInputNode.js
@@ -1,0 +1,23 @@
+import InputNode from './InputNode.js';
+
+class ArrayInputNode extends InputNode {
+
+	constructor( value = [] ) {
+
+		super();
+
+		this.value = value;
+
+	}
+
+	getType( builder ) {
+
+		return this.value[ 0 ].getType( builder );
+
+	}
+
+}
+
+ArrayInputNode.prototype.isArrayInputNode = true;
+
+export default ArrayInputNode;

--- a/examples/jsm/renderers/nodes/core/FunctionNode.js
+++ b/examples/jsm/renderers/nodes/core/FunctionNode.js
@@ -105,9 +105,15 @@ class FunctionNode extends CodeNode {
 				}
 
 				const type = propsMatches[ i ++ ][ 0 ];
+
+				let count = Number.parseInt( propsMatches[ i ][ 0 ] );
+
+				if ( Number.isNaN( count ) === false ) i ++;
+				else count = 0;
+
 				const name = propsMatches[ i ++ ][ 0 ];
 
-				inputs.push( new NodeFunctionInput( type, name, qualifier, isConst ) );
+				inputs.push( new NodeFunctionInput( type, name, qualifier, isConst, count ) );
 
 			}
 
@@ -135,7 +141,7 @@ class FunctionNode extends CodeNode {
 
 	}
 
-	call( parameters = null ) {
+	call( parameters = {} ) {
 
 		return new FunctionCallNode( this, parameters );
 

--- a/examples/jsm/renderers/nodes/core/InputNode.js
+++ b/examples/jsm/renderers/nodes/core/InputNode.js
@@ -40,7 +40,7 @@ class InputNode extends Node {
 
 		} else {
 
-			const nodeUniform = builder.getUniformFromNode( this, builder.shaderStage, this.getType( builder ) );
+			const nodeUniform = builder.getUniformFromNode( this, builder.shaderStage, type );
 			const propertyName = builder.getPropertyName( nodeUniform );
 
 			return builder.format( propertyName, type, output );

--- a/examples/jsm/renderers/nodes/core/NodeBuilder.js
+++ b/examples/jsm/renderers/nodes/core/NodeBuilder.js
@@ -102,12 +102,6 @@ class NodeBuilder {
 
 	}
 
-	getPMREM( texture ) {
-
-		console.warn( 'Abstract function.' );
-
-	}
-
 	getConst( type, value ) {
 
 		if ( type === 'float' ) return value + ( value % 1 ? '' : '.0' );
@@ -588,26 +582,26 @@ class NodeBuilder {
 			case 'float to vec4' : return `vec4( vec3( ${snippet} ), 1.0 )`;
 
 			case 'vec2 to float' : return `${snippet}.x`;
-			case 'vec2 to vec3' : return `vec3( ${snippet}, 0.0 )`;
-			case 'vec2 to vec4' : return `vec4( ${snippet}.xy, 0.0, 1.0 )`;
+			case 'vec2 to vec3'  : return `vec3( ${snippet}, 0.0 )`;
+			case 'vec2 to vec4'  : return `vec4( ${snippet}.xy, 0.0, 1.0 )`;
 
 			case 'vec3 to float' : return `${snippet}.x`;
-			case 'vec3 to vec2' : return `${snippet}.xy`;
-			case 'vec3 to vec4' : return `vec4( ${snippet}, 1.0 )`;
+			case 'vec3 to vec2'  : return `${snippet}.xy`;
+			case 'vec3 to vec4'  : return `vec4( ${snippet}, 1.0 )`;
 
 			case 'vec4 to float' : return `${snippet}.x`;
-			case 'vec4 to vec2' : return `${snippet}.xy`;
-			case 'vec4 to vec3' : return `${snippet}.xyz`;
+			case 'vec4 to vec2'  : return `${snippet}.xy`;
+			case 'vec4 to vec3'  : return `${snippet}.xyz`;
 
 			case 'mat3 to float' : return `( ${snippet} * vec3( 1.0 ) ).x`;
-			case 'mat3 to vec2' : return `( ${snippet} * vec3( 1.0 ) ).xy`;
-			case 'mat3 to vec3' : return `( ${snippet} * vec3( 1.0 ) ).xyz`;
-			case 'mat3 to vec4' : return `vec4( ${snippet} * vec3( 1.0 ), 1.0 )`;
+			case 'mat3 to vec2'  : return `( ${snippet} * vec3( 1.0 ) ).xy`;
+			case 'mat3 to vec3'  : return `( ${snippet} * vec3( 1.0 ) ).xyz`;
+			case 'mat3 to vec4'  : return `vec4( ${snippet} * vec3( 1.0 ), 1.0 )`;
 
 			case 'mat4 to float' : return `( ${snippet} * vec4( 1.0 ) ).x`;
-			case 'mat4 to vec2' : return `( ${snippet} * vec4( 1.0 ) ).xy`;
-			case 'mat4 to vec3' : return `( ${snippet} * vec4( 1.0 ) ).xyz`;
-			case 'mat4 to vec4' : return `( ${snippet} * vec4( 1.0 ) )`;
+			case 'mat4 to vec2'  : return `( ${snippet} * vec4( 1.0 ) ).xy`;
+			case 'mat4 to vec3'  : return `( ${snippet} * vec4( 1.0 ) ).xyz`;
+			case 'mat4 to vec4'  : return `( ${snippet} * vec4( 1.0 ) )`;
 
 		}
 

--- a/examples/jsm/renderers/nodes/core/NodeFunctionInput.js
+++ b/examples/jsm/renderers/nodes/core/NodeFunctionInput.js
@@ -1,11 +1,12 @@
 class NodeFunctionInput {
 
-	constructor( type, name, qualifier = '', isConst = false ) {
+	constructor( type, name, qualifier = '', isConst = false, count = 0 ) {
 
 		this.type = type;
 		this.name = name;
 		this.qualifier = qualifier;
 		this.isConst = isConst;
+		this.count = count;
 
 		Object.defineProperty( this, 'isNodeFunction', { value: true } );
 

--- a/examples/jsm/renderers/webgpu/WebGPUBufferUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBufferUtils.js
@@ -8,19 +8,26 @@ function getFloatLength( floatLength ) {
 
 }
 
-function getVectorLength( count, vectorLength ) {
+function getVectorLength( count, vectorLength = 4 ) {
 
-	const strideLength = 4;
+	const strideLength = getStrideLength( vectorLength );
 
-	vectorLength = vectorLength + ( ( strideLength - ( vectorLength % strideLength ) ) % strideLength );
-
-	const floatLength = vectorLength * count;
+	const floatLength = strideLength * count;
 
 	return getFloatLength( floatLength );
 
 }
 
+function getStrideLength( vectorLength ) {
+
+	const strideLength = 4;
+
+	return vectorLength + ( ( strideLength - ( vectorLength % strideLength ) ) % strideLength );
+
+}
+
 export {
 	getFloatLength,
-	getVectorLength
+	getVectorLength,
+	getStrideLength
 };


### PR DESCRIPTION
**Description**

This is the first approach for `Arrays of uniform` using `ArrayInputNode`. 

Soon we can optimize all `VBO` of `NodeMaterial` using `WebGPUUniformBuffer` but it can take a while.

### Include
```js
import ArrayInputNode from './jsm/renderers/nodes/core/ArrayInputNode.js';
```

### Example 1 - Vector3

```js
material.colorNode = new FunctionNode( `
vec3 ( vec3[2] value ) {

	// 0 -> cornflower blue
	// 1 -> orange

	return value[0];

}` ).call( {
	value: new ArrayInputNode( [
		new Vector3Node( new THREE.Vector3( 0, .5, 1 ) ), // cornflower blue
		new Vector3Node( new THREE.Vector3( 1, .5, 0 ) ) // orange
	] )
} );
```

### Example 2 - Matrix4

```js
material.colorNode = new FunctionNode( `
vec3 ( mat4[2] value ) {

	// 0 -> cornflower blue
	// 1 -> orange

	mat4 mtx = value[0];
	vec3 mtxPos = vec3( mtx[3] );

	return mtxPos;

}` ).call( {
	value: new ArrayInputNode( [
		new Matrix4Node( new THREE.Matrix4().setPosition( 0, .5, 1 ) ), // cornflower blue
		new Matrix4Node( new THREE.Matrix4().setPosition( 1, .5, 0 ) ) // orange
	] )
} );

```