### PR TITLE
Examples: Specify the raycaster recursive flag

### DIFF
--- a/examples/js/interactive/InteractiveGroup.js
+++ b/examples/js/interactive/InteractiveGroup.js
@@ -24,7 +24,7 @@
 				_pointer.x = event.clientX / element.clientWidth * 2 - 1;
 				_pointer.y = - ( event.clientY / element.clientHeight ) * 2 + 1;
 				raycaster.setFromCamera( _pointer, camera );
-				const intersects = raycaster.intersectObjects( scope.children );
+				const intersects = raycaster.intersectObjects( scope.children, false );
 
 				if ( intersects.length > 0 ) {
 
@@ -63,7 +63,7 @@
 				tempMatrix.identity().extractRotation( controller.matrixWorld );
 				raycaster.ray.origin.setFromMatrixPosition( controller.matrixWorld );
 				raycaster.ray.direction.set( 0, 0, - 1 ).applyMatrix4( tempMatrix );
-				const intersections = raycaster.intersectObjects( scope.children );
+				const intersections = raycaster.intersectObjects( scope.children, false );
 
 				if ( intersections.length > 0 ) {
 

--- a/examples/jsm/interactive/InteractiveGroup.js
+++ b/examples/jsm/interactive/InteractiveGroup.js
@@ -32,7 +32,7 @@ class InteractiveGroup extends Group {
 
 			raycaster.setFromCamera( _pointer, camera );
 
-			const intersects = raycaster.intersectObjects( scope.children );
+			const intersects = raycaster.intersectObjects( scope.children, false );
 
 			if ( intersects.length > 0 ) {
 
@@ -77,7 +77,7 @@ class InteractiveGroup extends Group {
 			raycaster.ray.origin.setFromMatrixPosition( controller.matrixWorld );
 			raycaster.ray.direction.set( 0, 0, - 1 ).applyMatrix4( tempMatrix );
 
-			const intersections = raycaster.intersectObjects( scope.children );
+			const intersections = raycaster.intersectObjects( scope.children, false );
 
 			if ( intersections.length > 0 ) {
 

--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -343,7 +343,7 @@ class OculusHandPointerModel extends THREE.Object3D {
 
 		if ( this.raycaster ) {
 
-			return this.raycaster.intersectObjects( objects );
+			return this.raycaster.intersectObjects( objects, false );
 
 		}
 
@@ -353,7 +353,7 @@ class OculusHandPointerModel extends THREE.Object3D {
 
 		if ( this.raycaster && ! this.attached ) {
 
-			const intersections = this.raycaster.intersectObjects( objects );
+			const intersections = this.raycaster.intersectObjects( objects, false );
 			const direction = new THREE.Vector3( 0, 0, - 1 );
 			if ( intersections.length > 0 ) {
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -279,7 +279,7 @@
 					raycaster.ray.origin.copy( controls.getObject().position );
 					raycaster.ray.origin.y -= 10;
 
-					const intersections = raycaster.intersectObjects( objects );
+					const intersections = raycaster.intersectObjects( objects, false );
 
 					const onObject = intersections.length > 0;
 

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -188,7 +188,7 @@
 
 				raycaster.setFromCamera( mouse, camera );
 
-				const intersects = raycaster.intersectObjects( scene.children );
+				const intersects = raycaster.intersectObjects( scene.children, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -371,7 +371,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersects = raycaster.intersectObjects( splineHelperObjects );
+				const intersects = raycaster.intersectObjects( splineHelperObjects, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -135,7 +135,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersects = raycaster.intersectObjects( scene.children );
+				const intersects = raycaster.intersectObjects( scene.children, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -143,7 +143,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersects = raycaster.intersectObjects( scene.children );
+				const intersects = raycaster.intersectObjects( scene.children, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -245,7 +245,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersections = raycaster.intersectObjects( pointclouds );
+				const intersections = raycaster.intersectObjects( pointclouds, false );
 				intersection = ( intersections.length ) > 0 ? intersections[ 0 ] : null;
 
 				if ( toggle > 0.02 && intersection !== null ) {

--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -117,7 +117,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersects = raycaster.intersectObjects( objects );
+				const intersects = raycaster.intersectObjects( objects, false );
 
 				if ( intersects.length > 0 ) {
 
@@ -138,7 +138,7 @@
 
 				raycaster.setFromCamera( pointer, camera );
 
-				const intersects = raycaster.intersectObjects( objects );
+				const intersects = raycaster.intersectObjects( objects, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webgl_loader_ifc.html
+++ b/examples/webgl_loader_ifc.html
@@ -82,7 +82,7 @@
 					const raycaster = new THREE.Raycaster();
 					raycaster.setFromCamera( mouse, camera );
 
-					const intersected = raycaster.intersectObjects( scene.children );
+					const intersected = raycaster.intersectObjects( scene.children, false );
 					if ( intersected.length ) {
 
 						const found = intersected[ 0 ];

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -179,7 +179,7 @@
 
 					rayCaster.setFromCamera( mouse, camera );
 					action = ACTION_NONE;
-					const intersects = rayCaster.intersectObjects( curveHandles );
+					const intersects = rayCaster.intersectObjects( curveHandles, false );
 					if ( intersects.length ) {
 
 						const target = intersects[ 0 ].object;

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -209,7 +209,7 @@
 
 					rayCaster.setFromCamera( mouse, camera );
 					action = ACTION_NONE;
-					const intersects = rayCaster.intersectObjects( curveHandles );
+					const intersects = rayCaster.intersectObjects( curveHandles, false );
 					if ( intersects.length ) {
 
 						const target = intersects[ 0 ].object;

--- a/examples/webgl_postprocessing_ssrr.html
+++ b/examples/webgl_postprocessing_ssrr.html
@@ -243,7 +243,7 @@
 
 
 			raycaster.setFromCamera( mouse, camera );
-			const intersect = raycaster.intersectObjects( objects )[ 0 ];
+			const intersect = raycaster.intersectObjects( objects, false )[ 0 ];
 
 			if ( intersect ) {
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -184,7 +184,7 @@
 				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
 
 				raycaster.setFromCamera( mouse, camera );
-				const intersects = raycaster.intersectObjects( scene.children );
+				const intersects = raycaster.intersectObjects( scene.children, false );
 				if ( intersects.length > 0 ) {
 
 					const object = intersects[ 0 ].object;

--- a/examples/webgl_raycast_texture.html
+++ b/examples/webgl_raycast_texture.html
@@ -328,7 +328,7 @@
 
 				raycaster.setFromCamera( mouse, camera );
 
-				return raycaster.intersectObjects( objects );
+				return raycaster.intersectObjects( objects, false );
 
 			}
 

--- a/examples/webxr_vr_cubes.html
+++ b/examples/webxr_vr_cubes.html
@@ -205,7 +205,7 @@
 				raycaster.ray.origin.setFromMatrixPosition( controller.matrixWorld );
 				raycaster.ray.direction.set( 0, 0, - 1 ).applyMatrix4( tempMatrix );
 
-				const intersects = raycaster.intersectObjects( room.children );
+				const intersects = raycaster.intersectObjects( room.children, false );
 
 				if ( intersects.length > 0 ) {
 

--- a/examples/webxr_vr_dragging.html
+++ b/examples/webxr_vr_dragging.html
@@ -217,7 +217,7 @@
 				raycaster.ray.origin.setFromMatrixPosition( controller.matrixWorld );
 				raycaster.ray.direction.set( 0, 0, - 1 ).applyMatrix4( tempMatrix );
 
-				return raycaster.intersectObjects( group.children );
+				return raycaster.intersectObjects( group.children, false );
 
 			}
 


### PR DESCRIPTION
Follow-on to #22460, which changed the default value.

In `raycaster.intersectObjects()`, if the `recursive` flag was `true`, I left it as-is.

(Since this is an example, I think it is best to specify the flag -- especially since there has been an API change.)

If the `recursive` flag was `false`, I left it as-is.

If the `recursive` flag was not specified, I set it to `false`, because that was the default value prior to #22460.

Thing is, I am a bit surprised at the number of `false` settings. Presumably, that is what was intended...

