### PR TITLE
SAOPass: Fix depthTexture initialization.

### DIFF
--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -32,7 +32,7 @@ import { UnpackDepthRGBAShader } from '../shaders/UnpackDepthRGBAShader.js';
 
 class SAOPass extends Pass {
 
-	constructor( scene, camera, depthTexture, useNormals, resolution ) {
+	constructor( scene, camera, useDepthTexture, useNormals, resolution ) {
 
 		super();
 
@@ -42,7 +42,7 @@ class SAOPass extends Pass {
 		this.clear = true;
 		this.needsSwap = false;
 
-		this.supportsDepthTextureExtension = ( depthTexture !== undefined ) ? depthTexture : false;
+		this.supportsDepthTextureExtension = ( useDepthTexture !== undefined ) ? useDepthTexture : false;
 		this.supportsNormalTexture = ( useNormals !== undefined ) ? useNormals : false;
 
 		this.originalClearColor = new Color();
@@ -78,6 +78,8 @@ class SAOPass extends Pass {
 			format: RGBAFormat
 		} );
 		this.depthRenderTarget = this.normalRenderTarget.clone();
+		
+		let depthTexture;
 
 		if ( this.supportsDepthTextureExtension ) {
 

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -81,7 +81,7 @@ class SAOPass extends Pass {
 
 		if ( this.supportsDepthTextureExtension ) {
 
-			const depthTexture = new DepthTexture();
+			depthTexture = new DepthTexture();
 			depthTexture.type = UnsignedShortType;
 
 			this.beautyRenderTarget.depthTexture = depthTexture;


### PR DESCRIPTION
**Description**

The constructor appears to expect the `depthTexture` argument to be a boolean:

```
this.supportsDepthTextureExtension = ( depthTexture !== undefined ) ? depthTexture : false;
```

If true, a texture is created:
```
		if ( this.supportsDepthTextureExtension ) {

			const depthTexture = new DepthTexture();
			depthTexture.type = UnsignedShortType;

			this.beautyRenderTarget.depthTexture = depthTexture;
			this.beautyRenderTarget.depthBuffer = true;

		}
```

the `const` above means the created depthTexture is not available when it is subsequently used, resulting in a value of `true` for the tDepth uniform:
```
this.saoMaterial.uniforms[ 'tDepth' ].value = ( this.supportsDepthTextureExtension ) ? depthTexture : this.depthRenderTarget.texture;
```

I believe it was intended instead to overwrite the argument value with the new depth texture.

This contribution is funded by [Proving Ground](https://www.provingground.io).
