### PR TITLE
Curve: Remove unneeded `.normalize()`.

### DIFF
--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -277,7 +277,6 @@ class Curve {
 			const u = i / segments;
 
 			tangents[ i ] = this.getTangentAt( u, new Vector3() );
-			tangents[ i ].normalize();
 
 		}
 


### PR DESCRIPTION
the vec returning from `getTangentAt()` seems to be normalized already. 