### PR TITLE
Docs and examples switching retains filter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,8 +53,10 @@
 		const exitSearchButton = document.getElementById( 'exitSearchButton' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const filterInput = document.getElementById( 'filterInput' );
-		const sectionLink = document.querySelector( '#sections > a' );
 		let iframe = document.querySelector( 'iframe' );
+
+		const sectionLink = document.querySelector( '#sections > a' );
+		const sectionDefaultHref = sectionLink.href;
 
 		const pageProperties = {};
 		const titles = {};
@@ -400,12 +402,6 @@
 
 			// update examples link
 
-			if ( ! sectionLink.href2 ) {
-
-				sectionLink.href2 = sectionLink.href;
-
-			}
-
 			if ( search ) {
 
 				let link = sectionLink.href.split( /[?#]/ )[ 0 ];
@@ -413,7 +409,7 @@
 
 			} else {
 
-				sectionLink.href = sectionLink.href2;
+				sectionLink.href = sectionDefaultHref;
 
 			}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
 		const exitSearchButton = document.getElementById( 'exitSearchButton' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const filterInput = document.getElementById( 'filterInput' );
-		const sectionLink = document.querySelector('#sections > a');
+		const sectionLink = document.querySelector( '#sections > a' );
 		let iframe = document.querySelector( 'iframe' );
 
 		const pageProperties = {};
@@ -188,7 +188,7 @@
 
 			} else {
 
-				updateLink('');
+				updateLink( '' );
 
 			}
 
@@ -396,7 +396,7 @@
 
 		}
 
-		function updateLink(search) {
+		function updateLink( search ) {
 
 			// update examples link
 
@@ -406,9 +406,9 @@
 
 			}
 
-			if (search) {
+			if ( search ) {
 
-				let link = sectionLink.href.split(/[?#]/)[0];
+				let link = sectionLink.href.split( /[?#]/ )[ 0 ];
 				sectionLink.href = `${link}?q=${search}`;
 
 			} else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -392,7 +392,7 @@
 
 			displayFilteredPanel();
 
-			updateLink(v);
+			updateLink( v );
 
 		}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,6 +53,7 @@
 		const exitSearchButton = document.getElementById( 'exitSearchButton' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const filterInput = document.getElementById( 'filterInput' );
+		const sectionLink = document.querySelector('#sections > a');
 		let iframe = document.querySelector( 'iframe' );
 
 		const pageProperties = {};
@@ -184,6 +185,10 @@
 				panel.classList.add( 'searchFocused' );
 
 				updateFilter();
+
+			} else {
+
+				updateLink('');
 
 			}
 
@@ -386,6 +391,31 @@
 			}
 
 			displayFilteredPanel();
+
+			updateLink(v);
+
+		}
+
+		function updateLink(search) {
+
+			// update examples link
+
+			if ( ! sectionLink.href2 ) {
+
+				sectionLink.href2 = sectionLink.href;
+
+			}
+
+			if (search) {
+
+				let link = sectionLink.href.split(/[?#]/)[0];
+				sectionLink.href = `${link}?q=${search}`;
+
+			} else {
+
+				sectionLink.href = sectionLink.href2;
+
+			}
 
 		}
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -53,8 +53,10 @@
 		const expandButton = document.getElementById( 'expandButton' );
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
-		const sectionLink = document.querySelector( '#sections > a' );
 		const previewsToggler = document.getElementById( 'previewsToggler' );
+
+		const sectionLink = document.querySelector( '#sections > a' );
+		const sectionDefaultHref = sectionLink.href;
 
 		const links = {};
 		const validRedirects = new Map();
@@ -277,13 +279,7 @@
 
 		function updateLink( search ) {
 
-			// update examples link
-
-			if ( ! sectionLink.href2 ) {
-
-				sectionLink.href2 = sectionLink.href;
-
-			}
+			// update docs link
 
 			if ( search ) {
 
@@ -292,7 +288,7 @@
 
 			} else {
 
-				sectionLink.href = sectionLink.href2;
+				sectionLink.href = sectionDefaultHref;
 
 			}
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -53,7 +53,7 @@
 		const expandButton = document.getElementById( 'expandButton' );
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
-		const sectionLink = document.querySelector('#sections > a');
+		const sectionLink = document.querySelector( '#sections > a' );
 		const previewsToggler = document.getElementById( 'previewsToggler' );
 
 		const links = {};
@@ -122,7 +122,7 @@
 
 			} else {
 
-				updateLink('');
+				updateLink( '' );
 
 			}
 
@@ -275,7 +275,7 @@
 
 		}
 
-		function updateLink(search) {
+		function updateLink( search ) {
 
 			// update examples link
 
@@ -285,9 +285,9 @@
 
 			}
 
-			if (search) {
+			if ( search ) {
 
-				let link = sectionLink.href.split(/[?#]/)[0];
+				let link = sectionLink.href.split( /[?#]/ )[ 0 ];
 				sectionLink.href = `${link}?q=${search}`;
 
 			} else {

--- a/examples/index.html
+++ b/examples/index.html
@@ -53,7 +53,7 @@
 		const expandButton = document.getElementById( 'expandButton' );
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
-
+		const sectionLink = document.querySelector('#sections > a');
 		const previewsToggler = document.getElementById( 'previewsToggler' );
 
 		const links = {};
@@ -119,6 +119,10 @@
 				panel.classList.add( 'searchFocused' );
 
 				updateFilter( files, tags );
+
+			} else {
+
+				updateLink('');
 
 			}
 
@@ -266,6 +270,31 @@
 			}
 
 			layoutList( files );
+
+			updateLink( v );
+
+		}
+
+		function updateLink(search) {
+
+			// update examples link
+
+			if ( ! sectionLink.href2 ) {
+
+				sectionLink.href2 = sectionLink.href;
+
+			}
+
+			if (search) {
+
+				let link = sectionLink.href.split(/[?#]/)[0];
+				sectionLink.href = `${link}?q=${search}`;
+
+			} else {
+
+				sectionLink.href = sectionLink.href2;
+
+			}
 
 		}
 


### PR DESCRIPTION
For example, if you search for "fog" in the examples, then click on "docs" link, the filter is emptied and it shows "Create a scene" page.
Same thing if you search in docs and click on the examples link.

With this PR, the search is retained, which personally helps me a lot.
Typical scenario is:
- Let's see if there are examples of ... parametric, so I type "param", cool I see an example.
- Now let's see if there's any doc about it, so I click on the docs link, then: "arghh, I have to type it again!!"
:)

Screenshots:
1) write "skin"
![image](https://user-images.githubusercontent.com/7278312/132528525-1e38d536-e196-4b32-97d9-a8e30b9c4508.png)

2) click on docs and this appears:
![image](https://user-images.githubusercontent.com/7278312/132528645-ad3f7fb8-955d-4d18-8c6f-1c583ba2e2a8.png)

3) click again on examples and this appears:
![image](https://user-images.githubusercontent.com/7278312/132528732-f6e4c888-67de-4032-9e37-9bd0d4dad9ff.png)
