### PR TITLE
NodeMaterial: Rename SwitchNode -> SplitNode

### DIFF
--- a/examples/jsm/renderers/nodes/utils/SplitNode.js
+++ b/examples/jsm/renderers/nodes/utils/SplitNode.js
@@ -1,6 +1,6 @@
 import Node from '../core/Node.js';
 
-class SwitchNode extends Node {
+class SplitNode extends Node {
 
 	constructor( node, components = 'x' ) {
 
@@ -30,4 +30,4 @@ class SwitchNode extends Node {
 
 }
 
-export default SwitchNode;
+export default SplitNode;

--- a/examples/webgl_materials_standard_nodes.html
+++ b/examples/webgl_materials_standard_nodes.html
@@ -36,7 +36,7 @@
 			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
 			import Vector3Node from './jsm/renderers/nodes/inputs/Vector3Node.js';
 			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import SwitchNode from './jsm/renderers/nodes/utils/SwitchNode.js';
+			import SplitNode from './jsm/renderers/nodes/utils/SplitNode.js';
 			import NormalMapNode from './jsm/renderers/nodes/display/NormalMapNode.js';
 
 			let container, stats;
@@ -99,8 +99,8 @@
 						material.colorNode = new OperatorNode( '*', new TextureNode( diffuseMap ), new Vector3Node( material.color ) );
 
 						// roughness is in G channel, metalness is in B channel
-						material.roughnessNode = new SwitchNode( mpMapNode, 'g' );
-						material.metalnessNode = new SwitchNode( mpMapNode, 'b' );
+						material.roughnessNode = new SplitNode( mpMapNode, 'g' );
+						material.metalnessNode = new SplitNode( mpMapNode, 'b' );
 
 						material.normalNode = new NormalMapNode( new TextureNode( normalMap ) );
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -37,7 +37,7 @@
 			import PositionNode from './jsm/renderers/nodes/accessors/PositionNode.js';
 			import NormalNode from './jsm/renderers/nodes/accessors/NormalNode.js';
 			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import SwitchNode from './jsm/renderers/nodes/utils/SwitchNode.js';
+			import SplitNode from './jsm/renderers/nodes/utils/SplitNode.js';
 			import TimerNode from './jsm/renderers/nodes/utils/TimerNode.js';
 
 			let camera, scene, renderer;
@@ -105,7 +105,7 @@
 				const geometrySphere = new THREE.SphereGeometry( .5, 64, 64 );
 				const materialSphere = new THREE.MeshBasicMaterial();
 
-				const displaceAnimated = new SwitchNode( new TextureNode( textureDisplace ), 'x' );
+				const displaceAnimated = new SplitNode( new TextureNode( textureDisplace ), 'x' );
 				const displaceY = new OperatorNode( '*', displaceAnimated, new FloatNode( .25 ).setConst( true ) );
 
 				const displace = new OperatorNode( '*', new NormalNode( NormalNode.LOCAL ), displaceY );
@@ -122,7 +122,7 @@
 				const geometryPlane = new THREE.PlaneGeometry();
 				const materialPlane = new THREE.MeshBasicMaterial();
 				materialPlane.colorNode = new OperatorNode( '+', new TextureNode( createDataTexture() ), new ColorNode( new THREE.Color( 0x0000FF ) ) );
-				materialPlane.opacityNode = new SwitchNode( new TextureNode( dxt5Texture ), 'a' );
+				materialPlane.opacityNode = new SplitNode( new TextureNode( dxt5Texture ), 'a' );
 				materialPlane.transparent = true;
 
 				const plane = new THREE.Mesh( geometryPlane, materialPlane );


### PR DESCRIPTION
**Description**

I think that this name would be better for the purpose of  the `node`.

Example
```js
// roughness is in G channel, metalness is in B channel
material.roughnessNode = new SplitNode( mpMapNode, 'g' );
material.metalnessNode = new SplitNode( mpMapNode, 'b' );
```

What do you think?

/ping @mrdoob @Mugen87 