### PR TITLE
ShapeGeometry: Make all parameters optional.

### DIFF
--- a/docs/api/en/geometries/ShapeGeometry.html
+++ b/docs/api/en/geometries/ShapeGeometry.html
@@ -59,7 +59,7 @@
 
 		<h3>[name]([param:Array shapes], [param:Integer curveSegments])</h3>
 		<p>
-		shapes — [page:Array] of shapes or a single [page:Shape shape].<br />
+		shapes — [page:Array] of shapes or a single [page:Shape shape]. Default is a single triangle shape.<br />
 		curveSegments - [page:Integer] - Number of segments per shape. Default is 12.
 		</p>
 

--- a/docs/api/zh/geometries/ShapeGeometry.html
+++ b/docs/api/zh/geometries/ShapeGeometry.html
@@ -59,7 +59,7 @@
 
 		<h3>[name]([param:Array shapes], [param:Integer curveSegments])</h3>
 		<p>
-		shapes — 一个单独的[page:Shape shape]，或者一个包含形状的[page:Array]。<br />
+		shapes — 一个单独的[page:Shape shape]，或者一个包含形状的[page:Array]。Default is a single triangle shape.<br />
 		curveSegments - [page:Integer] - 每一个形状的分段数，默认值为12。
 		</p>
 

--- a/src/geometries/ShapeGeometry.js
+++ b/src/geometries/ShapeGeometry.js
@@ -1,10 +1,12 @@
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
+import { Shape } from '../extras/core/Shape.js';
 import { ShapeUtils } from '../extras/ShapeUtils.js';
+import { Vector2 } from '../math/Vector2.js';
 
 class ShapeGeometry extends BufferGeometry {
 
-	constructor( shapes, curveSegments = 12 ) {
+	constructor( shapes = new Shape( [ new Vector2( 0, 0.5 ), new Vector2( - 0.5, - 0.5 ), new Vector2( 0.5, - 0.5 ) ] ), curveSegments = 12 ) {
 
 		super();
 		this.type = 'ShapeGeometry';


### PR DESCRIPTION
Related issue: #22499

**Description**

`ShapeGeometry` can now be created without ctor paramters. The default shape is a single triangle.