### PR TITLE
WebGLMorphtargets: Support normalized attributes.

### DIFF
--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -24,9 +24,7 @@ function denormalize( morph, attribute ) {
 	if ( array instanceof Int16Array ) denominator = 32767;
 	if ( array instanceof Int32Array ) denominator = 2147483647;
 
-	morph.x /= denominator;
-	morph.y /= denominator;
-	morph.z /= denominator;
+	morph.divideScalar( denominator );
 
 }
 

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -15,6 +15,21 @@ function absNumericalSort( a, b ) {
 
 }
 
+function denormalize( morph, attribute ) {
+
+	let denominator = 0;
+	const array = attribute.isInterleavedBufferAttribute ? attribute.data.array : attribute.array;
+
+	if ( array instanceof Int8Array ) denominator = 127;
+	if ( array instanceof Int16Array ) denominator = 32767;
+	if ( array instanceof Int32Array ) denominator = 2147483647;
+
+	morph.x /= denominator;
+	morph.y /= denominator;
+	morph.z /= denominator;
+
+}
+
 function WebGLMorphtargets( gl, capabilities, textures ) {
 
 	const influencesList = {};
@@ -86,6 +101,8 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 
 						morph.fromBufferAttribute( morphTarget, j );
 
+						if ( morphTarget.normalized === true ) denormalize( morph, morphTarget );
+
 						const stride = j * vertexDataStride;
 
 						buffer[ offset + stride + 0 ] = morph.x;
@@ -95,6 +112,8 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 						if ( hasMorphNormals === true ) {
 
 							morph.fromBufferAttribute( morphNormal, j );
+
+							if ( morphNormal.normalized === true ) denormalize( morph, morphNormal );
 
 							buffer[ offset + stride + 3 ] = morph.x;
 							buffer[ offset + stride + 4 ] = morph.y;

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -17,12 +17,13 @@ function absNumericalSort( a, b ) {
 
 function denormalize( morph, attribute ) {
 
-	let denominator = 0;
+	let denominator = 1;
 	const array = attribute.isInterleavedBufferAttribute ? attribute.data.array : attribute.array;
 
 	if ( array instanceof Int8Array ) denominator = 127;
-	if ( array instanceof Int16Array ) denominator = 32767;
-	if ( array instanceof Int32Array ) denominator = 2147483647;
+	else if ( array instanceof Int16Array ) denominator = 32767;
+	else if ( array instanceof Int32Array ) denominator = 2147483647;
+	else console.error( 'THREE.WebGLMorphtargets: Unsupported morph attribute data type: ', array );
 
 	morph.divideScalar( denominator );
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/22514#issuecomment-916258025

**Description**

Ensures normalized morph attribute data can be converted to the internal data texture.