### PR TITLE
chore: regex sanitizing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -360,7 +360,7 @@
 
 			//
 
-			const regExp = new RegExp( filterInput.value, 'gi' );
+			const regExp = new RegExp( filterInput.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi' );
 
 			for ( let pageName in pageProperties ) {
 


### PR DESCRIPTION
**Description**
![image](https://user-images.githubusercontent.com/71921036/132849685-f465400a-3cdd-4f1e-8894-50b25afe7488.png)

As you guys can see, the `.` matches everything and, I'm not sure if this was intended behaviour, if it isn't, then this PR resolves it :)