### PR TITLE
ExtrudeGeometry: Make all parameters optional.

### DIFF
--- a/docs/api/en/geometries/ExtrudeGeometry.html
+++ b/docs/api/en/geometries/ExtrudeGeometry.html
@@ -72,10 +72,10 @@
 			<ul>
 				<li>curveSegments — int. Number of points on the curves. Default is 12.</li>
 				<li>steps — int. Number of points used for subdividing segments along the depth of the extruded spline. Default is 1.</li>
-				<li>depth — float. Depth to extrude the shape. Default is 100.</li>
+				<li>depth — float. Depth to extrude the shape. Default is 1.</li>
 				<li>bevelEnabled — bool. Apply beveling to the shape. Default is true.</li>
-				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 6.</li>
-				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 2.</li>
+				<li>bevelThickness — float. How deep into the original shape the bevel goes. Default is 0.2.</li>
+				<li>bevelSize — float. Distance from the shape outline that the bevel extends. Default is bevelThickness - 0.1.</li>
 				<li>bevelOffset — float. Distance from the shape outline that the bevel starts. Default is 0.</li>
 				<li>bevelSegments — int. Number of bevel layers. Default is 3.</li>
 				<li>extrudePath — THREE.Curve. A 3D spline path along which the shape should be extruded. Bevels not supported for path extrusion.</li>

--- a/docs/api/zh/geometries/ExtrudeGeometry.html
+++ b/docs/api/zh/geometries/ExtrudeGeometry.html
@@ -72,10 +72,10 @@
 			<ul>
 				<li>curveSegments — int，曲线上点的数量，默认值是12。</li>
 				<li>steps — int，用于沿着挤出样条的深度细分的点的数量，默认值为1。</li>
-				<li>depth — float，挤出的形状的深度，默认值为100。</li>
+				<li>depth — float，挤出的形状的深度，默认值为1。</li>
 				<li>bevelEnabled — bool，对挤出的形状应用是否斜角，默认值为true。</li>
-				<li>bevelThickness — float，设置原始形状上斜角的厚度。默认值为6。</li>
-				<li>bevelSize — float。斜角与原始形状轮廓之间的延伸距离，默认值为bevelThickness-2。</li>
+				<li>bevelThickness — float，设置原始形状上斜角的厚度。默认值为0.2。</li>
+				<li>bevelSize — float。斜角与原始形状轮廓之间的延伸距离，默认值为bevelThickness-0.1。</li>
 				<li>bevelOffset — float. Distance from the shape outline that the bevel starts. Default is 0.</li>
 				<li>bevelSegments — int。斜角的分段层数，默认值为3。</li>
 				<li>extrudePath — THREE.Curve对象。一条沿着被挤出形状的三维样条线。Bevels not supported for path extrusion.</li>

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -25,11 +25,12 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 import * as Curves from '../extras/curves/Curves.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
+import { Shape } from '../extras/core/Shape.js';
 import { ShapeUtils } from '../extras/ShapeUtils.js';
 
 class ExtrudeGeometry extends BufferGeometry {
 
-	constructor( shapes, options ) {
+	constructor( shapes = new Shape( [ new Vector2( 0.5, 0.5 ), new Vector2( - 0.5, 0.5 ), new Vector2( - 0.5, - 0.5 ), new Vector2( 0.5, - 0.5 ) ] ), options = {} ) {
 
 		super();
 
@@ -71,11 +72,11 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			const curveSegments = options.curveSegments !== undefined ? options.curveSegments : 12;
 			const steps = options.steps !== undefined ? options.steps : 1;
-			let depth = options.depth !== undefined ? options.depth : 100;
+			let depth = options.depth !== undefined ? options.depth : 1;
 
 			let bevelEnabled = options.bevelEnabled !== undefined ? options.bevelEnabled : true;
-			let bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 6;
-			let bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 2;
+			let bevelThickness = options.bevelThickness !== undefined ? options.bevelThickness : 0.2;
+			let bevelSize = options.bevelSize !== undefined ? options.bevelSize : bevelThickness - 0.1;
 			let bevelOffset = options.bevelOffset !== undefined ? options.bevelOffset : 0;
 			let bevelSegments = options.bevelSegments !== undefined ? options.bevelSegments : 3;
 


### PR DESCRIPTION
Related issue: #22513

**Description**

`ExtrudeGeometry` can now be created without ctor paramters. The default shape is a quad.

The PR also improves the default values of `depth`, `bevelThickness` and `bevelSize` which were out of scale compared to other geometry generators.

This change does not affect `TextGeometry` which overwrites these default values in its ctor.