### PR TITLE
ParametricGeometry: Make all parameters optional.

### DIFF
--- a/docs/api/en/geometries/ParametricGeometry.html
+++ b/docs/api/en/geometries/ParametricGeometry.html
@@ -46,9 +46,9 @@
 
 		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<p>
-		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument<br />
-		slices — The count of slices to use for the parametric function <br />
-		stacks — The count of stacks to use for the parametric function
+		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument. Default is a function that generates a curved plane surface.<br />
+		slices — The count of slices to use for the parametric function. Default is *8*.<br />
+		stacks — The count of stacks to use for the parametric function. Default is *8*.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/zh/geometries/ParametricGeometry.html
+++ b/docs/api/zh/geometries/ParametricGeometry.html
@@ -46,9 +46,9 @@
 
 		<h3>[name]([param:Function func], [param:Integer slices], [param:Integer stacks])</h3>
 		<p>
-		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument<br />
-		slices — The count of slices to use for the parametric function <br />
-		stacks — The count of stacks to use for the parametric function
+		func — A function that takes in a [page:Float u] and [page:Float v] value each between 0 and 1 and modifies a third [page:Vector3] argument. Default is a function that generates a curved plane surface.<br />
+		slices — The count of slices to use for the parametric function. Default is *8*.<br />
+		stacks — The count of stacks to use for the parametric function. Default is *8*.
 		</p>
 
 		<h2>属性</h2>

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -9,7 +9,7 @@ import { Vector3 } from '../math/Vector3.js';
 
 class ParametricGeometry extends BufferGeometry {
 
-	constructor( func, slices, stacks ) {
+	constructor( func = ( u, v, target ) => target.set( u, v, Math.cos( u ) * Math.sin( v ) ), slices = 8, stacks = 8 ) {
 
 		super();
 


### PR DESCRIPTION
Related issue: #22536

**Description**

`ParametricGeometry` can now be created without ctor paramters. The default shape is a curved plane.
