### PR TITLE
Updated ShapeUtils docs

### DIFF
--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -39,8 +39,8 @@
 
 		<h3>[method:Array triangulateShape]( contour, holes )</h3>
 		<p>
-		contour -- 2D polygon. An array of THREE.Vector2()<br />
-		holes -- An array that holds arrays of THREE.Vector2()<br /><br />
+		contour -- 2D polygon. An array of [page:Vector2].<br />
+		holes -- An array that holds arrays of [page:Vector2]s. Each array represents a single hole definition.<br /><br />
 
 		Used internally by [page:ExtrudeGeometry ExtrudeGeometry] and [page:ShapeGeometry ShapeGeometry] to calculate faces in shapes with holes.
 		</p>

--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -40,7 +40,7 @@
 		<h3>[method:Array triangulateShape]( contour, holes )</h3>
 		<p>
 		contour -- 2D polygon. An array of THREE.Vector2()<br />
-		holes -- An array of THREE.Path()<br /><br />
+		holes -- An array that holds arrays of THREE.Vector2()<br /><br />
 
 		Used internally by [page:ExtrudeGeometry ExtrudeGeometry] and [page:ShapeGeometry ShapeGeometry] to calculate faces in shapes with holes.
 		</p>

--- a/docs/api/en/extras/ShapeUtils.html
+++ b/docs/api/en/extras/ShapeUtils.html
@@ -39,8 +39,8 @@
 
 		<h3>[method:Array triangulateShape]( contour, holes )</h3>
 		<p>
-		contour -- 2D polygon.<br />
-		holes -- array of holes<br /><br />
+		contour -- 2D polygon. An array of THREE.Vector2()<br />
+		holes -- An array of THREE.Path()<br /><br />
 
 		Used internally by [page:ExtrudeGeometry ExtrudeGeometry] and [page:ShapeGeometry ShapeGeometry] to calculate faces in shapes with holes.
 		</p>


### PR DESCRIPTION
Added details about the expected types of triangulateShape() parameters

**Description**

The ShapeUtil documentation page does not specify which type of parameters are expected by the `triangulateShape(contour, holes)` method. This PR aims to resolve this issue by adding more precise information about the expected types.