### PR TITLE
Add support for EXT_multisampled_render_to_texture extension and use it for WebXR

### DIFF
--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -70,6 +70,7 @@ function WebGLExtensions( gl ) {
 
 			getExtension( 'OES_texture_float_linear' );
 			getExtension( 'EXT_color_buffer_half_float' );
+			getExtension( 'EXT_multisampled_render_to_texture' );
 
 		},
 


### PR DESCRIPTION
The current approach via renderbuffers has the limitation that we can't apply foveation.
Foveation helps a lot for GPU limited scenes so we need to have support for both MSAA and foveation.

EXT_multisampled_render_to_texture is used under the hood in regular WebXR in the Oculus browser and this uses that extension so WebXR Layers (and potential other areas that needs MSAA) can use this.

The WebXR manager was also extended to support this.

This contribution is funded by [Oculus](https://oculus.com).
