### PR TITLE
MaterialLoader:createMaterial() for extended Material class

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -149,6 +149,7 @@ export { CurvePath } from './extras/core/CurvePath.js';
 export { Curve } from './extras/core/Curve.js';
 export { DataUtils } from './extras/DataUtils.js';
 export { ImageUtils } from './extras/ImageUtils.js';
+export * as MaterialUtils from './extras/MaterialUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
 export { PMREMGenerator } from './extras/PMREMGenerator.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';

--- a/src/extras/MaterialUtils.js
+++ b/src/extras/MaterialUtils.js
@@ -1,0 +1,9 @@
+import * as Materials from '../materials/Materials.js';
+
+function fromType( type ) {
+
+	return new Materials[ type ]();
+
+}
+
+export { fromType };

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -51,12 +51,6 @@ class MaterialLoader extends Loader {
 
 	}
 
-	createMaterial( type ) {
-
-		return new Materials[ type ]();
-
-	}
-
 	parse( json ) {
 
 		const textures = this.textures;
@@ -73,7 +67,7 @@ class MaterialLoader extends Loader {
 
 		}
 
-		const material = this.createMaterial( json.type );
+		const material = new Materials[ json.type ]();
 
 		if ( json.uuid !== undefined ) material.uuid = json.uuid;
 		if ( json.name !== undefined ) material.name = json.name;

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -51,6 +51,12 @@ class MaterialLoader extends Loader {
 
 	}
 
+	createMaterial( type ) {
+
+		return new Materials[ type ]();
+
+	}
+
 	parse( json ) {
 
 		const textures = this.textures;
@@ -67,7 +73,7 @@ class MaterialLoader extends Loader {
 
 		}
 
-		const material = new Materials[ json.type ]();
+		const material = this.createMaterial( json.type );
 
 		if ( json.uuid !== undefined ) material.uuid = json.uuid;
 		if ( json.name !== undefined ) material.name = json.name;

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -6,7 +6,7 @@ import { Matrix3 } from '../math/Matrix3.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { FileLoader } from './FileLoader.js';
 import { Loader } from './Loader.js';
-import * as Materials from '../materials/Materials.js';
+import * as MaterialUtils from '../extras/MaterialUtils.js';
 
 class MaterialLoader extends Loader {
 
@@ -67,7 +67,7 @@ class MaterialLoader extends Loader {
 
 		}
 
-		const material = new Materials[ json.type ]();
+		const material = MaterialUtils.fromType( json.type );
 
 		if ( json.uuid !== undefined ) material.uuid = json.uuid;
 		if ( json.name !== undefined ) material.name = json.name;


### PR DESCRIPTION
**Description**

The function `MaterialLoader.createMaterial( type )` can be useful to create loader for extended Materials, like `NodeMaterials`. 

Example:
```js
class NodeMaterialLoader extends MaterialLoader {

	constructor( manager ) {

		super( manager );

	}

	createMaterial( type ) {

		// use an extended material if here is

		if ( NodeMaterial[ type ] !== undefined ) {

			return new NodeMaterial[ type ]();

		}

		return super.createMaterial( type );

	}

	parse( json ) {

		const material = super.parse( json );

		// stuff

		return material;

	}

}
```

This contribution is funded by [Google via Igalia](https://www.igalia.com/).
