### PR TITLE
NodeMaterial: Accessing modules from Node lib

### DIFF
--- a/examples/jsm/renderers/nodes/Nodes.js
+++ b/examples/jsm/renderers/nodes/Nodes.js
@@ -1,0 +1,158 @@
+// core
+import ArrayInputNode from './core/ArrayInputNode.js';
+import AttributeNode from './core/AttributeNode.js';
+import CodeNode from './core/CodeNode.js';
+import ConstNode from './core/ConstNode.js';
+import ContextNode from './core/ContextNode.js';
+import ExpressionNode from './core/ExpressionNode.js';
+import FunctionCallNode from './core/FunctionCallNode.js';
+import FunctionNode from './core/FunctionNode.js';
+import InputNode from './core/InputNode.js';
+import Node from './core/Node.js';
+import NodeAttribute from './core/NodeAttribute.js';
+import NodeBuilder from './core/NodeBuilder.js';
+import NodeCode from './core/NodeCode.js';
+import NodeFrame from './core/NodeFrame.js';
+import NodeFunctionInput from './core/NodeFunctionInput.js';
+import NodeKeywords from './core/NodeKeywords.js';
+import NodeSerializer from './core/NodeSerializer.js';
+import NodeSlot from './core/NodeSlot.js';
+import NodeUniform from './core/NodeUniform.js';
+import NodeVar from './core/NodeVar.js';
+import NodeVary from './core/NodeVary.js';
+import PropertyNode from './core/PropertyNode.js';
+import StructNode from './core/StructNode.js';
+import StructVarNode from './core/StructVarNode.js';
+import TempNode from './core/TempNode.js';
+import VarNode from './core/VarNode.js';
+import VaryNode from './core/VaryNode.js';
+
+// accessors
+import CameraNode from './accessors/CameraNode.js';
+import MaterialNode from './accessors/MaterialNode.js';
+import MaterialReferenceNode from './accessors/MaterialReferenceNode.js';
+import ModelNode from './accessors/ModelNode.js';
+import ModelViewProjectionNode from './accessors/ModelViewProjectionNode.js';
+import NormalNode from './accessors/NormalNode.js';
+import Object3DNode from './accessors/Object3DNode.js';
+import PointUVNode from './accessors/PointUVNode.js';
+import PositionNode from './accessors/PositionNode.js';
+import ReferenceNode from './accessors/ReferenceNode.js';
+import UVNode from './accessors/UVNode.js';
+
+// inputs
+import ColorNode from './inputs/ColorNode.js';
+import FloatNode from './inputs/FloatNode.js';
+import Matrix3Node from './inputs/Matrix3Node.js';
+import Matrix4Node from './inputs/Matrix3Node.js';
+import TextureNode from './inputs/TextureNode.js';
+import Vector2Node from './inputs/Vector2Node.js';
+import Vector3Node from './inputs/Vector3Node.js';
+import Vector4Node from './inputs/Vector4Node.js';
+
+// display
+import ColorSpaceNode from './display/ColorSpaceNode.js';
+import NormalMapNode from './display/NormalMapNode.js';
+
+// math
+import MathNode from './math/MathNode.js';
+import OperatorNode from './math/OperatorNode.js';
+
+// lights
+import LightContextNode from './lights/LightContextNode.js';
+import LightNode from './lights/LightNode.js';
+import LightsNode from './lights/LightsNode.js';
+
+// utils
+import JoinNode from './utils/JoinNode.js';
+import SplitNode from './utils/SplitNode.js';
+import SpriteSheetUVNode from './utils/SpriteSheetUVNode.js';
+import TimerNode from './utils/TimerNode.js';
+
+// core
+export * from './core/constants.js';
+
+// functions
+export * from './functions/BSDFs.js';
+export * from './functions/EncodingFunctions.js';
+export * from './functions/MathFunctions.js';
+
+// consts
+export * from './consts/MathConsts.js';
+
+// materials
+export * from './materials/Materials.js';
+
+export {
+	// core
+	ArrayInputNode,
+	AttributeNode,
+	CodeNode,
+	ConstNode,
+	ContextNode,
+	ExpressionNode,
+	FunctionCallNode,
+	FunctionNode,
+	InputNode,
+	Node,
+	NodeAttribute,
+	NodeBuilder,
+	NodeCode,
+	NodeFrame,
+	NodeFunctionInput,
+	NodeKeywords,
+	NodeSerializer,
+	NodeSlot,
+	NodeUniform,
+	NodeVar,
+	NodeVary,
+	PropertyNode,
+	StructNode,
+	StructVarNode,
+	TempNode,
+	VarNode,
+	VaryNode,
+
+	// accessors
+	CameraNode,
+	MaterialNode,
+	MaterialReferenceNode,
+	ModelNode,
+	ModelViewProjectionNode,
+	NormalNode,
+	Object3DNode,
+	PointUVNode,
+	PositionNode,
+	ReferenceNode,
+	UVNode,
+
+	// inputs
+	ColorNode,
+	FloatNode,
+	Matrix3Node,
+	Matrix4Node,
+	TextureNode,
+	Vector2Node,
+	Vector3Node,
+	Vector4Node,
+
+	// display
+	ColorSpaceNode,
+	NormalMapNode,
+
+	// math
+	MathNode,
+	OperatorNode,
+
+	// lights
+	LightContextNode,
+	LightNode,
+	LightsNode,
+
+	// utils
+	JoinNode,
+	SplitNode,
+	SpriteSheetUVNode,
+	TimerNode
+};
+

--- a/examples/jsm/renderers/nodes/Nodes.js
+++ b/examples/jsm/renderers/nodes/Nodes.js
@@ -15,7 +15,6 @@ import NodeCode from './core/NodeCode.js';
 import NodeFrame from './core/NodeFrame.js';
 import NodeFunctionInput from './core/NodeFunctionInput.js';
 import NodeKeywords from './core/NodeKeywords.js';
-import NodeSerializer from './core/NodeSerializer.js';
 import NodeSlot from './core/NodeSlot.js';
 import NodeUniform from './core/NodeUniform.js';
 import NodeVar from './core/NodeVar.js';
@@ -101,7 +100,6 @@ export {
 	NodeFrame,
 	NodeFunctionInput,
 	NodeKeywords,
-	NodeSerializer,
 	NodeSlot,
 	NodeUniform,
 	NodeVar,

--- a/examples/jsm/renderers/nodes/materials/Materials.js
+++ b/examples/jsm/renderers/nodes/materials/Materials.js
@@ -1,0 +1,11 @@
+import LineBasicNodeMaterial from './LineBasicNodeMaterial.js';
+import MeshBasicNodeMaterial from './MeshBasicNodeMaterial.js';
+import MeshStandardNodeMaterial from './MeshStandardNodeMaterial.js';
+import PointsNodeMaterial from './PointsNodeMaterial.js';
+
+export {
+	LineBasicNodeMaterial,
+	MeshBasicNodeMaterial,
+	MeshStandardNodeMaterial,
+	PointsNodeMaterial
+};

--- a/examples/webgl_materials_instance_uniform_nodes.html
+++ b/examples/webgl_materials_instance_uniform_nodes.html
@@ -25,19 +25,18 @@
 			import Stats from './jsm/libs/stats.module.js';
 
 			import { nodeFrame } from './jsm/renderers/webgl/nodes/WebGLNodes.js';
-			import { NodeUpdateType } from './jsm/renderers/nodes/core/constants.js';
-			import Node from './jsm/renderers/nodes/core/Node.js';
-			import ColorNode from './jsm/renderers/nodes/inputs/ColorNode.js';
 
-			class InstanceUniformNode extends Node {
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
+
+			class InstanceUniformNode extends Nodes.Node {
 
 				constructor() {
 
 					super( 'vec3' );
 
-					this.updateType = NodeUpdateType.Object;
+					this.updateType = Nodes.NodeUpdateType.Object;
 
-					this.inputNode = new ColorNode();
+					this.inputNode = new Nodes.ColorNode();
 
 				}
 

--- a/examples/webgl_materials_standard_nodes.html
+++ b/examples/webgl_materials_standard_nodes.html
@@ -33,13 +33,7 @@
 
 			import { nodeFrame } from './jsm/renderers/webgl/nodes/WebGLNodes.js';
 
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-			import Vector3Node from './jsm/renderers/nodes/inputs/Vector3Node.js';
-			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import SplitNode from './jsm/renderers/nodes/utils/SplitNode.js';
-			import NormalMapNode from './jsm/renderers/nodes/display/NormalMapNode.js';
-
-			import MeshStandardNodeMaterial from './jsm/renderers/nodes/materials/MeshStandardNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let container, stats;
 
@@ -77,7 +71,7 @@
 
 				//
 
-				const material = new MeshStandardNodeMaterial();
+				const material = new Nodes.MeshStandardNodeMaterial();
 
 				new OBJLoader()
 					.setPath( 'models/obj/cerberus/' )
@@ -96,15 +90,15 @@
 						const normalMap = loader.load( 'Cerberus_N.jpg' );
 						normalMap.wrapS = THREE.RepeatWrapping;
 
-						const mpMapNode = new TextureNode( rmMap );
+						const mpMapNode = new Nodes.TextureNode( rmMap );
 
-						material.colorNode = new OperatorNode( '*', new TextureNode( diffuseMap ), new Vector3Node( material.color ) );
+						material.colorNode = new Nodes.OperatorNode( '*', new Nodes.TextureNode( diffuseMap ), new Nodes.Vector3Node( material.color ) );
 
 						// roughness is in G channel, metalness is in B channel
-						material.roughnessNode = new SplitNode( mpMapNode, 'g' );
-						material.metalnessNode = new SplitNode( mpMapNode, 'b' );
+						material.roughnessNode = new Nodes.SplitNode( mpMapNode, 'g' );
+						material.metalnessNode = new Nodes.SplitNode( mpMapNode, 'b' );
 
-						material.normalNode = new NormalMapNode( new TextureNode( normalMap ) );
+						material.normalNode = new Nodes.NormalMapNode( new Nodes.TextureNode( normalMap ) );
 
 						group.traverse( function ( child ) {
 

--- a/examples/webgl_points_nodes.html
+++ b/examples/webgl_points_nodes.html
@@ -33,18 +33,7 @@
 
 			import { nodeFrame } from './jsm/renderers/webgl/nodes/WebGLNodes.js';
 
-			import PointsNodeMaterial from './jsm/renderers/nodes/materials/PointsNodeMaterial.js';
-
-			import FloatNode from './jsm/renderers/nodes/inputs/FloatNode.js';
-			import Vector2Node from './jsm/renderers/nodes/inputs/Vector2Node.js';
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-			import PointUVNode from './jsm/renderers/nodes/accessors/PointUVNode.js';
-			import PositionNode from './jsm/renderers/nodes/accessors/PositionNode.js';
-			import AttributeNode from './jsm/renderers/nodes/core/AttributeNode.js';
-			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import MathNode from './jsm/renderers/nodes/math/MathNode.js';
-			import TimerNode from './jsm/renderers/nodes/utils/TimerNode.js';
-			import SpriteSheetUVNode from './jsm/renderers/nodes/utils/SpriteSheetUVNode.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer, stats;
 
@@ -101,28 +90,28 @@
 
 				// nodes
 
-				const targetPosition = new AttributeNode( 'targetPosition', 'vec3' );
-				const particleSpeed = new AttributeNode( 'particleSpeed', 'float' );
-				const particleIntensity = new AttributeNode( 'particleIntensity', 'float' );
-				const particleSize = new AttributeNode( 'particleSize', 'float' );
+				const targetPosition = new Nodes.AttributeNode( 'targetPosition', 'vec3' );
+				const particleSpeed = new Nodes.AttributeNode( 'particleSpeed', 'float' );
+				const particleIntensity = new Nodes.AttributeNode( 'particleIntensity', 'float' );
+				const particleSize = new Nodes.AttributeNode( 'particleSize', 'float' );
 
-				const time = new TimerNode();
+				const time = new Nodes.TimerNode();
 
-				const spriteSheetCount = new Vector2Node( new THREE.Vector2( 6, 6 ) ).setConst( true );
+				const spriteSheetCount = new Nodes.Vector2Node( new THREE.Vector2( 6, 6 ) ).setConst( true );
 
-				const fireUV = new SpriteSheetUVNode( spriteSheetCount, new PointUVNode() );
-				fireUV.frame = new OperatorNode( '*', time, particleSpeed );
+				const fireUV = new Nodes.SpriteSheetUVNode( spriteSheetCount, new Nodes.PointUVNode() );
+				fireUV.frame = new Nodes.OperatorNode( '*', time, particleSpeed );
 
-				const fireSprite = new TextureNode( fireMap, fireUV );
-				const fire = new OperatorNode( '*', fireSprite, particleIntensity );
+				const fireSprite = new Nodes.TextureNode( fireMap, fireUV );
+				const fire = new Nodes.OperatorNode( '*', fireSprite, particleIntensity );
 
-				const lerpPosition = new FloatNode( 0 );
+				const lerpPosition = new Nodes.FloatNode( 0 );
 
-				const positionNode = new MathNode( MathNode.MIX, new PositionNode( PositionNode.LOCAL ), targetPosition, lerpPosition );
+				const positionNode = new Nodes.MathNode( Nodes.MathNode.MIX, new Nodes.PositionNode( Nodes.PositionNode.LOCAL ), targetPosition, lerpPosition );
 
 				// material
 
-				const material = new PointsNodeMaterial( {
+				const material = new Nodes.PointsNodeMaterial( {
 					depthWrite: false,
 					transparent: true,
 					sizeAttenuation: true,

--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -34,11 +34,7 @@
 			import WebGPUUniformsGroup from './jsm/renderers/webgpu/WebGPUUniformsGroup.js';
 			import { Vector2Uniform } from './jsm/renderers/webgpu/WebGPUUniform.js';
 
-			import PositionNode from './jsm/renderers/nodes/accessors/PositionNode.js';
-			import ColorNode from './jsm/renderers/nodes/inputs/ColorNode.js';
-			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-
-			import PointsNodeMaterial from './jsm/renderers/nodes/materials/PointsNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer;
 			let pointer;
@@ -185,8 +181,8 @@
 					'position', particleBuffer.attribute
 				);
 
-				const pointsMaterial = new PointsNodeMaterial();
-				pointsMaterial.colorNode = new OperatorNode( '+', new PositionNode(), new ColorNode( new THREE.Color( 0x0000FF ) ) );
+				const pointsMaterial = new Nodes.PointsNodeMaterial();
+				pointsMaterial.colorNode = new Nodes.OperatorNode( '+', new Nodes.PositionNode(), new Nodes.ColorNode( new THREE.Color( 0x0000FF ) ) );
 
 				const mesh = new THREE.Points( pointsGeometry, pointsMaterial );
 				scene.add( mesh );

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -29,24 +29,19 @@
 
 			import { TeapotGeometry } from './jsm/geometries/TeapotGeometry.js';
 
-			import Node from './jsm/renderers/nodes/core/Node.js';
-			import AttributeNode from './jsm/renderers/nodes/core/AttributeNode.js';
-			import { NodeUpdateType } from './jsm/renderers/nodes/core/constants.js';
-			import ColorNode from './jsm/renderers/nodes/inputs/ColorNode.js';
-
-			import MeshBasicNodeMaterial from './jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			import Stats from './jsm/libs/stats.module.js';
 
-			class InstanceUniformNode extends Node {
+			class InstanceUniformNode extends Nodes.Node {
 
 				constructor() {
 
 					super( 'vec3' );
 
-					this.updateType = NodeUpdateType.Object;
+					this.updateType = Nodes.NodeUpdateType.Object;
 
-					this.inputNode = new ColorNode();
+					this.inputNode = new Nodes.ColorNode();
 
 				}
 
@@ -95,7 +90,7 @@
 				// Grid
 
 				const helper = new THREE.GridHelper( 1000, 40, 0x303030, 0x303030 );
-				helper.material.colorNode = new AttributeNode( 'color', 'vec3' );
+				helper.material.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
 				helper.position.y = - 75;
 				scene.add( helper );
 
@@ -103,7 +98,7 @@
 
 				const instanceUniform = new InstanceUniformNode();
 
-				const material = new MeshBasicNodeMaterial();
+				const material = new Nodes.MeshBasicNodeMaterial();
 				material.colorNode = instanceUniform;
 
 				// Geometry

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -28,12 +28,7 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
-			import ContextNode from './jsm/renderers/nodes/core/ContextNode.js';
-			import FunctionNode from './jsm/renderers/nodes/core/FunctionNode.js';
-
-			import LightsNode from './jsm/renderers/nodes/lights/LightsNode.js';
-
-			import PointsNodeMaterial from './jsm/renderers/nodes/materials/PointsNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer;
 
@@ -75,7 +70,7 @@
 
 				//light nodes ( selective lights )
 
-				const allLightsNode = LightsNode.fromLights( [ light1, light2, light3 ] );
+				const allLightsNode = Nodes.LightsNode.fromLights( [ light1, light2, light3 ] );
 
 				// points
 
@@ -89,11 +84,11 @@
 				}
 
 				const geometryPoints = new THREE.BufferGeometry().setFromPoints( points );
-				const materialPoints = new PointsNodeMaterial();
+				const materialPoints = new Nodes.PointsNodeMaterial();
 
 				// custom lighting model
 
-				const customLightingModel = new FunctionNode( `
+				const customLightingModel = new Nodes.FunctionNode( `
 					void ( inout ReflectedLight reflectedLight, vec3 lightColor ) {
 
 						// lightColor returns the light color with the intensity calculated
@@ -102,7 +97,7 @@
 
 					}` );
 
-				const lightingModelContext = new ContextNode( allLightsNode );
+				const lightingModelContext = new Nodes.ContextNode( allLightsNode );
 				lightingModelContext.setContextValue( 'lightingModel', customLightingModel );
 
 				materialPoints.lightNode = lightingModelContext;

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -37,11 +37,7 @@
 			import WebGPURenderer from './jsm/renderers/webgpu/WebGPURenderer.js';
 			import WebGPU from './jsm/renderers/webgpu/WebGPU.js';
 
-			import LightsNode from './jsm/renderers/nodes/lights/LightsNode.js';
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-			import NormalMapNode from './jsm/renderers/nodes/display/NormalMapNode.js';
-
-			import MeshStandardNodeMaterial from './jsm/renderers/nodes/materials/MeshStandardNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer,
 				light1, light2, light3, light4,
@@ -98,30 +94,30 @@
 
 				//light nodes ( selective lights )
 
-				const allLightsNode = LightsNode.fromLights( [ light1, light2, light3, light4 ] );
-				const redLightNode = LightsNode.fromLights( [ light1 ] );
-				const blueLightNode = LightsNode.fromLights( [ light2 ] );
+				const allLightsNode = Nodes.LightsNode.fromLights( [ light1, light2, light3, light4 ] );
+				const redLightNode = Nodes.LightsNode.fromLights( [ light1 ] );
+				const blueLightNode = Nodes.LightsNode.fromLights( [ light2 ] );
 
 				//models
 
 				const geometryTeapot = new TeapotGeometry( 8, 18 );
 
-				const leftObject = new THREE.Mesh( geometryTeapot, new MeshStandardNodeMaterial( { color: 0x555555 } ) );
+				const leftObject = new THREE.Mesh( geometryTeapot, new Nodes.MeshStandardNodeMaterial( { color: 0x555555 } ) );
 				leftObject.material.lightNode = redLightNode;
-				leftObject.material.roughnessNode = new TextureNode( alphaTexture );
+				leftObject.material.roughnessNode = new Nodes.TextureNode( alphaTexture );
 				leftObject.material.metalness = 0;
 				leftObject.position.x = - 30;
 				scene.add( leftObject );
 
-				const centerObject = new THREE.Mesh( geometryTeapot, new MeshStandardNodeMaterial( { color: 0x555555 } ) );
+				const centerObject = new THREE.Mesh( geometryTeapot, new Nodes.MeshStandardNodeMaterial( { color: 0x555555 } ) );
 				centerObject.material.lightNode = allLightsNode;
-				centerObject.material.normalNode = new NormalMapNode( new TextureNode( normalMapTexture ) );
+				centerObject.material.normalNode = new Nodes.NormalMapNode( new Nodes.TextureNode( normalMapTexture ) );
 				centerObject.material.roughness = .5;
 				scene.add( centerObject );
 
-				const rightObject = new THREE.Mesh( geometryTeapot, new MeshStandardNodeMaterial( { color: 0x555555 } ) );
+				const rightObject = new THREE.Mesh( geometryTeapot, new Nodes.MeshStandardNodeMaterial( { color: 0x555555 } ) );
 				rightObject.material.lightNode = blueLightNode;
-				rightObject.material.metalnessNode = new TextureNode( alphaTexture );
+				rightObject.material.metalnessNode = new Nodes.TextureNode( alphaTexture );
 				rightObject.position.x = 30;
 				scene.add( rightObject );
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -29,13 +29,7 @@
 
 			import { TeapotGeometry } from './jsm/geometries/TeapotGeometry.js';
 
-			import AttributeNode from './jsm/renderers/nodes/core/AttributeNode.js';
-			import PositionNode from './jsm/renderers/nodes/accessors/PositionNode.js';
-			import NormalNode from './jsm/renderers/nodes/accessors/NormalNode.js';
-			import FloatNode from './jsm/renderers/nodes/inputs/FloatNode.js';
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-
-			import MeshBasicNodeMaterial from './jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			import Stats from './jsm/libs/stats.module.js';
 
@@ -68,7 +62,7 @@
 				// Grid
 
 				const helper = new THREE.GridHelper( 1000, 40, 0x303030, 0x303030 );
-				helper.material.colorNode = new AttributeNode( 'color', 'vec3' );
+				helper.material.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
 				helper.position.y = - 75;
 				scene.add( helper );
 
@@ -87,41 +81,41 @@
 				let material;
 
 				// PositionNode.LOCAL
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new PositionNode( PositionNode.LOCAL );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.PositionNode( Nodes.PositionNode.LOCAL );
 				materials.push( material );
 
 				// NormalNode.LOCAL
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new NormalNode( NormalNode.LOCAL );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.LOCAL );
 				materials.push( material );
 
 				// NormalNode.WORLD
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new NormalNode( NormalNode.WORLD );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.WORLD );
 				materials.push( material );
 
 				// NormalNode.VIEW
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new NormalNode( NormalNode.VIEW );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.VIEW );
 				materials.push( material );
 
 				// TextureNode
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new TextureNode( texture );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.TextureNode( texture );
 				materials.push( material );
 
 				// Opacity
-				material = new MeshBasicNodeMaterial();
-				material.opacityNode = new TextureNode( texture );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.opacityNode = new Nodes.TextureNode( texture );
 				material.transparent = true;
 				materials.push( material );
 
 				// AlphaTest
-				material = new MeshBasicNodeMaterial();
-				material.colorNode = new TextureNode( texture );
-				material.opacityNode = new TextureNode( opacityTexture );
-				material.alphaTestNode = new FloatNode( 0.5 );
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = new Nodes.TextureNode( texture );
+				material.opacityNode = new Nodes.TextureNode( opacityTexture );
+				material.alphaTestNode = new Nodes.FloatNode( 0.5 );
 				materials.push( material );
 
 				// Geometry

--- a/examples/webgpu_rtt.html
+++ b/examples/webgpu_rtt.html
@@ -27,11 +27,7 @@
 			import WebGPUTextureRenderer from './jsm/renderers/webgpu/WebGPUTextureRenderer.js';
 			import WebGPU from './jsm/renderers/webgpu/WebGPU.js';
 
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import Vector2Node from './jsm/renderers/nodes/inputs/Vector2Node.js';
-
-			import MeshBasicNodeMaterial from './jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer;
 			const mouse = new THREE.Vector2();
@@ -66,8 +62,8 @@
 				const texture = loader.load( './textures/uv_grid_opengl.jpg' );
 
 				const geometryBox = new THREE.BoxGeometry();
-				const materialBox = new MeshBasicNodeMaterial();
-				materialBox.colorNode = new TextureNode( texture );
+				const materialBox = new Nodes.MeshBasicNodeMaterial();
+				materialBox.colorNode = new Nodes.TextureNode( texture );
 
 				//
 
@@ -96,10 +92,10 @@
 
 				// modulate the final color based on the mouse position
 
-				const screenFXNode = new OperatorNode( '+', new Vector2Node( mouse ), new Vector2Node( new THREE.Vector2( 0.5, 0.5 ) ).setConst( true ) );
+				const screenFXNode = new Nodes.OperatorNode( '+', new Nodes.Vector2Node( mouse ), new Nodes.Vector2Node( new THREE.Vector2( 0.5, 0.5 ) ).setConst( true ) );
 
-				const materialFX = new MeshBasicNodeMaterial();
-				materialFX.colorNode = new OperatorNode( '*', new TextureNode( textureRenderer.getTexture() ), screenFXNode );
+				const materialFX = new Nodes.MeshBasicNodeMaterial();
+				materialFX.colorNode = new Nodes.OperatorNode( '*', new Nodes.TextureNode( textureRenderer.getTexture() ), screenFXNode );
 
 				const quad = new THREE.Mesh( geometryFX, materialFX );
 				sceneFX.add( quad );

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -28,21 +28,7 @@
 			import WebGPURenderer from './jsm/renderers/webgpu/WebGPURenderer.js';
 			import WebGPU from './jsm/renderers/webgpu/WebGPU.js';
 
-			import AttributeNode from './jsm/renderers/nodes/core/AttributeNode.js';
-			import FloatNode from './jsm/renderers/nodes/inputs/FloatNode.js';
-			import Vector2Node from './jsm/renderers/nodes/inputs/Vector2Node.js';
-			import ColorNode from './jsm/renderers/nodes/inputs/ColorNode.js';
-			import TextureNode from './jsm/renderers/nodes/inputs/TextureNode.js';
-			import UVNode from './jsm/renderers/nodes/accessors/UVNode.js';
-			import PositionNode from './jsm/renderers/nodes/accessors/PositionNode.js';
-			import NormalNode from './jsm/renderers/nodes/accessors/NormalNode.js';
-			import OperatorNode from './jsm/renderers/nodes/math/OperatorNode.js';
-			import SplitNode from './jsm/renderers/nodes/utils/SplitNode.js';
-			import TimerNode from './jsm/renderers/nodes/utils/TimerNode.js';
-
-			import MeshBasicNodeMaterial from './jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js';
-			import LineBasicNodeMaterial from './jsm/renderers/nodes/materials/LineBasicNodeMaterial.js';
-			import PointsNodeMaterial from './jsm/renderers/nodes/materials/PointsNodeMaterial.js';
+			import * as Nodes from './jsm/renderers/nodes/Nodes.js';
 
 			let camera, scene, renderer;
 
@@ -86,15 +72,15 @@
 				// box mesh
 
 				const geometryBox = new THREE.BoxGeometry();
-				const materialBox = new MeshBasicNodeMaterial();
+				const materialBox = new Nodes.MeshBasicNodeMaterial();
 
-				const timerNode = new TimerNode();
+				const timerNode = new Nodes.TimerNode();
 
 				// birection speed
-				const timerScaleNode = new OperatorNode( '*', timerNode, new Vector2Node( new THREE.Vector2( - 0.5, 0.1 ) ).setConst( true ) );
-				const animateUV = new OperatorNode( '+', new UVNode(), timerScaleNode );
+				const timerScaleNode = new Nodes.OperatorNode( '*', timerNode, new Nodes.Vector2Node( new THREE.Vector2( - 0.5, 0.1 ) ).setConst( true ) );
+				const animateUV = new Nodes.OperatorNode( '+', new Nodes.UVNode(), timerScaleNode );
 
-				materialBox.colorNode = new TextureNode( texture, animateUV );
+				materialBox.colorNode = new Nodes.TextureNode( texture, animateUV );
 
 				// test uv 2
 				//geometryBox.setAttribute( 'uv2', geometryBox.getAttribute( 'uv' ) );
@@ -107,15 +93,15 @@
 				// displace example
 
 				const geometrySphere = new THREE.SphereGeometry( .5, 64, 64 );
-				const materialSphere = new MeshBasicNodeMaterial();
+				const materialSphere = new Nodes.MeshBasicNodeMaterial();
 
-				const displaceAnimated = new SplitNode( new TextureNode( textureDisplace ), 'x' );
-				const displaceY = new OperatorNode( '*', displaceAnimated, new FloatNode( .25 ).setConst( true ) );
+				const displaceAnimated = new Nodes.SplitNode( new Nodes.TextureNode( textureDisplace ), 'x' );
+				const displaceY = new Nodes.OperatorNode( '*', displaceAnimated, new Nodes.FloatNode( .25 ).setConst( true ) );
 
-				const displace = new OperatorNode( '*', new NormalNode( NormalNode.LOCAL ), displaceY );
+				const displace = new Nodes.OperatorNode( '*', new Nodes.NormalNode( Nodes.NormalNode.LOCAL ), displaceY );
 
 				materialSphere.colorNode = displaceY;
-				materialSphere.positionNode = new OperatorNode( '+', new PositionNode( PositionNode.LOCAL ), displace );
+				materialSphere.positionNode = new Nodes.OperatorNode( '+', new Nodes.PositionNode( Nodes.PositionNode.LOCAL ), displace );
 
 				const sphere = new THREE.Mesh( geometrySphere, materialSphere );
 				sphere.position.set( - 2, - 1, 0 );
@@ -124,9 +110,9 @@
 				// data texture
 
 				const geometryPlane = new THREE.PlaneGeometry();
-				const materialPlane = new MeshBasicNodeMaterial();
-				materialPlane.colorNode = new OperatorNode( '+', new TextureNode( createDataTexture() ), new ColorNode( new THREE.Color( 0x0000FF ) ) );
-				materialPlane.opacityNode = new SplitNode( new TextureNode( dxt5Texture ), 'a' );
+				const materialPlane = new Nodes.MeshBasicNodeMaterial();
+				materialPlane.colorNode = new Nodes.OperatorNode( '+', new Nodes.TextureNode( createDataTexture() ), new Nodes.ColorNode( new THREE.Color( 0x0000FF ) ) );
+				materialPlane.opacityNode = new Nodes.SplitNode( new Nodes.TextureNode( dxt5Texture ), 'a' );
 				materialPlane.transparent = true;
 
 				const plane = new THREE.Mesh( geometryPlane, materialPlane );
@@ -135,8 +121,8 @@
 
 				// compressed texture
 
-				const materialCompressed = new MeshBasicNodeMaterial();
-				materialCompressed.colorNode = new TextureNode( dxt5Texture );
+				const materialCompressed = new Nodes.MeshBasicNodeMaterial();
+				materialCompressed.colorNode = new Nodes.TextureNode( dxt5Texture );
 				materialCompressed.transparent = true;
 
 				const boxCompressed = new THREE.Mesh( geometryBox, materialCompressed );
@@ -155,9 +141,9 @@
 				}
 
 				const geometryPoints = new THREE.BufferGeometry().setFromPoints( points );
-				const materialPoints = new PointsNodeMaterial();
+				const materialPoints = new Nodes.PointsNodeMaterial();
 
-				materialPoints.colorNode = new OperatorNode( '*', new PositionNode(), new FloatNode( 3 ).setConst( true ) );
+				materialPoints.colorNode = new Nodes.OperatorNode( '*', new Nodes.PositionNode(), new Nodes.FloatNode( 3 ).setConst( true ) );
 
 				const pointCloud = new THREE.Points( geometryPoints, materialPoints );
 				pointCloud.position.set( 2, - 1, 0 );
@@ -174,8 +160,8 @@
 
 				geometryLine.setAttribute( 'color', geometryLine.getAttribute( 'position' ) );
 
-				const materialLine = new LineBasicNodeMaterial();
-				materialLine.colorNode = new AttributeNode( 'color', 'vec3' );
+				const materialLine = new Nodes.LineBasicNodeMaterial();
+				materialLine.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
 
 				const line = new THREE.Line( geometryLine, materialLine );
 				line.position.set( 2, 1, 0 );


### PR DESCRIPTION
**Description**

It can simplify the `NodeMaterial` creation by reducing the number of `imports` needs.

Usage:
```js
import * as Nodes from './jsm/renderers/nodes/Nodes.js';

const material = new Nodes.MeshStandardNodeMaterial();
material.colorNode = new Nodes.ColorNode( new THREE.Color( 0x0000FF ) );
```

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://www.igalia.com).
