### PR TITLE
WebGLRenderer: Compute .vertexTangents consistently.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1515,7 +1515,7 @@ function WebGLRenderer( parameters = {} ) {
 		const encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
 		const envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || environment );
 		const vertexAlphas = material.vertexColors === true && !! object.geometry && !! object.geometry.attributes.color && object.geometry.attributes.color.itemSize === 4;
-		const vertexTangents = !! object.geometry && !! object.geometry.attributes.tangent;
+		const vertexTangents = !! material.normalMap && !! object.geometry && !! object.geometry.attributes.tangent;
 		const morphTargets = !! object.geometry && !! object.geometry.morphAttributes.position;
 		const morphNormals = !! object.geometry && !! object.geometry.morphAttributes.normal;
 		const morphTargetsCount = ( !! object.geometry && !! object.geometry.morphAttributes.position ) ? object.geometry.morphAttributes.position.length : 0;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/22530

We need to compute program parameters consistently in these locations:

https://github.com/mrdoob/three.js/blob/7f6a0990feec2946225147ab2a4fbcaf69dcb359/src/renderers/WebGLRenderer.js#L1518

https://github.com/mrdoob/three.js/blob/7f6a0990feec2946225147ab2a4fbcaf69dcb359/src/renderers/webgl/WebGLPrograms.js#L231

That's easy to miss, and if they don't match can cause performance issues similar to the one identified in #22530. It'd be great if we can find a solution to #22530 that avoids having to compute these parameters in two locations. For now this PR just removes one case that may fall into that problem.