### PR TITLE
BufferGeometry: Fix clone().

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1004,31 +1004,7 @@ class BufferGeometry extends EventDispatcher {
 
 	clone() {
 
-		/*
-		 // Handle primitives
-
-		 const parameters = this.parameters;
-
-		 if ( parameters !== undefined ) {
-
-		 const values = [];
-
-		 for ( const key in parameters ) {
-
-		 values.push( parameters[ key ] );
-
-		 }
-
-		 const geometry = Object.create( this.constructor.prototype );
-		 this.constructor.apply( geometry, values );
-		 return geometry;
-
-		 }
-
 		 return new this.constructor().copy( this );
-		 */
-
-		return new BufferGeometry().copy( this );
 
 	}
 
@@ -1132,6 +1108,10 @@ class BufferGeometry extends EventDispatcher {
 		// user data
 
 		this.userData = source.userData;
+
+		// geometry generator parameters
+
+		if ( source.parameters !== undefined ) this.parameters = Object.assign( {}, source.parameters );
 
 		return this;
 

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -5,7 +5,7 @@ import { Vector2 } from '../math/Vector2.js';
 
 class PolyhedronGeometry extends BufferGeometry {
 
-	constructor( vertices, indices, radius = 1, detail = 0 ) {
+	constructor( vertices = [], indices = [], radius = 1, detail = 0 ) {
 
 		super();
 

--- a/test/unit/utils/qunit-utils.js
+++ b/test/unit/utils/qunit-utils.js
@@ -83,12 +83,10 @@ function checkGeometryClone( geom ) {
 	QUnit.assert.notEqual( copy.uuid, geom.uuid, "clone uuid should differ from original" );
 	QUnit.assert.notEqual( copy.id, geom.id, "clone id should differ from original" );
 
-	var excludedProperties = [ 'parameters', 'widthSegments', 'heightSegments', 'depthSegments' ];
-
-	var differingProp = getDifferingProp( geom, copy, excludedProperties );
+	var differingProp = getDifferingProp( geom, copy );
 	QUnit.assert.ok( differingProp === undefined, 'properties are equal' );
 
-	differingProp = getDifferingProp( copy, geom, excludedProperties );
+	differingProp = getDifferingProp( copy, geom );
 	QUnit.assert.ok( differingProp === undefined, 'properties are equal' );
 
 	// json round trip with clone
@@ -96,9 +94,7 @@ function checkGeometryClone( geom ) {
 
 }
 
-function getDifferingProp( geometryA, geometryB, excludedProperties ) {
-
-	excludedProperties = excludedProperties || [];
+function getDifferingProp( geometryA, geometryB ) {
 
 	var geometryKeys = Object.keys( geometryA );
 	var cloneKeys = Object.keys( geometryB );
@@ -108,8 +104,6 @@ function getDifferingProp( geometryA, geometryB, excludedProperties ) {
 	for ( var i = 0, l = geometryKeys.length; i < l; i ++ ) {
 
 		var key = geometryKeys[ i ];
-
-		if ( excludedProperties.indexOf( key ) >= 0 ) continue;
 
 		if ( cloneKeys.indexOf( key ) < 0 ) {
 
@@ -193,31 +187,6 @@ function checkGeometryJsonRoundtrip( geom ) {
 
 }
 
-// Look for undefined and NaN values in numerical fieds.
-function checkFinite( geom ) {
-
-	var allVerticesAreFinite = true;
-
-	var vertices = geom.vertices || [];
-
-	for ( var i = 0, l = vertices.length; i < l; i ++ ) {
-
-		var v = geom.vertices[ i ];
-
-		if ( ! ( isFinite( v.x ) || isFinite( v.y ) || isFinite( v.z ) ) ) {
-
-			allVerticesAreFinite = false;
-			break;
-
-		}
-
-	}
-
-	// TODO Buffers, normal, etc.
-
-	QUnit.assert.ok( allVerticesAreFinite, "contains only finite coordinates" );
-
-}
 
 // Run common geometry tests.
 function runStdGeometryTests( assert, geometries ) {
@@ -225,8 +194,6 @@ function runStdGeometryTests( assert, geometries ) {
 	for ( var i = 0, l = geometries.length; i < l; i ++ ) {
 
 		var geom = geometries[ i ];
-
-		checkFinite( geom );
 
 		// Clone
 		checkGeometryClone( geom );


### PR DESCRIPTION
Related issue: Fixed #8522.

**Description**

This PR fixes a long-standing issue in the engine. If you clone now a `BoxGeometry`, you actually get a new object of type `BoxGeometry` (and not `BufferGeometry`). The previous behavior produces an unexpected result and was confusing.