### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_buffergeometry_compression.html
+++ b/examples/webgl_buffergeometry_compression.html
@@ -237,14 +237,6 @@
 
 			function updateGroupGeometry( mesh, lineSegments, geometry, data ) {
 
-				if ( geometry.isGeometry ) {
-
-					geometry = new THREE.BufferGeometry().fromGeometry( geometry );
-
-					console.log( 'THREE.GeometryCompression: Converted Geometry to BufferGeometry.' );
-
-				}
-
 				// dispose first
 				lineSegments.geometry.dispose();
 				mesh.geometry.dispose();


### PR DESCRIPTION
Related issue: -

**Description**

Removes some legacy code in `webgl_buffergeometry_compression`.
