### PR TITLE
Ensure geometry helpers can use new `clone()` method.

### DIFF
--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -11,133 +11,128 @@ const _triangle = new Triangle();
 
 class EdgesGeometry extends BufferGeometry {
 
-	constructor( geometry, thresholdAngle ) {
+	constructor( geometry = null, thresholdAngle = 1 ) {
 
 		super();
-
 		this.type = 'EdgesGeometry';
 
 		this.parameters = {
+			geometry: geometry,
 			thresholdAngle: thresholdAngle
 		};
 
-		thresholdAngle = ( thresholdAngle !== undefined ) ? thresholdAngle : 1;
+		if ( geometry !== null ) {
 
-		if ( geometry.isGeometry === true ) {
+			const precisionPoints = 4;
+			const precision = Math.pow( 10, precisionPoints );
+			const thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
 
-			console.error( 'THREE.EdgesGeometry no longer supports THREE.Geometry. Use THREE.BufferGeometry instead.' );
-			return;
+			const indexAttr = geometry.getIndex();
+			const positionAttr = geometry.getAttribute( 'position' );
+			const indexCount = indexAttr ? indexAttr.count : positionAttr.count;
 
-		}
+			const indexArr = [ 0, 0, 0 ];
+			const vertKeys = [ 'a', 'b', 'c' ];
+			const hashes = new Array( 3 );
 
-		const precisionPoints = 4;
-		const precision = Math.pow( 10, precisionPoints );
-		const thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
+			const edgeData = {};
+			const vertices = [];
+			for ( let i = 0; i < indexCount; i += 3 ) {
 
-		const indexAttr = geometry.getIndex();
-		const positionAttr = geometry.getAttribute( 'position' );
-		const indexCount = indexAttr ? indexAttr.count : positionAttr.count;
+				if ( indexAttr ) {
 
-		const indexArr = [ 0, 0, 0 ];
-		const vertKeys = [ 'a', 'b', 'c' ];
-		const hashes = new Array( 3 );
+					indexArr[ 0 ] = indexAttr.getX( i );
+					indexArr[ 1 ] = indexAttr.getX( i + 1 );
+					indexArr[ 2 ] = indexAttr.getX( i + 2 );
 
-		const edgeData = {};
-		const vertices = [];
-		for ( let i = 0; i < indexCount; i += 3 ) {
+				} else {
 
-			if ( indexAttr ) {
+					indexArr[ 0 ] = i;
+					indexArr[ 1 ] = i + 1;
+					indexArr[ 2 ] = i + 2;
 
-				indexArr[ 0 ] = indexAttr.getX( i );
-				indexArr[ 1 ] = indexAttr.getX( i + 1 );
-				indexArr[ 2 ] = indexAttr.getX( i + 2 );
+				}
 
-			} else {
+				const { a, b, c } = _triangle;
+				a.fromBufferAttribute( positionAttr, indexArr[ 0 ] );
+				b.fromBufferAttribute( positionAttr, indexArr[ 1 ] );
+				c.fromBufferAttribute( positionAttr, indexArr[ 2 ] );
+				_triangle.getNormal( _normal );
 
-				indexArr[ 0 ] = i;
-				indexArr[ 1 ] = i + 1;
-				indexArr[ 2 ] = i + 2;
+				// create hashes for the edge from the vertices
+				hashes[ 0 ] = `${ Math.round( a.x * precision ) },${ Math.round( a.y * precision ) },${ Math.round( a.z * precision ) }`;
+				hashes[ 1 ] = `${ Math.round( b.x * precision ) },${ Math.round( b.y * precision ) },${ Math.round( b.z * precision ) }`;
+				hashes[ 2 ] = `${ Math.round( c.x * precision ) },${ Math.round( c.y * precision ) },${ Math.round( c.z * precision ) }`;
 
-			}
+				// skip degenerate triangles
+				if ( hashes[ 0 ] === hashes[ 1 ] || hashes[ 1 ] === hashes[ 2 ] || hashes[ 2 ] === hashes[ 0 ] ) {
 
-			const { a, b, c } = _triangle;
-			a.fromBufferAttribute( positionAttr, indexArr[ 0 ] );
-			b.fromBufferAttribute( positionAttr, indexArr[ 1 ] );
-			c.fromBufferAttribute( positionAttr, indexArr[ 2 ] );
-			_triangle.getNormal( _normal );
+					continue;
 
-			// create hashes for the edge from the vertices
-			hashes[ 0 ] = `${ Math.round( a.x * precision ) },${ Math.round( a.y * precision ) },${ Math.round( a.z * precision ) }`;
-			hashes[ 1 ] = `${ Math.round( b.x * precision ) },${ Math.round( b.y * precision ) },${ Math.round( b.z * precision ) }`;
-			hashes[ 2 ] = `${ Math.round( c.x * precision ) },${ Math.round( c.y * precision ) },${ Math.round( c.z * precision ) }`;
+				}
 
-			// skip degenerate triangles
-			if ( hashes[ 0 ] === hashes[ 1 ] || hashes[ 1 ] === hashes[ 2 ] || hashes[ 2 ] === hashes[ 0 ] ) {
+				// iterate over every edge
+				for ( let j = 0; j < 3; j ++ ) {
 
-				continue;
+					// get the first and next vertex making up the edge
+					const jNext = ( j + 1 ) % 3;
+					const vecHash0 = hashes[ j ];
+					const vecHash1 = hashes[ jNext ];
+					const v0 = _triangle[ vertKeys[ j ] ];
+					const v1 = _triangle[ vertKeys[ jNext ] ];
 
-			}
+					const hash = `${ vecHash0 }_${ vecHash1 }`;
+					const reverseHash = `${ vecHash1 }_${ vecHash0 }`;
 
-			// iterate over every edge
-			for ( let j = 0; j < 3; j ++ ) {
+					if ( reverseHash in edgeData && edgeData[ reverseHash ] ) {
 
-				// get the first and next vertex making up the edge
-				const jNext = ( j + 1 ) % 3;
-				const vecHash0 = hashes[ j ];
-				const vecHash1 = hashes[ jNext ];
-				const v0 = _triangle[ vertKeys[ j ] ];
-				const v1 = _triangle[ vertKeys[ jNext ] ];
+						// if we found a sibling edge add it into the vertex array if
+						// it meets the angle threshold and delete the edge from the map.
+						if ( _normal.dot( edgeData[ reverseHash ].normal ) <= thresholdDot ) {
 
-				const hash = `${ vecHash0 }_${ vecHash1 }`;
-				const reverseHash = `${ vecHash1 }_${ vecHash0 }`;
+							vertices.push( v0.x, v0.y, v0.z );
+							vertices.push( v1.x, v1.y, v1.z );
 
-				if ( reverseHash in edgeData && edgeData[ reverseHash ] ) {
+						}
 
-					// if we found a sibling edge add it into the vertex array if
-					// it meets the angle threshold and delete the edge from the map.
-					if ( _normal.dot( edgeData[ reverseHash ].normal ) <= thresholdDot ) {
+						edgeData[ reverseHash ] = null;
 
-						vertices.push( v0.x, v0.y, v0.z );
-						vertices.push( v1.x, v1.y, v1.z );
+					} else if ( ! ( hash in edgeData ) ) {
+
+						// if we've already got an edge here then skip adding a new one
+						edgeData[ hash ] = {
+
+							index0: indexArr[ j ],
+							index1: indexArr[ jNext ],
+							normal: _normal.clone(),
+
+						};
 
 					}
-
-					edgeData[ reverseHash ] = null;
-
-				} else if ( ! ( hash in edgeData ) ) {
-
-					// if we've already got an edge here then skip adding a new one
-					edgeData[ hash ] = {
-
-						index0: indexArr[ j ],
-						index1: indexArr[ jNext ],
-						normal: _normal.clone(),
-
-					};
 
 				}
 
 			}
 
-		}
+			// iterate over all remaining, unmatched edges and add them to the vertex array
+			for ( const key in edgeData ) {
 
-		// iterate over all remaining, unmatched edges and add them to the vertex array
-		for ( const key in edgeData ) {
+				if ( edgeData[ key ] ) {
 
-			if ( edgeData[ key ] ) {
+					const { index0, index1 } = edgeData[ key ];
+					_v0.fromBufferAttribute( positionAttr, index0 );
+					_v1.fromBufferAttribute( positionAttr, index1 );
 
-				const { index0, index1 } = edgeData[ key ];
-				_v0.fromBufferAttribute( positionAttr, index0 );
-				_v1.fromBufferAttribute( positionAttr, index1 );
+					vertices.push( _v0.x, _v0.y, _v0.z );
+					vertices.push( _v1.x, _v1.y, _v1.z );
 
-				vertices.push( _v0.x, _v0.y, _v0.z );
-				vertices.push( _v1.x, _v1.y, _v1.z );
+				}
 
 			}
 
-		}
+			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		}
 
 	}
 

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -4,57 +4,88 @@ import { Vector3 } from '../math/Vector3.js';
 
 class WireframeGeometry extends BufferGeometry {
 
-	constructor( geometry ) {
+	constructor( geometry = null ) {
 
 		super();
 		this.type = 'WireframeGeometry';
 
-		if ( geometry.isGeometry === true ) {
+		this.parameters = {
+			geometry: geometry
+		};
 
-			console.error( 'THREE.WireframeGeometry no longer supports THREE.Geometry. Use THREE.BufferGeometry instead.' );
-			return;
+		if ( geometry !== null ) {
 
-		}
+			// buffer
 
-		// buffer
+			const vertices = [];
+			const edges = new Set();
 
-		const vertices = [];
-		const edges = new Set();
+			// helper variables
 
-		// helper variables
+			const start = new Vector3();
+			const end = new Vector3();
 
-		const start = new Vector3();
-		const end = new Vector3();
+			if ( geometry.index !== null ) {
 
-		if ( geometry.index !== null ) {
+				// indexed BufferGeometry
 
-			// indexed BufferGeometry
+				const position = geometry.attributes.position;
+				const indices = geometry.index;
+				let groups = geometry.groups;
 
-			const position = geometry.attributes.position;
-			const indices = geometry.index;
-			let groups = geometry.groups;
+				if ( groups.length === 0 ) {
 
-			if ( groups.length === 0 ) {
+					groups = [ { start: 0, count: indices.count, materialIndex: 0 } ];
 
-				groups = [ { start: 0, count: indices.count, materialIndex: 0 } ];
+				}
 
-			}
+				// create a data structure that contains all eges without duplicates
 
-			// create a data structure that contains all eges without duplicates
+				for ( let o = 0, ol = groups.length; o < ol; ++ o ) {
 
-			for ( let o = 0, ol = groups.length; o < ol; ++ o ) {
+					const group = groups[ o ];
 
-				const group = groups[ o ];
+					const groupStart = group.start;
+					const groupCount = group.count;
 
-				const groupStart = group.start;
-				const groupCount = group.count;
+					for ( let i = groupStart, l = ( groupStart + groupCount ); i < l; i += 3 ) {
 
-				for ( let i = groupStart, l = ( groupStart + groupCount ); i < l; i += 3 ) {
+						for ( let j = 0; j < 3; j ++ ) {
+
+							const index1 = indices.getX( i + j );
+							const index2 = indices.getX( i + ( j + 1 ) % 3 );
+
+							start.fromBufferAttribute( position, index1 );
+							end.fromBufferAttribute( position, index2 );
+
+							if ( isUniqueEdge( start, end, edges ) === true ) {
+
+								vertices.push( start.x, start.y, start.z );
+								vertices.push( end.x, end.y, end.z );
+
+							}
+
+						}
+
+					}
+
+				}
+
+			} else {
+
+				// non-indexed BufferGeometry
+
+				const position = geometry.attributes.position;
+
+				for ( let i = 0, l = ( position.count / 3 ); i < l; i ++ ) {
 
 					for ( let j = 0; j < 3; j ++ ) {
 
-						const index1 = indices.getX( i + j );
-						const index2 = indices.getX( i + ( j + 1 ) % 3 );
+						// three edges per triangle, an edge is represented as (index1, index2)
+						// e.g. the first triangle has the following edges: (0,1),(1,2),(2,0)
+
+						const index1 = 3 * i + j;
+						const index2 = 3 * i + ( ( j + 1 ) % 3 );
 
 						start.fromBufferAttribute( position, index1 );
 						end.fromBufferAttribute( position, index2 );
@@ -72,41 +103,11 @@ class WireframeGeometry extends BufferGeometry {
 
 			}
 
-		} else {
+			// build geometry
 
-			// non-indexed BufferGeometry
-
-			const position = geometry.attributes.position;
-
-			for ( let i = 0, l = ( position.count / 3 ); i < l; i ++ ) {
-
-				for ( let j = 0; j < 3; j ++ ) {
-
-					// three edges per triangle, an edge is represented as (index1, index2)
-					// e.g. the first triangle has the following edges: (0,1),(1,2),(2,0)
-
-					const index1 = 3 * i + j;
-					const index2 = 3 * i + ( ( j + 1 ) % 3 );
-
-					start.fromBufferAttribute( position, index1 );
-					end.fromBufferAttribute( position, index2 );
-
-					if ( isUniqueEdge( start, end, edges ) === true ) {
-
-						vertices.push( start.x, start.y, start.z );
-						vertices.push( end.x, end.y, end.z );
-
-					}
-
-				}
-
-			}
+			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 		}
-
-		// build geometry
-
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR ensures that `EdgesGeometry` and `WireframeGeometry` are able to use the new `BufferGeometry.clone()` method.

IMO, it's a bit unlikely to clone both geometries since they depend on another object (like certain helper classes) but it's probably better to honor this use case for consistency.
