### PR TITLE
NodeMaterial: Node.type to Node.nodeType

### DIFF
--- a/examples/jsm/renderers/nodes/accessors/CameraNode.js
+++ b/examples/jsm/renderers/nodes/accessors/CameraNode.js
@@ -11,7 +11,7 @@ class CameraNode extends Object3DNode {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		const scope = this.scope;
 
@@ -21,7 +21,7 @@ class CameraNode extends Object3DNode {
 
 		}
 
-		return super.getType( builder );
+		return super.getNodeType( builder );
 
 	}
 

--- a/examples/jsm/renderers/nodes/accessors/MaterialNode.js
+++ b/examples/jsm/renderers/nodes/accessors/MaterialNode.js
@@ -19,7 +19,7 @@ class MaterialNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		const scope = this.scope;
 		const material = builder.getContextValue( 'material' );
@@ -99,9 +99,9 @@ class MaterialNode extends Node {
 
 		} else {
 
-			const type = this.getType( builder );
+			const outputType = this.getNodeType( builder );
 
-			node = new MaterialReferenceNode( scope, type );
+			node = new MaterialReferenceNode( scope, outputType );
 
 		}
 

--- a/examples/jsm/renderers/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/renderers/nodes/accessors/ModelViewProjectionNode.js
@@ -18,7 +18,7 @@ class ModelViewProjectionNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		const mvpSnipped = this._mvpMatrix.build( builder );
 		const positionSnipped = this.position.build( builder, 'vec3' );

--- a/examples/jsm/renderers/nodes/accessors/NormalNode.js
+++ b/examples/jsm/renderers/nodes/accessors/NormalNode.js
@@ -23,7 +23,7 @@ class NormalNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const nodeData = builder.getDataFromNode( this, builder.shaderStage );
 		const scope = this.scope;
 

--- a/examples/jsm/renderers/nodes/accessors/Object3DNode.js
+++ b/examples/jsm/renderers/nodes/accessors/Object3DNode.js
@@ -25,7 +25,7 @@ class Object3DNode extends Node {
 
 	}
 
-	getType() {
+	getNodeType() {
 
 		const scope = this.scope;
 

--- a/examples/jsm/renderers/nodes/accessors/PointUVNode.js
+++ b/examples/jsm/renderers/nodes/accessors/PointUVNode.js
@@ -12,7 +12,7 @@ class PointUVNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const snippet = 'vec2( gl_PointCoord.x, 1.0 - gl_PointCoord.y )';
 
 		return builder.format( snippet, type, output );

--- a/examples/jsm/renderers/nodes/accessors/PositionNode.js
+++ b/examples/jsm/renderers/nodes/accessors/PositionNode.js
@@ -23,7 +23,7 @@ class PositionNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const nodeData = builder.getDataFromNode( this );
 		const scope = this.scope;
 

--- a/examples/jsm/renderers/nodes/accessors/ReferenceNode.js
+++ b/examples/jsm/renderers/nodes/accessors/ReferenceNode.js
@@ -29,38 +29,38 @@ class ReferenceNode extends Node {
 	setNodeType( inputType ) {
 
 		let node = null;
-		let type = inputType;
+		let nodeType = inputType;
 
-		if ( type === 'float' ) {
+		if ( nodeType === 'float' ) {
 
 			node = new FloatNode();
 
-		} else if ( type === 'vec2' ) {
+		} else if ( nodeType === 'vec2' ) {
 
 			node = new Vector2Node( null );
 
-		} else if ( type === 'vec3' ) {
+		} else if ( nodeType === 'vec3' ) {
 
 			node = new Vector3Node( null );
 
-		} else if ( type === 'vec4' ) {
+		} else if ( nodeType === 'vec4' ) {
 
 			node = new Vector4Node( null );
 
-		} else if ( type === 'color' ) {
+		} else if ( nodeType === 'color' ) {
 
 			node = new ColorNode( null );
-			type = 'vec3';
+			nodeType = 'vec3';
 
-		} else if ( type === 'texture' ) {
+		} else if ( nodeType === 'texture' ) {
 
 			node = new TextureNode();
-			type = 'vec4';
+			nodeType = 'vec4';
 
 		}
 
 		this.node = node;
-		this.type = type;
+		this.nodeType = nodeType;
 		this.inputType = inputType;
 
 	}

--- a/examples/jsm/renderers/nodes/core/ArrayInputNode.js
+++ b/examples/jsm/renderers/nodes/core/ArrayInputNode.js
@@ -10,9 +10,9 @@ class ArrayInputNode extends InputNode {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		return this.value[ 0 ].getType( builder );
+		return this.value[ 0 ].getNodeType( builder );
 
 	}
 

--- a/examples/jsm/renderers/nodes/core/AttributeNode.js
+++ b/examples/jsm/renderers/nodes/core/AttributeNode.js
@@ -3,9 +3,9 @@ import VaryNode from './VaryNode.js';
 
 class AttributeNode extends Node {
 
-	constructor( attributeName, type ) {
+	constructor( attributeName, nodeType ) {
 
-		super( type );
+		super( nodeType );
 
 		this._attributeName = attributeName;
 
@@ -28,7 +28,7 @@ class AttributeNode extends Node {
 	generate( builder, output ) {
 
 		const attributeName = this.getAttributeName( builder );
-		const attributeType = this.getType( builder );
+		const attributeType = this.getNodeType( builder );
 
 		const attribute = builder.getAttribute( attributeName, attributeType );
 

--- a/examples/jsm/renderers/nodes/core/CodeNode.js
+++ b/examples/jsm/renderers/nodes/core/CodeNode.js
@@ -2,9 +2,9 @@ import Node from './Node.js';
 
 class CodeNode extends Node {
 
-	constructor( code = '', type = 'code' ) {
+	constructor( code = '', nodeType = 'code' ) {
 
-		super( type );
+		super( nodeType );
 
 		this.code = code;
 
@@ -66,7 +66,7 @@ class CodeNode extends Node {
 
 		}
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
 
 		nodeCode.code = this.code;

--- a/examples/jsm/renderers/nodes/core/ConstNode.js
+++ b/examples/jsm/renderers/nodes/core/ConstNode.js
@@ -16,7 +16,7 @@ class ConstNode extends CodeNode {
 
 		const code = super.generate( builder );
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
 
 		if ( this.name !== '' ) {

--- a/examples/jsm/renderers/nodes/core/ContextNode.js
+++ b/examples/jsm/renderers/nodes/core/ContextNode.js
@@ -2,9 +2,9 @@ import Node from './Node.js';
 
 class ContextNode extends Node {
 
-	constructor( node, type, context = {} ) {
+	constructor( node, nodeType, context = {} ) {
 
-		super( type );
+		super( nodeType );
 
 		this.node = node;
 
@@ -28,9 +28,9 @@ class ContextNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		return this.node.getType( builder );
+		return this.node.getNodeType( builder );
 
 	}
 

--- a/examples/jsm/renderers/nodes/core/ExpressionNode.js
+++ b/examples/jsm/renderers/nodes/core/ExpressionNode.js
@@ -2,9 +2,9 @@ import Node from './Node.js';
 
 class ExpressionNode extends Node {
 
-	constructor( snipped = '', type = null ) {
+	constructor( snipped = '', nodeType = null ) {
 
-		super( type );
+		super( nodeType );
 
 		this.snipped = snipped;
 
@@ -12,7 +12,7 @@ class ExpressionNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const snipped = this.snipped;
 
 		return builder.format( `( ${ snipped } )`, type, output );

--- a/examples/jsm/renderers/nodes/core/FunctionCallNode.js
+++ b/examples/jsm/renderers/nodes/core/FunctionCallNode.js
@@ -25,9 +25,9 @@ class FunctionCallNode extends TempNode {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		return this.functionNode.getType( builder );
+		return this.functionNode.getNodeType( builder );
 
 	}
 
@@ -56,7 +56,7 @@ class FunctionCallNode extends TempNode {
 
 		}
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const functionName = functionNode.build( builder, 'property' );
 
 		const callSnippet = `${functionName}( ${params.join( ', ' )} )`;

--- a/examples/jsm/renderers/nodes/core/FunctionNode.js
+++ b/examples/jsm/renderers/nodes/core/FunctionNode.js
@@ -27,7 +27,7 @@ class FunctionNode extends CodeNode {
 
 	}
 
-	getType( /*builder*/ ) {
+	getNodeType( builder ) {
 
 		if ( this.needsUpdate === true ) {
 
@@ -35,7 +35,7 @@ class FunctionNode extends CodeNode {
 
 		}
 
-		return this.type;
+		return super.getNodeType( builder );
 
 	}
 
@@ -120,7 +120,7 @@ class FunctionNode extends CodeNode {
 			const blockCode = mainCode.substring( declaration[ 0 ].length );
 
 			this.name = declaration[ 3 ] !== undefined ? declaration[ 3 ] : '';
-			this.type = declaration[ 2 ];
+			this.nodeType = declaration[ 2 ];
 
 			this.presicion = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
 
@@ -151,7 +151,7 @@ class FunctionNode extends CodeNode {
 
 		super.generate( builder );
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
 
 		if ( this.name !== '' ) {

--- a/examples/jsm/renderers/nodes/core/InputNode.js
+++ b/examples/jsm/renderers/nodes/core/InputNode.js
@@ -2,9 +2,9 @@ import Node from './Node.js';
 
 class InputNode extends Node {
 
-	constructor( type ) {
+	constructor( nodeType ) {
 
-		super( type );
+		super( nodeType );
 
 		this.constant = false;
 
@@ -26,13 +26,13 @@ class InputNode extends Node {
 
 	generateConst( builder ) {
 
-		return builder.getConst( this.getType( builder ), this.value );
+		return builder.getConst( this.getNodeType( builder ), this.value );
 
 	}
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		if ( this.constant === true ) {
 

--- a/examples/jsm/renderers/nodes/core/Node.js
+++ b/examples/jsm/renderers/nodes/core/Node.js
@@ -2,11 +2,17 @@ import { NodeUpdateType } from './constants.js';
 
 class Node {
 
-	constructor( type = null ) {
+	constructor( nodeType = null ) {
 
-		this.type = type;
+		this.nodeType = nodeType;
 
 		this.updateType = NodeUpdateType.None;
+
+	}
+
+	get type() {
+
+		return this.constructor.name;
 
 	}
 
@@ -16,15 +22,15 @@ class Node {
 
 	}
 
-	getType( /*builder*/ ) {
+	getNodeType( /*builder*/ ) {
 
-		return this.type;
+		return this.nodeType;
 
 	}
 
 	getTypeLength( builder ) {
 
-		return builder.getTypeLength( this.getType( builder ) );
+		return builder.getTypeLength( this.getNodeType( builder ) );
 
 	}
 

--- a/examples/jsm/renderers/nodes/core/PropertyNode.js
+++ b/examples/jsm/renderers/nodes/core/PropertyNode.js
@@ -2,18 +2,17 @@ import Node from './Node.js';
 
 class PropertyNode extends Node {
 
-	constructor( name, type ) {
+	constructor( name, nodeType ) {
 
-		super();
+		super( nodeType );
 
 		this.name = name;
-		this.type = type;
 
 	}
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		const nodeVary = builder.getVarFromNode( this, type );
 		nodeVary.name = this.name;

--- a/examples/jsm/renderers/nodes/core/StructNode.js
+++ b/examples/jsm/renderers/nodes/core/StructNode.js
@@ -12,7 +12,7 @@ class StructNode extends CodeNode {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		if ( this.name !== '' ) {
 
@@ -36,7 +36,7 @@ class StructNode extends CodeNode {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const inputs = this.inputs;
 
 		let code = `struct ${type} {\n`;

--- a/examples/jsm/renderers/nodes/core/StructVarNode.js
+++ b/examples/jsm/renderers/nodes/core/StructVarNode.js
@@ -14,15 +14,15 @@ class StructVarNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		return this.struct.getType( builder );
+		return this.struct.getNodeType( builder );
 
 	}
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		const struct = this.struct;
 

--- a/examples/jsm/renderers/nodes/core/TempNode.js
+++ b/examples/jsm/renderers/nodes/core/TempNode.js
@@ -10,7 +10,7 @@ class TempNode extends Node {
 
 	build( builder, output ) {
 
-		const type = builder.getVectorType( this.getType( builder ) );
+		const type = builder.getVectorType( this.getNodeType( builder ) );
 
 		if ( type !== 'void' ) {
 

--- a/examples/jsm/renderers/nodes/core/VarNode.js
+++ b/examples/jsm/renderers/nodes/core/VarNode.js
@@ -2,9 +2,9 @@ import Node from './Node.js';
 
 class VarNode extends Node {
 
-	constructor( value, name = '', type = null ) {
+	constructor( value, name = '', nodeType = null ) {
 
-		super( type );
+		super( nodeType );
 
 		this.value = value;
 		this.name = name;

--- a/examples/jsm/renderers/nodes/core/VarNode.js
+++ b/examples/jsm/renderers/nodes/core/VarNode.js
@@ -11,15 +11,15 @@ class VarNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		return this.type || this.value.getType( builder );
+		return super.getNodeType( builder ) || this.value.getNodeType( builder );
 
 	}
 
 	generate( builder, output ) {
 
-		const type = builder.getVectorType( this.type || this.getType( builder ) );
+		const type = builder.getVectorType( this.getNodeType( builder ) );
 		const name = this.name;
 		const value = this.value;
 

--- a/examples/jsm/renderers/nodes/core/VaryNode.js
+++ b/examples/jsm/renderers/nodes/core/VaryNode.js
@@ -11,17 +11,17 @@ class VaryNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		// VaryNode is auto type
 
-		return this.value.getType( builder );
+		return this.value.getNodeType( builder );
 
 	}
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const value = this.value;
 
 		const nodeVary = builder.getVaryFromNode( this, type );

--- a/examples/jsm/renderers/nodes/display/NormalMapNode.js
+++ b/examples/jsm/renderers/nodes/display/NormalMapNode.js
@@ -52,7 +52,7 @@ class NormalMapNode extends TempNode {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const normalMapType = this.normalMapType;
 
 		const nodeData = builder.getDataFromNode( this );

--- a/examples/jsm/renderers/nodes/inputs/TextureNode.js
+++ b/examples/jsm/renderers/nodes/inputs/TextureNode.js
@@ -17,7 +17,7 @@ class TextureNode extends InputNode {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		const textureProperty = super.generate( builder, type );
 

--- a/examples/jsm/renderers/nodes/lights/LightContextNode.js
+++ b/examples/jsm/renderers/nodes/lights/LightContextNode.js
@@ -17,7 +17,7 @@ class LightContextNode extends ContextNode {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 
 		const material = builder.material;
 

--- a/examples/jsm/renderers/nodes/lights/LightsNode.js
+++ b/examples/jsm/renderers/nodes/lights/LightsNode.js
@@ -21,7 +21,7 @@ class LightsNode extends Node {
 
 		}
 
-		return builder.format( 'vec3( 0.0 )', this.getType( builder ), output );
+		return builder.format( 'vec3( 0.0 )', this.getNodeType( builder ), output );
 
 	}
 

--- a/examples/jsm/renderers/nodes/math/MathNode.js
+++ b/examples/jsm/renderers/nodes/math/MathNode.js
@@ -69,23 +69,23 @@ class MathNode extends TempNode {
 
 		if ( aLen > bLen && aLen > cLen ) {
 
-			return this.a.getType( builder );
+			return this.a.getNodeType( builder );
 
 		} else if ( bLen > cLen ) {
 
-			return this.b.getType( builder );
+			return this.b.getNodeType( builder );
 
 		} else if ( cLen > aLen ) {
 
-			this.c.getType( builder )
+			this.c.getNodeType( builder )
 
 		}
 
-		return this.a.getType( builder );
+		return this.a.getNodeType( builder );
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		const method = this.method;
 
@@ -109,7 +109,7 @@ class MathNode extends TempNode {
 
 		const method = this.method;
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const inputType = this.getInputType( builder );
 
 		if ( method === MathNode.NEGATE ) {

--- a/examples/jsm/renderers/nodes/math/OperatorNode.js
+++ b/examples/jsm/renderers/nodes/math/OperatorNode.js
@@ -13,10 +13,10 @@ class OperatorNode extends TempNode {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
-		const typeA = this.a.getType( builder );
-		const typeB = this.b.getType( builder );
+		const typeA = this.a.getNodeType( builder );
+		const typeB = this.b.getNodeType( builder );
 
 		if ( builder.isMatrix( typeA ) && builder.isVector( typeB ) ) {
 
@@ -44,10 +44,10 @@ class OperatorNode extends TempNode {
 
 	generate( builder, output ) {
 
-		let typeA = this.a.getType( builder );
-		let typeB = this.b.getType( builder );
+		let typeA = this.a.getNodeType( builder );
+		let typeB = this.b.getNodeType( builder );
 
-		let type = this.getType( builder );
+		let type = this.getNodeType( builder );
 
 		if ( builder.isMatrix( typeA ) && builder.isVector( typeB ) ) {
 

--- a/examples/jsm/renderers/nodes/utils/JoinNode.js
+++ b/examples/jsm/renderers/nodes/utils/JoinNode.js
@@ -10,7 +10,7 @@ class JoinNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		return builder.getTypeFromLength( this.values.length );
 
@@ -18,7 +18,7 @@ class JoinNode extends Node {
 
 	generate( builder, output ) {
 
-		const type = this.getType( builder );
+		const type = this.getNodeType( builder );
 		const values = this.values;
 
 		const snippetValues = [];

--- a/examples/jsm/renderers/nodes/utils/SplitNode.js
+++ b/examples/jsm/renderers/nodes/utils/SplitNode.js
@@ -11,7 +11,7 @@ class SplitNode extends Node {
 
 	}
 
-	getType( builder ) {
+	getNodeType( builder ) {
 
 		return builder.getTypeFromLength( this.components.length );
 
@@ -19,12 +19,12 @@ class SplitNode extends Node {
 
 	generate( builder, output ) {
 
-		const nodeType = this.node.getType( builder );
-		const nodeSnippet = this.node.build( builder, nodeType );
+		const type = this.node.getNodeType( builder );
+		const nodeSnippet = this.node.build( builder, type );
 
 		const snippet = `${nodeSnippet}.${this.components}`;
 
-		return builder.format( snippet, this.getType( builder ), output );
+		return builder.format( snippet, this.getNodeType( builder ), output );
 
 	}
 


### PR DESCRIPTION
**Description**

Both `Object3D` and `Material` uses `.type` property to returns the `constructor.name`. 
I think that `NodeMaterial` can follow this standard. 

**Renames**
- `Node.type` -> `Node.nodeType`
- `Node.getType()` -> `Node.getNodeType()`

**New property**
- `Node.type` -> returns `constructor.name`

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
