### PR TITLE
WebGLMorphtargets: Fix data texture buffer alpha.

### DIFF
--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -107,6 +107,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 						buffer[ offset + stride + 0 ] = morph.x;
 						buffer[ offset + stride + 1 ] = morph.y;
 						buffer[ offset + stride + 2 ] = morph.z;
+						buffer[ offset + stride + 3 ] = 0;
 
 						if ( hasMorphNormals === true ) {
 
@@ -114,9 +115,10 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 
 							if ( morphNormal.normalized === true ) denormalize( morph, morphNormal );
 
-							buffer[ offset + stride + 3 ] = morph.x;
-							buffer[ offset + stride + 4 ] = morph.y;
-							buffer[ offset + stride + 5 ] = morph.z;
+							buffer[ offset + stride + 4 ] = morph.x;
+							buffer[ offset + stride + 5 ] = morph.y;
+							buffer[ offset + stride + 6 ] = morph.z;
+							buffer[ offset + stride + 7 ] = 0;
 
 						}
 


### PR DESCRIPTION
Related issue: Fixed https://github.com/mrdoob/three.js/pull/22293#issuecomment-925337636.

**Description**

Added missing alpha values for the RGBA texture. This bug only affected animations with morph normals.
