### PR TITLE
WebGLNodeBuilder: Fix sRGBEncoding map using WebGL2

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -266,15 +266,13 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 		const isWebGL2 = this.renderer.capabilities.isWebGL2;
 
-		let encoding = super.getTextureEncodingFromMap( map );
-
 		if ( isWebGL2 && map && map.isTexture && map.format === RGBAFormat && map.type === UnsignedByteType && map.encoding === sRGBEncoding ) {
 
-			encoding = LinearEncoding; // disable inline decode for sRGB textures in WebGL 2
+			return LinearEncoding; // disable inline decode for sRGB textures in WebGL 2
 
 		}
 
-		return encoding;
+		return super.getTextureEncodingFromMap( map );
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -2,7 +2,7 @@ import NodeBuilder from '../../nodes/core/NodeBuilder.js';
 import NodeSlot from '../../nodes/core/NodeSlot.js';
 import WebGLPhysicalContextNode from './WebGLPhysicalContextNode.js';
 
-import { ShaderChunk } from 'three';
+import { ShaderChunk, LinearEncoding, RGBAFormat, UnsignedByteType, sRGBEncoding } from 'three';
 
 const shaderStages = [ 'vertex', 'fragment' ];
 
@@ -259,6 +259,22 @@ class WebGLNodeBuilder extends NodeBuilder {
 			this.replaceCode( shaderStage, includeSnippet, code );
 
 		}
+
+	}
+
+	getTextureEncodingFromMap( map ) {
+
+		const isWebGL2 = this.renderer.capabilities.isWebGL2;
+
+		let encoding = super.getTextureEncodingFromMap( map );
+
+		if ( isWebGL2 && map && map.isTexture && map.format === RGBAFormat && map.type === UnsignedByteType && map.encoding === sRGBEncoding ) {
+
+			encoding = LinearEncoding; // disable inline decode for sRGB textures in WebGL 2
+
+		}
+
+		return encoding;
 
 	}
 


### PR DESCRIPTION
**Description**

- Disable inline decode for sRGB textures in WebGL 2

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
