### PR TITLE
BufferGeometry: set .type to base class after transform is applied

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -170,6 +170,14 @@ class BufferGeometry extends EventDispatcher {
 
 		}
 
+		if ( this.parameters !== undefined ) {
+
+			this.type = 'BufferGeometry';
+
+			delete this.parameters;
+
+		}
+
 		return this;
 
 	}


### PR DESCRIPTION
Fixes #22586

