### PR TITLE
USDZExporter: Fix output

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -380,7 +380,6 @@ function buildMaterial( material, textures ) {
             float outputs:r
             float outputs:g
             float outputs:b
-            float outputs:a
             float3 outputs:rgb
         }`;
 
@@ -456,11 +455,6 @@ function buildMaterial( material, textures ) {
 		inputs.push( `${pad}float inputs:opacityThreshold = 0.0001` );
 
 		samplers.push( buildTexture( material.alphaMap, 'opacity' ) );
-
-	} else if ( material.map !== null && material.map.format === 1023 ) {
-
-		inputs.push( `${pad}float inputs:opacity.connect = </Materials/Material_${material.id}/Texture_${material.map.id}_diffuse.outputs:a>` );
-		inputs.push( `${pad}float inputs:opacityThreshold = 0.0001` );
 
 	} else {
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -381,7 +381,7 @@ function buildMaterial( material, textures ) {
             float outputs:g
             float outputs:b
             float outputs:a
-            float3 outputs:rgba
+            float3 outputs:rgb
         }`;
 
 	}


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/22591

Fixing for now. I will make other approach for transparent texture used in `.map`.
Now `.alphaMap` and `diffuse` seems ok in my tests.

![image](https://user-images.githubusercontent.com/502810/134996779-6e684207-5e8a-42aa-85a1-08f4da26e5c8.png)

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
