### PR TITLE
Fix incorrect SVG <path> loader

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -1007,6 +1007,7 @@ class SVGLoader extends Loader {
 
 			addStyle( 'fill', 'fill' );
 			addStyle( 'fill-opacity', 'fillOpacity', clamp );
+			addStyle( 'fill-rule', 'fillRule' );
 			addStyle( 'opacity', 'opacity', clamp );
 			addStyle( 'stroke', 'stroke' );
 			addStyle( 'stroke-opacity', 'strokeOpacity', clamp );


### PR DESCRIPTION
Related issue: #22511

**Description**

Somehow 'fill-rule' <path> attribute was missing but actual functionality is in place
