### PR TITLE
Editor: Limit the min-width style for `.Panels` and `.Tabs`

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -74,19 +74,21 @@ textarea, input { outline: none; } /* osx */
 	position: relative;
 	display: block;
 	width: 100%;
+	min-width: 300px;
 }
 
-.TabbedPanel .Tabs .Tab {
-	padding: 10px;
-	text-transform: uppercase;
-}
+	.TabbedPanel .Tabs .Tab {
+		padding: 10px;
+		text-transform: uppercase;
+	}
 
-.TabbedPanel .Tabs .Panels {
-	position: relative;
-	display: block;
-	width: 100%;
-	height: 100%;
-}
+	.TabbedPanel .Panels {
+		position: relative;
+		display: block;
+		width: 100%;
+		height: 100%;
+		min-width: 300px;
+	}
 
 /* Listbox */
 .Listbox {


### PR DESCRIPTION
Related issue: #---

**Description**

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/23699926/135111283-f20a6cf4-6dc1-4a3e-8360-9f106deaaa99.png)|![image](https://user-images.githubusercontent.com/23699926/135110893-15e2e183-d1d1-424f-890d-aa690275e3ad.png)|



