### PR TITLE
Editor: Fix CRLF problem.

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -447,19 +447,17 @@ function MenubarFile( editor ) {
 			if ( config.getKey( 'project/editable' ) ) {
 
 				editButton = [
-					'',
 					'			var button = document.createElement( \'a\' );',
 					'			button.href = \'https://threejs.org/editor/#file=\' + location.href.split( \'/\' ).slice( 0, - 1 ).join( \'/\' ) + \'/app.json\';',
 					'			button.style.cssText = \'position: absolute; bottom: 20px; right: 20px; padding: 10px 16px; color: #fff; border: 1px solid #fff; border-radius: 20px; text-decoration: none;\';',
 					'			button.target = \'_blank\';',
 					'			button.textContent = \'EDIT\';',
 					'			document.body.appendChild( button );',
-					''
 				].join( '\n' );
 
 			}
 
-			content = content.replace( '\n\t\t\t/* edit button */\n', editButton );
+			content = content.replace( '\t\t\t/* edit button */', editButton );
 
 			toZip[ 'index.html' ] = strToU8( content );
 


### PR DESCRIPTION
Related issue: #---

**Description**

```javascript
// doesn't work in CRLF case
content = content.replace( '\n\t\t\t/* edit button */\n', editButton ); 

// work in CRLF case and LF case
content = content.replace( '\t\t\t/* edit button */', editButton ); 
```

![image](https://user-images.githubusercontent.com/23699926/135115724-d1ead7fa-0c4d-416c-91ed-4525b5d75d61.png)


