### PR TITLE
core: Clean up.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -113,8 +113,9 @@ class Object3D extends EventDispatcher {
 
 	}
 
-	onBeforeRender() {}
-	onAfterRender() {}
+	onBeforeRender( /* renderer, scene, camera, geometry, material, group */ ) {}
+
+	onAfterRender( /* renderer, scene, camera, geometry, material, group */ ) {}
 
 	applyMatrix4( matrix ) {
 


### PR DESCRIPTION
Related issue: #--

**Description**

Clean up api for `Object3D.onBeforeRender` and `Object3D.onAfterRender`.
