### PR TITLE
A fix for hand tracking in Oculus Browser v14

### DIFF
--- a/examples/jsm/webxr/XRHandPrimitiveModel.js
+++ b/examples/jsm/webxr/XRHandPrimitiveModel.js
@@ -11,6 +11,16 @@ import {
 const _matrix = new Matrix4();
 const _vector = new Vector3();
 
+const _oculusBrowserV14CorrectionRight = new Matrix4().identity();
+const _oculusBrowserV14CorrectionLeft = new Matrix4().identity();
+
+if ( /OculusBrowser\/14\./.test( navigator.userAgent ) ) {
+
+    _oculusBrowserV14CorrectionRight.makeRotationY( Math.PI / 2 );
+
+    _oculusBrowserV14CorrectionLeft.makeRotationY( - Math.PI / 2 );
+}
+
 class XRHandPrimitiveModel {
 
 	constructor( handModel, controller, path, handedness, options ) {
@@ -18,6 +28,10 @@ class XRHandPrimitiveModel {
 		this.controller = controller;
 		this.handModel = handModel;
 		this.envMap = null;
+
+        this.oculusBrowserV14Correction = handedness === 'left' 
+        	? _oculusBrowserV14CorrectionLeft 
+        	: _oculusBrowserV14CorrectionRight;
 
 		let geometry;
 
@@ -83,7 +97,9 @@ class XRHandPrimitiveModel {
 			if ( joint.visible ) {
 
 				_vector.setScalar( joint.jointRadius || defaultRadius );
-				_matrix.compose( joint.position, joint.quaternion, _vector );
+				_matrix.compose( joint.position, joint.quaternion, _vector )
+                    .multiply( this.oculusBrowserV14Correction );
+
 				this.handMesh.setMatrixAt( i, _matrix );
 
 				count ++;


### PR DESCRIPTION
Oculus Browser on the Quest line of devices supports hand tracking. In version 14, it requires toggling a flag in chrome://flags. The implementation in v14 is defective, however, and the finger joints are rotated in the wrong space.

You can see a video of what these janky, rotini-noodle hands look like here: https://www.youtube.com/watch?v=VBM_lGYiwvA

Position of the joints was correct, and the system is usable for targeting and manipulation, if not terrifyingly ugly. This patch corrects the rotation of the joints so that the hand now appears correctly.

Oculus fixed the issue in v15 and also enabled hand tracking by default. Oculus Browser on consumer-licensed devices is currently at v17. However, Oculus Browser for enterprise-licensed devices through Oculus for Business are currently stuck at v14, with no indication from Oculus when they will be upgraded.