### PR TITLE
ShaderNode: Proxy class

### DIFF
--- a/examples/jsm/renderers/nodes/ShaderNode.js
+++ b/examples/jsm/renderers/nodes/ShaderNode.js
@@ -18,6 +18,12 @@ import { Vector2, Vector3, Vector4, Color } from 'three';
 
 const NodeHandler = {
 
+	construct( NodeClosure, params ) {
+
+		return NodeClosure( params[ 0 ] );
+
+	},
+
 	get: function ( node, prop ) {
 
 		// Split Properties Pass
@@ -40,7 +46,7 @@ const NodeHandler = {
 
 };
 
-export const ShaderNodeObject = ( obj ) => {
+const ShaderNodeObject = ( obj ) => {
 
 	const type = typeof obj;
 
@@ -70,7 +76,7 @@ export const ShaderNodeObject = ( obj ) => {
 
 };
 
-export const ShaderNodeArray = ( array ) => {
+const ShaderNodeArray = ( array ) => {
 
 	const len = array.length;
 
@@ -84,7 +90,7 @@ export const ShaderNodeArray = ( array ) => {
 
 };
 
-export const ShaderNodeScript = ( jsFunc ) => {
+const ShaderNodeScript = function ( jsFunc ) {
 
 	return ( ...params ) => {
 
@@ -96,17 +102,13 @@ export const ShaderNodeScript = ( jsFunc ) => {
 
 };
 
-export const ShaderNode = ( obj ) => {
-
-	return ShaderNodeScript( obj );
-
-};
+export const ShaderNode = new Proxy( ShaderNodeScript, NodeHandler );
 
 //
 // Node Material Shader Syntax
 //
 
-export const uniform = ShaderNodeScript( ( inputNode ) => {
+export const uniform = new ShaderNode( ( inputNode ) => {
 
 	inputNode.setConst( false );
 

--- a/examples/jsm/renderers/nodes/procedural/CheckerNode.js
+++ b/examples/jsm/renderers/nodes/procedural/CheckerNode.js
@@ -5,7 +5,7 @@ import UVNode from '../accessors/UVNode.js';
 import { ShaderNode, float, add, mul, floor, mod, sign } from '../ShaderNode.js';
 
 // Three.JS Shader Language
-const checkerShaderNode = ShaderNode( ( uv ) => {
+const checkerShaderNode = new ShaderNode( ( uv ) => {
 
 	uv = mul( uv, 2.0 );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/22603#issuecomment-931249179

Usage
```js
const shaderNode = new ShaderNode( ... );
```

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
