### PR TITLE
KTX2Loader: Warn when multiple instances in use.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -37,6 +37,8 @@ const KTX2TransferSRGB = 2;
 const KTX2_ALPHA_PREMULTIPLIED = 1;
 const _taskCache = new WeakMap();
 
+let _activeLoaders = 0;
+
 class KTX2Loader extends Loader {
 
 	constructor( manager ) {
@@ -154,6 +156,21 @@ class KTX2Loader extends Loader {
 
 				} );
 
+			if ( _activeLoaders > 0 ) {
+
+				// Each instance loads a transcoder and allocates workers, increasing network and memory cost.
+
+				console.warn(
+
+					'THREE.KTX2Loader: Multiple active KTX2 loaders may cause performance issues.'
+					+ ' Use a single KTX2Loader instance, or call .dispose() on old instances.'
+
+				);
+
+			}
+
+			_activeLoaders++;
+
 		}
 
 		return this.transcoderPending;
@@ -247,6 +264,8 @@ class KTX2Loader extends Loader {
 
 		URL.revokeObjectURL( this.workerSourceURL );
 		this.workerPool.dispose();
+
+		_activeLoaders--;
 
 		return this;
 

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -63,21 +63,32 @@
 			};
 
 			// Samples: sample_etc1s.ktx2, sample_uastc.ktx2, sample_uastc_zstd.ktx2
-			new KTX2Loader()
+			const loader = new KTX2Loader()
 				.setTranscoderPath( 'js/libs/basis/' )
-				.detectSupport( renderer )
-				.load( './textures/compressed/sample_uastc_zstd.ktx2', ( texture ) => {
-
-					console.info( `transcoded to ${formatStrings[ texture.format ]}` );
-
-					material.map = texture;
-					material.transparent = true;
-
-					material.needsUpdate = true;
-
-				}, ( p ) => console.log( `...${p}` ), ( e ) => console.error( e ) );
+				.detectSupport( renderer );
 
 			animate();
+
+			try {
+
+				const texture = await loader.loadAsync( './textures/compressed/sample_uastc_zstd.ktx2' );
+
+				console.info( `transcoded to ${formatStrings[ texture.format ]}` );
+
+				material.map = texture;
+				material.transparent = true;
+
+				material.needsUpdate = true;
+
+			} catch ( e ) {
+
+				console.error( e );
+
+			} finally {
+
+				loader.dispose();
+
+			}
 
 			function animate() {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20958

Have been seeing demos (they happened to be with R3F, although I don't think the framework itself is causing this) where multiple KTX2Loader instances are created and the transcoder is fetched repeatedly. Hoping to warn users when that happens, and ensure that the web worker pool is used efficiently.