### PR TITLE
TDSLoader : Change size of object name string.

### DIFF
--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -199,17 +199,11 @@
 		readNamedObject( data ) {
 
 			const chunk = this.readChunk( data );
-			const name = this.readString( data, 64 );
+			const name = this.readString( data, 256 );
 			chunk.cur = this.position;
 			let next = this.nextChunk( data, chunk );
 
 			while ( next !== 0 ) {
-
-				if (next === 0x3338 ) {
-
-					var subChunk = this.readChunk( data );
-					next = this.nextChunk( data, subChunk );
-				}
 				
 				if ( next === N_TRI_OBJECT ) {
 

--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -205,6 +205,12 @@
 
 			while ( next !== 0 ) {
 
+				if (next === 0x3338 ) {
+
+					var subChunk = this.readChunk( data );
+					next = this.nextChunk( data, subChunk );
+				}
+				
 				if ( next === N_TRI_OBJECT ) {
 
 					this.resetPosition( data );


### PR DESCRIPTION
Jump over unknown ChunkType 0x3338

Related issue: #XXXX

Description

I have a .3ds file that can not be loaded with threeJs. That file encapsulate the N_TRI_OBJECT chunk in an unknown 0x3338 chunk.
This pull request ignores/jumps over the 0x3338 chunk type.
