### PR TITLE
Examples: Improved render in onWindowResize.

### DIFF
--- a/examples/webgl_interactive_voxelpainter.html
+++ b/examples/webgl_interactive_voxelpainter.html
@@ -109,6 +109,8 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
 			function onPointerMove( event ) {


### PR DESCRIPTION
Related issue: #---

**Description**

Add `render()` function to fixed `resize` event doesn't work problem.
