### PR TITLE
GLTFLoader: Warn about large Data URIs

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1905,7 +1905,13 @@ function resolveURL( url, path ) {
 	if ( /^(https?:)?\/\//i.test( url ) ) return url;
 
 	// Data URI
-	if ( /^data:.*,.*$/i.test( url ) ) return url;
+	if ( /^data:.*,.*$/i.test( url ) ) {
+
+		checkDataURI( url );
+
+		return url;
+
+	}
 
 	// Blob URL
 	if ( /^blob:.*$/i.test( url ) ) return url;
@@ -2151,6 +2157,25 @@ function getNormalizedComponentScale( constructor ) {
 
 		default:
 			throw new Error( 'THREE.GLTFLoader: Unsupported normalized accessor component type.' );
+
+	}
+
+}
+
+let _checkDataURI = true;
+
+function checkDataURI( url ) {
+
+	if ( _checkDataURI === true && url.length > 1e5 ) {
+
+		console.warn(
+
+			`THREE.GLTFLoader: Large Data URI (${ url.length } bytes) will increase file size and`
+			+ ' parsing time. Use ".glb", or ".gltf" with external resources, instead.'
+
+		);
+
+		_checkDataURI = false;
 
 	}
 


### PR DESCRIPTION
It doesn't seem like users are generally aware that `.gltf` files with embedded resources are both (1) larger than GLB or glTF with external resources, and (2) much slower to parse. I don't think there's any good reason to be using these models when they exceed 100kb or so, and would like to start showing a warning to that effect.

It's worth noting that if we switched FileLoader from XmlHttpRequest to fetch(), we'd be able to resolve Data URIs off the main thread (at least if my understanding of fetch() is right?) and that solves the slow parsing issue above. Safari doesn't support Data URIs with XmlHttpRequest so we have a (slow) workaround for that — affecting _all_ browsers — in FileLoader today.

Related: https://github.com/KhronosGroup/glTF/issues/1915
