### PR TITLE
Examples: Use loop unroll in PCSS demo.

### DIFF
--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -29,7 +29,6 @@
 				#define NUM_SAMPLES 17
 				#define NUM_RINGS 11
 				#define BLOCKER_SEARCH_NUM_SAMPLES NUM_SAMPLES
-				#define PCF_NUM_SAMPLES NUM_SAMPLES
 
 				vec2 poissonDisk[NUM_SAMPLES];
 
@@ -75,15 +74,20 @@
 
 				float PCF_Filter(sampler2D shadowMap, vec2 uv, float zReceiver, float filterRadius ) {
 					float sum = 0.0;
-					for( int i = 0; i < PCF_NUM_SAMPLES; i ++ ) {
-						float depth = unpackRGBAToDepth( texture2D( shadowMap, uv + poissonDisk[ i ] * filterRadius ) );
+					float depth;
+					#pragma unroll_loop_start
+					for( int i = 0; i < 17; i ++ ) {
+						depth = unpackRGBAToDepth( texture2D( shadowMap, uv + poissonDisk[ i ] * filterRadius ) );
 						if( zReceiver <= depth ) sum += 1.0;
 					}
-					for( int i = 0; i < PCF_NUM_SAMPLES; i ++ ) {
-						float depth = unpackRGBAToDepth( texture2D( shadowMap, uv + -poissonDisk[ i ].yx * filterRadius ) );
+					#pragma unroll_loop_end
+					#pragma unroll_loop_start
+					for( int i = 0; i < 17; i ++ ) {
+						depth = unpackRGBAToDepth( texture2D( shadowMap, uv + -poissonDisk[ i ].yx * filterRadius ) );
 						if( zReceiver <= depth ) sum += 1.0;
 					}
-					return sum / ( 2.0 * float( PCF_NUM_SAMPLES ) );
+					#pragma unroll_loop_end
+					return sum / ( 2.0 * float( 17 ) );
 				}
 
 				float PCSS ( sampler2D shadowMap, vec4 coords ) {


### PR DESCRIPTION
Related issue: Fixed #22638

**Description**

The problematic loops in the PCSS demo are now unrolled. To make this work, it is necessary to replace the define in the loop with the actual integer value. For internal defines, this is done by the engine in [WebGLProgram](https://github.com/mrdoob/three.js/blob/57d1ae0ebd6ea175765d4fcc14afc5257b0b9abe/src/renderers/webgl/WebGLProgram.js#L181-L201). However, this does not work for `PCF_NUM_SAMPLES` since it's a custom define.