### PR TITLE
ColladaLoader: Re-added normal map parsing

### DIFF
--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -1110,6 +1110,10 @@
 							data.parameters = parseEffectParameters( child );
 							break;
 
+						case 'extra':
+							data.extra = parseEffectExtra( child );
+							break;
+
 					}
 
 				}
@@ -1267,6 +1271,10 @@
 
 							break;
 
+						case 'bump':
+							data[ child.nodeName ] = parseEffectExtraTechniqueBump( child );
+							break;
+
 					}
 
 				}
@@ -1309,6 +1317,33 @@
 
 						case 'double_sided':
 							data[ child.nodeName ] = parseInt( child.textContent );
+							break;
+
+						case 'bump':
+							data[ child.nodeName ] = parseEffectExtraTechniqueBump( child );
+							break;
+
+					}
+
+				}
+
+				return data;
+
+			}
+
+			function parseEffectExtraTechniqueBump( xml ) {
+				var data = {};
+
+				for ( var i = 0, l = xml.childNodes.length; i < l; i ++ ) {
+
+					var child = xml.childNodes[ i ];
+
+					if ( child.nodeType !== 1 ) continue;
+
+					switch ( child.nodeName ) {
+
+						case 'texture':
+							data[ child.nodeName ] = { id: child.getAttribute( 'texture' ), texcoord: child.getAttribute( 'texcoord' ), extra: parseEffectParameterTexture( child ) };
 							break;
 
 					}
@@ -1570,9 +1605,28 @@
 				} //
 
 
-				if ( extra !== undefined && extra.technique !== undefined && extra.technique.double_sided === 1 ) {
+				if ( technique.extra !== undefined && technique.extra.technique !== undefined ) {
 
-					material.side = THREE.DoubleSide;
+					let techniques = technique.extra.technique;
+
+					for ( let k in techniques ) {
+
+						let v = techniques[k];
+
+						switch (k) {
+
+							case 'double_sided':
+								material.side = ( v === 1 ? THREE.DoubleSide : THREE.FrontSide );
+								break;
+
+							case 'bump':
+								material.normalMap = getTexture( v.texture );
+								material.normalScale = new THREE.Vector2( 1, 1 );
+								break;
+
+						}
+
+					}
 
 				}
 

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -1239,6 +1239,10 @@ class ColladaLoader extends Loader {
 						data.parameters = parseEffectParameters( child );
 						break;
 
+					case 'extra':
+						data.extra = parseEffectExtra( child );
+						break;
+
 				}
 
 			}
@@ -1399,6 +1403,10 @@ class ColladaLoader extends Loader {
 
 						break;
 
+					case 'bump':
+						data[ child.nodeName ] = parseEffectExtraTechniqueBump( child );
+						break;
+
 				}
 
 			}
@@ -1443,6 +1451,33 @@ class ColladaLoader extends Loader {
 
 					case 'double_sided':
 						data[ child.nodeName ] = parseInt( child.textContent );
+						break;
+
+					case 'bump':
+						data[ child.nodeName ] = parseEffectExtraTechniqueBump( child );
+						break;
+
+				}
+
+			}
+
+			return data;
+
+		}
+
+		function parseEffectExtraTechniqueBump( xml ) {
+			var data = {};
+
+			for ( var i = 0, l = xml.childNodes.length; i < l; i ++ ) {
+
+				var child = xml.childNodes[ i ];
+
+				if ( child.nodeType !== 1 ) continue;
+
+				switch ( child.nodeName ) {
+
+					case 'texture':
+						data[ child.nodeName ] = { id: child.getAttribute( 'texture' ), texcoord: child.getAttribute( 'texcoord' ), extra: parseEffectParameterTexture( child ) };
 						break;
 
 				}
@@ -1712,9 +1747,29 @@ class ColladaLoader extends Loader {
 
 			//
 
-			if ( extra !== undefined && extra.technique !== undefined && extra.technique.double_sided === 1 ) {
 
-				material.side = DoubleSide;
+			if ( technique.extra !== undefined && technique.extra.technique !== undefined ) {
+
+				let techniques = technique.extra.technique;
+
+				for ( let k in techniques ) {
+
+					let v = techniques[k];
+
+					switch (k) {
+
+						case 'double_sided':
+							material.side = ( v === 1 ? THREE.DoubleSide : THREE.FrontSide );
+							break;
+
+						case 'bump':
+							material.normalMap = getTexture( v.texture );
+							material.normalScale = new THREE.Vector2( 1, 1 );
+							break;
+
+					}
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: #15391

**Description**

It seems that at some point, support for loading normal maps from Collada files was lost.  This pull request restores that functionality to a working state, by parsing the material technique extras to handle the 'bump' option.
