### PR TITLE
Fix clipping in webgl2_materials_texture3d

### DIFF
--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -51,8 +51,8 @@
 			// Create camera (The volume renderer does not work very well with perspective yet)
 			const h = 512; // frustum height
 			const aspect = window.innerWidth / window.innerHeight;
-			camera = new THREE.OrthographicCamera( - h * aspect / 2, h * aspect / 2, h / 2, - h / 2, 1, 2000 );
-			camera.position.set( -1000, 0, 128 );
+			camera = new THREE.OrthographicCamera( - h * aspect / 2, h * aspect / 2, h / 2, - h / 2, 1, 1000 );
+			camera.position.set( - 64, - 64, 128 );
 			camera.up.set( 0, 0, 1 ); // In our data, z is up
 
 			// Create controls
@@ -61,6 +61,7 @@
 			controls.target.set( 64, 64, 128 );
 			controls.minZoom = 0.5;
 			controls.maxZoom = 4;
+			controls.enablePan = false;
 			controls.update();
 
 			// scene.add( new AxesHelper( 128 ) );

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -52,7 +52,7 @@
 			const h = 512; // frustum height
 			const aspect = window.innerWidth / window.innerHeight;
 			camera = new THREE.OrthographicCamera( - h * aspect / 2, h * aspect / 2, h / 2, - h / 2, 1, 1000 );
-			camera.position.set( 0, 0, 128 );
+			camera.position.set( -256, 0, 128 );
 			camera.up.set( 0, 0, 1 ); // In our data, z is up
 
 			// Create controls

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -51,8 +51,8 @@
 			// Create camera (The volume renderer does not work very well with perspective yet)
 			const h = 512; // frustum height
 			const aspect = window.innerWidth / window.innerHeight;
-			camera = new THREE.OrthographicCamera( - h * aspect / 2, h * aspect / 2, h / 2, - h / 2, 1, 1000 );
-			camera.position.set( -256, 0, 128 );
+			camera = new THREE.OrthographicCamera( - h * aspect / 2, h * aspect / 2, h / 2, - h / 2, 1, 2000 );
+			camera.position.set( -1000, 0, 128 );
 			camera.up.set( 0, 0, 1 ); // In our data, z is up
 
 			// Create controls


### PR DESCRIPTION
**Description**

The camera position was too close to the 3D texture, causing clipping
from certain angles.

Before the repositioning:
![threejs_before](https://user-images.githubusercontent.com/11084889/136242637-a40e1225-a669-4d30-97f5-6ad0d5486466.png)

After the repositioning:
![threejs_after](https://user-images.githubusercontent.com/11084889/136242720-c8d59ea9-fdca-4761-a53c-78222ff62192.png)


