### PR TITLE
lighter getProgramCacheKey when using RawShaderMaterials

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -2,6 +2,7 @@ import { BackSide, DoubleSide, CubeUVRefractionMapping, CubeUVReflectionMapping,
 import { WebGLProgram } from './WebGLProgram.js';
 import { ShaderLib } from '../shaders/ShaderLib.js';
 import { UniformsUtils } from '../shaders/UniformsUtils.js';
+import { hashString } from '../../utils.js';
 
 function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities, bindingStates, clipping ) {
 
@@ -309,8 +310,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 		} else {
 
-			array.push( parameters.fragmentShader );
-			array.push( parameters.vertexShader );
+			array.push( hashString( parameters.fragmentShader ) );
+			array.push( hashString( parameters.vertexShader ) );
 
 		}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,16 +68,26 @@ function createElementNS( name ) {
   * @param {number} seed, default 0
   * @returns number
   */
-function hashString(str, seed = 0) {
+function hashString( str, seed = 0 ) {
+
 	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
-	for (let i = 0, ch; i < str.length; i++) {
-		ch = str.charCodeAt(i);
-		h1 = Math.imul(h1 ^ ch, 2654435761);
-		h2 = Math.imul(h2 ^ ch, 1597334677);
+
+	for ( let i = 0, ch; i < str.length; i++ ) {
+
+		ch = str.charCodeAt( i );
+
+		h1 = Math.imul( h1 ^ ch, 2654435761 );
+
+		h2 = Math.imul( h2 ^ ch, 1597334677 );
+
 	}
-	h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-	h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-	return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+
+	h1 = Math.imul( h1 ^ ( h1 >>> 16 ), 2246822507 ) ^ Math.imul( h2 ^ ( h2 >>> 13 ), 3266489909 );
+
+	h2 = Math.imul( h2 ^ ( h2 >>> 16 ), 2246822507 ) ^ Math.imul( h1 ^ ( h1 >>> 13 ), 3266489909 );
+
+	return 4294967296 * ( 2097151 & h2 ) + ( h1 >>> 0 );
+
 }
 
 export { arrayMin, arrayMax, getTypedArray, createElementNS, hashString };

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,4 +54,30 @@ function createElementNS( name ) {
 
 }
 
-export { arrayMin, arrayMax, getTypedArray, createElementNS };
+ /**
+  * cyrb53 hash for string from: https://stackoverflow.com/a/52171480
+  * 
+  * Public Domain, @bryc - https://stackoverflow.com/users/815680/bryc
+  *
+  * It is roughly similar to the well-known MurmurHash/xxHash algorithms. It uses a combination
+  * of multiplication and Xorshift to generate the hash, but not as thorough. As a result it's
+  * faster than either would be in JavaScript and significantly simpler to implement. Keep in
+  * mind this is not a secure algorithm, if privacy/security is a concern, this is not for you.
+  *
+  * @param {string} str 
+  * @param {number} seed, default 0
+  * @returns number
+  */
+function hashString(str, seed = 0) {
+	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+	for (let i = 0, ch; i < str.length; i++) {
+		ch = str.charCodeAt(i);
+		h1 = Math.imul(h1 ^ ch, 2654435761);
+		h2 = Math.imul(h2 ^ ch, 1597334677);
+	}
+	h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+	h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+	return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+
+export { arrayMin, arrayMax, getTypedArray, createElementNS, hashString };

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,9 +54,9 @@ function createElementNS( name ) {
 
 }
 
- /**
+/**
   * cyrb53 hash for string from: https://stackoverflow.com/a/52171480
-  * 
+  *
   * Public Domain, @bryc - https://stackoverflow.com/users/815680/bryc
   *
   * It is roughly similar to the well-known MurmurHash/xxHash algorithms. It uses a combination
@@ -64,7 +64,7 @@ function createElementNS( name ) {
   * faster than either would be in JavaScript and significantly simpler to implement. Keep in
   * mind this is not a secure algorithm, if privacy/security is a concern, this is not for you.
   *
-  * @param {string} str 
+  * @param {string} str
   * @param {number} seed, default 0
   * @returns number
   */
@@ -72,7 +72,7 @@ function hashString( str, seed = 0 ) {
 
 	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
 
-	for ( let i = 0, ch; i < str.length; i++ ) {
+	for ( let i = 0, ch; i < str.length; i ++ ) {
 
 		ch = str.charCodeAt( i );
 


### PR DESCRIPTION
Related issue: #22530

**Description**

The gist of the problem: each new material instance gets run through this getProgramCacheKey function to see if three needs to build a program for that, or to connect a reference to an existing program.

The getProgramCacheKey function is ‘ok’ for built in shaders, but it has a pretty huge allocation for custom shaders, especially a relatively large ubershader, by way of making the key out of concatenating the full strings of the fragment/vertex shaders.

This wasn’t too much of an issue as long as the materials can be set up front, as it was a one time cost during load, but I'm noticing that with 3d-tiles based streaming, our current method of creating unique ShaderMaterial per tile, each new tile shown is a pretty large memory allocation, and for larger tilesets, where it’s possible to view thousands of tiles over time, this adds up to a healthy amount of GC pressure.

Hash function choice 1000% up for debate, this one was working fairly well, quickly, and with much lower allocation pressure showing in testing.

Before: ![image](https://user-images.githubusercontent.com/983807/136286470-cbc90c46-a278-494f-a54c-1842978bc4ea.png)

After: 
![image](https://user-images.githubusercontent.com/983807/136286520-5ad49ace-eb9c-4d65-a40d-be16fd8b2ef5.png)
