### PR TITLE
XRLayerHelper

### DIFF
--- a/examples/files.json
+++ b/examples/files.json
@@ -346,6 +346,7 @@
 		"webxr_vr_handinput_pressbutton",
 		"webxr_vr_haptics",
 		"webxr_vr_layers",
+		"webxr_vr_layer_helper",
 		"webxr_vr_panorama",
 		"webxr_vr_panorama_depth",
 		"webxr_vr_paint",

--- a/examples/jsm/webxr/XRLayerHelper.js
+++ b/examples/jsm/webxr/XRLayerHelper.js
@@ -1,18 +1,26 @@
 import {
-	Object3D
+	Mesh,
+	PlaneGeometry,
+	MeshBasicMaterial,
+	// testing
+	BoxGeometry,
+	MeshNormalMaterial
 } from '../../../build/three.module.js';
 
 const XRLAYER_MODE = 0;
 const MESH_MODE = 1;
 
-class XRLayerHelper extends Object3D {
+class XRLayerHelper extends Mesh {
 
-	constructor( renderer ) {
+	constructor( renderer, texture, width, height ) {
 
 		super();
 
 		this.isXRLayerHelper = true
 		this.renderer = renderer;
+		this.texture = texture;
+		this.width = width;
+		this.height = height;
 
 		this.init();
 
@@ -33,6 +41,34 @@ class XRLayerHelper extends Object3D {
 			this.glBinding = null;
 
 		} );
+
+		this.updateMesh();
+
+	}
+
+	updateMesh() {
+
+		this.geometry = new PlaneGeometry( this.width, this.height );
+
+		this.material = new MeshBasicMaterial( { map: this.texture } );
+
+		/*
+
+		snellenTexture = new THREE.TextureLoader().load( "textures/snellen.png" );
+		snellenTexture.repeat.x = snellenConfig.cropX;
+		snellenTexture.repeat.y = snellenConfig.cropY;
+
+		const snellenMeshMipMap = new THREE.Mesh(
+			new THREE.PlaneGeometry( snellenConfig.widthMeters, snellenConfig.heightMeters ),
+			new THREE.MeshBasicMaterial( { map: snellenTexture } )
+		);
+
+		snellenMeshMipMap.position.x = snellenConfig.x + snellenConfig.widthMeters;
+		snellenMeshMipMap.position.y = snellenConfig.y - snellenConfig.heightMeters;
+
+		eyeCharts.add( snellenMeshMipMap );
+
+		*/
 
 	}
 
@@ -75,8 +111,6 @@ class XRLayerHelper extends Object3D {
 			}
 
 		}
-
-		console.log( this.mode )
 
 	}
 

--- a/examples/jsm/webxr/XRLayerHelper.js
+++ b/examples/jsm/webxr/XRLayerHelper.js
@@ -1,0 +1,15 @@
+import {
+	Object3D
+} from '../../../build/three.module.js';
+
+class XRLayerHelper extends Object3D {
+
+	constructor() {
+
+		super();
+
+		this.isXRLayerHelper = true
+
+	}
+
+}

--- a/examples/jsm/webxr/XRLayerHelper.js
+++ b/examples/jsm/webxr/XRLayerHelper.js
@@ -2,14 +2,90 @@ import {
 	Object3D
 } from '../../../build/three.module.js';
 
+const XRLAYER_MODE = 0;
+const MESH_MODE = 1;
+
 class XRLayerHelper extends Object3D {
 
-	constructor() {
+	constructor( renderer ) {
 
 		super();
 
 		this.isXRLayerHelper = true
+		this.renderer = renderer;
+
+		this.init();
+
+	}
+
+	init() {
+
+		this.renderer.xr.addEventListener( 'sessionstart', () => {
+
+			this.session = this.renderer.xr.getSession();
+			this.glBinding = this.renderer.xr.getBinding();
+
+		} );
+
+		this.renderer.xr.addEventListener( 'sessionend', () => {
+
+			this.session = null;
+			this.glBinding = null;
+
+		} );
+
+	}
+
+	updateMode() {
+
+		if (
+			this.session &&
+			this.session.renderState.layers !== undefined
+		) {
+
+			this.mode = XRLAYER_MODE;
+
+		} else {
+
+			this.mode = MESH_MODE;
+
+		};
+
+		//
+
+		if ( this.mode === MESH_MODE ) {
+
+			this.XRLayer = null;
+
+			// apply the texture on the mesh, to emulate the behavior
+			// of an XRLayer ( with lower resolution and performance )
+
+			// this.mesh.material = this.material;
+
+		} else {
+
+			if ( !this.XRLayer ) {
+
+				// if the current mode is XRLAYER_MODE and this.XRLayer
+				// is falsy, it means we need to create an XRLayer and
+				// reference it in this.XRLayer.
+
+				// this.makeXRLayer();
+
+			}
+
+		}
+
+		console.log( this.mode )
+
+	}
+
+	update( frame ) {
+
+		this.updateMode();
 
 	}
 
 }
+
+export { XRLayerHelper };

--- a/examples/jsm/webxr/XRLayerHelper.js
+++ b/examples/jsm/webxr/XRLayerHelper.js
@@ -3,9 +3,9 @@ import {
 	PlaneGeometry,
 	MeshBasicMaterial,
 	Matrix4,
-	// testing
-	BoxGeometry,
-	MeshNormalMaterial
+	//
+
+	Color
 } from '../../../build/three.module.js';
 
 const XRLAYER_MODE = 0;
@@ -20,6 +20,8 @@ class XRLayerHelper extends Mesh {
 		this.isXRLayerHelper = true
 		this.renderer = renderer;
 		this.params = params;
+		// will be used to compare the last set XRLayer transforms with
+		// the current mesh transforms.
 		this.xrLayerMatrix = new Matrix4();
 
 		this.init();
@@ -42,27 +44,40 @@ class XRLayerHelper extends Mesh {
 
 		} );
 
+		//
+
+		this.params.cropX = this.params.widthPx / this.params.textureSizePx;
+		this.params.cropY = this.params.heightPx / this.params.textureSizePx;
+
+		this.params.texture.repeat.x = this.params.cropX;
+		this.params.texture.repeat.y = this.params.cropY;
+
+		//
+
 		this.updateMesh();
 
 	}
 
 	updateMesh() {
 
+		// the mesh is used both as depth mask when the XRLayer is visible,
+		// and as fallback when the XRLayer cannot be displayed.
+
 		this.geometry = new PlaneGeometry(
 			this.params.layerWidth,
 			this.params.layerHeight
 		);
 
-		this.material = new MeshBasicMaterial( { opacity: 0 } );
+		this.material = new MeshBasicMaterial( {
+			map: this.params.texture,
+			opacity: 0
+		} );
 
 	}
 
 	makeXRLayer() {
 
 		this.session.requestReferenceSpace( 'local-floor' ).then( ( refSpace ) => {
-
-			this.params.cropX = this.params.widthPx / this.params.textureSizePx;
-			this.params.cropY = this.params.heightPx / this.params.textureSizePx;
 
 			const quadLayerConfig = {
 				width: .5 * this.params.layerWidth / this.params.cropX,
@@ -71,14 +86,16 @@ class XRLayerHelper extends Mesh {
 				viewPixelHeight: this.params.textureSizePx,
 				isStatic: true,
 				space: refSpace,
-				layout: "mono"
+				layout: this.params.layout
 			};
 
-			// quadLayerConfig.mipLevels = this.params.mipLevels;
+			if ( this.params.mipLevels ) {
+
+				quadLayerConfig.mipLevels = this.params.mipLevels;
+
+			}
 
 			this.XRLayer = this.glBinding.createQuadLayer( quadLayerConfig );
-
-			this.updateTransform();
 
 			this.session.updateRenderState( {
 				layers: [
@@ -95,6 +112,9 @@ class XRLayerHelper extends Mesh {
 	updateTransform() {
 
 		if ( this.XRLayer ) {
+
+			// we compare the current transforms of the mesh with its transforms
+			// the last time we updated the XRLayer transforms.
 
 			this.updateMatrixWorld();
 
@@ -134,18 +154,9 @@ class XRLayerHelper extends Mesh {
 
 			this.XRLayer = null;
 
-			// apply the texture on the mesh, to emulate the behavior
-			// of an XRLayer ( with lower resolution and performance )
-
-			// this.mesh.material = this.material;
-
 		} else {
 
 			if ( !this.XRLayer ) {
-
-				// if the current mode is XRLAYER_MODE and this.XRLayer
-				// is falsy, it means we need to create an XRLayer and
-				// reference it in this.XRLayer.
 
 				this.makeXRLayer();
 
@@ -170,7 +181,8 @@ class XRLayerHelper extends Mesh {
 		) {
 
 			// Copy images to layers as required.
-			// needsRedraw is set on creation or if the underlying GL resources of a layer are lost.
+			// needsRedraw is set on creation or if the underlying
+			// GL resources of a layer are lost.
 
 			const gl = this.renderer.getContext();
 
@@ -183,14 +195,20 @@ class XRLayerHelper extends Mesh {
 			gl.texSubImage2D(
 				gl.TEXTURE_2D,
 				0,
-				( this.params.textureSizePx - this.params.widthPx ) / 2,
-				( this.params.textureSizePx - this.params.heightPx ) / 2,
+				( this.params.textureSizePx - this.params.widthPx ) * 0.5,
+				( this.params.textureSizePx - this.params.heightPx ) * 0.5,
 				this.params.widthPx,
 				this.params.heightPx,
 				gl.RGBA,
 				gl.UNSIGNED_BYTE,
 				this.params.texture.image
 			);
+
+			if ( this.params.mipLevels ) {
+
+				gl.generateMipmap( gl.TEXTURE_2D );
+
+			}
 
 		}
 

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js vr - layers</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> XRLayer helper<br/>
+		</div>
+
+		<script type="module">
+
+			import * as THREE from '../build/three.module.js';
+			import { VRButton } from './jsm/webxr/VRButton.js';
+
+			const scene = new THREE.Scene();
+			const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );
+
+			const renderer = new THREE.WebGLRenderer();
+			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.xr.enabled = true;
+			document.body.appendChild( renderer.domElement );
+			document.body.appendChild( VRButton.createButton( renderer ) );
+
+			const geometry = new THREE.BoxGeometry();
+			const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
+			const cube = new THREE.Mesh( geometry, material );
+			scene.add( cube );
+
+			camera.position.z = 5;
+
+			renderer.setAnimationLoop( function () {
+
+				cube.rotation.x += 0.01;
+				cube.rotation.y += 0.01;
+
+				renderer.render( scene, camera );
+
+			} );
+
+		</script>
+	</body>
+</html>

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -27,17 +27,11 @@
 			const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );
 			camera.position.y = 1.6;
 
-			const renderer = new THREE.WebGLRenderer();
+			const renderer = new THREE.WebGLRenderer({ antialias: true });
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.xr.enabled = true;
 			document.body.appendChild( renderer.domElement );
 			document.body.appendChild( VRButton.createButton( renderer ) );
-
-			const geometry = new THREE.BoxGeometry();
-			const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
-			const cube = new THREE.Mesh( geometry, material );
-			cube.position.set( 0, 1.2, -2 );
-			scene.add( cube );
 
 			const room = new THREE.LineSegments(
 				new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ).translate( 0, 3, 0 ),
@@ -47,16 +41,22 @@
 
 			// XR LAYER
 
-			const layer = new XRLayerHelper( renderer );
+			const texture = new THREE.TextureLoader().load( "textures/snellen.png" );
+			const layerWidth = 1.3;
+			const layerHeight = 0.5;
 
-			console.log( layer )
+			const layer = new XRLayerHelper( renderer, texture, layerWidth, layerHeight );
+			scene.add( layer );
 
 			// RENDER LOOP
 
-			renderer.setAnimationLoop( function ( _, xrFrame ) {
+			renderer.setAnimationLoop( function ( time, xrFrame ) {
 
-				cube.rotation.x += 0.01;
-				cube.rotation.y += 0.01;
+				layer.position.set(
+					Math.sin( time * 0.001 ) * 0.5,
+					Math.cos( time * 0.001 ) * 0.5 + 1.4,
+					-2
+				);
 
 				layer.update( xrFrame );
 

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -49,10 +49,10 @@
 				mipLevels: 3,
 				layerWidth: 0.5,
 				layerHeight: 0.7,
-				//
 				textureSizePx: 512,
 				widthPx: 320,
-				heightPx: 450
+				heightPx: 450,
+				layout: "mono" // "stereo" for a stereoscopic image
 			}
 
 			const layer = new XRLayerHelper( renderer, params );

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -16,7 +16,10 @@
 
 			import * as THREE from '../build/three.module.js';
 			import { VRButton } from './jsm/webxr/VRButton.js';
+			import { XRLayerHelper } from './jsm/webxr/XRLayerHelper.js';
 			import { BoxLineGeometry } from './jsm/geometries/BoxLineGeometry.js';
+
+			// BASIC VR SCENE SETUP
 
 			const scene = new THREE.Scene();
 			scene.background = new THREE.Color( 0x505050 );
@@ -42,14 +45,34 @@
 			);
 			scene.add( room );
 
-			renderer.setAnimationLoop( function () {
+			// XR LAYER
+
+			const layer = new XRLayerHelper( renderer );
+
+			console.log( layer )
+
+			// RENDER LOOP
+
+			renderer.setAnimationLoop( function ( _, xrFrame ) {
 
 				cube.rotation.x += 0.01;
 				cube.rotation.y += 0.01;
 
+				layer.update( xrFrame );
+
 				renderer.render( scene, camera );
 
 			} );
+
+			// RESIZING
+
+			window.addEventListener( 'resize', onWindowResize );
+
+			function onWindowResize() {
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+				renderer.setSize( window.innerWidth, window.innerHeight );
+			}
 
 		</script>
 	</body>

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -41,11 +41,21 @@
 
 			// XR LAYER
 
-			const texture = new THREE.TextureLoader().load( "textures/snellen.png" );
-			const layerWidth = 1.3;
-			const layerHeight = 0.5;
+			const params = {
+				texture: new THREE.TextureLoader().load( "textures/snellen.png" ),
+				textureSize: 1024,
+				textureWidth: 1024,
+				textureHeight: 512,
+				mipLevels: 3,
+				layerWidth: 0.5,
+				layerHeight: 0.7,
+				//
+				textureSizePx: 512,
+				widthPx: 320,
+				heightPx: 450
+			}
 
-			const layer = new XRLayerHelper( renderer, texture, layerWidth, layerHeight );
+			const layer = new XRLayerHelper( renderer, params );
 			scene.add( layer );
 
 			// RENDER LOOP
@@ -57,6 +67,8 @@
 					Math.cos( time * 0.001 ) * 0.5 + 1.4,
 					-2
 				);
+
+				layer.rotation.x = Math.cos( time * 0.001 ) * 0.5;
 
 				layer.update( xrFrame );
 

--- a/examples/webxr_vr_layer_helper.html
+++ b/examples/webxr_vr_layer_helper.html
@@ -16,9 +16,13 @@
 
 			import * as THREE from '../build/three.module.js';
 			import { VRButton } from './jsm/webxr/VRButton.js';
+			import { BoxLineGeometry } from './jsm/geometries/BoxLineGeometry.js';
 
 			const scene = new THREE.Scene();
+			scene.background = new THREE.Color( 0x505050 );
+
 			const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );
+			camera.position.y = 1.6;
 
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -29,9 +33,14 @@
 			const geometry = new THREE.BoxGeometry();
 			const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
 			const cube = new THREE.Mesh( geometry, material );
+			cube.position.set( 0, 1.2, -2 );
 			scene.add( cube );
 
-			camera.position.z = 5;
+			const room = new THREE.LineSegments(
+				new BoxLineGeometry( 6, 6, 6, 10, 10, 10 ).translate( 0, 3, 0 ),
+				new THREE.LineBasicMaterial( { color: 0x808080 } )
+			);
+			scene.add( room );
 
 			renderer.setAnimationLoop( function () {
 


### PR DESCRIPTION
Following @mrdoob [suggestion on Twitter](https://twitter.com/mrdoob/status/1443125484854943745)

### The problem

The use of XRLayer as shown in [the XRLayer example](https://threejs.org/examples/#webxr_vr_layers) is very verbose.

### The solution

A helper class to make XRLayers with a few lines of code.
This class creates a plane mesh which is used either as a fallback if the XRLayer cannot be displayed, or as a depth mask if the XRLayer can be displayed.
`.update()` internally manage the update of the XRLayer transform based on the mesh's transforms.

https://raw.githack.com/felixmariotto/three.js/xrlayer/examples/index.html#webxr_vr_layer_helper

### Questions

- `XRLayerHelper` is not a very intuitive name, any better idea ?
- I want to add support for `XRCylinderLayer`, should this be done in the same module ?
