### PR TITLE
3MFLoader: fixed multiple build items refecering the same object bug

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1433,9 +1433,16 @@ class ThreeMFLoader extends Loader {
 				const buildItem = buildData[ i ];
 				const object3D = objects[ buildItem[ 'objectId' ] ].clone(true);
 
-				for(let j = 0; j < object3D.children.length; j++){
-					object3D.children[j].geometry = object3D.children[j].geometry.clone();
-				}
+				(function cloneGeometry(children){
+					for(let i = 0; i < children.length; i ++ ){
+						if(children[i] instanceof Mesh){
+							children[i].geometry = children[i].geometry.clone();
+						}
+						else{
+							cloneGeometry(children[i].children);
+						}
+					}
+				})(object3D.children)
 
 				// apply transform
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1431,7 +1431,7 @@ class ThreeMFLoader extends Loader {
 			for ( let i = 0; i < buildData.length; i ++ ) {
 
 				const buildItem = buildData[ i ];
-				const object3D = objects[ buildItem[ 'objectId' ] ].clone( true );
+				const object3D = objects[ buildItem[ 'objectId' ] ].clone();
 
 				// apply transform
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1431,7 +1431,11 @@ class ThreeMFLoader extends Loader {
 			for ( let i = 0; i < buildData.length; i ++ ) {
 
 				const buildItem = buildData[ i ];
-				const object3D = objects[ buildItem[ 'objectId' ] ];
+				const object3D = objects[ buildItem[ 'objectId' ] ].clone(true);
+
+				for(let j = 0; j < object3D.children.length; j++){
+					object3D.children[j].geometry = object3D.children[j].geometry.clone();
+				}
 
 				// apply transform
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1433,17 +1433,6 @@ class ThreeMFLoader extends Loader {
 				const buildItem = buildData[ i ];
 				const object3D = objects[ buildItem[ 'objectId' ] ].clone(true);
 
-				(function cloneGeometry(children){
-					for(let i = 0; i < children.length; i ++ ){
-						if(children[i] instanceof Mesh){
-							children[i].geometry = children[i].geometry.clone();
-						}
-						else{
-							cloneGeometry(children[i].children);
-						}
-					}
-				})(object3D.children)
-
 				// apply transform
 
 				const transform = buildItem[ 'transform' ];

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1431,7 +1431,7 @@ class ThreeMFLoader extends Loader {
 			for ( let i = 0; i < buildData.length; i ++ ) {
 
 				const buildItem = buildData[ i ];
-				const object3D = objects[ buildItem[ 'objectId' ] ].clone(true);
+				const object3D = objects[ buildItem[ 'objectId' ] ].clone( true );
 
 				// apply transform
 


### PR DESCRIPTION
Multiple build items that reference the same resource object were being ignored as they referenced the same Object3d object. Also the build items meshes were using the same BufferGeometry's reference.