### PR TITLE
WebGPURenderPipeline: Use attributes location defined by NodeMaterial

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
@@ -32,7 +32,7 @@ class WebGPURenderPipeline {
 
 		// determine shader attributes
 
-		const shaderAttributes = this._parseShaderAttributes( nodeBuilder.vertexShader, geometry );
+		const shaderAttributes = this._getShaderAttributes( nodeBuilder, geometry );
 
 		// vertex buffers
 
@@ -701,42 +701,34 @@ class WebGPURenderPipeline {
 
 	}
 
-	_parseShaderAttributes( shader, geometry ) {
-
-		// find "layout (location = num) in type name" in vertex shader
-
-		const regex = /\s*layout\s*\(\s*location\s*=\s*(?<location>[0-9]+)\s*\)\s*in\s+(?<type>\w+)\s+(?<name>\w+)\s*;/gmi;
-		let shaderAttribute = null;
+	_getShaderAttributes( nodeBuilder, geometry ) {
 
 		const attributes = [];
+		const nodeAttributes = nodeBuilder.attributes;
 
-		while ( shaderAttribute = regex.exec( shader ) ) {
+		for ( let slot = 0; slot < nodeAttributes.length; slot++ ) {
 
-			const name = shaderAttribute.groups.name;
+			const attribute = nodeAttributes[ slot ];
+
+			const name = attribute.name;
+			const type = attribute.type;
 
 			const geometryAttribute = geometry.getAttribute( name );
 			const bytesPerElement = ( geometryAttribute !== undefined ) ? geometryAttribute.array.BYTES_PER_ELEMENT : 4;
 
-			const shaderLocation = parseInt( shaderAttribute.groups.location );
-			const arrayStride = this._getArrayStride( shaderAttribute.groups.type, bytesPerElement );
-			const vertexFormat = this._getVertexFormat( shaderAttribute.groups.type, bytesPerElement );
+			const arrayStride = this._getArrayStride( type, bytesPerElement );
+			const format = this._getVertexFormat( type, bytesPerElement );
 
 			attributes.push( {
-				name: name,
-				arrayStride: arrayStride,
-				slot: shaderLocation,
-				format: vertexFormat
+				name,
+				arrayStride,
+				format,
+				slot
 			} );
 
 		}
 
-		// the sort ensures to setup vertex buffers in the correct order
-
-		return attributes.sort( function ( a, b ) {
-
-			return a.slot - b.slot;
-
-		} );
+		return attributes;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
@@ -703,15 +703,15 @@ class WebGPURenderPipeline {
 
 	_getShaderAttributes( nodeBuilder, geometry ) {
 
-		const attributes = [];
 		const nodeAttributes = nodeBuilder.attributes;
+		const attributes = [];
 
 		for ( let slot = 0; slot < nodeAttributes.length; slot++ ) {
 
-			const attribute = nodeAttributes[ slot ];
+			const nodeAttribute = nodeAttributes[ slot ];
 
-			const name = attribute.name;
-			const type = attribute.type;
+			const name = nodeAttribute.name;
+			const type = nodeAttribute.type;
 
 			const geometryAttribute = geometry.getAttribute( name );
 			const bytesPerElement = ( geometryAttribute !== undefined ) ? geometryAttribute.array.BYTES_PER_ELEMENT : 4;


### PR DESCRIPTION
**Description**

Replace GLSL parser to NodeMaterial generate order.
It optimizes and is part of the WGSL integration.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
