### PR TITLE
SharderLib: Fixed uniforms.specularMap.value error.

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -311,6 +311,7 @@ ShaderLib.physical = {
 			specularIntensityMap: { value: null },
 			specularTint: { value: new Color( 1, 1, 1 ) },
 			specularTintMap: { value: null },
+			specularMap: { value: null },
 		}
 	] ),
 


### PR DESCRIPTION
Related issue: #---

**Description**

1. Loaded a .glb file with `specularMap` in `Editor` .
2.  `F5` refresh `Editor` page or click `Play` button.
3.  An error occurred `Uncaught TypeError: Cannot set properties of undefined (setting 'value')` in brower devtool.

Error Screenshot:

![image](https://user-images.githubusercontent.com/23699926/136794595-bbf01e0c-0538-4b48-9242-3780327ccc1e.png)



