### PR TITLE
Make icon repsonsive to color scheme preference

### DIFF
--- a/files/icon.svg
+++ b/files/icon.svg
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg fill="none" stroke-linecap="square" stroke-miterlimit="10" version="1.1" viewBox="0 0 226.77 226.77" xmlns="http://www.w3.org/2000/svg">
- <g transform="translate(8.964 4.2527)" fill-rule="evenodd" stroke="#000" stroke-linecap="butt" stroke-linejoin="round" stroke-width="4">
+ <style>
+   .lines { stroke: #000; }
+   @media (prefers-color-scheme: dark) {
+    .lines { stroke: #DDD; }
+   }
+ </style>
+ <g transform="translate(8.964 4.2527)" fill-rule="evenodd" class="lines" stroke-linecap="butt" stroke-linejoin="round" stroke-width="4">
   <path d="m63.02 200.61-43.213-174.94 173.23 49.874z"/>
   <path d="m106.39 50.612 21.591 87.496-86.567-24.945z"/>
   <path d="m84.91 125.03-10.724-43.465 43.008 12.346z"/>


### PR DESCRIPTION
I'm not sure if you want this or not but it will make the icon responsive to the user's color preference.

I chose `#DDD` instead of `#FFF` because if the page didn't set a body/html background color the page will be white and the icon will then be white on white.