### PR TITLE
ColladaLoader: Set material opacity when transparent.opaque is null or undefined

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -1735,6 +1735,7 @@ class ColladaLoader extends Loader {
 							material.opacity = color[ 0 ] * transparency.float;
 							break;
 						default:
+							material.opacity = 1 - transparency.float;
 							console.warn( 'THREE.ColladaLoader: Invalid opaque type "%s" of transparent tag.', transparent.opaque );
 
 					}


### PR DESCRIPTION
**Description**

In the case when transoarent.opaque is null or undefined, we should modify the material opacity.
Some old collad files don't have opaque value.
