### PR TITLE
docs: fix redirect condition for *BufferGeometry

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@
 
 			// *BufferGeometry to *Geometry
 
-			if ( /Instanced/.exec( window.location.hash ) !== null && /([\w]+)BufferGeometry$/.exec( window.location.hash ) ) {
+			if ( /Instanced/.exec( window.location.hash ) === null && /([\w]+)BufferGeometry$/.exec( window.location.hash ) ) {
 
 				window.location.hash = window.location.hash.replace( 'BufferGeometry', 'Geometry' );
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

The original condition added in #22153 looks like that it intended not to match `InstancedBufferGeometry`.
However, the current condition looks inverted.