### PR TITLE
GLTFLoader: Allow sharing textures between GLTF objects

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -214,6 +214,11 @@
 		[page:KTX2Loader ktx2Loader] — Instance of THREE.KTX2Loader, to be used for loading KTX2 compressed textures.
 		</p>
 
+		<h3>[method:null setTextureCache]( [param:GLTFTextureCache textureCache] )</h3>
+		<p>
+		[page:GLTFTextureCache textureCache] — Instance of THREE.GLTFTextureCache, to be used for caching textures.
+		</p>
+
 		<h3>[method:null parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />

--- a/docs/examples/en/loaders/GLTFTextureCache.html
+++ b/docs/examples/en/loaders/GLTFTextureCache.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:Loader] &rarr;
+
+		<h1>[name]</h1>
+		<p class="desc"> A texture cache interface for GLTF files.</p>
+
+    The simplest way to implement this is to just use a Javascript Map object.
+
+    <h2>Methods</h2>
+    <h3>[method:null set]( [param:string key] [param:Promise&lt;Texture&gt; texturePromise] )</h3>
+		<p>
+    [key] - unique string for texture
+		[page:Texture texture] — Instance of Promise&lt;THREE.Texture&gt;
+		</p>
+
+    <h3>[method:Promise&lt;Texture&gt; get]( [param:string key] )</h3>
+		<p>
+    [key] - unique string for texture
+		Returns instance of Promise&lt;THREE.Texture&gt;
+		</p>
+  </body>
+</html>

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -73,6 +73,7 @@ class GLTFLoader extends Loader {
 		this.dracoLoader = null;
 		this.ktx2Loader = null;
 		this.meshoptDecoder = null;
+		this.textureCache = null;
 
 		this.pluginCallbacks = [];
 
@@ -234,6 +235,13 @@ class GLTFLoader extends Loader {
 
 	}
 
+	setTextureCache( textureCache ) {
+
+		this.textureCache = textureCache;
+		return this;
+
+	}
+
 	register( callback ) {
 
 		if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
@@ -311,8 +319,8 @@ class GLTFLoader extends Loader {
 			requestHeader: this.requestHeader,
 			manager: this.manager,
 			ktx2Loader: this.ktx2Loader,
-			meshoptDecoder: this.meshoptDecoder
-
+			meshoptDecoder: this.meshoptDecoder,
+			textureCache: this.textureCache
 		} );
 
 		parser.fileLoader.setRequestHeader( this.requestHeader );
@@ -2181,7 +2189,7 @@ class GLTFParser {
 		this.cameraCache = { refs: {}, uses: {} };
 		this.lightCache = { refs: {}, uses: {} };
 
-		this.textureCache = {};
+		this.textureCache = options.textureCache || new Map();
 
 		// Track node names, to ensure no duplicates
 		this.nodeNamesUsed = {};
@@ -2770,10 +2778,10 @@ class GLTFParser {
 
 		const cacheKey = ( source.uri || source.bufferView ) + ':' + textureDef.sampler;
 
-		if ( this.textureCache[ cacheKey ] ) {
+		if ( this.textureCache.get( cacheKey ) ) {
 
 			// See https://github.com/mrdoob/three.js/issues/21559.
-			return this.textureCache[ cacheKey ];
+			return this.textureCache.get( cacheKey );
 
 		}
 
@@ -2857,7 +2865,7 @@ class GLTFParser {
 
 		} );
 
-		this.textureCache[ cacheKey ] = promise;
+		this.textureCache.set( cacheKey, promise );
 
 		return promise;
 


### PR DESCRIPTION
**Description**

We have a situation where we load quite a few GLB files that all reference the same ktx2 encoded external texture.  Even though the network request is normally cached, we do get slowdowns during decode and the texture itself is duplicated when it doesn't need to be.  This PR piggybacks on a [previous change](https://github.com/mrdoob/three.js/commit/c4002a6004dd88070b8dac7740020c9f169f27e9) by @donmccurdy that did the same thing within a single GLB/GLTF file.

I'm currently using this change like so:
```
  const textureCache = new Map<string, Promise<Texture>>();
  loader.setTextureCache = ({
    get: (key: string) => textureCache.get(key),
    set: (key: string, tex: Promise<Texture>) => {
      textureCache.set(key, tex);
      tex.then(loadedTex => {
        loadedTex.addEventListener('dispose', () => {
          textureCache.delete(key);
        });
      });
    },
  });
```

Seems like an opt-in strategy was best, so applications could choose their own caching strategies.  (Maybe an app knows a texture is unique and to not bother caching it for example)

