### PR TITLE
Texture: Add userData.

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -257,6 +257,11 @@
 		Set this to *true* to trigger an update next time the texture is used. Particularly important for setting the wrap mode.
 		</p>
 
+		<h3>[property:Object userData]</h3>
+		<p>
+		An object that can be used to store custom data about the texture. It should not hold
+		references to functions as these will not be cloned.
+		</p>
 
 		<h2>Methods</h2>
 

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -256,6 +256,11 @@
 			这对于设置包裹模式尤其重要。
 		</p>
 
+		<h3>[property:Object userData]</h3>
+		<p>
+		An object that can be used to store custom data about the texture. It should not hold
+		references to functions as these will not be cloned.
+		</p>
 
 		<h2>方法</h2>
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -696,6 +696,8 @@ class ObjectLoader extends Loader {
 				if ( data.premultiplyAlpha !== undefined ) texture.premultiplyAlpha = data.premultiplyAlpha;
 				if ( data.unpackAlignment !== undefined ) texture.unpackAlignment = data.unpackAlignment;
 
+				if ( data.userData !== undefined ) texture.userData = data.userData;
+
 				textures[ data.uuid ] = texture;
 
 			}

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -65,6 +65,8 @@ class Texture extends EventDispatcher {
 		// update. You need to explicitly call Material.needsUpdate to trigger it to recompile.
 		this.encoding = encoding;
 
+		this.userData = {};
+
 		this.version = 0;
 		this.onUpdate = null;
 
@@ -118,6 +120,8 @@ class Texture extends EventDispatcher {
 		this.flipY = source.flipY;
 		this.unpackAlignment = source.unpackAlignment;
 		this.encoding = source.encoding;
+
+		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
 		return this;
 
@@ -224,6 +228,8 @@ class Texture extends EventDispatcher {
 			output.image = image.uuid;
 
 		}
+
+		if ( JSON.stringify( this.userData ) !== '{}' ) output.userData = this.userData;
 
 		if ( ! isRootObject ) {
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/texture-has-no-userdata/27813

**Description**

This was requested at the forum. Since materials, geometries and 3D objects have a `userData` property, it seems appropriate to add it for textures, too.