### PR TITLE
LoaderUtils: Add resolveURL().

### DIFF
--- a/docs/api/en/loaders/LoaderUtils.html
+++ b/docs/api/en/loaders/LoaderUtils.html
@@ -30,6 +30,16 @@
 		</p>
 
 
+		<h3>[method:String resolveURL]( [param:String url], [param:String path]  )</h3>
+		<p>
+		[page:String url] —  The absolute or relative url resolve.
+		[page:String path] —  The base path for relative urls to be resolved against.
+		</p>
+		<p>
+		Resolves relative urls against the given path. Absolute paths, data urls, and blob urls will be returned as is. Invalid urls will return an empty string.
+		</p>
+
+
 		<h2>Source</h2>
 
 		<p>

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1958,34 +1958,6 @@ const ALPHA_MODES = {
 	BLEND: 'BLEND'
 };
 
-/* UTILITY FUNCTIONS */
-
-function resolveURL( url, path ) {
-
-	// Invalid URL
-	if ( typeof url !== 'string' || url === '' ) return '';
-
-	// Host Relative URL
-	if ( /^https?:\/\//i.test( path ) && /^\//.test( url ) ) {
-
-		path = path.replace( /(^https?:\/\/[^\/]+).*/i, '$1' );
-
-	}
-
-	// Absolute URL http://,https://,//
-	if ( /^(https?:)?\/\//i.test( url ) ) return url;
-
-	// Data URI
-	if ( /^data:.*,.*$/i.test( url ) ) return url;
-
-	// Blob URL
-	if ( /^blob:.*$/i.test( url ) ) return url;
-
-	// Relative URL
-	return path + url;
-
-}
-
 /**
  * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#default-material
  */
@@ -2625,6 +2597,7 @@ class GLTFParser {
 	 */
 	loadBuffer( bufferIndex ) {
 
+		const parser = this;
 		const bufferDef = this.json.buffers[ bufferIndex ];
 		const loader = this.fileLoader;
 
@@ -2645,7 +2618,7 @@ class GLTFParser {
 
 		return new Promise( function ( resolve, reject ) {
 
-			loader.load( resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
+			loader.load( parser.resolveURL( bufferDef.uri ), resolve, undefined, function () {
 
 				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
@@ -2891,7 +2864,7 @@ class GLTFParser {
 
 				}
 
-				loader.load( resolveURL( sourceURI, options.path ), onLoad, undefined, reject );
+				loader.load( parser.resolveURL( sourceURI ), onLoad, undefined, reject );
 
 			} );
 
@@ -3983,6 +3956,34 @@ class GLTFParser {
 			return scene;
 
 		} );
+
+	}
+
+	resolveURL( url ) {
+
+		const path = this.options.path;
+
+		// Invalid URL
+		if ( typeof url !== 'string' || url === '' ) return '';
+
+		// Host Relative URL
+		if ( /^https?:\/\//i.test( path ) && /^\//.test( url ) ) {
+
+			path = path.replace( /(^https?:\/\/[^\/]+).*/i, '$1' );
+
+		}
+
+		// Absolute URL http://,https://,//
+		if ( /^(https?:)?\/\//i.test( url ) ) return url;
+
+		// Data URI
+		if ( /^data:.*,.*$/i.test( url ) ) return url;
+
+		// Blob URL
+		if ( /^blob:.*$/i.test( url ) ) return url;
+
+		// Relative URL
+		return path + url;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2597,7 +2597,6 @@ class GLTFParser {
 	 */
 	loadBuffer( bufferIndex ) {
 
-		const parser = this;
 		const bufferDef = this.json.buffers[ bufferIndex ];
 		const loader = this.fileLoader;
 
@@ -2618,7 +2617,7 @@ class GLTFParser {
 
 		return new Promise( function ( resolve, reject ) {
 
-			loader.load( LoaderUtils.resolveURL( bufferDef.uri, parser.options.path ), resolve, undefined, function () {
+			loader.load( LoaderUtils.resolveURL( bufferDef.uri, options.path ), resolve, undefined, function () {
 
 				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
@@ -2864,7 +2863,7 @@ class GLTFParser {
 
 				}
 
-				loader.load( LoaderUtils.resolveURL( sourceURI, parser.options.path ), onLoad, undefined, reject );
+				loader.load( LoaderUtils.resolveURL( sourceURI, options.path ), onLoad, undefined, reject );
 
 			} );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2618,7 +2618,7 @@ class GLTFParser {
 
 		return new Promise( function ( resolve, reject ) {
 
-			loader.load( parser.resolveURL( bufferDef.uri ), resolve, undefined, function () {
+			loader.load( LoaderUtils.resolveURL( bufferDef.uri, parser.options.path ), resolve, undefined, function () {
 
 				reject( new Error( 'THREE.GLTFLoader: Failed to load buffer "' + bufferDef.uri + '".' ) );
 
@@ -2864,7 +2864,7 @@ class GLTFParser {
 
 				}
 
-				loader.load( parser.resolveURL( sourceURI ), onLoad, undefined, reject );
+				loader.load( LoaderUtils.resolveURL( sourceURI, parser.options.path ), onLoad, undefined, reject );
 
 			} );
 
@@ -3956,34 +3956,6 @@ class GLTFParser {
 			return scene;
 
 		} );
-
-	}
-
-	resolveURL( url ) {
-
-		const path = this.options.path;
-
-		// Invalid URL
-		if ( typeof url !== 'string' || url === '' ) return '';
-
-		// Host Relative URL
-		if ( /^https?:\/\//i.test( path ) && /^\//.test( url ) ) {
-
-			path = path.replace( /(^https?:\/\/[^\/]+).*/i, '$1' );
-
-		}
-
-		// Absolute URL http://,https://,//
-		if ( /^(https?:)?\/\//i.test( url ) ) return url;
-
-		// Data URI
-		if ( /^data:.*,.*$/i.test( url ) ) return url;
-
-		// Blob URL
-		if ( /^blob:.*$/i.test( url ) ) return url;
-
-		// Relative URL
-		return path + url;
 
 	}
 

--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -44,6 +44,32 @@ class LoaderUtils {
 
 	}
 
+	static resolveURL( url, path ) {
+
+		// Invalid URL
+		if ( typeof url !== 'string' || url === '' ) return '';
+
+		// Host Relative URL
+		if ( /^https?:\/\//i.test( path ) && /^\//.test( url ) ) {
+
+			path = path.replace( /(^https?:\/\/[^\/]+).*/i, '$1' );
+
+		}
+
+		// Absolute URL http://,https://,//
+		if ( /^(https?:)?\/\//i.test( url ) ) return url;
+
+		// Data URI
+		if ( /^data:.*,.*$/i.test( url ) ) return url;
+
+		// Blob URL
+		if ( /^blob:.*$/i.test( url ) ) return url;
+
+		// Relative URL
+		return path + url;
+
+	}
+
 }
 
 export { LoaderUtils };


### PR DESCRIPTION
**Description**

This PR exposes the `resolveURL` function on the `GLTFParser` class. This makes it easier to reuse this code in GLTFLoader plugins for loading assets that use relative uris.

For example in [three-omi](https://github.com/omigroup/three-omi/blob/main/src/loader/OMI_audio_emitter.ts#L69) I've copied the function into our codebase rather than reusing the three.js implementation.
