### PR TITLE
WebGLShadowMap: Make VSM samples a define.

### DIFF
--- a/src/renderers/shaders/ShaderLib/vsm.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm.glsl.js
@@ -10,11 +10,12 @@ export const fragment = /* glsl */`
 uniform sampler2D shadow_pass;
 uniform vec2 resolution;
 uniform float radius;
-uniform float samples;
 
 #include <packing>
 
 void main() {
+
+	const float samples = float( VSM_SAMPLES );
 
 	float mean = 0.0;
 	float squared_mean = 0.0;

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -31,12 +31,13 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 	const shadowSide = { 0: BackSide, 1: FrontSide, 2: DoubleSide };
 
 	const shadowMaterialVertical = new ShaderMaterial( {
-
+		defines: {
+			VSM_SAMPLES: 8
+		},
 		uniforms: {
 			shadow_pass: { value: null },
 			resolution: { value: new Vector2() },
-			radius: { value: 4.0 },
-			samples: { value: 8.0 }
+			radius: { value: 4.0 }
 		},
 
 		vertexShader: vsm.vertex,
@@ -202,12 +203,21 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		const geometry = _objects.update( fullScreenMesh );
 
+		if ( shadowMaterialVertical.defines.VSM_SAMPLES !== shadow.blurSamples ) {
+
+			shadowMaterialVertical.defines.VSM_SAMPLES = shadow.blurSamples;
+			shadowMaterialHorizontal.defines.VSM_SAMPLES = shadow.blurSamples;
+
+			shadowMaterialVertical.needsUpdate = true;
+			shadowMaterialHorizontal.needsUpdate = true;
+
+		}
+
 		// vertical pass
 
 		shadowMaterialVertical.uniforms.shadow_pass.value = shadow.map.texture;
 		shadowMaterialVertical.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialVertical.uniforms.radius.value = shadow.radius;
-		shadowMaterialVertical.uniforms.samples.value = shadow.blurSamples;
 		_renderer.setRenderTarget( shadow.mapPass );
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
@@ -217,7 +227,6 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		shadowMaterialHorizontal.uniforms.shadow_pass.value = shadow.mapPass.texture;
 		shadowMaterialHorizontal.uniforms.resolution.value = shadow.mapSize;
 		shadowMaterialHorizontal.uniforms.radius.value = shadow.radius;
-		shadowMaterialHorizontal.uniforms.samples.value = shadow.blurSamples;
 		_renderer.setRenderTarget( shadow.map );
 		_renderer.clear();
 		_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialHorizontal, fullScreenMesh, null );


### PR DESCRIPTION
Related issue: Fixed #22690.

**Description**

Makes the `samples` uniform of the VSM shader to a define in order to avoid a GLSL compilation error.
