### PR TITLE
ArcballControls: Expose raycaster.

### DIFF
--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -189,6 +189,11 @@
 			Maximum angular velocity allowed on rotation animation start.
 		</p>
 
+		<h3>[property:Raycaster raycaster]</h3>
+		<p>
+			The raycaster used to intersect objects for focusing.
+		</p>
+
 
 		<h2>Methods</h2>
 

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -189,11 +189,6 @@
 			Maximum angular velocity allowed on rotation animation start.
 		</p>
 
-		<h3>[property:Raycaster raycaster]</h3>
-		<p>
-			The raycaster used to intersect objects for focusing.
-		</p>
-
 
 		<h2>Methods</h2>
 
@@ -260,6 +255,14 @@
 		<h3>[method:null update] ()</h3>
 		<p>
 			Update the controls. Must be called after any manual changes to the camera's transform.
+		</p>
+		
+		<h3>[method:Raycaster getRaycaster] ()</h3>
+		<p>
+			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of
+			ArcballControls. If you set the [page:Object3D.layers .layers] property of the [name], you will also want to
+			set the [page:Raycaster.layers .layers] property on the [page:Raycaster] with a matching value, or else the [name]
+			won't work as expected.
 		</p>
 
 		<h2>Source</h2>

--- a/examples/js/controls/ArcballControls.js
+++ b/examples/js/controls/ArcballControls.js
@@ -2323,11 +2323,10 @@
 
 			this.unprojectOnObj = ( cursor, camera ) => {
 
-				const raycaster = new THREE.Raycaster();
-				raycaster.near = camera.near;
-				raycaster.far = camera.far;
-				raycaster.setFromCamera( cursor, camera );
-				const intersect = raycaster.intersectObjects( this.scene.children, true );
+				this.raycaster.near = camera.near;
+				this.raycaster.far = camera.far;
+				this.raycaster.setFromCamera( cursor, camera );
+				const intersect = this.raycaster.intersectObjects( this.scene.children, true );
 
 				for ( let i = 0; i < intersect.length; i ++ ) {
 
@@ -2681,6 +2680,7 @@
 			this.domElement = domElement;
 			this.scene = scene;
 			this.target = new THREE.Vector3( 0, 0, 0 );
+			this.raycaster = new Raycaster();
 			this.mouseActions = [];
 			this._mouseOp = null; //global vectors and matrices that are used in some operations to avoid creating new objects every time (e.g. every time cursor moves)
 

--- a/examples/js/controls/ArcballControls.js
+++ b/examples/js/controls/ArcballControls.js
@@ -40,6 +40,8 @@
 	const _endEvent = {
 		type: 'end'
 	};
+	
+	const _raycaster = new THREE.Raycaster();
 	/**
  *
  * @param {Camera} camera Virtual camera used in the scene
@@ -2321,12 +2323,19 @@
 
 			};
 
+			this.getRaycaster = () => {
+
+				return _raycaster;
+	
+			};
+
 			this.unprojectOnObj = ( cursor, camera ) => {
 
-				this.raycaster.near = camera.near;
-				this.raycaster.far = camera.far;
-				this.raycaster.setFromCamera( cursor, camera );
-				const intersect = this.raycaster.intersectObjects( this.scene.children, true );
+				const raycaster = this.getRaycaster();
+				raycaster.near = camera.near;
+				raycaster.far = camera.far;
+				raycaster.setFromCamera( cursor, camera );
+				const intersect = raycaster.intersectObjects( this.scene.children, true );
 
 				for ( let i = 0; i < intersect.length; i ++ ) {
 
@@ -2680,7 +2689,6 @@
 			this.domElement = domElement;
 			this.scene = scene;
 			this.target = new THREE.Vector3( 0, 0, 0 );
-			this.raycaster = new Raycaster();
 			this.mouseActions = [];
 			this._mouseOp = null; //global vectors and matrices that are used in some operations to avoid creating new objects every time (e.g. every time cursor moves)
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -64,6 +64,8 @@ const _changeEvent = { type: 'change' };
 const _startEvent = { type: 'start' };
 const _endEvent = { type: 'end' };
 
+const _raycaster = new Raycaster();
+
 
 /**
  *
@@ -80,7 +82,6 @@ class ArcballControls extends Object3D {
 		this.domElement = domElement;
 		this.scene = scene;
 		this.target = new Vector3( 0, 0, 0 );
-		this.raycaster = new Raycaster();
 
 		this.mouseActions = [];
 		this._mouseOp = null;
@@ -2809,6 +2810,13 @@ class ArcballControls extends Object3D {
 
 	};
 
+	
+	getRaycaster() {
+
+		return _raycaster;
+
+	}
+
 
 	/**
 	 * Unproject the cursor on the 3D object surface
@@ -2818,11 +2826,12 @@ class ArcballControls extends Object3D {
 	 */
 	unprojectOnObj = ( cursor, camera ) => {
 
-		this.raycaster.near = camera.near;
-		this.raycaster.far = camera.far;
-		this.raycaster.setFromCamera( cursor, camera );
+		const raycaster = this.getRaycaster();
+		raycaster.near = camera.near;
+		raycaster.far = camera.far;
+		raycaster.setFromCamera( cursor, camera );
 
-		const intersect = this.raycaster.intersectObjects( this.scene.children, true );
+		const intersect = raycaster.intersectObjects( this.scene.children, true );
 
 		for ( let i = 0; i < intersect.length; i ++ ) {
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -80,6 +80,7 @@ class ArcballControls extends Object3D {
 		this.domElement = domElement;
 		this.scene = scene;
 		this.target = new Vector3( 0, 0, 0 );
+		this.raycaster = new Raycaster();
 
 		this.mouseActions = [];
 		this._mouseOp = null;
@@ -2817,12 +2818,11 @@ class ArcballControls extends Object3D {
 	 */
 	unprojectOnObj = ( cursor, camera ) => {
 
-		const raycaster = new Raycaster();
-		raycaster.near = camera.near;
-		raycaster.far = camera.far;
-		raycaster.setFromCamera( cursor, camera );
+		this.raycaster.near = camera.near;
+		this.raycaster.far = camera.far;
+		this.raycaster.setFromCamera( cursor, camera );
 
-		const intersect = raycaster.intersectObjects( this.scene.children, true );
+		const intersect = this.raycaster.intersectObjects( this.scene.children, true );
 
 		for ( let i = 0; i < intersect.length; i ++ ) {
 


### PR DESCRIPTION
**Description**

This allows users to use their own raycaster (that has for example certain layers enabled/disabled). Since `unprojectOnObj` is used for the double click to focus functionality, passing in your own raycaster is useful if you want the double click to focus functionality also to work on objects that are in different layers.
