### PR TITLE
ArcballControls: Allow setting the gizmos radius factor

### DIFF
--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -189,6 +189,11 @@
 			Maximum angular velocity allowed on rotation animation start.
 		</p>
 
+		<h3>[property:Float radiusFactor]</h3>
+		<p>
+			The size of the gizmo relative to the screen width and height. Default is 0.67.
+		</p>
+
 
 		<h2>Methods</h2>
 

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -237,6 +237,11 @@
 			Set the visible property of gizmos.
 		</p>
 
+		<h3>[method:null setTbRadius] ( [param:Float value] )</h3>
+		<p>
+			Update the `radiusFactor` value, redraw the gizmo and send a `changeEvent` to visualise the changes.
+		</p>
+
 		<h3>[method:Boolean setMouseAction] ( [param:String operation], mouse, key )</h3>
 		<p>
 			Set a new mouse action by specifying the operation to be performed and a mouse/key combination. In case of conflict, replaces the existing one.<br><br>

--- a/examples/js/controls/ArcballControls.js
+++ b/examples/js/controls/ArcballControls.js
@@ -1591,7 +1591,6 @@
 
 			this.calculateTbRadius = camera => {
 
-				const factor = 0.67;
 				const distance = camera.position.distanceTo( this._gizmos.position );
 
 				if ( camera.type == 'PerspectiveCamera' ) {
@@ -1600,11 +1599,11 @@
 
 					const halfFovH = Math.atan( camera.aspect * Math.tan( halfFovV ) ); //horizontal fov/2 in radians
 
-					return Math.tan( Math.min( halfFovV, halfFovH ) ) * distance * factor;
+					return Math.tan( Math.min( halfFovV, halfFovH ) ) * distance * this.radiusFactor;
 
 				} else if ( camera.type == 'OrthographicCamera' ) {
 
-					return Math.min( camera.top, camera.right ) * factor;
+					return Math.min( camera.top, camera.right ) * this.radiusFactor;
 
 				}
 
@@ -2681,6 +2680,7 @@
 			this.domElement = domElement;
 			this.scene = scene;
 			this.target = new THREE.Vector3( 0, 0, 0 );
+			this.radiusFactor = 0.67;
 			this.mouseActions = [];
 			this._mouseOp = null; //global vectors and matrices that are used in some operations to avoid creating new objects every time (e.g. every time cursor moves)
 

--- a/examples/js/controls/ArcballControls.js
+++ b/examples/js/controls/ArcballControls.js
@@ -2929,6 +2929,33 @@
 			this.dispatchEvent( _changeEvent );
 
 		}
+
+		
+		/**
+   * Set gizmos radius factor and redraws gizmos
+   * @param {Float} value Value of radius factor
+   */
+		setTbRadius( value ) {
+
+			this.radiusFactor = value;
+			this._tbRadius = this.calculateTbRadius( this.camera );
+
+			const curve = new EllipseCurve( 0, 0, this._tbRadius, this._tbRadius );
+			const points = curve.getPoints( this._curvePts );
+			const curveGeometry = new BufferGeometry().setFromPoints( points );
+
+
+			for ( const gizmo in this._gizmos.children ) {
+
+				this._gizmos.children[ gizmo ].geometry = curveGeometry;
+
+			}
+
+			this.dispatchEvent( _changeEvent );
+
+		}
+
+
 		/**
    * Creates the rotation gizmos matching trackball center and radius
    * @param {Vector3} tbCenter The trackball center

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -2242,6 +2242,30 @@ class ArcballControls extends Object3D {
 	}
 
 	/**
+	 * Set gizmos radius factor and redraws gizmos
+	 * @param {Float} value Value of radius factor
+	 */
+	setTbRadius( value ) {
+
+		this.radiusFactor = value;
+		this._tbRadius = this.calculateTbRadius( this.camera );
+
+		const curve = new EllipseCurve( 0, 0, this._tbRadius, this._tbRadius );
+		const points = curve.getPoints( this._curvePts );
+		const curveGeometry = new BufferGeometry().setFromPoints( points );
+
+
+		for ( const gizmo in this._gizmos.children ) {
+
+			this._gizmos.children[ gizmo ].geometry = curveGeometry;
+
+		}
+
+		this.dispatchEvent( _changeEvent );
+
+	}
+
+	/**
 	 * Creates the rotation gizmos matching trackball center and radius
 	 * @param {Vector3} tbCenter The trackball center
 	 * @param {number} tbRadius The trackball radius

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -80,6 +80,7 @@ class ArcballControls extends Object3D {
 		this.domElement = domElement;
 		this.scene = scene;
 		this.target = new Vector3( 0, 0, 0 );
+		this.radiusFactor = 0.67;
 
 		this.mouseActions = [];
 		this._mouseOp = null;
@@ -1974,18 +1975,17 @@ class ArcballControls extends Object3D {
 	 */
 	calculateTbRadius = ( camera ) => {
 
-		const factor = 0.67;
 		const distance = camera.position.distanceTo( this._gizmos.position );
 
 		if ( camera.type == 'PerspectiveCamera' ) {
 
 			const halfFovV = MathUtils.DEG2RAD * camera.fov * 0.5; //vertical fov/2 in radians
 			const halfFovH = Math.atan( ( camera.aspect ) * Math.tan( halfFovV ) ); //horizontal fov/2 in radians
-			return Math.tan( Math.min( halfFovV, halfFovH ) ) * distance * factor;
+			return Math.tan( Math.min( halfFovV, halfFovH ) ) * distance * this.radiusFactor;
 
 		} else if ( camera.type == 'OrthographicCamera' ) {
 
-			return Math.min( camera.top, camera.right ) * factor;
+			return Math.min( camera.top, camera.right ) * this.radiusFactor;
 
 		}
 


### PR DESCRIPTION
**Description**

I would like to be able to set the gizmos radius factor. Currently the only way to do this is to extend the `ArcballControls` and overwrite the `calculateTbRadius` function, but I think it would be cleaner to have a way of setting it as a property.

@danielefornari let me know if you are happy with this (thanks for your great work on ArcballControls!) :)