### PR TITLE
Expose transmission texture creation to enable improved quality

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -576,7 +576,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		return _transmissionRenderTarget;
 
-	}
+	};
 
 	//
 


### PR DESCRIPTION
Related issues: #22729 #22009

**Description**

Currently the transmission render target can have quality issues because:
- its dimensions are uncoupled from the current viewport (fixed to 1024x1024), leading to asymmetrical warping
- it uses NearestFilter for magnification, leading to aliasing artefacts

A fix for the dimension issue isn't trivial because in WebGL1 power of two dimensions are required for mipmap sampling. Additionally if multiple passes use different viewports, we require different dimensions of transmission targets. While is possible to fully resolve these issues, the resolutions introduce complexity

In the PR I've moved creation of the transmission render target to a separate function exposed on `WebGLRenderer`. This allows users to override this function and implement their own transmission texture handling to best suit their application

An added benefit would be to enabling users to customize transmission roughness levels, which are currently implemented with a simple box filter (generateMipmaps). For example, users may want to replace this with a gaussian filter for improved realism
