### PR TITLE
ArcballControls: Derive from EventDispatcher.

### DIFF
--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -7,22 +7,24 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
+		[page:EventDispatcher] &rarr;
+
 		<h1>[name]</h1>
 
 		<p class="desc">
 		Arcball controls allow the camera to be controlled by a virtual trackball with full touch support and advanced navigation functionality. <br>
 		Cursor/finger positions and movements are mapped over a virtual trackball surface
-		represented by a gizmo and mapped in intuitive and consistent camera movements. 
+		represented by a gizmo and mapped in intuitive and consistent camera movements.
 		Dragging cursor/fingers will cause camera to orbit around the center of the trackball in a conservative way (returning to the starting point
 		will make the camera to return to its starting orientation).<br><br>
-		
+
 		In addition to supporting pan, zoom and pinch gestures, Arcball controls provide <i>focus</i> functionality with a double click/tap for
-		intuitively moving the object's point of interest in the center of the virtual trackball.   
-		Focus allows a much better inspection and navigation in complex environment. 
+		intuitively moving the object's point of interest in the center of the virtual trackball.
+		Focus allows a much better inspection and navigation in complex environment.
 		Moreover Arcball controls allow FOV manipulation (in a vertigo-style method) and z-rotation.
-		Saving and restoring of Camera State is supported also through clipboard 
+		Saving and restoring of Camera State is supported also through clipboard
 		(use ctrl+c and ctrl+v shortcuts for copy and paste the state).<br><br>
-		
+
 		Unlike [page:OrbitControls] and [page:TrackballControls], [name] doesn't require [page:.update] to be called externally in an animation loop when animations
 		are on.<br><br>
 
@@ -251,12 +253,12 @@
 			Mouse inputs can be specified as mouse buttons 0, 1 and 2 or 'WHEEL' for wheel notches.<br>
 			Keyboard modifiers can be specified as 'CTRL', 'SHIFT' or null if not needed.
 		</p>
-		
+
 		<h3>[method:null update] ()</h3>
 		<p>
 			Update the controls. Must be called after any manual changes to the camera's transform.
 		</p>
-		
+
 		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -659,11 +659,11 @@ class ArcballControls extends Object3D {
 
 							}
 
-							this.applyTransformMatrix( this.applyScale( size, scalePoint ) );
+							this.applyTransformMatrix( this.scale( size, scalePoint ) );
 
 						} else {
 
-							this.applyTransformMatrix( this.applyScale( size, this._gizmos.position ) );
+							this.applyTransformMatrix( this.scale( size, this._gizmos.position ) );
 
 						}
 
@@ -746,7 +746,7 @@ class ArcballControls extends Object3D {
 							size = x / newDistance;
 
 							this.setFov( newFov );
-							this.applyTransformMatrix( this.applyScale( size, this._gizmos.position, false ) );
+							this.applyTransformMatrix( this.scale( size, this._gizmos.position, false ) );
 
 						}
 
@@ -1058,7 +1058,7 @@ class ArcballControls extends Object3D {
 
 							}
 
-							this.applyTransformMatrix( this.applyScale( size, this._gizmos.position ) );
+							this.applyTransformMatrix( this.scale( size, this._gizmos.position ) );
 
 						}
 
@@ -1129,7 +1129,7 @@ class ArcballControls extends Object3D {
 							this._v3_2.setFromMatrixPosition( this._gizmoMatrixState );
 
 							this.setFov( newFov );
-							this.applyTransformMatrix( this.applyScale( size, this._v3_2, false ) );
+							this.applyTransformMatrix( this.scale( size, this._v3_2, false ) );
 
 							//adjusting distance
 							const direction = this._gizmos.position.clone().sub( this.camera.position ).normalize().multiplyScalar( newDistance / x );
@@ -1431,7 +1431,7 @@ class ArcballControls extends Object3D {
 
 			}
 
-			this.applyTransformMatrix( this.applyScale( amount, scalePoint ) );
+			this.applyTransformMatrix( this.scale( amount, scalePoint ) );
 			this.dispatchEvent( _changeEvent );
 
 		}
@@ -1539,7 +1539,7 @@ class ArcballControls extends Object3D {
 			this._v3_2.setFromMatrixPosition( this._gizmoMatrixState );
 
 			this.setFov( newFov );
-			this.applyTransformMatrix( this.applyScale( size, this._v3_2, false ) );
+			this.applyTransformMatrix( this.scale( size, this._v3_2, false ) );
 
 			//adjusting distance
 			const direction = this._gizmos.position.clone().sub( this.camera.position ).normalize().multiplyScalar( newDistance / x );
@@ -2018,7 +2018,7 @@ class ArcballControls extends Object3D {
 		//apply zoom
 		if ( this.enableZoom ) {
 
-			this.applyTransformMatrix( this.applyScale( size, this._gizmos.position ) );
+			this.applyTransformMatrix( this.scale( size, this._gizmos.position ) );
 
 		}
 
@@ -2598,7 +2598,7 @@ class ArcballControls extends Object3D {
 	 * @param {Boolean} scaleGizmos If gizmos should be scaled (Perspective only)
 	 * @returns {Object} Object with 'camera' and 'gizmo' fields containing transformation matrices resulting from the operation to be applied to the camera and gizmos
 	 */
-	applyScale = ( size, point, scaleGizmos = true ) => {
+	scale = ( size, point, scaleGizmos = true ) => {
 
 		const scalePoint = point.clone();
 		let sizeInverse = 1 / size;
@@ -2810,7 +2810,7 @@ class ArcballControls extends Object3D {
 
 	};
 
-
+	
 	getRaycaster() {
 
 		return _raycaster;
@@ -3107,7 +3107,7 @@ class ArcballControls extends Object3D {
 			if ( this.camera.zoom > this.maxZoom || this.camera.zoom < this.minZoom ) {
 
 				const newZoom = MathUtils.clamp( this.camera.zoom, this.minZoom, this.maxZoom );
-				this.applyTransformMatrix( this.applyScale( newZoom / this.camera.zoom, this._gizmos.position, true ) );
+				this.applyTransformMatrix( this.scale( newZoom / this.camera.zoom, this._gizmos.position, true ) );
 
 			}
 
@@ -3119,7 +3119,7 @@ class ArcballControls extends Object3D {
 			if ( distance > this.maxDistance + EPS || distance < this.minDistance - EPS ) {
 
 				const newDistance = MathUtils.clamp( distance, this.minDistance, this.maxDistance );
-				this.applyTransformMatrix( this.applyScale( newDistance / distance, this._gizmos.position ) );
+				this.applyTransformMatrix( this.scale( newDistance / distance, this._gizmos.position ) );
 				this.updateMatrixState();
 
 			 }

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -6,14 +6,14 @@ import {
 	LineBasicMaterial,
 	Raycaster,
 	Group,
-	Object3D,
 	Box3,
 	Sphere,
 	Quaternion,
 	Vector2,
 	Vector3,
 	Matrix4,
-	MathUtils
+	MathUtils,
+	EventDispatcher
 } from '../../../build/three.module.js';
 
 //trackball state
@@ -73,7 +73,7 @@ const _raycaster = new Raycaster();
  * @param {HTMLElement} domElement Renderer's dom element
  * @param {Scene} scene The scene to be rendered
  */
-class ArcballControls extends Object3D {
+class ArcballControls extends EventDispatcher {
 
 	constructor( camera, domElement, scene = null ) {
 
@@ -2810,7 +2810,7 @@ class ArcballControls extends Object3D {
 
 	};
 
-	
+
 	getRaycaster() {
 
 		return _raycaster;


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/22733#issuecomment-952336193

**Description**

This PR reverts the rename of `scale()` and also ensures `ArcballControls` is now derived from `EventDispatcher`.