### PR TITLE
WebXRManager: Native frame buffer scaling

### DIFF
--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -92,8 +92,9 @@
 		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
 
 		Specifies the scaling factor to use when determining the size of the framebuffer when rendering to a XR device.
-		The value is relative to the default XR device display resolution. Default is *1*. A value of *0.5* would specify
-		a framebuffer with 50% of the display's native resolution.
+		The value is relative to the default XR device framebuffer size, which may be less than the 'native' display resolution.
+		A value of *0.5* would specify a framebuffer of half the default framebuffer size of the device. Default is *1*.
+		To set a native resolution framebuffer, use [page:constant THREE.NativeFramebufferScaleFactor].
 		</p>
 
 		<p>

--- a/src/constants.js
+++ b/src/constants.js
@@ -198,3 +198,5 @@ export const StreamCopyUsage = 35042;
 
 export const GLSL1 = '100';
 export const GLSL3 = '300 es';
+
+export const NativeFramebufferScaleFactor = 0;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -5,6 +5,7 @@ import { Vector3 } from '../../math/Vector3.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
 import { WebXRController } from './WebXRController.js';
+import { NativeFramebufferScaleFactor } from '../../constants';
 
 class WebXRManager extends EventDispatcher {
 
@@ -237,6 +238,12 @@ class WebXRManager extends EventDispatcher {
 				if ( attributes.xrCompatible !== true ) {
 
 					await gl.makeXRCompatible();
+
+				}
+
+				if ( framebufferScaleFactor === NativeFramebufferScaleFactor ) {
+
+					framebufferScaleFactor = XRWebGLLayer.getNativeFramebufferScaleFactor( session );
 
 				}
 


### PR DESCRIPTION
**Description**

On the oculus quest 2 the default framebuffer scaling of `1` results in a framebuffer which is smaller then the native display resolution. The required scaling factor for native display size (`1.4222..` for quest 2) can be retrieved programmatically right before initialization. This PR enables usage of this factor through a new constant called `THREE.NativeFramebufferScaleFactor`.

More information here: https://github.com/immersive-web/webxr/blob/master/explainer.md#controlling-rendering-quality

Usage:
```
renderer.xr.enabled = true;
renderer.xr.setFramebufferScaleFactor(THREE.NativeFramebufferScaleFactor);
```