### PR TITLE
Fix RoughnessMipmapper for USDZExporter

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -98,6 +98,7 @@ class RoughnessMipmapper {
 			material.roughnessMap.repeat.copy( roughnessMap.repeat );
 			material.roughnessMap.center.copy( roughnessMap.center );
 			material.roughnessMap.rotation = roughnessMap.rotation;
+			material.roughnessMap.image = roughnessMap.image;
 
 			material.roughnessMap.matrixAutoUpdate = roughnessMap.matrixAutoUpdate;
 			material.roughnessMap.matrix.copy( roughnessMap.matrix );


### PR DESCRIPTION
I'm just upstreaming a small fix from model-viewer; since USDZ export uses the original `image` property of the texture, that needs to be copied when a new (differently sized) texture is created by `RoughnessMipmapper`. See https://github.com/google/model-viewer/pull/2878