### PR TITLE
FBXLoader fails when no pose nodes found for a node #22743

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1421,7 +1421,7 @@ class FBXTreeParser {
 
 			for ( const nodeID in BindPoseNode ) {
 
-				if ( BindPoseNode[ nodeID ].attrType === 'BindPose' ) {
+				if ( BindPoseNode[ nodeID ].attrType === 'BindPose' && BindPoseNode[ nodeID ].NbPoseNodes > 0 ) {
 
 					const poseNodes = BindPoseNode[ nodeID ].PoseNode;
 


### PR DESCRIPTION
Check number of pose nodes before accessing them.

Related issue: Fixed #22743

**Description**

Some models come with no pose nodes. The FBX tree has a property that tells the number of pose nodes (`NbPoseNodes`). I modified the code to check this property before accessing the object directly.