### PR TITLE
Examples: Rename frustum class for CSM.

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -7,11 +7,11 @@ import {
 	Matrix4,
 	Box3
 } from '../../../build/three.module.js';
-import { Frustum } from './Frustum.js';
+import { CSMFrustum } from './CSMFrustum.js';
 import { CSMShader } from './CSMShader.js';
 
 const _cameraToLightMatrix = new Matrix4();
-const _lightSpaceFrustum = new Frustum();
+const _lightSpaceFrustum = new CSMFrustum();
 const _center = new Vector3();
 const _bbox = new Box3();
 const _uniformArray = [];
@@ -37,7 +37,7 @@ export class CSM {
 		this.lightMargin = data.lightMargin || 200;
 		this.customSplitsCallback = data.customSplitsCallback;
 		this.fade = false;
-		this.mainFrustum = new Frustum();
+		this.mainFrustum = new CSMFrustum();
 		this.frustums = [];
 		this.breaks = [];
 

--- a/examples/jsm/csm/CSMFrustum.js
+++ b/examples/jsm/csm/CSMFrustum.js
@@ -2,7 +2,7 @@ import { Vector3, Matrix4 } from '../../../build/three.module.js';
 
 const inverseProjectionMatrix = new Matrix4();
 
-class Frustum {
+class CSMFrustum {
 
 	constructor( data ) {
 
@@ -81,7 +81,7 @@ class Frustum {
 
 		while ( breaks.length > target.length ) {
 
-			target.push( new Frustum() );
+			target.push( new CSMFrustum() );
 
 		}
 
@@ -149,4 +149,4 @@ class Frustum {
 
 }
 
-export { Frustum };
+export { CSMFrustum };


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/csm-this-mainfrustum-split-is-not-a-function/31249

**Description**

This PR renames `examples/jsm/csm/Frustum.js` to `examples/js/csm/CSMFrustum.js` to avoid a name conflict with `THREE.Frustum` when using the global script version.
