### PR TITLE
GLTFLoader: add parseAsync

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -385,6 +385,18 @@ class GLTFLoader extends Loader {
 
 	}
 
+	parseAsync( data, path ) {
+
+		const scope = this;
+
+		return new Promise( function ( resolve, reject ) {
+
+			scope.parse( data, path, resolve, reject );
+
+		} );
+
+	}
+
 }
 
 /* GLTFREGISTRY */


### PR DESCRIPTION
Related issue: #19118 #22031

**Description**

GLTFLoader extends Loader, this means it inherits `loadAsync`.
However also the `.parse()` method of GLTFLoader is async, but there is not `parseAsync` in Loader since most loader parse syncronously. 

This PR adds `parseAsync` to GLTFLoader to make it conform to other loaders such as ObjectLoader (#22031).