### PR TITLE
GLTFExporter: add parseAsync

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -106,6 +106,18 @@ class GLTFExporter {
 
 	}
 
+	parseAsync( input, options ) {
+
+		const scope = this;
+
+		return new Promise( function ( resolve ) {
+
+			scope.parse( input, resolve, options );
+
+		} );
+
+	}
+
 }
 
 //------------------------------------------------------------------------------

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -110,7 +110,7 @@ class GLTFExporter {
 
 		const scope = this;
 
-		return new Promise( function ( resolve ) {
+		return new Promise( function ( resolve, reject ) {
 
 		try {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -112,7 +112,15 @@ class GLTFExporter {
 
 		return new Promise( function ( resolve ) {
 
+		try {
+
 			scope.parse( input, resolve, options );
+
+		} catch ( e ) {
+
+			reject( e );
+
+		}
 
 		} );
 


### PR DESCRIPTION
Related issue: #19118 #22031

**Description**

This PR adds `parseAsync` to GLTFExporter to make it conform to other loaders/classes.