### PR TITLE
ImageUtils: encode jpgs as shorter jpg data uri

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -47,6 +47,12 @@ class ImageUtils {
 
 		}
 
+		if ( image.src.endsWith( '.jpg' ) ) {
+
+			return canvas.toDataURL( 'image/jpeg', 0.6 );
+
+		}
+
 		if ( canvas.width > 2048 || canvas.height > 2048 ) {
 
 			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -47,9 +47,6 @@ class ImageUtils {
 
 		}
 
-
-
-
 		if ( canvas.width > 2048 || canvas.height > 2048 ) {
 
 			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );
@@ -57,7 +54,6 @@ class ImageUtils {
 			return canvas.toDataURL( 'image/jpeg', 0.6 );
 
 		}
-
 
 		if ( /\.jpe?g$/i.test( image.src ) ) {
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -47,17 +47,21 @@ class ImageUtils {
 
 		}
 
-		if ( image.src.endsWith( '.jpg' ) ) {
 
-			return canvas.toDataURL( 'image/jpeg', 0.6 );
 
-		}
 
 		if ( canvas.width > 2048 || canvas.height > 2048 ) {
 
 			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );
 
 			return canvas.toDataURL( 'image/jpeg', 0.6 );
+
+		}
+
+
+		if ( /\.jpe?g$/i.test( image.src ) ) {
+
+			return canvas.toDataURL( 'image/jpeg' );
 
 		} else {
 


### PR DESCRIPTION
Related issue: -

**Description**

Currently, when you serialize a scene as a json, .jpg textures are encoded as .png data URIs, resulting in a much longer data uri string.

Is there a reason behind this?

If not, let's encode .jpg textures correctly as jpgs.