### PR TITLE
MeshPhysicalMaterial: Update thickness default.

### DIFF
--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -79,7 +79,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		this.transmissionMap = null;
 
-		this.thickness = 0.01;
+		this.thickness = 0;
 		this.thicknessMap = null;
 		this.attenuationDistance = 0.0;
 		this.attenuationColor = new Color( 1, 1, 1 );


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/22761#issuecomment-955199490

**Description**

The default value of `MeshPhysicalMaterial.thickness` is now equal to `thicknessFactor` of the glTF spec.

https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#properties
