### PR TITLE
GLTFLoader: Honor morph targets when using lines.

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3311,7 +3311,7 @@
 						// Node may be a THREE.Group (glTF mesh with several primitives) or a THREE.Mesh.
 						node.traverse( function ( object ) {
 
-							if ( object.morphTargetInfluences !== undefined && object.morphTargetInfluences ) {
+							if ( object.morphTargetInfluences ) {
 
 								targetNames.push( object.name ? object.name : object.uuid );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3311,7 +3311,7 @@
 						// Node may be a THREE.Group (glTF mesh with several primitives) or a THREE.Mesh.
 						node.traverse( function ( object ) {
 
-							if ( object.isMesh === true && object.morphTargetInfluences ) {
+							if ( object.morphTargetInfluences ) {
 
 								targetNames.push( object.name ? object.name : object.uuid );
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3311,7 +3311,7 @@
 						// Node may be a THREE.Group (glTF mesh with several primitives) or a THREE.Mesh.
 						node.traverse( function ( object ) {
 
-							if ( object.morphTargetInfluences ) {
+							if ( object.morphTargetInfluences !== undefined && object.morphTargetInfluences ) {
 
 								targetNames.push( object.name ? object.name : object.uuid );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3658,7 +3658,7 @@ class GLTFParser {
 					// Node may be a Group (glTF mesh with several primitives) or a Mesh.
 					node.traverse( function ( object ) {
 
-						if ( object.isMesh === true && object.morphTargetInfluences ) {
+						if ( object.morphTargetInfluences ) {
 
 							targetNames.push( object.name ? object.name : object.uuid );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3655,7 +3655,6 @@ class GLTFParser {
 
 				if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {
 
-					// Node may be a Group (glTF mesh with several primitives) or a Mesh.
 					node.traverse( function ( object ) {
 
 						if ( object.morphTargetInfluences ) {


### PR DESCRIPTION
The previous code prevented line geometries (LineSegments) with morph animations applied to them, grouped in a THREE.Group, being animated.