### PR TITLE
WebGLMultipleRenderTargets: Add Options to Constructor

### DIFF
--- a/docs/api/en/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/en/renderers/WebGLMultipleRenderTargets.html
@@ -27,12 +27,18 @@
 		<h2>Constructor</h2>
 
 
-		<h3>[name]([param:Number width], [param:Number height], [param:Number count])</h3>
+		<h3>[name]([param:Number width], [param:Number height], [param:Number count], [param:Object options])</h3>
 
 		<p>
 		[page:Number width] - The width of the render target. <br />
 		[page:Number height] - The height of the render target.<br />
 		[page:Number count] - The number of render targets.
+
+		options - (optional object that holds texture parameters for an auto-generated target
+		texture and depthBuffer/stencilBuffer booleans.
+
+		For an explanation of the texture parameters see [page:Texture Texture]. 
+		For a list of valid options, see [page:WebGLRenderTarget WebGLRenderTarget].<br /><br />
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/en/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/en/renderers/WebGLMultipleRenderTargets.html
@@ -32,7 +32,7 @@
 		<p>
 		[page:Number width] - The width of the render target. <br />
 		[page:Number height] - The height of the render target.<br />
-		[page:Number count] - The number of render targets.
+		[page:Number count] - The number of render targets.<br />
 
 		options - (optional object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.

--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -2,7 +2,7 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 
 class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 
-	constructor( width, height, count, options ) {
+	constructor( width, height, count, options = {} ) {
 
 		super( width, height, options );
 

--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -2,9 +2,9 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 
 class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 
-	constructor( width, height, count ) {
+	constructor( width, height, count, options ) {
 
-		super( width, height );
+		super( width, height, options );
 
 		const texture = this.texture;
 


### PR DESCRIPTION
This is a tiny PR which passes the options object through the constructor of WebGLMultipleRenderTargets.   

This is necessary to initialize the render textures properly on mobile 
(specifically, to get this GPGPU FEM Simulation working on iOS):
https://zalo.github.io/TetSim/