### PR TITLE
Update LWOLoader to more closely match LW native materials

### DIFF
--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -4,10 +4,10 @@
  * @desc Load files in LWO3 and LWO2 format on Three.js
  *
  * LWO3 format specification:
- * 	http://static.lightwave3d.com/sdk/2018/html/filefmts/lwo3.html
+ *  https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo3.html
  *
  * LWO2 format specification:
- * 	http://static.lightwave3d.com/sdk/2018/html/filefmts/lwo2.html
+ *  https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo2.html
  *
  **/
 
@@ -465,7 +465,7 @@ class MaterialParser {
 					break;
 				case 'Roughness':
 					maps.roughnessMap = texture;
-					maps.roughness = 0.5;
+					maps.roughness = 1;
 					break;
 				case 'Specular':
 					maps.specularMap = texture;
@@ -480,7 +480,7 @@ class MaterialParser {
 					break;
 				case 'Metallic':
 					maps.metalnessMap = texture;
-					maps.metalness = 0.5;
+					maps.metalness = 1;
 					break;
 				case 'Transparency':
 				case 'Alpha':
@@ -591,7 +591,7 @@ class MaterialParser {
 
 		if ( attributes[ 'Bump Height' ] ) params.bumpScale = attributes[ 'Bump Height' ].value * 0.1;
 
-		if ( attributes[ 'Refraction Index' ] ) params.refractionRatio = 1 / attributes[ 'Refraction Index' ].value;
+		if ( attributes[ 'Refraction Index' ] ) params.refractionRatio = 0.98 / attributes[ 'Refraction Index' ].value;
 
 		this.parsePhysicalAttributes( params, attributes, maps );
 		this.parseStandardAttributes( params, attributes, maps );
@@ -707,9 +707,11 @@ class MaterialParser {
 
 				if ( attributes.metalness !== undefined ) {
 
-					delete attributes.metalness;
+					attributes.metalness = 1; // For most transparent materials metalness should be set to 1 if not otherwise defined. If set to 0 no refraction will be visible
 
 				}
+
+				attributes.opacity = 1; // transparency fades out refraction, forcing opacity to 1 ensures a closer visual match to the material in Lightwave.
 
 			} else envMap.mapping = EquirectangularReflectionMapping;
 

--- a/examples/jsm/loaders/lwo/LWO2Parser.js
+++ b/examples/jsm/loaders/lwo/LWO2Parser.js
@@ -106,6 +106,7 @@ LWO2Parser.prototype = {
 			case 'WRPW': // image wrap w ( for cylindrical and spherical projections)
 			case 'WRPH': // image wrap h
 			case 'NMOD':
+			case 'NSEL':
 			case 'NPRW':
 			case 'NPLA':
 			case 'NODS':

--- a/examples/jsm/loaders/lwo/LWO3Parser.js
+++ b/examples/jsm/loaders/lwo/LWO3Parser.js
@@ -38,8 +38,8 @@ LWO3Parser.prototype = {
 			case 'NORM':
 
 			// ENVL FORM skipped
-			case 'PRE ':
-			case 'POST':
+			case 'PRE ': // Pre-loop behavior for the keyframe
+			case 'POST': // Post-loop behavior for the keyframe
 			case 'KEY ':
 			case 'SPAN':
 


### PR DESCRIPTION
This PR includes a few minor adjustments to allow LWO files loaded into three.js to more closely match their appearance in the native LW app.

Updated SDK reference to latest 2019 file format specs.

Adjusted refractionRatio to more closely match LWO rendering.

Adjusted default metalness value for transparent items to preserve refraction.

Opacity set to 1 for refractive materials preserving visible refraction.

Roughness and Metalness values set to 1 when a texture is present. The texture modulates this value and anything less than 1 will limit the maximum possible value.