### PR TITLE
SVGLoader: Make createShapes() retain curves

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -2084,7 +2084,7 @@ class SVGLoader extends Loader {
 
 			}
 
-			return { points: points, isCW: ShapeUtils.isClockWise( points ), identifier: identifier ++, boundingBox: new Box2( new Vector2( minX, minY ), new Vector2( maxX, maxY ) ) };
+			return { curves: p.curves, points: points, isCW: ShapeUtils.isClockWise( points ), identifier: identifier ++, boundingBox: new Box2( new Vector2( minX, minY ), new Vector2( maxX, maxY ) ) };
 
 		} );
 
@@ -2101,12 +2101,15 @@ class SVGLoader extends Loader {
 
 			if ( ! amIAHole.isHole ) {
 
-				const shape = new Shape( p.points );
+				const shape = new Shape();
+				shape.curves = p.curves;
 				const holes = isAHole.filter( h => h.isHole && h.for === p.identifier );
 				holes.forEach( h => {
 
-					const path = simplePaths[ h.identifier ];
-					shape.holes.push( new Path( path.points ) );
+					const hole = simplePaths[ h.identifier ];
+					const path = new Path();
+					path.curves = hole.curves;
+					shape.holes.push( path );
 
 				} );
 				shapesToReturn.push( shape );


### PR DESCRIPTION
The creation of new shapes and paths now works the same way as in [shapePath.toShapes()](https://github.com/mrdoob/three.js/blob/dev/src/extras/core/ShapePath.js). Instead of making them from points, it uses the curves array to preserve curve types.