### PR TITLE
Docs: Note about limitations of Object3D.attach

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -221,7 +221,11 @@
 		<p>Applies the rotation represented by the quaternion to the object.</p>
 
 		<h3>[method:this attach]( [param:Object3D object] )</h3>
-		<p>Adds *object* as a child of this, while maintaining the object's world transform.</p>
+		<p>Adds *object* as a child of this, while maintaining the object's world transform. 
+		<br /><br />	
+		Note: If the old or new parent of the object is scaled non-uniformly, the exact visible transformation will not be preserved.
+		This is a limitation of [page:Matrix4.decompose Matrix4].
+		</p>
 
 		<h3>[method:Object3D clone]( [param:Boolean recursive] )</h3>
 		<p>


### PR DESCRIPTION
Just a small note added to the docs to inform users of the limitations of `Object3D.attach`. It would have been useful for me to read this when discovering this issue. Related: https://github.com/mrdoob/three.js/issues/22769
