### PR TITLE
WebGLTexture: Basic support for gl.texStorage2D().

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -9,7 +9,13 @@
 	<body>
 		<h1>[name]</h1>
 
-		<p class="desc">Create a texture to apply to a surface or as a reflection or refraction map.</p>
+		<p class="desc">
+			Create a texture to apply to a surface or as a reflection or refraction map.
+		</p>
+
+		<p>
+			Note: After the initial use of a texture, its dimensions, format, and type cannot be changed. Instead, call [page:.dispose]() on the texture and instantiate a new one.
+		</p>
 
 		<h2>Code Example</h2>
 
@@ -286,7 +292,7 @@
 
 		<h3>[method:null dispose]()</h3>
 		<p>
-		Call [page:EventDispatcher EventDispatcher].dispatchEvent with a 'dispose' event type.
+		Frees the GPU related resources allocated by a texture. Call this method whenever a texture is no longer used in your app.
 		</p>
 
 		<h3>[method:Vector2 transformUv]( [param:Vector2 uv] )</h3>

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -879,6 +879,34 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
+	function texSubImage2D() {
+
+		try {
+
+			gl.texSubImage2D.apply( gl, arguments );
+
+		} catch ( error ) {
+
+			console.error( 'THREE.WebGLState:', error );
+
+		}
+
+	}
+
+	function texStorage2D() {
+
+		try {
+
+			gl.texStorage2D.apply( gl, arguments );
+
+		} catch ( error ) {
+
+			console.error( 'THREE.WebGLState:', error );
+
+		}
+
+	}
+
 	function texImage2D() {
 
 		try {
@@ -1056,6 +1084,9 @@ function WebGLState( gl, extensions, capabilities ) {
 		compressedTexImage2D: compressedTexImage2D,
 		texImage2D: texImage2D,
 		texImage3D: texImage3D,
+
+		texStorage2D: texStorage2D,
+		texSubImage2D: texSubImage2D,
 
 		scissor: scissor,
 		viewport: viewport,

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -707,10 +707,12 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			// set 0 level mipmap and then use GL to generate other mipmap levels
 
 			const levels = getMipLevels( texture, image, supportsMips );
+			const useTexStorage = ( isWebGL2 && texture.isVideoTexture !== true );
+			const allocateMemory = ( texture.version === 1 );
 
 			if ( mipmaps.length > 0 && supportsMips ) {
 
-				if ( isWebGL2 ) {
+				if ( useTexStorage && allocateMemory ) {
 
 					state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, mipmaps[ 0 ].width, mipmaps[ 0 ].height );
 
@@ -720,7 +722,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					mipmap = mipmaps[ i ];
 
-					if ( isWebGL2 ) {
+					if ( useTexStorage ) {
 
 						state.texSubImage2D( _gl.TEXTURE_2D, i, 0, 0, glFormat, glType, mipmap );
 
@@ -736,9 +738,10 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else {
 
-				if ( isWebGL2 ) {
+				if ( useTexStorage ) {
 
-					state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
+					if ( allocateMemory ) state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
+
 					state.texSubImage2D( _gl.TEXTURE_2D, 0, 0, 0, glFormat, glType, image );
 
 				} else {

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -736,7 +736,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				if ( useTexStorage ) {
 
-					if ( allocateMemory ) state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
+					if ( allocateMemory ) {
+
+						state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
+
+					}
 
 					state.texSubImage2D( _gl.TEXTURE_2D, 0, 0, 0, glFormat, glType, image );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -179,29 +179,25 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	function getMipLevels( texture, image, supportsMips ) {
 
-		let levels;
-
 		if ( textureNeedsGenerateMipmaps( texture, supportsMips ) === true ) {
 
 			// generated mipmaps via gl.generateMipmap()
 
-			levels = Math.log2( Math.max( image.width, image.height ) ) + 1;
+			return Math.log2( Math.max( image.width, image.height ) ) + 1;
 
 		} else if ( texture.mipmaps.length > 0 ) {
 
 			// user-defined mipmaps
 
-			levels = texture.mipmaps.length;
+			return texture.mipmaps.length;
 
 		} else {
 
 			// texture without mipmaps (only base level)
 
-			levels = 1;
+			return 1;
 
 		}
-
-		return levels;
 
 	}
 


### PR DESCRIPTION
Related issue: #21874

**Description**

Introduces the usage of the WebGL 2 API `texStorage2D()`. Only normal textures are supported right now (so no data, compressed or cube textures). Before rolling out it everywhere I thought we could do it an incremental fashion and thus easier spot potential issues.

The PR helps to mitigate #22758.
