### PR TITLE
Fix Line2 Raycasting bounds margin computation to support Orthographic Camera 

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -146,7 +146,7 @@ class LineSegments2 extends Mesh {
 		_box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
 		const distanceToBox = Math.max( camera.near, _box.distanceToPoint( ray.origin ) );
 
-		// increase the sphere bounds by the worst case line screen space width
+		// increase the box bounds by the worst case line screen space width
 		const boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, lineWidth, resolution );
 		_box.max.x += boxMargin;
 		_box.max.y += boxMargin;

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -94,10 +94,6 @@ class LineSegments2 extends Mesh {
 		// camera forward is negative
 		const near = - camera.near;
 
-		// clip space is [ - 1, 1 ] so multiply by two to get the full
-		// width in clip space
-		const ssMaxWidth = 2.0 * Math.max( lineWidth / resolution.width, lineWidth / resolution.height );
-
 		//
 
 		// check if we intersect the sphere bounds
@@ -110,13 +106,18 @@ class LineSegments2 extends Mesh {
 		_sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
 		const distanceToSphere = Math.max( camera.near, _sphere.distanceToPoint( ray.origin ) );
 
-		// get the w component to scale the world space line width
+		// transform into clip space, adjust the x and y values by the pixel width offset, then
+		// transform back into world space to get world offset. Note clip space is [-1, 1] so full
+		// width does not need to be halved.
 		_clipToWorldVector.set( 0, 0, - distanceToSphere, 1.0 ).applyMatrix4( camera.projectionMatrix );
 		_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+		_clipToWorldVector.x = lineWidth / resolution.width;
+		_clipToWorldVector.y = lineWidth / resolution.height;
 		_clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
+		_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
 
 		// increase the sphere bounds by the worst case line screen space width
-		const sphereMargin = Math.abs( ssMaxWidth / _clipToWorldVector.w ) * 0.5;
+		const sphereMargin = Math.abs( Math.max( _clipToWorldVector.x, _clipToWorldVector.y ) );
 		_sphere.radius += sphereMargin;
 
 		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) {
@@ -137,13 +138,18 @@ class LineSegments2 extends Mesh {
 		_box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
 		const distanceToBox = Math.max( camera.near, _box.distanceToPoint( ray.origin ) );
 
-		// get the w component to scale the world space line width
+		// transform into clip space, adjust the x and y values by the pixel width offset, then
+		// transform back into world space to get world offset. Note clip space is [-1, 1] so full
+		// width does not need to be halved.
 		_clipToWorldVector.set( 0, 0, - distanceToBox, 1.0 ).applyMatrix4( camera.projectionMatrix );
 		_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+		_clipToWorldVector.x = lineWidth / resolution.width;
+		_clipToWorldVector.y = lineWidth / resolution.height;
 		_clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
+		_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
 
 		// increase the sphere bounds by the worst case line screen space width
-		const boxMargin = Math.abs( ssMaxWidth / _clipToWorldVector.w ) * 0.5;
+		const boxMargin = Math.abs( Math.max( _clipToWorldVector.x, _clipToWorldVector.y ) )
 		_box.max.x += boxMargin;
 		_box.max.y += boxMargin;
 		_box.max.z += boxMargin;


### PR DESCRIPTION
Related issue: #22782

**Description**

This PR adjusts the logic for computing the margin for the sphere and box bounds around Line2 to correctly (I believe) determine the world-space width of the thickness of the line at the closest point on the bounding sphere / box.

The logic for computing the margin is now encapsulated in `getWorldSpaceHalfWidth`. It now transforms a point at the given distance into clip space, adjusts the point by the `pixel width / resolution`, then transforms back into world space and returns the max of the xy values as the margin. Tested by copying the jsfiddle of the above issue into one of the fat_lines three.js example pages for local dev.

@nkallen can you test this?

cc @WestLangley 