### PR TITLE
WebGLRenderer: Add data-engine="three.js r${REVISION}" to the canvas element

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1,4 +1,5 @@
 import {
+	REVISION,
 	BackSide,
 	DoubleSide,
 	FrontSide,
@@ -214,6 +215,8 @@ function WebGLRenderer( parameters = {} ) {
 			powerPreference: _powerPreference,
 			failIfMajorPerformanceCaveat: _failIfMajorPerformanceCaveat
 		};
+
+		_canvas.setAttribute( 'data-engine', `three-${REVISION}` );
 
 		// event listeners must be registered before WebGL context is created, see #12753
 


### PR DESCRIPTION
**Description**

I thought it would be a good idea to add a custom attribute to the canvas element (ie. `<canvas data-engine="three-135">`) element to track the engine usage in the wild more easily.

Seems like using `data-*` [is the way to go](http://html5doctor.com/html5-custom-data-attributes/).

Can anyone think of a reason why not to do this, or better ways or doing it?