### PR TITLE
Docs: Use undefined instead of void.

### DIFF
--- a/docs/api/en/extras/PMREMGenerator.html
+++ b/docs/api/en/extras/PMREMGenerator.html
@@ -54,17 +54,17 @@
 			The ideal input cube size is 256 x 256, as this matches best with the 256 x 256 cubemap output.
 		</p>
 
-		<h3>[method:void compileCubemapShader]()</h3>
+		<h3>[method:undefined compileCubemapShader]()</h3>
 		<p>
 			Pre-compiles the cubemap shader. You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
 		</p>
 
-		<h3>[method:void compileEquirectangularShader]()</h3>
+		<h3>[method:undefined compileEquirectangularShader]()</h3>
 		<p>
 			Pre-compiles the equirectangular shader. You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
 		</p>
 
-		<h3>[method:void dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			Disposes of the PMREMGenerator's internal memory. Note that PMREMGenerator is a static class, so you should not need more than one
 			PMREMGenerator object. If you do, calling dispose() on one of them will cause any others to also become unusable.

--- a/docs/api/en/helpers/Box3Helper.html
+++ b/docs/api/en/helpers/Box3Helper.html
@@ -49,7 +49,7 @@
 		<p>See the base [page:LineSegments] class for common methods.</p>
 
 
-		<h3>[method:void updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 			This overrides the method in the base [page:Object3D] class so that it
 			also updates the wireframe box to the extent of the [page:Box3Helper.box .box]

--- a/docs/api/en/helpers/PlaneHelper.html
+++ b/docs/api/en/helpers/PlaneHelper.html
@@ -50,7 +50,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:LineSegments] class for common methods.</p>
 
-		<h3>[method:void updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 			This overrides the method in the base [page:Object3D] class so that it also
 			updates the helper object according to the [page:PlaneHelper.plane .plane] and

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -62,7 +62,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:void load]()</h3>
+		<h3>[method:undefined load]()</h3>
 		<p>
 			This method needs to be implement by all concrete loaders. It holds the logic for loading the asset from the backend.
 		</p>
@@ -79,7 +79,7 @@
 		[page:Function onLoad] is handled by [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve Promise.resolve] and [page:Function onError] is handled by [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject Promise.reject].
 		</p>
 
-		<h3>[method:void parse]()</h3>
+		<h3>[method:undefined parse]()</h3>
 		<p>
 			This method needs to be implement by all concrete loaders. It holds the logic for parsing the asset into three.js entities.
 		</p>

--- a/docs/api/en/math/SphericalHarmonics3.html
+++ b/docs/api/en/math/SphericalHarmonics3.html
@@ -120,7 +120,7 @@
 
 		<h2>Static Methods</h2>
 
-		<h3>[method:void getBasisAt]( [param:Vector3 normal], [param:Array shBasis] )</h3>
+		<h3>[method:undefined getBasisAt]( [param:Vector3 normal], [param:Array shBasis] )</h3>
 		<p>
 			[page:Vector3 normal] - The normal vector (assumed to be unit length).<br />
 			[page:Array shBasis] - The resulting SH basis.<br /><br />

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -314,13 +314,13 @@
 		- *WEBGL_compressed_texture_etc1*
 		</p>
 
-		<h3>[method:void forceContextLoss]()</h3>
+		<h3>[method:undefined forceContextLoss]()</h3>
 		<p>
 		Simulate loss of the WebGL context. This requires support for the
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context WEBGL_lose_context] extensions.
 		</p>
 
-		<h3>[method:void forceContextRestore]( )</h3>
+		<h3>[method:undefined forceContextRestore]( )</h3>
 		<p>
 		Simulate restore of the WebGL context. This requires support for the
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context WEBGL_lose_context] extensions.

--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -87,7 +87,7 @@
 		Returns the *XRSession* object which allows a more fine-grained management of active WebXR sessions on application level.
 		</p>
 
-		<h3>[method:void setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
+		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
 		<p>
 		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
 
@@ -100,7 +100,7 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
-		<h3>[method:void setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
+		<h3>[method:undefined setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
 		<p>
 		[page:String referenceSpaceType] — The reference space type to set.<br /><br />
 
@@ -109,7 +109,7 @@
 		Please check out the [link:https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType MDN] for possible values and their use cases.
 		</p>
 
-		<h3>[method:void updateCamera]( [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined updateCamera]( [param:PerspectiveCamera camera] )</h3>
 		<p>
 		Updates the state of the XR camera. Use this method on app level if you set [page:.cameraAutoUpdate] to *false*.
 		The method requires the non-XR camera of the scene as a parameter. The passed in camera's transformation is automatically

--- a/docs/api/ko/extras/PMREMGenerator.html
+++ b/docs/api/ko/extras/PMREMGenerator.html
@@ -52,17 +52,17 @@
 			이상적인 입력 이미지 크기는 1k(1024 x 512)로, 256 x 256 큐브 맵 출력과 가장 잘 일치합니다.
 		</p>
 
-		<h3>[method:void compileCubemapShader]()</h3>
+		<h3>[method:undefined compileCubemapShader]()</h3>
 		<p>
 			큐브 맵 셰이더를 미리 컴파일합니다. 동시성을 높이기 위해 텍스쳐의 네트워크 로딩 중에 이 메서드를 호출하여 더 빨리 시작할 수 있습니다.
 		</p>
 
-		<h3>[method:void compileEquirectangularShader]()</h3>
+		<h3>[method:undefined compileEquirectangularShader]()</h3>
 		<p>
 			등장방형 셰이더를 미리 컴파일합니다. 동시성을 높이기 위해 텍스쳐의 네트워크 로딩 중에 이 메서드를 호출하여 더 빨리 시작할 수 있습니다.
 		</p>
 
-		<h3>[method:void dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			PMREM 제너레이터의 내장 메모리를 폐기합니다. 
 			PMREMGenerator는 정적 클래스이므로 두 개 이상의 PMREMGenerator 개체가 필요하지 않습니다. 

--- a/docs/api/zh/extras/PMREMGenerator.html
+++ b/docs/api/zh/extras/PMREMGenerator.html
@@ -54,17 +54,17 @@
 			The ideal input cube size is 256 x 256, as this matches best with the 256 x 256 cubemap output.
 		</p>
 
-		<h3>[method:void compileCubemapShader]()</h3>
+		<h3>[method:undefined compileCubemapShader]()</h3>
 		<p>
 			Pre-compiles the cubemap shader. You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
 		</p>
 
-		<h3>[method:void compileEquirectangularShader]()</h3>
+		<h3>[method:undefined compileEquirectangularShader]()</h3>
 		<p>
 			Pre-compiles the equirectangular shader. You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
 		</p>
 
-		<h3>[method:void dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			Disposes of the PMREMGenerator's internal memory. Note that PMREMGenerator is a static class, so you should not need more than one
 			PMREMGenerator object. If you do, calling dispose() on one of them will cause any others to also become unusable.

--- a/docs/api/zh/helpers/Box3Helper.html
+++ b/docs/api/zh/helpers/Box3Helper.html
@@ -47,7 +47,7 @@
 		<p>请到基类 [page:LineSegments] 页面查看公共方法.</p>
 
 
-		<h3>[method:void updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 			重写基类 [page:Object3D] 的该方法以便于
 			同时更新线框辅助对象与 [page:Box3Helper.box .box]

--- a/docs/api/zh/helpers/PlaneHelper.html
+++ b/docs/api/zh/helpers/PlaneHelper.html
@@ -49,7 +49,7 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:LineSegments] 页面查看公共方法.</p>
 
-		<h3>[method:void updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 			重写基类 [page:Object3D] 的该方法以便于
 			同时更新线框辅助对象与 [page:PlaneHelper.plane .plane] 和

--- a/docs/api/zh/loaders/Loader.html
+++ b/docs/api/zh/loaders/Loader.html
@@ -56,7 +56,7 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:void load]()</h3>
+		<h3>[method:undefined load]()</h3>
 		<p>
 			该方法需要被所有具体的加载器来实现。它包含了从后端加载资产的逻辑。
 		</p>
@@ -73,7 +73,7 @@
 		[page:Function onLoad] 由 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve Promise.resolve] 处理，而 [page:Function onError] 则由 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject Promise.reject] 处理。
 		</p>
 
-		<h3>[method:void parse]()</h3>
+		<h3>[method:undefined parse]()</h3>
 		<p>
 			该方法需要被所有具体的加载器来实现。它包含了解析资产到 three.js 实体的逻辑。
 		</p>

--- a/docs/api/zh/math/SphericalHarmonics3.html
+++ b/docs/api/zh/math/SphericalHarmonics3.html
@@ -120,7 +120,7 @@
 
 		<h2>Static Methods</h2>
 
-		<h3>[method:void getBasisAt]( [param:Vector3 normal], [param:Array shBasis] )</h3>
+		<h3>[method:undefined getBasisAt]( [param:Vector3 normal], [param:Array shBasis] )</h3>
 		<p>
 			[page:Vector3 normal] - The normal vector (assumed to be unit length).<br />
 			[page:Array shBasis] - The resulting SH basis.<br /><br />

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -298,13 +298,13 @@
 		- *WEBGL_compressed_texture_etc1*
 		</p>
 
-		<h3>[method:void forceContextLoss]()</h3>
+		<h3>[method:undefined forceContextLoss]()</h3>
 		<p>
 		模拟WebGL环境的丢失。需要支持
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context WEBGL_lose_context] 扩展才能用。
 		</p>
 
-		<h3>[method:void forceContextRestore]( )</h3>
+		<h3>[method:undefined forceContextRestore]( )</h3>
 		<p>
 		模拟WebGL环境的恢复。需要支持
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context WEBGL_lose_context] 扩展才能用。

--- a/docs/api/zh/renderers/webxr/WebXRManager.html
+++ b/docs/api/zh/renderers/webxr/WebXRManager.html
@@ -87,7 +87,7 @@
 		Returns the *XRSession* object which allows a more fine-grained management of active WebXR sessions on application level.
 		</p>
 
-		<h3>[method:void setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
+		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
 		<p>
 		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
 
@@ -100,7 +100,7 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
-		<h3>[method:void setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
+		<h3>[method:undefined setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
 		<p>
 		[page:String referenceSpaceType] — The reference space type to set.<br /><br />
 
@@ -109,7 +109,7 @@
 		Please check out the [link:https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType MDN] for possible values and their use cases.
 		</p>
 
-		<h3>[method:void updateCamera]( [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined updateCamera]( [param:PerspectiveCamera camera] )</h3>
 		<p>
 		Updates the state of the XR camera. Use this method on app level if you set [page:.cameraAutoUpdate] to *false*.
 		The method requires the non-XR camera of the scene as a parameter. The passed in camera's transformation is automatically

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -287,7 +287,7 @@ controls.touches = {
 			Returns the distance from the camera to the target.
 		</p>
 
-		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<h3>[method:undefined listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.
 		</p>

--- a/docs/examples/en/postprocessing/EffectComposer.html
+++ b/docs/examples/en/postprocessing/EffectComposer.html
@@ -82,7 +82,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:void addPass]( [param:Pass pass] )</h3>
+		<h3>[method:undefined addPass]( [param:Pass pass] )</h3>
 
 		<p>
 			pass -- The pass to add to the pass chain.<br /><br />
@@ -90,7 +90,7 @@
 			Adds the given pass to the pass chain.
 		</p>
 
-		<h3>[method:void insertPass]( [param:Pass pass], [param:Integer index] )</h3>
+		<h3>[method:undefined insertPass]( [param:Pass pass], [param:Integer index] )</h3>
 
 		<p>
 			pass -- The pass to insert into the pass chain.<br />
@@ -108,7 +108,7 @@
 			Used by [name] to determine when a pass should be rendered to screen.
 		</p>
 
-		<h3>[method:void removePass]( [param:Pass pass] )</h3>
+		<h3>[method:undefined removePass]( [param:Pass pass] )</h3>
 
 		<p>
 			pass -- The pass to remove from the pass chain.<br /><br />
@@ -116,7 +116,7 @@
 			Removes the given pass from the pass chain.
 		</p>
 
-		<h3>[method:void render]( [param:Float deltaTime] )</h3>
+		<h3>[method:undefined render]( [param:Float deltaTime] )</h3>
 
 		<p>
 			deltaTime -- The delta time value.<br /><br />
@@ -124,7 +124,7 @@
 			Executes all enabled post-processing passes in order to produce the final frame.
 		</p>
 
-		<h3>[method:void reset]( [param:WebGLRenderTarget renderTarget] )</h3>
+		<h3>[method:undefined reset]( [param:WebGLRenderTarget renderTarget] )</h3>
 
 		<p>
 			[page:WebGLRenderTarget renderTarget] -- (optional) A preconfigured render target internally used by [name]..<br /><br />
@@ -132,7 +132,7 @@
 			Resets the internal state of the [name].
 		</p>
 
-		<h3>[method:void setPixelRatio]( [param:Float pixelRatio] )</h3>
+		<h3>[method:undefined setPixelRatio]( [param:Float pixelRatio] )</h3>
 
 		<p>
 			pixelRatio -- The device pixel ratio.<br /><br />
@@ -141,7 +141,7 @@
 				Thus, the semantic of the method is similar to [page:WebGLRenderer.setPixelRatio]().
 		</p>
 
-		<h3>[method:void setSize]( [param:Integer width], [param:Integer height] )</h3>
+		<h3>[method:undefined setSize]( [param:Integer width], [param:Integer height] )</h3>
 
 		<p>
 			width -- The width of the [name].<br />
@@ -151,7 +151,7 @@
 				Thus, the semantic of the method is similar to [page:WebGLRenderer.setSize]().
 		</p>
 
-		<h3>[method:void swapBuffers]()</h3>
+		<h3>[method:undefined swapBuffers]()</h3>
 
 		<p>Swaps the internal read/write buffers.</p>
 

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -283,7 +283,7 @@ controls.touches = {
 			Returns the distance from the camera to the target.
 		</p>
 
-		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<h3>[method:undefined listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.
 		</p>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -285,7 +285,7 @@ controls.touches = {
 			Returns the distance from the camera to the target.
 		</p>
 
-		<h3>[method:void listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
+		<h3>[method:undefined listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			为指定的DOM元素添加按键监听。推荐将window作为指定的DOM元素。
 		</p>

--- a/docs/examples/zh/postprocessing/EffectComposer.html
+++ b/docs/examples/zh/postprocessing/EffectComposer.html
@@ -81,7 +81,7 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:void addPass]( [param:Pass pass] )</h3>
+		<h3>[method:undefined addPass]( [param:Pass pass] )</h3>
 
 		<p>
 			pass -- 将被添加到过程链的过程<br /><br />
@@ -89,7 +89,7 @@
 			将传入的过程添加到过程链。
 		</p>
 
-		<h3>[method:void insertPass]( [param:Pass pass], [param:Integer index] )</h3>
+		<h3>[method:undefined insertPass]( [param:Pass pass], [param:Integer index] )</h3>
 
 		<p>
 			pass -- 将被插入到过程链的过程。<br />
@@ -107,7 +107,7 @@
 			由[name]所使用，来决定哪一个过程应当被渲染到屏幕上。
 		</p>
 
-		<h3>[method:void removePass]( [param:Pass pass] )</h3>
+		<h3>[method:undefined removePass]( [param:Pass pass] )</h3>
 
 		<p>
 			pass -- The pass to remove from the pass chain.<br /><br />
@@ -115,7 +115,7 @@
 			Removes the given pass from the pass chain.
 		</p>
 
-		<h3>[method:void render]( [param:Float deltaTime] )</h3>
+		<h3>[method:undefined render]( [param:Float deltaTime] )</h3>
 
 		<p>
 			deltaTime -- The delta time value.<br /><br />
@@ -123,7 +123,7 @@
 			执行所有启用的后期处理过程，来产生最终的帧，
 		</p>
 
-		<h3>[method:void reset]( [param:WebGLRenderTarget renderTarget] )</h3>
+		<h3>[method:undefined reset]( [param:WebGLRenderTarget renderTarget] )</h3>
 
 		<p>
 			[page:WebGLRenderTarget renderTarget] -- （可选）一个预先配置的渲染目标，内部由 [name] 使用。<br /><br />
@@ -131,7 +131,7 @@
 			重置所有[name]的内部状态。
 		</p>
 
-		<h3>[method:void setPixelRatio]( [param:Float pixelRatio] )</h3>
+		<h3>[method:undefined setPixelRatio]( [param:Float pixelRatio] )</h3>
 
 		<p>
 			pixelRatio -- 设备像素比<br /><br />
@@ -141,7 +141,7 @@
 
 		</p>
 
-		<h3>[method:void setSize]( [param:Integer width], [param:Integer height] )</h3>
+		<h3>[method:undefined setSize]( [param:Integer width], [param:Integer height] )</h3>
 
 		<p>
 			width -- [name]的宽度。<br />
@@ -152,7 +152,7 @@
 
 		</p>
 
-		<h3>[method:void swapBuffers]()</h3>
+		<h3>[method:undefined swapBuffers]()</h3>
 
 		<p>交换内部的读/写缓冲。</p>
 


### PR DESCRIPTION
Related issue: see #22237

**Description**

Replaces `void` with `undefined` to achieve more consistent method signatures.
