### PR TITLE
Fix typo in webgpu/constants.js

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -168,7 +168,7 @@ class WebGPURenderer {
 
 		const swapChain = context.configure( {
 			device: device,
-			format: GPUTextureFormat.BRGA8Unorm // this is the only valid swap chain format right now (r121)
+			format: GPUTextureFormat.BGRA8Unorm // this is the only valid swap chain format right now (r121)
 		} );
 
 		this._adapter = adapter;
@@ -489,7 +489,7 @@ class WebGPURenderer {
 
 		} else {
 
-			format = GPUTextureFormat.BRGA8Unorm; // default swap chain format
+			format = GPUTextureFormat.BGRA8Unorm; // default swap chain format
 
 		}
 
@@ -896,7 +896,7 @@ class WebGPURenderer {
 					depthOrArrayLayers: 1
 				},
 				sampleCount: this._parameters.sampleCount,
-				format: GPUTextureFormat.BRGA8Unorm,
+				format: GPUTextureFormat.BGRA8Unorm,
 				usage: GPUTextureUsage.RENDER_ATTACHMENT
 			} );
 
@@ -935,7 +935,7 @@ class WebGPURenderer {
 
 			this._context.configure( {
 				device: device,
-				format: GPUTextureFormat.BRGA8Unorm,
+				format: GPUTextureFormat.BGRA8Unorm,
 				usage: GPUTextureUsage.RENDER_ATTACHMENT,
 				size: {
 					width: Math.floor( this._width * this._pixelRatio ),

--- a/examples/jsm/renderers/webgpu/constants.js
+++ b/examples/jsm/renderers/webgpu/constants.js
@@ -107,8 +107,8 @@ export const GPUTextureFormat = {
 	RGBA8Snorm: 'rgba8snorm',
 	RGBA8Uint: 'rgba8uint',
 	RGBA8Sint: 'rgba8sint',
-	BRGA8Unorm: 'bgra8unorm',
-	BRGA8UnormSRGB: 'bgra8unorm-srgb',
+	BGRA8Unorm: 'bgra8unorm',
+	BGRA8UnormSRGB: 'bgra8unorm-srgb',
 	// Packed 32-bit formats
 	RGB9E5UFloat: 'rgb9e5ufloat',
 	RGB10A2Unorm: 'rgb10a2unorm',


### PR DESCRIPTION
**Description**

This PR fixes a typo in `examples/jsm/renderers/webgpu/constants.js`.

```
BRGA8Unorm: 'bgra8unorm',
BRGA8UnormSRGB: 'bgra8unorm-srgb',
```

The values are `bgra*` but the keys  are `BRGA*`. I think the keys should be `BGRA*` unless they are intentional.