### PR TITLE
Docs: Use undefined instead of null.

### DIFF
--- a/docs/api/ar/animation/AnimationMixer.html
+++ b/docs/api/ar/animation/AnimationMixer.html
@@ -82,18 +82,18 @@
 			يكون هذا مفيدًا عندما تحتاج إلى الانتقال إلى وقت محدد في رسم متحرك. سيتم قياس القيمة المدخلة حسب مقياس الوقت لجهاز الخالط [page:.timeScale timeScale].
 		</p>
 
-		<h3>[method:null uncacheClip]([param:AnimationClip clip])</h3>
+		<h3>[method:undefined uncacheClip]([param:AnimationClip clip])</h3>
 
 		<p>
 			إلغاء تخصيص كل موارد الذاكرة لمقطع.
 		</p>
 
-		<h3>[method:null uncacheRoot]([param:Object3D root]) </h3>
+		<h3>[method:undefined uncacheRoot]([param:Object3D root]) </h3>
 		<p>
 			إلغاء تخصيص كافة موارد الذاكرة لكائن جذر.
 		</p>
 
-		<h3>[method:null uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
+		<h3>[method:undefined uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
 			إلغاء تخصيص كل موارد الذاكرة لإجراء ما.
 		</p>

--- a/docs/api/ar/animation/AnimationObjectGroup.html
+++ b/docs/api/ar/animation/AnimationObjectGroup.html
@@ -56,17 +56,17 @@
 		<h2>الوظائف (Methods)</h2>
 
 
-		<h3>[method:null add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			يضيف عددًا عشوائيًا من الكائنات إلى *AnimationObjectGroup*.
 		</p>
 
-		<h3>[method:null remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			يزيل عددًا عشوائيًا من الكائنات من *AnimationObjectGroup*.
 		</p>
 
-		<h3>[method:null uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			إلغاء تخصيص كافة موارد الذاكرة للكائنات التي تم تمريرها من *AnimationObjectGroup*.
 		</p>

--- a/docs/api/ar/animation/KeyframeTrack.html
+++ b/docs/api/ar/animation/KeyframeTrack.html
@@ -136,12 +136,12 @@
 			ترجع نسخة من هذا المسار.
 		</p>
 
-		<h3>[method:null createInterpolant]()</h3>
+		<h3>[method:Interpolant createInterpolant]()</h3>
 		<p>
 			ينشئ [page:LinearInterpolant LinearInterpolant] أو [page:CubicInterpolant CubicInterpolant] أو [page:DiscreteInterpolant DiscreteInterpolant] ، اعتمادًا على قيمة معلمة الاستيفاء التي تم تمريرها في الباني.
 		</p>
 
-		<h3>[method:null getInterpolation]()</h3>
+		<h3>[method:Interpolant getInterpolation]()</h3>
 		<p>
 			إرجاع نوع الاستيفاء (interpolation).
 		</p>
@@ -156,12 +156,12 @@
 			ينشئ [page:DiscreteInterpolant DiscreteInterpolant] جديدًا من [page:KeyframeTrack.times times] و [page:KeyframeTrack.times values]. يمكن تمرير Float32Array الذي سيحصل على النتائج. وإلا فسيتم إنشاء مصفوفة جديدة بالحجم المناسب تلقائيًا.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:LinearInterpolant InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			ينشئ [page:LinearInterpolant LinearInterpolant] جديدًا من page:KeyframeTrack.times times] و [page:KeyframeTrack.times values]. يمكن تمرير Float32Array الذي سيتلقى النتائج. وإلا فسيتم إنشاء مصفوفة جديدة بالحجم المناسب تلقائيًا.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:CubicInterpolant InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			قم بإنشاء [page:CubicInterpolant CubicInterpolant] جديد من [page:KeyframeTrack.times times] و [page:KeyframeTrack.times values]. يمكن تمرير Float32Array الذي سيحصل على النتائج. وإلا فسيتم إنشاء مصفوفة جديدة بالحجم المناسب تلقائيًا.
 		</p>

--- a/docs/api/ar/animation/PropertyBinding.html
+++ b/docs/api/ar/animation/PropertyBinding.html
@@ -71,21 +71,21 @@
 
 		<h2>الوظائف (Methods)</h2>
 
-		<h3>[method:null getValue]( [param:Array targetArray], [param:Number offset] )</h3>
+		<h3>[method:undefined getValue]( [param:Array targetArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
+		<h3>[method:undefined setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null bind]( )</h3>
+		<h3>[method:undefined bind]( )</h3>
 		<p>
 			إنشاء زوج getter / setter لخاصية في الرسم البياني للمشهد. تستخدم داخليا من قبل
 			[page:PropertyBinding.getValue getValue] و [page:PropertyBinding.setValue setValue].
 		</p>
 
-		<h3>[method:null unbind]( )</h3>
+		<h3>[method:undefined unbind]( )</h3>
 		<p>
 			تقوم بفك ربط زوج getter / setter لخاصية في الرسم البياني للمشهد.
 		</p>

--- a/docs/api/ar/animation/PropertyMixer.html
+++ b/docs/api/ar/animation/PropertyMixer.html
@@ -65,24 +65,24 @@
 		<h2>الوظائف (Methods)</h2>
 
 
-		<h3>[method:null accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
+		<h3>[method:undefined accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
 		<p>
 			تجميع البيانات في [page:PropertyMixer.buffer buffer][accuIndex] منطقة 'incoming' في 'accu[i]'.<br />
 
 			إذا كان الوزن *0* فهذا لا يفعل شيئًا.
 		</p>
 
-		<h3>[method:null apply]( [param:Number accuIndex] )</h3>
+		<h3>[method:undefined apply]( [param:Number accuIndex] )</h3>
 		<p>
 			تطبيق حالة [page:PropertyMixer.buffer buffer] 'accu[i]' على الربط عند اختلاف الاتهام.
 		</p>
 
-		<h3>[method:null saveOriginalState]( )</h3>
+		<h3>[method:undefined saveOriginalState]( )</h3>
 		<p>
 			تذكر حالة الملكية المقيدة وتنسخها إلى كلا المتهمين.
 		</p>
 
-		<h3>[method:null restoreOriginalState](  )</h3>
+		<h3>[method:undefined restoreOriginalState](  )</h3>
 		<p>
 			تقوم بتطبيق الحالة التي تم التقاطها مسبقًا عبر 'saveOriginalState' إلى binding.
 		</p>

--- a/docs/api/ar/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/BooleanKeyframeTrack.html
@@ -58,12 +58,12 @@
 			أنظر [page:KeyframeTrack] من أجل الخصائص الموروثة
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear ]()</h3>
 		<p>
 			قيمة هذه الوضيفة هي 'undefined'، حيث أنه لا يوجد سبب لإستعمالها على الخصائص المتفردة.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth ]()</h3>
 		<p>
 			قيمة هذه الوضيفة هي 'undefined'، حيث أنه لا يوجد سبب لإستعمالها على الخصائص المتفردة.
 		</p>

--- a/docs/api/ar/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/QuaternionKeyframeTrack.html
@@ -56,7 +56,7 @@
 			أنظر [page:KeyframeTrack] من أجل الخصائص الموروثة
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:QuaternionLinearInterpolant InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			إرجاع قيمة من نوع [page:QuaternionLinearInterpolant QuaternionLinearInterpolant] بناءا على
 			[page:KeyframeTrack.values values], [page:KeyframeTrack.times times] و

--- a/docs/api/ar/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/ar/animation/tracks/StringKeyframeTrack.html
@@ -61,12 +61,12 @@
 			أنظر [page:KeyframeTrack] من أجل الخصائص الموروثة
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			قيمة هذه الطريقة هنا 'undefined' ، لأنها لا معنى لها بالنسبة للخصائص المنفصلة.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth]()</h3>
 		<p>
 			قيمة هذه الطريقة هنا 'undefined' ، لأنها لا معنى لها بالنسبة للخصائص المنفصلة.
 		</p>

--- a/docs/api/ar/audio/Audio.html
+++ b/docs/api/ar/audio/Audio.html
@@ -151,7 +151,7 @@
 		إذا كانت [page:Audio.hasPlaybackControl hasPlaybackControl] تحمل قيمة *true* ، يقوم بإقاف التشغيل.
 		</p>
 
-		<h3>[method:null onEnded]()</h3>
+		<h3>[method:undefined onEnded]()</h3>
 		<p>
 		يتم مناداته تلقائيًا عند انتهاء التشغيل.
 		</p>

--- a/docs/api/ar/cameras/CubeCamera.html
+++ b/docs/api/ar/cameras/CubeCamera.html
@@ -70,19 +70,13 @@
 		<h2>الوظائف (Methods)</h2>
 		<p>راجع فئة [page: Object3D] الأساسية للخصائص العامة.</p>
 
-		<h3>[method:null update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
+		<h3>[method:undefined update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
 		<p>
 		renderer -- عارض WebGL الحالي <br />
 		scene -- المشهد الحالي
 		</p>
 		<p>
 		استدعاء هذا لتحديث [page:CubeCamera.renderTarget renderTarget].
-		</p>
-
-		<h3>[method:null clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
-		<p>
-		قم باستدعاء هذا لمسح لون وعمق و / أو مخازن الاستنسل *stencil buffers* المؤقتة الخاصة بالهدف.
-		يتم تعيين مخزن الألوان على اللون الواضح الحالي لجهاز العرض. القيم الافتراضية هي *true*.
 		</p>
 
 		<h2>المصدر (Source)</h2>

--- a/docs/api/en/Template.html
+++ b/docs/api/en/Template.html
@@ -35,7 +35,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null todo]()</h3>
+		<h3>[method:undefined todo]()</h3>
 		<p>todo</p>
 		<p>todo</p>
 

--- a/docs/api/en/animation/AnimationMixer.html
+++ b/docs/api/en/animation/AnimationMixer.html
@@ -91,18 +91,18 @@
 			This is useful when you need to jump to an exact time in an animation. The input parameter will be scaled by the mixer's [page:.timeScale timeScale].
 		</p>
 
-		<h3>[method:null uncacheClip]([param:AnimationClip clip])</h3>
+		<h3>[method:undefined uncacheClip]([param:AnimationClip clip])</h3>
 
 		<p>
 			Deallocates all memory resources for a clip. Before using this method make sure to call [page:AnimationAction.stop]() for all related actions.
 		</p>
 
-		<h3>[method:null uncacheRoot]([param:Object3D root]) </h3>
+		<h3>[method:undefined uncacheRoot]([param:Object3D root]) </h3>
 		<p>
 			Deallocates all memory resources for a root object. Before using this method make sure to call [page:AnimationAction.stop]() for all related actions.
 		</p>
 
-		<h3>[method:null uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
+		<h3>[method:undefined uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
 			Deallocates all memory resources for an action. Before using this method make sure to call [page:AnimationAction.stop]() to deactivate the action.
 		</p>

--- a/docs/api/en/animation/AnimationObjectGroup.html
+++ b/docs/api/en/animation/AnimationObjectGroup.html
@@ -60,17 +60,17 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:null add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			Adds an arbitrary number of objects to this *AnimationObjectGroup*.
 		</p>
 
-		<h3>[method:null remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			Removes an arbitrary number of objects from this *AnimationObjectGroup*.
 		</p>
 
-		<h3>[method:null uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			Deallocates all memory resources for the passed objects of this *AnimationObjectGroup*.
 		</p>

--- a/docs/api/en/animation/KeyframeTrack.html
+++ b/docs/api/en/animation/KeyframeTrack.html
@@ -163,14 +163,14 @@
 			Returns a copy of this track.
 		</p>
 
-		<h3>[method:null createInterpolant]()</h3>
+		<h3>[method:Interpolant createInterpolant]()</h3>
 		<p>
 			Creates a [page:LinearInterpolant LinearInterpolant], [page:CubicInterpolant CubicInterpolant]
 			or [page:DiscreteInterpolant DiscreteInterpolant], depending on the value of the interpolation
 			parameter passed in the constructor.
 		</p>
 
-		<h3>[method:null getInterpolation]()</h3>
+		<h3>[method:Interpolant getInterpolation]()</h3>
 		<p>
 			Returns the interpolation type.
 		</p>
@@ -189,7 +189,7 @@
 			created automatically.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:LinearInterpolant InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			Creates a new [page:LinearInterpolant LinearInterpolant] from the
 			[page:KeyframeTrack.times times] and [page:KeyframeTrack.times values]. A Float32Array can be
@@ -197,7 +197,7 @@
 			created automatically.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:CubicInterpolant InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			Create a new [page:CubicInterpolant CubicInterpolant] from the
 			[page:KeyframeTrack.times times] and [page:KeyframeTrack.times values]. A Float32Array can be

--- a/docs/api/en/animation/PropertyBinding.html
+++ b/docs/api/en/animation/PropertyBinding.html
@@ -71,21 +71,21 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null getValue]( [param:Array targetArray], [param:Number offset] )</h3>
+		<h3>[method:undefined getValue]( [param:Array targetArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
+		<h3>[method:undefined setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null bind]( )</h3>
+		<h3>[method:undefined bind]( )</h3>
 		<p>
 			Create getter / setter pair for a property in the scene graph. Used internally by
 			[page:PropertyBinding.getValue getValue] and [page:PropertyBinding.setValue setValue].
 		</p>
 
-		<h3>[method:null unbind]( )</h3>
+		<h3>[method:undefined unbind]( )</h3>
 		<p>
 			Unbind getter / setter pair for a property in the scene graph.
 		</p>

--- a/docs/api/en/animation/PropertyMixer.html
+++ b/docs/api/en/animation/PropertyMixer.html
@@ -66,24 +66,24 @@
 		<h2>Methods</h2>
 
 
-		<h3>[method:null accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
+		<h3>[method:undefined accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
 		<p>
 			Accumulate data in [page:PropertyMixer.buffer buffer][accuIndex] 'incoming' region into 'accu[i]'.<br />
 
 			If weight is *0* this does nothing.
 		</p>
 
-		<h3>[method:null apply]( [param:Number accuIndex] )</h3>
+		<h3>[method:undefined apply]( [param:Number accuIndex] )</h3>
 		<p>
 			Apply the state of [page:PropertyMixer.buffer buffer] 'accu[i]' to the binding when accus differ.
 		</p>
 
-		<h3>[method:null saveOriginalState]( )</h3>
+		<h3>[method:undefined saveOriginalState]( )</h3>
 		<p>
 			Remember the state of the bound property and copy it to both accus.
 		</p>
 
-		<h3>[method:null restoreOriginalState](  )</h3>
+		<h3>[method:undefined restoreOriginalState](  )</h3>
 		<p>
 			Apply the state previously taken via 'saveOriginalState' to the binding.
 		</p>

--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -58,12 +58,12 @@
 			See [page:KeyframeTrack] for inherited methods.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear ]()</h3>
 		<p>
 			The value of this method here is 'undefined', as it does not make sense for discrete properties.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth ]()</h3>
 		<p>
 			The value of this method here is 'undefined', as it does not make sense for discrete properties.
 		</p>

--- a/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
@@ -56,7 +56,7 @@
 			See [page:KeyframeTrack] for inherited methods.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:QuaternionLinearInterpolant InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			Returns a new [page:QuaternionLinearInterpolant QuaternionLinearInterpolant] based on the
 			[page:KeyframeTrack.values values], [page:KeyframeTrack.times times] and

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -61,12 +61,12 @@
 			See [page:KeyframeTrack] for inherited methods.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear]()</h3>
 		<p>
 		  The value of this method here is 'undefined', as it does not make sense for discrete properties.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth]()</h3>
 		<p>
 		  The value of this method here is 'undefined', as it does not make sense for discrete properties.
 		</p>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -157,7 +157,7 @@
 		If [page:Audio.hasPlaybackControl hasPlaybackControl] is true, pauses playback.
 		</p>
 
-		<h3>[method:null onEnded]()</h3>
+		<h3>[method:undefined onEnded]()</h3>
 		<p>
 		Called automatically when playback finished.
 		</p>

--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -70,7 +70,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
+		<h3>[method:undefined update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
 		<p>
 		renderer -- The current WebGL renderer <br />
 		scene -- The current scene

--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -101,7 +101,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Camera] class for common methods.</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — full width of multiview setup<br />
 		fullHeight — full height of multiview setup<br />
@@ -115,12 +115,12 @@
 			For an example on how to use it see [page:PerspectiveCamera.setViewOffset PerspectiveCamera].
 		</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>
 		Removes any offset set by the .setViewOffset method.
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		Updates the camera projection matrix. Must be called after any change of parameters.
 		</p>

--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -104,7 +104,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Camera] class for common methods.</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>Removes any offset set by the [page:PerspectiveCamera.setViewOffset .setViewOffset] method.</p>
 
 		<h3>[method:Float getEffectiveFOV]()</h3>
@@ -125,14 +125,14 @@
 		<h3>[method:Float getFocalLength]()</h3>
 		<p>Returns the focal length of the current .fov in respect to .filmGauge.</p>
 
-		<h3>[method:null setFocalLength]( [param:Float focalLength] )</h3>
+		<h3>[method:undefined setFocalLength]( [param:Float focalLength] )</h3>
 		<p>
 		Sets the FOV by focal length in respect to the current [page:PerspectiveCamera.filmGauge .filmGauge].<br /><br />
 
 		By default, the focal length is specified for a 35mm (full frame) camera.
 		</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — full width of multiview setup<br />
 		fullHeight — full height of multiview setup<br />
@@ -181,7 +181,7 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 		Note there is no reason monitors have to be the same size or in a grid.
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		Updates the camera projection matrix. Must be called after any change of parameters.
 		</p>

--- a/docs/api/en/cameras/StereoCamera.html
+++ b/docs/api/en/cameras/StereoCamera.html
@@ -46,7 +46,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null update]( [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined update]( [param:PerspectiveCamera camera] )</h3>
 		<p>
 		Update the stereo cameras based on the camera passed in.
 		</p>

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -131,7 +131,7 @@
 			for notes on requirements if copying a TypedArray.
 		</p>
 
-		<h3>[method:null copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
+		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>Copy a vector from bufferAttribute[index2] to [page:BufferAttribute.array array][index1].</p>
 
 		<h3>[method:BufferAttribute copyColorsArray]( [param:Array colors] ) </h3>

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -169,7 +169,7 @@
 		attributes.
 		</p>
 
-		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
+		<h3>[method:undefined addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
 		<p>
 			Adds a group to this geometry; see the [page:BufferGeometry.groups groups]
 			property for details.
@@ -191,31 +191,31 @@
 		<h3>[method:BufferGeometry copy]( [param:BufferGeometry bufferGeometry] )</h3>
 		<p>Copies another BufferGeometry to this BufferGeometry.</p>
 
-		<h3>[method:null clearGroups]( )</h3>
+		<h3>[method:undefined clearGroups]( )</h3>
 		<p>Clears all groups.</p>
 
-		<h3>[method:null computeBoundingBox]()</h3>
+		<h3>[method:undefined computeBoundingBox]()</h3>
 		<p>
 		Computes bounding box of the geometry, updating [page:.boundingBox] attribute.<br />
 		Bounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
 		</p>
 
-		<h3>[method:null computeBoundingSphere]()</h3>
+		<h3>[method:undefined computeBoundingSphere]()</h3>
 		<p>
 		Computes bounding sphere of the geometry, updating [page:.boundingSphere] attribute.<br />
 		Bounding spheres aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
 		</p>
 
-		<h3>[method:null computeTangents]()</h3>
+		<h3>[method:undefined computeTangents]()</h3>
 		<p>
 		Calculates and adds a tangent attribute to this geometry.<br />
 		The computation is only supported for indexed geometries and if position, normal, and uv attributes are defined.
 		</p>
 
-		<h3>[method:null computeVertexNormals]()</h3>
+		<h3>[method:undefined computeVertexNormals]()</h3>
 		<p>Computes vertex normals by averaging face normals.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Disposes the object from memory. <br />
 		You need to call this when you want the BufferGeometry removed while the application is running.
@@ -238,10 +238,10 @@
 		Use [page:Object3D.lookAt] for typical real-time mesh usage.
 		</p>
 
-		<h3>[method:null merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
+		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
 		<p>Merge in another BufferGeometry with an optional offset of where to start merging in.</p>
 
-		<h3>[method:null normalizeNormals]()</h3>
+		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 		Every normal vector in a geometry will have a magnitude of 1.
 		This will correct lighting on the geometry surfaces.
@@ -277,7 +277,7 @@
 		<h3>[method:BufferGeometry setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>Set the [page:.index] buffer.</p>
 
-		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
+		<h3>[method:undefined setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
 		<p>Set the [page:.drawRange] property. For non-indexed BufferGeometry, count is the number of vertices to render.
 		For indexed BufferGeometry, count is the number of indices to render.</p>
 

--- a/docs/api/en/core/Clock.html
+++ b/docs/api/en/core/Clock.html
@@ -55,13 +55,13 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null start]()</h3>
+		<h3>[method:undefined start]()</h3>
 		<p>
 		Starts clock. Also sets the [page:Clock.startTime startTime] and [page:Clock.oldTime oldTime]
 		to the current time, sets [page:Clock.elapsedTime elapsedTime] to *0* and [page:Clock.running running] to *true*.
 		</p>
 
-		<h3>[method:null stop]()</h3>
+		<h3>[method:undefined stop]()</h3>
 		<p>
 		Stops clock and sets [page:Clock.oldTime oldTime] to the current time.
 		</p>

--- a/docs/api/en/core/EventDispatcher.html
+++ b/docs/api/en/core/EventDispatcher.html
@@ -52,7 +52,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - The type of event to listen to.<br />
 		listener - The function that gets called when the event is fired.
@@ -70,7 +70,7 @@
 		Checks if listener is added to an event type.
 		</p>
 
-		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - The type of the listener that gets removed.<br />
 		listener - The listener function that gets removed.
@@ -79,7 +79,7 @@
 		Removes a listener from an event type.
 		</p>
 
-		<h3>[method:null dispatchEvent]( [param:Object event] )</h3>
+		<h3>[method:undefined dispatchEvent]( [param:Object event] )</h3>
 		<p>
 		event - The event that gets fired.
 		</p>

--- a/docs/api/en/core/GLBufferAttribute.html
+++ b/docs/api/en/core/GLBufferAttribute.html
@@ -86,16 +86,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setBuffer]( buffer ) </h3>
+		<h3>[method:this setBuffer]( buffer ) </h3>
 		<p>Sets the *buffer* property.</p>
 
-		<h3>[method:null setType]( type, elementSize ) </h3>
+		<h3>[method:this setType]( type, elementSize ) </h3>
 		<p>Sets the both *type* and *elementSize* properties.</p>
 
-		<h3>[method:null setItemSize]( itemSize ) </h3>
+		<h3>[method:this setItemSize]( itemSize ) </h3>
 		<p>Sets the *itemSize* property.</p>
 
-		<h3>[method:null setCount]( count ) </h3>
+		<h3>[method:this setCount]( count ) </h3>
 		<p>Sets the *count* property.</p>
 
 		<h3>[property:Integer version]</h3>

--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -87,25 +87,25 @@
 		<h3>[method:Number getW]( [param:Integer index] ) </h3>
 		<p>Returns the w component of the item at the given index.</p>
 
-		<h3>[method:null setX]( [param:Integer index], [param:Float x] ) </h3>
+		<h3>[method:this setX]( [param:Integer index], [param:Float x] ) </h3>
 		<p>Sets the x component of the item at the given index.</p>
 
-		<h3>[method:null setY]( [param:Integer index], [param:Float y] ) </h3>
+		<h3>[method:this setY]( [param:Integer index], [param:Float y] ) </h3>
 		<p>Sets the y component of the item at the given index.</p>
 
-		<h3>[method:null setZ]( [param:Integer index], [param:Float z] ) </h3>
+		<h3>[method:this setZ]( [param:Integer index], [param:Float z] ) </h3>
 		<p>Sets the z component of the item at the given index.</p>
 
-		<h3>[method:null setW]( [param:Integer index], [param:Float w] ) </h3>
+		<h3>[method:this setW]( [param:Integer index], [param:Float w] ) </h3>
 		<p>Sets the w component of the item at the given index.</p>
 
-		<h3>[method:null setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
+		<h3>[method:this setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
 		<p>Sets the x and y components of the item at the given index.</p>
 
-		<h3>[method:null setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
+		<h3>[method:this setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
 		<p>Sets the x, y and z components of the item at the given index.</p>
 
-		<h3>[method:null setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
+		<h3>[method:this setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
 		<p>Sets the x, y, z and w components of the item at the given index.</p>
 
 

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -44,21 +44,21 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null disable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined disable]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Remove membership of this *layer*.
 		</p>
 
-		<h3>[method:null enable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined enable]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Add membership of this *layer*.
 		</p>
 
-		<h3>[method:null set]( [param:Integer layer] )</h3>
+		<h3>[method:undefined set]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
@@ -72,19 +72,19 @@
 			Returns true if this and the passed *layers* object have at least one layer in common.
 		</p>
 
-		<h3>[method:null toggle]( [param:Integer layer] )</h3>
+		<h3>[method:undefined toggle]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
 			Toggle membership of *layer*.
 		</p>
 
-		<h3>[method:null enableAll]()</h3>
+		<h3>[method:undefined enableAll]()</h3>
 		<p>
 			Add membership to all layers.
 		</p>
 
-		<h3>[method:null disableAll]()</h3>
+		<h3>[method:undefined disableAll]()</h3>
 		<p>
 			Remove membership from all layers.
 		</p>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -214,7 +214,7 @@
 		See [page:Group] for info on manually grouping objects.
 		</p>
 
-		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>Applies the matrix transform to the object and updates the object's position, rotation and scale.</p>
 
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
@@ -300,8 +300,8 @@
 		Converts the vector from this object's local space to world space.
 		</p>
 
-		<h3>[method:null lookAt]( [param:Vector3 vector] )<br />
-		[method:null lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:undefined lookAt]( [param:Vector3 vector] )<br />
+		[method:undefined lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
 		vector - A vector representing a position in world space.<br /><br />
 		Optionally, the [page:.x x], [page:.y y] and [page:.z z] components of the world space position.<br /><br />
@@ -371,7 +371,7 @@
 		Rotates the object around z axis in local space.
 		</p>
 
-		<h3>[method:null setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
+		<h3>[method:undefined setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 			axis -- A normalized vector in object space. <br />
 			angle -- angle in radians<br /><br />
@@ -380,7 +380,7 @@
 			on the [page:.quaternion].
 		</p>
 
-		<h3>[method:null setRotationFromEuler]( [param:Euler euler] )</h3>
+		<h3>[method:undefined setRotationFromEuler]( [param:Euler euler] )</h3>
 		<p>
 			euler -- Euler angle specifying rotation amount.<br />
 
@@ -388,7 +388,7 @@
 			on the [page:.quaternion].
 		</p>
 
-		<h3>[method:null setRotationFromMatrix]( [param:Matrix4 m] )</h3>
+		<h3>[method:undefined setRotationFromMatrix]( [param:Matrix4 m] )</h3>
 		<p>
 			m -- rotate the quaternion by the rotation component of the matrix.<br />
 
@@ -398,7 +398,7 @@
 			Note that this assumes that the upper 3x3 of m is a pure rotation matrix (i.e, unscaled).
 		</p>
 
-		<h3>[method:null setRotationFromQuaternion]( [param:Quaternion q] )</h3>
+		<h3>[method:undefined setRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<p>
 			q -- normalized Quaternion.<br /><br />
 
@@ -428,7 +428,7 @@
 		<h3>[method:this translateZ]( [param:Float distance] )</h3>
 		<p>Translates object along z axis in object space by *distance* units.</p>
 
-		<h3>[method:null traverse]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverse]( [param:Function callback] )</h3>
 		<p>
 		callback - A function with as first argument an object3D object.<br /><br />
 
@@ -436,7 +436,7 @@
 		Note: Modifying the scene graph inside the callback is discouraged.
 		</p>
 
-		<h3>[method:null traverseVisible]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverseVisible]( [param:Function callback] )</h3>
 		<p>
 		callback - A function with as first argument an object3D object.<br /><br />
 
@@ -445,7 +445,7 @@
 		Note: Modifying the scene graph inside the callback is discouraged.
 		</p>
 
-		<h3>[method:null traverseAncestors]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverseAncestors]( [param:Function callback] )</h3>
 		<p>
 		callback - A function with as first argument an object3D object.<br /><br />
 
@@ -453,13 +453,13 @@
 		Note: Modifying the scene graph inside the callback is discouraged.
 		</p>
 
-		<h3>[method:null updateMatrix]()</h3>
+		<h3>[method:undefined updateMatrix]()</h3>
 		<p>Updates the local transform.</p>
 
-		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>Updates the global transform of the object and its descendants.</p>
 
-		<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
+		<h3>[method:undefined updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 		<p>
 		updateParents - recursively updates global transform of ancestors.<br />
 		updateChildren - recursively updates global transform of descendants.<br /><br />

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -139,7 +139,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
+		<h3>[method:undefined set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<p>
 		[page:Vector3 origin] — The origin vector where the ray casts from.<br />
 		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
@@ -148,7 +148,7 @@
 		Updates the ray with a new origin and direction. Please note that this method only copies the values from the arguments.
 		</p>
 
-		<h3>[method:null setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
+		<h3>[method:undefined setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
 		<p>
 		[page:Vector2 coords] — 2D coordinates of the mouse, in normalized device coordinates (NDC)---X and Y components should be between -1 and 1.<br />
 		[page:Camera camera] — camera from which the ray should originate

--- a/docs/api/en/extras/core/Curve.html
+++ b/docs/api/en/extras/core/Curve.html
@@ -68,10 +68,10 @@
 		<h3>[method:Array getLengths]( [param:Integer divisions] )</h3>
 		<p>Get list of cumulative segment lengths.</p>
 
-		<h3>[method:null updateArcLengths]()</h3>
+		<h3>[method:undefined updateArcLengths]()</h3>
 		<p>
 			Update the cumlative segment distance cache. The method must be called every time curve parameters are changed.
-			If an updated curve is part of a composed curve like [page:CurvePath], [page:.updateArcLengths]() must be 
+			If an updated curve is part of a composed curve like [page:CurvePath], [page:.updateArcLengths]() must be
 			called on the composed curve, too.
 		</p>
 

--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -35,10 +35,10 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Curve] class for common methods.</p>
 
-		<h3>[method:null add]( [param:Curve curve] )</h3>
+		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>Add a curve to the [page:.curves] array.</p>
 
-		<h3>[method:null closePath]()</h3>
+		<h3>[method:undefined closePath]()</h3>
 		<p>Adds a [page:LineCurve lineCurve] to close the path.</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/en/helpers/ArrowHelper.html
+++ b/docs/api/en/helpers/ArrowHelper.html
@@ -59,14 +59,14 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null setColor]([param:Color color])</h3>
+		<h3>[method:undefined setColor]([param:Color color])</h3>
 		<p>
 		color -- The desired color.<br /><br />
 
 		Sets the color of the arrowHelper.
 		</p>
 
-		<h3>[method:null setLength]([param:Number length], [param:Number headLength], [param:Number headWidth])</h3>
+		<h3>[method:undefined setLength]([param:Number length], [param:Number headLength], [param:Number headWidth])</h3>
 		<p>
 		length -- The desired length.<br />
 		headLength -- The length of the head of the arrow.<br />
@@ -75,7 +75,7 @@
 		Sets the length of the arrowhelper.
 		</p>
 
-		<h3>[method:null setDirection]([param:Vector3 dir])</h3>
+		<h3>[method:undefined setDirection]([param:Vector3 dir])</h3>
 		<p>
 		dir -- The desired direction. Must be a unit vector.<br /><br />
 

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -49,7 +49,7 @@ scene.add( axesHelper );
 		Sets the axes colors to [page:Color xAxisColor], [page:Color yAxisColor], [page:Color zAxisColor].
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Disposes of the internally-created [page:Line.material material] and [page:Line.geometry geometry] used by this helper.
 		</p>

--- a/docs/api/en/helpers/BoxHelper.html
+++ b/docs/api/en/helpers/BoxHelper.html
@@ -54,7 +54,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:LineSegments] class for common methods.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>
 			Updates the helper's geometry to match the dimensions
 			of the object, including any children. See [page:Box3.setFromObject].

--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -52,7 +52,7 @@ scene.add( helper );
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the 
+			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
 			camera's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 
@@ -64,7 +64,7 @@ scene.add( helper );
 			Disposes of the internally-created [page:Line.material material] and [page:Line.geometry geometry] used by this helper.
 		</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>Updates the helper based on the projectionMatrix of the camera.</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/helpers/DirectionalLightHelper.html
+++ b/docs/api/en/helpers/DirectionalLightHelper.html
@@ -67,11 +67,11 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common properties.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>Dispose of the directionalLightHelper.</p>
 
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>Updates the helper to match the position and direction of the [page:.light directionalLight] being visualized.</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/helpers/HemisphereLightHelper.html
+++ b/docs/api/en/helpers/HemisphereLightHelper.html
@@ -61,10 +61,10 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>Dispose of the hemisphereLightHelper.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>Updates the helper to match the position and direction of the [page:.light].</p>
 
 

--- a/docs/api/en/helpers/PointLightHelper.html
+++ b/docs/api/en/helpers/PointLightHelper.html
@@ -69,11 +69,11 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>Dispose of the pointLightHelper.</p>
 
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>Updates the helper to match the position of the [page:.light].</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/helpers/SpotLightHelper.html
+++ b/docs/api/en/helpers/SpotLightHelper.html
@@ -65,10 +65,10 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>Disposes of the light helper.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>Updates the light helper.</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -110,7 +110,7 @@
 		Used internally by the renderer to extend the shadow map to contain all viewports
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light] )</h3>
+		<h3>[method:undefined updateMatrices]( [param:Light light] )</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 

--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -72,7 +72,7 @@
 			See the base [page:LightShadow LightShadow] class for common methods.
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
+		<h3>[method:undefined updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 

--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -59,7 +59,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -76,7 +76,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -68,7 +68,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />

--- a/docs/api/en/loaders/Cache.html
+++ b/docs/api/en/loaders/Cache.html
@@ -40,7 +40,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null add]( [param:String key], [param:Object file] )</h3>
+		<h3>[method:undefined add]( [param:String key], [param:Object file] )</h3>
 		<p>
 		[page:String key] — the [page:String key] to reference the cached file by.<br />
 		[page:Object file] — The file to be cached.<br /><br />
@@ -49,21 +49,21 @@
 		it is overwritten.
 		</p>
 
-		<h3>[method:null get]( [param:String key] )</h3>
+		<h3>[method:Any get]( [param:String key] )</h3>
 		<p>
 		[page:String key] — A string key <br /><br />
 
 		Get the value of [page:String key]. If the key does not exist *undefined* is returned.
 		</p>
 
-		<h3>[method:null remove]( [param:String key] )</h3>
+		<h3>[method:undefined remove]( [param:String key] )</h3>
 		<p>
 		[page:String key] — A string key that references a cached file.<br /><br />
 
 		Remove the cached file associated with the key.
 		</p>
 
-		<h3>[method:null clear]()</h3>
+		<h3>[method:undefined clear]()</h3>
 		<p>Remove all values from the cache.</p>
 
 

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -78,7 +78,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -62,7 +62,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -72,7 +72,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -171,7 +171,7 @@
 manager.addHandler( /\.tga$/i, new TGALoader() );
 		</code>
 
-		<h3>[method:null getHandler]( [param:String file] )</h3>
+		<h3>[method:Loader getHandler]( [param:String file] )</h3>
 		<p>
 		[page:String file] — The file path.
 		<p>
@@ -193,7 +193,7 @@ manager.addHandler( /\.tga$/i, new TGALoader() );
 		URL modifier is set, returns the original URL.
 		</p>
 
-		<h3>[method:null setURLModifier]( [param:Function callback] )</h3>
+		<h3>[method:this setURLModifier]( [param:Function callback] )</h3>
 		<p>
 		[page:Function callback] — URL modifier callback. Called with [page:String url] argument, and
 		must return [page:String resolvedURL].<br /><br />
@@ -210,21 +210,21 @@ manager.addHandler( /\.tga$/i, new TGALoader() );
 			them directly.</em>
 		</p>
 
-		<h3>[method:null itemStart]( [param:String url] )</h3>
+		<h3>[method:undefined itemStart]( [param:String url] )</h3>
 		<p>
 		[page:String url] — the url to load<br /><br />
 
 		This should be called by any loader using the manager when the loader starts loading an url.
 		</p>
 
-		<h3>[method:null itemEnd]( [param:String url] )</h3>
+		<h3>[method:undefined itemEnd]( [param:String url] )</h3>
 		<p>
 		[page:String url] — the loaded url<br /><br />
 
 		This should be called by any loader using the manager when the loader ended loading an url.
 		</p>
 
-		<h3>[method:null itemError]( [param:String url] )</h3>
+		<h3>[method:undefined itemError]( [param:String url] )</h3>
 		<p>
 		[page:String url] — the loaded url<br /><br />
 

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -324,13 +324,13 @@
 		<h3>[method:Material copy]( [param:material material] )</h3>
 		<p>Copy the parameters from the passed material into this material.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		This disposes the material. Textures of a material don't get disposed.
 		These needs to be disposed by [page:Texture Texture].
 		</p>
 
-		<h3>[method:null onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
+		<h3>[method:undefined onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
 		<p>
 		An optional callback that is executed immediately before the shader program is compiled.
 		This function is called with the shader source code as a parameter. Useful for the modification of built-in materials.
@@ -369,7 +369,7 @@
 		Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 		</p>
 
-		<h3>[method:null setValues]( [param:Object values] )</h3>
+		<h3>[method:undefined setValues]( [param:Object values] )</h3>
 		<p>
 		values -- a container with parameters.<br />
 		Sets the properties based on the *values*.

--- a/docs/api/en/math/Interpolant.html
+++ b/docs/api/en/math/Interpolant.html
@@ -71,7 +71,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 		Evaluate the interpolant at position *t*.
 		</p>

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -134,7 +134,7 @@
 		that has zero 1st and 2nd order derivatives at x=0 and x=1.
 		</p>
 
-		<h3>[method:null setQuaternionFromProperEuler]( [param:Quaternion q], [param:Float a], [param:Float b], [param:Float c], [param:String order] )</h3>
+		<h3>[method:undefined setQuaternionFromProperEuler]( [param:Quaternion q], [param:Float a], [param:Float b], [param:Float c], [param:String order] )</h3>
 		<p>
 		[page:Quaternion q] - the quaternion to be set<br />
 		[page:Float a] - the rotation applied to the first axis, in radians <br />

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -139,7 +139,7 @@ m.elements = [ 11, 21, 31, 41,
 		matrix's translation component.
 		</p>
 
-		<h3>[method:null decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
+		<h3>[method:this decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
 		<p>
 		Decomposes this matrix into its [page:Vector3 position], [page:Quaternion quaternion] and [page:Vector3 scale] components.<br/><br/>
 		Note: Not all matrices are decomposable in this way. For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, and this method may not be appropriate.

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -219,7 +219,7 @@
 
 		<h2>Static Methods</h2>
 
-		<h3>[method:null slerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float t] )</h3>
+		<h3>[method:undefined slerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float t] )</h3>
 		<p>
 		[page:Array dst] - The output array.<br />
 		[page:Integer dstOffset] - An offset into the output array.<br />

--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -292,7 +292,7 @@
 		<h3>[method:this set]( [param:Float x], [param:Float y] )</h3>
 		<p>Sets the [page:.x x] and [page:.y y] components of this vector.</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0 or 1.<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -340,7 +340,7 @@
 		<h3>[method:this set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>Sets the [page:.x x], [page:.y y] and [page:.z z] components of this vector.</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -276,7 +276,7 @@
 			Sets the [page:.x x], [page:.y y] and [page:.z z] to the axis of rotation and [page:.w w] to the angle.
 		</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0, 1 or 2.<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/en/math/interpolants/CubicInterpolant.html
+++ b/docs/api/en/math/interpolants/CubicInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 		Evaluate the interpolant at position *t*.
 		</p>

--- a/docs/api/en/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/en/math/interpolants/DiscreteInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 		Evaluate the interpolant at position *t*.
 		</p>

--- a/docs/api/en/math/interpolants/LinearInterpolant.html
+++ b/docs/api/en/math/interpolants/LinearInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 		Evaluate the interpolant at position *t*.
 		</p>

--- a/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/en/math/interpolants/QuaternionLinearInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 		Evaluate the interpolant at position *t*.
 		</p>

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -63,12 +63,12 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			Frees the internal resources of this instance.
 		</p>
 
-		<h3>[method:null getColorAt]( [param:Integer index], [param:Color color] )</h3>
+		<h3>[method:undefined getColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>
@@ -79,7 +79,7 @@
 			Get the color of the defined instance.
 		</p>
 
-		<h3>[method:null getMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined getMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>
@@ -90,7 +90,7 @@
 			Get the local transformation matrix of the defined instance.
 		</p>
 
-		<h3>[method:null setColorAt]( [param:Integer index], [param:Color color] )</h3>
+		<h3>[method:undefined setColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>
@@ -102,7 +102,7 @@
 			Make sure you set [page:.instanceColor][page:BufferAttribute.needsUpdate .needsUpdate] to true after updating all the colors.
 		</p>
 
-		<h3>[method:null setMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined setMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -113,7 +113,7 @@
 		Create a JSON structure with details of this LOD object.
 		</p>
 
-		<h3>[method:null update]( [param:Camera camera] )</h3>
+		<h3>[method:undefined update]( [param:Camera camera] )</h3>
 		<p>
 			Set the visibility of each [page:levels level]'s [page:Object3D object] based on
 			distance from the [page:Camera camera].

--- a/docs/api/en/objects/Line.html
+++ b/docs/api/en/objects/Line.html
@@ -79,7 +79,7 @@
 		Computes an array of distance values which are necessary for [page:LineDashedMaterial]. For each vertex in the geometry, the method calculates the cumulative length from the current point to the very beginning of the line.
 		</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted [page:Ray] and this Line.
 		[page:Raycaster.intersectObject] will call this method.
@@ -90,7 +90,7 @@
 		Returns a clone of this Line object and its descendants.
 		</p>
 
-		<h3>[method:null updateMorphTargets]()</h3>
+		<h3>[method:undefined updateMorphTargets]()</h3>
 		<p>
 		Updates the morphTargets to have no influence on the object. Resets the
 		[page:.morphTargetInfluences] and [page:.morphTargetDictionary] properties.

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -67,13 +67,13 @@
 		<h3>[method:Mesh clone]()</h3>
 		<p>Returns a clone of this [name] object and its descendants.</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted ray and this mesh.
 		[page:Raycaster.intersectObject] will call this method, but the results are not ordered.
 		</p>
 
-		<h3>[method:null updateMorphTargets]()</h3>
+		<h3>[method:undefined updateMorphTargets]()</h3>
 		<p>
 		Updates the morphTargets to have no influence on the object. Resets the
 		[page:Mesh.morphTargetInfluences morphTargetInfluences] and

--- a/docs/api/en/objects/Points.html
+++ b/docs/api/en/objects/Points.html
@@ -56,7 +56,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Object3D] class for common methods.</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted ray and this Points.
 		[page:Raycaster.intersectObject] will call this method.
@@ -67,7 +67,7 @@
 		Returns a clone of this Points object and its descendants.
 		</p>
 
-		<h3>[method:null updateMorphTargets]()</h3>
+		<h3>[method:undefined updateMorphTargets]()</h3>
 		<p>
 		Updates the morphTargets to have no influence on the object. Resets the
 		[page:Points.morphTargetInfluences morphTargetInfluences] and

--- a/docs/api/en/objects/Skeleton.html
+++ b/docs/api/en/objects/Skeleton.html
@@ -91,16 +91,16 @@
 		Returns a clone of this Skeleton object.
 		</p>
 
-		<h3>[method:null calculateInverses]()</h3>
+		<h3>[method:undefined calculateInverses]()</h3>
 		<p>Generates the [page:.boneInverses boneInverses] array if not provided in the constructor.</p>
 
-		<h3>[method:null computeBoneTexture]()</h3>
+		<h3>[method:this computeBoneTexture]()</h3>
 		<p>Computes an instance of [page:DataTexture] in order to pass the bone data more efficiently to the shader. The texture is assigned to [page:.boneTexture boneTexture].</p>
 
-		<h3>[method:null pose]()</h3>
+		<h3>[method:undefined pose]()</h3>
 		<p>Returns the skeleton to the base pose.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>
 		Updates the [page:Float32Array boneMatrices] and [page:DataTexture boneTexture] after changing the bones.
 		This is called automatically by the [page:WebGLRenderer] if the skeleton is used with a [page:SkinnedMesh].
@@ -113,7 +113,7 @@
 		Searches through the skeleton's bone array and returns the first with a matching name.<br />
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Can be used if an instance of [name] becomes obsolete in an application. The method will free internal resources.
 		</p>

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -123,7 +123,7 @@
 		<h2>Methods</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
-		<h3>[method:null bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
+		<h3>[method:undefined bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
 		<p>
 		[page:Skeleton skeleton] - [page:Skeleton] created from a [page:Bone Bones] tree.<br/>
 		[page:Matrix4 bindMatrix] - [page:Matrix4] that represents the base transform of the skeleton.<br /><br />
@@ -137,17 +137,17 @@
 		Returns a clone of this SkinnedMesh object and any descendants.
 		</p>
 
-		<h3>[method:null normalizeSkinWeights]()</h3>
+		<h3>[method:undefined normalizeSkinWeights]()</h3>
 		<p>
 		Normalizes the skin weights.
 		</p>
 
-		<h3>[method:null pose]()</h3>
+		<h3>[method:undefined pose]()</h3>
 		<p>
 		This method sets the skinned mesh in the rest pose (resets the pose).
 		</p>
 
-		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 		Updates the [page:Matrix4 MatrixWorld].
 		</p>

--- a/docs/api/en/objects/Sprite.html
+++ b/docs/api/en/objects/Sprite.html
@@ -68,7 +68,7 @@
 		Copies the properties of the passed sprite to this one.
 		</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted ray and this sprite. [page:Raycaster.intersectObject]() will call this method.
 		The raycaster must be initialized by calling [page:Raycaster.setFromCamera]() before raycasting against sprites.

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -96,7 +96,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setSize]( [param:Number width], [param:Number height] )</h3>
+		<h3>[method:undefined setSize]( [param:Number width], [param:Number height] )</h3>
 		<p>
 		Sets the size of the render target.
 		</p>
@@ -111,7 +111,7 @@
 		Adopts the settings of the given render target.
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Dispatches a dispose event.
 		</p>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -271,35 +271,35 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
+		<h3>[method:undefined clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
 		<p>
 		Tells the renderer to clear its color, depth or stencil drawing buffer(s).
 			This method initializes the color buffer to the current clear color value.<br />
 		Arguments default to *true*.
 		</p>
 
-		<h3>[method:null clearColor]( )</h3>
+		<h3>[method:undefined clearColor]( )</h3>
 		<p>Clear the color buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( true, false, false ).</p>
 
-		<h3>[method:null clearDepth]( )</h3>
+		<h3>[method:undefined clearDepth]( )</h3>
 		<p>Clear the depth buffer. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, true, false ).</p>
 
-		<h3>[method:null clearStencil]( )</h3>
+		<h3>[method:undefined clearStencil]( )</h3>
 		<p>Clear the stencil buffers. Equivalent to calling [page:WebGLRenderer.clear .clear]( false, false, true ).</p>
 
-		<h3>[method:null compile]( [param:Object3D scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined compile]( [param:Object3D scene], [param:Camera camera] )</h3>
 		<p>Compiles all materials in the scene with the camera. This is useful to precompile shaders before the first rendering.</p>
 
-		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
+		<h3>[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<p>Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
+		<h3>[method:undefined copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
 		<p>Copies all pixels of a texture to an existing texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture3D]( [param:Box3 sourceBox], [param:Vector3 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
+		<h3>[method:undefined copyTextureToTexture3D]( [param:Box3 sourceBox], [param:Vector3 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
 		<p>Copies the pixels of a texture in the bounds '[page:Box3 sourceBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D WebGL2RenderingContext.texSubImage3D].</p>
 
-		<h3>[method:null dispose]( )</h3>
+		<h3>[method:undefined dispose]( )</h3>
 		<p>Dispose of the current rendering context.</p>
 
 		<h3>[method:Object extensions.get]( [param:String extensionName] )</h3>
@@ -388,20 +388,20 @@
 		Returns the viewport.
 		</p>
 
-		<h3>[method:null initTexture]( [param:Texture texture] )</h3>
+		<h3>[method:undefined initTexture]( [param:Texture texture] )</h3>
 		<p> Initializes the given texture. Useful for preloading a texture rather than waiting until first render (which can cause noticeable lags due to decode and GPU upload overhead).</p>
 
-		<h3>[method:null resetGLState]( )</h3>
+		<h3>[method:undefined resetGLState]( )</h3>
 		<p>Reset the GL state to default. Called internally if the WebGL context is lost.</p>
 
-		<h3>[method:null readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], [param:TypedArray buffer], [param:Integer activeCubeFaceIndex] )</h3>
+		<h3>[method:undefined readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], [param:TypedArray buffer], [param:Integer activeCubeFaceIndex] )</h3>
 		<p>buffer - Uint8Array is the only destination type supported in all cases, other types are renderTarget and platform dependent. See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.</p>
 		<p>Reads the pixel data from the renderTarget into the buffer you pass in. This is a wrapper around [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]().</p>
 		<p>See the [example:webgl_interactive_cubes_gpu interactive / cubes / gpu] example.</p>
 		<p>For reading out a [page:WebGLCubeRenderTarget WebGLCubeRenderTarget] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
 
 
-		<h3>[method:null render]( [param:Object3D scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined render]( [param:Object3D scene], [param:Camera camera] )</h3>
 		<p>
 			Render a [page:Scene scene] or another type of [page:Object3D object] using a [page:Camera camera].<br />
 
@@ -412,23 +412,23 @@
 			[page:WebGLRenderer.autoClearDepth autoClearDepth] properties to false. To forcibly clear one ore more buffers call [page:WebGLRenderer.clear .clear].
 		</p>
 
-		<h3>[method:null resetState]()</h3>
+		<h3>[method:undefined resetState]()</h3>
 		<p>Can be used to reset the internal WebGL state. This method is mostly relevant for applications which share a single WebGL context across multiple WebGL libraries.</p>
 
-		<h3>[method:null setAnimationLoop]( [param:Function callback] )</h3>
+		<h3>[method:undefined setAnimationLoop]( [param:Function callback] )</h3>
 		<p>[page:Function callback] — The function will be called every available frame. If `null` is passed it will stop any already ongoing animation.</p>
 		<p>A built in function that can be used instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]. For WebXR projects this function must be used.</p>
 
-		<h3>[method:null setClearAlpha]( [param:Float alpha] )</h3>
+		<h3>[method:undefined setClearAlpha]( [param:Float alpha] )</h3>
 		<p>Sets the clear alpha. Valid input is a float between *0.0* and *1.0*.</p>
 
-		<h3>[method:null setClearColor]( [param:Color color], [param:Float alpha] )</h3>
+		<h3>[method:undefined setClearColor]( [param:Color color], [param:Float alpha] )</h3>
 		<p>Sets the clear color and opacity.</p>
 
-		<h3>[method:null setPixelRatio]( [param:number value] )</h3>
+		<h3>[method:undefined setPixelRatio]( [param:number value] )</h3>
 		<p>Sets device pixel ratio. This is usually used for HiDPI device to prevent bluring output canvas.</p>
 
-		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
+		<h3>[method:undefined setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
 		<p>
 		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated. When *null* is given, the canvas is set as the active render target instead.<br />
 		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLCubeRenderTarget] (optional).<br />
@@ -436,8 +436,8 @@
 		This method sets the active rendertarget.
 		</p>
 
-		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
-		[method:null setScissor]( [param:Vector4 vector] )</h3>
+		<h3>[method:undefined setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
+		[method:undefined setScissor]( [param:Vector4 vector] )</h3>
 
 		<p>
 		The x, y, width, and height parameters of the scissor region.<br />
@@ -447,31 +447,31 @@
 		(x, y) is the lower-left corner of the scissor region.
 		</p>
 
-		<h3>[method:null setScissorTest]( [param:Boolean boolean] )</h3>
+		<h3>[method:undefined setScissorTest]( [param:Boolean boolean] )</h3>
 		<p>
 		Enable or disable the scissor test. When this is enabled, only the pixels within the defined
 			scissor area will be affected by further renderer actions.
 		</p>
 
-		<h3>[method:null setOpaqueSort]( [param:Function method] )</h3>
+		<h3>[method:undefined setOpaqueSort]( [param:Function method] )</h3>
 		<p>
 		Sets the custom opaque sort function for the WebGLRenderLists. Pass null to use the default painterSortStable function.
 		</p>
 
-		<h3>[method:null setTransparentSort]( [param:Function method] )</h3>
+		<h3>[method:undefined setTransparentSort]( [param:Function method] )</h3>
 		<p>
 		Sets the custom transparent sort function for the WebGLRenderLists. Pass null to use the default reversePainterSortStable function.
 		</p>
 
-		<h3>[method:null setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
+		<h3>[method:undefined setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
 		<p>
 		Resizes the output canvas to (width, height) with device pixel ratio taken into account,
 			and also sets the viewport to fit that size, starting in (0, 0).
 			Setting [page:Boolean updateStyle] to false prevents any style changes to the output canvas.
 		</p>
 
-		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
-		[method:null setViewport]( [param:Vector4 vector] )</h3>
+		<h3>[method:undefined setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )<br />
+		[method:undefined setViewport]( [param:Vector4 vector] )</h3>
 
 		<p>
 		The x, y, width, and height parameters of the viewport.<br />

--- a/docs/api/en/renderers/webgl/WebGLProgram.html
+++ b/docs/api/en/renderers/webgl/WebGLProgram.html
@@ -155,7 +155,7 @@
 		Returns a name-value mapping of all active vertex attribute locations.
 		</p>
 
-		<h3>[method:null destroy]()</h3>
+		<h3>[method:undefined destroy]()</h3>
 		<p>
 		Destroys an instance of [name].
 		</p>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -267,7 +267,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher] methods are available on this class.</h3>
 
-		<h3>[method:null updateMatrix]()</h3>
+		<h3>[method:undefined updateMatrix]()</h3>
 		<p>
 		Update the texture's uv-transform [page:Texture.matrix .matrix] from the texture properties [page:Texture.offset .offset], [page:Texture.repeat .repeat],
 		[page:Texture.rotation .rotation], and [page:Texture.center .center].
@@ -284,7 +284,7 @@
 		Convert the texture to three.js [link:https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 JSON Object/Scene format].
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Call [page:EventDispatcher EventDispatcher].dispatchEvent with a 'dispose' event type.
 		</p>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -79,7 +79,7 @@
 		See the base [page:Texture Texture] class for common methods.
 		</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>
 		This is called automatically and sets [property:Boolean needsUpdate] to *true* every time
 		a new frame is available.

--- a/docs/api/ko/animation/AnimationMixer.html
+++ b/docs/api/ko/animation/AnimationMixer.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			AnimationMixer는 장면에 있는 특정 오브젝트의 애니메이션 플레이어입니다. 한 장면에서 여러 개의 오브젝트들이 
+			AnimationMixer는 장면에 있는 특정 오브젝트의 애니메이션 플레이어입니다. 한 장면에서 여러 개의 오브젝트들이
 			독립적으로 움직인다면, 각각 다른 AnimationMixer가 사용되고 있다고 볼 수 있습니다.<br /><br />
 
 			three.js 애니메이션 시스템의 다양한 엘레먼트에 관해서는 매뉴얼의 "심화과정" 중 "애니메이션 시스템" 문서를 참고하세요.
@@ -38,7 +38,7 @@
 		<p>
 			글로벌 배속 [page:.time mixer time].<br /><br />
 
-			참고: 믹서의 timeScale를 0으로 설정했다가 나중에 1로 설정하는 방식으로 정지/재생 기능을 
+			참고: 믹서의 timeScale를 0으로 설정했다가 나중에 1로 설정하는 방식으로 정지/재생 기능을
 			믹서를 통해 사용할 수 있습니다.
 		</p>
 
@@ -48,7 +48,7 @@
 
 		<h3>[method:AnimationAction clipAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
-			전달받은 클립의 [page:AnimationAction]을 리턴하며, 믹서의 루트 경로가 아닌 다른 루트 경로를 사용할 수도 있습니다. 
+			전달받은 클립의 [page:AnimationAction]을 리턴하며, 믹서의 루트 경로가 아닌 다른 루트 경로를 사용할 수도 있습니다.
 			첫 번째 파라미터는 [page:AnimationClip] 오브젝트 및 AnimationClip 이름으로 사용할 수 있습니다.<br /><br />
 
 			클립에 동작은 설정되었는데 루트 파라미터가 아직 존재하지 않는다면, 이 메서드를 통해 자동으로 생성될 것입니다.
@@ -86,18 +86,18 @@
 			애니메이션의 정확한 시간대로 이동할 때 유용합니다. 입력되는 파라미터는 믹서의 [page:.timeScale timeScale]의 배율을 따라갑니다.
 		</p>
 
-		<h3>[method:null uncacheClip]([param:AnimationClip clip])</h3>
+		<h3>[method:undefined uncacheClip]([param:AnimationClip clip])</h3>
 
 		<p>
 			클립에 있는 모든 메모리 리소스를 할당 해제합니다.
 		</p>
 
-		<h3>[method:null uncacheRoot]([param:Object3D root]) </h3>
+		<h3>[method:undefined uncacheRoot]([param:Object3D root]) </h3>
 		<p>
 			루트 오브젝트의 모든 메모리 리소스를 할당 해제합니다.
 		</p>
 
-		<h3>[method:null uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
+		<h3>[method:undefined uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
 			동작의 모든 메모리 리소스를 할당 해제합니다.
 		</p>

--- a/docs/api/ko/animation/AnimationObjectGroup.html
+++ b/docs/api/ko/animation/AnimationObjectGroup.html
@@ -17,7 +17,7 @@
 		<h2>사용:</h2>
 
 		<p class="desc">
-			'root'로 생성자에 넘기거나 'root'로 오브젝트를 넘기는 대신 
+			'root'로 생성자에 넘기거나 'root'로 오브젝트를 넘기는 대신
 			[page:AnimationMixer AnimationMixer]의 [page:AnimationMixer.clipAction clipAction]메서드를 통해 넘긴
 			오브젝트들을 추가합니다.
 			<br /><br />
@@ -52,7 +52,7 @@
 
 		<h3>[property:String uuid]</h3>
 		<p>
-			*AnimationObjectGroup*의 [link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID]. 
+			*AnimationObjectGroup*의 [link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID].
 			자동으로 할당괴며 수정이 불가능합니다.
 		</p>
 
@@ -60,17 +60,17 @@
 		<h2>메서드</h2>
 
 
-		<h3>[method:null add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			*AnimationObjectGroup*에 임의 갯수만큼의 오브젝트를 추가합니다.
 		</p>
 
-		<h3>[method:null remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			*AnimationObjectGroup*의 임의 갯수만큼의 오브젝트를 제거합니다.
 		</p>
 
-		<h3>[method:null uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			*AnimationObjectGroup*의 전달받은 오브젝트들의 모든 메모리 리소스를 할당 해제합니다.
 		</p>

--- a/docs/api/ko/animation/KeyframeTrack.html
+++ b/docs/api/ko/animation/KeyframeTrack.html
@@ -82,7 +82,7 @@
 
 		<h3>[property:String name]</h3>
 		<p>
-			트랙의 이름은 morph targets 혹은 [page:SkinnedMesh bones] 및 
+			트랙의 이름은 morph targets 혹은 [page:SkinnedMesh bones] 및
 			다른 애니메이션 오브젝트에 들어있는 값들을 참조할 수 있습니다. See
 			프로퍼티로 파싱될 수 있는 문자열 폼에 대해서는 [page:PropertyBinding.parseTrackName] 를 참고하세요.
 		</p>
@@ -148,13 +148,13 @@
 			트랙의 복사본을 리턴합니다.
 		</p>
 
-		<h3>[method:null createInterpolant]()</h3>
+		<h3>[method:Interpolant createInterpolant]()</h3>
 		<p>
 			생성자에서 넘어온 보간법 파라미터 값에 기반한 [page:LinearInterpolant LinearInterpolant], [page:CubicInterpolant CubicInterpolant]
 			혹은 [page:DiscreteInterpolant DiscreteInterpolant]를 생성합니다.
 		</p>
 
-		<h3>[method:null getInterpolation]()</h3>
+		<h3>[method:Interpolant getInterpolation]()</h3>
 		<p>
 			보간법 타입을 리턴합니다.
 		</p>
@@ -172,7 +172,7 @@
 			그렇지 않다면 적당한 크기가 자동으로 생성될 것입니다.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:LinearInterpolant InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			[page:KeyframeTrack.times times] 와 [page:KeyframeTrack.times values]를 통해
 			새 [page:LinearInterpolant LinearInterpolant]를 만듭니다.
@@ -180,7 +180,7 @@
 			그렇지 않다면 적당한 크기가 자동으로 생성될 것입니다.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:CubicInterpolant InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			[page:KeyframeTrack.times times] 와 [page:KeyframeTrack.times values]를 통해
 			새 [page:CubicInterpolant CubicInterpolant]를 만듭니다.

--- a/docs/api/ko/animation/PropertyBinding.html
+++ b/docs/api/ko/animation/PropertyBinding.html
@@ -71,21 +71,21 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null getValue]( [param:Array targetArray], [param:Number offset] )</h3>
+		<h3>[method:undefined getValue]( [param:Array targetArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
+		<h3>[method:undefined setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null bind]( )</h3>
+		<h3>[method:undefined bind]( )</h3>
 		<p>
 			씬 그래프에 있는 프로퍼티에 대한 게터와 세터를 생성합니다. 내부적으로
 			[page:PropertyBinding.getValue getValue] 와 [page:PropertyBinding.setValue setValue]로 사용됩니다.
 		</p>
 
-		<h3>[method:null unbind]( )</h3>
+		<h3>[method:undefined unbind]( )</h3>
 		<p>
 			씬 그래프에 있는 프로퍼티에 대한 게터와 세터의 연결을 끊습니다.
 		</p>

--- a/docs/api/ko/animation/PropertyMixer.html
+++ b/docs/api/ko/animation/PropertyMixer.html
@@ -66,24 +66,24 @@
 		<h2>메서드</h2>
 
 
-		<h3>[method:null accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
+		<h3>[method:undefined accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
 		<p>
 			[page:PropertyMixer.buffer buffer][accuIndex] 'incoming' 영역의 데이터를 'accu[i]'에 축적합니다.<br />
 
 			가중치가 *0*이면 아무 동작을 하지 않습니다.
 		</p>
 
-		<h3>[method:null apply]( [param:Number accuIndex] )</h3>
+		<h3>[method:undefined apply]( [param:Number accuIndex] )</h3>
 		<p>
 			누적치가 달라지면 [page:PropertyMixer.buffer buffer] 'accu[i]'의 상태를 적용합니다.
 		</p>
 
-		<h3>[method:null saveOriginalState]( )</h3>
+		<h3>[method:undefined saveOriginalState]( )</h3>
 		<p>
 			기본 프로퍼티의 상태를 기억하고 양 쪽의 누적치에 복사합니다.
 		</p>
 
-		<h3>[method:null restoreOriginalState](  )</h3>
+		<h3>[method:undefined restoreOriginalState](  )</h3>
 		<p>
 			'saveOriginalState'로 받은 이전 상태를 다시 연결합니다.
 		</p>

--- a/docs/api/ko/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/ko/animation/tracks/BooleanKeyframeTrack.html
@@ -58,12 +58,12 @@
 			상속 메서드는 [page:KeyframeTrack]를 확인하세요.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear ]()</h3>
 		<p>
 			이 메서드의 값은 'undefined'이기 때문에, 이산 프로퍼티에 영향을 미치지 않습니다.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth ]()</h3>
 		<p>
 			이 메서드의 값은 'undefined'이기 때문에, 이산 프로퍼티에 영향을 미치지 않습니다.
 		</p>

--- a/docs/api/ko/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/ko/animation/tracks/QuaternionKeyframeTrack.html
@@ -56,12 +56,12 @@
 			상속 메서드는 [page:KeyframeTrack]를 참고하세요.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:QuaternionLinearInterpolant InterpolantFactoryMethodLinear]()</h3>
 		<p>
-			키프레임의 [page:KeyframeTrack.values values], [page:KeyframeTrack.times times] 및 
+			키프레임의 [page:KeyframeTrack.values values], [page:KeyframeTrack.times times] 및
 			[page:KeyframeTrack.valueSize valueSize]를 기반으로
 			새 [page:QuaternionLinearInterpolant QuaternionLinearInterpolant]를 리턴합니다.
-			
+
 		</p>
 
 

--- a/docs/api/ko/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/ko/animation/tracks/StringKeyframeTrack.html
@@ -56,12 +56,12 @@
 			상속 메서드는 [page:KeyframeTrack]를 참고하세요.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			이 메서드의 값은 'undefined'이기 때문에, 이산 프로퍼티에 영향을 미치지 않습니다.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth]()</h3>
 		<p>
 			이 메서드의 값은 'undefined'이기 때문에, 이산 프로퍼티에 영향을 미치지 않습니다.
 		</p>

--- a/docs/api/ko/audio/Audio.html
+++ b/docs/api/ko/audio/Audio.html
@@ -154,7 +154,7 @@
 		[page:Audio.hasPlaybackControl hasPlaybackControl]가 true면, 재생을 멈춥니다.
 		</p>
 
-		<h3>[method:null onEnded]()</h3>
+		<h3>[method:undefined onEnded]()</h3>
 		<p>
 		재생이 끝나면 자동으로 호출됩니다.
 		</p>

--- a/docs/api/ko/cameras/CubeCamera.html
+++ b/docs/api/ko/cameras/CubeCamera.html
@@ -69,7 +69,7 @@
 		<h2>메서드</h2>
 		<p>일반 메서드는 기본 [page:Object3D] 클래스를 참고하세요.</p>
 
-		<h3>[method:null update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
+		<h3>[method:undefined update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
 		<p>
 		renderer -- 현재의 WebGL 렌더러 <br />
 		scene -- 현재 장면

--- a/docs/api/ko/cameras/OrthographicCamera.html
+++ b/docs/api/ko/cameras/OrthographicCamera.html
@@ -98,7 +98,7 @@
 		<h2>메서드</h2>
 		<p>일반적인 메서드는 기본 [page:Camera] 클래스를 참고하세요.</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — 멀티뷰 설정 최대 너비<br />
 		fullHeight — 멀티뷰 설정 최대 높이<br />
@@ -112,12 +112,12 @@
 			사용 예제는 [page:PerspectiveCamera.setViewOffset PerspectiveCamera]를 참고하세요.
 		</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>
 		.setViewOffset 메서드로 설정된 오프셋을 모두 제거합니다.
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		카메라 투영 매트릭스를 업데이트합니다. 파라미터 변경 후에 반드시 호출해야 합니다.
 		</p>

--- a/docs/api/ko/cameras/PerspectiveCamera.html
+++ b/docs/api/ko/cameras/PerspectiveCamera.html
@@ -50,7 +50,7 @@
 		<h2>프로퍼티</h2>
 		<p>
 			일반 프로퍼티는 기본 [page:Camera] 클래스를 참고하세요.<br>
-			대부분의 이 프로퍼티들은 수정한 후에 반드시 변경된 효과 적용을 위해 
+			대부분의 이 프로퍼티들은 수정한 후에 반드시 변경된 효과 적용을 위해
 			[page:PerspectiveCamera.updateProjectionMatrix .updateProjectionMatrix]를 호출해야 하는 점을 주의하세요.
 		</p>
 
@@ -102,7 +102,7 @@
 		<h2>메서드</h2>
 		<p>일반 메서드는 기본 [page:Camera] 클래스를 참고하세요.</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>[page:PerspectiveCamera.setViewOffset .setViewOffset] 메서드로 설정된 오프셋을 모두 제거합니다.</p>
 
 		<h3>[method:Float getEffectiveFOV]()</h3>
@@ -110,27 +110,27 @@
 
 		<h3>[method:Float getFilmHeight]()</h3>
 		<p>
-		필름에 있는 이미지의 높이를 리턴합니다. 
+		필름에 있는 이미지의 높이를 리턴합니다.
 		.aspect가 1보다 작거나 같으면(portraot 포맷) 결과는 .filmGauge와 동일합니다.
 		</p>
 
 		<h3>[method:Float getFilmWidth]()</h3>
 		<p>
-		필름에 있는 이미지의 너비를 리턴합니다. 
+		필름에 있는 이미지의 너비를 리턴합니다.
 		.aspect가 1보다 크거나 같으면(landscape 포맷) 결과는 .filmGauge와 동일합니다.
 		</p>
 
 		<h3>[method:Float getFocalLength]()</h3>
 		<p>.filmGauge에 대해 현재 .fov의 초점 길이를 리턴합니다.</p>
 
-		<h3>[method:null setFocalLength]( [param:Float focalLength] )</h3>
+		<h3>[method:undefined setFocalLength]( [param:Float focalLength] )</h3>
 		<p>
 		현재 [page:PerspectiveCamera.filmGauge .filmGauge]에 대해 초점 길이로 FOV를 설정합니다.<br /><br />
 
 		기본적으로 초점 길이는 35mm(전체 프레임) 카메라로 지정됩니다.
 		</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — 멀티뷰 설정의 최대너비<br />
 		fullHeight — 멀티뷰 설정의 최대높이<br />
@@ -179,7 +179,7 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 		모니터들이 반드시 같은 크기나 구조여야 할 필요가 없다는 점을 참고하세요.
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		카메라 투영 매트릭스를 업데이트합니다. 파라미터 변경 후에 반드시 호출해야합니다.
 		</p>

--- a/docs/api/ko/cameras/StereoCamera.html
+++ b/docs/api/ko/cameras/StereoCamera.html
@@ -11,7 +11,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		듀얼 [page:PerspectiveCamera PerspectiveCamera]로서 [link:https://en.wikipedia.org/wiki/Anaglyph_3D 3D Anaglyph] 
+		듀얼 [page:PerspectiveCamera PerspectiveCamera]로서 [link:https://en.wikipedia.org/wiki/Anaglyph_3D 3D Anaglyph]
 		혹은 [link:https://en.wikipedia.org/wiki/parallax_barrier Parallax Barrier] 효과에 사용됩니다.
 		</p>
 
@@ -44,7 +44,7 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null update]( [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined update]( [param:PerspectiveCamera camera] )</h3>
 		<p>
 		전달받은 카메라에 기반해 스테레오 카메라를 업데이트합니다.
 		</p>

--- a/docs/api/ko/core/BufferAttribute.html
+++ b/docs/api/ko/core/BufferAttribute.html
@@ -11,7 +11,7 @@
 
 		<p class="desc">
 		이 클래스에는 [page:BufferGeometry]와 연관된 속성 데이터(꼭짓점 위치, 면 순서, 법선, 색깔,
-		UV, 모든 커스텀 속성들 등)를 저장하고 있으며, GPU에 보다 효율적으로 데이터를 전송할 수 있게 합니다. 
+		UV, 모든 커스텀 속성들 등)를 저장하고 있으며, GPU에 보다 효율적으로 데이터를 전송할 수 있게 합니다.
 		세부사항 및 활용 예제를 확인해보세요.<br /><br />
 
 		데이터는 모든 길이가 벡터로 저장되며 ([page:BufferAttribute.itemSize itemSize]로 정의된 값),
@@ -23,7 +23,7 @@
 		<p>
 		[page:TypedArray array] -- 반드시 [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/TypedArray TypedArray]여야 합니다.
 		버퍼를 시작하는데에 사용됩니다. <br />
-		배열에는 
+		배열에는
 	 	<code>itemSize * numVertices</code>
 		엘레먼트가 있어야 하며, numVertices는 [page:BufferGeometry BufferGeometry]와 연관된 꼭짓점의 갯수입니다.<br /><br />
 
@@ -32,9 +32,9 @@
 		예를 들어 이 속성에서 3개의 벡터(위치, 법선, 색 처럼)를 저장하고 있다면, itemSize는 3이 됩니다.
 		<br /><br />
 
-		[page:Boolean normalized] -- (생략가능) 정수 데이터에만 적용됩니다. 버퍼에 있는 기저 데이터가 GLSL 코드에서 값으로 맵핑되는 방식입니다. 
-		예를 들어 [page:TypedArray array]가 UInt16Array의 인스턴스이고, [page:Boolean normalized]가 true면 배열에 있는 0 - +65535 값들은 
-		GLSL 속성에서 0.0f - +1.0f로 매핑될 것입니다. Int16Array (기호 있는)는 -32767 - +32767 가 -1.0f - +1.0f 로 매핑될 것입니다. 
+		[page:Boolean normalized] -- (생략가능) 정수 데이터에만 적용됩니다. 버퍼에 있는 기저 데이터가 GLSL 코드에서 값으로 맵핑되는 방식입니다.
+		예를 들어 [page:TypedArray array]가 UInt16Array의 인스턴스이고, [page:Boolean normalized]가 true면 배열에 있는 0 - +65535 값들은
+		GLSL 속성에서 0.0f - +1.0f로 매핑될 것입니다. Int16Array (기호 있는)는 -32767 - +32767 가 -1.0f - +1.0f 로 매핑될 것입니다.
 		[page:Boolean normalized]가 false라면, 값은 수정 없이 floats로 변환될 것입니다. 예) 32767은 32767.0f로 변환.
 		</p>
 
@@ -71,7 +71,7 @@
 
 		<h3>[property:Boolean normalized]</h3>
 		<p>
-		버퍼에 있는 기저 데이터가 GLSL 코드에서 값으로 맵핑되는 방식입니다. 
+		버퍼에 있는 기저 데이터가 GLSL 코드에서 값으로 맵핑되는 방식입니다.
 		자세한 내용은 위의 생성자 부분을 참고하세요.
 		</p>
 
@@ -90,7 +90,7 @@
 
 		<h3>[property:Usage usage]</h3>
 		<p>
-			최적화를 목적으로 특정 데이터 저장 패턴 사용을 정의합니다. 
+			최적화를 목적으로 특정 데이터 저장 패턴 사용을 정의합니다.
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData WebGLRenderingContext.bufferData]()의 *usage* 파라미터에 대응됩니다.
 			기본값은 *THREE.StaticDrawUsage*입니다.
 		</p>
@@ -125,7 +125,7 @@
 			를 참고해 주세요.
 		</p>
 
-		<h3>[method:null copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
+		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>bufferAttribute[index2]의 벡터를 [page:BufferAttribute.array array][index1]에 복사합니다.</p>
 
 		<h3>[method:BufferAttribute copyColorsArray]( [param:Array colors] ) </h3>
@@ -156,7 +156,7 @@
 		<p>
 		onUploadCallback 속성의 값을 설정합니다.<br /><br />
 
-		이 값은 [example:webgl_buffergeometry WebGL / Buffergeometry]에서 버퍼가 GPU로 전송된 후에 자유 메모리로 사용됩니다. 
+		이 값은 [example:webgl_buffergeometry WebGL / Buffergeometry]에서 버퍼가 GPU로 전송된 후에 자유 메모리로 사용됩니다.
 		</p>
 
 		<h3>[method:BufferAttribute set] ( [param:Array value], [param:Integer offset] ) </h3>

--- a/docs/api/ko/core/BufferGeometry.html
+++ b/docs/api/ko/core/BufferGeometry.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p>
-		메쉬, 선, 점 기하학의 표현입니다. 꼭짓점의 위치, 면 순서, 법선, 색상, UV, 버퍼에 있는 커스텀 속성을 포함하고 있으며, 데이터를 GPU에 전달하는 
+		메쉬, 선, 점 기하학의 표현입니다. 꼭짓점의 위치, 면 순서, 법선, 색상, UV, 버퍼에 있는 커스텀 속성을 포함하고 있으며, 데이터를 GPU에 전달하는
 		자원을 줄여줍니다.
 		</p>
 		<p>
@@ -67,19 +67,19 @@
 
 		<h3>[property:Box3 boundingBox]</h3>
 		<p>
-			bufferGeometry의 바운딩 박스이며 [page:.computeBoundingBox]()로 계산할 수 있습니다. 
+			bufferGeometry의 바운딩 박스이며 [page:.computeBoundingBox]()로 계산할 수 있습니다.
 			기본값은 *null*입니다.
 		</p>
 
 		<h3>[property:Sphere boundingSphere]</h3>
 		<p>
-			bufferGeometry의 바운딩 스피어이며 [page:.computeBoundingSphere]()로 계산할 수 있습니다. 
+			bufferGeometry의 바운딩 스피어이며 [page:.computeBoundingSphere]()로 계산할 수 있습니다.
 			기본값은 *null*입니다.
 		</p>
 
 		<h3>[property:Object drawRange]</h3>
 		<p>
-			렌더링할 기하학의 부분을 정의합니다. 직접 설정하면 안되며 [page:.setDrawRange]를 사용해야 합니다. 
+			렌더링할 기하학의 부분을 정의합니다. 직접 설정하면 안되며 [page:.setDrawRange]를 사용해야 합니다.
 			기본 값은 다음과 같습니다.
 			<code>
 				{ start: 0, count: Infinity }
@@ -96,7 +96,7 @@
 			각자의 그룹은 형태의 객체입니다:
 			<code>{ start: Integer, count: Integer, materialIndex: Integer }</code>
 			start는 이 드리기 요청에서 첫 번째 엘레먼드를 지정하지만 – 첫 번째 인덱스가 없는 기하학이기때문이지만,
-			다른 경우는 첫 번째 삼각형 인덱스입니다. Count는 몇 개의 꼭짓점(혹은 인덱스)가 포함되었는지, 
+			다른 경우는 첫 번째 삼각형 인덱스입니다. Count는 몇 개의 꼭짓점(혹은 인덱스)가 포함되었는지,
 			materialIndex는 사용할 재질 배열 인덱스를 지정합니다.
 
 			배열을 직접 수정하기보다는 [page:.addGroup]를 사용해 그룹을 추가합니다.
@@ -123,7 +123,7 @@
 			각각의 삼각형은 세 꼭짓점의 인덱스와 연관되어 있습니다. 이 속성은 따라서 각 삼각형 면의 각 꼭짓점의 인덱스를 저장하고 있습니다.
 
 			이 속성이 설정되어 있지 않다면, [page:WebGLRenderer renderer]는 세 연속된 위치가 단일 삼각형을 나타낸다고 추정합니다.
-			
+
 			기본값은 *null* 입니다.
 		</p>
 
@@ -162,17 +162,17 @@
 
 		<h3>[method:BufferGeometry setAttribute]( [param:String name], [param:BufferAttribute attribute] )</h3>
 		<p>
-		기하학에 대한 속성을 설정합니다. [page:.attributes]의 내부 해시맵은 속성들의 반복 속도 증가를 위해 유지되기 때문에, 
+		기하학에 대한 속성을 설정합니다. [page:.attributes]의 내부 해시맵은 속성들의 반복 속도 증가를 위해 유지되기 때문에,
 		속성 프로퍼티 대신 이 메서드를 사용하세요.
 		</p>
 
-		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
+		<h3>[method:undefined addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
 		<p>
 			기하학에 그룹을 추가합니다; 프로퍼티 상세에 대해서는 [page:BufferGeometry.groups groups] 페이지를 참고하세요.
 		</p>
 
 
-		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:this applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>꼭짓점 좌표로 직접 매트릭스 변형을 합니다.</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>
@@ -184,31 +184,31 @@
 		<h3>[method:BufferGeometry copy]( [param:BufferGeometry bufferGeometry] )</h3>
 		<p>다른 BufferGeometry를 이 BufferGeometry에 복사합니다.</p>
 
-		<h3>[method:null clearGroups]( )</h3>
+		<h3>[method:undefined clearGroups]( )</h3>
 		<p>모든 그룹을 제거합니다.</p>
 
-		<h3>[method:null computeBoundingBox]()</h3>
+		<h3>[method:undefined computeBoundingBox]()</h3>
 		<p>
 		기하학의 바운딩 박스를 계산하고 [page:.boundingBox] 속성을 업데이트합니다.<br />
 		바운딩 박스는 자동으로 계산되지 않습니다. 명시적으로 계산되어야하며 그렇지 않으면 *null* 값입니다.
 		</p>
 
-		<h3>[method:null computeBoundingSphere]()</h3>
+		<h3>[method:undefined computeBoundingSphere]()</h3>
 		<p>
 		기하학의 바운딩 스피어를 계산하고 [page:.boundingSphere] 속성을 업데이트합니다.<br />
 		바운딩 스피어는 자동으로 계산되지 않습니다. 명시적으로 계산되어야하며 그렇지 않으면 *null* 값입니다.
 		</p>
 
-		<h3>[method:null computeTangents]()</h3>
+		<h3>[method:undefined computeTangents]()</h3>
 		<p>
 		기하학에 탄젠트 속성을 계산하고 추가합니다.<br />
 		이 계산은 인덱스가 있는 기하학에만 지원되며 위치, 법선, uv 속성이 정의되어야 합니다.
 		</p>
 
-		<h3>[method:null computeVertexNormals]()</h3>
+		<h3>[method:undefined computeVertexNormals]()</h3>
 		<p>면의 법선 평균값을 통해 꼭짓점 법선을 계산합니다.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		메모리에서 객체를 정리합니다. <br />
 		앱이 동작중인데 BufferGeometry를 삭제하고 싶을 때 호출합니다.
@@ -231,10 +231,10 @@
 		일반적인 리얼타임 메쉬 사용은 [page:Object3D.lookAt] 을 사용하세요.
 		</p>
 
-		<h3>[method:null merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
+		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
 		<p>병합을 시작할 지점인 임의의 오프셋으로 다른 BufferGeometry에 병합합니다.</p>
 
-		<h3>[method:null normalizeNormals]()</h3>
+		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 		기하학의 모든 법선 벡터는 1의 크기를 갖습니다.
 		기하학 표면의 광도를 수정합니다.
@@ -270,7 +270,7 @@
 		<h3>[method:BufferGeometry setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>[page:.index] 버퍼를 설정합니다.</p>
 
-		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
+		<h3>[method:undefined setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
 		<p>[page:.drawRange] 프로퍼티를 설정합니다. 인덱스가 없는 BufferGeometry에서, count는 렌더링할 꼭짓점의 수입니다.
 		인덱스가 있는 BufferGeometry에서 count는 렌더링할 인덱스의 수입니다.</p>
 

--- a/docs/api/ko/core/Clock.html
+++ b/docs/api/ko/core/Clock.html
@@ -54,13 +54,13 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null start]()</h3>
+		<h3>[method:undefined start]()</h3>
 		<p>
 		시계를 시작시킵니다. 또한 [page:Clock.startTime startTime] 및 [page:Clock.oldTime oldTime]을 현재 시간으로 업데이트하고
 		[page:Clock.elapsedTime elapsedTime] 를 *0*으로, [page:Clock.running running] *true*로 설정합니다.
 		</p>
 
-		<h3>[method:null stop]()</h3>
+		<h3>[method:undefined stop]()</h3>
 		<p>
 		시계를 멈추고 [page:Clock.oldTime oldTime]을 현재 시간으로 설정합니다.
 		</p>

--- a/docs/api/ko/core/EventDispatcher.html
+++ b/docs/api/ko/core/EventDispatcher.html
@@ -52,7 +52,7 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 리스닝할 이벤트의 타입입니다.<br />
 		listener - 이벤트가 작동하면 호출될 함수입니다.
@@ -70,7 +70,7 @@
 		리스너가 이벤트 타입에 추가되었는지를 체크합니다.
 		</p>
 
-		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 제거될 리스너의 타입입니다.<br />
 		listener - 제거될 리스너 함수입니다.
@@ -79,7 +79,7 @@
 		이벤트 타입에서 리스너를 제거합니다.
 		</p>
 
-		<h3>[method:null dispatchEvent]( [param:Object event] )</h3>
+		<h3>[method:undefined dispatchEvent]( [param:Object event] )</h3>
 		<p>
 		event - 작동하는 이벤트입니다.
 		</p>

--- a/docs/api/ko/core/GLBufferAttribute.html
+++ b/docs/api/ko/core/GLBufferAttribute.html
@@ -81,16 +81,16 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null setBuffer]( buffer ) </h3>
+		<h3>[method:this setBuffer]( buffer ) </h3>
 		<p>*buffer* 속성을 설정합니다.</p>
 
-		<h3>[method:null setType]( type, elementSize ) </h3>
+		<h3>[method:this setType]( type, elementSize ) </h3>
 		<p>*type* 및 *elementSize* 속성을 설정합니다.</p>
 
-		<h3>[method:null setItemSize]( itemSize ) </h3>
+		<h3>[method:this setItemSize]( itemSize ) </h3>
 		<p>*itemSize* 속성을 설정합니다.</p>
 
-		<h3>[method:null setCount]( count ) </h3>
+		<h3>[method:this setCount]( count ) </h3>
 		<p>*count* 속성을 설정합니다.</p>
 
 		<h3>[property:Integer version]</h3>

--- a/docs/api/ko/core/InterleavedBufferAttribute.html
+++ b/docs/api/ko/core/InterleavedBufferAttribute.html
@@ -87,25 +87,25 @@
 		<h3>[method:Number getW]( [param:Integer index] ) </h3>
 		<p>해당 index의 항목의 w 컴포넌트를 리턴합니다.</p>
 
-		<h3>[method:null setX]( [param:Integer index], [param:Float x] ) </h3>
+		<h3>[method:this setX]( [param:Integer index], [param:Float x] ) </h3>
 		<p>해당 index의 항목의 x 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setY]( [param:Integer index], [param:Float y] ) </h3>
+		<h3>[method:this setY]( [param:Integer index], [param:Float y] ) </h3>
 		<p>해당 index의 항목의 y 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setZ]( [param:Integer index], [param:Float z] ) </h3>
+		<h3>[method:this setZ]( [param:Integer index], [param:Float z] ) </h3>
 		<p>해당 index의 항목의 z 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setW]( [param:Integer index], [param:Float w] ) </h3>
+		<h3>[method:this setW]( [param:Integer index], [param:Float w] ) </h3>
 		<p>해당 index의 항목의 w 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
+		<h3>[method:this setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
 		<p>해당 index의 항목의 x, y 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
+		<h3>[method:this setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
 		<p>해당 index의 항목의 x, y, z 컴포넌트를 설정합니다.</p>
 
-		<h3>[method:null setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
+		<h3>[method:this setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
 		<p>해당 index의 항목의 x, y, z, w 컴포넌트를 설정합니다.</p>
 
 

--- a/docs/api/ko/core/Layers.html
+++ b/docs/api/ko/core/Layers.html
@@ -11,7 +11,7 @@
 
 		<p class="desc">
 			[page:Layers] 오브젝트는 [page:Object3D]를 1개에서 32개의 레이어에 0에서 31의 숫자로 할당합니다.
-			- 내부적으로 레이어들은 [link:https://en.wikipedia.org/wiki/Mask_(computing) bit mask]로 저장되며, 기본값으로 모든 
+			- 내부적으로 레이어들은 [link:https://en.wikipedia.org/wiki/Mask_(computing) bit mask]로 저장되며, 기본값으로 모든
 			Object3D들은 0번 레이어의 멤버입니다. <br /><br />
 
 			가시성을 컨트롤하는데에 사용할 수 있습니다. - 카메라의 뷰가 렌더링될 때 오브젝트는 반드시 [page:Camera camera]와 가시 레이어를 공유해야합니다.<br /><br />
@@ -43,21 +43,21 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null disable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined disable]( [param:Integer layer] )</h3>
 		<p>
 			layer - 0부터 31까지의 정수.<br /><br />
 
 			이 *layer*의 멤버 속성을 제거합니다.
 		</p>
 
-		<h3>[method:null enable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined enable]( [param:Integer layer] )</h3>
 		<p>
 			layer - 0부터 31까지의 정수.<br /><br />
 
 			이 *layer*에 멤버 속성을 추가합니다.
 		</p>
 
-		<h3>[method:null set]( [param:Integer layer] )</h3>
+		<h3>[method:undefined set]( [param:Integer layer] )</h3>
 		<p>
 			layer - 0부터 31까지의 정수.<br /><br />
 
@@ -71,19 +71,19 @@
 			전달받은 *layers* 오브젝트가 적어도 1개 이상의 레이어를 가지고 있으면 true를 리턴합니다.
 		</p>
 
-		<h3>[method:null toggle]( [param:Integer layer] )</h3>
+		<h3>[method:undefined toggle]( [param:Integer layer] )</h3>
 		<p>
 			layer - 0부터 31까지의 정수.<br /><br />
 
 			ㄴ*layer*의 멤버 속성을 전환합니다.
 		</p>
 
-		<h3>[method:null enableAll]()</h3>
+		<h3>[method:undefined enableAll]()</h3>
 		<p>
 			모든 레이어에 멤버 속성을 추가합니다.
 		</p>
 
-		<h3>[method:null disableAll]()</h3>
+		<h3>[method:undefined disableAll]()</h3>
 		<p>
 			모든 레이어의 멤버 속성을 제거합니다.
 		</p>

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -206,7 +206,7 @@
 		수동으로 객체 그룹핑을 하는 내용은 [page:Group]를 참고하세요.
 		</p>
 
-		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p>매트릭스 변환을 객체에 적용하고 객체의 위치, 회전 및 스케일을 업데이트합니다.</p>
 
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
@@ -291,8 +291,8 @@
 		이 객체의 로컬 스페이스를 월드 스페이스로 전환합니다.
 		</p>
 
-		<h3>[method:null lookAt]( [param:Vector3 vector] )<br />
-		[method:null lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:undefined lookAt]( [param:Vector3 vector] )<br />
+		[method:undefined lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
 		vector - 로컬 스페이스에서의 위치를 나타내는 벡터입니다.<br /><br />
 		부가적으로, 월드 스페이스의 [page:.x x], [page:.y y] 및 [page:.z z] 위치 컴포넌트를 설정할 수 있습니다.<br /><br />
@@ -361,7 +361,7 @@
 		로컬 스페이스에서 z 축을 기준으로 회전시킵니다.
 		</p>
 
-		<h3>[method:null setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
+		<h3>[method:undefined setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>
 			axis -- 오브젝트 스페이스의 정규화 벡터입니다. <br />
 			angle -- 라디안 각도입니다<br /><br />
@@ -369,14 +369,14 @@
 			[page:.quaternion]에서 [page:Quaternion.setFromAxisAngle setFromAxisAngle]( [page:Float axis], [page:Float angle] )를 호출합니다.
 		</p>
 
-		<h3>[method:null setRotationFromEuler]( [param:Euler euler] )</h3>
+		<h3>[method:undefined setRotationFromEuler]( [param:Euler euler] )</h3>
 		<p>
 			euler -- 회전 정도를 나타내는 오일러 각입니다.<br />
 
 			 [page:Quaternion.setRotationFromEuler setRotationFromEuler]( [page:Euler euler])를 호출합니다.
 		</p>
 
-		<h3>[method:null setRotationFromMatrix]( [param:Matrix4 m] )</h3>
+		<h3>[method:undefined setRotationFromMatrix]( [param:Matrix4 m] )</h3>
 		<p>
 			m -- 매트릭스의 회전 컴포넌트만큼 쿼터니언을 회전시킵니다.<br />
 
@@ -385,7 +385,7 @@
 			m의 상위 3x3은 순수 회전 매트릭스(예를 들어 스케일이 없는 매트릭스)로 가정합니다.
 		</p>
 
-		<h3>[method:null setRotationFromQuaternion]( [param:Quaternion q] )</h3>
+		<h3>[method:undefined setRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<p>
 			q -- 정규화 쿼터니언입니다.<br /><br />
 
@@ -415,7 +415,7 @@
 		<h3>[method:this translateZ]( [param:Float distance] )</h3>
 		<p>객체 스페이스에서 *distance*만큼 객체를 z축으로 이동시킵니다.</p>
 
-		<h3>[method:null traverse]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverse]( [param:Function callback] )</h3>
 		<p>
 		callback - object3D 객체의 첫 번째 인자 함수입니다.<br /><br />
 
@@ -423,7 +423,7 @@
 		주의: 콜백에서 씬 그래프를 수정하는 것은 허용되지 않습니다.
 		</p>
 
-		<h3>[method:null traverseVisible]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverseVisible]( [param:Function callback] )</h3>
 		<p>
 		callback - object3D 객체의 첫 번째 인자 함수입니다.<br /><br />
 
@@ -432,7 +432,7 @@
 		주의: 콜백에서 씬 그래프를 수정하는 것은 허용되지 않습니다.
 		</p>
 
-		<h3>[method:null traverseAncestors]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverseAncestors]( [param:Function callback] )</h3>
 		<p>
 		callback - object3D 객체의 첫 번째 인자 함수입니다.<br /><br />
 
@@ -440,13 +440,13 @@
 		주의: 콜백에서 씬 그래프를 수정하는 것은 허용되지 않습니다.
 		</p>
 
-		<h3>[method:null updateMatrix]()</h3>
+		<h3>[method:undefined updateMatrix]()</h3>
 		<p>로컬 변형을 업데이트합니다.</p>
 
-		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>객체와 자식들의 글로벌 변형을 업데이트합니다.</p>
 
-		<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
+		<h3>[method:undefined updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 		<p>
 		updateParents - 재귀적으로 부모의 글로벌 변형을 업데이트합니다.<br />
 		updateChildren - 재귀적으로 자식의 글로벌 변형을 업데이트합니다.<br /><br />

--- a/docs/api/ko/core/Raycaster.html
+++ b/docs/api/ko/core/Raycaster.html
@@ -97,7 +97,7 @@
 
 		<h3>[property:Camera camera]</h3>
 		<p>
-		[page:Sprites]같은 빌보드객체처럼 뷰에 의존하는 객체에 대항 레이캐스팅 시에 사용되는 카메라입니다. 
+		[page:Sprites]같은 빌보드객체처럼 뷰에 의존하는 객체에 대항 레이캐스팅 시에 사용되는 카메라입니다.
 		이 값은 수동으로 설정하거나 "setFromCamera"를 호출해야 합니다.
 
 		기본값은 null입니다.
@@ -137,7 +137,7 @@
 
 		<h2>메서드</h2>
 
-		<h3>[method:null set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
+		<h3>[method:undefined set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<p>
 		[page:Vector3 origin] — 레이캐스팅이 활용되는 시점 벡터입니다.<br />
 		[page:Vector3 direction] — 레이 방향을 정하는 정규화된 방향 벡터입니다.
@@ -146,7 +146,7 @@
 		새 시점과 방향으로 레이를 업데이트합니다. 이 메서드는 인자의 값만을 복사한다는 점에 주의하세요.
 		</p>
 
-		<h3>[method:null setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
+		<h3>[method:undefined setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
 		<p>
 		[page:Vector2 coords] — 마우스의 2D 좌표이며 정규화 디바이스 좌표입니다(NDC)---X 및 Y 컴포넌트는 -1 과 1 사이입니다.<br />
 		[page:Camera camera] — 레이의 시점이 되는 카메라입니다.
@@ -181,8 +181,8 @@
 		*Raycaster*는 레이가 객체에 교차하는지 아닌지 판단할 때의 전달받은 객체의 [page:Object3D.raycast raycast] 메서드를 대신합니다. 이는 [page:Line lines]과 [page:Points pointclouds]와 달리 [page:Mesh meshes]가 레이캐스팅에 다르게 반응할 수 있게 합니다.
 		</p>
 		<p>
-		메쉬의 면은 [page:.ray ray]의 시점에서 탐지 가능할 수 있도록 마주보고 있어야 하는 것에 주의하세요; 
-		면의 뒤쪽을 통과하는 레이 교차는 탐지디지 않을 것입니다. 
+		메쉬의 면은 [page:.ray ray]의 시점에서 탐지 가능할 수 있도록 마주보고 있어야 하는 것에 주의하세요;
+		면의 뒤쪽을 통과하는 레이 교차는 탐지디지 않을 것입니다.
 		객체의 양 면을 레이캐스팅하고 싶다면, [page:Mesh.material material]의 [page:Material.side side] 프로퍼티를 *THREE.DoubleSide*로 설정해야합니다.
 		</p>
 

--- a/docs/api/ko/extras/core/Curve.html
+++ b/docs/api/ko/extras/core/Curve.html
@@ -25,7 +25,7 @@
 		<h2>프로퍼티</h2>
 
 		<h3>[property:Integer arcLengthDivisions]</h3>
-		<p>이 값은 곡선의 누적 세그먼트 길이를 계산할 때 [page:.getLengths]를 통해 분할할 양을 결정합니다. 
+		<p>이 값은 곡선의 누적 세그먼트 길이를 계산할 때 [page:.getLengths]를 통해 분할할 양을 결정합니다.
 			[page:.getSpacedPoints]같은 메서드를 사용할 때 정확도를 위해, 곡선이 아주 크다면 [page:.arcLengthDivisions]를 올리는 것을 추천합니다. 기본값은 200입니다.</p>
 
 		<h2>메서드</h2>
@@ -66,7 +66,7 @@
 		<h3>[method:Array getLengths]( [param:Integer divisions] )</h3>
 		<p>누적 세그먼트 길이 목록을 가져옵니다.</p>
 
-		<h3>[method:null updateArcLengths]()</h3>
+		<h3>[method:undefined updateArcLengths]()</h3>
 		<p>누적 세그먼트 거리 캐시를 업데이트합니다.</p>
 
 		<h3>[method:Float getUtoTmapping]( [param:Float u], [param:Float distance] )</h3>
@@ -80,7 +80,7 @@
 			[page:Float t] - 곡선의 위치입니다 [ 0, 1 ] 범위여야합니다. <br>
 			[page:Vector optionalTarget] — (생략가능) 값이 지정되면, 결과값이 이 벡터에 복제될 것이고 생략되면 새 Vector가 생성됩니다. <br /><br />
 
-			t에서 접선하는 단위 벡터를 반환합니다. 
+			t에서 접선하는 단위 벡터를 반환합니다.
 			파생 곡선이 접선 유도법을 구현하지 않는 경우, 작은 델타 간격의 두 점이 합리적인 근사치의 기울기를 찾는 데 사용됩니다.
 		</p>
 

--- a/docs/api/ko/extras/core/CurvePath.html
+++ b/docs/api/ko/extras/core/CurvePath.html
@@ -34,10 +34,10 @@
 		<h2>메서드</h2>
 		<p>일빈 프로퍼티는 기본 [page:Curve] 클래스를 참고하세요.</p>
 
-		<h3>[method:null add]( [param:Curve curve] )</h3>
+		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>[page:.curves] 배열에 곡선을 추가합니다.</p>
 
-		<h3>[method:null closePath]()</h3>
+		<h3>[method:undefined closePath]()</h3>
 		<p>path를 닫기위해 [page:LineCurve lineCurve]를 추가합니다.</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>
@@ -54,9 +54,9 @@
 		<p>
 			divisions -- 곡선을 나눌 조각 수입니다. 기본값은 *12*입니다.<br /><br />
 
-			곡선 시퀀스를 나타내는 점 배열을 반환합니다. 
-			*divisions* 파라미터는 각 곡선이 분할되는 조각 수를 정의합니다. 
-			하지만 최적화 및 품질 목적을 위해 각 곡선의 실제 표본 해상도는 유형에 따라 달라집니다. 
+			곡선 시퀀스를 나타내는 점 배열을 반환합니다.
+			*divisions* 파라미터는 각 곡선이 분할되는 조각 수를 정의합니다.
+			하지만 최적화 및 품질 목적을 위해 각 곡선의 실제 표본 해상도는 유형에 따라 달라집니다.
 			예를 들어 [page:LineCurve]의 경우, 반환되는 점 수는 항상 2개입니다.
 		</p>
 

--- a/docs/api/zh/animation/AnimationMixer.html
+++ b/docs/api/zh/animation/AnimationMixer.html
@@ -82,18 +82,18 @@
 			通常在渲染循环中完成, 传入按照混合器的时间比例([page:.timeScale timeScale])缩放过的[page:Clock.getDelta clock.getDelta]
 		</p>
 
-		<h3>[method:null uncacheClip]([param:AnimationClip clip])</h3>
+		<h3>[method:undefined uncacheClip]([param:AnimationClip clip])</h3>
 
 		<p>
 			释放剪辑的所有内存资源
 		</p>
 
-		<h3>[method:null uncacheRoot]([param:Object3D root]) </h3>
+		<h3>[method:undefined uncacheRoot]([param:Object3D root]) </h3>
 		<p>
 			释放根对象的所有内存资源
 		</p>
 
-		<h3>[method:null uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
+		<h3>[method:undefined uncacheAction]([param:AnimationClip clip], [param:Object3D optionalRoot])</h3>
 		<p>
 			释放动作的所有内存资源
 		</p>

--- a/docs/api/zh/animation/AnimationObjectGroup.html
+++ b/docs/api/zh/animation/AnimationObjectGroup.html
@@ -57,17 +57,17 @@
 		<h2>方法</h2>
 
 
-		<h3>[method:null add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			将任意数量的对象添加到这个动画对象组(AnimationObjectGroup)。
 		</p>
 
-		<h3>[method:null remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			将任意数量的对象从这个动画对象组(AnimationObjectGroup)中删除。
 		</p>
 
-		<h3>[method:null uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
+		<h3>[method:undefined uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
 			释放此动画对象组(AnimationObjectGroup)传递的对象的所有内存资源
 		</p>

--- a/docs/api/zh/animation/KeyframeTrack.html
+++ b/docs/api/zh/animation/KeyframeTrack.html
@@ -139,13 +139,13 @@
 		<h3>[method:KeyframeTrack clone]()</h3>
 		<p></p>
 
-		<h3>[method:null createInterpolant]()</h3>
+		<h3>[method:Interpolant createInterpolant]()</h3>
 		<p>
 			根据传入构造器中的插值类型参数，创建线性插值([page:LinearInterpolant LinearInterpolant])，立方插值([page:CubicInterpolant CubicInterpolant])或离散插值
 			([page:DiscreteInterpolant DiscreteInterpolant])
 		</p>
 
-		<h3>[method:null getInterpolation]()</h3>
+		<h3>[method:Interpolant getInterpolation]()</h3>
 		<p>
 			返回插值类型
 		</p>
@@ -162,13 +162,13 @@
 			可传入一个Float32Array类型的变量来接收结果， 否则会自动创建一个长度适宜的新数组。
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:LinearInterpolant InterpolantFactoryMethodLinear]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			根据时间([page:KeyframeTrack.times times])和值([page:KeyframeTrack.times values])创建一个新的线性插值([page:LinearInterpolant LinearInterpolant])。
 			可传入一个Float32Array类型的变量来接收结果， 否则会自动创建一个长度适宜的新数组。
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
+		<h3>[method:CubicInterpolant InterpolantFactoryMethodSmooth]( [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array result] )</h3>
 		<p>
 			根据时间([page:KeyframeTrack.times times])和值([page:KeyframeTrack.times values])创建一个新的立方插值([page:CubicInterpolant CubicInterpolant])。
 			可传入一个Float32Array类型的变量来接收结果， 否则会自动创建一个长度适宜的新数组。

--- a/docs/api/zh/animation/PropertyBinding.html
+++ b/docs/api/zh/animation/PropertyBinding.html
@@ -71,20 +71,20 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null getValue]( [param:Array targetArray], [param:Number offset] )</h3>
+		<h3>[method:undefined getValue]( [param:Array targetArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
+		<h3>[method:undefined setValue]( [param:Array sourceArray], [param:Number offset] )</h3>
 		<p>
 		</p>
 
-		<h3>[method:null bind]( )</h3>
+		<h3>[method:undefined bind]( )</h3>
 		<p>
 			为场景图中的属性创建 getter / setter对。 被[page:PropertyBinding.getValue getValue]和[page:PropertyBinding.setValue setValue]方法内部使用。
 		</p>
 
-		<h3>[method:null unbind]( )</h3>
+		<h3>[method:undefined unbind]( )</h3>
 		<p>
 			解绑场景图中某属性的getter / setter对。
 		</p>

--- a/docs/api/zh/animation/PropertyMixer.html
+++ b/docs/api/zh/animation/PropertyMixer.html
@@ -65,24 +65,24 @@
 		<h2>方法</h2>
 
 
-		<h3>[method:null accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
+		<h3>[method:undefined accumulate]( [param:Number accuIndex], [param:Number weight] )</h3>
 		<p>
 			将[page:PropertyMixer.buffer buffer][accuIndex]中'incoming'区的数据累加到'accu[i]'区中。<br />
 
 			如果权值为0，则什么都不做。
 		</p>
 
-		<h3>[method:null apply]( [param:Number accuIndex] )</h3>
+		<h3>[method:undefined apply]( [param:Number accuIndex] )</h3>
 		<p>
 			当累加值不同时，将[page:PropertyMixer.buffer buffer] 'accu[i]区的状态应用于绑定.
 		</p>
 
-		<h3>[method:null saveOriginalState]( )</h3>
+		<h3>[method:undefined saveOriginalState]( )</h3>
 		<p>
 			记住绑定属性的状态并复制到两个'accu'区中.
 		</p>
 
-		<h3>[method:null restoreOriginalState](  )</h3>
+		<h3>[method:undefined restoreOriginalState](  )</h3>
 		<p>
 			将预先通过'saveOriginalState'方法取得的状态应用于绑定。
 		</p>

--- a/docs/api/zh/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/BooleanKeyframeTrack.html
@@ -58,12 +58,12 @@
 			参见 [page:KeyframeTrack] 查看继承的方法.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear ]()</h3>
 		<p>
 			这个方法在这里的值为 'undefined', 因为他对离散属性没有意义.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth ]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth ]()</h3>
 		<p>
 			这个方法在这里的值为 'undefined', 因为他对离散属性没有意义.
 		</p>

--- a/docs/api/zh/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/QuaternionKeyframeTrack.html
@@ -56,7 +56,7 @@
 			参见 [page:KeyframeTrack] 查看继承的方法.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:QuaternionLinearInterpolant InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			根据值数组 ([page:KeyframeTrack.values values])，
 			时间 ([page:KeyframeTrack.times times])

--- a/docs/api/zh/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/zh/animation/tracks/StringKeyframeTrack.html
@@ -61,12 +61,12 @@
 			参见 [page:KeyframeTrack] 查看继承的方法.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodLinear]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodLinear]()</h3>
 		<p>
 			这个方法在这里的值为 'undefined', 因为他对离散属性没有意义.
 		</p>
 
-		<h3>[method:null InterpolantFactoryMethodSmooth]()</h3>
+		<h3>[method:undefined InterpolantFactoryMethodSmooth]()</h3>
 		<p>
 			这个方法在这里的值为 'undefined', 因为他对离散属性没有意义.
 		</p>

--- a/docs/api/zh/audio/Audio.html
+++ b/docs/api/zh/audio/Audio.html
@@ -153,7 +153,7 @@
 		如果[page:Audio.hasPlaybackControl hasPlaybackControl]是true, 暂停播放.
 		</p>
 
-		<h3>[method:null onEnded]()</h3>
+		<h3>[method:undefined onEnded]()</h3>
 		<p>
 		播放完成后自动调用.
 		</p>

--- a/docs/api/zh/cameras/CubeCamera.html
+++ b/docs/api/zh/cameras/CubeCamera.html
@@ -72,7 +72,7 @@
 		<p>共有方法请参见其基类[page:Object3D]。</p>
 
 
-		<h3>[method:null update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
+		<h3>[method:undefined update]( [param:WebGLRenderer renderer], [param:Scene scene] )</h3>
 		<p>
 		renderer -- 当前的WebGL渲染器<br />
 		scene -- 当前的场景

--- a/docs/api/zh/cameras/OrthographicCamera.html
+++ b/docs/api/zh/cameras/OrthographicCamera.html
@@ -105,7 +105,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Camera]。</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — 多视图的全宽设置<br />
 		fullHeight — 多视图的全高设置<br />
@@ -119,12 +119,12 @@
 
 		</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>
 		清除任何由.setViewOffset设置的偏移量。
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		更新摄像机投影矩阵。在任何参数被改变以后必须被调用。
 		</p>

--- a/docs/api/zh/cameras/PerspectiveCamera.html
+++ b/docs/api/zh/cameras/PerspectiveCamera.html
@@ -101,7 +101,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Camera]。</p>
 
-		<h3>[method:null clearViewOffset]()</h3>
+		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>清除任何由[page:PerspectiveCamera.setViewOffset .setViewOffset]设置的偏移量。</p>
 
 		<h3>[method:Float getEffectiveFOV]()</h3>
@@ -121,13 +121,13 @@
 		<h3>[method:Float getFocalLength]()</h3>
 		<p>返回当前.fov（视野角度）相对于.filmGauge（胶片尺寸）的焦距。
 
-		<h3>[method:null setFocalLength]( [param:Float focalLength] )</h3>
+		<h3>[method:undefined setFocalLength]( [param:Float focalLength] )</h3>
 		<p>
 			通过相对于当前[page:PerspectiveCamera.filmGauge .filmGauge]的焦距，设置FOV。
 		<br /><br />
 			默认情况下，焦距是为35mm（全画幅）摄像机而指定的。</p>
 
-		<h3>[method:null setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
+		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>
 		<p>
 		fullWidth — 多视图的全宽设置<br />
 		fullHeight — 多视图的全高设置<br />
@@ -174,7 +174,7 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 		请注意，显示器的不必具有相同的大小，或者不必在网格中。
 		</p>
 
-		<h3>[method:null updateProjectionMatrix]()</h3>
+		<h3>[method:undefined updateProjectionMatrix]()</h3>
 		<p>
 		更新摄像机投影矩阵。在任何参数被改变以后必须被调用。
 		</p>

--- a/docs/api/zh/cameras/StereoCamera.html
+++ b/docs/api/zh/cameras/StereoCamera.html
@@ -43,7 +43,7 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null update]( [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined update]( [param:PerspectiveCamera camera] )</h3>
 		<p>
 		基于摄像机通过场景，更新立体摄像机。
 		</p>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -161,13 +161,13 @@
 			所以，你需要使用该方法来添加 attributes。
 		</p>
 
-		<h3>[method:null addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
+		<h3>[method:undefined addGroup]( [param:Integer start], [param:Integer count], [param:Integer materialIndex] )</h3>
 		<p>
 			为当前几何体增加一个 group，详见 [page:BufferGeometry.groups groups] 属性。
 		</p>
 
 
-		<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
+		<h3>[method:this applyMatrix4]( [param:Matrix4 matrix] )</h3>
 		<p> 用给定矩阵转换几何体的顶点坐标。</p>
 
 		<h3>[method:BufferGeometry center] ()</h3>
@@ -179,31 +179,31 @@
 		<h3>[method:BufferGeometry copy]( [param:BufferGeometry bufferGeometry] )</h3>
 		<p>将参数指定的 BufferGeometry 的值拷贝到当前 BufferGeometry 中。</p>
 
-		<h3>[method:null clearGroups]( )</h3>
+		<h3>[method:undefined clearGroups]( )</h3>
 		<p>清空所有的 groups。</p>
 
-		<h3>[method:null computeBoundingBox]()</h3>
+		<h3>[method:undefined computeBoundingBox]()</h3>
 		<p>
 			计算当前几何体的的边界矩形，该操作会更新已有 [param:.boundingBox]。<br />
 			边界矩形不会默认计算，需要调用该接口指定计算边界矩形，否则保持默认值 *null*。
 		</p>
 
-		<h3>[method:null computeBoundingSphere]()</h3>
+		<h3>[method:undefined computeBoundingSphere]()</h3>
 		<p>
 			计算当前几何体的的边界球形，该操作会更新已有 [param:.boundingSphere]。<br />
 			边界球形不会默认计算，需要调用该接口指定计算边界球形，否则保持默认值 *null*。
 		</p>
 
-		<h3>[method:null computeTangents]()</h3>
+		<h3>[method:undefined computeTangents]()</h3>
 		<p>
 		Calculates and adds a tangent attribute to this geometry.<br />
 		The computation is only supported for indexed geometries and if position, normal, and uv attributes are defined.
 		</p>
 
-		<h3>[method:null computeVertexNormals]()</h3>
+		<h3>[method:undefined computeVertexNormals]()</h3>
 		<p>通过面片法向量的平均值计算每个顶点的法向量。</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			从内存中销毁对象。 <br />
 			如果在运行是需要从内存中删除 BufferGeometry，则需要调用该函数。
@@ -225,10 +225,10 @@
 			旋转几何体朝向控件中的一点。该过程通常在一次处理中完成，不会循环处理。典型的用法是过通过调用 [page:Object3D.lookAt] 实时改变 mesh 朝向。
 		</p>
 
-		<h3>[method:null merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
+		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
 		<p>同参数指定的 BufferGeometry 进行合并。可以通过可选参数指定，从哪个偏移位置开始进行 merge。</p>
 
-		<h3>[method:null normalizeNormals]()</h3>
+		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 			几何体中的每个法向量长度将会为 1。这样操作会更正光线在表面的效果。
 		</p>
@@ -259,7 +259,7 @@
 		<h3>[method:BufferGeometry setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>设置缓存的 [page:.index]。</p>
 
-		<h3>[method:null setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
+		<h3>[method:undefined setDrawRange] ( [param:Integer start], [param:Integer count] )</h3>
 		<p>设置缓存的 [page:.drawRange]。详见相关属性说明。</p>
 
 		<h3>[method:BufferGeometry setFromPoints] ( [param:Array points] )</h3>

--- a/docs/api/zh/core/Clock.html
+++ b/docs/api/zh/core/Clock.html
@@ -53,13 +53,13 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null start]()</h3>
+		<h3>[method:undefined start]()</h3>
 		<p>
 			启动时钟。同时将 [page:Clock.startTime startTime] 和 [page:Clock.oldTime oldTime] 设置为当前时间。
 			设置 [page:Clock.elapsedTime elapsedTime] 为 *0*，并且设置 [page:Clock.running running] 为 *true*.
 		</p>
 
-		<h3>[method:null stop]()</h3>
+		<h3>[method:undefined stop]()</h3>
 		<p>
 			停止时钟。同时将 [page:Clock.oldTime oldTime] 设置为当前时间。
 		</p>

--- a/docs/api/zh/core/EventDispatcher.html
+++ b/docs/api/zh/core/EventDispatcher.html
@@ -52,7 +52,7 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null addEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined addEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 需要添加监听的事件类型。<br />
 		listener - 事件发生时被调用到的函数。
@@ -70,7 +70,7 @@
 		检查监听函数是否已经添加到指定事件。
 		</p>
 
-		<h3>[method:null removeEventListener]( [param:String type], [param:Function listener] )</h3>
+		<h3>[method:undefined removeEventListener]( [param:String type], [param:Function listener] )</h3>
 		<p>
 		type - 需要移除监听的事件类型。<br />
 		listener - 需要被移除的监听函数。
@@ -79,7 +79,7 @@
 		从指定事件类型中移除监听函数。
 		</p>
 
-		<h3>[method:null dispatchEvent]( [param:Object event] )</h3>
+		<h3>[method:undefined dispatchEvent]( [param:Object event] )</h3>
 		<p>
 		event - 将被触发的事件。
 		</p>

--- a/docs/api/zh/core/GLBufferAttribute.html
+++ b/docs/api/zh/core/GLBufferAttribute.html
@@ -86,16 +86,16 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null setBuffer]( buffer ) </h3>
+		<h3>[method:this setBuffer]( buffer ) </h3>
 		<p>Sets the *buffer* property.</p>
 
-		<h3>[method:null setType]( type, elementSize ) </h3>
+		<h3>[method:this setType]( type, elementSize ) </h3>
 		<p>Sets the both *type* and *elementSize* properties.</p>
 
-		<h3>[method:null setItemSize]( itemSize ) </h3>
+		<h3>[method:this setItemSize]( itemSize ) </h3>
 		<p>Sets the *itemSize* property.</p>
 
-		<h3>[method:null setCount]( count ) </h3>
+		<h3>[method:this setCount]( count ) </h3>
 		<p>Sets the *count* property.</p>
 
 		<h3>[property:Integer version]</h3>

--- a/docs/api/zh/core/InterleavedBufferAttribute.html
+++ b/docs/api/zh/core/InterleavedBufferAttribute.html
@@ -86,25 +86,25 @@
 		<h3>[method:Number getW]( [param:Integer index] ) </h3>
 		<p>返回给定索引矢量的第四个元素 （W 值）。</p>
 
-		<h3>[method:null setX]( [param:Integer index], [param:Float x] ) </h3>
+		<h3>[method:this setX]( [param:Integer index], [param:Float x] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第一个元素 （X 值）。</p>
 
-		<h3>[method:null setY]( [param:Integer index], [param:Float y] ) </h3>
+		<h3>[method:this setY]( [param:Integer index], [param:Float y] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第二个元素 （Y 值）。</p>
 
-		<h3>[method:null setZ]( [param:Integer index], [param:Float z] ) </h3>
+		<h3>[method:this setZ]( [param:Integer index], [param:Float z] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第三个元素 （Z 值）。</p>
 
-		<h3>[method:null setW]( [param:Integer index], [param:Float w] ) </h3>
+		<h3>[method:this setW]( [param:Integer index], [param:Float w] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第四个元素 （W 值）。</p>
 
-		<h3>[method:null setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
+		<h3>[method:this setXY]( [param:Integer index], [param:Float x], [param:Float y] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第一、二个元素 （X 和 Y 值）。</p>
 
-		<h3>[method:null setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
+		<h3>[method:this setXYZ]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第一、二、三个元素 （X Y 和 Z 值）。</p>
 
-		<h3>[method:null setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
+		<h3>[method:this setXYZW]( [param:Integer index], [param:Float x], [param:Float y], [param:Float z], [param:Float w] ) </h3>
 		<p>通过给定参数，设置指定索引矢量的第一、二、三、四个元素 （X Y Z 和 W 值）。</p>
 
 		<h2>源代码</h2>

--- a/docs/api/zh/core/Layers.html
+++ b/docs/api/zh/core/Layers.html
@@ -39,21 +39,21 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null disable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined disable]( [param:Integer layer] )</h3>
 		<p>
 			layer - 一个 0 - 31 的整数。<br /><br />
 
 			删除图层对象与参数指定图层的对应关系。
 		</p>
 
-		<h3>[method:null enable]( [param:Integer layer] )</h3>
+		<h3>[method:undefined enable]( [param:Integer layer] )</h3>
 		<p>
 			layer - 一个 0 - 31 的整数。<br /><br />
 
 			增加图层对象与参数指定图层的对应关系。
 		</p>
 
-		<h3>[method:null set]( [param:Integer layer] )</h3>
+		<h3>[method:undefined set]( [param:Integer layer] )</h3>
 		<p>
 			layer - 一个 0 - 31 的整数。<br /><br />
 
@@ -67,19 +67,19 @@
 			如果传入图层对象与当前对象属于相同的一组图层，则返回 true，否则返回 false。
 		</p>
 
-		<h3>[method:null toggle]( [param:Integer layer] )</h3>
+		<h3>[method:undefined toggle]( [param:Integer layer] )</h3>
 		<p>
 			layer - 一个 0 - 31 的整数。<br /><br />
 
 			根据参数切换对象所属图层。
 		</p>
 
-		<h3>[method:null enableAll]()</h3>
+		<h3>[method:undefined enableAll]()</h3>
 		<p>
 			Add membership to all layers.
 		</p>
 
- 		<h3>[method:null disableAll]()</h3>
+ 		<h3>[method:undefined disableAll]()</h3>
 		<p>
 			Remove membership from all layers.
 		</p>

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -196,14 +196,14 @@
 
 	<h3>[page:EventDispatcher EventDispatcher] 方法在这个类上是可用的。</h3>
 
-	<h3>[method:null add]( [param:Object3D object], ... )</h3>
+	<h3>[method:this add]( [param:Object3D object], ... )</h3>
 	<p>
 		添加<b>对象</b>到这个对象的子级，可以添加任意数量的对象。
 		当前传入的对象中的父级将在这里被移除，因为一个对象仅能有一个父级。<br /><br />
 		请参阅[page:Group]来查看手动编组对象的相关信息。
 	</p>
 
-	<h3>[method:null applyMatrix4]( [param:Matrix4 matrix] )</h3>
+	<h3>[method:undefined applyMatrix4]( [param:Matrix4 matrix] )</h3>
 	<p>对当前物体应用这个变换矩阵，并更新物体的位置、旋转和缩放。</p>
 
 	<h3>[method:Object3D applyQuaternion]( [param:Quaternion quaternion] )</h3>
@@ -284,8 +284,8 @@
 		将该向量从物体的局部空间转换到世界空间。
 	</p>
 
-	<h3>[method:null lookAt]( [param:Vector3 vector] )<br />
-		[method:null lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+	<h3>[method:undefined lookAt]( [param:Vector3 vector] )<br />
+		[method:undefined lookAt]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 	<p>
 		vector - 一个表示世界空间中位置的向量。<br /><br />
 		也可以使用世界空间中[page:.x x]、[page:.y y]和[page:.z z]的位置分量。<br /><br />
@@ -298,7 +298,7 @@
 		在一些子类，例如[page:Mesh], [page:Line], and [page:Points]实现了这个方法，以用于光线投射。
 	</p>
 
-	<h3>[method:null remove]( [param:Object3D object], ... )</h3>
+	<h3>[method:this remove]( [param:Object3D object], ... )</h3>
 	<p>
 		从当前对象的子级中移除<b>对象</b>。可以移除任意数量的对象。
 	</p>
@@ -342,7 +342,7 @@
 		绕局部空间的Z轴旋转这个物体。
 	</p>
 
-	<h3>[method:null setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
+	<h3>[method:undefined setRotationFromAxisAngle]( [param:Vector3 axis], [param:Float angle] )</h3>
 	<p>
 		axis -- 一个在局部空间中的标准化向量。<br />
 		angle -- 角度（以弧度来表示）。<br /><br />
@@ -350,7 +350,7 @@
 		调用[page:.quaternion]中的[page:Quaternion.setFromAxisAngle setFromAxisAngle]( [page:Float axis], [page:Float angle] )。
 	</p>
 
-	<h3>[method:null setRotationFromEuler]( [param:Euler euler] )</h3>
+	<h3>[method:undefined setRotationFromEuler]( [param:Euler euler] )</h3>
 	<p>
 		euler -- 指定了旋转量的欧拉角。<br />
 
@@ -358,7 +358,7 @@
 
 	</p>
 
-	<h3>[method:null setRotationFromMatrix]( [param:Matrix4 m] )</h3>
+	<h3>[method:undefined setRotationFromMatrix]( [param:Matrix4 m] )</h3>
 	<p>
 		m -- 通过该矩阵中的旋转分量来旋转四元数。<br />
 
@@ -368,7 +368,7 @@
 		请注意，这里假设m上的3x3矩阵是一个纯旋转矩阵（即未缩放的矩阵）。
 	</p>
 
-	<h3>[method:null setRotationFromQuaternion]( [param:Quaternion q] )</h3>
+	<h3>[method:undefined setRotationFromQuaternion]( [param:Quaternion q] )</h3>
 	<p>
 		q -- 标准化的四元数。<br /><br />
 
@@ -397,7 +397,7 @@
 	<h3>[method:this translateZ]( [param:Float distance] )</h3>
 	<p>沿着Z轴将平移*distance*个单位。</p>
 
-	<h3>[method:null traverse]( [param:Function callback] )</h3>
+	<h3>[method:undefined traverse]( [param:Function callback] )</h3>
 	<p>
 
 		callback - 以一个object3D对象作为第一个参数的函数。
@@ -406,7 +406,7 @@
 		在对象以及后代中执行的回调函数。
 	</p>
 
-	<h3>[method:null traverseVisible]( [param:Function callback] )</h3>
+	<h3>[method:undefined traverseVisible]( [param:Function callback] )</h3>
 	<p>
 			callback - 以一个object3D对象作为第一个参数的函数。
 			<br /><br />
@@ -414,20 +414,20 @@
 		类似traverse函数，但在这里，回调函数仅对可见的对象执行，不可见对象的后代将不遍历。
 	</p>
 
-	<h3>[method:null traverseAncestors]( [param:Function callback] )</h3>
+	<h3>[method:undefined traverseAncestors]( [param:Function callback] )</h3>
 	<p>
 		callback - 以一个object3D对象作为第一个参数的函数。<br /><br />
 
 		在所有的祖先中执行回调函数。
 	</p>
 
-	<h3>[method:null updateMatrix]()</h3>
+	<h3>[method:undefined updateMatrix]()</h3>
 	<p>更新局部变换。</p>
 
-	<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
+	<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 	<p>更新物体及其后代的全局变换。</p>
 
-	<h3>[method:null updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
+	<h3>[method:undefined updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 	<p>
 		updateParents - recursively updates global transform of ancestors.<br />
 		updateChildren - recursively updates global transform of descendants.<br /><br />

--- a/docs/api/zh/core/Raycaster.html
+++ b/docs/api/zh/core/Raycaster.html
@@ -140,7 +140,7 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
+		<h3>[method:undefined set]( [param:Vector3 origin], [param:Vector3 direction] )</h3>
 		<p>
 		[page:Vector3 origin] —— 光线投射的原点向量。<br />
 		[page:Vector3 direction] —— 为光线提供方向的标准化方向向量。
@@ -149,7 +149,7 @@
 			使用一个新的原点和方向来更新射线。
 		</p>
 
-		<h3>[method:null setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
+		<h3>[method:undefined setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
 		<p>
 		[page:Vector2 coords] —— 在标准化设备坐标中鼠标的二维坐标 —— X分量与Y分量应当在-1到1之间。<br />
 

--- a/docs/api/zh/extras/core/Curve.html
+++ b/docs/api/zh/extras/core/Curve.html
@@ -65,7 +65,7 @@
 		<h3>[method:Array getLengths]( [param:Integer divisions] )</h3>
 		<p>获取累积段长度的列表。</p>
 
-		<h3>[method:null updateArcLengths]()</h3>
+		<h3>[method:undefined updateArcLengths]()</h3>
 		<p>更新累积段距离缓存。</p>
 
 		<h3>[method:Float getUtoTmapping]( [param:Float u], [param:Float distance] )</h3>

--- a/docs/api/zh/extras/core/CurvePath.html
+++ b/docs/api/zh/extras/core/CurvePath.html
@@ -42,10 +42,10 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Curve]。</p>
 
-		<h3>[method:null add]( [param:Curve curve] )</h3>
+		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>添加一条曲线到[page:.curves]数组中。</p>
 
-		<h3>[method:null closePath]()</h3>
+		<h3>[method:undefined closePath]()</h3>
 		<p>添加一条[page:LineCurve lineCurve]用于闭合路径。</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/zh/helpers/ArrowHelper.html
+++ b/docs/api/zh/helpers/ArrowHelper.html
@@ -61,14 +61,14 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:Object3D] 页面查看公共方法.</p>
 
-		<h3>[method:null setColor]([param:Color color])</h3>
+		<h3>[method:undefined setColor]([param:Color color])</h3>
 		<p>
 		color -- 所需的颜色。<br /><br />
 
 		设置箭头辅助对象的颜色.
 		</p>
 
-		<h3>[method:null setLength]([param:Number length], [param:Number headLength], [param:Number headWidth])</h3>
+		<h3>[method:undefined setLength]([param:Number length], [param:Number headLength], [param:Number headWidth])</h3>
 		<p>
 		length -- 要设置的长度.<br />
 		headLength -- 要设置的箭头头部(锥体)的长度.<br />
@@ -77,7 +77,7 @@
 		设置箭头辅助对象的长度.
 		</p>
 
-		<h3>[method:null setDirection]([param:Vector3 dir])</h3>
+		<h3>[method:undefined setDirection]([param:Vector3 dir])</h3>
 		<p>
 		dir -- 要设置的方向. 必须为单位向量.<br /><br />
 

--- a/docs/api/zh/helpers/BoxHelper.html
+++ b/docs/api/zh/helpers/BoxHelper.html
@@ -55,7 +55,7 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:LineSegments] 页面查看公共方法.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>
 			更新辅助对象的几何体，与目标对象尺寸
 			保持一致, 包围目标对象所有子对象. 请查看 [page:Box3.setFromObject].

--- a/docs/api/zh/helpers/CameraHelper.html
+++ b/docs/api/zh/helpers/CameraHelper.html
@@ -70,7 +70,7 @@
 		<p>请到基类 [page:LineSegments] 页面查看公共方法.</p>
 
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>基于相机的投影矩阵更新辅助对象.</p>
 
 		<h2>源码</h2>

--- a/docs/api/zh/helpers/DirectionalLightHelper.html
+++ b/docs/api/zh/helpers/DirectionalLightHelper.html
@@ -67,11 +67,11 @@
 		<h2>方法</h2>
 		<p>请到基类  [page:Object3D] 页面查看公共方法.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>销毁该平行光辅助对象.</p>
 
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>更新辅助对象，与模拟的 [page:.light directionalLight] 光源的位置和方向保持一致.</p>
 
 		<h2>源码</h2>

--- a/docs/api/zh/helpers/HemisphereLightHelper.html
+++ b/docs/api/zh/helpers/HemisphereLightHelper.html
@@ -62,10 +62,10 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:Object3D] 页面查看公共方法.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>销毁该半球形光源辅助对象.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>更新辅助对象，与 [page:.light] 属性的位置和方向保持一致.</p>
 
 

--- a/docs/api/zh/helpers/PointLightHelper.html
+++ b/docs/api/zh/helpers/PointLightHelper.html
@@ -69,11 +69,11 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:Mesh] 页面查看公共方法.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>销毁该点光源辅助对象.</p>
 
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>更新辅助对象，与 [page:.light] 属性的位置保持一致.</p>
 
 		<h2>源码</h2>

--- a/docs/api/zh/helpers/SpotLightHelper.html
+++ b/docs/api/zh/helpers/SpotLightHelper.html
@@ -64,10 +64,10 @@
 		<h2>方法</h2>
 		<p>请到基类 [page:Object3D] 页面查看公共属性.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>销毁该聚光灯辅助对象.</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>更新聚光灯辅助对象.</p>
 
 		<h2>源码</h2>

--- a/docs/api/zh/lights/shadows/LightShadow.html
+++ b/docs/api/zh/lights/shadows/LightShadow.html
@@ -105,7 +105,7 @@
 		Used internally by the renderer to extend the shadow map to contain all viewports
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light] )</h3>
+		<h3>[method:undefined updateMatrices]( [param:Light light] )</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -72,7 +72,7 @@
 			共有方法请参见其基类[page:LightShadow LightShadow]。
 		</p>
 
-		<h3>[method:null updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
+		<h3>[method:undefined updateMatrices]( [param:Light light], [param:number viewportIndex])</h3>
 		<p>
 		Update the matrices for the camera and shadow, used internally by the renderer.<br /><br />
 

--- a/docs/api/zh/loaders/AnimationLoader.html
+++ b/docs/api/zh/loaders/AnimationLoader.html
@@ -59,7 +59,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/zh/loaders/AudioLoader.html
+++ b/docs/api/zh/loaders/AudioLoader.html
@@ -76,7 +76,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/zh/loaders/BufferGeometryLoader.html
+++ b/docs/api/zh/loaders/BufferGeometryLoader.html
@@ -68,7 +68,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />

--- a/docs/api/zh/loaders/Cache.html
+++ b/docs/api/zh/loaders/Cache.html
@@ -40,7 +40,7 @@ THREE.Cache.enabled = true.
 
 		<h2>方法</h2>
 
-		<h3>[method:null add]( [param:String key], file )</h3>
+		<h3>[method:undefined add]( [param:String key], file )</h3>
 		<p>
 		[page:String key] — 通过引用缓存文件的[page:String key]。<br />
 		[page:Object file] — 所被缓存的文件<br /><br />
@@ -48,21 +48,21 @@ THREE.Cache.enabled = true.
 			使用key为引用文件增加一个缓存入口。如果该key已持有一个文件，则会被覆盖。
 		</p>
 
-		<h3>[method:null get]( [param:String key] )</h3>
+		<h3>[method:Any get]( [param:String key] )</h3>
 		<p>
 		[page:String key] — 一个字符串key <br /><br />
 
 		获得该[page:String key]的值。 如果该key不存在，则以*undefined*被返回。
 		</p>
 
-		<h3>[method:null remove]( [param:String key] )</h3>
+		<h3>[method:undefined remove]( [param:String key] )</h3>
 		<p>
 		[page:String key] — 引用缓存文件的一个字符串key<br /><br />
 
 		使用key来删除相应的缓存文件。
 		</p>
 
-		<h3>[method:null clear]()</h3>
+		<h3>[method:undefined clear]()</h3>
 		<p>清除所有缓存中的值。</p>
 
 

--- a/docs/api/zh/loaders/ImageBitmapLoader.html
+++ b/docs/api/zh/loaders/ImageBitmapLoader.html
@@ -80,7 +80,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/zh/loaders/MaterialLoader.html
+++ b/docs/api/zh/loaders/MaterialLoader.html
@@ -63,7 +63,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
@@ -81,7 +81,7 @@
 		解析<em>JSON</em>结构，以json对象的参数中的[page:String json.type]类型，创建一个新的[page:Material]。
 		</p>
 
-		<h3>[method:null setTextures]( [param:Object textures] )</h3>
+		<h3>[method:this setTextures]( [param:Object textures] )</h3>
 		<p>
 		[page:Object textures] — 对象包含任何被材质所使用的纹理。
 		</p>

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -72,7 +72,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Loader]。</p>
 
-		<h3>[method:null load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
+		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
 		[page:String url] — 文件的URL或者路径，也可以为
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />

--- a/docs/api/zh/loaders/managers/LoadingManager.html
+++ b/docs/api/zh/loaders/managers/LoadingManager.html
@@ -168,7 +168,7 @@
 manager.addHandler( /\.tga$/i, new TGALoader() );
 		</code>
 
-		<h3>[method:null getHandler]( [param:String file] )</h3>
+		<h3>[method:Loader getHandler]( [param:String file] )</h3>
 		<p>
 		[page:String file] — The file path.
 		<p>
@@ -189,7 +189,7 @@ manager.addHandler( /\.tga$/i, new TGALoader() );
 		给定URL，使用URL修饰符回调（如果有）并返回已解析的URL。如果未设置URL修饰符，则返回原始URL。
 		</p>
 
-		<h3>[method:null setURLModifier]( [param:Function callback] )</h3>
+		<h3>[method:this setURLModifier]( [param:Function callback] )</h3>
 		<p>
 		[page:Function callback] — 设置URL修饰符成功时回调。使用url参数进行回调，并且必须返回 [page:String resolvedURL] 。<br /><br />
 
@@ -204,21 +204,21 @@ manager.addHandler( /\.tga$/i, new TGALoader() );
 			them directly.</em>
 		</p>
 
-		<h3>[method:null itemStart]( [param:String url] )</h3>
+		<h3>[method:undefined itemStart]( [param:String url] )</h3>
 		<p>
 		[page:String url] — 所要加载的url<br /><br />
 
 		任何使用管理器的加载器都会调用此方法， 当加载器需要开始加载URL时。
 		</p>
 
-		<h3>[method:null itemEnd]( [param:String url] )</h3>
+		<h3>[method:undefined itemEnd]( [param:String url] )</h3>
 		<p>
 		[page:String url] — 所要加载的url<br /><br />
 
 		任何使用管理器的加载器都会调用此方法， 当加载器需要加载URL结束时。
 		</p>
 
-		<h3>[method:null itemError]( [param:String url] )</h3>
+		<h3>[method:undefined itemError]( [param:String url] )</h3>
 		<p>
 		[page:String url] — 所要加载的url<br /><br />
 

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -281,11 +281,11 @@ This starts at *0* and counts how many times [property:Boolean needsUpdate] is s
 <h3>[method:Material copy]( [param:material material] )</h3>
 <p> 将被传入材质中的参数复制到此材质中。</p>
 
-<h3>[method:null dispose]()</h3>
+<h3>[method:undefined dispose]()</h3>
 <p> 处理材质。材质的纹理不会被处理。需要通过[page:Texture Texture]处理。
 </p>
 
-<h3>[method:null onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
+<h3>[method:undefined onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
 <p> 在编译shader程序之前立即执行的可选回调。此函数使用shader源码作为参数。用于修改内置材质。
 </p>
 <p>
@@ -322,7 +322,7 @@ then customProgramCacheKey should be set like this:<br />
 Unlike properties, the callback is not supported by [page:Material.clone .clone](), [page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 </p>
 
-<h3>[method:null setValues]( [param:Object values] )</h3>
+<h3>[method:undefined setValues]( [param:Object values] )</h3>
 <p> values -- 具有参数的容器。
 	根据*values*设置属性。<br/>
 </p>

--- a/docs/api/zh/math/Interpolant.html
+++ b/docs/api/zh/math/Interpolant.html
@@ -70,7 +70,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 			计算补间函数在位置 *t* 的值。
 		</p>

--- a/docs/api/zh/math/MathUtils.html
+++ b/docs/api/zh/math/MathUtils.html
@@ -128,7 +128,7 @@
 		返回一个0-1之间的值。它和smoothstep相同，但变动更平缓。[link:https://en.wikipedia.org/wiki/Smoothstep#Variations variation on smoothstep] 在x=0和x=1处有0阶和二阶导数。
 		</p>
 
-		<h3>[method:null setQuaternionFromProperEuler]( [param:Quaternion q], [param:Float a], [param:Float b], [param:Float c], [param:String order] )</h3>
+		<h3>[method:undefined setQuaternionFromProperEuler]( [param:Quaternion q], [param:Float a], [param:Float b], [param:Float c], [param:String order] )</h3>
 		<p>
 		[page:Quaternion q] - 将被设置的的四元数。<br />
 		[page:Float a] - 应用于第一个轴的旋转，以弧度为单位。<br />

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -129,7 +129,7 @@ m.elements = [ 11, 21, 31, 41,
 		将给定矩阵 [param:Matrix4 m] 的平移分量拷贝到当前矩阵中。
 		</p>
 
-		<h3>[method:null decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
+		<h3>[method:this decompose]( [param:Vector3 position], [param:Quaternion quaternion], [param:Vector3 scale] )</h3>
 		<p>
 			将矩阵分解到给定的平移[page:Vector3 position] ,旋转 [page:Quaternion quaternion]，缩放[page:Vector3 scale]分量中。<br/><br/>
 			注意：并非所有矩阵都可以通过这种方式分解。 例如，如果一个对象有一个非均匀缩放的父对象，那么该对象的世界矩阵可能是不可分解的，这种方法可能不合适。

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -204,7 +204,7 @@
 
 		<h2>静态方法</h2>
 
-		<h3>[method:null slerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float t] )</h3>
+		<h3>[method:undefined slerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float t] )</h3>
 		<p>
 		[page:Array dst] - 输出数组<br />
 		[page:Integer dstOffset] - 输出数组的偏移量<br />

--- a/docs/api/zh/math/Vector2.html
+++ b/docs/api/zh/math/Vector2.html
@@ -36,7 +36,7 @@
 		<p>
 			Iterating through a Vector2 instance will yield its components (x, y) in the corresponding order.
 		</p>
-		
+
 		<h2>代码示例</h2>
 
 		<code>
@@ -294,7 +294,7 @@
 		<h3>[method:this set]( [param:Float x], [param:Float y] )</h3>
 		<p>设置该向量的[page:.x x]和[page:.y y]分量。</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0 或 1<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -336,7 +336,7 @@
 		<h3>[method:this set]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>设置该向量的[page:.x x]、[page:.y y] 和 [page:.z z] 分量。</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0、1 或 2。<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/zh/math/Vector4.html
+++ b/docs/api/zh/math/Vector4.html
@@ -276,7 +276,7 @@
 			将该向量的[page:.x x]、[page:.y y]和[page:.z z]设置为旋转轴，[page:.w w]为角度。
 		</p>
 
-		<h3>[method:null setComponent]( [param:Integer index], [param:Float value] )</h3>
+		<h3>[method:this setComponent]( [param:Integer index], [param:Float value] )</h3>
 		<p>
 		[page:Integer index] - 0、1、2 或 3。<br />
 		[page:Float value] - [page:Float]<br /><br />

--- a/docs/api/zh/math/interpolants/CubicInterpolant.html
+++ b/docs/api/zh/math/interpolants/CubicInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>方法(Methods)</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 			评估位置*t*处的插值。
 		</p>

--- a/docs/api/zh/math/interpolants/DiscreteInterpolant.html
+++ b/docs/api/zh/math/interpolants/DiscreteInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>Methods</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 			评估位置*t*处的插值。
 		</p>

--- a/docs/api/zh/math/interpolants/LinearInterpolant.html
+++ b/docs/api/zh/math/interpolants/LinearInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>方法(Methods)</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 			评估位置*t*处的插值。
 		</p>

--- a/docs/api/zh/math/interpolants/QuaternionLinearInterpolant.html
+++ b/docs/api/zh/math/interpolants/QuaternionLinearInterpolant.html
@@ -72,7 +72,7 @@ interpolant.evaluate( 0.5 );
 
 		<h2>方法(Methods)</h2>
 
-		<h3>[method:null evaluate]( [param:Number t] )</h3>
+		<h3>[method:Array evaluate]( [param:Number t] )</h3>
 		<p>
 			评估位置*t*处的插值。
 		</p>

--- a/docs/api/zh/objects/InstancedMesh.html
+++ b/docs/api/zh/objects/InstancedMesh.html
@@ -62,12 +62,12 @@
 		<h2>方法</h2>
 		<p>See the base [page:Mesh] class for common methods.</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			Frees the internal resources of this instance.
 		</p>
 
-		<h3>[method:null getColorAt]( [param:Integer index], [param:Color color] )</h3>
+		<h3>[method:undefined getColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>
@@ -78,7 +78,7 @@
 			Get the color of the defined instance.
 		</p>
 
-		<h3>[method:null getMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined getMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
 		<p>
 			[page:Integer index]: 实例的索引。值必须在 [0, count] 区间。
 		</p>
@@ -89,7 +89,7 @@
 			获得已定义实例的本地变换矩阵。
 		</p>
 
-		<h3>[method:null setColorAt]( [param:Integer index], [param:Color color] )</h3>
+		<h3>[method:undefined setColorAt]( [param:Integer index], [param:Color color] )</h3>
 		<p>
 			[page:Integer index]: The index of an instance. Values have to be in the range [0, count].
 		</p>
@@ -101,7 +101,7 @@
 			Make sure you set [page:.instanceColor][page:BufferAttribute.needsUpdate .needsUpdate] to true after updating all the colors.
 		</p>
 
-		<h3>[method:null setMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
+		<h3>[method:undefined setMatrixAt]( [param:Integer index], [param:Matrix4 matrix] )</h3>
 		<p>
 			[page:Integer index]: 实例的索引。值必须在 [0, count] 区间。
 		</p>

--- a/docs/api/zh/objects/LOD.html
+++ b/docs/api/zh/objects/LOD.html
@@ -107,7 +107,7 @@
 			使用这个方法，为LOD对象中的每个细节层次创建一个JSON结构。
 		</p>
 
-		<h3>[method:null update]( [param:Camera camera] )</h3>
+		<h3>[method:undefined update]( [param:Camera camera] )</h3>
 		<p>
 			基于每个[page:levels level]中的[page:Object3D object]和[page:Camera camera]（摄像机）之间的距离，来设置其可见性。
 		</p>

--- a/docs/api/zh/objects/Line.html
+++ b/docs/api/zh/objects/Line.html
@@ -77,7 +77,7 @@
 			对于几何体中的每一个顶点，这个方法计算出了当前点到线的起始点的累积长度。
 		</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 			在一条投射出去的[page:Ray]（射线）和这条线之间产生交互。
 			[page:Raycaster.intersectObject]将会调用这个方法。
@@ -88,7 +88,7 @@
 			返回这条线及其子集的一个克隆对象。
 		</p>
 
-		<h3>[method:null updateMorphTargets]()</h3>
+		<h3>[method:undefined updateMorphTargets]()</h3>
 		<p>
 		Updates the morphTargets to have no influence on the object. Resets the
 		[page:.morphTargetInfluences] and [page:.morphTargetDictionary] properties.

--- a/docs/api/zh/objects/Mesh.html
+++ b/docs/api/zh/objects/Mesh.html
@@ -68,13 +68,13 @@
 		<h3>[method:Mesh clone]()</h3>
 		<p>返回这个[name]对象及其子级的克隆。</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 			在一条投射出去的[page:Ray]（射线）和这个网格之间产生交互。
 			[page:Raycaster.intersectObject]将会调用这个方法。
 		</p>
 
-		<h3>[method:null updateMorphTargets]()</h3>
+		<h3>[method:undefined updateMorphTargets]()</h3>
 		<p>
 			更新morphTargets，使其不对对象产生影响，重置[page:Mesh.morphTargetInfluences morphTargetInfluences] and
 			[page:Mesh.morphTargetDictionary morphTargetDictionary]属性。

--- a/docs/api/zh/objects/Points.html
+++ b/docs/api/zh/objects/Points.html
@@ -58,7 +58,7 @@
 	<h2>方法</h2>
 	<p>共有方法请参见其基类[page:Object3D]。</p>
 
-	<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+	<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 	<p>
 		在一条投射出去的[page:Ray]（射线）和点之间产生交互。
 		[page:Raycaster.intersectObject]将会调用这个方法。
@@ -69,7 +69,7 @@
 		返回这个点及其子集的一个克隆对象。
 	</p>
 
-	<h3>[method:null updateMorphTargets]()</h3>
+	<h3>[method:undefined updateMorphTargets]()</h3>
 	<p>
 		更新morphTargets，使其不对对象产生影响，重置[page:Points.morphTargetInfluences morphTargetInfluences] 和
 		[page:Points.morphTargetDictionary morphTargetDictionary]属性。

--- a/docs/api/zh/objects/Skeleton.html
+++ b/docs/api/zh/objects/Skeleton.html
@@ -88,17 +88,17 @@
 			返回一个当前Skeleton对象的克隆。
 		</p>
 
-		<h3>[method:null calculateInverses]()</h3>
+		<h3>[method:undefined calculateInverses]()</h3>
 		<p>如果没有在构造器中提供，生成[page:.boneInverses boneInverses]数组。
 		</p>
 
-		<h3>[method:null computeBoneTexture]()</h3>
+		<h3>[method:this computeBoneTexture]()</h3>
 		<p>Computes an instance of [page:DataTexture] in order to pass the bone data more efficiently to the shader. The texture is assigned to [page:.boneTexture boneTexture].</p>
 
-		<h3>[method:null pose]()</h3>
+		<h3>[method:undefined pose]()</h3>
 		<p>返回骨架的基础姿势。</p>
 
-		<h3>[method:null update]()</h3>
+		<h3>[method:undefined update]()</h3>
 		<p>
 			在改变骨骼后，更新[page:Float32Array boneMatrices] 和 [page:DataTexture boneTexture]的值。
 			如果骨架被用于[page:SkinnedMesh]，则它将会被[page:WebGLRenderer]自动调用。
@@ -111,7 +111,7 @@
 		在骨架中的骨骼数组中遍览，并返回第一个能够和name匹配上的骨骼对象。<br />
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Can be used if an instance of [name] becomes obsolete in an application. The method will free internal resources.
 		</p>

--- a/docs/api/zh/objects/SkinnedMesh.html
+++ b/docs/api/zh/objects/SkinnedMesh.html
@@ -127,7 +127,7 @@
 		<h2>方法</h2>
 		<p>共有方法请参见其基类[page:Mesh]。</p>
 
-		<h3>[method:null bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
+		<h3>[method:undefined bind]( [param:Skeleton skeleton], [param:Matrix4 bindMatrix] )</h3>
 		<p>
 		[page:Skeleton skeleton] —— 由一棵[page:Bone Bones]树创建的[page:Skeleton]。<br/>
 		[page:Matrix4 bindMatrix] —— 表示骨架基本变换的[page:Matrix4]（4x4矩阵）。<br /><br />
@@ -139,17 +139,17 @@
 		返回当前SkinnedMesh对象的一个克隆及其任何后代。
 		</p>
 
-		<h3>[method:null normalizeSkinWeights]()</h3>
+		<h3>[method:undefined normalizeSkinWeights]()</h3>
 		<p>
 		标准化蒙皮的权重。
 		</p>
 
-		<h3>[method:null pose]()</h3>
+		<h3>[method:undefined pose]()</h3>
 		<p>
 		这个方法设置了在“休息”状态下蒙皮网格的姿势（重置姿势）。
 		</p>
 
-		<h3>[method:null updateMatrixWorld]( [param:Boolean force] )</h3>
+		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
 		<p>
 		更新[page:Matrix4 MatrixWorld]矩阵。
 		</p>

--- a/docs/api/zh/objects/Sprite.html
+++ b/docs/api/zh/objects/Sprite.html
@@ -66,7 +66,7 @@
 			将前一个Sprite对象的属性复制给当前的这个对象。
 		</p>
 
-		<h3>[method:null raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		在投射的光线和精灵之前产生交互。[page:Raycaster.intersectObject]将会调用这个方法。
 		在对sprite进行射线投射之前，射线投射必须通过调用[page:Raycaster.setFromCamera]()来初始化。		</p>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -248,22 +248,22 @@
 
 		<h2>方法</h2>
 
-		<h3>[method:null clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
+		<h3>[method:undefined clear]( [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
 		<p>
 		告诉渲染器清除颜色、深度或模板缓存.
 		此方法将颜色缓存初始化为当前颜色。参数们默认都是*true*
 		</p>
 
-		<h3>[method:null clearColor]( )</h3>
+		<h3>[method:undefined clearColor]( )</h3>
 		<p>清除颜色缓存。 相当于调用[page:WebGLRenderer.clear .clear]( true, false, false )</p>
 
-		<h3>[method:null clearDepth]( )</h3>
+		<h3>[method:undefined clearDepth]( )</h3>
 		<p>清除深度缓存。相当于调用[page:WebGLRenderer.clear .clear]( false, true, false )</p>
 
-		<h3>[method:null clearStencil]( )</h3>
+		<h3>[method:undefined clearStencil]( )</h3>
 		<p>清除模板缓存。相当于调用[page:WebGLRenderer.clear .clear]( false, false, true )</p>
 
-		<h3>[method:null clearTarget]([param:WebGLRenderTarget renderTarget], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil])</h3>
+		<h3>[method:undefined clearTarget]([param:WebGLRenderTarget renderTarget], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil])</h3>
 		<p>
 		renderTarget -- 需要被清除的[page:WebGLRenderTarget renderTarget]<br />
 		color -- 如果设置, 颜色会被清除 <br />
@@ -274,16 +274,16 @@
 		该方法清楚了一个rendertarget。为此它会激活此endertarget
 		</p>
 
-		<h3>[method:null compile]( [param:Object3D scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined compile]( [param:Object3D scene], [param:Camera camera] )</h3>
 		<p>使用相机编译场景中的所有材质。这对于在首次渲染之前预编译着色器很有用。</p>
 
-		<h3>[method:null copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
+		<h3>[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:Texture texture], [param:Number level] )</h3>
 		<p>将当前WebGLFramebuffer中的像素复制到2D纹理中。可访问[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
-		<h3>[method:null copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
+		<h3>[method:undefined copyTextureToTexture]( [param:Vector2 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
 		<p>将纹理的所有像素复制到一个已有的从给定位置开始的纹理中。可访问[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D WebGLRenderingContext.texSubImage2D].</p>
 
-		<h3>[method:null dispose]( )</h3>
+		<h3>[method:undefined dispose]( )</h3>
 		<p>处理当前的渲染环境</p>
 
 		<h3>[method:Object extensions.get]( [param:String extensionName] )</h3>
@@ -343,19 +343,19 @@
 		<h3>[method:Object getSize]()</h3>
 		<p>返回包含渲染器输出canvas的宽度和高度(单位像素)的对象。</p>
 
-		<h3>[method:null initTexture]( [param:Texture texture] )</h3>
+		<h3>[method:undefined initTexture]( [param:Texture texture] )</h3>
 		<p> Initializes the given texture. Useful for preloading a texture rather than waiting until first render (which can cause noticeable lags due to decode and GPU upload overhead).</p>
 
-		<h3>[method:null resetGLState]( )</h3>
+		<h3>[method:undefined resetGLState]( )</h3>
 		<p>将GL状态重置为默认值。WebGL环境丢失时会内部调用</p>
 
-		<h3>[method:null readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], [param:TypedArray buffer], [param:Integer activeCubeFaceIndex] )</h3>
+		<h3>[method:undefined readRenderTargetPixels]( [param:WebGLRenderTarget renderTarget], [param:Float x], [param:Float y], [param:Float width], [param:Float height], [param:TypedArray buffer], [param:Integer activeCubeFaceIndex] )</h3>
 		<p>buffer - Uint8Array is the only destination type supported in all cases, other types are renderTarget and platform dependent. See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12 WebGL spec] for details.</p>
 		<p>将enderTarget中的像素数据读取到传入的缓冲区中。这是[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels WebGLRenderingContext.readPixels]()的包装器<br />
 		示例：[example:webgl_interactive_cubes_gpu interactive / cubes / gpu]</p>
 		<p>For reading out a [page:WebGLCubeRenderTarget WebGLCubeRenderTarget] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
 
-		<h3>[method:null render]( [param:Object3D scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined render]( [param:Object3D scene], [param:Camera camera] )</h3>
 		<p>
 			用相机([page:Camera camera])渲染一个场景([page:Scene scene])或是其它类型的[page:Object3D object]。<br />
 
@@ -366,23 +366,23 @@
 			即便forceClear设为true, 也可以通过将[page:WebGLRenderer.autoClearColor autoClearColor]、[page:WebGLRenderer.autoClearStencil autoClearStencil]或[page:WebGLRenderer.autoClearDepth autoClearDepth]属性的值设为false来阻止对应缓存被清除。
 		</p>
 
-		<h3>[method:null resetState]()</h3>
+		<h3>[method:undefined resetState]()</h3>
 		<p>Can be used to reset the internal WebGL state. This method is mostly relevant for applications which share a single WebGL context across multiple WebGL libraries.</p>
 
-		<h3>[method:null setAnimationLoop]( [param:Function callback] )</h3>
+		<h3>[method:undefined setAnimationLoop]( [param:Function callback] )</h3>
 		<p>[page:Function callback] — 每个可用帧都会调用的函数。 如果传入‘null’,所有正在进行的动画都会停止。</p>
 		<p>可用来代替[link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]的内置函数. 对于WebXR项目，必须使用此函数。</p>
 
-		<h3>[method:null setClearAlpha]( [param:Float alpha] )</h3>
+		<h3>[method:undefined setClearAlpha]( [param:Float alpha] )</h3>
 		<p>设置alpha。合法参数是一个*0.0*到 *1.0*之间的浮点数</p>
 
-		<h3>[method:null setClearColor]( [param:Color color], [param:Float alpha] )</h3>
+		<h3>[method:undefined setClearColor]( [param:Color color], [param:Float alpha] )</h3>
 		<p>设置颜色及其透明度</p>
 
-		<h3>[method:null setPixelRatio]( [param:number value] )</h3>
+		<h3>[method:undefined setPixelRatio]( [param:number value] )</h3>
 		<p>设置设备像素比。通常用于避免HiDPI设备上绘图模糊</p>
 
-		<h3>[method:null setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
+		<h3>[method:undefined setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
 		<p>
 		renderTarget -- 需要被激活的[page:WebGLRenderTarget renderTarget](可选)。若此参数为空，则将canvas设置成活跃render target。<br />
 		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLCubeRenderTarget] (optional).<br />
@@ -390,24 +390,24 @@
 		该方法设置活跃rendertarget。
 		</p>
 
-		<h3>[method:null setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
+		<h3>[method:undefined setScissor]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
 		<p>
 		将剪裁区域设为(x, y)到(x + width, y + height)
 		Sets the scissor area from
 		</p>
 
-		<h3>[method:null setScissorTest]( [param:Boolean boolean] )</h3>
+		<h3>[method:undefined setScissorTest]( [param:Boolean boolean] )</h3>
 		<p>
 		启用或禁用剪裁检测. 若启用，则只有在所定义的裁剪区域内的像素才会受之后的渲染器影响。
 		</p>
 
-		<h3>[method:null setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
+		<h3>[method:undefined setSize]( [param:Integer width], [param:Integer height], [param:Boolean updateStyle] )</h3>
 		<p>
 		将输出canvas的大小调整为(width, height)并考虑设备像素比，且将视口从(0, 0)开始调整到适合大小
 		将[page:Boolean updateStyle]设置为false以阻止对canvas的样式做任何改变。
 		</p>
 
-		<h3>[method:null setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
+		<h3>[method:undefined setViewport]( [param:Integer x], [param:Integer y], [param:Integer width], [param:Integer height] )</h3>
 		<p>将视口大小设置为(x, y)到 (x + width, y + height).</p>
 
 		<h2>源码</h2>

--- a/docs/api/zh/renderers/webgl/WebGLProgram.html
+++ b/docs/api/zh/renderers/webgl/WebGLProgram.html
@@ -145,7 +145,7 @@
 		返回所有活动态的顶点属性位置的name-value映射
 		</p>
 
-		<h3>[method:null destroy]()</h3>
+		<h3>[method:undefined destroy]()</h3>
 		<p>
 		Destroys an instance of [name].
 		</p>

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -266,7 +266,7 @@
 
 		<h3>[page:EventDispatcher EventDispatcher]方法在这个类上可以使用。</h3>
 
-		<h3>[method:null updateMatrix]()</h3>
+		<h3>[method:undefined updateMatrix]()</h3>
 		<p>
 			从纹理的[page:Texture.offset .offset]、[page:Texture.repeat .repeat]、
 			[page:Texture.rotation .rotation]和[page:Texture.center .center]属性来更新纹理的UV变换矩阵（uv-transform [page:Texture.matrix .matrix]）。
@@ -283,7 +283,7 @@
 		将Texture对象转换为 three.js [link:https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 JSON Object/Scene format]（three.js JSON 物体/场景格式）。
 		</p>
 
-		<h3>[method:null dispose]()</h3>
+		<h3>[method:undefined dispose]()</h3>
 		<p>
 			使用“废置”事件类型调用[page:EventDispatcher EventDispatcher].dispatchEvent。
 		</p>

--- a/docs/api/zh/textures/VideoTexture.html
+++ b/docs/api/zh/textures/VideoTexture.html
@@ -78,7 +78,7 @@ const texture = new THREE.VideoTexture( video );
 		共有方法请参见其基类[page:Texture Texture]。
 	</p>
 
-	<h3>[method:null update]()</h3>
+	<h3>[method:undefined update]()</h3>
 		<p>
 		在每一次新的一帧可用时，这个方法将被自动调用，
 		并将[property:Boolean needsUpdate]设置为*true*。


### PR DESCRIPTION
Related issue: Follow-up of #22794.

**Description**

When a method has no `return` statement, the documentation should use `undefined` as return type (not `null`).

This PR updates `/api/` first. `/examples/` is done with a subsequent PR.
