### PR TITLE
Default material color for 3mf loader

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -47,13 +47,13 @@ class ThreeMFLoader extends Loader {
 		super( manager );
 
 		this.availableExtensions = [];
-		this.defaultMaterialColor = 0xaaaaff;
+		this.defaultMaterialColor = new Color (0xaaaaff);
 
 	}
 
 	setDefaultMaterialColor( defaultMaterialColor ) {
 		
-		this.defaultMaterialColor = defaultMaterialColor;
+		this.defaultMaterialColor.set( defaultMaterialColor );
 		
 	}
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -47,7 +47,7 @@ class ThreeMFLoader extends Loader {
 		super( manager );
 
 		this.availableExtensions = [];
-		this.defaultMaterialColor = new Color (0xaaaaff);
+		this.defaultMaterialColor = new Color( 0xaaaaff );
 
 	}
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -47,7 +47,14 @@ class ThreeMFLoader extends Loader {
 		super( manager );
 
 		this.availableExtensions = [];
+		this.defaultMaterialColor = 0xaaaaff;
 
+	}
+
+	setDefaultMaterialColor( defaultMaterialColor ) {
+		
+		this.defaultMaterialColor = defaultMaterialColor;
+		
 	}
 
 	load( url, onLoad, onProgress, onError ) {
@@ -1077,7 +1084,7 @@ class ThreeMFLoader extends Loader {
 			geometry.setIndex( new BufferAttribute( meshData[ 'triangles' ], 1 ) );
 			geometry.setAttribute( 'position', new BufferAttribute( meshData[ 'vertices' ], 3 ) );
 
-			const material = new MeshPhongMaterial( { color: 0xaaaaff, flatShading: true } );
+			const material = new MeshPhongMaterial( { color: scope.defaultMaterialColor, flatShading: true } );
 
 			const mesh = new Mesh( geometry, material );
 


### PR DESCRIPTION
3mf files often come without material definitions. In this case the default material color was gratuitously purple. I've added the possibility to set this default color from the outside.
