### PR TITLE
LineSegments2: Fix type for "isLineSegments2" identifier

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -285,6 +285,6 @@ class LineSegments2 extends Mesh {
 
 }
 
-LineSegments2.prototype.LineSegments2 = true;
+LineSegments2.prototype.isLineSegments2 = true;
 
 export { LineSegments2 };


### PR DESCRIPTION
Related issue: --

**Description**

"isLineSegments2" was mistyped as "LineSegments2"