### PR TITLE
Fix WebXR Hand pointer examples

### DIFF
--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -329,31 +329,31 @@ class OculusHandPointerModel extends THREE.Object3D {
 
 	}
 
-	intersectObject( object ) {
+	intersectObject( object, recursive = true ) {
 
 		if ( this.raycaster ) {
 
-			return this.raycaster.intersectObject( object );
+			return this.raycaster.intersectObject( object, recursive );
 
 		}
 
 	}
 
-	intersectObjects( objects ) {
+	intersectObjects( objects, recursive = true ) {
 
 		if ( this.raycaster ) {
 
-			return this.raycaster.intersectObjects( objects, false );
+			return this.raycaster.intersectObjects( objects, recursive );
 
 		}
 
 	}
 
-	checkIntersections( objects ) {
+	checkIntersections( objects, recursive = false ) {
 
 		if ( this.raycaster && ! this.attached ) {
 
-			const intersections = this.raycaster.intersectObjects( objects, false );
+			const intersections = this.raycaster.intersectObjects( objects, recursive );
 			const direction = new THREE.Vector3( 0, 0, - 1 );
 			if ( intersections.length > 0 ) {
 

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -101,7 +101,7 @@
 					this.queries.intersectable.results.forEach( entity => {
 
 						const object = entity.getComponent( Object3D ).object;
-						const intersections = hp.intersectObject( object );
+						const intersections = hp.intersectObject( object, false );
 						if ( intersections && intersections.length > 0 ) {
 
 							if ( distance == null || intersections[ 0 ].distance < distance ) {

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -151,7 +151,7 @@
 					this.queries.intersectable.results.forEach( entity => {
 
 						const object = entity.getComponent( Object3D ).object;
-						const intersections = hp.intersectObject( object );
+						const intersections = hp.intersectObject( object, false );
 						if ( intersections && intersections.length > 0 ) {
 
 							if ( distance == null || intersections[ 0 ].distance < distance ) {


### PR DESCRIPTION
**Description**

The recent change in r133 to make `recursive` true by default in Raycaster's `intersectObject` broke the button hovering / pressing logic in the WebXR hand pointer examples. This manually sets `recursive` to false in those examples (via the `OculusHandPointerModel.js` file) to fix them.

This contribution is funded by [Oculus](https://www.oculus.com/).
