### PR TITLE
BufferGeometry: Allow computeTangents to be called without an Index attribute

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -575,23 +575,18 @@ class BufferGeometry extends EventDispatcher {
 
 			for ( let j = start, jl = start + count; j < jl; j += 3 ) {
 
+				let j0 = j + 0;
+				let j1 = j + 1;
+				let j2 = j + 2;
 				if ( indices !== null ) {
 
-					handleTriangle(
-						indices[ j + 0 ],
-						indices[ j + 1 ],
-						indices[ j + 2 ]
-					);
-
-				} else {
-
-					handleTriangle(
-						j + 0,
-						j + 1,
-						j + 2,
-					);
+					j0 = indices[ j0 ];
+					j1 = indices[ j1 ];
+					j2 = indices[ j2 ];
 
 				}
+
+				handleTriangle( j0, j1, j2 );
 
 			}
 
@@ -634,19 +629,20 @@ class BufferGeometry extends EventDispatcher {
 
 			for ( let j = start, jl = start + count; j < jl; j += 3 ) {
 
+				let j0 = j + 0;
+				let j1 = j + 1;
+				let j2 = j + 2;
 				if ( indices !== null ) {
 
-					handleVertex( indices[ j + 0 ] );
-					handleVertex( indices[ j + 1 ] );
-					handleVertex( indices[ j + 2 ] );
-
-				} else {
-
-					handleVertex( j + 0 );
-					handleVertex( j + 1 );
-					handleVertex( j + 2 );
+					j0 = indices[ j0 ];
+					j1 = indices[ j1 ];
+					j2 = indices[ j2 ];
 
 				}
+
+				handleVertex( j0 );
+				handleVertex( j1 );
+				handleVertex( j2 );
 
 			}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -469,28 +469,28 @@ class BufferGeometry extends EventDispatcher {
 
 	computeTangents() {
 
-		const index = this.index;
 		const attributes = this.attributes;
 
 		// based on http://www.terathon.com/code/tangent.html
 		// (per vertex tangents)
 
-		if ( index === null ||
-			 attributes.position === undefined ||
+		if ( attributes.position === undefined ||
 			 attributes.normal === undefined ||
 			 attributes.uv === undefined ) {
 
-			console.error( 'THREE.BufferGeometry: .computeTangents() failed. Missing required attributes (index, position, normal or uv)' );
+			console.error( 'THREE.BufferGeometry: .computeTangents() failed. Missing required attributes (position, normal or uv)' );
 			return;
 
 		}
 
-		const indices = index.array;
+		const index = this.index;
+		const indices = index ? index.array : null;
 		const positions = attributes.position.array;
 		const normals = attributes.normal.array;
 		const uvs = attributes.uv.array;
 
 		const nVertices = positions.length / 3;
+		const nIndices = index ? index.count : nVertices;
 
 		if ( attributes.tangent === undefined ) {
 
@@ -561,7 +561,7 @@ class BufferGeometry extends EventDispatcher {
 
 			groups = [ {
 				start: 0,
-				count: indices.length
+				count: nIndices
 			} ];
 
 		}
@@ -575,11 +575,23 @@ class BufferGeometry extends EventDispatcher {
 
 			for ( let j = start, jl = start + count; j < jl; j += 3 ) {
 
-				handleTriangle(
-					indices[ j + 0 ],
-					indices[ j + 1 ],
-					indices[ j + 2 ]
-				);
+				if ( indices !== null ) {
+
+					handleTriangle(
+						indices[ j + 0 ],
+						indices[ j + 1 ],
+						indices[ j + 2 ]
+					);
+
+				} else {
+
+					handleTriangle(
+						j + 0,
+						j + 1,
+						j + 2,
+					);
+
+				}
 
 			}
 
@@ -622,9 +634,19 @@ class BufferGeometry extends EventDispatcher {
 
 			for ( let j = start, jl = start + count; j < jl; j += 3 ) {
 
-				handleVertex( indices[ j + 0 ] );
-				handleVertex( indices[ j + 1 ] );
-				handleVertex( indices[ j + 2 ] );
+				if ( indices !== null ) {
+
+					handleVertex( indices[ j + 0 ] );
+					handleVertex( indices[ j + 1 ] );
+					handleVertex( indices[ j + 2 ] );
+
+				} else {
+
+					handleVertex( j + 0 );
+					handleVertex( j + 1 );
+					handleVertex( j + 2 );
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: --

**Description**

Currently when calling `computeTangents` it fails if the geometry does not have an index buffer. This PR adjusts the function so it can be called on geometry with or without an index buffer.

Tested by changing the `webgl_helpers` demo to convert the geometry to non indexed before computing tangents. You can see in the image below that different tangents are generated for the same vertices when they are no longer merged because different triangle edges are being used to derive the tangents and they are not being averaged:

| Indexed Geometry | Non Indexed Geometry |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/141251165-cfa0798f-e45d-4640-960b-d5bb8fb93380.png) | ![image](https://user-images.githubusercontent.com/734200/141251070-a3b48f1e-a2ef-408c-bb8f-9e38e88988e4.png) |

cc @WestLangley @donmccurdy 