### PR TITLE
DragControls: Added `.getRaycaster()`.

### DIFF
--- a/examples/js/controls/DragControls.js
+++ b/examples/js/controls/DragControls.js
@@ -65,6 +65,12 @@
 
 			}
 
+			function getRaycaster() {
+
+				return _raycaster;
+
+			}
+
 			function onPointerMove( event ) {
 
 				if ( scope.enabled === false ) return;

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -64,6 +64,12 @@ class DragControls extends EventDispatcher {
 
 		}
 
+		function getRaycaster() {
+
+			return _raycaster;
+
+		}
+
 		function onPointerMove( event ) {
 
 			if ( scope.enabled === false ) return;


### PR DESCRIPTION
Related issue: #22844

**Description**

to expose raycaster in drag control to change it its layer when objects are not in the default layer ( layer 0 ).
