### PR TITLE
OrbitControls: Add "sticky controls patch" back.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -581,12 +581,6 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
-		function handleMouseUp( /*event*/ ) {
-
-			// no-op
-
-		}
-
 		function handleMouseWheel( event ) {
 
 			if ( event.deltaY < 0 ) {
@@ -793,12 +787,6 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
-		function handleTouchEnd( /*event*/ ) {
-
-			// no-op
-
-		}
-
 		//
 		// event handlers - FSM: listen for events and reset state
 		//
@@ -850,30 +838,20 @@ class OrbitControls extends EventDispatcher {
 
 		function onPointerUp( event ) {
 
-			if ( scope.enabled === false ) return;
+		    removePointer( event );
 
-			if ( event.pointerType === 'touch' ) {
+		    if ( pointers.length === 0 ) {
 
-				onTouchEnd();
+		        scope.domElement.releasePointerCapture( event.pointerId );
 
-			} else {
+		        scope.domElement.removeEventListener( 'pointermove', onPointerMove );
+		        scope.domElement.removeEventListener( 'pointerup', onPointerUp );
 
-				onMouseUp( event );
+		    }
 
-			}
+		    scope.dispatchEvent( _endEvent );
 
-			removePointer( event );
-
-			//
-
-			if ( pointers.length === 0 ) {
-
-				scope.domElement.releasePointerCapture( event.pointerId );
-
-				scope.domElement.removeEventListener( 'pointermove', onPointerMove );
-				scope.domElement.removeEventListener( 'pointerup', onPointerUp );
-
-			}
+		    state = STATE.NONE;
 
 		}
 
@@ -1011,16 +989,6 @@ class OrbitControls extends EventDispatcher {
 					break;
 
 			}
-
-		}
-
-		function onMouseUp( event ) {
-
-			handleMouseUp( event );
-
-			scope.dispatchEvent( _endEvent );
-
-			state = STATE.NONE;
 
 		}
 
@@ -1181,16 +1149,6 @@ class OrbitControls extends EventDispatcher {
 					state = STATE.NONE;
 
 			}
-
-		}
-
-		function onTouchEnd( event ) {
-
-			handleTouchEnd( event );
-
-			scope.dispatchEvent( _endEvent );
-
-			state = STATE.NONE;
 
 		}
 


### PR DESCRIPTION
Related issue: Fixed #22848.

**Description**

Adds a fix back to `OrbitControls` that avoids a sticky behavior when the controls are disabled during an interaction.
