### PR TITLE
support async in LoadingManager

### DIFF
--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -17,11 +17,11 @@ class LoadingManager {
 		this.onLoad = onLoad;
 		this.onProgress = onProgress;
 		this.onError = onError;
-		
+
 		let resolvePromise;
 		let rejectPromise;
 
-		this.promise = new Promise ( function ( resolve, reject ) {
+		this.promise = new Promise( function ( resolve, reject ) {
 
 			resolvePromise = resolve;
 			rejectPromise = reject;
@@ -67,6 +67,7 @@ class LoadingManager {
 				}
 
 				resolvePromise();
+
 			}
 
 		};
@@ -78,7 +79,7 @@ class LoadingManager {
 				scope.onError( url );
 
 			}
-			
+
 			rejectPromise( url );
 
 		};

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -17,6 +17,16 @@ class LoadingManager {
 		this.onLoad = onLoad;
 		this.onProgress = onProgress;
 		this.onError = onError;
+		
+		let resolvePromise;
+		let rejectPromise;
+
+		this.promise = new Promise ( function ( resolve, reject ) {
+
+			resolvePromise = resolve;
+			rejectPromise = reject;
+
+		} );
 
 		this.itemStart = function ( url ) {
 
@@ -56,6 +66,7 @@ class LoadingManager {
 
 				}
 
+				resolvePromise();
 			}
 
 		};
@@ -67,6 +78,8 @@ class LoadingManager {
 				scope.onError( url );
 
 			}
+			
+			rejectPromise( url );
 
 		};
 


### PR DESCRIPTION
It has come to my attention that while Loader-s now have .loadAsync() method there is no support for async in loading manager - hence this draft PR (should be fine as is, but Idk what your linter thinks). With this, you could do
```js
await manager.promise;
```
or
```js
manager.promise.then( yourHandler );
```