### PR TITLE
Layers: Fix set()

### DIFF
--- a/src/core/Layers.js
+++ b/src/core/Layers.js
@@ -8,7 +8,7 @@ class Layers {
 
 	set( channel ) {
 
-		this.mask = 1 << channel | 0;
+		this.mask = ( 1 << channel | 0 ) >>> 0;
 
 	}
 


### PR DESCRIPTION
Related issue: Fixed #22817

**Description**
After calling `set(31)`, the value of mask will be updated to 2147483648 instead of -2147483648
