### PR TITLE
WebGPURenderer: More efficient texture updates.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -78,7 +78,7 @@ class WebGPUBindings {
 
 	}
 
-	update( object, camera ) {
+	update( object ) {
 
 		const textures = this.textures;
 
@@ -141,10 +141,10 @@ class WebGPUBindings {
 
 				const texture = binding.getTexture();
 
-				const forceUpdate = textures.updateTexture( texture );
+				const needsTextureRefresh = textures.updateTexture( texture );
 				const textureGPU = textures.getTextureGPU( texture );
 
-				if ( textureGPU !== undefined && binding.textureGPU !== textureGPU || forceUpdate === true ) {
+				if ( textureGPU !== undefined && binding.textureGPU !== textureGPU || needsTextureRefresh === true ) {
 
 					binding.textureGPU = textureGPU;
 					needsBindGroupRefresh = true;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -773,7 +773,7 @@ class WebGPURenderer {
 						passEncoder.setViewport( vp.x, vp.y, vp.width, vp.height, minDepth, maxDepth );
 
 						this._nodes.update( object, camera2 );
-						this._bindings.update( object, camera2 );
+						this._bindings.update( object );
 						this._renderObject( object, passEncoder );
 
 					}
@@ -783,7 +783,7 @@ class WebGPURenderer {
 			} else {
 
 				this._nodes.update( object, camera );
-				this._bindings.update( object, camera );
+				this._bindings.update( object );
 				this._renderObject( object, passEncoder );
 
 			}


### PR DESCRIPTION
Related issue: see #22790

**Description**

Because of the new texture update policy defined in #22790, it's now possible to simplify and speed up the texture updates in `WebGPURenderer`. It's sufficient to create a WebGPU texture object once for an instance of `THREE.Texture` and then reuse it for all upcoming updates.