### PR TITLE
Texture: Make Freshly Cloned Texture Renderable

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -122,6 +122,8 @@ class Texture extends EventDispatcher {
 		this.encoding = source.encoding;
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
+		
+		this.version = source.version;
 
 		return this;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -122,7 +122,7 @@ class Texture extends EventDispatcher {
 		this.encoding = source.encoding;
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
-		
+
 		this.version = source.version;
 
 		return this;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -123,7 +123,7 @@ class Texture extends EventDispatcher {
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
-		this.version++;
+		this.version ++;
 
 		return this;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -123,7 +123,7 @@ class Texture extends EventDispatcher {
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
-		this.version = source.version;
+		this.version++;
 
 		return this;
 


### PR DESCRIPTION
**Description**

Currently, a freshly cloned texture does not get rendered without incrementing the version manually. 

In our implementation using Three v0.133, I use this method to clone a texture that will successfully be rendered by ThreeJS.

```
  const fixedClone = (texture: Texture) => {
    const newTexture = texture.clone();
    newTexture.version++;     
    return newTexture;
  };
  ```
  
This seems to indicate that users might be surprised that their new clone cannot be used. This PR should address that.

There are other possible ways to address this, but this seemed like one of the simplest. This is my first contribution, so I welcome any criticisms or objections to this approach.

