### PR TITLE
Updated Texture Clone Method Documentation

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -282,6 +282,8 @@
 		<h3>[method:Texture clone]()</h3>
 		<p>
 		Make copy of the texture. Note this is not a "deep copy", the image is shared.
+
+		Also note, the texture may not be immediately renderable. In that case, refer to [page:Texture.needsUpdate .needsUpdate]
 		</p>
 
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>


### PR DESCRIPTION
Related issue: #22718 
Related PR: (https://github.com/mrdoob/three.js/pull/22870)

**Description**

Clarify Texture Clone method documentation to avoid developer surprises such as cloned texture not being rendered.
