### PR TITLE
Upgrade `actions/setup-node` action and cache dependencies on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
       - name: Install packages
         run: npm ci
@@ -40,7 +40,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
       - name: Install packages
         run: |
@@ -67,7 +67,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
       - name: Install packages
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
       - name: Install packages
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'npm'
       - name: Install packages
         run: npm ci
 
@@ -37,9 +38,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'npm'
       - name: Install packages
         run: |
           npm ci
@@ -63,9 +65,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'npm'
       - name: Install packages
         run: |
           npm ci
@@ -84,9 +87,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'npm'
       - name: Install packages
         run: npm ci
 


### PR DESCRIPTION
**Description**

This PR upgrades the `setup-node` action to its latest version and also caches dependencies on CI. Dependency caching will speed up CI times.

References:

* https://github.com/actions/setup-node#caching-packages-dependencies
