### PR TITLE
Object3D.detach()

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -214,6 +214,9 @@
 		<h3>[method:this attach]( [param:Object3D object] )</h3>
 		<p>Adds *object* as a child of this, while maintaining the object's world transform.</p>
 
+		<h3>[method:this detach]( [param:Object3D object] )</h3>
+		<p>Removes *object* as a child of this, while maintaining the object's world transform.</p>
+
 		<h3>[method:Object3D clone]( [param:Boolean recursive] )</h3>
 		<p>
 		recursive -- if true, descendants of the object are also cloned. Default is true.<br /><br />

--- a/src/core/Object3D.d.ts
+++ b/src/core/Object3D.d.ts
@@ -294,6 +294,11 @@ export class Object3D extends EventDispatcher {
 	attach( object: Object3D ): this;
 
 	/**
+	 * Removes object as a child of this, while maintaining the object's world transform.
+	 */
+	detach( object: Object3D ): this;
+
+	/**
 	 * Searches through the object's children and returns the first with a matching id.
 	 * @param id	Unique number of the object instance
 	 */

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -404,6 +404,36 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	},
 
+	detach: function ( object ) {
+
+		if ( arguments.length > 1 ) {
+
+			for ( var i = 0; i < arguments.length; i ++ ) {
+
+				this.detach( arguments[ i ] );
+
+			}
+
+			return this;
+
+		}
+
+		var index = this.children.indexOf( object );
+
+		if ( index !== - 1 ) {
+
+			object.parent = null;
+			this.children.splice( index, 1 );
+
+			object.matrixWorld.decompose( object.position, object.quaternion, object.scale );
+			object.dispatchEvent( _removedEvent );
+
+		}
+
+		return this;
+
+	},
+
 	getObjectById: function ( id ) {
 
 		return this.getObjectByProperty( 'id', id );


### PR DESCRIPTION

Added a detach method to Object3D. 
The attach method is very handy and I was wondered why there is no method that does the opposite. 

I found Mugen87's solution here [https://discourse.threejs.org/t/threejs-detach-child-object-from-its-parent/19407](https://discourse.threejs.org/t/threejs-detach-child-object-from-its-parent/19407) and would like to see it added.

The new method is a copy of the remove method with one added line that decomposes the worldMatrix after removing the child. I am not sure if this is the best way, I chose this because the remove method does not confirm if the object is actually removed ( as a child of 'this' object ) unless you add an event to the object, but that seems unlogical in this case.
