### PR TITLE
Fix collada transparency handling.

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -1276,7 +1276,7 @@ class ColladaLoader extends Loader {
 						break;
 					case 'transparent':
 						data[ child.nodeName ] = {
-							opaque: child.getAttribute( 'opaque' ),
+							opaque: child.hasAttribute( 'opaque' ) ? child.getAttribute( 'opaque' ) : 'A_ONE',
 							data: parseEffectParameter( child )
 						};
 						break;
@@ -1737,7 +1737,6 @@ class ColladaLoader extends Loader {
 							material.opacity = color[ 0 ] * transparency.float;
 							break;
 						default:
-							material.opacity = 1 - transparency.float;
 							console.warn( 'THREE.ColladaLoader: Invalid opaque type "%s" of transparent tag.', transparent.opaque );
 
 					}


### PR DESCRIPTION
**Description**

The modification made in #22679 broke the transparency handling, because some models now appear fully transparent, but they shouldn't. According to the [official collada specification](https://www.khronos.org/collada), the opaque attribute for the transparent object is optional, and the default value is 'A_ONE'.

Now I implemented this behaviour, and also removed the code added in #22679. I don't fully understand how the previous solution would solve the problem of missing opaque value, but it wasn't correct according to the specification.
