### PR TITLE
MeshToonMaterial: Only sample the red channel of gradientMap.

### DIFF
--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -48,12 +48,21 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0x444488 );
 
+				//
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+				renderer.outputEncoding = THREE.sRGBEncoding;
+
 				// Materials
 
 				const cubeWidth = 400;
 				const numberOfSphersPerSide = 5;
 				const sphereRadius = ( cubeWidth / numberOfSphersPerSide ) * 0.8 * 0.5;
 				const stepSize = 1.0 / numberOfSphersPerSide;
+				const format = ( renderer.capabilities.isWebGL2 ) ? THREE.RedFormat : THREE.LuminanceFormat;
 
 				const geometry = new THREE.SphereGeometry( sphereRadius, 32, 16 );
 
@@ -67,10 +76,7 @@
 
 					}
 
-					const gradientMap = new THREE.DataTexture( colors, colors.length, 1, THREE.LuminanceFormat );
-					gradientMap.minFilter = THREE.NearestFilter;
-					gradientMap.magFilter = THREE.NearestFilter;
-					gradientMap.generateMipmaps = false;
+					const gradientMap = new THREE.DataTexture( colors, colors.length, 1, format );
 
 					for ( let beta = 0; beta <= 1.0; beta += stepSize ) {
 
@@ -137,12 +143,6 @@
 				particleLight.add( pointLight );
 
 				//
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				container.appendChild( renderer.domElement );
-				renderer.outputEncoding = THREE.sRGBEncoding;
 
 				effect = new OutlineEffect( renderer );
 

--- a/src/renderers/shaders/ShaderChunk/gradientmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/gradientmap_pars_fragment.glsl.js
@@ -14,7 +14,7 @@ vec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {
 
 	#ifdef USE_GRADIENTMAP
 
-		return texture2D( gradientMap, coord ).rgb;
+		return vec3( texture2D( gradientMap, coord ).r );
 
 	#else
 


### PR DESCRIPTION
Related issue: -

**Description**

When we want to use `texStorage2D()` it's important to understand that `gl.LUMINANCE` can not be used as an internal format. The idea is to use `gl.RED` instead which is converted to the sized formats `gl.R8`, `gl.R16F` or `gl.R32F` by the renderer depending on the data type.

When using a texture with e.g. `gl.R8`, only the `r` channel can be sampled. This PR refactors the toon material such that the shader only samples the red channel and not RGB. In this way, the gradient map does not break if we use `THREE.RedFormat` with WebGL 2.

I'm not sure why it was implemented differently since gradient maps for toon materials are usually grayscale maps with a (n,1) dimension.