### PR TITLE
Improve render order for SVGLoader example

### DIFF
--- a/examples/models/svg/tests/ordering.svg
+++ b/examples/models/svg/tests/ordering.svg
@@ -1,0 +1,8 @@
+<svg id="color-fill" xmlns="http://www.w3.org/2000/svg" version="1.1" width="300" height="300" xmlns:xlink="http://www.w3.org/1999/xlink">
+    
+    <rect x="25" y="25" width="250" height="250" style="fill:#ff0000;fill-opacity:0.2;stroke:none" />
+    <rect x="50" y="50" width="100" height="200" style="fill:#000000;fill-opacity:1;stroke:none" />
+    <rect x="75" y="75" width="150" height="150" style="fill:#00ff00;fill-opacity:0.5;stroke:none" />
+    <rect x="100" y="100" width="100" height="100" style="fill:#000080;fill-opacity:1;stroke:none" />
+
+</svg>

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -103,6 +103,7 @@
 					"Test 8": 'models/svg/tests/8.svg',
 					"Test 9": 'models/svg/tests/9.svg',
 					"Units": 'models/svg/tests/units.svg',
+					"Ordering": 'models/svg/tests/ordering.svg',
 					"Defs": 'models/svg/tests/testDefs/Svg-defs.svg',
 					"Defs2": 'models/svg/tests/testDefs/Svg-defs2.svg',
 					"Defs3": 'models/svg/tests/testDefs/Wave-defs.svg',
@@ -165,7 +166,7 @@
 							const material = new THREE.MeshBasicMaterial( {
 								color: new THREE.Color().setStyle( fillColor ),
 								opacity: path.userData.style.fillOpacity,
-								transparent: path.userData.style.fillOpacity < 1,
+								transparent: true,
 								side: THREE.DoubleSide,
 								depthWrite: false,
 								wireframe: guiData.fillShapesWireframe
@@ -193,7 +194,7 @@
 							const material = new THREE.MeshBasicMaterial( {
 								color: new THREE.Color().setStyle( strokeColor ),
 								opacity: path.userData.style.strokeOpacity,
-								transparent: path.userData.style.strokeOpacity < 1,
+								transparent: true,
 								side: THREE.DoubleSide,
 								depthWrite: false,
 								wireframe: guiData.strokesWireframe


### PR DESCRIPTION
- Set all materials as transparent, so all will be rendered as part of the same render list
- Ordering will fall back to the final object.id ordering in reversePainterSortStable
- Add an example SVG that is rendered in the correct order after this change

Related issue: #22898

**Description**

SVGLoader generates multiple meshes that need to be rendered in-order. Before this commit, the transparent attribute of the generated materials was set based on the fill or stroke opacity, which separated materials into the opaque and transparent render lists, and gave the incorrect render ordering.

Additionally as all the meshes are in the z=0 plane (SVG is a 2D format), depthWrite is set false for all of the materials. This is another reason to have all SVG meshes in the transparent render list, as it means they will behave correctly with respect to 3D meshes in the scene that do render into the depth buffer.