### PR TITLE
WebXR Render Target Encoding Now Uses renderer.outputEncoding

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -13,10 +13,9 @@ import {
 	DepthStencilFormat,
 	RGBAFormat,
 	RGBFormat,
-	sRGBEncoding,
 	UnsignedByteType,
 	UnsignedShortType,
-	UnsignedInt248Type
+	UnsignedInt248Type,
 } from '../../constants.js';
 
 class WebXRManager extends EventDispatcher {
@@ -300,7 +299,7 @@ class WebXRManager extends EventDispatcher {
 								stencilBuffer: attributes.stencil,
 								ignoreDepth: glProjLayer.ignoreDepthValues,
 								useRenderToTexture: hasMultisampledRenderToTexture,
-								encoding: sRGBEncoding
+								encoding: renderer.outputEncoding
 							} );
 
 					} else {
@@ -314,7 +313,7 @@ class WebXRManager extends EventDispatcher {
 								depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
 								stencilBuffer: attributes.stencil,
 								ignoreDepth: glProjLayer.ignoreDepthValues,
-								encoding: sRGBEncoding
+								encoding: renderer.outputEncoding
 							} );
 
 					}


### PR DESCRIPTION
Follow up to https://github.com/mrdoob/three.js/pull/22918

**Description**

the previous PR fixed the darkness issue caused by not setting the encoding format, but the solution was inelegant and limited the encoding format to sRGB, this has been fixed to follow whatever is specified in the WebGLRenderer passed into the WebXRManager

<!-- Remove the line below if is not relevant -->

This contribution is funded by [XRFoundation](https://xrfoundation.io).
