### PR TITLE
fix. FileLoader not showing correct error message when onLoad throws …

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -196,6 +196,12 @@ class FileLoader extends Loader {
 				// Abort errors and other errors are handled the same
 
 				const callbacks = loading[ url ];
+
+				if( ! callbacks ) {
+					// When onLoad was called and url was deleted in `loading`
+					throw err;
+				}
+
 				delete loading[ url ];
 
 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {


### PR DESCRIPTION
Related issue: #22923

**Description**

Once the fetch of FileLoader is fulfilled, `url` will be deleted in `loading` object.
If there are any error being throwed inside the `onLoad` callback, `catch` function of the fetch will throw confusing error message instead of real error.
