### PR TITLE
FileLoader: Incorrect error handling.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -197,9 +197,10 @@ class FileLoader extends Loader {
 
 				const callbacks = loading[ url ];
 
-				if ( ! callbacks ) {
+				if ( callbacks === undefined ) {
 
 					// When onLoad was called and url was deleted in `loading`
+					this.manager.itemError( url );
 					throw err;
 
 				}

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -197,9 +197,11 @@ class FileLoader extends Loader {
 
 				const callbacks = loading[ url ];
 
-				if( ! callbacks ) {
+				if ( ! callbacks ) {
+
 					// When onLoad was called and url was deleted in `loading`
 					throw err;
+
 				}
 
 				delete loading[ url ];

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -196,6 +196,12 @@ class FileLoader extends Loader {
 				// Abort errors and other errors are handled the same
 
 				const callbacks = loading[ url ];
+
+				if( ! callbacks ) {
+					// When onLoad was called and url was deleted in `loading`
+					throw err;
+				}
+
 				delete loading[ url ];
 
 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -188,8 +188,6 @@ class FileLoader extends Loader {
 
 				}
 
-				this.manager.itemEnd( url );
-
 			} )
 			.catch( err => {
 
@@ -215,6 +213,10 @@ class FileLoader extends Loader {
 				}
 
 				this.manager.itemError( url );
+
+			} )
+			.finally( () => {
+
 				this.manager.itemEnd( url );
 
 			} );


### PR DESCRIPTION
Related issue: Fixed #22923

**Description**

Once the fetch of FileLoader is fulfilled, `url` will be deleted in `loading` object.
If there are any error being throwed inside the `onLoad` callback, `catch` function of the fetch will throw confusing error message instead of real error.