### PR TITLE
LatheGeometry: Improve normal generation.

### DIFF
--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -30,14 +30,73 @@ class LatheGeometry extends BufferGeometry {
 		const indices = [];
 		const vertices = [];
 		const uvs = [];
+		const initNormals = [];
+		const normals = [];
 
 		// helper variables
 
 		const inverseSegments = 1.0 / segments;
 		const vertex = new Vector3();
 		const uv = new Vector2();
+		const normal = new Vector3();
+		const curNormal = new Vector3();
+		const prevNormal = newVector3();
+		
+		// pre-compute normals for initial "meridian"
+		
+		for ( let j = 0; j <= ( points.length - 1 ); j ++ ) {
 
-		// generate vertices and uvs
+			switch ( j ) {
+
+				case 0:				// special handling for 1st vertex on path
+
+					dx = points[ j + 1 ].x - points[ j ].x;
+					dy = points[ j + 1 ].y - points[ j ].y;
+
+					normal.x = dy * 1.0;
+					normal.y = - dx;
+					normal.z = dy * 0.0;
+
+					prevNormal.copy( normal );
+
+					normal.normalize();
+
+					initNormals.push( normal.x, normal.y, normal.z );
+
+					break;
+
+				case ( points.length - 1 ):	// special handling for last Vertex on path
+
+					initNormals.push( prevNormal.x, prevNormal.y, prevNormal.z );
+
+					break;
+
+				default:			// default handling for all vertices in between
+
+					dx = points[ j + 1 ].x - points[ j ].x;
+					dy = points[ j + 1 ].y - points[ j ].y;
+
+					normal.x = dy * 1.0;
+					normal.y = - dx;
+					normal.z = dy * 0.0;
+
+					curNormal.copy( normal );
+
+					normal.x += prevNormal.x;
+					normal.y += prevNormal.y;
+					normal.z += prevNormal.z;
+
+					normal.normalize();
+
+					initNormals.push( normal.x, normal.y, normal.z );
+
+					prevNormal.copy( curNormal );
+
+			}
+
+		}
+
+		// generate vertices, uvs and normals
 
 		for ( let i = 0; i <= segments; i ++ ) {
 
@@ -63,6 +122,13 @@ class LatheGeometry extends BufferGeometry {
 
 				uvs.push( uv.x, uv.y );
 
+				// normal
+
+				const x = initNormals[ 3 * j + 0 ] * sin;
+				const y = initNormals[ 3 * j + 1 ];
+				const z = initNormals[ 3 * j + 0 ] * cos;
+
+				normals.push( x, y, z );
 
 			}
 
@@ -95,52 +161,7 @@ class LatheGeometry extends BufferGeometry {
 		this.setIndex( indices );
 		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
-
-		// generate normals
-
-		this.computeVertexNormals();
-
-		// if the geometry is closed, we need to average the normals along the seam.
-		// because the corresponding vertices are identical (but still have different UVs).
-
-		if ( phiLength === Math.PI * 2 ) {
-
-			const normals = this.attributes.normal.array;
-			const n1 = new Vector3();
-			const n2 = new Vector3();
-			const n = new Vector3();
-
-			// this is the buffer offset for the last line of vertices
-
-			const base = segments * points.length * 3;
-
-			for ( let i = 0, j = 0; i < points.length; i ++, j += 3 ) {
-
-				// select the normal of the vertex in the first line
-
-				n1.x = normals[ j + 0 ];
-				n1.y = normals[ j + 1 ];
-				n1.z = normals[ j + 2 ];
-
-				// select the normal of the vertex in the last line
-
-				n2.x = normals[ base + j + 0 ];
-				n2.y = normals[ base + j + 1 ];
-				n2.z = normals[ base + j + 2 ];
-
-				// average normals
-
-				n.addVectors( n1, n2 ).normalize();
-
-				// assign the new values to both normals
-
-				normals[ j + 0 ] = normals[ base + j + 0 ] = n.x;
-				normals[ j + 1 ] = normals[ base + j + 1 ] = n.y;
-				normals[ j + 2 ] = normals[ base + j + 2 ] = n.z;
-
-			}
-
-		}
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
 
 	}
 

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -40,7 +40,9 @@ class LatheGeometry extends BufferGeometry {
 		const uv = new Vector2();
 		const normal = new Vector3();
 		const curNormal = new Vector3();
-		const prevNormal = newVector3();
+		const prevNormal = new Vector3();
+		let dx = 0;
+		let dy = 0;
 		
 		// pre-compute normals for initial "meridian"
 		

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -43,9 +43,9 @@ class LatheGeometry extends BufferGeometry {
 		const prevNormal = new Vector3();
 		let dx = 0;
 		let dy = 0;
-		
+
 		// pre-compute normals for initial "meridian"
-		
+
 		for ( let j = 0; j <= ( points.length - 1 ); j ++ ) {
 
 			switch ( j ) {


### PR DESCRIPTION
This proposed change follows a two-step approach:
1. pre-compute normals in 2D-domain (all z = 0) for initial "meridian" of vertices as defined in the points[] array

<img width="623" alt="Normals_in_2D_domain" src="https://user-images.githubusercontent.com/75781596/144704615-0731cccd-d850-44cc-9803-18768cc17494.png">
Path: blue; Vertices on path: red; axis of lathe: green; Normals: red

2. rotate pre-computed normals along with vertices for each additional meridian in lathing
.
**Advantages:**
* Considerably reduces computational expense of setting up normals.
* perfect normal precision (within limits of numerical accuracy), avoids considerable deviations from precision in low lathe-segment count situations of current approach
* seam-handling obsoleted by design

This is going to be my first pull request.  Please see attached screenshots for clarification of the concept.

Related issue: #XXXX

**Description**

I observed significant mis-alignment of normals computed via computeVertexNormals() from their expected true orientation, especially in low lathe segment counts. Those mis-alignments have considerable impact on the quality and fidelity of computed reflections.

I found the cause for the observed mis-alignments to be a lack of symmetry in the faces surrounding a shared vertex. The lack of symmetry may manifest itself in an unequal number of faces "pulling" left vs. right, or up vs. down, or different sizes of neighbouring faces sharing the same vertex. Consider for instance the following 4-segment, full circle lathe of a 2-vertex path:

points.length = 0;
points.push( new THREE.Vector2( 15.0,  0.0 ) ); 
points.push( new THREE.Vector2(  5.0, 10.0 ) ); 

Looking straight down the Y-axis, **seam at bottom meridian**:

<img width="616" alt="pic1" src="https://user-images.githubusercontent.com/75781596/144209300-2a8069b7-7bf6-4c76-9073-2356401e68d4.png">

Vertex number 8 (counting from 1 to 8), circled green, is a case in point: two adjacent faces on the south-west slope pulling down, only one face on the north-west slope pulling up. Hence we observe a systematic CCW twist of the projected normal @ all inner vertices away from the expected radial orientation - except for the seam, which looks pretty much OK (but still isn't, if you look at the numeric components of the normal @ vertex  number 2.
Likewise, for the same reason, we observe a systematic CW twist of the projected normals @ all outer vertices away from the expected radial orientation - again except for the seam.

My proposed change yields perfect radial alignment of the projected (along the axis of lathing) normals and makes special seam handling obsolete by design.

Please note, that fixing the mis-aligned normals of the current approach may break some E2E test. This is in itself would not be indicative of an error.
