### PR TITLE
WebGLTextures: Use `gl.texStorage2D()` with compressed textures.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -878,6 +878,20 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
+	function compressedTexSubImage2D() {
+
+		try {
+
+			gl.compressedTexSubImage2D.apply( gl, arguments );
+
+		} catch ( error ) {
+
+			console.error( 'THREE.WebGLState:', error );
+
+		}
+
+	}
+
 	function texStorage2D() {
 
 		try {
@@ -1070,6 +1084,7 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		texStorage2D: texStorage2D,
 		texSubImage2D: texSubImage2D,
+		compressedTexSubImage2D: compressedTexSubImage2D,
 
 		scissor: scissor,
 		viewport: viewport,


### PR DESCRIPTION
Related issue:  see https://github.com/mrdoob/three.js/pull/22790#issuecomment-971396395 and #21874

**Description**

Introduces the usage of `gl.texStorage2D()` with compressed textures.