### PR TITLE
add layout-qualifier to pc_fragColor in fragment shader program for webgl2

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -722,7 +722,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 		prefixFragment = [
 			'#define varying in',
-			( parameters.glslVersion === GLSL3 ) ? '' : 'out highp vec4 pc_fragColor;',
+			( parameters.glslVersion === GLSL3 ) ? '' : 'layout(location = 0) out highp vec4 pc_fragColor;',
 			( parameters.glslVersion === GLSL3 ) ? '' : '#define gl_FragColor pc_fragColor',
 			'#define gl_FragDepthEXT gl_FragDepth',
 			'#define texture2D texture',


### PR DESCRIPTION
Related issue: Fixed #22920, related https://github.com/mrdoob/three.js/pull/16390#issuecomment-500162658

**Description**

`layout(location = 0) out highp vec4 pc_fragColor`, layout qualifier is specificed in https://www.khronos.org/registry/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html#layout-qualifiers, and if use multiple render target, the location field must be declared. 
