### PR TITLE
added dispose() method to Reflector and Refractor classes

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -196,7 +196,9 @@ class Reflector extends Mesh {
 		this.dispose = function () {
 
 			renderTarget.dispose();
-		}
+			scope.material.dispose();
+
+		};
 
 	}
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -193,6 +193,11 @@ class Reflector extends Mesh {
 
 		};
 
+		this.dispose = function () {
+
+			renderTarget.dispose();
+		}
+
 	}
 
 }

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -262,6 +262,11 @@ class Refractor extends Mesh {
 
 		};
 
+		this.dispose = function () {
+
+			renderTarget.dispose();
+		}
+
 	}
 
 }

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -265,7 +265,9 @@ class Refractor extends Mesh {
 		this.dispose = function () {
 
 			renderTarget.dispose();
-		}
+			scope.material.dispose();
+
+		};
 
 	}
 


### PR DESCRIPTION
**Description**

Reflector and Refractor classes from examples are missing a dispose() method to dispose the internal render target.
[See discussion on forum](https://discourse.threejs.org/t/reflector-js-internal-render-target-dispose/32265)


