### PR TITLE
Add Unittests to WEBGLExtensions 

### DIFF
--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -1,27 +1,6 @@
 function WebGLExtensions( gl ) {
 
 	const extensions = {};
-	const aliasses = {
-		'WEBGL_depth_texture': [
-			'WEBGL_depth_texture',
-			'MOZ_WEBGL_depth_texture',
-			'WEBKIT_WEBGL_depth_texture'
-		],
-		'EXT_texture_filter_anisotropic': [
-			'EXT_texture_filter_anisotropic',
-			'MOZ_EXT_texture_filter_anisotropic',
-			'WEBKIT_EXT_texture_filter_anisotropic'
-		],
-		'WEBGL_compressed_texture_s3tc': [
-			'WEBGL_compressed_texture_s3tc',
-			'MOZ_WEBGL_compressed_texture_s3tc',
-			'WEBKIT_WEBGL_compressed_texture_s3tc'
-		],
-		'WEBGL_compressed_texture_pvrtc': [
-			'WEBGL_compressed_texture_pvrtc',
-			'WEBKIT_WEBGL_compressed_texture_pvrtc'
-		]
-	};
 
 	function getExtension( name ) {
 
@@ -33,23 +12,26 @@ function WebGLExtensions( gl ) {
 
 		let extension;
 
-		if ( aliasses[ name ] === undefined ) {
+		switch ( name ) {
 
-			extension = gl.getExtension( name );
+			case 'WEBGL_depth_texture':
+				extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
+				break;
 
-		} else {
+			case 'EXT_texture_filter_anisotropic':
+				extension = gl.getExtension( 'EXT_texture_filter_anisotropic' ) || gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' ) || gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
+				break;
 
-			for ( let i = 0; i < aliasses[ name ].length; i ++ ) {
+			case 'WEBGL_compressed_texture_s3tc':
+				extension = gl.getExtension( 'WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
+				break;
 
-				extension = gl.getExtension( aliasses[ name ][ i ] );
+			case 'WEBGL_compressed_texture_pvrtc':
+				extension = gl.getExtension( 'WEBGL_compressed_texture_pvrtc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_pvrtc' );
+				break;
 
-				if ( extension !== null ) {
-
-					break;
-
-				}
-
-			}
+			default:
+				extension = gl.getExtension( name );
 
 		}
 

--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -1,6 +1,27 @@
 function WebGLExtensions( gl ) {
 
 	const extensions = {};
+	const aliasses = {
+		'WEBGL_depth_texture': [
+			'WEBGL_depth_texture',
+			'MOZ_WEBGL_depth_texture',
+			'WEBKIT_WEBGL_depth_texture'
+		],
+		'EXT_texture_filter_anisotropic': [
+			'EXT_texture_filter_anisotropic',
+			'MOZ_EXT_texture_filter_anisotropic',
+			'WEBKIT_EXT_texture_filter_anisotropic'
+		],
+		'WEBGL_compressed_texture_s3tc': [
+			'WEBGL_compressed_texture_s3tc',
+			'MOZ_WEBGL_compressed_texture_s3tc',
+			'WEBKIT_WEBGL_compressed_texture_s3tc'
+		],
+		'WEBGL_compressed_texture_pvrtc': [
+			'WEBGL_compressed_texture_pvrtc',
+			'WEBKIT_WEBGL_compressed_texture_pvrtc'
+		]
+	};
 
 	function getExtension( name ) {
 
@@ -12,26 +33,23 @@ function WebGLExtensions( gl ) {
 
 		let extension;
 
-		switch ( name ) {
+		if ( aliasses[ name ] === undefined ) {
 
-			case 'WEBGL_depth_texture':
-				extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
-				break;
+			extension = gl.getExtension( name );
 
-			case 'EXT_texture_filter_anisotropic':
-				extension = gl.getExtension( 'EXT_texture_filter_anisotropic' ) || gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' ) || gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
-				break;
+		} else {
 
-			case 'WEBGL_compressed_texture_s3tc':
-				extension = gl.getExtension( 'WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
-				break;
+			for ( let i = 0; i < aliasses[ name ].length; i ++ ) {
 
-			case 'WEBGL_compressed_texture_pvrtc':
-				extension = gl.getExtension( 'WEBGL_compressed_texture_pvrtc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_pvrtc' );
-				break;
+				extension = gl.getExtension( aliasses[ name ][ i ] );
 
-			default:
-				extension = gl.getExtension( name );
+				if ( extension !== null ) {
+
+					break;
+
+				}
+
+			}
 
 		}
 

--- a/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
@@ -4,7 +4,7 @@ import { WebGLExtensions } from '../../../../../src/renderers/webgl/WebGLExtensi
 
 const WebglContextMock = function ( supportedExtensions ) {
 
-	this.supportedExtensions = supportedExtensions ?? [];
+	this.supportedExtensions = supportedExtensions || [];
 	this.getExtension = function ( name ) {
 
 		if ( this.supportedExtensions.indexOf( name ) > - 1 ) {

--- a/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
@@ -2,6 +2,25 @@
 
 import { WebGLExtensions } from '../../../../../src/renderers/webgl/WebGLExtensions';
 
+const WebglContextMock = function ( supportedExtensions ) {
+
+	this.supportedExtensions = supportedExtensions ?? [];
+	this.getExtension = function ( name ) {
+
+		if ( this.supportedExtensions.indexOf( name ) > - 1 ) {
+
+			return { 'name': name };
+
+		} else {
+
+			return null;
+
+		}
+
+	};
+
+};
+
 export default QUnit.module( 'Renderers', () => {
 
 	QUnit.module( 'WebGL', () => {
@@ -9,16 +28,68 @@ export default QUnit.module( 'Renderers', () => {
 		QUnit.module( 'WebGLExtensions', () => {
 
 			// INSTANCING
-			QUnit.todo( "Instancing", ( assert ) => {
+			QUnit.test( 'Instancing', ( assert ) => {
 
-				assert.ok( false, "everything's gonna be alright" );
+				const gl = new WebglContextMock();
+				const extensions = new WebGLExtensions( gl );
+				assert.ok( extensions !== undefined );
 
 			} );
 
-			// PUBLIC STUFF
-			QUnit.todo( "get", ( assert ) => {
+			QUnit.test( 'has', ( assert ) => {
 
-				assert.ok( false, "everything's gonna be alright" );
+				const gl = new WebglContextMock( [ 'Extension1', 'Extension2' ] );
+				const extensions = new WebGLExtensions( gl );
+				assert.ok( extensions.has( 'Extension1' ) );
+				assert.ok( extensions.has( 'Extension2' ) );
+				assert.ok( extensions.has( 'Extension1' ) );
+				assert.notOk( extensions.has( 'NonExistingExtension' ) );
+
+			} );
+
+			QUnit.test( 'has (with aliasses)', ( assert ) => {
+
+				const gl = new WebglContextMock( [ 'WEBKIT_WEBGL_depth_texture' ] );
+				const extensions = new WebGLExtensions( gl );
+				assert.ok( extensions.has( 'WEBGL_depth_texture' ) );
+				assert.ok( extensions.has( 'WEBKIT_WEBGL_depth_texture' ) );
+				assert.notOk( extensions.has( 'EXT_texture_filter_anisotropic' ) );
+				assert.notOk( extensions.has( 'NonExistingExtension' ) );
+
+			} );
+
+			QUnit.test( 'get', ( assert ) => {
+
+				const gl = new WebglContextMock( [ 'Extension1', 'Extension2' ] );
+				const extensions = new WebGLExtensions( gl );
+				assert.ok( extensions.get( 'Extension1' ) );
+				assert.ok( extensions.get( 'Extension2' ) );
+				assert.ok( extensions.get( 'Extension1' ) );
+				assert.notOk( extensions.get( 'NonExistingExtension' ) );
+
+			} );
+
+			QUnit.test( 'get (with aliasses)', ( assert ) => {
+
+				const gl = new WebglContextMock( [ 'WEBKIT_WEBGL_depth_texture' ] );
+				const extensions = new WebGLExtensions( gl );
+				assert.ok( extensions.get( 'WEBGL_depth_texture' ) );
+				assert.ok( extensions.get( 'WEBKIT_WEBGL_depth_texture' ) );
+				assert.notOk( extensions.get( 'EXT_texture_filter_anisotropic' ) );
+				assert.notOk( extensions.get( 'NonExistingExtension' ) );
+
+			} );
+
+			QUnit.test( 'init', ( assert ) => {
+
+				const gl = new WebglContextMock();
+				const extensions = new WebGLExtensions( gl );
+				extensions.init( { isWebGL2: false } );
+				assert.ok( extensions );
+				const gl2 = new WebglContextMock();
+				const extensions2 = new WebGLExtensions( gl2 );
+				extensions2.init( { isWebGL2: true } );
+				assert.ok( extensions2 );
 
 			} );
 


### PR DESCRIPTION
**Description**

This cleans up the WebglExtensions file and adds unit tests to verify changes to it.
This makes it easier to add aliases to extension names in of webgl extensions. 
