### PR TITLE
Make headers stand out in API reference

### DIFF
--- a/files/main.css
+++ b/files/main.css
@@ -316,6 +316,11 @@ h1 a {
 			padding-top: 12px;
 		}
 
+	        #panel #content h3 {
+			color: var(--text-color);
+			font-weight: 900;
+		}
+
 		#panel #content a {
 			position: relative;
 			color: var(--text-color);


### PR DESCRIPTION
Before: (Look at "Math")
![Screen Shot 2021-12-03 at 9 33 05 AM](https://user-images.githubusercontent.com/49038/144579884-225b834d-5712-42c0-9890-de7ca2554888.png)

After:
![Screen Shot 2021-12-03 at 9 32 48 AM](https://user-images.githubusercontent.com/49038/144579903-76b07db1-8ae0-4b65-a425-c396d7f417ed.png)

**Description**: Makes it more obvious what is a header vs a clickable example.
