### PR TITLE
Dispose loader after loading the object

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -199,6 +199,7 @@ function Loader( editor ) {
 
 						}
 
+						loader.dispose();
 						editor.execute( new AddObjectCommand( editor, object ) );
 
 					} );


### PR DESCRIPTION
Related issue: #22944

**Description**

Partially resolves the issue of loading multiple models. This disposes of the loader after loading the model which removes the workers who otherwise stay loaded. 

In #22944, the loaders created 341 workers which stayed alive and used up the memory.
