### PR TITLE
Manual: Fix fullscreen mode.

### DIFF
--- a/manual/resources/lesson.css
+++ b/manual/resources/lesson.css
@@ -234,7 +234,7 @@ div[data-diagram] {
     position: fixed !important;
     left: var(--panel-width);
     top: 0;
-    right: 0;
+    width: calc(100% - var(--panel-width)) !important;
     height: 100% !important;
     z-index: 100;
 }

--- a/manual/resources/lesson.css
+++ b/manual/resources/lesson.css
@@ -232,9 +232,9 @@ div[data-diagram] {
 }
 .fullscreen {
     position: fixed !important;
-    left: 0;
+    left: var(--panel-width);
     top: 0;
-    width: 100% !important;
+    right: 0;
     height: 100% !important;
     z-index: 100;
 }


### PR DESCRIPTION
Fixed #22890.

@Mugen87 we dont even need mobile media query here since the toolbar with the fullscreen button disappears at widths < 1000px