### PR TITLE
Water2: Remove encoding option.

### DIFF
--- a/examples/jsm/objects/Water2.js
+++ b/examples/jsm/objects/Water2.js
@@ -1,7 +1,6 @@
 import {
 	Clock,
 	Color,
-	LinearEncoding,
 	Matrix4,
 	Mesh,
 	RepeatWrapping,
@@ -41,7 +40,6 @@ class Water extends Mesh {
 		const reflectivity = options.reflectivity || 0.02;
 		const scale = options.scale || 1;
 		const shader = options.shader || Water.WaterShader;
-		const encoding = options.encoding !== undefined ? options.encoding : LinearEncoding;
 
 		const textureLoader = new TextureLoader();
 
@@ -73,15 +71,13 @@ class Water extends Mesh {
 		const reflector = new Reflector( geometry, {
 			textureWidth: textureWidth,
 			textureHeight: textureHeight,
-			clipBias: clipBias,
-			encoding: encoding
+			clipBias: clipBias
 		} );
 
 		const refractor = new Refractor( geometry, {
 			textureWidth: textureWidth,
 			textureHeight: textureHeight,
-			clipBias: clipBias,
-			encoding: encoding
+			clipBias: clipBias
 		} );
 
 		reflector.matrixAutoUpdate = false;


### PR DESCRIPTION
Related issue: -

**Description**

Removing a leftover from a previous color space logic. 
