### PR TITLE
LDrawLoader: Fail gracefully if an object could not be loaded, improve file compatibility

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -967,13 +967,14 @@ class LDrawLoader extends Loader {
 			mainEdgeColourCode: parentScope ? parentScope.mainEdgeColourCode : '24',
 			currentMatrix: new Matrix4(),
 			matrix: new Matrix4(),
+			type: 'Model',
 
 			// If false, it is a root material scope previous to parse
 			isFromParse: true,
 
-			faces: null,
-			lineSegments: null,
-			conditionalSegments: null,
+			faces: [],
+			lineSegments: [],
+			conditionalSegments: [],
 			totalFaces: 0,
 
 			// If true, this object is the start of a construction step
@@ -1443,9 +1444,6 @@ class LDrawLoader extends Loader {
 
 								type = lp.getToken();
 
-								currentParseScope.faces = [];
-								currentParseScope.lineSegments = [];
-								currentParseScope.conditionalSegments = [];
 								currentParseScope.type = type;
 
 								const isRoot = ! parentParseScope.isFromParse;
@@ -1856,6 +1854,13 @@ class LDrawLoader extends Loader {
 
 	finalizeObject( subobjectParseScope ) {
 
+		// fail gracefully if an object could not be loaded
+		if ( subobjectParseScope === null ) {
+
+			return;
+
+		}
+
 		const parentParseScope = subobjectParseScope.parentScope;
 
 		// Smooth the normals if this is a part or if this is a case where the subpart
@@ -2045,6 +2050,7 @@ class LDrawLoader extends Loader {
 			} ).catch( function () {
 
 				console.warn( 'LDrawLoader: Subobject "' + subobject.fileName + '" could not be found.' );
+				return null;
 
 			} );
 


### PR DESCRIPTION
cc @yomboprime 

**Description**

- Changes "parse scope" defaults to use values that accommodate real work demo files
   - Change parse scope to default empty arrays for "faces", "lines" and "conditionalLines" since not all internal file definitions include an "!LDRAW_ORG" command where they were intialized.
   - Change default parse scope type of "type" to "Model" since not all internal file definitions include an "!LDRAW_ORG" command.
- Fail gracefully if a file could not be loaded instead of trying to finalize an "undefined" object.

Tested with the "Scorpion Temple" file [here](https://omr.ldraw.org/files/402).

![image](https://user-images.githubusercontent.com/734200/144725925-0f6d0581-8fbb-4d25-9336-6c528654a1c1.png)

**Some other notes for a future PR**

- There's some weird smoothing on the scorpion claw that I'll try to track down at some point. Maybe smoothing is happening before all part edges are included?

<img src="https://user-images.githubusercontent.com/734200/144725980-602958fa-f47e-41bf-9ee0-801871eaaf4a.png" width="400" />

- For some reason these pieces that are supposed to be a yellow color are rendering as black. Perhaps some metallic material settings need tweaking?

<img src="https://user-images.githubusercontent.com/734200/144726515-62fca708-acca-44b5-9859-a06fd79f6eea.png" width="400" />

