### PR TITLE
SelectionBox: Honor transformation of InstancedMesh.

### DIFF
--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -182,6 +182,7 @@ class SelectionBox {
 
 					object.getMatrixAt( instanceId, _matrix );
 					_matrix.decompose( _center, _quaternion, _scale );
+					_center.applyMatrix4( object.matrixWorld );
 
 					if ( frustum.containsPoint( _center ) ) {
 


### PR DESCRIPTION
Related issue: #22399

**Description**

point should apply matrixworld in InstancedMesh when using frustum.containsPoint
