### PR TITLE
EventDispatcher: Moved init to a 1 fn, & change collection types.

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -9,7 +9,7 @@ class EventDispatcher {
 		const listeners = this.getEventListeners( type );
 
 		listeners.add( listener );
-		
+
 	}
 
 	hasEventListener( type, listener ) {
@@ -28,7 +28,7 @@ class EventDispatcher {
 
 		event.target = this;
 
-		const invokeListener = listener => listener.call( this, event ); 
+		const invokeListener = listener => listener.call( this, event );
 
 		this.getEventListeners( event.type ).forEach( invokeListener );
 
@@ -43,8 +43,8 @@ class EventDispatcher {
 			this._listeners = new Map();
 
 		}
-		
-		if ( !this._listeners.has( type ) ) {
+
+		if ( ! this._listeners.has( type ) ) {
 
 			this._listeners.set( type, new Set() );
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -4,7 +4,7 @@
 
 class EventDispatcher {
 
-	addEventListener( type, listener ){
+	addEventListener( type, listener ) {
 
 		const listeners = this.getEventListeners( type );
 
@@ -12,19 +12,19 @@ class EventDispatcher {
 		
 	}
 
-	hasEventListener( type, listener ){
+	hasEventListener( type, listener ) {
 
 		return this.getEventListeners( type ).has( listener );
 
 	}
 
-	removeEventListener( type, listener ){
+	removeEventListener( type, listener ) {
 
 		this.getEventListeners( type ).remove( listener );
 
 	}
 
-	dispatchEvent( event ){
+	dispatchEvent( event ) {
 
 			event.target = this;
 
@@ -37,7 +37,7 @@ class EventDispatcher {
 	}
 	
 	
-	getEventListeners( type ){
+	getEventListeners( type ) {
 
 		if ( undefined === this._listeners ) {
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -4,54 +4,55 @@
 
 class EventDispatcher {
 
-	addEventListener( type, listener ) {
+	addEventListener( type, listener ){
 
 		const listeners = this.getEventListeners( type );
-		
+
 		listeners.add( listener );
 		
 	}
 
-	hasEventListener( type, listener ) {
+	hasEventListener( type, listener ){
 
 		return this.getEventListeners( type ).has( listener );
+
 	}
 
-	removeEventListener( type, listener ) {
+	removeEventListener( type, listener ){
 
 		this.getEventListeners( type ).remove( listener );
 
 	}
 
-	dispatchEvent( event ) {
+	dispatchEvent( event ){
 
 			event.target = this;
-		
+
 			const invokeListener = listener => listener.call( this, event ); 
-		
+
 			this.getEventListeners( event.type ).forEach( invokeListener );
 
 			event.target = null;
 
-		}
+	}
 	
 	
 	getEventListeners( type ){
-		
+
 		if ( undefined === this._listeners ) {
-			
+
 			this._listeners = new Map();
-			
+
 		}
 		
 		if (  ! this._listeners.has( type ) )  {
-		
+
 			this._listeners.set( type, new Set( ) );
-			
+
 		}
-		
+
 		return this._listeners.get( type );
-		
+
 	}
 
 }

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -6,79 +6,52 @@ class EventDispatcher {
 
 	addEventListener( type, listener ) {
 
-		if ( this._listeners === undefined ) this._listeners = {};
-
-		const listeners = this._listeners;
-
-		if ( listeners[ type ] === undefined ) {
-
-			listeners[ type ] = [];
-
-		}
-
-		if ( listeners[ type ].indexOf( listener ) === - 1 ) {
-
-			listeners[ type ].push( listener );
-
-		}
-
+		const listeners = this.getEventListeners( type );
+		
+		listeners.add( listener );
+		
 	}
 
 	hasEventListener( type, listener ) {
 
-		if ( this._listeners === undefined ) return false;
-
-		const listeners = this._listeners;
-
-		return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
-
+		return this.getEventListeners( type ).has( listener );
 	}
 
 	removeEventListener( type, listener ) {
 
-		if ( this._listeners === undefined ) return;
-
-		const listeners = this._listeners;
-		const listenerArray = listeners[ type ];
-
-		if ( listenerArray !== undefined ) {
-
-			const index = listenerArray.indexOf( listener );
-
-			if ( index !== - 1 ) {
-
-				listenerArray.splice( index, 1 );
-
-			}
-
-		}
+		this.getEventListeners( type ).remove( listener );
 
 	}
 
 	dispatchEvent( event ) {
 
-		if ( this._listeners === undefined ) return;
-
-		const listeners = this._listeners;
-		const listenerArray = listeners[ event.type ];
-
-		if ( listenerArray !== undefined ) {
-
 			event.target = this;
-
-			// Make a copy, in case listeners are removed while iterating.
-			const array = listenerArray.slice( 0 );
-
-			for ( let i = 0, l = array.length; i < l; i ++ ) {
-
-				array[ i ].call( this, event );
-
-			}
+		
+			const invokeListener = listener => listener.call( this, event ); 
+		
+			this.getEventListeners( event.type ).forEach( invokeListener );
 
 			event.target = null;
 
 		}
-
+	
+	
+	getEventListeners( type ){
+		
+		if ( undefined === this._listeners ) {
+			
+			this._listeners = new Map();
+			
+		}
+		
+		if (  ! this._listeners.has( type ) )  {
+		
+			this._listeners.set( type, new Set( ) );
+			
+		}
+		
+		return this._listeners.get( type );
+		
 	}
 
 }

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -45,9 +45,9 @@ class EventDispatcher {
 
 		}
 		
-		if (  ! this._listeners.has( type ) )  {
+		if ( !this._listeners.has( type ) ) {
 
-			this._listeners.set( type, new Set( ) );
+			this._listeners.set( type, new Set() );
 
 		}
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -26,17 +26,16 @@ class EventDispatcher {
 
 	dispatchEvent( event ) {
 
-			event.target = this;
+		event.target = this;
 
-			const invokeListener = listener => listener.call( this, event ); 
+		const invokeListener = listener => listener.call( this, event ); 
 
-			this.getEventListeners( event.type ).forEach( invokeListener );
+		this.getEventListeners( event.type ).forEach( invokeListener );
 
-			event.target = null;
+		event.target = null;
 
 	}
-	
-	
+
 	getEventListeners( type ) {
 
 		if ( undefined === this._listeners ) {


### PR DESCRIPTION
- Changed all the various ``` if ( this._listeners === undefined...``` into a single function
- Changed the main collection type from a generic Object {} to a Map (better performance, cleaner syntax, avoids collisions with Object.prototype)
- Changed the sub collections from Arrays [] to a Set (auto-checks for duplicates faster, better syntax)

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Example](https://example.com).
