### PR TITLE
Docs: Fix Matrix4.lookAt() parameter.

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -202,9 +202,9 @@ zAxis = (c, g, k)
 		<h3>[method:this identity]()</h3>
 		<p>Resets this matrix to the [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].</p>
 
-		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
+		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up], )</h3>
 		<p>
-			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 center]
+			Constructs a rotation matrix, looking from [page:Vector3 eye] towards [page:Vector3 target]
 			oriented by the [page:Vector3 up] vector.
 		</p>
 

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -187,9 +187,9 @@ zAxis = (c, g, k)
 		<h3>[method:this identity]()</h3>
 		<p>将当前矩阵重置为单位矩阵[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix]。</p>
 
-		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 center], [param:Vector3 up], )</h3>
+		<h3>[method:this lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up], )</h3>
 		<p>
-			构造一个旋转矩阵，从[page:Vector3 eye] 指向 [page:Vector3 center]，由向量 [page:Vector3 up] 定向。
+			构造一个旋转矩阵，从[page:Vector3 eye] 指向 [page:Vector3 target]，由向量 [page:Vector3 up] 定向。
 		</p>
 
 		<h3>[method:this makeRotationAxis]( [param:Vector3 axis], [param:Float theta] )</h3>


### PR DESCRIPTION
**Description**
I found the second parameter of Matrix4.lookAt in the current document, which is different from the matrix.lookat parameter in the code. I think the naming of target is more reasonable than that of center, so I keep the document parameters consistent with the code.