### PR TITLE
Add Quaternion.pow(exp) method

### DIFF
--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -135,6 +135,11 @@
 		Adapted from the method outlined [link:http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm here].
 		</p>
 
+		<h3>[method:this pow]( [param:Float exp] )</h3>
+		<p>
+		Raises this quaternion into power [page:Float exp] (i.e. multiplies the angle of rotation of this quaternion by [param:Float exp]).
+		</p>
+
 		<h3>[method:this premultiply]( [param:Quaternion q] )</h3>
 		<p>Pre-multiplies this quaternion by [page:Quaternion q].</p>
 

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -137,7 +137,8 @@
 
 		<h3>[method:this pow]( [param:Float exp] )</h3>
 		<p>
-		Raises this quaternion into power [page:Float exp] (i.e. multiplies the angle of rotation of this quaternion by [param:Float exp]).
+		Raises this quaternion into power [page:Float exp] (i.e. multiplies the angle of rotation of this quaternion by [param:Float exp]).<br />
+		This quaternion is assumed to be normalized.
 		</p>
 
 		<h3>[method:this premultiply]( [param:Quaternion q] )</h3>

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -442,10 +442,13 @@ class Quaternion {
 
 		} else {
 
+			const mod = newHalfAngle - Math.floor( newHalfAngle / ( 2 * Math.PI ) ) * 2 * Math.PI;
+			const sign = ( mod > Math.PI / 2 ) && ( mod < 3 * Math.PI / 2 ) ? -1 : 1;
+
 			this._x *= ratio;
 			this._y *= ratio;
 			this._z *= ratio;
-			this._w = Math.sqrt( 1 - newS * newS );
+			this._w = sign * Math.sqrt( 1 - newS * newS ); // Math.cos( newHalfAngle );
 
 		}
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -425,6 +425,9 @@ class Quaternion {
 
 	pow( exp ) {
 
+		// Assumes that this quaternion is normalized
+		// Is based on Quaternion.setFromAxisAngle and Vector4.setAxisAngleFromQuaternion (and function pow from glMatrix: https://github.com/toji/gl-matrix/blob/master/src/quat.js#L280)
+
 		// const _vec3 = new Vector3();
 		// const _vec4 = new Vector4();
 		// _vec4.setAxisAngleFromQuaternion( this );

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -437,16 +437,16 @@ class Quaternion {
 		const ratio = newS / oldS;
 
 		if ( ratio === Infinity ) {
-	
+
 			return this;
-	
+
 		} else {
-	
+
 			this._x *= ratio;
 			this._y *= ratio;
 			this._z *= ratio;
 			this._w = Math.sqrt( 1 - newS * newS );
-	
+
 		}
 
 		this._onChangeCallback();

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -422,39 +422,38 @@ class Quaternion {
 		return this;
 
 	}
-	
+
 	pow( exp ) {
-		
+
 		// const _vec3 = new Vector3();
 		// const _vec4 = new Vector4();
 		// _vec4.setAxisAngleFromQuaternion( this );
 		// this.setFromAxisAngle( _vec3.set( _vec4.x, _vec4.y, _vec4.z ), _vec4.w * exp );
-		
+
 		const newHalfAngle = Math.acos( this._w ) * exp;
-		
+
 		const oldS = Math.sqrt( 1 - this._w * this._w );
 		const newS = Math.sin( newHalfAngle );
 		const ratio = newS / oldS;
-		
+
 		if ( ratio === Infinity ) {
-			
+	
 			return this;
-			
+	
 		} else {
-			
+	
 			this._x *= ratio;
 			this._y *= ratio;
 			this._z *= ratio;
 			this._w = Math.sqrt( 1 - newS * newS );
-			
-		}
-		
-		this._onChangeCallback();
-		
-		return this;
-		
-	}
 	
+		}
+
+		this._onChangeCallback();
+
+		return this;
+
+	}
 
 	identity() {
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -443,7 +443,7 @@ class Quaternion {
 		} else {
 
 			const mod = newHalfAngle - Math.floor( newHalfAngle / ( 2 * Math.PI ) ) * 2 * Math.PI;
-			const sign = ( mod > Math.PI / 2 ) && ( mod < 3 * Math.PI / 2 ) ? -1 : 1;
+			const sign = ( mod > Math.PI / 2 ) && ( mod < 3 * Math.PI / 2 ) ? - 1 : 1;
 
 			this._x *= ratio;
 			this._y *= ratio;

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -436,7 +436,7 @@ class Quaternion {
 		const newS = Math.sin( newHalfAngle );
 		const ratio = newS / oldS;
 
-		if ( ratio === Infinity ) {
+		if ( oldS === 0 ) {
 
 			return this;
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -422,6 +422,39 @@ class Quaternion {
 		return this;
 
 	}
+	
+	pow( exp ) {
+		
+		// const _vec3 = new Vector3();
+		// const _vec4 = new Vector4();
+		// _vec4.setAxisAngleFromQuaternion( this );
+		// this.setFromAxisAngle( _vec3.set( _vec4.x, _vec4.y, _vec4.z ), _vec4.w * exp );
+		
+		const newHalfAngle = Math.acos( this._w ) * exp;
+		
+		const oldS = Math.sqrt( 1 - this._w * this._w );
+		const newS = Math.sin( newHalfAngle );
+		const ratio = newS / oldS;
+		
+		if ( ratio === Infinity ) {
+			
+			return this;
+			
+		} else {
+			
+			this._x *= ratio;
+			this._y *= ratio;
+			this._z *= ratio;
+			this._w = Math.sqrt( 1 - newS * newS );
+			
+		}
+		
+		this._onChangeCallback();
+		
+		return this;
+		
+	}
+	
 
 	identity() {
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -433,27 +433,25 @@ class Quaternion {
 		// _vec4.setAxisAngleFromQuaternion( this );
 		// this.setFromAxisAngle( _vec3.set( _vec4.x, _vec4.y, _vec4.z ), _vec4.w * exp );
 
+		if ( ( this._w === 1 ) || ( this._w === - 1 ) ) {
+
+			return this;
+
+		}
+
 		const newHalfAngle = Math.acos( this._w ) * exp;
 
 		const oldS = Math.sqrt( 1 - this._w * this._w );
 		const newS = Math.sin( newHalfAngle );
 		const ratio = newS / oldS;
 
-		if ( oldS === 0 ) {
+		const mod = newHalfAngle - Math.floor( newHalfAngle / ( 2 * Math.PI ) ) * 2 * Math.PI;
+		const sign = ( mod > Math.PI / 2 ) && ( mod < 3 * Math.PI / 2 ) ? - 1 : 1;
 
-			return this;
-
-		} else {
-
-			const mod = newHalfAngle - Math.floor( newHalfAngle / ( 2 * Math.PI ) ) * 2 * Math.PI;
-			const sign = ( mod > Math.PI / 2 ) && ( mod < 3 * Math.PI / 2 ) ? - 1 : 1;
-
-			this._x *= ratio;
-			this._y *= ratio;
-			this._z *= ratio;
-			this._w = sign * Math.sqrt( 1 - newS * newS ); // Math.cos( newHalfAngle );
-
-		}
+		this._x *= ratio;
+		this._y *= ratio;
+		this._z *= ratio;
+		this._w = sign * Math.sqrt( 1 - newS * newS ); // Math.cos( newHalfAngle );
 
 		this._onChangeCallback();
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -525,7 +525,7 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( "pow", ( assert ) => {
 
-			var a = new Quaternion( x, y, z, w );
+			var a = new Quaternion( x, y, z, w ).normalize(); // pow works only on normalized quaternions
 			var b = new Quaternion();
 
 			var _vec3 = new Vector3();
@@ -535,10 +535,10 @@ export default QUnit.module( 'Maths', () => {
 			_vec3.set( _vec4.x, _vec4.y, _vec4.z );
 
 			b.setFromAxisAngle( _vec3, _vec4.w / 50 );
-			assert.ok( b.equals( a.clone().pow( 1 / 50 ) ) === true, "Passed!" );
+			assert.ok( Math.abs( b.dot( a.clone().pow( 1 / 50 ) ) - 1 ) <= 1E-15, "Passed!" );
 
 			b.setFromAxisAngle( _vec3, _vec4.w * 50 );
-			assert.ok( b.equals( a.clone().pow( 50 ) ) === true, "Passed!" );
+			assert.ok( Math.abs( b.dot( a.clone().pow( 50 ) ) - 1 ) <= 1E-15, "Passed!" );
 
 			a = new Quaternion( 0, 0, 0, 1 ); 
 			b = new Quaternion( 0, 0, 0, 1 );

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -523,6 +523,30 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( "pow", ( assert ) => {
+
+			var a = new Quaternion( x, y, z, w );
+			var b = new Quaternion();
+
+			var _vec3 = new Vector3();
+			var _vec4 = new Vector4();
+
+			_vec4.setAxisAngleFromQuaternion( a );
+			_vec3.set( _vec4.x, _vec4.y, _vec4.z );
+
+			b.setFromAxisAngle( _vec3, _vec4.w / 50 );
+			assert.ok( b.equals( a.clone().pow( 1 / 50 ) ) === true, "Passed!" );
+
+			b.setFromAxisAngle( _vec3, _vec4.w * 50 );
+			assert.ok( b.equals( a.clone().pow( 50 ) ) === true, "Passed!" );
+
+			a = new Quaternion( 0, 0, 0, 1 ); 
+			b = new Quaternion( 0, 0, 0, 1 );
+
+			assert.ok( b.equals( a.pow( 50 ) ) === true, "Passed!" ); // test for zero angle - then oldS is zero
+
+		} );
+
 		QUnit.test( "identity", ( assert ) => {
 
 			var a = new Quaternion();


### PR DESCRIPTION
Related issue: Fixed https://github.com/mrdoob/three.js/issues/22959

**Description**

This pull request adds Quaternion.pow(exp) method.