### PR TITLE
TransformControls.js: Added reset() method

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -161,11 +161,6 @@
 			Should be called if the controls is no longer required.
 		</p>
 
-		<h3>[method:undefined reset] ()</h3>
-		<p>
-			Resets the object's position, rotation and scale to when the current dragging's transform action began.
-		</p>
-
 		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of
@@ -177,6 +172,11 @@
 		<h3>[method:String getMode] ()</h3>
 		<p>
 			Returns the transformation mode.
+		</p>
+
+		<h3>[method:undefined reset] ()</h3>
+		<p>
+			Resets the object's position, rotation and scale to when the current transform began.
 		</p>
 
 		<h3>[method:undefined setMode] ( [param:String mode] )</h3>
@@ -196,6 +196,16 @@
 			</p>
 			<p>
 				Sets the rotation snap.
+			</p>
+		</p>
+
+		<h3>[method:undefined setScaleSnap] ( [param:Number scaleSnap] )</h3>
+		<p>
+			<p>
+				[page:Number scaleSnap]: The scale snap.
+			</p>
+			<p>
+				Sets the scale snap.
 			</p>
 		</p>
 

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -161,6 +161,16 @@
 			Should be called if the controls is no longer required.
 		</p>
 
+		<h3>[method:null reset] ( [param:Boolean stopCurrentTransform] )</h3>
+		<p>
+			<p>
+				[page:Boolean stopCurrentTransform]: (optional) Stop transforming the object after resetting its position, rotation and scale. Default is *false*.
+			</p>
+			<p>
+				Resets the object's position, rotation and scale to when the current dragging's transform action began and stops further transform if [param:Boolean stopCurrentTransform] evaluates to true.
+			</p>
+		</p>
+
 		<h3>[method:Raycaster getRaycaster] ()</h3>
 		<p>
 			Returns the [page:Raycaster] object that is used for user interaction. This object is shared between all instances of

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -161,14 +161,9 @@
 			Should be called if the controls is no longer required.
 		</p>
 
-		<h3>[method:null reset] ( [param:Boolean stopCurrentTransform] )</h3>
+		<h3>[method:undefined reset] ()</h3>
 		<p>
-			<p>
-				[page:Boolean stopCurrentTransform]: (optional) Stop transforming the object after resetting its position, rotation and scale. Default is *false*.
-			</p>
-			<p>
-				Resets the object's position, rotation and scale to when the current dragging's transform action began and stops further transform if [param:Boolean stopCurrentTransform] evaluates to true.
-			</p>
+			Resets the object's position, rotation and scale to when the current dragging's transform action began.
 		</p>
 
 		<h3>[method:Raycaster getRaycaster] ()</h3>

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -545,6 +545,8 @@
 				this.dispatchEvent( _changeEvent );
 				this.dispatchEvent( _objectChangeEvent );
 
+				this.pointStart.copy( this.pointEnd );
+
 			}
 
 		}

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -532,7 +532,7 @@
 
 		}
 
-		reset( stopCurrentTransform ) {
+		reset() {
 
 			if ( ! this.enabled ) return;
 
@@ -544,12 +544,6 @@
 
 				this.dispatchEvent( _changeEvent );
 				this.dispatchEvent( _objectChangeEvent );
-
-			}
-
-			if ( stopCurrentTransform ) {
-
-				this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
 
 			}
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -532,6 +532,29 @@
 
 		}
 
+		reset( stopCurrentTransform ) {
+
+			if ( ! this.enabled ) return;
+
+			if ( this.dragging ) {
+
+				this.object.position.copy( this._positionStart );
+				this.object.quaternion.copy( this._quaternionStart );
+				this.object.scale.copy( this._scaleStart );
+
+				this.dispatchEvent( _changeEvent );
+				this.dispatchEvent( _objectChangeEvent );
+
+			}
+
+			if ( stopCurrentTransform ) {
+
+				this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+
+			}
+
+		}
+
 		getRaycaster() {
 
 			return _raycaster;

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -577,6 +577,8 @@ class TransformControls extends Object3D {
 			this.dispatchEvent( _changeEvent );
 			this.dispatchEvent( _objectChangeEvent );
 
+			this.pointStart.copy( this.pointEnd );
+
 		}
 
 	}

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -564,7 +564,7 @@ class TransformControls extends Object3D {
 
 	}
 
-	reset( stopCurrentTransform ) {
+	reset() {
 
 		if ( ! this.enabled ) return;
 
@@ -576,12 +576,6 @@ class TransformControls extends Object3D {
 
 			this.dispatchEvent( _changeEvent );
 			this.dispatchEvent( _objectChangeEvent );
-
-		}
-
-		if ( stopCurrentTransform ) {
-
-			this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
 
 		}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -564,6 +564,29 @@ class TransformControls extends Object3D {
 
 	}
 
+	reset( stopCurrentTransform ) {
+
+		if ( ! this.enabled ) return;
+
+		if ( this.dragging ) {
+
+			this.object.position.copy( this._positionStart );
+			this.object.quaternion.copy( this._quaternionStart );
+			this.object.scale.copy( this._scaleStart );
+
+			this.dispatchEvent( _changeEvent );
+			this.dispatchEvent( _objectChangeEvent );
+
+		}
+
+		if ( stopCurrentTransform ) {
+
+			this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+
+		}
+
+	}
+
 	getRaycaster() {
 
 		return _raycaster;

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -12,6 +12,7 @@
 			"W" translate | "E" rotate | "R" scale | "+/-" adjust size<br />
 			"Q" toggle world/local space |  "Shift" snap to grid<br />
 			"X" toggle X | "Y" toggle Y | "Z" toggle Z | "Spacebar" toggle enabled<br />
+			"Esc" reset current transform<br />
 			"C" toggle camera | "V" random zoom
 		</div>
 
@@ -154,6 +155,10 @@
 
 						case 32: // Spacebar
 							control.enabled = ! control.enabled;
+							break;
+
+						case 27: // Esc
+							control.reset();
 							break;
 
 					}


### PR DESCRIPTION
**Description**
There was no (easy) way to cancel/abort a transform action. The pull request adds that functionality.

Added method to reset object to state when the transform dragging started. Further transform action can be stopped immediately after resetting the object by using the optional parameter set to `true`.

**Changes from outdated related prior pull request: #21661**
The prior pull request involved two methods (`cancel` and `stop`). Looking at what the added functionality is, naming it `reset` seems more appropriate. Also, the added `stop` method was overly complex, so the optional unbinding of the `pointermove` event is included in the `reset` method.

Resolves #21655, closes #21661