### PR TITLE
KTX2Loader: Don't select ETC1 for textures with alpha

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -519,8 +519,8 @@ KTX2Loader.BasisWorker = function () {
 		{
 			if: 'etc1Supported',
 			basisFormat: [ BasisFormat.ETC1S, BasisFormat.UASTC_4x4 ],
-			transcoderFormat: [ TranscoderFormat.ETC1, TranscoderFormat.ETC1 ],
-			engineFormat: [ EngineFormat.RGB_ETC1_Format, EngineFormat.RGB_ETC1_Format ],
+			transcoderFormat: [ TranscoderFormat.ETC1 ],
+			engineFormat: [ EngineFormat.RGB_ETC1_Format ],
 			priorityETC1S: 2,
 			priorityUASTC: 4,
 			needsPowerOfTwo: false,
@@ -560,6 +560,7 @@ KTX2Loader.BasisWorker = function () {
 
 			if ( ! config[ opt.if ] ) continue;
 			if ( ! opt.basisFormat.includes( basisFormat ) ) continue;
+			if ( hasAlpha && opt.transcoderFormat.length < 2 ) continue;
 			if ( opt.needsPowerOfTwo && ! ( isPowerOfTwo( width ) && isPowerOfTwo( height ) ) ) continue;
 
 			transcoderFormat = opt.transcoderFormat[ hasAlpha ? 1 : 0 ];


### PR DESCRIPTION
Fixes #22899.

Tested in WebGL 1.0, but wasn't able to test in WebGL 2.0 due to https://github.com/mrdoob/three.js/pull/22928#issuecomment-987554666.