### PR TITLE
GLTFLoader: Provide option to disable ImageBitmapLoader

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -214,6 +214,18 @@
 		[page:KTX2Loader ktx2Loader] — Instance of THREE.KTX2Loader, to be used for loading KTX2 compressed textures.
 		</p>
 
+		<h3>[method:this setImageBitmapLoaderEnabled]( [param:boolean enabled] )</h3>
+		<p>
+		Configures whether the [link:https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap createImageBitmap] API is used. When enabled,
+		image decoding is transferred off the main thread reducing GPU texture upload latency. Disabling may be necessary to avoid certain browser bugs.
+		By default, createImageBitmap is enabled when available.
+		</p>
+
+		<h3>[method:this setMeshoptDecoder]( [param:MeshoptDecoder MeshoptDecoder] )</h3>
+		<p>
+		MeshoptDecoder — MeshoptDecoder module, to be used for decoding assets compressed with EXT_meshopt_compression.
+		</p>
+
 		<h3>[method:undefined parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
 		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -204,6 +204,23 @@
 		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco#readme readme]来了解Draco及其解码器的详细信息。
 		</p>
 
+		<h3>[method:this setKTX2Loader]( [param:KTX2Loader ktx2Loader] )</h3>
+		<p>
+		[page:KTX2Loader ktx2Loader] — Instance of THREE.KTX2Loader, to be used for loading KTX2 compressed textures.
+		</p>
+
+		<h3>[method:this setImageBitmapLoaderEnabled]( [param:boolean enabled] )</h3>
+		<p>
+		Configures whether the [link:https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap createImageBitmap] API is used. When enabled,
+		image decoding is transferred off the main thread reducing GPU texture upload latency. Disabling may be necessary to avoid certain browser bugs.
+		By default, createImageBitmap is enabled when available.
+		</p>
+
+		<h3>[method:this setMeshoptDecoder]( [param:MeshoptDecoder MeshoptDecoder] )</h3>
+		<p>
+		MeshoptDecoder — MeshoptDecoder module, to be used for decoding assets compressed with EXT_meshopt_compression.
+		</p>
+
 		<h3>[method:undefined parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
 		[page:ArrayBuffer data] — 需要解析的glTF文件，值为一个ArrayBuffer或<em>JSON</em>字符串。<br />

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -74,6 +74,10 @@ class GLTFLoader extends Loader {
 		this.ktx2Loader = null;
 		this.meshoptDecoder = null;
 
+		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
+		// expensive work of uploading a texture to the GPU off the main thread.
+		this.imageBitmapLoaderEnabled = typeof createImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
+
 		this.pluginCallbacks = [];
 
 		this.register( function ( parser ) {
@@ -240,6 +244,13 @@ class GLTFLoader extends Loader {
 
 	}
 
+	setImageBitmapLoaderEnabled( enabled ) {
+
+		this.imageBitmapLoaderEnabled = enabled;
+		return this;
+
+	}
+
 	register( callback ) {
 
 		if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
@@ -317,7 +328,8 @@ class GLTFLoader extends Loader {
 			requestHeader: this.requestHeader,
 			manager: this.manager,
 			ktx2Loader: this.ktx2Loader,
-			meshoptDecoder: this.meshoptDecoder
+			meshoptDecoder: this.meshoptDecoder,
+			imageBitmapLoaderEnabled: this.imageBitmapLoaderEnabled,
 
 		} );
 
@@ -2251,9 +2263,7 @@ class GLTFParser {
 		// Track node names, to ensure no duplicates
 		this.nodeNamesUsed = {};
 
-		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
-		// expensive work of uploading a texture to the GPU off the main thread.
-		if ( typeof createImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false ) {
+		if ( this.options.imageBitmapLoaderEnabled ) {
 
 			this.textureLoader = new ImageBitmapLoader( this.options.manager );
 


### PR DESCRIPTION
Related: 
- #22652

Provides an option to disable use of `createImageBitmap` in GLTFLoader. Intended as a workaround at least until upstream issues in Safari (https://bugs.webkit.org/show_bug.cgi?id=232357) are fixed. 

/cc @takahirox 