### PR TITLE
Sphere: Fix edge case in union().

### DIFF
--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -193,7 +193,16 @@ class Sphere {
 		// 1) Enclose the farthest point on the other sphere into this sphere.
 		// 2) Enclose the opposite point of the farthest point into this sphere.
 
-		_toFarthestPoint.subVectors( sphere.center, this.center ).normalize().multiplyScalar( sphere.radius );
+		 if ( this.center.equals( sphere.center ) === true ) {
+
+			 _toFarthestPoint.set( 0, 0, 1 ).multiplyScalar( sphere.radius );
+
+
+		} else {
+
+			_toFarthestPoint.subVectors( sphere.center, this.center ).normalize().multiplyScalar( sphere.radius );
+
+		}
 
 		this.expandByPoint( _v1.copy( sphere.center ).add( _toFarthestPoint ) );
 		this.expandByPoint( _v1.copy( sphere.center ).sub( _toFarthestPoint ) );

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -279,6 +279,16 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.center.equals( new Vector3( 1, 0, 0 ) ), 'Passed!' );
 			assert.ok( c.radius === 4, 'Passed!' );
 
+			// edge case: both spheres have the same center point
+
+			var e = new Sphere( new Vector3(), 1 );
+			var f = new Sphere( new Vector3(), 4 );
+
+			e.union( f );
+
+			assert.ok( e.center.equals( new Vector3( 0, 0, 0 ) ), 'Passed!' );
+			assert.ok( e.radius === 4, 'Passed!' );
+
 		} );
 
 		QUnit.test( 'equals', ( assert ) => {


### PR DESCRIPTION
Related issue: Fixed #22980.

**Description**

Ensures `union()` does not break when two spheres have the same center.
