### PR TITLE
KTX2Loader: Don't transcode to ETC1 in WebGL2

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -94,6 +94,14 @@ class KTX2Loader extends Loader {
 				|| renderer.extensions.has( 'WEBKIT_WEBGL_compressed_texture_pvrtc' )
 		};
 
+
+		if ( renderer.capabilities.isWebGL2 ) {
+
+			// https://github.com/mrdoob/three.js/pull/22928
+			this.workerConfig.etc1Supported = false;
+
+		}
+
 		return this;
 
 	}


### PR DESCRIPTION
Context:

- https://github.com/mrdoob/three.js/pull/22928#issuecomment-988163691

