### PR TITLE
SVGLoader: Fix setting first path point after multiple moveTo commands

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -248,7 +248,7 @@ class SVGLoader extends Loader {
 
 							}
 
-							if ( j === 0 && doSetFirstPoint === true ) firstPoint.copy( point );
+							if ( j === 0 ) firstPoint.copy( point );
 
 						}
 
@@ -440,7 +440,7 @@ class SVGLoader extends Loader {
 
 							}
 
-							if ( j === 0 && doSetFirstPoint === true ) firstPoint.copy( point );
+							if ( j === 0 ) firstPoint.copy( point );
 
 						}
 


### PR DESCRIPTION
There’s a bug in interpreting `m` and `M` commands in the path `d` attribute. Here’s an example of SVG as rendered by a browser and Inkscape:

[hindi.svg.zip](https://github.com/mrdoob/three.js/files/7678840/hindi.svg.zip)


![firefox](https://user-images.githubusercontent.com/146383/145280337-fb32de03-598e-44ad-8ae9-b21c6ac2c163.png)

Here’s how it is loaded by SVGLoader (note how the last char is inset to the center):

![before](https://user-images.githubusercontent.com/146383/145280449-38699814-dac9-45da-bed2-aec0b6605dca.png)

Here’s a result with the patch applied:

![after](https://user-images.githubusercontent.com/146383/145280617-13f4759d-0ba4-4a4d-8eee-0cd5a685aa98.png)

The problem is in the definition of the _initial point_ (`firstPoint` in terms of three.js). The [SVG standard](https://www.w3.org/TR/SVG/paths.html) says:

> § 9.3.4 The "closepath" (Z or z) ends the current subpath by connecting it back to its initial point. An automatic straight line is drawn from the current point to the _initial point_ of the current subpath. 

And:

> § 9.3.3 The "moveto" commands (M or m) _must_ establish a new _initial point_ and a new current point. The effect is as if the "pen" were lifted and moved to a new location.

That “must” from the later is basically not applied in the current implementation. This leads to glitches in paths that contain `Z` after multiple `M` commands because only the very first `M` sets the initial point and the path is mistakenly joined with it.