### PR TITLE
RoughnessMipmapper: Restore fix for USDZExporter.

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -87,6 +87,7 @@ class RoughnessMipmapper {
 		material.roughnessMap.repeat.copy( roughnessMap.repeat );
 		material.roughnessMap.center.copy( roughnessMap.center );
 		material.roughnessMap.rotation = roughnessMap.rotation;
+		material.roughnessMap.image = roughnessMap.image; // required for USDZExporter, see #22741
 
 		material.roughnessMap.matrixAutoUpdate = roughnessMap.matrixAutoUpdate;
 		material.roughnessMap.matrix.copy( roughnessMap.matrix );


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/22916#discussion_r766073293

**Description**

Restores a fix for `USDZExporter` and also adds a comment that explains the new line of code.
