### PR TITLE
WebXRManager: Fix dark WebXR renders.

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -257,7 +257,12 @@ class WebXRManager extends EventDispatcher {
 
 					newRenderTarget = new WebGLRenderTarget(
 						glBaseLayer.framebufferWidth,
-						glBaseLayer.framebufferHeight
+						glBaseLayer.framebufferHeight,
+						{
+							format: RGBAFormat,
+							type: UnsignedByteType,
+							encoding: renderer.outputEncoding
+						}
 					);
 
 				} else {


### PR DESCRIPTION
Followup to #22919 

This was the right solution, but only fixed the problem for the `layers` code path. This applies the encoding fix to the other code  path and I've verified it fixes the MV issue: https://github.com/mrdoob/three.js/pull/22558#issuecomment-990140243

@Mugen87 @mrdoob @cabanier 