### PR TITLE
WebGPU: Fixes

### DIFF
--- a/examples/jsm/renderers/nodes/functions/PhysicalMaterialFunctions.js
+++ b/examples/jsm/renderers/nodes/functions/PhysicalMaterialFunctions.js
@@ -18,7 +18,7 @@ export const getRoughness = new ShaderNode( ( inputs ) => {
 
 	const geometryRoughness = getGeometryRoughness();
 
-	let roughnessFactor = max( roughness, 0.0525 ); // 0.0525 corresponds to the base mip of a 256 cubemap.
+	let roughnessFactor = max( roughness.r, 0.0525 ); // 0.0525 corresponds to the base mip of a 256 cubemap.
 	roughnessFactor = add( roughnessFactor, geometryRoughness );
 	roughnessFactor = min( roughnessFactor, 1.0 );
 

--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -29,7 +29,6 @@ class WebGPUTextureUtils {
 		this.device = device;
 
 		const mipmapVertexSource = `
-[[ block ]]
 struct VarysStruct {
 
 	[[ builtin( position ) ]] Position: vec4<f32>;

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -148,7 +148,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			}
 
-			colorNode = this.addFlow( 'fragment', new VarNode( colorNode, 'Color', 'vec3' ) );
+			colorNode = this.addFlow( 'fragment', new VarNode( colorNode, 'Color', 'vec4' ) );
 
 			this.addFlow( 'fragment', new VarNode( colorNode, 'DiffuseColor', 'vec4' ) );
 
@@ -232,7 +232,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 				// SPECULAR_TINT
 
-				this.addFlow( 'fragment', new VarNode( new ExpressionNode( 'mix( vec3<f32>( 0.04 ), Color, Metalness )', 'vec3' ), 'SpecularColor', 'color' ) );
+				this.addFlow( 'fragment', new VarNode( new ExpressionNode( 'mix( vec3<f32>( 0.04 ), Color.rgb, Metalness )', 'vec3' ), 'SpecularColor', 'color' ) );
 
 				// NORMAL_VIEW
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -783,7 +783,7 @@ fn main( ${shaderData.varys} ) -> [[ location( 0 ) ]] vec4<f32> {
 
 	_getWGSLStruct( name, vars ) {
 
-		return `[[ block ]]
+		return `
 struct ${name} {
 \n${vars}
 };`;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/22901#issuecomment-991724483

**Description**

- WGSL: deprecated attribute: [[ block ]] 
- fix alpha(`vec4`) used in `material.colorNode`
- fix non-float used in `material.roughnessNode`

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
