### PR TITLE
WGSL: remove deprecated attribute: [[ block ]]

### DIFF
--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -104,14 +104,12 @@
 					// Buffer
 					//
 
-					[[ block ]]
 					struct Particle {
 						value : array< vec4<f32> >;
 					};
 					[[ binding( 0 ), group( 0 ) ]]
 					var<storage,read_write> particle : Particle;
 
-					[[ block ]]
 					struct Velocity {
 						value : array< vec4<f32> >;
 					};
@@ -122,14 +120,12 @@
 					// Uniforms
 					//
 
-					[[ block ]]
 					struct Scale {
 						value : array< vec3<f32>, 2 >;
 					};
 					[[ binding( 2 ), group( 0 ) ]]
 					var<uniform> scaleUniform : Scale;
 
-					[[block]]
 					struct MouseUniforms {
 						pointer : vec2<f32>;
 					};


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23003

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
