### PR TITLE
EXRLoader: support single channel luminance - RedFormat

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -6,10 +6,9 @@ import {
 	LinearEncoding,
 	LinearFilter,
 	NearestFilter,
+	RedFormat,
 	RGBAFormat,
 	RGBEEncoding,
-	RGBEFormat,
-	RGBFormat,
 	UnsignedByteType
 } from '../../../build/three.module.js';
 import * as fflate from '../libs/fflate.module.js';
@@ -1312,8 +1311,7 @@ class EXRLoader extends DataTextureLoader {
 			var inDataView = info.viewer;
 			var inOffset = { value: info.offset.value };
 
-			var tmpBufSize = info.width * scanlineBlockSize * ( EXRHeader.channels.length * info.type );
-			var outBuffer = new Uint16Array( tmpBufSize );
+			var outBuffer = new Uint16Array( info.width * info.scanlineBlockSize * ( info.channels * info.type ) );
 			var bitmap = new Uint8Array( BITMAP_SIZE );
 
 			// Setup channel info
@@ -1333,6 +1331,7 @@ class EXRLoader extends DataTextureLoader {
 			}
 
 			// Read range compression data
+
 			var minNonZero = parseUint16( inDataView, inOffset );
 			var maxNonZero = parseUint16( inDataView, inOffset );
 
@@ -1489,7 +1488,7 @@ class EXRLoader extends DataTextureLoader {
 
 			var inDataView = info.viewer;
 			var inOffset = { value: info.offset.value };
-			var outBuffer = new Uint8Array( info.width * info.lines * ( EXRHeader.channels.length * info.type * INT16_SIZE ) );
+			var outBuffer = new Uint8Array( info.width * info.lines * ( info.channels * info.type * INT16_SIZE ) );
 
 			// Read compression header information
 			var dwaHeader = {
@@ -1734,16 +1733,6 @@ class EXRLoader extends DataTextureLoader {
 			offset.value = offset.value + size;
 
 			return stringValue;
-
-		}
-
-		function parseUlong( dataView, offset ) {
-
-			var uLong = dataView.getUint32( 0, true );
-
-			offset.value = offset.value + ULONG_SIZE;
-
-			return uLong;
 
 		}
 
@@ -2037,270 +2026,268 @@ class EXRLoader extends DataTextureLoader {
 
 		}
 
-		var bufferDataView = new DataView( buffer );
-		var uInt8Array = new Uint8Array( buffer );
+		function parseHeader( dataView, buffer, offset ) {
 
-		var EXRHeader = {};
+			const EXRHeader = {};
 
-		bufferDataView.getUint32( 0, true ); // magic
-		bufferDataView.getUint8( 4, true ); // versionByteZero
-		bufferDataView.getUint8( 5, true ); // fullMask
+			if ( dataView.getUint32( 0, true ) != 20000630 ) // magic
+				throw "THREE.EXRLoader: provided file doesn't appear to be in OpenEXR format.";
 
-		// start of header
+			EXRHeader.version = dataView.getUint8( 4, true );
 
-		var offset = { value: 8 }; // start at 8, after magic stuff
+			const spec = dataView.getUint8( 5, true ); // fullMask
 
-		var keepReading = true;
+			EXRHeader.spec = {
+				singleTile: !!(spec & 1),
+				longName: !!(spec & 2),
+				deepFormat: !!(spec & 4),
+				multiPart: !!(spec & 8),
+			}
 
-		while ( keepReading ) {
+			// start of header
 
-			var attributeName = parseNullTerminatedString( buffer, offset );
+			offset.value = 8; // start at 8 - after pre-amble
 
-			if ( attributeName == 0 ) {
+			var keepReading = true;
 
-				keepReading = false;
+			while ( keepReading ) {
 
-			} else {
+				var attributeName = parseNullTerminatedString( buffer, offset );
 
-				var attributeType = parseNullTerminatedString( buffer, offset );
-				var attributeSize = parseUint32( bufferDataView, offset );
-				var attributeValue = parseValue( bufferDataView, buffer, offset, attributeType, attributeSize );
+				if ( attributeName == 0 ) {
 
-				if ( attributeValue === undefined ) {
-
-					console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${ attributeType }\'.` );
+					keepReading = false;
 
 				} else {
 
-					EXRHeader[ attributeName ] = attributeValue;
+					var attributeType = parseNullTerminatedString( buffer, offset );
+					var attributeSize = parseUint32( dataView, offset );
+					var attributeValue = parseValue( dataView, buffer, offset, attributeType, attributeSize );
+
+					if ( attributeValue === undefined ) {
+
+						console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${attributeType}\'.` );
+
+					} else {
+
+						EXRHeader[ attributeName ] = attributeValue;
+
+					}
 
 				}
 
+			} 
+
+			if ( spec != 0 ) {
+				console.error( "EXRHeader:", EXRHeader );
+				throw "THREE.EXRLoader: provided file is currently unsupported."
 			}
 
-		}
-
-		// offsets
-		var dataWindowHeight = EXRHeader.dataWindow.yMax + 1;
-
-		var uncompress;
-		var scanlineBlockSize;
-
-		switch ( EXRHeader.compression ) {
-
-			case 'NO_COMPRESSION':
-
-				scanlineBlockSize = 1;
-				uncompress = uncompressRAW;
-				break;
-
-			case 'RLE_COMPRESSION':
-
-				scanlineBlockSize = 1;
-				uncompress = uncompressRLE;
-				break;
-
-			case 'ZIPS_COMPRESSION':
-
-				scanlineBlockSize = 1;
-				uncompress = uncompressZIP;
-				break;
-
-			case 'ZIP_COMPRESSION':
-
-				scanlineBlockSize = 16;
-				uncompress = uncompressZIP;
-				break;
-
-			case 'PIZ_COMPRESSION':
-
-				scanlineBlockSize = 32;
-				uncompress = uncompressPIZ;
-				break;
-
-			case 'PXR24_COMPRESSION':
-
-				scanlineBlockSize = 16;
-				uncompress = uncompressPXR;
-				break;
-
-			case 'DWAA_COMPRESSION':
-
-				scanlineBlockSize = 32;
-				uncompress = uncompressDWA;
-				break;
-
-			case 'DWAB_COMPRESSION':
-
-				scanlineBlockSize = 256;
-				uncompress = uncompressDWA;
-				break;
-
-			default:
-
-				throw 'EXRLoader.parse: ' + EXRHeader.compression + ' is unsupported';
+			return EXRHeader;
 
 		}
 
-		var size_t;
-		var getValue;
+		function setupDecoder( EXRHeader, dataView, uInt8Array, offset, outputType ) {
 
-		// mixed pixelType not supported
-		var pixelType = EXRHeader.channels[ 0 ].pixelType;
+			const EXRDecoder = { 
+				size: 0,
+				viewer: dataView,
+				array: uInt8Array,
+				offset: offset,
+				width: EXRHeader.dataWindow.xMax - EXRHeader.dataWindow.xMin + 1,
+				height: EXRHeader.dataWindow.yMax - EXRHeader.dataWindow.yMin + 1,
+				channels: EXRHeader.channels.length,
+				bytesPerLine: null,
+				lines: null,
+				inputSize: null,
+				type: EXRHeader.channels[ 0 ].pixelType,
+				uncompress: null,
+				getter: null,
+				format: null,
+				encoding: null,
+			};
 
-		if ( pixelType === 1 ) { // half
+			switch ( EXRHeader.compression ) {
 
-			switch ( this.type ) {
+				case 'NO_COMPRESSION':
+					EXRDecoder.lines = 1;
+					EXRDecoder.uncompress = uncompressRAW;
+					break;
+
+				case 'RLE_COMPRESSION':
+					EXRDecoder.lines = 1;
+					EXRDecoder.uncompress = uncompressRLE;
+					break;
+
+				case 'ZIPS_COMPRESSION':
+					EXRDecoder.lines = 1;
+					EXRDecoder.uncompress = uncompressZIP;
+					break;
+
+				case 'ZIP_COMPRESSION':
+					EXRDecoder.lines = 16;
+					EXRDecoder.uncompress = uncompressZIP;
+					break;
+
+				case 'PIZ_COMPRESSION':
+					EXRDecoder.lines = 32;
+					EXRDecoder.uncompress = uncompressPIZ;
+					break;
+
+				case 'PXR24_COMPRESSION':
+					EXRDecoder.lines = 16;
+					EXRDecoder.uncompress = uncompressPXR;
+					break;
+
+				case 'DWAA_COMPRESSION':
+					EXRDecoder.lines = 32;
+					EXRDecoder.uncompress = uncompressDWA;
+					break;
+
+				case 'DWAB_COMPRESSION':
+					EXRDecoder.lines = 256;
+					EXRDecoder.uncompress = uncompressDWA;
+					break;
+
+				default:
+					throw 'EXRLoader.parse: ' + EXRHeader.compression + ' is unsupported';
+
+			}
+
+			EXRDecoder.scanlineBlockSize = EXRDecoder.lines;
+
+			if ( EXRDecoder.type == 1 ) {
+
+				// half
+				switch ( outputType ) {
+
+					case UnsignedByteType:
+					case FloatType:
+						EXRDecoder.getter = parseFloat16;
+						EXRDecoder.inputSize = INT16_SIZE;
+						break;
+
+					case HalfFloatType:
+						EXRDecoder.getter = parseUint16;
+						EXRDecoder.inputSize = INT16_SIZE;
+						break;
+
+				}
+
+			} else if ( EXRDecoder.type == 2 ) {
+
+				// float
+				switch ( outputType ) {
+
+					case UnsignedByteType:
+					case FloatType:
+						EXRDecoder.getter = parseFloat32;
+						EXRDecoder.inputSize = FLOAT32_SIZE;
+						break;
+
+					case HalfFloatType:
+						EXRDecoder.getter = decodeFloat32;
+						EXRDecoder.inputSize = FLOAT32_SIZE;
+
+				}
+
+			} else {
+
+				throw 'EXRLoader.parse: unsupported pixelType ' + EXRDecoder.type + ' for ' + EXRHeader.compression + '.';
+
+			}
+
+			EXRDecoder.blockCount = ( EXRHeader.dataWindow.yMax + 1 ) / EXRDecoder.scanlineBlockSize;
+
+			for ( var i = 0; i < EXRDecoder.blockCount; i ++ )
+				parseInt64( dataView, offset ) // scanlineOffset 
+				
+			// we should be passed the scanline offset table, ready to start reading pixel data.
+
+			// RGB images will be converted to RGBA format, preventing software emulation in select devices.
+			EXRDecoder.outputChannels = ( ( EXRDecoder.channels == 3 ) ? 4 : EXRDecoder.channels );
+			const size = EXRDecoder.width * EXRDecoder.height * EXRDecoder.outputChannels;
+
+			switch ( outputType ) {
 
 				case UnsignedByteType:
 				case FloatType:
+					EXRDecoder.byteArray = new Float32Array( size );
 
-					getValue = parseFloat16;
-					size_t = INT16_SIZE;
+					// Fill initially with 1s for the alpha value if the texture is not RGBA, RGB values will be overwritten
+					if ( EXRDecoder.channels < EXRDecoder.outputChannels )
+						EXRDecoder.byteArray.fill( 1, 0, size ); 
+				
 					break;
 
 				case HalfFloatType:
+					EXRDecoder.byteArray = new Uint16Array( size );
+					
+					if ( EXRDecoder.channels < EXRDecoder.outputChannels )
+						EXRDecoder.byteArray.fill( 0x3C00, 0, size ); // Uint16Array holds half float data, 0x3C00 is 1
 
-					getValue = parseUint16;
-					size_t = INT16_SIZE;
+					break;
+
+				default:
+					console.error( 'THREE.EXRLoader: unsupported type: ', outputType );
 					break;
 
 			}
 
-		} else if ( pixelType === 2 ) { // float
+			EXRDecoder.bytesPerLine = EXRDecoder.width * EXRDecoder.inputSize * EXRDecoder.channels;
 
-			switch ( this.type ) {
-
-				case UnsignedByteType:
-				case FloatType:
-
-					getValue = parseFloat32;
-					size_t = FLOAT32_SIZE;
-					break;
-
-				case HalfFloatType:
-
-					getValue = decodeFloat32;
-					size_t = FLOAT32_SIZE;
-
+			if ( EXRDecoder.outputChannels == 4 ) {
+				EXRDecoder.format = RGBAFormat;
+				EXRDecoder.encoding = ( outputType == UnsignedByteType ) ? RGBEEncoding : LinearEncoding;
+			} else {
+				EXRDecoder.format = RedFormat;
+				EXRDecoder.encoding = LinearEncoding;
 			}
 
-		} else {
-
-			throw 'EXRLoader.parse: unsupported pixelType ' + pixelType + ' for ' + EXRHeader.compression + '.';
+			return EXRDecoder;
 
 		}
 
-		var numBlocks = dataWindowHeight / scanlineBlockSize;
+		// start parsing file [START]
 
-		for ( var i = 0; i < numBlocks; i ++ ) {
+		const bufferDataView = new DataView( buffer );
+		const uInt8Array = new Uint8Array( buffer );
+		const offset = { value: 0 };
 
-			parseUlong( bufferDataView, offset ); // scanlineOffset
+		// get header information and validate format.
+		const EXRHeader = parseHeader( bufferDataView, buffer, offset );
 
-		}
+		// get input compression information and prepare decoding.
+		const EXRDecoder = setupDecoder( EXRHeader, bufferDataView, uInt8Array, offset, this.type );
 
-		// we should be passed the scanline offset table, start reading pixel data
+		const tmpOffset = { value: 0 };
+		const channelOffsets = { R: 0, G: 1, B: 2, A: 3, Y: 0 };
 
-		var width = EXRHeader.dataWindow.xMax - EXRHeader.dataWindow.xMin + 1;
-		var height = EXRHeader.dataWindow.yMax - EXRHeader.dataWindow.yMin + 1;
-		// Firefox only supports RGBA (half) float textures
-		// var numChannels = EXRHeader.channels.length;
-		var numChannels = 4;
-		var size = width * height * numChannels;
+		for ( let scanlineBlockIdx = 0; scanlineBlockIdx < EXRDecoder.height / EXRDecoder.scanlineBlockSize; scanlineBlockIdx ++ ) {
+			
+			const line = parseUint32( bufferDataView, offset ); // line_no
+			EXRDecoder.size = parseUint32( bufferDataView, offset ); // data_len
+			EXRDecoder.lines = ( ( line + EXRDecoder.scanlineBlockSize > EXRDecoder.height ) ? (EXRDecoder.height-line) : EXRDecoder.scanlineBlockSize );
 
-		// Fill initially with 1s for the alpha value if the texture is not RGBA, RGB values will be overwritten
-		switch ( this.type ) {
+			const isCompressed = EXRDecoder.size < EXRDecoder.lines * EXRDecoder.bytesPerLine;
+			const viewer = isCompressed ? EXRDecoder.uncompress( EXRDecoder ) : uncompressRAW( EXRDecoder );
 
-			case UnsignedByteType:
-			case FloatType:
+			offset.value += EXRDecoder.size;
 
-				var byteArray = new Float32Array( size );
+			for ( let line_y = 0; line_y < EXRDecoder.scanlineBlockSize; line_y ++ ) {
 
-				if ( EXRHeader.channels.length < numChannels ) {
+				const true_y = line_y + scanlineBlockIdx * EXRDecoder.scanlineBlockSize;
+				if ( true_y >= EXRDecoder.height ) break;
 
-					byteArray.fill( 1, 0, size );
+				for ( let channelID = 0; channelID < EXRDecoder.channels; channelID ++ ) {
 
-				}
+					const cOff = channelOffsets[ EXRHeader.channels[ channelID ].name ];
 
-				break;
+					for ( var x = 0; x < EXRDecoder.width; x ++ ) {
 
-			case HalfFloatType:
-
-				var byteArray = new Uint16Array( size );
-
-				if ( EXRHeader.channels.length < numChannels ) {
-
-					byteArray.fill( 0x3C00, 0, size ); // Uint16Array holds half float data, 0x3C00 is 1
-
-				}
-
-				break;
-
-			default:
-
-				console.error( 'THREE.EXRLoader: unsupported type: ', this.type );
-				break;
-
-		}
-
-		var channelOffsets = {
-			R: 0,
-			G: 1,
-			B: 2,
-			A: 3
-		};
-
-		var compressionInfo = {
-
-			size: 0,
-			width: width,
-			lines: scanlineBlockSize,
-
-			offset: offset,
-			array: uInt8Array,
-			viewer: bufferDataView,
-
-			type: pixelType,
-			channels: EXRHeader.channels.length,
-
-		};
-
-		var line;
-		var size;
-		var viewer;
-		var tmpOffset = { value: 0 };
-
-		for ( var scanlineBlockIdx = 0; scanlineBlockIdx < height / scanlineBlockSize; scanlineBlockIdx ++ ) {
-
-			line = parseUint32( bufferDataView, offset ); // line_no
-			size = parseUint32( bufferDataView, offset ); // data_len
-
-			compressionInfo.lines = ( line + scanlineBlockSize > height ) ? height - line : scanlineBlockSize;
-			compressionInfo.offset = offset;
-			compressionInfo.size = size;
-
-			viewer = uncompress( compressionInfo );
-
-			offset.value += size;
-
-			for ( var line_y = 0; line_y < scanlineBlockSize; line_y ++ ) {
-
-				var true_y = line_y + ( scanlineBlockIdx * scanlineBlockSize );
-
-				if ( true_y >= height ) break;
-
-				for ( var channelID = 0; channelID < EXRHeader.channels.length; channelID ++ ) {
-
-					var cOff = channelOffsets[ EXRHeader.channels[ channelID ].name ];
-
-					for ( var x = 0; x < width; x ++ ) {
-
-						var idx = ( line_y * ( EXRHeader.channels.length * width ) ) + ( channelID * width ) + x;
-						tmpOffset.value = idx * size_t;
-
-						var val = getValue( viewer, tmpOffset );
-
-						byteArray[ ( ( ( height - 1 - true_y ) * ( width * numChannels ) ) + ( x * numChannels ) ) + cOff ] = val;
+						tmpOffset.value = ( line_y * ( EXRDecoder.channels * EXRDecoder.width ) + channelID * EXRDecoder.width + x ) * EXRDecoder.inputSize;
+						const outIndex = ( EXRDecoder.height - 1 - true_y ) * ( EXRDecoder.width * EXRDecoder.outputChannels ) + x * EXRDecoder.outputChannels + cOff;
+						EXRDecoder.byteArray[ outIndex ] = EXRDecoder.getter( viewer, tmpOffset );
 
 					}
 
@@ -2310,24 +2297,23 @@ class EXRLoader extends DataTextureLoader {
 
 		}
 
-		if ( this.type === UnsignedByteType ) {
+		// convert to RGBE if user specifies Uint8 output on a RGB input texture
+		if ( EXRDecoder.encoding == RGBEEncoding ) {
 
 			let v, i;
-			const size = byteArray.length;
+			const size = EXRDecoder.byteArray.length;
 			const RGBEArray = new Uint8Array( size );
 
-			for ( let h = 0; h < height; ++ h ) {
+			for ( let h = 0; h < EXRDecoder.height; ++ h ) {
 
-				for ( let w = 0; w < width; ++ w ) {
+				for ( let w = 0; w < EXRDecoder.width; ++ w ) {
 
-					i = h * width * 4 + w * 4;
-
-					const red = byteArray[ i ];
-					const green = byteArray[ i + 1 ];
-					const blue = byteArray[ i + 2 ];
-
-					v = ( red > green ) ? red : green;
-					v = ( blue > v ) ? blue : v;
+					i = h * EXRDecoder.width * 4 + w * 4;
+					const red = EXRDecoder.byteArray[ i ];
+					const green = EXRDecoder.byteArray[ i + 1 ];
+					const blue = EXRDecoder.byteArray[ i + 2 ];
+					v = red > green ? red : green;
+					v = blue > v ? blue : v;
 
 					if ( v < 1e-32 ) {
 
@@ -2337,7 +2323,6 @@ class EXRLoader extends DataTextureLoader {
 
 						const res = frexp( v );
 						v = res[ 0 ] * 256 / v;
-
 						RGBEArray[ i ] = red * v;
 						RGBEArray[ i + 1 ] = green * v;
 						RGBEArray[ i + 2 ] = blue * v;
@@ -2349,19 +2334,18 @@ class EXRLoader extends DataTextureLoader {
 
 			}
 
-			byteArray = RGBEArray;
+			EXRDecoder.byteArray = RGBEArray;
 
 		}
-
-		const format = ( this.type === UnsignedByteType ) ? RGBEFormat : ( numChannels === 4 ) ? RGBAFormat : RGBFormat;
-
+		
 		return {
 			header: EXRHeader,
-			width: width,
-			height: height,
-			data: byteArray,
-			format: format,
-			type: this.type
+			width: EXRDecoder.width,
+			height: EXRDecoder.height,
+			data: EXRDecoder.byteArray,
+			format: EXRDecoder.format,
+			encoding: EXRDecoder.encoding,
+			type: this.type,
 		};
 
 	}
@@ -2377,28 +2361,11 @@ class EXRLoader extends DataTextureLoader {
 
 		function onLoadCallback( texture, texData ) {
 
-			switch ( texture.type ) {
-
-				case UnsignedByteType:
-
-					texture.encoding = RGBEEncoding;
-					texture.minFilter = NearestFilter;
-					texture.magFilter = NearestFilter;
-					texture.generateMipmaps = false;
-					texture.flipY = false;
-					break;
-
-				case FloatType:
-				case HalfFloatType:
-
-					texture.encoding = LinearEncoding;
-					texture.minFilter = LinearFilter;
-					texture.magFilter = LinearFilter;
-					texture.generateMipmaps = false;
-					texture.flipY = false;
-					break;
-
-			}
+			texture.encoding = texData.encoding;
+			texture.minFilter = ( texture.encoding == RGBEEncoding ) ? NearestFilter : LinearFilter;
+			texture.magFilter = ( texture.encoding == RGBEEncoding ) ? NearestFilter : LinearFilter;
+			texture.generateMipmaps = false;
+			texture.flipY = false;
 
 			if ( onLoad ) onLoad( texture, texData );
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -2283,7 +2283,7 @@ class EXRLoader extends DataTextureLoader {
 
 					const cOff = channelOffsets[ EXRHeader.channels[ channelID ].name ];
 
-					for ( var x = 0; x < EXRDecoder.width; x ++ ) {
+					for ( let x = 0; x < EXRDecoder.width; x ++ ) {
 
 						tmpOffset.value = ( line_y * ( EXRDecoder.channels * EXRDecoder.width ) + channelID * EXRDecoder.width + x ) * EXRDecoder.inputSize;
 						const outIndex = ( EXRDecoder.height - 1 - true_y ) * ( EXRDecoder.width * EXRDecoder.outputChannels ) + x * EXRDecoder.outputChannels + cOff;


### PR DESCRIPTION
Addresses https://github.com/mrdoob/three.js/issues/20195#issuecomment-986023382

I noticed a difference between our implementation and OpenEXR's in trying to decompress a block only if input-data is actually smaller than the expected data-size. This PR standardizes this issue and makes equivalent to OpenEXR implementation.

It also initially includes support for luminance - single channel files `HalfFloatType / FloatType`. 
Luminance images are treated as `RedFormat` - WebGL2 only context.

Updated  `textureData` header info to include specification flags, to help identify if problematic files contain lack of supported features like  Deep-Image, Multi-Part or Tiled image files.

![image](https://user-images.githubusercontent.com/3927951/145721039-782c6775-50b6-4b80-90c0-4cb8b92d1884.png)

I largely tested these changes, but would appreciate further testing - @Mugen87, @WestLangley 

-- 

Currently we fail to support `.setDataType( THREE.UnsignedByteType )` on Luminance maps. 

`setDataType` is properly followed even in cases where there is an underlying mismatch between input-type and output-types.  
( e.g like a float32b input file transformed into a half16b texture ). When we set the output-type to `UnsignedByteType` on a RGB/RGBA files we also encode the output-texture as `RGBEEncoding` and transform the data appropriately.

However transforming a luminance map of 32/16 type to an uint8 type is not yet specified, should I explicitly allow that transformation? If so, should I then change the texture format to `LuminanceFormat` in order to support WebGL1 contexts?



