### PR TITLE
TrackballControls: optional target if scene not centered on origin

### DIFF
--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -12,7 +12,7 @@ const _endEvent = { type: 'end' };
 
 class TrackballControls extends EventDispatcher {
 
-	constructor( object, domElement ) {
+	constructor( object, domElement, target ) {
 
 		super();
 
@@ -52,7 +52,7 @@ class TrackballControls extends EventDispatcher {
 
 		// internals
 
-		this.target = new Vector3();
+		this.target = (typeof target !== 'undefined') ?  target : new Vector3();
 
 		const EPS = 0.000001;
 


### PR DESCRIPTION
**Description**

By default, `TrackballControls` sets the target to (0,0,0), whether the input camera already `lookAt` a different point. This pull request adds an optional `target` to avoid this overridding of the input target. 

With this change, I get the expected results and can use `TrackballControls` on scenes where the centroid is far from (0,0,0). 



