### PR TITLE
WebGLRenderer: Add emissiveIntensity uniform

### DIFF
--- a/examples/jsm/environments/RoomEnvironment.js
+++ b/examples/jsm/environments/RoomEnvironment.js
@@ -6,7 +6,7 @@ import {
  	BackSide,
  	BoxGeometry,
  	Mesh,
-	MeshBasicMaterial,
+	MeshLambertMaterial,
  	MeshStandardMaterial,
  	PointLight,
  	Scene,
@@ -111,9 +111,10 @@ class RoomEnvironment extends Scene {
 }
 
 function createAreaLightMaterial( intensity ) {
-
-	const material = new MeshBasicMaterial();
-	material.color.setScalar( intensity );
+	const material = new MeshLambertMaterial();
+	material.color.setScalar( 0 );
+	material.emissive.setScalar( 1 );
+	material.emissiveIntensity = intensity;
 	return material;
 
 }

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -36,7 +36,8 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) }
+				emissive: { value: new Color( 0x000000 ) },
+				emissiveIntensity: { value: 1.0 }
 			}
 		] ),
 
@@ -61,6 +62,7 @@ const ShaderLib = {
 			UniformsLib.lights,
 			{
 				emissive: { value: new Color( 0x000000 ) },
+				emissiveIntensity: { value: 1.0 },
 				specular: { value: new Color( 0x111111 ) },
 				shininess: { value: 30 }
 			}
@@ -88,6 +90,7 @@ const ShaderLib = {
 			UniformsLib.lights,
 			{
 				emissive: { value: new Color( 0x000000 ) },
+				emissiveIntensity: { value: 1.0 },
 				roughness: { value: 1.0 },
 				metalness: { value: 0.0 },
 				envMapIntensity: { value: 1 } // temporary
@@ -113,7 +116,8 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) }
+				emissive: { value: new Color( 0x000000 ) },
+				emissiveIntensity: { value: 1.0 }
 			}
 		] ),
 

--- a/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
@@ -53,6 +53,7 @@ void main() {
 export const fragment = /* glsl */`
 uniform vec3 diffuse;
 uniform vec3 emissive;
+uniform float emissiveIntensity;
 uniform float opacity;
 
 varying vec3 vLightFront;
@@ -94,7 +95,7 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-	vec3 totalEmissiveRadiance = emissive;
+	vec3 totalEmissiveRadiance = emissive * emissiveIntensity;
 
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong.glsl.js
@@ -53,6 +53,7 @@ export const fragment = /* glsl */`
 
 uniform vec3 diffuse;
 uniform vec3 emissive;
+uniform float emissiveIntensity;
 uniform vec3 specular;
 uniform float shininess;
 uniform float opacity;
@@ -90,7 +91,7 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-	vec3 totalEmissiveRadiance = emissive;
+	vec3 totalEmissiveRadiance = emissive * emissiveIntensity;
 
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -67,6 +67,7 @@ export const fragment = /* glsl */`
 
 uniform vec3 diffuse;
 uniform vec3 emissive;
+uniform float emissiveIntensity;
 uniform float roughness;
 uniform float metalness;
 uniform float opacity;
@@ -144,7 +145,7 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-	vec3 totalEmissiveRadiance = emissive;
+	vec3 totalEmissiveRadiance = emissive * emissiveIntensity;
 
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>

--- a/src/renderers/shaders/ShaderLib/meshtoon.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon.glsl.js
@@ -51,6 +51,7 @@ export const fragment = /* glsl */`
 
 uniform vec3 diffuse;
 uniform vec3 emissive;
+uniform float emissiveIntensity;
 uniform float opacity;
 
 #include <common>
@@ -83,7 +84,7 @@ void main() {
 
 	vec4 diffuseColor = vec4( diffuse, opacity );
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-	vec3 totalEmissiveRadiance = emissive;
+	vec3 totalEmissiveRadiance = emissive * emissiveIntensity;
 
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -117,7 +117,8 @@ function WebGLMaterials( properties ) {
 
 		if ( material.emissive ) {
 
-			uniforms.emissive.value.copy( material.emissive ).multiplyScalar( material.emissiveIntensity );
+			uniforms.emissive.value.copy( material.emissive );
+			uniforms.emissiveIntensity.value = material.emissiveIntensity;
 
 		}
 


### PR DESCRIPTION
Related issue:
- https://github.com/mrdoob/three.js/pull/22346#issuecomment-991993424

Scaling a `THREE.Color` by linear intensity is more complicated once we accept sRGB inputs. One prominent example was RoomEnvironment. This PR changes RoomEnvironment to use emissive and emissiveIntensity instead of `color.setScalar( intensity )`, and adds a uniform to ensure that emissive and emissiveIntensity are not pre-multiplied.

If we don't want to ever consider Color values to be sRGB, then this change is not necessary.

This PR can be safely merged with or without the addition of a linear workflow, and is more consistent with how we handle `specularColor` and `specularIntensity` already.
