### PR TITLE
Docs: Update links to manual.

### DIFF
--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -26,7 +26,7 @@
 		<h3>الشروع في العمل مع three.js</h3>
 		<ul>
 			<li>
-				[link:https://threejsfundamentals.org/threejs/lessons/threejs-fundamentals.html Three.js Fundamentals starting lesson]
+				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
 			</li>
 			<li>
 				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] بواسطة [link:https://codepen.io/rachsmith/ Rachel Smith].
@@ -40,9 +40,6 @@
 		<ul>
 			<li>
 				[link:https://discoverthreejs.com/ Discover three.js]
-			</li>
-			<li>
-				[link:https://threejsfundamentals.org/ Three.js Fundamentals]
 			</li>
 			<li>
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -30,7 +30,7 @@
 		<h3>Getting started with three.js</h3>
 		<ul>
 			<li>
-				[link:https://threejsfundamentals.org/threejs/lessons/threejs-fundamentals.html Three.js Fundamentals starting lesson]
+				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
 			</li>
 			<li>
 				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] by [link:https://codepen.io/rachsmith/ Rachel Smith].
@@ -44,9 +44,6 @@
 		<ul>
 			<li>
 				[link:https://discoverthreejs.com/ Discover three.js]
-			</li>
-			<li>
-				[link:https://threejsfundamentals.org/ Three.js Fundamentals]
 			</li>
 			<li>
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].

--- a/docs/manual/ja/introduction/Useful-links.html
+++ b/docs/manual/ja/introduction/Useful-links.html
@@ -28,7 +28,7 @@
 		<h3>three.jsを始める</h3>
 		<ul>
 			<li>
-				[link:https://threejsfundamentals.org/threejs/lessons/threejs-fundamentals.html Three.js Fundamentals starting lesson]
+				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
 			</li>
 			<li>
 				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] by [link:https://codepen.io/rachsmith/ Rachel Smith].
@@ -42,9 +42,6 @@
 		<ul>
 			<li>
 				[link:https://discoverthreejs.com/ Discover three.js]
-			</li>
-			<li>
-				[link:https://threejsfundamentals.org/ Three.js Fundamentals]
 			</li>
 			<li>
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].

--- a/docs/manual/ko/introduction/Useful-links.html
+++ b/docs/manual/ko/introduction/Useful-links.html
@@ -11,7 +11,7 @@
 
 		<p class="desc">
             다음 링크들은 three.js를 배울때 유용한 링크들 모음입니다.<br />
-            여기에 추가하고 싶은 링크가 있거나 더 이상 작동하지 않거나 관련되지 않은 링크가 있다면 
+            여기에 추가하고 싶은 링크가 있거나 더 이상 작동하지 않거나 관련되지 않은 링크가 있다면
             아래 '수정' 버튼을 클릭해 변경해주세요!<br /><br />
 
 			three.js는 자주 업데이트 되고 있기 때문에, 많은 링크들이 지난 버전의 내용을 담고 있을 수도 있습니다.
@@ -29,7 +29,7 @@
 		<h3>three.js 입문</h3>
 		<ul>
 			<li>
-				[link:https://threejsfundamentals.org/threejs/lessons/threejs-fundamentals.html Three.js Fundamentals starting lesson]
+				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
 			</li>
 			<li>
 				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] - [link:https://codepen.io/rachsmith/ Rachel Smith].
@@ -43,9 +43,6 @@
 		<ul>
 			<li>
 				[link:https://discoverthreejs.com/ Discover three.js]
-			</li>
-			<li>
-				[link:https://threejsfundamentals.org/ Three.js Fundamentals]
 			</li>
 			<li>
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -32,7 +32,7 @@
 		<h3>three.js入门</h3>
 		<ul>
 			<li>
-				[link:https://threejsfundamentals.org/threejs/lessons/threejs-fundamentals.html Three.js Fundamentals starting lesson]
+				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
 			</li>
 			<li>
 				[link:https://codepen.io/rachsmith/post/beginning-with-3d-webgl-pt-1-the-scene Beginning with 3D WebGL] by [link:https://codepen.io/rachsmith/ Rachel Smith].
@@ -46,9 +46,6 @@
 		<ul>
 			<li>
 				[link:https://discoverthreejs.com/ Discover three.js]
-			</li>
-			<li>
-				[link:https://threejsfundamentals.org/ Three.js Fundamentals]
 			</li>
 			<li>
 				[link:http://blog.cjgammon.com/ Collection of tutorials] by [link:http://www.cjgammon.com/ CJ Gammon].


### PR DESCRIPTION
Related issue: Closes #22984

**Description**

Fixed a link a to the manual in `Useful-links` and removed a duplicate link further down the page.
