### PR TITLE
The PLY format starts with the ply magic word

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -88,7 +88,7 @@ class PLYLoader extends Loader {
 
 		function parseHeader( data ) {
 
-			const patternHeader = /ply([\s\S]*)end_header\r?\n/;
+			const patternHeader = /^ply([\s\S]*)end_header\r?\n/;
 			let headerText = '';
 			let headerLength = 0;
 			const result = patternHeader.exec( data );


### PR DESCRIPTION
**Description**

The PLY format starts with the ply magic word. So there is no need to search in other location for it.
This solves the following LGTM error: [link](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/de39edd30ad3fe07a742c408dd8c6b9f90c230b5/files/examples/jsm/loaders/PLYLoader.js?sort=name&dir=ASC&mode=heatmap#L94)

