### PR TITLE
Manual: Fix exponential backtracking in lessons-helper.js.

### DIFF
--- a/manual/examples/resources/lessons-helper.js
+++ b/manual/examples/resources/lessons-helper.js
@@ -252,7 +252,7 @@
     if ((/chrome|opera/i).test(browser.name)) {
       lineNdx = 3;
       matcher = function(line) {
-        const m = /at ([^(]+)*?\(*(.*?):(\d+):(\d+)/.exec(line);
+        const m = /at ([^(]*?)\(*(.*?):(\d+):(\d+)/.exec(line);
         if (m) {
           let userFnName = m[1];
           let url = m[2];


### PR DESCRIPTION
**Description**

Fix the exponential backtracking regex in lessons-helper.js. This resolves the following [lgtm error](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/c1e3b64f01fab5c36f4f7c0bd862523f0db983c5/files/manual/examples/resources/lessons-helper.js?sort=name&dir=ASC&mode=heatmap#x55bad3ba60782ff2:1).
This is fixed by making sure there are no 2 quantifiers on top of each other meaning the + quantifier and the *? quantifier in the regex.
