### PR TITLE
ArcballControls: Remove keydown event listener.

### DIFF
--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -232,7 +232,6 @@ class ArcballControls extends EventDispatcher {
 		this.domElement.addEventListener( 'pointerdown', this.onPointerDown );
 		this.domElement.addEventListener( 'pointercancel', this.onPointerCancel );
 
-		window.addEventListener( 'keydown', this.onKeyDown );
 		window.addEventListener( 'resize', this.onWindowResize );
 
 	}
@@ -767,28 +766,6 @@ class ArcballControls extends EventDispatcher {
 						break;
 
 				}
-
-			}
-
-		}
-
-	};
-
-	onKeyDown = ( event ) => {
-
-		if ( event.key == 'c' ) {
-
-			if ( event.ctrlKey || event.metaKey ) {
-
-				this.copyState();
-
-			}
-
-		} else if ( event.key == 'v' ) {
-
-			if ( event.ctrlKey || event.metaKey ) {
-
-				this.pasteState();
 
 			}
 

--- a/examples/misc_controls_arcball.html
+++ b/examples/misc_controls_arcball.html
@@ -156,6 +156,7 @@
 							} );
 
 
+						window.addEventListener( 'keydown', onKeyDown );
 						window.addEventListener( 'resize', onWindowResize );
 
 						//
@@ -235,6 +236,28 @@
 			function render() {
 
 				renderer.render( scene, camera );
+
+			}
+
+			function onKeyDown( event ) {
+
+				if ( event.key === 'c' ) {
+
+					if ( event.ctrlKey || event.metaKey ) {
+
+						controls.copyState();
+
+					}
+
+				} else if ( event.key === 'v' ) {
+
+					if ( event.ctrlKey || event.metaKey ) {
+
+						controls.pasteState();
+
+					}
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: Fixed #23023

**Description**

Removes the `keydown` event listener of `ArcballControls` and implements it on app level.

This approach makes less assumptions on how the app wants to save/restore the state of the controls.
