### PR TITLE
FileLoader: Support environments without ReadableStream

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -84,6 +84,12 @@ class FileLoader extends Loader {
 
 					}
 
+					if ( typeof ReadableStream === 'undefined' || response.body.getReader === undefined ) {
+
+						return response;
+
+					}
+
 					const callbacks = loading[ url ];
 					const reader = response.body.getReader();
 					const contentLength = response.headers.get( 'Content-Length' );
@@ -92,7 +98,7 @@ class FileLoader extends Loader {
 					let loaded = 0;
 
 					// periodically read data into the new stream tracking while download progress
-					return new ReadableStream( {
+					const stream = new ReadableStream( {
 						start( controller ) {
 
 							readData();
@@ -130,6 +136,8 @@ class FileLoader extends Loader {
 
 					} );
 
+					return new Response( stream );
+
 				} else {
 
 					throw Error( `fetch for "${response.url}" responded with ${response.status}: ${response.statusText}` );
@@ -137,9 +145,7 @@ class FileLoader extends Loader {
 				}
 
 			} )
-			.then( stream => {
-
-				const response = new Response( stream );
+			.then( response => {
 
 				switch ( this.responseType ) {
 


### PR DESCRIPTION
Related issue: #23015 

**Description**

Adds a check to FileLoader to skip using ReadableStream and `response.body.getReader` if they are not supported by the current environment. Both of these were only added to Firefox within the last couple years and it seems most polyfills do not provide support for these, either.

With this change you can use the `node-fetch` package to enable FileLoader in node environments:

```js
import { OBJLoader } from './examples/jsm/loaders/OBJLoader.js';
import fetch, { Request, Response, Headers } from 'node-fetch';

global.fetch = fetch;
global.Request = Request;
global.Response = Response;
global.Headers = Headers;

new OBJLoader()
  .loadAsync( 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/obj/tree.obj' ).then( res => {

    console.log(res);

  } );
```

This doesn't completely address the react-native case, though. In order for that to be fixed `FileReader.readAsArrayBuffer` must be implemented in react native because it's used by the fetch polyfill they're depending on. https://github.com/facebook/react-native/pull/30769 has implemented the function but unfortunately it's gotten no attention from the project.

cc @CodyJasonBennett 
