### PR TITLE
MathNode: Fix typo in STEP

### DIFF
--- a/examples/jsm/renderers/nodes/math/MathNode.js
+++ b/examples/jsm/renderers/nodes/math/MathNode.js
@@ -187,7 +187,7 @@ class MathNode extends TempNode {
 			} else if ( method === MathNode.STEP ) {
 
 				params.push(
-					b.build( builder, builder.getTypeLength( a.getNodeType( builder ) ) === 1 ? 'float' : inputType ),
+					a.build( builder, builder.getTypeLength( a.getNodeType( builder ) ) === 1 ? 'float' : inputType ),
 					b.build( builder, inputType )
 				);
 


### PR DESCRIPTION
While creating a MathNode like this:

```js
const nodeC = new Nodes.MathNode(Nodes.MathNode.STEP, nodeA, nodeB);
```

The resulting GLSL code was something like this:

```
nodeVar2 = step( nodeVar1, nodeVar1 );
```
when it should instead be:

```
nodeVar2 = step( nodeVar0, nodeVar1 );
```

cc @sunag 