### PR TITLE
WebGLNodeBuilder: Move sizeNode under positionNode

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -116,15 +116,15 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 		}
 
-		if ( material.sizeNode && material.sizeNode.isNode ) {
-
-			this.addSlot( 'vertex', new SlotNode( material.sizeNode, 'SIZE', 'float' ) );
-
-		}
-
 		if ( material.positionNode && material.positionNode.isNode ) {
 
 			this.addSlot( 'vertex', new SlotNode( material.positionNode, 'POSITION', 'vec3' ) );
+
+		}
+
+		if ( material.sizeNode && material.sizeNode.isNode ) {
+
+			this.addSlot( 'vertex', new SlotNode( material.sizeNode, 'SIZE', 'float' ) );
 
 		}
 


### PR DESCRIPTION
I faced a "race condition" bug while using `PointsNodeMaterial` with `positionNode` + `sizeNode`.

**How:**
I was changing the position of each points with a couple nodes, then I re-used one of those nodes inside the node hierarchy of my `sizeNode`.

**Result:**
The position of each points was 0,0,0 because, in the resulting shader code, every variables generated by my nodes where appended where the size is defined (after `gl_PointSize = size;`), therefore the position definition above was referencing a variable that is not yet set (something like this: `transformed = nodeVar7;`), therefore the position was not set.

I wonder if there could be other race conditions like this ? Would it be a good idea to always put all variables at the top instead ?

cc @sunag 