### PR TITLE
VRMLLoader: Simplify regex to reduce exponential backtracking

### DIFF
--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -192,7 +192,7 @@ class VRMLLoader extends Loader {
 
 			//
 
-			const StringLiteral = createToken( { name: 'StringLiteral', pattern: /"(:?[^\\"\n\r]|\\(:?[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/ } );
+			const StringLiteral = createToken( { name: 'StringLiteral', pattern: /"(?:[^\\"\n\r]|\\[bfnrtv"\\/]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])*"/ } );
 			const HexLiteral = createToken( { name: 'HexLiteral', pattern: /0[xX][0-9a-fA-F]+/ } );
 			const NumberLiteral = createToken( { name: 'NumberLiteral', pattern: /[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?/ } );
 			const TrueLiteral = createToken( { name: 'TrueLiteral', pattern: /TRUE/ } );


### PR DESCRIPTION
**Description**

A simplification and correction of the string literal regex in the VRML Loader. There was also the intention of using non capturing groups but the ':' and '?' were switched in place. The new regex also affects the following LGTM error: [link](https://lgtm.com/projects/g/mrdoob/three.js/snapshot/64f5ba4ce33580708c5f5a078b4b26bf9ca2fb6f/files/examples/js/loaders/VRMLLoader.js#x6353cce5871c8f0f:1)

Example: https://raw.githack.com/gero3/three.js/SimplifyRegex/examples/webgl_loader_vrml.html