### PR TITLE
WebGLRenderer: Remove RGBDEncoding.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -561,7 +561,6 @@
 		THREE.sRGBEncoding
 		THREE.GammaEncoding
 		THREE.RGBEEncoding
-		THREE.RGBDEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -555,8 +555,6 @@
 		THREE.sRGBEncoding
 		THREE.GammaEncoding
 		THREE.RGBEEncoding
-		THREE.LogLuvEncoding
-		THREE.RGBDEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -550,8 +550,6 @@
 		THREE.sRGBEncoding
 		THREE.GammaEncoding
 		THREE.RGBEEncoding
-		THREE.LogLuvEncoding
-		THREE.RGBDEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/examples/jsm/nodes/utils/ColorSpaceNode.js
+++ b/examples/jsm/nodes/utils/ColorSpaceNode.js
@@ -2,12 +2,10 @@ import {
 	GammaEncoding,
 	LinearEncoding,
 	RGBEEncoding,
-	RGBDEncoding,
 	sRGBEncoding
 } from '../../../../build/three.module.js';
 
 import { TempNode } from '../core/TempNode.js';
-import { FloatNode } from '../inputs/FloatNode.js';
 import { FunctionNode } from '../core/FunctionNode.js';
 import { ExpressionNode } from '../core/ExpressionNode.js';
 
@@ -163,26 +161,6 @@ ColorSpaceNode.Nodes = ( function () {
 		}`
 	);
 
-	// reference: http://iwasbeingirony.blogspot.ca/2010/06/difference-between-rgbm-and-rgbd.html
-
-	const RGBDToLinear = new FunctionNode( /* glsl */`
-		vec3 RGBDToLinear( in vec4 value, in float maxRange ) {
-
-			return vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );
-
-		}`
-	);
-
-	const LinearToRGBD = new FunctionNode( /* glsl */`
-		vec3 LinearToRGBD( in vec4 value, in float maxRange ) {
-
-			float maxRGB = max( value.x, max( value.g, value.b ) );
-			float D      = max( maxRange / maxRGB, 1.0 );
-			D            = clamp( floor( D ) / 255.0, 0.0, 1.0 );
-			return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
-
-		}`
-	);
 
 	return {
 		LinearToLinear: LinearToLinear,
@@ -191,9 +169,7 @@ ColorSpaceNode.Nodes = ( function () {
 		sRGBToLinear: sRGBToLinear,
 		LinearTosRGB: LinearTosRGB,
 		RGBEToLinear: RGBEToLinear,
-		LinearToRGBE: LinearToRGBE,
-		RGBDToLinear: RGBDToLinear,
-		LinearToRGBD: LinearToRGBD
+		LinearToRGBE: LinearToRGBE
 	};
 
 } )();
@@ -209,10 +185,6 @@ ColorSpaceNode.LINEAR_TO_SRGB = 'LinearTosRGB';
 ColorSpaceNode.RGBE_TO_LINEAR = 'RGBEToLinear';
 ColorSpaceNode.LINEAR_TO_RGBE = 'LinearToRGBE';
 
-
-ColorSpaceNode.RGBD_TO_LINEAR = 'RGBDToLinear';
-ColorSpaceNode.LINEAR_TO_RGBD = 'LinearToRGBD';
-
 ColorSpaceNode.getEncodingComponents = function ( encoding ) {
 
 	switch ( encoding ) {
@@ -223,8 +195,6 @@ ColorSpaceNode.getEncodingComponents = function ( encoding ) {
 			return [ 'sRGB' ];
 		case RGBEEncoding:
 			return [ 'RGBE' ];
-		case RGBDEncoding:
-			return [ 'RGBD', new FloatNode( 256.0 ).setReadonly( true ) ];
 		case GammaEncoding:
 			return [ 'Gamma', new ExpressionNode( 'float( GAMMA_FACTOR )', 'f' ) ];
 

--- a/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
@@ -5,8 +5,7 @@ import { ShaderNode,
 	lessThanEqual } from '../ShaderNode.js';
 
 import { LinearEncoding,
-	sRGBEncoding/*, RGBEEncoding,
-	RGBDEncoding, GammaEncoding*/ } from '../../../../../build/three.module.js';
+	sRGBEncoding/*, RGBEEncoding, GammaEncoding*/ } from '../../../../../build/three.module.js';
 
 export const LinearToLinear = new ShaderNode( ( inputs ) => {
 
@@ -63,8 +62,6 @@ function getEncodingComponents( encoding ) {
 /*
 		case RGBEEncoding:
 			return [ 'RGBE' ];
-		case RGBDEncoding:
-			return [ 'RGBD', new FloatNode( 256.0 ).setConst( true ) ];
 		case GammaEncoding:
 			return [ 'Gamma', new CodeNode( 'float( GAMMA_FACTOR )' ) ];
 */
@@ -85,9 +82,6 @@ class ColorSpaceNode extends TempNode {
 
 	static RGBE_TO_LINEAR = 'RGBEToLinear';
 	static LINEAR_TO_RGBE = 'LinearToRGBE';
-
-	static RGBD_TO_LINEAR = 'RGBDToLinear';
-	static LINEAR_TO_RGBD = 'LinearToRGBD';
 */
 	constructor( method, node ) {
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -159,7 +159,6 @@ export const LinearEncoding = 3000;
 export const sRGBEncoding = 3001;
 export const GammaEncoding = 3007;
 export const RGBEEncoding = 3002;
-export const RGBDEncoding = 3006;
 export const BasicDepthPacking = 3200;
 export const RGBADepthPacking = 3201;
 export const TangentSpaceNormalMap = 0;

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -7,7 +7,6 @@ import {
 	LinearFilter,
 	NoToneMapping,
 	NoBlending,
-	RGBDEncoding,
 	RGBEEncoding,
 	RGBAFormat,
 	UnsignedByteType,
@@ -49,7 +48,6 @@ const ENCODINGS = {
 	[ LinearEncoding ]: 0,
 	[ sRGBEncoding ]: 1,
 	[ RGBEEncoding ]: 2,
-	[ RGBDEncoding ]: 5,
 	[ GammaEncoding ]: 6
 };
 
@@ -915,10 +913,6 @@ function _getEncodings() {
 			} else if ( inputEncoding == 2 ) {
 
 				return RGBEToLinear( value );
-
-			} else if ( inputEncoding == 5 ) {
-
-				return RGBDToLinear( value, 256.0 );
 
 			} else {
 

--- a/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
@@ -32,19 +32,4 @@ vec4 LinearToRGBE( in vec4 value ) {
 	// return vec4( value.brg, ( 3.0 + 128.0 ) / 256.0 );
 }
 
-// reference: http://iwasbeingirony.blogspot.ca/2010/06/difference-between-rgbm-and-rgbd.html
-vec4 RGBDToLinear( in vec4 value, in float maxRange ) {
-	return vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );
-}
-
-vec4 LinearToRGBD( in vec4 value, in float maxRange ) {
-	float maxRGB = max( value.r, max( value.g, value.b ) );
-	float D = max( maxRange / maxRGB, 1.0 );
-	// NOTE: The implementation with min causes the shader to not compile on
-	// a common Alcatel A502DL in Chrome 78/Android 8.1. Some research suggests
-	// that the chipset is Mediatek MT6739 w/ IMG PowerVR GE8100 GPU.
-	// D = min( floor( D ) / 255.0, 1.0 );
-	D = clamp( floor( D ) / 255.0, 0.0, 1.0 );
-	return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
-}
 `;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { RGBFormat, NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBDEncoding, RGBEEncoding, sRGBEncoding, LinearEncoding, GLSL3 } from '../../constants.js';
+import { RGBFormat, NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, RGBEEncoding, sRGBEncoding, LinearEncoding, GLSL3 } from '../../constants.js';
 
 let programIdCount = 0;
 
@@ -29,8 +29,6 @@ function getEncodingComponents( encoding ) {
 			return [ 'sRGB', '( value )' ];
 		case RGBEEncoding:
 			return [ 'RGBE', '( value )' ];
-		case RGBDEncoding:
-			return [ 'RGBD', '( value, 256.0 )' ];
 		case GammaEncoding:
 			return [ 'Gamma', '( value, float( GAMMA_FACTOR ) )' ];
 		default:

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -133,7 +133,6 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.sRGBEncoding, 3001, 'sRGBEncoding is equal to 3001' );
 		assert.equal( Constants.GammaEncoding, 3007, 'GammaEncoding is equal to 3007' );
 		assert.equal( Constants.RGBEEncoding, 3002, 'RGBEEncoding is equal to 3002' );
-		assert.equal( Constants.RGBDEncoding, 3006, 'RGBDEncoding is equal to 3006' );
 		assert.equal( Constants.BasicDepthPacking, 3200, 'BasicDepthPacking is equal to 3200' );
 		assert.equal( Constants.RGBADepthPacking, 3201, 'RGBADepthPacking is equal to 3201' );
 


### PR DESCRIPTION
Related issue: #23039

**Description**

This PR removes `RGBDEncoding` from the engine. Since no example used it and there is no `RGBDLoader`, the removal was straightforward.
