### PR TITLE
This removes the shaderID from getProgramCacheKey

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -128,7 +128,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		}
 
 		let vertexShader, fragmentShader;
-		let customVertexShaderID, customFragmentShaderID;
 
 		if ( shaderID ) {
 
@@ -142,12 +141,12 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			vertexShader = material.vertexShader;
 			fragmentShader = material.fragmentShader;
 
-			_customShaders.update( material );
-
-			customVertexShaderID = _customShaders.getVertexShaderID( material );
-			customFragmentShaderID = _customShaders.getFragmentShaderID( material );
-
 		}
+
+		_customShaders.update( material, vertexShader, fragmentShader );
+
+		const customVertexShaderID = _customShaders.getVertexShaderID( material );
+		const customFragmentShaderID = _customShaders.getFragmentShaderID( material );
 
 		const currentRenderTarget = renderer.getRenderTarget();
 
@@ -300,16 +299,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 		const array = [];
 
-		if ( parameters.shaderID ) {
-
-			array.push( parameters.shaderID );
-
-		} else {
-
-			array.push( parameters.customVertexShaderID );
-			array.push( parameters.customFragmentShaderID );
-
-		}
+		array.push( parameters.customVertexShaderID );
+		array.push( parameters.customFragmentShaderID );
 
 		if ( parameters.defines !== undefined ) {
 

--- a/src/renderers/webgl/WebGLShaderCache.js
+++ b/src/renderers/webgl/WebGLShaderCache.js
@@ -9,10 +9,7 @@ class WebGLShaderCache {
 
 	}
 
-	update( material ) {
-
-		const vertexShader = material.vertexShader;
-		const fragmentShader = material.fragmentShader;
+	update( material, vertexShader, fragmentShader ) {
 
 		const vertexShaderStage = this._getShaderStage( vertexShader );
 		const fragmentShaderStage = this._getShaderStage( fragmentShader );


### PR DESCRIPTION
**Description**
This is a start to reduce the difference between 'shader materials' and 'default materials'.  It uses the vertex shader and fragment shader to determine the program cache key.
