### PR TITLE
[TransformControls] Don't attempt to capture pointer if pointerlock is active

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -649,7 +649,11 @@
 	function onPointerDown( event ) {
 
 		if ( ! this.enabled ) return;
-		this.domElement.setPointerCapture( event.pointerId );
+		if (!document.pointerLockElement) {
+
+			this.domElement.setPointerCapture( event.pointerId );
+
+		}
 		this.domElement.addEventListener( 'pointermove', this._onPointerMove );
 		this.pointerHover( this._getPointer( event ) );
 		this.pointerDown( this._getPointer( event ) );

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -650,7 +650,7 @@
 
 		if ( ! this.enabled ) return;
 
-		if (!document.pointerLockElement) {
+		if ( ! document.pointerLockElement ) {
 
 			this.domElement.setPointerCapture( event.pointerId );
 

--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -649,11 +649,13 @@
 	function onPointerDown( event ) {
 
 		if ( ! this.enabled ) return;
+
 		if (!document.pointerLockElement) {
 
 			this.domElement.setPointerCapture( event.pointerId );
 
 		}
+		
 		this.domElement.addEventListener( 'pointermove', this._onPointerMove );
 		this.pointerHover( this._getPointer( event ) );
 		this.pointerDown( this._getPointer( event ) );

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -688,7 +688,11 @@ function onPointerDown( event ) {
 
 	if ( ! this.enabled ) return;
 
-	this.domElement.setPointerCapture( event.pointerId );
+	if (!document.pointerLockElement) {
+
+		this.domElement.setPointerCapture( event.pointerId );
+
+	}
 
 	this.domElement.addEventListener( 'pointermove', this._onPointerMove );
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -688,7 +688,7 @@ function onPointerDown( event ) {
 
 	if ( ! this.enabled ) return;
 
-	if (!document.pointerLockElement) {
+	if ( ! document.pointerLockElement ) {
 
 		this.domElement.setPointerCapture( event.pointerId );
 


### PR DESCRIPTION
Attempting to interact with TransformControls when pointerlock is already active in your app throws the following error:

```Uncaught DOMException: Failed to execute 'setPointerCapture' on 'Element': InvalidStateError at TransformControls.onPointerDown```

This patch skips the attempt to call `this.domElement.setPointerCapture( event.pointerId )` if pointerlock is already active