### PR TITLE
added IBL Sheen support

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -22,6 +22,25 @@ struct PhysicalMaterial {
 
 // temporary
 vec3 clearcoatSpecular = vec3( 0.0 );
+vec3 sheenSpecular = vec3( 0.0 );
+
+// This is a curve-fit approxmation to the "Charlie sheen" BRDF integrated over the hemisphere from 
+// Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF"
+float IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float r) {
+
+	float dotNV = saturate( dot( normal, viewDir ) );
+
+	float r2 = r * r;
+
+	float a = r < 0.25 ? -339.2 * r2 + 161.4 * r - 25.9 : -8.48 * r2 + 14.3 * r - 9.95;
+
+	float b = r < 0.25 ? 44.0 * r2 - 23.7 * r + 3.26 : 1.97 * r2 - 3.27 * r + 0.72;
+
+	float DG = exp( a * dotNV + b ) + ( r < 0.25 ? 0.0 : 0.1 * ( r - 0.25 ) );
+
+	return saturate( DG * RECIPROCAL_PI );
+
+}
 
 // Analytical approximation of the DFG LUT, one half of the
 // split-sum approximation used in indirect specular lighting.
@@ -133,7 +152,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 	#ifdef USE_SHEEN
 
-		reflectedLight.directSpecular += irradiance * BRDF_Sheen( directLight.direction, geometry.viewDir, geometry.normal, material.sheenColor, material.sheenRoughness );
+		sheenSpecular += irradiance * BRDF_Sheen( directLight.direction, geometry.viewDir, geometry.normal, material.sheenColor, material.sheenRoughness );
 
 	#endif
 
@@ -154,6 +173,12 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 	#ifdef USE_CLEARCOAT
 
 		clearcoatSpecular += clearcoatRadiance * EnvironmentBRDF( geometry.clearcoatNormal, geometry.viewDir, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
+
+	#endif
+
+	#ifdef USE_SHEEN
+
+		sheenSpecular += irradiance * material.sheenColor * IBLSheenBRDF( geometry.normal, geometry.viewDir, material.sheenRoughness );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -25,18 +25,19 @@ vec3 clearcoatSpecular = vec3( 0.0 );
 vec3 sheenSpecular = vec3( 0.0 );
 
 // This is a curve-fit approxmation to the "Charlie sheen" BRDF integrated over the hemisphere from 
-// Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF"
-float IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float r) {
+// Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF". The analysis can be found
+// in the Sheen section of https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
+float IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float roughness) {
 
 	float dotNV = saturate( dot( normal, viewDir ) );
 
-	float r2 = r * r;
+	float r2 = roughness * roughness;
 
-	float a = r < 0.25 ? -339.2 * r2 + 161.4 * r - 25.9 : -8.48 * r2 + 14.3 * r - 9.95;
+	float a = roughness < 0.25 ? -339.2 * r2 + 161.4 * roughness - 25.9 : -8.48 * r2 + 14.3 * roughness - 9.95;
 
-	float b = r < 0.25 ? 44.0 * r2 - 23.7 * r + 3.26 : 1.97 * r2 - 3.27 * r + 0.72;
+	float b = roughness < 0.25 ? 44.0 * r2 - 23.7 * roughness + 3.26 : 1.97 * r2 - 3.27 * roughness + 0.72;
 
-	float DG = exp( a * dotNV + b ) + ( r < 0.25 ? 0.0 : 0.1 * ( r - 0.25 ) );
+	float DG = exp( a * dotNV + b ) + ( roughness < 0.25 ? 0.0 : 0.1 * ( roughness - 0.25 ) );
 
 	return saturate( DG * RECIPROCAL_PI );
 

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -175,6 +175,14 @@ void main() {
 
 	vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;
 
+	#ifdef USE_SHEEN
+
+		float sheen = max3( material.sheenColor );
+
+		outgoingLight = outgoingLight * ( 1.0 - 0.157 * sheen ) + sheenSpecular;
+
+	#endif
+
 	#ifdef USE_CLEARCOAT
 
 		float dotNVcc = saturate( dot( geometry.clearcoatNormal, geometry.viewDir ) );
@@ -182,14 +190,6 @@ void main() {
 		vec3 Fcc = F_Schlick( material.clearcoatF0, material.clearcoatF90, dotNVcc );
 
 		outgoingLight = outgoingLight * ( 1.0 - material.clearcoat * Fcc ) + clearcoatSpecular * material.clearcoat;
-
-	#endif
-
-	#ifdef USE_SHEEN
-
-		float sheen = max( material.sheenColor.r, max( material.sheenColor.g, material.sheenColor.b ) );
-
-		outgoingLight = outgoingLight * ( 1.0 - 0.157 * sheen ) + sheenSpecular;
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -185,6 +185,14 @@ void main() {
 
 	#endif
 
+	#ifdef USE_SHEEN
+
+		float sheen = max( material.sheenColor.r, max( material.sheenColor.g, material.sheenColor.b ) );
+
+		outgoingLight = outgoingLight * ( 1.0 - 0.157 * sheen ) + sheenSpecular;
+
+	#endif
+
 	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>


### PR DESCRIPTION
Fixes #22359 

@WestLangley @mrdoob 

I finally did the math to  curve fit the integrated BRDF for sheen so it can be  applied to the IBL (filament and gltf sample viewer use a LUT stored in a texture instead). That approximation is  pretty good. The really wild approximation is using our PMREM for the sheen lookup, since the sheen BRDF is very different from Trowbridge-Reitz (our base roughness model) and it's anisotropic. All the realtime renderers  I've seen do this, but they sample their PMREM in different ways. Some choose to sample at the reflection vector and the sheen roughness value, but I don't think this is a very good choice (not that anything is very  accurate). I opted for using our diffuse sample instead (the sheen BRDF is close to a tangent-plane circle for all roughness values, so this at least pulls light evenly from this circle, though also from above), and has the major advantage of not requiring an extra texture lookup. My way also ensures you don't get an image reflection when sheen roughness goes to zero, which may happen with the other approach. 

I did my  best to follow the  style of the ClearCoat extension. I have an energy preservation term in  there too that also came from my curve fitting. The sheen layer  is  the top layer, above clear coat, which  seems reasonable, as it might represent a dusty surface. 

Here are some example renders:
![model-viewer-golden](https://user-images.githubusercontent.com/1649964/147154938-1be73ddd-7480-4cdb-b9b7-3d0ae9499ec8.png)
![model-viewer-golden](https://user-images.githubusercontent.com/1649964/147154952-37e9f6f7-2afb-4504-996e-53e63c3d884c.png)

