### PR TITLE
Ability to cancel ongoing HTTP requests in loaders

### DIFF
--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -60,6 +60,11 @@
 			The [link:https://developer.mozilla.org/en-US/docs/Glossary/Request_header request header] used in HTTP request. See [page:.setRequestHeader]. Default is empty object.
 		</p>
 
+		<h3>[property:AbortSignal abortSignal]</h3>
+		<p>
+			An [link:https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal AbortSignal] instance used to cancel the requests. See [page:.setAbortSignal]. Default is null.
+		</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:undefined load]()</h3>
@@ -112,6 +117,20 @@
 
 			Set the [link:https://developer.mozilla.org/en-US/docs/Glossary/Request_header request header] used in HTTP request.
 		</p>
+
+		<h3>[method:this setAbortSignal( [param:AbortSignal abortSignal] )</h3>
+		<p>
+			[page:AbortSignal abortSignal] - Set the [link:https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal AbortSignal] instance used to cancel the requests.<br/><br />
+			<strong>Warning:</strong> once the signal has been triggered, the loader will always immediately cancel new requests, you must then provide a new signal (from a new AbortController).
+		</p>
+		<code>
+			const controller = new AbortController();
+			const loader = new FileLoader();
+			loader.setAbortSignal(controller.signal);
+
+			loader.load(/* .... */);
+			controller.abort();
+		</code>
 
 		<h2>Source</h2>
 

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -681,7 +681,7 @@ class Rhino3dmLoader extends Loader {
 			const binaryLoader = new FileLoader( this.manager );
 			binaryLoader.setPath( this.libraryPath );
 			binaryLoader.setResponseType( 'arraybuffer' );
-			jsLoader.setAbortSignal( this.abortSignal );
+			binaryLoader.setAbortSignal( this.abortSignal );
 
 			const binaryContent = binaryLoader.loadAsync( 'rhino3dm.wasm' );
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -58,6 +58,8 @@ class ThreeMFLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			try {
@@ -88,6 +90,8 @@ class ThreeMFLoader extends Loader {
 
 		const scope = this;
 		const textureLoader = new TextureLoader( this.manager );
+		textureLoader.setCrossOrigin( this.crossOrigin );
+		textureLoader.setAbortSignal( this.abortSignal );
 
 		function loadDocument( data ) {
 

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -44,6 +44,8 @@ class AMFLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/BVHLoader.js
+++ b/examples/jsm/loaders/BVHLoader.js
@@ -36,6 +36,8 @@ class BVHLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -58,6 +58,8 @@ class ColladaLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -83,6 +83,7 @@ class FBXLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
 
 		loader.load( url, function ( buffer ) {
 
@@ -138,7 +139,10 @@ class FBXLoader extends Loader {
 
 		// console.log( fbxTree );
 
-		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+		const textureLoader = new TextureLoader( this.manager );
+		textureLoader.setPath( this.resourcePath || path );
+		textureLoader.setCrossOrigin( this.crossOrigin );
+		textureLoader.setAbortSignal( this.abortSignal );
 
 		return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
 

--- a/examples/jsm/loaders/FontLoader.js
+++ b/examples/jsm/loaders/FontLoader.js
@@ -19,7 +19,9 @@ class FontLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
-		loader.setWithCredentials( scope.withCredentials );
+		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			let json;

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -36,6 +36,8 @@ class GCodeLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -185,6 +185,7 @@ class GLTFLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( data ) {
 
@@ -314,13 +315,12 @@ class GLTFLoader extends Loader {
 			path: path || this.resourcePath || '',
 			crossOrigin: this.crossOrigin,
 			requestHeader: this.requestHeader,
+			abortSignal: this.abortSignal,
 			manager: this.manager,
 			ktx2Loader: this.ktx2Loader,
 			meshoptDecoder: this.meshoptDecoder
 
 		} );
-
-		parser.fileLoader.setRequestHeader( this.requestHeader );
 
 		for ( let i = 0; i < this.pluginCallbacks.length; i ++ ) {
 
@@ -2263,9 +2263,12 @@ class GLTFParser {
 
 		this.textureLoader.setCrossOrigin( this.options.crossOrigin );
 		this.textureLoader.setRequestHeader( this.options.requestHeader );
+		this.textureLoader.setAbortSignal( this.options.abortSignal );
 
 		this.fileLoader = new FileLoader( this.options.manager );
 		this.fileLoader.setResponseType( 'arraybuffer' );
+		this.fileLoader.setRequestHeader( this.options.requestHeader );
+		this.fileLoader.setAbortSignal( this.options.abortSignal );
 
 		if ( this.options.crossOrigin === 'use-credentials' ) {
 

--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -73,6 +73,7 @@ class HDRCubeTextureLoader extends Loader {
 				.setPath( scope.path )
 				.setResponseType( 'arraybuffer' )
 				.setWithCredentials( scope.withCredentials )
+				.setAbortSignal( scope.abortSignal )
 				.load( urls[ i ], function ( buffer ) {
 
 					loaded ++;

--- a/examples/jsm/loaders/IFCLoader.js
+++ b/examples/jsm/loaders/IFCLoader.js
@@ -2387,6 +2387,8 @@ class IFCLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, async function ( buffer ) {
 
 			try {

--- a/examples/jsm/loaders/KMZLoader.js
+++ b/examples/jsm/loaders/KMZLoader.js
@@ -24,6 +24,8 @@ class KMZLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -746,6 +746,7 @@ class LDrawParsedCache {
 			fileLoader.setPath( loader.partsLibraryPath );
 			fileLoader.setRequestHeader( loader.requestHeader );
 			fileLoader.setWithCredentials( loader.withCredentials );
+			fileLoader.setAbortSignal( loader.abortSignal );
 
 			try {
 
@@ -1558,6 +1559,8 @@ class LDrawLoader extends Loader {
 		fileLoader.setPath( this.path );
 		fileLoader.setRequestHeader( this.requestHeader );
 		fileLoader.setWithCredentials( this.withCredentials );
+		fileLoader.setAbortSignal( this.abortSignal );
+
 		fileLoader.load( url, text => {
 
 			const parsedInfo = this.parseCache.parse( text );

--- a/examples/jsm/loaders/LUT3dlLoader.js
+++ b/examples/jsm/loaders/LUT3dlLoader.js
@@ -18,6 +18,9 @@ export class LUT3dlLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.setResponseType( 'text' );
+		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, text => {
 
 			try {

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -19,6 +19,9 @@ export class LUTCubeLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.setResponseType( 'text' );
+		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, text => {
 
 			try {

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -65,6 +65,8 @@ class LWOLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( scope.path );
 		loader.setResponseType( 'arraybuffer' );
+		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
 
 		loader.load( url, function ( buffer ) {
 
@@ -102,7 +104,10 @@ class LWOLoader extends Loader {
 
 		// console.log( 'lwoTree', lwoTree );
 
-		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+		const textureLoader = new TextureLoader( this.manager );
+		textureLoader.setPath( this.resourcePath || path );
+		textureLoader.setCrossOrigin( this.crossOrigin );
+		textureLoader.setAbortSignal( this.abortSignal );
 
 		return new LWOTreeParser( textureLoader ).parse( modelName );
 

--- a/examples/jsm/loaders/LottieLoader.js
+++ b/examples/jsm/loaders/LottieLoader.js
@@ -23,6 +23,7 @@ class LottieLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( text ) {
 

--- a/examples/jsm/loaders/MD2Loader.js
+++ b/examples/jsm/loaders/MD2Loader.js
@@ -108,6 +108,8 @@ class MD2Loader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			try {

--- a/examples/jsm/loaders/MDDLoader.js
+++ b/examples/jsm/loaders/MDDLoader.js
@@ -33,6 +33,9 @@ class MDDLoader extends Loader {
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.path );
 		loader.setResponseType( 'arraybuffer' );
+		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( data ) {
 
 			onLoad( scope.parse( data ) );

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -110,7 +110,9 @@ class MMDLoader extends Loader {
 	 */
 	load( url, onLoad, onProgress, onError ) {
 
-		const builder = this.meshBuilder.setCrossOrigin( this.crossOrigin );
+		const builder = this.meshBuilder
+			.setCrossOrigin( this.crossOrigin )
+			.setAbortSignal( this.abortSignal );
 
 		// resource path
 
@@ -223,6 +225,7 @@ class MMDLoader extends Loader {
 			.setResponseType( 'arraybuffer' )
 			.setRequestHeader( this.requestHeader )
 			.setWithCredentials( this.withCredentials )
+			.setAbortSignal( this.abortSignal )
 			.load( url, function ( buffer ) {
 
 				onLoad( parser.parsePmd( buffer, true ) );
@@ -249,6 +252,7 @@ class MMDLoader extends Loader {
 			.setResponseType( 'arraybuffer' )
 			.setRequestHeader( this.requestHeader )
 			.setWithCredentials( this.withCredentials )
+			.setAbortSignal( this.abortSignal )
 			.load( url, function ( buffer ) {
 
 				onLoad( parser.parsePmx( buffer, true ) );
@@ -280,7 +284,8 @@ class MMDLoader extends Loader {
 			.setPath( this.animationPath )
 			.setResponseType( 'arraybuffer' )
 			.setRequestHeader( this.requestHeader )
-			.setWithCredentials( this.withCredentials );
+			.setWithCredentials( this.withCredentials )
+			.setAbortSignal( this.abortSignal );
 
 		for ( let i = 0, il = urls.length; i < il; i ++ ) {
 
@@ -315,6 +320,7 @@ class MMDLoader extends Loader {
 			.setResponseType( 'text' )
 			.setRequestHeader( this.requestHeader )
 			.setWithCredentials( this.withCredentials )
+			.setAbortSignal( this.abortSignal )
 			.load( url, function ( text ) {
 
 				onLoad( parser.parseVpd( text, true ) );
@@ -390,6 +396,7 @@ class MeshBuilder {
 	constructor( manager ) {
 
 		this.crossOrigin = 'anonymous';
+		this.abortSignal = null;
 		this.geometryBuilder = new GeometryBuilder();
 		this.materialBuilder = new MaterialBuilder( manager );
 
@@ -407,6 +414,17 @@ class MeshBuilder {
 	}
 
 	/**
+	 * @param {AbortSignal} abortSignal
+	 * @return {MeshBuilder}
+	 */
+	setAbortSignal( abortSignal ) {
+
+		this.abortSignal = abortSignal;
+		return this;
+
+	}
+
+	/**
 	 * @param {Object} data - parsed PMD/PMX data
 	 * @param {string} resourcePath
 	 * @param {function} onProgress
@@ -418,6 +436,7 @@ class MeshBuilder {
 		const geometry = this.geometryBuilder.build( data );
 		const material = this.materialBuilder
 			.setCrossOrigin( this.crossOrigin )
+			.setAbortSignal( this.abortSignal )
 			.setResourcePath( resourcePath )
 			.build( data, geometry, onProgress, onError );
 
@@ -1046,6 +1065,7 @@ class MaterialBuilder {
 		this.tgaLoader = null; // lazy generation
 
 		this.crossOrigin = 'anonymous';
+		this.abortSignal = null;
 		this.resourcePath = undefined;
 
 	}
@@ -1057,6 +1077,17 @@ class MaterialBuilder {
 	setCrossOrigin( crossOrigin ) {
 
 		this.crossOrigin = crossOrigin;
+		return this;
+
+	}
+
+	/**
+	 * @param {AbortSignal} abortSignal
+	 * @return {MaterialBuilder}
+	 */
+	setAbortSignal( abortSignal ) {
+
+		this.abortSignal = abortSignal;
 		return this;
 
 	}
@@ -1086,6 +1117,7 @@ class MaterialBuilder {
 		const textures = {};
 
 		this.textureLoader.setCrossOrigin( this.crossOrigin );
+		this.textureLoader.setAbortSignal( this.abortSignal );
 
 		// materials
 
@@ -1347,6 +1379,9 @@ class MaterialBuilder {
 			this.tgaLoader = new TGALoader( this.manager );
 
 		}
+
+		this.tgaLoader.setWithCredentials( this.crossOrigin === 'use-credentials' );
+		this.tgaLoader.setAbortSignal( this.abortSignal );
 
 		return this.tgaLoader;
 

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -46,6 +46,8 @@ class MTLLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -24,6 +24,8 @@ class NRRDLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( data ) {
 
 			try {

--- a/examples/jsm/loaders/NodeMaterialLoader.js
+++ b/examples/jsm/loaders/NodeMaterialLoader.js
@@ -25,6 +25,10 @@ class NodeMaterialLoader extends Loader {
 
 		const loader = new FileLoader( scope.manager );
 		loader.setPath( scope.path );
+		loader.setRequestHeader( scope.requestHeader );
+		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			onLoad( scope.parse( JSON.parse( text ) ) );

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -447,6 +447,8 @@ class OBJLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -27,6 +27,8 @@ class PCDLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( data ) {
 
 			try {

--- a/examples/jsm/loaders/PDBLoader.js
+++ b/examples/jsm/loaders/PDBLoader.js
@@ -21,6 +21,8 @@ class PDBLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -52,6 +52,8 @@ class PLYLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/PRWMLoader.js
+++ b/examples/jsm/loaders/PRWMLoader.js
@@ -236,6 +236,7 @@ class PRWMLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
 
 		url = url.replace( /\*/g, isBigEndianPlatform() ? 'be' : 'le' );
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -77,6 +77,7 @@ class STLLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( text ) {
 

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -35,6 +35,8 @@ class SVGLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -58,6 +58,7 @@ class TDSLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( data ) {
 

--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -29,6 +29,8 @@ class TTFLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			try {

--- a/examples/jsm/loaders/TiltLoader.js
+++ b/examples/jsm/loaders/TiltLoader.js
@@ -24,6 +24,7 @@ class TiltLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( buffer ) {
 

--- a/examples/jsm/loaders/VOXLoader.js
+++ b/examples/jsm/loaders/VOXLoader.js
@@ -21,6 +21,8 @@ class VOXLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			try {

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -63,6 +63,8 @@ class VRMLLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {
@@ -3189,7 +3191,9 @@ class VRMLLoader extends Loader {
 		//
 
 		const textureLoader = new TextureLoader( this.manager );
-		textureLoader.setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+		textureLoader.setPath( this.resourcePath || path );
+		textureLoader.setCrossOrigin( this.crossOrigin );
+		textureLoader.setAbortSignal( this.abortSignal );
 
 		// check version (only 2.0 is supported)
 

--- a/examples/jsm/loaders/VRMLoader.js
+++ b/examples/jsm/loaders/VRMLoader.js
@@ -28,6 +28,10 @@ class VRMLoader extends Loader {
 
 		const scope = this;
 
+		this.gltfLoader.setRequestHeader( this.requestHeader );
+		this.gltfLoader.setWithCredentials( this.withCredentials );
+		this.gltfLoader.setAbortSignal( this.abortSignal );
+
 		this.gltfLoader.load( url, function ( gltf ) {
 
 			try {

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -25,6 +25,8 @@ class VTKLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( scope.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/examples/jsm/loaders/XYZLoader.js
+++ b/examples/jsm/loaders/XYZLoader.js
@@ -15,6 +15,8 @@ class XYZLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/src/loaders/AnimationLoader.js
+++ b/src/loaders/AnimationLoader.js
@@ -18,6 +18,8 @@ class AnimationLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -19,6 +19,8 @@ class AudioLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			try {

--- a/src/loaders/BufferGeometryLoader.js
+++ b/src/loaders/BufferGeometryLoader.js
@@ -26,6 +26,8 @@ class BufferGeometryLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/src/loaders/CompressedTextureLoader.js
+++ b/src/loaders/CompressedTextureLoader.js
@@ -30,6 +30,7 @@ class CompressedTextureLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		let loaded = 0;
 

--- a/src/loaders/CubeTextureLoader.js
+++ b/src/loaders/CubeTextureLoader.js
@@ -17,6 +17,7 @@ class CubeTextureLoader extends Loader {
 		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
+		loader.setAbortSignal( this.abortSignal );
 
 		let loaded = 0;
 

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -27,7 +27,7 @@ class DataTextureLoader extends Loader {
 		loader.setResponseType( 'arraybuffer' );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setPath( this.path );
-		loader.setWithCredentials( scope.withCredentials );
+		loader.setWithCredentials( this.withCredentials );
 		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( buffer ) {

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -28,6 +28,8 @@ class DataTextureLoader extends Loader {
 		loader.setRequestHeader( this.requestHeader );
 		loader.setPath( this.path );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( buffer ) {
 
 			const texData = scope.parse( buffer );

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -129,7 +129,12 @@ class FileLoader extends Loader {
 
 									}
 
-								} );
+								} )
+								.catch( ( err ) => {
+
+									 onError( err );
+
+								});
 
 							}
 

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -66,11 +66,12 @@ class FileLoader extends Loader {
 		const req = new Request( url, {
 			headers: new Headers( this.requestHeader ),
 			credentials: this.withCredentials ? 'include' : 'same-origin',
-			// An abort controller could be added within a future PR
 		} );
 
 		// start the fetch
-		fetch( req )
+		fetch( req, {
+			signal: this.abortSignal,
+		} )
 			.then( response => {
 
 				if ( response.status === 200 || response.status === 0 ) {

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -59,11 +59,14 @@ class ImageBitmapLoader extends Loader {
 
 		}
 
-		const fetchOptions = {};
-		fetchOptions.credentials = ( this.crossOrigin === 'anonymous' ) ? 'same-origin' : 'include';
-		fetchOptions.headers = this.requestHeader;
+		const req = new Request( url, {
+			credentials: ( this.crossOrigin === 'anonymous' ) ? 'same-origin' : 'include',
+			headers: new Headers( this.requestHeader ),
+		} );
 
-		fetch( url, fetchOptions ).then( function ( res ) {
+		fetch( req, {
+			signal: this.abortSignal,
+		} ).then( function ( res ) {
 
 			return res.blob();
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -61,15 +61,33 @@ class ImageLoader extends Loader {
 
 		}
 
+		function onAbortSignal() {
+
+			image.src = null;
+
+		}
+
 		function removeEventListeners() {
 
 			image.removeEventListener( 'load', onImageLoad, false );
 			image.removeEventListener( 'error', onImageError, false );
 
+			if ( this.abortSignal ) {
+
+				this.abortSignal.removeEventListener( 'abort', onAbortSignal, false );
+
+			}
+
 		}
 
 		image.addEventListener( 'load', onImageLoad, false );
 		image.addEventListener( 'error', onImageError, false );
+
+		if ( this.abortSignal ) {
+
+			this.abortSignal.addEventListener( 'abort', onAbortSignal, false );
+
+		}
 
 		if ( url.substr( 0, 5 ) !== 'data:' ) {
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -80,7 +80,7 @@ class ImageLoader extends Loader {
 
 		function onAbortSignal() {
 
-			image.src = null;
+			image.src = '';
 
 		}
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -54,7 +54,24 @@ class ImageLoader extends Loader {
 
 			removeEventListeners();
 
-			if ( onError ) onError( event );
+			if ( onError ) {
+
+				if ( this.abortSignal && this.abortSignal.aborted ) {
+
+					// Simulate an error similar to the DOMException thrown by the Fetch API
+					// (DOMException is not instanciable)
+					const e = new Error();
+					e.name = 'AbortError';
+					e.message = 'The operation was aborted.';
+					onError( e );
+
+				} else {
+
+					onError( event );
+
+				}
+
+			}
 
 			scope.manager.itemError( url );
 			scope.manager.itemEnd( url );

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -11,6 +11,7 @@ class Loader {
 		this.path = '';
 		this.resourcePath = '';
 		this.requestHeader = {};
+		this.abortSignal = null;
 
 	}
 
@@ -61,6 +62,13 @@ class Loader {
 	setRequestHeader( requestHeader ) {
 
 		this.requestHeader = requestHeader;
+		return this;
+
+	}
+
+	setAbortSignal( abortSignal ) {
+
+		this.abortSignal = abortSignal;
 		return this;
 
 	}

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -25,6 +25,8 @@ class MaterialLoader extends Loader {
 		loader.setPath( scope.path );
 		loader.setRequestHeader( scope.requestHeader );
 		loader.setWithCredentials( scope.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			try {

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -79,6 +79,8 @@ class ObjectLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
+
 		loader.load( url, function ( text ) {
 
 			let json = null;
@@ -123,6 +125,7 @@ class ObjectLoader extends Loader {
 		loader.setPath( this.path );
 		loader.setRequestHeader( this.requestHeader );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setAbortSignal( this.abortSignal );
 
 		const text = await loader.loadAsync( url, onProgress );
 
@@ -451,6 +454,7 @@ class ObjectLoader extends Loader {
 
 			loader = new ImageLoader( manager );
 			loader.setCrossOrigin( this.crossOrigin );
+			loader.setAbortSignal( this.abortSignal );
 
 			for ( let i = 0, il = json.length; i < il; i ++ ) {
 
@@ -550,6 +554,7 @@ class ObjectLoader extends Loader {
 
 			loader = new ImageLoader( this.manager );
 			loader.setCrossOrigin( this.crossOrigin );
+			loader.setAbortSignal( this.abortSignal );
 
 			for ( let i = 0, il = json.length; i < il; i ++ ) {
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -17,6 +17,7 @@ class TextureLoader extends Loader {
 		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
+		loader.setAbortSignal( this.abortSignal );
 
 		loader.load( url, function ( image ) {
 


### PR DESCRIPTION
Related issue: #20705

**Description**

This adds an optional `abortSignal` to all loaders using `FileLoader`.

Usage :

```js
const loader = new FileLoader();

const abortCtrl = new AbortController();

loader.setAbortSignal(abortCtrl.signal);

loader.load(url);

abortCtrl.abort();
```

---

This design was done as requested by gkjohnson. I personally would prefer to pass the abort signal to each load call, in order to be able to use the same loader for multiple parallel requests (see [this reply](https://github.com/mrdoob/three.js/pull/23070#issuecomment-1459093630)) and thus no having the overhead of instanciating multiple loader whild loading a bunch of tiled textures for example.
