### PR TITLE
Examples: Placeholder - add user-select: none

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -415,6 +415,7 @@
 							display: flex;
 							align-items: center;
 							justify-content: center;
+							user-select: none;
 						}
 						</style>
 					</head>


### PR DESCRIPTION
Follow-on to #23045.

Thing is, it appears to have no effect on macOS Safari 15.1. Works on Chrome, Firefox.