### PR TITLE
Docs: Clarify SkinnedMesh.clone().

### DIFF
--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -134,7 +134,7 @@
 
 		<h3>[method:SkinnedMesh clone]()</h3>
 		<p>
-		Returns a clone of this SkinnedMesh object and any descendants.
+		This method does currently not clone an instance of [name] correctly. Please use [page:SkeletonUtils.clone]() in the meanwhile.
 		</p>
 
 		<h3>[method:undefined normalizeSkinWeights]()</h3>
@@ -145,11 +145,6 @@
 		<h3>[method:undefined pose]()</h3>
 		<p>
 		This method sets the skinned mesh in the rest pose (resets the pose).
-		</p>
-
-		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
-		<p>
-		Updates the [page:Matrix4 MatrixWorld].
 		</p>
 
 		<h3>[method:Vector3 boneTransform]( [index:Integer], [target:Vector3] )</h3>

--- a/docs/api/zh/objects/SkinnedMesh.html
+++ b/docs/api/zh/objects/SkinnedMesh.html
@@ -136,7 +136,7 @@
 
 		<h3>[method:SkinnedMesh clone]()</h3>
 		<p>
-		返回当前SkinnedMesh对象的一个克隆及其任何后代。
+		This method does currently not clone an instance of [name] correctly. Please use [page:SkeletonUtils.clone]() in the meanwhile.
 		</p>
 
 		<h3>[method:undefined normalizeSkinWeights]()</h3>
@@ -147,11 +147,6 @@
 		<h3>[method:undefined pose]()</h3>
 		<p>
 		这个方法设置了在“休息”状态下蒙皮网格的姿势（重置姿势）。
-		</p>
-
-		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
-		<p>
-		更新[page:Matrix4 MatrixWorld]矩阵。
 		</p>
 
 		<h2>源代码</h2>


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/issues/19419#issuecomment-999889449

**Description**

Clarifies that `SkeletonUtils.clone()` should be used when cloning skinned meshes.
