### PR TITLE
WebGLRenderer: Remove gammaFactor and GammaEncoding.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -556,7 +556,6 @@
 		<code>
 		THREE.LinearEncoding
 		THREE.sRGBEncoding
-		THREE.GammaEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -158,9 +158,6 @@
 		various WebGL extensions are supported.
 		</p>
 
-		<h3>[property:Float gammaFactor]</h3>
-		<p>Default is *2*. </p>
-
 		<h3>[property:number outputEncoding]</h3>
 		<p>Defines the output encoding of the renderer. Default is [page:Textures THREE.LinearEncoding].</p>
 		<p>If a render target has been set using [page:WebGLRenderer.setRenderTarget .setRenderTarget] then renderTarget.texture.encoding will be used instead.</p>

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -550,7 +550,6 @@
 		<code>
 		THREE.LinearEncoding
 		THREE.sRGBEncoding
-		THREE.GammaEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -545,7 +545,6 @@
 	<code>
 		THREE.LinearEncoding
 		THREE.sRGBEncoding
-		THREE.GammaEncoding
 		THREE.BasicDepthPacking
 		THREE.RGBADepthPacking
 		</code>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -137,9 +137,6 @@
 		[page:WebGLRenderer.extensions.get .extensions.get]方法的包装, 用于检查是否支持各种WebGL扩展
 		</p>
 
-		<h3>[property:Float gammaFactor]</h3>
-		<p>默认是 *2*. </p>
-
 		<h3>[property:number outputEncoding]</h3>
 		<p>定义渲染器的输出编码。默认为[page:Textures THREE.LinearEncoding]</p>
 		<p>如果渲染目标已经使用 [page:WebGLRenderer.setRenderTarget .setRenderTarget]、之后将直接使用renderTarget.texture.encoding</p>

--- a/examples/js/shaders/GammaCorrectionShader.js
+++ b/examples/js/shaders/GammaCorrectionShader.js
@@ -34,7 +34,7 @@
 
 			vec4 tex = texture2D( tDiffuse, vUv );
 
-			gl_FragColor = LinearTosRGB( tex ); // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
+			gl_FragColor = LinearTosRGB( tex );
 
 		}`
 	};

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -4,7 +4,7 @@ import {
 	CubeUVReflectionMapping,
 	CubeUVRefractionMapping,
 	LinearEncoding,
-	GammaEncoding
+	sRGBEncoding
 } from '../../../../build/three.module.js';
 
 import { NodeUniform } from './NodeUniform.js';
@@ -951,7 +951,7 @@ class NodeBuilder {
 
 		if ( encoding === LinearEncoding && this.context.gamma ) {
 
-			encoding = GammaEncoding;
+			encoding = sRGBEncoding;
 
 		}
 

--- a/examples/jsm/nodes/utils/ColorSpaceNode.js
+++ b/examples/jsm/nodes/utils/ColorSpaceNode.js
@@ -1,12 +1,10 @@
 import {
-	GammaEncoding,
 	LinearEncoding,
 	sRGBEncoding
 } from '../../../../build/three.module.js';
 
 import { TempNode } from '../core/TempNode.js';
 import { FunctionNode } from '../core/FunctionNode.js';
-import { ExpressionNode } from '../core/ExpressionNode.js';
 
 class ColorSpaceNode extends TempNode {
 
@@ -100,28 +98,10 @@ class ColorSpaceNode extends TempNode {
 
 ColorSpaceNode.Nodes = ( function () {
 
-	// For a discussion of what this is, please read this: http://lousodrome.net/blog/light/2013/05/26/gamma-correct-and-hdr-rendering-in-a-32-bits-buffer/
-
 	const LinearToLinear = new FunctionNode( /* glsl */`
 		vec4 LinearToLinear( in vec4 value ) {
 
 			return value;
-
-		}`
-	);
-
-	const GammaToLinear = new FunctionNode( /* glsl */`
-		vec4 GammaToLinear( in vec4 value, in float gammaFactor ) {
-
-			return vec4( pow( value.xyz, vec3( gammaFactor ) ), value.w );
-
-		}`
-	);
-
-	const LinearToGamma = new FunctionNode( /* glsl */`
-		vec4 LinearToGamma( in vec4 value, in float gammaFactor ) {
-
-			return vec4( pow( value.xyz, vec3( 1.0 / gammaFactor ) ), value.w );
 
 		}`
 	);
@@ -144,8 +124,6 @@ ColorSpaceNode.Nodes = ( function () {
 
 	return {
 		LinearToLinear: LinearToLinear,
-		GammaToLinear: GammaToLinear,
-		LinearToGamma: LinearToGamma,
 		sRGBToLinear: sRGBToLinear,
 		LinearTosRGB: LinearTosRGB
 	};
@@ -153,9 +131,6 @@ ColorSpaceNode.Nodes = ( function () {
 } )();
 
 ColorSpaceNode.LINEAR_TO_LINEAR = 'LinearToLinear';
-
-ColorSpaceNode.GAMMA_TO_LINEAR = 'GammaToLinear';
-ColorSpaceNode.LINEAR_TO_GAMMA = 'LinearToGamma';
 
 ColorSpaceNode.SRGB_TO_LINEAR = 'sRGBToLinear';
 ColorSpaceNode.LINEAR_TO_SRGB = 'LinearTosRGB';
@@ -168,8 +143,6 @@ ColorSpaceNode.getEncodingComponents = function ( encoding ) {
 			return [ 'Linear' ];
 		case sRGBEncoding:
 			return [ 'sRGB' ];
-		case GammaEncoding:
-			return [ 'Gamma', new ExpressionNode( 'float( GAMMA_FACTOR )', 'f' ) ];
 
 	}
 

--- a/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
@@ -4,8 +4,7 @@ import { ShaderNode,
 	pow, mul, add, sub, mix, join,
 	lessThanEqual } from '../ShaderNode.js';
 
-import { LinearEncoding,
-	sRGBEncoding/*, GammaEncoding*/ } from '../../../../../build/three.module.js';
+import { LinearEncoding, sRGBEncoding } from '../../../../../build/three.module.js';
 
 export const LinearToLinear = new ShaderNode( ( inputs ) => {
 
@@ -59,10 +58,6 @@ function getEncodingComponents( encoding ) {
 			return [ 'Linear' ];
 		case sRGBEncoding:
 			return [ 'sRGB' ];
-/*
-		case GammaEncoding:
-			return [ 'Gamma', new CodeNode( 'float( GAMMA_FACTOR )' ) ];
-*/
 
 	}
 
@@ -74,10 +69,7 @@ class ColorSpaceNode extends TempNode {
 
 	static SRGB_TO_LINEAR = 'sRGBToLinear';
 	static LINEAR_TO_SRGB = 'LinearTosRGB';
-	/*
-	static GAMMA_TO_LINEAR = 'GammaToLinear';
-	static LINEAR_TO_GAMMA = 'LinearToGamma';
-*/
+
 	constructor( method, node ) {
 
 		super( 'vec4' );

--- a/examples/jsm/shaders/GammaCorrectionShader.js
+++ b/examples/jsm/shaders/GammaCorrectionShader.js
@@ -32,7 +32,7 @@ const GammaCorrectionShader = {
 
 			vec4 tex = texture2D( tDiffuse, vUv );
 
-			gl_FragColor = LinearTosRGB( tex ); // optional: LinearToGamma( tex, float( GAMMA_FACTOR ) );
+			gl_FragColor = LinearTosRGB( tex );
 
 		}`
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1597,7 +1597,19 @@ Object.defineProperties( WebGLRenderer.prototype, {
 
 		}
 	},
+	gammaFactor: {
+		get: function () {
 
+			console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
+			return 2;
+
+		},
+		set: function () {
+
+			console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
+
+		}
+	}
 } );
 
 Object.defineProperties( WebGLShadowMap.prototype, {

--- a/src/constants.js
+++ b/src/constants.js
@@ -156,7 +156,6 @@ export const TriangleStripDrawMode = 1;
 export const TriangleFanDrawMode = 2;
 export const LinearEncoding = 3000;
 export const sRGBEncoding = 3001;
-export const GammaEncoding = 3007;
 export const BasicDepthPacking = 3200;
 export const RGBADepthPacking = 3201;
 export const TangentSpaceNormalMap = 0;

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -2,7 +2,6 @@ import {
 	CubeReflectionMapping,
 	CubeRefractionMapping,
 	CubeUVReflectionMapping,
-	GammaEncoding,
 	LinearEncoding,
 	LinearFilter,
 	NoToneMapping,
@@ -45,8 +44,7 @@ const MAX_SAMPLES = 20;
 
 const ENCODINGS = {
 	[ LinearEncoding ]: 0,
-	[ sRGBEncoding ]: 1,
-	[ GammaEncoding ]: 6
+	[ sRGBEncoding ]: 1
 };
 
 const _flatCamera = /*@__PURE__*/ new OrthographicCamera();
@@ -904,13 +902,9 @@ function _getEncodings() {
 
 				return value;
 
-			} else if ( inputEncoding == 1 ) {
-
-				return sRGBToLinear( value );
-
 			} else {
 
-				return GammaToLinear( value, 2.2 );
+				return sRGBToLinear( value );
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -110,7 +110,6 @@ function WebGLRenderer( parameters = {} ) {
 
 	// physically based shading
 
-	this.gammaFactor = 2.0;	// for backwards compatibility
 	this.outputEncoding = LinearEncoding;
 
 	// physical lights

--- a/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js
@@ -1,16 +1,7 @@
 export default /* glsl */`
-// For a discussion of what this is, please read this: http://lousodrome.net/blog/light/2013/05/26/gamma-correct-and-hdr-rendering-in-a-32-bits-buffer/
 
 vec4 LinearToLinear( in vec4 value ) {
 	return value;
-}
-
-vec4 GammaToLinear( in vec4 value, in float gammaFactor ) {
-	return vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );
-}
-
-vec4 LinearToGamma( in vec4 value, in float gammaFactor ) {
-	return vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );
 }
 
 vec4 sRGBToLinear( in vec4 value ) {

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { RGBFormat, NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GammaEncoding, sRGBEncoding, LinearEncoding, GLSL3 } from '../../constants.js';
+import { RGBFormat, NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, sRGBEncoding, LinearEncoding, GLSL3 } from '../../constants.js';
 
 let programIdCount = 0;
 
@@ -27,8 +27,6 @@ function getEncodingComponents( encoding ) {
 			return [ 'Linear', '( value )' ];
 		case sRGBEncoding:
 			return [ 'sRGB', '( value )' ];
-		case GammaEncoding:
-			return [ 'Gamma', '( value, float( GAMMA_FACTOR ) )' ];
 		default:
 			console.warn( 'THREE.WebGLProgram: Unsupported encoding:', encoding );
 			return [ 'Linear', '( value )' ];
@@ -389,9 +387,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 	const envMapModeDefine = generateEnvMapModeDefine( parameters );
 	const envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
 
-
-	const gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;
-
 	const customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters );
 
 	const customDefines = generateDefines( defines );
@@ -442,8 +437,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.instancingColor ? '#define USE_INSTANCING_COLOR' : '',
 
 			parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
-
-			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 			'#define MAX_BONES ' + parameters.maxBones,
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
@@ -592,8 +585,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			'#define SHADER_NAME ' + parameters.shaderName,
 
 			customDefines,
-
-			'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
 			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -327,7 +327,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			getProgramCacheKeyParameters( array, parameters );
 			getProgramCacheKeyBooleans( array, parameters );
 			array.push( renderer.outputEncoding );
-			array.push( renderer.gammaFactor );
 
 		}
 

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -130,7 +130,6 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.TriangleFanDrawMode, 2, 'TriangleFanDrawMode is equal to 2' );
 		assert.equal( Constants.LinearEncoding, 3000, 'LinearEncoding is equal to 3000' );
 		assert.equal( Constants.sRGBEncoding, 3001, 'sRGBEncoding is equal to 3001' );
-		assert.equal( Constants.GammaEncoding, 3007, 'GammaEncoding is equal to 3007' );
 		assert.equal( Constants.BasicDepthPacking, 3200, 'BasicDepthPacking is equal to 3200' );
 		assert.equal( Constants.RGBADepthPacking, 3201, 'RGBADepthPacking is equal to 3201' );
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes `WebGLRenderer.gammaFactor` and `THREE.GammaEncoding`.

I think the only values `WebGLRenderer.outputEncoding` should accept are `THREE.sRGBEncoding` and `THREE.LinearEncoding`(with `THREE.sRGBEncoding` as the future default).

Users who want a special gamma correction have to use post processing and a custom version of `GammaCorrectionShader` now.

Supporting `THREE.GammaEncoding` for `Texture.encoding` seems not necessary to me. It should be safe when the renderer assumes only textures with  `THREE.sRGBEncoding` or `THREE.LinearEncoding` are processed by its internal logic. 
