### PR TITLE
Color: Remove gamma-related methods

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -113,18 +113,6 @@ const color7 = new THREE.Color( 1, 0, 0 );
 			Copies the [page:.r r], [page:.g g] and [page:.b b] parameters from [page:Color color] in to this color.
 		</p>
 
-		<h3>[method:this convertGammaToLinear]( [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
-		Converts this color from gamma space to linear space by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
-		</p>
-
-		<h3>[method:this convertLinearToGamma]( [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
-		Converts this color from linear space to gamma space by taking [page:.r r], [page:.g g] and [page:.b b] to the power of 1 / [page:Float gammaFactor].
-		</p>
-
 		<h3>[method:this convertLinearToSRGB]() </h3>
 		<p>
 		Converts this color from linear space to sRGB space.
@@ -133,24 +121,6 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		<h3>[method:this convertSRGBToLinear]() </h3>
 		<p>
 		Converts this color from sRGB space to linear space.
-		</p>
-
-		<h3>[method:this copyGammaToLinear]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Color color] — Color to copy.<br />
-		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
-
-		Copies the given color into this color, and then converts this color from gamma space to linear space
-		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of [page:Float gammaFactor].
-		</p>
-
-		<h3>[method:this copyLinearToGamma]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Color color] — Color to copy.<br />
-		[page:Float gammaFactor] - (optional). Default is *2.0*.<br /><br />
-
-		Copies the given color into this color, and then converts this color from linear space to gamma space
-		by taking [page:.r r], [page:.g g] and [page:.b b] to the power of 1 / [page:Float gammaFactor].
 		</p>
 
 		<h3>[method:this copyLinearToSRGB]( [param:Color color]] ) </h3>

--- a/docs/api/zh/math/Color.html
+++ b/docs/api/zh/math/Color.html
@@ -113,18 +113,6 @@
 			从 [page:Color color] 中拷贝 [page:.r r], [page:.g g] 和 [page:.b b] 值到当前的颜色。
 		</p>
 
-		<h3>[method:this convertGammaToLinear]( [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Float gammaFactor] - (可选参数). 默认值 *2.0*.<br /><br />
-		通过取颜色 [page:.r r], [page:.g g] and [page:.b b] 的 [page:Float gammaFactor] 次方将颜色从伽马空间转换成线性空间。
-		</p>
-
-		<h3>[method:this convertLinearToGamma]( [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Float gammaFactor] - (可选参数). 默认值 *2.0*.<br /><br />
-		通过取颜色 [page:.r r], [page:.g g] and [page:.b b] 的 1/[page:Float gammaFactor] 次方将颜色从线性空间转换成伽马空间。
-		</p>
-
 		<h3>[method:this convertLinearToSRGB]() </h3>
 		<p>
 			将此颜色从线性空间转换成sRGB空间。
@@ -133,22 +121,6 @@
 		<h3>[method:this convertSRGBToLinear]() </h3>
 		<p>
 			将此颜色从sRGB空间转换成线性空间。
-		</p>
-
-		<h3>[method:this copyGammaToLinear]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Color color] — 需要拷贝的颜色。<br />
-		[page:Float gammaFactor] - (可选参数). 默认值为 *2.0*.<br /><br />
-
-		将传入的 [param:Color color] 从伽马空间转换到线性空间然后复制给当前颜色。
-		</p>
-
-		<h3>[method:this copyLinearToGamma]( [param:Color color], [param:Float gammaFactor] ) </h3>
-		<p>
-		[page:Color color] — 需要拷贝的颜色。<br />
-		[page:Float gammaFactor] - (可选参数). 默认值为 *2.0*.<br /><br />
-
-		将传入的 [param:Color color] 从线性空间转换到伽马空间然后复制给当前颜色。
 		</p>
 
 		<h3>[method:this copyLinearToSRGB]( [param:Color color]] ) </h3>

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -298,44 +298,6 @@ class Color {
 
 	}
 
-	copyGammaToLinear( color, gammaFactor = 2.0 ) {
-
-		this.r = Math.pow( color.r, gammaFactor );
-		this.g = Math.pow( color.g, gammaFactor );
-		this.b = Math.pow( color.b, gammaFactor );
-
-		return this;
-
-	}
-
-	copyLinearToGamma( color, gammaFactor = 2.0 ) {
-
-		const safeInverse = ( gammaFactor > 0 ) ? ( 1.0 / gammaFactor ) : 1.0;
-
-		this.r = Math.pow( color.r, safeInverse );
-		this.g = Math.pow( color.g, safeInverse );
-		this.b = Math.pow( color.b, safeInverse );
-
-		return this;
-
-	}
-
-	convertGammaToLinear( gammaFactor ) {
-
-		this.copyGammaToLinear( this, gammaFactor );
-
-		return this;
-
-	}
-
-	convertLinearToGamma( gammaFactor ) {
-
-		this.copyLinearToGamma( this, gammaFactor );
-
-		return this;
-
-	}
-
 	copySRGBToLinear( color ) {
 
 		this.r = SRGBToLinear( color.r );

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -177,49 +177,49 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'copyGammaToLinear', ( assert ) => {
+		QUnit.test( 'copySRGBToLinear', ( assert ) => {
 
 			var c = new Color();
 			var c2 = new Color();
 			c2.setRGB( 0.3, 0.5, 0.9 );
-			c.copyGammaToLinear( c2 );
-			assert.ok( c.r == 0.09, 'Red c: ' + c.r + ' Red c2: ' + c2.r );
-			assert.ok( c.g == 0.25, 'Green c: ' + c.g + ' Green c2: ' + c2.g );
-			assert.ok( c.b == 0.81, 'Blue c: ' + c.b + ' Blue c2: ' + c2.b );
+			c.copySRGBToLinear( c2 );
+			assert.numEqual( c.r, 0.09, 'Red c: ' + c.r + ' Red c2: ' + c2.r );
+			assert.numEqual( c.g, 0.25, 'Green c: ' + c.g + ' Green c2: ' + c2.g );
+			assert.numEqual( c.b, 0.81, 'Blue c: ' + c.b + ' Blue c2: ' + c2.b );
 
 		} );
 
-		QUnit.test( 'copyLinearToGamma', ( assert ) => {
+		QUnit.test( 'copyLinearToSRGB', ( assert ) => {
 
 			var c = new Color();
 			var c2 = new Color();
 			c2.setRGB( 0.09, 0.25, 0.81 );
-			c.copyLinearToGamma( c2 );
-			assert.ok( c.r == 0.3, 'Red c: ' + c.r + ' Red c2: ' + c2.r );
-			assert.ok( c.g == 0.5, 'Green c: ' + c.g + ' Green c2: ' + c2.g );
-			assert.ok( c.b == 0.9, 'Blue c: ' + c.b + ' Blue c2: ' + c2.b );
+			c.copyLinearToSRGB( c2 );
+			assert.numEqual( c.r, 0.3, 'Red c: ' + c.r + ' Red c2: ' + c2.r );
+			assert.numEqual( c.g, 0.5, 'Green c: ' + c.g + ' Green c2: ' + c2.g );
+			assert.numEqual( c.b, 0.9, 'Blue c: ' + c.b + ' Blue c2: ' + c2.b );
 
 		} );
 
-		QUnit.test( 'convertGammaToLinear', ( assert ) => {
+		QUnit.test( 'convertSRGBToLinear', ( assert ) => {
 
 			var c = new Color();
 			c.setRGB( 0.3, 0.5, 0.9 );
-			c.convertGammaToLinear();
-			assert.ok( c.r == 0.09, 'Red: ' + c.r );
-			assert.ok( c.g == 0.25, 'Green: ' + c.g );
-			assert.ok( c.b == 0.81, 'Blue: ' + c.b );
+			c.convertSRGBToLinear();
+			assert.numEqual( c.r, 0.09, 'Red: ' + c.r );
+			assert.numEqual( c.g, 0.25, 'Green: ' + c.g );
+			assert.numEqual( c.b, 0.81, 'Blue: ' + c.b );
 
 		} );
 
-		QUnit.test( 'convertLinearToGamma', ( assert ) => {
+		QUnit.test( 'convertLinearToSRGB', ( assert ) => {
 
 			var c = new Color();
 			c.setRGB( 4, 9, 16 );
-			c.convertLinearToGamma();
-			assert.ok( c.r == 2, 'Red: ' + c.r );
-			assert.ok( c.g == 3, 'Green: ' + c.g );
-			assert.ok( c.b == 4, 'Blue: ' + c.b );
+			c.convertLinearToSRGB();
+			assert.numEqual( c.r, 1.82, 'Red: ' + c.r );
+			assert.numEqual( c.g, 2.58, 'Green: ' + c.g );
+			assert.numEqual( c.b, 3.29, 'Blue: ' + c.b );
 
 		} );
 


### PR DESCRIPTION
- Removed: copyGammaToLinear, copyLinearToGamma, convertGammaToLinear, convertLinearToGamma.
- Recommended: copySRGBToLinear, copyLinearToSRGB, convertSRGBToLinear, convertLinearToSRGB.

See: #23080