### PR TITLE
LDrawLoader: Make normal smoothing condition more explicit

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1862,8 +1862,7 @@ class LDrawLoader extends Loader {
 		const doSmooth =
 			isPartType( subobjectParseScope.type ) ||
 			(
-				! isPartType( subobjectParseScope.type ) &&
-				! isModelType( subobjectParseScope.type ) &&
+				isPrimitiveType( subobjectParseScope.type ) &&
 				isModelType( subobjectParseScope.parentScope.type )
 			);
 


### PR DESCRIPTION
Related issue: Fixed #23085.

**Description**

Previously some primitives were getting smoothed multiple times due to the labeling of the file include hierarchy. This changes the condition for when the face normals are smoothed to be more explicit -- either when when a "Part" is being finalized or a set of faces (a "Primitive" type) is being added directly into a "Model" type.

Unfortunately the LDraw spec seems to be pretty vague when it comes to what "types" are valid (or the files are just a bit loose with them). In the case of the car model there was an extra type called "Configuration" that was triggering a extra "smooth normals" step with the previous condition which resulted in incorrect normals.

Here's the example page with the fix:

https://raw.githack.com/gkjohnson/three.js/ldraw-black-bit-fix/examples/webgl_loader_ldraw.html

Notice the black spots on the car model are fixed _and_ the ribbed pipes and blue rubber band inside the model in the AT-ST file are smoothed correctly, as well (which was the original intent behind the condition).

Happy holidays!