### PR TITLE
LDrawLoader: fileMap should exist when parsing.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -392,7 +392,6 @@ function Loader( editor ) {
 					var { LDrawLoader } = await import( '../../examples/jsm/loaders/LDrawLoader.js' );
 
 					var loader = new LDrawLoader();
-					loader.fileMap = {}; // TODO Uh...
 					loader.setPath( '../../examples/models/ldraw/officialLibrary/' );
 					loader.parse( event.target.result, undefined, function ( group ) {
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -899,6 +899,12 @@ class LDrawLoader extends Loader {
 
 	parse( text, path, onLoad ) {
 
+		if ( ! this.fileMap ) {
+
+			this.fileMap = {};
+
+		}
+
 		// Async parse.  This function calls onParse with the parsed THREE.Object3D as parameter
 		this.processObject( text, null, path, this.rootParseScope )
 			.then( function ( result ) {

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -815,7 +815,7 @@ class LDrawLoader extends Loader {
 		this.cache = new LDrawFileCache( this );
 
 		// This object is a map from file names to paths. It agilizes the paths search. If it is not set then files will be searched by trial and error.
-		this.fileMap = null;
+		this.fileMap = {};
 
 		this.rootParseScope = this.newParseScopeLevel();
 
@@ -874,12 +874,6 @@ class LDrawLoader extends Loader {
 
 	load( url, onLoad, onProgress, onError ) {
 
-		if ( ! this.fileMap ) {
-
-			this.fileMap = {};
-
-		}
-
 		const fileLoader = new FileLoader( this.manager );
 		fileLoader.setPath( this.path );
 		fileLoader.setRequestHeader( this.requestHeader );
@@ -898,12 +892,6 @@ class LDrawLoader extends Loader {
 	}
 
 	parse( text, path, onLoad ) {
-
-		if ( ! this.fileMap ) {
-
-			this.fileMap = {};
-
-		}
 
 		// Async parse.  This function calls onParse with the parsed THREE.Object3D as parameter
 		this.processObject( text, null, path, this.rootParseScope )


### PR DESCRIPTION
**Description**
'fileMap' should exist when parsing the LDRAW model. This also removes a TODO from the editor.
