### PR TITLE
LDrawLoader Example: Demonstrate loading flat colors to match instruction booklet style

### DIFF
--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -175,6 +175,7 @@
 
 						model = group2;
 
+						// demonstrate how to use convert to flat colors to better mimic the lego instructions look
 						if ( guiData.flatColors ) {
 
 							function convertMaterial( material ) {

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -97,7 +97,8 @@
 					conditionalLines: true,
 					smoothNormals: true,
 					constructionStep: 0,
-					noConstructionSteps: 'No steps.'
+					noConstructionSteps: 'No steps.',
+					flatColors: false,
 				};
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -174,6 +175,43 @@
 
 						model = group2;
 
+						if ( guiData.flatColors ) {
+
+							function convertMaterial( material ) {
+
+								const newMaterial = new THREE.MeshBasicMaterial();
+								newMaterial.color.copy( material.color );
+								newMaterial.polygonOffset = material.polygonOffset;
+								newMaterial.polygonOffsetUnits = material.polygonOffsetUnits;
+								newMaterial.polygonOffsetFactor = material.polygonOffsetFactor;
+								newMaterial.opacity = material.opacity;
+								newMaterial.transparent = material.transparent;
+								newMaterial.depthWrite = material.depthWrite;
+
+								return newMaterial;
+
+							}
+
+							model.traverse( c => {
+
+								if ( c.isMesh ) {
+
+									if ( Array.isArray( c.material ) ) {
+
+										c.material = c.material.map( convertMaterial );
+
+									} else {
+
+										c.material = convertMaterial( c.material );
+
+									}
+
+								}
+
+							} );
+
+						}
+
 						// Convert from LDraw coordinates: rotate 180 degrees around OX
 						model.rotation.x = Math.PI;
 
@@ -231,6 +269,12 @@
 				} );
 
 				gui.add( guiData, 'separateObjects' ).name( 'Separate Objects' ).onChange( function () {
+
+					reloadObject( false );
+
+				} );
+
+				gui.add( guiData, 'flatColors' ).name( 'Flat Colors' ).onChange( function () {
 
 					reloadObject( false );
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -189,6 +189,7 @@
 								newMaterial.opacity = material.opacity;
 								newMaterial.transparent = material.transparent;
 								newMaterial.depthWrite = material.depthWrite;
+								newMaterial.toneMapping = false;
 
 								return newMaterial;
 
@@ -211,12 +212,6 @@
 								}
 
 							} );
-
-							renderer.toneMapping = THREE.NoToneMapping;
-
-						} else {
-
-							renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
 						}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -160,9 +160,10 @@
 				updateProgressBar( 0 );
 				showProgressBar();
 
+				// only smooth when not rendering with flat colors to improve processing time
 				const lDrawLoader = new LDrawLoader();
 				lDrawLoader.separateObjects = guiData.separateObjects;
-				lDrawLoader.smoothNormals = guiData.smoothNormals;
+				lDrawLoader.smoothNormals = guiData.smoothNormals && ! guiData.flatColors;
 				lDrawLoader
 					.setPath( ldrawPath )
 					.load( guiData.modelFileName, function ( group2 ) {
@@ -210,6 +211,12 @@
 								}
 
 							} );
+
+							renderer.toneMapping = THREE.NoToneMapping;
+
+						} else {
+
+							renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
 						}
 


### PR DESCRIPTION
Related issue: --

**Description**

Adds a "Flat Colors" option to the LDrawLoader example to better match the rendering style used in official lego instruction manuals.

Live demo:

https://raw.githack.com/gkjohnson/three.js/ldraw-flat-colors/examples/webgl_loader_ldraw.html

| Default | Flat Colors | Instruction Manual |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/734200/147497612-c1d0dac6-50ed-4213-8126-6f2590aaf8a3.png) | ![image](https://user-images.githubusercontent.com/734200/147497337-fb74a587-33a9-47a4-b1b9-c52af17ddf10.png) | ![image](https://user-images.githubusercontent.com/734200/147497063-1941e56d-6066-4cad-a62d-15fb9325cecd.png) |
| ![image](https://user-images.githubusercontent.com/734200/147498064-1f1c84ee-6f4f-4664-a99e-d301d98ec677.png) | ![image](https://user-images.githubusercontent.com/734200/147498073-d14fa3de-a082-4215-b35a-664592060bd8.png) | ![image](https://user-images.githubusercontent.com/734200/147498010-5ebb7ad4-e5b8-4eae-8d57-76a9610cdbf5.png) |

Comparing to the instruction manuals again it definitely looks like the instruction manual rendering is a bit more stylized with subtle lighting and uses an orthographic camera but I think the flat materials suit the instruction book look more closely. It seems this is also how at least one of the LDraw editor tools, [LeoCAD, renders the models](https://www.snapfiles.com/screenshots/leocad.htm).

cc @yomboprime 
