### PR TITLE
AnimationMixer: Fix wrong reference count in `_bindAction()`.

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -1,15 +1,13 @@
-import { AnimationAction } from './AnimationAction.js';
-import { EventDispatcher } from '../core/EventDispatcher.js';
-import { LinearInterpolant } from '../math/interpolants/LinearInterpolant.js';
-import { PropertyBinding } from './PropertyBinding.js';
-import { PropertyMixer } from './PropertyMixer.js';
-import { AnimationClip } from './AnimationClip.js';
-import { NormalAnimationBlendMode } from '../constants.js';
+import { AnimationAction } from "./AnimationAction.js";
+import { EventDispatcher } from "../core/EventDispatcher.js";
+import { LinearInterpolant } from "../math/interpolants/LinearInterpolant.js";
+import { PropertyBinding } from "./PropertyBinding.js";
+import { PropertyMixer } from "./PropertyMixer.js";
+import { AnimationClip } from "./AnimationClip.js";
+import { NormalAnimationBlendMode } from "../constants.js";
 
 class AnimationMixer extends EventDispatcher {
-
-	constructor( root ) {
-
+	constructor(root) {
 		super();
 
 		this._root = root;
@@ -17,11 +15,9 @@ class AnimationMixer extends EventDispatcher {
 		this._accuIndex = 0;
 		this.time = 0;
 		this.timeScale = 1.0;
-
 	}
 
-	_bindAction( action, prototypeAction ) {
-
+	_bindAction(action, prototypeAction) {
 		const root = action._localRoot || this._root,
 			tracks = action._clip.tracks,
 			nTracks = tracks.length,
@@ -30,137 +26,111 @@ class AnimationMixer extends EventDispatcher {
 			rootUuid = root.uuid,
 			bindingsByRoot = this._bindingsByRootAndName;
 
-		let bindingsByName = bindingsByRoot[ rootUuid ];
+		let bindingsByName = bindingsByRoot[rootUuid];
 
-		if ( bindingsByName === undefined ) {
-
+		if (bindingsByName === undefined) {
 			bindingsByName = {};
-			bindingsByRoot[ rootUuid ] = bindingsByName;
-
+			bindingsByRoot[rootUuid] = bindingsByName;
 		}
 
-		for ( let i = 0; i !== nTracks; ++ i ) {
-
-			const track = tracks[ i ],
+		for (let i = 0; i !== nTracks; ++i) {
+			const track = tracks[i],
 				trackName = track.name;
 
-			let binding = bindingsByName[ trackName ];
+			let binding = bindingsByName[trackName];
 
-			if ( binding !== undefined ) {
-
-				bindings[ i ] = binding;
-
+			if (binding !== undefined) {
+				++binding.referenceCount;
+				bindings[i] = binding;
 			} else {
+				binding = bindings[i];
 
-				binding = bindings[ i ];
-
-				if ( binding !== undefined ) {
-
+				if (binding !== undefined) {
 					// existing binding, make sure the cache knows
 
-					if ( binding._cacheIndex === null ) {
-
-						++ binding.referenceCount;
-						this._addInactiveBinding( binding, rootUuid, trackName );
-
+					if (binding._cacheIndex === null) {
+						++binding.referenceCount;
+						this._addInactiveBinding(binding, rootUuid, trackName);
 					}
 
 					continue;
-
 				}
 
-				const path = prototypeAction && prototypeAction.
-					_propertyBindings[ i ].binding.parsedPath;
+				const path =
+					prototypeAction &&
+					prototypeAction._propertyBindings[i].binding.parsedPath;
 
 				binding = new PropertyMixer(
-					PropertyBinding.create( root, trackName, path ),
-					track.ValueTypeName, track.getValueSize() );
+					PropertyBinding.create(root, trackName, path),
+					track.ValueTypeName,
+					track.getValueSize()
+				);
 
-				++ binding.referenceCount;
-				this._addInactiveBinding( binding, rootUuid, trackName );
+				++binding.referenceCount;
+				this._addInactiveBinding(binding, rootUuid, trackName);
 
-				bindings[ i ] = binding;
-
+				bindings[i] = binding;
 			}
 
-			interpolants[ i ].resultBuffer = binding.buffer;
-
+			interpolants[i].resultBuffer = binding.buffer;
 		}
-
 	}
 
-	_activateAction( action ) {
-
-		if ( ! this._isActiveAction( action ) ) {
-
-			if ( action._cacheIndex === null ) {
-
+	_activateAction(action) {
+		if (!this._isActiveAction(action)) {
+			if (action._cacheIndex === null) {
 				// this action has been forgotten by the cache, but the user
 				// appears to be still using it -> rebind
 
-				const rootUuid = ( action._localRoot || this._root ).uuid,
+				const rootUuid = (action._localRoot || this._root).uuid,
 					clipUuid = action._clip.uuid,
-					actionsForClip = this._actionsByClip[ clipUuid ];
+					actionsForClip = this._actionsByClip[clipUuid];
 
-				this._bindAction( action,
-					actionsForClip && actionsForClip.knownActions[ 0 ] );
+				this._bindAction(
+					action,
+					actionsForClip && actionsForClip.knownActions[0]
+				);
 
-				this._addInactiveAction( action, clipUuid, rootUuid );
-
+				this._addInactiveAction(action, clipUuid, rootUuid);
 			}
 
 			const bindings = action._propertyBindings;
 
 			// increment reference counts / sort out state
-			for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
+			for (let i = 0, n = bindings.length; i !== n; ++i) {
+				const binding = bindings[i];
 
-				const binding = bindings[ i ];
-
-				if ( binding.useCount ++ === 0 ) {
-
-					this._lendBinding( binding );
+				if (binding.useCount++ === 0) {
+					this._lendBinding(binding);
 					binding.saveOriginalState();
-
 				}
-
 			}
 
-			this._lendAction( action );
-
+			this._lendAction(action);
 		}
-
 	}
 
-	_deactivateAction( action ) {
-
-		if ( this._isActiveAction( action ) ) {
-
+	_deactivateAction(action) {
+		if (this._isActiveAction(action)) {
 			const bindings = action._propertyBindings;
 
 			// decrement reference counts / sort out state
-			for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
+			for (let i = 0, n = bindings.length; i !== n; ++i) {
+				const binding = bindings[i];
 
-				const binding = bindings[ i ];
-
-				if ( -- binding.useCount === 0 ) {
-
+				if (--binding.useCount === 0) {
 					binding.restoreOriginalState();
-					this._takeBackBinding( binding );
-
+					this._takeBackBinding(binding);
 				}
-
 			}
 
-			this._takeBackAction( action );
-
+			this._takeBackAction(action);
 		}
-
 	}
 
 	// Memory manager
 
 	_initMemoryManager() {
-
 		this._actions = []; // 'nActiveActions' followed by inactive ones
 		this._nActiveActions = 0;
 
@@ -171,12 +141,10 @@ class AnimationMixer extends EventDispatcher {
 		// 	actionByRoot: AnimationAction - lookup
 		// }
 
-
 		this._bindings = []; // 'nActiveBindings' followed by inactive ones
 		this._nActiveBindings = 0;
 
 		this._bindingsByRootAndName = {}; // inside: Map< name, PropertyMixer >
-
 
 		this._controlInterpolants = []; // same game as above
 		this._nActiveControlInterpolants = 0;
@@ -184,158 +152,117 @@ class AnimationMixer extends EventDispatcher {
 		const scope = this;
 
 		this.stats = {
-
 			actions: {
 				get total() {
-
 					return scope._actions.length;
-
 				},
 				get inUse() {
-
 					return scope._nActiveActions;
-
-				}
+				},
 			},
 			bindings: {
 				get total() {
-
 					return scope._bindings.length;
-
 				},
 				get inUse() {
-
 					return scope._nActiveBindings;
-
-				}
+				},
 			},
 			controlInterpolants: {
 				get total() {
-
 					return scope._controlInterpolants.length;
-
 				},
 				get inUse() {
-
 					return scope._nActiveControlInterpolants;
-
-				}
-			}
-
+				},
+			},
 		};
-
 	}
 
 	// Memory management for AnimationAction objects
 
-	_isActiveAction( action ) {
-
+	_isActiveAction(action) {
 		const index = action._cacheIndex;
 		return index !== null && index < this._nActiveActions;
-
 	}
 
-	_addInactiveAction( action, clipUuid, rootUuid ) {
-
+	_addInactiveAction(action, clipUuid, rootUuid) {
 		const actions = this._actions,
 			actionsByClip = this._actionsByClip;
 
-		let actionsForClip = actionsByClip[ clipUuid ];
+		let actionsForClip = actionsByClip[clipUuid];
 
-		if ( actionsForClip === undefined ) {
-
+		if (actionsForClip === undefined) {
 			actionsForClip = {
-
-				knownActions: [ action ],
-				actionByRoot: {}
-
+				knownActions: [action],
+				actionByRoot: {},
 			};
 
 			action._byClipCacheIndex = 0;
 
-			actionsByClip[ clipUuid ] = actionsForClip;
-
+			actionsByClip[clipUuid] = actionsForClip;
 		} else {
-
 			const knownActions = actionsForClip.knownActions;
 
 			action._byClipCacheIndex = knownActions.length;
-			knownActions.push( action );
-
+			knownActions.push(action);
 		}
 
 		action._cacheIndex = actions.length;
-		actions.push( action );
+		actions.push(action);
 
-		actionsForClip.actionByRoot[ rootUuid ] = action;
-
+		actionsForClip.actionByRoot[rootUuid] = action;
 	}
 
-	_removeInactiveAction( action ) {
-
+	_removeInactiveAction(action) {
 		const actions = this._actions,
-			lastInactiveAction = actions[ actions.length - 1 ],
+			lastInactiveAction = actions[actions.length - 1],
 			cacheIndex = action._cacheIndex;
 
 		lastInactiveAction._cacheIndex = cacheIndex;
-		actions[ cacheIndex ] = lastInactiveAction;
+		actions[cacheIndex] = lastInactiveAction;
 		actions.pop();
 
 		action._cacheIndex = null;
 
-
 		const clipUuid = action._clip.uuid,
 			actionsByClip = this._actionsByClip,
-			actionsForClip = actionsByClip[ clipUuid ],
+			actionsForClip = actionsByClip[clipUuid],
 			knownActionsForClip = actionsForClip.knownActions,
-
-			lastKnownAction =
-				knownActionsForClip[ knownActionsForClip.length - 1 ],
-
+			lastKnownAction = knownActionsForClip[knownActionsForClip.length - 1],
 			byClipCacheIndex = action._byClipCacheIndex;
 
 		lastKnownAction._byClipCacheIndex = byClipCacheIndex;
-		knownActionsForClip[ byClipCacheIndex ] = lastKnownAction;
+		knownActionsForClip[byClipCacheIndex] = lastKnownAction;
 		knownActionsForClip.pop();
 
 		action._byClipCacheIndex = null;
 
-
 		const actionByRoot = actionsForClip.actionByRoot,
-			rootUuid = ( action._localRoot || this._root ).uuid;
+			rootUuid = (action._localRoot || this._root).uuid;
 
-		delete actionByRoot[ rootUuid ];
+		delete actionByRoot[rootUuid];
 
-		if ( knownActionsForClip.length === 0 ) {
-
-			delete actionsByClip[ clipUuid ];
-
+		if (knownActionsForClip.length === 0) {
+			delete actionsByClip[clipUuid];
 		}
 
-		this._removeInactiveBindingsForAction( action );
-
+		this._removeInactiveBindingsForAction(action);
 	}
 
-	_removeInactiveBindingsForAction( action ) {
-
+	_removeInactiveBindingsForAction(action) {
 		const bindings = action._propertyBindings;
 
-		for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
+		for (let i = 0, n = bindings.length; i !== n; ++i) {
+			const binding = bindings[i];
 
-			const binding = bindings[ i ];
-
-			if ( -- binding.referenceCount === 0 ) {
-
-				this._removeInactiveBinding( binding );
-
+			if (--binding.referenceCount === 0) {
+				this._removeInactiveBinding(binding);
 			}
-
 		}
-
 	}
 
-	_lendAction( action ) {
-
+	_lendAction(action) {
 		// [ active actions |  inactive actions  ]
 		// [  active actions >| inactive actions ]
 		//                 s        a
@@ -344,21 +271,17 @@ class AnimationMixer extends EventDispatcher {
 
 		const actions = this._actions,
 			prevIndex = action._cacheIndex,
-
-			lastActiveIndex = this._nActiveActions ++,
-
-			firstInactiveAction = actions[ lastActiveIndex ];
+			lastActiveIndex = this._nActiveActions++,
+			firstInactiveAction = actions[lastActiveIndex];
 
 		action._cacheIndex = lastActiveIndex;
-		actions[ lastActiveIndex ] = action;
+		actions[lastActiveIndex] = action;
 
 		firstInactiveAction._cacheIndex = prevIndex;
-		actions[ prevIndex ] = firstInactiveAction;
-
+		actions[prevIndex] = firstInactiveAction;
 	}
 
-	_takeBackAction( action ) {
-
+	_takeBackAction(action) {
 		// [  active actions  | inactive actions ]
 		// [ active actions |< inactive actions  ]
 		//        a        s
@@ -367,268 +290,222 @@ class AnimationMixer extends EventDispatcher {
 
 		const actions = this._actions,
 			prevIndex = action._cacheIndex,
-
-			firstInactiveIndex = -- this._nActiveActions,
-
-			lastActiveAction = actions[ firstInactiveIndex ];
+			firstInactiveIndex = --this._nActiveActions,
+			lastActiveAction = actions[firstInactiveIndex];
 
 		action._cacheIndex = firstInactiveIndex;
-		actions[ firstInactiveIndex ] = action;
+		actions[firstInactiveIndex] = action;
 
 		lastActiveAction._cacheIndex = prevIndex;
-		actions[ prevIndex ] = lastActiveAction;
-
+		actions[prevIndex] = lastActiveAction;
 	}
 
 	// Memory management for PropertyMixer objects
 
-	_addInactiveBinding( binding, rootUuid, trackName ) {
-
+	_addInactiveBinding(binding, rootUuid, trackName) {
 		const bindingsByRoot = this._bindingsByRootAndName,
 			bindings = this._bindings;
 
-		let bindingByName = bindingsByRoot[ rootUuid ];
+		let bindingByName = bindingsByRoot[rootUuid];
 
-		if ( bindingByName === undefined ) {
-
+		if (bindingByName === undefined) {
 			bindingByName = {};
-			bindingsByRoot[ rootUuid ] = bindingByName;
-
+			bindingsByRoot[rootUuid] = bindingByName;
 		}
 
-		bindingByName[ trackName ] = binding;
+		bindingByName[trackName] = binding;
 
 		binding._cacheIndex = bindings.length;
-		bindings.push( binding );
-
+		bindings.push(binding);
 	}
 
-	_removeInactiveBinding( binding ) {
-
+	_removeInactiveBinding(binding) {
 		const bindings = this._bindings,
 			propBinding = binding.binding,
 			rootUuid = propBinding.rootNode.uuid,
 			trackName = propBinding.path,
 			bindingsByRoot = this._bindingsByRootAndName,
-			bindingByName = bindingsByRoot[ rootUuid ],
-
-			lastInactiveBinding = bindings[ bindings.length - 1 ],
+			bindingByName = bindingsByRoot[rootUuid],
+			lastInactiveBinding = bindings[bindings.length - 1],
 			cacheIndex = binding._cacheIndex;
 
 		lastInactiveBinding._cacheIndex = cacheIndex;
-		bindings[ cacheIndex ] = lastInactiveBinding;
+		bindings[cacheIndex] = lastInactiveBinding;
 		bindings.pop();
 
-		delete bindingByName[ trackName ];
+		delete bindingByName[trackName];
 
-		if ( Object.keys( bindingByName ).length === 0 ) {
-
-			delete bindingsByRoot[ rootUuid ];
-
+		if (Object.keys(bindingByName).length === 0) {
+			delete bindingsByRoot[rootUuid];
 		}
-
 	}
 
-	_lendBinding( binding ) {
-
+	_lendBinding(binding) {
 		const bindings = this._bindings,
 			prevIndex = binding._cacheIndex,
-
-			lastActiveIndex = this._nActiveBindings ++,
-
-			firstInactiveBinding = bindings[ lastActiveIndex ];
+			lastActiveIndex = this._nActiveBindings++,
+			firstInactiveBinding = bindings[lastActiveIndex];
 
 		binding._cacheIndex = lastActiveIndex;
-		bindings[ lastActiveIndex ] = binding;
+		bindings[lastActiveIndex] = binding;
 
 		firstInactiveBinding._cacheIndex = prevIndex;
-		bindings[ prevIndex ] = firstInactiveBinding;
-
+		bindings[prevIndex] = firstInactiveBinding;
 	}
 
-	_takeBackBinding( binding ) {
-
+	_takeBackBinding(binding) {
 		const bindings = this._bindings,
 			prevIndex = binding._cacheIndex,
-
-			firstInactiveIndex = -- this._nActiveBindings,
-
-			lastActiveBinding = bindings[ firstInactiveIndex ];
+			firstInactiveIndex = --this._nActiveBindings,
+			lastActiveBinding = bindings[firstInactiveIndex];
 
 		binding._cacheIndex = firstInactiveIndex;
-		bindings[ firstInactiveIndex ] = binding;
+		bindings[firstInactiveIndex] = binding;
 
 		lastActiveBinding._cacheIndex = prevIndex;
-		bindings[ prevIndex ] = lastActiveBinding;
-
+		bindings[prevIndex] = lastActiveBinding;
 	}
-
 
 	// Memory management of Interpolants for weight and time scale
 
 	_lendControlInterpolant() {
-
 		const interpolants = this._controlInterpolants,
-			lastActiveIndex = this._nActiveControlInterpolants ++;
+			lastActiveIndex = this._nActiveControlInterpolants++;
 
-		let interpolant = interpolants[ lastActiveIndex ];
+		let interpolant = interpolants[lastActiveIndex];
 
-		if ( interpolant === undefined ) {
-
+		if (interpolant === undefined) {
 			interpolant = new LinearInterpolant(
-				new Float32Array( 2 ), new Float32Array( 2 ),
-				1, this._controlInterpolantsResultBuffer );
+				new Float32Array(2),
+				new Float32Array(2),
+				1,
+				this._controlInterpolantsResultBuffer
+			);
 
 			interpolant.__cacheIndex = lastActiveIndex;
-			interpolants[ lastActiveIndex ] = interpolant;
-
+			interpolants[lastActiveIndex] = interpolant;
 		}
 
 		return interpolant;
-
 	}
 
-	_takeBackControlInterpolant( interpolant ) {
-
+	_takeBackControlInterpolant(interpolant) {
 		const interpolants = this._controlInterpolants,
 			prevIndex = interpolant.__cacheIndex,
-
-			firstInactiveIndex = -- this._nActiveControlInterpolants,
-
-			lastActiveInterpolant = interpolants[ firstInactiveIndex ];
+			firstInactiveIndex = --this._nActiveControlInterpolants,
+			lastActiveInterpolant = interpolants[firstInactiveIndex];
 
 		interpolant.__cacheIndex = firstInactiveIndex;
-		interpolants[ firstInactiveIndex ] = interpolant;
+		interpolants[firstInactiveIndex] = interpolant;
 
 		lastActiveInterpolant.__cacheIndex = prevIndex;
-		interpolants[ prevIndex ] = lastActiveInterpolant;
-
+		interpolants[prevIndex] = lastActiveInterpolant;
 	}
 
 	// return an action for a clip optionally using a custom root target
 	// object (this method allocates a lot of dynamic memory in case a
 	// previously unknown clip/root combination is specified)
-	clipAction( clip, optionalRoot, blendMode ) {
-
+	clipAction(clip, optionalRoot, blendMode) {
 		const root = optionalRoot || this._root,
 			rootUuid = root.uuid;
 
-		let clipObject = typeof clip === 'string' ? AnimationClip.findByName( root, clip ) : clip;
+		let clipObject =
+			typeof clip === "string" ? AnimationClip.findByName(root, clip) : clip;
 
 		const clipUuid = clipObject !== null ? clipObject.uuid : clip;
 
-		const actionsForClip = this._actionsByClip[ clipUuid ];
+		const actionsForClip = this._actionsByClip[clipUuid];
 		let prototypeAction = null;
 
-		if ( blendMode === undefined ) {
-
-			if ( clipObject !== null ) {
-
+		if (blendMode === undefined) {
+			if (clipObject !== null) {
 				blendMode = clipObject.blendMode;
-
 			} else {
-
 				blendMode = NormalAnimationBlendMode;
-
 			}
-
 		}
 
-		if ( actionsForClip !== undefined ) {
+		if (actionsForClip !== undefined) {
+			const existingAction = actionsForClip.actionByRoot[rootUuid];
 
-			const existingAction = actionsForClip.actionByRoot[ rootUuid ];
-
-			if ( existingAction !== undefined && existingAction.blendMode === blendMode ) {
-
+			if (
+				existingAction !== undefined &&
+				existingAction.blendMode === blendMode
+			) {
 				return existingAction;
-
 			}
 
 			// we know the clip, so we don't have to parse all
 			// the bindings again but can just copy
-			prototypeAction = actionsForClip.knownActions[ 0 ];
+			prototypeAction = actionsForClip.knownActions[0];
 
 			// also, take the clip from the prototype action
-			if ( clipObject === null )
-				clipObject = prototypeAction._clip;
-
+			if (clipObject === null) clipObject = prototypeAction._clip;
 		}
 
 		// clip must be known when specified via string
-		if ( clipObject === null ) return null;
+		if (clipObject === null) return null;
 
 		// allocate all resources required to run it
-		const newAction = new AnimationAction( this, clipObject, optionalRoot, blendMode );
+		const newAction = new AnimationAction(
+			this,
+			clipObject,
+			optionalRoot,
+			blendMode
+		);
 
-		this._bindAction( newAction, prototypeAction );
+		this._bindAction(newAction, prototypeAction);
 
 		// and make the action known to the memory manager
-		this._addInactiveAction( newAction, clipUuid, rootUuid );
+		this._addInactiveAction(newAction, clipUuid, rootUuid);
 
 		return newAction;
-
 	}
 
 	// get an existing action
-	existingAction( clip, optionalRoot ) {
-
+	existingAction(clip, optionalRoot) {
 		const root = optionalRoot || this._root,
 			rootUuid = root.uuid,
-
-			clipObject = typeof clip === 'string' ?
-				AnimationClip.findByName( root, clip ) : clip,
-
+			clipObject =
+				typeof clip === "string" ? AnimationClip.findByName(root, clip) : clip,
 			clipUuid = clipObject ? clipObject.uuid : clip,
+			actionsForClip = this._actionsByClip[clipUuid];
 
-			actionsForClip = this._actionsByClip[ clipUuid ];
-
-		if ( actionsForClip !== undefined ) {
-
-			return actionsForClip.actionByRoot[ rootUuid ] || null;
-
+		if (actionsForClip !== undefined) {
+			return actionsForClip.actionByRoot[rootUuid] || null;
 		}
 
 		return null;
-
 	}
 
 	// deactivates all previously scheduled actions
 	stopAllAction() {
-
 		const actions = this._actions,
 			nActions = this._nActiveActions;
 
-		for ( let i = nActions - 1; i >= 0; -- i ) {
-
-			actions[ i ].stop();
-
+		for (let i = nActions - 1; i >= 0; --i) {
+			actions[i].stop();
 		}
 
 		return this;
-
 	}
 
 	// advance the time and update apply the animation
-	update( deltaTime ) {
-
+	update(deltaTime) {
 		deltaTime *= this.timeScale;
 
 		const actions = this._actions,
 			nActions = this._nActiveActions,
-
-			time = this.time += deltaTime,
-			timeDirection = Math.sign( deltaTime ),
-
-			accuIndex = this._accuIndex ^= 1;
+			time = (this.time += deltaTime),
+			timeDirection = Math.sign(deltaTime),
+			accuIndex = (this._accuIndex ^= 1);
 
 		// run active actions
 
-		for ( let i = 0; i !== nActions; ++ i ) {
+		for (let i = 0; i !== nActions; ++i) {
+			const action = actions[i];
 
-			const action = actions[ i ];
-
-			action._update( time, deltaTime, timeDirection, accuIndex );
-
+			action._update(time, deltaTime, timeDirection, accuIndex);
 		}
 
 		// update scene graph
@@ -636,132 +513,102 @@ class AnimationMixer extends EventDispatcher {
 		const bindings = this._bindings,
 			nBindings = this._nActiveBindings;
 
-		for ( let i = 0; i !== nBindings; ++ i ) {
-
-			bindings[ i ].apply( accuIndex );
-
+		for (let i = 0; i !== nBindings; ++i) {
+			bindings[i].apply(accuIndex);
 		}
 
 		return this;
-
 	}
 
 	// Allows you to seek to a specific time in an animation.
-	setTime( timeInSeconds ) {
-
+	setTime(timeInSeconds) {
 		this.time = 0; // Zero out time attribute for AnimationMixer object;
-		for ( let i = 0; i < this._actions.length; i ++ ) {
-
-			this._actions[ i ].time = 0; // Zero out time attribute for all associated AnimationAction objects.
-
+		for (let i = 0; i < this._actions.length; i++) {
+			this._actions[i].time = 0; // Zero out time attribute for all associated AnimationAction objects.
 		}
 
-		return this.update( timeInSeconds ); // Update used to set exact time. Returns "this" AnimationMixer object.
-
+		return this.update(timeInSeconds); // Update used to set exact time. Returns "this" AnimationMixer object.
 	}
 
 	// return this mixer's root target object
 	getRoot() {
-
 		return this._root;
-
 	}
 
 	// free all resources specific to a particular clip
-	uncacheClip( clip ) {
-
+	uncacheClip(clip) {
 		const actions = this._actions,
 			clipUuid = clip.uuid,
 			actionsByClip = this._actionsByClip,
-			actionsForClip = actionsByClip[ clipUuid ];
+			actionsForClip = actionsByClip[clipUuid];
 
-		if ( actionsForClip !== undefined ) {
-
+		if (actionsForClip !== undefined) {
 			// note: just calling _removeInactiveAction would mess up the
 			// iteration state and also require updating the state we can
 			// just throw away
 
 			const actionsToRemove = actionsForClip.knownActions;
 
-			for ( let i = 0, n = actionsToRemove.length; i !== n; ++ i ) {
+			for (let i = 0, n = actionsToRemove.length; i !== n; ++i) {
+				const action = actionsToRemove[i];
 
-				const action = actionsToRemove[ i ];
-
-				this._deactivateAction( action );
+				this._deactivateAction(action);
 
 				const cacheIndex = action._cacheIndex,
-					lastInactiveAction = actions[ actions.length - 1 ];
+					lastInactiveAction = actions[actions.length - 1];
 
 				action._cacheIndex = null;
 				action._byClipCacheIndex = null;
 
 				lastInactiveAction._cacheIndex = cacheIndex;
-				actions[ cacheIndex ] = lastInactiveAction;
+				actions[cacheIndex] = lastInactiveAction;
 				actions.pop();
 
-				this._removeInactiveBindingsForAction( action );
-
+				this._removeInactiveBindingsForAction(action);
 			}
 
-			delete actionsByClip[ clipUuid ];
-
+			delete actionsByClip[clipUuid];
 		}
-
 	}
 
 	// free all resources specific to a particular root target object
-	uncacheRoot( root ) {
-
+	uncacheRoot(root) {
 		const rootUuid = root.uuid,
 			actionsByClip = this._actionsByClip;
 
-		for ( const clipUuid in actionsByClip ) {
+		for (const clipUuid in actionsByClip) {
+			const actionByRoot = actionsByClip[clipUuid].actionByRoot,
+				action = actionByRoot[rootUuid];
 
-			const actionByRoot = actionsByClip[ clipUuid ].actionByRoot,
-				action = actionByRoot[ rootUuid ];
-
-			if ( action !== undefined ) {
-
-				this._deactivateAction( action );
-				this._removeInactiveAction( action );
-
+			if (action !== undefined) {
+				this._deactivateAction(action);
+				this._removeInactiveAction(action);
 			}
-
 		}
 
 		const bindingsByRoot = this._bindingsByRootAndName,
-			bindingByName = bindingsByRoot[ rootUuid ];
+			bindingByName = bindingsByRoot[rootUuid];
 
-		if ( bindingByName !== undefined ) {
-
-			for ( const trackName in bindingByName ) {
-
-				const binding = bindingByName[ trackName ];
+		if (bindingByName !== undefined) {
+			for (const trackName in bindingByName) {
+				const binding = bindingByName[trackName];
 				binding.restoreOriginalState();
-				this._removeInactiveBinding( binding );
-
+				this._removeInactiveBinding(binding);
 			}
-
 		}
-
 	}
 
 	// remove a targeted clip from the cache
-	uncacheAction( clip, optionalRoot ) {
+	uncacheAction(clip, optionalRoot) {
+		const action = this.existingAction(clip, optionalRoot);
 
-		const action = this.existingAction( clip, optionalRoot );
-
-		if ( action !== null ) {
-
-			this._deactivateAction( action );
-			this._removeInactiveAction( action );
-
+		if (action !== null) {
+			this._deactivateAction(action);
+			this._removeInactiveAction(action);
 		}
-
 	}
-
 }
 
-AnimationMixer.prototype._controlInterpolantsResultBuffer = new Float32Array( 1 );
+AnimationMixer.prototype._controlInterpolantsResultBuffer = new Float32Array(1);
 
 export { AnimationMixer };

--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -1,13 +1,15 @@
-import { AnimationAction } from "./AnimationAction.js";
-import { EventDispatcher } from "../core/EventDispatcher.js";
-import { LinearInterpolant } from "../math/interpolants/LinearInterpolant.js";
-import { PropertyBinding } from "./PropertyBinding.js";
-import { PropertyMixer } from "./PropertyMixer.js";
-import { AnimationClip } from "./AnimationClip.js";
-import { NormalAnimationBlendMode } from "../constants.js";
+import { AnimationAction } from './AnimationAction.js';
+import { EventDispatcher } from '../core/EventDispatcher.js';
+import { LinearInterpolant } from '../math/interpolants/LinearInterpolant.js';
+import { PropertyBinding } from './PropertyBinding.js';
+import { PropertyMixer } from './PropertyMixer.js';
+import { AnimationClip } from './AnimationClip.js';
+import { NormalAnimationBlendMode } from '../constants.js';
 
 class AnimationMixer extends EventDispatcher {
-	constructor(root) {
+
+	constructor( root ) {
+
 		super();
 
 		this._root = root;
@@ -15,9 +17,11 @@ class AnimationMixer extends EventDispatcher {
 		this._accuIndex = 0;
 		this.time = 0;
 		this.timeScale = 1.0;
+
 	}
 
-	_bindAction(action, prototypeAction) {
+	_bindAction( action, prototypeAction ) {
+
 		const root = action._localRoot || this._root,
 			tracks = action._clip.tracks,
 			nTracks = tracks.length,
@@ -26,111 +30,138 @@ class AnimationMixer extends EventDispatcher {
 			rootUuid = root.uuid,
 			bindingsByRoot = this._bindingsByRootAndName;
 
-		let bindingsByName = bindingsByRoot[rootUuid];
+		let bindingsByName = bindingsByRoot[ rootUuid ];
 
-		if (bindingsByName === undefined) {
+		if ( bindingsByName === undefined ) {
+
 			bindingsByName = {};
-			bindingsByRoot[rootUuid] = bindingsByName;
+			bindingsByRoot[ rootUuid ] = bindingsByName;
+
 		}
 
-		for (let i = 0; i !== nTracks; ++i) {
-			const track = tracks[i],
+		for ( let i = 0; i !== nTracks; ++ i ) {
+
+			const track = tracks[ i ],
 				trackName = track.name;
 
-			let binding = bindingsByName[trackName];
+			let binding = bindingsByName[ trackName ];
 
-			if (binding !== undefined) {
-				++binding.referenceCount;
-				bindings[i] = binding;
+			if ( binding !== undefined ) {
+
+				++ binding.referenceCount;
+				bindings[ i ] = binding;
+
 			} else {
-				binding = bindings[i];
 
-				if (binding !== undefined) {
+				binding = bindings[ i ];
+
+				if ( binding !== undefined ) {
+
 					// existing binding, make sure the cache knows
 
-					if (binding._cacheIndex === null) {
-						++binding.referenceCount;
-						this._addInactiveBinding(binding, rootUuid, trackName);
+					if ( binding._cacheIndex === null ) {
+
+						++ binding.referenceCount;
+						this._addInactiveBinding( binding, rootUuid, trackName );
+
 					}
 
 					continue;
+
 				}
 
-				const path =
-					prototypeAction &&
-					prototypeAction._propertyBindings[i].binding.parsedPath;
+				const path = prototypeAction && prototypeAction.
+					_propertyBindings[ i ].binding.parsedPath;
 
 				binding = new PropertyMixer(
-					PropertyBinding.create(root, trackName, path),
-					track.ValueTypeName,
-					track.getValueSize()
-				);
+					PropertyBinding.create( root, trackName, path ),
+					track.ValueTypeName, track.getValueSize() );
 
-				++binding.referenceCount;
-				this._addInactiveBinding(binding, rootUuid, trackName);
+				++ binding.referenceCount;
+				this._addInactiveBinding( binding, rootUuid, trackName );
 
-				bindings[i] = binding;
+				bindings[ i ] = binding;
+
 			}
 
-			interpolants[i].resultBuffer = binding.buffer;
+			interpolants[ i ].resultBuffer = binding.buffer;
+
 		}
+
 	}
 
-	_activateAction(action) {
-		if (!this._isActiveAction(action)) {
-			if (action._cacheIndex === null) {
+	_activateAction( action ) {
+
+		if ( ! this._isActiveAction( action ) ) {
+
+			if ( action._cacheIndex === null ) {
+
 				// this action has been forgotten by the cache, but the user
 				// appears to be still using it -> rebind
 
-				const rootUuid = (action._localRoot || this._root).uuid,
+				const rootUuid = ( action._localRoot || this._root ).uuid,
 					clipUuid = action._clip.uuid,
-					actionsForClip = this._actionsByClip[clipUuid];
+					actionsForClip = this._actionsByClip[ clipUuid ];
 
-				this._bindAction(
-					action,
-					actionsForClip && actionsForClip.knownActions[0]
-				);
+				this._bindAction( action,
+					actionsForClip && actionsForClip.knownActions[ 0 ] );
 
-				this._addInactiveAction(action, clipUuid, rootUuid);
+				this._addInactiveAction( action, clipUuid, rootUuid );
+
 			}
 
 			const bindings = action._propertyBindings;
 
 			// increment reference counts / sort out state
-			for (let i = 0, n = bindings.length; i !== n; ++i) {
-				const binding = bindings[i];
+			for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
 
-				if (binding.useCount++ === 0) {
-					this._lendBinding(binding);
+				const binding = bindings[ i ];
+
+				if ( binding.useCount ++ === 0 ) {
+
+					this._lendBinding( binding );
 					binding.saveOriginalState();
+
 				}
+
 			}
 
-			this._lendAction(action);
+			this._lendAction( action );
+
 		}
+
 	}
 
-	_deactivateAction(action) {
-		if (this._isActiveAction(action)) {
+	_deactivateAction( action ) {
+
+		if ( this._isActiveAction( action ) ) {
+
 			const bindings = action._propertyBindings;
 
 			// decrement reference counts / sort out state
-			for (let i = 0, n = bindings.length; i !== n; ++i) {
-				const binding = bindings[i];
+			for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
 
-				if (--binding.useCount === 0) {
+				const binding = bindings[ i ];
+
+				if ( -- binding.useCount === 0 ) {
+
 					binding.restoreOriginalState();
-					this._takeBackBinding(binding);
+					this._takeBackBinding( binding );
+
 				}
+
 			}
 
-			this._takeBackAction(action);
+			this._takeBackAction( action );
+
 		}
+
 	}
 
 	// Memory manager
 
 	_initMemoryManager() {
+
 		this._actions = []; // 'nActiveActions' followed by inactive ones
 		this._nActiveActions = 0;
 
@@ -141,10 +172,12 @@ class AnimationMixer extends EventDispatcher {
 		// 	actionByRoot: AnimationAction - lookup
 		// }
 
+
 		this._bindings = []; // 'nActiveBindings' followed by inactive ones
 		this._nActiveBindings = 0;
 
 		this._bindingsByRootAndName = {}; // inside: Map< name, PropertyMixer >
+
 
 		this._controlInterpolants = []; // same game as above
 		this._nActiveControlInterpolants = 0;
@@ -152,117 +185,158 @@ class AnimationMixer extends EventDispatcher {
 		const scope = this;
 
 		this.stats = {
+
 			actions: {
 				get total() {
+
 					return scope._actions.length;
+
 				},
 				get inUse() {
+
 					return scope._nActiveActions;
-				},
+
+				}
 			},
 			bindings: {
 				get total() {
+
 					return scope._bindings.length;
+
 				},
 				get inUse() {
+
 					return scope._nActiveBindings;
-				},
+
+				}
 			},
 			controlInterpolants: {
 				get total() {
+
 					return scope._controlInterpolants.length;
+
 				},
 				get inUse() {
+
 					return scope._nActiveControlInterpolants;
-				},
-			},
+
+				}
+			}
+
 		};
+
 	}
 
 	// Memory management for AnimationAction objects
 
-	_isActiveAction(action) {
+	_isActiveAction( action ) {
+
 		const index = action._cacheIndex;
 		return index !== null && index < this._nActiveActions;
+
 	}
 
-	_addInactiveAction(action, clipUuid, rootUuid) {
+	_addInactiveAction( action, clipUuid, rootUuid ) {
+
 		const actions = this._actions,
 			actionsByClip = this._actionsByClip;
 
-		let actionsForClip = actionsByClip[clipUuid];
+		let actionsForClip = actionsByClip[ clipUuid ];
 
-		if (actionsForClip === undefined) {
+		if ( actionsForClip === undefined ) {
+
 			actionsForClip = {
-				knownActions: [action],
-				actionByRoot: {},
+
+				knownActions: [ action ],
+				actionByRoot: {}
+
 			};
 
 			action._byClipCacheIndex = 0;
 
-			actionsByClip[clipUuid] = actionsForClip;
+			actionsByClip[ clipUuid ] = actionsForClip;
+
 		} else {
+
 			const knownActions = actionsForClip.knownActions;
 
 			action._byClipCacheIndex = knownActions.length;
-			knownActions.push(action);
+			knownActions.push( action );
+
 		}
 
 		action._cacheIndex = actions.length;
-		actions.push(action);
+		actions.push( action );
 
-		actionsForClip.actionByRoot[rootUuid] = action;
+		actionsForClip.actionByRoot[ rootUuid ] = action;
+
 	}
 
-	_removeInactiveAction(action) {
+	_removeInactiveAction( action ) {
+
 		const actions = this._actions,
-			lastInactiveAction = actions[actions.length - 1],
+			lastInactiveAction = actions[ actions.length - 1 ],
 			cacheIndex = action._cacheIndex;
 
 		lastInactiveAction._cacheIndex = cacheIndex;
-		actions[cacheIndex] = lastInactiveAction;
+		actions[ cacheIndex ] = lastInactiveAction;
 		actions.pop();
 
 		action._cacheIndex = null;
 
+
 		const clipUuid = action._clip.uuid,
 			actionsByClip = this._actionsByClip,
-			actionsForClip = actionsByClip[clipUuid],
+			actionsForClip = actionsByClip[ clipUuid ],
 			knownActionsForClip = actionsForClip.knownActions,
-			lastKnownAction = knownActionsForClip[knownActionsForClip.length - 1],
+
+			lastKnownAction =
+				knownActionsForClip[ knownActionsForClip.length - 1 ],
+
 			byClipCacheIndex = action._byClipCacheIndex;
 
 		lastKnownAction._byClipCacheIndex = byClipCacheIndex;
-		knownActionsForClip[byClipCacheIndex] = lastKnownAction;
+		knownActionsForClip[ byClipCacheIndex ] = lastKnownAction;
 		knownActionsForClip.pop();
 
 		action._byClipCacheIndex = null;
 
+
 		const actionByRoot = actionsForClip.actionByRoot,
-			rootUuid = (action._localRoot || this._root).uuid;
+			rootUuid = ( action._localRoot || this._root ).uuid;
 
-		delete actionByRoot[rootUuid];
+		delete actionByRoot[ rootUuid ];
 
-		if (knownActionsForClip.length === 0) {
-			delete actionsByClip[clipUuid];
+		if ( knownActionsForClip.length === 0 ) {
+
+			delete actionsByClip[ clipUuid ];
+
 		}
 
-		this._removeInactiveBindingsForAction(action);
+		this._removeInactiveBindingsForAction( action );
+
 	}
 
-	_removeInactiveBindingsForAction(action) {
+	_removeInactiveBindingsForAction( action ) {
+
 		const bindings = action._propertyBindings;
 
-		for (let i = 0, n = bindings.length; i !== n; ++i) {
-			const binding = bindings[i];
+		for ( let i = 0, n = bindings.length; i !== n; ++ i ) {
 
-			if (--binding.referenceCount === 0) {
-				this._removeInactiveBinding(binding);
+			const binding = bindings[ i ];
+
+			if ( -- binding.referenceCount === 0 ) {
+
+				this._removeInactiveBinding( binding );
+
 			}
+
 		}
+
 	}
 
-	_lendAction(action) {
+	_lendAction( action ) {
+
 		// [ active actions |  inactive actions  ]
 		// [  active actions >| inactive actions ]
 		//                 s        a
@@ -271,17 +345,21 @@ class AnimationMixer extends EventDispatcher {
 
 		const actions = this._actions,
 			prevIndex = action._cacheIndex,
-			lastActiveIndex = this._nActiveActions++,
-			firstInactiveAction = actions[lastActiveIndex];
+
+			lastActiveIndex = this._nActiveActions ++,
+
+			firstInactiveAction = actions[ lastActiveIndex ];
 
 		action._cacheIndex = lastActiveIndex;
-		actions[lastActiveIndex] = action;
+		actions[ lastActiveIndex ] = action;
 
 		firstInactiveAction._cacheIndex = prevIndex;
-		actions[prevIndex] = firstInactiveAction;
+		actions[ prevIndex ] = firstInactiveAction;
+
 	}
 
-	_takeBackAction(action) {
+	_takeBackAction( action ) {
+
 		// [  active actions  | inactive actions ]
 		// [ active actions |< inactive actions  ]
 		//        a        s
@@ -290,222 +368,268 @@ class AnimationMixer extends EventDispatcher {
 
 		const actions = this._actions,
 			prevIndex = action._cacheIndex,
-			firstInactiveIndex = --this._nActiveActions,
-			lastActiveAction = actions[firstInactiveIndex];
+
+			firstInactiveIndex = -- this._nActiveActions,
+
+			lastActiveAction = actions[ firstInactiveIndex ];
 
 		action._cacheIndex = firstInactiveIndex;
-		actions[firstInactiveIndex] = action;
+		actions[ firstInactiveIndex ] = action;
 
 		lastActiveAction._cacheIndex = prevIndex;
-		actions[prevIndex] = lastActiveAction;
+		actions[ prevIndex ] = lastActiveAction;
+
 	}
 
 	// Memory management for PropertyMixer objects
 
-	_addInactiveBinding(binding, rootUuid, trackName) {
+	_addInactiveBinding( binding, rootUuid, trackName ) {
+
 		const bindingsByRoot = this._bindingsByRootAndName,
 			bindings = this._bindings;
 
-		let bindingByName = bindingsByRoot[rootUuid];
+		let bindingByName = bindingsByRoot[ rootUuid ];
 
-		if (bindingByName === undefined) {
+		if ( bindingByName === undefined ) {
+
 			bindingByName = {};
-			bindingsByRoot[rootUuid] = bindingByName;
+			bindingsByRoot[ rootUuid ] = bindingByName;
+
 		}
 
-		bindingByName[trackName] = binding;
+		bindingByName[ trackName ] = binding;
 
 		binding._cacheIndex = bindings.length;
-		bindings.push(binding);
+		bindings.push( binding );
+
 	}
 
-	_removeInactiveBinding(binding) {
+	_removeInactiveBinding( binding ) {
+
 		const bindings = this._bindings,
 			propBinding = binding.binding,
 			rootUuid = propBinding.rootNode.uuid,
 			trackName = propBinding.path,
 			bindingsByRoot = this._bindingsByRootAndName,
-			bindingByName = bindingsByRoot[rootUuid],
-			lastInactiveBinding = bindings[bindings.length - 1],
+			bindingByName = bindingsByRoot[ rootUuid ],
+
+			lastInactiveBinding = bindings[ bindings.length - 1 ],
 			cacheIndex = binding._cacheIndex;
 
 		lastInactiveBinding._cacheIndex = cacheIndex;
-		bindings[cacheIndex] = lastInactiveBinding;
+		bindings[ cacheIndex ] = lastInactiveBinding;
 		bindings.pop();
 
-		delete bindingByName[trackName];
+		delete bindingByName[ trackName ];
 
-		if (Object.keys(bindingByName).length === 0) {
-			delete bindingsByRoot[rootUuid];
+		if ( Object.keys( bindingByName ).length === 0 ) {
+
+			delete bindingsByRoot[ rootUuid ];
+
 		}
+
 	}
 
-	_lendBinding(binding) {
+	_lendBinding( binding ) {
+
 		const bindings = this._bindings,
 			prevIndex = binding._cacheIndex,
-			lastActiveIndex = this._nActiveBindings++,
-			firstInactiveBinding = bindings[lastActiveIndex];
+
+			lastActiveIndex = this._nActiveBindings ++,
+
+			firstInactiveBinding = bindings[ lastActiveIndex ];
 
 		binding._cacheIndex = lastActiveIndex;
-		bindings[lastActiveIndex] = binding;
+		bindings[ lastActiveIndex ] = binding;
 
 		firstInactiveBinding._cacheIndex = prevIndex;
-		bindings[prevIndex] = firstInactiveBinding;
+		bindings[ prevIndex ] = firstInactiveBinding;
+
 	}
 
-	_takeBackBinding(binding) {
+	_takeBackBinding( binding ) {
+
 		const bindings = this._bindings,
 			prevIndex = binding._cacheIndex,
-			firstInactiveIndex = --this._nActiveBindings,
-			lastActiveBinding = bindings[firstInactiveIndex];
+
+			firstInactiveIndex = -- this._nActiveBindings,
+
+			lastActiveBinding = bindings[ firstInactiveIndex ];
 
 		binding._cacheIndex = firstInactiveIndex;
-		bindings[firstInactiveIndex] = binding;
+		bindings[ firstInactiveIndex ] = binding;
 
 		lastActiveBinding._cacheIndex = prevIndex;
-		bindings[prevIndex] = lastActiveBinding;
+		bindings[ prevIndex ] = lastActiveBinding;
+
 	}
+
 
 	// Memory management of Interpolants for weight and time scale
 
 	_lendControlInterpolant() {
+
 		const interpolants = this._controlInterpolants,
-			lastActiveIndex = this._nActiveControlInterpolants++;
+			lastActiveIndex = this._nActiveControlInterpolants ++;
 
-		let interpolant = interpolants[lastActiveIndex];
+		let interpolant = interpolants[ lastActiveIndex ];
 
-		if (interpolant === undefined) {
+		if ( interpolant === undefined ) {
+
 			interpolant = new LinearInterpolant(
-				new Float32Array(2),
-				new Float32Array(2),
-				1,
-				this._controlInterpolantsResultBuffer
-			);
+				new Float32Array( 2 ), new Float32Array( 2 ),
+				1, this._controlInterpolantsResultBuffer );
 
 			interpolant.__cacheIndex = lastActiveIndex;
-			interpolants[lastActiveIndex] = interpolant;
+			interpolants[ lastActiveIndex ] = interpolant;
+
 		}
 
 		return interpolant;
+
 	}
 
-	_takeBackControlInterpolant(interpolant) {
+	_takeBackControlInterpolant( interpolant ) {
+
 		const interpolants = this._controlInterpolants,
 			prevIndex = interpolant.__cacheIndex,
-			firstInactiveIndex = --this._nActiveControlInterpolants,
-			lastActiveInterpolant = interpolants[firstInactiveIndex];
+
+			firstInactiveIndex = -- this._nActiveControlInterpolants,
+
+			lastActiveInterpolant = interpolants[ firstInactiveIndex ];
 
 		interpolant.__cacheIndex = firstInactiveIndex;
-		interpolants[firstInactiveIndex] = interpolant;
+		interpolants[ firstInactiveIndex ] = interpolant;
 
 		lastActiveInterpolant.__cacheIndex = prevIndex;
-		interpolants[prevIndex] = lastActiveInterpolant;
+		interpolants[ prevIndex ] = lastActiveInterpolant;
+
 	}
 
 	// return an action for a clip optionally using a custom root target
 	// object (this method allocates a lot of dynamic memory in case a
 	// previously unknown clip/root combination is specified)
-	clipAction(clip, optionalRoot, blendMode) {
+	clipAction( clip, optionalRoot, blendMode ) {
+
 		const root = optionalRoot || this._root,
 			rootUuid = root.uuid;
 
-		let clipObject =
-			typeof clip === "string" ? AnimationClip.findByName(root, clip) : clip;
+		let clipObject = typeof clip === 'string' ? AnimationClip.findByName( root, clip ) : clip;
 
 		const clipUuid = clipObject !== null ? clipObject.uuid : clip;
 
-		const actionsForClip = this._actionsByClip[clipUuid];
+		const actionsForClip = this._actionsByClip[ clipUuid ];
 		let prototypeAction = null;
 
-		if (blendMode === undefined) {
-			if (clipObject !== null) {
+		if ( blendMode === undefined ) {
+
+			if ( clipObject !== null ) {
+
 				blendMode = clipObject.blendMode;
+
 			} else {
+
 				blendMode = NormalAnimationBlendMode;
+
 			}
+
 		}
 
-		if (actionsForClip !== undefined) {
-			const existingAction = actionsForClip.actionByRoot[rootUuid];
+		if ( actionsForClip !== undefined ) {
 
-			if (
-				existingAction !== undefined &&
-				existingAction.blendMode === blendMode
-			) {
+			const existingAction = actionsForClip.actionByRoot[ rootUuid ];
+
+			if ( existingAction !== undefined && existingAction.blendMode === blendMode ) {
+
 				return existingAction;
+
 			}
 
 			// we know the clip, so we don't have to parse all
 			// the bindings again but can just copy
-			prototypeAction = actionsForClip.knownActions[0];
+			prototypeAction = actionsForClip.knownActions[ 0 ];
 
 			// also, take the clip from the prototype action
-			if (clipObject === null) clipObject = prototypeAction._clip;
+			if ( clipObject === null )
+				clipObject = prototypeAction._clip;
+
 		}
 
 		// clip must be known when specified via string
-		if (clipObject === null) return null;
+		if ( clipObject === null ) return null;
 
 		// allocate all resources required to run it
-		const newAction = new AnimationAction(
-			this,
-			clipObject,
-			optionalRoot,
-			blendMode
-		);
+		const newAction = new AnimationAction( this, clipObject, optionalRoot, blendMode );
 
-		this._bindAction(newAction, prototypeAction);
+		this._bindAction( newAction, prototypeAction );
 
 		// and make the action known to the memory manager
-		this._addInactiveAction(newAction, clipUuid, rootUuid);
+		this._addInactiveAction( newAction, clipUuid, rootUuid );
 
 		return newAction;
+
 	}
 
 	// get an existing action
-	existingAction(clip, optionalRoot) {
+	existingAction( clip, optionalRoot ) {
+
 		const root = optionalRoot || this._root,
 			rootUuid = root.uuid,
-			clipObject =
-				typeof clip === "string" ? AnimationClip.findByName(root, clip) : clip,
-			clipUuid = clipObject ? clipObject.uuid : clip,
-			actionsForClip = this._actionsByClip[clipUuid];
 
-		if (actionsForClip !== undefined) {
-			return actionsForClip.actionByRoot[rootUuid] || null;
+			clipObject = typeof clip === 'string' ?
+				AnimationClip.findByName( root, clip ) : clip,
+
+			clipUuid = clipObject ? clipObject.uuid : clip,
+
+			actionsForClip = this._actionsByClip[ clipUuid ];
+
+		if ( actionsForClip !== undefined ) {
+
+			return actionsForClip.actionByRoot[ rootUuid ] || null;
+
 		}
 
 		return null;
+
 	}
 
 	// deactivates all previously scheduled actions
 	stopAllAction() {
+
 		const actions = this._actions,
 			nActions = this._nActiveActions;
 
-		for (let i = nActions - 1; i >= 0; --i) {
-			actions[i].stop();
+		for ( let i = nActions - 1; i >= 0; -- i ) {
+
+			actions[ i ].stop();
+
 		}
 
 		return this;
+
 	}
 
 	// advance the time and update apply the animation
-	update(deltaTime) {
+	update( deltaTime ) {
+
 		deltaTime *= this.timeScale;
 
 		const actions = this._actions,
 			nActions = this._nActiveActions,
-			time = (this.time += deltaTime),
-			timeDirection = Math.sign(deltaTime),
-			accuIndex = (this._accuIndex ^= 1);
+
+			time = this.time += deltaTime,
+			timeDirection = Math.sign( deltaTime ),
+
+			accuIndex = this._accuIndex ^= 1;
 
 		// run active actions
 
-		for (let i = 0; i !== nActions; ++i) {
-			const action = actions[i];
+		for ( let i = 0; i !== nActions; ++ i ) {
 
-			action._update(time, deltaTime, timeDirection, accuIndex);
+			const action = actions[ i ];
+
+			action._update( time, deltaTime, timeDirection, accuIndex );
+
 		}
 
 		// update scene graph
@@ -513,102 +637,132 @@ class AnimationMixer extends EventDispatcher {
 		const bindings = this._bindings,
 			nBindings = this._nActiveBindings;
 
-		for (let i = 0; i !== nBindings; ++i) {
-			bindings[i].apply(accuIndex);
+		for ( let i = 0; i !== nBindings; ++ i ) {
+
+			bindings[ i ].apply( accuIndex );
+
 		}
 
 		return this;
+
 	}
 
 	// Allows you to seek to a specific time in an animation.
-	setTime(timeInSeconds) {
+	setTime( timeInSeconds ) {
+
 		this.time = 0; // Zero out time attribute for AnimationMixer object;
-		for (let i = 0; i < this._actions.length; i++) {
-			this._actions[i].time = 0; // Zero out time attribute for all associated AnimationAction objects.
+		for ( let i = 0; i < this._actions.length; i ++ ) {
+
+			this._actions[ i ].time = 0; // Zero out time attribute for all associated AnimationAction objects.
+
 		}
 
-		return this.update(timeInSeconds); // Update used to set exact time. Returns "this" AnimationMixer object.
+		return this.update( timeInSeconds ); // Update used to set exact time. Returns "this" AnimationMixer object.
+
 	}
 
 	// return this mixer's root target object
 	getRoot() {
+
 		return this._root;
+
 	}
 
 	// free all resources specific to a particular clip
-	uncacheClip(clip) {
+	uncacheClip( clip ) {
+
 		const actions = this._actions,
 			clipUuid = clip.uuid,
 			actionsByClip = this._actionsByClip,
-			actionsForClip = actionsByClip[clipUuid];
+			actionsForClip = actionsByClip[ clipUuid ];
 
-		if (actionsForClip !== undefined) {
+		if ( actionsForClip !== undefined ) {
+
 			// note: just calling _removeInactiveAction would mess up the
 			// iteration state and also require updating the state we can
 			// just throw away
 
 			const actionsToRemove = actionsForClip.knownActions;
 
-			for (let i = 0, n = actionsToRemove.length; i !== n; ++i) {
-				const action = actionsToRemove[i];
+			for ( let i = 0, n = actionsToRemove.length; i !== n; ++ i ) {
 
-				this._deactivateAction(action);
+				const action = actionsToRemove[ i ];
+
+				this._deactivateAction( action );
 
 				const cacheIndex = action._cacheIndex,
-					lastInactiveAction = actions[actions.length - 1];
+					lastInactiveAction = actions[ actions.length - 1 ];
 
 				action._cacheIndex = null;
 				action._byClipCacheIndex = null;
 
 				lastInactiveAction._cacheIndex = cacheIndex;
-				actions[cacheIndex] = lastInactiveAction;
+				actions[ cacheIndex ] = lastInactiveAction;
 				actions.pop();
 
-				this._removeInactiveBindingsForAction(action);
+				this._removeInactiveBindingsForAction( action );
+
 			}
 
-			delete actionsByClip[clipUuid];
+			delete actionsByClip[ clipUuid ];
+
 		}
+
 	}
 
 	// free all resources specific to a particular root target object
-	uncacheRoot(root) {
+	uncacheRoot( root ) {
+
 		const rootUuid = root.uuid,
 			actionsByClip = this._actionsByClip;
 
-		for (const clipUuid in actionsByClip) {
-			const actionByRoot = actionsByClip[clipUuid].actionByRoot,
-				action = actionByRoot[rootUuid];
+		for ( const clipUuid in actionsByClip ) {
 
-			if (action !== undefined) {
-				this._deactivateAction(action);
-				this._removeInactiveAction(action);
+			const actionByRoot = actionsByClip[ clipUuid ].actionByRoot,
+				action = actionByRoot[ rootUuid ];
+
+			if ( action !== undefined ) {
+
+				this._deactivateAction( action );
+				this._removeInactiveAction( action );
+
 			}
+
 		}
 
 		const bindingsByRoot = this._bindingsByRootAndName,
-			bindingByName = bindingsByRoot[rootUuid];
+			bindingByName = bindingsByRoot[ rootUuid ];
 
-		if (bindingByName !== undefined) {
-			for (const trackName in bindingByName) {
-				const binding = bindingByName[trackName];
+		if ( bindingByName !== undefined ) {
+
+			for ( const trackName in bindingByName ) {
+
+				const binding = bindingByName[ trackName ];
 				binding.restoreOriginalState();
-				this._removeInactiveBinding(binding);
+				this._removeInactiveBinding( binding );
+
 			}
+
 		}
+
 	}
 
 	// remove a targeted clip from the cache
-	uncacheAction(clip, optionalRoot) {
-		const action = this.existingAction(clip, optionalRoot);
+	uncacheAction( clip, optionalRoot ) {
 
-		if (action !== null) {
-			this._deactivateAction(action);
-			this._removeInactiveAction(action);
+		const action = this.existingAction( clip, optionalRoot );
+
+		if ( action !== null ) {
+
+			this._deactivateAction( action );
+			this._removeInactiveAction( action );
+
 		}
+
 	}
+
 }
 
-AnimationMixer.prototype._controlInterpolantsResultBuffer = new Float32Array(1);
+AnimationMixer.prototype._controlInterpolantsResultBuffer = new Float32Array( 1 );
 
 export { AnimationMixer };


### PR DESCRIPTION
Related issue: Fixed #23096

**Description**

When calling the uncacheAction, uncacheClip, and uncacheRoot methods, an exception will be thrown.
