### PR TITLE
WebGLMorphtargets: Dispose morph textures when corresponding geometry is disposed.

### DIFF
--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -135,6 +135,18 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 
 				morphTextures.set( geometry, entry );
 
+				function disposeTexture() {
+
+					texture.dispose();
+
+					morphTextures.delete( geometry );
+
+					geometry.removeEventListener( 'dispose', disposeTexture );
+
+				}
+
+				geometry.addEventListener( 'dispose', disposeTexture );
+
 			}
 
 			//


### PR DESCRIPTION
Original discussion: https://discourse.threejs.org/t/how-do-i-free-morph-textures/33033

### Description

Morph textures are not disposed when disposing corresponding geometries.

In WebGLMorphtargets, since each morph textures are one-to-one to each geometries and it only referred from this part,
it can be safely disposed once geometry is disposed.

I have added an event listener of `'dispose'` to geometry that disposes the morph texture.
This will ensure morph textures be freed once it's no longer necessary.
