### PR TITLE
partial RoughnessMipmapper fix

### DIFF
--- a/examples/jsm/utils/RoughnessMipmapper.js
+++ b/examples/jsm/utils/RoughnessMipmapper.js
@@ -100,7 +100,7 @@ class RoughnessMipmapper {
 
 		const texelSize = _mipmapMaterial.uniforms.texelSize.value;
 
-		for ( let mip = 0; width >= 1 && height >= 1; ++ mip, width /= 2, height /= 2 ) {
+		for ( let mip = 0; width >= 2 && height >= 2; ++ mip, width /= 2, height /= 2 ) {
 
 			// Rendering to a mip level is not allowed in webGL1. Instead we must set
 			// up a secondary texture to write the result to, then copy it back to the
@@ -123,8 +123,6 @@ class RoughnessMipmapper {
 			_mipmapMaterial.uniforms.roughnessMap.value = material.roughnessMap;
 
 		}
-
-		roughnessMap.dispose();
 
 		_renderer.setRenderTarget( oldTarget );
 


### PR DESCRIPTION
I noticed a WebGL error (`GL ERROR :GL_INVALID_VALUE : glCopyTexSubImage2D: bad dimensions.`) that I don't think was actually affecting the output at all, but was easily fixed when I realized my loop was going one level too deep.

However, I'm still running into a strange problem where generating the roughness mipmaps is somehow affecting my AO channel. I removed the dispose, since that seemed like it could be the problem, but with no luck. Honestly, I'm sick of hunting down weird problems with this code and having it run on all the MV models even though it makes a noticeable difference on  only a small number. 

The final nail for me is that this can't even work on KTX2 textures, and those in fact must include their mipmaps in the file, which means they can be properly generated there to account for the smoothing of the normal map. So I'm now planning to [remove](https://github.com/google/model-viewer/pull/2935) this from MV and tell anyone who wants it to use KTX2 instead and hopefully a tool exists that will generate mipmaps properly rather than blindly. So @mrdoob, if you'd like to remove RoughnessMipmapper from three.js entirely, that's fine with me. 