### PR TITLE
[Feature] `sessiongranted` support for VRButton to enable in-VR navigation

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -132,6 +132,12 @@ class VRButton {
 
 				supported ? showEnterVR() : showWebXRNotFound();
 
+				if ( supported && VRButton.xrSessionIsGranted ) {
+
+					button.click();
+
+				}
+
 			} );
 
 			return button;
@@ -164,6 +170,24 @@ class VRButton {
 
 	}
 
+	static xrSessionIsGranted = false;
+
+	static registerSessionGrantedListener() {
+
+		if ( 'xr' in navigator ) {
+
+			navigator.xr.addEventListener( 'sessiongranted', () => {
+
+				VRButton.xrSessionIsGranted = true;
+
+			} );
+
+		}
+
+	}
+
 }
+
+VRButton.registerSessionGrantedListener();
 
 export { VRButton };


### PR DESCRIPTION
The `sessiongranted` event is the current proposal for immersive web navigation (https://github.com/immersive-web/navigation#api-proposal). While still a proposal and only working in the Oculus Quest browser right now, it allows building connected VR pages (and AR pages, but that's not part of this PR).

**Description**

Navigation between pages was causing the session to exit and the user having to initiate the session again. If already authorized, sessiongranted allows to keep the VR session running instead.

A-Frame has implemented this a while ago already (https://aframe.io/docs/1.2.0/components/link.html) and people are creating nice demos with it, now it's coming to three.js :)

**Notes**

Currently, session navigation needs to be enabled via chrome://flags/#webxr-navigation-permission in the Oculus browser.