### PR TITLE
Quaternion: Fix return value of .slerpQuaternions().

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -604,7 +604,7 @@ class Quaternion {
 
 	slerpQuaternions( qa, qb, t ) {
 
-		this.copy( qa ).slerp( qb, t );
+		return this.copy( qa ).slerp( qb, t );
 
 	}
 


### PR DESCRIPTION
Related issue:  N/A

**Description**

`Quaterion.slerpQuaternions` is [documented to return `this`](https://threejs.org/docs/?q=Quaternion#api/en/math/Quaternion.slerpQuaternions) but [does not](https://github.com/mrdoob/three.js/blob/dev/src/math/Quaternion.js#L607).

This PR fixes that.
