### PR TITLE
MeshMatcapMaterial: update default matcap

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshmatcap.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap.glsl.js
@@ -90,7 +90,7 @@ void main() {
 
 	#else
 
-		vec4 matcapColor = vec4( 1.0 );
+		vec4 matcapColor = vec4( vec3( mix( 0.2, 0.8, uv.y ) ), 1.0 ); // default if matcap is missing
 
 	#endif
 


### PR DESCRIPTION
Previously, if the `matcap` was not defined, the shader would render white:

<img width="798" alt="Screen Shot 2021-12-30 at 5 49 14 PM" src="https://user-images.githubusercontent.com/1000017/147793130-11774e8e-645d-4ed9-97cc-c0db02ac3cbf.png">

We can actually improve on the default with a small change to the shader:

<img width="797" alt="Screen Shot 2021-12-30 at 5 51 22 PM" src="https://user-images.githubusercontent.com/1000017/147793184-8bfcf4df-dfbd-45b9-8c9e-79205f8e6d41.png">

Just a suggestion...  :-)