### PR TITLE
distribute e2e jobs  better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         CI: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
     env:
       CI: ${{ matrix.CI }}
+      JOBS: 8
       FORCE_COLOR: 1
     steps:
       - name: Git checkout

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -101,7 +101,7 @@
 				scene.add( groundMesh );
 
 				// model
-				function loadModel() {
+				async function loadModel() {
 
 					object.traverse( function ( child ) {
 
@@ -148,8 +148,13 @@
 
 						for ( let i = 0; i < 300; i ++ ) {
 
-							render();
+							await ( async () => {
 
+								console.log( `render ${i}` );
+								render();
+			
+							} )();
+			
 						}
 
 					}
@@ -180,6 +185,7 @@
 
 			function createGUI() {
 
+				console.log( 'createGUI' );
 				const gui = new GUI( { name: 'Accumulation Settings' } );
 				gui.add( params, 'Enable' );
 				gui.add( params, 'Blur Edges' );
@@ -192,6 +198,7 @@
 
 			function onWindowResize() {
 
+				console.log( 'onWindowResize' );
 				camera.aspect = window.innerWidth / window.innerHeight;
 				camera.updateProjectionMatrix();
 				renderer.setSize( window.innerWidth, window.innerHeight );
@@ -199,6 +206,8 @@
 			}
 
 			function render() {
+
+				const start = performance._now();
 
 				// Update the inertia on the orbit controls
 				controls.update();
@@ -245,11 +254,13 @@
 
 				// Render Scene
 				renderer.render( scene, camera );
+				console.log( `render ended in  ${performance._now() - start} milliseconds` );
 
 			}
 
 			function animate() {
 
+				console.log( 'animate' );
 				requestAnimationFrame( animate );
 				render();
 

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -156,12 +156,13 @@
 
 				}
 
-				const manager = new THREE.LoadingManager( loadModel );
-				const loader = new GLTFLoader( manager );
+				/*const manager = new THREE.LoadingManager( /*loadModel );*/
+				const loader = new GLTFLoader( /*manager*/ );
 				loader.load( 'models/gltf/ShadowmappableMesh.glb', function ( obj ) {
 
 					object = obj.scene.children[ 0 ];
-
+					loadModel( object );
+			
 				} );
 
 				// controls

--- a/test/e2e/clean-page.js
+++ b/test/e2e/clean-page.js
@@ -2,6 +2,7 @@
 ( function () {
 
 
+	console.log( 'cleanPage started' );
 	/* Remove start screen ( or press some button ) */
 
 	const button = document.getElementById( 'startButton' );
@@ -12,6 +13,7 @@
 
 	}
 
+	console.log( 'button clicked' );
 
 	/* Remove gui and fonts */
 
@@ -20,6 +22,7 @@
 	style.innerHTML = `body { font size: 0 !important; }
       #info, button, input, body > div.lil-gui, body > div.lbl { display: none !important; }`;
 
+	console.log( 'style created' );
 	const head = document.getElementsByTagName( 'head' );
 
 	if ( head.length > 0 ) {
@@ -27,6 +30,8 @@
 		head[ 0 ].appendChild( style );
 
 	}
+
+	console.log( 'style added' );
 
 	/* Remove stats.js */
 
@@ -41,5 +46,7 @@
 		}
 
 	}
+
+	console.log( 'canvas hidden' );
 
 }() );

--- a/test/e2e/deterministic-injection.js
+++ b/test/e2e/deterministic-injection.js
@@ -34,6 +34,7 @@
 	const maxFrameId = 2;
 	window.requestAnimationFrame = function ( cb ) {
 
+		console.log( 'requestAnimationFrame' );
 		if ( ! _renderStarted ) {
 
 			setTimeout( function () {

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -92,9 +92,10 @@ const pup = puppeteer.launch( {
 		.replace( /Math\.random\(\) \* 0xffffffff/g, 'Math._random() * 0xffffffff' );
 	await page.setRequestInterception( true );
 
-	page.on( 'console', msg => ( msg.text().slice( 0, 8 ) === 'Warning.' ) ? console.null( msg.text() ) : {} );
+	page.on( 'console', msg => console.log( msg.text() ) );
 	page.on( 'request', async ( request ) => {
 
+		console.log( `response: ${request.url()}` );
 		if ( request.url() === 'http://localhost:1234/build/three.module.js' ) {
 
 			await request.respond( {
@@ -112,6 +113,7 @@ const pup = puppeteer.launch( {
 	} );
 	page.on( 'response', async ( response ) => {
 
+		console.log( `response: ${response.request().url()}` );
 		try {
 
 			await response.buffer().then( buffer => pageSize += buffer.length );
@@ -187,17 +189,18 @@ const pup = puppeteer.launch( {
 			try {
 
 				/* Render page */
-
+				console.log( 'cleanPage started' );
 				await page.evaluate( cleanPage );
-
+				console.log( 'cleanPage ended' );
 				await page.evaluate( async ( pageSize, pageSizeMinTax, pageSizeMaxTax, networkTax, renderTimeout, attemptProgress ) => {
 
 
 					/* Resource timeout */
-
 					const resourcesSize = Math.min( 1, ( pageSize / 1024 / 1024 - pageSizeMinTax ) / pageSizeMaxTax );
-					await new Promise( resolve => setTimeout( resolve, networkTax * resourcesSize * attemptProgress ) );
 
+					console.log( resourcesSize );
+					await new Promise( resolve => setTimeout( resolve, networkTax * resourcesSize * attemptProgress ) );
+					console.log( networkTax * resourcesSize * attemptProgress );
 
 					/* Resolve render promise */
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -144,20 +144,21 @@ const pup = puppeteer.launch( {
 	let pageSize, file, attemptProgress;
 	const failedScreenshots = [];
 
-	let beginId = 0;
-	let endId = files.length;
+	const beginId = 0;
+	const endId = files.length;
+	let jobs = 1;
+	let jobID = 0;
 
 	if ( 'CI' in process.env ) {
 
-		const jobs = 8;
-
-		beginId = Math.floor( parseInt( process.env.CI.slice( 0, 1 ) ) * files.length / jobs );
-		endId = Math.floor( ( parseInt( process.env.CI.slice( - 1 ) ) + 1 ) * files.length / jobs );
+		jobs = parseInt( process.env.JOBS, 10 );
+		jobID = parseInt( process.env.CI, 10 );
 
 	}
 
 	for ( let id = beginId; id < endId; ++ id ) {
 
+		if ( id % jobs !== jobID ) continue;
 		/* At least 3 attempts before fail */
 
 		let attemptId = isMakeScreenshot ? 1.5 : 0;


### PR DESCRIPTION
**Description**
e2e jobs now get distributed in blocks based on file name which has the disadvantage that job 7 takes longer since those contain the bigger examples. This PR loops through the examples and distributes them evenly.
So like the following scheme:
JOB 0: Example 0, Example 8, Example 16, ...
JOB 1: Example 1, Example 9, Example 17, ...
JOB 2: Example 2, Example 10, Example 18, ...
JOB 3: Example 3, Example 11, Example 19, ...
JOB 4: Example 4, Example 12, Example 20, ...
JOB 5: Example 5, Example 13, Example 21, ...
JOB 6: Example 6, Example 14, Example 22, ...
JOB 7: Example 7, Example 15, Example 23, ...

This PR also makes the total amount of jobs configurable from ci.yml by adding the environment variable JOBS.