### PR TITLE
LDrawLoader: remove separateobjects flag

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1560,14 +1560,6 @@ class LDrawLoader extends Loader {
 
 								currentParseScope.type = type;
 
-								// If the scale of the object is negated then the triangle winding order
-								// needs to be flipped.
-								if ( currentParseScope.matrix.determinant() < 0 && isPrimitiveType( type ) ) {
-
-									currentParseScope.inverted = ! currentParseScope.inverted;
-
-								}
-
 								faces = currentParseScope.faces;
 								lineSegments = currentParseScope.lineSegments;
 								conditionalSegments = currentParseScope.conditionalSegments;
@@ -2027,13 +2019,14 @@ class LDrawLoader extends Loader {
 			const conditionalSegments = subobjectParseScope.conditionalSegments;
 			const faces = subobjectParseScope.faces;
 			const faceMaterials = subobjectParseScope.faceMaterials;
+			const matrix = subobjectParseScope.matrix;
 
 			for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
 
 				const ls = lineSegments[ i ];
 				const vertices = ls.vertices;
-				vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-				vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
+				vertices[ 0 ].applyMatrix4( matrix );
+				vertices[ 1 ].applyMatrix4( matrix );
 
 				parentLineSegments.push( ls );
 
@@ -2044,10 +2037,10 @@ class LDrawLoader extends Loader {
 				const os = conditionalSegments[ i ];
 				const vertices = os.vertices;
 				const controlPoints = os.controlPoints;
-				vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-				vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
-				controlPoints[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-				controlPoints[ 1 ].applyMatrix4( subobjectParseScope.matrix );
+				vertices[ 0 ].applyMatrix4( matrix );
+				vertices[ 1 ].applyMatrix4( matrix );
+				controlPoints[ 0 ].applyMatrix4( matrix );
+				controlPoints[ 1 ].applyMatrix4( matrix );
 
 				parentConditionalSegments.push( os );
 
@@ -2059,7 +2052,15 @@ class LDrawLoader extends Loader {
 				const vertices = tri.vertices;
 				for ( let i = 0, l = vertices.length; i < l; i ++ ) {
 
-					vertices[ i ].applyMatrix4( subobjectParseScope.matrix );
+					vertices[ i ].applyMatrix4( matrix );
+
+				}
+
+				// If the scale of the object is negated then the triangle winding order
+				// needs to be flipped.
+				if ( matrix.determinant() < 0 ) {
+
+					vertices.reverse();
 
 				}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1094,7 +1094,6 @@ class LDrawLoader extends Loader {
 			currentFileName: null,
 			mainColourCode: parentScope ? parentScope.mainColourCode : '16',
 			mainEdgeColourCode: parentScope ? parentScope.mainEdgeColourCode : '24',
-			currentMatrix: new Matrix4(),
 			matrix: new Matrix4(),
 			type: 'Model',
 			groupObject: null,
@@ -2087,7 +2086,6 @@ class LDrawLoader extends Loader {
 		// Set current matrix
 		if ( subobject ) {
 
-			parseScope.currentMatrix.multiplyMatrices( parentParseScope.currentMatrix, subobject.matrix );
 			parseScope.matrix.copy( subobject.matrix );
 			parseScope.inverted = subobject.inverted;
 			parseScope.startingConstructionStep = subobject.startingConstructionStep;

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -587,6 +587,12 @@ class LineParser {
 
 	}
 
+	getVector() {
+
+		return new Vector3( parseFloat( this.getToken() ), parseFloat( this.getToken() ), parseFloat( this.getToken() ) );
+
+	}
+
 	getRemainingString() {
 
 		return this.line.substring( this.currentCharIndex, this.lineLength );
@@ -1487,12 +1493,6 @@ class LDrawLoader extends Loader {
 
 		};
 
-		const parseVector = lp => {
-
-			return new Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
-
-		};
-
 		// Parse all line commands
 		for ( let lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
 
@@ -1759,8 +1759,8 @@ class LDrawLoader extends Loader {
 				case '2':
 
 					material = parseColourCode( lp, true );
-					v0 = parseVector( lp );
-					v1 = parseVector( lp );
+					v0 = lp.getVector();
+					v1 = lp.getVector();
 
 					segment = {
 						material: material.userData.edgeMaterial,
@@ -1779,10 +1779,10 @@ class LDrawLoader extends Loader {
 				case '5':
 
 					material = parseColourCode( lp, true );
-					v0 = parseVector( lp );
-					v1 = parseVector( lp );
-					c0 = parseVector( lp );
-					c1 = parseVector( lp );
+					v0 = lp.getVector();
+					v1 = lp.getVector();
+					c0 = lp.getVector();
+					c1 = lp.getVector();
 
 					segment = {
 						material: material.userData.edgeMaterial.userData.conditionalEdgeMaterial,
@@ -1806,15 +1806,15 @@ class LDrawLoader extends Loader {
 
 					if ( ccw === true ) {
 
-						v0 = parseVector( lp );
-						v1 = parseVector( lp );
-						v2 = parseVector( lp );
+						v0 = lp.getVector();
+						v1 = lp.getVector();
+						v2 = lp.getVector();
 
 					} else {
 
-						v2 = parseVector( lp );
-						v1 = parseVector( lp );
-						v0 = parseVector( lp );
+						v2 = lp.getVector();
+						v1 = lp.getVector();
+						v0 = lp.getVector();
 
 					}
 
@@ -1855,17 +1855,17 @@ class LDrawLoader extends Loader {
 
 					if ( ccw === true ) {
 
-						v0 = parseVector( lp );
-						v1 = parseVector( lp );
-						v2 = parseVector( lp );
-						v3 = parseVector( lp );
+						v0 = lp.getVector();
+						v1 = lp.getVector();
+						v2 = lp.getVector();
+						v3 = lp.getVector();
 
 					} else {
 
-						v3 = parseVector( lp );
-						v2 = parseVector( lp );
-						v1 = parseVector( lp );
-						v0 = parseVector( lp );
+						v3 = lp.getVector();
+						v2 = lp.getVector();
+						v1 = lp.getVector();
+						v0 = lp.getVector();
 
 					}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2020,6 +2020,7 @@ class LDrawLoader extends Loader {
 			const faces = subobjectParseScope.faces;
 			const faceMaterials = subobjectParseScope.faceMaterials;
 			const matrix = subobjectParseScope.matrix;
+			const matrixScaleInverted = matrix.determinant() < 0;
 
 			for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
 
@@ -2058,7 +2059,7 @@ class LDrawLoader extends Loader {
 
 				// If the scale of the object is negated then the triangle winding order
 				// needs to be flipped.
-				if ( matrix.determinant() < 0 ) {
+				if ( matrixScaleInverted ) {
 
 					vertices.reverse();
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -965,10 +965,6 @@ class LDrawLoader extends Loader {
 			this.parseColourMetaDirective( new LineParser( 'Edge_Colour CODE 24 VALUE #A0A0A0 EDGE #333333' ) )
 		] );
 
-		// If this flag is set to true, each subobject will be a Object.
-		// If not (the default), only one object which contains all the merged primitives will be created.
-		this.separateObjects = false;
-
 		// If this flag is set to true the vertex normals will be smoothed.
 		this.smoothNormals = true;
 
@@ -1494,15 +1490,7 @@ class LDrawLoader extends Loader {
 
 		const parseVector = lp => {
 
-			const v = new Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
-
-			if ( ! this.separateObjects ) {
-
-				v.applyMatrix4( currentParseScope.currentMatrix );
-
-			}
-
-			return v;
+			return new Vector3( parseFloat( lp.getToken() ), parseFloat( lp.getToken() ), parseFloat( lp.getToken() ) );
 
 		};
 
@@ -1575,11 +1563,7 @@ class LDrawLoader extends Loader {
 
 								// If the scale of the object is negated then the triangle winding order
 								// needs to be flipped.
-								if (
-									currentParseScope.matrix.determinant() < 0 && (
-										this.separateObjects && isPrimitiveType( type ) ||
-											! this.separateObjects
-									) ) {
+								if ( currentParseScope.matrix.determinant() < 0 && isPrimitiveType( type ) ) {
 
 									currentParseScope.inverted = ! currentParseScope.inverted;
 
@@ -1932,7 +1916,7 @@ class LDrawLoader extends Loader {
 		currentParseScope.subobjectIndex = 0;
 
 		const isRoot = ! parentParseScope.isFromParse;
-		if ( isRoot || this.separateObjects && ! isPrimitiveType( type ) ) {
+		if ( isRoot || ! isPrimitiveType( type ) ) {
 
 			currentParseScope.groupObject = new Group();
 			currentParseScope.groupObject.userData.startingConstructionStep = currentParseScope.startingConstructionStep;
@@ -2000,7 +1984,7 @@ class LDrawLoader extends Loader {
 		}
 
 		const isRoot = ! parentParseScope.isFromParse;
-		if ( this.separateObjects && ! isPrimitiveType( subobjectParseScope.type ) || isRoot ) {
+		if ( ! isPrimitiveType( subobjectParseScope.type ) || isRoot ) {
 
 			const objGroup = subobjectParseScope.groupObject;
 
@@ -2035,7 +2019,6 @@ class LDrawLoader extends Loader {
 
 		} else {
 
-			const separateObjects = this.separateObjects;
 			const parentLineSegments = parentParseScope.lineSegments;
 			const parentConditionalSegments = parentParseScope.conditionalSegments;
 			const parentFaces = parentParseScope.faces;
@@ -2049,14 +2032,9 @@ class LDrawLoader extends Loader {
 			for ( let i = 0, l = lineSegments.length; i < l; i ++ ) {
 
 				const ls = lineSegments[ i ];
-
-				if ( separateObjects ) {
-
-					const vertices = ls.vertices;
-					vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-					vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
-
-				}
+				const vertices = ls.vertices;
+				vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
+				vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
 
 				parentLineSegments.push( ls );
 
@@ -2065,17 +2043,12 @@ class LDrawLoader extends Loader {
 			for ( let i = 0, l = conditionalSegments.length; i < l; i ++ ) {
 
 				const os = conditionalSegments[ i ];
-
-				if ( separateObjects ) {
-
-					const vertices = os.vertices;
-					const controlPoints = os.controlPoints;
-					vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-					vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
-					controlPoints[ 0 ].applyMatrix4( subobjectParseScope.matrix );
-					controlPoints[ 1 ].applyMatrix4( subobjectParseScope.matrix );
-
-				}
+				const vertices = os.vertices;
+				const controlPoints = os.controlPoints;
+				vertices[ 0 ].applyMatrix4( subobjectParseScope.matrix );
+				vertices[ 1 ].applyMatrix4( subobjectParseScope.matrix );
+				controlPoints[ 0 ].applyMatrix4( subobjectParseScope.matrix );
+				controlPoints[ 1 ].applyMatrix4( subobjectParseScope.matrix );
 
 				parentConditionalSegments.push( os );
 
@@ -2084,15 +2057,10 @@ class LDrawLoader extends Loader {
 			for ( let i = 0, l = faces.length; i < l; i ++ ) {
 
 				const tri = faces[ i ];
+				const vertices = tri.vertices;
+				for ( let i = 0, l = vertices.length; i < l; i ++ ) {
 
-				if ( separateObjects ) {
-
-					const vertices = tri.vertices;
-					for ( let i = 0, l = vertices.length; i < l; i ++ ) {
-
-						vertices[ i ].applyMatrix4( subobjectParseScope.matrix );
-
-					}
+					vertices[ i ].applyMatrix4( subobjectParseScope.matrix );
 
 				}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -92,7 +92,6 @@
 
 				guiData = {
 					modelFileName: modelFileList[ 'Car' ],
-					separateObjects: false,
 					displayLines: true,
 					conditionalLines: true,
 					smoothNormals: true,
@@ -162,7 +161,6 @@
 
 				// only smooth when not rendering with flat colors to improve processing time
 				const lDrawLoader = new LDrawLoader();
-				lDrawLoader.separateObjects = guiData.separateObjects;
 				lDrawLoader.smoothNormals = guiData.smoothNormals && ! guiData.flatColors;
 				lDrawLoader
 					.setPath( ldrawPath )
@@ -271,29 +269,19 @@
 
 				} );
 
-				gui.add( guiData, 'separateObjects' ).name( 'Separate Objects' ).onChange( function () {
-
-					reloadObject( false );
-
-				} );
-
 				gui.add( guiData, 'flatColors' ).name( 'Flat Colors' ).onChange( function () {
 
 					reloadObject( false );
 
 				} );
 
-				if ( guiData.separateObjects ) {
+				if ( model.userData.numConstructionSteps > 1 ) {
 
-					if ( model.userData.numConstructionSteps > 1 ) {
+					gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( updateObjectsVisibility );
 
-						gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( updateObjectsVisibility );
+				} else {
 
-					} else {
-
-						gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( updateObjectsVisibility );
-
-					}
+					gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( updateObjectsVisibility );
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23139#issue-1093050834

**Description**

- Removes the `LDrawLoader.separateObjectst` flag from both the class and the example -- this can be added back at a future time if needed.
- This PR also moved the inversion of primitive winding order if the transformation matrix is scale inverted out of `objectParse`, as well.
- Moves the `parseVector` function to `LineParser.getVector`.

Next up will be rethinking the "main" color used when loading a sub file so the parsed contents of individual files can be more easily cached.