### PR TITLE
Set the no-throw-literal eslint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
       "GPUTextureUsage": "readonly"
     },
     "rules": {
+      "no-throw-literal": [
+        "error"
+      ],
       "quotes": [
         "error",
         "single"


### PR DESCRIPTION
Related issue: #23137

**Description**
Set the eslint rule to always throw errors instead of literals.