### PR TITLE
WebGLRenderer: Simplify env map generation.

### DIFF
--- a/src/renderers/webgl/WebGLCubeMaps.js
+++ b/src/renderers/webgl/WebGLCubeMaps.js
@@ -40,13 +40,9 @@ function WebGLCubeMaps( renderer ) {
 
 					if ( image && image.height > 0 ) {
 
-						const currentRenderTarget = renderer.getRenderTarget();
-
 						const renderTarget = new WebGLCubeRenderTarget( image.height / 2 );
 						renderTarget.fromEquirectangularTexture( renderer, texture );
 						cubemaps.set( texture, renderTarget );
-
-						renderer.setRenderTarget( currentRenderTarget );
 
 						texture.addEventListener( 'dispose', onTextureDispose );
 

--- a/src/renderers/webgl/WebGLCubeUVMaps.js
+++ b/src/renderers/webgl/WebGLCubeUVMaps.js
@@ -30,14 +30,10 @@ function WebGLCubeUVMaps( renderer ) {
 
 					if ( ( isEquirectMap && image && image.height > 0 ) || ( isCubeMap && image && isCubeTextureComplete( image ) ) ) {
 
-						const currentRenderTarget = renderer.getRenderTarget();
-
 						if ( pmremGenerator === null ) pmremGenerator = new PMREMGenerator( renderer );
 
 						const renderTarget = isEquirectMap ? pmremGenerator.fromEquirectangular( texture ) : pmremGenerator.fromCubemap( texture );
 						cubeUVmaps.set( texture, renderTarget );
-
-						renderer.setRenderTarget( currentRenderTarget );
 
 						texture.addEventListener( 'dispose', onTextureDispose );
 


### PR DESCRIPTION
Related issue: -

**Description**

It is not necessary to store the current render target in `WebGLCubeMaps` and `WebGLCubeUVMaps` since `PMREMGenerator` and `WebGLCubeRenderTarget.fromEquirectangularTexture()` do not overwrite the current render target.
