### PR TITLE
LDrawLoader: Refactor, cache pre-parsed file contents

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -870,7 +870,7 @@ class LDrawParsedCache {
 								material = loader.parseColourMetaDirective( lp );
 								if ( material ) {
 
-									materials[ material.userData.colourCode ] = material;
+									materials[ material.userData.code ] = material;
 
 								}	else {
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -628,7 +628,7 @@ class LDrawParsedCache {
 
 	}
 
-	cloneResult( original, depth = 0 ) {
+	cloneResult( original ) {
 
 		if ( original === null ) {
 
@@ -638,24 +638,20 @@ class LDrawParsedCache {
 
 			return original.clone();
 
+		} else if ( original.isMaterial ) {
+
+			return original;
+
 		} else if ( Array.isArray( original ) ) {
 
-			return original.map( e => this.cloneResult( e, depth + 1 ) );
+			return original.map( e => this.cloneResult( e ) );
 
 		} else if ( typeof original === 'object' ) {
 
 			const result = {};
 			for ( const key in original ) {
 
-				if ( key === 'materials' && depth === 0 ) {
-
-					result.materials = [ ...original.materials ];
-
-				} else {
-
-					result[ key ] = this.cloneResult( original[ key ], depth + 1 );
-
-				}
+				result[ key ] = this.cloneResult( original[ key ] );
 
 			}
 
@@ -755,12 +751,11 @@ class LDrawParsedCache {
 		const lineSegments = [];
 		const conditionalSegments = [];
 		const subobjects = [];
-		const materials = [];
-		const materialMap = {};
+		const materials = {};
 
 		const getLocalMaterial = colourCode => {
 
-			return colourCode in materialMap ? materialMap[ colourCode ] : null;
+			return colourCode in materials ? materials[ colourCode ] : null;
 
 		};
 
@@ -861,8 +856,7 @@ class LDrawParsedCache {
 								material = loader.parseColourMetaDirective( lp );
 								if ( material ) {
 
-									materials.push( material );
-									materialMap[ material.userData.colourCode ] = material;
+									materials[ material.userData.colourCode ] = material;
 
 								}	else {
 
@@ -2001,11 +1995,11 @@ class LDrawLoader extends Loader {
 
 		}
 
-		materials.forEach( m => {
+		for ( const colourCode in materials ) {
 
-			this.addMaterial( m, currentParseScope );
+			this.addMaterial( materials[ colourCode ], currentParseScope );
 
-		} );
+		}
 
 		for ( let i = 0, l = faces.length; i < l; i ++ ) {
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2003,7 +2003,7 @@ class LDrawLoader extends Loader {
 
 			const face = faces[ i ];
 			const colourCode = face.colourCode;
-			face.material = parseColourCode( colourCode, currentParseScope );
+			face.material = parseColourCode( colourCode, false );
 
 		}
 
@@ -2011,7 +2011,7 @@ class LDrawLoader extends Loader {
 
 			const ls = lineSegments[ i ];
 			const colourCode = ls.colourCode;
-			ls.material = parseColourCode( colourCode, currentParseScope );
+			ls.material = parseColourCode( colourCode, true ).userData.edgeMaterial;
 
 		}
 
@@ -2019,7 +2019,7 @@ class LDrawLoader extends Loader {
 
 			const cs = conditionalSegments[ i ];
 			const colourCode = cs.colourCode;
-			cs.material = parseColourCode( colourCode, currentParseScope );
+			cs.material = parseColourCode( colourCode, true ).userData.edgeMaterial.userData.conditionalEdgeMaterial
 
 		}
 
@@ -2187,7 +2187,7 @@ class LDrawLoader extends Loader {
 
 				// If the scale of the object is negated then the triangle winding order
 				// needs to be flipped.
-				if ( matrixScaleInverted ) {
+				if ( matrixScaleInverted !== subobjectParseScope.inverted ) {
 
 					vertices.reverse();
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -630,38 +630,52 @@ class LDrawParsedCache {
 
 	cloneResult( original ) {
 
-		if ( original === null ) {
+		const result = {};
 
-			return null;
+		// vertices are transformed and normals computed before being converted to geometry
+		// so these pieces must be cloned.
+		result.faces = original.faces.map( face => {
 
-		} else if ( original.isVector3 ) {
+			return {
+				colourCode: face.colourCode,
+				material: face.material,
+				vertices: face.vertices.map( v => v.clone() ),
+				normals: face.normals.map( () => null ),
+				faceNormal: null
+			};
 
-			return original.clone();
+		} );
 
-		} else if ( original.isMaterial ) {
+		result.conditionalSegments = original.conditionalSegments.map( face => {
 
-			return original;
+			return {
+				colourCode: face.colourCode,
+				material: face.material,
+				vertices: face.vertices.map( v => v.clone() ),
+				controlPoints: face.controlPoints.map( v => v.clone() )
+			};
 
-		} else if ( Array.isArray( original ) ) {
+		} );
 
-			return original.map( e => this.cloneResult( e ) );
+		result.lineSegments = original.lineSegments.map( face => {
 
-		} else if ( typeof original === 'object' ) {
+			return {
+				colourCode: face.colourCode,
+				material: face.material,
+				vertices: face.vertices.map( v => v.clone() )
+			};
 
-			const result = {};
-			for ( const key in original ) {
+		} );
 
-				result[ key ] = this.cloneResult( original[ key ] );
-
-			}
-
-			return result;
-
-		} else {
-
-			return original;
-
-		}
+		// none if this is subsequently modified
+		result.type = original.type;
+		result.category = original.category;
+		result.keywords = original.keywords;
+		result.subobjects = original.subobjects;
+		result.totalFaces = original.totalFaces;
+		result.startingConstructionStep = original.startingConstructionStep;
+		result.materials = original.materials;
+		return result;
 
 	}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -958,7 +958,7 @@ class LDrawLoader extends Loader {
 
 		// Not using THREE.Cache here because it returns the previous HTML error response instead of calling onError()
 		// This also allows to handle the embedded text files ("0 FILE" lines)
-		this.cache = new LDrawFileCache( this );
+		this.fileCache = new LDrawFileCache( this );
 
 		// This object is a map from file names to paths. It agilizes the paths search. If it is not set then files will be searched by trial and error.
 		this.fileMap = {};
@@ -1505,7 +1505,7 @@ class LDrawLoader extends Loader {
 				if ( line.startsWith( '0 FILE ' ) ) {
 
 					// Save previous embedded file in the cache
-					this.cache.setData( currentEmbeddedFileName.toLowerCase(), currentEmbeddedText );
+					this.fileCache.setData( currentEmbeddedFileName.toLowerCase(), currentEmbeddedText );
 
 					// New embedded text file
 					currentEmbeddedFileName = line.substring( 7 );
@@ -1896,7 +1896,7 @@ class LDrawLoader extends Loader {
 
 		if ( parsingEmbeddedFiles ) {
 
-			this.cache.setData( currentEmbeddedFileName.toLowerCase(), currentEmbeddedText );
+			this.fileCache.setData( currentEmbeddedFileName.toLowerCase(), currentEmbeddedText );
 
 		}
 


### PR DESCRIPTION
Related issue: --

**Description**

This PR looks fairly big but it's mostly rearranging code. The significant change here is that LDraw files are now parsed without context so they parsed contents are no longer specific to a scope being processed in the moment. Instead the context-specific parameters (face inversion, materials, scale) are applied after the fact when the file contents are being applied to a part. This lets us cache the parsed contents of the file and clone the result rather than reparse the text file contents every time. The big adjustment is that the `LDrawFileCache` has been changed to the `LDrawParsedCache` and the logic from `objectParse` has been moved into the cache.

This included a _bit_ of a speed boost (around 12% or 700ms on the AT-ST model when loading without smooth normals) but the bigger benefit is that this is a big step towards producing generalize geometry lists for full parts and cache smooth normals so they only have to be generated once. And from there it should be easy to produce only a single piece geometry per part to share among all meshes that use it. That should enable a much larger speed boost when loading a model especially with smooth normals.

I tested this with the Scorpion Pyramid model to check part library models as well as all the packed models in the repo.

https://raw.githack.com/gkjohnson/three.js/cache-parsed-data/examples/webgl_loader_ldraw.html

Sorry for the big change list @yomboprime 😅. I think it's only one more big one after this to make a cache for the reusable, smoothed geometry.