### PR TITLE
Examples: Inline small utility methods for examples/js

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -63,6 +63,7 @@ import {
 	VectorKeyframeTrack,
 	sRGBEncoding
 } from '../../../build/three.module.js';
+import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
 
 class GLTFLoader extends Loader {
 
@@ -4248,100 +4249,6 @@ function addPrimitiveAttributes( geometry, primitiveDef, parser ) {
 			: geometry;
 
 	} );
-
-}
-
-/**
- * @param {BufferGeometry} geometry
- * @param {Number} drawMode
- * @return {BufferGeometry}
- */
-function toTrianglesDrawMode( geometry, drawMode ) {
-
-	let index = geometry.getIndex();
-
-	// generate index if not present
-
-	if ( index === null ) {
-
-		const indices = [];
-
-		const position = geometry.getAttribute( 'position' );
-
-		if ( position !== undefined ) {
-
-			for ( let i = 0; i < position.count; i ++ ) {
-
-				indices.push( i );
-
-			}
-
-			geometry.setIndex( indices );
-			index = geometry.getIndex();
-
-		} else {
-
-			console.error( 'THREE.GLTFLoader.toTrianglesDrawMode(): Undefined position attribute. Processing not possible.' );
-			return geometry;
-
-		}
-
-	}
-
-	//
-
-	const numberOfTriangles = index.count - 2;
-	const newIndices = [];
-
-	if ( drawMode === TriangleFanDrawMode ) {
-
-		// gl.TRIANGLE_FAN
-
-		for ( let i = 1; i <= numberOfTriangles; i ++ ) {
-
-			newIndices.push( index.getX( 0 ) );
-			newIndices.push( index.getX( i ) );
-			newIndices.push( index.getX( i + 1 ) );
-
-		}
-
-	} else {
-
-		// gl.TRIANGLE_STRIP
-
-		for ( let i = 0; i < numberOfTriangles; i ++ ) {
-
-			if ( i % 2 === 0 ) {
-
-				newIndices.push( index.getX( i ) );
-				newIndices.push( index.getX( i + 1 ) );
-				newIndices.push( index.getX( i + 2 ) );
-
-
-			} else {
-
-				newIndices.push( index.getX( i + 2 ) );
-				newIndices.push( index.getX( i + 1 ) );
-				newIndices.push( index.getX( i ) );
-
-			}
-
-		}
-
-	}
-
-	if ( ( newIndices.length / 3 ) !== numberOfTriangles ) {
-
-		console.error( 'THREE.GLTFLoader.toTrianglesDrawMode(): Unable to generate correct amount of triangles.' );
-
-	}
-
-	// build final geometry
-
-	const newGeometry = geometry.clone();
-	newGeometry.setIndex( newIndices );
-
-	return newGeometry;
 
 }
 

--- a/examples/jsm/modifiers/EdgeSplitModifier.js
+++ b/examples/jsm/modifiers/EdgeSplitModifier.js
@@ -3,7 +3,7 @@ import {
 	BufferGeometry,
 	Vector3
 } from '../../../build/three.module.js';
-import * as BufferGeometryUtils from '../utils/BufferGeometryUtils.js';
+import { mergeVertices } from '../utils/BufferGeometryUtils.js';
 
 const _A = new Vector3();
 const _B = new Vector3();
@@ -181,13 +181,7 @@ class EdgeSplitModifier {
 
 		if ( geometry.index == null ) {
 
-			if ( BufferGeometryUtils === undefined ) {
-
-				throw new Error( 'THREE.EdgeSplitModifier relies on BufferGeometryUtils' );
-
-			}
-
-			geometry = BufferGeometryUtils.mergeVertices( geometry );
+			geometry = mergeVertices( geometry );
 
 		}
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -3,7 +3,7 @@ import {
 	Float32BufferAttribute,
 	Vector3
 } from '../../../build/three.module.js';
-import * as BufferGeometryUtils from '../utils/BufferGeometryUtils.js';
+import { mergeVertices } from '../utils/BufferGeometryUtils.js';
 
 /**
  *	Simplification Geometry Modifier
@@ -16,16 +16,6 @@ import * as BufferGeometryUtils from '../utils/BufferGeometryUtils.js';
 const _cb = new Vector3(), _ab = new Vector3();
 
 class SimplifyModifier {
-
-	constructor() {
-
-		if ( BufferGeometryUtils === undefined ) {
-
-			throw new Error( 'THREE.SimplifyModifier relies on BufferGeometryUtils' );
-
-		}
-
-	}
 
 	modify( geometry, count ) {
 
@@ -47,7 +37,7 @@ class SimplifyModifier {
 
 		}
 
-		geometry = BufferGeometryUtils.mergeVertices( geometry );
+		geometry = mergeVertices( geometry );
 
 		//
 		// put data of original geometry in different data structures

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -19,10 +19,10 @@ function computeTangents( geometry ) {
 }
 
 /**
-	 * @param  {Array<BufferGeometry>} geometries
-	 * @param  {Boolean} useGroups
-	 * @return {BufferGeometry}
-	 */
+ * @param  {Array<BufferGeometry>} geometries
+ * @param  {Boolean} useGroups
+ * @return {BufferGeometry}
+ */
 function mergeBufferGeometries( geometries, useGroups = false ) {
 
 	const isIndexed = geometries[ 0 ].index !== null;

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -191,6 +191,11 @@ const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
 	'offscreen/**/*',
 ] } );
 
+// Small utilities can be individually inlined into examples.
+const inline = [
+	'BufferGeometryUtils.js',
+	'WorkerPool.js',
+];
 
 // Create a rollup config for each .js file
 export default files.map( file => {
@@ -202,12 +207,10 @@ export default files.map( file => {
 	return {
 
 		input: inputPath,
-		treeshake: true,
+		treeshake: 'recommended',
 		external: ( id ) => {
 
-			// Small utility methods can be individually inlined into examples,
-			// so users don't have to import the entire utility file.
-			if ( /BufferGeometryUtils/.test( id ) ) {
+			if ( inline.some( ( _id ) => id.includes( _id ) ) ) {
 
 				return false;
 

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -202,8 +202,20 @@ export default files.map( file => {
 	return {
 
 		input: inputPath,
-		treeshake: false,
-		external: () => true, // don't bundle anything
+		treeshake: true,
+		external: ( id ) => {
+
+			// Small utility methods can be individually inlined into examples,
+			// so users don't have to import the entire utility file.
+			if ( /BufferGeometryUtils/.test( id ) ) {
+
+				return false;
+
+			}
+
+			return true;
+
+		},
 		plugins: [
 			babel( {
 				babelHelpers: 'bundled',


### PR DESCRIPTION
Currently there appear to be two choices for files in `examples/{js,jsm}` that depend on utilities like BufferGeometryUtils or WorkerPool:

- (A) Copy/paste the necessary methods
  - Duplicates the code; harder to maintain.
- (B) `import * as BufferGeometryUtils`
  - Results in larger bundles for ESM users, and requires CJS/UMD users to manually import the utils file.

I think we could improve things a bit by allowing Rollup to inline methods from certain utility files when it compiles the `examples/js` versions. This means ESM users get strictly smaller bundles, and CJS/UMD users will have a better developer experience and *usually* get smaller bundles, although some duplication is still possible there if loading multiple files that depend on the same utilities. Particularly for the ESM  benefits I think that's a good tradeoff.

The main side-effect here is related to enabling `treeshake: 'recommended'`. Rollup tree-shakes a fair bit of dead code from existing examples, but I can't think of any downside to that.