### PR TITLE
LDrawLoader: Fix a corner case when smoothing normals

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -191,14 +191,22 @@ function generateFaceNormals( faces ) {
 const _ray = new Ray();
 function smoothNormals( faces, lineSegments, checkSubSegments = false ) {
 
+	// NOTE: 1e2 is pretty coarse but was chosen to quantize the resulting value because
+	// it allows edges to be smoothed as expected (see minifig arms).
+	// --
+	// And the vector values are initialize multiplied by 1 + 1e-10 to account for floating
+	// point errors on vertices along quantization boundaries. Ie after matrix multiplication
+	// vertices that should be merged might be set to "1.7" and "1.6999..." meaning they won't
+	// get merged. This added epsilon attempts to push these error values to the same quantized
+	// value for the sake of hashing. See "AT-ST mini" dishes.
+
+	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
 	function hashVertex( v ) {
 
-		// NOTE: 1e2 is pretty coarse but was chosen because it allows edges
-		// to be smoothed as expected (see minifig arms). The errors between edges
-		// could be due to matrix multiplication.
-		const x = ~ ~ ( v.x * 1e2 );
-		const y = ~ ~ ( v.y * 1e2 );
-		const z = ~ ~ ( v.z * 1e2 );
+		const x = ~ ~ ( v.x * hashMultiplier );
+		const y = ~ ~ ( v.y * hashMultiplier );
+		const z = ~ ~ ( v.z * hashMultiplier );
+
 		return `${ x },${ y },${ z }`;
 
 	}

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -198,7 +198,7 @@ function smoothNormals( faces, lineSegments, checkSubSegments = false ) {
 	// point errors on vertices along quantization boundaries. Ie after matrix multiplication
 	// vertices that should be merged might be set to "1.7" and "1.6999..." meaning they won't
 	// get merged. This added epsilon attempts to push these error values to the same quantized
-	// value for the sake of hashing. See "AT-ST mini" dishes.
+	// value for the sake of hashing. See "AT-ST mini" dishes. See mrdoob/three#23169.
 
 	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
 	function hashVertex( v ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23157#issuecomment-1006968324

**Description**

This PR fixes a small visual glitch is normal smoothing that has been bugging me for awhile and I finally took a moment to look into it. The way vertices are determined to be close enough to be merged is via vertex hashing which effectively quantizes all vertices into bins which should be expected to have artifacts at points that lie exactly on these quantization boundaries especially when the points being merged may have matrix operations applied to them incurring error. It's much faster than other more robust methods, though. This was happening in this dish element here:

<img src="https://user-images.githubusercontent.com/734200/148487517-1ae5e655-ba58-40b5-b3eb-80950513a6a1.png" width="400px"/>

The points on the top strip of the artifact have y set to `1.7` and the points on the bottom strip are set to `1.6999...` which get quantized to `170` and `169` respectively meaning they won't get merged. The inclusion of multiplying the value by `1 + 1e-10` thereby adding a small epsilon to `1.6999...` to offset the error and pushes it in to the appropriate value to be merged. This effectively moves the boundaries of the quantization by a very small amount meaning the error could still happen but given the nature of the data in the LDraw files it seems much more unlikely.

If there are other thoughts on how to address this let me know!

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/148488085-31fb9599-a2c0-4af0-8083-b27ae0fae2f0.png) | ![image](https://user-images.githubusercontent.com/734200/148488163-a6d12bed-941e-4374-8231-9fc4294d8b91.png) |


