### PR TITLE
Editor: Suport window-controls-overlay feature.

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -334,13 +334,13 @@ select {
 
 #menubar {
 	position: absolute;
-	width: 100%;
-	height: 32px;
 	background: #eee;
 	padding: 0;
 	margin: 0;
-	right: 0;
-	top: 0;
+	top: env(titlebar-area-y, 0);
+	left: env(titlebar-area-x, 0);
+	width: env(titlebar-area-width, 100%);
+	height: env(titlebar-area-height, 32px);
 	app-region: drag;
 }
 

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -341,6 +341,7 @@ select {
 	left: env(titlebar-area-x, 0);
 	width: env(titlebar-area-width, 100%);
 	height: env(titlebar-area-height, 32px);
+	min-width: 600px;
 	app-region: drag;
 }
 

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -341,12 +341,14 @@ select {
 	margin: 0;
 	right: 0;
 	top: 0;
+	app-region: drag;
 }
 
 	#menubar .menu {
 		float: left;
 		cursor: pointer;
 		padding-right: 8px;
+		app-region: no-drag;
 	}
 
 	#menubar .menu.right {

--- a/editor/manifest.json
+++ b/editor/manifest.json
@@ -10,5 +10,6 @@
       "type": "image/png",
       "sizes": "144x144"
     }
-  ]
+  ],
+  "display_override": ["window-controls-overlay"]
 }


### PR DESCRIPTION
Related issue: #23153 

**Description**

Editor suport Chrome 97's new feature `window-controls-overlay feature`.

Screenshot:

![image](https://user-images.githubusercontent.com/23699926/148647266-fdcf9668-2ab7-4a6b-99bb-5c49418a8a21.png)

