### PR TITLE
Fix DOMException when trying to use XR inside an iframe

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -133,6 +133,16 @@ class ARButton {
 
 		}
 
+		function showARNotAllowed( exception ) {
+
+			disableButton();
+
+			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+
+			button.textContent = 'AR NOT ALLOWED';
+
+		}
+
 		function stylizeElement( element ) {
 
 			element.style.position = 'absolute';
@@ -161,7 +171,7 @@ class ARButton {
 
 				supported ? showStartAR() : showARNotSupported();
 
-			} ).catch( showARNotSupported );
+			} ).catch( showARNotAllowed );
 
 			return button;
 

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -104,6 +104,16 @@ class VRButton {
 
 		}
 
+		function showVRNotAllowed( exception ) {
+
+			disableButton();
+
+			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+
+			button.textContent = 'VR NOT ALLOWED';
+
+		}
+
 		function stylizeElement( element ) {
 
 			element.style.position = 'absolute';
@@ -138,7 +148,7 @@ class VRButton {
 
 				}
 
-			} );
+			} ).catch( showVRNotAllowed );
 
 			return button;
 


### PR DESCRIPTION
- Fix DOMException when trying to use XR inside an iFrame
- show "VR NOT ALLOWED"  / "AR NOT ALLOWED" instead
- align VRButton/ARButton code more closely

**Description**

Fixes a DOMException that can happen when someone tried to use the VR/AR buttons inside an iFrame, which needs a special iFrame permission `xr-spatial-tracking`. Instead of throwing, the exception is now logged as warning to the console as well.

ARButton already had that, so this PR adds it to VRButton and amends the messaging for both somewhat (now saying "NOT ALLOWED" instead of "NOT SUPPORTED").

To see the current state with DOMException go to this page and look at the console before Glitch fixes iframe permissions on their end: https://glitch.com/~three-xr

This contribution is funded by [🌵 Needle](https://needle.tools).