### PR TITLE
Examples: remove unnecessary checks

### DIFF
--- a/examples/jsm/modifiers/EdgeSplitModifier.js
+++ b/examples/jsm/modifiers/EdgeSplitModifier.js
@@ -181,12 +181,6 @@ class EdgeSplitModifier {
 
 		if ( geometry.index == null ) {
 
-			if ( BufferGeometryUtils === undefined ) {
-
-				throw new Error( 'THREE.EdgeSplitModifier relies on BufferGeometryUtils' );
-
-			}
-
 			geometry = BufferGeometryUtils.mergeVertices( geometry );
 
 		}

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -17,16 +17,6 @@ const _cb = new Vector3(), _ab = new Vector3();
 
 class SimplifyModifier {
 
-	constructor() {
-
-		if ( BufferGeometryUtils === undefined ) {
-
-			throw new Error( 'THREE.SimplifyModifier relies on BufferGeometryUtils' );
-
-		}
-
-	}
-
 	modify( geometry, count ) {
 
 		if ( geometry.isGeometry === true ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23167#issuecomment-1007751533

**Description**

These checks don't make sense in the `jsm` world, a module will always be defined.
We can live without them in the `examples/js` files as well.