### PR TITLE
ConvexGeometry: Support clone().

### DIFF
--- a/examples/jsm/geometries/ConvexGeometry.js
+++ b/examples/jsm/geometries/ConvexGeometry.js
@@ -6,7 +6,7 @@ import { ConvexHull } from '../math/ConvexHull.js';
 
 class ConvexGeometry extends BufferGeometry {
 
-	constructor( points ) {
+	constructor( points = [] ) {
 
 		super();
 

--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -46,27 +46,21 @@ class ConvexHull {
 
 	setFromPoints( points ) {
 
-		if ( Array.isArray( points ) !== true ) {
+		// The algorithm needs at least four points.
 
-			console.error( 'THREE.ConvexHull: Points parameter is not an array.' );
+		if ( points.length >= 4 ) {
 
-		}
+			this.makeEmpty();
 
-		if ( points.length < 4 ) {
+			for ( let i = 0, l = points.length; i < l; i ++ ) {
 
-			console.error( 'THREE.ConvexHull: The algorithm needs at least four points.' );
+				this.vertices.push( new VertexNode( points[ i ] ) );
 
-		}
+			}
 
-		this.makeEmpty();
-
-		for ( let i = 0, l = points.length; i < l; i ++ ) {
-
-			this.vertices.push( new VertexNode( points[ i ] ) );
+			this.compute();
 
 		}
-
-		this.compute();
 
 		return this;
 


### PR DESCRIPTION
Fixed #23176.

**Description**

Ensures `ConvexGeometry` uses the same pattern of built-in geometry generators to support `clone()`.
