### PR TITLE
Docs: cleanup Loaders

### DIFF
--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -64,8 +64,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:AnimationClip animation clips].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called if load errors.<br /><br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called if load errors.<br /><br />
 
 		Begin loading from url and pass the loaded animation to onLoad.
 		</p>

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -81,8 +81,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded text response.<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and pass the loaded [page:String AudioBuffer] to onLoad.

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -73,8 +73,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:BufferGeometry].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and call onLoad with the parsed response content.

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -45,8 +45,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded texture.<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and pass the loaded texture to onLoad.

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -44,12 +44,12 @@
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
-		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded texture.<br />
+		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded texture.<br />
 		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
-		Begin loading from url and pass the loaded texture to onLoad.
+		Begin loading from url and pass the loaded texture to onLoad. The method also returns a new texture object which can directly be used for material creation.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -64,7 +64,7 @@ scene.background = new THREE.CubeTextureLoader()
 		when looking up the positive-z axis -- in other words, using a left-handed coordinate system.
 		Since three.js uses a right-handed coordinate system, environment maps used in three.js will have pos-x and neg-x swapped.<br />
 		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded [page:CubeTexture texture].<br />
-     	[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
+		[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -63,12 +63,12 @@ scene.background = new THREE.CubeTextureLoader()
 		Note that, by convention, cube maps are specified in a coordinate system in which positive-x is to the right
 		when looking up the positive-z axis -- in other words, using a left-handed coordinate system.
 		Since three.js uses a right-handed coordinate system, environment maps used in three.js will have pos-x and neg-x swapped.<br />
-		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Texture texture].<br />
+		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded [page:CubeTexture texture].<br />
      	[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
-		Begin loading from url and pass the loaded [page:CubeTexture texture] to onLoad.
+		Begin loading from url and pass the loaded [page:CubeTexture texture] to onLoad. The method also returns a new texture object which can directly be used for material creation.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -64,8 +64,8 @@ scene.background = new THREE.CubeTextureLoader()
 		when looking up the positive-z axis -- in other words, using a left-handed coordinate system.
 		Since three.js uses a right-handed coordinate system, environment maps used in three.js will have pos-x and neg-x swapped.<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Texture texture].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+     	[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and pass the loaded [page:CubeTexture texture] to onLoad.

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -44,12 +44,12 @@
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
-		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded texture.<br />
+		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded texture.<br />
 		[page:Function onProgress] (optional) — Will be called while load progresses.The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
-		Begin loading from url and pass the loaded texture to onLoad.
+		Begin loading from url and pass the loaded texture to onLoad. The method also returns a new texture object which can directly be used for material creation.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -45,8 +45,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded texture.<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses.The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and pass the loaded texture to onLoad.

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -12,7 +12,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A low level class for loading resources with XMLHttpRequest, used internaly by most loaders.
+			A low level class for loading resources with Fetch, used internaly by most loaders.
 			It can also be used directly to load any file type that does not have a loader.
 		</p>
 
@@ -79,8 +79,7 @@
 			[page:String url] — the path or URL to the file. This can also be a
 				[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] (optional) — Will be called when loading completes. The argument will be the loaded response.<br />
-			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the XMLHttpRequest instance,
-				which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called if an error occurs.<br /><br />
 
 			Load the URL and pass the response to the onLoad function.

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -83,8 +83,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Image image].<br />
-		[page:Function onProgress] — This callback function is currently not supported.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and return the [page:ImageBitmap image] object that will contain the data.

--- a/docs/api/en/loaders/ImageLoader.html
+++ b/docs/api/en/loaders/ImageLoader.html
@@ -78,8 +78,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Image image].<br />
-		[page:Function onProgress] — This callback function is currently not supported.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and return the [page:Image image] object that will contain the data.

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -70,7 +70,7 @@
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
 		[page:String url] — A string containing the path/URL of the file to be loaded.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — A function to be called while the loading is in progress. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		</p>
 		<p>
 		This method is equivalent to [page:.load], but returns a [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promise].

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -67,8 +67,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Material].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br /><br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br /><br />
 
 		Begin loading from url.
 		</p>

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -77,8 +77,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Object3D object].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>
 		Begin loading from url and call onLoad with the parsed response content.

--- a/docs/api/en/loaders/TextureLoader.html
+++ b/docs/api/en/loaders/TextureLoader.html
@@ -84,7 +84,7 @@
 		<p>
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
-		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Texture texture].<br />
+		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded [page:Texture texture].<br />
 		[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br /><br />
 

--- a/docs/api/en/loaders/TextureLoader.html
+++ b/docs/api/en/loaders/TextureLoader.html
@@ -85,8 +85,8 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Texture texture].<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
-		[page:Function onError] — Will be called when load errors.<br /><br />
+		[page:Function onProgress] (optional) — This callback function is currently not supported.<br />
+		[page:Function onError] (optional) — Will be called when load errors.<br /><br />
 
 		Begin loading from the given URL and pass the fully loaded [page:Texture texture] to onLoad. The method also returns a new texture object which can directly be used for material creation.
 		If you do it this way, the texture may pop up in your scene once the respective loading process is finished.


### PR DESCRIPTION
**Description**

Update the documentation of all loaders which are still referencing XMLHttpRequest.

This was contained in #23070 but I extracted it for sanity.
