### PR TITLE
SVGLoader: fixed multiple css classes

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -659,9 +659,14 @@ class SVGLoader extends Loader {
 
 				for ( let j = 0; j < selectorList.length; j ++ ) {
 
+					// Remove empty rules
+					const definitions = Object.fromEntries(
+						Object.entries( stylesheet.style ).filter( ( [ _, v ] ) => v !== '' )
+					);
+
 					stylesheets[ selectorList[ j ] ] = Object.assign(
 						stylesheets[ selectorList[ j ] ] || {},
-						stylesheet.style
+						definitions
 					);
 
 				}

--- a/examples/models/svg/multiple-css-classes.svg
+++ b/examples/models/svg/multiple-css-classes.svg
@@ -1,0 +1,11 @@
+<svg width="377.7" height="571.5" version="1.1" viewBox="0 0 99.93 151.2" xmlns="http://www.w3.org/2000/svg">
+<style type="text/css">
+  .fill-red { fill: red; }
+  .stroke-green { stroke: green; }
+</style>
+  <g transform="translate(0 -54.56)">
+    <rect class="fill-red" x="5" y="59.56" width="89.93" height="35.5" />
+    <rect class="stroke-green" x="5" y="111.6" width="89.53" height="35.1" />
+    <rect class="fill-red stroke-green" x="5" y="165.7" width="89.53" height="35.1" />
+  </g>
+</svg>

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -101,6 +101,7 @@
 					"Defs3": 'models/svg/tests/testDefs/Wave-defs.svg',
 					"Defs4": 'models/svg/tests/testDefs/defs4.svg',
 					"Defs5": 'models/svg/tests/testDefs/defs5.svg',
+					"Multiple CSS classes": 'models/svg/multiple-css-classes.svg',
 					"Zero Radius": 'models/svg/zero-radius.svg'
 
 				} ).name( 'SVG File' ).onChange( update );


### PR DESCRIPTION
Multiple CSS classes don't work with SVGLoader.

## Demo
https://codesandbox.io/s/three-js-svg-multiple-classes-wdxhd

## Expected
![expected](https://user-images.githubusercontent.com/660716/148738348-70502378-634a-4381-bf94-5364192f0bfa.png)

## Actual
![actual](https://user-images.githubusercontent.com/660716/148738357-c5163fe9-9bb5-4170-951a-f72d114060c5.png)

## Problem
The attributes of the first class are overridden by empty strings from the next ones
```
Object.assign({ fill: "red" }, { fill: '' }) // produces {fill: ''}
```
Clearing the attributes with empty strings should be sufficient