### PR TITLE
Respect physicallyCorrectLights on lightmaps in MeshBasicMaterial

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
@@ -86,8 +86,17 @@ void main() {
 	// accumulation (baked indirect lighting only)
 	#ifdef USE_LIGHTMAP
 
-		vec4 lightMapTexel= texture2D( lightMap, vUv2 );
-		reflectedLight.indirectDiffuse += lightMapTexel.rgb * lightMapIntensity;
+		vec4 lightMapTexel = texture2D( lightMap, vUv2 );
+		vec3 lightMapIrradiance = lightMapTexel.rgb * lightMapIntensity;
+
+		// Lightmaps are the only source of "light" for basic materials, respect them being "phsyically correct"
+		#ifdef PHYSICALLY_CORRECT_LIGHTS
+
+			lightMapIrradiance *= RECIPROCAL_PI;
+
+		#endif
+
+		reflectedLight.indirectDiffuse += lightMapIrradiance;
 
 	#else
 


### PR DESCRIPTION
Related issue: #21912

**Description**

**MeshBasicMaterial** allows the use of lightmaps but these lightmaps do not respect the `physicallyCorrectLights` renderer setting. This makes it difficult to combine **MeshBasicMaterial** with **MeshStandardMaterial** in the same scene.

