### PR TITLE
WebGLState: Simplify checks in drawBuffers().

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -500,10 +500,9 @@ function WebGLState( gl, extensions, capabilities ) {
 
 			} else {
 
-				if ( drawBuffers.length !== 1 || drawBuffers[ 0 ] !== gl.COLOR_ATTACHMENT0 ) {
+				if ( drawBuffers[ 0 ] !== gl.COLOR_ATTACHMENT0 ) {
 
 					drawBuffers[ 0 ] = gl.COLOR_ATTACHMENT0;
-					drawBuffers.length = 1;
 
 					needsUpdate = true;
 
@@ -513,10 +512,9 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		} else {
 
-			if ( drawBuffers.length !== 1 || drawBuffers[ 0 ] !== gl.BACK ) {
+			if ( drawBuffers[ 0 ] !== gl.BACK ) {
 
 				drawBuffers[ 0 ] = gl.BACK;
-				drawBuffers.length = 1;
 
 				needsUpdate = true;
 


### PR DESCRIPTION
Related issue: #23194

**Description**

Two checks in `WebGLState.drawBuffers()` can be simplified since there is now a draw buffers configuration per framebuffer.
