### PR TITLE
Loaders: Stop usage of RGBFormat.

### DIFF
--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -6,8 +6,7 @@ import {
 	HalfFloatType,
 	LinearEncoding,
 	LinearFilter,
-	Loader,
-	RGBFormat
+	Loader
 } from '../../../build/three.module.js';
 import { RGBELoader } from '../loaders/RGBELoader.js';
 
@@ -46,7 +45,6 @@ class HDRCubeTextureLoader extends Loader {
 			case FloatType:
 
 				texture.encoding = LinearEncoding;
-				texture.format = RGBFormat;
 				texture.minFilter = LinearFilter;
 				texture.magFilter = LinearFilter;
 				texture.generateMipmaps = false;
@@ -55,7 +53,6 @@ class HDRCubeTextureLoader extends Loader {
 			case HalfFloatType:
 
 				texture.encoding = LinearEncoding;
-				texture.format = RGBFormat;
 				texture.minFilter = LinearFilter;
 				texture.magFilter = LinearFilter;
 				texture.generateMipmaps = false;

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -6,7 +6,6 @@ import {
 	Vector3,
 	DataTexture,
 	DataTexture3D,
-	RGBFormat,
 	UnsignedByteType,
 	ClampToEdgeWrapping,
 	LinearFilter,
@@ -77,7 +76,7 @@ export class LUTCubeLoader extends Loader {
 					// more precision than can be captured with Uint8Array.
 					const sizeToken = split[ 1 ];
 					size = parseFloat( sizeToken );
-					data = new Uint8Array( size * size * size * 3 );
+					data = new Uint8Array( size * size * size * 4 );
 					break;
 				case 'DOMAIN_MIN':
 					domainMin.x = parseFloat( split[ 1 ] );
@@ -107,7 +106,8 @@ export class LUTCubeLoader extends Loader {
 					data[ currIndex + 0 ] = r * 255;
 					data[ currIndex + 1 ] = g * 255;
 					data[ currIndex + 2 ] = b * 255;
-					currIndex += 3;
+					data[ currIndex + 3 ] = 255;
+					currIndex += 4;
 
 			}
 
@@ -117,7 +117,6 @@ export class LUTCubeLoader extends Loader {
 		texture.image.data = data;
 		texture.image.width = size;
 		texture.image.height = size * size;
-		texture.format = RGBFormat;
 		texture.type = UnsignedByteType;
 		texture.magFilter = LinearFilter;
 		texture.minFilter = LinearFilter;
@@ -131,7 +130,6 @@ export class LUTCubeLoader extends Loader {
 		texture3D.image.width = size;
 		texture3D.image.height = size;
 		texture3D.image.depth = size;
-		texture3D.format = RGBFormat;
 		texture3D.type = UnsignedByteType;
 		texture3D.magFilter = LinearFilter;
 		texture3D.minFilter = LinearFilter;

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -4,8 +4,7 @@ import {
 	FloatType,
 	HalfFloatType,
 	LinearEncoding,
-	LinearFilter,
-	RGBFormat,
+	LinearFilter
 } from '../../../build/three.module.js';
 
 // https://github.com/mrdoob/three.js/issues/5552
@@ -342,6 +341,7 @@ class RGBELoader extends DataTextureLoader {
 			destArray[ destOffset + 0 ] = sourceArray[ sourceOffset + 0 ] * scale;
 			destArray[ destOffset + 1 ] = sourceArray[ sourceOffset + 1 ] * scale;
 			destArray[ destOffset + 2 ] = sourceArray[ sourceOffset + 2 ] * scale;
+			destArray[ destOffset + 3 ] = 1;
 
 		};
 
@@ -354,6 +354,7 @@ class RGBELoader extends DataTextureLoader {
 			destArray[ destOffset + 0 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 0 ] * scale, 65504 ) );
 			destArray[ destOffset + 1 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 1 ] * scale, 65504 ) );
 			destArray[ destOffset + 2 ] = DataUtils.toHalfFloat( Math.min( sourceArray[ sourceOffset + 2 ] * scale, 65504 ) );
+			destArray[ destOffset + 3 ] = DataUtils.toHalfFloat( 1 );
 
 		};
 
@@ -377,32 +378,30 @@ class RGBELoader extends DataTextureLoader {
 					case FloatType:
 
 						numElements = image_rgba_data.length / 4;
-						const floatArray = new Float32Array( numElements * 3 );
+						const floatArray = new Float32Array( numElements * 4 );
 
 						for ( let j = 0; j < numElements; j ++ ) {
 
-							RGBEByteToRGBFloat( image_rgba_data, j * 4, floatArray, j * 3 );
+							RGBEByteToRGBFloat( image_rgba_data, j * 4, floatArray, j * 4 );
 
 						}
 
 						data = floatArray;
-						format = RGBFormat;
 						type = FloatType;
 						break;
 
 					case HalfFloatType:
 
 						numElements = image_rgba_data.length / 4;
-						const halfArray = new Uint16Array( numElements * 3 );
+						const halfArray = new Uint16Array( numElements * 4 );
 
 						for ( let j = 0; j < numElements; j ++ ) {
 
-							RGBEByteToRGBHalf( image_rgba_data, j * 4, halfArray, j * 3 );
+							RGBEByteToRGBHalf( image_rgba_data, j * 4, halfArray, j * 4 );
 
 						}
 
 						data = halfArray;
-						format = RGBFormat;
 						type = HalfFloatType;
 						break;
 

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -25,7 +25,6 @@ import {
 	PointsMaterial,
 	Quaternion,
 	RGBAFormat,
-	RGBFormat,
 	RepeatWrapping,
 	Scene,
 	ShapeUtils,
@@ -1265,6 +1264,7 @@ class VRMLLoader extends Loader {
 					color.r = value;
 					color.g = value;
 					color.b = value;
+					color.a = 1;
 					break;
 
 				case TEXTURE_TYPE.INTENSITY_ALPHA:
@@ -1281,6 +1281,7 @@ class VRMLLoader extends Loader {
 					color.r = parseInt( '0x' + hex.substring( 2, 4 ) );
 					color.g = parseInt( '0x' + hex.substring( 4, 6 ) );
 					color.b = parseInt( '0x' + hex.substring( 6, 8 ) );
+					color.a = 1;
 					break;
 
 				case TEXTURE_TYPE.RGBA:
@@ -1348,11 +1349,9 @@ class VRMLLoader extends Loader {
 						const height = fieldValues[ 1 ];
 						const num_components = fieldValues[ 2 ];
 
-						const useAlpha = ( num_components === 2 || num_components === 4 );
 						const textureType = getTextureType( num_components );
 
-						const size = ( ( useAlpha === true ) ? 4 : 3 ) * ( width * height );
-						const data = new Uint8Array( size );
+						const data = new Uint8Array( 4 * width * height );
 
 						const color = { r: 0, g: 0, b: 0, a: 0 };
 
@@ -1360,28 +1359,16 @@ class VRMLLoader extends Loader {
 
 							parseHexColor( fieldValues[ j ], textureType, color );
 
-							if ( useAlpha === true ) {
+							const stride = k * 4;
 
-								const stride = k * 4;
-
-								data[ stride + 0 ] = color.r;
-								data[ stride + 1 ] = color.g;
-								data[ stride + 2 ] = color.b;
-								data[ stride + 3 ] = color.a;
-
-							} else {
-
-								const stride = k * 3;
-
-								data[ stride + 0 ] = color.r;
-								data[ stride + 1 ] = color.g;
-								data[ stride + 2 ] = color.b;
-
-							}
+							data[ stride + 0 ] = color.r;
+							data[ stride + 1 ] = color.g;
+							data[ stride + 2 ] = color.b;
+							data[ stride + 3 ] = color.a;
 
 						}
 
-						texture = new DataTexture( data, width, height, ( useAlpha === true ) ? RGBAFormat : RGBFormat );
+						texture = new DataTexture( data, width, height );
 						texture.needsUpdate = true;
 						texture.__type = textureType; // needed for material modifications
 						break;


### PR DESCRIPTION
Related issue: -

**Description**

We can't use `RGBELoader` with `WebGPURenderer` right now since the loader returns RGB textures. 3 channel formats are not supported with WebGPU. And also in context of WebGL it's recommended to always use RBGA since RGB might be emulated (e.g. with a Metal backend).