### PR TITLE
Examples: Simplify Reflector, Refractor and Water render targets.

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -1,12 +1,10 @@
 import {
 	Color,
 	LinearFilter,
-	MathUtils,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,
 	Plane,
-	RGBFormat,
 	ShaderMaterial,
 	UniformsUtils,
 	Vector3,
@@ -47,19 +45,7 @@ class Reflector extends Mesh {
 		const textureMatrix = new Matrix4();
 		const virtualCamera = new PerspectiveCamera();
 
-		const parameters = {
-			minFilter: LinearFilter,
-			magFilter: LinearFilter,
-			format: RGBFormat
-		};
-
-		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, parameters );
-
-		if ( ! MathUtils.isPowerOfTwo( textureWidth ) || ! MathUtils.isPowerOfTwo( textureHeight ) ) {
-
-			renderTarget.texture.generateMipmaps = false;
-
-		}
+		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
 
 		const material = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( shader.uniforms ),

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -1,6 +1,5 @@
 import {
 	Color,
-	LinearFilter,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -1,13 +1,11 @@
 import {
 	Color,
 	LinearFilter,
-	MathUtils,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,
 	Plane,
 	Quaternion,
-	RGBFormat,
 	ShaderMaterial,
 	UniformsUtils,
 	Vector3,
@@ -44,19 +42,7 @@ class Refractor extends Mesh {
 
 		// render target
 
-		const parameters = {
-			minFilter: LinearFilter,
-			magFilter: LinearFilter,
-			format: RGBFormat
-		};
-
-		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, parameters );
-
-		if ( ! MathUtils.isPowerOfTwo( textureWidth ) || ! MathUtils.isPowerOfTwo( textureHeight ) ) {
-
-			renderTarget.texture.generateMipmaps = false;
-
-		}
+		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
 
 		// material
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -1,6 +1,5 @@
 import {
 	Color,
-	LinearFilter,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -2,12 +2,10 @@ import {
 	Color,
 	FrontSide,
 	LinearFilter,
-	MathUtils,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,
 	Plane,
-	RGBFormat,
 	ShaderMaterial,
 	UniformsLib,
 	UniformsUtils,
@@ -64,19 +62,7 @@ class Water extends Mesh {
 
 		const mirrorCamera = new PerspectiveCamera();
 
-		const parameters = {
-			minFilter: LinearFilter,
-			magFilter: LinearFilter,
-			format: RGBFormat
-		};
-
-		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, parameters );
-
-		if ( ! MathUtils.isPowerOfTwo( textureWidth ) || ! MathUtils.isPowerOfTwo( textureHeight ) ) {
-
-			renderTarget.texture.generateMipmaps = false;
-
-		}
+		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
 
 		const mirrorShader = {
 

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -1,7 +1,6 @@
 import {
 	Color,
 	FrontSide,
-	LinearFilter,
 	Matrix4,
 	Mesh,
 	PerspectiveCamera,


### PR DESCRIPTION
Related issue: -

**Description**

All three classes use RGBA render targets now and create their render targets without parameters. The defaults are already correct.

All respective shaders properly write alpha values.
