### PR TITLE
Examples: Use RedFormat in GlitchPass.

### DIFF
--- a/examples/jsm/postprocessing/GlitchPass.js
+++ b/examples/jsm/postprocessing/GlitchPass.js
@@ -2,7 +2,8 @@ import {
 	DataTexture,
 	FloatType,
 	MathUtils,
-	RGBFormat,
+	RedFormat,
+	LuminanceFormat,
 	ShaderMaterial,
 	UniformsUtils
 } from '../../../build/three.module.js';
@@ -38,6 +39,8 @@ class GlitchPass extends Pass {
 	}
 
 	render( renderer, writeBuffer, readBuffer /*, deltaTime, maskActive */ ) {
+
+		if ( renderer.capabilities.isWebGL2 === false ) this.uniforms[ 'tDisp' ].value.format = LuminanceFormat;
 
 		this.uniforms[ 'tDiffuse' ].value = readBuffer.texture;
 		this.uniforms[ 'seed' ].value = Math.random();//default seeding
@@ -94,19 +97,17 @@ class GlitchPass extends Pass {
 
 	generateHeightmap( dt_size ) {
 
-		const data_arr = new Float32Array( dt_size * dt_size * 3 );
+		const data_arr = new Float32Array( dt_size * dt_size );
 		const length = dt_size * dt_size;
 
 		for ( let i = 0; i < length; i ++ ) {
 
 			const val = MathUtils.randFloat( 0, 1 );
-			data_arr[ i * 3 + 0 ] = val;
-			data_arr[ i * 3 + 1 ] = val;
-			data_arr[ i * 3 + 2 ] = val;
+			data_arr[ i ] = val;
 
 		}
 
-		const texture = new DataTexture( data_arr, dt_size, dt_size, RGBFormat, FloatType );
+		const texture = new DataTexture( data_arr, dt_size, dt_size, RedFormat, FloatType );
 		texture.needsUpdate = true;
 		return texture;
 

--- a/examples/jsm/shaders/DigitalGlitch.js
+++ b/examples/jsm/shaders/DigitalGlitch.js
@@ -62,7 +62,7 @@ const DigitalGlitch = {
 				float xs = floor(gl_FragCoord.x / 0.5);
 				float ys = floor(gl_FragCoord.y / 0.5);
 				//based on staffantans glitch shader for unity https://github.com/staffantan/unityglitch
-				vec4 normal = texture2D (tDisp, p*seed*seed);
+				float disp = texture2D(tDisp, p*seed*seed).r;
 				if(p.y<distortion_x+col_s && p.y>distortion_x-col_s*seed) {
 					if(seed_x>0.){
 						p.y = 1. - (p.y + distortion_y);
@@ -79,8 +79,8 @@ const DigitalGlitch = {
 						p.x = 1. - (p.x + distortion_x);
 					}
 				}
-				p.x+=normal.x*seed_x*(seed/5.);
-				p.y+=normal.y*seed_y*(seed/5.);
+				p.x+=disp*seed_x*(seed/5.);
+				p.y+=disp*seed_y*(seed/5.);
 				//base from RGB shift shader
 				vec2 offset = amount * vec2( cos(angle), sin(angle));
 				vec4 cr = texture2D(tDiffuse, p + offset);


### PR DESCRIPTION
Related issue: -

**Description**

There is no need to use a 3 or 4 channel texture in `GlitchPass` since the height map's R, G and B values are equal. The code uses now `THREE.RedFormat` and `THREE.LuminanceFormat` as WebGL 1 fallback.
