### PR TITLE
NodeMaterial: Revert "Don't use importmap on WebGL..."

### DIFF
--- a/examples/jsm/node-editor/NodeEditor.js
+++ b/examples/jsm/node-editor/NodeEditor.js
@@ -20,31 +20,30 @@ import { NormalEditor } from './accessors/NormalEditor.js';
 import { TimerEditor } from './utils/TimerEditor.js';
 import { OscillatorEditor } from './utils/OscillatorEditor.js';
 import { CheckerEditor } from './procedural/CheckerEditor.js';
-
-import { EventDispatcher } from '../../../build/three.module.js';
+import { EventDispatcher } from 'three';
 
 export const ClassLib = {
-	StandardMaterialEditor,
-	OperatorEditor,
-	NormalizeEditor,
-	InvertEditor,
-	LimiterEditor,
-	DotEditor,
-	PowerEditor,
-	TrigonometryEditor,
-	FloatEditor,
-	Vector2Editor,
-	Vector3Editor,
-	Vector4Editor,
-	SliderEditor,
-	ColorEditor,
-	BlendEditor,
-	UVEditor,
-	PositionEditor,
-	NormalEditor,
-	TimerEditor,
-	OscillatorEditor,
-	CheckerEditor
+	'StandardMaterialEditor': StandardMaterialEditor,
+	'OperatorEditor': OperatorEditor,
+	'NormalizeEditor': NormalizeEditor,
+	'InvertEditor': InvertEditor,
+	'LimiterEditor': LimiterEditor,
+	'DotEditor': DotEditor,
+	'PowerEditor': PowerEditor,
+	'TrigonometryEditor': TrigonometryEditor,
+	'FloatEditor': FloatEditor,
+	'Vector2Editor': Vector2Editor,
+	'Vector3Editor': Vector3Editor,
+	'Vector4Editor': Vector4Editor,
+	'SliderEditor': SliderEditor,
+	'ColorEditor': ColorEditor,
+	'BlendEditor': BlendEditor,
+	'UVEditor': UVEditor,
+	'PositionEditor': PositionEditor,
+	'NormalEditor': NormalEditor,
+	'TimerEditor': TimerEditor,
+	'OscillatorEditor': OscillatorEditor,
+	'CheckerEditor': CheckerEditor
 };
 
 export class NodeEditor extends EventDispatcher {

--- a/examples/jsm/node-editor/materials/StandardMaterialEditor.js
+++ b/examples/jsm/node-editor/materials/StandardMaterialEditor.js
@@ -1,6 +1,6 @@
 import { ObjectNode, ColorInput, SliderInput, LabelElement } from '../../libs/flow.module.js';
 import { MeshStandardNodeMaterial } from '../../renderers/nodes/Nodes.js';
-import * as THREE from '../../../../build/three.module.js';
+import * as THREE from 'three';
 
 export class StandardMaterialEditor extends ObjectNode {
 

--- a/examples/jsm/renderers/nodes/ShaderNode.js
+++ b/examples/jsm/renderers/nodes/ShaderNode.js
@@ -25,7 +25,7 @@ import JoinNode from './utils/JoinNode.js';
 import SplitNode from './utils/SplitNode.js';
 
 // core
-import { Vector2, Vector3, Vector4, Color } from '../../../../build/three.module.js';
+import { Vector2, Vector3, Vector4, Color } from 'three';
 
 const NodeHandler = {
 

--- a/examples/jsm/renderers/nodes/core/Node.js
+++ b/examples/jsm/renderers/nodes/core/Node.js
@@ -1,6 +1,6 @@
 import { NodeUpdateType } from './constants.js';
 
-import { MathUtils } from '../../../../../build/three.module.js';
+import { MathUtils } from 'three';
 
 class Node {
 

--- a/examples/jsm/renderers/nodes/core/NodeBuilder.js
+++ b/examples/jsm/renderers/nodes/core/NodeBuilder.js
@@ -6,7 +6,7 @@ import NodeCode from './NodeCode.js';
 import NodeKeywords from './NodeKeywords.js';
 import { NodeUpdateType } from './constants.js';
 
-import { REVISION, LinearEncoding } from '../../../../../build/three.module.js';
+import { REVISION, LinearEncoding } from 'three';
 
 const shaderStages = [ 'fragment', 'vertex' ];
 

--- a/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/renderers/nodes/display/ColorSpaceNode.js
@@ -4,7 +4,7 @@ import { ShaderNode,
 	pow, mul, sub, mix, join,
 	lessThanEqual } from '../ShaderNode.js';
 
-import { LinearEncoding, sRGBEncoding } from '../../../../../build/three.module.js';
+import { LinearEncoding, sRGBEncoding } from 'three';
 
 export const LinearToLinear = new ShaderNode( ( inputs ) => {
 

--- a/examples/jsm/renderers/nodes/display/NormalMapNode.js
+++ b/examples/jsm/renderers/nodes/display/NormalMapNode.js
@@ -8,7 +8,7 @@ import TempNode from '../core/TempNode.js';
 import ModelNode from '../accessors/ModelNode.js';
 import { ShaderNode, cond, add, mul, dFdx, dFdy, cross, max, dot, normalize, inversesqrt, equal } from '../ShaderNode.js';
 
-import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from '../../../../../build/three.module.js';
+import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from 'three';
 
 // Normal Mapping Without Precomputed Tangents
 // http://www.thetenthplanet.de/archives/1180

--- a/examples/jsm/renderers/nodes/inputs/ColorNode.js
+++ b/examples/jsm/renderers/nodes/inputs/ColorNode.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Color } from '../../../../../build/three.module.js';
+import { Color } from 'three';
 
 class ColorNode extends InputNode {
 

--- a/examples/jsm/renderers/nodes/inputs/Matrix3Node.js
+++ b/examples/jsm/renderers/nodes/inputs/Matrix3Node.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Matrix3 } from '../../../../../build/three.module.js';
+import { Matrix3 } from 'three';
 
 class Matrix3Node extends InputNode {
 

--- a/examples/jsm/renderers/nodes/inputs/Matrix4Node.js
+++ b/examples/jsm/renderers/nodes/inputs/Matrix4Node.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Matrix4 } from '../../../../../build/three.module.js';
+import { Matrix4 } from 'three';
 
 class Matrix4Node extends InputNode {
 

--- a/examples/jsm/renderers/nodes/inputs/Vector2Node.js
+++ b/examples/jsm/renderers/nodes/inputs/Vector2Node.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Vector2 } from '../../../../../build/three.module.js';
+import { Vector2 } from 'three';
 
 class Vector2Node extends InputNode {
 

--- a/examples/jsm/renderers/nodes/inputs/Vector3Node.js
+++ b/examples/jsm/renderers/nodes/inputs/Vector3Node.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Vector3 } from '../../../../../build/three.module.js';
+import { Vector3 } from 'three';
 
 class Vector3Node extends InputNode {
 

--- a/examples/jsm/renderers/nodes/inputs/Vector4Node.js
+++ b/examples/jsm/renderers/nodes/inputs/Vector4Node.js
@@ -1,5 +1,5 @@
 import InputNode from '../core/InputNode.js';
-import { Vector4 } from '../../../../../build/three.module.js';
+import { Vector4 } from 'three';
 
 class Vector4Node extends InputNode {
 

--- a/examples/jsm/renderers/nodes/lights/LightNode.js
+++ b/examples/jsm/renderers/nodes/lights/LightNode.js
@@ -8,7 +8,7 @@ import MathNode from '../math/MathNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { getDistanceAttenuation } from '../functions/BSDFs.js';
 
-import { Color } from '../../../../../build/three.module.js';
+import { Color } from 'three';
 
 class LightNode extends Node {
 

--- a/examples/jsm/renderers/nodes/materials/LineBasicNodeMaterial.js
+++ b/examples/jsm/renderers/nodes/materials/LineBasicNodeMaterial.js
@@ -1,4 +1,4 @@
-import { LineBasicMaterial } from '../../../../../build/three.module.js';
+import { LineBasicMaterial } from 'three';
 
 class LineBasicNodeMaterial extends LineBasicMaterial {
 

--- a/examples/jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js
+++ b/examples/jsm/renderers/nodes/materials/MeshBasicNodeMaterial.js
@@ -1,4 +1,4 @@
-import { MeshBasicMaterial } from '../../../../../build/three.module.js';
+import { MeshBasicMaterial } from 'three';
 
 class MeshBasicNodeMaterial extends MeshBasicMaterial {
 

--- a/examples/jsm/renderers/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/renderers/nodes/materials/MeshStandardNodeMaterial.js
@@ -1,4 +1,4 @@
-import { MeshStandardMaterial } from '../../../../../build/three.module.js';
+import { MeshStandardMaterial } from 'three';
 
 class MeshStandardNodeMaterial extends MeshStandardMaterial {
 

--- a/examples/jsm/renderers/nodes/materials/PointsNodeMaterial.js
+++ b/examples/jsm/renderers/nodes/materials/PointsNodeMaterial.js
@@ -1,4 +1,4 @@
-import { PointsMaterial } from '../../../../../build/three.module.js';
+import { PointsMaterial } from 'three';
 
 class PointsNodeMaterial extends PointsMaterial {
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -3,7 +3,7 @@ import SlotNode from './SlotNode.js';
 import GLSLNodeParser from '../../nodes/parsers/GLSLNodeParser.js';
 import WebGLPhysicalContextNode from './WebGLPhysicalContextNode.js';
 
-import { ShaderChunk, LinearEncoding, RGBAFormat, UnsignedByteType, sRGBEncoding } from '../../../../../build/three.module.js';
+import { ShaderChunk, LinearEncoding, RGBAFormat, UnsignedByteType, sRGBEncoding } from 'three';
 
 const shaderStages = [ 'vertex', 'fragment' ];
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodes.js
@@ -1,7 +1,7 @@
 import { WebGLNodeBuilder } from './WebGLNodeBuilder.js';
 import NodeFrame from '../../nodes/core/NodeFrame.js';
 
-import { Material } from '../../../../../build/three.module.js';
+import { Material } from 'three';
 
 const builders = new WeakMap();
 export const nodeFrame = new NodeFrame();

--- a/examples/webgl_materials_nodes_playground.html
+++ b/examples/webgl_materials_nodes_playground.html
@@ -9,6 +9,13 @@
 		<link type="text/css" rel="stylesheet" href="main.css">
   </head>
   <body>
+	<script type="importmap">
+	{
+		"imports": {
+			"three": "../build/three.module.js"
+		}
+	}
+	</script>
 	<style>
 	body {
 		overflow: hidden;
@@ -34,7 +41,7 @@
 	</style>
 	<script type="module">
 
-		import * as THREE from '../build/three.module.js';
+		import * as THREE from 'three';
 
 		import { nodeFrame } from './jsm/renderers/webgl/nodes/WebGLNodes.js';
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/22936

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://google.com).
