### PR TITLE
Examples: Remove remaining RGBFormat usage.

### DIFF
--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -12,7 +12,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			Creates a simulated lens flare that tracks a light.
+			Creates a simulated lens flare that tracks a light. [name] can only be used when setting the *alpha* context parameter of [page:WebGLRenderer] to *true*.
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/examples/zh/objects/Lensflare.html
+++ b/docs/examples/zh/objects/Lensflare.html
@@ -12,7 +12,7 @@
 		<h1>镜头光晕（[name]）</h1>
 
 		<p class="desc">
-			创建一个模拟追踪着灯光的镜头光晕。
+			创建一个模拟追踪着灯光的镜头光晕。 [name] can only be used when setting the *alpha* context parameter of [page:WebGLRenderer] to *true*.
 		</p>
 
 		<h2>代码示例</h2>

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -15,7 +15,6 @@ import {
 	NearestMipmapNearestFilter,
 	PropertyBinding,
 	RGBAFormat,
-	RGBFormat,
 	RepeatWrapping,
 	Scene,
 	Vector3
@@ -962,7 +961,7 @@ class GLTFWriter {
 	/**
 	 * Process image
 	 * @param  {Image} image to process
-	 * @param  {Integer} format of the image (e.g. RGBFormat, RGBAFormat etc)
+	 * @param  {Integer} format of the image (RGBAFormat)
 	 * @param  {Boolean} flipY before writing out the image
 	 * @return {Integer}     Index of the processed texture in the "images" array
 	 */
@@ -1011,9 +1010,9 @@ class GLTFWriter {
 
 			} else {
 
-				if ( format !== RGBAFormat && format !== RGBFormat ) {
+				if ( format !== RGBAFormat ) {
 
-					console.error( 'GLTFExporter: Only RGB and RGBA formats are supported.' );
+					console.error( 'GLTFExporter: Only RGBAFormat is supported.' );
 
 				}
 
@@ -1025,27 +1024,12 @@ class GLTFWriter {
 
 				const data = new Uint8ClampedArray( image.height * image.width * 4 );
 
-				if ( format === RGBAFormat ) {
+				for ( let i = 0; i < data.length; i += 4 ) {
 
-					for ( let i = 0; i < data.length; i += 4 ) {
-
-						data[ i + 0 ] = image.data[ i + 0 ];
-						data[ i + 1 ] = image.data[ i + 1 ];
-						data[ i + 2 ] = image.data[ i + 2 ];
-						data[ i + 3 ] = image.data[ i + 3 ];
-
-					}
-
-				} else {
-
-					for ( let i = 0, j = 0; i < data.length; i += 4, j += 3 ) {
-
-						data[ i + 0 ] = image.data[ j + 0 ];
-						data[ i + 1 ] = image.data[ j + 1 ];
-						data[ i + 2 ] = image.data[ j + 2 ];
-						data[ i + 3 ] = 255;
-
-					}
+					data[ i + 0 ] = image.data[ i + 0 ];
+					data[ i + 1 ] = image.data[ i + 1 ];
+					data[ i + 2 ] = image.data[ i + 2 ];
+					data[ i + 3 ] = image.data[ i + 3 ];
 
 				}
 

--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -8,11 +8,11 @@ import {
 	InterleavedBufferAttribute,
 	Mesh,
 	MeshBasicMaterial,
-	RGBFormat,
 	RawShaderMaterial,
 	Vector2,
 	Vector3,
-	Vector4
+	Vector4,
+	RGBAFormat
 } from '../../../build/three.module.js';
 
 class Lensflare extends Mesh {
@@ -32,8 +32,8 @@ class Lensflare extends Mesh {
 
 		// textures
 
-		const tempMap = new FramebufferTexture( 16, 16, RGBFormat );
-		const occlusionMap = new FramebufferTexture( 16, 16, RGBFormat );
+		const tempMap = new FramebufferTexture( 16, 16, RGBAFormat );
+		const occlusionMap = new FramebufferTexture( 16, 16, RGBAFormat );
 
 		// material
 

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -112,7 +112,7 @@
 
 				// renderer
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.outputEncoding = THREE.sRGBEncoding;


### PR DESCRIPTION
Related issue: #XXXX

**Description**

This PR removes the remaining usage of `RGBFormat`. 

- `GLTFExporter` only supports RGBA8 now.
- `Lensflare` can only be used when the `alpha` context parameter of `WebGLRenderer` is set to `true`. That is because `Lensflare` uses an instance of `FramebufferTexture` with `RGBAFormat` so the drawing buffer requires alpha, too.
