### PR TITLE
Global: Avoid usage of RGBFormat.

### DIFF
--- a/docs/api/ar/cameras/CubeCamera.html
+++ b/docs/api/ar/cameras/CubeCamera.html
@@ -17,7 +17,7 @@
 
 		<code>
 		// Create cube render target
-		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
 
 		// Create cube camera
 		const cubeCamera = new THREE.CubeCamera( 1, 100000, cubeRenderTarget );

--- a/docs/api/en/cameras/CubeCamera.html
+++ b/docs/api/en/cameras/CubeCamera.html
@@ -17,7 +17,7 @@
 
 		<code>
 		// Create cube render target
-		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
 
 		// Create cube camera
 		const cubeCamera = new THREE.CubeCamera( 1, 100000, cubeRenderTarget );

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -128,11 +128,6 @@
 		When drawing 2D overlays it can be useful to disable the depth writing in order to layer several things together without creating z-index artifacts.
 		</p>
 
-		<h3>[property:Number format]</h3>
-		<p>
-		When this property is set to [page:Textures THREE.RGBFormat], the material is considered to be opaque and alpha values are ignored. Default is [page:Textures THREE.RGBAFormat].
-		</p>
-
 		<h3>[property:Boolean stencilWrite]</h3>
 		<p>
 		Whether stencil operations are performed against the stencil buffer. In order to perform writes or comparisons against the stencil buffer this value must be *true*. Default is *false*.

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -40,7 +40,7 @@
 		const height = 512;
 
 		const size = width * height;
-		const data = new Uint8Array( 3 * size );
+		const data = new Uint8Array( 4 * size );
 		const color = new THREE.Color( 0xffffff );
 
 		const r = Math.floor( color.r * 255 );
@@ -49,17 +49,18 @@
 
 		for ( let i = 0; i < size; i ++ ) {
 
-			const stride = i * 3;
+			const stride = i * 4;
 
 			data[ stride ] = r;
 			data[ stride + 1 ] = g;
 			data[ stride + 2 ] = b;
+			data[ stride + 3 ] = 255;
 
 		}
 
 		// used the buffer to create a [name]
 
-		const texture = new THREE.DataTexture( data, width, height, THREE.RGBFormat );
+		const texture = new THREE.DataTexture( data, width, height );
 		texture.needsUpdate = true;
 		</code>
 

--- a/docs/api/en/textures/DataTexture2DArray.html
+++ b/docs/api/en/textures/DataTexture2DArray.html
@@ -43,7 +43,7 @@
 		const depth = 100;
 
 		const size = width * height;
-		const data = new Uint8Array( 3 * size * depth );
+		const data = new Uint8Array( 4 * size * depth );
 
 		for ( let i = 0; i < depth; i ++ ) {
 
@@ -54,11 +54,12 @@
 
 			for ( let j = 0; j < size; j ++ ) {
 
-				const stride = ( i * size + j ) * 3;
+				const stride = ( i * size + j ) * 4;
 
 				data[ stride ] = r;
 				data[ stride + 1 ] = g;
 				data[ stride + 2 ] = b;
+				data[ stride + 3 ] = 255;
 
 			}
 		}
@@ -66,7 +67,6 @@
 		// used the buffer to create a [name]
 
 		const texture = new THREE.DataTexture2DArray( data, width, height, depth );
-		texture.format = THREE.RGBFormat;
 		texture.needsUpdate = true;
 		</code>
 

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -117,8 +117,7 @@
 
 		<h3>[property:number format]</h3>
 		<p>
-		The default is [page:Textures THREE.RGBAFormat], although the [page:TextureLoader TextureLoader] will automatically
-		set this to [page:Textures THREE.RGBFormat] for JPG images. <br /><br />
+		The default is [page:Textures THREE.RGBAFormat].<br /><br />
 
 		See the [page:Textures texture constants] page for details of other formats.
 		</p>

--- a/docs/api/ko/cameras/CubeCamera.html
+++ b/docs/api/ko/cameras/CubeCamera.html
@@ -17,7 +17,7 @@
 
 		<code>
 		// Create cube render target
-		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
 
 		// Create cube camera
 		const cubeCamera = new THREE.CubeCamera( 1, 100000, cubeRenderTarget );

--- a/docs/api/zh/cameras/CubeCamera.html
+++ b/docs/api/zh/cameras/CubeCamera.html
@@ -17,7 +17,7 @@
 
 		<code>
 		// Create cube render target
-		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+		const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 128, { generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
 
 		// Create cube camera
 		const cubeCamera = new THREE.CubeCamera( 1, 100000, cubeRenderTarget );

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -107,11 +107,6 @@ Default is *false*.
 	在绘制2D叠加时，将多个事物分层在一起而不创建z-index时，禁用深度写入会很有用。
 </p>
 
-<h3>[property:Number format]</h3>
-<p>
-When this property is set to [page:Textures THREE.RGBFormat], the material is considered to be opaque and alpha values are ignored. Default is [page:Textures THREE.RGBAFormat].
-</p>
-
 <h3>[property:Boolean stencilWrite]</h3>
 <p>
 Whether stencil operations are performed against the stencil buffer. In order to perform writes or comparisons against the stencil buffer this value must be *true*. Default is *false*.

--- a/docs/api/zh/textures/DataTexture.html
+++ b/docs/api/zh/textures/DataTexture.html
@@ -40,7 +40,7 @@
 		const height = 512;
 
 		const size = width * height;
-		const data = new Uint8Array( 3 * size );
+		const data = new Uint8Array( 4 * size );
 		const color = new THREE.Color( 0xffffff );
 
 		const r = Math.floor( color.r * 255 );
@@ -49,17 +49,18 @@
 
 		for ( let i = 0; i < size; i ++ ) {
 
-			const stride = i * 3;
+			const stride = i * 4;
 
 			data[ stride ] = r;
 			data[ stride + 1 ] = g;
 			data[ stride + 2 ] = b;
+			data[ stride + 3 ] = 255;
 
 		}
 
 		// used the buffer to create a [name]
 
-		const texture = new THREE.DataTexture( data, width, height, THREE.RGBFormat );
+		const texture = new THREE.DataTexture( data, width, height );
 		texture.needsUpdate = true;
 		</code>
 

--- a/docs/api/zh/textures/DataTexture2DArray.html
+++ b/docs/api/zh/textures/DataTexture2DArray.html
@@ -43,7 +43,7 @@
 		const depth = 100;
 
 		const size = width * height;
-		const data = new Uint8Array( 3 * size * depth );
+		const data = new Uint8Array( 4 * size * depth );
 
 		for ( let i = 0; i < depth; i ++ ) {
 
@@ -54,11 +54,12 @@
 
 			for ( let j = 0; j < size; j ++ ) {
 
-				const stride = ( i * size + j ) * 3;
+				const stride = ( i * size + j ) * 4;
 
 				data[ stride ] = r;
 				data[ stride + 1 ] = g;
 				data[ stride + 2 ] = b;
+				data[ stride + 3 ] = 255;
 
 			}
 		}
@@ -66,7 +67,6 @@
 		// used the buffer to create a [name]
 
 		const texture = new THREE.DataTexture2DArray( data, width, height, depth );
-		texture.format = THREE.RGBFormat;
 		texture.needsUpdate = true;
 		</code>
 

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -110,8 +110,7 @@
 
 		<h3>[property:number format]</h3>
 		<p>
-		默认值为[page:Textures THREE.RGBAFormat]，
-		但[page:TextureLoader TextureLoader]将会在载入JPG图片时自动将这个值设置为[page:Textures THREE.RGBFormat]。<br /><br />
+		默认值为[page:Textures THREE.RGBAFormat]。<br /><br />
 
 		请参阅[page:Textures texture constants]页面来了解其它格式。
 		</p>

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -123,11 +123,9 @@
 				];
 
 				const reflectionCube = cubeTextureLoader.load( urls );
-				reflectionCube.format = THREE.RGBFormat;
 
 				const refractionCube = cubeTextureLoader.load( urls );
 				refractionCube.mapping = THREE.CubeRefractionMapping;
-				refractionCube.format = THREE.RGBFormat;
 
 				return {
 					none: null,

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -98,7 +98,6 @@ class UITexture extends UISpan {
 
 						const texture = new THREE.Texture( this, mapping );
 						texture.sourceFile = file.name;
-						texture.format = file.type === 'image/jpeg' ? THREE.RGBFormat : THREE.RGBAFormat;
 						texture.needsUpdate = true;
 
 						scope.setValue( texture );

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -42,9 +42,7 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 0, 0, 30 );
 
-				const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 256, {
-					format: THREE.RGBAFormat
-				} );
+				const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 256 );
 
 				cubeCamera = new THREE.CubeCamera( 1, 1000, cubeRenderTarget );
 


### PR DESCRIPTION
Related issue: -

**Description**

Avoids the usage of `RGBFormat` whenever possible in the docs and editor.