### PR TITLE
VideoTexture: Switch to RGBAFormat.

### DIFF
--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -49,7 +49,7 @@
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
 		The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
-		[page:Constant format] -- The default is [page:Textures THREE.RGBFormat].
+		[page:Constant format] -- The default is [page:Textures THREE.RGBAFormat].
 		See [page:Textures format constants] for other choices.
 		Note that a bug has been reported with Firefox's WebGL implementation where use of [page:Textures THREE.RGBFormat] on a VideoTexture can result in a significant performance penalty, if you encounter this issue it is recommended to pass in [page:Textures THREE.RGBAFormat] instead.<br />
 

--- a/docs/api/zh/textures/VideoTexture.html
+++ b/docs/api/zh/textures/VideoTexture.html
@@ -49,7 +49,7 @@ const texture = new THREE.VideoTexture( video );
 		[page:Constant minFilter] -- 当一个纹素覆盖小于一个像素时，贴图将如何采样。
 		其默认值为[page:Textures THREE.LinearMipmapLinearFilter]。请参阅[page:Textures minification filter constants]（缩小滤镜常量）来了解其它选项。<br />
 
-		[page:Constant format] -- 在纹理贴图中使用的格式。
+		[page:Constant format] -- The default is [page:Textures THREE.RGBAFormat].
 	 	请参阅[page:Textures format constants]（格式常量）来了解各个选项。<br />
 
 		[page:Constant type] -- 默认值是[page:Textures THREE.UnsignedByteType].

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -1,4 +1,4 @@
-import { RGBFormat, LinearFilter } from '../constants.js';
+import { LinearFilter } from '../constants.js';
 import { Texture } from './Texture.js';
 
 class VideoTexture extends Texture {
@@ -6,8 +6,6 @@ class VideoTexture extends Texture {
 	constructor( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy ) {
 
 		super( video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
-
-		this.format = format !== undefined ? format : RGBFormat;
 
 		this.minFilter = minFilter !== undefined ? minFilter : LinearFilter;
 		this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;


### PR DESCRIPTION
Partially reverts #15178.

**Description**

We can only use `VideoTexture`s in WebGPU if they are defined in the RGBA format.
