### PR TITLE
ShaderNode: Share nodeObjects

### DIFF
--- a/examples/jsm/renderers/nodes/ShaderNode.js
+++ b/examples/jsm/renderers/nodes/ShaderNode.js
@@ -69,6 +69,8 @@ const NodeHandler = {
 
 };
 
+const nodeObjects = new WeakMap();
+
 const ShaderNodeObject = ( obj ) => {
 
 	const type = typeof obj;
@@ -81,15 +83,16 @@ const ShaderNodeObject = ( obj ) => {
 
 		if ( obj.isNode === true ) {
 
-			const node = obj;
+			let nodeObject = nodeObjects.get( obj );
 
-			if ( node.isProxyNode !== true ) {
+			if ( nodeObject === undefined ) {
 
-				node.isProxyNode = true;
-
-				return new Proxy( node, NodeHandler );
+				nodeObject = new Proxy( obj, NodeHandler );
+				nodeObjects.set( obj, nodeObject );
 
 			}
+
+			return nodeObject;
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23216#issuecomment-1012000655

**Description**

I am using a `WeekMap` for it. It should be shared already used `ShaderNodeObject` and reduce memory usage.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://google.com).
