### PR TITLE
Texture: Remove RGBFormat.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -145,7 +145,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBFormat
 		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
@@ -175,8 +174,6 @@
 		The texels are read as integers instead of floating point.
 		(can only be used with a WebGL 2 rendering context).
 		<br /><br />
-
-		[page:constant RGBFormat] discards the alpha components and reads the red, green and blue components.<br /><br />
 
 		[page:constant RGBIntegerFormat] discards the alpha components and reads the red, green and blue components.
 		(can only be used with a WebGL 2 rendering context).

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -24,7 +24,7 @@
 		<p>
 			The interpretation of the data depends on type and format:
 			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
-			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity). Similarly, THREE.RGBFormat specifies a format where only three values are used for each texel.<br />
+			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
 
 			For the packed types, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type or THREE.UnsignedShort565Type, all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
 

--- a/docs/api/en/textures/DataTexture2DArray.html
+++ b/docs/api/en/textures/DataTexture2DArray.html
@@ -24,7 +24,7 @@
 		<p>
 			The interpretation of the data depends on type and format:
 			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
-			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity). Similarly, THREE.RGBFormat specifies a format where only three values are used for each texel.<br />
+			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
 
 			For the packed types, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type or THREE.UnsignedShort565Type, all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
 

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -50,9 +50,8 @@
 		The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
 		[page:Constant format] -- The default is [page:Textures THREE.RGBAFormat].
-		See [page:Textures format constants] for other choices.
-		Note that a bug has been reported with Firefox's WebGL implementation where use of [page:Textures THREE.RGBFormat] on a VideoTexture can result in a significant performance penalty, if you encounter this issue it is recommended to pass in [page:Textures THREE.RGBAFormat] instead.<br />
-
+		See [page:Textures format constants] for other choices.<br />
+	
 		[page:Constant type] -- Default is [page:Textures THREE.UnsignedByteType].
 		See [page:Textures type constants] for other choices.<br />
 

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -142,7 +142,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBFormat
 		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
@@ -172,8 +171,6 @@
 		texel은 부동 소수점 대신 정수로 읽어들입니다.
 		(WebGL 2 렌더링 시에만 사용 가능).
 		<br /><br />
-
-		[page:constant RGBFormat] alpha 요소를 버리고 red, green 및 blue 요소를 읽어들입니다.<br /><br />
 
 		[page:constant RGBIntegerFormat] alpha 요소를 버리고 red, green 및 blue 요소를 읽어들입니다.
 		(WebGL 2 렌더링 시에만 사용 가능).

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -135,7 +135,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBFormat
 		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
@@ -164,8 +163,6 @@
 		The texels are read as integers instead of floating point.
 		(can only be used with a WebGL 2 rendering context).
 		<br /><br />
-
-		[page:constant RGBFormat] 丢弃Alpha分量，仅读取红、绿、蓝分量。<br /><br />
 
 		[page:constant RGBIntegerFormat] discards the alpha components and reads the red, green and blue components.
 		(can only be used with a WebGL 2 rendering context).

--- a/docs/api/zh/textures/DataTexture.html
+++ b/docs/api/zh/textures/DataTexture.html
@@ -24,7 +24,7 @@
 		<p>
 			数据的解释取决于type与format：
 			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
-			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity). Similarly, THREE.RGBFormat specifies a format where only three values are used for each texel.<br />
+			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
 
 			For the packed types, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type or THREE.UnsignedShort565Type, all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
 

--- a/docs/api/zh/textures/DataTexture2DArray.html
+++ b/docs/api/zh/textures/DataTexture2DArray.html
@@ -24,7 +24,7 @@
 		<p>
 			The interpretation of the data depends on type and format:
 			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
-			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity). Similarly, THREE.RGBFormat specifies a format where only three values are used for each texel.<br />
+			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
 
 			For the packed types, THREE.UnsignedShort4444Type, THREE.UnsignedShort5551Type or THREE.UnsignedShort565Type, all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -87,7 +87,6 @@ export const UnsignedShort5551Type = 1018;
 export const UnsignedShort565Type = 1019;
 export const UnsignedInt248Type = 1020;
 export const AlphaFormat = 1021;
-export const RGBFormat = 1022;
 export const RGBAFormat = 1023;
 export const LuminanceFormat = 1024;
 export const LuminanceAlphaFormat = 1025;
@@ -178,5 +177,4 @@ export const StreamCopyUsage = 35042;
 export const GLSL1 = '100';
 export const GLSL3 = '300 es';
 
-export const _SRGBFormat = 1034; // fallback for WebGL 1
 export const _SRGBAFormat = 1035; // fallback for WebGL 1

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, sRGBEncoding, LinearEncoding, UnsignedByteType, _SRGBFormat, _SRGBAFormat } from '../../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, sRGBEncoding, LinearEncoding, UnsignedByteType, _SRGBAFormat } from '../../constants.js';
 import * as MathUtils from '../../math/MathUtils.js';
 import { ImageUtils } from '../../extras/ImageUtils.js';
 import { createElementNS } from '../../utils.js';
@@ -719,7 +719,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				mipmap = mipmaps[ i ];
 
-				if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
+				if ( texture.format !== RGBAFormat ) {
 
 					if ( glFormat !== null ) {
 
@@ -936,7 +936,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					const mipmap = mipmaps[ j ];
 
-					if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
+					if ( texture.format !== RGBAFormat ) {
 
 						if ( glFormat !== null ) {
 
@@ -1355,16 +1355,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const isRenderTarget3D = texture.isDataTexture3D || texture.isDataTexture2DArray;
 		const supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
 
-		// Handles WebGL2 RGBFormat fallback - #18858
-
-		if ( isWebGL2 && texture.format === RGBFormat && ( texture.type === FloatType || texture.type === HalfFloatType ) ) {
-
-			texture.format = RGBAFormat;
-
-			console.warn( 'THREE.WebGLRenderer: Rendering to textures with RGB format is not supported. Using RGBA format instead.' );
-
-		}
-
 		// Setup framebuffer
 
 		if ( isCube ) {
@@ -1641,7 +1631,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const format = texture.format;
 		const type = texture.type;
 
-		if ( texture.isCompressedTexture === true || texture.format === _SRGBFormat || texture.format === _SRGBAFormat ) return image;
+		if ( texture.isCompressedTexture === true || texture.format === _SRGBAFormat ) return image;
 
 		if ( encoding !== LinearEncoding ) {
 
@@ -1653,12 +1643,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					// in WebGL 1, try to use EXT_sRGB extension and unsized formats
 
-					if ( extensions.has( 'EXT_sRGB' ) === true && ( format === RGBFormat || format === RGBAFormat ) ) {
+					if ( extensions.has( 'EXT_sRGB' ) === true && format === RGBAFormat ) {
 
-						if ( format === RGBFormat ) texture.format = _SRGBFormat;
-						if ( format === RGBAFormat ) texture.format = _SRGBAFormat;
+						texture.format = _SRGBAFormat;
 
-						// it's not possible to generate mips in WebGL 1 with the above formats
+						// it's not possible to generate mips in WebGL 1 with this extension
 
 						texture.minFilter = LinearFilter;
 						texture.generateMipmaps = false;

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -1,4 +1,4 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, RGBFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, sRGBEncoding, _SRGBFormat, _SRGBAFormat } from '../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, sRGBEncoding, _SRGBAFormat } from '../../constants.js';
 
 function WebGLUtils( gl, extensions, capabilities ) {
 
@@ -39,7 +39,6 @@ function WebGLUtils( gl, extensions, capabilities ) {
 		}
 
 		if ( p === AlphaFormat ) return gl.ALPHA;
-		if ( p === RGBFormat ) return gl.RGB;
 		if ( p === RGBAFormat ) return gl.RGBA;
 		if ( p === LuminanceFormat ) return gl.LUMINANCE;
 		if ( p === LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
@@ -49,14 +48,13 @@ function WebGLUtils( gl, extensions, capabilities ) {
 
 		// WebGL 1 sRGB fallback
 
-		if ( p === _SRGBFormat || p === _SRGBAFormat ) {
+		if ( p === _SRGBAFormat ) {
 
 			extension = extensions.get( 'EXT_sRGB' );
 
 			if ( extension !== null ) {
 
-				if ( p === _SRGBFormat ) return extension.SRGB_EXT;
-				if ( p === _SRGBAFormat ) return extension.SRGB_ALPHA_EXT;
+				return extension.SRGB_ALPHA_EXT;
 
 			} else {
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -12,7 +12,6 @@ import {
 	DepthFormat,
 	DepthStencilFormat,
 	RGBAFormat,
-	RGBFormat,
 	sRGBEncoding,
 	UnsignedByteType,
 	UnsignedShortType,
@@ -282,16 +281,10 @@ class WebXRManager extends EventDispatcher {
 					}
 
 					const projectionlayerInit = {
-						colorFormat: ( attributes.alpha || isMultisample ) ? gl.RGBA8 : gl.RGB8,
+						colorFormat: ( renderer.outputEncoding === sRGBEncoding ) ? gl.SRGB8_ALPHA8 : gl.RGBA8,
 						depthFormat: glDepthFormat,
 						scaleFactor: framebufferScaleFactor
 					};
-
-					if ( renderer.outputEncoding === sRGBEncoding ) {
-
-						projectionlayerInit.colorFormat = ( attributes.alpha || isMultisample ) ? gl.SRGB8_ALPHA8 : gl.SRGB8;
-
-					}
 
 					glBinding = new XRWebGLBinding( session, gl );
 
@@ -320,7 +313,7 @@ class WebXRManager extends EventDispatcher {
 							glProjLayer.textureWidth,
 							glProjLayer.textureHeight,
 							{
-								format: attributes.alpha ? RGBAFormat : RGBFormat,
+								format: RGBAFormat,
 								type: UnsignedByteType,
 								depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
 								stencilBuffer: attributes.stencil,

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -87,7 +87,6 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.UnsignedShort565Type, 1019, 'UnsignedShort565Type is equal to 1019' );
 		assert.equal( Constants.UnsignedInt248Type, 1020, 'UnsignedInt248Type is equal to 1020' );
 		assert.equal( Constants.AlphaFormat, 1021, 'AlphaFormat is equal to 1021' );
-		assert.equal( Constants.RGBFormat, 1022, 'RGBFormat is equal to 1022' );
 		assert.equal( Constants.RGBAFormat, 1023, 'RGBAFormat is equal to 1023' );
 		assert.equal( Constants.LuminanceFormat, 1024, 'LuminanceFormat is equal to 1024' );
 		assert.equal( Constants.LuminanceAlphaFormat, 1025, 'LuminanceAlphaFormat is equal to 1025' );


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes `THREE.RGBFormat`. There are three major reasons for this step:

- `THREE.RGBFormat` is slow. Not all devices natively support RGB texture formats which requires an emulation in software. Several resources in the WebGL space recommend to always use RGBA.
- sRGB encoded color textures have to be in RGBA8 otherwise mipmap generation via WebGL is not possible. That makes the usage of RGB8 impractical.
- WebGPU does not support 3 channel formats. By aligning WebGL and WebGPU we automatically improve the portability of apps or components like loaders.

Devs who are affected by this change should use `RGBAFormat` instead.
