### PR TITLE
LDrawLoader Docs: Fix unclosed <ul> tag

### DIFF
--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -118,7 +118,7 @@
 			of the same color code (in the LDraw format, each surface material is also related to an edge material)</li>
 			<li>.conditionalEdgeMaterial: Only in a [page:LineSegments] material, indicates the [page:Material] belonging
 			to conditional edges of the same color code.</li>
-		<ul>
+		</ul>
 		</p>
 
 		<br>


### PR DESCRIPTION
Related issue: --

**Description**

Fix an unclosed `<ul>` tag that's causing unexpected indentation on the docs page.

https://raw.githack.com/mrdoob/three.js/ldraw-docs-fix/docs/index.html#examples/en/loaders/LDrawLoader