### PR TITLE
FBXLoader example wasn't using LoadingManager

### DIFF
--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -99,7 +99,6 @@
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl_loader_fbx WebGL / loader / fbx]<br />
 			[example:webgl_loader_obj WebGL / loader / obj]<br />
 			[example:webgl_materials_physical_reflectivity WebGL / materials / physical / reflectivity]<br />
 			[example:webgl_postprocessing_outline WebGL / postprocesing / outline]


### PR DESCRIPTION
**Description**

- The linked example had no usage of LoadingManager, so I removed it.
