### PR TITLE
WebGLRenderTarget: Refactor copy().

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -86,7 +86,10 @@ class WebGLRenderTarget extends EventDispatcher {
 		this.viewport.copy( source.viewport );
 
 		this.texture = source.texture.clone();
-		this.texture.image = { ...this.texture.image }; // See #20328.
+
+		// ensure image object is not shared, see #20328
+
+		this.texture.image = Object.assign( {}, source.texture.image );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/compare/dev...Mugen87:dev62?expand=1

**Description**

Ensures the `image` property is correctly processed in `copy()`. Also avoid the usage of the spread operator to avoid issues with bundlers, see #22618.
