### PR TITLE
Docs: Improve BufferAttribute page.

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -38,7 +38,7 @@
 		in the buffer maps to the values in the GLSL code. For instance, if [page:TypedArray array] is an instance
 		of UInt16Array, and [page:Boolean normalized] is true, the values 0 - +65535 in the array
 		 data will be mapped to 0.0f - +1.0f in the GLSL attribute. An Int16Array (signed) would map
-		 from -32767 - +32767  to -1.0f - +1.0f. If [page:Boolean normalized] is false, the values
+		 from -32768 - +32767  to -1.0f - +1.0f. If [page:Boolean normalized] is false, the values
 		 will be converted to floats unmodified, i.e. 32767 becomes 32767.0f.
 		</p>
 


### PR DESCRIPTION
**Description**

Fixed min value of `Int16Array` in documentation from `-32767` to `-32768`