### PR TITLE
Texture: Remove RGBIntegerFormat.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -145,7 +145,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
 		THREE.LuminanceFormat
@@ -172,10 +171,6 @@
 
 		[page:constant RGIntegerFormat] discards the alpha, and blue components and reads the red, and green components.
 		The texels are read as integers instead of floating point.
-		(can only be used with a WebGL 2 rendering context).
-		<br /><br />
-
-		[page:constant RGBIntegerFormat] discards the alpha components and reads the red, green and blue components.
 		(can only be used with a WebGL 2 rendering context).
 		<br /><br />
 

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -142,7 +142,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
 		THREE.LuminanceFormat
@@ -169,10 +168,6 @@
 
 		[page:constant RGIntegerFormat] alpha, blue 요소를 버리고 red, green 요소만 읽어들입니다.
 		texel은 부동 소수점 대신 정수로 읽어들입니다.
-		(WebGL 2 렌더링 시에만 사용 가능).
-		<br /><br />
-
-		[page:constant RGBIntegerFormat] alpha 요소를 버리고 red, green 및 blue 요소를 읽어들입니다.
 		(WebGL 2 렌더링 시에만 사용 가능).
 		<br /><br />
 

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -135,7 +135,6 @@
 		THREE.RedIntegerFormat
 		THREE.RGFormat
 		THREE.RGIntegerFormat
-		THREE.RGBIntegerFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
 		THREE.LuminanceFormat
@@ -161,10 +160,6 @@
 
 		[page:constant RGIntegerFormat] discards the alpha, and blue components and reads the red, and green components.
 		The texels are read as integers instead of floating point.
-		(can only be used with a WebGL 2 rendering context).
-		<br /><br />
-
-		[page:constant RGBIntegerFormat] discards the alpha components and reads the red, green and blue components.
 		(can only be used with a WebGL 2 rendering context).
 		<br /><br />
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -96,7 +96,6 @@ export const RedFormat = 1028;
 export const RedIntegerFormat = 1029;
 export const RGFormat = 1030;
 export const RGIntegerFormat = 1031;
-export const RGBIntegerFormat = 1032;
 export const RGBAIntegerFormat = 1033;
 
 export const RGB_S3TC_DXT1_Format = 33776;

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -1,4 +1,4 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, sRGBEncoding, _SRGBAFormat } from '../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort565Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, sRGBEncoding, _SRGBAFormat } from '../../constants.js';
 
 function WebGLUtils( gl, extensions, capabilities ) {
 
@@ -69,7 +69,6 @@ function WebGLUtils( gl, extensions, capabilities ) {
 		if ( p === RedIntegerFormat ) return gl.RED_INTEGER;
 		if ( p === RGFormat ) return gl.RG;
 		if ( p === RGIntegerFormat ) return gl.RG_INTEGER;
-		if ( p === RGBIntegerFormat ) return gl.RGB_INTEGER;
 		if ( p === RGBAIntegerFormat ) return gl.RGBA_INTEGER;
 
 		// S3TC


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/23228#issuecomment-1013949551

**Description**

Removes `RGBIntegerFormat`.
