### PR TITLE
Fix utils: getTypedArray unit test.

### DIFF
--- a/test/unit/src/utils.tests.js
+++ b/test/unit/src/utils.tests.js
@@ -31,15 +31,15 @@ QUnit.module( 'utils', () => {
 
 	QUnit.test( 'getTypedArray', ( assert ) => {
 
-		assert.ok( getTypedArray( 'Int8Array', Buffer.from( '', 'utf8' ) ) instanceof Int8Array, 'Int8Array' );
-		assert.ok( getTypedArray( 'Uint8Array', Buffer.from( '', 'utf8' ) ) instanceof Uint8Array, 'Uint8Array' );
-		assert.ok( getTypedArray( 'Uint8ClampedArray', Buffer.from( '', 'utf8' ) ) instanceof Uint8ClampedArray, 'Uint8ClampedArray' );
-		assert.ok( getTypedArray( 'Int16Array', Buffer.from( '', 'utf8' ) ) instanceof Int16Array, 'Int16Array' );
-		assert.ok( getTypedArray( 'Uint16Array', Buffer.from( '', 'utf8' ) ) instanceof Uint16Array, 'Uint16Array' );
-		assert.ok( getTypedArray( 'Int32Array', Buffer.from( '', 'utf8' ) ) instanceof Int32Array, 'Int32Array' );
-		assert.ok( getTypedArray( 'Uint32Array', Buffer.from( '', 'utf8' ) ) instanceof Uint32Array, 'Uint32Array' );
-		assert.ok( getTypedArray( 'Float32Array', Buffer.from( '', 'utf8' ) ) instanceof Float32Array, 'Float32Array' );
-		assert.ok( getTypedArray( 'Float64Array', Buffer.from( '', 'utf8' ) ) instanceof Float64Array, 'Float64Array' );
+		assert.ok( getTypedArray( 'Int8Array', new ArrayBuffer() ) instanceof Int8Array, 'Int8Array' );
+		assert.ok( getTypedArray( 'Uint8Array', new ArrayBuffer() ) instanceof Uint8Array, 'Uint8Array' );
+		assert.ok( getTypedArray( 'Uint8ClampedArray', new ArrayBuffer() ) instanceof Uint8ClampedArray, 'Uint8ClampedArray' );
+		assert.ok( getTypedArray( 'Int16Array', new ArrayBuffer() ) instanceof Int16Array, 'Int16Array' );
+		assert.ok( getTypedArray( 'Uint16Array', new ArrayBuffer() ) instanceof Uint16Array, 'Uint16Array' );
+		assert.ok( getTypedArray( 'Int32Array', new ArrayBuffer() ) instanceof Int32Array, 'Int32Array' );
+		assert.ok( getTypedArray( 'Uint32Array', new ArrayBuffer() ) instanceof Uint32Array, 'Uint32Array' );
+		assert.ok( getTypedArray( 'Float32Array', new ArrayBuffer() ) instanceof Float32Array, 'Float32Array' );
+		assert.ok( getTypedArray( 'Float64Array', new ArrayBuffer() ) instanceof Float64Array, 'Float64Array' );
 
 	} );
 


### PR DESCRIPTION
Fixes: #23257

**Description**

`getTypedArray()` unit test fails on browsers with `ReferenceError: Buffer is not defined` error while the test passes on Node.js.

I think `Buffer` is Node.js specific. Better to replace it with `ArrayBuffer` which is available on both Node.js and browsers.

Basically the test just does `new TypedArray( buffer )` and check the instance type. I don't think replacing with `ArrayBuffer` is problematic.

Refer to #23257 for the problem.
