### PR TITLE
WebGLRenderer: Allow negative morph influence values.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
@@ -10,7 +10,7 @@ export default /* glsl */`
 
 		for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {
 
-			if ( morphTargetInfluences[ i ] > 0.0 ) objectNormal += getMorph( gl_VertexID, i, 1, 2 ) * morphTargetInfluences[ i ];
+			if ( morphTargetInfluences[ i ] != 0.0 ) objectNormal += getMorph( gl_VertexID, i, 1, 2 ) * morphTargetInfluences[ i ];
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
@@ -12,11 +12,11 @@ export default /* glsl */`
 
 			#ifndef USE_MORPHNORMALS
 
-				if ( morphTargetInfluences[ i ] > 0.0 ) transformed += getMorph( gl_VertexID, i, 0, 1 ) * morphTargetInfluences[ i ];
+				if ( morphTargetInfluences[ i ] != 0.0 ) transformed += getMorph( gl_VertexID, i, 0, 1 ) * morphTargetInfluences[ i ];
 
 			#else
 
-				if ( morphTargetInfluences[ i ] > 0.0 ) transformed += getMorph( gl_VertexID, i, 0, 2 ) * morphTargetInfluences[ i ];
+				if ( morphTargetInfluences[ i ] != 0.0 ) transformed += getMorph( gl_VertexID, i, 0, 2 ) * morphTargetInfluences[ i ];
 
 			#endif
 


### PR DESCRIPTION
Related issue: #5712 regression from f1ca24cde4a37e08bc51872b971b330ca0f150cc

**Description**

Morph targets can be applied with negative influence - a good example might be eyebrows raised/lowered - or jaw side-to-side.

These are the only places in the code base I can find that clamp the influences. Changing these lines fixed it for me™
