### PR TITLE
Examples: Add a criterion to determine whether an Object3D is a Mesh

### DIFF
--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -88,7 +88,7 @@
 
 					model.traverse( function ( object ) {
 
-						if ( object.isMesh ) object.castShadow = true;
+						if ( object instanceof THREE.Mesh && object.isMesh ) object.castShadow = true;
 
 					} );
 


### PR DESCRIPTION
Only if the object is an instance of `THREE.Mesh` it will have the `isMesh` property.