### PR TITLE
EXRLoader: handle unsupported BigInt Safari mobile

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1756,9 +1756,18 @@ class EXRLoader extends DataTextureLoader {
 
 		}
 
-		function parseInt64( dataView, offset ) {
+		const parseInt64 = ( dataView, offset ) => {
 
-			var int = Number( dataView.getBigInt64( offset.value, true ) );
+			let int;
+
+			if ( DataView.prototype.getBigInt64 ) {
+			
+				int = Number( dataView.getBigInt64( offset.value, true ) );
+
+			} else {
+
+				int = dataView.getUint32( offset.value + 4, true ) + Number( dataView.getUint32( offset.value, true ) << 32 );
+			}
 
 			offset.value += ULONG_SIZE;
 
@@ -2003,10 +2012,10 @@ class EXRLoader extends DataTextureLoader {
 			const spec = dataView.getUint8( 5, true ); // fullMask
 
 			EXRHeader.spec = {
-				singleTile: !! ( spec & 1 ),
-				longName: !! ( spec & 2 ),
-				deepFormat: !! ( spec & 4 ),
-				multiPart: !! ( spec & 8 ),
+				singleTile: !! ( spec & 2 ),
+				longName: !! ( spec & 4 ),
+				deepFormat: !! ( spec & 8 ),
+				multiPart: !! ( spec & 16 ),
 			};
 
 			// start of header

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1760,8 +1760,8 @@ class EXRLoader extends DataTextureLoader {
 
 			let int;
 
-			if ( DataView.prototype.getBigInt64 ) {
-			
+			if ( 'getBigInt64' in DataView.prototype ) {
+				
 				int = Number( dataView.getBigInt64( offset.value, true ) );
 
 			} else {

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1756,7 +1756,7 @@ class EXRLoader extends DataTextureLoader {
 
 		}
 
-		const parseInt64 = ( dataView, offset ) => {
+		const parseInt64 = function( dataView, offset ) {
 
 			let int;
 


### PR DESCRIPTION
Fixed #23260

Utilizes alternative Int64 handling when `DataView.prototype.getBigInt64` isn't available.

Also fixes a small mistake on my part on retrieving specification flags information, it should be properly reflecting the actual file information now.

[DWAA Example](https://rawcdn.githack.com/sciecode/three.js/8a20ad90238aaccdc0a07af0d2d1076d96712f5e/examples/webgl_loader_texture_exr.html) - @inear please validate the example loads correctly.