### PR TITLE
LDrawLoader: Convert to linear colors when parsing models

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2329,6 +2329,7 @@ class LDrawLoader extends Loader {
 		material.premultipliedAlpha = true;
 		material.opacity = alpha;
 		material.depthWrite = ! isTransparent;
+		material.color.convertSRGBToLinear();
 
 		material.polygonOffset = true;
 		material.polygonOffsetFactor = 1;
@@ -2350,6 +2351,7 @@ class LDrawLoader extends Loader {
 			} );
 			edgeMaterial.userData.code = code;
 			edgeMaterial.name = name + ' - Edge';
+			edgeMaterial.color.convertSRGBToLinear();
 
 			// This is the material used for conditional edges
 			edgeMaterial.userData.conditionalEdgeMaterial = new LDrawConditionalLineMaterial( {
@@ -2361,6 +2363,7 @@ class LDrawLoader extends Loader {
 				opacity: alpha,
 
 			} );
+			edgeMaterial.userData.conditionalEdgeMaterial.color.convertSRGBToLinear();
 
 		}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -76,6 +76,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 


### PR DESCRIPTION
Related issue: --

https://raw.githack.com/gkjohnson/three.js/ldraw-linear-color/examples/webgl_loader_ldraw.html

**Description**

Semi-related to @donmccurdy's color space consistency efforts (#22346) -- all loaders should appropriately label texture color spaces, convert colors to Linear color space, and set the renderer output color space to sRGB. This PR does so for LDrawLoader.

From what I can tell these are the loader examples that still are not setting `renderer.outputEncoding = sRGBEncoding` on the page meaning they don't appropriately set the model color spaces for linear lighting calculations on load where I think the color space should be known at parse time:

- ColladaLoader examples
- FBXLoader examples
- IFCjs example
- OBJLoader examples
- SVGLoader (example logic only)
- Maybe: Vox, VRML, VTK, PCD, GCode

Here are some before and after screenshots. It seems to get rid of the blue specular look on the black pieces. The AT-ST line colors significantly darker now, as well, because tone mapping is being applied to Linear rather than sRGB values. I'm kind of on the fence about the change because while converting the colors to linear is more correct I kind of stylistically prefer some of the "before" screenshots better. Or maybe I'm just used to them. The spaceman blue definitely looks more like the real model now, though:

| BEFORE | AFTER | AFTER w/o Tone Mapping |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/734200/150074418-0ad3e6cb-ec9f-40b3-9066-da69e74cfe98.png) | ![image](https://user-images.githubusercontent.com/734200/150074400-36285eee-877a-48c4-9284-3539df320d47.png) | ![image](https://user-images.githubusercontent.com/734200/150076960-22f12194-cd19-4410-9df6-9d678e222a92.png) |
| ![image](https://user-images.githubusercontent.com/734200/150074785-08021c70-76c0-4b4c-91f1-6ad87f9605ee.png) | ![image](https://user-images.githubusercontent.com/734200/150074828-1a372456-ccfc-4292-8a2e-1219ac812491.png) | ![image](https://user-images.githubusercontent.com/734200/150077056-97baaf1e-8ead-4882-9b95-97fb3bba2cd4.png) |
| ![image](https://user-images.githubusercontent.com/734200/150076328-50c12b83-8465-4024-8d42-0510359ca777.png) | ![image](https://user-images.githubusercontent.com/734200/150076301-869482a4-5e41-459c-88fb-25accd21b2ef.png) | ![image](https://user-images.githubusercontent.com/734200/150076989-a8db3101-9740-4cf0-b6f4-b3582fa161cf.png) |

cc @WestLangley 

