### PR TITLE
WebGPURenderer - support scene fog

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -1,4 +1,4 @@
-import { Color, FogExp2, LinearEncoding, Vector3, Vector4 } from 'three';
+import { Color, Fog, LinearEncoding, Vector3, Vector4 } from 'three';
 
 import WebGPUNodeUniformsGroup from './WebGPUNodeUniformsGroup.js';
 import {
@@ -319,7 +319,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 				}
 
-				if ( scene.fog instanceof FogExp2 ) {
+				if ( scene.fog instanceof Fog ) {
 
 					useNearFar = 1.0;
 


### PR DESCRIPTION
Related issue: none

**Description**

This PR introduces fog to the WebGPURenderer. The code is mostly adopted from https://snayss.medium.com/three-js-fog-hacks-fc0b42f63386 and changed for the Node material system and WGSL. While it is compatible with **THREE.Fog** and **THREE.FogExp2**, there are some additional features:

-  it is possible to set a **nearColor** parameter for having a gradient color effect (default nearColor value is completely transparent).
-  all colors can be passed besides as **THREE.Color** as **THREE.Vector4** with alpha value, for example to create a vanishing effect in the distance (default alpha value is 1.0).
-  with the **useNoise** parameter is is possible to apply a Perlin 3D noise to the fog (which is more performance-costly, so default value is _false_)

![fogscreen01](https://user-images.githubusercontent.com/9590338/150105287-d77f3532-38f3-41b9-af74-d58fb141e167.png)

A complete example would be:

```
scene.fog = new THREE.Fog({
        color: new THREE.Vector4( 1.0, 1.0, 1.0, 0.5 ),
        near: 1,
        far: 1000
});

// new (optional) params
scene.fog.nearColor = new THREE.Vector4( 1.0, 1.0, 1.0, 0.5 );
scene.fog.fogDensity = 0.0001;
scene.fog.useNoise = true;
scene.fog.fogNoiseImpact = 0.5;
scene.fog.fogNoiseFreq = 0.0012;
 `
