### PR TITLE
Inherit layers from parent object when creating hand and controller models

### DIFF
--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -237,6 +237,8 @@ class OculusHandPointerModel extends THREE.Object3D {
 		this.pointerObject.add( this.cursorObject );
 
 		this.add( this.pointerObject );
+		this.pointerObject.layers.mask = this.layers.mask;
+		this.pointerMesh.layers.mask = this.layers.mask;
 
 	}
 

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -199,6 +199,17 @@ function addAssetSceneToControllerModel( controllerModel, scene ) {
 
 	}
 
+	// inherit layers from the controller model
+	if ( controllerModel.layers.mask != 0 ) {
+
+		scene.traverse( ( child ) => {
+
+			child.layers.mask = controllerModel.layers.mask;
+
+		} );
+
+	}
+
 	// Add the glTF scene to the controllerModel.
 	controllerModel.add( scene );
 

--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -22,6 +22,7 @@ class XRHandMeshModel {
 
 			const object = gltf.scene.children[ 0 ];
 			this.handModel.add( object );
+			object.layers.mask = this.handModel.layers.mask;
 
 			const mesh = object.getObjectByProperty( 'type', 'SkinnedMesh' );
 			mesh.frustumCulled = false;

--- a/examples/jsm/webxr/XRHandPrimitiveModel.js
+++ b/examples/jsm/webxr/XRHandPrimitiveModel.js
@@ -39,6 +39,7 @@ class XRHandPrimitiveModel {
 		this.handMesh.castShadow = true;
 		this.handMesh.receiveShadow = true;
 		this.handModel.add( this.handMesh );
+		this.handMesh.layers.mask = this.handModel.layers.mask;
 
 		this.joints = [
 			'wrist',


### PR DESCRIPTION
**Description**

Since controller models and hand meshes are created asynchronously at runtime (e.g. fetched after controller connection), there's no good way to set layers on them (one would have to poll until they exist, or there would need to be an event for full creation being complete).

This PR makes them inherit layers from their parent objects on creation.

This contribution is funded by 🌵 [needle](https://needle.tools).