### PR TITLE
SVGLoader Example: Use srgb output in the svg example

### DIFF
--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -58,6 +58,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
 
 				//
@@ -169,7 +170,7 @@
 						if ( guiData.drawFillShapes && fillColor !== undefined && fillColor !== 'none' ) {
 
 							const material = new THREE.MeshBasicMaterial( {
-								color: new THREE.Color().setStyle( fillColor ),
+								color: new THREE.Color().setStyle( fillColor ).convertSRGBToLinear(),
 								opacity: path.userData.style.fillOpacity,
 								transparent: true,
 								side: THREE.DoubleSide,
@@ -197,7 +198,7 @@
 						if ( guiData.drawStrokes && strokeColor !== undefined && strokeColor !== 'none' ) {
 
 							const material = new THREE.MeshBasicMaterial( {
-								color: new THREE.Color().setStyle( strokeColor ),
+								color: new THREE.Color().setStyle( strokeColor ).convertSRGBToLinear(),
 								opacity: path.userData.style.strokeOpacity,
 								transparent: true,
 								side: THREE.DoubleSide,


### PR DESCRIPTION
Related issue: #23272

**Description**

Converts the SVGLoader example page to use sRGB output rather than Linear. I'll note that given that MeshBasicMaterials and therefore no lighting is being used it could be considered more optimal to leave the demo as-is but for the sake of encouraging users to generally use the correct workflow this seems like a good change?

https://raw.githack.com/gkjohnson/three.js/linear-svg-colors/examples/webgl_loader_svg.html

I was taking a look at ColladaLoader and OBJLoader, as well. It doesn't look like there's very explicit documentation on color spaces for these formats and they're more specification by convention. Given that our demos don't adjust the default output color space for the renderer it seems like the assumption is that the textures and colors are sRGB. Is there any evidence or example models that show this isn't always the right thing to do?

cc @donmccurdy @WestLangley @Mugen87 

