### PR TITLE
BufferGeometry: Faster setIndex from Array

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -8,7 +8,7 @@ import { Object3D } from './Object3D.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import * as MathUtils from '../math/MathUtils.js';
-import { arrayContainsOver } from '../utils.js';
+import { arrayNeedsUint32 } from '../utils.js';
 
 let _id = 0;
 
@@ -59,7 +59,7 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( Array.isArray( index ) ) {
 
-			this.index = new ( arrayContainsOver( index, 65535 ) ? Uint32BufferAttribute : Uint16BufferAttribute )( index, 1 );
+			this.index = new ( arrayNeedsUint32( index ) ? Uint32BufferAttribute : Uint16BufferAttribute )( index, 1 );
 
 		} else {
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -8,7 +8,7 @@ import { Object3D } from './Object3D.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import * as MathUtils from '../math/MathUtils.js';
-import { arrayMax } from '../utils.js';
+import { arrayContainsOver } from '../utils.js';
 
 let _id = 0;
 
@@ -59,7 +59,7 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( Array.isArray( index ) ) {
 
-			this.index = new ( arrayMax( index ) > 65535 ? Uint32BufferAttribute : Uint16BufferAttribute )( index, 1 );
+			this.index = new ( arrayContainsOver( index, 65535 ) ? Uint32BufferAttribute : Uint16BufferAttribute )( index, 1 );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -1,5 +1,5 @@
 import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
-import { arrayContainsOver } from '../../utils.js';
+import { arrayNeedsUint32 } from '../../utils.js';
 
 function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
@@ -133,7 +133,7 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 		}
 
-		const attribute = new ( arrayContainsOver( indices, 65535 ) ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
+		const attribute = new ( arrayNeedsUint32( indices ) ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 		attribute.version = version;
 
 		// Updating index buffer in VAO now. See WebGLBindingStates

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -1,5 +1,5 @@
 import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
-import { arrayMax } from '../../utils.js';
+import { arrayContainsOver } from '../../utils.js';
 
 function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
@@ -133,7 +133,7 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 		}
 
-		const attribute = new ( arrayMax( indices ) > 65535 ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
+		const attribute = new ( arrayContainsOver( indices, 65535 ) ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 		attribute.version = version;
 
 		// Updating index buffer in VAO now. See WebGLBindingStates

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,13 +30,13 @@ function arrayMax( array ) {
 
 }
 
-function arrayContainsOver( array, value ) {
+function arrayNeedsUint32( array ) {
 
 	// assumes larger values usually on last
 
 	for ( let i = array.length - 1; i >= 0; -- i ) {
 
-		if ( array[ i ] > value ) return true;
+		if ( array[ i ] > 65535 ) return true;
 
 	}
 
@@ -68,4 +68,4 @@ function createElementNS( name ) {
 
 }
 
-export { arrayMin, arrayMax, arrayContainsOver, getTypedArray, createElementNS };
+export { arrayMin, arrayMax, arrayNeedsUint32, getTypedArray, createElementNS };

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,20 @@ function arrayMax( array ) {
 
 }
 
+function arrayContainsOver( array, value ) {
+
+	// assumes larger values usually on last
+
+	for ( let i = array.length - 1; i >= 0; -- i ) {
+
+		if ( array[ i ] > value ) return true;
+
+	}
+
+	return false;
+
+}
+
 const TYPED_ARRAYS = {
 	Int8Array: Int8Array,
 	Uint8Array: Uint8Array,
@@ -54,4 +68,4 @@ function createElementNS( name ) {
 
 }
 
-export { arrayMin, arrayMax, getTypedArray, createElementNS };
+export { arrayMin, arrayMax, arrayContainsOver, getTypedArray, createElementNS };


### PR DESCRIPTION
Related issue: #10603

**Description**

`BufferGeometry.prototype.setIndex` calculates the max value of the Array with iterating all items.
It would be enough to find just one item over 65535, and the max value is not necessary.