### PR TITLE
LatheGeometry: Change index order.

### DIFF
--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -152,7 +152,7 @@ class LatheGeometry extends BufferGeometry {
 				// faces
 
 				indices.push( a, b, d );
-				indices.push( b, c, d );
+				indices.push( c, d, b );
 
 			}
 


### PR DESCRIPTION
LatheGeometry() produces bands of quads, each of which are further subdivided into an upper-right (blue) and a lower-left(green) triangle. The two triangles which are the result of quad subdivision, although different in shape and size, share common properties: Both comprise a horizontal edge, a slanted edge and a (shared) diagonal edge. The vertices of each triangle are specified in a CCW orientation.

To facilitate further processing in an i.e. custom shader, it would be advantageous, if 1st and 2nd index always specify the horizontal edge, and 1st and 3rd vertex always specify the slanted edge. This is currently not the case.

My proposed change involves a cyclical CCW rotation by one position of the indices of the upper-right triangle, in order to match the order already specified in the lower-left triangle.  ==>  b, c, d   becomes c, d, b
**Note** that the one-letter vertex "names" in the sketch match the variable names in source code.

<img width="1482" alt="quad" src="https://user-images.githubusercontent.com/75781596/150529264-9a8dee15-dad7-4be4-8ab5-3dbef2fa8f94.png">


