### PR TITLE
OBJ / MTLLoader: Label and convert textures and colors correctly in MTLLoader

### DIFF
--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -8,7 +8,8 @@ import {
 	MeshPhongMaterial,
 	RepeatWrapping,
 	TextureLoader,
-	Vector2
+	Vector2,
+	sRGBEncoding
 } from 'three';
 
 /**
@@ -358,6 +359,12 @@ class MaterialCreator {
 			map.wrapS = scope.wrap;
 			map.wrapT = scope.wrap;
 
+			if ( mapType === 'map' || mapType === 'emissiveMap' ) {
+
+				map.encoding = sRGBEncoding;
+
+			}
+
 			params[ mapType ] = map;
 
 		}
@@ -377,21 +384,21 @@ class MaterialCreator {
 
 					// Diffuse color (color under white light) using RGB values
 
-					params.color = new Color().fromArray( value );
+					params.color = new Color().fromArray( value ).convertSRGBToLinear();
 
 					break;
 
 				case 'ks':
 
 					// Specular color (color when light is reflected from shiny surface) using RGB values
-					params.specular = new Color().fromArray( value );
+					params.specular = new Color().fromArray( value ).convertSRGBToLinear();
 
 					break;
 
 				case 'ke':
 
 					// Emissive using RGB values
-					params.emissive = new Color().fromArray( value );
+					params.emissive = new Color().fromArray( value ).convertSRGBToLinear();
 
 					break;
 

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -105,6 +105,7 @@
 				//
 
 				renderer = new THREE.WebGLRenderer();
+				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );


### PR DESCRIPTION
Related issue: #23283 

**Description**

Convert colors to Linear and label color textures as `sRGB` when loading MTL materials. Also update the OBJ demo with MTL files to use `outputEncoding = sRGBEncoding`.

https://raw.githack.com/gkjohnson/three.js/srgb-obj/examples/webgl_loader_obj_mtl.html
