### PR TITLE
SVGLoader: fix use.href in non-browser environments

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -110,7 +110,9 @@
 
 					case 'use':
 						style = parseStyle( node, style );
-						const usedNodeId = node.href.baseVal.substring( 1 );
+
+						const href = node.getAttributeNS( "http://www.w3.org/1999/xlink", "href" ) || "";
+						const usedNodeId = href.substring( 1 );
 						const usedNode = node.viewportElement.getElementById( usedNodeId );
 
 						if ( usedNode ) {


### PR DESCRIPTION
The current code processing `<use>` tag tries to access `href` attribute using DOM element _property_ ignoring the fact it is namespaced (conventionally with `xlink` alias).

It works in major browsers but fails in some environments that follow the W3C standard. Notably, [jsdom](https://github.com/jsdom/jsdom). This patch makes it possible to use SVGLoader in NodeJS, and still keeps the original behavior in browsers. Also, it makes the code a little more consistent with surroundings that explicitly use `getAttribute` method rather than propetry-based access.