### PR TITLE
create typed array view rather than copy

### DIFF
--- a/examples/js/loaders/DDSLoader.js
+++ b/examples/js/loaders/DDSLoader.js
@@ -62,8 +62,8 @@
 			function loadARGBMip( buffer, dataOffset, width, height ) {
 
 				const dataLength = width * height * 4;
-				const srcBuffer = new Uint8Array( buffer, dataOffset, dataLength );
-				const byteArray = new Uint8Array( dataLength );
+				const srcBuffer = new Uint8Array( buffer.buffer, buffer.byteOffset + dataOffset, dataLength );
+				const byteArray = new Uint8ClampedArray( dataLength );
 				let dst = 0;
 				let src = 0;
 
@@ -124,7 +124,7 @@
 			// let off_caps4 = 30;
 			// Parse header
 
-			const header = new Int32Array( buffer, 0, headerLengthInt );
+			const header = new Int32Array( buffer.buffer, buffer.byteOffset, headerLengthInt );
 
 			if ( header[ off_magic ] !== DDS_MAGIC ) {
 
@@ -223,7 +223,7 @@
 					} else {
 
 						dataLength = Math.max( 4, width ) / 4 * Math.max( 4, height ) / 4 * blockBytes;
-						byteArray = new Uint8Array( buffer, dataOffset, dataLength );
+						byteArray = new Uint8ClampedArray( buffer.buffer, buffer.byteOffset + dataOffset, dataLength );
 
 					}
 

--- a/examples/jsm/loaders/DDSLoader.js
+++ b/examples/jsm/loaders/DDSLoader.js
@@ -137,7 +137,7 @@ class DDSLoader extends CompressedTextureLoader {
 
 		// Parse header
 
-		const header = new Int32Array( buffer.buffer, buffer.byteOffset, HEADER_LENGTH );
+		const header = new Int32Array( buffer.buffer, buffer.byteOffset, headerLengthInt );
 
 		if ( header[ off_magic ] !== DDS_MAGIC ) {
 

--- a/examples/jsm/loaders/DDSLoader.js
+++ b/examples/jsm/loaders/DDSLoader.js
@@ -79,8 +79,8 @@ class DDSLoader extends CompressedTextureLoader {
 		function loadARGBMip( buffer, dataOffset, width, height ) {
 
 			const dataLength = width * height * 4;
-			const srcBuffer = new Uint8Array( buffer, dataOffset, dataLength );
-			const byteArray = new Uint8Array( dataLength );
+			const srcBuffer = new Uint8Array( buffer.buffer, buffer.byteOffset + dataOffset, dataLength );
+			const byteArray = new Uint8ClampedArray( dataLength );
 			let dst = 0;
 			let src = 0;
 			for ( let y = 0; y < height; y ++ ) {
@@ -137,7 +137,7 @@ class DDSLoader extends CompressedTextureLoader {
 
 		// Parse header
 
-		const header = new Int32Array( buffer, 0, headerLengthInt );
+		const header = new Int32Array( buffer.buffer, buffer.byteOffset, HEADER_LENGTH );
 
 		if ( header[ off_magic ] !== DDS_MAGIC ) {
 
@@ -256,7 +256,7 @@ class DDSLoader extends CompressedTextureLoader {
 				} else {
 
 					dataLength = Math.max( 4, width ) / 4 * Math.max( 4, height ) / 4 * blockBytes;
-					byteArray = new Uint8Array( buffer, dataOffset, dataLength );
+					byteArray = new Uint8ClampedArray( buffer.buffer, buffer.byteOffset + dataOffset, dataLength );
 
 				}
 


### PR DESCRIPTION
**Description**

In `DDSLoader.parse()` we were creating several copies of the same input buffer, this is costly when loading a lot of these! 

Instead, this PR uses the underlying `ArrayBuffer` in UInt8Array constructor to create a view over it rather than copying it.

Also in this PR the Uint8Array type is changed to `Uint8ClampedArray` to match the [ImageData.data](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data) type.
