### PR TITLE
Sized PMREM

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -86,7 +86,7 @@ class PMREMGenerator {
 		this._sizeLods = [];
 		this._sigmas = [];
 
-		this._blurMaterial = null
+		this._blurMaterial = null;
 		this._equirectShader = null;
 		this._cubemapShader = null;
 
@@ -192,8 +192,10 @@ class PMREMGenerator {
 	// private interface
 
 	_setSize( cubeSize ) {
+
 		this._lodMax = Math.floor( Math.log2( cubeSize ) );
 		this._cubeSize = Math.pow( 2, this._lodMax );
+
 	}
 
 	_dispose() {
@@ -220,10 +222,14 @@ class PMREMGenerator {
 
 	_fromTexture( texture, renderTarget ) {
 
-		if(texture.mapping === CubeReflectionMapping || texture.mapping === CubeRefractionMapping){
-			this._setSize( texture.image.length === 0 ? 16 : texture.image[0].width ?? texture.image[0].image.width );
-		}else{// Equirectangular
+		if ( texture.mapping === CubeReflectionMapping || texture.mapping === CubeRefractionMapping ) {
+
+			this._setSize( texture.image.length === 0 ? 16 : texture.image[ 0 ].width ?? texture.image[ 0 ].image.width );
+
+		} else { // Equirectangular
+
 			this._setSize( texture.image.width / 4 ?? 256 );
+
 		}
 
 		_oldTarget = this._renderer.getRenderTarget();
@@ -236,7 +242,7 @@ class PMREMGenerator {
 
 	}
 
-	_allocateTargets() { // warning: null texture is valid
+	_allocateTargets() {
 
 		const width = 3 * Math.max( this._cubeSize, 16 * 7 );
 		const height = 4 * this._cubeSize - 32;
@@ -553,15 +559,7 @@ class PMREMGenerator {
 
 }
 
-function _createRenderTarget( width, height, params ) {
 
-	const cubeUVRenderTarget = new WebGLRenderTarget( width, height, params );
-	cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
-	cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
-	cubeUVRenderTarget.scissorTest = true;
-	return cubeUVRenderTarget;
-
-}
 
 function _createPlanes( lodMax ) {
 
@@ -640,6 +638,16 @@ function _createPlanes( lodMax ) {
 	}
 
 	return { lodPlanes, sizeLods, sigmas };
+
+}
+
+function _createRenderTarget( width, height, params ) {
+
+	const cubeUVRenderTarget = new WebGLRenderTarget( width, height, params );
+	cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
+	cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
+	cubeUVRenderTarget.scissorTest = true;
+	return cubeUVRenderTarget;
 
 }
 

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -272,7 +272,7 @@ class PMREMGenerator {
 
 			const { _lodMax } = this;
 			( { sizeLods: this._sizeLods, lodPlanes: this._lodPlanes, sigmas: this._sigmas } = _createPlanes( _lodMax ) );
-			
+
 			this._blurMaterial = _getBlurShader( _lodMax, width, height );
 
 		}
@@ -666,7 +666,7 @@ function _getBlurShader( lodMax, width, height ) {
 
 		name: 'SphericalGaussianBlur',
 
-		defines: { 
+		defines: {
 			'n': MAX_SAMPLES,
 			'CUBEUV_TEXEL_WIDTH': 1.0 / width,
 			'CUBEUV_TEXEL_HEIGHT': 1.0 / height,

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -221,9 +221,9 @@ class PMREMGenerator {
 	_fromTexture( texture, renderTarget ) {
 
 		if(texture.mapping === CubeReflectionMapping || texture.mapping === CubeRefractionMapping){
-			this._setSize( texture.image[0].width??texture.image[0].image.width );
+			this._setSize( texture.image.length === 0 ? 16 : texture.image[0].width ?? texture.image[0].image.width );
 		}else{// Equirectangular
-			this._setSize( this._cubeSize=texture.image.width/4 );
+			this._setSize( texture.image.width / 4 ?? 256 );
 		}
 
 		_oldTarget = this._renderer.getRenderTarget();

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -1,9 +1,7 @@
 export default /* glsl */`
 #ifdef ENVMAP_TYPE_CUBE_UV
 
-	#define cubeUV_maxMipLevel 8.0
 	#define cubeUV_minMipLevel 4.0
-	#define cubeUV_maxTileSize 256.0
 	#define cubeUV_minTileSize 16.0
 
 	// These shader functions convert between the UV coordinates of a single face of
@@ -87,8 +85,6 @@ export default /* glsl */`
 
 		float faceSize = exp2( mipInt );
 
-		float texelSize = 1.0 / ( 3.0 * cubeUV_maxTileSize );
-
 		vec2 uv = getUV( direction, face ) * ( faceSize - 1.0 ) + 0.5;
 
 		if ( face > 2.0 ) {
@@ -101,17 +97,12 @@ export default /* glsl */`
 
 		uv.x += face * faceSize;
 
-		if ( mipInt < cubeUV_maxMipLevel ) {
+		uv.x += filterInt * 3.0 * cubeUV_minTileSize;
 
-			uv.y += 2.0 * cubeUV_maxTileSize;
+		uv.y += 4.0 * ( exp2( CUBEUV_MAX_MIP ) - faceSize );
 
-		}
-
-		uv.y += filterInt * 2.0 * cubeUV_minTileSize;
-
-		uv.x += 3.0 * max( 0.0, cubeUV_maxTileSize - 2.0 * faceSize );
-
-		uv *= texelSize;
+		uv.x *= CUBEUV_TEXEL_WIDTH;
+		uv.y *= CUBEUV_TEXEL_HEIGHT;
 
 		return texture2D( envMap, uv ).rgb;
 
@@ -166,7 +157,7 @@ export default /* glsl */`
 
 	vec4 textureCubeUV( sampler2D envMap, vec3 sampleDir, float roughness ) {
 
-		float mip = clamp( roughnessToMip( roughness ), m0, cubeUV_maxMipLevel );
+		float mip = clamp( roughnessToMip( roughness ), m0, CUBEUV_MAX_MIP );
 
 		float mipF = fract( mip );
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -95,7 +95,7 @@ function getToneMappingFunction( functionName, toneMapping ) {
 function generateExtensions( parameters ) {
 
 	const chunks = [
-		( parameters.extensionDerivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+		( parameters.extensionDerivatives || !!parameters.cubeUVHeight || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
 		( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
 		( parameters.extensionShaderTextureLOD || parameters.envMap || parameters.transmission ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -363,6 +363,22 @@ function generateEnvMapBlendingDefine( parameters ) {
 
 }
 
+function generateCubeUVSize( parameters ) {
+
+	const imageHeight = parameters.cubeUVHeight;
+
+	if ( imageHeight === null ) return null;
+
+	const maxMip = Math.log2( imageHeight / 32 + 1 ) + 3;
+
+	const texelHeight = 1.0 / imageHeight;
+
+	const texelWidth = 1.0 / ( 3 * Math.max( Math.pow(2, maxMip), 7 ) );
+
+	return {texelWidth, texelHeight, maxMip};
+
+}
+
 function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 	// TODO Send this event to Three.js DevTools
@@ -379,6 +395,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 	const envMapTypeDefine = generateEnvMapTypeDefine( parameters );
 	const envMapModeDefine = generateEnvMapModeDefine( parameters );
 	const envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
+	const cubeUVSize = generateCubeUVSize( parameters );
 
 	const customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters );
 
@@ -588,6 +605,9 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.envMap ? '#define ' + envMapTypeDefine : '',
 			parameters.envMap ? '#define ' + envMapModeDefine : '',
 			parameters.envMap ? '#define ' + envMapBlendingDefine : '',
+			cubeUVSize ? '#define CUBEUV_TEXEL_WIDTH ' + cubeUVSize.texelWidth : '',
+			cubeUVSize ? '#define CUBEUV_TEXEL_HEIGHT ' + cubeUVSize.texelHeight : '',
+			cubeUVSize ? '#define CUBEUV_MAX_MIP ' + cubeUVSize.maxMip + '.0' : '',
 			parameters.lightMap ? '#define USE_LIGHTMAP' : '',
 			parameters.aoMap ? '#define USE_AOMAP' : '',
 			parameters.emissiveMap ? '#define USE_EMISSIVEMAP' : '',

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -95,7 +95,7 @@ function getToneMappingFunction( functionName, toneMapping ) {
 function generateExtensions( parameters ) {
 
 	const chunks = [
-		( parameters.extensionDerivatives || !!parameters.cubeUVHeight || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+		( parameters.extensionDerivatives || !! parameters.cubeUVHeight || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
 		( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
 		( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
 		( parameters.extensionShaderTextureLOD || parameters.envMap || parameters.transmission ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -373,9 +373,9 @@ function generateCubeUVSize( parameters ) {
 
 	const texelHeight = 1.0 / imageHeight;
 
-	const texelWidth = 1.0 / ( 3 * Math.max( Math.pow(2, maxMip), 7 ) );
+	const texelWidth = 1.0 / ( 3 * Math.max( Math.pow( 2, maxMip ), 7 ) );
 
-	return {texelWidth, texelHeight, maxMip};
+	return { texelWidth, texelHeight, maxMip };
 
 }
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -78,6 +78,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		const environment = material.isMeshStandardMaterial ? scene.environment : null;
 
 		const envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || environment );
+		const useCubeUV = ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) );
 
 		const shaderID = shaderIDs[ material.type ];
 
@@ -153,7 +154,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			matcap: !! material.matcap,
 			envMap: !! envMap,
 			envMapMode: envMap && envMap.mapping,
-			envMapCubeUV: ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) ),
+			envMapCubeUV: useCubeUV,
+			cubeUVHeight: useCubeUV ? envMap.image.height : null,
 			lightMap: !! material.lightMap,
 			aoMap: !! material.aoMap,
 			emissiveMap: !! material.emissiveMap,
@@ -307,6 +309,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		array.push( parameters.precision );
 		array.push( parameters.outputEncoding );
 		array.push( parameters.envMapMode );
+		array.push( parameters.cubeUVHeight );
 		array.push( parameters.combine );
 		array.push( parameters.vertexUvs );
 		array.push( parameters.fogExp2 );

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -78,7 +78,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		const environment = material.isMeshStandardMaterial ? scene.environment : null;
 
 		const envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || environment );
-		const useCubeUV = ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) );
+		const cubeUVHeight = ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) ) ? envMap.image.height : null;
 
 		const shaderID = shaderIDs[ material.type ];
 
@@ -154,8 +154,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			matcap: !! material.matcap,
 			envMap: !! envMap,
 			envMapMode: envMap && envMap.mapping,
-			envMapCubeUV: useCubeUV,
-			cubeUVHeight: useCubeUV ? envMap.image.height : null,
+			cubeUVHeight: cubeUVHeight,
 			lightMap: !! material.lightMap,
 			aoMap: !! material.aoMap,
 			emissiveMap: !! material.emissiveMap,
@@ -350,56 +349,54 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			_programLayers.enable( 5 );
 		if ( parameters.envMap )
 			_programLayers.enable( 6 );
-		if ( parameters.envMapCubeUV )
-			_programLayers.enable( 7 );
 		if ( parameters.lightMap )
-			_programLayers.enable( 8 );
+			_programLayers.enable( 7 );
 		if ( parameters.aoMap )
-			_programLayers.enable( 9 );
+			_programLayers.enable( 8 );
 		if ( parameters.emissiveMap )
-			_programLayers.enable( 10 );
+			_programLayers.enable( 9 );
 		if ( parameters.bumpMap )
-			_programLayers.enable( 11 );
+			_programLayers.enable( 10 );
 		if ( parameters.normalMap )
-			_programLayers.enable( 12 );
+			_programLayers.enable( 11 );
 		if ( parameters.objectSpaceNormalMap )
-			_programLayers.enable( 13 );
+			_programLayers.enable( 12 );
 		if ( parameters.tangentSpaceNormalMap )
-			_programLayers.enable( 14 );
+			_programLayers.enable( 13 );
 		if ( parameters.clearcoat )
-			_programLayers.enable( 15 );
+			_programLayers.enable( 14 );
 		if ( parameters.clearcoatMap )
-			_programLayers.enable( 16 );
+			_programLayers.enable( 15 );
 		if ( parameters.clearcoatRoughnessMap )
-			_programLayers.enable( 17 );
+			_programLayers.enable( 16 );
 		if ( parameters.clearcoatNormalMap )
-			_programLayers.enable( 18 );
+			_programLayers.enable( 17 );
 		if ( parameters.displacementMap )
-			_programLayers.enable( 19 );
+			_programLayers.enable( 18 );
 		if ( parameters.specularMap )
-			_programLayers.enable( 20 );
+			_programLayers.enable( 19 );
 		if ( parameters.roughnessMap )
-			_programLayers.enable( 21 );
+			_programLayers.enable( 20 );
 		if ( parameters.metalnessMap )
-			_programLayers.enable( 22 );
+			_programLayers.enable( 21 );
 		if ( parameters.gradientMap )
-			_programLayers.enable( 23 );
+			_programLayers.enable( 22 );
 		if ( parameters.alphaMap )
-			_programLayers.enable( 24 );
+			_programLayers.enable( 23 );
 		if ( parameters.alphaTest )
-			_programLayers.enable( 25 );
+			_programLayers.enable( 24 );
 		if ( parameters.vertexColors )
-			_programLayers.enable( 26 );
+			_programLayers.enable( 25 );
 		if ( parameters.vertexAlphas )
-			_programLayers.enable( 27 );
+			_programLayers.enable( 26 );
 		if ( parameters.vertexUvs )
-			_programLayers.enable( 28 );
+			_programLayers.enable( 27 );
 		if ( parameters.vertexTangents )
-			_programLayers.enable( 29 );
+			_programLayers.enable( 28 );
 		if ( parameters.uvsVertexOnly )
-			_programLayers.enable( 30 );
+			_programLayers.enable( 29 );
 		if ( parameters.fog )
-			_programLayers.enable( 31 );
+			_programLayers.enable( 30 );
 
 		array.push( _programLayers.mask );
 		_programLayers.disableAll();


### PR DESCRIPTION
At long last, I've finally refactored PMREM to have variable size, based on the size of the input environment map. This helps in several ways:
1) First, if an equirect environment image was smaller than 1024x512, it used to get blurred too much (https://github.com/mrdoob/three.js/pull/23171#issuecomment-1007339829).
2) If the image was larger, then its reflection detail was simply lost.
3) If a small environment image was used, it was handled internally as though it was 1024x512, which meant there was no cache efficiency or generation time advantage to using a smaller envMap.

These are all now fixed. I also changed the internal PMREM format a bit to make it scale more easily. @mrdoob @Mugen87 @WestLangley 

It should be noted that there is a direct relationship between the minimum roughness value you want to resolve on your materials and the required environment size. For instance, the old default of 1024x512 (or a cubemap of 256x256) handled down to roughness 0.05. For 0.1, only a 64x64 cubemap is required (which can save a lot of bandwidth on your HDR). The WebXR lighting cubemap is 16x16, so it can only resolve roughness down to 0.21. Now, you may also be able to get away with less environment map resolution if you are rendering to a small canvas or your shiny parts are more curved. However, keep in mind that in the limit of roughness => 0, you may need infinite environment resolution to avoid seeing pixels (this is  just the physics of optics). 

As an example, here is the old code with a 1024x512 envMap (and zero roughness on the visor):
![image](https://user-images.githubusercontent.com/1649964/150883858-a56acc81-dae2-463e-a44f-4b7a32ccd92c.png)

And here is the new way with the HDR downsampled to 256x128 (130kb vs 450kb).
![image](https://user-images.githubusercontent.com/1649964/150883972-fa25a74a-e971-4e80-befb-1e69f4c3d273.png)
