### PR TITLE
HTMLTexture: Don't overwrite dispatchEvent().

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -20,7 +20,7 @@ class HTMLMesh extends Mesh {
 
 		function onEvent( event ) {
 
-			material.map.dispatchEvent( event );
+			material.map.dispatchDOMEvent( event );
 
 		}
 
@@ -48,7 +48,7 @@ class HTMLTexture extends CanvasTexture {
 
 	}
 
-	dispatchEvent( event ) {
+	dispatchDOMEvent( event ) {
 
 		htmlevent( this.dom, event.type, event.data.x, event.data.y );
 


### PR DESCRIPTION
Related #23319.

**Description**

The PR ensures that `HTMLTexture` does not overwrite `Texture.dispatchEvent()` which breaks `Texture.dispose()`. There is now a new method called `dispatchDOMEvent()` to dispatches events to the DOM.
