### PR TITLE
HTMLMesh: Introduce dispose().

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -29,6 +29,20 @@ class HTMLMesh extends Mesh {
 		this.addEventListener( 'mouseup', onEvent );
 		this.addEventListener( 'click', onEvent );
 
+		this.dispose = function () {
+
+			geometry.dispose();
+			material.dispose();
+
+			material.map.dispose();
+
+			this.removeEventListener( 'mousedown', onEvent );
+			this.removeEventListener( 'mousemove', onEvent );
+			this.removeEventListener( 'mouseup', onEvent );
+			this.removeEventListener( 'click', onEvent );
+
+		};
+
 	}
 
 }


### PR DESCRIPTION
Fixed #23319.

**Description**

Similar to helpers, `HTMLMesh.dispose()` can now be used to clean up internals. The method also ensures to remove all event listeners.
