### PR TITLE
Rollup: Added constant RGB5_A1.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -92,6 +92,7 @@ export function glconstants() {
 		POLYGON_OFFSET_FILL: 32823,
 		RGB8: 32849,
 		RGBA4: 32854,
+		RGB5_A1: 32855,
 		RGBA8: 32856,
 		TEXTURE_3D: 32879,
 		CLAMP_TO_EDGE: 33071,


### PR DESCRIPTION
Related issue: #---

**Description**

Fixed error in cmd.

error info: 
```bash
[ROLLUP] * Unhandled GL Constant: RGB5_A
```
