### PR TITLE
LDrawLoader: Fix getMainEdgeMaterial()

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2125,7 +2125,8 @@ class LDrawLoader extends Loader {
 
 	getMainEdgeMaterial() {
 
-		return this.getMaterial( MAIN_EDGE_COLOUR_CODE );
+		const mainMat = this.getMainMaterial();
+		return mainMat && mainMat.userData ? mainMat.userData.edgeMaterial : null;
 
 	}
 


### PR DESCRIPTION
Related issue: ---

**Description**

For some reason, ```LDrawLoader.getMainEdgeMaterial()``` is returning a material that when updated it does not correspond to the edge lines objects main material. If instead, ```LDrawLoader.getMainEdgeMaterial().userData.edgeMaterial``` is used, the correct colors appear in the lines objects when the material is updated.

So I've changed the implementation of the method to return the ```userData.edgeMaterial``` member instead.