### PR TITLE
Examples: Always use FloatType in GPGPU examples with WebGL 2.

### DIFF
--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -502,7 +502,7 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
-				if ( isSafari() ) {
+				if ( renderer.capabilities.isWebGL2 === false ) {
 
 					gpuCompute.setDataType( THREE.HalfFloatType );
 
@@ -546,12 +546,6 @@
 					console.error( error );
 
 				}
-
-			}
-
-			function isSafari() {
-
-				return !! navigator.userAgent.match( /Safari/i ) && ! navigator.userAgent.match( /Chrome/i );
 
 			}
 

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -446,7 +446,7 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
-				if ( isSafari() ) {
+				if ( renderer.capabilities.isWebGL2 === false ) {
 
 					gpuCompute.setDataType( THREE.HalfFloatType );
 
@@ -490,12 +490,6 @@
 					console.error( error );
 
 				}
-
-			}
-
-			function isSafari() {
-
-				return !! navigator.userAgent.match( /Safari/i ) && ! navigator.userAgent.match( /Chrome/i );
 
 			}
 

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -322,7 +322,7 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
-				if ( isSafari() ) {
+				if ( renderer.capabilities.isWebGL2 === false ) {
 
 					gpuCompute.setDataType( THREE.HalfFloatType );
 
@@ -351,12 +351,6 @@
 					console.error( error );
 
 				}
-
-			}
-
-			function isSafari() {
-
-				return !! navigator.userAgent.match( /Safari/i ) && ! navigator.userAgent.match( /Chrome/i );
 
 			}
 

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -451,7 +451,7 @@
 
 				gpuCompute = new GPUComputationRenderer( WIDTH, WIDTH, renderer );
 
-				if ( isSafari() ) {
+				if ( renderer.capabilities.isWebGL2 === false ) {
 
 					gpuCompute.setDataType( THREE.HalfFloatType );
 
@@ -501,12 +501,6 @@
 					type: THREE.UnsignedByteType,
 					depthBuffer: false
 				} );
-
-			}
-
-			function isSafari() {
-
-				return !! navigator.userAgent.match( /Safari/i ) && ! navigator.userAgent.match( /Chrome/i );
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

To avoid browser sniffing I suggest to always use `FloatType` with WebGL 2 and `HalfFloatType` with WebGL 1. Apple devices using latest iOS, iPadOS or macOS should support WebGL 2 anyway.
