### PR TITLE
OBJLoader: Convert vertex colors to Linear from sRGB

### DIFF
--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -11,7 +11,8 @@ import {
 	MeshPhongMaterial,
 	Points,
 	PointsMaterial,
-	Vector3
+	Vector3,
+	Color
 } from 'three';
 
 // o object_name | g group_name
@@ -29,6 +30,8 @@ const _vC = new Vector3();
 
 const _ab = new Vector3();
 const _cb = new Vector3();
+
+const _color = new Color();
 
 function ParserState() {
 
@@ -536,12 +539,13 @@ class OBJLoader extends Loader {
 						);
 						if ( data.length >= 7 ) {
 
-							state.colors.push(
+							_color.setRGB(
 								parseFloat( data[ 4 ] ),
 								parseFloat( data[ 5 ] ),
 								parseFloat( data[ 6 ] )
+							).convertSRGBToLinear();
 
-							);
+							state.colors.push( _color.r, _color.g, _color.b );
 
 						} else {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23296#issuecomment-1022071425

**Description**

Completes the OBJLoader conversion for #23283 by ensuring the vertex colors are converted from sRGB colors to Linear.

Test model from [this StackOverflow post](https://stackoverflow.com/questions/61776972/loading-obj-with-objloader2-to-load-vertex-colors).

| r136 | r137 | this PR |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/734200/151228638-ec69c2be-5cf0-4557-9544-2e12d5177054.png) | ![image](https://user-images.githubusercontent.com/734200/151228940-117861c2-b300-47ae-bb5b-ee0633434d62.png) | ![image](https://user-images.githubusercontent.com/734200/151229045-d9425c84-28d2-4e82-9c04-c48fae1f5b58.png) |


