### PR TITLE
PLYLoader: convert vertex colors to linear

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -3,7 +3,8 @@ import {
 	FileLoader,
 	Float32BufferAttribute,
 	Loader,
-	LoaderUtils
+	LoaderUtils,
+	Color
 } from 'three';
 
 /**
@@ -32,6 +33,7 @@ import {
  *
  */
 
+const _color = new Color();
 
 class PLYLoader extends Loader {
 
@@ -407,7 +409,13 @@ class PLYLoader extends Loader {
 
 				if ( attrR !== null && attrG !== null && attrB !== null ) {
 
-					buffer.colors.push( element[ attrR ] / 255.0, element[ attrG ] / 255.0, element[ attrB ] / 255.0 );
+					_color.setRGB(
+						element[ attrR ] / 255.0,
+						element[ attrG ] / 255.0,
+						element[ attrB ] / 255.0
+					).convertSRGBToLinear();
+
+					buffer.colors.push( _color.r, _color.g, _color.b );
 
 				}
 


### PR DESCRIPTION
Related issue: #23283

**Description**

Convert the loaded vertex colors from PLY from srgb to linear.

Tested using the "dolphins_colored.ply" file in the repo. All the vertex colors seem to be fully 0 or 1 in that file so changes in brightness are not so apparent but you can see the differences in the transition between colors on the rainbow dolphin.

| BEFORE | AFTER |
|---|---|
| ![image](https://user-images.githubusercontent.com/734200/151247869-1f03b742-ccc1-4222-a766-94f5680584a3.png) | ![image](https://user-images.githubusercontent.com/734200/151247829-4bb48db2-5fc1-4bd0-876c-de89d80e3481.png) |