### PR TITLE
Fix skypack issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
       "import": "./build/three.module.js",
       "require": "./build/three.cjs"
     },
-    "./examples/jsm/*": "./examples/jsm/*.js",
-    "./src/*": "./src/*.js"
+    "./examples/jsm/*": "./examples/jsm/*",
+    "./src/*": "./src/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related issue: https://github.com/skypackjs/skypack-cdn/issues/261#issuecomment-1022907739, [https://discourse.threejs.org/34148](https://discourse.threejs.org/t/r137-import-jsm-module-with-webpack-build-pipeline-error-since-r137/34148)

**Description**

It looks like the skypack issue with r137 was the extra `.js` extension.

@mrdoob we need a patch release after this 😇

After the `0.137.1` relese, this jsfiddle should work fine: https://jsfiddle.net/s45v6jdq