### PR TITLE
ShaderLib: Added OPAQUE snippet to meshnormal shader.

### DIFF
--- a/src/renderers/shaders/ShaderLib/meshnormal.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshnormal.glsl.js
@@ -72,5 +72,11 @@ void main() {
 
 	gl_FragColor = vec4( packNormalToRGB( normal ), opacity );
 
+	#ifdef OPAQUE
+
+		gl_FragColor.a = 1.0;
+
+	#endif
+
 }
 `;


### PR DESCRIPTION
Related issue: #23361

**Description**

`MeshNormalMaterial`'s `opacity` and `transparent` should behave like the other materials.