### PR TITLE
Examples: Fix webgl_worker_offscreencanvas.

### DIFF
--- a/examples/jsm/offscreen/scene.js
+++ b/examples/jsm/offscreen/scene.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from '../../../build/three.module.js';
 
 var camera, scene, renderer, group;
 

--- a/examples/webgl_worker_offscreencanvas.html
+++ b/examples/webgl_worker_offscreencanvas.html
@@ -68,14 +68,6 @@
 		<!-- Remove this when import maps will be widely supported -->
 		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 
-		<script type="importmap">
-			{
-				"imports": {
-					"three": "../build/three.module.js"
-				}
-			}
-		</script>
-
 		<script type="module">
 
 			import initJank from './jsm/offscreen/jank.js';


### PR DESCRIPTION
Related issue: #23255

**Description**

It seems the spec of Import Maps has not yet defined how they should work with Web Workers (see https://github.com/WICG/import-maps/issues/2). Hence `webgl_worker_offscreencanvas` is currently broken.

This PR is a hotfix to make `webgl_worker_offscreencanvas` work again. However, the PR is essentially wrong since using `import * as THREE from '../../../build/three.module.js';` does not allow the usage of example modules.

I'm afraid the missing import maps support in workers was not discussed in #23255.

/cc @marcofugaro 