### PR TITLE
Removed rogue bracket

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -123,7 +123,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Converts this color from sRGB space to linear space.
 		</p>
 
-		<h3>[method:this copyLinearToSRGB]( [param:Color color]] ) </h3>
+		<h3>[method:this copyLinearToSRGB]( [param:Color color] ) </h3>
 		<p>
 		[page:Color color] — Color to copy.<br />
 


### PR DESCRIPTION
Related issue: None

Fixed typo in THREE.Color() docs, removed extra bracket.
