### PR TITLE
Manual: Improve compatibility with import maps.

### DIFF
--- a/manual/en/align-html-elements-to-3d.html
+++ b/manual/en/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/backgrounds.html
+++ b/manual/en/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/billboards.html
+++ b/manual/en/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/cameras.html
+++ b/manual/en/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/canvas-textures.html
+++ b/manual/en/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/cleanup.html
+++ b/manual/en/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/custom-buffergeometry.html
+++ b/manual/en/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/custom-geometry.html
+++ b/manual/en/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/debugging-glsl.html
+++ b/manual/en/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/debugging-javascript.html
+++ b/manual/en/debugging-javascript.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/fog.html
+++ b/manual/en/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/fundamentals.html
+++ b/manual/en/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/game.html
+++ b/manual/en/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/indexed-textures.html
+++ b/manual/en/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/lights.html
+++ b/manual/en/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/load-gltf.html
+++ b/manual/en/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/load-obj.html
+++ b/manual/en/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/material-table.html
+++ b/manual/en/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/materials.html
+++ b/manual/en/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/multiple-scenes.html
+++ b/manual/en/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/offscreencanvas.html
+++ b/manual/en/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/optimize-lots-of-objects-animated.html
+++ b/manual/en/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/optimize-lots-of-objects.html
+++ b/manual/en/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/picking.html
+++ b/manual/en/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/post-processing-3dlut.html
+++ b/manual/en/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/post-processing.html
+++ b/manual/en/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/prerequisites.html
+++ b/manual/en/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/primitives.html
+++ b/manual/en/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/rendering-on-demand.html
+++ b/manual/en/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/rendertargets.html
+++ b/manual/en/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/responsive.html
+++ b/manual/en/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/scenegraph.html
+++ b/manual/en/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/setup.html
+++ b/manual/en/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/shadertoy.html
+++ b/manual/en/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/shadows.html
+++ b/manual/en/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/textures.html
+++ b/manual/en/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/tips.html
+++ b/manual/en/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/transparency.html
+++ b/manual/en/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/voxel-geometry.html
+++ b/manual/en/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/webxr-look-to-select.html
+++ b/manual/en/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/webxr-point-to-select.html
+++ b/manual/en/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/en/webxr.html
+++ b/manual/en/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/examples/align-html-elements-to-3d-globe-too-many-labels.html
+++ b/manual/examples/align-html-elements-to-3d-globe-too-many-labels.html
@@ -58,8 +58,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/align-html-elements-to-3d-globe.html
+++ b/manual/examples/align-html-elements-to-3d-globe.html
@@ -58,8 +58,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/align-html-to-3d-w-hiding.html
+++ b/manual/examples/align-html-to-3d-w-hiding.html
@@ -55,8 +55,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/align-html-to-3d-w-sorting.html
+++ b/manual/examples/align-html-to-3d-w-sorting.html
@@ -57,8 +57,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/align-html-to-3d.html
+++ b/manual/examples/align-html-to-3d.html
@@ -55,8 +55,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/background-css.html
+++ b/manual/examples/background-css.html
@@ -22,8 +22,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/background-cubemap.html
+++ b/manual/examples/background-cubemap.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/background-equirectangularmap.html
+++ b/manual/examples/background-equirectangularmap.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/background-scene-background-fixed-aspect.html
+++ b/manual/examples/background-scene-background-fixed-aspect.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/background-scene-background.html
+++ b/manual/examples/background-scene-background.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/background-separate-scene-bad-aspect.html
+++ b/manual/examples/background-separate-scene-bad-aspect.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/background-separate-scene.html
+++ b/manual/examples/background-separate-scene.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/background-v01.html
+++ b/manual/examples/background-v01.html
@@ -21,8 +21,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/background.html
+++ b/manual/examples/background.html
@@ -21,8 +21,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/billboard-labels-w-sprites-adjust-height.html
+++ b/manual/examples/billboard-labels-w-sprites-adjust-height.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/billboard-labels-w-sprites.html
+++ b/manual/examples/billboard-labels-w-sprites.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/billboard-trees-no-billboards.html
+++ b/manual/examples/billboard-trees-no-billboards.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/billboard-trees-static-billboards.html
+++ b/manual/examples/billboard-trees-static-billboards.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/cameras-logarithmic-depth-buffer.html
+++ b/manual/examples/cameras-logarithmic-depth-buffer.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/cameras-orthographic-2-scenes.html
+++ b/manual/examples/cameras-orthographic-2-scenes.html
@@ -36,8 +36,20 @@
        <div id="view2" tabindex="2"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/cameras-orthographic-canvas-top-left-origin.html
+++ b/manual/examples/cameras-orthographic-canvas-top-left-origin.html
@@ -32,8 +32,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/cameras-perspective-2-scenes.html
+++ b/manual/examples/cameras-perspective-2-scenes.html
@@ -36,8 +36,20 @@
        <div id="view2" tabindex="2"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/cameras-perspective.html
+++ b/manual/examples/cameras-perspective.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/cameras-z-fighting.html
+++ b/manual/examples/cameras-z-fighting.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/canvas-textured-cube-qix.html
+++ b/manual/examples/canvas-textured-cube-qix.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/canvas-textured-cube.html
+++ b/manual/examples/canvas-textured-cube.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/canvas-textured-labels-one-canvas.html
+++ b/manual/examples/canvas-textured-labels-one-canvas.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/canvas-textured-labels-scale-to-fit.html
+++ b/manual/examples/canvas-textured-labels-scale-to-fit.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/canvas-textured-labels.html
+++ b/manual/examples/canvas-textured-labels.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/cleanup-loaded-files.html
+++ b/manual/examples/cleanup-loaded-files.html
@@ -25,8 +25,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 
 class ResourceTracker {

--- a/manual/examples/cleanup-simple.html
+++ b/manual/examples/cleanup-simple.html
@@ -25,8 +25,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 class ResourceTracker {
   constructor() {

--- a/manual/examples/custom-buffergeometry-cube-indexed.html
+++ b/manual/examples/custom-buffergeometry-cube-indexed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-buffergeometry-cube-typedarrays.html
+++ b/manual/examples/custom-buffergeometry-cube-typedarrays.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-buffergeometry-cube.html
+++ b/manual/examples/custom-buffergeometry-cube.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-buffergeometry-dynamic.html
+++ b/manual/examples/custom-buffergeometry-dynamic.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube-face-colors.html
+++ b/manual/examples/custom-geometry-cube-face-colors.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube-face-normals.html
+++ b/manual/examples/custom-geometry-cube-face-normals.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube-texcoords.html
+++ b/manual/examples/custom-geometry-cube-texcoords.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube-vertex-colors.html
+++ b/manual/examples/custom-geometry-cube-vertex-colors.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube-vertex-normals.html
+++ b/manual/examples/custom-geometry-cube-vertex-normals.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-cube.html
+++ b/manual/examples/custom-geometry-cube.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/custom-geometry-heightmap.html
+++ b/manual/examples/custom-geometry-heightmap.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/debug-js-clearing-logger.html
+++ b/manual/examples/debug-js-clearing-logger.html
@@ -33,8 +33,20 @@
       <pre></pre>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 class ClearingLogger {
   constructor(elem) {

--- a/manual/examples/debug-js-html-elements.html
+++ b/manual/examples/debug-js-html-elements.html
@@ -34,8 +34,20 @@
       <div>z:<span id="z"></span></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/debug-js-params.html
+++ b/manual/examples/debug-js-params.html
@@ -44,8 +44,20 @@
     </div>
     <div id="info">click to launch</div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 /**
   * Returns the query parameters as a key/value object.

--- a/manual/examples/debugging-mcve.html
+++ b/manual/examples/debugging-mcve.html
@@ -1,8 +1,20 @@
 <body>
   <canvas id="c"></canvas>
 </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/fog-gui.html
+++ b/manual/examples/fog-gui.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 
 function main() {

--- a/manual/examples/fog.html
+++ b/manual/examples/fog.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/fundamentals-3-cubes.html
+++ b/manual/examples/fundamentals-3-cubes.html
@@ -9,8 +9,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/fundamentals-with-animation.html
+++ b/manual/examples/fundamentals-with-animation.html
@@ -9,8 +9,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/fundamentals-with-light.html
+++ b/manual/examples/fundamentals-with-light.html
@@ -9,8 +9,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/fundamentals.html
+++ b/manual/examples/fundamentals.html
@@ -9,8 +9,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/game-check-animations.html
+++ b/manual/examples/game-check-animations.html
@@ -73,8 +73,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/game-conga-line-w-notes.html
+++ b/manual/examples/game-conga-line-w-notes.html
@@ -148,8 +148,20 @@
     </div>
     <div id="labels"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/game-conga-line.html
+++ b/manual/examples/game-conga-line.html
@@ -148,8 +148,20 @@
     </div>
     <div id="labels"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/game-just-player.html
+++ b/manual/examples/game-just-player.html
@@ -79,8 +79,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/game-load-models.html
+++ b/manual/examples/game-load-models.html
@@ -73,8 +73,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/game-player-input.html
+++ b/manual/examples/game-player-input.html
@@ -119,8 +119,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from '../../examples/jsm/utils/SkeletonUtils.js';

--- a/manual/examples/indexed-textures-picking-and-highlighting.html
+++ b/manual/examples/indexed-textures-picking-and-highlighting.html
@@ -58,8 +58,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/indexed-textures-picking-debounced.html
+++ b/manual/examples/indexed-textures-picking-debounced.html
@@ -59,8 +59,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/indexed-textures-picking.html
+++ b/manual/examples/indexed-textures-picking.html
@@ -58,8 +58,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/indexed-textures-random-colors.html
+++ b/manual/examples/indexed-textures-random-colors.html
@@ -58,8 +58,20 @@
       <div id="labels"></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/lights-ambient.html
+++ b/manual/examples/lights-ambient.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-directional-w-helper.html
+++ b/manual/examples/lights-directional-w-helper.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-directional.html
+++ b/manual/examples/lights-directional.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-hemisphere.html
+++ b/manual/examples/lights-hemisphere.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-point-physically-correct.html
+++ b/manual/examples/lights-point-physically-correct.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-point.html
+++ b/manual/examples/lights-point.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/lights-rectarea.html
+++ b/manual/examples/lights-rectarea.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {RectAreaLightUniformsLib} from '../../examples/jsm/lights/RectAreaLightUniformsLib.js';
 import {RectAreaLightHelper} from '../../examples/jsm/helpers/RectAreaLightHelper.js';

--- a/manual/examples/lights-spot-w-helper.html
+++ b/manual/examples/lights-spot-w-helper.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/load-gltf-animated-cars.html
+++ b/manual/examples/load-gltf-animated-cars.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-car-path-fixed.html
+++ b/manual/examples/load-gltf-car-path-fixed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-car-path.html
+++ b/manual/examples/load-gltf-car-path.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-dump-scenegraph-extra.html
+++ b/manual/examples/load-gltf-dump-scenegraph-extra.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-dump-scenegraph.html
+++ b/manual/examples/load-gltf-dump-scenegraph.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-rotate-cars-fixed.html
+++ b/manual/examples/load-gltf-rotate-cars-fixed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-rotate-cars.html
+++ b/manual/examples/load-gltf-rotate-cars.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-gltf-shadows.html
+++ b/manual/examples/load-gltf-shadows.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';

--- a/manual/examples/load-gltf.html
+++ b/manual/examples/load-gltf.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/load-obj-auto-camera-xz.html
+++ b/manual/examples/load-obj-auto-camera-xz.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 

--- a/manual/examples/load-obj-auto-camera.html
+++ b/manual/examples/load-obj-auto-camera.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 

--- a/manual/examples/load-obj-materials-fixed.html
+++ b/manual/examples/load-obj-materials-fixed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 import {MTLLoader} from '../../examples/jsm/loaders/MTLLoader.js';

--- a/manual/examples/load-obj-materials-windmill2.html
+++ b/manual/examples/load-obj-materials-windmill2.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 import {MTLLoader} from '../../examples/jsm/loaders/MTLLoader.js';

--- a/manual/examples/load-obj-materials.html
+++ b/manual/examples/load-obj-materials.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 import {MTLLoader} from '../../examples/jsm/loaders/MTLLoader.js';

--- a/manual/examples/load-obj-no-materials.html
+++ b/manual/examples/load-obj-no-materials.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 

--- a/manual/examples/load-obj-wat.html
+++ b/manual/examples/load-obj-wat.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {OBJLoader} from '../../examples/jsm/loaders/OBJLoader.js';
 

--- a/manual/examples/lots-of-objects-animated.html
+++ b/manual/examples/lots-of-objects-animated.html
@@ -41,8 +41,20 @@
     <canvas id="c"></canvas>
     <div id="ui"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {TWEEN} from '../../examples/jsm/libs/tween.module.min.js';

--- a/manual/examples/lots-of-objects-merged-vertexcolors.html
+++ b/manual/examples/lots-of-objects-merged-vertexcolors.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 

--- a/manual/examples/lots-of-objects-merged.html
+++ b/manual/examples/lots-of-objects-merged.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 

--- a/manual/examples/lots-of-objects-morphtargets-w-colors.html
+++ b/manual/examples/lots-of-objects-morphtargets-w-colors.html
@@ -41,8 +41,20 @@
     <canvas id="c"></canvas>
     <div id="ui"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {TWEEN} from '../../examples/jsm/libs/tween.module.min.js';

--- a/manual/examples/lots-of-objects-morphtargets.html
+++ b/manual/examples/lots-of-objects-morphtargets.html
@@ -41,8 +41,20 @@
     <canvas id="c"></canvas>
     <div id="ui"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {TWEEN} from '../../examples/jsm/libs/tween.module.min.js';

--- a/manual/examples/lots-of-objects-multiple-data-sets.html
+++ b/manual/examples/lots-of-objects-multiple-data-sets.html
@@ -41,8 +41,20 @@
     <canvas id="c"></canvas>
     <div id="ui"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 

--- a/manual/examples/lots-of-objects-slow.html
+++ b/manual/examples/lots-of-objects-slow.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/multiple-scenes-controls.html
+++ b/manual/examples/multiple-scenes-controls.html
@@ -48,8 +48,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {TrackballControls} from '../../examples/jsm/controls/TrackballControls.js';
 
 function main() {

--- a/manual/examples/multiple-scenes-copy-canvas.html
+++ b/manual/examples/multiple-scenes-copy-canvas.html
@@ -43,8 +43,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {TrackballControls} from '../../examples/jsm/controls/TrackballControls.js';
 
 function main() {

--- a/manual/examples/multiple-scenes-generic.html
+++ b/manual/examples/multiple-scenes-generic.html
@@ -48,8 +48,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/multiple-scenes-selector.html
+++ b/manual/examples/multiple-scenes-selector.html
@@ -48,8 +48,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/multiple-scenes-v1.html
+++ b/manual/examples/multiple-scenes-v1.html
@@ -48,8 +48,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/multiple-scenes-v2.html
+++ b/manual/examples/multiple-scenes-v2.html
@@ -49,8 +49,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/multiple-scenes-v3.html
+++ b/manual/examples/multiple-scenes-v3.html
@@ -49,8 +49,20 @@
       and finding a undiscovered tomb full of mummies and treasure.
     </p>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/offscreencanvas-cubes.js
+++ b/manual/examples/offscreencanvas-cubes.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'https://cdn.skypack.dev/three@0.136.0/build/three.module.js';
 
 const state = {
   width: 300,   // canvas default

--- a/manual/examples/offscreencanvas-worker-orbitcontrols.js
+++ b/manual/examples/offscreencanvas-worker-orbitcontrols.js
@@ -1,5 +1,5 @@
 import {init} from './shared-orbitcontrols.js';
-import {EventDispatcher} from '../../build/three.module.js';
+import {EventDispatcher} from 'https://cdn.skypack.dev/three@0.136.0/build/three.module.js';
 
 function noop() {
 }

--- a/manual/examples/picking-gpu.html
+++ b/manual/examples/picking-gpu.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/picking-raycaster-complex-geo.html
+++ b/manual/examples/picking-raycaster-complex-geo.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/picking-raycaster-transparency.html
+++ b/manual/examples/picking-raycaster-transparency.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/picking-raycaster.html
+++ b/manual/examples/picking-raycaster.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/postprocessing-3dlut-identity.html
+++ b/manual/examples/postprocessing-3dlut-identity.html
@@ -19,8 +19,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';

--- a/manual/examples/postprocessing-3dlut-prep.html
+++ b/manual/examples/postprocessing-3dlut-prep.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 

--- a/manual/examples/postprocessing-3dlut-w-loader.html
+++ b/manual/examples/postprocessing-3dlut-w-loader.html
@@ -19,10 +19,18 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
+import * as THREE from 'three';
 import * as lutParser from './resources/lut-reader.js';
 import * as dragAndDrop from './resources/drag-and-drop.js';
-import * as THREE from '../../build/three.module.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';

--- a/manual/examples/postprocessing-3dlut.html
+++ b/manual/examples/postprocessing-3dlut.html
@@ -19,8 +19,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';

--- a/manual/examples/postprocessing-adobe-lut-to-png-converter.html
+++ b/manual/examples/postprocessing-adobe-lut-to-png-converter.html
@@ -30,10 +30,18 @@
     <p><button type="button">Save...</button></p>
     <div id="cube"><canvas id="c"></canvas></div>
   </body>
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
+import * as THREE from 'three';
 import * as lutParser from './resources/lut-reader.js';
 import * as dragAndDrop from './resources/drag-and-drop.js';
-import * as THREE from '../../build/three.module.js';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';
 import {RenderPass} from '../../examples/jsm/postprocessing/RenderPass.js';
 import {ShaderPass} from '../../examples/jsm/postprocessing/ShaderPass.js';

--- a/manual/examples/postprocessing-custom.html
+++ b/manual/examples/postprocessing-custom.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';
 import {RenderPass} from '../../examples/jsm/postprocessing/RenderPass.js';
 import {ShaderPass} from '../../examples/jsm/postprocessing/ShaderPass.js';

--- a/manual/examples/postprocessing-gui.html
+++ b/manual/examples/postprocessing-gui.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';
 import {RenderPass} from '../../examples/jsm/postprocessing/RenderPass.js';
 import {BloomPass} from '../../examples/jsm/postprocessing/BloomPass.js';

--- a/manual/examples/postprocessing.html
+++ b/manual/examples/postprocessing.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {EffectComposer} from '../../examples/jsm/postprocessing/EffectComposer.js';
 import {RenderPass} from '../../examples/jsm/postprocessing/RenderPass.js';
 import {BloomPass} from '../../examples/jsm/postprocessing/BloomPass.js';

--- a/manual/examples/primitives-text.html
+++ b/manual/examples/primitives-text.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {FontLoader} from '../../examples/jsm/loaders/FontLoader.js';
 import {TextGeometry} from '../../examples/jsm/geometries/TextGeometry.js';
 

--- a/manual/examples/primitives.html
+++ b/manual/examples/primitives.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {FontLoader} from '../../examples/jsm/loaders/FontLoader.js';
 import {ParametricGeometry} from '../../examples/jsm/geometries/ParametricGeometry.js';
 import {TextGeometry} from '../../examples/jsm/geometries/TextGeometry.js';

--- a/manual/examples/render-on-demand-w-damping.html
+++ b/manual/examples/render-on-demand-w-damping.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/render-on-demand-w-gui.html
+++ b/manual/examples/render-on-demand-w-gui.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/render-on-demand.html
+++ b/manual/examples/render-on-demand.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c" tabindex="1"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/render-target.html
+++ b/manual/examples/render-target.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/resources/editor-settings.js
+++ b/manual/examples/resources/editor-settings.js
@@ -61,7 +61,7 @@ function fixSourceLinks(url, source) {
   const urlPropRE = /(url:\s*)('|")(.*?)('|")/g;
   const workerRE = /(new\s+Worker\s*\(\s*)('|")(.*?)('|")/g;
   const importScriptsRE = /(importScripts\s*\(\s*)('|")(.*?)('|")/g;
-  const moduleRE = /(import.*?)('|")(.*?)('|")/g;
+  const moduleRE = /(import.*?)(?!'three')('|")(.*?)('|")/g;
   const prefix = getPrefix(url);
   const rootPrefix = getRootPrefix(url);
 

--- a/manual/examples/resources/editor.html
+++ b/manual/examples/resources/editor.html
@@ -190,6 +190,9 @@ button:focus {
     border-bottom: none !important;
     border-top: 5px solid #666 !important;
 }
+.button-export {
+	display: none; /* TODO: Fix export with import maps */
+}
 .button-result {
     margin-left: 2em !important;
 }

--- a/manual/examples/resources/editor.js
+++ b/manual/examples/resources/editor.js
@@ -178,7 +178,7 @@ async function getWorkerScripts(text, baseUrl, scriptInfos = {}) {
   const parentScriptInfo = scriptInfos[baseUrl];
   const workerRE = /(new\s+Worker\s*\(\s*)('|")(.*?)('|")/g;
   const importScriptsRE = /(importScripts\s*\(\s*)('|")(.*?)('|")/g;
-  const importRE = /(import.*?)('|")(.*?)('|")/g;
+  const importRE = /(import.*?)(?!'three')('|")(.*?)('|")/g;
 
   const newScripts = [];
   const slashRE = /\/manual\/examples\/[^/]+$/;
@@ -295,6 +295,8 @@ async function parseHTML(url, html) {
   // We need a way to pass parameters to a blob. Normally they'd be passed as
   // query params but that only works in Firefox >:(
   html = html.replace('</head>', '<script id="hackedparams">window.hackedParams = ${hackedParams}\n</script>\n</head>');
+
+	html = html.replace('../../build/three.module.js', window.location.origin + '/build/three.module.js');
 
   html = extraHTMLParsing(html, htmlParts);
 
@@ -1440,6 +1442,3 @@ function start() {
 
 start();
 }());
-
-
-

--- a/manual/examples/responsive-editor.html
+++ b/manual/examples/responsive-editor.html
@@ -49,6 +49,13 @@
       </div>
     </div>
   </body>
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
 <script type="module" src="threejs-responsive.js"></script>
 <script src="../3rdparty/split.min.js"></script>
 <script type="module">
@@ -72,4 +79,3 @@ Split(['#view', '#controls'], {  // eslint-disable-line new-cap
 });
 </script>
 </html>
-

--- a/manual/examples/responsive-hd-dpi.html
+++ b/manual/examples/responsive-hd-dpi.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/responsive-no-resize.html
+++ b/manual/examples/responsive-no-resize.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/responsive-paragraph.html
+++ b/manual/examples/responsive-paragraph.html
@@ -29,6 +29,12 @@ magna id sem faucibus sollicitudin.  Proin nunc mi, rutrum et elementum
 ut, auctor eget massa.
 </p>
   </body>
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
 <script type="module" src="threejs-responsive.js"></script>
 </html>
-

--- a/manual/examples/responsive-update-camera.html
+++ b/manual/examples/responsive-update-camera.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/responsive.html
+++ b/manual/examples/responsive.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-car.html
+++ b/manual/examples/scenegraph-car.html
@@ -21,8 +21,20 @@
     <canvas id="c"></canvas>
   </body>
 <script src="resources/threejs-lessons-helper.js"></script> <!-- you can and should delete this script. it is only used on the site to help with errors -->
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun-earth-moon-axes-grids.html
+++ b/manual/examples/scenegraph-sun-earth-moon-axes-grids.html
@@ -46,8 +46,20 @@
     <canvas id="c"></canvas>
     <div id="ui"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 
 function main() {

--- a/manual/examples/scenegraph-sun-earth-moon-axes.html
+++ b/manual/examples/scenegraph-sun-earth-moon-axes.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun-earth-moon.html
+++ b/manual/examples/scenegraph-sun-earth-moon.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun-earth-orbit-fixed.html
+++ b/manual/examples/scenegraph-sun-earth-orbit-fixed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun-earth-orbit.html
+++ b/manual/examples/scenegraph-sun-earth-orbit.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun-earth.html
+++ b/manual/examples/scenegraph-sun-earth.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-sun.html
+++ b/manual/examples/scenegraph-sun.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/scenegraph-tank.html
+++ b/manual/examples/scenegraph-tank.html
@@ -30,8 +30,20 @@
     <canvas id="c"></canvas>
     <div id="info"></div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadertoy-as-texture.html
+++ b/manual/examples/shadertoy-as-texture.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadertoy-basic-x40.html
+++ b/manual/examples/shadertoy-basic-x40.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadertoy-basic.html
+++ b/manual/examples/shadertoy-basic.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadertoy-bleepy-blocks.html
+++ b/manual/examples/shadertoy-bleepy-blocks.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadertoy-prep.html
+++ b/manual/examples/shadertoy-prep.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadows-directional-light-shadow-acne.html
+++ b/manual/examples/shadows-directional-light-shadow-acne.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-directional-light-with-camera-gui.html
+++ b/manual/examples/shadows-directional-light-with-camera-gui.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-directional-light-with-camera-helper.html
+++ b/manual/examples/shadows-directional-light-with-camera-helper.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-directional-light.html
+++ b/manual/examples/shadows-directional-light.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-fake.html
+++ b/manual/examples/shadows-fake.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/shadows-point-light.html
+++ b/manual/examples/shadows-point-light.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-spot-light-with-camera-gui.html
+++ b/manual/examples/shadows-spot-light-with-camera-gui.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shadows-spot-light-with-shadow-radius.html
+++ b/manual/examples/shadows-spot-light-with-shadow-radius.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/shared-cubes.js
+++ b/manual/examples/shared-cubes.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'https://cdn.skypack.dev/three@0.136.0/build/three.module.js';
 
 export const state = {
   width: 300,   // canvas default
@@ -86,4 +86,3 @@ export function init(data) {  /* eslint-disable-line no-unused-vars */
 
   requestAnimationFrame(render);
 }
-

--- a/manual/examples/shared-orbitcontrols.js
+++ b/manual/examples/shared-orbitcontrols.js
@@ -1,5 +1,5 @@
-import * as THREE from '../../build/three.module.js';
-import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'https://cdn.skypack.dev/three@0.136.0/build/three.module.js';
+import { OrbitControls } from 'https://cdn.skypack.dev/three@0.136.0/examples/jsm/controls/OrbitControls.js';
 
 export function init(data) {   /* eslint-disable-line no-unused-vars */
   const {canvas, inputElement} = data;
@@ -156,4 +156,3 @@ export function init(data) {   /* eslint-disable-line no-unused-vars */
 
   inputElement.addEventListener('touchend', clearPickPosition);
 }
-

--- a/manual/examples/shared-picking.js
+++ b/manual/examples/shared-picking.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'https://cdn.skypack.dev/three@0.136.0/build/three.module.js';
 
 export const state = {
   width: 300,   // canvas default
@@ -120,4 +120,3 @@ export function init(data) {  // eslint-disable-line no-unused-vars
 
   requestAnimationFrame(render);
 }
-

--- a/manual/examples/textured-cube-6-textures.html
+++ b/manual/examples/textured-cube-6-textures.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/textured-cube-adjust.html
+++ b/manual/examples/textured-cube-adjust.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 
 function main() {

--- a/manual/examples/textured-cube-wait-for-all-textures.html
+++ b/manual/examples/textured-cube-wait-for-all-textures.html
@@ -45,8 +45,20 @@
       <div class="progress"><div class="progressbar"></div></div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/textured-cube-wait-for-texture.html
+++ b/manual/examples/textured-cube-wait-for-texture.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/textured-cube.html
+++ b/manual/examples/textured-cube.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/threejs-responsive.js
+++ b/manual/examples/threejs-responsive.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');
@@ -79,4 +79,3 @@ function main() {
 }
 
 main();
-

--- a/manual/examples/tips-preservedrawingbuffer.html
+++ b/manual/examples/tips-preservedrawingbuffer.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/tips-screenshot-bad.html
+++ b/manual/examples/tips-screenshot-bad.html
@@ -37,8 +37,20 @@
     <canvas id="c"></canvas>
     <button id="screenshot" type="button">Save...</button>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/tips-screenshot-good.html
+++ b/manual/examples/tips-screenshot-good.html
@@ -37,8 +37,20 @@
     <canvas id="c"></canvas>
     <button id="screenshot" type="button">Save...</button>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/tips-transparent-canvas.html
+++ b/manual/examples/tips-transparent-canvas.html
@@ -47,8 +47,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/transparency-doubleside-hack.html
+++ b/manual/examples/transparency-doubleside-hack.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/transparency-doubleside.html
+++ b/manual/examples/transparency-doubleside.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/transparency-intersecting-planes-alphatest.html
+++ b/manual/examples/transparency-intersecting-planes-alphatest.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/examples/transparency-intersecting-planes-fixed.html
+++ b/manual/examples/transparency-intersecting-planes-fixed.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/transparency-intersecting-planes.html
+++ b/manual/examples/transparency-intersecting-planes.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/transparency.html
+++ b/manual/examples/transparency.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/voxel-geometry-culled-faces-ui.html
+++ b/manual/examples/voxel-geometry-culled-faces-ui.html
@@ -71,8 +71,20 @@
       </div>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 class VoxelWorld {

--- a/manual/examples/voxel-geometry-culled-faces-with-textures.html
+++ b/manual/examples/voxel-geometry-culled-faces-with-textures.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 class VoxelWorld {

--- a/manual/examples/voxel-geometry-culled-faces.html
+++ b/manual/examples/voxel-geometry-culled-faces.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 class VoxelWorld {

--- a/manual/examples/voxel-geometry-merged.html
+++ b/manual/examples/voxel-geometry-merged.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 

--- a/manual/examples/voxel-geometry-separate-cubes.html
+++ b/manual/examples/voxel-geometry-separate-cubes.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 function main() {

--- a/manual/examples/webxr-basic-vr-optional.html
+++ b/manual/examples/webxr-basic-vr-optional.html
@@ -29,8 +29,20 @@
       <a href="?" id="nonvr">Use Non-VR Mode</a>
     </div>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 

--- a/manual/examples/webxr-basic-w-background.html
+++ b/manual/examples/webxr-basic-w-background.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/examples/webxr-basic.html
+++ b/manual/examples/webxr-basic.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/examples/webxr-look-to-select-selector.html
+++ b/manual/examples/webxr-look-to-select-selector.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 
 function main() {
   const canvas = document.querySelector('#c');

--- a/manual/examples/webxr-look-to-select-w-cursor.html
+++ b/manual/examples/webxr-look-to-select-w-cursor.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/examples/webxr-look-to-select.html
+++ b/manual/examples/webxr-look-to-select.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/examples/webxr-point-to-select-w-move.html
+++ b/manual/examples/webxr-point-to-select-w-move.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/examples/webxr-point-to-select.html
+++ b/manual/examples/webxr-point-to-select.html
@@ -20,8 +20,20 @@
   <body>
     <canvas id="c"></canvas>
   </body>
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
+
 <script type="module">
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {VRButton} from '../../examples/jsm/webxr/VRButton.js';
 
 function main() {

--- a/manual/fr/align-html-elements-to-3d.html
+++ b/manual/fr/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/backgrounds.html
+++ b/manual/fr/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/billboards.html
+++ b/manual/fr/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/cameras.html
+++ b/manual/fr/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/canvas-textures.html
+++ b/manual/fr/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/cleanup.html
+++ b/manual/fr/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/custom-buffergeometry.html
+++ b/manual/fr/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/custom-geometry.html
+++ b/manual/fr/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/debugging-glsl.html
+++ b/manual/fr/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/debugging-javascript.html
+++ b/manual/fr/debugging-javascript.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/fog.html
+++ b/manual/fr/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/fundamentals.html
+++ b/manual/fr/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/game.html
+++ b/manual/fr/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/indexed-textures.html
+++ b/manual/fr/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/lights.html
+++ b/manual/fr/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/load-gltf.html
+++ b/manual/fr/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/load-obj.html
+++ b/manual/fr/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/material-table.html
+++ b/manual/fr/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/materials.html
+++ b/manual/fr/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/multiple-scenes.html
+++ b/manual/fr/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/offscreencanvas.html
+++ b/manual/fr/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/optimize-lots-of-objects-animated.html
+++ b/manual/fr/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/optimize-lots-of-objects.html
+++ b/manual/fr/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/picking.html
+++ b/manual/fr/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/post-processing-3dlut.html
+++ b/manual/fr/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/post-processing.html
+++ b/manual/fr/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/prerequisites.html
+++ b/manual/fr/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/primitives.html
+++ b/manual/fr/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/rendering-on-demand.html
+++ b/manual/fr/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/rendertargets.html
+++ b/manual/fr/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/responsive.html
+++ b/manual/fr/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/scenegraph.html
+++ b/manual/fr/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/setup.html
+++ b/manual/fr/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/shadertoy.html
+++ b/manual/fr/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/shadows.html
+++ b/manual/fr/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/textures.html
+++ b/manual/fr/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/tips.html
+++ b/manual/fr/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/transparency.html
+++ b/manual/fr/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/voxel-geometry.html
+++ b/manual/fr/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/webxr-look-to-select.html
+++ b/manual/fr/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/webxr-point-to-select.html
+++ b/manual/fr/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/fr/webxr.html
+++ b/manual/fr/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/align-html-elements-to-3d.html
+++ b/manual/ja/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/backgrounds.html
+++ b/manual/ja/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/billboards.html
+++ b/manual/ja/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/cameras.html
+++ b/manual/ja/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/canvas-textures.html
+++ b/manual/ja/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/cleanup.html
+++ b/manual/ja/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/custom-buffergeometry.html
+++ b/manual/ja/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/custom-geometry.html
+++ b/manual/ja/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/debugging-glsl.html
+++ b/manual/ja/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/debugging-javascript.html
+++ b/manual/ja/debugging-javascript.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/fog.html
+++ b/manual/ja/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/fundamentals.html
+++ b/manual/ja/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/game.html
+++ b/manual/ja/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/indexed-textures.html
+++ b/manual/ja/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/lights.html
+++ b/manual/ja/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/load-gltf.html
+++ b/manual/ja/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/load-obj.html
+++ b/manual/ja/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/material-table.html
+++ b/manual/ja/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/materials.html
+++ b/manual/ja/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/multiple-scenes.html
+++ b/manual/ja/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/offscreencanvas.html
+++ b/manual/ja/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/optimize-lots-of-objects-animated.html
+++ b/manual/ja/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/optimize-lots-of-objects.html
+++ b/manual/ja/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/picking.html
+++ b/manual/ja/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/post-processing-3dlut.html
+++ b/manual/ja/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/post-processing.html
+++ b/manual/ja/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/prerequisites.html
+++ b/manual/ja/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/primitives.html
+++ b/manual/ja/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/rendering-on-demand.html
+++ b/manual/ja/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/rendertargets.html
+++ b/manual/ja/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/responsive.html
+++ b/manual/ja/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/scenegraph.html
+++ b/manual/ja/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/setup.html
+++ b/manual/ja/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/shadertoy.html
+++ b/manual/ja/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/shadows.html
+++ b/manual/ja/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/textures.html
+++ b/manual/ja/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/tips.html
+++ b/manual/ja/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/transparency.html
+++ b/manual/ja/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/voxel-geometry.html
+++ b/manual/ja/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/webxr-look-to-select.html
+++ b/manual/ja/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/webxr-point-to-select.html
+++ b/manual/ja/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ja/webxr.html
+++ b/manual/ja/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ko/align-html-elements-to-3d.html
+++ b/manual/ko/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/backgrounds.html
+++ b/manual/ko/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/billboards.html
+++ b/manual/ko/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/cameras.html
+++ b/manual/ko/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/canvas-textures.html
+++ b/manual/ko/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/cleanup.html
+++ b/manual/ko/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/custom-buffergeometry.html
+++ b/manual/ko/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/custom-geometry.html
+++ b/manual/ko/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/debugging-glsl.html
+++ b/manual/ko/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/debugging-javascript.html
+++ b/manual/ko/debugging-javascript.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/fog.html
+++ b/manual/ko/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/fundamentals.html
+++ b/manual/ko/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/game.html
+++ b/manual/ko/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/indexed-textures.html
+++ b/manual/ko/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/lights.html
+++ b/manual/ko/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/load-gltf.html
+++ b/manual/ko/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/load-obj.html
+++ b/manual/ko/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/material-table.html
+++ b/manual/ko/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/materials.html
+++ b/manual/ko/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/multiple-scenes.html
+++ b/manual/ko/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/offscreencanvas.html
+++ b/manual/ko/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/optimize-lots-of-objects-animated.html
+++ b/manual/ko/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/optimize-lots-of-objects.html
+++ b/manual/ko/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/picking.html
+++ b/manual/ko/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/post-processing-3dlut.html
+++ b/manual/ko/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/post-processing.html
+++ b/manual/ko/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/prerequisites.html
+++ b/manual/ko/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/primitives.html
+++ b/manual/ko/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/rendering-on-demand.html
+++ b/manual/ko/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/rendertargets.html
+++ b/manual/ko/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/responsive.html
+++ b/manual/ko/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/scenegraph.html
+++ b/manual/ko/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/setup.html
+++ b/manual/ko/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/shadertoy.html
+++ b/manual/ko/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/shadows.html
+++ b/manual/ko/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/textures.html
+++ b/manual/ko/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/tips.html
+++ b/manual/ko/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/transparency.html
+++ b/manual/ko/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/voxel-geometry.html
+++ b/manual/ko/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/webxr-look-to-select.html
+++ b/manual/ko/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/webxr-point-to-select.html
+++ b/manual/ko/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/ko/webxr.html
+++ b/manual/ko/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/ko/lang.css">
   </head>
   <body>

--- a/manual/resources/threejs-cameras.js
+++ b/manual/resources/threejs-cameras.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 
 {

--- a/manual/resources/threejs-custom-buffergeometry.js
+++ b/manual/resources/threejs-custom-buffergeometry.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 
 {

--- a/manual/resources/threejs-fog.js
+++ b/manual/resources/threejs-fog.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {GLTFLoader} from '../../examples/jsm/loaders/GLTFLoader.js';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 

--- a/manual/resources/threejs-lesson-utils.js
+++ b/manual/resources/threejs-lesson-utils.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 
 export const threejsLessonUtils = {

--- a/manual/resources/threejs-lights.js
+++ b/manual/resources/threejs-lights.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {OrbitControls} from '../../examples/jsm/controls/OrbitControls.js';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 

--- a/manual/resources/threejs-lots-of-objects.js
+++ b/manual/resources/threejs-lots-of-objects.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 import {GUI} from '../../examples/jsm/libs/lil-gui.module.min.js';
 

--- a/manual/resources/threejs-materials.js
+++ b/manual/resources/threejs-materials.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 
 {

--- a/manual/resources/threejs-primitives.js
+++ b/manual/resources/threejs-primitives.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 import {FontLoader} from '../../examples/jsm/loaders/FontLoader.js';
 import {ParametricGeometry} from '../../examples/jsm/geometries/ParametricGeometry.js';

--- a/manual/resources/threejs-textures.js
+++ b/manual/resources/threejs-textures.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 
 {

--- a/manual/resources/threejs-voxel-geometry.js
+++ b/manual/resources/threejs-voxel-geometry.js
@@ -1,4 +1,4 @@
-import * as THREE from '../../build/three.module.js';
+import * as THREE from 'three';
 import * as BufferGeometryUtils from '../../examples/jsm/utils/BufferGeometryUtils.js';
 import {threejsLessonUtils} from './threejs-lesson-utils.js';
 

--- a/manual/ru/align-html-elements-to-3d.html
+++ b/manual/ru/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/backgrounds.html
+++ b/manual/ru/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/billboards.html
+++ b/manual/ru/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/cameras.html
+++ b/manual/ru/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/canvas-textures.html
+++ b/manual/ru/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/cleanup.html
+++ b/manual/ru/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/custom-buffergeometry.html
+++ b/manual/ru/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/custom-geometry.html
+++ b/manual/ru/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/debugging-glsl.html
+++ b/manual/ru/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/debugging-javascript.html
+++ b/manual/ru/debugging-javascript.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/fog.html
+++ b/manual/ru/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/fundamentals.html
+++ b/manual/ru/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/game.html
+++ b/manual/ru/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/indexed-textures.html
+++ b/manual/ru/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/lights.html
+++ b/manual/ru/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/load-gltf.html
+++ b/manual/ru/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/load-obj.html
+++ b/manual/ru/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/material-table.html
+++ b/manual/ru/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/materials.html
+++ b/manual/ru/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/multiple-scenes.html
+++ b/manual/ru/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/offscreencanvas.html
+++ b/manual/ru/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/optimize-lots-of-objects-animated.html
+++ b/manual/ru/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/optimize-lots-of-objects.html
+++ b/manual/ru/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/picking.html
+++ b/manual/ru/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/post-processing-3dlut.html
+++ b/manual/ru/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/post-processing.html
+++ b/manual/ru/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/prerequisites.html
+++ b/manual/ru/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/primitives.html
+++ b/manual/ru/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/rendering-on-demand.html
+++ b/manual/ru/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/rendertargets.html
+++ b/manual/ru/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/responsive.html
+++ b/manual/ru/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/scenegraph.html
+++ b/manual/ru/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/setup.html
+++ b/manual/ru/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/shadertoy.html
+++ b/manual/ru/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/shadows.html
+++ b/manual/ru/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/textures.html
+++ b/manual/ru/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/tips.html
+++ b/manual/ru/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/transparency.html
+++ b/manual/ru/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/voxel-geometry.html
+++ b/manual/ru/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/webxr-look-to-select.html
+++ b/manual/ru/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/webxr-point-to-select.html
+++ b/manual/ru/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/ru/webxr.html
+++ b/manual/ru/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
   </head>
   <body>
     <div class="container">

--- a/manual/zh/align-html-elements-to-3d.html
+++ b/manual/zh/align-html-elements-to-3d.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/backgrounds.html
+++ b/manual/zh/backgrounds.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/billboards.html
+++ b/manual/zh/billboards.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/cameras.html
+++ b/manual/zh/cameras.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/canvas-textures.html
+++ b/manual/zh/canvas-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/cleanup.html
+++ b/manual/zh/cleanup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/custom-buffergeometry.html
+++ b/manual/zh/custom-buffergeometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/custom-geometry.html
+++ b/manual/zh/custom-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/debugging-glsl.html
+++ b/manual/zh/debugging-glsl.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/debugging-javascript.html
+++ b/manual/zh/debugging-javascript.html
@@ -14,6 +14,17 @@
 
 	<link rel="stylesheet" href="/manual/resources/lesson.css">
 	<link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
 </head>
 
 <body>

--- a/manual/zh/fog.html
+++ b/manual/zh/fog.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/fundamentals.html
+++ b/manual/zh/fundamentals.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/game.html
+++ b/manual/zh/game.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/indexed-textures.html
+++ b/manual/zh/indexed-textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/lights.html
+++ b/manual/zh/lights.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/load-gltf.html
+++ b/manual/zh/load-gltf.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/load-obj.html
+++ b/manual/zh/load-obj.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/material-table.html
+++ b/manual/zh/material-table.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/materials.html
+++ b/manual/zh/materials.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/multiple-scenes.html
+++ b/manual/zh/multiple-scenes.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/offscreencanvas.html
+++ b/manual/zh/offscreencanvas.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/optimize-lots-of-objects-animated.html
+++ b/manual/zh/optimize-lots-of-objects-animated.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/optimize-lots-of-objects.html
+++ b/manual/zh/optimize-lots-of-objects.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/picking.html
+++ b/manual/zh/picking.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/post-processing-3dlut.html
+++ b/manual/zh/post-processing-3dlut.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/post-processing.html
+++ b/manual/zh/post-processing.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/prerequisites.html
+++ b/manual/zh/prerequisites.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/primitives.html
+++ b/manual/zh/primitives.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/rendering-on-demand.html
+++ b/manual/zh/rendering-on-demand.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/rendertargets.html
+++ b/manual/zh/rendertargets.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/responsive.html
+++ b/manual/zh/responsive.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/scenegraph.html
+++ b/manual/zh/scenegraph.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/setup.html
+++ b/manual/zh/setup.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/shadertoy.html
+++ b/manual/zh/shadertoy.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/shadows.html
+++ b/manual/zh/shadows.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/textures.html
+++ b/manual/zh/textures.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/tips.html
+++ b/manual/zh/tips.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/transparency.html
+++ b/manual/zh/transparency.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/voxel-geometry.html
+++ b/manual/zh/voxel-geometry.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/webxr-look-to-select.html
+++ b/manual/zh/webxr-look-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/webxr-point-to-select.html
+++ b/manual/zh/webxr-point-to-select.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>

--- a/manual/zh/webxr.html
+++ b/manual/zh/webxr.html
@@ -11,6 +11,17 @@
 
     <link rel="stylesheet" href="/manual/resources/lesson.css">
     <link rel="stylesheet" href="/manual/resources/lang.css">
+<!-- Import maps polyfill -->
+<!-- Remove this when import maps will be widely supported -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "../../build/three.module.js"
+  }
+}
+</script>
     <link rel="stylesheet" href="/manual/zh/lang.css">
   </head>
   <body>


### PR DESCRIPTION
Fixed #23363.

**Description**

This PR fixes the examples of the manual. They should work standalone and in the editor view again.

The script export to sites like jsfiddle is not yet fixed. I've hidden the export button until this feature works again.

@greggman Your pointers were really helpful! I've tried to make the changes to `editor.js` and `editor-settings.js` as simple as possible. There are surely more smart solutions but at least the examples should work again.