### PR TITLE
OBJExporter: Convert Linear vertex colors to sRGB

### DIFF
--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -251,7 +251,7 @@ class OBJExporter {
 
 					if ( colors !== undefined ) {
 
-						color.fromBufferAttribute( colors, i );
+						color.fromBufferAttribute( colors, i ).convertLinearToSRGB();
 
 						output += ' ' + color.r + ' ' + color.g + ' ' + color.b;
 

--- a/examples/misc_exporter_obj.html
+++ b/examples/misc_exporter_obj.html
@@ -130,7 +130,7 @@
 				} else if ( type === 6 ) {
 
 					const points = [ 0, 0, 0, 100, 0, 0, 100, 100, 0, 0, 100, 0 ];
-					const colors = [ 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0 ];
+					const colors = [ 0.5, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0.5, 0 ];
 
 					const geometry = new THREE.BufferGeometry();
 					geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( points, 3 ) );
@@ -149,6 +149,7 @@
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
+				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );


### PR DESCRIPTION
Related issue: #23283

**Description**

Convert colors to sRGB before OBJ Export. It looks like OBJExporter was only including colors for points instead of triangles.

https://raw.githack.com/gkjohnson/three.js/obj-export-color/examples/misc_exporter_obj.html

Note that because colors are converted now it's possible that the final color value is formed from a long decimal value:

```js
v 0 0 0 0.7353606352856507 0 0
v 100 0 0 0.7353606352856507 0 0
v 100 100 0 0 0.7353606352856507 0
v 0 100 0 0 0.7353606352856507 0
```

Is there a quick way to truncate that to 4 or 5 decimal places? I only know of `parseFloat( color.r.toFixed( 4 ) )` which works but seems a bit roundabout. Or do we need to do that? It looks like the positions are not truncated in any way.