### PR TITLE
docs: Change Discord link on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 					<h2>Community</h2>
 					<ul>
 						<li><a href="https://stackoverflow.com/questions/tagged/three.js">questions</a></li>
-						<li><a href="https://discord.gg/HF4UdyF">discord</a></li>
+						<li><a href="https://discord.gg/56GBJwAnUS">discord</a></li>
 						<li><a href="https://discourse.threejs.org/">forum</a></li>
 						<li><a href="https://join.slack.com/t/threejs/shared_invite/zt-rnuegz5e-FQpc6YboDVW~5idlp7GfDw">slack</a></li>
 						<li><a href="https://twitter.com/threejs">twitter</a></li>


### PR DESCRIPTION
### Description

Applied the same change as I did in #23378 .
now it's directed to #welcome instead of #general.

This PR is directed into `gh-pages`.
This will update the [https://threejs.org](https://threejs.org) , am I right?
