### PR TITLE
HTMLMesh: Render number input values.

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -229,7 +229,7 @@ function html2canvas( element ) {
 			drawBorder( style, 'borderBottom', x, y + height, width, 0 );
 			drawBorder( style, 'borderRight', x + width, y, 0, height );
 
-			if ( element.type === 'color' || element.type === 'text' ) {
+			if ( element.type === 'color' || element.type === 'text' || element.type === 'number' ) {
 
 				clipper.add( { x: x, y: y, width: width, height: height } );
 


### PR DESCRIPTION

**Description**

Render number input values in HTMLMesh. Fixes checking number type in  html2canvas

Before
![image](https://user-images.githubusercontent.com/314997/151662419-ea3e3370-bda7-4398-8632-7e96c8cae589.png)


After
![image](https://user-images.githubusercontent.com/314997/151662396-e14b38b3-7ce9-4cba-92ea-53023c719d31.png)

