### PR TITLE
Remove deprecated WGSL syntax from compute example

### DIFF
--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -110,13 +110,13 @@
 					struct Particle {
 						value : array< vec4<f32> >;
 					};
-					[[ binding( 0 ), group( 0 ) ]]
+					@binding( 0 ) @group( 0 )
 					var<storage,read_write> particle : Particle;
 
 					struct Velocity {
 						value : array< vec4<f32> >;
 					};
-					[[ binding( 1 ), group( 0 ) ]]
+					@binding( 1 ) @group( 0 )
 					var<storage,read_write> velocity : Velocity;
 
 					//
@@ -126,17 +126,17 @@
 					struct Scale {
 						value : array< vec3<f32>, 2 >;
 					};
-					[[ binding( 2 ), group( 0 ) ]]
+					@binding( 2 ) @group( 0 )
 					var<uniform> scaleUniform : Scale;
 
 					struct MouseUniforms {
 						pointer : vec2<f32>;
 					};
-					[[ binding( 3 ), group( 0 ) ]]
+					@binding( 3 ) @group( 0 )
 					var<uniform> mouseUniforms : MouseUniforms;
 
-					[[ stage( compute ), workgroup_size( 64 ) ]]
-					fn main( [[builtin(global_invocation_id)]] id : vec3<u32> ) {
+					@stage( compute ) @workgroup_size( 64 )
+					fn main( @builtin(global_invocation_id) id : vec3<u32> ) {
 
 						// get particle index
 


### PR DESCRIPTION
This is a follow up PR to #23393.

**Description**

There is also deprecated WGSL syntax in WebGPU compute example (Sorry I overlooked it when reviewing). This PR updates it to follow the latest spec.
