### PR TITLE
Update Useful-links.html

### DIFF
--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -150,9 +150,6 @@
 			[link:http://www.slideshare.net/yomotsu/webgl-and-threejs WebGL and Three.js] by [link:http://github.com/yomotsu Akihiro Oyamada] (slideshow).
 		</li>
 		<li>
-			[link:http://bkcore.com/blog/general/adobe-user-group-nl-talk-video-hexgl.html Fast HTML5 game development using three.js] by [link:https://github.com/BKcore BKcore] (video).
-		</li>
-		<li>
 			<a href="https://www.youtube.com/watch?v=VdQnOaolrPA" target="_blank">Trigger Rally</a>  by [link:https://github.com/jareiko jareiko] (video).
 		</li>
 		<li>


### PR DESCRIPTION
removed "Fast HTML5 game development using three.js" from the list. As the following link don't have any relevant doc or video(as mentioned)
the shown video on the following link just redirects you to a broken link
