### PR TITLE
PLYExporter: convert vertex colors to srgb before export

### DIFF
--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -1,6 +1,7 @@
 import {
 	Matrix3,
-	Vector3
+	Vector3,
+	Color
 } from 'three';
 
 /**
@@ -112,6 +113,7 @@ class PLYExporter {
 
 		} );
 
+		const tempColor = new Color();
 		const includeIndices = excludeAttributes.indexOf( 'index' ) === - 1;
 		includeNormals = includeNormals && excludeAttributes.indexOf( 'normal' ) === - 1;
 		includeColors = includeColors && excludeAttributes.indexOf( 'color' ) === - 1;
@@ -305,13 +307,17 @@ class PLYExporter {
 
 						if ( colors != null ) {
 
-							output.setUint8( vOffset, Math.floor( colors.getX( i ) * 255 ) );
+							tempColor
+								.fromBufferAttribute( colors, i )
+								.convertLinearToSRGB();
+
+							output.setUint8( vOffset, Math.floor( tempColor.r * 255 ) );
 							vOffset += 1;
 
-							output.setUint8( vOffset, Math.floor( colors.getY( i ) * 255 ) );
+							output.setUint8( vOffset, Math.floor( tempColor.g * 255 ) );
 							vOffset += 1;
 
-							output.setUint8( vOffset, Math.floor( colors.getZ( i ) * 255 ) );
+							output.setUint8( vOffset, Math.floor( tempColor.b * 255 ) );
 							vOffset += 1;
 
 						} else {
@@ -464,10 +470,14 @@ class PLYExporter {
 
 						if ( colors != null ) {
 
+							tempColor
+								.fromBufferAttribute( colors, i )
+								.convertLinearToSRGB();
+
 							line += ' ' +
-								Math.floor( colors.getX( i ) * 255 ) + ' ' +
-								Math.floor( colors.getY( i ) * 255 ) + ' ' +
-								Math.floor( colors.getZ( i ) * 255 );
+								Math.floor( tempColor.r * 255 ) + ' ' +
+								Math.floor( tempColor.g * 255 ) + ' ' +
+								Math.floor( tempColor.b * 255 );
 
 						} else {
 


### PR DESCRIPTION
Related issue: #23283

**Description**

Convert mesh linear colors to sRGB before PLY export.

https://raw.githack.com/gkjohnson/three.js/ply-export-update/examples/misc_exporter_ply.html
