### PR TITLE
ColladaExporter: Convert vertex, material colors to sRGB before export

### DIFF
--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -144,10 +144,31 @@ class ColladaExporter {
 
 		// gets the attribute array. Generate a new array if the attribute is interleaved
 		const getFuncs = [ 'getX', 'getY', 'getZ', 'getW' ];
+		const tempColor = new Color();
 
-		function attrBufferToArray( attr ) {
+		function attrBufferToArray( attr, isColor = false ) {
 
-			if ( attr.isInterleavedBufferAttribute ) {
+			console.log( attr, attr.count, isColor )
+			if ( isColor ) {
+
+				// convert the colors to srgb before export
+				// colors are always written as floats
+				const arr = new Float32Array( attr.count * 3 );
+				for ( let i = 0, l = attr.count; i < l; i ++ ) {
+
+					tempColor
+						.fromBufferAttribute( attr, i )
+						.convertLinearToSRGB();
+
+					arr[ 3 * i + 0 ] = tempColor.r;
+					arr[ 3 * i + 1 ] = tempColor.g;
+					arr[ 3 * i + 2 ] = tempColor.b;
+
+				}
+
+				return arr;
+
+			} else if ( attr.isInterleavedBufferAttribute ) {
 
 				// use the typed array constructor to save on memory
 				const arr = new attr.array.constructor( attr.count * attr.itemSize );
@@ -183,9 +204,9 @@ class ColladaExporter {
 		}
 
 		// Returns the string for a geometry's attribute
-		function getAttribute( attr, name, params, type ) {
+		function getAttribute( attr, name, params, type, isColor = false ) {
 
-			const array = attrBufferToArray( attr );
+			const array = attrBufferToArray( attr, isColor );
 			const res =
 					`<source id="${ name }">` +
 
@@ -296,8 +317,9 @@ class ColladaExporter {
 				// serialize colors
 				if ( 'color' in bufferGeometry.attributes ) {
 
+					// colors are always written as floats
 					const colName = `${ meshid }-color`;
-					gnode += getAttribute( bufferGeometry.attributes.color, colName, [ 'X', 'Y', 'Z' ], 'uint8' );
+					gnode += getAttribute( bufferGeometry.attributes.color, colName, [ 'R', 'G', 'B' ], 'float', true );
 					triangleInputs += `<input semantic="COLOR" source="#${ colName }" offset="0" />`;
 
 				}
@@ -418,6 +440,9 @@ class ColladaExporter {
 				const specular = m.specular ? m.specular : new Color( 1, 1, 1 );
 				const shininess = m.shininess || 0;
 				const reflectivity = m.reflectivity || 0;
+
+				emissive.convertLinearToSRGB();
+				diffuse.convertLinearToSRGB();
 
 				// Do not export and alpha map for the reasons mentioned in issue (#13792)
 				// in three.js alpha maps are black and white, but collada expects the alpha

--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -442,6 +442,7 @@ class ColladaExporter {
 				const reflectivity = m.reflectivity || 0;
 
 				emissive.convertLinearToSRGB();
+				specular.convertLinearToSRGB();
 				diffuse.convertLinearToSRGB();
 
 				// Do not export and alpha map for the reasons mentioned in issue (#13792)


### PR DESCRIPTION
Related issue: #23283

**Description**

Converts material colors (diffuse, emissive, specular color) and vertex colors to sRGB before exporting as a Collada file. It looks like vertex color export wasn't actually working correctly so this fixes that up, too, by correctly declaring vertex color accessors as R, G, B, and always writing colors as float values.

Tested by exporting the vertex-colored teapot from the exporter and loading it in the Collada loader example. Relatedly the ColladaLoader doesn't looks like it actually sets material.vertexColors = true anywhere so that needs to be set manually on load to test.