### PR TITLE
Examples: Allow tree-shaking for curves

### DIFF
--- a/examples/jsm/curves/CurveExtras.js
+++ b/examples/jsm/curves/CurveExtras.js
@@ -404,21 +404,19 @@ class DecoratedTorusKnot5c extends Curve {
 
 }
 
-const Curves = {
-	GrannyKnot: GrannyKnot,
-	HeartCurve: HeartCurve,
-	VivianiCurve: VivianiCurve,
-	KnotCurve: KnotCurve,
-	HelixCurve: HelixCurve,
-	TrefoilKnot: TrefoilKnot,
-	TorusKnot: TorusKnot,
-	CinquefoilKnot: CinquefoilKnot,
-	TrefoilPolynomialKnot: TrefoilPolynomialKnot,
-	FigureEightPolynomialKnot: FigureEightPolynomialKnot,
-	DecoratedTorusKnot4a: DecoratedTorusKnot4a,
-	DecoratedTorusKnot4b: DecoratedTorusKnot4b,
-	DecoratedTorusKnot5a: DecoratedTorusKnot5a,
-	DecoratedTorusKnot5c: DecoratedTorusKnot5c
+export {
+	GrannyKnot,
+	HeartCurve,
+	VivianiCurve,
+	KnotCurve,
+	HelixCurve,
+	TrefoilKnot,
+	TorusKnot,
+	CinquefoilKnot,
+	TrefoilPolynomialKnot,
+	FigureEightPolynomialKnot,
+	DecoratedTorusKnot4a,
+	DecoratedTorusKnot4b,
+	DecoratedTorusKnot5a,
+	DecoratedTorusKnot5c
 };
-
-export { Curves };

--- a/examples/webgl_geometries_parametric.html
+++ b/examples/webgl_geometries_parametric.html
@@ -29,7 +29,7 @@
 
 			import Stats from './jsm/libs/stats.module.js';
 
-			import { Curves } from './jsm/curves/CurveExtras.js';
+			import * as Curves from './jsm/curves/CurveExtras.js';
 			import { ParametricGeometry } from './jsm/geometries/ParametricGeometry.js';
 			import { ParametricGeometries } from './jsm/geometries/ParametricGeometries.js';
 

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -41,7 +41,7 @@
 			import Stats from './jsm/libs/stats.module.js';
 			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
-			import { Curves } from './jsm/curves/CurveExtras.js';
+			import * as Curves from './jsm/curves/CurveExtras.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
 			let container, stats;


### PR DESCRIPTION
Related issue: -

**Description**

Remove the unnecessary `Curves` object to allow tree-shaking for curves.

The users that imported curves like this:

```js
import { Curves } from 'three/examples/jsm/curves/CurveExtras.js';
```

will now import them like this:

```js
import * as Curves from 'three/examples/jsm/curves/CurveExtras.js';
```