### PR TITLE
exporting the CCDIKHelper class also

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -461,4 +461,4 @@ class CCDIKHelper extends Object3D {
 
 }
 
-export { CCDIKSolver };
+export { CCDIKSolver, CCDIKHelper };


### PR DESCRIPTION
The `CCDIKHelper` class was not `export`ed.

Context: I needed it in an example I made using `SkinnedMesh`+`CCDIKSolver`: https://codesandbox.io/s/romantic-rubin-n0df6?file=/src/index.js -- In my example, because that class was not exported, I had to [copy it to that file](https://codesandbox.io/s/romantic-rubin-n0df6?file=/src/CCDIKHelper.js) to be able to reuse it, which is not ideal: that's why I make that PR

