### PR TITLE
Examples: Rework UI of exporter examples.

### DIFF
--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -8,8 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - collada<br /><br />
-			<button id="export">Export COLLADA</button>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - collada
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -196,7 +195,9 @@
 					body: true,
 					fitLid: false,
 					nonblinn: false,
-					newShading: 'glossy'
+					newShading: 'glossy',
+
+					export: exportCollada
 				};
 
 				let h;
@@ -250,8 +251,8 @@
 
 				gui.add( effectController, 'newShading', [ 'wireframe', 'flat', 'smooth', 'glossy', 'textured', 'normal', 'reflective' ] ).name( 'Shading' ).onChange( render );
 
-				const exportButton = document.getElementById( 'export' );
-				exportButton.addEventListener( 'click', exportCollada );
+				h = gui.addFolder( 'Export' );
+				h.add( effectController, 'export' ).name( 'Export Collada' );
 
 			}
 

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -8,8 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - draco<br/><br/>
-			<button id="exportFile">Export DRC</button>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - draco
 		</div>
 
 		<script src="js/libs/draco/draco_encoder.js"></script>
@@ -32,8 +31,13 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { DRACOExporter } from './jsm/exporters/DRACOExporter.js';
+			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
 			let scene, camera, renderer, exporter, mesh;
+
+			const params = {
+				export: exportFile
+			};
 
 			init();
 			animate();
@@ -108,8 +112,11 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				const exportButton = document.getElementById( 'exportFile' );
-				exportButton.addEventListener( 'click', exportFile );
+				const gui = new GUI();
+
+				gui.add( params, 'export' ).name( 'Export DRC' );
+				gui.open();
+
 
 			}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -8,19 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - gltf<br/><br/>
-			<button id="export_scene">Export Scene1</button>
-			<button id="export_scenes">Export Scene1 and THREE.Scene 2</button>
-			<button id="export_object">Export Sphere</button><br/>
-			<button id="export_obj">Export WaltHead</button>
-			<button id="export_objects">Export Sphere and Grid</button>
-			<button id="export_scene_object">Export Scene1 and Sphere</button>
-			<br/><br/>
-			<label><input id="option_trs" name="trs" type="checkbox"/>TRS</label>
-			<label><input id="option_visible" name="visible" type="checkbox" checked="checked"/>Only Visible</label>
-			<label><input id="option_drawrange" name="visible" type="checkbox" checked="checked"/>Truncate drawRange</label><br/>
-			<label><input id="option_binary" name="visible" type="checkbox">Binary (<code>.glb</code>)</label>
-			<label><input id="option_maxsize" name="maxSize" type="number" value="4096" min="2" max="8192" step="1"> Max texture size</label>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - gltf
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -41,17 +29,18 @@
 
 			import { OBJLoader } from './jsm/loaders/OBJLoader.js';
 			import { GLTFExporter } from './jsm/exporters/GLTFExporter.js';
+			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
 			function exportGLTF( input ) {
 
 				const gltfExporter = new GLTFExporter();
 
 				const options = {
-					trs: document.getElementById( 'option_trs' ).checked,
-					onlyVisible: document.getElementById( 'option_visible' ).checked,
-					truncateDrawRange: document.getElementById( 'option_drawrange' ).checked,
-					binary: document.getElementById( 'option_binary' ).checked,
-					maxTextureSize: Number( document.getElementById( 'option_maxsize' ).value ) || Infinity // To prevent NaN value
+					trs: params.trs,
+					onlyVisible: params.onlyVisible,
+					truncateDrawRange: params.truncateDrawRange,
+					binary: params.binary,
+					maxTextureSize: params.maxTextureSize
 				};
 				gltfExporter.parse(
 					input,
@@ -79,43 +68,6 @@
 				);
 
 			}
-
-			document.getElementById( 'export_scene' ).addEventListener( 'click', function () {
-
-				exportGLTF( scene1 );
-
-			} );
-
-			document.getElementById( 'export_scenes' ).addEventListener( 'click', function () {
-
-				exportGLTF( [ scene1, scene2 ] );
-
-			} );
-
-			document.getElementById( 'export_object' ).addEventListener( 'click', function () {
-
-				exportGLTF( sphere );
-
-			} );
-
-			document.getElementById( 'export_obj' ).addEventListener( 'click', function () {
-
-				exportGLTF( waltHead );
-
-			} );
-
-			document.getElementById( 'export_objects' ).addEventListener( 'click', function () {
-
-				exportGLTF( [ sphere, gridHelper ] );
-
-			} );
-
-			document.getElementById( 'export_scene_object' ).addEventListener( 'click', function () {
-
-				exportGLTF( [ scene1, gridHelper ] );
-
-			} );
-
 
 			const link = document.createElement( 'a' );
 			link.style.display = 'none';
@@ -149,6 +101,20 @@
 			let camera, object, object2, material, geometry, scene1, scene2, renderer;
 			let gridHelper, sphere, waltHead;
 
+			const params = {
+				trs: false,
+				onlyVisible: true,
+				truncateDrawRange: true,
+				binary: false,
+				maxTextureSize: 4096,
+				exportScene1: exportScene1,
+				exportScenes: exportScenes,
+				exportSphere: exportSphere,
+				exportHead: exportHead,
+				exportObjects: exportObjects,
+				exportSceneObject: exportSceneObject
+			};
+
 			init();
 			animate();
 
@@ -170,7 +136,7 @@
 						data[ stride ] = Math.round( 255 * y / 99 );
 						data[ stride + 1 ] = Math.round( 255 - 255 * y / 99 );
 						data[ stride + 2 ] = 0;
-						data[ stride + 3 ] = 1;
+						data[ stride + 3 ] = 255;
 
 					}
 
@@ -522,6 +488,61 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
+
+				const gui = new GUI();
+
+				let h = gui.addFolder( 'Settings' );
+				h.add( params, 'trs' ).name( 'use TRS' );
+				h.add( params, 'onlyVisible' ).name( 'Only Visible Objects' );
+				h.add( params, 'truncateDrawRange' ).name( 'Truncate Draw Range' );
+				h.add( params, 'binary' ).name( 'Binary (GLB)' );
+				h.add( params, 'maxTextureSize', 2, 8192 ).name( 'Max Texture Size' ).step( 1 );
+
+				h = gui.addFolder( 'Export' );
+				h.add( params, 'exportScene1' ).name( 'Export Scene 1' );
+				h.add( params, 'exportScenes' ).name( 'Export Scene 1 and 2' );
+				h.add( params, 'exportSphere' ).name( 'Export Sphere' );
+				h.add( params, 'exportHead' ).name( 'Export Head' );
+				h.add( params, 'exportObjects' ).name( 'Export Sphere With Grid' );
+				h.add( params, 'exportSceneObject' ).name( 'Export Scene 1 and Object' );
+
+				gui.open();
+
+			}
+
+			function exportScene1() {
+
+				exportGLTF( scene1 );
+
+			}
+
+			function exportScenes() {
+
+				exportGLTF( [ scene1, scene2 ] );
+
+			}
+
+			function exportSphere() {
+
+				exportGLTF( sphere );
+
+			}
+
+			function exportHead() {
+
+				exportGLTF( waltHead );
+
+			}
+
+			function exportObjects() {
+
+				exportGLTF( [ sphere, gridHelper ] );
+
+			}
+
+			function exportSceneObject() {
+
+				exportGLTF( [ scene1, gridHelper ] );
 
 			}
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -492,7 +492,7 @@
 				const gui = new GUI();
 
 				let h = gui.addFolder( 'Settings' );
-				h.add( params, 'trs' ).name( 'use TRS' );
+				h.add( params, 'trs' ).name( 'Use TRS' );
 				h.add( params, 'onlyVisible' ).name( 'Only Visible Objects' );
 				h.add( params, 'truncateDrawRange' ).name( 'Truncate Draw Range' );
 				h.add( params, 'binary' ).name( 'Binary (GLB)' );

--- a/examples/misc_exporter_obj.html
+++ b/examples/misc_exporter_obj.html
@@ -5,33 +5,10 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			.floating {
-				background : #000000;
-				opacity : 0.8;
-				width : 80%;
-				height : 80%;
-				position : absolute;
-				left : 10%;
-				top : 10%;
-				border : 1px solid #555555;
-				padding : 10px;
-				display : none;
-				overflow : auto;
-				z-index: 100;
-			}
-		</style>
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - obj<br /><br />
-			<button id="triangle">triangle</button>
-			<button id="cube">cube</button>
-			<button id="cylinder">cylinder</button>
-			<button id="multiple">multiple</button>
-			<button id="transformed">transformed</button>
-			<button id="points">points</button><br /><br />
-			<button id="export">export to obj</button>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - obj
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -50,18 +27,74 @@
 
 			import * as THREE from 'three';
 
+			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { OBJExporter } from './jsm/exporters/OBJExporter.js';
+			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
-			let camera, scene, light, renderer;
-			let exportButton, floatingDiv;
-			let mouseX = 0, mouseY = 0;
+			let camera, scene, renderer;
+
+			const params = {
+				addTriangle: addTriangle,
+				addCube: addCube,
+				addCylinder: addCylinder,
+				addMultiple: addMultiple,
+				addTransformed: addTransformed,
+				addPoints: addPoints,
+				exportToObj: exportToObj
+			};
+
+			init();
+			animate();
+
+			function init() {
+
+				renderer = new THREE.WebGLRenderer();
+				renderer.outputEncoding = THREE.sRGBEncoding;
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
+
+				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 0, 0, 400 );
+
+				scene = new THREE.Scene();
+
+				const ambientLight = new THREE.AmbientLight( 0xcccccc, 0.4 );
+				scene.add( ambientLight );
+
+				const directionalLight = new THREE.DirectionalLight( 0xffffff, 0.8 );
+				directionalLight.position.set( 0, 1, 1 );
+				scene.add( directionalLight );
+
+				const gui = new GUI();
+
+				let h = gui.addFolder( 'Geometry Selection' );
+				h.add( params, 'addTriangle' ).name( 'Triangle' );
+				h.add( params, 'addCube' ).name( 'Cube' );
+				h.add( params, 'addCylinder' ).name( 'Cylinder' );
+				h.add( params, 'addMultiple' ).name( 'Multiple objects' );
+				h.add( params, 'addTransformed' ).name( 'Transformed objects' );
+				h.add( params, 'addPoints' ).name( 'Point Cloud' );
+
+				h = gui.addFolder( 'Export' );
+				h.add( params, 'exportToObj' ).name( 'Export OBJ' );
+
+				gui.open();
+
+				addGeometry( 1 );
+
+				window.addEventListener( 'resize', onWindowResize );
+
+				const controls = new OrbitControls( camera, renderer.domElement );
+				controls.enablePan = false;
+
+			}
 
 			function exportToObj() {
 
 				const exporter = new OBJExporter();
 				const result = exporter.parse( scene );
-				floatingDiv.style.display = 'block';
-				floatingDiv.innerHTML = result.split( '\n' ).join( '<br />' );
+				saveString( result, 'object.obj' );
 
 			}
 
@@ -146,96 +179,57 @@
 
 			}
 
-			function init() {
-
-				renderer = new THREE.WebGLRenderer();
-				renderer.outputEncoding = THREE.sRGBEncoding;
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				document.body.appendChild( renderer.domElement );
-
-				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0, 0, 400 );
-
-				scene = new THREE.Scene();
-
-				light = new THREE.DirectionalLight( 0xffffff );
-				scene.add( light );
+			function addTriangle() {
 
 				addGeometry( 1 );
 
-				window.addEventListener( 'click', onWindowClick );
-				window.addEventListener( 'resize', onWindowResize );
-				document.addEventListener( 'mousemove', onDocumentMouseMove );
-				document.addEventListener( 'mouseover', onDocumentMouseMove );
+			}
 
-				document.getElementById( 'triangle' ).addEventListener( 'click', function () {
+			function addCube() {
 
-					addGeometry( 1 );
-
-				} );
-				document.getElementById( 'cube' ).addEventListener( 'click', function () {
-
-					addGeometry( 2 );
-
-				} );
-				document.getElementById( 'cylinder' ).addEventListener( 'click', function () {
-
-					addGeometry( 3 );
-
-				} );
-				document.getElementById( 'multiple' ).addEventListener( 'click', function () {
-
-					addGeometry( 4 );
-
-				} );
-				document.getElementById( 'transformed' ).addEventListener( 'click', function () {
-
-					addGeometry( 5 );
-
-				} );
-				document.getElementById( 'points' ).addEventListener( 'click', function () {
-
-					addGeometry( 6 );
-
-				} );
-
-				exportButton = document.getElementById( 'export' );
-				exportButton.addEventListener( 'click', function () {
-
-					exportToObj();
-
-				} );
-
-				floatingDiv = document.createElement( 'div' );
-				floatingDiv.className = 'floating';
-				document.body.appendChild( floatingDiv );
+				addGeometry( 2 );
 
 			}
 
-			function onWindowClick( event ) {
+			function addCylinder() {
 
-				let needToClose = true;
-				let target = event.target;
+				addGeometry( 3 );
 
-				while ( target !== null ) {
+			}
 
-					if ( target === floatingDiv || target === exportButton ) {
+			function addMultiple() {
 
-						needToClose = false;
-						break;
+				addGeometry( 4 );
 
-					}
+			}
 
-					target = target.parentElement;
+			function addTransformed() {
 
-				}
+				addGeometry( 5 );
 
-				if ( needToClose ) {
+			}
 
-					floatingDiv.style.display = 'none';
+			function addPoints() {
 
-				}
+				addGeometry( 6 );
+
+			}
+
+			const link = document.createElement( 'a' );
+			link.style.display = 'none';
+			document.body.appendChild( link );
+
+			function save( blob, filename ) {
+
+				link.href = URL.createObjectURL( blob );
+				link.download = filename;
+				link.click();
+
+			}
+
+			function saveString( text, filename ) {
+
+				save( new Blob( [ text ], { type: 'text/plain' } ), filename );
 
 			}
 
@@ -248,24 +242,10 @@
 
 			}
 
-			function onDocumentMouseMove( event ) {
-
-				const windowHalfX = window.innerWidth / 2;
-				const windowHalfY = window.innerHeight / 2;
-				mouseX = ( event.clientX - windowHalfX ) / 2;
-				mouseY = ( event.clientY - windowHalfY ) / 2;
-
-			}
-
 			function animate() {
 
 				requestAnimationFrame( animate );
 
-				camera.position.x += ( mouseX - camera.position.x ) * 0.05;
-				camera.position.y += ( - mouseY - camera.position.y ) * 0.05;
-				camera.lookAt( scene.position );
-
-				light.position.set( camera.position.x, camera.position.y, camera.position.z ).normalize();
 				renderer.render( scene, camera );
 
 			}
@@ -285,10 +265,6 @@
 				return geometry;
 
 			}
-
-			init();
-			animate();
-
 
 		</script>
 

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -8,8 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - ply<br/><br/>
-			<button id="exportASCII">export ASCII</button> <button id="exportBinaryBigEndian">export binary (Big Endian)</button> <button id="exportBinaryLittleEndian">export binary (Little Endian)</button>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - ply
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -30,8 +29,15 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { PLYExporter } from './jsm/exporters/PLYExporter.js';
+			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
 			let scene, camera, renderer, exporter, mesh;
+
+			const params = {
+				exportASCII: exportASCII,
+				exportBinaryBigEndian: exportBinaryBigEndian,
+				exportBinaryLittleEndian: exportBinaryLittleEndian
+			};
 
 			init();
 			animate();
@@ -87,6 +93,7 @@
 					else colors[ i ] = 0;
 
 				}
+
 				geometry.setAttribute( 'color', new THREE.BufferAttribute( colors, 3, false ) );
 
 				mesh = new THREE.Mesh( geometry, material );
@@ -113,14 +120,12 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				const buttonExportASCII = document.getElementById( 'exportASCII' );
-				buttonExportASCII.addEventListener( 'click', exportASCII );
+				const gui = new GUI();
 
-				const buttonExportBinaryBE = document.getElementById( 'exportBinaryBigEndian' );
-				buttonExportBinaryBE.addEventListener( 'click', exportBinaryBigEndian );
-
-				const buttonExportBinaryLE = document.getElementById( 'exportBinaryLittleEndian' );
-				buttonExportBinaryLE.addEventListener( 'click', exportBinaryLittleEndian );
+				gui.add( params, 'exportASCII' ).name( 'Export PLY (ASCII)' );
+				gui.add( params, 'exportBinaryBigEndian' ).name( 'Export PLY (Binary BE)' );
+				gui.add( params, 'exportBinaryLittleEndian' ).name( 'Export PLY (Binary LE)' );
+				gui.open();
 
 			}
 

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -8,8 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - stl<br/><br/>
-			<button id="exportASCII">export ASCII</button> <button id="exportBinary">export binary</button>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - exporter - stl
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -30,8 +29,14 @@
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 			import { STLExporter } from './jsm/exporters/STLExporter.js';
+			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
 			let scene, camera, renderer, exporter, mesh;
+
+			const params = {
+				exportASCII: exportASCII,
+				exportBinary: exportBinary
+			};
 
 			init();
 			animate();
@@ -102,11 +107,11 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				const buttonExportASCII = document.getElementById( 'exportASCII' );
-				buttonExportASCII.addEventListener( 'click', exportASCII );
+				const gui = new GUI();
 
-				const buttonExportBinary = document.getElementById( 'exportBinary' );
-				buttonExportBinary.addEventListener( 'click', exportBinary );
+				gui.add( params, 'exportASCII' ).name( 'Export STL (ASCII)' );
+				gui.add( params, 'exportBinary' ).name( 'Export STL (Binary)' );
+				gui.open();
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

Ensures the exporter examples use `lil-gui` for their UI and not plain HTML buttons or checkboxes.