### PR TITLE
Update GLTFLoader doc for texture transform extension

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -60,8 +60,7 @@
 			<sup>2</sup>UV transforms are supported, with several key limitations. Transforms applied to
 			a texture using the first UV slot (all textures except aoMap and lightMap) must share the same
 			transform, or no transform at all. The aoMap and lightMap textures cannot be transformed. No
-			more than one transform may be used per material. Each use of a texture with a unique
-			transform will result in an additional GPU texture upload. See
+			more than one transform may be used per material. See
 			#[link:https://github.com/mrdoob/three.js/pull/13831 13831] and
 			#[link:https://github.com/mrdoob/three.js/issues/12788 12788].
 		</i></p>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -60,7 +60,6 @@
 			a texture using the first UV slot (all textures except aoMap and lightMap) must share the same
 			transform, or no transform at all.
 			aoMap 和 lightMap 纹理不能被变换。每个材质最多只能使用一次变换。
-			每次对使用具有唯一变换的纹理都会导致一次额外的GPU纹理上传。
 			请参阅#[link:https://github.com/mrdoob/three.js/pull/13831 13831] 和
 			#[link:https://github.com/mrdoob/three.js/issues/12788 12788]。
 		</i></p>


### PR DESCRIPTION
**Description**

If I'm right, as Source has been introduced #17766, GLTFLoader texture transform extension no longer needs duplicate texture upload to GPU.

/cc @donmccurdy 
