### PR TITLE
WebGLTextures: Fix empty image check.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -431,9 +431,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			const image = texture.image;
 
-			if ( image === undefined ) {
+			if ( image === null ) {
 
-				console.warn( 'THREE.WebGLRenderer: Texture marked for update but image is undefined' );
+				console.warn( 'THREE.WebGLRenderer: Texture marked for update but no image data found.' );
 
 			} else if ( image.complete === false ) {
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -298,7 +298,7 @@ class Texture extends EventDispatcher {
 
 }
 
-Texture.DEFAULT_IMAGE = undefined;
+Texture.DEFAULT_IMAGE = null;
 Texture.DEFAULT_MAPPING = UVMapping;
 
 Texture.prototype.isTexture = true;


### PR DESCRIPTION
Related issue: -

**Description**

It is necessary to check for `null` and not `undefined`  since `Texure.image` refers to `Source.data` now.
