### PR TITLE
clarify the example in SkinnedMesh docs

### DIFF
--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -38,7 +38,8 @@
 		<code>
 		const geometry = new THREE.CylinderGeometry( 5, 5, 5, 5, 15, 5, 30 );
 
-		// create the skin indices and skin weights
+		// create the skin indices and skin weights manually
+		// (typically a loader would read this data from a 3D model for you)
 
 		const position = geometry.attributes.position;
 


### PR DESCRIPTION
Someone at [discord](https://discord.com/channels/685241246557667386/685241247233081362/938756163187646515) was trying to create skin weights by code before noticing you could just import them from blender, because the example in docs made them think this is the way. So why dont we have a comment there to stop people from wasting their time 😅 
