### PR TITLE
Use number of indices instead of vertices when setting draw range

### DIFF
--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -233,7 +233,7 @@
 
 			/* BAKE ANIMATION INTO TEXTURE and CREATE GEOMETRY FROM BASE MODEL */
 			const BirdGeometry = new THREE.BufferGeometry();
-			let textureAnimation, durationAnimation, birdMesh, materialShader, vertexPerBird;
+			let textureAnimation, durationAnimation, birdMesh, materialShader, indicesPerBird;
 
 			function nextPowerOf2( n ) {
 
@@ -260,7 +260,7 @@
 				const morphAttributes = birdGeo.morphAttributes.position;
 				const tHeight = nextPowerOf2( durationAnimation );
 				const tWidth = nextPowerOf2( birdGeo.getAttribute( 'position' ).count );
-				vertexPerBird = birdGeo.getAttribute( 'position' ).count;
+				indicesPerBird = birdGeo.index.count;
 				const tData = new Float32Array( 4 * tWidth * tHeight );
 
 				for ( let i = 0; i < tWidth; i ++ ) {
@@ -425,7 +425,7 @@
 					velocityUniforms[ "cohesionDistance" ].value = effectController.cohesion;
 					velocityUniforms[ "freedomFactor" ].value = effectController.freedom;
 					if ( materialShader ) materialShader.uniforms[ "size" ].value = effectController.size;
-					BirdGeometry.setDrawRange( 0, vertexPerBird * effectController.count );
+					BirdGeometry.setDrawRange( 0, indicesPerBird * effectController.count );
 
 				};
 

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -414,7 +414,7 @@
 					cohesion: 20.0,
 					freedom: 0.75,
 					size: sizes[ selectModel ],
-					count: BIRDS
+					count: Math.floor( BIRDS / 4 )
 
 				};
 


### PR DESCRIPTION
**Description**

The GPGPU examples with GLTF birds uses vertices per bird as a way to set the draw range. Since this is indexed geometry this results in a rather sad looking flamingo (in fact even if the count is set to 2, it barely draws one bird):

![Screenshot 2022-02-06 at 00 58 22](https://user-images.githubusercontent.com/238667/152663191-da1d243e-afaa-40f8-95be-020375ae3eb7.png)

Using the number of indices instead fixes this. Look at this pretty bird:

![Screenshot 2022-02-06 at 01 01 16](https://user-images.githubusercontent.com/238667/152663203-6100365a-5798-4fdc-8425-7329d62b9cd1.png)

A side result is that there are now **a lot** more birds, before we were simulating them all but drawing only a part of their flock. :)
