### PR TITLE
WebGPUTextures: Fix Texture.image !== null

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -365,7 +365,7 @@ class WebGPUTextures {
 
 		} else {
 
-			if ( image !== undefined ) {
+			if ( image !== null ) {
 
 				// assume HTMLImageElement, HTMLCanvasElement or ImageBitmap
 
@@ -701,7 +701,7 @@ class WebGPUTextures {
 			height = ( image.length > 0 ) ? image[ 0 ].height : 1;
 			depth = 6; // one image for each side of the cube map
 
-		} else if ( image !== undefined ) {
+		} else if ( image !== null ) {
 
 			width = image.width;
 			height = image.height;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/22846

**Description**

Fix conditional.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
