### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -163,8 +163,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-		Divides this vector by scalar [page:Float s].<br />
-		Sets vector to *( 0, 0 )* if [page:Float s] = 0.
+		Divides this vector by scalar [page:Float s].
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector2 v] )</h3>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -195,8 +195,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-		Divides this vector by scalar [page:Float s].<br />
-		Sets vector to *( 0, 0, 0 )* if *[page:Float s] = 0*.
+		Divides this vector by scalar [page:Float s].
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector3 v] )</h3>

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -144,8 +144,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-		Divides this vector by scalar [page:Float s].<br />
-		Sets vector to *( 0, 0, 0, 0 )* if *[page:Float s] = 0*.
+		Divides this vector by scalar [page:Float s].
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector4 v] )</h3>

--- a/docs/api/zh/math/Vector2.html
+++ b/docs/api/zh/math/Vector2.html
@@ -162,8 +162,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-			将该向量除以标量[page:Float s]。<br />
-			如果传入的[page:Float s] = 0，则向量将被设置为*( 0, 0 )*。
+			将该向量除以标量[page:Float s]。
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector2 v] )</h3>

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -193,8 +193,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-		将该向量除以标量[page:Float s]。<br />
-		如果传入的[page:Float s] = 0，则向量将被设置为*( 0, 0, 0 )*。
+		将该向量除以标量[page:Float s]。
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector3 v] )</h3>

--- a/docs/api/zh/math/Vector4.html
+++ b/docs/api/zh/math/Vector4.html
@@ -142,8 +142,7 @@
 
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>
-		将该向量除以标量[page:Float s]。<br />
-		如果传入的[page:Float s] = 0，则向量将被设置为*( 0, 0, 0, 0 )*。
+		将该向量除以标量[page:Float s]。
 		</p>
 
 		<h3>[method:Float dot]( [param:Vector4 v] )</h3>


### PR DESCRIPTION
Fixed #23429.

**Description**

Updates the description of `Vector*.divideScalar()`.
