### PR TITLE
Reflector/Refractor: Add multisampling support.

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -8,7 +8,8 @@ import {
 	UniformsUtils,
 	Vector3,
 	Vector4,
-	WebGLRenderTarget
+	WebGLRenderTarget,
+	WebGLMultisampleRenderTarget
 } from 'three';
 
 class Reflector extends Mesh {
@@ -26,6 +27,7 @@ class Reflector extends Mesh {
 		const textureHeight = options.textureHeight || 512;
 		const clipBias = options.clipBias || 0;
 		const shader = options.shader || Reflector.ReflectorShader;
+		const multisample = options.multisample || 4;
 
 		//
 
@@ -44,7 +46,18 @@ class Reflector extends Mesh {
 		const textureMatrix = new Matrix4();
 		const virtualCamera = new PerspectiveCamera();
 
-		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
+		let renderTarget;
+
+		if ( multisample > 0 ) {
+
+			renderTarget = new WebGLMultisampleRenderTarget( textureWidth, textureHeight );
+			renderTarget.samples = multisample;
+
+		} else {
+
+			renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
+
+		}
 
 		const material = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( shader.uniforms ),

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -9,7 +9,8 @@ import {
 	UniformsUtils,
 	Vector3,
 	Vector4,
-	WebGLRenderTarget
+	WebGLRenderTarget,
+	WebGLMultisampleRenderTarget
 } from 'three';
 
 class Refractor extends Mesh {
@@ -27,6 +28,7 @@ class Refractor extends Mesh {
 		const textureHeight = options.textureHeight || 512;
 		const clipBias = options.clipBias || 0;
 		const shader = options.shader || Refractor.RefractorShader;
+		const multisample = options.multisample || 4;
 
 		//
 
@@ -41,7 +43,18 @@ class Refractor extends Mesh {
 
 		// render target
 
-		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
+		let renderTarget;
+
+		if ( multisample > 0 ) {
+
+			renderTarget = new WebGLMultisampleRenderTarget( textureWidth, textureHeight );
+			renderTarget.samples = multisample;
+
+		} else {
+
+			renderTarget = new WebGLRenderTarget( textureWidth, textureHeight );
+
+		}
 
 		// material
 


### PR DESCRIPTION
Related issue: #22933

**Description**

Introducing multisampling support to `Reflector` and `Refractor`.

I've noticed there are multiple ways how `three.js` currently names variables/properties which define how many samples are used in context of multisampling:

- `WebGLMultisampleRenderTarget` is currently using `samples`.
- #22933 suggested the usage of `multisample` which is used in this PR, too.
- WebGPU and `WebGPURenderer`  use `sampleCount`.

If I had to make a choice I would pick `sampleCount` although the others are of course good, too. We should just ensure to use the same syntax everywhere.
