### PR TITLE
NormalMapEditor and some improvements

### DIFF
--- a/examples/jsm/node-editor/NodeEditor.js
+++ b/examples/jsm/node-editor/NodeEditor.js
@@ -18,6 +18,7 @@ import { SliderEditor } from './inputs/SliderEditor.js';
 import { ColorEditor } from './inputs/ColorEditor.js';
 import { TextureEditor } from './inputs/TextureEditor.js';
 import { BlendEditor } from './display/BlendEditor.js';
+import { NormalMapEditor } from './display/NormalMapEditor.js';
 import { UVEditor } from './accessors/UVEditor.js';
 import { PositionEditor } from './accessors/PositionEditor.js';
 import { NormalEditor } from './accessors/NormalEditor.js';
@@ -104,6 +105,11 @@ export const NodeList = [
 				name: 'Blend',
 				icon: 'layers-subtract',
 				nodeClass: BlendEditor
+			},
+			{
+				name: 'Normal Map',
+				icon: 'chart-line',
+				nodeClass: NormalMapEditor
 			}
 		]
 	},
@@ -250,6 +256,7 @@ export const ClassLib = {
 	ColorEditor,
 	TextureEditor,
 	BlendEditor,
+	NormalMapEditor,
 	UVEditor,
 	PositionEditor,
 	NormalEditor,

--- a/examples/jsm/node-editor/display/NormalMapEditor.js
+++ b/examples/jsm/node-editor/display/NormalMapEditor.js
@@ -1,0 +1,49 @@
+import { SelectInput, Element, LabelElement } from '../../libs/flow.module.js';
+import { BaseNode } from '../core/BaseNode.js';
+import { NormalMapNode, FloatNode } from '../../renderers/nodes/Nodes.js';
+import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from 'three';
+
+const nullValue = new FloatNode( 0 ).setConst( true );
+
+export class NormalMapEditor extends BaseNode {
+
+	constructor() {
+
+		const node = new NormalMapNode( nullValue );
+
+		super( 'Normal Map', 3, node, 175 );
+
+		const source = new LabelElement( 'Source' ).setInput( 3 ).onConnect( () => {
+
+			node.node = source.getLinkedObject() || nullValue;
+
+			this.invalidate();
+
+		} );
+
+		const scale = new LabelElement( 'Scale' ).setInput( 3 ).onConnect( () => {
+
+			node.scaleNode = scale.getLinkedObject();
+
+			this.invalidate();
+
+		} );
+
+		const optionsField = new SelectInput( [
+			{ name: 'Tangent Space', value: TangentSpaceNormalMap },
+			{ name: 'Object Space', value: ObjectSpaceNormalMap }
+		], TangentSpaceNormalMap ).onChange( () => {
+
+			node.normalMapType = Number( optionsField.getValue() );
+
+			this.invalidate();
+
+		} );
+
+		this.add( new Element().add( optionsField ) )
+			.add( source )
+			.add( scale );
+
+	}
+
+}

--- a/examples/jsm/node-editor/materials/PointsMaterialEditor.js
+++ b/examples/jsm/node-editor/materials/PointsMaterialEditor.js
@@ -1,4 +1,4 @@
-import { ColorInput, SliderInput, LabelElement } from '../../libs/flow.module.js';
+import { ColorInput, ToggleInput, SliderInput, LabelElement } from '../../libs/flow.module.js';
 import { BaseNode } from '../core/BaseNode.js';
 import { PointsNodeMaterial } from '../../renderers/nodes/Nodes.js';
 import * as THREE from 'three';
@@ -7,12 +7,7 @@ export class PointsMaterialEditor extends BaseNode {
 
 	constructor() {
 
-		const material = new PointsNodeMaterial( {
-			depthWrite: false,
-			transparent: true,
-			sizeAttenuation: true,
-			blending: THREE.AdditiveBlending
-		} );
+		const material = new PointsNodeMaterial();
 
 		super( 'Points Material', 1, material );
 
@@ -22,6 +17,7 @@ export class PointsMaterialEditor extends BaseNode {
 		const opacity = new LabelElement( 'opacity' ).setInput( 1 );
 		const size = new LabelElement( 'size' ).setInput( 1 );
 		const position = new LabelElement( 'position' ).setInput( 3 );
+		const sizeAttenuation = new LabelElement( 'Size Attenuation' );
 
 		color.add( new ColorInput( material.color.getHex() ).onChange( ( input ) => {
 
@@ -37,20 +33,29 @@ export class PointsMaterialEditor extends BaseNode {
 
 		} ) );
 
+		sizeAttenuation.add( new ToggleInput( material.sizeAttenuation ).onClick( ( input ) => {
+
+			material.sizeAttenuation = input.getValue();
+			material.dispose();
+
+		} ) );
+
 		color.onConnect( () => this.update(), true );
 		opacity.onConnect( () => this.update(), true );
-		size.onConnect(() => this.update(), true );
-		position.onConnect(() => this.update(), true );
+		size.onConnect( () => this.update(), true );
+		position.onConnect( () => this.update(), true );
 
 		this.add( color )
 			.add( opacity )
 			.add( size )
-			.add( position );
+			.add( position )
+			.add( sizeAttenuation );
 
 		this.color = color;
 		this.opacity = opacity;
 		this.size = size;
 		this.position = position;
+		this.sizeAttenuation = sizeAttenuation;
 
 		this.material = material;
 

--- a/examples/jsm/node-editor/materials/StandardMaterialEditor.js
+++ b/examples/jsm/node-editor/materials/StandardMaterialEditor.js
@@ -15,9 +15,10 @@ export class StandardMaterialEditor extends BaseNode {
 
 		const color = new LabelElement( 'color' ).setInput( 3 );
 		const opacity = new LabelElement( 'opacity' ).setInput( 1 );
-		const normal = new LabelElement( 'normal' ).setInput( 1 );
 		const metalness = new LabelElement( 'metalness' ).setInput( 1 );
 		const roughness = new LabelElement( 'roughness' ).setInput( 1 );
+		const emissive = new LabelElement( 'emissive' ).setInput( 3 );
+		const normal = new LabelElement( 'normal' ).setInput( 1 );
 		const position = new LabelElement( 'position' ).setInput( 3 );
 
 		color.add( new ColorInput( material.color.getHex() ).onChange( ( input ) => {
@@ -48,23 +49,26 @@ export class StandardMaterialEditor extends BaseNode {
 
 		color.onConnect( () => this.update(), true );
 		opacity.onConnect( () => this.update(), true );
-		normal.onConnect(() => this.update(), true );
 		metalness.onConnect( () => this.update(), true );
 		roughness.onConnect( () => this.update(), true );
-		position.onConnect(() => this.update(), true );
+		emissive.onConnect( () => this.update(), true );
+		normal.onConnect( () => this.update(), true );
+		position.onConnect( () => this.update(), true );
 
 		this.add( color )
 			.add( opacity )
-			.add( normal )
 			.add( metalness )
 			.add( roughness )
+			.add( emissive )
+			.add( normal )
 			.add( position );
 
 		this.color = color;
 		this.opacity = opacity;
-		this.normal = normal;
 		this.metalness = metalness;
 		this.roughness = roughness;
+		this.emissive = emissive;
+		this.normal = normal;
 		this.position = position;
 
 		this.material = material;
@@ -75,7 +79,7 @@ export class StandardMaterialEditor extends BaseNode {
 
 	update() {
 
-		const { material, color, opacity, normal, roughness, metalness, position } = this;
+		const { material, color, opacity, emissive, roughness, metalness, normal, position } = this;
 
 		color.setEnabledInputs( ! color.getLinkedObject() );
 		opacity.setEnabledInputs( ! opacity.getLinkedObject() );
@@ -83,12 +87,13 @@ export class StandardMaterialEditor extends BaseNode {
 		metalness.setEnabledInputs( ! metalness.getLinkedObject() );
 
 		material.colorNode = color.getLinkedObject();
-		material.opacityNode = opacity.getLinkedObject() || null;
-		material.normalNode = normal.getLinkedObject() || null;
+		material.opacityNode = opacity.getLinkedObject();
 		material.metalnessNode = metalness.getLinkedObject();
 		material.roughnessNode = roughness.getLinkedObject();
+		material.emissiveNode = emissive.getLinkedObject();
+		material.normalNode = normal.getLinkedObject();
 
-		material.positionNode = position.getLinkedObject() || null;
+		material.positionNode = position.getLinkedObject();
 
 		material.dispose();
 

--- a/examples/jsm/node-editor/materials/StandardMaterialEditor.js
+++ b/examples/jsm/node-editor/materials/StandardMaterialEditor.js
@@ -18,7 +18,7 @@ export class StandardMaterialEditor extends BaseNode {
 		const metalness = new LabelElement( 'metalness' ).setInput( 1 );
 		const roughness = new LabelElement( 'roughness' ).setInput( 1 );
 		const emissive = new LabelElement( 'emissive' ).setInput( 3 );
-		const normal = new LabelElement( 'normal' ).setInput( 1 );
+		const normal = new LabelElement( 'normal' ).setInput( 3 );
 		const position = new LabelElement( 'position' ).setInput( 3 );
 
 		color.add( new ColorInput( material.color.getHex() ).onChange( ( input ) => {

--- a/examples/jsm/node-editor/materials/StandardMaterialEditor.js
+++ b/examples/jsm/node-editor/materials/StandardMaterialEditor.js
@@ -15,6 +15,7 @@ export class StandardMaterialEditor extends BaseNode {
 
 		const color = new LabelElement( 'color' ).setInput( 3 );
 		const opacity = new LabelElement( 'opacity' ).setInput( 1 );
+		const normal = new LabelElement( 'normal' ).setInput( 1 );
 		const metalness = new LabelElement( 'metalness' ).setInput( 1 );
 		const roughness = new LabelElement( 'roughness' ).setInput( 1 );
 		const position = new LabelElement( 'position' ).setInput( 3 );
@@ -47,18 +48,21 @@ export class StandardMaterialEditor extends BaseNode {
 
 		color.onConnect( () => this.update(), true );
 		opacity.onConnect( () => this.update(), true );
+		normal.onConnect(() => this.update(), true );
 		metalness.onConnect( () => this.update(), true );
 		roughness.onConnect( () => this.update(), true );
 		position.onConnect(() => this.update(), true );
 
 		this.add( color )
 			.add( opacity )
+			.add( normal )
 			.add( metalness )
 			.add( roughness )
 			.add( position );
 
 		this.color = color;
 		this.opacity = opacity;
+		this.normal = normal;
 		this.metalness = metalness;
 		this.roughness = roughness;
 		this.position = position;
@@ -71,7 +75,7 @@ export class StandardMaterialEditor extends BaseNode {
 
 	update() {
 
-		const { material, color, opacity, roughness, metalness, position } = this;
+		const { material, color, opacity, normal, roughness, metalness, position } = this;
 
 		color.setEnabledInputs( ! color.getLinkedObject() );
 		opacity.setEnabledInputs( ! opacity.getLinkedObject() );
@@ -80,6 +84,7 @@ export class StandardMaterialEditor extends BaseNode {
 
 		material.colorNode = color.getLinkedObject();
 		material.opacityNode = opacity.getLinkedObject() || null;
+		material.normalNode = normal.getLinkedObject() || null;
 		material.metalnessNode = metalness.getLinkedObject();
 		material.roughnessNode = roughness.getLinkedObject();
 

--- a/examples/jsm/node-editor/math/InvertEditor.js
+++ b/examples/jsm/node-editor/math/InvertEditor.js
@@ -10,12 +10,12 @@ export class InvertEditor extends BaseNode {
 
 		const node = new MathNode( MathNode.INVERT, DEFAULT_VALUE );
 
-		super( 'Invert / Negate', 1, node );
+		super( 'Invert / Negate', 1, node, 175 );
 
 		const optionsField = new SelectInput( [
 			{ name: 'Invert ( 1 - Source )', value: MathNode.INVERT },
 			{ name: 'Negate ( - Source )', value: MathNode.NEGATE }
-		] ).onChange( () => {
+		], MathNode.INVERT ).onChange( () => {
 
 			node.method = optionsField.getValue();
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -25,7 +25,7 @@ import ColorSpaceNode from '../../nodes/display/ColorSpaceNode.js';
 import LightContextNode from '../../nodes/lights/LightContextNode.js';
 import OperatorNode from '../../nodes/math/OperatorNode.js';
 import WGSLNodeParser from '../../nodes/parsers/WGSLNodeParser.js';
-import { join, nodeObject } from '../../nodes/ShaderNode.js';
+import { add, join, nodeObject } from '../../nodes/ShaderNode.js';
 import { getRoughness } from '../../nodes/functions/PhysicalMaterialFunctions.js';
 
 const wgslTypeLib = {
@@ -264,13 +264,23 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			}
 
-			// RESULT
+			// OUTGOING LIGHT
 
-			const outputNodeObj = nodeObject( outputNode );
+			let outgoingLightNode = nodeObject( outputNode ).xyz;
 
-			outputNode = join( outputNodeObj.x, outputNodeObj.y, outputNodeObj.z, nodeObject( diffuseColorNode ).w );
+			// EMISSIVE
 
-			//
+			const emissiveNode = material.emissiveNode;
+
+			if ( emissiveNode && emissiveNode.isNode ) {
+
+				outgoingLightNode = add( emissiveNode, outgoingLightNode );
+
+			}
+
+			outputNode = join( outgoingLightNode.xyz, nodeObject( diffuseColorNode ).w );
+
+			// OUTPUT
 
 			const outputEncoding = this.renderer.outputEncoding;
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -128,6 +128,8 @@
 
 				const materialCompressed = new Nodes.MeshBasicNodeMaterial();
 				materialCompressed.colorNode = new Nodes.TextureNode( dxt5Texture );
+				materialCompressed.emissiveNode = new Nodes.ColorNode( new THREE.Color( 0x663300 ) );
+				materialCompressed.alphaTestNode = new Nodes.OscNode();
 				materialCompressed.transparent = true;
 
 				const boxCompressed = new THREE.Mesh( geometryBox, materialCompressed );


### PR DESCRIPTION
**Description**

- [x]  `PointsMaterialEditor`: add `Size Attenuation` support
- [x] `NormalMapNode`: add `scaleNode` support
- [x] `NormalMapEditor`: add `normal` support
- [x] `WebGPU`: add `.emissiveNode` support
- [x] `StandardMaterialEditor`: add `.emissive` support
- [x] `InvertEditor`: cleanup

![image](https://user-images.githubusercontent.com/502810/153218539-84276b1a-bf4e-4b09-8643-718e25faa1c2.png)

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
