### PR TITLE
WebGLRenderer: Refactor creation of transmission render target.

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -188,7 +188,9 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*. This feature can only be used with a WebGL 2 rendering context.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.<br />
+
+		This feature can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>

--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -188,7 +188,7 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*. This feature can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -184,7 +184,9 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*. This feature can only be used with a WebGL 2 rendering context.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.<br />
+
+		This feature can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -184,7 +184,7 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*. This feature can only be used with a WebGL 2 rendering context.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/22731#issuecomment-1034110601

**Description**

This PR sets the size of the transmission render target to half of the drawing buffer's size. It also makes `MeshPhysicalMaterial.transmission` to a WebGL 2 only property so it's easier use mipmap generation. Besides, the transmission render target's texture now uses `LinearFilter` to its `magFilter` property.

The PR also fixes issue 5 in #22009.