### PR TITLE
WebGLRenderer: Limited WebGL1 backwards compatibility for transmission.

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -188,9 +188,7 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.<br />
-
-		This feature can only be used with a WebGL 2 rendering context.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -184,9 +184,7 @@
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.<br />
-
-		This feature can only be used with a WebGL 2 rendering context.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1200,8 +1200,6 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		// set size of transmission render target to half size of drawing buffer
-
 		_this.getDrawingBufferSize( _vector2 );
 		_transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -9,6 +9,7 @@ import {
 	UnsignedByteType,
 	LinearEncoding,
 	NoToneMapping,
+	LinearFilter,
 	LinearMipmapLinearFilter
 } from '../constants.js';
 import { Frustum } from '../math/Frustum.js';
@@ -1184,21 +1185,16 @@ function WebGLRenderer( parameters = {} ) {
 
 	function renderTransmissionPass( opaqueObjects, scene, camera ) {
 
-		if ( capabilities.isWebGL2 === false ) {
-
-			console.error( 'THREE.WebGLRenderer: Transmission can only be used with WebGL 2.' );
-			return;
-
-		}
+		const isWebGL2 = capabilities.isWebGL2;
 
 		if ( _transmissionRenderTarget === null ) {
 
-			const renderTargetType = ( _antialias === true ) ? WebGLMultisampleRenderTarget : WebGLRenderTarget;
+			const renderTargetType = ( isWebGL2 && _antialias === true ) ? WebGLMultisampleRenderTarget : WebGLRenderTarget;
 
 			_transmissionRenderTarget = new renderTargetType( 1, 1, {
 				generateMipmaps: true,
 				type: HalfFloatType,
-				minFilter: LinearMipmapLinearFilter,
+				minFilter: isWebGL2 ? LinearMipmapLinearFilter : LinearFilter,
 				useRenderToTexture: extensions.has( 'WEBGL_multisampled_render_to_texture' )
 			} );
 
@@ -1206,7 +1202,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		// set size of transmission render target to half size of drawing buffer
 
-		_this.getDrawingBufferSize( _vector2 ).multiplyScalar( 0.5 ).floor();
+		_this.getDrawingBufferSize( _vector2 );
 		_transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
 
 		//


### PR DESCRIPTION
Related issues: #22731 #23450

**Description**

Rather than completely removing transmission support in WebGL1, I think we can provide limited support by ignoring roughness (mipmapping).

| Before | After |
| --- | --- |
| <img width="979" alt="Screen Shot 2022-02-10 at 10 29 13 AM" src="https://user-images.githubusercontent.com/97088/153441278-39686dff-cc93-4964-b5a3-12906306caee.png"> | <img width="977" alt="Screen Shot 2022-02-10 at 10 26 42 AM" src="https://user-images.githubusercontent.com/97088/153441548-8a7d4c9f-0249-4e7b-a9ac-f03a069cad2f.png"> |

I've also increased the `_transmissionRenderTarget` resolution to 1x which fully solves issue 5 in #22009.
