### PR TITLE
Assign 3MF object names to the created groups and meshes.

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1119,6 +1119,16 @@ class ThreeMFLoader extends Loader {
 
 			}
 
+			if ( objectData.name ) {
+
+				for ( let i = 0; i < meshes.length; i ++ ) {
+
+					meshes[ i ].name = objectData.name;
+
+				}
+
+			}
+
 			return meshes;
 
 		}
@@ -1341,6 +1351,12 @@ class ThreeMFLoader extends Loader {
 				const compositeData = objectData[ 'components' ];
 
 				objects[ objectData.id ] = getBuild( compositeData, objects, modelData, textureData, objectData, buildComposite );
+
+			}
+
+			if ( objectData.name ) {
+
+				objects[ objectData.id ].name = objectData.name;
 
 			}
 


### PR DESCRIPTION
**Description**

3MF contains names for the objects in it. For some viewers it's useful to have these names in the loaded three.js objects as well. A 3MF object becomes a `THREE.Group`, and now it gets the name of the object. I also assign the name of the object to all the `THREE.Mesh` objects inside the group to make sure that every object has a proper name.
