### PR TITLE
add support for renderOrder to CSS2DRenderer

### DIFF
--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -177,6 +177,12 @@
 
 				const sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
 
+					if ( a.renderOrder !== b.renderOrder ) {
+
+						return b.renderOrder - a.renderOrder;
+
+					}
+
 					const distanceA = cache.objects.get( a ).distanceToCameraSquared;
 					const distanceB = cache.objects.get( b ).distanceToCameraSquared;
 					return distanceA - distanceB;

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -189,6 +189,12 @@ class CSS2DRenderer {
 
 			const sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
 
+				if ( a.renderOrder !== b.renderOrder ) {
+
+					return b.renderOrder - a.renderOrder;
+
+				}
+
 				const distanceA = cache.objects.get( a ).distanceToCameraSquared;
 				const distanceB = cache.objects.get( b ).distanceToCameraSquared;
 


### PR DESCRIPTION
Related issue: NA

**Description**

CSS2DRenderer did not have any support for `renderOrder`. This change adds support for `renderOrder`, where objects with a greater `renderOrder` will always cover those with a lesser `renderOrder`. Where objects have the same `renderOrder`, the pre-existing behavior is preserved where the object that is closest to the camera will cover any objects further from the camera according to each objects `position` property.

