### PR TITLE
Support transmission roughness on WebGL1

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -12,6 +12,7 @@ import {
 	LinearFilter,
 	LinearMipmapLinearFilter
 } from '../constants.js';
+import { floorPowerOfTwo } from '../math/MathUtils';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Vector2 } from '../math/Vector2.js';
@@ -1194,14 +1195,18 @@ function WebGLRenderer( parameters = {} ) {
 			_transmissionRenderTarget = new renderTargetType( 1, 1, {
 				generateMipmaps: true,
 				type: HalfFloatType,
-				minFilter: isWebGL2 ? LinearMipmapLinearFilter : LinearFilter,
+				minFilter: LinearMipmapLinearFilter,
 				useRenderToTexture: extensions.has( 'WEBGL_multisampled_render_to_texture' )
 			} );
 
 		}
 
 		_this.getDrawingBufferSize( _vector2 );
-		_transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
+		if (isWebGL2) {
+			_transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
+		} else {
+			_transmissionRenderTarget.setSize( floorPowerOfTwo( _vector2.x ), floorPowerOfTwo( _vector2.y ) );
+		}
 
 		//
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -9,7 +9,6 @@ import {
 	UnsignedByteType,
 	LinearEncoding,
 	NoToneMapping,
-	LinearFilter,
 	LinearMipmapLinearFilter
 } from '../constants.js';
 import { floorPowerOfTwo } from '../math/MathUtils';
@@ -1202,10 +1201,15 @@ function WebGLRenderer( parameters = {} ) {
 		}
 
 		_this.getDrawingBufferSize( _vector2 );
-		if (isWebGL2) {
+
+		if ( isWebGL2 ) {
+
 			_transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
+
 		} else {
+
 			_transmissionRenderTarget.setSize( floorPowerOfTwo( _vector2.x ), floorPowerOfTwo( _vector2.y ) );
+
 		}
 
 		//


### PR DESCRIPTION
Related issue: #22009

**Description**

Enables transmission roughness on WebGL1 by flooring to power of two, extends https://github.com/mrdoob/three.js/pull/23452#issuecomment-1035393035 following comment here https://github.com/mrdoob/three.js/pull/22731#issuecomment-1035154789

