### PR TITLE
GLTFExporter: Fix buildORMTexture()

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -695,7 +695,7 @@ class GLTFWriter {
 		const roughness = material.roughnessMap?.image;
 		const metalness = material.metalnessMap?.image;
 
-		if ( occlusion === roughness && roughness === metalness ) return occlusion;
+		if ( occlusion === roughness && roughness === metalness ) return material.aoMap;
 
 		if ( occlusion || roughness || metalness ) {
 


### PR DESCRIPTION
**Description**

Currently `buildORMTexture()` in `GLTFExporter` returns `Texture.image` if `aoMap.image`, `roughnessMap.image`, and `metalnessMap.image` are identical but it should return `Texture` for the type consistency and the return value is used for `processTexture()`, passing `Texture.image` to it can cause an error.

This PR fixes the problem by returning `Texture`.

This is just an easy and quick fix. We may need some more tweaks and clean up.
