### PR TITLE
Fix tests

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -11,7 +11,7 @@ import {
 	NoToneMapping,
 	LinearMipmapLinearFilter
 } from '../constants.js';
-import { floorPowerOfTwo } from '../math/MathUtils';
+import { floorPowerOfTwo } from '../math/MathUtils.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Vector2 } from '../math/Vector2.js';


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23455#issuecomment-1036434584

**Description**

The tests were broken in https://github.com/mrdoob/three.js/pull/23460 because of an import with no `.js` extension.