### PR TITLE
PMREMGenerator: Set minFilter to NearestFilter.

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -4,6 +4,7 @@ import {
 	CubeUVReflectionMapping,
 	LinearEncoding,
 	LinearFilter,
+	NearestFilter,
 	NoToneMapping,
 	NoBlending,
 	RGBAFormat,
@@ -249,7 +250,7 @@ class PMREMGenerator {
 
 		const params = {
 			magFilter: LinearFilter,
-			minFilter: LinearFilter,
+			minFilter: NearestFilter,
 			generateMipmaps: false,
 			type: HalfFloatType,
 			format: RGBAFormat,


### PR DESCRIPTION
Related issue: https://github.com/google/model-viewer/issues/3145

**Description**

@kenrussell suggested this workaround for cases where users override the `texture.anisotropy` setting from the Nvidia settings panel which produce seams when generating the atlas.

@elalish Can you think of any side effects this PR may have?