### PR TITLE
Fix Raycaster error on missing material

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -169,6 +169,12 @@ class Mesh extends Object3D {
 						const group = groups[ i ];
 						const groupMaterial = material[ group.materialIndex ];
 
+						if ( groupMaterial === undefined ) {
+
+							continue;
+
+						}
+
 						const start = Math.max( group.start, drawRange.start );
 						const end = Math.min( index.count, Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) ) );
 
@@ -226,6 +232,12 @@ class Mesh extends Object3D {
 
 						const group = groups[ i ];
 						const groupMaterial = material[ group.materialIndex ];
+
+						if ( groupMaterial === undefined ) {
+
+							continue;
+
+						}
 
 						const start = Math.max( group.start, drawRange.start );
 						const end = Math.min( position.count, Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) ) );


### PR DESCRIPTION
**Description**

When a mesh is using multiple materials with the help of groups, and some materials are not defined, a raycast will error with "material is undefined" in the "checkIntersection" function.

Example application : I made a 360 panorama viewer with tiling, each tile is loaded only when entering the viewport and placed accordingly in the materials array (as well as updating the UVs). Hence a lot of materials are not defined until the user visits every spot of the panorama.  
This is not a problem for rendering but crashes the raycaster.

I fixed it on my side by initializing the materials array to a transparent MeshBasicMaterial but I think it is worth to add this null check.