### PR TITLE
Re-enable custom depth and distance materials

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -300,9 +300,9 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		result.clippingPlanes = material.clippingPlanes;
 		result.clipIntersection = material.clipIntersection;
 
-		result.displacementMap = material.displacementMap;
-		result.displacementScale = material.displacementScale;
-		result.displacementBias = material.displacementBias;
+		result.displacementMap ||= material.displacementMap;
+		result.displacementScale ||= material.displacementScale;
+		result.displacementBias ||= material.displacementBias;
 
 		result.wireframeLinewidth = material.wireframeLinewidth;
 		result.linewidth = material.linewidth;


### PR DESCRIPTION
Related issue: #22287

**Description**

Previously https://github.com/mrdoob/three.js/commit/6cca448b2a067d71ff2624ff62690f1d0ac1e429 enabled shadows for `displacementMap` modified geometries automatically, but the change also (presumably unintentionally) prevents the use of `customDepthMaterial` and `customDistanceMaterial` as their displacement attributes are clobbered by the original material. This change maintains the change, but reverts back to the original behavior if a custom material is present.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Influence](https://influenceth.io).
