### PR TITLE
Euler is missing lerp and clamp methods

### DIFF
--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -275,6 +275,19 @@ class Euler {
 
 	}
 
+	clamp( min, max ) {
+
+		// assumes min < max, componentwise
+
+		this._x = Math.max( min.x, Math.min( max.x, this._x ) );
+		this._y = Math.max( min.y, Math.min( max.y, this._y ) );
+		this._z = Math.max( min.z, Math.min( max.z, this._z ) );
+		this._onChangeCallback();
+
+		return this;
+
+	}
+
 	fromArray( array ) {
 
 		this._x = array[ 0 ];

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -264,6 +264,17 @@ class Euler {
 
 	}
 
+	lerp( e, alpha ) {
+
+		this._x += ( e.x - this._x ) * alpha;
+		this._y += ( e.y - this._y ) * alpha;
+		this._z += ( e.z - this._z ) * alpha;
+		this._onChangeCallback();
+
+		return this;
+
+	}
+
 	fromArray( array ) {
 
 		this._x = array[ 0 ];


### PR DESCRIPTION
I worked on a project with an object that should smoothly move and rotate depending on mouse position. I found that we can simply lerp and clamp "position", but it's not so easy for "rotation" of an Object3D. Instead of hacking I simply moved some logic from Vector3 class and adjusted them so they work with Euler. By using `e.x` instead of `e._x` I made sure that also Vector3 objects can be used as parameters in both added methods. This made my code much cleaner and it can help others with similar problem.