### PR TITLE
Add method for visualizing Octree

### DIFF
--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -1,5 +1,7 @@
 import {
 	Box3,
+	Box3Helper,
+	Group,
 	Line3,
 	Plane,
 	Sphere,
@@ -129,6 +131,22 @@ class Octree {
 		this.split( 0 );
 
 		return this;
+
+	}
+
+	showTree( currentTree = this.subTrees, group = new Group() ) {
+
+		for ( let i = 0; i < currentTree.length; i ++ ) {
+
+			const box = new Box3Helper( currentTree[ i ].box, 0xffff00 );
+
+			group.add( box );
+
+			this.showTree( currentTree[ i ].subTrees, group );
+
+		}
+
+		return group;
 
 	}
 


### PR DESCRIPTION
I added a method for showing a visual representation of the Octree data structure.

It can be useful for visualizations or debugging purposes.

Usage:
```js
// ...
const drawBoxes = worldOctree.showTree()
scene.add( drawBoxes )
```

![fps_example_show_octree](https://user-images.githubusercontent.com/66022459/153754980-a02a76a0-4b25-4e51-bab9-cd75b0ac0031.png)



