### PR TITLE
Add visual Octree Helper (#23478)

### DIFF
--- a/examples/jsm/helpers/OctreeHelper.js
+++ b/examples/jsm/helpers/OctreeHelper.js
@@ -3,33 +3,35 @@ import { Group, Box3Helper } from 'three';
 
 class OctreeHelper {
 
-	constructor( octree = null, color = 0xffff00 ) {
+  constructor(octree = null, color = 0xffff00) {
 
-		this.subTrees = octree.subTrees;
-		this.color = color;
+    if (!octree) return octree
 
-		this.group = new Group();
-		this.createBoxes = this.traverseTree( this.subTrees, this.group );
+    this.subTrees = octree.subTrees;
+    this.color = color;
 
-		return this.createBoxes;
+    this.group = new Group();
+    this.createBoxes = this.traverseTree(this.subTrees, this.group);
 
-	}
+    return this.createBoxes;
 
-	traverseTree( currentTree, group ) {
+  }
 
-		for ( let i = 0; i < currentTree.length; i ++ ) {
+  traverseTree(currentTree, group) {
 
-			const box = new Box3Helper( currentTree[ i ].box, this.color );
+    for (let i = 0; i < currentTree.length; i++) {
 
-			group.add( box );
+      const box = new Box3Helper(currentTree[i].box, this.color);
 
-			this.traverseTree( currentTree[ i ].subTrees, group );
+      group.add(box);
 
-		}
+      this.traverseTree(currentTree[i].subTrees, group);
 
-		return group;
+    }
 
-	}
+    return group;
+
+  }
 
 }
 

--- a/examples/jsm/helpers/OctreeHelper.js
+++ b/examples/jsm/helpers/OctreeHelper.js
@@ -1,4 +1,3 @@
-
 import {
 	LineSegments,
 	BufferGeometry,

--- a/examples/jsm/helpers/OctreeHelper.js
+++ b/examples/jsm/helpers/OctreeHelper.js
@@ -1,37 +1,58 @@
 
-import { Group, Box3Helper } from 'three';
+import {
+	LineSegments,
+	BufferGeometry,
+	Float32BufferAttribute,
+	LineBasicMaterial
+} from 'three';
 
-class OctreeHelper {
+class OctreeHelper extends LineSegments {
 
-  constructor(octree = null, color = 0xffff00) {
+	constructor( octree, color = 0xffff00 ) {
 
-    if (!octree) return octree
+		const vertices = [];
 
-    this.subTrees = octree.subTrees;
-    this.color = color;
+		function traverse( tree ) {
 
-    this.group = new Group();
-    this.createBoxes = this.traverseTree(this.subTrees, this.group);
+			for ( let i = 0; i < tree.length; i ++ ) {
 
-    return this.createBoxes;
+				const min = tree[ i ].box.min;
+				const max = tree[ i ].box.max;
 
-  }
+				vertices.push( max.x, max.y, max.z ); vertices.push( min.x, max.y, max.z ); // 0, 1
+				vertices.push( min.x, max.y, max.z ); vertices.push( min.x, min.y, max.z ); // 1, 2
+				vertices.push( min.x, min.y, max.z ); vertices.push( max.x, min.y, max.z ); // 2, 3
+				vertices.push( max.x, min.y, max.z ); vertices.push( max.x, max.y, max.z ); // 3, 0
 
-  traverseTree(currentTree, group) {
+				vertices.push( max.x, max.y, min.z ); vertices.push( min.x, max.y, min.z ); // 4, 5
+				vertices.push( min.x, max.y, min.z ); vertices.push( min.x, min.y, min.z ); // 5, 6
+				vertices.push( min.x, min.y, min.z ); vertices.push( max.x, min.y, min.z ); // 6, 7
+				vertices.push( max.x, min.y, min.z ); vertices.push( max.x, max.y, min.z ); // 7, 4
 
-    for (let i = 0; i < currentTree.length; i++) {
+				vertices.push( max.x, max.y, max.z ); vertices.push( max.x, max.y, min.z ); // 0, 4
+				vertices.push( min.x, max.y, max.z ); vertices.push( min.x, max.y, min.z ); // 1, 5
+				vertices.push( min.x, min.y, max.z ); vertices.push( min.x, min.y, min.z ); // 2, 6
+				vertices.push( max.x, min.y, max.z ); vertices.push( max.x, min.y, min.z ); // 3, 7
 
-      const box = new Box3Helper(currentTree[i].box, this.color);
+				traverse( tree[ i ].subTrees );
 
-      group.add(box);
+			}
 
-      this.traverseTree(currentTree[i].subTrees, group);
+		}
 
-    }
+		traverse( octree.subTrees );
 
-    return group;
+		const geometry = new BufferGeometry();
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
-  }
+		super( geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+
+		this.octree = octree;
+		this.color = color;
+
+		this.type = 'OctreeHelper';
+
+	}
 
 }
 

--- a/examples/jsm/helpers/OctreeHelper.js
+++ b/examples/jsm/helpers/OctreeHelper.js
@@ -1,0 +1,36 @@
+
+import { Group, Box3Helper } from 'three';
+
+class OctreeHelper {
+
+	constructor( octree = null, color = 0xffff00 ) {
+
+		this.subTrees = octree.subTrees;
+		this.color = color;
+
+		this.group = new Group();
+		this.createBoxes = this.traverseTree( this.subTrees, this.group );
+
+		return this.createBoxes;
+
+	}
+
+	traverseTree( currentTree, group ) {
+
+		for ( let i = 0; i < currentTree.length; i ++ ) {
+
+			const box = new Box3Helper( currentTree[ i ].box, this.color );
+
+			group.add( box );
+
+			this.traverseTree( currentTree[ i ].subTrees, group );
+
+		}
+
+		return group;
+
+	}
+
+}
+
+export { OctreeHelper };


### PR DESCRIPTION
Simple visual Octree helper for showing a visual representation of the Octree data structure. Reference (#23478)

![fps_example_show_octree](https://user-images.githubusercontent.com/66022459/153754980-a02a76a0-4b25-4e51-bab9-cd75b0ac0031.png)

Usage:
```js
import { Octree } from 'three/examples/jsm/math/Octree.js';
import { OctreeHelper } from 'three/examples/jsm/helpers/OctreeHelper.js'

const octree = new Octree();
octree.fromGraphNode("Your Group or Object3D model here");

const octreeHelper = new OctreeHelper(octree)
scene.add( octreeHelper )
```
Note: OctreeHelper should be instantiated after we call octree.fromGraphNode.

 Let me know if anything can be imporved.