### PR TITLE
Manual: Avoid usage of minimum pixel ratio.

### DIFF
--- a/manual/resources/threejs-lesson-utils.js
+++ b/manual/resources/threejs-lesson-utils.js
@@ -17,7 +17,7 @@ export const threejsLessonUtils = {
       powerPreference: 'low-power',
       ...options.threejsOptions,
     });
-    this.pixelRatio = Math.max(2, window.devicePixelRatio);
+    this.pixelRatio = window.devicePixelRatio;
 
     this.renderer = renderer;
     this.elemToRenderFuncMap = new Map();


### PR DESCRIPTION
Fixed #23474.

**Description**

Avoids the usage of a minimum pixel ratio value. Otherwise the application might end up with too large drawing buffer sizes.
