### PR TITLE
WebGLRenderer: Fixed transmission rendering when using ArrayCamera

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1010,12 +1010,6 @@ function WebGLRenderer( parameters = {} ) {
 
 		if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
 
-		// Ensure depth buffer writing is enabled so it can be cleared on next render
-
-		state.buffers.depth.setTest( true );
-		state.buffers.depth.setMask( true );
-		state.buffers.color.setMask( true );
-
 		state.setPolygonOffset( false );
 
 		// _gl.finish();
@@ -1179,6 +1173,12 @@ function WebGLRenderer( parameters = {} ) {
 		if ( opaqueObjects.length > 0 ) renderObjects( opaqueObjects, scene, camera );
 		if ( transmissiveObjects.length > 0 ) renderObjects( transmissiveObjects, scene, camera );
 		if ( transparentObjects.length > 0 ) renderObjects( transparentObjects, scene, camera );
+
+		// Ensure depth buffer writing is enabled so it can be cleared on next render
+
+		state.buffers.depth.setTest( true );
+		state.buffers.depth.setMask( true );
+		state.buffers.color.setMask( true );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1010,8 +1010,6 @@ function WebGLRenderer( parameters = {} ) {
 
 		if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
 
-		state.setPolygonOffset( false );
-
 		// _gl.finish();
 
 		bindingStates.resetDefaultState();
@@ -1179,6 +1177,8 @@ function WebGLRenderer( parameters = {} ) {
 		state.buffers.depth.setTest( true );
 		state.buffers.depth.setMask( true );
 		state.buffers.color.setMask( true );
+
+		state.setPolygonOffset( false );
 
 	}
 


### PR DESCRIPTION
**Description**

The depth buffer was not writable when rendering the opaque objects for the transmissive pass in the second eye.

| Before | After |
| --- | --- |
| <img width="861" alt="Screen Shot 2022-02-14 at 8 27 53 AM" src="https://user-images.githubusercontent.com/97088/153875311-639d3e22-84ed-47d8-b226-922196e11ce4.png"> | <img width="861" alt="Screen Shot 2022-02-14 at 8 26 43 AM" src="https://user-images.githubusercontent.com/97088/153875346-5e75cd5a-e39f-4828-8bce-3d3b08562442.png"> |
