### PR TITLE
Math: Added Vector3.setFromEuler(); removed Euler.toVector3()

### DIFF
--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -143,15 +143,6 @@
 		Returns an array of the form [[page:.x x], [page:.y y], [page:.z z], [page:.order order ]].
 		</p>
 
-		<h3>[method:Vector3 toVector3]( [param:Vector3 optionalResult] )</h3>
-		<p>
-			[page:Vector3 optionalResult] — (optional) If specified, the result will be copied into this Vector,
-			otherwise a new one will be created. <br /><br />
-
-			Returns the Euler's [page:.x x], [page:.y y] and [page:.z z] properties as a [page:Vector3].
-		</p>
-
-
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -357,6 +357,11 @@
 		<h3>[method:this setFromCylindricalCoords]( [param:Float radius], [param:Float theta], [param:Float y] )</h3>
 		<p>Sets this vector from the cylindrical coordinates [page:Cylindrical radius], [page:Cylindrical theta] and [page:Cylindrical y].</p>
 
+		<h3>[method:this setFromEuler]( [param:Euler euler] )</h3>
+		<p>
+		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] components from the x, y, and z components of the specified [page:Euler Euler Angle].
+		</p>
+
 		<h3>[method:this setFromMatrixColumn]( [param:Matrix4 matrix], [param:Integer index] )</h3>
 		<p>
 		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] components from [page:Integer index] column of [page:Matrix4 matrix].

--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -403,7 +403,7 @@ function SidebarObject( editor ) {
 			}
 
 			const newRotation = new THREE.Euler( objectRotationX.getValue() * THREE.MathUtils.DEG2RAD, objectRotationY.getValue() * THREE.MathUtils.DEG2RAD, objectRotationZ.getValue() * THREE.MathUtils.DEG2RAD );
-			if ( object.rotation.toVector3().distanceTo( newRotation.toVector3() ) >= 0.01 ) {
+			if ( new THREE.Vector3().setFromEuler( object.rotation ).distanceTo( new THREE.Vector3().setFromEuler( newRotation ) ) >= 0.01 ) {
 
 				editor.execute( new SetRotationCommand( editor, object, newRotation ) );
 

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -186,19 +186,13 @@ class CCDIKSolver {
 
 				if ( rotationMin !== undefined ) {
 
-					link.rotation.setFromVector3(
-						link.rotation
-							.toVector3( _vector )
-							.max( rotationMin ) );
+					link.rotation.setFromVector3( _vector.setFromEuler( link.rotation ).max( rotationMin ) );
 
 				}
 
 				if ( rotationMax !== undefined ) {
 
-					link.rotation.setFromVector3(
-						link.rotation
-							.toVector3( _vector )
-							.min( rotationMax ) );
+					link.rotation.setFromVector3( _vector.setFromEuler( link.rotation ).min( rotationMax ) );
 
 				}
 

--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -49,6 +49,7 @@ import { PointsMaterial } from './materials/PointsMaterial.js';
 import { ShaderMaterial } from './materials/ShaderMaterial.js';
 import { Box2 } from './math/Box2.js';
 import { Box3 } from './math/Box3.js';
+import { Euler } from './math/Euler.js';
 import { Sphere } from './math/Sphere.js';
 import { Color } from './math/Color.js';
 import { Frustum } from './math/Frustum.js';
@@ -398,6 +399,15 @@ Box3.prototype.size = function ( optionalTarget ) {
 	return this.getSize( optionalTarget );
 
 };
+
+//
+
+Euler.prototype.toVector3 = function () {
+
+	console.error( 'THREE.Euler: .toVector3() has been removed. Use Vector3.setFromEuler() instead' );
+
+};
+
 
 //
 

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -1,5 +1,4 @@
 import { Quaternion } from './Quaternion.js';
-import { Vector3 } from './Vector3.js';
 import { Matrix4 } from './Matrix4.js';
 import { clamp } from './MathUtils.js';
 
@@ -285,20 +284,6 @@ class Euler {
 		array[ offset + 3 ] = this._order;
 
 		return array;
-
-	}
-
-	toVector3( optionalResult ) {
-
-		if ( optionalResult ) {
-
-			return optionalResult.set( this._x, this._y, this._z );
-
-		} else {
-
-			return new Vector3( this._x, this._y, this._z );
-
-		}
 
 	}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -659,6 +659,16 @@ class Vector3 {
 
 	}
 
+	setFromEuler( e ) {
+
+		this.x = e._x;
+		this.y = e._y;
+		this.z = e._z;
+
+		return this;
+
+	}
+
 	equals( v ) {
 
 		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -200,25 +200,6 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'set/setFromVector3/toVector3', ( assert ) => {
-
-			var a = new Euler();
-
-			a.set( 0, 1, 0, 'ZYX' );
-			assert.ok( a.equals( eulerAzyx ), 'Passed!' );
-			assert.ok( ! a.equals( eulerAxyz ), 'Passed!' );
-			assert.ok( ! a.equals( eulerZero ), 'Passed!' );
-
-			var vec = new Vector3( 0, 1, 0 );
-
-			var b = new Euler().setFromVector3( vec, 'ZYX' );
-			assert.ok( a.equals( b ), 'Passed!' );
-
-			var c = b.toVector3();
-			assert.ok( c.equals( vec ), 'Passed!' );
-
-		} );
-
 		QUnit.test( 'clone/copy/equals', ( assert ) => {
 
 			var a = eulerAxyz.clone();


### PR DESCRIPTION
This new method parallels the existing `Vector3.setFrom*()` methods.

Similarly, `Euler.setFromVector3()`.

We also avoid "optional targets" in core. This should have been fixed previously; it was just missed.

