### PR TITLE
Test: Update qunit to solve Windows failure.

### DIFF
--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -13,7 +13,7 @@
         "jimp": "^0.16.1",
         "pixelmatch": "^5.2.1",
         "puppeteer": "^13.1.2",
-        "qunit": "^2.17.2",
+        "qunit": "^2.18.0",
         "serve-handler": "^6.1.3"
       }
     },
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/node-watch": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.2.tgz",
-      "integrity": "sha512-g53VjSARRv1JdST0LZRIg8RiuLr1TaBbVPsVvxh0/0Ymvi0xYUjDuoqQQAWtHJQUXhiShowPT/aXKNeHBcyQsw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1382,13 +1382,13 @@
       }
     },
     "node_modules/qunit": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.17.2.tgz",
-      "integrity": "sha512-17isVvuOmALzsPjiV7wFg/6O5vJYXBrQZPwocfQSSh0I/rXvfX7bKMFJ4GMVW3U4P8r2mBeUy8EAngti4QD2Vw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.18.0.tgz",
+      "integrity": "sha512-Xw/zUm5t1JY8SNErki/qtw4fCuaaOZL+bPloZU+0kto+fO8j1JV9MQWqXO4kATfhEyJohlsKZpfg1HF7GOkpXw==",
       "dev": true,
       "dependencies": {
         "commander": "7.2.0",
-        "node-watch": "0.7.2",
+        "node-watch": "0.7.3",
         "tiny-glob": "0.2.9"
       },
       "bin": {
@@ -2563,9 +2563,9 @@
       }
     },
     "node-watch": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.2.tgz",
-      "integrity": "sha512-g53VjSARRv1JdST0LZRIg8RiuLr1TaBbVPsVvxh0/0Ymvi0xYUjDuoqQQAWtHJQUXhiShowPT/aXKNeHBcyQsw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
       "dev": true
     },
     "omggif": {
@@ -2764,13 +2764,13 @@
       }
     },
     "qunit": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.17.2.tgz",
-      "integrity": "sha512-17isVvuOmALzsPjiV7wFg/6O5vJYXBrQZPwocfQSSh0I/rXvfX7bKMFJ4GMVW3U4P8r2mBeUy8EAngti4QD2Vw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.18.0.tgz",
+      "integrity": "sha512-Xw/zUm5t1JY8SNErki/qtw4fCuaaOZL+bPloZU+0kto+fO8j1JV9MQWqXO4kATfhEyJohlsKZpfg1HF7GOkpXw==",
       "dev": true,
       "requires": {
         "commander": "7.2.0",
-        "node-watch": "0.7.2",
+        "node-watch": "0.7.3",
         "tiny-glob": "0.2.9"
       }
     },

--- a/test/package.json
+++ b/test/package.json
@@ -13,7 +13,7 @@
     "jimp": "^0.16.1",
     "pixelmatch": "^5.2.1",
     "puppeteer": "^13.1.2",
-    "qunit": "^2.17.2",
+    "qunit": "^2.18.0",
     "serve-handler": "^6.1.3"
   }
 }


### PR DESCRIPTION
Fixed #23424.

**Description**

The latest qunit release fixed the Windows import issue with ESM modules (see https://github.com/qunitjs/qunit/pull/1675).
