### PR TITLE
PMREMGenerator: Set RenderTargets minFilter to NearestFilter only in the blur pass

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -250,7 +250,7 @@ class PMREMGenerator {
 
 		const params = {
 			magFilter: LinearFilter,
-			minFilter: NearestFilter,
+			minFilter: LinearFilter,
 			generateMipmaps: false,
 			type: HalfFloatType,
 			format: RGBAFormat,
@@ -454,6 +454,9 @@ class PMREMGenerator {
 
 		const pingPongRenderTarget = this._pingPongRenderTarget;
 
+		cubeUVRenderTarget.texture.minFilter = NearestFilter;
+		pingPongRenderTarget.texture.minFilter = NearestFilter;
+
 		this._halfBlur(
 			cubeUVRenderTarget,
 			pingPongRenderTarget,
@@ -471,6 +474,9 @@ class PMREMGenerator {
 			sigma,
 			'longitudinal',
 			poleAxis );
+
+		cubeUVRenderTarget.texture.minFilter = LinearFilter;
+		pingPongRenderTarget.texture.minFilter = LinearFilter;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23468#issuecomment-1042725753

**Description**

Setting `minFilter` to NearestFilter produced darker render. This sets it only during the blur pass.

I'll merge but I'll also check with the nvidia users to make sure this workaround works for them.