### PR TITLE
Docs: Add pages for new render targets.

### DIFF
--- a/docs/api/en/renderers/WebGL3DRenderTarget.html
+++ b/docs/api/en/renderers/WebGL3DRenderTarget.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:WebGLRenderTarget] &rarr;
+
+		<h1>[name]</h1>
+
+		<p class="desc">
+			Represents a three-dimensional render target.
+		</p>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]( [param:Number width], [param:Number height], [param:Number depth] )</h3>
+		<p>
+		[page:Number width] - the width of the render target, in pixels.<br />
+		[page:Number height] - the height of the render target, in pixels.<br />
+		[page:Number depth] - the depth of the render target.<br /><br />
+
+		Creates a new [name].
+		</p>
+
+		<h2>Properties</h2>
+
+		<h3>See [page:WebGLRenderTarget] for inherited properties</h3>
+
+		<h3>[property:number depth]</h3>
+		<p>
+		The depth of the render target.
+		</p>
+
+		<h3>[property:Data3DTexture texture]</h3>
+		<p>
+		The texture property is overwritten with an instance of [page:Data3DTexture].
+		</p>
+
+		<h2>Methods</h2>
+
+		<h3>See [page:WebGLRenderTarget] for inherited methods</h3>
+
+		<h2>Source</h2>
+
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		</p>
+	</body>
+</html>

--- a/docs/api/en/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/en/renderers/WebGLArrayRenderTarget.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:WebGLRenderTarget] &rarr;
+
+		<h1>[name]</h1>
+
+		<p class="desc">
+			This type of render target represents an array of textures.
+		</p>
+
+		<h2>Examples</h2>
+
+		<p>
+			[example:webgl2_rendertarget_texture2darray WebGL 2 / render target / array]<br />
+		</p>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]( [param:Number width], [param:Number height], [param:Number depth] )</h3>
+		<p>
+		[page:Number width] - the width of the render target, in pixels.<br />
+		[page:Number height] - the height of the render target, in pixels.<br />
+		[page:Number depth] - the depth/layer count of the render target.<br /><br />
+
+		Creates a new [name].
+		</p>
+
+		<h2>Properties</h2>
+
+		<h3>See [page:WebGLRenderTarget] for inherited properties</h3>
+
+		<h3>[property:number depth]</h3>
+		<p>
+		The depth of the render target.
+		</p>
+
+		<h3>[property:DataArrayTexture texture]</h3>
+		<p>
+		The texture property is overwritten with an instance of [page:DataArrayTexture].
+		</p>
+
+		<h2>Methods</h2>
+
+		<h3>See [page:WebGLRenderTarget] for inherited methods</h3>
+
+		<h2>Source</h2>
+
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
+		</p>
+	</body>
+</html>

--- a/docs/list.json
+++ b/docs/list.json
@@ -286,6 +286,8 @@
 				"WebGLRenderer": "api/en/renderers/WebGLRenderer",
 				"WebGL1Renderer": "api/en/renderers/WebGL1Renderer",
 				"WebGLRenderTarget": "api/en/renderers/WebGLRenderTarget",
+				"WebGL3DRenderTarget": "api/en/renderers/WebGL3DRenderTarget",
+				"WebGLArrayRenderTarget": "api/en/renderers/WebGLArrayRenderTarget",
 				"WebGLCubeRenderTarget": "api/en/renderers/WebGLCubeRenderTarget"
 			},
 


### PR DESCRIPTION
Related issue: #23498

**Description**

Adds the doc pages for `WebGL3DRenderTarget` and `WebGLArrayRenderTarget`.
