### PR TITLE
PointerLockControls: Add `.pointerSpeed`.

### DIFF
--- a/docs/examples/en/controls/PointerLockControls.html
+++ b/docs/examples/en/controls/PointerLockControls.html
@@ -96,6 +96,11 @@
 			Camera pitch, lower limit. Range is 0 to Math.PI radians. Default is 0.
 		</p>
 
+		<h3>[property:Float pointerSpeed]</h3>
+		<p>
+			Multiplier for how much the pointer movement influences the camera rotation. Default is 1.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>

--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -18,7 +18,7 @@
 
 	class PointerLockControls extends THREE.EventDispatcher {
 
-		constructor( camera, domElement, options = {} ) {
+		constructor( camera, domElement ) {
 
 			super();
 
@@ -37,7 +37,7 @@
 
 			this.maxPolarAngle = Math.PI; // radians
 
-			this.mouseSpeed = options.mouseSpeed || 0.002;
+			this.mouseSpeed = 1.0;
 
 			const scope = this;
 
@@ -49,8 +49,8 @@
 
 				_euler.setFromQuaternion( camera.quaternion );
 
-				_euler.y -= movementX * scope.mouseSpeed;
-				_euler.x -= movementY * scope.mouseSpeed;
+				_euler.y -= movementX * 0.002 * scope.mouseSpeed;
+				_euler.x -= movementY * 0.002 * scope.mouseSpeed;
 				_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 				camera.quaternion.setFromEuler( _euler );
 				scope.dispatchEvent( _changeEvent );

--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -37,7 +37,7 @@
 
 			this.maxPolarAngle = Math.PI; // radians
 
-			this.mouseSpeed = 1.0;
+			this.pointerSpeed = 1.0;
 
 			const scope = this;
 
@@ -49,8 +49,8 @@
 
 				_euler.setFromQuaternion( camera.quaternion );
 
-				_euler.y -= movementX * 0.002 * scope.mouseSpeed;
-				_euler.x -= movementY * 0.002 * scope.mouseSpeed;
+				_euler.y -= movementX * 0.002 * scope.pointerSpeed;
+				_euler.x -= movementY * 0.002 * scope.pointerSpeed;
 				_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 				camera.quaternion.setFromEuler( _euler );
 				scope.dispatchEvent( _changeEvent );

--- a/examples/js/controls/PointerLockControls.js
+++ b/examples/js/controls/PointerLockControls.js
@@ -18,7 +18,7 @@
 
 	class PointerLockControls extends THREE.EventDispatcher {
 
-		constructor( camera, domElement ) {
+		constructor( camera, domElement, options = {} ) {
 
 			super();
 
@@ -37,6 +37,8 @@
 
 			this.maxPolarAngle = Math.PI; // radians
 
+			this.mouseSpeed = options.mouseSpeed || 0.002;
+
 			const scope = this;
 
 			function onMouseMove( event ) {
@@ -47,8 +49,8 @@
 
 				_euler.setFromQuaternion( camera.quaternion );
 
-				_euler.y -= movementX * 0.002;
-				_euler.x -= movementY * 0.002;
+				_euler.y -= movementX * scope.mouseSpeed;
+				_euler.x -= movementY * scope.mouseSpeed;
 				_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 				camera.quaternion.setFromEuler( _euler );
 				scope.dispatchEvent( _changeEvent );

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -15,7 +15,7 @@ const _PI_2 = Math.PI / 2;
 
 class PointerLockControls extends EventDispatcher {
 
-	constructor( camera, domElement ) {
+	constructor( camera, domElement, options = {} ) {
 
 		super();
 
@@ -34,6 +34,8 @@ class PointerLockControls extends EventDispatcher {
 		this.minPolarAngle = 0; // radians
 		this.maxPolarAngle = Math.PI; // radians
 
+		this.mouseSpeed = options.mouseSpeed || 0.002;
+
 		const scope = this;
 
 		function onMouseMove( event ) {
@@ -45,8 +47,8 @@ class PointerLockControls extends EventDispatcher {
 
 			_euler.setFromQuaternion( camera.quaternion );
 
-			_euler.y -= movementX * 0.002;
-			_euler.x -= movementY * 0.002;
+			_euler.y -= movementX * scope.mouseSpeed;
+			_euler.x -= movementY * scope.mouseSpeed;
 
 			_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -34,7 +34,7 @@ class PointerLockControls extends EventDispatcher {
 		this.minPolarAngle = 0; // radians
 		this.maxPolarAngle = Math.PI; // radians
 
-		this.mouseSpeed = 1.0;
+		this.pointerSpeed = 1.0;
 
 		const scope = this;
 
@@ -47,8 +47,8 @@ class PointerLockControls extends EventDispatcher {
 
 			_euler.setFromQuaternion( camera.quaternion );
 
-			_euler.y -= movementX * 0.002 * scope.mouseSpeed;
-			_euler.x -= movementY * 0.002 * scope.mouseSpeed;
+			_euler.y -= movementX * 0.002 * scope.pointerSpeed;
+			_euler.x -= movementY * 0.002 * scope.pointerSpeed;
 
 			_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -15,7 +15,7 @@ const _PI_2 = Math.PI / 2;
 
 class PointerLockControls extends EventDispatcher {
 
-	constructor( camera, domElement, options = {} ) {
+	constructor( camera, domElement ) {
 
 		super();
 
@@ -34,7 +34,7 @@ class PointerLockControls extends EventDispatcher {
 		this.minPolarAngle = 0; // radians
 		this.maxPolarAngle = Math.PI; // radians
 
-		this.mouseSpeed = options.mouseSpeed || 0.002;
+		this.mouseSpeed = 1.0;
 
 		const scope = this;
 
@@ -47,8 +47,8 @@ class PointerLockControls extends EventDispatcher {
 
 			_euler.setFromQuaternion( camera.quaternion );
 
-			_euler.y -= movementX * scope.mouseSpeed;
-			_euler.x -= movementY * scope.mouseSpeed;
+			_euler.y -= movementX * 0.002 * scope.mouseSpeed;
+			_euler.x -= movementY * 0.002 * scope.mouseSpeed;
 
 			_euler.x = Math.max( _PI_2 - scope.maxPolarAngle, Math.min( _PI_2 - scope.minPolarAngle, _euler.x ) );
 


### PR DESCRIPTION
Related issue: #23513

**Description**

This PR adds a new `mouseSpeed` property to `PointerLockControls`. Changing this property changes the mouse sensitivity for controlling the camera look direction. The PR also adds a new optional `options` parameter to the constructor for setting `mouseSpeed` when a new `PointerLockControls` instance is made.

<!-- Remove the line below if is not relevant -->
