### PR TITLE
PMREMGenerator: Revert NearestFilter change.

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -4,7 +4,6 @@ import {
 	CubeUVReflectionMapping,
 	LinearEncoding,
 	LinearFilter,
-	NearestFilter,
 	NoToneMapping,
 	NoBlending,
 	RGBAFormat,
@@ -216,7 +215,6 @@ class PMREMGenerator {
 	_cleanup( outputTarget ) {
 
 		this._renderer.setRenderTarget( _oldTarget );
-		outputTarget.scissorTest = false;
 		_setViewport( outputTarget, 0, 0, outputTarget.width, outputTarget.height );
 
 	}
@@ -454,9 +452,6 @@ class PMREMGenerator {
 
 		const pingPongRenderTarget = this._pingPongRenderTarget;
 
-		cubeUVRenderTarget.texture.minFilter = NearestFilter;
-		pingPongRenderTarget.texture.minFilter = NearestFilter;
-
 		this._halfBlur(
 			cubeUVRenderTarget,
 			pingPongRenderTarget,
@@ -474,9 +469,6 @@ class PMREMGenerator {
 			sigma,
 			'longitudinal',
 			poleAxis );
-
-		cubeUVRenderTarget.texture.minFilter = LinearFilter;
-		pingPongRenderTarget.texture.minFilter = LinearFilter;
 
 	}
 
@@ -652,7 +644,6 @@ function _createRenderTarget( width, height, params ) {
 	const cubeUVRenderTarget = new WebGLRenderTarget( width, height, params );
 	cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
 	cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
-	cubeUVRenderTarget.scissorTest = true;
 	return cubeUVRenderTarget;
 
 }
@@ -660,7 +651,6 @@ function _createRenderTarget( width, height, params ) {
 function _setViewport( target, x, y, width, height ) {
 
 	target.viewport.set( x, y, width, height );
-	target.scissor.set( x, y, width, height );
 
 }
 


### PR DESCRIPTION
Related issue: #17855 #23468 #23511

**Description**

I couldn't stop thinking about this and while having lunch I realized I could easily "reproduce" the problem by setting `anisotropy: 16` in the PMREM render target.

Sure enough:

<img width="969" alt="Screen Shot 2022-02-17 at 6 09 47 PM" src="https://user-images.githubusercontent.com/97088/154587036-c81821a8-ee77-4d53-bdc0-947b87f041e9.png">

What I learned:

1. [_textureToCubeUV](https://github.com/mrdoob/three.js/blob/85557d8ae7b1c3cf733e675d3ece5cb6b0d11609/src/extras/PMREMGenerator.js#L379-L424) is not affected.

2. [_applyPMREM](https://github.com/mrdoob/three.js/blob/85557d8ae7b1c3cf733e675d3ece5cb6b0d11609/src/extras/PMREMGenerator.js#L426-L444) is affected:
<img width="969" alt="Screen Shot 2022-02-17 at 6 15 29 PM" src="https://user-images.githubusercontent.com/97088/154587663-58215a88-01d0-43e4-8669-6f6ddbd9a47b.png">

3. Even if we skip [_applyPMREM](https://github.com/mrdoob/three.js/blob/85557d8ae7b1c3cf733e675d3ece5cb6b0d11609/src/extras/PMREMGenerator.js#L239) we get seams:
<img width="969" alt="Screen Shot 2022-02-17 at 6 19 23 PM" src="https://user-images.githubusercontent.com/97088/154587974-36bd555d-377b-4212-83f9-32360a2068fd.png">

4. The`minFilter: NearestFilter` workaround doesn't fully remove the seams:

<img width="967" alt="Screen Shot 2022-02-17 at 6 23 04 PM" src="https://user-images.githubusercontent.com/97088/154588369-f6ed256c-46e9-4227-ab2d-035dcadd65c7.png">

So the problem doesn't only affect the PMREM atlas but also the sampling from the material shader plus we get [different renders](https://github.com/mrdoob/three.js/pull/23511#issuecomment-1043327731).

**After playing with all this for a while I'm starting to believe we should not add a workaround for this and consider this a "user error" unless someone can prove that the NVIDIA panel come with that override anisotropy setting enabled by default.**


PS: @elalish Are you confident that the `scissorTest` and `scissor()` calls are needed? I didn't see any change by removing them.