### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -327,9 +327,9 @@
 
 			const hash = location.hash;
 			if ( hash === '' ) return;
-			const docType = hash.substr( 0, hash.indexOf( '/' ) + 1 );
-			let docLink = hash.substr( hash.indexOf( '/' ) + 1 );
-			docLink = docLink.substr( docLink.indexOf( '/' ) );
+			const docType = hash.slice( 0, hash.indexOf( '/' ) + 1 );
+			let docLink = hash.slice( hash.indexOf( '/' ) + 1 );
+			docLink = docLink.slice( docLink.indexOf( '/' ) );
 			location.href = docType + language + docLink;
 
 		}
@@ -342,7 +342,7 @@
 
 			if ( search.indexOf( '?q=' ) !== - 1 ) {
 
-				return decodeURI( search.substr( 3 ) );
+				return decodeURI( search.slice( 3 ) );
 
 			}
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -6,7 +6,7 @@ if ( ! window.frameElement && window.location.protocol !== 'file:' ) {
 
 	let href = window.location.href;
 	const splitIndex = href.lastIndexOf( '/docs/' ) + 6;
-	const docsBaseURL = href.substr( 0, splitIndex );
+	const docsBaseURL = href.slice( 0, splitIndex );
 
 	let hash = window.location.hash;
 
@@ -36,7 +36,7 @@ function onDocumentLoad() {
 	switch ( section ) {
 
 		case 'api':
-			localizedPath = /\/api\/[A-Za-z0-9\/]+/.exec( pathname ).toString().substr( 5 );
+			localizedPath = /\/api\/[A-Za-z0-9\/]+/.exec( pathname ).toString().slice( 5 );
 
 			// Remove localized part of the path (e.g. 'en/' or 'es-MX/'):
 			path = localizedPath.replace( /^[A-Za-z0-9-]+\//, '' );
@@ -44,14 +44,14 @@ function onDocumentLoad() {
 			break;
 
 		case 'examples':
-			path = localizedPath = /\/examples\/[A-Za-z0-9\/]+/.exec( pathname ).toString().substr( 10 );
+			path = localizedPath = /\/examples\/[A-Za-z0-9\/]+/.exec( pathname ).toString().slice( 10 );
 			break;
 
 		case 'manual':
 			name = name.replace( /\-/g, ' ' );
 
 			path = pathname.replace( /\ /g, '-' );
-			path = localizedPath = /\/manual\/[-A-Za-z0-9\/]+/.exec( path ).toString().substr( 8 );
+			path = localizedPath = /\/manual\/[-A-Za-z0-9\/]+/.exec( path ).toString().slice( 8 );
 			break;
 
 	}

--- a/editor/index.html
+++ b/editor/index.html
@@ -223,9 +223,9 @@
 			var isLoadingFromHash = false;
 			var hash = window.location.hash;
 
-			if ( hash.substr( 1, 5 ) === 'file=' ) {
+			if ( hash.slice( 1, 6 ) === 'file=' ) {
 
-				var file = hash.substr( 6 );
+				var file = hash.slice( 6 );
 
 				if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
 

--- a/editor/js/LoaderUtils.js
+++ b/editor/js/LoaderUtils.js
@@ -60,7 +60,7 @@ const LoaderUtils = {
 
 					files.push( file );
 
-					filesMap[ entry.fullPath.substr( 1 ) ] = file;
+					filesMap[ entry.fullPath.slice( 1 ) ] = file;
 					onEntryHandled();
 
 				} );

--- a/examples/index.html
+++ b/examples/index.html
@@ -381,7 +381,7 @@
 
 			if ( search.indexOf( '?q=' ) !== - 1 ) {
 
-				return decodeURI( search.substr( 3 ) );
+				return decodeURI( search.slice( 3 ) );
 
 			}
 

--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1352,7 +1352,7 @@
 			for ( let attributeName in geometry.attributes ) {
 
 				// Ignore morph target attributes, which are exported later.
-				if ( attributeName.substr( 0, 5 ) === 'morph' ) continue;
+				if ( attributeName.slice( 0, 5 ) === 'morph' ) continue;
 				const attribute = geometry.attributes[ attributeName ];
 				attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase(); // Prefix all geometry attributes except the ones specifically
 				// listed in the spec; non-spec attributes are considered custom.

--- a/examples/js/loaders/ColladaLoader.js
+++ b/examples/js/loaders/ColladaLoader.js
@@ -2805,7 +2805,7 @@
 							const param = child.getElementsByTagName( 'param' )[ 0 ];
 							data.axis = param.textContent;
 							const tmpJointIndex = data.axis.split( 'inst_' ).pop().split( 'axis' )[ 0 ];
-							data.jointIndex = tmpJointIndex.substr( 0, tmpJointIndex.length - 1 );
+							data.jointIndex = tmpJointIndex.substring( 0, tmpJointIndex.length - 1 );
 							break;
 
 					}

--- a/examples/js/loaders/KMZLoader.js
+++ b/examples/js/loaders/KMZLoader.js
@@ -48,7 +48,7 @@
 
 				for ( const path in zip ) {
 
-					if ( path.substr( - url.length ) === url ) {
+					if ( path.slice( - url.length ) === url ) {
 
 						return zip[ path ];
 

--- a/examples/js/loaders/LWOLoader.js
+++ b/examples/js/loaders/LWOLoader.js
@@ -955,7 +955,7 @@
 
 		const index = url.indexOf( dir );
 		if ( index === - 1 ) return './';
-		return url.substr( 0, index );
+		return url.slice( 0, index );
 
 	}
 

--- a/examples/js/loaders/OBJLoader.js
+++ b/examples/js/loaders/OBJLoader.js
@@ -491,7 +491,7 @@
 
 				} else if ( lineFirstChar === 'f' ) {
 
-					const lineData = line.substr( 1 ).trim();
+					const lineData = line.slice( 1 ).trim();
 					const vertexData = lineData.split( /\s+/ );
 					const faceVertices = []; // Parse the face vertex data into an easy to work with format
 
@@ -545,7 +545,7 @@
 
 				} else if ( lineFirstChar === 'p' ) {
 
-					const lineData = line.substr( 1 ).trim();
+					const lineData = line.slice( 1 ).trim();
 					const pointData = lineData.split( ' ' );
 					state.addPointGeometry( pointData );
 
@@ -555,8 +555,8 @@
 					// or
 					// g group_name
 					// WORKAROUND: https://bugs.chromium.org/p/v8/issues/detail?id=2869
-					// let name = result[ 0 ].substr( 1 ).trim();
-					const name = ( ' ' + result[ 0 ].substr( 1 ).trim() ).substr( 1 );
+					// let name = result[ 0 ].slice( 1 ).trim();
+					const name = ( ' ' + result[ 0 ].slice( 1 ).trim() ).slice( 1 );
 					state.startObject( name );
 
 				} else if ( _material_use_pattern.test( line ) ) {

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -108,10 +108,10 @@
 
 				const PCDheader = {};
 				const result1 = data.search( /[\r\n]DATA\s(\S*)\s/i );
-				const result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.substr( result1 - 1 ) );
+				const result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.slice( result1 - 1 ) );
 				PCDheader.data = result2[ 1 ];
 				PCDheader.headerLen = result2[ 0 ].length + result1;
-				PCDheader.str = data.substr( 0, PCDheader.headerLen ); // remove comments
+				PCDheader.str = data.slice( 0, PCDheader.headerLen ); // remove comments
 
 				PCDheader.str = PCDheader.str.replace( /\#.*/gi, '' ); // parse
 
@@ -199,7 +199,7 @@
 			if ( PCDheader.data === 'ascii' ) {
 
 				const offset = PCDheader.offset;
-				const pcdData = textData.substr( PCDheader.headerLen );
+				const pcdData = textData.slice( PCDheader.headerLen );
 				const lines = pcdData.split( '\n' );
 
 				for ( let i = 0, l = lines.length; i < l; i ++ ) {

--- a/examples/js/loaders/PDBLoader.js
+++ b/examples/js/loaders/PDBLoader.js
@@ -52,7 +52,7 @@
 
 			function capitalize( text ) {
 
-				return text.charAt( 0 ).toUpperCase() + text.substr( 1 ).toLowerCase();
+				return text.charAt( 0 ).toUpperCase() + text.slice( 1 ).toLowerCase();
 
 			}
 
@@ -64,7 +64,7 @@
 
 			function parseBond( start, length, satom, i ) {
 
-				const eatom = parseInt( lines[ i ].substr( start, length ) );
+				const eatom = parseInt( lines[ i ].slice( start, start + length ) );
 
 				if ( eatom ) {
 
@@ -271,17 +271,17 @@
 
 			for ( let i = 0, l = lines.length; i < l; i ++ ) {
 
-				if ( lines[ i ].substr( 0, 4 ) === 'ATOM' || lines[ i ].substr( 0, 6 ) === 'HETATM' ) {
+				if ( lines[ i ].slice( 0, 4 ) === 'ATOM' || lines[ i ].slice( 0, 6 ) === 'HETATM' ) {
 
-					const x = parseFloat( lines[ i ].substr( 30, 7 ) );
-					const y = parseFloat( lines[ i ].substr( 38, 7 ) );
-					const z = parseFloat( lines[ i ].substr( 46, 7 ) );
-					const index = parseInt( lines[ i ].substr( 6, 5 ) ) - 1;
-					let e = trim( lines[ i ].substr( 76, 2 ) ).toLowerCase();
+					const x = parseFloat( lines[ i ].slice( 30, 37 ) );
+					const y = parseFloat( lines[ i ].slice( 38, 45 ) );
+					const z = parseFloat( lines[ i ].slice( 46, 53 ) );
+					const index = parseInt( lines[ i ].slice( 6, 11 ) ) - 1;
+					let e = trim( lines[ i ].slice( 76, 78 ) ).toLowerCase();
 
 					if ( e === '' ) {
 
-						e = trim( lines[ i ].substr( 12, 2 ) ).toLowerCase();
+						e = trim( lines[ i ].slice( 12, 14 ) ).toLowerCase();
 
 					}
 
@@ -289,9 +289,9 @@
 					atoms.push( atomData );
 					_atomMap[ index ] = atomData;
 
-				} else if ( lines[ i ].substr( 0, 6 ) === 'CONECT' ) {
+				} else if ( lines[ i ].slice( 0, 6 ) === 'CONECT' ) {
 
-					const satom = parseInt( lines[ i ].substr( 6, 5 ) );
+					const satom = parseInt( lines[ i ].slice( 6, 11 ) );
 					parseBond( 11, 5, satom, i );
 					parseBond( 16, 5, satom, i );
 					parseBond( 21, 5, satom, i );

--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -193,7 +193,7 @@
 
 					const command = commands[ i ];
 					const type = command.charAt( 0 );
-					const data = command.substr( 1 ).trim();
+					const data = command.slice( 1 ).trim();
 
 					if ( isFirstPoint === true ) {
 
@@ -1261,8 +1261,8 @@
 
 						if ( openParPos > 0 && openParPos < closeParPos ) {
 
-							const transformType = transformText.substr( 0, openParPos );
-							const array = parseFloats( transformText.substr( openParPos + 1, closeParPos - openParPos - 1 ) );
+							const transformType = transformText.slice( 0, openParPos );
+							const array = parseFloats( transformText.slice( openParPos + 1 ) );
 							currentTransform.identity();
 
 							switch ( transformType ) {

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1467,7 +1467,7 @@ class GLTFWriter {
 		for ( let attributeName in geometry.attributes ) {
 
 			// Ignore morph target attributes, which are exported later.
-			if ( attributeName.substr( 0, 5 ) === 'morph' ) continue;
+			if ( attributeName.slice( 0, 5 ) === 'morph' ) continue;
 
 			const attribute = geometry.attributes[ attributeName ];
 			attributeName = nameConversion[ attributeName ] || attributeName.toUpperCase();

--- a/examples/jsm/libs/flow.module.js
+++ b/examples/jsm/libs/flow.module.js
@@ -2873,7 +2873,7 @@ class ColorInput extends Input {
 
 	getValue() {
 
-		return parseInt( super.getValue().substr( 1 ), 16 );
+		return parseInt( super.getValue().slice( 1 ), 16 );
 
 	}
 

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -101,7 +101,7 @@ class AMFLoader extends Loader {
 
 				for ( file in zip ) {
 
-					if ( file.toLowerCase().substr( - 4 ) === '.amf' ) {
+					if ( file.toLowerCase().slice( - 4 ) === '.amf' ) {
 
 						break;
 

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -3001,7 +3001,7 @@ class ColladaLoader extends Loader {
 						const param = child.getElementsByTagName( 'param' )[ 0 ];
 						data.axis = param.textContent;
 						const tmpJointIndex = data.axis.split( 'inst_' ).pop().split( 'axis' )[ 0 ];
-						data.jointIndex = tmpJointIndex.substr( 0, tmpJointIndex.length - 1 );
+						data.jointIndex = tmpJointIndex.substring( 0, tmpJointIndex.length - 1 );
 						break;
 
 				}

--- a/examples/jsm/loaders/KMZLoader.js
+++ b/examples/jsm/loaders/KMZLoader.js
@@ -56,7 +56,7 @@ class KMZLoader extends Loader {
 
 			for ( const path in zip ) {
 
-				if ( path.substr( - url.length ) === url ) {
+				if ( path.slice( - url.length ) === url ) {
 
 					return zip[ path ];
 

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -1060,7 +1060,7 @@ function extractParentUrl( url, dir ) {
 
 	if ( index === - 1 ) return './';
 
-	return url.substr( 0, index );
+	return url.slice( 0, index );
 
 }
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -574,7 +574,7 @@ class OBJLoader extends Loader {
 
 			} else if ( lineFirstChar === 'f' ) {
 
-				const lineData = line.substr( 1 ).trim();
+				const lineData = line.slice( 1 ).trim();
 				const vertexData = lineData.split( /\s+/ );
 				const faceVertices = [];
 
@@ -637,7 +637,7 @@ class OBJLoader extends Loader {
 
 			} else if ( lineFirstChar === 'p' ) {
 
-				const lineData = line.substr( 1 ).trim();
+				const lineData = line.slice( 1 ).trim();
 				const pointData = lineData.split( ' ' );
 
 				state.addPointGeometry( pointData );
@@ -649,8 +649,8 @@ class OBJLoader extends Loader {
 				// g group_name
 
 				// WORKAROUND: https://bugs.chromium.org/p/v8/issues/detail?id=2869
-				// let name = result[ 0 ].substr( 1 ).trim();
-				const name = ( ' ' + result[ 0 ].substr( 1 ).trim() ).substr( 1 );
+				// let name = result[ 0 ].slice( 1 ).trim();
+				const name = ( ' ' + result[ 0 ].slice( 1 ).trim() ).slice( 1 );
 
 				state.startObject( name );
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -114,11 +114,11 @@ class PCDLoader extends Loader {
 
 			const PCDheader = {};
 			const result1 = data.search( /[\r\n]DATA\s(\S*)\s/i );
-			const result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.substr( result1 - 1 ) );
+			const result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.slice( result1 - 1 ) );
 
 			PCDheader.data = result2[ 1 ];
 			PCDheader.headerLen = result2[ 0 ].length + result1;
-			PCDheader.str = data.substr( 0, PCDheader.headerLen );
+			PCDheader.str = data.slice( 0, PCDheader.headerLen );
 
 			// remove comments
 
@@ -235,7 +235,7 @@ class PCDLoader extends Loader {
 		if ( PCDheader.data === 'ascii' ) {
 
 			const offset = PCDheader.offset;
-			const pcdData = textData.substr( PCDheader.headerLen );
+			const pcdData = textData.slice( PCDheader.headerLen );
 			const lines = pcdData.split( '\n' );
 
 			for ( let i = 0, l = lines.length; i < l; i ++ ) {

--- a/examples/jsm/loaders/PDBLoader.js
+++ b/examples/jsm/loaders/PDBLoader.js
@@ -59,7 +59,7 @@ class PDBLoader extends Loader {
 
 		function capitalize( text ) {
 
-			return text.charAt( 0 ).toUpperCase() + text.substr( 1 ).toLowerCase();
+			return text.charAt( 0 ).toUpperCase() + text.slice( 1 ).toLowerCase();
 
 		}
 
@@ -71,7 +71,7 @@ class PDBLoader extends Loader {
 
 		function parseBond( start, length, satom, i ) {
 
-			const eatom = parseInt( lines[ i ].substr( start, length ) );
+			const eatom = parseInt( lines[ i ].slice( start, start + length ) );
 
 			if ( eatom ) {
 
@@ -183,18 +183,18 @@ class PDBLoader extends Loader {
 
 		for ( let i = 0, l = lines.length; i < l; i ++ ) {
 
-			if ( lines[ i ].substr( 0, 4 ) === 'ATOM' || lines[ i ].substr( 0, 6 ) === 'HETATM' ) {
+			if ( lines[ i ].slice( 0, 4 ) === 'ATOM' || lines[ i ].slice( 0, 6 ) === 'HETATM' ) {
 
-				const x = parseFloat( lines[ i ].substr( 30, 7 ) );
-				const y = parseFloat( lines[ i ].substr( 38, 7 ) );
-				const z = parseFloat( lines[ i ].substr( 46, 7 ) );
-				const index = parseInt( lines[ i ].substr( 6, 5 ) ) - 1;
+				const x = parseFloat( lines[ i ].slice( 30, 37 ) );
+				const y = parseFloat( lines[ i ].slice( 38, 45 ) );
+				const z = parseFloat( lines[ i ].slice( 46, 53 ) );
+				const index = parseInt( lines[ i ].slice( 6, 11 ) ) - 1;
 
-				let e = trim( lines[ i ].substr( 76, 2 ) ).toLowerCase();
+				let e = trim( lines[ i ].slice( 76, 78 ) ).toLowerCase();
 
 				if ( e === '' ) {
 
-					e = trim( lines[ i ].substr( 12, 2 ) ).toLowerCase();
+					e = trim( lines[ i ].slice( 12, 14 ) ).toLowerCase();
 
 				}
 
@@ -203,9 +203,9 @@ class PDBLoader extends Loader {
 				atoms.push( atomData );
 				_atomMap[ index ] = atomData;
 
-			} else if ( lines[ i ].substr( 0, 6 ) === 'CONECT' ) {
+			} else if ( lines[ i ].slice( 0, 6 ) === 'CONECT' ) {
 
-				const satom = parseInt( lines[ i ].substr( 6, 5 ) );
+				const satom = parseInt( lines[ i ].slice( 6, 11 ) );
 
 				parseBond( 11, 5, satom, i );
 				parseBond( 16, 5, satom, i );

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -218,7 +218,7 @@ class SVGLoader extends Loader {
 				const command = commands[ i ];
 
 				const type = command.charAt( 0 );
-				const data = command.substr( 1 ).trim();
+				const data = command.slice( 1 ).trim();
 
 				if ( isFirstPoint === true ) {
 
@@ -1437,9 +1437,9 @@ class SVGLoader extends Loader {
 
 					if ( openParPos > 0 && openParPos < closeParPos ) {
 
-						const transformType = transformText.substr( 0, openParPos );
+						const transformType = transformText.slice( 0, openParPos );
 
-						const array = parseFloats( transformText.substr( openParPos + 1, closeParPos - openParPos - 1 ) );
+						const array = parseFloats( transformText.slice( openParPos + 1 ) );
 
 						currentTransform.identity();
 

--- a/examples/jsm/loaders/ifc/web-ifc-api.js
+++ b/examples/jsm/loaders/ifc/web-ifc-api.js
@@ -173,7 +173,7 @@ var require_web_ifc = __commonJS({
             scriptDirectory = _scriptDir;
           }
           if (scriptDirectory.indexOf("blob:") !== 0) {
-            scriptDirectory = scriptDirectory.substr(0, scriptDirectory.lastIndexOf("/") + 1);
+            scriptDirectory = scriptDirectory.slice(0, scriptDirectory.lastIndexOf("/") + 1);
           } else {
             scriptDirectory = "";
           }
@@ -728,7 +728,7 @@ var require_web_ifc = __commonJS({
           }
           return parts;
         }, normalize: function(path) {
-          var isAbsolute = path.charAt(0) === "/", trailingSlash = path.substr(-1) === "/";
+          var isAbsolute = path.charAt(0) === "/", trailingSlash = path.slice(-1) === "/";
           path = PATH.normalizeArray(path.split("/").filter(function(p) {
             return !!p;
           }), !isAbsolute).join("/");
@@ -745,7 +745,7 @@ var require_web_ifc = __commonJS({
             return ".";
           }
           if (dir) {
-            dir = dir.substr(0, dir.length - 1);
+            dir = dir.slice(0, dir.length - 1);
           }
           return root + dir;
         }, basename: function(path) {
@@ -756,7 +756,7 @@ var require_web_ifc = __commonJS({
           var lastSlash = path.lastIndexOf("/");
           if (lastSlash === -1)
             return path;
-          return path.substr(lastSlash + 1);
+          return path.slice(lastSlash + 1);
         }, extname: function(path) {
           return PATH.splitPath(path)[3];
         }, join: function() {
@@ -802,8 +802,8 @@ var require_web_ifc = __commonJS({
           }), !resolvedAbsolute).join("/");
           return (resolvedAbsolute ? "/" : "") + resolvedPath || ".";
         }, relative: function(from, to) {
-          from = PATH_FS.resolve(from).substr(1);
-          to = PATH_FS.resolve(to).substr(1);
+          from = PATH_FS.resolve(from).slice(1);
+          to = PATH_FS.resolve(to).slice(1);
           function trim(arr) {
             var start = 0;
             for (; start < arr.length; start++) {
@@ -2692,7 +2692,7 @@ var require_web_ifc = __commonJS({
         }, doMkdir: function(path, mode) {
           path = PATH.normalize(path);
           if (path[path.length - 1] === "/")
-            path = path.substr(0, path.length - 1);
+            path = path.slice(0, path.length - 1);
           FS.mkdir(path, mode, 0);
           return 0;
         }, doMknod: function(path, mode, dev) {
@@ -47501,3 +47501,4 @@ export {
 
 
  var WasmPath = "";
+

--- a/examples/jsm/node-editor/inputs/ColorEditor.js
+++ b/examples/jsm/node-editor/inputs/ColorEditor.js
@@ -36,9 +36,9 @@ export class ColorEditor extends BaseNode {
 
 			}
 
-			fieldR.setTagColor( `#${hexString.substr( 0, 2 )}0000` );
-			fieldG.setTagColor( `#00${hexString.substr( 2, 2 )}00` );
-			fieldB.setTagColor( `#0000${hexString.substr( 4, 2 )}` );
+			fieldR.setTagColor( `#${hexString.slice( 0, 2 )}0000` );
+			fieldG.setTagColor( `#00${hexString.slice( 2, 4 )}00` );
+			fieldB.setTagColor( `#0000${hexString.slice( 4, 6 )}` );
 
 		};
 
@@ -56,7 +56,7 @@ export class ColorEditor extends BaseNode {
 
 			if ( value.indexOf( '#' ) === 0 ) {
 
-				const hexStr = value.substr( 1 ).padEnd( 6, '0' );
+				const hexStr = value.slice( 1 ).padEnd( 6, '0' );
 
 				node.value.setHex( parseInt( hexStr, 16 ) );
 

--- a/examples/jsm/renderers/nodes/core/NodeBuilder.js
+++ b/examples/jsm/renderers/nodes/core/NodeBuilder.js
@@ -271,7 +271,7 @@ class NodeBuilder {
 
 	getVectorFromMatrix( type ) {
 
-		return 'vec' + type.substr( 3 );
+		return 'vec' + type.slice( 3 );
 
 	}
 

--- a/examples/jsm/renderers/nodes/parsers/GLSLNodeFunction.js
+++ b/examples/jsm/renderers/nodes/parsers/GLSLNodeFunction.js
@@ -12,7 +12,7 @@ const parse = ( source ) => {
 
 	const pragmaMainIndex = source.indexOf( pragmaMain );
 
-	const mainCode = pragmaMainIndex !== - 1 ? source.substr( pragmaMainIndex + pragmaMain.length ) : source;
+	const mainCode = pragmaMainIndex !== - 1 ? source.slice( pragmaMainIndex + pragmaMain.length ) : source;
 
 	const declaration = mainCode.match( declarationRegexp );
 
@@ -81,7 +81,7 @@ const parse = ( source ) => {
 
 		const presicion = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
 
-		const headerCode = pragmaMainIndex !== - 1 ? source.substr( 0, pragmaMainIndex ) : '';
+		const headerCode = pragmaMainIndex !== - 1 ? source.slice( 0, pragmaMainIndex ) : '';
 
 		return {
 			type,

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -108,7 +108,7 @@
 			function decimalToHex( d ) {
 
 				let hex = Number( d ).toString( 16 );
-				hex = '000000'.substr( 0, 6 - hex.length ) + hex;
+				hex = '000000'.substring( 0, 6 - hex.length ) + hex;
 				return hex.toUpperCase();
 
 			}
@@ -145,7 +145,7 @@
 
 				// Get text from hash
 
-				const hash = document.location.hash.substr( 1 );
+				const hash = document.location.hash.slice( 1 );
 
 				if ( hash.length !== 0 ) {
 

--- a/examples/webgl_instancing_dynamic.html
+++ b/examples/webgl_instancing_dynamic.html
@@ -30,7 +30,7 @@
 			let camera, scene, renderer, stats;
 
 			let mesh;
-			const amount = parseInt( window.location.search.substr( 1 ) ) || 10;
+			const amount = parseInt( window.location.search.slice( 1 ) ) || 10;
 			const count = Math.pow( amount, 3 );
 			const dummy = new THREE.Object3D();
 

--- a/examples/webgl_instancing_raycast.html
+++ b/examples/webgl_instancing_raycast.html
@@ -30,7 +30,7 @@
 			let camera, scene, renderer, controls, stats;
 
 			let mesh;
-			const amount = parseInt( window.location.search.substr( 1 ) ) || 10;
+			const amount = parseInt( window.location.search.slice( 1 ) ) || 10;
 			const count = Math.pow( amount, 3 );
 
 			const raycaster = new THREE.Raycaster();

--- a/manual/en/post-processing-3dlut.html
+++ b/manual/en/post-processing-3dlut.html
@@ -388,7 +388,7 @@ dragAndDrop.onDropFile(readLUTFile);
 
 function ext(s) {
   const period = s.lastIndexOf('.');
-  return s.substr(period + 1);
+  return s.slice(period + 1);
 }
 
 function readLUTFile(file) {

--- a/manual/examples/postprocessing-3dlut-w-loader.html
+++ b/manual/examples/postprocessing-3dlut-w-loader.html
@@ -378,7 +378,7 @@ function main() {
 
   function ext(s) {
     const period = s.lastIndexOf('.');
-    return s.substr(period + 1);
+    return s.slice(period + 1);
   }
 
   function readLUTFile(file) {

--- a/manual/examples/postprocessing-adobe-lut-to-png-converter.html
+++ b/manual/examples/postprocessing-adobe-lut-to-png-converter.html
@@ -203,7 +203,7 @@ function main() {
 
   function ext(s) {
     const period = s.lastIndexOf('.');
-    return s.substr(period + 1);
+    return s.slice(period + 1);
   }
 
   function readLUTFile(file) {

--- a/manual/examples/resources/lut-reader.js
+++ b/manual/examples/resources/lut-reader.js
@@ -49,7 +49,7 @@ const isNum = s => intRE.test(s);
 
 const quotesRE = /^".*"$/;
 function trimQuotes(s) {
-  return quotesRE.test(s) ? s.substr(s, s.length - 2) : s;
+  return quotesRE.test(s) ? s.slice(1, -1) : s;
 }
 
 const splitToNumbers = s => s.split(' ').map(parseFloat);
@@ -82,7 +82,7 @@ export function parseCSP(str) {
       break;
     }
     if (line.startsWith('TITLE ')) {
-      lut.name = trimQuotes(line.substr(6).trim());
+      lut.name = trimQuotes(line.slice(6).trim());
     }
   }
 

--- a/manual/index.html
+++ b/manual/index.html
@@ -310,7 +310,7 @@
 
 			const hash = location.hash;
 			if ( hash === '' ) return;
-			const docLink = hash.substr( hash.indexOf( '/' ) );
+			const docLink = hash.slice( hash.indexOf( '/' ) );
 			location.href = '#' + language + docLink;
 
 		}
@@ -323,7 +323,7 @@
 
 			if ( search.indexOf( '?q=' ) !== - 1 ) {
 
-				return decodeURI( search.substr( 3 ) );
+				return decodeURI( search.slice( 3 ) );
 
 			}
 
@@ -428,7 +428,7 @@
 
 			if ( url.origin === window.location.origin ) {
 
-				const hrefNoOrigin = url.href.substr( url.origin.length );
+				const hrefNoOrigin = url.href.slice( url.origin.length );
 				const m = re.exec( hrefNoOrigin );
 				const [ , base, path ] = m;
 				if ( base.includes( 'manual' ) ) {
@@ -495,8 +495,8 @@
 				const subHash = splitHash[0].indexOf('#');
 				let src;
 				if (subHash >= 0) {
-					const beforeSubHash = splitHash[0].substr(0, subHash);
-					const afterSubHash = splitHash[0].substr(subHash);
+					const beforeSubHash = splitHash[0].slice(0, subHash);
+					const afterSubHash = splitHash[0].slice(subHash);
 					src = `${beforeSubHash}.html${afterSubHash}${splitHash[ 1 ]}`;
 				} else {
 					src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];

--- a/manual/ja/post-processing-3dlut.html
+++ b/manual/ja/post-processing-3dlut.html
@@ -424,7 +424,7 @@ dragAndDrop.onDropFile(readLUTFile);
 
 function ext(s) {
   const period = s.lastIndexOf('.');
-  return s.substr(period + 1);
+  return s.slice(period + 1);
 }
 
 function readLUTFile(file) {

--- a/manual/ko/post-processing-3dlut.html
+++ b/manual/ko/post-processing-3dlut.html
@@ -390,7 +390,7 @@ dragAndDrop.onDropFile(readLUTFile);
 
 function ext(s) {
   const period = s.lastIndexOf('.');
-  return s.substr(period + 1);
+  return s.slice(period + 1);
 }
 
 function readLUTFile(file) {

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -71,7 +71,7 @@ class ImageLoader extends Loader {
 		image.addEventListener( 'load', onImageLoad, false );
 		image.addEventListener( 'error', onImageError, false );
 
-		if ( url.substr( 0, 5 ) !== 'data:' ) {
+		if ( url.slice( 0, 5 ) !== 'data:' ) {
 
 			if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
 

--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -40,7 +40,7 @@ class LoaderUtils {
 
 		if ( index === - 1 ) return './';
 
-		return url.substr( 0, index + 1 );
+		return url.slice( 0, index + 1 );
 
 	}
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.