### PR TITLE
fix orbit controls with translated parent

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -54,7 +54,7 @@
 
 		<h3>[name]( [param:Camera object], [param:HTMLDOMElement domElement] )</h3>
 		<p>
-			[page:Camera object]: (required) The camera to be controlled. The camera must not be a child of another object, unless that object is the scene itself.<br><br>
+			[page:Camera object]: (required) The camera to be controlled.<br><br>
 
 			[page:HTMLDOMElement domElement]: The HTML element used for event listeners.
 		</p>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -54,7 +54,7 @@
 
 		<h3>[name]( [param:Camera object], [param:HTMLDOMElement domElement] )</h3>
 		<p>
-			[page:Camera object]: （必须）将要被控制的相机。该相机不允许是其他任何对象的子级，除非该对象是场景自身。<br><br>
+			[page:Camera object]: （必须）将要被控制的相机。<br><br>
 
 			[page:HTMLDOMElement domElement]: 用于事件监听的HTML元素。
 		</p>

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -164,11 +164,9 @@ class OrbitControls extends EventDispatcher {
 
 			const twoPI = 2 * Math.PI;
 
-			const _position = object.position;
-
 			return function update() {
 
-				const position = scope.object.getWorldPosition( _position );
+				const position = scope.object.getWorldPosition( object.position );
 
 				offset.copy( position ).sub( scope.target );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -164,9 +164,11 @@ class OrbitControls extends EventDispatcher {
 
 			const twoPI = 2 * Math.PI;
 
+			const _position = object.position;
+
 			return function update() {
 
-				const position = getPosition( scope.object, scope.object.position );
+				const position = scope.object.getWorldPosition( _position );
 
 				offset.copy( position ).sub( scope.target );
 
@@ -248,7 +250,7 @@ class OrbitControls extends EventDispatcher {
 				offset.applyQuaternion( quatInverse );
 
 				position.copy( scope.target ).add( offset );
-				setPosition( scope.object, position );
+				scope.object.parent.worldToLocal( position );
 
 				scope.object.lookAt( scope.target );
 
@@ -359,27 +361,6 @@ class OrbitControls extends EventDispatcher {
 		const pointers = [];
 		const pointerPositions = {};
 
-
-		function getPosition( obj, vec ) {
-
-			if ( ! obj.parent || obj.parent.type === 'Scene' )
-				return vec.copy( obj.position );
-
-			obj.getWorldPosition( vec );
-
-			return vec;
-
-		}
-
-		function setPosition( obj, val ) {
-
-			if ( obj.parent )
-				obj.parent.worldToLocal( val );
-
-			obj.position.copy( val );
-
-		}
-
 		function getAutoRotationAngle() {
 
 			return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
@@ -457,7 +438,7 @@ class OrbitControls extends EventDispatcher {
 				if ( scope.object.isPerspectiveCamera ) {
 
 					// perspective
-					getPosition( scope.object, position );
+					scope.object.getWorldPosition( position );
 					offset.copy( position ).sub( scope.target );
 					let targetDistance = offset.length();
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -376,7 +376,7 @@ class OrbitControls extends EventDispatcher {
 			if ( obj.parent )
 				obj.parent.worldToLocal( val );
 
-			obj.position.set( val.x, val.y, val.z );
+			obj.position.copy( val );
 
 		}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -250,7 +250,7 @@ class OrbitControls extends EventDispatcher {
 				offset.applyQuaternion( quatInverse );
 
 				position.copy( scope.target ).add( offset );
-				scope.object.parent.worldToLocal( position );
+				scope.object.parent ? scope.object.parent.worldToLocal( position ) : scope.object.position.copy( position )
 
 				scope.object.lookAt( scope.target );
 


### PR DESCRIPTION
**Description**

Orbit controls don't work properly when parented to a non-root object in the hierarchy and orbiting behaves unexpectedly when parent object has some offset.

This PR replaces direct access to ``position`` and instead calls two new internal methods: ``getPosition`` and ``setPosition``. These in turn do check if the object is parented to the scene (if yes they just return the object's local position) and if not they convert from and to world position.

This contribution is funded by 🌵 [needle](https://needle.tools).

Example hierarchy:
![20220218-145316_Fork](https://user-images.githubusercontent.com/5083203/154695739-d09ee8d8-ac7a-4892-9a65-c03ec7d3d436.png)
![image](https://user-images.githubusercontent.com/5083203/154695766-c10c827c-188b-4bf8-8651-3c004a401de5.png)

Behaviour before:
https://user-images.githubusercontent.com/5083203/154695840-4b344a61-c3c3-40de-bafb-ee7d237217ee.mp4

Behaviour with PR applied:
https://user-images.githubusercontent.com/5083203/154695884-5462c725-9ca2-47f8-a932-8c16db842efd.mp4


