### PR TITLE
Fix enum in the switch case

### DIFF
--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -230,14 +230,14 @@
 
 					switch ( val ) {
 
-						case '0':
+						case 0:
 							line.visible = true;
 
 							line1.visible = false;
 
 							break;
 
-						case '1':
+						case 1:
 							line.visible = false;
 
 							line1.visible = true;
@@ -285,7 +285,7 @@
 
 					switch ( val ) {
 
-						case '0':
+						case 0:
 							matLine.dashSize = 2;
 							matLine.gapSize = 1;
 
@@ -294,7 +294,7 @@
 
 							break;
 
-						case '1':
+						case 1:
 							matLine.dashSize = 1;
 							matLine.gapSize = 1;
 
@@ -303,7 +303,7 @@
 
 							break;
 
-						case '2':
+						case 2:
 							matLine.dashSize = 1;
 							matLine.gapSize = 2;
 

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -191,14 +191,14 @@
 
 					switch ( val ) {
 
-						case '0':
+						case 0:
 							wireframe.visible = true;
 
 							wireframe1.visible = false;
 
 							break;
 
-						case '1':
+						case 1:
 							wireframe.visible = false;
 
 							wireframe1.visible = true;
@@ -240,7 +240,7 @@
 
 					switch ( val ) {
 
-						case '0':
+						case 0:
 							matLine.dashSize = 2;
 							matLine.gapSize = 1;
 
@@ -249,7 +249,7 @@
 
 							break;
 
-						case '1':
+						case 1:
 							matLine.dashSize = 1;
 							matLine.gapSize = 1;
 
@@ -258,7 +258,7 @@
 
 							break;
 
-						case '2':
+						case 2:
 							matLine.dashSize = 1;
 							matLine.gapSize = 2;
 


### PR DESCRIPTION
**Description**

I'm not sure since when this is broken - probably from the migration to the new GUI system: https://github.com/mrdoob/three.js/pull/22765

Live link to the examples:
https://raw.githack.com/bergden-resonai/three.js/switch-enum-examples-fix/examples/webgl_lines_fat.html

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Resonai](https://resonai.com).
