### PR TITLE
Add type conversions in ShaderNode

### DIFF
--- a/examples/jsm/renderers/nodes/ShaderNode.js
+++ b/examples/jsm/renderers/nodes/ShaderNode.js
@@ -194,11 +194,11 @@ export const nodeObject = ( val ) => {
 };
 
 export const float = ( val ) => {
-	
+
 	if ( val?.isNode === true ) {
-		
+
 		return nodeObject( new ConvertNode( val, 'float' ) );
-	
+
 	}
 
 	return nodeObject( new FloatNode( val ).setConst( true ) );
@@ -206,11 +206,11 @@ export const float = ( val ) => {
 };
 
 export const int = ( val ) => {
-	
+
 	if ( val?.isNode === true ) {
-		
+
 		return nodeObject( new ConvertNode( val, 'int' ) );
-	
+
 	}
 
 	return nodeObject( new IntNode( val ).setConst( true ) );
@@ -218,11 +218,11 @@ export const int = ( val ) => {
 };
 
 export const color = ( ...params ) => {
-	
-	if ( params[0]?.isNode === true ) {
-		
+
+	if ( params[ 0 ]?.isNode === true ) {
+
 		return nodeObject( new ConvertNode( params[0], 'color' ) );
-	
+
 	}
 
 	return nodeObject( new ColorNode( new Color( ...params ) ).setConst( true ) );

--- a/examples/jsm/renderers/nodes/ShaderNode.js
+++ b/examples/jsm/renderers/nodes/ShaderNode.js
@@ -194,18 +194,36 @@ export const nodeObject = ( val ) => {
 };
 
 export const float = ( val ) => {
+	
+	if ( val?.isNode === true ) {
+		
+		return nodeObject( new ConvertNode( val, 'float' ) );
+	
+	}
 
 	return nodeObject( new FloatNode( val ).setConst( true ) );
 
 };
 
 export const int = ( val ) => {
+	
+	if ( val?.isNode === true ) {
+		
+		return nodeObject( new ConvertNode( val, 'int' ) );
+	
+	}
 
 	return nodeObject( new IntNode( val ).setConst( true ) );
 
 };
 
 export const color = ( ...params ) => {
+	
+	if ( params[0]?.isNode === true ) {
+		
+		return nodeObject( new ConvertNode( params[0], 'color' ) );
+	
+	}
 
 	return nodeObject( new ColorNode( new Color( ...params ) ).setConst( true ) );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/23534

**Description**

This PR adds type conversions (except for vec234(), as they are already added) to the ShaderNode.
(I marked this PR as draft because bool(), uint(), and possibly buffer(), texture(), and mat234() are not added yet)