### PR TITLE
FileLoader: Added workaround for Alipay browser's bug.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -88,6 +88,8 @@ class FileLoader extends Loader {
 
 					}
 
+					// Workaround: Checking if response.body === undefined for Alipay browser #23548
+
 					if ( typeof ReadableStream === 'undefined' || response.body === undefined || response.body.getReader === undefined ) {
 
 						return response;

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -88,7 +88,7 @@ class FileLoader extends Loader {
 
 					}
 
-					if ( typeof ReadableStream === 'undefined' || response.body.getReader === undefined ) {
+					if ( typeof ReadableStream === 'undefined' || response.body === undefined || response.body.getReader === undefined ) {
 
 						return response;
 


### PR DESCRIPTION
Related issue: #23015

**Description**
In Alipay browser, response.body is undefined, when i change it,I load .Glb file successfully in Alipay browser.

