### PR TITLE
Fix PMREM anisotropic filtering

### DIFF
--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -104,7 +104,15 @@ export default /* glsl */`
 		uv.x *= CUBEUV_TEXEL_WIDTH;
 		uv.y *= CUBEUV_TEXEL_HEIGHT;
 
-		return texture2D( envMap, uv ).rgb;
+		#ifdef TEXTURE_LOD_EXT
+
+			return texture2DGradEXT( envMap, uv, vec2( 0.0 ), vec2( 0.0 ) ).rgb; // disable anisotropic filtering
+
+		#else
+
+			return texture2D( envMap, uv ).rgb;
+
+		#endif
 
 	}
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -423,7 +423,8 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 		prefixFragment = [
 
 			customExtensions,
-			customDefines
+			customDefines,
+			parameters.rendererExtensionShaderTextureLod ? '#define TEXTURE_LOD_EXT' : ''
 
 		].filter( filterEmptyLine ).join( '\n' );
 
@@ -700,7 +701,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 	vertexShader = unrollLoops( vertexShader );
 	fragmentShader = unrollLoops( fragmentShader );
 
-	if ( parameters.isWebGL2 && parameters.isRawShaderMaterial !== true ) {
+	if ( parameters.isWebGL2 ) {
 
 		// GLSL 3.0 conversion for built-in materials and ShaderMaterial
 


### PR DESCRIPTION
Related issue: #23517 https://github.com/mrdoob/three.js/issues/17855 https://github.com/mrdoob/three.js/pull/23468 https://github.com/mrdoob/three.js/pull/23511

**Description**

Okay, so the problem with the envMap seams showing up on certain Nvidia GPUs turns out to be because they force anisotropic filtering to be on, but that is not compatible with our unusual texture lookups for the PMREM. The NEAREST option changes the interpolation in a not-great way, so I've disabled it instead by using `textureGrad` and setting the pixel derivatives to zero. This appears to completely fix the problem, but I had to make some other changes that should probably get a bit more scrutiny:

Even though `RawShaderMaterial` inherits from `ShaderMaterial`, the `extensions` object seems to be broken: I needed to specify the `texture_lod` extension, but it only got part of the glsl; not enough to actually enable it. I'm assuming that's a bug, since it's not documented behavior and it was already getting part of the needed glsl. However, I probably haven't fixed it all and it could also use a little code cleanup if this is acceptable - @Mugen87 @mrdoob.

To reproduce the problem on a non-Nvidia GPU, simply add `anisotropy: 16` to line 258 of `PMREMGenerator.js`.

I believe #23517 should be merged as well as this change to complete the fix.