### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -329,7 +329,7 @@
 		<h3>[method:Color getClearColor]( [param:Color target] )</h3>
 		<p>Returns a [page:Color THREE.Color] instance with the current clear color.</p>
 
-		<h3>[method:WebGLRenderingContext getContext]()</h3>
+		<h3>[method:WebGL2RenderingContext getContext]()</h3>
 		<p>Return the current WebGL context.</p>
 
 		<h3>[method:WebGLContextAttributes getContextAttributes]()</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -299,7 +299,7 @@
 		<h3>[method:Color getClearColor]( [param:Color target] )</h3>
 		<p>返回一个表示当前颜色值的[page:Color THREE.Color]实例</p>
 
-		<h3>[method:WebGLRenderingContext getContext]()</h3>
+		<h3>[method:WebGL2RenderingContext getContext]()</h3>
 		<p>返回当前WebGL环境</p>
 
 		<h3>[method:WebGLContextAttributes getContextAttributes]()</h3>


### PR DESCRIPTION
Fixed #23555.

**Description**

Use the more common `WebGL2RenderingContext` as the return type of `getContext()`.
