### PR TITLE
Add the shadow map and matrix uniforms to markUniformsLightsNeedsUpdate

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1771,6 +1771,12 @@ function WebGLRenderer( parameters = {} ) {
 		uniforms.rectAreaLights.needsUpdate = value;
 		uniforms.hemisphereLights.needsUpdate = value;
 
+		uniforms.directionalShadowMap.needsUpdate = value;
+		uniforms.directionalShadowMatrix.needsUpdate = value;
+		uniforms.spotShadowMap.needsUpdate = value;
+		uniforms.spotShadowMatrix.needsUpdate = value;
+		uniforms.pointShadowMap.needsUpdate = value;
+		uniforms.pointShadowMatrix.needsUpdate = value;
 	}
 
 	function materialNeedsLights( material ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1777,6 +1777,7 @@ function WebGLRenderer( parameters = {} ) {
 		uniforms.spotShadowMatrix.needsUpdate = value;
 		uniforms.pointShadowMap.needsUpdate = value;
 		uniforms.pointShadowMatrix.needsUpdate = value;
+
 	}
 
 	function materialNeedsLights( material ) {


### PR DESCRIPTION
Add the shadow map and matrix uniforms to the markUniformsLightsNeeds function

This reduces redundant uniform setting when using shadows.

Related issue: None

**Description**

I noticed a bunch of redundant uniform setting for the shadow maps and shadow matrix values when running CSM on a complex scene.  Other lighting values get their updates suppressed via this function, but these do not (they all get set up in the same place in getProgram).  After adding this, I saw the number of uniforms go down, performance go up, and didn't see any bugs or artifacts.  I checked the other shadow examples and they all appeared to work correctly.
