### PR TITLE
Nodes: Follow three.js static property style

### DIFF
--- a/examples/jsm/node-editor/accessors/NormalEditor.js
+++ b/examples/jsm/node-editor/accessors/NormalEditor.js
@@ -11,11 +11,11 @@ export class NormalEditor extends BaseNode {
 		super( 'Normal', 3, node, 200 );
 
 		const optionsField = new SelectInput( [
-			{ name: 'Local', value: NormalNode.LOCAL },
-			{ name: 'World', value: NormalNode.WORLD },
-			{ name: 'View', value: NormalNode.VIEW },
-			{ name: 'Geometry', value: NormalNode.GEOMETRY }
-		], NormalNode.LOCAL ).onChange( () => {
+			{ name: 'Local', value: NormalNode.Local },
+			{ name: 'World', value: NormalNode.World },
+			{ name: 'View', value: NormalNode.View },
+			{ name: 'Geometry', value: NormalNode.Geometry }
+		], NormalNode.Local ).onChange( () => {
 
 			node.scope = optionsField.getValue();
 

--- a/examples/jsm/node-editor/accessors/PositionEditor.js
+++ b/examples/jsm/node-editor/accessors/PositionEditor.js
@@ -11,11 +11,11 @@ export class PositionEditor extends BaseNode {
 		super( 'Position', 3, node, 200 );
 
 		const optionsField = new SelectInput( [
-			{ name: 'Local', value: PositionNode.LOCAL },
-			{ name: 'World', value: PositionNode.WORLD },
-			{ name: 'View', value: PositionNode.VIEW },
-			{ name: 'View Direction', value: PositionNode.VIEW_DIRECTION }
-		], PositionNode.LOCAL ).onChange( () => {
+			{ name: 'Local', value: PositionNode.Local },
+			{ name: 'World', value: PositionNode.World },
+			{ name: 'View', value: PositionNode.View },
+			{ name: 'View Direction', value: PositionNode.ViewDirection }
+		], PositionNode.Local ).onChange( () => {
 
 			node.scope = optionsField.getValue();
 

--- a/examples/jsm/node-editor/display/BlendEditor.js
+++ b/examples/jsm/node-editor/display/BlendEditor.js
@@ -9,7 +9,7 @@ export class BlendEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.MIX, NULL_VALUE, NULL_VALUE, ONE_VALUE );
+		const node = new MathNode( MathNode.Mix, NULL_VALUE, NULL_VALUE, ONE_VALUE );
 
 		super( 'Blend', 3, node, 200 );
 

--- a/examples/jsm/node-editor/math/AngleEditor.js
+++ b/examples/jsm/node-editor/math/AngleEditor.js
@@ -8,14 +8,14 @@ export class AngleEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.SIN, DEFAULT_VALUE );
+		const node = new MathNode( MathNode.Sin, DEFAULT_VALUE );
 
 		super( 'Angle', 1, node, 175 );
 
 		const optionsField = new SelectInput( [
-			{ name: 'Degrees to Radians', value: MathNode.RAD },
-			{ name: 'Radians to Degrees', value: MathNode.DEG }
-		], MathNode.RAD ).onChange( () => {
+			{ name: 'Degrees to Radians', value: MathNode.Radians },
+			{ name: 'Radians to Degrees', value: MathNode.Degrees }
+		], MathNode.Radians ).onChange( () => {
 
 			node.method = optionsField.getValue();
 

--- a/examples/jsm/node-editor/math/DotEditor.js
+++ b/examples/jsm/node-editor/math/DotEditor.js
@@ -8,7 +8,7 @@ export class DotEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.DOT, NULL_VALUE, NULL_VALUE );
+		const node = new MathNode( MathNode.Dot, NULL_VALUE, NULL_VALUE );
 
 		super( 'Dot Product', 1, node, 175 );
 

--- a/examples/jsm/node-editor/math/InvertEditor.js
+++ b/examples/jsm/node-editor/math/InvertEditor.js
@@ -8,14 +8,14 @@ export class InvertEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.INVERT, DEFAULT_VALUE );
+		const node = new MathNode( MathNode.Invert, DEFAULT_VALUE );
 
 		super( 'Invert / Negate', 1, node, 175 );
 
 		const optionsField = new SelectInput( [
-			{ name: 'Invert ( 1 - Source )', value: MathNode.INVERT },
-			{ name: 'Negate ( - Source )', value: MathNode.NEGATE }
-		], MathNode.INVERT ).onChange( () => {
+			{ name: 'Invert ( 1 - Source )', value: MathNode.Invert },
+			{ name: 'Negate ( - Source )', value: MathNode.Negate }
+		], MathNode.Invert ).onChange( () => {
 
 			node.method = optionsField.getValue();
 

--- a/examples/jsm/node-editor/math/LimiterEditor.js
+++ b/examples/jsm/node-editor/math/LimiterEditor.js
@@ -9,21 +9,21 @@ export class LimiterEditor extends BaseNode {
 
 		const NULL_VALUE = new FloatNode();
 
-		const node = new MathNode( MathNode.MIN, NULL_VALUE, NULL_VALUE );
+		const node = new MathNode( MathNode.Min, NULL_VALUE, NULL_VALUE );
 
 		super( 'Limiter', 1, node, 175 );
 
 		const methodInput = new SelectInput( [
-			{ name: 'Min', value: MathNode.MIN },
-			{ name: 'Max', value: MathNode.MAX },
-			// { name: 'Clamp', value: MathNode.CLAMP }
-			{ name: 'Saturate', value: MathNode.SATURATE }
-		], MathNode.MIN );
+			{ name: 'Min', value: MathNode.Min },
+			{ name: 'Max', value: MathNode.Max },
+			// { name: 'Clamp', value: MathNode.Clamp }
+			{ name: 'Saturate', value: MathNode.Saturate }
+		], MathNode.Min );
 
 		methodInput.onChange( ( data ) => {
 
 			node.method = data.getValue();
-			bElement.setVisible( data.getValue() !== MathNode.SATURATE );
+			bElement.setVisible( data.getValue() !== MathNode.Saturate );
 
 			this.invalidate();
 

--- a/examples/jsm/node-editor/math/NormalizeEditor.js
+++ b/examples/jsm/node-editor/math/NormalizeEditor.js
@@ -8,7 +8,7 @@ export class NormalizeEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.NORMALIZE, DEFAULT_VALUE );
+		const node = new MathNode( MathNode.Normalize, DEFAULT_VALUE );
 
 		super( 'Normalize', 3, node, 175 );
 

--- a/examples/jsm/node-editor/math/PowerEditor.js
+++ b/examples/jsm/node-editor/math/PowerEditor.js
@@ -8,7 +8,7 @@ export class PowerEditor extends BaseNode {
 	constructor() {
 
 		const NULL_VALUE = new FloatNode();
-		const node = new MathNode( MathNode.POW, NULL_VALUE, NULL_VALUE );
+		const node = new MathNode( MathNode.Pow, NULL_VALUE, NULL_VALUE );
 
 		super( 'Power', 1, node, 175 );
 

--- a/examples/jsm/node-editor/math/TrigonometryEditor.js
+++ b/examples/jsm/node-editor/math/TrigonometryEditor.js
@@ -8,19 +8,19 @@ export class TrigonometryEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new MathNode( MathNode.SIN, DEFAULT_VALUE );
+		const node = new MathNode( MathNode.Sin, DEFAULT_VALUE );
 
 		super( 'Trigonometry', 1, node, 175 );
 
 		const optionsField = new SelectInput( [
-			{ name: 'Sin', value: MathNode.SIN },
-			{ name: 'Cos', value: MathNode.COS },
-			{ name: 'Tan', value: MathNode.TAN },
+			{ name: 'Sin', value: MathNode.Sin },
+			{ name: 'Cos', value: MathNode.Cos },
+			{ name: 'Tan', value: MathNode.Tan },
 
-			{ name: 'asin', value: MathNode.ASIN },
-			{ name: 'acos', value: MathNode.ACOS },
-			{ name: 'atan', value: MathNode.ATAN }
-		], MathNode.SIN ).onChange( () => {
+			{ name: 'asin', value: MathNode.Asin },
+			{ name: 'acos', value: MathNode.Acos },
+			{ name: 'atan', value: MathNode.Atan }
+		], MathNode.Sin ).onChange( () => {
 
 			node.method = optionsField.getValue();
 

--- a/examples/jsm/node-editor/utils/OscillatorEditor.js
+++ b/examples/jsm/node-editor/utils/OscillatorEditor.js
@@ -8,16 +8,16 @@ export class OscillatorEditor extends BaseNode {
 
 	constructor() {
 
-		const node = new OscNode( OscNode.SINE, NULL_VALUE );
+		const node = new OscNode( OscNode.Sine, NULL_VALUE );
 
 		super( 'Oscillator', 1, node, 175 );
 
 		const methodInput = new SelectInput( [
-			{ name: 'Sine', value: OscNode.SINE },
-			{ name: 'Square', value: OscNode.SQUARE },
-			{ name: 'Triangle', value: OscNode.TRIANGLE },
-			{ name: 'Sawtooth', value: OscNode.SAWTOOTH }
-		], OscNode.SINE );
+			{ name: 'Sine', value: OscNode.Sine },
+			{ name: 'Square', value: OscNode.Square },
+			{ name: 'Triangle', value: OscNode.Triangle },
+			{ name: 'Sawtooth', value: OscNode.Sawtooth }
+		], OscNode.Sine );
 
 		methodInput.onChange( () => {
 

--- a/examples/jsm/nodes/ShaderNode.js
+++ b/examples/jsm/nodes/ShaderNode.js
@@ -221,7 +221,7 @@ export const color = ( ...params ) => {
 
 	if ( params[ 0 ]?.isNode === true ) {
 
-		return nodeObject( new ConvertNode( params[0], 'color' ) );
+		return nodeObject( new ConvertNode( params[ 0 ], 'color' ) );
 
 	}
 
@@ -337,16 +337,16 @@ export const shiftRight = ShaderNodeProxy( OperatorNode, '>>' );
 
 export const element = ShaderNodeProxy( ArrayElementNode );
 
-export const normalGeometry = ShaderNodeObject( new NormalNode( NormalNode.GEOMETRY ) );
-export const normalLocal = ShaderNodeObject( new NormalNode( NormalNode.LOCAL ) );
-export const normalWorld = ShaderNodeObject( new NormalNode( NormalNode.WORLD ) );
-export const normalView = ShaderNodeObject( new NormalNode( NormalNode.VIEW ) );
-export const transformedNormalView = ShaderNodeObject( new VarNode( new NormalNode( NormalNode.VIEW ), 'TransformedNormalView', 'vec3' ) );
+export const normalGeometry = ShaderNodeObject( new NormalNode( NormalNode.Geometry ) );
+export const normalLocal = ShaderNodeObject( new NormalNode( NormalNode.Local ) );
+export const normalWorld = ShaderNodeObject( new NormalNode( NormalNode.World ) );
+export const normalView = ShaderNodeObject( new NormalNode( NormalNode.View ) );
+export const transformedNormalView = ShaderNodeObject( new VarNode( new NormalNode( NormalNode.View ), 'TransformedNormalView', 'vec3' ) );
 
-export const positionLocal = ShaderNodeObject( new PositionNode( PositionNode.LOCAL ) );
-export const positionWorld = ShaderNodeObject( new PositionNode( PositionNode.WORLD ) );
-export const positionView = ShaderNodeObject( new PositionNode( PositionNode.VIEW ) );
-export const positionViewDirection = ShaderNodeObject( new PositionNode( PositionNode.VIEW_DIRECTION ) );
+export const positionLocal = ShaderNodeObject( new PositionNode( PositionNode.Local ) );
+export const positionWorld = ShaderNodeObject( new PositionNode( PositionNode.World ) );
+export const positionView = ShaderNodeObject( new PositionNode( PositionNode.View ) );
+export const positionViewDirection = ShaderNodeObject( new PositionNode( PositionNode.ViewDirection ) );
 
 export const PI = float( 3.141592653589793 );
 export const PI2 = float( 6.283185307179586 );

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -3,7 +3,7 @@ import Matrix4Node from '../inputs/Matrix4Node.js';
 
 class CameraNode extends Object3DNode {
 
-	static PROJECTION_MATRIX = 'projectionMatrix';
+	static ProjectionMatrix = 'projectionMatrix';
 
 	constructor( scope = CameraNode.POSITION ) {
 
@@ -17,7 +17,7 @@ class CameraNode extends Object3DNode {
 
 		const scope = this.scope;
 
-		if ( scope === CameraNode.PROJECTION_MATRIX ) {
+		if ( scope === CameraNode.ProjectionMatrix ) {
 
 			return 'mat4';
 
@@ -33,11 +33,11 @@ class CameraNode extends Object3DNode {
 		const inputNode = this._inputNode;
 		const scope = this.scope;
 
-		if ( scope === CameraNode.PROJECTION_MATRIX ) {
+		if ( scope === CameraNode.ProjectionMatrix ) {
 
 			inputNode.value = camera.projectionMatrix;
 
-		} else if ( scope === CameraNode.VIEW_MATRIX ) {
+		} else if ( scope === CameraNode.ViewMatrix ) {
 
 			inputNode.value = camera.matrixWorldInverse;
 
@@ -53,7 +53,7 @@ class CameraNode extends Object3DNode {
 
 		const scope = this.scope;
 
-		if ( scope === CameraNode.PROJECTION_MATRIX ) {
+		if ( scope === CameraNode.ProjectionMatrix ) {
 
 			this._inputNode = new Matrix4Node( null );
 

--- a/examples/jsm/nodes/accessors/MaterialNode.js
+++ b/examples/jsm/nodes/accessors/MaterialNode.js
@@ -4,14 +4,14 @@ import MaterialReferenceNode from './MaterialReferenceNode.js';
 
 class MaterialNode extends Node {
 
-	static ALPHA_TEST = 'alphaTest';
-	static COLOR = 'color';
-	static OPACITY = 'opacity';
-	static SPECULAR = 'specular';
-	static ROUGHNESS = 'roughness';
-	static METALNESS = 'metalness';
+	static AlphaTest = 'alphaTest';
+	static Color = 'color';
+	static Opacity = 'opacity';
+	static Specular = 'specular';
+	static Roughness = 'roughness';
+	static Metalness = 'metalness';
 
-	constructor( scope = MaterialNode.COLOR ) {
+	constructor( scope = MaterialNode.Color ) {
 
 		super();
 
@@ -24,19 +24,19 @@ class MaterialNode extends Node {
 		const scope = this.scope;
 		const material = builder.context.material;
 
-		if ( scope === MaterialNode.COLOR ) {
+		if ( scope === MaterialNode.Color ) {
 
 			return material.map !== null ? 'vec4' : 'vec3';
 
-		} else if ( scope === MaterialNode.OPACITY ) {
+		} else if ( scope === MaterialNode.Opacity ) {
 
 			return 'float';
 
-		} else if ( scope === MaterialNode.SPECULAR ) {
+		} else if ( scope === MaterialNode.Specular ) {
 
 			return 'vec3';
 
-		} else if ( scope === MaterialNode.ROUGHNESS || scope === MaterialNode.METALNESS ) {
+		} else if ( scope === MaterialNode.Roughness || scope === MaterialNode.Metalness ) {
 
 			return 'float';
 
@@ -51,11 +51,11 @@ class MaterialNode extends Node {
 
 		let node = null;
 
-		if ( scope === MaterialNode.ALPHA_TEST ) {
+		if ( scope === MaterialNode.AlphaTest ) {
 
 			node = new MaterialReferenceNode( 'alphaTest', 'float' );
 
-		} else if ( scope === MaterialNode.COLOR ) {
+		} else if ( scope === MaterialNode.Color ) {
 
 			const colorNode = new MaterialReferenceNode( 'color', 'color' );
 
@@ -69,7 +69,7 @@ class MaterialNode extends Node {
 
 			}
 
-		} else if ( scope === MaterialNode.OPACITY ) {
+		} else if ( scope === MaterialNode.Opacity ) {
 
 			const opacityNode = new MaterialReferenceNode( 'opacity', 'float' );
 
@@ -83,7 +83,7 @@ class MaterialNode extends Node {
 
 			}
 
-		} else if ( scope === MaterialNode.SPECULAR ) {
+		} else if ( scope === MaterialNode.Specular ) {
 
 			const specularColorNode = new MaterialReferenceNode( 'specularColor', 'color' );
 

--- a/examples/jsm/nodes/accessors/ModelNode.js
+++ b/examples/jsm/nodes/accessors/ModelNode.js
@@ -2,7 +2,7 @@ import Object3DNode from './Object3DNode.js';
 
 class ModelNode extends Object3DNode {
 
-	constructor( scope = ModelNode.VIEW_MATRIX ) {
+	constructor( scope = ModelNode.ViewMatrix ) {
 
 		super( scope );
 

--- a/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
@@ -18,7 +18,7 @@ class ModelViewProjectionNode extends Node {
 
 		const position = this.position;
 
-		const mvpMatrix = new OperatorNode( '*', new CameraNode( CameraNode.PROJECTION_MATRIX ), new ModelNode( ModelNode.VIEW_MATRIX ) );
+		const mvpMatrix = new OperatorNode( '*', new CameraNode( CameraNode.ProjectionMatrix ), new ModelNode( ModelNode.ViewMatrix ) );
 		const mvpNode = new OperatorNode( '*', mvpMatrix, position );
 
 		return mvpNode.build( builder );

--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -8,12 +8,12 @@ import MathNode from '../math/MathNode.js';
 
 class NormalNode extends Node {
 
-	static GEOMETRY = 'geometry';
-	static LOCAL = 'local';
-	static WORLD = 'world';
-	static VIEW = 'view';
+	static Geometry = 'geometry';
+	static Local = 'local';
+	static World = 'world';
+	static View = 'view';
 
-	constructor( scope = NormalNode.LOCAL ) {
+	constructor( scope = NormalNode.Local ) {
 
 		super( 'vec3' );
 
@@ -33,24 +33,24 @@ class NormalNode extends Node {
 
 		let outputNode = null;
 
-		if ( scope === NormalNode.GEOMETRY ) {
+		if ( scope === NormalNode.Geometry ) {
 
 			outputNode = new AttributeNode( 'normal', 'vec3' );
 
-		} else if ( scope === NormalNode.LOCAL ) {
+		} else if ( scope === NormalNode.Local ) {
 
-			outputNode = new VaryNode( new NormalNode( NormalNode.GEOMETRY ) );
+			outputNode = new VaryNode( new NormalNode( NormalNode.Geometry ) );
 
-		} else if ( scope === NormalNode.VIEW ) {
+		} else if ( scope === NormalNode.View ) {
 
-			const vertexNormalNode = new OperatorNode( '*', new ModelNode( ModelNode.NORMAL_MATRIX ), new NormalNode( NormalNode.LOCAL ) );
-			outputNode = new MathNode( MathNode.NORMALIZE, new VaryNode( vertexNormalNode ) );
+			const vertexNormalNode = new OperatorNode( '*', new ModelNode( ModelNode.NormalMatrix ), new NormalNode( NormalNode.Local ) );
+			outputNode = new MathNode( MathNode.Normalize, new VaryNode( vertexNormalNode ) );
 
-		} else if ( scope === NormalNode.WORLD ) {
+		} else if ( scope === NormalNode.World ) {
 
 			// To use INVERSE_TRANSFORM_DIRECTION only inverse the param order like this: MathNode( ..., Vector, Matrix );
-			const vertexNormalNode = new MathNode( MathNode.TRANSFORM_DIRECTION, new NormalNode( NormalNode.VIEW ), new CameraNode( CameraNode.VIEW_MATRIX ) );
-			outputNode = new MathNode( MathNode.NORMALIZE, new VaryNode( vertexNormalNode ) );
+			const vertexNormalNode = new MathNode( MathNode.TransformDirection, new NormalNode( NormalNode.View ), new CameraNode( CameraNode.ViewMatrix ) );
+			outputNode = new MathNode( MathNode.Normalize, new VaryNode( vertexNormalNode ) );
 
 		}
 

--- a/examples/jsm/nodes/accessors/Object3DNode.js
+++ b/examples/jsm/nodes/accessors/Object3DNode.js
@@ -6,13 +6,13 @@ import { NodeUpdateType } from '../core/constants.js';
 
 class Object3DNode extends Node {
 
-	static VIEW_MATRIX = 'viewMatrix';
-	static NORMAL_MATRIX = 'normalMatrix';
-	static WORLD_MATRIX = 'worldMatrix';
-	static POSITION = 'position';
-	static VIEW_POSITION = 'viewPosition';
+	static ViewMatrix = 'viewMatrix';
+	static NormalMatrix = 'normalMatrix';
+	static WorldMatrix = 'worldMatrix';
+	static Position = 'position';
+	static ViewPosition = 'viewPosition';
 
-	constructor( scope = Object3DNode.VIEW_MATRIX, object3d = null ) {
+	constructor( scope = Object3DNode.ViewMatrix, object3d = null ) {
 
 		super();
 
@@ -29,15 +29,15 @@ class Object3DNode extends Node {
 
 		const scope = this.scope;
 
-		if ( scope === Object3DNode.WORLD_MATRIX || scope === Object3DNode.VIEW_MATRIX ) {
+		if ( scope === Object3DNode.WorldMatrix || scope === Object3DNode.ViewMatrix ) {
 
 			return 'mat4';
 
-		} else if ( scope === Object3DNode.NORMAL_MATRIX ) {
+		} else if ( scope === Object3DNode.NormalMatrix ) {
 
 			return 'mat3';
 
-		} else if ( scope === Object3DNode.POSITION || scope === Object3DNode.VIEW_POSITION ) {
+		} else if ( scope === Object3DNode.Position || scope === Object3DNode.ViewPosition ) {
 
 			return 'vec3';
 
@@ -52,23 +52,23 @@ class Object3DNode extends Node {
 		const camera = frame.camera;
 		const scope = this.scope;
 
-		if ( scope === Object3DNode.VIEW_MATRIX ) {
+		if ( scope === Object3DNode.ViewMatrix ) {
 
 			inputNode.value = object.modelViewMatrix;
 
-		} else if ( scope === Object3DNode.NORMAL_MATRIX ) {
+		} else if ( scope === Object3DNode.NormalMatrix ) {
 
 			inputNode.value = object.normalMatrix;
 
-		} else if ( scope === Object3DNode.WORLD_MATRIX ) {
+		} else if ( scope === Object3DNode.WorldMatrix ) {
 
 			inputNode.value = object.matrixWorld;
 
-		} else if ( scope === Object3DNode.POSITION ) {
+		} else if ( scope === Object3DNode.Position ) {
 
 			inputNode.value.setFromMatrixPosition( object.matrixWorld );
 
-		} else if ( scope === Object3DNode.VIEW_POSITION ) {
+		} else if ( scope === Object3DNode.ViewPosition ) {
 
 			inputNode.value.setFromMatrixPosition( object.matrixWorld );
 
@@ -82,15 +82,15 @@ class Object3DNode extends Node {
 
 		const scope = this.scope;
 
-		if ( scope === Object3DNode.WORLD_MATRIX || scope === Object3DNode.VIEW_MATRIX ) {
+		if ( scope === Object3DNode.WorldMatrix || scope === Object3DNode.ViewMatrix ) {
 
 			this._inputNode = new Matrix4Node( /*null*/ );
 
-		} else if ( scope === Object3DNode.NORMAL_MATRIX ) {
+		} else if ( scope === Object3DNode.NormalMatrix ) {
 
 			this._inputNode = new Matrix3Node( /*null*/ );
 
-		} else if ( scope === Object3DNode.POSITION || scope === Object3DNode.VIEW_POSITION ) {
+		} else if ( scope === Object3DNode.Position || scope === Object3DNode.ViewPosition ) {
 
 			this._inputNode = new Vector3Node();
 

--- a/examples/jsm/nodes/accessors/PositionNode.js
+++ b/examples/jsm/nodes/accessors/PositionNode.js
@@ -7,13 +7,13 @@ import OperatorNode from '../math/OperatorNode.js';
 
 class PositionNode extends Node {
 
-	static GEOMETRY = 'geometry';
-	static LOCAL = 'local';
-	static WORLD = 'world';
-	static VIEW = 'view';
-	static VIEW_DIRECTION = 'viewDirection';
+	static Geometry = 'geometry';
+	static Local = 'local';
+	static World = 'world';
+	static View = 'view';
+	static ViewDirection = 'viewDirection';
 
-	constructor( scope = PositionNode.LOCAL ) {
+	constructor( scope = PositionNode.Local ) {
 
 		super( 'vec3' );
 
@@ -33,28 +33,28 @@ class PositionNode extends Node {
 
 		let outputNode = null;
 
-		if ( scope === PositionNode.GEOMETRY ) {
+		if ( scope === PositionNode.Geometry ) {
 
 			outputNode = new AttributeNode( 'position', 'vec3' );
 
-		} else if ( scope === PositionNode.LOCAL ) {
+		} else if ( scope === PositionNode.Local ) {
 
-			outputNode = new VaryNode( new PositionNode( PositionNode.GEOMETRY ) );
+			outputNode = new VaryNode( new PositionNode( PositionNode.Geometry ) );
 
-		} else if ( scope === PositionNode.WORLD ) {
+		} else if ( scope === PositionNode.World ) {
 
-			const vertexPositionNode = new MathNode( MathNode.TRANSFORM_DIRECTION, new ModelNode( ModelNode.WORLD_MATRIX ), new PositionNode( PositionNode.LOCAL ) );
+			const vertexPositionNode = new MathNode( MathNode.TransformDirection, new ModelNode( ModelNode.WorldMatrix ), new PositionNode( PositionNode.Local ) );
 			outputNode = new VaryNode( vertexPositionNode );
 
-		} else if ( scope === PositionNode.VIEW ) {
+		} else if ( scope === PositionNode.View ) {
 
-			const vertexPositionNode = new OperatorNode( '*', new ModelNode( ModelNode.VIEW_MATRIX ), new PositionNode( PositionNode.LOCAL ) );
+			const vertexPositionNode = new OperatorNode( '*', new ModelNode( ModelNode.ViewMatrix ), new PositionNode( PositionNode.Local ) );
 			outputNode = new VaryNode( vertexPositionNode );
 
-		} else if ( scope === PositionNode.VIEW_DIRECTION ) {
+		} else if ( scope === PositionNode.ViewDirection ) {
 
-			const vertexPositionNode = new MathNode( MathNode.NEGATE, new PositionNode( PositionNode.VIEW ) );
-			outputNode = new MathNode( MathNode.NORMALIZE, new VaryNode( vertexPositionNode ) );
+			const vertexPositionNode = new MathNode( MathNode.Negate, new PositionNode( PositionNode.View ) );
+			outputNode = new MathNode( MathNode.Normalize, new VaryNode( vertexPositionNode ) );
 
 		}
 

--- a/examples/jsm/nodes/accessors/SkinningNode.js
+++ b/examples/jsm/nodes/accessors/SkinningNode.js
@@ -75,8 +75,8 @@ class SkinningNode extends Node {
 	generate( builder ) {
 
 		// inout nodes
-		const position = new PositionNode( PositionNode.LOCAL );
-		const normal = new NormalNode( NormalNode.LOCAL );
+		const position = new PositionNode( PositionNode.Local );
+		const normal = new NormalNode( NormalNode.Local );
 
 		const index = this.skinIndexNode;
 		const weight = this.skinWeightNode;

--- a/examples/jsm/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/nodes/display/ColorSpaceNode.js
@@ -35,8 +35,8 @@ const EncodingLib = {
 
 class ColorSpaceNode extends TempNode {
 
-	static LINEAR_TO_LINEAR = 'LinearToLinear';
-	static LINEAR_TO_SRGB = 'LinearTosRGB';
+	static LinearToLinear = 'LinearToLinear';
+	static LinearTosRGB = 'LinearTosRGB';
 
 	constructor( method, node ) {
 
@@ -75,7 +75,7 @@ class ColorSpaceNode extends TempNode {
 		const method = this.method;
 		const node = this.node;
 
-		if ( method !== ColorSpaceNode.LINEAR_TO_LINEAR ) {
+		if ( method !== ColorSpaceNode.LinearToLinear ) {
 
 			const encodingFunctionNode = EncodingLib[ method ];
 

--- a/examples/jsm/nodes/display/NormalMapNode.js
+++ b/examples/jsm/nodes/display/NormalMapNode.js
@@ -70,17 +70,17 @@ class NormalMapNode extends TempNode {
 
 		if ( normalMapType === ObjectSpaceNormalMap ) {
 
-			const vertexNormalNode = new OperatorNode( '*', new ModelNode( ModelNode.NORMAL_MATRIX ), normalMap );
+			const vertexNormalNode = new OperatorNode( '*', new ModelNode( ModelNode.NormalMatrix ), normalMap );
 
-			const normal = new MathNode( MathNode.NORMALIZE, vertexNormalNode );
+			const normal = new MathNode( MathNode.Normalize, vertexNormalNode );
 
 			return normal.build( builder, type );
 
 		} else if ( normalMapType === TangentSpaceNormalMap ) {
 
 			const perturbNormal2ArbCall = perturbNormal2ArbNode( {
-				eye_pos: new PositionNode( PositionNode.VIEW ),
-				surf_norm: new NormalNode( NormalNode.VIEW ),
+				eye_pos: new PositionNode( PositionNode.View ),
+				surf_norm: new NormalNode( NormalNode.View ),
 				mapN: normalMap,
 				faceDirection: new FloatNode( 1.0 ).setConst( true ),
 				uv: new UVNode()

--- a/examples/jsm/nodes/lights/LightNode.js
+++ b/examples/jsm/nodes/lights/LightNode.js
@@ -37,14 +37,14 @@ class LightNode extends Node {
 
 	generate( builder ) {
 
-		const lightPositionView = new Object3DNode( Object3DNode.VIEW_POSITION );
-		const positionView = new PositionNode( PositionNode.VIEW );
+		const lightPositionView = new Object3DNode( Object3DNode.ViewPosition );
+		const positionView = new PositionNode( PositionNode.View );
 
 		const lVector = new OperatorNode( '-', lightPositionView, positionView );
 
-		const lightDirection = new MathNode( MathNode.NORMALIZE, lVector );
+		const lightDirection = new MathNode( MathNode.Normalize, lVector );
 
-		const lightDistance = new MathNode( MathNode.LENGTH, lVector );
+		const lightDistance = new MathNode( MathNode.Length, lVector );
 
 		const lightAttenuation = getDistanceAttenuation( {
 			lightDistance,

--- a/examples/jsm/nodes/math/MathNode.js
+++ b/examples/jsm/nodes/math/MathNode.js
@@ -8,54 +8,54 @@ class MathNode extends TempNode {
 
 	// 1 input
 
-	static RAD = 'radians';
-	static DEG = 'degrees';
-	static EXP = 'exp';
-	static EXP2 = 'exp2';
-	static LOG = 'log';
-	static LOG2 = 'log2';
-	static SQRT = 'sqrt';
-	static INV_SQRT = 'inversesqrt';
-	static FLOOR = 'floor';
-	static CEIL = 'ceil';
-	static NORMALIZE = 'normalize';
-	static FRACT = 'fract';
-	static SIN = 'sin';
-	static COS = 'cos';
-	static TAN = 'tan';
-	static ASIN = 'asin';
-	static ACOS = 'acos';
-	static ATAN = 'atan';
-	static ABS = 'abs';
-	static SIGN = 'sign';
-	static LENGTH = 'length';
-	static NEGATE = 'negate';
-	static INVERT = 'invert';
-	static DFDX = 'dFdx';
-	static DFDY = 'dFdy';
-	static SATURATE = 'saturate';
-	static ROUND = 'round';
+	static Radians = 'radians';
+	static Degrees = 'degrees';
+	static Exp = 'exp';
+	static Exp2 = 'exp2';
+	static Log = 'log';
+	static Log2 = 'log2';
+	static Sqrt = 'sqrt';
+	static InverseSqrt = 'inversesqrt';
+	static Floor = 'floor';
+	static Ceil = 'ceil';
+	static Normalize = 'normalize';
+	static Fract = 'fract';
+	static Sin = 'sin';
+	static Cos = 'cos';
+	static Tan = 'tan';
+	static Asin = 'asin';
+	static Acos = 'acos';
+	static Atan = 'atan';
+	static Abs = 'abs';
+	static Sign = 'sign';
+	static Length = 'length';
+	static Negate = 'negate';
+	static Invert = 'invert';
+	static DFdx = 'dFdx';
+	static DFdy = 'dFdy';
+	static Saturate = 'saturate';
+	static Round = 'round';
 
 	// 2 inputs
 
-	static MIN = 'min';
-	static MAX = 'max';
-	static MOD = 'mod';
-	static STEP = 'step';
-	static REFLECT = 'reflect';
-	static DISTANCE = 'distance';
-	static DOT = 'dot';
-	static CROSS = 'cross';
-	static POW = 'pow';
-	static TRANSFORM_DIRECTION = 'transformDirection';
+	static Min = 'min';
+	static Max = 'max';
+	static Mod = 'mod';
+	static Step = 'step';
+	static Reflect = 'reflect';
+	static Distance = 'distance';
+	static Dot = 'dot';
+	static Cross = 'cross';
+	static Pow = 'pow';
+	static TransformDirection = 'transformDirection';
 
 	// 3 inputs
 
-	static MIX = 'mix';
-	static CLAMP = 'clamp';
-	static REFRACT = 'refract';
-	static SMOOTHSTEP = 'smoothstep';
-	static FACEFORWARD = 'faceforward';
+	static Mix = 'mix';
+	static Clamp = 'clamp';
+	static Refract = 'refract';
+	static Smoothstep = 'smoothstep';
+	static Faceforward = 'faceforward';
 
 	constructor( method, aNode, bNode = null, cNode = null ) {
 
@@ -101,11 +101,11 @@ class MathNode extends TempNode {
 
 		const method = this.method;
 
-		if ( method === MathNode.LENGTH || method === MathNode.DISTANCE || method === MathNode.DOT ) {
+		if ( method === MathNode.Length || method === MathNode.Distance || method === MathNode.Dot ) {
 
 			return 'float';
 
-		} else if ( method === MathNode.CROSS ) {
+		} else if ( method === MathNode.Cross ) {
 
 			return 'vec3';
 
@@ -130,7 +130,7 @@ class MathNode extends TempNode {
 
 		const isWebGL = builder.renderer.isWebGLRenderer === true;
 
-		if ( isWebGL && ( method === MathNode.DFDX || method === MathNode.DFDY ) && output === 'vec3' ) {
+		if ( isWebGL && ( method === MathNode.DFdx || method === MathNode.DFdy ) && output === 'vec3' ) {
 
 			// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
@@ -140,7 +140,7 @@ class MathNode extends TempNode {
 				new MathNode( method, new SplitNode( a, 'z' ) )
 			] ).build( builder );
 
-		} else if ( method === MathNode.TRANSFORM_DIRECTION ) {
+		} else if ( method === MathNode.TransformDirection ) {
 
 			// dir can be either a direction vector or a normal vector
 			// upper-left 3x3 of matrix is assumed to be orthogonal
@@ -160,17 +160,17 @@ class MathNode extends TempNode {
 
 			const mulNode = new SplitNode( new OperatorNode( '*', tA, tB ), 'xyz' );
 
-			return new MathNode( MathNode.NORMALIZE, mulNode ).build( builder );
+			return new MathNode( MathNode.Normalize, mulNode ).build( builder );
 
-		} else if ( method === MathNode.SATURATE ) {
+		} else if ( method === MathNode.Saturate ) {
 
 			return builder.format( `clamp( ${ a.build( builder, inputType ) }, 0.0, 1.0 )`, type, output );
 
-		} else if ( method === MathNode.NEGATE ) {
+		} else if ( method === MathNode.Negate ) {
 
 			return builder.format( '( -' + a.build( builder, inputType ) + ' )', type, output );
 
-		} else if ( method === MathNode.INVERT ) {
+		} else if ( method === MathNode.Invert ) {
 
 			return builder.format( '( 1.0 - ' + a.build( builder, inputType ) + ' )', type, output );
 
@@ -178,21 +178,21 @@ class MathNode extends TempNode {
 
 			const params = [];
 
-			if ( method === MathNode.CROSS ) {
+			if ( method === MathNode.Cross ) {
 
 				params.push(
 					a.build( builder, type ),
 					b.build( builder, type )
 				);
 
-			} else if ( method === MathNode.STEP ) {
+			} else if ( method === MathNode.Step ) {
 
 				params.push(
 					a.build( builder, builder.getTypeLength( a.getNodeType( builder ) ) === 1 ? 'float' : inputType ),
 					b.build( builder, inputType )
 				);
 
-			} else if ( ( isWebGL && ( method === MathNode.MIN || method === MathNode.MAX ) ) || method === MathNode.MOD ) {
+			} else if ( ( isWebGL && ( method === MathNode.Min || method === MathNode.Max ) ) || method === MathNode.Mod ) {
 
 				params.push(
 					a.build( builder, inputType ),
@@ -207,7 +207,7 @@ class MathNode extends TempNode {
 					c.build( builder, 'float' )
 				);
 
-			} else if ( method === MathNode.MIX ) {
+			} else if ( method === MathNode.Mix ) {
 
 				params.push(
 					a.build( builder, inputType ),

--- a/examples/jsm/nodes/utils/OscNode.js
+++ b/examples/jsm/nodes/utils/OscNode.js
@@ -4,12 +4,12 @@ import { abs, fract, round, sin, add, sub, mul, PI2 } from '../ShaderNode.js';
 
 class OscNode extends Node {
 
-	static SINE = 'sine';
-	static SQUARE = 'square';
-	static TRIANGLE = 'triangle';
-	static SAWTOOTH = 'sawtooth';
+	static Sine = 'sine';
+	static Square = 'square';
+	static Triangle = 'triangle';
+	static Sawtooth = 'sawtooth';
 
-	constructor( method = OscNode.SINE, timeNode = new TimerNode() ) {
+	constructor( method = OscNode.Sine, timeNode = new TimerNode() ) {
 
 		super();
 
@@ -31,19 +31,19 @@ class OscNode extends Node {
 
 		let outputNode = null;
 
-		if ( method === OscNode.SINE ) {
+		if ( method === OscNode.Sine ) {
 
 			outputNode = add( mul( sin( mul( add( timeNode, .75 ), PI2 ) ), .5 ), .5 );
 
-		} else if ( method === OscNode.SQUARE ) {
+		} else if ( method === OscNode.Square ) {
 
 			outputNode = round( fract( timeNode ) );
 
-		} else if ( method === OscNode.TRIANGLE ) {
+		} else if ( method === OscNode.Triangle ) {
 
 			outputNode = abs( sub( 1, mul( fract( add( timeNode, .5 ) ), 2 ) ) );
 
-		} else if ( method === OscNode.SAWTOOTH ) {
+		} else if ( method === OscNode.Sawtooth ) {
 
 			outputNode = fract( timeNode );
 

--- a/examples/jsm/nodes/utils/SpriteSheetUVNode.js
+++ b/examples/jsm/nodes/utils/SpriteSheetUVNode.js
@@ -31,12 +31,12 @@ class SpriteSheetUVNode extends Node {
 
 		const total = new OperatorNode( '*', width, height );
 
-		const roundFrame = new MathNode( MathNode.FLOOR, new MathNode( MathNode.MOD, frame, total ) );
+		const roundFrame = new MathNode( MathNode.Floor, new MathNode( MathNode.Mod, frame, total ) );
 
 		const frameNum = new OperatorNode( '+', roundFrame, one );
 
-		const cell = new MathNode( MathNode.MOD, roundFrame, width );
-		const row = new MathNode( MathNode.CEIL, new OperatorNode( '/', frameNum, width ) );
+		const cell = new MathNode( MathNode.Mod, roundFrame, width );
+		const row = new MathNode( MathNode.Ceil, new OperatorNode( '/', frameNum, width ) );
 		const rowInv = new OperatorNode( '-', height, row );
 
 		const scale = new OperatorNode( '/', one, count );

--- a/examples/jsm/nodes/utils/TimerNode.js
+++ b/examples/jsm/nodes/utils/TimerNode.js
@@ -3,11 +3,11 @@ import { NodeUpdateType } from '../core/constants.js';
 
 class TimerNode extends FloatNode {
 
-	static LOCAL = 'local';
-	static GLOBAL = 'global';
-	static DELTA = 'delta';
+	static Local = 'local';
+	static Global = 'global';
+	static Delta = 'delta';
 
-	constructor( scope = TimerNode.LOCAL ) {
+	constructor( scope = TimerNode.Local ) {
 
 		super();
 
@@ -23,11 +23,11 @@ class TimerNode extends FloatNode {
 		const scope = this.scope;
 		const scale = this.scale;
 
-		if ( scope === TimerNode.LOCAL ) {
+		if ( scope === TimerNode.Local ) {
 
 			this.value += frame.deltaTime * scale;
 
-		} else if ( scope === TimerNode.DELTA ) {
+		} else if ( scope === TimerNode.Delta ) {
 
 			this.value = frame.deltaTime * scale;
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -128,8 +128,8 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 		if ( material.envNode && material.envNode.isNode ) {
 
-			const envRadianceNode = new WebGLPhysicalContextNode( WebGLPhysicalContextNode.RADIANCE, material.envNode );
-			const envIrradianceNode = new WebGLPhysicalContextNode( WebGLPhysicalContextNode.IRRADIANCE, material.envNode );
+			const envRadianceNode = new WebGLPhysicalContextNode( WebGLPhysicalContextNode.Radiance, material.envNode );
+			const envIrradianceNode = new WebGLPhysicalContextNode( WebGLPhysicalContextNode.Irradiance, material.envNode );
 
 			this.addSlot( 'fragment', new SlotNode( envRadianceNode, 'RADIANCE', 'vec3' ) );
 			this.addSlot( 'fragment', new SlotNode( envIrradianceNode, 'IRRADIANCE', 'vec3' ) );

--- a/examples/jsm/renderers/webgl/nodes/WebGLPhysicalContextNode.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLPhysicalContextNode.js
@@ -5,8 +5,8 @@ import FloatNode from 'three-nodes/inputs/FloatNode.js';
 
 class WebGLPhysicalContextNode extends ContextNode {
 
-	static RADIANCE = 'radiance';
-	static IRRADIANCE = 'irradiance';
+	static Radiance = 'radiance';
+	static Irradiance = 'irradiance';
 
 	constructor( scope, node ) {
 
@@ -22,15 +22,15 @@ class WebGLPhysicalContextNode extends ContextNode {
 
 		let roughness = null;
 
-		if ( scope === WebGLPhysicalContextNode.RADIANCE ) {
+		if ( scope === WebGLPhysicalContextNode.Radiance ) {
 
 			roughness = new ExpressionNode( 'roughnessFactor', 'float' );
 
-		} else if ( scope === WebGLPhysicalContextNode.IRRADIANCE ) {
+		} else if ( scope === WebGLPhysicalContextNode.Irradiance ) {
 
 			roughness = new FloatNode( 1.0 ).setConst( true );
 
-			this.context.uv = new NormalNode( NormalNode.WORLD );
+			this.context.uv = new NormalNode( NormalNode.World );
 
 		}
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -108,7 +108,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			// VERTEX STAGE
 
-			let vertex = new PositionNode( PositionNode.GEOMETRY );
+			let vertex = new PositionNode( PositionNode.Geometry );
 
 			if ( lightNode === null && this.lightNode && this.lightNode.hasLights === true ) {
 
@@ -118,7 +118,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			if ( material.positionNode && material.positionNode.isNode ) {
 
-				const assignPositionNode = new OperatorNode( '=', new PositionNode( PositionNode.LOCAL ), material.positionNode );
+				const assignPositionNode = new OperatorNode( '=', new PositionNode( PositionNode.Local ), material.positionNode );
 
 				vertex = new BypassNode( vertex, assignPositionNode );
 
@@ -144,7 +144,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			} else {
 
-				colorNode = new MaterialNode( MaterialNode.COLOR );
+				colorNode = new MaterialNode( MaterialNode.Color );
 
 			}
 
@@ -162,7 +162,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			} else {
 
-				opacityNode = new VarNode( new MaterialNode( MaterialNode.OPACITY ) );
+				opacityNode = new VarNode( new MaterialNode( MaterialNode.Opacity ) );
 
 			}
 
@@ -180,7 +180,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			} else if ( material.alphaTest > 0 ) {
 
-				alphaTest = new MaterialNode( MaterialNode.ALPHA_TEST );
+				alphaTest = new MaterialNode( MaterialNode.AlphaTest );
 
 			}
 
@@ -204,7 +204,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 				} else {
 
-					metalnessNode = new MaterialNode( MaterialNode.METALNESS );
+					metalnessNode = new MaterialNode( MaterialNode.Metalness );
 
 				}
 
@@ -222,7 +222,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 				} else {
 
-					roughnessNode = new MaterialNode( MaterialNode.ROUGHNESS );
+					roughnessNode = new MaterialNode( MaterialNode.Roughness );
 
 				}
 
@@ -244,7 +244,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 				} else {
 
-					normalNode = new NormalNode( NormalNode.VIEW );
+					normalNode = new NormalNode( NormalNode.View );
 
 				}
 
@@ -286,7 +286,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			if ( outputEncoding !== LinearEncoding ) {
 
-				outputNode = new ColorSpaceNode( ColorSpaceNode.LINEAR_TO_LINEAR, outputNode );
+				outputNode = new ColorSpaceNode( ColorSpaceNode.LinearToLinear, outputNode );
 				outputNode.fromEncoding( outputEncoding );
 
 			}

--- a/examples/webgl_points_nodes.html
+++ b/examples/webgl_points_nodes.html
@@ -115,7 +115,7 @@
 
 				const lerpPosition = new Nodes.FloatNode( 0 );
 
-				const positionNode = new Nodes.MathNode( Nodes.MathNode.MIX, new Nodes.PositionNode( Nodes.PositionNode.LOCAL ), targetPosition, lerpPosition );
+				const positionNode = new Nodes.MathNode( Nodes.MathNode.Mix, new Nodes.PositionNode( Nodes.PositionNode.Local ), targetPosition, lerpPosition );
 
 				// material
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -89,24 +89,24 @@
 				//	BASIC
 				//
 
-				// PositionNode.LOCAL
+				// PositionNode.Local
 				material = new Nodes.MeshBasicNodeMaterial();
-				material.colorNode = new Nodes.PositionNode( Nodes.PositionNode.LOCAL );
+				material.colorNode = new Nodes.PositionNode( Nodes.PositionNode.Local );
 				materials.push( material );
 
-				// NormalNode.LOCAL
+				// NormalNode.Local
 				material = new Nodes.MeshBasicNodeMaterial();
-				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.LOCAL );
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.Local );
 				materials.push( material );
 
-				// NormalNode.WORLD
+				// NormalNode.World
 				material = new Nodes.MeshBasicNodeMaterial();
-				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.WORLD );
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.World );
 				materials.push( material );
 
-				// NormalNode.VIEW
+				// NormalNode.View
 				material = new Nodes.MeshBasicNodeMaterial();
-				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.VIEW );
+				material.colorNode = new Nodes.NormalNode( Nodes.NormalNode.View );
 				materials.push( material );
 
 				// TextureNode

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -103,10 +103,10 @@
 				const displaceAnimated = new Nodes.SplitNode( new Nodes.TextureNode( textureDisplace ), 'x' );
 				const displaceY = new Nodes.OperatorNode( '*', displaceAnimated, new Nodes.FloatNode( .25 ).setConst( true ) );
 
-				const displace = new Nodes.OperatorNode( '*', new Nodes.NormalNode( Nodes.NormalNode.LOCAL ), displaceY );
+				const displace = new Nodes.OperatorNode( '*', new Nodes.NormalNode( Nodes.NormalNode.Local ), displaceY );
 
 				materialSphere.colorNode = displaceY;
-				materialSphere.positionNode = new Nodes.OperatorNode( '+', new Nodes.PositionNode( Nodes.PositionNode.LOCAL ), displace );
+				materialSphere.positionNode = new Nodes.OperatorNode( '+', new Nodes.PositionNode( Nodes.PositionNode.Local ), displace );
 
 				const sphere = new THREE.Mesh( geometrySphere, materialSphere );
 				sphere.position.set( - 2, - 1, 0 );


### PR DESCRIPTION
**Description**

The static properties of Three.js don't use all caps by default like `POSITION` but `Position`. I think it's good to adapt `NodeMaterial`  as soon as possible for this style?

```js
// before
new NormalNode( NormalNode.LOCAL );
new PositionNode( PositionNode.VIEW_DIRECTION );

// after
new NormalNode( NormalNode.Local );
new PositionNode( PositionNode.ViewDirection );
```

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
