### PR TITLE
Reuse 'setDrawingBufferSize' from 'setSize' in WebGLRenderer

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -385,11 +385,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		_width = width;
-		_height = height;
-
-		_canvas.width = Math.floor( width * _pixelRatio );
-		_canvas.height = Math.floor( height * _pixelRatio );
+		this.setDrawingBufferSize(width, height, _pixelRatio);
 
 		if ( updateStyle !== false ) {
 
@@ -397,8 +393,6 @@ function WebGLRenderer( parameters = {} ) {
 			_canvas.style.height = height + 'px';
 
 		}
-
-		this.setViewport( 0, 0, width, height );
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -385,7 +385,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		this.setDrawingBufferSize(width, height, _pixelRatio);
+		this.setDrawingBufferSize( width, height, _pixelRatio );
 
 		if ( updateStyle !== false ) {
 


### PR DESCRIPTION
**Description**

The major piece of `WebGLRenderer.setSize` implementation is pretty similar to `WebGLRenderer.setDrawingBufferSize` so I'm wondering whether the latter could be reused from the former to honor the DRY principle. 

Is there any reason to keep these both methods unrelated even when their implementations are similar?


