### PR TITLE
added loaders to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
+    "./examples/jsm/loaders/*": "./examples/jsm/loaders/*",
     "./src/*": "./src/*"
   },
   "repository": {


### PR DESCRIPTION
Added the `examples/jsm/loaders` folder to the exports list in package.json. 

The import:
`import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";`
Would give the error: 
`Package "three" exists but package.json "exports" does not include entry for "./examples/jsm/loaders/GLTFLoader.js".`

But this fixes it. (This doesn't include every other folder in /examples, though, just loaders)