### PR TITLE
Example: Orient objects normal to hittest in webxr_ar_hittest

### DIFF
--- a/examples/webxr_ar_hittest.html
+++ b/examples/webxr_ar_hittest.html
@@ -76,7 +76,7 @@
 
 						const material = new THREE.MeshPhongMaterial( { color: 0xffffff * Math.random() } );
 						const mesh = new THREE.Mesh( geometry, material );
-						mesh.position.setFromMatrixPosition( reticle.matrix );
+						reticle.matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
 						mesh.scale.y = Math.random() * 2 + 1;
 						scene.add( mesh );
 

--- a/examples/webxr_ar_hittest.html
+++ b/examples/webxr_ar_hittest.html
@@ -76,7 +76,7 @@
 
 						const material = new THREE.MeshPhongMaterial( { color: 0xffffff * Math.random() } );
 						const mesh = new THREE.Mesh( geometry, material );
-						reticle.matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
+						reticle.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
 						mesh.scale.y = Math.random() * 2 + 1;
 						scene.add( mesh );
 


### PR DESCRIPTION
Related issue: #23506

The webxr_ar_hittest example is great to show XR capabilites with a reticle and when tapping it generates cylinders at the position raycasted in your room.

In this small PR we added the normal orientation using the Hit test normal.
![image](https://user-images.githubusercontent.com/158514/155425331-9136af0e-6f32-4648-a1aa-54b47ddef782.png)
