### PR TITLE
Docs: Fix transparency in material browser.

### DIFF
--- a/docs/manual/ar/introduction/How-to-update-things.html
+++ b/docs/manual/ar/introduction/How-to-update-things.html
@@ -140,6 +140,7 @@ line.geometry.computeBoundingSphere();
 						<li>morphing</li>
 						<li>shadow map</li>
 						<li>alpha test</li>
+						<li>transparent</li>
 					</ul>
 				</li>
 			</ul>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -150,6 +150,7 @@ line.geometry.computeBoundingSphere();
 						<li>morphing</li>
 						<li>shadow map</li>
 						<li>alpha test</li>
+						<li>transparent</li>
 					</ul>
 				</li>
 			</ul>

--- a/docs/manual/ja/introduction/How-to-update-things.html
+++ b/docs/manual/ja/introduction/How-to-update-things.html
@@ -149,6 +149,7 @@ line.geometry.computeBoundingSphere();
                     <li>morphing</li>
                     <li>shadow map</li>
                     <li>alpha test</li>
+										<li>transparent</li>
                 </ul>
             </li>
         </ul>

--- a/docs/manual/ja/introduction/How-to-update-things.html
+++ b/docs/manual/ja/introduction/How-to-update-things.html
@@ -149,7 +149,7 @@ line.geometry.computeBoundingSphere();
                     <li>morphing</li>
                     <li>shadow map</li>
                     <li>alpha test</li>
-										<li>transparent</li>
+                    <li>transparent</li>
                 </ul>
             </li>
         </ul>

--- a/docs/manual/ko/introduction/How-to-update-things.html
+++ b/docs/manual/ko/introduction/How-to-update-things.html
@@ -146,6 +146,7 @@ line.geometry.computeBoundingSphere();
 						<li>morphing</li>
 						<li>shadow map</li>
 						<li>alpha test</li>
+						<li>transparent</li>
 					</ul>
 				</li>
 			</ul>

--- a/docs/manual/zh/introduction/How-to-update-things.html
+++ b/docs/manual/zh/introduction/How-to-update-things.html
@@ -135,6 +135,7 @@ line.geometry.attributes.position.needsUpdate = true; // 需要加在第一次�
 						<li>morphing</li>
 						<li>shadow map</li>
 						<li>alpha test</li>
+						<li>transparent</li>
 					</ul>
 				</li>
 			</ul>

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -343,7 +343,7 @@
 
 				const folder = gui.addFolder( 'THREE.Material' );
 
-				folder.add( material, 'transparent' );
+				folder.add( material, 'transparent' ).onChange( needsUpdate( material, geometry ) );
 				folder.add( material, 'opacity', 0, 1 ).step( 0.01 );
 				// folder.add( material, 'blending', constants.blendingMode );
 				// folder.add( material, 'blendSrc', constants.destinationFactors );


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/opacity-bug-in-materials-documentation/35251

**Description**

Since `Material.transparent` controls the `opaque` program parameter, it is necessary to call `needsUpdate` to `true` if the transparency setting changes over time.