### PR TITLE
Docs: Add Quaternion.multiplyQuaternionsFlat().

### DIFF
--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -233,9 +233,20 @@
 		[page:Array src1] - The source array of the target quaternion.<br />
 		[page:Integer srcOffset1] - An offset into the array *src1*.<br />
 		[page:Float t] - Normalized interpolation factor (between 0 and 1).<br /><br />
+
+		This SLERP implementation assumes the quaternion data are managed in flat arrays.
 		</p>
+
+		<h3>[method:Array multiplyQuaternionsFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1] )</h3>
 		<p>
-		Like the static *slerp* method above, but operates directly on flat arrays of numbers.
+		[page:Array dst] - The output array.<br />
+		[page:Integer dstOffset] - An offset into the output array.<br />
+		[page:Array src0] - The source array of the starting quaternion.<br />
+		[page:Integer srcOffset0] - An offset into the array *src0*.<br />
+		[page:Array src1] - The source array of the target quaternion.<br />
+		[page:Integer srcOffset1] - An offset into the array *src1*.<br /><br />
+
+		This multiplication implementation assumes the quaternion data are managed in flat arrays.
 		</p>
 
 		<!-- Note: Do not add non-static methods to the bottom of this page. Put them above the <h2>Static Methods</h2> -->

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -218,9 +218,20 @@
 		[page:Array src1] - 目标四元数的源数组<br />
 		[page:Integer srcOffset1] - 数组 *src1* 的偏移量<br />
 		[page:Float t] - 归一化插值因子(介于 0 和 1 之间)<br /><br />
+
+		This SLERP implementation assumes the quaternion data are managed in flat arrays.
 		</p>
+
+		<h3>[method:Array multiplyQuaternionsFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1] )</h3>
 		<p>
-		类似于上面的 *slerp* 方法，但直接对平面数组进行操作。
+		[page:Array dst] - The output array.<br />
+		[page:Integer dstOffset] - An offset into the output array.<br />
+		[page:Array src0] - The source array of the starting quaternion.<br />
+		[page:Integer srcOffset0] - An offset into the array *src0*.<br />
+		[page:Array src1] - The source array of the target quaternion.<br />
+		[page:Integer srcOffset1] - An offset into the array *src1*.<br /><br />
+
+		This multiplication implementation assumes the quaternion data are managed in flat arrays.
 		</p>
 
 		<!-- Note: Do not add non-static methods to the bottom of this page. Put them above the <h2>Static Methods</h2> -->


### PR DESCRIPTION
Related issue: #23509

**Description**

Documents the missing `multiplyQuaternionsFlat()` method.
