### PR TITLE
CubeCamera: Disable outputencoding and tonemapping

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -1,3 +1,4 @@
+import { LinearEncoding, NoToneMapping } from '../constants.js';
 import { Object3D } from '../core/Object3D.js';
 import { Vector3 } from '../math/Vector3.js';
 import { PerspectiveCamera } from './PerspectiveCamera.js';
@@ -67,9 +68,14 @@ class CubeCamera extends Object3D {
 
 		const [ cameraPX, cameraNX, cameraPY, cameraNY, cameraPZ, cameraNZ ] = this.children;
 
-		const currentXrEnabled = renderer.xr.enabled;
 		const currentRenderTarget = renderer.getRenderTarget();
 
+		const currentOutputEncoding = renderer.outputEncoding;
+		const currentToneMapping = renderer.toneMapping;
+		const currentXrEnabled = renderer.xr.enabled;
+
+		renderer.outputEncoding = LinearEncoding;
+		renderer.toneMapping = NoToneMapping;
 		renderer.xr.enabled = false;
 
 		const generateMipmaps = renderTarget.texture.generateMipmaps;
@@ -98,6 +104,8 @@ class CubeCamera extends Object3D {
 
 		renderer.setRenderTarget( currentRenderTarget );
 
+		renderer.outputEncoding = currentOutputEncoding;
+		renderer.toneMapping = currentToneMapping;
 		renderer.xr.enabled = currentXrEnabled;
 
 		renderTarget.texture.needsPMREMUpdate = true;


### PR DESCRIPTION
**Description**

| Before | After |
| --- | --- |
| <img width="1278" alt="Screen Shot 2022-02-24 at 9 37 25 AM" src="https://user-images.githubusercontent.com/97088/155577608-8151cd26-a01b-47cc-abea-c5e7fa4052b0.png"> | <img width="1279" alt="Screen Shot 2022-02-24 at 9 37 48 AM" src="https://user-images.githubusercontent.com/97088/155577645-8075808a-869a-43d2-ae03-27b37698617f.png"> |

