### PR TITLE
USDZExporter: Support opacity materials

### DIFF
--- a/examples/js/exporters/USDZExporter.js
+++ b/examples/js/exporters/USDZExporter.js
@@ -375,6 +375,7 @@ ${array.join( '' )}
             float outputs:g
             float outputs:b
             float3 outputs:rgb
+            ${material.transparent || material.alphaTest > 0.0 ? 'float outputs:a' : ''}
         }`;
 
 		}
@@ -382,6 +383,18 @@ ${array.join( '' )}
 		if ( material.map !== null ) {
 
 			inputs.push( `${pad}color3f inputs:diffuseColor.connect = </Materials/Material_${material.id}/Texture_${material.map.id}_diffuse.outputs:rgb>` );
+
+			if ( material.transparent ) {
+
+				inputs.push( `${pad}float inputs:opacity.connect = </Materials/Material_${material.id}/Texture_${material.map.id}_diffuse.outputs:a>` );
+
+			} else if ( material.alphaTest > 0.0 ) {
+
+				inputs.push( `${pad}float inputs:opacity.connect = </Materials/Material_${material.id}/Texture_${material.map.id}_diffuse.outputs:a>` );
+				inputs.push( `${pad}float inputs:opacityThreshold = ${material.alphaTest}` );
+
+			}
+
 			samplers.push( buildTexture( material.map, 'diffuse', material.color ) );
 
 		} else {

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -402,6 +402,7 @@ function buildMaterial( material, textures ) {
             float outputs:g
             float outputs:b
             float3 outputs:rgb
+            ${ material.transparent || material.alphaTest > 0.0 ? 'float outputs:a' : '' }
         }`;
 
 	}
@@ -409,6 +410,17 @@ function buildMaterial( material, textures ) {
 	if ( material.map !== null ) {
 
 		inputs.push( `${ pad }color3f inputs:diffuseColor.connect = </Materials/Material_${ material.id }/Texture_${ material.map.id }_diffuse.outputs:rgb>` );
+
+		if ( material.transparent ) {
+
+			inputs.push( `${ pad }float inputs:opacity.connect = </Materials/Material_${ material.id }/Texture_${ material.map.id }_diffuse.outputs:a>` );
+
+		} else if ( material.alphaTest > 0.0 ) {
+
+			inputs.push( `${ pad }float inputs:opacity.connect = </Materials/Material_${ material.id }/Texture_${ material.map.id }_diffuse.outputs:a>` );
+			inputs.push( `${ pad }float inputs:opacityThreshold = ${material.alphaTest}` );
+
+		}
 
 		samplers.push( buildTexture( material.map, 'diffuse', material.color ) );
 


### PR DESCRIPTION
Fixed #22205
Related issue: google/model-viewer#2476

**Description**

Added support for displaying materials with transparent textures.

I implemented this by referring to the [USD spec](https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html) and [RealityConverter](https://developer.apple.com/augmented-reality/tools/)'s output.

Tested with Reality Converter on mac os and iOS 15.3.1 AR QuickLook, works!

The photos below were taken of this [model](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AlphaBlendModeTest) using the AR QuickLook on the iPhone.
| Before | After |
| -- | -- | 
| ![image](https://user-images.githubusercontent.com/20057935/155655864-f2164785-82e8-407a-b409-709b5cc6472f.png) | ![image](https://user-images.githubusercontent.com/20057935/155655885-8e6d5b67-d92d-4757-9ada-58b934185654.png) |
