### PR TITLE
GLTF: export same mimetype as import

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -758,21 +758,7 @@ class GLTFWriter {
 
 			const texture = new Texture( canvas );
 
-			let mimeType = material.roughnessMap.userData.mimeType;
-
-			if ( ! mimeType ) {
-
-				mimeType = material.metalnessMap.userData.mimeType;
-
-			} 
-			
-			if ( ! mimeType ) {
-
-				mimeType = material.aoMap.userData.mimeType;
-
-			}
-			
-			texture.userData.mimeType = mimeType;
+			texture.userData.mimeType = material.roughnessMap.userData.mimeType || material.metalnessMap.userData.mimeType || material.aoMap.userData.mimeType;
 
 			return texture;
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -756,7 +756,11 @@ class GLTFWriter {
 
 			context.putImageData( composite, 0, 0 );
 
-			return new Texture( canvas );
+			const texture = new Texture( canvas );
+
+			texture.userData.mimeType = material.roughnessMap.userData.mimeType ?? material.metalnessMap.userData.mimeType ?? material.aoMap.userData.mimeType;
+
+			return texture;
 
 		}
 
@@ -1037,9 +1041,10 @@ class GLTFWriter {
 	 * @param  {Image} image to process
 	 * @param  {Integer} format of the image (RGBAFormat)
 	 * @param  {Boolean} flipY before writing out the image
+	 * @param  {String} mimeType export format
 	 * @return {Integer}     Index of the processed texture in the "images" array
 	 */
-	processImage( image, format, flipY ) {
+	processImage( image, format, flipY, mimeType = 'image/png' ) {
 
 		const writer = this;
 		const cache = writer.cache;
@@ -1050,7 +1055,7 @@ class GLTFWriter {
 		if ( ! cache.images.has( image ) ) cache.images.set( image, {} );
 
 		const cachedImages = cache.images.get( image );
-		const mimeType = 'image/png';
+
 		const key = mimeType + ':flipY/' + flipY.toString();
 
 		if ( cachedImages[ key ] !== undefined ) return cachedImages[ key ];
@@ -1184,7 +1189,7 @@ class GLTFWriter {
 
 		const textureDef = {
 			sampler: this.processSampler( map ),
-			source: this.processImage( map.image, map.format, map.flipY )
+			source: this.processImage( map.image, map.format, map.flipY, map.userData.mimeType )
 		};
 
 		if ( map.name ) textureDef.name = map.name;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1187,7 +1187,9 @@ class GLTFWriter {
 
 		if ( ! json.textures ) json.textures = [];
 
-		const mimeType = map.userData.mimeType === 'image/webp' ? 'image/png' : map.userData.mimeType;
+		let mimeType = map.userData.mimeType;
+
+		if ( mimeType === 'image/webp' ) mimeType = 'image/png';
 
 		const textureDef = {
 			sampler: this.processSampler( map ),

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -758,7 +758,21 @@ class GLTFWriter {
 
 			const texture = new Texture( canvas );
 
-			texture.userData.mimeType = material.roughnessMap.userData.mimeType ?? material.metalnessMap.userData.mimeType ?? material.aoMap.userData.mimeType;
+			let mimeType = material.roughnessMap.userData.mimeType;
+
+			if ( ! mimeType ) {
+
+				mimeType = material.metalnessMap.userData.mimeType;
+
+			} 
+			
+			if ( ! mimeType ) {
+
+				mimeType = material.aoMap.userData.mimeType;
+
+			}
+			
+			texture.userData.mimeType = mimeType;
 
 			return texture;
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1187,9 +1187,11 @@ class GLTFWriter {
 
 		if ( ! json.textures ) json.textures = [];
 
+		const mimeType = map.userData.mimeType === 'image/webp' ? 'image/png' : map.userData.mimeType;
+
 		const textureDef = {
 			sampler: this.processSampler( map ),
-			source: this.processImage( map.image, map.format, map.flipY, map.userData.mimeType )
+			source: this.processImage( map.image, map.format, map.flipY, mimeType )
 		};
 
 		if ( map.name ) textureDef.name = map.name;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2968,10 +2968,10 @@ class GLTFParser {
 
 			texture.userData.mimeType = sourceDef.mimeType;
 
-			if ( ! sourceDef.mimeType || sourceDef.mimeType === 'image/webp' ) {
+			if ( ! sourceDef.mimeType ) {
 
 				const ext = sourceDef.uri.split( '.' ).pop().toLowerCase();
-				texture.userData.mimeType = ext.includes( 'jp' ) ? 'image/jpeg' : 'image/png';
+				texture.userData.mimeType = ( ext.includes( 'jp' ) || ext === 'webp' ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2968,10 +2968,10 @@ class GLTFParser {
 
 			texture.userData.mimeType = sourceDef.mimeType;
 
-			if ( !sourceDef.mimeType ) {
+			if ( ! sourceDef.mimeType ) {
 
-				const ext = sourceDef.uri.split('.').pop().toLowerCase();
-				texture.userData.mimeType = ext.includes('jp') ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
+				const ext = sourceDef.uri.split( '.' ).pop().toLowerCase();
+				texture.userData.mimeType = ext.includes( 'jp' ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2971,7 +2971,7 @@ class GLTFParser {
 			if ( ! sourceDef.mimeType ) {
 
 				const ext = sourceDef.uri.split( '.' ).pop().toLowerCase();
-				texture.userData.mimeType = ( ext.includes( 'jp' ) || ext === 'webp' ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
+				texture.userData.mimeType = ( ext.includes( 'jp' ) ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2968,10 +2968,10 @@ class GLTFParser {
 
 			texture.userData.mimeType = sourceDef.mimeType;
 
-			if ( ! sourceDef.mimeType ) {
+			if ( ! sourceDef.mimeType || sourceDef.mimeType === 'image/webp' ) {
 
 				const ext = sourceDef.uri.split( '.' ).pop().toLowerCase();
-				texture.userData.mimeType = ext.includes( 'jp' ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
+				texture.userData.mimeType = ext.includes( 'jp' ) ? 'image/jpeg' : 'image/png';
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2966,6 +2966,15 @@ class GLTFParser {
 
 			}
 
+			texture.userData.mimeType = sourceDef.mimeType;
+
+			if ( !sourceDef.mimeType ) {
+
+				const ext = sourceDef.uri.split('.').pop().toLowerCase();
+				texture.userData.mimeType = ext.includes('jp') ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
+
+			}
+
 			return texture;
 
 		} ).catch( function ( error ) {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2234,6 +2234,15 @@ function getNormalizedComponentScale( constructor ) {
 
 }
 
+function getImageURIMimeType( uri ) {
+
+	if ( uri.search( /\.jpe?g($|\?)/i ) > 0 || uri.search( /^data\:image\/jpeg/ ) === 0 ) return 'image/jpeg';
+	if ( uri.search( /\.webp($|\?)/i ) > 0 || uri.search( /^data\:image\/webp/ ) === 0 ) return 'image/webp';
+
+	return 'image/png';
+
+}
+
 /* GLTF PARSER */
 
 class GLTFParser {
@@ -2966,14 +2975,7 @@ class GLTFParser {
 
 			}
 
-			texture.userData.mimeType = sourceDef.mimeType;
-
-			if ( ! sourceDef.mimeType ) {
-
-				const ext = sourceDef.uri.split( '.' ).pop().toLowerCase();
-				texture.userData.mimeType = ( ext.includes( 'jp' ) ) ? 'image/jpeg' : ext === 'webp' ? 'image/webp' : 'image/png';
-
-			}
+			texture.userData.mimeType = sourceDef.mimeType || getImageURIMimeType( sourceDef.uri );
 
 			return texture;
 


### PR DESCRIPTION
Fixes: #23587

**Description**

This allows GLTFExporter to create textures of the same mimeType as the input, so keep file size from growing. @donmccurdy @Mugen87 