### PR TITLE
CSS2DRenderer: Fix culling regression.

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -113,15 +113,15 @@ class CSS2DRenderer {
 
 			if ( object.isCSS2DObject ) {
 
-				const visible = object.visible && _vector.z >= - 1 && _vector.z <= 1 && object.layers.test( camera.layers );
-				object.element.style.display = visible ? '' : 'none';
+				_vector.setFromMatrixPosition( object.matrixWorld );
+				_vector.applyMatrix4( _viewProjectionMatrix );
 
-				if ( visible ) {
+				const visible = ( object.visible === true ) && ( _vector.z >= - 1 && _vector.z <= 1 ) && ( object.layers.test( camera.layers ) === true );
+				object.element.style.display = ( visible === true ) ? '' : 'none';
+
+				if ( visible === true ) {
 
 					object.onBeforeRender( _this, scene, camera );
-
-					_vector.setFromMatrixPosition( object.matrixWorld );
-					_vector.applyMatrix4( _viewProjectionMatrix );
 
 					const element = object.element;
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -239,11 +239,10 @@ class CSS3DRenderer {
 
 			if ( object.isCSS3DObject ) {
 
-				const visible = object.visible && object.layers.test( camera.layers );
-				object.element.style.display = visible ? '' : 'none';
+				const visible = ( object.visible === true ) && ( object.layers.test( camera.layers ) === true );
+				object.element.style.display = ( visible === true ) ? '' : 'none';
 
-				// only getObjectCSSMatrix when object.visible
-				if ( visible ) {
+				if ( visible === true ) {
 
 					object.onBeforeRender( _this, scene, camera );
 


### PR DESCRIPTION
Fixed #23593.

**Description**

Fixed a culling regression in `CSS2DRenderer`. The `_vector` variable always needs an update so its `z` value can be used for testing.

Also cleaned up some code style issues in `CSS3DRenderer`.
