### PR TITLE
Src: Set WebGLRenderTarget `texture.flipY` to false

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -28,6 +28,7 @@ class WebGLRenderTarget extends EventDispatcher {
 		this.texture = new Texture( image, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 		this.texture.isRenderTargetTexture = true;
 
+		this.texture.flipY = false;
 		this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
 		this.texture.internalFormat = options.internalFormat !== undefined ? options.internalFormat : null;
 		this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;


### PR DESCRIPTION
`PMREM` `CubeUV` textures have `.flipY` set to `true`. But `.flipY` does not apply to render target textures.

I think the most appropriate fix is for `WebGLRenderTarget` to set `.flipY` to `false`.

/ping @Mugen87 