### PR TITLE
Core: Remove artist-friendly factor of PI from LightMap shader

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1726,7 +1726,7 @@ function WebGLRenderer( parameters = {} ) {
 
 			}
 
-			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
+			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget, _this.physicallyCorrectLights );
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -308,7 +308,7 @@ function WebGLRenderer( parameters = {} ) {
 		morphtargets = new WebGLMorphtargets( _gl, capabilities, textures );
 		clipping = new WebGLClipping( properties );
 		programCache = new WebGLPrograms( _this, cubemaps, cubeuvmaps, extensions, capabilities, bindingStates, clipping );
-		materials = new WebGLMaterials( properties );
+		materials = new WebGLMaterials( _this, properties );
 		renderLists = new WebGLRenderLists();
 		renderStates = new WebGLRenderStates( extensions, capabilities );
 		background = new WebGLBackground( _this, cubemaps, state, objects, _alpha, _premultipliedAlpha );
@@ -1726,7 +1726,7 @@ function WebGLRenderer( parameters = {} ) {
 
 			}
 
-			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget, _this.physicallyCorrectLights );
+			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lightmap_fragment.glsl.js
@@ -4,12 +4,6 @@ export default /* glsl */`
 	vec4 lightMapTexel = texture2D( lightMap, vUv2 );
 	vec3 lightMapIrradiance = lightMapTexel.rgb * lightMapIntensity;
 
-	#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-		lightMapIrradiance *= PI;
-
-	#endif
-
 	reflectedLight.indirectDiffuse += lightMapIrradiance;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -6,12 +6,6 @@ export default /* glsl */`
 		vec4 lightMapTexel = texture2D( lightMap, vUv2 );
 		vec3 lightMapIrradiance = lightMapTexel.rgb * lightMapIntensity;
 
-		#ifndef PHYSICALLY_CORRECT_LIGHTS
-
-			lightMapIrradiance *= PI;
-
-		#endif
-
 		irradiance += lightMapIrradiance;
 
 	#endif

--- a/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
@@ -87,8 +87,8 @@ void main() {
 	// accumulation (baked indirect lighting only)
 	#ifdef USE_LIGHTMAP
 
-		vec4 lightMapTexel= texture2D( lightMap, vUv2 );
-		reflectedLight.indirectDiffuse += lightMapTexel.rgb * lightMapIntensity;
+		vec4 lightMapTexel = texture2D( lightMap, vUv2 );
+		reflectedLight.indirectDiffuse += lightMapTexel.rgb * lightMapIntensity * RECIPROCAL_PI;
 
 	#else
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -19,30 +19,30 @@ function WebGLMaterials( properties ) {
 
 	}
 
-	function refreshMaterialUniforms( uniforms, material, pixelRatio, height, transmissionRenderTarget ) {
+	function refreshMaterialUniforms( uniforms, material, pixelRatio, height, transmissionRenderTarget, physicallyCorrectLights ) {
 
 		if ( material.isMeshBasicMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 
 		} else if ( material.isMeshLambertMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsLambert( uniforms, material );
 
 		} else if ( material.isMeshToonMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsToon( uniforms, material );
 
 		} else if ( material.isMeshPhongMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsPhong( uniforms, material );
 
 		} else if ( material.isMeshStandardMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 
 			if ( material.isMeshPhysicalMaterial ) {
 
@@ -56,22 +56,22 @@ function WebGLMaterials( properties ) {
 
 		} else if ( material.isMeshMatcapMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsMatcap( uniforms, material );
 
 		} else if ( material.isMeshDepthMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsDepth( uniforms, material );
 
 		} else if ( material.isMeshDistanceMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsDistance( uniforms, material );
 
 		} else if ( material.isMeshNormalMaterial ) {
 
-			refreshUniformsCommon( uniforms, material );
+			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
 			refreshUniformsNormal( uniforms, material );
 
 		} else if ( material.isLineBasicMaterial ) {
@@ -105,7 +105,7 @@ function WebGLMaterials( properties ) {
 
 	}
 
-	function refreshUniformsCommon( uniforms, material ) {
+	function refreshUniformsCommon( uniforms, material, physicallyCorrectLights ) {
 
 		uniforms.opacity.value = material.opacity;
 
@@ -162,7 +162,11 @@ function WebGLMaterials( properties ) {
 		if ( material.lightMap ) {
 
 			uniforms.lightMap.value = material.lightMap;
-			uniforms.lightMapIntensity.value = material.lightMapIntensity;
+
+			// artist-friendly light intensity scaling factor
+			const scaleFactor = ( physicallyCorrectLights !== true ) ? Math.PI : 1;
+
+			uniforms.lightMapIntensity.value = material.lightMapIntensity * scaleFactor;
 
 		}
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -1,6 +1,6 @@
 import { BackSide } from '../../constants.js';
 
-function WebGLMaterials( properties ) {
+function WebGLMaterials( renderer, properties ) {
 
 	function refreshFogUniforms( uniforms, fog ) {
 
@@ -19,30 +19,30 @@ function WebGLMaterials( properties ) {
 
 	}
 
-	function refreshMaterialUniforms( uniforms, material, pixelRatio, height, transmissionRenderTarget, physicallyCorrectLights ) {
+	function refreshMaterialUniforms( uniforms, material, pixelRatio, height, transmissionRenderTarget ) {
 
 		if ( material.isMeshBasicMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 
 		} else if ( material.isMeshLambertMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsLambert( uniforms, material );
 
 		} else if ( material.isMeshToonMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsToon( uniforms, material );
 
 		} else if ( material.isMeshPhongMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsPhong( uniforms, material );
 
 		} else if ( material.isMeshStandardMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 
 			if ( material.isMeshPhysicalMaterial ) {
 
@@ -56,22 +56,22 @@ function WebGLMaterials( properties ) {
 
 		} else if ( material.isMeshMatcapMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsMatcap( uniforms, material );
 
 		} else if ( material.isMeshDepthMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsDepth( uniforms, material );
 
 		} else if ( material.isMeshDistanceMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsDistance( uniforms, material );
 
 		} else if ( material.isMeshNormalMaterial ) {
 
-			refreshUniformsCommon( uniforms, material, physicallyCorrectLights );
+			refreshUniformsCommon( uniforms, material );
 			refreshUniformsNormal( uniforms, material );
 
 		} else if ( material.isLineBasicMaterial ) {
@@ -105,7 +105,7 @@ function WebGLMaterials( properties ) {
 
 	}
 
-	function refreshUniformsCommon( uniforms, material, physicallyCorrectLights ) {
+	function refreshUniformsCommon( uniforms, material ) {
 
 		uniforms.opacity.value = material.opacity;
 
@@ -164,7 +164,7 @@ function WebGLMaterials( properties ) {
 			uniforms.lightMap.value = material.lightMap;
 
 			// artist-friendly light intensity scaling factor
-			const scaleFactor = ( physicallyCorrectLights !== true ) ? Math.PI : 1;
+			const scaleFactor = ( renderer.physicallyCorrectLights !== true ) ? Math.PI : 1;
 
 			uniforms.lightMapIntensity.value = material.lightMapIntensity * scaleFactor;
 


### PR DESCRIPTION
Follow-on to #22393 and #22397.

Related to #21912.

This PR is an alternate implementation to #23197.

The objective of this PR is two-fold:
1. To move the artist-friendly factor of PI for light maps into the renderer, and out of the shader
2. To modify the behavior of light maps for `MeshBasicMaterial` so it is more consistent with the other materials.


With the exception of `MeshBasicMaterial`,  the built-in materials supporting light maps should continue to render the same as they did previously.

@netpro2k @memelotsqui Please have a look. Is this doing what you what?

