### PR TITLE
Source: Expose class.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -17,7 +17,7 @@ import {
 	RGBAFormat,
 	RepeatWrapping,
 	Scene,
-	Texture,
+	Source,
 	Vector3
 } from 'three';
 
@@ -747,8 +747,7 @@ class GLTFWriter {
 
 		const texture = reference.clone();
 
-		// TODO Use new Source() instead?
-		texture.source = new Texture( canvas ).source;
+		texture.source = new Source( canvas );
 
 		return texture;
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -28,6 +28,7 @@ export { Points } from './objects/Points.js';
 export { Group } from './objects/Group.js';
 export { VideoTexture } from './textures/VideoTexture.js';
 export { FramebufferTexture } from './textures/FramebufferTexture.js';
+export { Source } from './textures/Source.js';
 export { DataTexture } from './textures/DataTexture.js';
 export { DataArrayTexture } from './textures/DataArrayTexture.js';
 export { Data3DTexture } from './textures/Data3DTexture.js';


### PR DESCRIPTION
see https://github.com/mrdoob/three.js/pull/23616#discussion_r816564760

**Description**

Exposes `Source` so it can be used in classes like `GLTFExporter`.
