### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -12,11 +12,7 @@
 		<p class="desc">
 		This class stores data for an attribute (such as vertex positions, face indices, normals,
 		colors, UVs, and any custom attributes ) associated with a [page:BufferGeometry], which allows
-		for more efficient passing of data to the GPU. See that page for details and a usage example.<br /><br />
-
-		Data is stored as vectors of any length (defined by [page:BufferAttribute.itemSize itemSize]),
-		and in general in the methods outlined below if passing in an index, this is automatically
-		multiplied by the vector length.
+		for more efficient passing of data to the GPU. See that page for details and a usage example.
 		</p>
 
 		<h2>Constructor</h2>


### PR DESCRIPTION
Related issue: -

**Description**

Removing a paragraph from `BufferAttribute` which causes confusion in the community.

- A `BufferAttribute` can't have "any" item size/length.
- Data are not necessarily stored as vectors. There are also matrix attributes (something like `attribute mat4 instanceMatrix;`).
