### PR TITLE
Docs: Add missing ctor parameter 'mapping' of DepthTexture.

### DIFF
--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [param:Number width], [param:Number height], [param:Constant type], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy], [param:Constant format] )</h3>
+		<h3>[name]( [param:Number width], [param:Number height], [param:Constant type], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Number anisotropy], [param:Constant format] )</h3>
 
 		<p>
 		[page:Number width] -- width of the texture.<br />


### PR DESCRIPTION
Related issue: #XXXX

**Description**

DepthTexture.html constructor parameter list missing 'mapping', updated to include missing parameter.
