### PR TITLE
apply dampingFactor to dollyOut/dollyIn in OrbitControls.js

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -225,18 +225,26 @@ class OrbitControls extends EventDispatcher {
 				spherical.makeSafe();
 
 				if ( scope.enableDamping === true ) {
-					if ( scale != 1 ){
-						from_radius = spherical.radius;
-						dst_radius = spherical.radius*scale;
-						delta_radius = (dst_radius - from_radius)*3; // x3 because slow
+
+					if ( scale !== 1 ) {
+
+						zoomFrom = spherical.radius;
+						zoomTo = spherical.radius * scale;
+						zoomDelta = ( zoomTo - zoomFrom ) * 3; // x3 because slow
 					}
-					spherical.radius += delta_radius * scope.dampingFactor 
-					delta_radius = delta_radius - delta_radius * scope.dampingFactor
-					if ( Math.abs( delta_radius )< EPS*10 ){
-						delta_radius = 0
+
+					spherical.radius += zoomDelta * scope.dampingFactor;
+					zoomDelta = zoomDelta - zoomDelta * scope.dampingFactor;
+
+					if ( Math.abs( zoomDelta ) < EPS * 10 ) {
+
+						zoomDelta = 0;
 					}
-				}else{
+
+				} else {
+
 					spherical.radius *= scale;
+
 				}
 
 				// restrict radius to be between desired limits
@@ -352,9 +360,9 @@ class OrbitControls extends EventDispatcher {
 		const sphericalDelta = new Spherical();
 
 		let scale = 1;
-		let dst_radius = 1
-		let from_radius = 1
-		let delta_radius = 1
+		let zoomTo = 1;
+		let zoomFrom = 1;
+		let zoomDelta = 1;
 		const panOffset = new Vector3();
 		let zoomChanged = false;
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -224,8 +224,20 @@ class OrbitControls extends EventDispatcher {
 
 				spherical.makeSafe();
 
-
-				spherical.radius *= scale;
+				if ( scope.enableDamping === true ) {
+					if ( scale != 1 ){
+						from_radius = spherical.radius;
+						dst_radius = spherical.radius*scale;
+						delta_radius = (dst_radius - from_radius)*3; // x3 because slow
+					}
+					spherical.radius += delta_radius * scope.dampingFactor 
+					delta_radius = delta_radius - delta_radius * scope.dampingFactor
+					if ( Math.abs( delta_radius )< EPS*10 ){
+						delta_radius = 0
+					}
+				}else{
+					spherical.radius *= scale;
+				}
 
 				// restrict radius to be between desired limits
 				spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
@@ -340,6 +352,9 @@ class OrbitControls extends EventDispatcher {
 		const sphericalDelta = new Spherical();
 
 		let scale = 1;
+		let dst_radius = 1
+		let from_radius = 1
+		let delta_radius = 1
 		const panOffset = new Vector3();
 		let zoomChanged = false;
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -60,6 +60,7 @@ class OrbitControls extends EventDispatcher {
 		// If damping is enabled, you must call controls.update() in your animation loop
 		this.enableDamping = false;
 		this.dampingFactor = 0.05;
+		this.zoomDampingFactor = this.dampingFactor * 3
 
 		// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
 		// Set to false to disable zooming
@@ -230,13 +231,13 @@ class OrbitControls extends EventDispatcher {
 
 						zoomFrom = spherical.radius;
 						zoomTo = spherical.radius * scale;
-						zoomDelta = ( zoomTo - zoomFrom ) * 3; // x3 because slow
+						zoomDelta = ( zoomTo - zoomFrom );
 					}
 
-					spherical.radius += zoomDelta * scope.dampingFactor;
-					zoomDelta = zoomDelta - zoomDelta * scope.dampingFactor;
+					spherical.radius += zoomDelta * scope.zoomDampingFactor;
+					zoomDelta = zoomDelta - zoomDelta * scope.zoomDampingFactor;
 
-					if ( Math.abs( zoomDelta ) < EPS * 10 ) {
+					if ( Math.abs( zoomDelta ) < EPS ) {
 
 						zoomDelta = 0;
 					}
@@ -362,7 +363,7 @@ class OrbitControls extends EventDispatcher {
 		let scale = 1;
 		let zoomTo = 1;
 		let zoomFrom = 1;
-		let zoomDelta = 1;
+		let zoomDelta = 0;
 		const panOffset = new Vector3();
 		let zoomChanged = false;
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -227,12 +227,12 @@ class OrbitControls extends EventDispatcher {
 				if ( scope.enableDamping === true ) {
 					if ( scale != 1 ){
 						from_radius = spherical.radius;
-						dst_radius = spherical.radius*scale;
-						delta_radius = (dst_radius - from_radius)*3; // x3 because slow
+						dst_radius = spherical.radius * scale;
+						delta_radius = (dst_radius - from_radius) * 3; // x3 to dolly in/out faster
 					}
 					spherical.radius += delta_radius * scope.dampingFactor 
 					delta_radius = delta_radius - delta_radius * scope.dampingFactor
-					if ( Math.abs( delta_radius )< EPS*10 ){
+					if ( Math.abs( delta_radius ) < EPS*10 ){
 						delta_radius = 0
 					}
 				}else{


### PR DESCRIPTION
Related issue: In orbit control, the dolly in / dolly out was not controlled by damping

**Description**
apply dampingFactor to dollyOut/dollyIn,
making zoom in/ zoom out looks more smooth.

