### PR TITLE
Prevent ShaderNodeObjecting a ShaderNodeObject

### DIFF
--- a/examples/jsm/nodes/ShaderNode.js
+++ b/examples/jsm/nodes/ShaderNode.js
@@ -95,6 +95,7 @@ const ShaderNodeObject = function( obj ) {
 
 				nodeObject = new Proxy( obj, NodeHandler );
 				nodeObjects.set( obj, nodeObject );
+				nodeObjects.set( nodeObject, nodeObject );
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

If ShaderNodeObject is given an object which is already a ShaderNodeObject, return it.