### PR TITLE
GLTFLoader: Fix color space for specular map.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3311,6 +3311,7 @@ class GLTFParser {
 			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;
+			if ( material.specularMap ) material.specularMap.encoding = sRGBEncoding;
 
 			assignExtrasToUserData( material, materialDef );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3308,7 +3308,7 @@ class GLTFParser {
 
 			if ( materialDef.name ) material.name = materialDef.name;
 
-			// baseColorTexture, emissiveTexture, specularColorMap, sheenColorMap and specularGlossinessTexture use sRGB encoding.
+			// baseColorTexture, emissiveTexture, sheenColorMap, specularColorMap and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;
 			if ( material.sheenColorMap ) material.sheenColorMap.encoding = sRGBEncoding;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3308,9 +3308,11 @@ class GLTFParser {
 
 			if ( materialDef.name ) material.name = materialDef.name;
 
-			// baseColorTexture, emissiveTexture, and specularGlossinessTexture use sRGB encoding.
+			// baseColorTexture, emissiveTexture, specularColorMap, sheenColorMap and specularGlossinessTexture use sRGB encoding.
 			if ( material.map ) material.map.encoding = sRGBEncoding;
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;
+			if ( material.sheenColorMap ) material.sheenColorMap.encoding = sRGBEncoding;
+			if ( material.specularColorMap ) material.specularColorMap.encoding = sRGBEncoding;
 			if ( material.specularMap ) material.specularMap.encoding = sRGBEncoding;
 
 			assignExtrasToUserData( material, materialDef );


### PR DESCRIPTION
Related issue: #23627

**Description**

This PR defines the color space for `specularMap`. Only relevant for `KHR_materials_pbrSpecularGlossiness`. `SpecGlossVsMetalRough.glb` now renders as expected.

<img width="857" alt="image" src="https://user-images.githubusercontent.com/12612165/156336931-292ec92a-453d-4992-bacf-9d6422bfd5ec.png">

