### PR TITLE
WebGLRenderer: Fix setRenderTargetTextures().

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1825,8 +1825,7 @@ function WebGLRenderer( parameters = {} ) {
 				if ( extensions.has( 'WEBGL_multisampled_render_to_texture' ) === true ) {
 
 					console.warn( 'THREE.WebGLRenderer: Render-to-texture extension was disabled because an external texture was provided' );
-					renderTarget.useRenderToTexture = false;
-					renderTarget.useRenderbuffer = true;
+					renderTargetProperties.__useRenderToTexture = false;
 
 				}
 


### PR DESCRIPTION
Fixed #23642.

**Description**

Ensures `setRenderTargetTextures()` sets the right flag.