### PR TITLE
Nodes: fixes and revision

### DIFF
--- a/examples/jsm/nodes/ShaderNode.js
+++ b/examples/jsm/nodes/ShaderNode.js
@@ -201,33 +201,23 @@ export const nodeObject = ( val ) => {
 
 };
 
-export const label = ( node, name = null, nodeType = null ) => {
+export const label = ( node, name ) => {
+
+	node = nodeObject( node );
 
 	if ( node.isVarNode === true ) {
 
-		// node is already a VarNode
+		node.name = name;
 
-		if ( ( node.name !== name ) && ( name !== null ) ) {
-
-			node.name = name;
-
-		}
-
-		if ( ( node.nodeType !== nodeType ) && ( nodeType !== null ) ) {
-
-			node.nodeType = nodeType;
-
-		}
-
-		return nodeObject( node );
+		return node;
 
 	}
 
-	return nodeObject( new VarNode( nodeObject( node ), name, nodeType ) );
+	return nodeObject( new VarNode( node, name ) );
 
 };
 
-export const temp = ( node, nodeType = null ) => label( node, null, nodeType );
+export const temp = ( node ) => nodeObject( new VarNode( nodeObject( node ), name ) );
 
 const ConvertType = function ( nodeClass, type, valueClass = null, valueComponents = 1 ) {
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -152,12 +152,12 @@ class NodeBuilder {
 
 	}
 
-	// rename to generate
+	// @TODO: rename to .generateConst()
 	getConst( type, value ) {
 
 		if ( type === 'float' ) return toFloat( value );
 		if ( type === 'int' ) return `${ Math.round( value ) }`;
-		if ( type === 'uint' ) return ( value >= 0 ) ? `${ Math.round( value ) }` : '0';
+		if ( type === 'uint' ) return value >= 0 ? `${ Math.round( value ) }` : '0';
 		if ( type === 'bool' ) return value ? 'true' : 'false';
 		if ( type === 'vec2' ) return `${ this.getType( 'vec2' ) }( ${ toFloat( value.x ) }, ${ toFloat( value.y ) } )`;
 		if ( type === 'vec3' ) return `${ this.getType( 'vec3' ) }( ${ toFloat( value.x ) }, ${ toFloat( value.y ) }, ${ toFloat( value.z ) } )`;
@@ -598,7 +598,7 @@ class NodeBuilder {
 		fromType = this.getVectorType( fromType );
 		toType = this.getVectorType( toType );
 
-		if ( ( fromType === toType ) || ( toType === null ) ) {
+		if ( fromType === toType || toType === 'void' || toType === null ) {
 
 			return snippet;
 
@@ -617,7 +617,10 @@ class NodeBuilder {
 
 		if ( toTypeLength === 0 ) { // toType is matrix-like
 
-			return `${ this.getType( toType ) }( ${ snippet } )`;
+			// ignore for now
+			//return `${ this.getType( toType ) }( ${ snippet } )`;
+
+			return snippet;
 
 		}
 

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -46,18 +46,18 @@ class OperatorNode extends TempNode {
 			return typeA;
 
 		} else if ( op === '&' || op === '|' || op === '^' || op === '>>' || op === '<<' ) {
-			
+
 			return 'int';
-			
+
 		} else if ( op === '==' || op === '&&' || op === '||' || op === '^^' ) {
 
 			return 'bool';
 
-		} else if ( op === '<=' || op === '>=' || op === '<' || op === '>' ) {
+		} else if ( op === '<' || op === '>' || op === '<=' || op === '>=' ) {
 
-			const length = builder.getTypeLength( output );
+			const typeLength = builder.getTypeLength( output );
 
-			return length > 1 ? `bvec${ length }` : 'bool';
+			return typeLength > 1 ? `bvec${ typeLength }` : 'bool';
 
 		} else {
 
@@ -111,6 +111,18 @@ class OperatorNode extends TempNode {
 			if ( op === '=' ) {
 
 				typeB = typeA;
+
+			} else if ( op === '<' || op === '>' || op === '<=' || op === '>=' ) {
+
+				if ( builder.isVector( typeA ) ) {
+
+					typeB = typeA;
+
+				} else {
+
+					typeA = typeB = 'float';
+
+				}
 
 			} else if ( builder.isMatrix( typeA ) && builder.isVector( typeB ) ) {
 


### PR DESCRIPTION
**Description**

Fixes some examples e cleanup after merger https://github.com/mrdoob/three.js/pull/23638, https://github.com/mrdoob/three.js/pull/23636.

@LeviPesin I think that we can ignore `nodeType` argument in `label` and others functions. 
We can use a syntax similar to this below to create a named var with a fixed type:
```js
const someNode = float( 1.0 );
const myVec3 = label( vec3( someNode ), 'MY_VEC3' );
```

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
