### PR TITLE
Removed a non supported parameter from the docstring

### DIFF
--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -4,8 +4,6 @@ import { Color } from '../math/Color.js';
 /**
  * parameters = {
  *  color: <hex>,
- *  opacity: <float>,
- *
  *  linewidth: <float>,
  *  linecap: "round",
  *  linejoin: "round"


### PR DESCRIPTION


Related issue: #XXXX

**Description**

The `opacity` parameter is not valid for LineBasicMaterial, it's also not mentioned in the documentation.
But this was mentioned in the parameters docstring, which VSCode also provides as a possible suggestion.
I've removed that line in this PR

<!-- Remove the line below if is not relevant -->
