### PR TITLE
HtmlMesh doesn't handle html comment

### DIFF
--- a/examples/js/interactive/HTMLMesh.js
+++ b/examples/js/interactive/HTMLMesh.js
@@ -210,7 +210,7 @@
 				width = 0,
 				height = 0;
 
-			if ( element.nodeType === 3 ) {
+			if ( element.nodeType === Node.TEXT_NODE ) {
 
 				// text
 				range.selectNode( element );
@@ -220,6 +220,10 @@
 				width = rect.width;
 				height = rect.height;
 				drawText( style, x, y, element.nodeValue.trim() );
+
+			} else if ( element.nodeType === Node.COMMENT_NODE ) {
+
+				return;
 
 			} else if ( element instanceof HTMLCanvasElement ) {
 
@@ -333,7 +337,7 @@
 
 		function traverse( element ) {
 
-			if ( element.nodeType !== 3 ) {
+			if ( element.nodeType !== Node.TEXT_NODE && element.nodeType !== Node.COMMENT_NODE ) {
 
 				const rect = element.getBoundingClientRect();
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -223,7 +223,7 @@ function html2canvas( element ) {
 
 		let x = 0, y = 0, width = 0, height = 0;
 
-		if ( element.nodeType === 3 ) {
+		if ( element.nodeType === Node.TEXT_NODE ) {
 
 			// text
 
@@ -237,6 +237,10 @@ function html2canvas( element ) {
 			height = rect.height;
 
 			drawText( style, x, y, element.nodeValue.trim() );
+
+		} else if ( element.nodeType === Node.COMMENT_NODE ) {
+
+			return;
 
 		} else if ( element instanceof HTMLCanvasElement ) {
 
@@ -355,7 +359,7 @@ function htmlevent( element, event, x, y ) {
 
 	function traverse( element ) {
 
-		if ( element.nodeType !== 3 ) {
+		if ( element.nodeType !== Node.TEXT_NODE && element.nodeType !== Node.COMMENT_NODE ) {
 
 			const rect = element.getBoundingClientRect();
 

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -7,6 +7,15 @@
 		<link type="text/css" rel="stylesheet" href="main.css">
 	</head>
 	<body>
+		<div id="basic-html-mesh" style="position: absolute; left: 100px">
+			Items:
+			<!-- this is a comment! -->
+			<ul>
+				<li>one</li>
+				<li>two</li>
+			</ul>
+		</div>
+
 		<!-- Import maps polyfill -->
 		<!-- Remove this when import maps will be widely supported -->
 		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
@@ -38,6 +47,7 @@
 			let camera, scene, renderer;
 			let reflector;
 			let stats, statsMesh;
+			let basicHtmlMesh;
 
 			const parameters = {
 				radius: 0.6,
@@ -209,6 +219,16 @@
 				statsMesh.rotation.y = Math.PI / 4;
 				statsMesh.scale.setScalar( 2.5 );
 				group.add( statsMesh );
+
+				// add basic htmlmesh
+				basicHtmlMesh = new HTMLMesh(document.querySelector('#basic-html-mesh'));
+				basicHtmlMesh.position.x = - 0.55;
+				basicHtmlMesh.position.y = 2;
+				basicHtmlMesh.position.z = - 0.6;
+				basicHtmlMesh.rotation.y = Math.PI / 4;
+				basicHtmlMesh.scale.setScalar( 2.5 );
+				group.add( basicHtmlMesh );
+
 
 			}
 

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -210,7 +210,6 @@
 				statsMesh.scale.setScalar( 2.5 );
 				group.add( statsMesh );
 
-
 			}
 
 			function onWindowResize() {

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -7,15 +7,6 @@
 		<link type="text/css" rel="stylesheet" href="main.css">
 	</head>
 	<body>
-		<div id="basic-html-mesh" style="position: absolute; left: 100px">
-			Items:
-			<!-- this is a comment! -->
-			<ul>
-				<li>one</li>
-				<li>two</li>
-			</ul>
-		</div>
-
 		<!-- Import maps polyfill -->
 		<!-- Remove this when import maps will be widely supported -->
 		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
@@ -47,7 +38,6 @@
 			let camera, scene, renderer;
 			let reflector;
 			let stats, statsMesh;
-			let basicHtmlMesh;
 
 			const parameters = {
 				radius: 0.6,
@@ -219,15 +209,6 @@
 				statsMesh.rotation.y = Math.PI / 4;
 				statsMesh.scale.setScalar( 2.5 );
 				group.add( statsMesh );
-
-				// add basic htmlmesh
-				basicHtmlMesh = new HTMLMesh(document.querySelector('#basic-html-mesh'));
-				basicHtmlMesh.position.x = - 0.55;
-				basicHtmlMesh.position.y = 2;
-				basicHtmlMesh.position.z = - 0.6;
-				basicHtmlMesh.rotation.y = Math.PI / 4;
-				basicHtmlMesh.scale.setScalar( 2.5 );
-				group.add( basicHtmlMesh );
 
 
 			}


### PR DESCRIPTION
**Description**
HTMLMesh didn't handled when html contains comment `<!-- this is a comment! -->`. Fix that. (Should I had first created an issue?)
Also use [Node constants](https://developer.mozilla.org/fr/docs/Web/API/Node/nodeType) instead of magic number.
Add an example in webxr_vr_sandbox


That error was output when the html had a comment : 
```
HTMLMesh.js:258 Uncaught TypeError: Cannot read properties of undefined (reading 'display')
    at drawElement (HTMLMesh.js:258)
    at drawElement (HTMLMesh.js:307)
    at html2canvas (HTMLMesh.js:337)
    at new HTMLTexture (HTMLMesh.js:54)
    at new HTMLMesh (HTMLMesh.js:14)
    at init (webxr_vr_sandbox.html:224)
    at webxr_vr_sandbox.html:62
```

[Try it here]( https://remy-mellet.com/three.js/examples/#webxr_vr_sandbox)  (I'll probably update the example on my gh-page next days, as I would like to add more feature which faile : shadowRoot, event / changes not reflected, etc...)
