### PR TITLE
BloomPass: Use custom combine shader.

### DIFF
--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -8,7 +8,6 @@ import {
 	WebGLRenderTarget
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
-import { CopyShader } from '../shaders/CopyShader.js';
 import { ConvolutionShader } from '../shaders/ConvolutionShader.js';
 
 class BloomPass extends Pass {
@@ -26,21 +25,17 @@ class BloomPass extends Pass {
 		this.renderTargetY = new WebGLRenderTarget( resolution, resolution, pars );
 		this.renderTargetY.texture.name = 'BloomPass.y';
 
-		// copy material
+		// combine material
 
-		if ( CopyShader === undefined ) console.error( 'THREE.BloomPass relies on CopyShader' );
+		this.combineUniforms = UniformsUtils.clone( CombineShader.uniforms );
 
-		const copyShader = CopyShader;
+		this.combineUniforms[ 'strength' ].value = strength;
 
-		this.copyUniforms = UniformsUtils.clone( copyShader.uniforms );
+		this.materialCombine = new ShaderMaterial( {
 
-		this.copyUniforms[ 'opacity' ].value = strength;
-
-		this.materialCopy = new ShaderMaterial( {
-
-			uniforms: this.copyUniforms,
-			vertexShader: copyShader.vertexShader,
-			fragmentShader: copyShader.fragmentShader,
+			uniforms: this.combineUniforms,
+			vertexShader: CombineShader.vertexShader,
+			fragmentShader: CombineShader.fragmentShader,
 			blending: AdditiveBlending,
 			transparent: true
 
@@ -102,9 +97,9 @@ class BloomPass extends Pass {
 
 		// Render original scene with superimposed blur to texture
 
-		this.fsQuad.material = this.materialCopy;
+		this.fsQuad.material = this.materialCombine;
 
-		this.copyUniforms[ 'tDiffuse' ].value = this.renderTargetY.texture;
+		this.combineUniforms[ 'tDiffuse' ].value = this.renderTargetY.texture;
 
 		if ( maskActive ) renderer.state.buffers.stencil.setTest( true );
 
@@ -115,6 +110,43 @@ class BloomPass extends Pass {
 	}
 
 }
+
+const CombineShader = {
+
+	uniforms: {
+
+		'tDiffuse': { value: null },
+		'strength': { value: 1.0 }
+
+	},
+
+	vertexShader: /* glsl */`
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`,
+
+	fragmentShader: /* glsl */`
+
+		uniform float strength;
+
+		uniform sampler2D tDiffuse;
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vec4 texel = texture2D( tDiffuse, vUv );
+			gl_FragColor = strength * texel;
+
+		}`
+
+};
 
 BloomPass.blurX = new Vector2( 0.001953125, 0.0 );
 BloomPass.blurY = new Vector2( 0.0, 0.001953125 );

--- a/examples/webgl_shaders_tonemapping.html
+++ b/examples/webgl_shaders_tonemapping.html
@@ -441,7 +441,7 @@
 				requestAnimationFrame( animate );
 				if ( bloomPass ) {
 
-					bloomPass.copyUniforms[ "opacity" ].value = params.bloomAmount;
+					bloomPass.combineUniforms[ "strength" ].value = params.bloomAmount;
 
 				}
 


### PR DESCRIPTION
Related issue: -

**Description**

`BloomPass` uses `CopyShader` for its implementation. In this context, it maps its `strength` property to `opacity` which is not correct since `strength` isn't restricted to the `[0-1]` range. `BloomPass` actually misuses `CopyShader` in an unexpected way.

I think it's less confusing when `BloomPass` has its own combine shader.
