### PR TITLE
Examples: Fix opacity in copy and blend shaders.

### DIFF
--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -44,7 +44,6 @@ class SSAARenderPass extends Pass {
 			uniforms: this.copyUniforms,
 			vertexShader: copyShader.vertexShader,
 			fragmentShader: copyShader.fragmentShader,
-			premultipliedAlpha: true,
 			transparent: true,
 			blending: AdditiveBlending,
 			depthTest: false,

--- a/examples/jsm/shaders/BlendShader.js
+++ b/examples/jsm/shaders/BlendShader.js
@@ -38,7 +38,8 @@ const BlendShader = {
 
 			vec4 texel1 = texture2D( tDiffuse1, vUv );
 			vec4 texel2 = texture2D( tDiffuse2, vUv );
-			gl_FragColor = opacity * mix( texel1, texel2, mixRatio );
+			gl_FragColor = mix( texel1, texel2, mixRatio );
+			gl_FragColor.a *= opacity;
 
 		}`
 

--- a/examples/jsm/shaders/CopyShader.js
+++ b/examples/jsm/shaders/CopyShader.js
@@ -32,8 +32,9 @@ const CopyShader = {
 
 		void main() {
 
-			vec4 texel = texture2D( tDiffuse, vUv );
-			gl_FragColor = opacity * texel;
+			gl_FragColor = texture2D( tDiffuse, vUv );
+			gl_FragColor.a *= opacity;
+
 
 		}`
 


### PR DESCRIPTION
Fixed #19531.

**Description**

I've noticed that the blending of the texture pass in [webgl_postprocessing_backgrounds](https://threejs.org/examples/webgl_postprocessing_backgrounds) produces a too dark result. The root cause is the way how opacity is implemented in `CopyShader`. Instead of using premultiplied alpha, the code uses straight alpha now for simplicity.