### PR TITLE
Docs: Added OBJExporter page.

### DIFF
--- a/docs/examples/en/exporters/ColladaExporter.html
+++ b/docs/examples/en/exporters/ColladaExporter.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 		An exporter for *Collada*.
 		<br /><br />
-		<a href="https://www.khronos.org/collada/">Collada</a> is a
+		<a href="https://www.khronos.org/collada/" target="_blank">Collada</a> is a
 		file format for robust representation of scenes, materials, animations, and other 3D content in an xml format.
 		This exporter only supports exporting geometry, materials, textures, and scene hierarchy.
 		</p>

--- a/docs/examples/en/exporters/EXRExporter.html
+++ b/docs/examples/en/exporters/EXRExporter.html
@@ -12,8 +12,8 @@
 		<p class="desc">
 		An exporter for *EXR*.
 		<br /><br />
-		<a href="https://www.openexr.com/">EXR</a> ( Extended Dynamic Range) is an
-		<a href="https://github.com/AcademySoftwareFoundation/openexr">open format specification</a>
+		<a href="https://www.openexr.com/" target="_blank">EXR</a> ( Extended Dynamic Range) is an
+		<a href="https://github.com/AcademySoftwareFoundation/openexr" target="_blank">open format specification</a>
 		for professional-grade image storage format of the motion picture industry. The purpose of
 		format is to accurately and efficiently represent high-dynamic-range scene-linear image data
 		and associated metadata. The library is widely used in host application software where accuracy

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -12,8 +12,8 @@
 		<p class="desc">
 		An exporter for *glTF* 2.0.
 		<br /><br />
-		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
-		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
+		<a href="https://www.khronos.org/gltf" target="_blank">glTF</a> (GL Transmission Format) is an
+		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0" target="_blank">open format specification</a>
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
 		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,

--- a/docs/examples/en/exporters/OBJExporter.html
+++ b/docs/examples/en/exporters/OBJExporter.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		<h1>[name]</h1>
+
+		<p class="desc">
+		An exporter for the <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file" target="_blank">OBJ</a> file format.
+		</p>
+		<p class="desc">
+		[name] is not able to export material data into MTL files so only geoemtry data are supported.
+		</p>
+
+		<h2>Code Example</h2>
+
+		<code>
+		// Instantiate an exporter
+		const exporter = new OBJExporter();
+
+		// Parse the input and generate the OBJ output
+		const data = exporter.parse( scene );
+		downloadFile( data );
+		</code>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]()</h3>
+		<p>
+		</p>
+		<p>
+		Creates a new [name].
+		</p>
+
+		<h2>Methods</h2>
+
+		<h3>[method:String parse]( [param:Object3D object] )</h3>
+		<p>
+		[page:Object object] — Object3D to be exported.
+		</p>
+		<p>
+		Generates a string holding the OBJ data.
+		</p>
+
+		<h2>Source</h2>
+
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/OBJExporter.js examples/jsm/exporters/OBJExporter.js]
+		</p>
+	</body>
+</html>

--- a/docs/examples/en/exporters/PLYExporter.html
+++ b/docs/examples/en/exporters/PLYExporter.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 		An exporter for *PLY*.
 		<br /><br />
-		<a href="https://en.wikipedia.org/wiki/PLY_(file_format)">PLY</a> (Polygon or Stanford Triangle Format) is a
+		<a href="https://en.wikipedia.org/wiki/PLY_(file_format)" target="_blank">PLY</a> (Polygon or Stanford Triangle Format) is a
 		file format for efficient delivery and loading of simple, static 3D content in a dense format.
 		Both binary and ascii formats are supported. PLY can store vertex positions, colors, normals and
 		uv coordinates. No textures or texture references are saved.

--- a/docs/examples/zh/exporters/ColladaExporter.html
+++ b/docs/examples/zh/exporters/ColladaExporter.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 		An exporter for *Collada*.
 		<br /><br />
-		<a href="https://www.khronos.org/collada/">Collada</a> is a
+		<a href="https://www.khronos.org/collada/" target="_blank">Collada</a> is a
 		file format for robust representation of scenes, materials, animations, and other 3D content in an xml format.
 		This exporter only supports exporting geometry, materials, textures, and scene hierarchy.
 		</p>

--- a/docs/examples/zh/exporters/GLTFExporter.html
+++ b/docs/examples/zh/exporters/GLTFExporter.html
@@ -12,8 +12,8 @@
 		<p class="desc">
 		An exporter for *glTF* 2.0.
 		<br /><br />
-		<a href="https://www.khronos.org/gltf">glTF</a> (GL Transmission Format) is an
-		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0">open format specification</a>
+		<a href="https://www.khronos.org/gltf" target="_blank">glTF</a> (GL Transmission Format) is an
+		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0" target="_blank">open format specification</a>
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
 		or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
 		data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,

--- a/docs/examples/zh/exporters/PLYExporter.html
+++ b/docs/examples/zh/exporters/PLYExporter.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 		An exporter for *PLY*.
 		<br /><br />
-		<a href="https://en.wikipedia.org/wiki/PLY_(file_format)">PLY</a> (Polygon or Stanford Triangle Format) is a
+		<a href="https://en.wikipedia.org/wiki/PLY_(file_format)" target="_blank">PLY</a> (Polygon or Stanford Triangle Format) is a
 		file format for efficient delivery and loading of simple, static 3D content in a dense format.
 		Both binary and ascii formats are supported. PLY can store vertex positions, colors, normals and
 		uv coordinates. No textures or texture references are saved.

--- a/docs/list.json
+++ b/docs/list.json
@@ -389,10 +389,11 @@
 			},
 
 			"Exporters": {
-				"GLTFExporter": "examples/en/exporters/GLTFExporter",
-				"PLYExporter": "examples/en/exporters/PLYExporter",
 				"ColladaExporter": "examples/en/exporters/ColladaExporter",
-				"EXRExporter": "examples/en/exporters/EXRExporter"
+				"EXRExporter": "examples/en/exporters/EXRExporter",
+				"GLTFExporter": "examples/en/exporters/GLTFExporter",
+				"OBJExporter": "examples/en/exporters/OBJExporter",
+				"PLYExporter": "examples/en/exporters/PLYExporter"
 			},
 
 			"Math": {
@@ -885,9 +886,9 @@
 			},
 
 			"导出器": {
+				"ColladaExporter": "examples/zh/exporters/ColladaExporter",
 				"GLTFExporter": "examples/zh/exporters/GLTFExporter",
-				"PLYExporter": "examples/zh/exporters/PLYExporter",
-				"ColladaExporter": "examples/zh/exporters/ColladaExporter"
+				"PLYExporter": "examples/zh/exporters/PLYExporter"
 			},
 
 			"数学库": {


### PR DESCRIPTION
Fixed #23673.

**Description**

Added the documentation page for `OBJExporter` and also fixed some links in other exporter pages.