### PR TITLE
VTKLoader: Fix parsing of VTP data with multiple components.

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -688,8 +688,13 @@
 						// The [DATA] portion stores contiguously every block appended together. The offset from the beginning of the data section to the beginning of a block is
 						// computed by summing the compressed block sizes from preceding blocks according to the header.
 
+						const textNode = ele['#text'];
+						const rawData = (
+							( textNode instanceof Array )
+								? textNode[0]
+								: textNode
+						);
 
-						const rawData = ele[ '#text' ];
 						const byteData = Base64toByteArray( rawData );
 						let blocks = byteData[ 0 ];
 

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -689,11 +689,7 @@
 						// computed by summing the compressed block sizes from preceding blocks according to the header.
 
 						const textNode = ele[ '#text' ];
-						const rawData = (
-							( textNode instanceof Array )
-								? textNode[ 0 ]
-								: textNode
-						);
+						const rawData = Array.isArray( textNode ) ? textNode[ 0 ] : textNode;
 
 						const byteData = Base64toByteArray( rawData );
 						let blocks = byteData[ 0 ];

--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -688,10 +688,10 @@
 						// The [DATA] portion stores contiguously every block appended together. The offset from the beginning of the data section to the beginning of a block is
 						// computed by summing the compressed block sizes from preceding blocks according to the header.
 
-						const textNode = ele['#text'];
+						const textNode = ele[ '#text' ];
 						const rawData = (
 							( textNode instanceof Array )
-								? textNode[0]
+								? textNode[ 0 ]
 								: textNode
 						);
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -736,7 +736,12 @@ class VTKLoader extends Loader {
 					// The [DATA] portion stores contiguously every block appended together. The offset from the beginning of the data section to the beginning of a block is
 					// computed by summing the compressed block sizes from preceding blocks according to the header.
 
-					const rawData = ele[ '#text' ];
+					const textNode = ele['#text'];
+					const rawData = (
+						( textNode instanceof Array )
+							? textNode[0]
+							: textNode
+					);
 
 					const byteData = Base64toByteArray( rawData );
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -736,10 +736,10 @@ class VTKLoader extends Loader {
 					// The [DATA] portion stores contiguously every block appended together. The offset from the beginning of the data section to the beginning of a block is
 					// computed by summing the compressed block sizes from preceding blocks according to the header.
 
-					const textNode = ele['#text'];
+					const textNode = ele[ '#text' ];
 					const rawData = (
 						( textNode instanceof Array )
-							? textNode[0]
+							? textNode[ 0 ]
 							: textNode
 					);
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -737,11 +737,7 @@ class VTKLoader extends Loader {
 					// computed by summing the compressed block sizes from preceding blocks according to the header.
 
 					const textNode = ele[ '#text' ];
-					const rawData = (
-						( textNode instanceof Array )
-							? textNode[ 0 ]
-							: textNode
-					);
+					const rawData = Array.isArray( textNode ) ? textNode[ 0 ] : textNode;
 
 					const byteData = Base64toByteArray( rawData );
 


### PR DESCRIPTION
**Description**

Fix parsing of VTP, currently failing when a data item contains multiple
components.
In that case, ele['#text'] is not the compressed data but
an array of 1 element (this data). This makes the parsing fail as Base64toByteArray expects a string.
Use the array's content for parsing.

Fixed #23683