### PR TITLE
Examples: Canvas font property order fix.

### DIFF
--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -154,7 +154,7 @@
 				ctx.fillRect( 0, 0, 128, 32 );
 
 				ctx.fillStyle = 'white';
-				ctx.font = '12pt arial bold';
+				ctx.font = 'bold 12pt arial';
 				ctx.fillText( text, 10, 22 );
 
 				const map = new THREE.CanvasTexture( canvas );

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -216,7 +216,7 @@
 				ctx.fillRect( 0, 0, 128, 32 );
 
 				ctx.fillStyle = 'white';
-				ctx.font = '12pt arial bold';
+				ctx.font = 'bold 11pt arial';
 				ctx.fillText( text, 8, 22 );
 
 				const map = new THREE.CanvasTexture( canvas );


### PR DESCRIPTION
**Description**

Currently the text labels on these examples show as non-arial, non-bold as in `font` property short hand, the `font-weight` property (bold) must come first.