### PR TITLE
WebGLRenderer: Use self instead of window.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -891,7 +891,7 @@ function WebGLRenderer( parameters = {} ) {
 	const animation = new WebGLAnimation();
 	animation.setAnimationLoop( onAnimationFrame );
 
-	if ( typeof window !== 'undefined' ) animation.setContext( window );
+	if ( typeof self !== 'undefined' ) animation.setContext( self );
 
 	this.setAnimationLoop = function ( callback ) {
 

--- a/src/renderers/webgl/WebGLAnimation.js
+++ b/src/renderers/webgl/WebGLAnimation.js
@@ -9,7 +9,15 @@ function WebGLAnimation() {
 
 		animationLoop( time, frame );
 
-		requestId = context.requestAnimationFrame( onAnimationFrame );
+		requestId = _requestAnimationFrame();
+
+	}
+
+	function _requestAnimationFrame() {
+
+		return context
+			? context.requestAnimationFrame( onAnimationFrame )
+			: requestAnimationFrame( onAnimationFrame );
 
 	}
 
@@ -20,7 +28,7 @@ function WebGLAnimation() {
 			if ( isAnimating === true ) return;
 			if ( animationLoop === null ) return;
 
-			requestId = context.requestAnimationFrame( onAnimationFrame );
+			requestId = _requestAnimationFrame();
 
 			isAnimating = true;
 
@@ -28,7 +36,9 @@ function WebGLAnimation() {
 
 		stop: function () {
 
-			context.cancelAnimationFrame( requestId );
+			context
+				? context.cancelAnimationFrame( requestId )
+				: cancelAnimationFrame( requestId );
 
 			isAnimating = false;
 

--- a/src/renderers/webgl/WebGLAnimation.js
+++ b/src/renderers/webgl/WebGLAnimation.js
@@ -9,15 +9,7 @@ function WebGLAnimation() {
 
 		animationLoop( time, frame );
 
-		requestId = _requestAnimationFrame();
-
-	}
-
-	function _requestAnimationFrame() {
-
-		return context
-			? context.requestAnimationFrame( onAnimationFrame )
-			: requestAnimationFrame( onAnimationFrame );
+		requestId = context.requestAnimationFrame( onAnimationFrame );
 
 	}
 
@@ -28,7 +20,7 @@ function WebGLAnimation() {
 			if ( isAnimating === true ) return;
 			if ( animationLoop === null ) return;
 
-			requestId = _requestAnimationFrame();
+			requestId = context.requestAnimationFrame( onAnimationFrame );
 
 			isAnimating = true;
 
@@ -36,9 +28,7 @@ function WebGLAnimation() {
 
 		stop: function () {
 
-			context
-				? context.cancelAnimationFrame( requestId )
-				: cancelAnimationFrame( requestId );
+			context.cancelAnimationFrame( requestId );
 
 			isAnimating = false;
 


### PR DESCRIPTION
Summary:
Three.js throws an exception when WebGLRenderer is disposed in a web-worker.

Reason:
On WebGLRenderer.dispose, WebGLAnimation.stop() is called. The "context" which is usually window, is not accessible in a
web-worker context.

Fix:
If context is not availabe, call request/cancelAnimationFrame without context