### PR TITLE
OrbitControls: fix crash in web workers

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -26,7 +26,7 @@ class OrbitControls extends EventDispatcher {
 		super();
 
 		if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
+		if ( typeof WorkerGlobalScope === 'undefined' && domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 		this.object = object;
 		this.domElement = domElement;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -26,7 +26,7 @@ class OrbitControls extends EventDispatcher {
 		super();
 
 		if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-		if ( typeof WorkerGlobalScope === 'undefined' && domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
+		if ( domElement === self.document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
 		this.object = object;
 		this.domElement = domElement;


### PR DESCRIPTION
Summary:
OrbitControls crash when used in web-workers

Reason:
document is not available in web-worker context

Fix:
Check if we are in a web-worker context and omit document check