### PR TITLE
check needsUpdate before reassigning currentState

### DIFF
--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -18,14 +18,14 @@
 
 			const state = getBindingState( geometry, program, material );
 
+			updateBuffers = needsUpdate( geometry, index );
+
 			if ( currentState !== state ) {
 
 				currentState = state;
 				bindVertexArrayObject( currentState.object );
 
 			}
-
-			updateBuffers = needsUpdate( geometry, index );
 
 			if ( updateBuffers ) saveCache( geometry, index );
 


### PR DESCRIPTION
Related issue: #23688

**Description**

In `WebGLBindingStates.setup`, `needsUpdate` should compare the current and new state before reassigning `currentState`.  Otherwise `updateBuffers` is erroneously set to false and `setupVertexAttributes` does not get called further down in the function.

.. I think.  I am a novice with GL and three.js. This was the result of a long debugging session, so opening the PR for discussion if my details sound off base.  Thanks.