### PR TITLE
Examples: Fix raycasting in `webgl_lines_fat_raycasting` example.

### DIFF
--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -232,6 +232,11 @@
 				renderer.setViewport( 0, 0, window.innerWidth, window.innerHeight );
 
 				raycaster.setFromCamera( pointer, camera );
+				
+				// renderer will set this eventually
+				// set the new resolution before raycasting so it is set correctly
+				matLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
+				matThresholdLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
 
 				const obj = line.visible ? line : segments;
 				const intersects = raycaster.intersectObject( obj, true );
@@ -256,10 +261,6 @@
 					renderer.domElement.style.cursor = '';
 
 				}
-
-				// renderer will set this eventually
-				matLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
-				matThresholdLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
 
 				gpuPanel.startQuery();
 				renderer.render( scene, camera );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23358#issuecomment-1046029933

**Description**

Adjust where the line material resolution is set so the raycast result is correct. Previously the material resolution was being set after the raycast occurred meaning the line width was incorrect during the raycast.

**BEFORE**
https://raw.githack.com/mrdoob/three.js/f35120c9083ce31f1994575cef075357bc98f53d/examples/webgl_lines_fat_raycasting.html


**AFTER**
https://raw.githack.com/mrdoob/three.js/fix-fat-lines-raycast/examples/webgl_lines_fat_raycasting.html

cc @bergden-resonai 