### PR TITLE
WebGLBindingStates : Force update after reset() call.

### DIFF
--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -60,9 +60,11 @@
 
 		}
 
-		if (mustUpdateBuffers) {
+		if ( mustUpdateBuffers ) {
+
 			updateBuffers = true;
 			mustUpdateBuffers = false;
+
 		}
 
 		if ( updateBuffers ) {
@@ -560,6 +562,7 @@
 	}
 
 	function reset() {
+
 		resetDefaultState();
 		mustUpdateBuffers = true;
 
@@ -567,6 +570,7 @@
 
 		currentState = defaultState;
 		bindVertexArrayObject( currentState.object );
+
 	}
 
 	// for backward-compatilibity

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -9,6 +9,7 @@
 
 	const defaultState = createBindingState( null );
 	let currentState = defaultState;
+	let mustUpdateBuffers = false;
 
 	function setup( object, material, program, geometry, index ) {
 
@@ -57,6 +58,11 @@
 
 			attributes.update( index, gl.ELEMENT_ARRAY_BUFFER );
 
+		}
+
+		if (mustUpdateBuffers) {
+			updateBuffers = true;
+			mustUpdateBuffers = false;
 		}
 
 		if ( updateBuffers ) {
@@ -554,14 +560,13 @@
 	}
 
 	function reset() {
-
 		resetDefaultState();
+		mustUpdateBuffers = true;
 
 		if ( currentState === defaultState ) return;
 
 		currentState = defaultState;
 		bindVertexArrayObject( currentState.object );
-
 	}
 
 	// for backward-compatilibity

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -9,7 +9,7 @@
 
 	const defaultState = createBindingState( null );
 	let currentState = defaultState;
-	let mustUpdateBuffers = false;
+	let forceUpdate = false;
 
 	function setup( object, material, program, geometry, index ) {
 
@@ -60,14 +60,9 @@
 
 		}
 
-		if ( mustUpdateBuffers ) {
+		if ( updateBuffers || forceUpdate ) {
 
-			updateBuffers = true;
-			mustUpdateBuffers = false;
-
-		}
-
-		if ( updateBuffers ) {
+			forceUpdate = false;
 
 			setupVertexAttributes( object, material, program, geometry );
 
@@ -564,7 +559,7 @@
 	function reset() {
 
 		resetDefaultState();
-		mustUpdateBuffers = true;
+		forceUpdate = true;
 
 		if ( currentState === defaultState ) return;
 


### PR DESCRIPTION
Fixed #23688.

Description

Use a flag to force `WebGLBindingStates.setup` to update buffers following a call to WebGLBindingStates.reset().

This isn't a pretty solution, but wanted to open a PR and see how the e2e tests go and maybe provoke a discussion if I'm going down the wrong path here.
