### PR TITLE
WebGLTexture: Call invalidateFramebuffer() only in Oculus Browser

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -11,6 +11,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 	const maxTextureSize = capabilities.maxTextureSize;
 	const maxSamples = capabilities.maxSamples;
 	const multisampledRTTExt = extensions.has( 'WEBGL_multisampled_render_to_texture' ) ? extensions.get( 'WEBGL_multisampled_render_to_texture' ) : null;
+	const supportsInvalidateFramenbuffer = /OculusBrowser/g.test( navigator.userAgent );
 
 	const _videoTextures = new WeakMap();
 	let _canvas;
@@ -1714,7 +1715,12 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			}
 
 			_gl.blitFramebuffer( 0, 0, width, height, 0, 0, width, height, mask, _gl.NEAREST );
-			_gl.invalidateFramebuffer( _gl.READ_FRAMEBUFFER, invalidationArray );
+
+			if ( supportsInvalidateFramenbuffer ) {
+
+				_gl.invalidateFramebuffer( _gl.READ_FRAMEBUFFER, invalidationArray );
+
+			}
 
 			state.bindFramebuffer( _gl.READ_FRAMEBUFFER, null );
 			state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, renderTargetProperties.__webglMultisampledFramebuffer );


### PR DESCRIPTION
Fixes #22967

**Description**

Call only `invalidateFramebuffer()` in browsers that can do it.

The developer shouldn't have to know about this browser issue so adding `skipInvalidateFramebuffer` to the API as suggested in #22992 is not an option.

In #22992, @cabanier [said](https://github.com/mrdoob/three.js/pull/22992/files#r790010227) that HoloLens could benefit from this...
We can add this to HoloLens later, right now the priority is fixing the regression we've had for 4 months.