### PR TITLE
Clock: Fixed autoStart

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -1,60 +1,60 @@
 class Clock {
 
-    constructor( autoStart = true ) {
+	constructor( autoStart = true ) {
 
-        this.autoStart = autoStart;
-        this.running = this.autoStart;
+		this.autoStart = autoStart;
+		this.running = this.autoStart;
 
-        this.startTime = 0;
-        this.oldTime = 0;
-        this.elapsedTime = 0;
+		this.startTime = 0;
+		this.oldTime = 0;
+		this.elapsedTime = 0;
 
-        this.running && this.start();
+		this.running && this.start();
 
-    }
+	}
 
-    start() {
+	start() {
 
-        this.startTime = now();
-        this.oldTime = this.startTime;
-        this.elapsedTime = 0;
-        this.running = true;
+		this.startTime = now();
+		this.oldTime = this.startTime;
+		this.elapsedTime = 0;
+		this.running = true;
 
-    }
+	}
 
-    stop() {
+	stop() {
 
-        this.getElapsedTime();
-        this.running = false;
+		this.getElapsedTime();
+		this.running = false;
 
-    }
+	}
 
-    getElapsedTime() {
+	getElapsedTime() {
 
-        this.getDelta();
+		this.getDelta();
 
-        return this.elapsedTime;
+		return this.elapsedTime;
 
-    }
+	}
 
-    getDelta() {
+	getDelta() {
 
-        let diff = 0;
+		let diff = 0;
 
-        if ( this.running ) {
+		if ( this.running ) {
 
-            const newTime = now();
+			const newTime = now();
 
-            diff = ( newTime - this.oldTime ) / 1000;
+			diff = ( newTime - this.oldTime ) / 1000;
 
-            this.oldTime = newTime;
-            this.elapsedTime += diff;
+			this.oldTime = newTime;
+			this.elapsedTime += diff;
 
-        }
+		}
 
-        return diff;
+		return diff;
 
-    }
+	}
 
 }
 

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -1,67 +1,60 @@
 class Clock {
 
-	constructor( autoStart = true ) {
+    constructor( autoStart = true ) {
 
-		this.autoStart = autoStart;
+        this.autoStart = autoStart;
+        this.running = this.autoStart;
 
-		this.startTime = 0;
-		this.oldTime = 0;
-		this.elapsedTime = 0;
+        this.startTime = 0;
+        this.oldTime = 0;
+        this.elapsedTime = 0;
 
-		this.running = false;
+        this.running && this.start();
 
-	}
+    }
 
-	start() {
+    start() {
 
-		this.startTime = now();
+        this.startTime = now();
+        this.oldTime = this.startTime;
+        this.elapsedTime = 0;
+        this.running = true;
 
-		this.oldTime = this.startTime;
-		this.elapsedTime = 0;
-		this.running = true;
+    }
 
-	}
+    stop() {
 
-	stop() {
+        this.getElapsedTime();
+        this.running = false;
 
-		this.getElapsedTime();
-		this.running = false;
-		this.autoStart = false;
+    }
 
-	}
+    getElapsedTime() {
 
-	getElapsedTime() {
+        this.getDelta();
 
-		this.getDelta();
-		return this.elapsedTime;
+        return this.elapsedTime;
 
-	}
+    }
 
-	getDelta() {
+    getDelta() {
 
-		let diff = 0;
+        let diff = 0;
 
-		if ( this.autoStart && ! this.running ) {
+        if ( this.running ) {
 
-			this.start();
-			return 0;
+            const newTime = now();
 
-		}
+            diff = ( newTime - this.oldTime ) / 1000;
 
-		if ( this.running ) {
+            this.oldTime = newTime;
+            this.elapsedTime += diff;
 
-			const newTime = now();
+        }
 
-			diff = ( newTime - this.oldTime ) / 1000;
-			this.oldTime = newTime;
+        return diff;
 
-			this.elapsedTime += diff;
-
-		}
-
-		return diff;
-
-	}
+    }
 
 }
 


### PR DESCRIPTION
# Description

### Pre-information:
`autoStart` is the input parameter of the Clock constructor, which is defined as "whether to automatically start the clock when it is created" (the original meaning is "whether to automatically start the clock").

### describe the bug:

1. No matter what the value of `autoStart` is, the Clock instance will not start automatically because the `start` method is never called internally by the `constructor`.
2. When `autoStart` is `true`, the value of `running` is `false`, which is semantically contradictory, for example:
```js
const clock = new Clock( true );

clock.autoStart; // output: true
clock.running;   // output: false
```

### My advice and practices

- Inside the `constructor`, depending on the value of `autoStart` to decide whether to call the `start` method, this can solve both bug1 and bug2.
- The rest of the methods except the `constructor` method should not rewrite `autoStart` , because once the Clock instance is created, changing `autoStart` doesn't make any sense and will cause confusion.
- Remove the `if ( this.autoStart && ! this.running )` branch in the `getDelta` method. The meaning of this branch is to patch for bug2. Now that bug2 is fixed from the source, this patch can be retired.

### Other
I noticed that the community decided to replace `Clock` with the new `Timer` ( #17679, #17912 ), but seems to have been delaying the launch of `Timer`. I think it is still necessary to optimize `Clock` before `Timer` goes live.