### PR TITLE
PMREMGenerator: Fix dispose().

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -201,7 +201,7 @@ class PMREMGenerator {
 
 	_dispose() {
 
-		this._blurMaterial.dispose();
+		if ( this._blurMaterial !== null ) this._blurMaterial.dispose();
 
 		if ( this._pingPongRenderTarget !== null ) this._pingPongRenderTarget.dispose();
 


### PR DESCRIPTION
Fixed #23695.

**Description**

It's necessary to check if `_blurMaterial` is `null` before calling `dispose()`.
