### PR TITLE
VTKLoader: fix parsing VTP containing DataArrays of type Int32

### DIFF
--- a/examples/js/loaders/VTKLoader.js
+++ b/examples/js/loaders/VTKLoader.js
@@ -672,7 +672,7 @@
 
 							txt = new Float32Array();
 
-						} else if ( ele.attributes.type === 'Int64' ) {
+						} else if ( ele.attributes.type === 'Int32' || ele.attributes.type === 'Int64' ) {
 
 							txt = new Int32Array();
 
@@ -737,7 +737,7 @@
 								content = new Float32Array( content );
 								txt = Float32Concat( txt, content );
 
-							} else if ( ele.attributes.type === 'Int64' ) {
+							} else if ( ele.attributes.type === 'Int32' || ele.attributes.type === 'Int64' ) {
 
 								content = new Int32Array( content );
 								txt = Int32Concat( txt, content );

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -718,7 +718,7 @@ class VTKLoader extends Loader {
 
 						txt = new Float32Array( );
 
-					} else if ( ele.attributes.type === 'Int64' ) {
+					} else if ( ele.attributes.type === 'Int32' || ele.attributes.type === 'Int64' ) {
 
 						txt = new Int32Array( );
 
@@ -786,7 +786,7 @@ class VTKLoader extends Loader {
 							content = new Float32Array( content );
 							txt = Float32Concat( txt, content );
 
-						} else if ( ele.attributes.type === 'Int64' ) {
+						} else if ( ele.attributes.type === 'Int32' || ele.attributes.type === 'Int64' ) {
 
 							content = new Int32Array( content );
 							txt = Int32Concat( txt, content );


### PR DESCRIPTION
**Description**

Fix parsing of VTP files who contain DataArray nodes
of type "Int32". Those nodes were currently ignored,
resulting in an exception.

Fixed #23698