### PR TITLE
PositionalAudio: Disconnect panner in disconnect()

### DIFF
--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -19,6 +19,14 @@ class PositionalAudio extends Audio {
 
 	}
 
+	disconnect() {
+
+		super.disconnect();
+
+		this.panner.disconnect( this.gain );
+
+	}
+
 	getOutput() {
 
 		return this.panner;


### PR DESCRIPTION
Fixes #12775

**Description**

`PositionalAudio` didn't have a way to disconnect its panner.
