### PR TITLE
NodeMaterial : fix properties shared across instances

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -18,11 +18,23 @@ class NodeMaterial extends ShaderMaterial {
 		// This approach is to reuse the native refreshUniforms*
 		// and turn available the use of features like transmission and environment in core
 
+		let value;
+
 		for ( const property in values ) {
+
+			value = values[ property ];
 
 			if ( this[ property ] === undefined ) {
 
-				this[ property ] = values[ property ];
+				if ( value && typeof value.clone === 'function' ) {
+
+					this[ property ] = value.clone();
+
+				} else {
+
+					this[ property ] = value;
+
+				}
 
 			}
 


### PR DESCRIPTION
**Description**

Since v138, every properties of a NodeMaterial (except primitive values) will be shared across all instances of the same material. [This codepen illustrates the problem](https://codepen.io/wmcmurray/pen/NWXKMbQ?editors=1010), there are 2 sets of points, each with a differently coloured material (red and blue), but both are rendered blue.

**Explanation**

My understanding is that NodeMaterials does not extend base material classes anymore, instead the `NodeMaterial.setDefaultValues()` is used to copy properties into the NodeMaterial instances. But since properties are copied from [a single instance](https://github.com/mrdoob/three.js/blob/98985923afe4fe4030fce256b0cc0d02dc68696f/examples/jsm/renderers/nodes/materials/PointsNodeMaterial.js#L4) of the base material, properties that are an instance of Color (for example) will be copied by reference, therefore every material instances will share the same value.

**Disclaimer**

I tested this PR only with PointsNodeMaterial, and only inside my project.

cc @sunag 