### PR TITLE
MathUtils code documentation

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -35,7 +35,7 @@ function clamp( value, min, max ) {
 
 }
 
-// compute euclidian modulo of m % n
+// compute euclidean modulo of m % n
 // https://en.wikipedia.org/wiki/Modulo_operation
 function euclideanModulo( n, m ) {
 


### PR DESCRIPTION
Typo in code comment:
- `euclidian` => `euclidean`
