### PR TITLE
Documentation

### DIFF
--- a/docs/api/en/animation/AnimationObjectGroup.html
+++ b/docs/api/en/animation/AnimationObjectGroup.html
@@ -38,7 +38,7 @@
 
 		<h3>[name]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
-			[page:Object obj] - an abitrary number of meshes that share the same animation state.
+			[page:Object obj] - an arbitrary number of meshes that share the same animation state.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/examples/en/exporters/OBJExporter.html
+++ b/docs/examples/en/exporters/OBJExporter.html
@@ -13,7 +13,7 @@
 		An exporter for the <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file" target="_blank">OBJ</a> file format.
 		</p>
 		<p class="desc">
-		[name] is not able to export material data into MTL files so only geoemtry data are supported.
+		[name] is not able to export material data into MTL files so only geometry data are supported.
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/examples/zh/animations/MMDPhysics.html
+++ b/docs/examples/zh/animations/MMDPhysics.html
@@ -78,7 +78,7 @@
 
 		<h3>[method:this reset]()</h3>
 		<p>
-		Resets Rigid bodies transorm to current bone's.
+		Resets Rigid bodies transform to current bone's.
 		</p>
 
 		<h3>[method:this setGravity]( [param:Vector3 gravity] )</h3>

--- a/docs/examples/zh/exporters/ColladaExporter.html
+++ b/docs/examples/zh/exporters/ColladaExporter.html
@@ -57,7 +57,7 @@
 			// Collada file content
 			data: "",
 
-			// List of referenced texures
+			// List of referenced textures
 			textures: [{
 
 				// File directory, name, and extension of the texture data

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -37,7 +37,7 @@
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );
 
 			},
-			// called when the loading failes
+			// called when the loading fails
 			function ( error ) {
 
 				console.log( 'An error happened' );

--- a/docs/examples/zh/math/convexhull/HalfEdge.html
+++ b/docs/examples/zh/math/convexhull/HalfEdge.html
@@ -54,7 +54,7 @@
 		<h2>Methods</h2>
 
 		<h3>[method:VertexNode head]()</h3>
-		<p>Returns the destintation vertex.</p>
+		<p>Returns the destination vertex.</p>
 
 		<h3>[method:VertexNode tail]()</h3>
 		<p>Returns the origin vertex.</p>


### PR DESCRIPTION
Typos found within the `docs/` folder.

- `abitrary` => `arbitrary`
- `destintation` => `destination`
- `failes` => `fails`
- `geoemtry` => `geometry`
- `texures` => `textures`
- `transorm` => `transform`

Documentation isn't autogenerated, I think?  Submitting separately in case the canonical source of this is elsewhere.

