### PR TITLE
WebGLRenderer: Use texelFetch() to sample morph target texture.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
@@ -7,13 +7,13 @@ export default /* glsl */`
 
 		uniform float morphTargetInfluences[ MORPHTARGETS_COUNT ];
 		uniform sampler2DArray morphTargetsTexture;
-		uniform vec2 morphTargetsTextureSize;
+		uniform ivec2 morphTargetsTextureSize;
 
 		vec4 getMorph( const in int vertexIndex, const in int morphTargetIndex, const in int offset ) {
 
-			float texelIndex = float( vertexIndex * MORPHTARGETS_TEXTURE_STRIDE + offset );
-			float y = floor( texelIndex / morphTargetsTextureSize.x );
-			float x = texelIndex - y * morphTargetsTextureSize.x;
+			int texelIndex = vertexIndex * MORPHTARGETS_TEXTURE_STRIDE + offset;
+			int y = texelIndex / morphTargetsTextureSize.x;
+			int x = texelIndex - y * morphTargetsTextureSize.x;
 
 			ivec3 morphUV = ivec3( x, y, morphTargetIndex );
 			return texelFetch( morphTargetsTexture, morphUV, 0 );

--- a/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
@@ -15,8 +15,8 @@ export default /* glsl */`
 			float y = floor( texelIndex / morphTargetsTextureSize.x );
 			float x = texelIndex - y * morphTargetsTextureSize.x;
 
-			vec3 morphUV = vec3( ( x + 0.5 ) / morphTargetsTextureSize.x, y / morphTargetsTextureSize.y, morphTargetIndex );
-			return texture( morphTargetsTexture, morphUV );
+			ivec3 morphUV = ivec3( x, y, morphTargetIndex );
+			return texelFetch( morphTargetsTexture, morphUV, 0 );
 
 		}
 


### PR DESCRIPTION
Related issue: #23711

**Description**

@kenrussell recommended the usage of `texelFetch()` to sample the morph target texture (see https://bugs.chromium.org/p/chromium/issues/detail?id=1305968#c4). This actually solves the issue reported in #23711 on a Windows laptop 🎉 . 

Looking at the details of `texelFetch()`, it's indeed the more appropriate function for this use case.
