### PR TITLE
WebGLRenderTarget: Fix copy().

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -78,6 +78,7 @@ class WebGLRenderTarget extends EventDispatcher {
 		this.viewport.copy( source.viewport );
 
 		this.texture = source.texture.clone();
+		this.texture.isRenderTargetTexture = true;
 
 		// ensure image object is not shared, see #20328
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20328#issuecomment-1069257169

**Description**

When the texture is cloned in `WebGLRenderTarget.copy()`, it's necessary to set `isRenderTargetTexture` back to `true`.
