### PR TITLE
Docs: Clarify BufferGeometry.groups.

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -103,6 +103,7 @@
 			Use [page:.addGroup] to add groups, rather than modifying this array directly.<br /><br />
 
 			The geometry is considered as invalid when parts of the vertex data or indices are in groups but others are not.
+			It is also invalid when groups overlap. Meaning vertex data should only be assigned to a single group.
 		</p>
 
 

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -92,7 +92,7 @@
 		<h3>[property:Array groups]</h3>
 		<p>
 			Split the geometry into groups, each of which will be rendered in a separate WebGL draw call.
-			This allows an array of materials to be used with the bufferGeometry.<br /><br />
+			This allows an array of materials to be used with the geometry.<br /><br />
 
 			Each group is an object of the form:
 			<code>{ start: Integer, count: Integer, materialIndex: Integer }</code>
@@ -100,7 +100,9 @@
 			otherwise the first triangle index. Count specifies how many vertices (or indices) are included, and
 			materialIndex specifies the material array index to use.<br /><br />
 
-			Use [page:.addGroup] to add groups, rather than modifying this array directly.
+			Use [page:.addGroup] to add groups, rather than modifying this array directly.<br /><br />
+
+			The geometry is considered as invalid when parts of the vertex data or indices are in groups but others are not.
 		</p>
 
 

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -102,8 +102,7 @@
 
 			Use [page:.addGroup] to add groups, rather than modifying this array directly.<br /><br />
 
-			The geometry is considered as invalid when parts of the vertex data or indices are in groups but others are not.
-			It is also invalid when groups overlap. Meaning vertex data should only be assigned to a single group.
+			Every vertex and index must belong to exactly one group — groups must not share vertices or indices, and must not leave vertices or indices unused.
 		</p>
 
 


### PR DESCRIPTION
Fixed #22555.

**Description**

I'd like to clarify the policy of using `BufferGeometry.groups`:

When groups are defined, it is invalid when parts of the vertex data are in groups but others are not. Such partial definitions are problematic for logic operating on group data. It is also not valid when groups overlap.