### PR TITLE
Editor: adding iframe for script execution

### DIFF
--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -58,7 +58,13 @@ var APP = {
 			}
 
 			var scriptWrapResult = JSON.stringify( scriptWrapResultObj ).replace( /\"/g, '' );
+			
+			var iframe = document.createElement( 'iframe' );
 
+			document.body.appendChild( iframe );
+			
+			var F = iframe.contentWindow.Function;
+			
 			for ( var uuid in json.scripts ) {
 
 				var object = scene.getObjectByProperty( 'uuid', uuid, true );
@@ -71,12 +77,6 @@ var APP = {
 				}
 
 				var scripts = json.scripts[ uuid ];
-
-				var iframe = document.createElement( 'iframe' );
-
-				document.body.appendChild( iframe );
-
-				var F = iframe.contentWindow.Function;
 
 				for ( var i = 0; i < scripts.length; i ++ ) {
 
@@ -101,9 +101,9 @@ var APP = {
 
 				}
 
-				document.body.removeChild( iframe );
-
 			}
+			
+			document.body.removeChild( iframe );
 
 			dispatch( events.init, arguments );
 

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -47,7 +47,7 @@ var APP = {
 				update: []
 			};
 
-			var scriptWrapParams = 'player,renderer,scene,camera';
+			var scriptWrapParams = 'player,renderer,scene,camera,THREE';
 			var scriptWrapResultObj = {};
 
 			for ( var eventKey in events ) {
@@ -72,11 +72,17 @@ var APP = {
 
 				var scripts = json.scripts[ uuid ];
 
+				var iframe = document.createElement( 'iframe' );
+
+				document.body.appendChild( iframe );
+
+				var F = iframe.contentWindow.Function;
+
 				for ( var i = 0; i < scripts.length; i ++ ) {
 
 					var script = scripts[ i ];
 
-					var functions = ( new Function( scriptWrapParams, script.source + '\nreturn ' + scriptWrapResult + ';' ).bind( object ) )( this, renderer, scene, camera );
+					var functions = ( new F( scriptWrapParams, script.source + '\nreturn ' + scriptWrapResult + ';' ).bind( object ) )( this, renderer, scene, camera, THREE );
 
 					for ( var name in functions ) {
 
@@ -94,6 +100,8 @@ var APP = {
 					}
 
 				}
+
+				document.body.removeChild( iframe );
 
 			}
 


### PR DESCRIPTION
Related issue: No related issue

**Description**

Execute script into an iframe for avoiding bad code and usage of for example `eval`. This change could be useful in the future if you add a `share` function to the editor for shared projects.

