### PR TITLE
docs: Updated vscode comment-tagged-templates syntax highlighter.

### DIFF
--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -107,7 +107,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
-			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates comment-tagged-templates] - VSCode extension syntax highlighting for tagged template strings, like: glsl.js.
+			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
+			<br />
+			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.
 		</li>
 		<li>
 			[link:https://github.com/MozillaReality/WebXR-emulator-extension WebXR-emulator-extension]

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -116,7 +116,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
-			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates comment-tagged-templates] - VSCode extension syntax highlighting for tagged template strings, like: glsl.js.
+			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
+			<br />
+			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.
 		</li>
 		<li>
 			[link:https://github.com/MozillaReality/WebXR-emulator-extension WebXR-emulator-extension]

--- a/docs/manual/ja/introduction/Useful-links.html
+++ b/docs/manual/ja/introduction/Useful-links.html
@@ -114,7 +114,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
-			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates comment-tagged-templates] - VSCode extension syntax highlighting for tagged template strings, like: glsl.js.
+			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
+			<br />
+			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.
 		</li>
 		<li>
 			[link:https://github.com/MozillaReality/WebXR-emulator-extension WebXR-emulator-extension]

--- a/docs/manual/ko/introduction/Useful-links.html
+++ b/docs/manual/ko/introduction/Useful-links.html
@@ -116,7 +116,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
-			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates comment-tagged-templates] - VSCode extension syntax highlighting for tagged template strings, like: glsl.js.
+			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
+			<br />
+			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.
 		</li>
 		<li>
 			[link:https://github.com/MozillaReality/WebXR-emulator-extension WebXR-emulator-extension]

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -118,7 +118,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
-			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates comment-tagged-templates] - VSCode extension syntax highlighting for tagged template strings, like: glsl.js.
+			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
+			<br />
+			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.
 		</li>
 		<li>
 			[link:https://github.com/MozillaReality/WebXR-emulator-extension WebXR-emulator-extension]


### PR DESCRIPTION
Related issue: https://github.com/mjbvz/vscode-comment-tagged-templates/issues/7

**Description**

Updated vscode comment-tagged-templates syntax highlighter of [vscode shader](https://marketplace.visualstudio.com/items?itemName=slevesque.shader).
