### PR TITLE
Camera: Moved clearViewOffset up in camera hierarchy

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -61,7 +61,7 @@ class Camera extends Object3D {
 
 	}
 
-    clearViewOffset() {
+	clearViewOffset() {
 
 		if ( this.view !== null ) {
 
@@ -72,6 +72,7 @@ class Camera extends Object3D {
 		this.updateProjectionMatrix();
 
 	}
+
 }
 
 Camera.prototype.isCamera = true;

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -61,6 +61,17 @@ class Camera extends Object3D {
 
 	}
 
+    clearViewOffset() {
+
+		if ( this.view !== null ) {
+
+			this.view.enabled = false;
+
+		}
+
+		this.updateProjectionMatrix();
+
+	}
 }
 
 Camera.prototype.isCamera = true;

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -69,18 +69,6 @@ class OrthographicCamera extends Camera {
 
 	}
 
-	clearViewOffset() {
-
-		if ( this.view !== null ) {
-
-			this.view.enabled = false;
-
-		}
-
-		this.updateProjectionMatrix();
-
-	}
-
 	updateProjectionMatrix() {
 
 		const dx = ( this.right - this.left ) / ( 2 * this.zoom );

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -162,18 +162,6 @@ class PerspectiveCamera extends Camera {
 
 	}
 
-	clearViewOffset() {
-
-		if ( this.view !== null ) {
-
-			this.view.enabled = false;
-
-		}
-
-		this.updateProjectionMatrix();
-
-	}
-
 	updateProjectionMatrix() {
 
 		const near = this.near;


### PR DESCRIPTION
**Description**

clearViewOffset is identical in the Camera subclasses. I moved it up to the Camera class.

Personal context: Hey there, I'm currently working on my bachelor's thesis, which is about automatic refactoring using jscodeshift codemods. I test my codemods on open source projects like yours, and my codemod found this opportunity to move a method up in the hierarchy.  I don't really have a big clue on what this might break or not, but it would be really cool, if my codemod did an actual refactoring that was used in a big project :D 
