### PR TITLE
Destructuring assignment

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -939,17 +939,10 @@
 		}
 
 		transpose() {
-			let tmp;
 			const m = this.elements;
-			tmp = m[1];
-			m[1] = m[3];
-			m[3] = tmp;
-			tmp = m[2];
-			m[2] = m[6];
-			m[6] = tmp;
-			tmp = m[5];
-			m[5] = m[7];
-			m[7] = tmp;
+			m[1], m[3] = m[3], m[1];
+			m[2], m[6] = m[6], m[2];
+			m[5], m[7] = m[7], m[5];
 			return this;
 		}
 

--- a/build/three.js
+++ b/build/three.js
@@ -939,10 +939,17 @@
 		}
 
 		transpose() {
+			let tmp;
 			const m = this.elements;
-			m[1], m[3] = m[3], m[1];
-			m[2], m[6] = m[6], m[2];
-			m[5], m[7] = m[7], m[5];
+			tmp = m[1];
+			m[1] = m[3];
+			m[3] = tmp;
+			tmp = m[2];
+			m[2] = m[6];
+			m[6] = tmp;
+			tmp = m[5];
+			m[5] = m[7];
+			m[7] = tmp;
 			return this;
 		}
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -185,12 +185,11 @@ class Matrix3 {
 
 	transpose() {
 
-		let tmp;
 		const m = this.elements;
 
-		tmp = m[ 1 ]; m[ 1 ] = m[ 3 ]; m[ 3 ] = tmp;
-		tmp = m[ 2 ]; m[ 2 ] = m[ 6 ]; m[ 6 ] = tmp;
-		tmp = m[ 5 ]; m[ 5 ] = m[ 7 ]; m[ 7 ] = tmp;
+		m[1], m[3] = m[3], m[1];
+		m[2], m[6] = m[6], m[2];
+		m[5], m[7] = m[7], m[5];
 
 		return this;
 


### PR DESCRIPTION
Related issue: None

**Description**

Changed the Value Change Method with a temporary variable to the Destructuring Assignment Method.
This makes no difference to the end result but is a cleaner and shorter way to swap elements by removing the tmp variable.
https://www.programiz.com/javascript/examples/swap-variables
Because of fewer characters, the code will also be loaded faster.
This is like nearly everything supported by all relevant browsers.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#browser_compatibility