### PR TITLE
BufferGeometryUtils: Add mergeGroups().

### DIFF
--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -54,6 +54,13 @@
 
 		</p>
 
+		<h3>[method:BufferGeometry mergeGroups]( [param:BufferGeometry geometry] )</h3>
+		<p>
+		geometry -- Instance of [page:BufferGeometry BufferGeometry] to merge the groups of.<br /><br />
+
+		Merges the [page:BufferGeometry.groups groups] for the given geometry.
+		</p>
+
 		<h3>[method:BufferGeometry mergeVertices]( [param:BufferGeometry geometry], [param:Number tolerance] )</h3>
 		<p>
 		geometry -- Instance of [page:BufferGeometry BufferGeometry] to merge the vertices of.<br />

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -51,6 +51,13 @@
 
 		</p>
 
+		<h3>[method:BufferGeometry mergeGroups]( [param:BufferGeometry geometry] )</h3>
+		<p>
+		geometry -- Instance of [page:BufferGeometry BufferGeometry] to merge the groups of.<br /><br />
+
+		Merges the [page:BufferGeometry.groups groups] for the given geometry.
+		</p>
+
 		<h3>[method:BufferGeometry mergeVertices]( [param:BufferGeometry geometry], [param:Number tolerance] )</h3>
 		<p>
 		geometry -- 用于合并顶点的 [page:BufferGeometry BufferGeometry] 实例。<br />

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -929,7 +929,107 @@ function computeMorphedAttributes( object ) {
 
 }
 
+function mergeGroups( geometry ) {
 
+	if ( geometry.groups.length === 0 ) {
+
+		console.warn( 'THREE.BufferGeometryUtils.mergeGroups(): No groups are defined. Nothing to merge.' );
+		return geometry;
+
+	}
+
+	let groups = geometry.groups;
+
+	// sort groups by material index
+
+	groups = groups.sort( ( a, b ) => {
+
+		if ( a.materialIndex !== b.materialIndex ) return a.materialIndex - b.materialIndex;
+
+		return a.start - b.start;
+
+	} );
+
+	// create index for non-indexed geometries
+
+	if ( geometry.getIndex() === null ) {
+
+		const positionAttribute = geometry.getAttribute( 'position' );
+		const indices = [];
+
+		for ( let i = 0; i < positionAttribute.count; i += 3 ) {
+
+			indices.push( i, i + 1, i + 2 );
+
+		}
+
+		geometry.setIndex( indices );
+
+	}
+
+	// sort index
+
+	const index = geometry.getIndex();
+
+	const newIndices = [];
+
+	for ( let i = 0; i < groups.length; i ++ ) {
+
+		const group = groups[ i ];
+
+		const groupStart = group.start;
+		const groupLength = groupStart + group.count;
+
+		for ( let j = groupStart; j < groupLength; j ++ ) {
+
+			newIndices.push( index.getX( j ) );
+
+		}
+
+	}
+
+	geometry.dispose(); // Required to force buffer recreation
+	geometry.setIndex( newIndices );
+
+	// update groups indices
+
+	let start = 0;
+
+	for ( let i = 0; i < groups.length; i ++ ) {
+
+		const group = groups[ i ];
+
+		group.start = start;
+		start += group.count;
+
+	}
+
+	// merge groups
+
+	let currentGroup = groups[ 0 ];
+
+	geometry.groups = [ currentGroup ];
+
+	for ( let i = 1; i < groups.length; i ++ ) {
+
+		const group = groups[ i ];
+
+		if ( currentGroup.materialIndex === group.materialIndex ) {
+
+			currentGroup.count += group.count;
+
+		} else {
+
+			currentGroup = group;
+			geometry.groups.push( currentGroup );
+
+		}
+
+	}
+
+	return geometry;
+
+}
 
 export {
 	computeTangents,
@@ -940,4 +1040,5 @@ export {
 	mergeVertices,
 	toTrianglesDrawMode,
 	computeMorphedAttributes,
+	mergeGroups
 };


### PR DESCRIPTION
Depends on #23740.

**Description**

Introduces a utility function to merge groups in geometries. Can be used to optimize the rendering of multi-material meshes by lowering draw calls. Also required for an upcoming routine that converts a multi-material mesh into separate meshes.

 As suggested in https://github.com/mrdoob/three.js/pull/13748#issuecomment-380234401, this PR adds an index if not present and only sorts the index. It can also work on interleaved index data.

Closes #13748.
