### PR TITLE
Use fromBufferAttribute

### DIFF
--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -60,9 +60,7 @@ class OBJExporter {
 
 				for ( let i = 0, l = vertices.count; i < l; i ++, nbVertex ++ ) {
 
-					vertex.x = vertices.getX( i );
-					vertex.y = vertices.getY( i );
-					vertex.z = vertices.getZ( i );
+					vertex.fromBufferAttribute( vertices, i );
 
 					// transform the vertex to world space
 					vertex.applyMatrix4( mesh.matrixWorld );
@@ -80,8 +78,7 @@ class OBJExporter {
 
 				for ( let i = 0, l = uvs.count; i < l; i ++, nbVertexUvs ++ ) {
 
-					uv.x = uvs.getX( i );
-					uv.y = uvs.getY( i );
+					uv.fromBufferAttribute( uvs, i );
 
 					// transform the uv to export format
 					output += 'vt ' + uv.x + ' ' + uv.y + '\n';
@@ -98,9 +95,7 @@ class OBJExporter {
 
 				for ( let i = 0, l = normals.count; i < l; i ++, nbNormals ++ ) {
 
-					normal.x = normals.getX( i );
-					normal.y = normals.getY( i );
-					normal.z = normals.getZ( i );
+					normal.fromBufferAttribute( normals, i );
 
 					// transform the normal to world space
 					normal.applyMatrix3( normalMatrixWorld ).normalize();
@@ -180,9 +175,7 @@ class OBJExporter {
 
 				for ( let i = 0, l = vertices.count; i < l; i ++, nbVertex ++ ) {
 
-					vertex.x = vertices.getX( i );
-					vertex.y = vertices.getY( i );
-					vertex.z = vertices.getZ( i );
+					vertex.fromBufferAttribute( vertices, i );
 
 					// transform the vertex to world space
 					vertex.applyMatrix4( line.matrixWorld );

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -227,9 +227,7 @@ class PLYExporter {
 
 				for ( let i = 0, l = vertices.count; i < l; i ++ ) {
 
-					vertex.x = vertices.getX( i );
-					vertex.y = vertices.getY( i );
-					vertex.z = vertices.getZ( i );
+					vertex.fromBufferAttribute( vertices, i );
 
 					vertex.applyMatrix4( mesh.matrixWorld );
 
@@ -249,9 +247,7 @@ class PLYExporter {
 
 						if ( normals != null ) {
 
-							vertex.x = normals.getX( i );
-							vertex.y = normals.getY( i );
-							vertex.z = normals.getZ( i );
+							vertex.fromBufferAttribute( normals, i );
 
 							vertex.applyMatrix3( normalMatrixWorld ).normalize();
 
@@ -411,9 +407,7 @@ class PLYExporter {
 				// form each line
 				for ( let i = 0, l = vertices.count; i < l; i ++ ) {
 
-					vertex.x = vertices.getX( i );
-					vertex.y = vertices.getY( i );
-					vertex.z = vertices.getZ( i );
+					vertex.fromBufferAttribute( vertices, i );
 
 					vertex.applyMatrix4( mesh.matrixWorld );
 
@@ -429,9 +423,7 @@ class PLYExporter {
 
 						if ( normals != null ) {
 
-							vertex.x = normals.getX( i );
-							vertex.y = normals.getY( i );
-							vertex.z = normals.getZ( i );
+							vertex.fromBufferAttribute( normals, i );
 
 							vertex.applyMatrix3( normalMatrixWorld ).normalize();
 

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -67,9 +67,9 @@ class VertexNormalsHelper extends LineSegments {
 
 			for ( let j = 0, jl = objPos.count; j < jl; j ++ ) {
 
-				_v1.set( objPos.getX( j ), objPos.getY( j ), objPos.getZ( j ) ).applyMatrix4( matrixWorld );
+				_v1.fromBufferAttribute( objPos, j ).applyMatrix4( matrixWorld );
 
-				_v2.set( objNorm.getX( j ), objNorm.getY( j ), objNorm.getZ( j ) );
+				_v2.fromBufferAttribute( objNorm, j );
 
 				_v2.applyMatrix3( _normalMatrix ).normalize().multiplyScalar( this.size ).add( _v1 );
 

--- a/examples/jsm/helpers/VertexTangentsHelper.js
+++ b/examples/jsm/helpers/VertexTangentsHelper.js
@@ -56,9 +56,9 @@ class VertexTangentsHelper extends LineSegments {
 
 		for ( let j = 0, jl = objPos.count; j < jl; j ++ ) {
 
-			_v1.set( objPos.getX( j ), objPos.getY( j ), objPos.getZ( j ) ).applyMatrix4( matrixWorld );
+			_v1.fromBufferAttribute( objPos, j ).applyMatrix4( matrixWorld );
 
-			_v2.set( objTan.getX( j ), objTan.getY( j ), objTan.getZ( j ) );
+			_v2.fromBufferAttribute( objTan, j );
 
 			_v2.transformDirection( matrixWorld ).multiplyScalar( this.size ).add( _v1 );
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -222,9 +222,7 @@ class BufferAttribute {
 
 		for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.applyMatrix4( m );
 
@@ -240,9 +238,7 @@ class BufferAttribute {
 
 		for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.applyNormalMatrix( m );
 
@@ -258,9 +254,7 @@ class BufferAttribute {
 
 		for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.transformDirection( m );
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -39,9 +39,7 @@ class InterleavedBufferAttribute {
 
 		for ( let i = 0, l = this.data.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.applyMatrix4( m );
 
@@ -57,9 +55,7 @@ class InterleavedBufferAttribute {
 
 		for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.applyNormalMatrix( m );
 
@@ -75,9 +71,7 @@ class InterleavedBufferAttribute {
 
 		for ( let i = 0, l = this.count; i < l; i ++ ) {
 
-			_vector.x = this.getX( i );
-			_vector.y = this.getY( i );
-			_vector.z = this.getZ( i );
+			_vector.fromBufferAttribute( this, i );
 
 			_vector.transformDirection( m );
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -72,10 +72,7 @@ class SkinnedMesh extends Mesh {
 
 		for ( let i = 0, l = skinWeight.count; i < l; i ++ ) {
 
-			vector.x = skinWeight.getX( i );
-			vector.y = skinWeight.getY( i );
-			vector.z = skinWeight.getZ( i );
-			vector.w = skinWeight.getW( i );
+			vector.fromBufferAttribute( skinWeight, i );
 
 			const scale = 1.0 / vector.manhattanLength();
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/23761.

**Description**

This PR changes quite common uses of `vector.x = attribute.getX( i ); vector.y = attribute.getY( i );` to `vector.fromBufferAttribute( i )`.