### PR TITLE
Doc: update chinese doc for WebGLRenderer.

### DIFF
--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -323,7 +323,7 @@
 		<h3>[method:number getPixelRatio]()</h3>
 		<p>返回当前使用设备像素比</p>
 
-		<h3>[method:Object getSize]()</h3>
+		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
 		<p>返回包含渲染器输出canvas的宽度和高度(单位像素)的对象。</p>
 
 		<h3>[method:undefined initTexture]( [param:Texture texture] )</h3>


### PR DESCRIPTION
## Description
The Chinese documentation is missing a description of the required parameter `target` of `getSize`.