### PR TITLE
VideoTexture: Fix color space when using with Scene.background.

### DIFF
--- a/src/renderers/shaders/ShaderLib/background.glsl.js
+++ b/src/renderers/shaders/ShaderLib/background.glsl.js
@@ -20,6 +20,14 @@ void main() {
 
 	gl_FragColor = texture2D( t2D, vUv );
 
+	#ifdef DECODE_VIDEO_TEXTURE
+
+		// inline sRGB decode (TODO: Remove this code when https://crbug.com/1256340 is solved)
+
+		gl_FragColor = vec4( mix( pow( gl_FragColor.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), gl_FragColor.rgb * 0.0773993808, vec3( lessThanEqual( gl_FragColor.rgb, vec3( 0.04045 ) ) ) ), gl_FragColor.w );
+
+	#endif
+
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 


### PR DESCRIPTION
Fixed #23780.

**Description**

Video textures are still decoded inline (see https://github.com/mrdoob/three.js/issues/23109#issuecomment-1004368837) so the `background` shader also needs the code mentioned in #23780.

@nyan-left Do you mind checking if this PR fixes your issue? At least the demo from the codesandbox now renders as expected on my local computer.