### PR TITLE
Don't convert type of node if it is not needed

### DIFF
--- a/examples/jsm/nodes/ShaderNode.js
+++ b/examples/jsm/nodes/ShaderNode.js
@@ -236,7 +236,13 @@ const ConvertType = function ( type, cacheMap = null ) {
 
 			const nodes = params.map( getAutoTypedConstNode );
 
-			return nodeObject( new ConvertNode( nodes.length === 1 ? nodes[ 0 ] : new JoinNode( nodes ), type ) );
+			if ( nodes.length === 1 ) {
+
+				return nodeObject( nodes[ 0 ].nodeType === type ? nodes[ 0 ] : new ConvertNode( nodes[ 0 ], type ) );
+
+			}
+
+			return nodeObject( new ConvertNode( new JoinNode( nodes ), type ) );
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

Don't convert the node if it is already of a correct type.