### PR TITLE
perf (Clock): Determine time provider only once

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -65,9 +65,11 @@ class Clock {
 
 }
 
+const provider = typeof performance === 'undefined' ? Date : performance; // see #10732
+
 function now() {
 
-	return ( typeof performance === 'undefined' ? Date : performance ).now(); // see #10732
+	return provider.now();
 
 }
 


### PR DESCRIPTION
**Description**

The function `now()` was testing for available time provider every invocation. I wasn't able to find any info if this was intentional for some reason, so I went ahead and made it select the provider only once for sake of optimization, since this function is called every frame most of the time.
