### PR TITLE
Docs: fixed minor typo on manual

### DIFF
--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -79,7 +79,7 @@
 			capabilities of available display devices. Colors are expressed as a ratio of the primary colors.
 		</li>
 		<li>
-			<b>White point:</b> Most color spaces are engineed such that an equally weighted sum of
+			<b>White point:</b> Most color spaces are engineered such that an equally weighted sum of
 			primaries <i>R = G = B</i> will appear to be without color, or "achromatic". The appearance
 			of achromatic values (like white or grey) depend on human perception, which in turn depends
 			heavily on the context of the observer. A color space specifies its "white point" to balance


### PR DESCRIPTION
This fixes an unbearably small typo on the [color management page](https://threejs.org/docs/#manual/en/introduction/Color-management) in the docs ("engineed" into "engineered"). Still, important because it's so front-and-center.

cc @donmccurdy 