### PR TITLE
Fix: addEventListener in navigator.xr seems to throw in some cases

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -186,6 +186,11 @@ class VRButton {
 
 		if ( 'xr' in navigator ) {
 
+			// WebXRViewer (based on Firefox) has a bug where addEventListener 
+			// throws a silent exception and aborts execution entirely.
+			const isWebXRViewer = /WebXRViewer\//i.test( navigator.userAgent );
+			if( isWebXRViewer ) return;
+
 			navigator.xr.addEventListener( 'sessiongranted', () => {
 
 				VRButton.xrSessionIsGranted = true;


### PR DESCRIPTION
**Description**

We encountered a weird page crash in Mozilla's WebXR viewer and XR Browser (fork of the former).
Turns out that while those have "navigator.xr", they throw a funny exception when someone actually uses it:

```
// @TODO: Relax this add/remove/dispatch event limitations?
Shim: We don't expect user adds event before stating session
```

...

So this PR simply catches that exception. Can't hurt I think...



Relevant user agents:

**Firefox iOS** (does not currently have navigator.xr)
`User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15 `

**XRViewer** (silent exception when accessing addEventListener)
`User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko)  Mobile WebXRViewer/v2.0(280) `

**XR Browser** (silent exception when accessing addEventListener)
`User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 WebXRViewer/1.0 Safari/605.1.15 `