### PR TITLE
WebGLTextures: Ensure texStorage2D() is called when forceUpload is true.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -697,7 +697,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			const mipmaps = texture.mipmaps;
 
 			const useTexStorage = ( isWebGL2 && texture.isVideoTexture !== true );
-			const allocateMemory = ( textureProperties.__version === undefined );
+			const allocateMemory = ( textureProperties.__version === undefined ) || ( forceUpload === true );
 			const levels = getMipLevels( texture, image, supportsMips );
 
 			if ( texture.isDepthTexture ) {


### PR DESCRIPTION
Related issue: https://stackoverflow.com/q/71649039/5250847

**Description**

`WebGLTextures` has to ensure that `texStorage2D()` is always called when a new instance of `WebGLTexture` has been created. The flag to detect this situation already exists, it is just not evaluated at a specific spot.
