### PR TITLE
GLTFLoader: Support animation loading via extension

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2580,7 +2580,11 @@ class GLTFParser {
 					break;
 
 				case 'animation':
-					dependency = this.loadAnimation( index );
+					dependency = this._invokeOne( function ( ext ) {
+		
+						return ext.loadAnimation && ext.loadAnimation( index );
+		
+					} );
 					break;
 
 				case 'camera':


### PR DESCRIPTION
Related issue: [GLTF KHR_animation](https://github.com/KhronosGroup/glTF/pull/2033)

**Description**.

This PR replaces the direct call to ``loadAnimation`` with the ``_invokeOne`` call to allow extensions to handle loading of AnimationClips to start working on an implementation of [the GLTF KHR_animation2 proposal](https://github.com/ux3d/glTF/tree/extensions/KHR_animation2/extensions/2.0/Khronos/KHR_animation2)


This contribution is funded by 🌵 [Needle](https://needle.tools).
