### PR TITLE
WebGLUtils: Add WebGL constant fallback to convert().

### DIFF
--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -250,6 +250,10 @@ function WebGLUtils( gl, extensions, capabilities ) {
 
 		}
 
+		// if "p" can't be resolved, assume the user defines a WebGL constant as a string (fallback/workaround for packed RGB formats)
+
+		return ( gl[ p ] !== undefined ) ? gl[ p ] : null;
+
 	}
 
 	return { convert: convert };


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23228#issuecomment-1082808224

**Description**

If `WebGLUtils.convert()` is unable to resolve the given constant, it applies the same logic like for `Texture.internalFormat`.