### PR TITLE
BufferGeometryUtils: Add "deinterleaveAttribute", "deinterleaveGeometry" functions

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -468,11 +468,20 @@ export function deinterleaveGeometry( geometry ) {
 
 	const attributes = geometry.attributes;
 	const morphTargets = geometry.morphTargets;
+	const attrMap = new Map();
+
 	for ( const key in attributes ) {
 
-		if ( attributes[ key ].isInterleavedBufferAttribute ) {
+		const attr = attributes[ key ];
+		if ( attr.isInterleavedBufferAttribute ) {
 
-			attributes[ key ] = deinterleaveAttribute( attributes[ key ] );
+			if ( ! attrMap.has( attr ) ) {
+
+				attrMap.set( attr, deinterleaveAttribute( attr ) );
+
+			}
+
+			attributes[ key ] = attrMap.get( attr );
 
 		}
 
@@ -480,9 +489,16 @@ export function deinterleaveGeometry( geometry ) {
 
 	for ( const key in morphTargets ) {
 
-		if ( morphTargets[ key ].isInstancedInterleavedBufferAttribute ) {
+		const attr = morphTargets[ key ];
+		if ( attr.isInterleavedBufferAttribute ) {
 
-			morphTargets[ key ] = deinterleaveAttribute( morphTargets[ key ] );
+			if ( ! attrMap.has( attr ) ) {
+
+				attrMap.set( attr, deinterleaveAttribute( attr ) );
+
+			}
+
+			morphTargets[ key ] = attrMap.get( attr );
 
 		}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -466,19 +466,25 @@ export function deinterleaveAttribute( attribute ) {
 // deinterleaves all attributes on the geometry
 export function deinterleaveGeometry( geometry ) {
 
-	for ( const key in geometry.attributes ) {
+	const attributes = geometry.attributes;
+	const morphTargets = geometry.morphTargets;
+	for ( const key in attributes ) {
 
-		if ( geometry.attributes[ key ].isInterleavedBufferAttribute ) {
+		if ( attributes[ key ].isInterleavedBufferAttribute ) {
 
-			geometry.attributes[ key ] = deinterleaveAttribute( geometry.attributes[ key ] );
+			attributes[ key ] = deinterleaveAttribute( attributes[ key ] );
 
 		}
 
 	}
 
-	if ( geometry.index && geometry.index.isInterleavedBufferAttribute ) {
+	for ( const key in morphTargets ) {
 
-		geometry.index = deinterleaveAttribute( geometry.index );
+		if ( morphTargets[ key ].isInstancedInterleavedBufferAttribute ) {
+
+			morphTargets[ key ] = deinterleaveAttribute( morphTargets[ key ] );
+
+		}
 
 	}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -415,6 +415,75 @@ function interleaveAttributes( attributes ) {
 
 }
 
+// returns a new, non-interleaved version of the provided attribute
+export function deinterleaveAttribute( attribute ) {
+
+	const cons = attribute.data.array.constructor;
+	const count = attribute.count;
+	const itemSize = attribute.itemSize;
+	const normalized = attribute.normalized;
+
+	const array = new cons( count * itemSize );
+	let newAttribute;
+	if ( attribute.isInstancedInterleavedBufferAttribute ) {
+
+		newAttribute = new InstancedBufferAttribute( array, itemSize, normalized, attribute.meshPerAttribute );
+
+	} else {
+
+		newAttribute = new BufferAttribute( array, itemSize, normalized );
+
+	}
+
+	for ( let i = 0; i < count; i ++ ) {
+
+		newAttribute.setX( i, attribute.getX( i ) );
+
+		if ( itemSize >= 2 ) {
+
+			newAttribute.setY( i, attribute.getY( i ) );
+
+		}
+
+		if ( itemSize >= 3 ) {
+
+			newAttribute.setZ( i, attribute.getZ( i ) );
+
+		}
+
+		if ( itemSize >= 4 ) {
+
+			newAttribute.setW( i, attribute.getW( i ) );
+
+		}
+
+	}
+
+	return newAttribute;
+
+}
+
+// deinterleaves all attributes on the geometry
+export function deinterleaveGeometry( geometry ) {
+
+	for ( const key in geometry.attributes ) {
+
+		if ( geometry.attributes[ key ].isInterleavedBufferAttribute ) {
+
+			geometry.attributes[ key ] = deinterleaveAttribute( geometry.attributes[ key ] );
+
+		}
+
+	}
+
+	if ( geometry.index && geometry.index.isInterleavedBufferAttribute ) {
+
+		geometry.index = deinterleaveAttribute( geometry.index );
+
+	}
+
+}
+
 /**
  * @param {Array<BufferGeometry>} geometry
  * @return {number}


### PR DESCRIPTION
Related issue: --

**Description**

Adds two functions to produce deinterleaved attributes and deinterleave all attributes on a particular geometry in place. This is useful because there are some scenarios where working with interleaved attributes can be a bit of a pain. Specifically "mergeBufferGeometries" does not support interleaved attributes (though maybe that could be updated) and it's risky to transfer an interleaved attribute buffer to a webworker since it may wind up neutering other interleaved attribute buffer arrays which is otherwise not super traceable.

Both uses cases are what I'm concerned with for the current path tracing work since buffer geometries must be merged and the index and position attribute arrays are transferred to a web worker to be used for generating a BVH.
