### PR TITLE
BufferGeometryUtils: Rename and improve warnings for MikkTSpace tangents

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -217,7 +217,7 @@
 		<p>
 		Calculates and adds a tangent attribute to this geometry.<br />
 		The computation is only supported for indexed geometries and if position, normal, and uv attributes are defined. When using a tangent space normal map, prefer the MikkTSpace algorithm provided by
-		[page:BufferGeometryUtils.computeTangents] instead.
+		[page:BufferGeometryUtils.computeMikkTSpaceTangents] instead.
 		</p>
 
 		<h3>[method:undefined computeVertexNormals]()</h3>

--- a/docs/api/ko/core/BufferGeometry.html
+++ b/docs/api/ko/core/BufferGeometry.html
@@ -209,7 +209,7 @@
 		기하학에 탄젠트 속성을 계산하고 추가합니다.<br />
 		이 계산은 인덱스가 있는 기하학에만 지원되며 위치, 법선, uv 속성이 정의되어야 합니다.
 		When using a tangent space normal map, prefer the MikkTSpace algorithm provided by
-		[page:BufferGeometryUtils.computeTangents] instead.
+		[page:BufferGeometryUtils.computeMikkTSpaceTangents] instead.
 		</p>
 
 		<h3>[method:undefined computeVertexNormals]()</h3>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -203,7 +203,7 @@
 		<p>
 		Calculates and adds a tangent attribute to this geometry.<br />
 		The computation is only supported for indexed geometries and if position, normal, and uv attributes are defined. When using a tangent space normal map, prefer the MikkTSpace algorithm provided by
-		[page:BufferGeometryUtils.computeTangents] instead.
+		[page:BufferGeometryUtils.computeMikkTSpaceTangents] instead.
 		</p>
 
 		<h3>[method:undefined computeVertexNormals]()</h3>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -96,7 +96,7 @@
 
 		</p>
 
-		<h3>[method:Object computeTangents]( [param:BufferGeometry geometry], [param:Object MikkTSpace], [param:Boolean negateSign] = true )</h3>
+		<h3>[method:Object computeMikkTSpaceTangents]( [param:BufferGeometry geometry], [param:Object MikkTSpace], [param:Boolean negateSign] = true )</h3>
 		<ul>
 			<li>geometry -- Instance of [page:BufferGeometry].</li>
 			<li>MikkTSpace -- Instance of <i>examples/jsm/libs/mikktspace.module.js</i>, or <i>mikktspace</i> npm package. Await <i>MikkTSpace.ready</i> before use.

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -91,7 +91,7 @@
 
 		</p>
 
-		<h3>[method:Object computeTangents]( [param:BufferGeometry geometry], [param:Object MikkTSpace], [param:Boolean negateSign] = true )</h3>
+		<h3>[method:Object computeMikkTSpaceTangents]( [param:BufferGeometry geometry], [param:Object MikkTSpace], [param:Boolean negateSign] = true )</h3>
 		<ul>
 			<li>geometry -- Instance of [page:BufferGeometry].</li>
 			<li>MikkTSpace -- Instance of <i>examples/jsm/libs/mikktspace.module.js</i>, or <i>mikktspace</i> npm package. Await <i>MikkTSpace.ready</i> before use.

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -11,12 +11,23 @@ import {
 	Vector3,
 } from 'three';
 
+function computeTangents() {
 
-function computeTangents( geometry, MikkTSpace, negateSign = true ) {
+	throw new Error( 'BufferGeometryUtils: computeTangents renamed to computeMikkTSpaceTangents.' );
+
+}
+
+function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 	if ( ! MikkTSpace || ! MikkTSpace.isReady ) {
 
 		throw new Error( 'BufferGeometryUtils: Initialized MikkTSpace library required.' );
+
+	}
+
+	if ( ! geometry.hasAttribute( 'position' ) || ! geometry.hasAttribute( 'normal' ) || ! geometry.hasAttribute( 'uv' ) ) {
+
+		throw new Error( 'BufferGeometryUtils: Tangents require "position", "normal", and "uv" attributes.' );
 
 	}
 
@@ -1109,7 +1120,7 @@ function mergeGroups( geometry ) {
 }
 
 export {
-	computeTangents,
+	computeMikkTSpaceTangents,
 	mergeBufferGeometries,
 	mergeBufferAttributes,
 	interleaveAttributes,

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1120,6 +1120,7 @@ function mergeGroups( geometry ) {
 }
 
 export {
+	computeTangents,
 	computeMikkTSpaceTangents,
 	mergeBufferGeometries,
 	mergeBufferAttributes,


### PR DESCRIPTION
- Renamed computeTangents → computeMikkTSpaceTangents
- Add warnings when position, normal, or uv attributes omitted

Related issue:

- #23802
