### PR TITLE
FBXLoader: Fixed wrong animation duration. 

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2606,6 +2606,10 @@ class AnimationParser {
 			tracks = tracks.concat( scope.generateTracks( rawTracks ) );
 
 		} );
+		
+		tracks.forEach(function (track) {
+			track.times = track.times.map(time => time - track.times[0]);
+		});
 
 		return new AnimationClip( rawClip.name, - 1, tracks );
 


### PR DESCRIPTION
Fixed #20256

**Description**

when more than one animation in the fbx model，from the second animation, the duration and tracks time is wrong.I try the issue #20256 way, can fix the problem.

we can test with this fbx models

[error fbx.zip](https://github.com/mrdoob/three.js/files/8386799/error.fbx.zip)

