### PR TITLE
GLTFLoader.js : Update WebP Texture Loader

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1116,7 +1116,7 @@ class GLTFTextureWebPExtension {
 
 		return this.detectSupport().then( function ( isSupported ) {
 
-			if ( isSupported ) return parser.loadTextureImage( textureIndex, source, loader );
+			if ( isSupported ) return parser.loadTextureImage( textureIndex, extension.source, loader );
 
 			if ( json.extensionsRequired && json.extensionsRequired.indexOf( name ) >= 0 ) {
 


### PR DESCRIPTION
Fixed #23822.

**Description**

Replace parameter 2 to parser.loadTextureImage with extension.source (it must be an index, not an object)