### PR TITLE
WebGPU: set compositingAlphaMode to premultiplied

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -172,7 +172,7 @@ class WebGPURenderer {
 		context.configure( {
 			device: device,
 			format: GPUTextureFormat.BGRA8Unorm, // this is the only valid context format right now (r121)
-			compositingAlphaMode: 'opaque'
+			compositingAlphaMode: 'premultiplied'
 		} );
 
 		this._adapter = adapter;
@@ -957,6 +957,7 @@ class WebGPURenderer {
 				device: device,
 				format: GPUTextureFormat.BGRA8Unorm,
 				usage: GPUTextureUsage.RENDER_ATTACHMENT,
+				compositingAlphaMode: 'premultiplied',
 				size: {
 					width: Math.floor( this._width * this._pixelRatio ),
 					height: Math.floor( this._height * this._pixelRatio ),


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23776

**Description**

From the conversation, it seems to be the best option.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
