### PR TITLE
NodeMaterial: Fix cache

### DIFF
--- a/examples/jsm/nodes/core/TempNode.js
+++ b/examples/jsm/nodes/core/TempNode.js
@@ -13,21 +13,21 @@ class TempNode extends Node {
 		const type = builder.getVectorType( this.getNodeType( builder, output ) );
 		const nodeData = builder.getDataFromNode( this );
 
-		if ( builder.context.temp !== false && type !== 'void ' && output !== 'void' && nodeData.dependenciesCount > 1 ) {
+		if ( nodeData.propertyName !== undefined ) {
 
-			if ( nodeData.snippet === undefined ) {
+			return builder.format( nodeData.propertyName, type, output );
 
-				const snippet = super.build( builder, type );
+		} else if ( builder.context.temp !== false && type !== 'void ' && output !== 'void' && nodeData.dependenciesCount > 1 ) {
 
-				const nodeVar = builder.getVarFromNode( this, type );
-				const propertyName = builder.getPropertyName( nodeVar );
+			const snippet = super.build( builder, type );
 
-				builder.addFlowCode( `${propertyName} = ${snippet}` );
+			const nodeVar = builder.getVarFromNode( this, type );
+			const propertyName = builder.getPropertyName( nodeVar );
 
-				nodeData.snippet = snippet;
-				nodeData.propertyName = propertyName;
+			builder.addFlowCode( `${propertyName} = ${snippet}` );
 
-			}
+			nodeData.snippet = snippet;
+			nodeData.propertyName = propertyName;
 
 			return builder.format( nodeData.propertyName, type, output );
 

--- a/examples/jsm/nodes/core/TempNode.js
+++ b/examples/jsm/nodes/core/TempNode.js
@@ -39,4 +39,6 @@ class TempNode extends Node {
 
 }
 
+TempNode.prototype.isTempNode = true;
+
 export default TempNode;

--- a/examples/jsm/nodes/core/VarNode.js
+++ b/examples/jsm/nodes/core/VarNode.js
@@ -25,9 +25,16 @@ class VarNode extends Node {
 
 	generate( builder ) {
 
-		const type = builder.getVectorType( this.getNodeType( builder ) );
 		const node = this.node;
+
+		if ( node.isTempNode === true ) {
+
+			return node.build( builder );
+
+		}
+
 		const name = this.name;
+		const type = builder.getVectorType( this.getNodeType( builder ) );
 
 		const snippet = node.build( builder, type );
 		const nodeVar = builder.getVarFromNode( this, type );

--- a/examples/jsm/nodes/math/CondNode.js
+++ b/examples/jsm/nodes/math/CondNode.js
@@ -4,11 +4,11 @@ import ContextNode from '../core/ContextNode.js';
 
 class CondNode extends Node {
 
-	constructor( node, ifNode, elseNode ) {
+	constructor( condNode, ifNode, elseNode ) {
 
 		super();
 
-		this.node = node;
+		this.condNode = condNode;
 
 		this.ifNode = ifNode;
 		this.elseNode = elseNode;
@@ -37,7 +37,7 @@ class CondNode extends Node {
 		const context = { temp: false };
 		const nodeProperty = new PropertyNode( null, type ).build( builder );
 
-		const nodeSnippet = new ContextNode( this.node/*, context*/ ).build( builder, 'bool' ),
+		const nodeSnippet = new ContextNode( this.condNode/*, context*/ ).build( builder, 'bool' ),
 			ifSnippet = new ContextNode( this.ifNode, context ).build( builder, type ),
 			elseSnippet = new ContextNode( this.elseNode, context ).build( builder, type );
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -118,7 +118,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		}
 
-		super.addFlowCode( '\t' + code + '\n' );
+		super.addFlowCode( code + '\n\t' );
 
 	}
 
@@ -481,7 +481,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			let flow = '// code\n';
 			flow += `\t${ this.flowCode[ shaderStage ] }`;
-			flow += '\n';
+			flow += '\n\t';
 
 			const flowNodes = this.flowNodes[ shaderStage ];
 			const mainNode = flowNodes[ flowNodes.length - 1 ];

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -118,7 +118,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		}
 
-		super.addFlowCode( code + '\n\t' );
+		super.addFlowCode( '\t' + code + '\n' );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/23728, https://github.com/mrdoob/three.js/issues/23170, https://github.com/mrdoob/three.js/issues/23537

**Description**

- [x] Reuse `temp var` if already declared even in `context = {temp:false}` - [commit](https://github.com/mrdoob/three.js/commit/99bc51a620fe64922c3cf7c055aa757f3349db5b)
- [x] `CondNode`: rename `.node` to `.condNode`
- [x] fix beautifier initial tab in flow code
- [x] [prevent create TempNode over a VarNode](https://github.com/mrdoob/three.js/pull/23828/commits/4bb190134c6b7e59252a946fc4c89ea17bd67355)

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
