### PR TITLE
WebXRManager: Fix for hand controllers

### DIFF
--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -83,10 +83,13 @@ class XRHandModelFactory {
 
 			}
 
+			controller.visible = true;
+
 		} );
 
 		controller.addEventListener( 'disconnected', () => {
 
+			controller.visible = false;
 			// handModel.motionController = null;
 			// handModel.remove( scene );
 			// scene = null;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -331,8 +331,8 @@ class WebXRManager extends EventDispatcher {
 
 			for ( let i = 0; i < inputSources.length; i ++ ) {
 
-				const offset = inputSources[ i ].handedness === 'right' ? 1 : 0;
-				inputSourcesMap.set( inputSources[ i ], controllers[ offset ] );
+				const index = inputSources[ i ].handedness === 'right' ? 1 : 0;
+				inputSourcesMap.set( inputSources[ i ], controllers[ index ] );
 
 			}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -327,11 +327,12 @@ class WebXRManager extends EventDispatcher {
 
 			const inputSources = session.inputSources;
 
-			// Assign inputSources to available controllers
+			// Assign controllers to available inputSources
 
-			for ( let i = 0; i < controllers.length; i ++ ) {
+			for ( let i = 0; i < inputSources.length; i ++ ) {
 
-				inputSourcesMap.set( inputSources[ i ], controllers[ i ] );
+				const offset = inputSources[ i ].handedness === 'right' ? 1 : 0;
+				inputSourcesMap.set( inputSources[ i ], controllers[ offset ] );
 
 			}
 
@@ -641,10 +642,14 @@ class WebXRManager extends EventDispatcher {
 
 			for ( let i = 0; i < controllers.length; i ++ ) {
 
-				const controller = controllers[ i ];
 				const inputSource = inputSources[ i ];
+				const controller = inputSourcesMap.get( inputSource );
 
-				controller.update( inputSource, frame, referenceSpace );
+				if ( controller !== undefined ) {
+
+					controller.update( inputSource, frame, referenceSpace );
+
+				}
 
 			}
 


### PR DESCRIPTION
When the hand controllers go in and out of view, the browser is allowed to remove them from the input sources list.
The current implementation in the Oculus quest alway returns them, but that is not true going forward or in devices such as the Hololens.

On those devices, the right hand will be assigned the left controller which will cause it to deform.

This fix addresses that issues by looking up the correct controller instead of blindly using the index.