### PR TITLE
Add OrbitControls connect method

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -267,9 +267,19 @@ controls.touches = {
 
 		<h2>Methods</h2>
 
-		<h3>[method:undefined dispose] ()</h3>
+		<h3>[method:undefined connect] ()</h3>
+		<p>
+			Attach all the event listeners.
+		</p>
+
+		<h3>[method:undefined disconnect] ()</h3>
 		<p>
 			Remove all the event listeners.
+		</p>
+
+		<h3>[method:undefined dispose] ()</h3>
+		<p>
+			Alias of [page:.disconnect].
 		</p>
 
 		<h3>[method:radians getAzimuthalAngle] ()</h3>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -267,7 +267,7 @@ controls.touches = {
 
 		<h2>Methods</h2>
 
-		<h3>[method:undefined connect] ()</h3>
+		<h3>[method:undefined connect] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
 			Attach all the event listeners.
 		</p>

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -288,7 +288,7 @@ class OrbitControls extends EventDispatcher {
 
 		}();
 
-		this.connect = function (domElement) {
+		this.connect = function ( domElement ) {
 
 			if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -330,8 +330,6 @@ class OrbitControls extends EventDispatcher {
 
 		this.dispose = function () {
 
-			console.warn( 'THREE.OrbitControls: dispose() has been deprecated. Use disconnect() instead.' );
-
 			scope.disconnect();
 
 		};

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -305,7 +305,7 @@ class OrbitControls extends EventDispatcher {
 
 		this.disconnect = function () {
 
-			if (scope.domElement !== null) {
+			if ( scope.domElement !== null ) {
 
 				scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
 
@@ -1228,9 +1228,9 @@ class OrbitControls extends EventDispatcher {
 
 		//
 
-		if (_domElement) {
+		if ( _domElement ) {
 
-			this.connect(_domElement);
+			this.connect( _domElement );
 
 		}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -21,16 +21,11 @@ const _endEvent = { type: 'end' };
 
 class OrbitControls extends EventDispatcher {
 
-	constructor( object, domElement ) {
+	constructor( object, _domElement ) {
 
 		super();
 
-		if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
-
 		this.object = object;
-		this.domElement = domElement;
-		this.domElement.style.touchAction = 'none'; // disable touch scroll
 
 		// Set to false to disable this control
 		this.enabled = true;
@@ -291,6 +286,24 @@ class OrbitControls extends EventDispatcher {
 			};
 
 		}();
+
+		this.connect = function (domElement) {
+
+			if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
+
+			scope.domElement = domElement;
+			scope.domElement.style.touchAction = 'none'; // disable touch scroll
+
+			scope.domElement.addEventListener( 'contextmenu', onContextMenu );
+
+			scope.domElement.addEventListener( 'pointerdown', onPointerDown );
+			scope.domElement.addEventListener( 'pointercancel', onPointerCancel );
+			scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
+
+			// force an update at start
+
+			scope.update();
+		};
 
 		this.dispose = function () {
 
@@ -1206,17 +1219,13 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
-		//
+		if (_domElement) {
 
-		scope.domElement.addEventListener( 'contextmenu', onContextMenu );
+			console.warn( 'THREE.OrbitControls: The domElement constructor param has been deprecated. Use .connect() instead.' );
 
-		scope.domElement.addEventListener( 'pointerdown', onPointerDown );
-		scope.domElement.addEventListener( 'pointercancel', onPointerCancel );
-		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
+			this.connect(_domElement);
 
-		// force an update at start
-
-		this.update();
+		}
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1222,8 +1222,6 @@ class OrbitControls extends EventDispatcher {
 
 		if (_domElement) {
 
-			console.warn( 'THREE.OrbitControls: The domElement constructor param has been deprecated. Use .connect() instead.' );
-
 			this.connect(_domElement);
 
 		}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -303,7 +303,7 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
-		this.dispose = function () {
+		this.disconnect = function () {
 
 			if (scope.domElement !== null) {
 
@@ -325,6 +325,14 @@ class OrbitControls extends EventDispatcher {
 			}
 
 			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+
+		};
+
+		this.dispose = function () {
+
+			console.warn( 'THREE.OrbitControls: dispose() has been deprecated. Use disconnect() instead.' );
+
+			scope.disconnect();
 
 		};
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1226,6 +1226,8 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
+		//
+
 		if (_domElement) {
 
 			this.connect(_domElement);

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -26,6 +26,7 @@ class OrbitControls extends EventDispatcher {
 		super();
 
 		this.object = object;
+		this.domElement = null;
 
 		// Set to false to disable this control
 		this.enabled = true;
@@ -300,22 +301,22 @@ class OrbitControls extends EventDispatcher {
 			scope.domElement.addEventListener( 'pointercancel', onPointerCancel );
 			scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 
-			// force an update at start
-
-			scope.update();
 		};
 
 		this.dispose = function () {
 
-			scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
+			if (scope.domElement !== null) {
 
-			scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
-			scope.domElement.removeEventListener( 'pointercancel', onPointerCancel );
-			scope.domElement.removeEventListener( 'wheel', onMouseWheel );
+				scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
 
-			scope.domElement.removeEventListener( 'pointermove', onPointerMove );
-			scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+				scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+				scope.domElement.removeEventListener( 'pointercancel', onPointerCancel );
+				scope.domElement.removeEventListener( 'wheel', onMouseWheel );
 
+				scope.domElement.removeEventListener( 'pointermove', onPointerMove );
+				scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+
+			}
 
 			if ( scope._domElementKeyEvents !== null ) {
 
@@ -1226,6 +1227,10 @@ class OrbitControls extends EventDispatcher {
 			this.connect(_domElement);
 
 		}
+
+		// force an update at start
+
+		this.update();
 
 	}
 


### PR DESCRIPTION
Related issue: #20575

**Description**

Add a `connect` method which will perform the side-effects (attach event listeners). Backwards compatibility is kept but a warning message is logged.

`connect` with `dispose` sounds a bit weird. `connect` + `disconnect` feels more natural but `dispose` is what you commonly use. Happy to bike-shed more about naming

I'll fix the remaining todo's once I get an OK on the change

**TODO**
- [x] Update docs
- [x] ~Update examples~