### PR TITLE
FBXLoader: Fix uv translation being ignored.

### DIFF
--- a/examples/js/loaders/FBXLoader.js
+++ b/examples/js/loaders/FBXLoader.js
@@ -325,6 +325,15 @@
 				texture.repeat.y = values[ 1 ];
 
 			}
+			
+			if ( 'Translation' in textureNode ) {
+
+				const values = textureNode.Translation.value;
+
+				texture.offset.x = values[ 0 ];
+				texture.offset.y = values[ 1 ];
+
+			}
 
 			return texture;
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -389,6 +389,15 @@ class FBXTreeParser {
 
 		}
 
+		if ( 'Translation' in textureNode ) {
+
+			const values = textureNode.Translation.value;
+
+			texture.offset.x = values[ 0 ];
+			texture.offset.y = values[ 1 ];
+
+		}
+
 		return texture;
 
 	}


### PR DESCRIPTION
**Description**

Seems FBXLoader was applying texture scaling, but not translation.

**Reference:**
(note that the mirrored 4-cat image uses "Mirror" wrap mode which is not supported in FBX, so no way that can come over unfortunately)
![20220402-192850_Unity](https://user-images.githubusercontent.com/2693840/161395614-d180dc8e-34fa-4187-8f57-845e54b48574.png)

**Before this PR in three.js:**
![image](https://user-images.githubusercontent.com/2693840/161395674-aabe842d-1027-44f8-b2b9-dd8ff12c706b.png)

**After this PR in three.js:**
![20220402-200325_chrome](https://user-images.githubusercontent.com/2693840/161395688-f4093bc0-f960-4a5b-a60b-fabfe62d8a67.png)

(checking this was super easy thanks to https://github.com/mrdoob/three.js/pull/23773, would be great to have such a simple drag-and-drop viewer for everyone at some point...) 