### PR TITLE
ArcballControls: Fix drifting when zooming with the mouse cursor

### DIFF
--- a/examples/js/controls/ArcballControls.js
+++ b/examples/js/controls/ArcballControls.js
@@ -845,7 +845,9 @@
 
 									}
 
-									this.applyTransformMatrix( this.scale( size, this._gizmos.position ) );
+									this._v3_1.setFromMatrixPosition(this._gizmoMatrixState);
+
+									this.applyTransformMatrix( this.scale( size, this._v3_1 ) );
 
 								}
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -1040,7 +1040,9 @@ class ArcballControls extends EventDispatcher {
 
 							}
 
-							this.applyTransformMatrix( this.scale( size, this._gizmos.position ) );
+							this._v3_1.setFromMatrixPosition(this._gizmoMatrixState);
+
+							this.applyTransformMatrix( this.scale( size, this._v3_1 ) );
 
 						}
 


### PR DESCRIPTION
**Description**

The intention of passing in `this._gizmos.position` to `this.scale` is to scale around the gizmo position. This means that in `this.scale` the `_scalePointTemp` should be `(0, 0, 0)`, and the camera position translation should result in `(0, 0, 0)` as well. However, there are situations where this does not happen and that's when the `this._gizmos.position` gets updated. Because in `this.scale` this happens:

```javascript
_scalePointTemp.copy( point );

[...]

this._v3_1.setFromMatrixPosition( this._gizmoMatrixState );	//gizmos position

[...]

_scalePointTemp.sub( this._v3_1 );

const amount = _scalePointTemp.clone().multiplyScalar( sizeInverse );
_scalePointTemp.sub( amount );

this._m4_1.makeTranslation( _scalePointTemp.x, _scalePointTemp.y, _scalePointTemp.z );
```

This means that if `this._gizmos.position` and `this._gizmoMatrixState` are out-of-sync, a translation happens which propagates and causes the camera position to drift and at some point grow massively.

By passing in the position coming from `this._gizmoMatrixState` this issue would be resolved.

Note that in other calls to `this.scale` where `this._gizmos.position` is passed we always call `updateTbState`, which syncs the `this._gizmos.position` and `this._gizmoMatrixState` (I tried to do that here as well, but it causes an issue with zooming, probably because it would also update `this._zoomState` and the function doesn't expect that).