### PR TITLE
workaround for Pixel PMREM

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -247,7 +247,7 @@ class PMREMGenerator {
 	_allocateTargets() {
 
 		const width = 3 * Math.max( this._cubeSize, 16 * 7 );
-		const height = 4 * this._cubeSize - 32;
+		const height = 4 * this._cubeSize;
 
 		const params = {
 			magFilter: LinearFilter,
@@ -588,9 +588,9 @@ function _createPlanes( lodMax ) {
 
 		sigmas.push( sigma );
 
-		const texelSize = 1.0 / ( sizeLod - 1 );
-		const min = - texelSize / 2;
-		const max = 1 + texelSize / 2;
+		const texelSize = 1.0 / ( sizeLod - 2 );
+		const min = - texelSize;
+		const max = 1 + texelSize;
 		const uv1 = [ min, min, max, min, max, max, min, min, max, max, min, max ];
 
 		const cubeFaces = 6;

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -85,7 +85,7 @@ export default /* glsl */`
 
 		float faceSize = exp2( mipInt );
 
-		vec2 uv = getUV( direction, face ) * ( faceSize - 1.0 ) + 0.5;
+		vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0;
 
 		if ( face > 2.0 ) {
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -373,7 +373,7 @@ function generateCubeUVSize( parameters ) {
 
 	if ( imageHeight === null ) return null;
 
-	const maxMip = Math.log2( imageHeight / 32 + 1 ) + 3;
+	const maxMip = Math.log2( imageHeight / 32 ) + 3;
 
 	const texelHeight = 1.0 / imageHeight;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -373,7 +373,7 @@ function generateCubeUVSize( parameters ) {
 
 	if ( imageHeight === null ) return null;
 
-	const maxMip = Math.log2( imageHeight / 32 ) + 3;
+	const maxMip = Math.log2( imageHeight ) - 2;
 
 	const texelHeight = 1.0 / imageHeight;
 


### PR DESCRIPTION
Related issue: https://github.com/google/model-viewer/issues/3336

The error was also visible on this example: https://threejs.org/examples/?q=hdr#webgl_materials_envmaps_hdr If you used a Pixel phone and set metalness = 1 and roughness = ~0.1 (this was only to make it the most obvious, and it's still kind of subtle): 
<img width="432" alt="image" src="https://user-images.githubusercontent.com/1649964/161638938-cf46b014-a973-42cb-9245-8e403990afee.png">
Note the faint black lines in the sky, following the corners of the cube map. 

Anyway, I'm pretty sure I found at least two different Pixel GPU driver bugs, but I could not pin down what was causing them. I did find two workarounds though:

1) Increasing the padding on the cube sides from half a pixel to a full pixel fixed the visible seams. 
2) While I was debugging and had PMREM blur disabled, I noticed a bizarre artifact in the lower mips where I was really not getting the right [data](https://github.com/google/model-viewer/issues/3336#issuecomment-1088043515) (again, only on Pixel). It was probably masked by all the blurring on top of it, but I found that giving the texture a little padding on the top mostly fixed it, so I went ahead and included that here too, since who knows when it might become a visible artifact. 

@mrdoob, thanks for noticing, though I wish I had a more satisfying answer.
