### PR TITLE
Docs: WebGLRenderTarget options can contain samples

### DIFF
--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -41,7 +41,8 @@
 		[page:Number anisotropy] - default is *1*. See [page:Texture.anisotropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
 		[page:Boolean depthBuffer] - default is *true*. <br />
-		[page:Boolean stencilBuffer] - default is *false*.<br /><br />
+		[page:Boolean stencilBuffer] - default is *false*.<br />
+		[page:Number samples] - default is 0.<br /><br />
 
 		Creates a new [name]
 		</p>


### PR DESCRIPTION
Docs page https://threejs.org/docs/#api/en/renderers/WebGLRenderTarget is missing `samples` as a valid option.
