### PR TITLE
WebGPUBackground: Ensure clear color is alpha premultiplied.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackground.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackground.js
@@ -57,6 +57,8 @@ class WebGPUBackground {
 
 			if ( renderer.autoClearColor === true ) {
 
+				_clearColor.multiplyScalar( _clearAlpha );
+
 				colorAttachment.clearValue = { r: _clearColor.r, g: _clearColor.g, b: _clearColor.b, a: _clearAlpha };
 				colorAttachment.loadOp = GPULoadOp.Clear;
 				colorAttachment.storeOp = GPUStoreOp.Store;


### PR DESCRIPTION
Fixed #23847.

**Description**

Ensures the clear color is alpha premultiplied.