### PR TITLE
WebGLTextures: Fix FramebufferTexture's allocation.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -926,9 +926,18 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
 
-				} else {
+				} else if ( allocateMemory ) {
 
-					state.texImage2D( _gl.TEXTURE_2D, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
+					let width = image.width, height = image.height;
+
+					for ( let i = 0; i < levels; i ++ ) {
+
+						state.texImage2D( _gl.TEXTURE_2D, i, glInternalFormat, width, height, 0, glFormat, glType, null );
+
+						width >>= 1;
+						height >>= 1;
+
+					}
 
 				}
 


### PR DESCRIPTION
There were two bugs in the allocation code:

1. Didn't check if memory needs to be allocated and always used null pixels.
2. Didn't allocate the memory needed for mipmap.

@Mugen87 for review?

<!-- Remove the line below if is not relevant -->

This contribution is funded by [OppenFuture Technologies](https://oppentech.com/en).
