### PR TITLE
GLTFExporter WebWorker Support

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -349,7 +349,7 @@ function getCanvas() {
 
 	try {
 
-		if ( typeof OffscreenCanvas !== "undefined" ) {
+		if ( typeof OffscreenCanvas !== 'undefined' ) {
 
 			const canvas = new OffscreenCanvas();
 			cachedCanvas = canvas;
@@ -359,7 +359,7 @@ function getCanvas() {
 
 	} catch ( err ) {
 
-		const canvas = document.createElement( "canvas" );
+		const canvas = document.createElement( 'canvas' );
 		cachedCanvas = canvas;
 		return canvas;
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -347,25 +347,17 @@ function getCanvas() {
 
 	}
 
-	try {
+	if ( typeof OffscreenCanvas !== 'undefined' ) {
 
-		if ( typeof OffscreenCanvas !== 'undefined' ) {
-
-			const canvas = new OffscreenCanvas( 1, 1 );
-			cachedCanvas = canvas;
-			return canvas;
-
-		}
-
-	} catch ( err ) {
-
-		console.error( err );
-
-		const canvas = document.createElement( 'canvas' );
+		const canvas = new OffscreenCanvas( 1, 1 );
 		cachedCanvas = canvas;
 		return canvas;
 
 	}
+
+	const canvas = document.createElement( 'canvas' );
+	cachedCanvas = canvas;
+	return canvas;
 
 }
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1119,15 +1119,15 @@ class GLTFWriter {
 
 				}
 
-				pending.push( toBlobPromise.then( blob => {
+				pending.push( toBlobPromise.then( blob =>
 
 					writer.processBufferViewImage( blob ).then( bufferViewIndex => {
 
 						imageDef.bufferView = bufferViewIndex;
 
-					} );
+					} )
 
-				} ) );
+				) );
 
 			} else {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1072,7 +1072,7 @@ class GLTFWriter {
 
 			}
 
-			if ( image.data !== undefined ) {
+			if ( image.data !== undefined ) { // THREE.DataTexture
 
 				if ( format !== RGBAFormat ) {
 


### PR DESCRIPTION
**Description**

This PR makes the GLTFExporter work in a WebWorker with OffscreenCanvas support. All references to classes/methods not available on the WorkerGlobalScope have been removed or replaced.

This contribution is funded by [Matrix.org](https://matrix.org).
