### PR TITLE
Mobile Support Code Editor

### DIFF
--- a/editor/js/libs/codemirror/codemirror.js
+++ b/editor/js/libs/codemirror/codemirror.js
@@ -32,7 +32,7 @@
   var mac_geMountainLion = /Mac OS X 1\d\D([8-9]|\d\d)\D/.test(userAgent);
   var phantom = /PhantomJS/.test(userAgent);
 
-  var ios = safari && (/Mobile\/\w+/.test(userAgent) || navigator.maxTouchPoints > 2);
+  var ios = false;
   var android = /Android/.test(userAgent);
   // This is woefully incomplete. Suggestions for alternative methods welcome.
   var mobile = ios || android || /webOS|BlackBerry|Opera Mini|Opera Mobi|IEMobile/i.test(userAgent);


### PR DESCRIPTION
Editor didn’t work on iOS. I just fixed that

Related issue: The code editor on iOS didn’t show the indicator and didn’t allow the user to use space

**Description**

The mobile version of the code editor is broken so the users have to use the working desktop editor (line 35: var ios = false;)

<!-- Remove the line below if is not relevant -->
