### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -335,7 +335,8 @@
 
 		<script>
 
-			const parent = document.scripts[ document.scripts.length - 1 ].parentNode;
+			/* eslint-disable prefer-const*/
+			let parent = document.scripts[ document.scripts.length - 1 ].parentNode;
 
 			parent.displacement = function ( x, y, z, t, target ) {
 


### PR DESCRIPTION
Fixed #23856.

**Description**

Because of the special structure of `webgl_multiple_elements_text.html`, using `const` at one places produces a runtime error.