### PR TITLE
WebGPU: fix show distant instances

### DIFF
--- a/examples/webgpu_skinning_instancing.html
+++ b/examples/webgpu_skinning_instancing.html
@@ -51,7 +51,7 @@
 
 				}
 
-				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 5000 );
 				camera.position.set( 100, 200, 300 );
 
 				scene = new THREE.Scene();
@@ -78,7 +78,7 @@
 					const action = mixer.clipAction( object.animations[ 0 ] );
 					action.play();
 
-					const instanceCount = 50;
+					const instanceCount = 30;
 					const dummy = new THREE.Object3D();
 
 					object.traverse( ( child ) => {


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/23835

**Description**

`Camera.far` value prevented some instances from being rendered.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [Google via Igalia](https://igalia.com).
