### PR TITLE
Reflector/Refractor: Add missing encodings fragment to default shader.

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -253,6 +253,8 @@ Reflector.ReflectorShader = {
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
+			#include <encodings_fragment>
+
 		}`
 };
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -316,6 +316,8 @@ Refractor.RefractorShader = {
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
 
+			#include <encodings_fragment>
+
 		}`
 
 };


### PR DESCRIPTION
Fixed #23862.

**Description**

Added the missing `encodings_fragment` shader chunk to the default materials.