### PR TITLE
WebGLTextures: Fix DepthTexture's allocation

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -780,7 +780,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					state.texStorage2D( _gl.TEXTURE_2D, 1, glInternalFormat, image.width, image.height );
 
-				} else {
+				} else if ( allocateMemory ) {
 
 					state.texImage2D( _gl.TEXTURE_2D, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -776,13 +776,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				//
 
-				if ( useTexStorage && allocateMemory ) {
+				if ( allocateMemory ) {
 
-					state.texStorage2D( _gl.TEXTURE_2D, 1, glInternalFormat, image.width, image.height );
+					if ( useTexStorage ) {
 
-				} else if ( allocateMemory ) {
+						state.texStorage2D( _gl.TEXTURE_2D, 1, glInternalFormat, image.width, image.height );
 
-					state.texImage2D( _gl.TEXTURE_2D, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
+					} else {
+
+						state.texImage2D( _gl.TEXTURE_2D, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
+
+					}
 
 				}
 
@@ -924,20 +928,24 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else if ( texture.isFramebufferTexture ) {
 
-				if ( useTexStorage && allocateMemory ) {
+				if ( allocateMemory ) {
 
-					state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
+					if ( useTexStorage ) {
 
-				} else if ( allocateMemory ) {
+						state.texStorage2D( _gl.TEXTURE_2D, levels, glInternalFormat, image.width, image.height );
 
-					let width = image.width, height = image.height;
+					} else {
 
-					for ( let i = 0; i < levels; i ++ ) {
+						let width = image.width, height = image.height;
 
-						state.texImage2D( _gl.TEXTURE_2D, i, glInternalFormat, width, height, 0, glFormat, glType, null );
+						for ( let i = 0; i < levels; i ++ ) {
 
-						width >>= 1;
-						height >>= 1;
+							state.texImage2D( _gl.TEXTURE_2D, i, glInternalFormat, width, height, 0, glFormat, glType, null );
+
+							width >>= 1;
+							height >>= 1;
+
+						}
 
 					}
 


### PR DESCRIPTION
I don't have any test to show this is really a bug. Just found it suspicious during reading code. Feel free to close this PR if I misundertood the code.

<!-- Remove the line below if is not relevant -->

This contribution is funded by [OppenFuture Technologies](https://oppentech.com/en).
