### PR TITLE
Docs: Add path tracer, ik library links to libraries and tools page

### DIFF
--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -85,7 +85,7 @@
 		<ul>
 			<li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
 			<li>[link:https://github.com/lo-th/fullik fullik]</li>
-			<li>[link:https://github.com/gkjohnson/closed-chain-ik closed-chain-ik]</li>
+			<li>[link:https://github.com/gkjohnson/closed-chain-ik-js closed-chain-ik]</li>
 		</ul>
 
 		<h3>Game AI</h3>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -41,6 +41,12 @@
 			<li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
 		</ul>
 
+		<h3>Path Tracing</h3>
+		
+		<ul>
+			<li>[link:https://github.com/gkjohnson/three-gpu-pathtracer three-gpu-pathtracer]</li>
+		</ul>
+		
 		<h3>File Formats</h3>
 
 		<p>
@@ -79,6 +85,7 @@
 		<ul>
 			<li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
 			<li>[link:https://github.com/lo-th/fullik fullik]</li>
+			<li>[link:https://github.com/gkjohnson/closed-chain-ik closed-chain-ik]</li>
 		</ul>
 
 		<h3>Game AI</h3>


### PR DESCRIPTION
Related issue: --

**Description**

Add three-gpu-pathtracer and closed-chain-ik links.