### PR TITLE
WebGLRenderer: Fix transmission render target type check

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1201,7 +1201,7 @@ function WebGLRenderer( parameters = {} ) {
 
 			_transmissionRenderTarget = new WebGLRenderTarget( 1, 1, {
 				generateMipmaps: true,
-				type: utils.convert( HalfFloatType ) !== null ? HalfFloatType : UnsignedByteType,
+				type: extensions.has( 'EXT_color_buffer_half_float' ) ? HalfFloatType : UnsignedByteType,
 				minFilter: LinearMipmapLinearFilter,
 				samples: ( isWebGL2 && _antialias === true ) ? 4 : 0
 			} );


### PR DESCRIPTION
**Description**

Currently, transmission won't work under

1. A WebGL2 context without either `EXT_color_buffer_half_float` or `EXT_color_buffer_float` support.
2. A WebGL1 context without `EXT_color_buffer_half_float` support.

This commit fixes that.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [OppenFuture Technologies](https://oppentech.com/en)*
