### PR TITLE
MMDLoader: Handle shininess properly

### DIFF
--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -2133,7 +2133,6 @@ class MMDToonMaterial extends ShaderMaterial {
 		// merged from MeshToon/Phong/MatcapMaterial
 		const exposePropertyNames = [
 			'specular',
-			'shininess',
 			'opacity',
 			'diffuse',
 
@@ -2187,6 +2186,25 @@ class MMDToonMaterial extends ShaderMaterial {
 			} );
 
 		}
+
+		// Special path for shininess to handle zero shininess properly
+		this._shininess = 30;
+		Object.defineProperty( this, 'shininess', {
+
+			get: function () {
+
+				return this._shininess;
+
+			},
+
+			set: function ( value ) {
+
+				this._shininess = value;
+				this.uniforms.shininess.value = Math.max( this._shininess, 1e-4 ); // To prevent pow( 0.0, 0.0 )
+
+			},
+
+		} );
 
 		Object.defineProperty(
 			this,


### PR DESCRIPTION
Related issue: #23855

**Description**

`MMDToonMaterial` is derived from `MeshToon/Phong/MatcapMaterial`. Similar to `MeshPhongMaterial`, `shininess` should have lower limit to prevent pow(0.0, 0.0) in the shader code.
