### PR TITLE
Reflector/Refractor: Expose virtual camera as a property.

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -18,6 +18,7 @@ class Reflector extends Mesh {
 		super( geometry );
 
 		this.type = 'Reflector';
+		this.camera = new PerspectiveCamera();
 
 		const scope = this;
 
@@ -43,7 +44,7 @@ class Reflector extends Mesh {
 		const q = new Vector4();
 
 		const textureMatrix = new Matrix4();
-		const virtualCamera = new PerspectiveCamera();
+		const virtualCamera = this.camera;
 
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, { samples: multisample } );
 
@@ -252,9 +253,8 @@ Reflector.ReflectorShader = {
 
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
-
+			
 			#include <encodings_fragment>
-
 		}`
 };
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -253,8 +253,9 @@ Reflector.ReflectorShader = {
 
 			vec4 base = texture2DProj( tDiffuse, vUv );
 			gl_FragColor = vec4( blendOverlay( base.rgb, color ), 1.0 );
-			
+
 			#include <encodings_fragment>
+
 		}`
 };
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -19,6 +19,7 @@ class Refractor extends Mesh {
 		super( geometry );
 
 		this.type = 'Refractor';
+		this.camera = new PerspectiveCamera();
 
 		const scope = this;
 
@@ -31,7 +32,7 @@ class Refractor extends Mesh {
 
 		//
 
-		const virtualCamera = new PerspectiveCamera();
+		const virtualCamera = this.camera;
 		virtualCamera.matrixAutoUpdate = false;
 		virtualCamera.userData.refractor = true;
 


### PR DESCRIPTION
**Description**

It may be useful to control some properties of the camera used by Reflector, for example to set its layers. This pull request expose the camera used by Reflector as a property of the object. 
