### PR TITLE
Docs: Improve PointsMaterial.

### DIFF
--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -85,7 +85,7 @@
 		<p>Sets the color of the points using data from a [page:Texture].</p>
 
 		<h3>[property:Number size]</h3>
-		<p>Sets the size of the points. Default is 1.0.<br/>
+		<p>Defines the size of the points in pixels. Default is 1.0.<br/>
 			Will be capped if it exceeds the hardware dependent parameter [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParameter gl.ALIASED_POINT_SIZE_RANGE].</p>
 
 		<h3>[property:Boolean sizeAttenuation]</h3>


### PR DESCRIPTION
Related issue: -

**Description**

Adds the unit of `PointsMaterial.size` to the doc page.
