### PR TITLE
WebGLLights: Remove redundant computation.

### DIFF
--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -529,7 +529,6 @@ function WebGLLights( extensions, capabilities ) {
 
 				uniforms.direction.setFromMatrixPosition( light.matrixWorld );
 				uniforms.direction.transformDirection( viewMatrix );
-				uniforms.direction.normalize();
 
 				hemiLength ++;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/23891#issuecomment-1096984404

**Description**

Removes a redundant call of `normalize()`. When using `transformDirection()`, the method ensures the vector is normalized.
