### PR TITLE
FileLoader: Add response headers to onProgress callback

### DIFF
--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -64,7 +64,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:AnimationClip animation clips].<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called if load errors.<br /><br />
 
 		Begin loading from url and pass the loaded animation to onLoad.

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -81,7 +81,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded text response.<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -73,7 +73,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:BufferGeometry].<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/CompressedTextureLoader.html
+++ b/docs/api/en/loaders/CompressedTextureLoader.html
@@ -45,7 +45,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded texture.<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/DataTextureLoader.html
+++ b/docs/api/en/loaders/DataTextureLoader.html
@@ -45,7 +45,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] (optional) — Will be called when load completes. The argument will be the loaded texture.<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses.The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -79,7 +79,7 @@
 			[page:String url] — the path or URL to the file. This can also be a
 				[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] (optional) — Will be called when loading completes. The argument will be the loaded response.<br />
-			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called if an error occurs.<br /><br />
 
 			Load the URL and pass the response to the onLoad function.

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -70,7 +70,7 @@
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
 		[page:String url] — A string containing the path/URL of the file to be loaded.<br />
-		[page:Function onProgress] (optional) — A function to be called while the loading is in progress. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		</p>
 		<p>
 		This method is equivalent to [page:.load], but returns a [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promise].

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -67,7 +67,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Material].<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br /><br />
 
 		Begin loading from url.

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -77,7 +77,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded [page:Object3D object].<br />
-		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be the ProgressEvent instance, which contains .[page:Boolean lengthComputable], .[page:Integer total] and .[page:Integer loaded]. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -165,7 +165,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.3dm</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -108,7 +108,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.drc</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/FontLoader.html
+++ b/docs/examples/en/loaders/FontLoader.html
@@ -71,7 +71,7 @@
 		[page:String url] — the path or URL to the file. This can also be a
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Will be called when load completes. The argument will be the loaded font.<br />
-		[page:Function onProgress] — Will be called while load progresses. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — Will be called when load errors.<br /><br />
 
 		Begin loading from url and pass the loaded [page:Texture texture] to onLoad.

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -193,7 +193,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -84,7 +84,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.basis</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -144,7 +144,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the LDraw file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -75,7 +75,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pmd</em> or <em>.pmx</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
@@ -87,7 +87,7 @@
 		[page:String url] — A string or an array of string containing the path/URL of the <em>.vmd</em> file(s).If two or more files are specified, they'll be merged.<br />
 		[page:Object3D object] — [page:SkinnedMesh] or [page:Camera]. Clip and its tracks will be fitting to this object.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
@@ -99,7 +99,7 @@
 		[page:String modelUrl] — A string containing the path/URL of the <em>.pmd</em> or <em>.pmx</em> file.<br />
 		[page:String vmdUrl] — A string or an array of string containing the path/URL of the <em>.vmd</em> file(s).<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/MTLLoader.html
+++ b/docs/examples/en/loaders/MTLLoader.html
@@ -36,7 +36,7 @@
 		<p>
 			[page:String url] — A string containing the path/URL of the <em>.mtl</em> file.<br />
 			[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
-			[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 			[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -74,7 +74,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.obj</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -78,7 +78,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pcd</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -75,7 +75,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pdb</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the object having the following properties. [page:BufferGeometry geometryAtoms], [page:BufferGeometry geometryBonds] and the [page:Object JSON] structure.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/PRWMLoader.html
+++ b/docs/examples/en/loaders/PRWMLoader.html
@@ -76,7 +76,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.prwm</em> file. Any <em>*</em> character in the URL will be automatically replaced by <em>le</em> or <em>be</em> depending on the platform endianness.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:BufferGeometry] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -97,7 +97,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives an array of [page:ShapePath] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -76,7 +76,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.tga</em> file. <br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:DataTexture] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -103,7 +103,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.drc</em> file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/zh/loaders/PDBLoader.html
+++ b/docs/examples/zh/loaders/PDBLoader.html
@@ -75,7 +75,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.pdb</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the object having the following properties. [page:BufferGeometry geometryAtoms], [page:BufferGeometry geometryBonds] and the [page:Object JSON] structure.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/zh/loaders/PRWMLoader.html
+++ b/docs/examples/zh/loaders/PRWMLoader.html
@@ -76,7 +76,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.prwm</em> file. Any <em>*</em> character in the URL will be automatically replaced by <em>le</em> or <em>be</em> depending on the platform endianness.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:BufferGeometry] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -97,7 +97,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives an array of [page:ShapePath] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -76,7 +76,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the <em>.tga</em> file. <br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:DataTexture] as an argument.<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
+		[page:Function onProgress] — (optional) Will be called while load progresses. The argument will contain [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable lengthComputable], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total total], [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/loaded loaded] and the [link:https://developer.mozilla.org/en-US/docs/Web/API/Response response]. If the server does not set the Content-Length header; [page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
 		</p>
 		<p>

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -121,7 +121,7 @@ class FileLoader extends Loader {
 
 										loaded += value.byteLength;
 
-										const event = new ProgressEvent( 'progress', { lengthComputable, loaded, total } );
+										const event = { lengthComputable, loaded, total, response };
 										for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
 
 											const callback = callbacks[ i ];


### PR DESCRIPTION
**Description**

Since https://github.com/mrdoob/three.js/pull/22510 the response headers can't be accessed anymore in the progress callback. A custom response header can be used to send the uncompressed content length of large compressed files (gzip, brotli) to report loading progress to the user. The `total` content length currently reported by the `ProgressEvent`, is the content length of the compressed file and the `loaded` bytes are currently reported for the uncompressed file loading progress of the `ReadableStream`. Even with the new Fetch API, this is still an unresolved issue: https://github.com/whatwg/fetch/issues/1358.

Before the Fetch API was introduced, the `onProgress` callback received the XMLHttpRequest object as the event target, which gave access to the [response headers](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getResponseHeader).

This PR adds the response headers as an argument to the `onProgress` callback to provide access to the response headers again.