### PR TITLE
Remove unnecessary line from CubeCamera

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -73,8 +73,7 @@ class CubeCamera extends Object3D {
 		const currentOutputEncoding = renderer.outputEncoding;
 		const currentToneMapping = renderer.toneMapping;
 		const currentXrEnabled = renderer.xr.enabled;
-
-		renderer.outputEncoding = LinearEncoding;
+		
 		renderer.toneMapping = NoToneMapping;
 		renderer.xr.enabled = false;
 

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -1,4 +1,4 @@
-import { LinearEncoding, NoToneMapping } from '../constants.js';
+import { NoToneMapping } from '../constants.js';
 import { Object3D } from '../core/Object3D.js';
 import { Vector3 } from '../math/Vector3.js';
 import { PerspectiveCamera } from './PerspectiveCamera.js';
@@ -73,7 +73,7 @@ class CubeCamera extends Object3D {
 		const currentOutputEncoding = renderer.outputEncoding;
 		const currentToneMapping = renderer.toneMapping;
 		const currentXrEnabled = renderer.xr.enabled;
-		
+
 		renderer.toneMapping = NoToneMapping;
 		renderer.xr.enabled = false;
 


### PR DESCRIPTION
**Description**

This pull request removes an unnecessary line in `CubeCamera` where `WebGLRenderer.outputEncoding` is set.
See [discussion on forum](https://discourse.threejs.org/t/is-this-line-really-setting-cubecamera-render-target-encoding/37118)

