### PR TITLE
GLTFLoader: Honor Firefox version when checking for ImageBitmap.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2315,13 +2315,19 @@ class GLTFParser {
 
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
-		if ( typeof createImageBitmap !== 'undefined' && /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === false && navigator.userAgent.match( /Firefox\/([0-9]+)\./ )?.[ 1 ] < 98 === false ) {
 
-			this.textureLoader = new ImageBitmapLoader( this.options.manager );
+		const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
+		const isFirefox = navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > - 1;
+		const firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
+
+		if ( typeof createImageBitmap === 'undefined' || isSafari || ( isFirefox && firefoxVersion < 98 ) ) {
+
+			this.textureLoader = new TextureLoader( this.options.manager );
 
 		} else {
 
-			this.textureLoader = new TextureLoader( this.options.manager );
+			console.log( true );
+			this.textureLoader = new ImageBitmapLoader( this.options.manager );
 
 		}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -650,7 +650,7 @@ class GLTFMaterialsUnlitExtension {
  *
  * Specification: https://github.com/KhronosGroup/glTF/blob/5768b3ce0ef32bc39cdf1bef10b948586635ead3/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md
  */
- class GLTFMaterialsEmissiveStrengthExtension {
+class GLTFMaterialsEmissiveStrengthExtension {
 
 	constructor( parser ) {
 
@@ -670,8 +670,8 @@ class GLTFMaterialsUnlitExtension {
 
 		}
 
-		const emissiveStrength = materialDef.extensions[this.name].emissiveStrength;
-		
+		const emissiveStrength = materialDef.extensions[ this.name ].emissiveStrength;
+
 		if ( emissiveStrength !== undefined ) {
 
 			materialParams.emissiveIntensity = emissiveStrength;
@@ -2315,7 +2315,7 @@ class GLTFParser {
 
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
-		if ( typeof createImageBitmap !== 'undefined' && /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === false ) {
+		if ( typeof createImageBitmap !== 'undefined' && /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === false && navigator.userAgent.match( /Firefox\/([0-9]+)\./ )?.[ 1 ] < 98 === false ) {
 
 			this.textureLoader = new ImageBitmapLoader( this.options.manager );
 
@@ -2627,9 +2627,9 @@ class GLTFParser {
 
 				case 'animation':
 					dependency = this._invokeOne( function ( ext ) {
-		
+
 						return ext.loadAnimation && ext.loadAnimation( index );
-		
+
 					} );
 					break;
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2317,7 +2317,7 @@ class GLTFParser {
 		// expensive work of uploading a texture to the GPU off the main thread.
 
 		const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
-		const isFirefox = navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > - 1;
+		const isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
 		const firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
 
 		if ( typeof createImageBitmap === 'undefined' || isSafari || ( isFirefox && firefoxVersion < 98 ) ) {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2326,7 +2326,6 @@ class GLTFParser {
 
 		} else {
 
-			console.log( true );
 			this.textureLoader = new ImageBitmapLoader( this.options.manager );
 
 		}


### PR DESCRIPTION
Fixed #23906.

**Description**

Only use `ImageBitmapLoader` when the version of Firefox is => 98.
