### PR TITLE
Docs: Add WebXRManager.setReferenceSpace().

### DIFF
--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -112,6 +112,13 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
+		<h3>[method:undefined setReferenceSpace]( [param:XRReferenceSpace referenceSpace] )</h3>
+		<p>
+		[page:XRReferenceSpace referenceSpace] — A custom reference space.<br /><br />
+
+		Can be used to configure a custom reference space which overwrites the default reference space.
+		</p>
+
 		<h3>[method:undefined setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
 		<p>
 		[page:String referenceSpaceType] — The reference space type to set.<br /><br />

--- a/docs/api/zh/renderers/webxr/WebXRManager.html
+++ b/docs/api/zh/renderers/webxr/WebXRManager.html
@@ -100,6 +100,13 @@
 		Note: It is not possible to change the framebuffer scale factor while presenting XR content.
 		</p>
 
+		<h3>[method:undefined setReferenceSpace]( [param:XRReferenceSpace referenceSpace] )</h3>
+		<p>
+		[page:XRReferenceSpace referenceSpace] — A custom reference space.<br /><br />
+
+		Can be used to configure a custom reference space which overwrites the default reference space.
+		</p>
+
 		<h3>[method:undefined setReferenceSpaceType]( [param:String referenceSpaceType] )</h3>
 		<p>
 		[page:String referenceSpaceType] — The reference space type to set.<br /><br />


### PR DESCRIPTION
Related issue: #20949

**Description**

Adds the new `setReferenceSpace()` method to the `WebXRManager` doc page.