### PR TITLE
Docs: Clarify fog property of certain material types.

### DIFF
--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -79,7 +79,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null.</p>

--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -90,7 +90,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null.</p>

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -81,7 +81,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture normalMap]</h3>
 		<p>

--- a/docs/api/zh/materials/MeshDepthMaterial.html
+++ b/docs/api/zh/materials/MeshDepthMaterial.html
@@ -68,7 +68,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p> 材质是否受雾影响。默认值为*false*。</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>

--- a/docs/api/zh/materials/MeshDistanceMaterial.html
+++ b/docs/api/zh/materials/MeshDistanceMaterial.html
@@ -79,7 +79,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p> 材质是否受雾影响。默认值为*false*。</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>颜色贴图。默认为null。</p>

--- a/docs/api/zh/materials/MeshNormalMaterial.html
+++ b/docs/api/zh/materials/MeshNormalMaterial.html
@@ -67,7 +67,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>材质是否受雾影响。默认值为*false*。</p>
+		<p>Read-only property to indicate no fog support. Value is *false*.</p>
 
 		<h3>[property:Texture normalMap]</h3>
 		<p> 用于创建法线贴图的纹理。RGB值会影响每个像素片段的曲面法线，并更改颜色照亮的方式。法线贴图不会改变曲面的实际形状，只会改变光照。


### PR DESCRIPTION
Fixed #23915.

**Description**

Certain materials do not support fog. The PR clarifies the documentation of the `fog` property for these materials.
