### PR TITLE
Exposing cubemaps and cubeuvmaps cache on the renderer

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -321,6 +321,8 @@ function WebGLRenderer( parameters = {} ) {
 
 		_this.capabilities = capabilities;
 		_this.extensions = extensions;
+		_this.cubemaps = cubemaps;
+		_this.cubeuvmaps = cubeuvmaps;
 		_this.properties = properties;
 		_this.renderLists = renderLists;
 		_this.shadowMap = shadowMap;


### PR DESCRIPTION
**Description**

I'm trying to create a `RawShaderMaterial` and give it an environment map uniform, something like:

```javascript
const envMap = new RGBELoader().load('/empty_warehouse_01_2k.hdr', () => {
  envMap.mapping = three.EquirectangularReflectionMapping;
  newMat.needsUpdate = true;
});
scene.background = envMap;

const newMat = new three.RawShaderMaterial({
  uniforms: {
    ...three.ShaderLib.physical.uniforms,
    envMap: { value: envMap },
  },
  vertexShader,
  fragmentShader,
});
```

When I do this, the envMap read in the shader is black, and I believe this is because this is an incorrect way to pass the texture data to the shader.

In the threejs source, I see a call to [`cubemaps.get`](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLCubeMaps.js#L24) which looks like it does the magic to generate the proper `Texture` data to pass to the shader.

This change exposes the the `cubemaps` and `cubeuvmaps` cache on the renderer, with the intention being in my code, I can now do 
```
new three.RawShaderMaterial({
  uniforms: {
    envMap: { value: renderer.cubemaps.get(envMap) },
  },
});
```

Here's an example codesandbox showing the issue in action: https://codesandbox.io/s/three-js-rawshadermaterial-envmap-lsn0dv