### PR TITLE
SkinnedMesh: Require floating point vertex textures.

### DIFF
--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -12,7 +12,9 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.
+			A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.<br /><br />
+
+			[name] can only be used with WebGL 2. With WebGL 1 *OES_texture_float* and vertex textures support is required.
 		</p>
 
 		<iframe id="scene" src="scenes/bones-browser.html"></iframe>

--- a/docs/api/zh/objects/SkinnedMesh.html
+++ b/docs/api/zh/objects/SkinnedMesh.html
@@ -12,7 +12,9 @@
 		<h1>蒙皮网格（[name]）</h1>
 
 		<p class="desc">
-			具有[page:Skeleton]（骨架）和[page:Bone bones]（骨骼）的网格，可用于给几何体上的顶点添加动画。
+			具有[page:Skeleton]（骨架）和[page:Bone bones]（骨骼）的网格，可用于给几何体上的顶点添加动画。<br /><br />
+
+			[name] can only be used with WebGL 2. With WebGL 1 *OES_texture_float* and vertex textures support is required.
 		</p>
 
 		<iframe id="scene" src="scenes/bones-browser.html"></iframe>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1675,7 +1675,7 @@ function WebGLRenderer( parameters = {} ) {
 
 				} else {
 
-					p_uniforms.setOptional( _gl, skeleton, 'boneMatrices' );
+					console.warn( 'THREE.WebGLRenderer: SkinnedMesh can only be used with WebGL 2. With WebGL 1 OES_texture_float and vertex textures support is required.' );
 
 				}
 

--- a/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
@@ -4,45 +4,30 @@ export default /* glsl */`
 	uniform mat4 bindMatrix;
 	uniform mat4 bindMatrixInverse;
 
-	#ifdef BONE_TEXTURE
+	uniform highp sampler2D boneTexture;
+	uniform int boneTextureSize;
 
-		uniform highp sampler2D boneTexture;
-		uniform int boneTextureSize;
+	mat4 getBoneMatrix( const in float i ) {
 
-		mat4 getBoneMatrix( const in float i ) {
+		float j = i * 4.0;
+		float x = mod( j, float( boneTextureSize ) );
+		float y = floor( j / float( boneTextureSize ) );
 
-			float j = i * 4.0;
-			float x = mod( j, float( boneTextureSize ) );
-			float y = floor( j / float( boneTextureSize ) );
+		float dx = 1.0 / float( boneTextureSize );
+		float dy = 1.0 / float( boneTextureSize );
 
-			float dx = 1.0 / float( boneTextureSize );
-			float dy = 1.0 / float( boneTextureSize );
+		y = dy * ( y + 0.5 );
 
-			y = dy * ( y + 0.5 );
+		vec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );
+		vec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );
+		vec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );
+		vec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );
 
-			vec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );
-			vec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );
-			vec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );
-			vec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );
+		mat4 bone = mat4( v1, v2, v3, v4 );
 
-			mat4 bone = mat4( v1, v2, v3, v4 );
+		return bone;
 
-			return bone;
-
-		}
-
-	#else
-
-		uniform mat4 boneMatrices[ MAX_BONES ];
-
-		mat4 getBoneMatrix( const in float i ) {
-
-			mat4 bone = boneMatrices[ int(i) ];
-			return bone;
-
-		}
-
-	#endif
+	}
 
 #endif
 `;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -460,7 +460,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
 
-			'#define MAX_BONES ' + parameters.maxBones,
 			( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
 			( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
@@ -505,7 +504,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.flatShading ? '#define FLAT_SHADED' : '',
 
 			parameters.skinning ? '#define USE_SKINNING' : '',
-			parameters.useVertexTexture ? '#define BONE_TEXTURE' : '',
 
 			parameters.morphTargets ? '#define USE_MORPHTARGETS' : '',
 			parameters.morphNormals && parameters.flatShading === false ? '#define USE_MORPHNORMALS' : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -13,8 +13,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 	const isWebGL2 = capabilities.isWebGL2;
 	const logarithmicDepthBuffer = capabilities.logarithmicDepthBuffer;
-	const floatVertexTextures = capabilities.floatVertexTextures;
-	const maxVertexUniforms = capabilities.maxVertexUniforms;
 	const vertexTextures = capabilities.vertexTextures;
 	let precision = capabilities.precision;
 
@@ -36,42 +34,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		SpriteMaterial: 'sprite'
 	};
 
-	function getMaxBones( object ) {
-
-		const skeleton = object.skeleton;
-		const bones = skeleton.bones;
-
-		if ( floatVertexTextures ) {
-
-			return 1024;
-
-		} else {
-
-			// default for when object is not specified
-			// ( for example when prebuilding shader to be used with multiple objects )
-			//
-			//  - leave some extra space for other uniforms
-			//  - limit here is ANGLE's 254 max uniform vectors
-			//    (up to 54 should be safe)
-
-			const nVertexUniforms = maxVertexUniforms;
-			const nVertexMatrices = Math.floor( ( nVertexUniforms - 20 ) / 4 );
-
-			const maxBones = Math.min( nVertexMatrices, bones.length );
-
-			if ( maxBones < bones.length ) {
-
-				console.warn( 'THREE.WebGLRenderer: Skeleton has ' + bones.length + ' bones. This GPU supports ' + maxBones + '.' );
-				return 0;
-
-			}
-
-			return maxBones;
-
-		}
-
-	}
-
 	function getParameters( material, lights, shadows, scene, object ) {
 
 		const fog = scene.fog;
@@ -85,8 +47,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 		// heuristics to create shader parameters according to lights in the scene
 		// (not to blow over maxLights budget)
-
-		const maxBones = object.isSkinnedMesh ? getMaxBones( object ) : 0;
 
 		if ( material.precision !== null ) {
 
@@ -223,9 +183,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			sizeAttenuation: material.sizeAttenuation,
 			logarithmicDepthBuffer: logarithmicDepthBuffer,
 
-			skinning: object.isSkinnedMesh === true && maxBones > 0,
-			maxBones: maxBones,
-			useVertexTexture: floatVertexTextures,
+			skinning: object.isSkinnedMesh === true,
 
 			morphTargets: geometry.morphAttributes.position !== undefined,
 			morphNormals: geometry.morphAttributes.normal !== undefined,
@@ -331,7 +289,6 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		array.push( parameters.vertexUvs );
 		array.push( parameters.fogExp2 );
 		array.push( parameters.sizeAttenuation );
-		array.push( parameters.maxBones );
 		array.push( parameters.morphTargetsCount );
 		array.push( parameters.morphAttributeCount );
 		array.push( parameters.numDirLights );
@@ -428,48 +385,46 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			_programLayers.enable( 2 );
 		if ( parameters.skinning )
 			_programLayers.enable( 3 );
-		if ( parameters.useVertexTexture )
-			_programLayers.enable( 4 );
 		if ( parameters.morphTargets )
-			_programLayers.enable( 5 );
+			_programLayers.enable( 4 );
 		if ( parameters.morphNormals )
-			_programLayers.enable( 6 );
+			_programLayers.enable( 5 );
 		if ( parameters.morphColors )
-			_programLayers.enable( 7 );
+			_programLayers.enable( 6 );
 		if ( parameters.premultipliedAlpha )
-			_programLayers.enable( 8 );
+			_programLayers.enable( 7 );
 		if ( parameters.shadowMapEnabled )
-			_programLayers.enable( 9 );
+			_programLayers.enable( 8 );
 		if ( parameters.physicallyCorrectLights )
-			_programLayers.enable( 10 );
+			_programLayers.enable( 9 );
 		if ( parameters.doubleSided )
-			_programLayers.enable( 11 );
+			_programLayers.enable( 10 );
 		if ( parameters.flipSided )
-			_programLayers.enable( 12 );
+			_programLayers.enable( 11 );
 		if ( parameters.useDepthPacking )
-			_programLayers.enable( 13 );
+			_programLayers.enable( 12 );
 		if ( parameters.dithering )
-			_programLayers.enable( 14 );
+			_programLayers.enable( 13 );
 		if ( parameters.specularIntensityMap )
-			_programLayers.enable( 15 );
+			_programLayers.enable( 14 );
 		if ( parameters.specularColorMap )
-			_programLayers.enable( 16 );
+			_programLayers.enable( 15 );
 		if ( parameters.transmission )
-			_programLayers.enable( 17 );
+			_programLayers.enable( 16 );
 		if ( parameters.transmissionMap )
-			_programLayers.enable( 18 );
+			_programLayers.enable( 17 );
 		if ( parameters.thicknessMap )
-			_programLayers.enable( 19 );
+			_programLayers.enable( 18 );
 		if ( parameters.sheen )
-			_programLayers.enable( 20 );
+			_programLayers.enable( 19 );
 		if ( parameters.sheenColorMap )
-			_programLayers.enable( 21 );
+			_programLayers.enable( 20 );
 		if ( parameters.sheenRoughnessMap )
-			_programLayers.enable( 22 );
+			_programLayers.enable( 21 );
 		if ( parameters.decodeVideoTexture )
-			_programLayers.enable( 23 );
+			_programLayers.enable( 22 );
 		if ( parameters.opaque )
-			_programLayers.enable( 24 );
+			_programLayers.enable( 23 );
 
 		array.push( _programLayers.mask );
 


### PR DESCRIPTION
Closes #23921.

**Description**

With `r135` the project requires half float texture extension support for HDR workflows in WebGL 1. I'd like to suggest the next step in limiting WebGL 1 support by restricting the usage of `SkinnedMesh`. 

With this PR `SkinnedMesh` only works with WebGL 1 if floating point textures inside the vertex shader are supported. This is true for most WebGL 1 devices however a small subset of older ones do not support this. Stats are rare but according to #20704 and #23921 it is a number around 5 - 10 %.

Merging this PR would allow the project to remove a legacy code path which is also buggy. Fixes like suggested in #23922 or #20704 would affect all applications no matter if they use skinning or WebGL 1 or 2.