### PR TITLE
Examples: Add update() to MarchingCubes

### DIFF
--- a/examples/jsm/objects/MarchingCubes.js
+++ b/examples/jsm/objects/MarchingCubes.js
@@ -28,7 +28,6 @@ class MarchingCubes extends Mesh {
 
 		this.enableUvs = enableUvs;
 		this.enableColors = enableColors;
-		this.autoUpdate = true;
 
 		// functions have to be object properties
 		// prototype functions kill performance
@@ -859,16 +858,6 @@ class MarchingCubes extends Mesh {
 			// safety check
 
 			if ( this.count / 3 > maxPolyCount ) console.warn( 'THREE.MarchingCubes: Geometry buffers too small for rendering. Please create an instance with a higher poly count.' );
-
-		};
-
-		this.onBeforeRender = function () {
-
-			if ( this.autoUpdate ) {
-
-				this.update();
-
-			}
 
 		};
 

--- a/examples/jsm/objects/MarchingCubes.js
+++ b/examples/jsm/objects/MarchingCubes.js
@@ -844,13 +844,9 @@ class MarchingCubes extends Mesh {
 
 			}
 
-			// reset unneeded data
+			// set the draw range to only the processed triangles
 
-			for ( let i = this.count * 3; i < this.positionArray.length; i ++ ) {
-
-				this.positionArray[ i ] = 0.0;
-
-			}
+			this.geometry.setDrawRange( 0, this.count );
 
 			// update geometry data
 

--- a/examples/jsm/objects/MarchingCubes.js
+++ b/examples/jsm/objects/MarchingCubes.js
@@ -28,6 +28,7 @@ class MarchingCubes extends Mesh {
 
 		this.enableUvs = enableUvs;
 		this.enableColors = enableColors;
+		this.autoUpdate = true;
 
 		// functions have to be object properties
 		// prototype functions kill performance
@@ -812,7 +813,7 @@ class MarchingCubes extends Mesh {
 
 		};
 
-		this.onBeforeRender = function () {
+		this.update = function () {
 
 			this.count = 0;
 
@@ -862,6 +863,16 @@ class MarchingCubes extends Mesh {
 			// safety check
 
 			if ( this.count / 3 > maxPolyCount ) console.warn( 'THREE.MarchingCubes: Geometry buffers too small for rendering. Please create an instance with a higher poly count.' );
+
+		};
+
+		this.onBeforeRender = function () {
+
+			if ( this.autoUpdate ) {
+
+				this.update();
+
+			}
 
 		};
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -316,6 +316,8 @@
 			if ( wallz ) object.addPlaneZ( 2, 12 );
 			if ( wallx ) object.addPlaneX( 2, 12 );
 
+			object.update();
+
 		}
 
 		//


### PR DESCRIPTION
Related issue: #22642

**Description**

Adds support for disabling marching cubes updating every frame automatically in addition to triggering an update on demand since it only needs to rerun when the data changes.