### PR TITLE
WebGLRenderer: Consider .outputEncoding for background, clear color, and fog

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -123,22 +123,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	// physically based shading
 
-	let _outputEncoding = LinearEncoding;
-
-	Object.defineProperty( this, 'outputEncoding', {
-
-		get: () => _outputEncoding,
-
-		set: ( encoding ) => {
-
-			_outputEncoding = encoding;
-
-			// Reapply color space conversion.
-			background.setClearColor( background.getClearColor() );
-
-		},
-
-	} );
+	this.outputEncoding = LinearEncoding;
 
 	// physical lights
 
@@ -1510,7 +1495,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		const fog = scene.fog;
 		const environment = material.isMeshStandardMaterial ? scene.environment : null;
-		const encoding = ( _currentRenderTarget === null ) ? _outputEncoding : ( _currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.encoding : LinearEncoding );
+		const encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : ( _currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.encoding : LinearEncoding );
 		const envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || environment );
 		const vertexAlphas = material.vertexColors === true && !! geometry.attributes.color && geometry.attributes.color.itemSize === 4;
 		const vertexTangents = !! material.normalMap && !! geometry.attributes.tangent;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -123,7 +123,22 @@ function WebGLRenderer( parameters = {} ) {
 
 	// physically based shading
 
-	this.outputEncoding = LinearEncoding;
+	let _outputEncoding = LinearEncoding;
+
+	Object.defineProperty( this, 'outputEncoding', {
+
+		get: () => _outputEncoding,
+
+		set: ( encoding ) => {
+
+			_outputEncoding = encoding;
+
+			// Reapply color space conversion.
+			background.setClearColor( background.getClearColor() );
+
+		},
+
+	} );
 
 	// physical lights
 
@@ -1495,7 +1510,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		const fog = scene.fog;
 		const environment = material.isMeshStandardMaterial ? scene.environment : null;
-		const encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : ( _currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.encoding : LinearEncoding );
+		const encoding = ( _currentRenderTarget === null ) ? _outputEncoding : ( _currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.encoding : LinearEncoding );
 		const envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || environment );
 		const vertexAlphas = material.vertexColors === true && !! geometry.attributes.color && geometry.attributes.color.itemSize === 4;
 		const vertexTangents = !! material.normalMap && !! geometry.attributes.tangent;

--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -1,3 +1,5 @@
+import { sRGBEncoding, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
+
 /**
  * Uniform Utilities
  */
@@ -70,6 +72,19 @@ export function cloneUniformsGroups( src ) {
 	}
 
 	return dst;
+
+}
+
+export function getUnlitUniformColorSpace( renderer ) {
+
+	if ( renderer.getRenderTarget() === null ) {
+
+		// https://github.com/mrdoob/three.js/pull/23937#issuecomment-1111067398
+		return renderer.outputEncoding === sRGBEncoding ? SRGBColorSpace : LinearSRGBColorSpace;
+
+	}
+
+	return LinearSRGBColorSpace;
 
 }
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,11 +1,11 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping, sRGBEncoding, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
+import { BackSide, FrontSide, CubeUVReflectionMapping } from '../../constants.js';
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
 import { Color } from '../../math/Color.js';
 import { Mesh } from '../../objects/Mesh.js';
 import { ShaderLib } from '../shaders/ShaderLib.js';
-import { cloneUniforms } from '../shaders/UniformsUtils.js';
+import { cloneUniforms, getUnlitUniformColorSpace } from '../shaders/UniformsUtils.js';
 
 const _rgb = { r: 0, b: 0, g: 0 };
 
@@ -193,11 +193,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 	function setClear( color, alpha ) {
 
-		const outputColorSpace = renderer.outputEncoding === sRGBEncoding
-			? SRGBColorSpace
-			: LinearSRGBColorSpace;
-
-		color.getRGB( _rgb, outputColorSpace );
+		color.getRGB( _rgb, getUnlitUniformColorSpace( renderer ) );
 
 		state.buffers.color.setClear( _rgb.r, _rgb.g, _rgb.b, alpha, premultipliedAlpha );
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,4 +1,4 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping } from '../../constants.js';
+import { BackSide, FrontSide, CubeUVReflectionMapping, LinearEncoding, sRGBEncoding, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
@@ -6,6 +6,8 @@ import { Color } from '../../math/Color.js';
 import { Mesh } from '../../objects/Mesh.js';
 import { ShaderLib } from '../shaders/ShaderLib.js';
 import { cloneUniforms } from '../shaders/UniformsUtils.js';
+
+const _rgb = { r: 0, b: 0, g: 0 };
 
 function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha, premultipliedAlpha ) {
 
@@ -191,7 +193,13 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 	function setClear( color, alpha ) {
 
-		state.buffers.color.setClear( color.r, color.g, color.b, alpha, premultipliedAlpha );
+		const outputColorSpace = renderer.outputEncoding === sRGBEncoding
+			? SRGBColorSpace
+			: LinearSRGBColorSpace;
+
+		color.getRGB( _rgb, outputColorSpace );
+
+		state.buffers.color.setClear( _rgb.r, _rgb.g, _rgb.b, alpha, premultipliedAlpha );
 
 	}
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,4 +1,4 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping, LinearEncoding, sRGBEncoding, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
+import { BackSide, FrontSide, CubeUVReflectionMapping, sRGBEncoding, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -1,10 +1,11 @@
 import { BackSide } from '../../constants.js';
+import { getUnlitUniformColorSpace } from '../shaders/UniformsUtils.js';
 
 function WebGLMaterials( renderer, properties ) {
 
 	function refreshFogUniforms( uniforms, fog ) {
 
-		uniforms.fogColor.value.copy( fog.color );
+		fog.color.getRGB( uniforms.fogColor.value, getUnlitUniformColorSpace( renderer ) );
 
 		if ( fog.isFog ) {
 


### PR DESCRIPTION
Currently, at least three Color properties (renderer clear color, scene.background color, and scene.fog color) are exempt from the WebGLRenderer specified output color space. These exceptions create confusion — to make the ground plane match the background or fog color, for example, you need to specify the same color in two color spaces, for reasons that are mostly based on _how_ WebGLRenderer applies the output color space conversion. However, if the user provides post-processing that handles color space conversion, the color space used for background and fog colors must change.

This PR is an idea for how to clear up that inconsistency, applied only when `ColorManagement.legacyMode = false`. In this case — as with THREE.Color setters — hexadecimal and CSS-string inputs are understood to be sRGB, and converted automatically to Linear-sRGB. Then internally, WebGLRenderer (which now _knows_ it is dealing with something in the working color space, Linear-sRGB) can make the conversion appropriate for the output color space.

With this change, all of these colors will match:

```javascript
document.body.style.background = '#123456';
scene.background.color.setHex( 0x123456 );
renderer.setClearColor( 0x123456 );
material.color.setHex( 0x123456 );
```

~~NOTE: The statement above assumes no post-processing, and renderer output to sRGB. One thing I'm not sure about is how `renderer.outputEncoding` and `renderTarget.encoding` are (or ideally should be?) respected in a post-processing chain. This relates to @WestLangley's comments https://github.com/mrdoob/three.js/issues/23614#issuecomment-1107473639 and https://github.com/mrdoob/three.js/issues/18942#issuecomment-613221973.~~