### PR TITLE
Fixed a typo in the manual in Russian. 

### DIFF
--- a/manual/ru/textures.html
+++ b/manual/ru/textures.html
@@ -118,7 +118,7 @@ const material = new THREE.MeshBasicMaterial({
 
 <p></p>
 <p>Однако следует отметить, что по умолчанию единственной геометрией, которая поддерживает 
-несколько материалов, является <a href="/docs/#api/en/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a> и <a href="/docs/#api/en/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a>. В других случаях вам 
+несколько материалов, является <a href="/docs/#api/en/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a> и <a href="/docs/#api/en/geometries/ConeGeometry"><code class="notranslate" translate="no">ConeGeometry</code></a>. В других случаях вам 
 нужно будет создать или загрузить пользовательскую геометрию и/или изменить координаты 
 текстуры. Гораздо более распространенным является использование 
 <a href="https://ru.wikipedia.org/wiki/Текстурный_атлас">Текстурного атласа</a> 


### PR DESCRIPTION
Fixed a typo in the manual in Russian. Previously duplicated BoxGeometry