### PR TITLE
Manual: Modify korean docs headers, title, meta text

### DIFF
--- a/manual/ko/cameras.html
+++ b/manual/ko/cameras.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>카메라</title>
+    <title>카메라(Cameras)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 카메라">
+    <meta name="twitter:title" content="Three.js – 카메라(Cameras)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>카메라</h1>
+        <h1>카메라(Cameras)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/custom-geometry.html
+++ b/manual/ko/custom-geometry.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>사용자 지정 Geometry</title>
+    <title>사용자 지정 Geometry(Custom BufferGeometry)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 사용자 지정 Geometry">
+    <meta name="twitter:title" content="Three.js – 사용자 지정 Geometry(Custom BufferGeometry)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>사용자 지정 Geometry</h1>
+        <h1>사용자 지정 Geometry(Custom BufferGeometry)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/fog.html
+++ b/manual/ko/fog.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>안개</title>
+    <title>안개(Fog)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 안개">
+    <meta name="twitter:title" content="Three.js – 안개(Fog)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>안개</h1>
+        <h1>안개(Fog)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/fundamentals.html
+++ b/manual/ko/fundamentals.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>란?</title>
+    <title>Three.js란?</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 란?">
+    <meta name="twitter:title" content="Three.js – Three.js란?">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>란?</h1>
+        <h1>Three.js란?</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/lights.html
+++ b/manual/ko/lights.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>의 조명</title>
+    <title>조명(Lights)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 의 조명">
+    <meta name="twitter:title" content="Three.js – 조명(Lights)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>의 조명</h1>
+        <h1>조명(Lights)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/materials.html
+++ b/manual/ko/materials.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>의 재질(Materials)</title>
+    <title>재질(Materials)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 의 재질(Materials)">
+    <meta name="twitter:title" content="Three.js – 재질(Materials)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>의 재질(Materials)</h1>
+        <h1>재질(Materials)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/primitives.html
+++ b/manual/ko/primitives.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>의 원시 모델</title>
+    <title>원시 모델(primitives)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 의 원시 모델">
+    <meta name="twitter:title" content="Three.js – 원시 모델(primitives)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>의 원시 모델</h1>
+        <h1>원시 모델(primitives)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/rendertargets.html
+++ b/manual/ko/rendertargets.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>렌더 타겟</title>
+    <title>렌더 타겟(Render Targets)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 렌더 타겟">
+    <meta name="twitter:title" content="Three.js – 렌더 타겟(Render Targets)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>렌더 타겟</h1>
+        <h1>렌더 타겟(Render Targets)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/scenegraph.html
+++ b/manual/ko/scenegraph.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>의 씬 그래프</title>
+    <title>씬 그래프(Scene graph)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 의 씬 그래프">
+    <meta name="twitter:title" content="Three.js – 씬 그래프(Scene graph)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,14 +27,14 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>의 씬 그래프</h1>
+        <h1>씬 그래프(Scene graph)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">
           <p>※ 이 글은 Three.js의 튜토리얼 시리즈로서,
 먼저 <a href="fundamentals.html">Three.js의 기본 구조에 관한 글</a>을
 읽고 오길 권장합니다.</p>
-<p>Three.js에서 가장 중요한 것은 무엇보다 씬 그래프(scene graph)입니다.
+<p>Three.js에서 가장 중요한 것은 무엇보다 씬 그래프(Scene graph)입니다.
 3D 엔진에서 씬 그래프란 요소(node)의 계층 구조를 그림으로 나타낸 것으로,
 여기서 각 요소는 각각의 "지역 공간(local space)"을 가리킵니다.</p>
 <p><img src="../resources/images/scenegraph-generic.svg" align="center"></p>

--- a/manual/ko/shadows.html
+++ b/manual/ko/shadows.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>그림자</title>
+    <title>그림자<(Shadows)/title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 그림자">
+    <meta name="twitter:title" content="Three.js – 그림자(Shadows)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>그림자</h1>
+        <h1>그림자(Shadows)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/ko/textures.html
+++ b/manual/ko/textures.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
-    <title>의 텍스처(Textures)</title>
+    <title>텍스처(Textures)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
-    <meta name="twitter:title" content="Three.js – 의 텍스처(Textures)">
+    <meta name="twitter:title" content="Three.js – 텍스처(Textures)">
     <meta property="og:image" content="https://threejs.org/files/share.png">
     <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)">
     <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)">
@@ -27,7 +27,7 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>의 텍스처(Textures)</h1>
+        <h1>텍스처(Textures)</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">

--- a/manual/list.json
+++ b/manual/list.json
@@ -190,8 +190,8 @@
 			"개발 환경": "ko/setup"
 		},
 		"기본 구조": {
-			"원시 모델": "ko/primitives",
-			"씬 그래프": "ko/scenegraph",
+			"원시 모델(Primitives)": "ko/primitives",
+			"씬 그래프(Scenegraph)": "ko/scenegraph",
 			"재질(Materials)": "ko/materials",
 			"텍스처(Textures)": "ko/textures",
 			"조명(Lights)": "ko/lights",


### PR DESCRIPTION
Related issue: none

**Description**

There was an error in the header of the Korean Foundation and it was also in the meta title and nav-list too.
And the `<h1>`, `<title>`and `<meta name="twitter:title">` tags on each page have no sense of unity. So I made sure that the tag contains Korean and English text.


<!-- Remove the line below if is not relevant -->

