### PR TITLE
Fix: attributes.setUsage() does not update after buffer creation

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -25,6 +25,8 @@ class BufferAttribute {
 		this.normalized = normalized === true;
 
 		this.usage = StaticDrawUsage;
+		this.cachedUsage = StaticDrawUsage;
+
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -40,6 +42,12 @@ class BufferAttribute {
 	}
 
 	setUsage( value ) {
+
+		if ( this.usage !== value ) {
+
+			this.version ++;
+
+		}
 
 		this.usage = value;
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -10,6 +10,7 @@ class InterleavedBuffer {
 		this.count = array !== undefined ? array.length / stride : 0;
 
 		this.usage = StaticDrawUsage;
+		this.cachedUsage = StaticDrawUsage;
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -27,6 +28,12 @@ class InterleavedBuffer {
 	}
 
 	setUsage( value ) {
+
+		if ( this.usage !== value ) {
+
+			this.version ++;
+
+		}
 
 		this.usage = value;
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -9,11 +9,7 @@ function WebGLAttributes( gl, capabilities ) {
 		const array = attribute.array;
 		const usage = attribute.usage;
 
-		if ( attribute.cachedUsage !== usage ) {
-
-			attribute.cachedUsage = usage;
-
-		}
+		attribute.cachedUsage = usage;
 
 		const buffer = gl.createBuffer();
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -94,7 +94,6 @@ function WebGLAttributes( gl, capabilities ) {
 
 			attribute.cachedUsage = attribute.usage;
 			gl.bufferData( bufferType, array, attribute.usage );
-			console.log(attribute.usage)
 
 		}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -95,7 +95,7 @@ function WebGLAttributes( gl, capabilities ) {
 			attribute.cachedUsage = attribute.usage;
 			gl.bufferData( bufferType, array, attribute.usage );
 			updateRange.count = - 1; // reset range
-			return
+			return;
 
 		}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -9,6 +9,12 @@ function WebGLAttributes( gl, capabilities ) {
 		const array = attribute.array;
 		const usage = attribute.usage;
 
+		if ( attribute.cachedUsage !== usage ) {
+
+			attribute.cachedUsage = usage;
+
+		}
+
 		const buffer = gl.createBuffer();
 
 		gl.bindBuffer( bufferType, buffer );
@@ -87,6 +93,14 @@ function WebGLAttributes( gl, capabilities ) {
 		const updateRange = attribute.updateRange;
 
 		gl.bindBuffer( bufferType, buffer );
+
+		if ( attribute.cachedUsage !== attribute.usage ) {
+
+			attribute.cachedUsage = attribute.usage;
+			gl.bufferData( bufferType, array, attribute.usage );
+			console.log(attribute.usage)
+
+		}
 
 		if ( updateRange.count === - 1 ) {
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -94,6 +94,8 @@ function WebGLAttributes( gl, capabilities ) {
 
 			attribute.cachedUsage = attribute.usage;
 			gl.bufferData( bufferType, array, attribute.usage );
+			updateRange.count = - 1; // reset range
+			return
 
 		}
 


### PR DESCRIPTION
The method to update the usage pattern of the array buffer was not doing anything post-creation.

Added a `cachedUsage` property in `BufferAttribute` and `InterleavedBuffer`.
That value is also set in `WebGLAttributes.createBuffer()` (basically before calling bufferData).

Then, if the usage pattern is changed through setUsage(), in the method `WebGLAttributes.updateBuffer()` we call again bufferData with the new usage pattern:
```js
if ( attribute.cachedUsage !== attribute.usage ) {

	attribute.cachedUsage = attribute.usage;
	gl.bufferData( bufferType, array, attribute.usage );
	updateRange.count = - 1; // reset range
	return;

}
```

Since `updateBuffer` was only using `bufferSubData` it was not possible to update the usage so I call `bufferData` with the new usage, then return as any further sub update would be useless.