### PR TITLE
Docs: Mentioned the need for ImageBitmap.close().

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -20,6 +20,11 @@
 		textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
 		</p>
 
+		<p>
+			[name] uses [page:ImageBitmapLoader] whenever possible. Be advised that image bitmaps are not automatically GC-collected when they are no longer referenced,
+			and they require special handling during the disposal process. More information in the [link:https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects How to dispose of objects] guide.
+		</p>
+
 		<h2>Extensions</h2>
 
 		<p>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -19,6 +19,11 @@
 		包括网格、材质、贴图、蒙皮、骨架、变形目标、动画、灯光以及摄像机。
 		</p>
 
+		<p>
+			[name] uses [page:ImageBitmapLoader] whenever possible. Be advised that image bitmaps are not automatically GC-collected when they are no longer referenced,
+			and they require special handling during the disposal process. More information in the [link:https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects How to dispose of objects] guide.
+		</p>
+
 		<h2>扩展</h2>
 
 		<p>

--- a/docs/manual/ar/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/ar/introduction/How-to-dispose-of-objects.html
@@ -37,6 +37,11 @@
 			على غرار المخازن المؤقتة ، لا يمكن حذف هذا الكائن إلا عن طريق استدعاء [page:Texture.dispose]().
 		</p>
 
+		<p>
+			If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+			An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+		</p>
+
 		<h2>أهداف العرض</h2>
 
 		<p>

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -44,6 +44,11 @@
 		Similar to buffers, this object can only be deleted by calling [page:Texture.dispose]().
 	</p>
 
+	<p>
+		If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+		An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+	</p>
+
 	<h2>Render Targets</h2>
 
 	<p>

--- a/docs/manual/ja/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/ja/introduction/How-to-dispose-of-objects.html
@@ -50,6 +50,11 @@
 		バッファと同様に、このオブジェクトは[page:Texture.dispose]()を呼ぶことでしか削除できません。
 	</p>
 
+	<p>
+		If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+		An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+	</p>
+
 	<h2>Render Targets</h2>
 
 	<p>

--- a/docs/manual/ko/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/ko/introduction/How-to-dispose-of-objects.html
@@ -42,6 +42,11 @@
         buffer와 비슷하게, 이 오브젝트는 [page:Texture.dispose]() 호출로만 삭제가 가능합니다.
 	</p>
 
+	<p>
+        If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+        An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+	</p>
+
 	<h2>렌더링 대상</h2>
 
 	<p>

--- a/docs/manual/zh/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/zh/introduction/How-to-dispose-of-objects.html
@@ -44,6 +44,11 @@
 		和buffer相似，该对象只能通过调用[page:Texture.dispose]()来删除。
 	</p>
 
+	<p>
+		If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+		An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+	</p>
+
 	<h2>渲染目标</h2>
 
 	<p>


### PR DESCRIPTION
Fixed #23953.

**Description**

Clarifies the relevance of `ImageBitmap.close()`.
