### PR TITLE
Update CONTRIBUTING.md with additional test installation instrucitons

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,11 +30,11 @@ This script will start a local server similar to [threejs.org](https://threejs.o
 
 The next most important script runs all the appropriate testing. The E-2-E testing is intended to be run by github actions.
 
-First, run this command from the root folder to install test dependencies:
+Run this command from the root folder to install test dependencies.
 
     npm install --prefix test
 
-Next, run the tests.
+And run tests.
 
     npm test
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,6 +30,12 @@ This script will start a local server similar to [threejs.org](https://threejs.o
 
 The next most important script runs all the appropriate testing. The E-2-E testing is intended to be run by github actions.
 
+First, run this command from the root folder to install test dependencies:
+
+    npm install --prefix test
+
+Next, run the tests.
+
     npm test
 
 The linting is there to keep a consistent code style across all of the code and the testing is there to help catch bugs and check that the code behaves as expected. It is important that neither of these steps comes up with any errors due to your changes.


### PR DESCRIPTION
Added missing information about installing test dependencies at `CONTRIBUTING.md` file.
See [2342 comment](https://github.com/mrdoob/three.js/issues/23424#issuecomment-1112432379).

