### PR TITLE
Stop checking isFramebufferTexture in copyFramebufferToTexture.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2007,13 +2007,6 @@ function WebGLRenderer( parameters = {} ) {
 
 	this.copyFramebufferToTexture = function ( position, texture, level = 0 ) {
 
-		if ( texture.isFramebufferTexture !== true ) {
-
-			console.error( 'THREE.WebGLRenderer: copyFramebufferToTexture() can only be used with FramebufferTexture.' );
-			return;
-
-		}
-
 		const levelScale = Math.pow( 2, - level );
 		const width = Math.floor( texture.image.width * levelScale );
 		const height = Math.floor( texture.image.height * levelScale );


### PR DESCRIPTION
**Description**

`FramebufferTexture` was first added in https://github.com/mrdoob/three.js/pull/22916 because `copyTexImage2D` doesn't work with `texStorage2D`. However, `copyTexImage2D` was later replaced by `copyTexSubImage2D` in https://github.com/mrdoob/three.js/pull/22985, making checking `FramebufferTexture` unnecessary.

However, `FramebufferTexture` is still useful in that we don't have to set an image to allocate texture memory.

*This contribution is funded by [OppenFuture Technologies](https://oppentech.com/en)*
