### PR TITLE
WebGPU: Fix FrontFace

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderPipeline.js
@@ -448,8 +448,8 @@ class WebGPURenderPipeline {
 		switch ( material.side ) {
 
 			case FrontSide:
-				descriptor.frontFace = GPUFrontFace.CCW;
-				descriptor.cullMode = GPUCullMode.Back;
+				descriptor.frontFace = GPUFrontFace.CW;
+				descriptor.cullMode = GPUCullMode.Front;
 				break;
 
 			case BackSide:
@@ -458,7 +458,7 @@ class WebGPURenderPipeline {
 				break;
 
 			case DoubleSide:
-				descriptor.frontFace = GPUFrontFace.CCW;
+				descriptor.frontFace = GPUFrontFace.CW;
 				descriptor.cullMode = GPUCullMode.None;
 				break;
 


### PR DESCRIPTION
**Description**

In some comparative tests, I notice that built-in `front_facing`, it is `NormalMap` was inverted because of the direction of `frontFace`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
