### PR TITLE
WebGLRenderer: Fix for runtime error that happens when null is provided as context

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -69,7 +69,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	let _alpha;
 
-	if ( parameters.context !== undefined ) {
+	if ( _context !== null ) {
 
 		_alpha = _context.getContextAttributes().alpha;
 


### PR DESCRIPTION
**Description**

If someone passes a context to the `WebGLRenderer`, but the context is `null` (because the user's device doesn't support `webgl`, or `webgl2`, or whatever context they tried to create), we have a runtime error, saying `TypeError: _context is null`.

The problem was introduced with this commit: https://github.com/mrdoob/three.js/commit/fb9d575c15c495e857ae8e8fb4f38e847adc8e8d

To make things a little bit more confusing, the official documentation says that the default value for `context` is `null`: https://threejs.org/docs/index.html?q=webg#api/en/renderers/WebGLRenderer

Which is, of course, technically incorrect. It's not `null`, but `undefined` by default. The root of the problems is that some of the checks inside the `WebGLRenderer`'s "constructor" is checking whether the `context` is `undefined`. If it's not, it assumes it has a valid value, although it can be easily `null`. Because `canvas.getContext` either returns a context, or `null`.

For a long time this was the [official recommended way](https://github.com/Mugen87/three.js/blob/15b0d2b67337ce964e8533cd2e917e08966139a1/docs/manual/en/introduction/How-to-use-WebGL2.html) for creating `WebGLRenderer` with WebGL 2.0 context:

```
var context = canvas.getContext( 'webgl2' );
var renderer = new THREE.WebGLRenderer( { canvas: canvas, context: context } );
```

I know this can be now considered "legacy code", but still, if `webgl2` is not available on a device, and someone still uses the code like this, it will give the user an error instead of trying to fall back to `webgl` 1.


~~This PR replaces the strict comparisons `context !== undefined` with `context != undefined`, and provides a technically more accurate default value in the documentation.~~