### PR TITLE
NormalMapNode: Two sides supports and updates

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -49,6 +49,7 @@ import ComputeNode from './gpgpu/ComputeNode.js';
 
 // display
 import ColorSpaceNode from './display/ColorSpaceNode.js';
+import FrontFacingNode from './display/FrontFacingNode.js';
 import NormalMapNode from './display/NormalMapNode.js';
 import ToneMappingNode from './display/ToneMappingNode.js';
 

--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -148,6 +148,7 @@ const nodeLib = {
 
 	// display
 	ColorSpaceNode,
+	FrontFacingNode,
 	NormalMapNode,
 	ToneMappingNode,
 
@@ -245,6 +246,7 @@ export {
 
 	// display
 	ColorSpaceNode,
+	FrontFacingNode,
 	NormalMapNode,
 	ToneMappingNode,
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -41,6 +41,10 @@ class NodeBuilder {
 		this.updateNodes = [];
 		this.hashNodes = {};
 
+		this.scene = null;
+		this.lightsNode = null;
+		this.fogNode = null;
+
 		this.vertexShader = null;
 		this.fragmentShader = null;
 		this.computeShader = null;
@@ -158,7 +162,13 @@ class NodeBuilder {
 
 	}
 
-	getInstanceIndex( /*shaderStage*/ ) {
+	getInstanceIndex() {
+
+		console.warn( 'Abstract function.' );
+
+	}
+
+	getFrontFacing() {
 
 		console.warn( 'Abstract function.' );
 

--- a/examples/jsm/nodes/display/FrontFacingNode.js
+++ b/examples/jsm/nodes/display/FrontFacingNode.js
@@ -1,0 +1,21 @@
+import Node from '../core/Node.js';
+
+class FrontFacingNode extends Node {
+
+	constructor() {
+
+		super( 'bool' );
+
+	}
+
+	generate( builder ) {
+
+		return builder.getFrontFacing();
+
+	}
+
+}
+
+FrontFacingNode.prototype.isFrontFacingNode = true;
+
+export default FrontFacingNode;

--- a/examples/jsm/nodes/display/NormalMapNode.js
+++ b/examples/jsm/nodes/display/NormalMapNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import ModelNode from '../accessors/ModelNode.js';
-import { ShaderNode, positionView, normalView, uv, vec3, cond, add, sub, mul, dFdx, dFdy, cross, max, dot, normalize, inversesqrt, equal } from '../shadernode/ShaderNodeBaseElements.js';
+import { ShaderNode, positionView, normalView, uv, vec3, cond, add, sub, mul, dFdx, dFdy, cross, max, dot, normalize, inversesqrt, equal, faceDirection } from '../shadernode/ShaderNodeBaseElements.js';
 
 import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from 'three';
 
@@ -9,7 +9,7 @@ import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from 'three';
 
 const perturbNormal2ArbNode = new ShaderNode( ( inputs ) => {
 
-	const { eye_pos, surf_norm, mapN, faceDirection, uv } = inputs;
+	const { eye_pos, surf_norm, mapN, uv } = inputs;
 
 	const q0 = dFdx( eye_pos.xyz );
 	const q1 = dFdy( eye_pos.xyz );
@@ -74,7 +74,6 @@ class NormalMapNode extends TempNode {
 				eye_pos: positionView,
 				surf_norm: normalView,
 				mapN: normalMap,
-				faceDirection: 1.0,
 				uv: uv()
 			} );
 

--- a/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
@@ -257,7 +257,7 @@ export const faceforward = nodeProxy( MathNode, MathNode.FACEFORWARD );
 
 // display
 
-export const frontFacing = nodeObject( new FrontFacingNode() );
+export const frontFacing = nodeImmutable( FrontFacingNode );
 export const faceDirection = sub( mul( float( frontFacing ), 2 ), 1 );
 
 // lights

--- a/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
@@ -28,6 +28,9 @@ import StorageBufferNode from '../accessors/StorageBufferNode.js';
 import TextureNode from '../accessors/TextureNode.js';
 import UVNode from '../accessors/UVNode.js';
 
+// display
+import FrontFacingNode from '../display/FrontFacingNode.js';
+
 // gpgpu
 import ComputeNode from '../gpgpu/ComputeNode.js';
 
@@ -251,6 +254,11 @@ export const clamp = nodeProxy( MathNode, MathNode.CLAMP );
 export const refract = nodeProxy( MathNode, MathNode.REFRACT );
 export const smoothstep = nodeProxy( MathNode, MathNode.SMOOTHSTEP );
 export const faceforward = nodeProxy( MathNode, MathNode.FACEFORWARD );
+
+// display
+
+export const frontFacing = nodeObject( new FrontFacingNode() );
+export const faceDirection = sub( mul( float( frontFacing ), 2 ), 1 );
 
 // lights
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -106,10 +106,10 @@ class WebGPUNodeBuilder extends NodeBuilder {
 		this.uniformsGroup = {};
 
 		this.builtins = {
-			vertex: new Set(),
-			fragment: new Set(),
-			compute: new Set(),
-			attribute: new Set()
+			vertex: new Map(),
+			fragment: new Map(),
+			compute: new Map(),
+			attribute: new Map()
 		};
 
 	}
@@ -371,11 +371,17 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 	getBuiltin( name, property, type, shaderStage = this.shaderStage ) {
 
-		this.builtins[ shaderStage ].add( {
-			name,
-			property,
-			type
-		} );
+		const map = this.builtins[ shaderStage ];
+
+		if ( map.has( name ) === false ) {
+
+			map.set( name, {
+				name,
+				property,
+				type
+			} );
+
+		}
 
 		return property;
 
@@ -411,7 +417,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			}
 
-			for ( const { name, property, type } of this.builtins[ 'attribute' ] ) {
+			for ( const { name, property, type } of this.builtins.attribute.values() ) {
 
 				snippets.push( `@builtin( ${name} ) ${property} : ${type}` );
 
@@ -488,7 +494,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		}
 
-		for ( const { name, property, type } of this.builtins[ shaderStage ] ) {
+		for ( const { name, property, type } of this.builtins[ shaderStage ].values() ) {
 
 			snippets.push( `@builtin( ${name} ) ${property} : ${type}` );
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -105,7 +105,12 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		this.uniformsGroup = {};
 
-		this.builtins = new Set();
+		this.builtins = {
+			vertex: new Set(),
+			fragment: new Set(),
+			compute: new Set(),
+			attribute: new Set()
+		};
 
 	}
 
@@ -364,11 +369,33 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 	}
 
-	getInstanceIndex( shaderStage = this.shaderStage ) {
+	getBuiltin( name, property, type, shaderStage = this.shaderStage ) {
 
-		this.builtins.add( 'instance_index' );
+		this.builtins[ shaderStage ].add( {
+			name,
+			property,
+			type
+		} );
+
+		return property;
+
+	}
+
+	getInstanceIndex() {
+
+		if ( this.shaderStage === 'vertex' ) {
+
+			return this.getBuiltin( 'instance_index', 'instanceIndex', 'u32', 'attribute' );
+
+		}
 
 		return 'instanceIndex';
+
+	}
+
+	getFrontFacing() {
+
+		return this.getBuiltin( 'front_facing', 'isFront', 'bool' );
 
 	}
 
@@ -380,11 +407,13 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 			if ( shaderStage === 'compute' ) {
 
-				snippets.push( `@builtin( global_invocation_id ) id : vec3<u32>` );
+				this.getBuiltin( 'global_invocation_id', 'id', 'vec3<u32>', 'attribute' );
 
-			} else if ( this.builtins.has( 'instance_index' ) ) {
+			}
 
-				snippets.push( `@builtin( instance_index ) instanceIndex : u32` );
+			for ( const { name, property, type } of this.builtins[ 'attribute' ] ) {
+
+				snippets.push( `@builtin( ${name} ) ${property} : ${type}` );
 
 			}
 
@@ -433,7 +462,7 @@ class WebGPUNodeBuilder extends NodeBuilder {
 
 		if ( shaderStage === 'vertex' ) {
 
-			snippets.push( '@builtin( position ) Vertex: vec4<f32>' );
+			this.getBuiltin( 'position', 'Vertex', 'vec4<f32>', 'vertex' );
 
 			const varys = this.varys;
 
@@ -456,6 +485,12 @@ class WebGPUNodeBuilder extends NodeBuilder {
 				snippets.push( `@location( ${index} ) ${ vary.name } : ${ this.getType( vary.type ) }` );
 
 			}
+
+		}
+
+		for ( const { name, property, type } of this.builtins[ shaderStage ] ) {
+
+			snippets.push( `@builtin( ${name} ) ${property} : ${type}` );
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23965

**Description**

Add `NormalMapNode` two sides supports and others indirect features.

- [x] [NodeBuilder: add .getFrontFacing() and cleanup builtin](https://github.com/mrdoob/three.js/commit/28deed7b3d26f7f51fb9810bc8ca6724fb58ac82)
- [x] [add FrontFacingNode](https://github.com/mrdoob/three.js/commit/897208110167add539849a864abe9af4492b5107)
- [x] [ShaderNode: add frontFacing and faceDirection](https://github.com/mrdoob/three.js/commit/10cd1c12ab414445e59397e2d2ed82bf07e8a7e2)
- [x] [NormalMapNode: two sides supports](https://github.com/mrdoob/three.js/commit/01a889a9f7438cd09d547538424c15ab460efdd8)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
