### PR TITLE
 WebXRManager: support more than 2 views

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -561,6 +561,15 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
+		function addCamera( i ) {
+
+			const camera = new PerspectiveCamera();
+			camera.layers.enable( i );
+			camera.viewport = new Vector4();
+			cameras.push( camera );
+
+		}
+
 		// Animation Loop
 
 		let onAnimationFrameCallback = null;
@@ -620,6 +629,8 @@ class WebXRManager extends EventDispatcher {
 						}
 
 					}
+
+					if ( ! cameras[ i ] ) addCamera( i );
 
 					const camera = cameras[ i ];
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -561,15 +561,6 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
-		function addCamera( i ) {
-
-			const camera = new PerspectiveCamera();
-			camera.layers.enable( i );
-			camera.viewport = new Vector4();
-			cameras.push( camera );
-
-		}
-
 		// Animation Loop
 
 		let onAnimationFrameCallback = null;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -630,9 +630,16 @@ class WebXRManager extends EventDispatcher {
 
 					}
 
-					if ( ! cameras[ i ] ) addCamera( i );
+					let camera = cameras[ i ];
 
-					const camera = cameras[ i ];
+					if ( camera === undefined ) {
+
+						camera = new PerspectiveCamera();
+						camera.layers.enable( i );
+						camera.viewport = new Vector4();
+						cameras[ i ] = camera;
+
+					}
 
 					camera.matrix.fromArray( view.transform.matrix );
 					camera.projectionMatrix.fromArray( view.projectionMatrix );


### PR DESCRIPTION
Related issue: #19387

**Description**

I was chatting with @BryanChrisBrown about WebXRManager's limitation to two XRCameras (also noted in https://github.com/three-types/three-ts-types/pull/169) and found @brianpeiris's previous work sufficient enough to support multiview as described in https://github.com/kainino0x/holoplay-webxr/issues/9#issuecomment-955620666.

I tested this with a few demos and a (webxr) emulator equipped with multiview to try:

<details>
  <summary>r140 dev (baseline)</summary>

Demo: https://webxr-multicam-4zetdnsmg-codyb.vercel.app/
Code: https://github.com/CodyJasonBennett/webxr-multicam/blob/r140dev-baseline/index.html

[![image](https://user-images.githubusercontent.com/23324155/166072023-2c95e771-af83-4cac-b6c9-27c013fcdd15.png)](https://webxr-multicam-4zetdnsmg-codyb.vercel.app/)

</details>

<details>
  <summary>fix/webxr-multicamera (PR)</summary>

Demo: https://webxr-multicam.vercel.app/
Code: https://github.com/CodyJasonBennett/webxr-multicam/blob/main/index.html


[![image](https://user-images.githubusercontent.com/23324155/166068382-f04ecd3e-b37f-4b3a-bc72-faaa7b47b34d.png)](https://webxr-multicam.vercel.app/)

</details>

The only notable changes since have been with RGB depreciations, internal encoding changes, and foveation & reference space features so this worked OOTB.