### PR TITLE
LoaderUtils: Add support for Windows path separator in extractUrlBase().

### DIFF
--- a/src/loaders/LoaderUtils.js
+++ b/src/loaders/LoaderUtils.js
@@ -36,7 +36,7 @@ class LoaderUtils {
 
 	static extractUrlBase( url ) {
 
-		const index = url.lastIndexOf( '/' );
+		const index = Math.max( url.lastIndexOf( '/' ), url.lastIndexOf( '\\' ) );
 
 		if ( index === - 1 ) return './';
 

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -22,6 +22,7 @@ export default QUnit.module( 'Loaders', () => {
 			assert.equal( '/path/to/', LoaderUtils.extractUrlBase( '/path/to/model.glb' ) );
 			assert.equal( './', LoaderUtils.extractUrlBase( 'model.glb' ) );
 			assert.equal( '/', LoaderUtils.extractUrlBase( '/model.glb' ) );
+			assert.equal( '/host/to\\folder\\', LoaderUtils.extractUrlBase( '/host/to\\folder\\model.glb' ) );
 
 		} );
 


### PR DESCRIPTION
Related issue: -

**Description**

When I use [file-loader](https://v4.webpack.js.org/loaders/file-loader/) of webpack to import gltf resources in Windows, the file is parsed as a string with the path separator of Windows. However, `extractUrlBase` can't work properly because it does not resolve backslashes.

Code: 
```javascript
import gltf from './glTF/DamagedHelmet.gltf';

const loader = new GLTFLoader();
loader.load( gltf, function ( gltf ) {

    scene.add( gltf.scene );

    render();

} );
```

By the way, in my project, if I print the url at the beginning of the function `extractUrlBase`, I will get the following result:
`http://localhost:8081/main/../cby_scene\glTF\DamagedHelmet.gltf`