### PR TITLE
GLTFLoader: Remove uv2 attribute when not being used

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3044,6 +3044,9 @@ class GLTFParser {
 
 		return this.getDependency( 'texture', mapDef.index ).then( function ( texture ) {
 
+			// TODO(mrdoob) Clean up
+			texture.userData._gltfTexCoord = mapDef.texCoord;
+
 			// Materials sample aoMap from UV set 1 and other maps from UV set 0 - this can't be configured
 			// However, we will copy UV set 0 to UV set 1 on demand for aoMap
 			if ( mapDef.texCoord !== undefined && mapDef.texCoord != 0 && ! ( mapName === 'aoMap' && mapDef.texCoord == 1 ) ) {
@@ -3174,11 +3177,28 @@ class GLTFParser {
 
 		}
 
-		// workarounds for mesh and geometry
+		// TODO(mrdoob) Clean up
 
-		if ( material.aoMap && geometry.attributes.uv2 === undefined && geometry.attributes.uv !== undefined ) {
+		if ( material.aoMap ) {
 
-			geometry.setAttribute( 'uv2', geometry.attributes.uv );
+			if ( geometry.attributes.uv2 === undefined ) {
+
+				if ( material.aoMap.userData._gltfTexCoord !== 0 && geometry.attributes.uv !== undefined ) {
+
+					geometry.setAttribute( 'uv2', geometry.attributes.uv );
+
+				}
+
+			} else {
+
+				if ( material.aoMap.userData._gltfTexCoord === 0 ) {
+
+					console.warn( 'THREE.GLTFLoader: Removed uv2 attribute as it\'s not being used.' );
+					geometry.deleteAttribute( 'uv2' );
+
+				}
+
+			}
 
 		}
 


### PR DESCRIPTION
**Description**

This is a quick workaround until we improve the current uvset code (coming up soon in my todo list!)

Some gltf models may have second uv set but the aoMap may not use it, resulting in broken models.

| Before | After |
| --- | --- |
| <img width="930" alt="Screen Shot 2022-04-30 at 4 37 24 PM" src="https://user-images.githubusercontent.com/97088/166096770-8a26d5ce-2f0e-467c-a823-ba1dd1d72a8c.png"> | <img width="931" alt="Screen Shot 2022-04-30 at 4 35 11 PM" src="https://user-images.githubusercontent.com/97088/166096784-1ea6a188-b39d-4aef-9667-dd5fc30527e4.png"> |

/cc @elalish @donmccurdy 