### PR TITLE
Add static function `lerpFlat` to `Vector3`.

### DIFF
--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -458,6 +458,21 @@
 		Sets this vector to a uniformly random point on a unit sphere.
 		</p>
 
+		<h2>Static Methods</h2>
+
+		<h3>[method:undefined lerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float alpha] )</h3>
+		<p>
+		[page:Array dst] - The output array.<br />
+		[page:Integer dstOffset] - An offset into the output array.<br />
+		[page:Array src0] - The source array of the starting vector3.<br />
+		[page:Integer srcOffset0] - An offset into the array *src0*.<br />
+		[page:Array src1] - The source array of the target vector3.<br />
+		[page:Integer srcOffset1] - An offset into the array *src1*.<br />
+		[page:Float alpha] - Normalized interpolation factor (between 0 and 1).<br /><br />
+
+		This LERP implementation assumes the vector3 data are managed in flat arrays.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/zh/math/Vector3.html
+++ b/docs/api/zh/math/Vector3.html
@@ -443,6 +443,21 @@
 		将该向量的每个分量(x、y、z)设置为介于 0 和 1 之间的伪随机数，不包括 1。
 		</p>
 
+		<h2>静态方法</h2>
+
+		<h3>[method:undefined lerpFlat]( [param:Array dst], [param:Integer dstOffset], [param:Array src0], [param:Integer srcOffset0], [param:Array src1], [param:Integer srcOffset1], [param:Float t] )</h3>
+		<p>
+		[page:Array dst] - 输出数组<br />
+		[page:Integer dstOffset] - 输出数组的偏移量<br />
+		[page:Array src0] - 起始三维向量的源数组<br />
+		[page:Integer srcOffset0] - 数组 *src0* 的偏移量<br />
+		[page:Array src1] - 目标三维向量的源数组<br />
+		[page:Integer srcOffset1] - 数组 *src1* 的偏移量<br />
+		[page:Float t] - 归一化插值因子(介于 0 和 1 之间)<br /><br />
+
+		此 LERP 实现假定三维向量数据在扁平数组中进行管理。
+		</p>
+
 		<h2>源代码</h2>
 
 		<p>

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -11,7 +11,7 @@ class Vector3 {
 
 	}
 
-	static lerpFlat( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
+	static lerpFlat( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, alpha ) {
 
 		let x0 = src0[ srcOffset0 + 0 ],
 			y0 = src0[ srcOffset0 + 1 ],

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -13,7 +13,7 @@ class Vector3 {
 
 	static lerpFlat( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, alpha ) {
 
-		let x0 = src0[ srcOffset0 + 0 ],
+		const x0 = src0[ srcOffset0 + 0 ],
 			y0 = src0[ srcOffset0 + 1 ],
 			z0 = src0[ srcOffset0 + 2 ];
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -11,6 +11,22 @@ class Vector3 {
 
 	}
 
+	static lerpFlat( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
+
+		let x0 = src0[ srcOffset0 + 0 ],
+			y0 = src0[ srcOffset0 + 1 ],
+			z0 = src0[ srcOffset0 + 2 ];
+
+		const x1 = src1[ srcOffset1 + 0 ],
+			y1 = src1[ srcOffset1 + 1 ],
+			z1 = src1[ srcOffset1 + 2 ];
+
+		dst[ dstOffset + 0 ] = x0 + ( x1 - x0 ) * alpha;
+		dst[ dstOffset + 1 ] = y0 + ( y1 - y0 ) * alpha;
+		dst[ dstOffset + 2 ] = z0 + ( z1 - z0 ) * alpha;
+
+	}
+
 	set( x, y, z ) {
 
 		if ( z === undefined ) z = this.z; // sprite.scale.set(x,y)


### PR DESCRIPTION
Related issue: None.

**Description**

Add static function `lerpFlat` to `Vector3`.

I want to use it to solve some `tempVector3` conflict problems.
And it should improve overall performance by reduce conversions.

And align with `Quaternion.slerpFlat` https://threejs.org/docs/?q=quater#api/en/math/Quaternion.slerpFlat
