### PR TITLE
WebGLNodeBuilder: .getFrontFacing()

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -331,6 +331,12 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 	}
 
+	getFrontFacing() {
+
+		return 'gl_FrontFacing';
+
+	}
+
 	buildCode() {
 
 		const shaderData = {};


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23971

**Description**

This fix `webgl_materials_standard_nodes` example. 

Is it possible to make a `cherrey-pick` to `master` too?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
