### PR TITLE
WebXRManager: add undefined check in onSessionEnd()

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -133,7 +133,11 @@ class WebXRManager extends EventDispatcher {
 
 			inputSourcesMap.forEach( function ( controller, inputSource ) {
 
-				controller.disconnect( inputSource );
+				if( controller ) {
+
+					controller.disconnect( inputSource );
+
+				}
 
 			} );
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -133,7 +133,7 @@ class WebXRManager extends EventDispatcher {
 
 			inputSourcesMap.forEach( function ( controller, inputSource ) {
 
-				if( controller ) {
+				if ( controller ) {
 
 					controller.disconnect( inputSource );
 


### PR DESCRIPTION
This commit adds a undefined check prior to disconnecting the controller in `onSessionEnd()` as described in https://github.com/mrdoob/three.js/issues/23983

Fixed #23983 

**Description**

Lack of undefined check for controllers in onSessionEnd causes errors if getController is never called. Undefined check prevents errors

<!-- Remove the line below if is not relevant -->
