### PR TITLE
WebGPU: Improve approach to generate mipmaps of a CubeMap

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -121,7 +121,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 
 	}
 
-	generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer = 0, mipLevelOffset = 1 ) {
+	generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer = 0 ) {
 
 		const pipeline = this.getMipmapPipeline( textureGPUDescriptor.format );
 
@@ -130,10 +130,11 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 
 		let srcView = textureGPU.createView( {
 			baseMipLevel: 0,
-			mipLevelCount: 1
+			mipLevelCount: 1,
+			baseArrayLayer
 		} );
 
-		for ( let i = mipLevelOffset; i < textureGPUDescriptor.mipLevelCount; i ++ ) {
+		for ( let i = 1; i < textureGPUDescriptor.mipLevelCount; i ++ ) {
 
 			const dstView = textureGPU.createView( {
 				baseMipLevel: i,

--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -421,15 +421,15 @@ class WebGPUTextures {
 
 	_copyCubeMapToTexture( images, texture, textureGPU, textureGPUDescriptor, needsMipmaps ) {
 
-		for ( let i = 5; i >= 0; i -- ) {
+		for ( let i = 0; i < 6; i ++ ) {
 
 			const image = images[ i ];
 
 			this._getImageBitmap( image, texture ).then( imageBitmap => {
 
-				this._copyExternalImageToTexture( imageBitmap, textureGPU );
+				this._copyExternalImageToTexture( imageBitmap, textureGPU, { z : i } );
 
-				if ( needsMipmaps === true ) this._generateMipmaps( textureGPU, textureGPUDescriptor, i, i > 0 ? 0 : 1 );
+				if ( needsMipmaps === true ) this._generateMipmaps( textureGPU, textureGPUDescriptor, i );
 
 			} );
 
@@ -490,7 +490,7 @@ class WebGPUTextures {
 
 	}
 
-	_generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer, mipLevelOffset ) {
+	_generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer ) {
 
 		if ( this.utils === null ) {
 
@@ -498,7 +498,7 @@ class WebGPUTextures {
 
 		}
 
-		this.utils.generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer, mipLevelOffset );
+		this.utils.generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23743

**Description**

Updated approach. It prevents the need to copy 5 faces remaining of the cube.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
