### PR TITLE
BufferGeometryUtils: Add `toCreasedNormals()`.

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1202,7 +1202,7 @@ function mergeGroups( geometry ) {
 
 // Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
 // an angle greater than the crease angle.
-export function generateSmoothNormalsWithCrease( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
+function generateSmoothNormalsWithCrease( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
 
 	const creaseDot = Math.cos( creaseAngle );
 	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1202,7 +1202,7 @@ function mergeGroups( geometry ) {
 
 // Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
 // an angle greater than the crease angle.
-function generateSmoothNormalsWithCrease( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
+function toCreasedNormalGeometry( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
 
 	const creaseDot = Math.cos( creaseAngle );
 	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
@@ -1316,5 +1316,5 @@ export {
 	toTrianglesDrawMode,
 	computeMorphedAttributes,
 	mergeGroups,
-	generateSmoothNormalsWithCrease,
+	toCreasedNormalGeometry,
 };

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1202,7 +1202,7 @@ function mergeGroups( geometry ) {
 
 // Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
 // an angle greater than the crease angle.
-function toCreasedNormalGeometry( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
+function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
 
 	const creaseDot = Math.cos( creaseAngle );
 	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
@@ -1316,5 +1316,5 @@ export {
 	toTrianglesDrawMode,
 	computeMorphedAttributes,
 	mergeGroups,
-	toCreasedNormalGeometry,
+	toCreasedNormals
 };

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1199,6 +1199,112 @@ function mergeGroups( geometry ) {
 
 }
 
+
+// Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
+// an angle greater than the crease angle.
+export function generateSmoothNormalsWithCrease( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
+
+	const creaseDot = Math.cos( creaseAngle );
+	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
+
+	// reusable vertors
+	const verts = [ new Vector3(), new Vector3(), new Vector3() ];
+	const tempVec1 = new Vector3();
+	const tempVec2 = new Vector3();
+	const tempNorm = new Vector3();
+	const tempNorm2 = new Vector3();
+
+	// hashes a vector
+	function hashVertex( v ) {
+
+		const x = ~ ~ ( v.x * hashMultiplier );
+		const y = ~ ~ ( v.y * hashMultiplier );
+		const z = ~ ~ ( v.z * hashMultiplier );
+		return `${x},${y},${z}`;
+
+	}
+
+	const resultGeometry = geometry.toNonIndexed();
+	const posAttr = resultGeometry.attributes.position;
+	const vertexMap = {};
+
+	// find all the normals shared by commonly located vertices
+	for ( let i = 0, l = posAttr.count / 3; i < l; i ++ ) {
+
+		const i3 = 3 * i;
+		const a = verts[ 0 ].fromBufferAttribute( posAttr, i3 + 0 );
+		const b = verts[ 1 ].fromBufferAttribute( posAttr, i3 + 1 );
+		const c = verts[ 2 ].fromBufferAttribute( posAttr, i3 + 2 );
+
+		tempVec1.subVectors( c, b );
+		tempVec2.subVectors( a, b );
+
+		// add the normal to the map for all vertices
+		const normal = new Vector3().crossVectors( tempVec1, tempVec2 ).normalize();
+		for ( let n = 0; n < 3; n ++ ) {
+
+			const vert = verts[ n ];
+			const hash = hashVertex( vert );
+			if ( ! ( hash in vertexMap ) ) {
+
+				vertexMap[ hash ] = [];
+
+			}
+
+			vertexMap[ hash ].push( normal );
+
+		}
+
+	}
+
+	// average normals from all vertices that share a common location if they are within the
+	// provided crease threshold
+	const normalArray = new Float32Array( posAttr.count * 3 );
+	const normAttr = new BufferAttribute( normalArray, 3, false );
+	for ( let i = 0, l = posAttr.count / 3; i < l; i ++ ) {
+
+		// get the face normal for this vertex
+		const i3 = 3 * i;
+		const a = verts[ 0 ].fromBufferAttribute( posAttr, i3 + 0 );
+		const b = verts[ 1 ].fromBufferAttribute( posAttr, i3 + 1 );
+		const c = verts[ 2 ].fromBufferAttribute( posAttr, i3 + 2 );
+
+		tempVec1.subVectors( c, b );
+		tempVec2.subVectors( a, b );
+
+		tempNorm.crossVectors( tempVec1, tempVec2 ).normalize();
+
+		// average all normals that meet the threshold and set the normal value
+		for ( let n = 0; n < 3; n ++ ) {
+
+			const vert = verts[ n ];
+			const hash = hashVertex( vert );
+			const otherNormals = vertexMap[ hash ];
+			tempNorm2.set( 0, 0, 0 );
+
+			for ( let k = 0, lk = otherNormals.length; k < lk; k ++ ) {
+
+				const otherNorm = otherNormals[ k ];
+				if ( tempNorm.dot( otherNorm ) > creaseDot ) {
+
+					tempNorm2.add( otherNorm );
+
+				}
+
+			}
+
+			tempNorm2.normalize();
+			normAttr.setXYZ( i3 + n, tempNorm2.x, tempNorm2.y, tempNorm2.z );
+
+		}
+
+	}
+
+	resultGeometry.setAttribute( 'normal', normAttr );
+	return resultGeometry;
+
+}
+
 export {
 	computeTangents,
 	computeMikkTSpaceTangents,
@@ -1209,5 +1315,6 @@ export {
 	mergeVertices,
 	toTrianglesDrawMode,
 	computeMorphedAttributes,
-	mergeGroups
+	mergeGroups,
+	generateSmoothNormalsWithCrease,
 };


### PR DESCRIPTION
Related issue: #3670

**Description**

Adds a function to generate a new, non-indexed geometry with smooth normals for edges where the faces are within the provided angle threshold.

Also related: https://discourse.threejs.org/t/is-there-a-merge-vertices-smooth-normals-utility-with-a-crease-angle-argument-available/37679 

| Original | Merge + Smooth | Smooth w/ Crease Angle |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/734200/166254494-829fee23-a97f-4c1d-b8ca-e31c1050dc97.png) | ![image](https://user-images.githubusercontent.com/734200/166254357-9a1afe1b-4262-4738-ad66-d8442dd30da9.png) | ![image](https://user-images.githubusercontent.com/734200/166254134-12c7eaf3-1b8c-455f-8af2-cb07fdbdba1a.png) |