### PR TITLE
GPUStatsPanel: Prevent infinite loop when webgl context is lost

### DIFF
--- a/examples/jsm/utils/GPUStatsPanel.js
+++ b/examples/jsm/utils/GPUStatsPanel.js
@@ -86,7 +86,7 @@ export class GPUStatsPanel extends Stats.Panel {
 					this.activeQueries --;
 
 
-				} else {
+				} else if ( !gl.isContextLost() ) {
 
 					// otherwise try again the next frame
 					requestAnimationFrame( checkQuery );

--- a/examples/jsm/utils/GPUStatsPanel.js
+++ b/examples/jsm/utils/GPUStatsPanel.js
@@ -86,7 +86,7 @@ export class GPUStatsPanel extends Stats.Panel {
 					this.activeQueries --;
 
 
-				} else if ( !gl.isContextLost() ) {
+				} else if ( ! gl.isContextLost() ) {
 
 					// otherwise try again the next frame
 					requestAnimationFrame( checkQuery );


### PR DESCRIPTION
**Description**

An infinite loop was created when the webgl context is lost because an unstoppable recursive call to `requestAnimationFrame` is done inside the `GPUStatsPanel.startQuery` method.

This PR will stop this recursive call when the context is lost.