### PR TITLE
Examples: Correct spelling mistake.

### DIFF
--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -88,7 +88,7 @@
 
 							const normalMap4 = textureLoader.load( 'textures/golfball.jpg' );
 
-							const clearcoatNormaMap = textureLoader.load( 'textures/pbr/Scratched_gold/Scratched_gold_01_1K_Normal.png' );
+							const clearcoatNormalMap = textureLoader.load( 'textures/pbr/Scratched_gold/Scratched_gold_01_1K_Normal.png' );
 
 							// car paint
 
@@ -128,7 +128,7 @@
 								roughness: 0.1,
 								clearcoat: 1.0,
 								normalMap: normalMap4,
-								clearcoatNormalMap: clearcoatNormaMap,
+								clearcoatNormalMap: clearcoatNormalMap,
 
 								// y scale is negated to compensate for normal map handedness.
 								clearcoatNormalScale: new THREE.Vector2( 2.0, - 2.0 )
@@ -146,7 +146,7 @@
 								color: 0xff0000,
 								normalMap: normalMap2,
 								normalScale: new THREE.Vector2( 0.15, 0.15 ),
-								clearcoatNormalMap: clearcoatNormaMap,
+								clearcoatNormalMap: clearcoatNormalMap,
 
 								// y scale is negated to compensate for normal map handedness.
 								clearcoatNormalScale: new THREE.Vector2( 2.0, - 2.0 )


### PR DESCRIPTION
Missing l in clearcoatNormalMap
