### PR TITLE
WebGLRenderTarget: Fix regression when cloning / copying after Source API addition

### DIFF
--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -2,6 +2,7 @@ import { EventDispatcher } from '../core/EventDispatcher.js';
 import { Texture } from '../textures/Texture.js';
 import { LinearFilter } from '../constants.js';
 import { Vector4 } from '../math/Vector4.js';
+import { Source } from '../textures/Source.js';
 
 /*
  In options, we can specify:
@@ -82,7 +83,8 @@ class WebGLRenderTarget extends EventDispatcher {
 
 		// ensure image object is not shared, see #20328
 
-		this.texture.image = Object.assign( {}, source.texture.image );
+		const image = Object.assign( {}, source.texture.image );
+		this.texture.source = new Source( image );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;


### PR DESCRIPTION
Related issue: #20328

**Description**

After the addition of `Source` it's no longer enough to set "image" to ensure render targets no longer share an instance of data.