### PR TITLE
GLTFExporter: Check for document before creating OffscreenCanvas

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1115,7 +1115,26 @@ class GLTFWriter {
 
 				} else {
 
-					toBlobPromise = canvas.convertToBlob( { type: mimeType } );
+					let quality;
+
+					// Blink's implementation of convertToBlob seems to default to a quality level of 100%
+					// Use the Blink default quality levels of toBlob instead so that file sizes are comparable.
+					if ( mimeType === 'image/jpeg' ) {
+
+						quality = 0.92;
+
+					} else if ( mimeType === 'image/webp' ) {
+
+						quality = 0.8;
+
+					}
+
+					toBlobPromise = canvas.convertToBlob( {
+
+						type: mimeType,
+						quality: quality
+
+					} );
 
 				}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -347,7 +347,7 @@ function getCanvas() {
 
 	}
 
-	if ( typeof OffscreenCanvas !== 'undefined' ) {
+	if ( typeof document === 'undefined' && typeof OffscreenCanvas !== 'undefined' ) {
 
 		cachedCanvas = new OffscreenCanvas( 1, 1 );
 


### PR DESCRIPTION
Related issue: #23995

**Description**

This PR fixes a regression in GLTFExporter file sizes reported in #23995. It seems as if the `OffscreenCanvas.convertToBlob` function uses a 100% quality level by default in Blink powered browsers.

To fix this I've made two changes.

1. Check for the existence of `document` to identify if we are currently in a worker context. If we are, check for the existence of `OffscreenCanvas` and use it if it exists. If both are false, use the canvas API.
2. Infer default quality levels to pass to `OffscreenCanvas.convertToBlob` based on the given `mimeType`. Based on Blink's code the [default JPEG quality level](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/image-encoders/image_encoder.cc;l=85;drc=52f06e6b43ff95eccf79e0a5df8d4d83c029130a;bpv=0;bpt=1) should be 92% and the [default WebP quality](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/image-encoders/image_encoder.cc;l=100;drc=52f06e6b43ff95eccf79e0a5df8d4d83c029130a;bpv=0;bpt=1) should be 80%.

*This contribution is funded by [Matrix.org](https://matrix.org)*
