### PR TITLE
ExtrudeGeometry: Fix toJSON() when using extrudePath.

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -784,6 +784,7 @@ const WorldUVGenerator = {
 function toJSON( shapes, options, data ) {
 
 	data.shapes = [];
+	data.options = Object.assign( {}, options );
 
 	if ( Array.isArray( shapes ) ) {
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -784,7 +784,6 @@ const WorldUVGenerator = {
 function toJSON( shapes, options, data ) {
 
 	data.shapes = [];
-	data.options = Object.assign( {}, options );
 
 	if ( Array.isArray( shapes ) ) {
 
@@ -802,6 +801,8 @@ function toJSON( shapes, options, data ) {
 
 	}
 
+	data.options = Object.assign( {}, options );
+	
 	if ( options.extrudePath !== undefined ) data.options.extrudePath = options.extrudePath.toJSON();
 
 	return data;

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -802,7 +802,7 @@ function toJSON( shapes, options, data ) {
 	}
 
 	data.options = Object.assign( {}, options );
-	
+
 	if ( options.extrudePath !== undefined ) data.options.extrudePath = options.extrudePath.toJSON();
 
 	return data;


### PR DESCRIPTION
Fixed #24010.

**Description**

This PR ensures that the `data` object does have a reference to original `options` parameter object of `ExtrudeGeometry`.
