### PR TITLE
Update WebGLRenderer.js

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -396,12 +396,13 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		if ( !Number.isInteger(height) && !Number.isInteger(width) ) {
+		if ( ! Number.isInteger( height ) && ! Number.isInteger( width ) ) {
 
 			console.warn( 'THREE.WebGLRenderer: Can\'t change size while width or height is not Number.' );
 			return;
 
 		}
+
 		
 		_width = width;
 		_height = height;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -396,6 +396,13 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
+		if ( !Number.isInteger(height) && !Number.isInteger(width) ) {
+
+			console.warn( 'THREE.WebGLRenderer: Can\'t change size while width or height is not Number.' );
+			return;
+
+		}
+		
 		_width = width;
 		_height = height;
 


### PR DESCRIPTION
Exit the function when the width and height are not of type Number

**Description**

When I built a new scene, I used the previous method, but the rendered picture could not appear anyway. After checking, I found that when the width and height input by the setSize function are not of Nunber type, the calculation result of Math.floor is 0, which caused me to not be able to see the rendered result. So I added this tip in the hope that someone who encounters the same problem in the future can receive this tip.