### PR TITLE
DepthTexture: change default type to UnsignedIntType

### DIFF
--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -30,7 +30,7 @@
 
 		[page:Number height] -- height of the texture.<br />
 
-		[page:Constant type] -- Default is [page:Textures THREE.UnsignedShortType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
+		[page:Constant type] -- Default is [page:Textures THREE.UnsignedIntType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
 		See [page:Textures type constants] for other choices.<br />
 
 		[page:Constant mapping] --
@@ -72,7 +72,7 @@
 
 		<h3>[page:Texture.type type]</h3>
 		<p>
-		Default is [page:Textures THREE.UnsignedShortType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
+		Default is [page:Textures THREE.UnsignedIntType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
 		See [page:Textures format constants] for details.<br />
 		</p>
 

--- a/docs/api/zh/textures/DepthTexture.html
+++ b/docs/api/zh/textures/DepthTexture.html
@@ -29,7 +29,7 @@
 
 		[page:Number height] -- 纹理的高度。<br />
 
-		[page:Constant type] -- Default is [page:Textures THREE.UnsignedShortType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
+		[page:Constant type] -- Default is [page:Textures THREE.UnsignedIntType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
 		请参阅[page:Textures type constants]（类型常量）来了解其他选项。<br />
 
 		[page:Constant mapping] --
@@ -71,7 +71,7 @@
 
 		<h3>[page:Texture.type type]</h3>
 		<p>
-		Default is [page:Textures THREE.UnsignedShortType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
+		Default is [page:Textures THREE.UnsignedIntType] when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] when using [page:Textures DepthStencilFormat].
 		请参阅[page:Textures format constants]来了解详细信息。<br />
 		</p>
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -747,7 +747,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 						console.warn( 'THREE.WebGLRenderer: Use UnsignedShortType or UnsignedIntType for DepthFormat DepthTexture.' );
 
-						texture.type = UnsignedShortType;
+						texture.type = UnsignedIntType;
 						glType = utils.convert( texture.type );
 
 					}

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -13,7 +13,7 @@ import {
 	RGBAFormat,
 	sRGBEncoding,
 	UnsignedByteType,
-	UnsignedShortType,
+	UnsignedIntType,
 	UnsignedInt248Type,
 } from '../../constants.js';
 
@@ -283,7 +283,7 @@ class WebXRManager extends EventDispatcher {
 
 						glDepthFormat = attributes.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
 						depthFormat = attributes.stencil ? DepthStencilFormat : DepthFormat;
-						depthType = attributes.stencil ? UnsignedInt248Type : UnsignedShortType;
+						depthType = attributes.stencil ? UnsignedInt248Type : UnsignedIntType;
 
 					}
 

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -1,5 +1,5 @@
 import { Texture } from './Texture.js';
-import { NearestFilter, UnsignedShortType, UnsignedInt248Type, DepthFormat, DepthStencilFormat } from '../constants.js';
+import { NearestFilter, UnsignedIntType, UnsignedInt248Type, DepthFormat, DepthStencilFormat } from '../constants.js';
 
 class DepthTexture extends Texture {
 
@@ -13,7 +13,7 @@ class DepthTexture extends Texture {
 
 		}
 
-		if ( type === undefined && format === DepthFormat ) type = UnsignedShortType;
+		if ( type === undefined && format === DepthFormat ) type = UnsignedIntType;
 		if ( type === undefined && format === DepthStencilFormat ) type = UnsignedInt248Type;
 
 		super( null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy );
@@ -24,7 +24,7 @@ class DepthTexture extends Texture {
 		this.minFilter = minFilter !== undefined ? minFilter : NearestFilter;
 
 		this.flipY = false;
-		this.generateMipmaps	= false;
+		this.generateMipmaps = false;
 
 	}
 


### PR DESCRIPTION
**Description**

I noticed depth precision issues (horizontal banding + z-fighting) when rendering my project with post-processing (using WebGLRenderTargets) starting at very short distances (10 - 15 meters, where 1 unit = 1 meter), and those issues did not happen when rendering the same scene directly to canvas !

So I investigated, and it turns out setting a DepthTexture with the `UnsignedIntType` type into `renderTarget.depthTexture` fixed my issues. Precision issues only appear at much greater distances now (as expected) and exactly where they start appearing when rendering directly to canvas.


**About this PR**

So I changed the default to `UnsignedIntType` because I believe defaults should give best results out of the box, **but I don't know what I'm doing, I didn't test anything beyond my project, and I don't know the implications of this change** ⚠️
(also updated the docs + bits of code that seemed relevant)

_This example: https://threejs.org/examples/webgl_depth_texture.html helped me to visualize different types, just zoom out until the meshes are barely visible and you should notice banding with `UnsignedShortType`._