### PR TITLE
remove OffscreenCanvas to fix errors

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -305,15 +305,7 @@
 
 		}
 
-		if ( typeof OffscreenCanvas !== 'undefined' ) {
-
-			cachedCanvas = new OffscreenCanvas( 1, 1 );
-
-		} else {
-
-			cachedCanvas = document.createElement( 'canvas' );
-
-		}
+		cachedCanvas = document.createElement( 'canvas' );
 
 		return cachedCanvas;
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -347,15 +347,7 @@ function getCanvas() {
 
 	}
 
-	if ( typeof OffscreenCanvas !== 'undefined' ) {
-
-		cachedCanvas = new OffscreenCanvas( 1, 1 );
-
-	} else {
-
-		cachedCanvas = document.createElement( 'canvas' );
-
-	}
+	cachedCanvas = document.createElement( 'canvas' );
 
 	return cachedCanvas;
 


### PR DESCRIPTION
Related issue:  N/A

**Description**

When exporting a model with images to gltf format, an error occurs:
GLTFExporter.js:1134 Uncaught (in promise) TypeError: canvas.toDataURL is not a function
    at GLTFWriter.processImage (GLTFExporter.js:1134:27)
    at GLTFWriter.processTexture (GLTFExporter.js:1192:17)
    at GLTFWriter.processMaterial (GLTFExporter.js:1274:42)
    at GLTFWriter.processMesh (GLTFExporter.js:1665:26)
    at GLTFWriter.processNode (GLTFExporter.js:1952:27)
    at GLTFWriter.processNode (GLTFExporter.js:1974:29)
    at GLTFWriter.processScene (GLTFExporter.js:2028:28)
    at GLTFWriter.processInput (GLTFExporter.js:2084:10)
    at GLTFWriter.write (GLTFExporter.js:437:8)
    at GLTFExporter.parse (GLTFExporter.js:120:10)

The easiest solution is to remove OffscreenCanvas and use ordinary canvas uniformly.
