### PR TITLE
Manual: Fix links of primitives page.

### DIFF
--- a/manual/resources/threejs-primitives.js
+++ b/manual/resources/threejs-primitives.js
@@ -707,6 +707,7 @@ const geometry = new THREE.WireframeGeometry(
 
   function addLink(parent, name, href) {
     const a = document.createElement('a');
+    a.setAttribute('target', '_blank');
     a.href = href || `https://threejs.org/docs/#api/geometries/${name}`;
     const code = document.createElement('code');
     code.textContent = name;


### PR DESCRIPTION
Fixed #24025

**Description**

An error occurred when clicking on [Box Geometry](https://threejs.org/manual/#en/primitives) because it creates another [panel](https://github.com/mrdoob/three.js/blob/dev/docs/index.html#L50-L51) within the iframe.

The location is different between docs and manual, so I think there will be a lot of side effects. So I modified it to replace the parent page if the HTML is loaded within the iframe.

I would appreciate it if you could let me know if there is another good way.

---

Thanks to the kind document, I am having fun studying threejs