### PR TITLE
AnimationMixer: remove unnecessary prototype access

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -6,6 +6,10 @@ import { PropertyMixer } from './PropertyMixer.js';
 import { AnimationClip } from './AnimationClip.js';
 import { NormalAnimationBlendMode } from '../constants.js';
 
+
+const _controlInterpolantsResultBuffer = /*@__PURE__*/ new Float32Array( 1 );
+
+
 class AnimationMixer extends EventDispatcher {
 
 	constructor( root ) {
@@ -478,7 +482,7 @@ class AnimationMixer extends EventDispatcher {
 
 			interpolant = new LinearInterpolant(
 				new Float32Array( 2 ), new Float32Array( 2 ),
-				1, this._controlInterpolantsResultBuffer );
+				1, _controlInterpolantsResultBuffer );
 
 			interpolant.__cacheIndex = lastActiveIndex;
 			interpolants[ lastActiveIndex ] = interpolant;
@@ -762,7 +766,5 @@ class AnimationMixer extends EventDispatcher {
 	}
 
 }
-
-AnimationMixer.prototype._controlInterpolantsResultBuffer = new Float32Array( 1 );
 
 export { AnimationMixer };


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24006#issuecomment-1117942513

**Description**

Don't know why that class was using the prototype to store a variable, it is not necessary since `_controlInterpolantsResultBuffer` is just a variable that holds the result.

This PR improves tree-shaking: 

| Before this PR | After this PR |
|-------------|-------------|
| <img width="502" alt="Screenshot 2022-05-09 at 18 16 06" src="https://user-images.githubusercontent.com/7217420/167453539-8504883b-6749-4327-a662-558e8cbb1a1c.png"> | <img width="499" alt="Screenshot 2022-05-09 at 18 16 12" src="https://user-images.githubusercontent.com/7217420/167453560-72570d5e-0f75-4356-9c84-2061c049f5a7.png"> |




