### PR TITLE
THREE.Legacy.js: Move deprecated propeties and methods to classes.

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -1,59 +1,7 @@
 import { BufferGeometry } from './core/BufferGeometry.js';
-import { Material } from './materials/Material.js';
-import { Euler } from './math/Euler.js';
-import { WebGLRenderer } from './renderers/WebGLRenderer.js';
 import { WebGLRenderTarget } from './renderers/WebGLRenderTarget.js';
 import { DataArrayTexture } from './textures/DataArrayTexture.js';
 import { Data3DTexture } from './textures/Data3DTexture.js';
-
-// r138, 02cf0df1cb4575d5842fef9c85bb5a89fe020d53
-
-Euler.prototype.toVector3 = function () {
-
-	console.error( 'THREE.Euler: .toVector3() has been removed. Use Vector3.setFromEuler() instead' );
-
-};
-
-//
-
-Object.defineProperties( Material.prototype, {
-
-	// r131, f5803c62cc4a29d90744e9dc7811d086e354c1d8
-
-	vertexTangents: {
-		get: function () {
-
-			console.warn( 'THREE.' + this.type + ': .vertexTangents has been removed.' );
-
-		},
-		set: function () {
-
-			console.warn( 'THREE.' + this.type + ': .vertexTangents has been removed.' );
-
-		}
-	},
-
-} );
-
-Object.defineProperties( WebGLRenderer.prototype, {
-
-	// r136, 0e21088102b4de7e0a0a33140620b7a3424b9e6d
-
-	gammaFactor: {
-		get: function () {
-
-			console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
-			return 2;
-
-		},
-		set: function () {
-
-			console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
-
-		}
-	}
-
-} );
 
 // r133, c5bb5434555a3c3ddd784944a0a124f996fc721b
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -479,6 +479,21 @@ class Material extends EventDispatcher {
 
 	}
 
+	// @deprecated since r131, f5803c62cc4a29d90744e9dc7811d086e354c1d8
+
+	get vertexTangents() {
+
+		console.warn( 'THREE.' + this.type + ': .vertexTangents has been removed.' );
+		return false;
+
+	}
+
+	set vertexTangents( value ) {
+
+		console.warn( 'THREE.' + this.type + ': .vertexTangents has been removed.' );
+
+	}
+
 }
 
 Material.prototype.isMaterial = true;

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -306,6 +306,14 @@ class Euler {
 
 	}
 
+	// @deprecated since r138, 02cf0df1cb4575d5842fef9c85bb5a89fe020d53
+
+	toVector3() {
+
+		console.error( 'THREE.Euler: .toVector3() has been removed. Use Vector3.setFromEuler() instead' );
+
+	}
+
 }
 
 Euler.prototype.isEuler = true;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -131,6 +131,28 @@ function WebGLRenderer( parameters = {} ) {
 	this.toneMapping = NoToneMapping;
 	this.toneMappingExposure = 1.0;
 
+	//
+
+	Object.defineProperties( WebGLRenderer.prototype, {
+
+		// @deprecated since r136, 0e21088102b4de7e0a0a33140620b7a3424b9e6d
+
+		gammaFactor: {
+			get: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
+				return 2;
+
+			},
+			set: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );
+
+			}
+		}
+
+	} );
+
 	// internal properties
 
 	const _this = this;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -138,6 +138,7 @@ function WebGLRenderer( parameters = {} ) {
 		// @deprecated since r136, 0e21088102b4de7e0a0a33140620b7a3424b9e6d
 
 		gammaFactor: {
+			configurable: true,
 			get: function () {
 
 				console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );


### PR DESCRIPTION
Related issue: #24006

**Description**

This PR moves legacy properties and methods to classes instead of keeping them in `THREE.Legacy.js`. 

Deprecated code is marked with the `@deprecated` annotation. By searching for `@deprecated` in the `src` directory, you quickly see all legacy code sections and the respective release when they were removed.
