### PR TITLE
Update getMaxAnisotropy reference in docs/texture

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -116,7 +116,7 @@
 		<p>
 		The number of samples taken along the axis through the pixel that has the highest density of texels.
 		By default, this value is 1. A higher value gives a less blurry result than a basic mipmap,
-		at the cost of more texture samples being used. Use [page:WebGLRenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() to
+		at the cost of more texture samples being used. Use [page:WebGLRenderer.capabilities renderer.capabilities.getMaxAnisotropy]() to
 		find the maximum valid anisotropy value for the GPU; this value is usually a power of 2.
 		</p>
 

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -110,7 +110,7 @@
 		<p>
 		沿着轴，通过具有最高纹素密度的像素的样本数。
 		默认情况下，这个值为1。设置一个较高的值将会产生比基本的mipmap更清晰的效果，代价是需要使用更多纹理样本。
-		使用[page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() 来查询GPU中各向异性的最大有效值；这个值通常是2的幂。
+		使用[page:WebGLRenderer.capabilities renderer.capabilities.getMaxAnisotropy]() 来查询GPU中各向异性的最大有效值；这个值通常是2的幂。
 		</p>
 
 		<h3>[property:number format]</h3>


### PR DESCRIPTION
Update the documentation in Texture
`renderer.getMaxAnisotropy()` is now `renderer.capabilities.getMaxAnisotropy()`, spotted in the warnings 


![Screenshot 2022-05-10 at 15 06 42](https://user-images.githubusercontent.com/6367879/167635841-0a8f0872-c444-4bd8-ba25-50b6fc8b612d.png)

