### PR TITLE
HTMLMesh: Add support for Image elements.

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -447,12 +447,22 @@ function html2canvas( element ) {
 
 			if ( element instanceof HTMLImageElement ) {
 
-				element.addEventListener( 'load', () => {
+				const drawImage = () => {
 
 					buildRectPath( x, y, width, height, 2 );
 					context.drawImage( element, x, y, element.width, element.height );
 
-				} );
+				}
+				
+				if ( element.complete ) {
+
+					drawImage();
+
+				} else {
+					
+					element.addEventListener( 'load', drawImage );
+
+				}
 
 			}
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -445,6 +445,17 @@ function html2canvas( element ) {
 
 			}
 
+			if ( element instanceof HTMLImageElement ) {
+
+				element.addEventListener( 'load', () => {
+
+					buildRectPath( x, y, width, height, 2 );
+					context.drawImage( element, x, y, element.width, element.height );
+
+				} );
+
+			}
+
 		}
 
 		/*

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -237,7 +237,7 @@ function html2canvas( element ) {
 
 	}
 
-	function drawImage() {
+	function drawImage( element, x, y, width, height ) {
 
 		element.removeEventListener( 'load', drawImage );
 		buildRectPath( x, y, width, height, 2 );
@@ -457,11 +457,11 @@ function html2canvas( element ) {
 				
 				if ( element.complete ) {
 
-					drawImage();
+					drawImage( element, x, y, width, height );
 
 				} else {
 					
-					element.addEventListener( 'load', drawImage );
+					element.addEventListener( 'load', drawImage( element, x, y, width, height ) );
 
 				}
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -449,6 +449,7 @@ function html2canvas( element ) {
 
 				const drawImage = () => {
 
+					element.removeEventListener( 'load', drawImage );
 					buildRectPath( x, y, width, height, 2 );
 					context.drawImage( element, x, y, element.width, element.height );
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -461,7 +461,7 @@ function html2canvas( element ) {
 
 				} else {
 					
-					element.addEventListener( 'load', drawImage( element, x, y, width, height ) );
+					element.addEventListener( 'load', () => drawImage( element, x, y, width, height ) );
 
 				}
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -237,6 +237,14 @@ function html2canvas( element ) {
 
 	}
 
+	function drawImage() {
+
+		element.removeEventListener( 'load', drawImage );
+		buildRectPath( x, y, width, height, 2 );
+		context.drawImage( element, x, y, element.width, element.height );
+
+	}
+
 	function drawElement( element, style ) {
 
 		let x = 0, y = 0, width = 0, height = 0;
@@ -446,14 +454,6 @@ function html2canvas( element ) {
 			}
 
 			if ( element instanceof HTMLImageElement ) {
-
-				const drawImage = () => {
-
-					element.removeEventListener( 'load', drawImage );
-					buildRectPath( x, y, width, height, 2 );
-					context.drawImage( element, x, y, element.width, element.height );
-
-				}
 				
 				if ( element.complete ) {
 


### PR DESCRIPTION
**Description**

This PR is a simple addition that allows images to be included into an HTMLMesh while respecting scaled width/height on the `<img>` element. Below is an example of the following rendered with HTMLMesh (original image was 512x512):
```html
<h1>Test</h1>
<img id="image" src="https://i.imgur.com/jf4lNex.png" width="150" height="150" crossorigin="anonymous">
```

![](https://cdn.discordapp.com/attachments/759166287901098024/973813136207540244/unknown.png)
