### PR TITLE
WebGLRenderer: Simplify legacy code.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -133,12 +133,11 @@ function WebGLRenderer( parameters = {} ) {
 
 	//
 
-	Object.defineProperties( WebGLRenderer.prototype, {
+	Object.defineProperties( this, {
 
 		// @deprecated since r136, 0e21088102b4de7e0a0a33140620b7a3424b9e6d
 
 		gammaFactor: {
-			configurable: true,
 			get: function () {
 
 				console.warn( 'THREE.WebGLRenderer: .gammaFactor has been removed.' );


### PR DESCRIPTION
Related issue: #24040

**Description**

I've realized this morning that the legacy code in `WebGLRenderer` can be simplified. Better not touching `WebGLRenderer.prototype` but using `this` instead.