### PR TITLE
EXRLoader: enable long-name attribute flag

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -2056,7 +2056,7 @@ class EXRLoader extends DataTextureLoader {
 
 			}
 
-			if ( spec != 0 ) {
+			if ( ( spec & ~0x04 ) != 0 ) { // unsupported tiled, deep-image, multi-part
 
 				console.error( 'EXRHeader:', EXRHeader );
 				throw new Error( 'THREE.EXRLoader: provided file is currently unsupported.' );


### PR DESCRIPTION
Fixed #24042

Correctly enables "long-name string" header attributes.

@donmccurdy [Demo Link](https://rawcdn.githack.com/sciecode/three.js/70dfd3ce5858fdb95c88c5a6f006501787ca700f/examples/webgl_loader_texture_exr.html) ( great cornell box btw )
