### PR TITLE
AttributeNode: .nodeType is now optional

### DIFF
--- a/examples/jsm/nodes/core/AttributeNode.js
+++ b/examples/jsm/nodes/core/AttributeNode.js
@@ -3,7 +3,7 @@ import VaryNode from './VaryNode.js';
 
 class AttributeNode extends Node {
 
-	constructor( attributeName, nodeType ) {
+	constructor( attributeName, nodeType = null ) {
 
 		super( nodeType );
 
@@ -14,6 +14,23 @@ class AttributeNode extends Node {
 	getHash( builder ) {
 
 		return this.getAttributeName( builder );
+
+	}
+
+	getNodeType( builder ) {
+
+		let nodeType = super.getNodeType( builder );
+
+		if ( nodeType === null ) {
+
+			const attributeName = this.getAttributeName( builder );
+			const attribute = builder.geometry.getAttribute( attributeName );
+
+			nodeType = builder.getTypeFromLength( attribute.itemSize );
+
+		}
+
+		return nodeType;
 
 	}
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -34,6 +34,7 @@ class NodeBuilder {
 
 		this.object = object;
 		this.material = object.material || null;
+		this.geometry = object.geometry || null;
 		this.renderer = renderer;
 		this.parser = parser;
 

--- a/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
@@ -108,7 +108,7 @@ export const uniform = ( nodeOrType ) => {
 
 };
 
-export const attribute = ( name, nodeOrType ) => nodeObject( new AttributeNode( name, getConstNodeType( nodeOrType ) ) );
+export const attribute = ( name, nodeType ) => nodeObject( new AttributeNode( name, nodeType ) );
 export const property = ( name, nodeOrType ) => nodeObject( new PropertyNode( name, getConstNodeType( nodeOrType ) ) );
 
 export const bypass = nodeProxy( BypassNode );

--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -83,8 +83,8 @@
 
 				// create buffers
 
-				const particleBuffer = new THREE.InstancedBufferAttribute( particleArray );
-				const velocityBuffer = new THREE.InstancedBufferAttribute( velocityArray );
+				const particleBuffer = new THREE.InstancedBufferAttribute( particleArray, 2 );
+				const velocityBuffer = new THREE.InstancedBufferAttribute( velocityArray, 2 );
 
 				const particleBufferNode = storage( particleBuffer, 'vec2', particleNum );
 				const velocityBufferNode = storage( velocityBuffer, 'vec2', particleNum );
@@ -123,7 +123,7 @@
 				const particleNode = attribute( 'particle', 'vec2' );
 
 				const pointsGeometry = new THREE.BufferGeometry();
-				pointsGeometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 3 ) ) ); // single vertex ( not triangle )
+				pointsGeometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 3 ), 3 ) ); // single vertex ( not triangle )
 				pointsGeometry.setAttribute( 'particle', particleBuffer ); // dummy the position points as instances
 				pointsGeometry.drawRange.count = 1; // force render points as instances ( not triangle )
 

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -99,7 +99,7 @@
 				// Grid
 
 				const helper = new THREE.GridHelper( 1000, 40, 0x303030, 0x303030 );
-				helper.material.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
+				helper.material.colorNode = new Nodes.AttributeNode( 'color' );
 				helper.position.y = - 75;
 				scene.add( helper );
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -67,7 +67,7 @@
 				// Grid
 
 				const helper = new THREE.GridHelper( 1000, 40, 0x303030, 0x303030 );
-				helper.material.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
+				helper.material.colorNode = new Nodes.AttributeNode( 'color' );
 				helper.position.y = - 75;
 				scene.add( helper );
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -168,7 +168,7 @@
 				geometryLine.setAttribute( 'color', geometryLine.getAttribute( 'position' ) );
 
 				const materialLine = new Nodes.LineBasicNodeMaterial();
-				materialLine.colorNode = new Nodes.AttributeNode( 'color', 'vec3' );
+				materialLine.colorNode = new Nodes.AttributeNode( 'color' );
 
 				const line = new THREE.Line( geometryLine, materialLine );
 				line.position.set( 2, 1, 0 );


### PR DESCRIPTION
**Description**

Usage:
```js
// auto node type
material.colorNode = attribute( 'color' );

// declared node type
material.colorNode = attribute( 'color', 'vec3' );
```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
