### PR TITLE
Docs: Clarify WebGLRenderer alpha parameter.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -36,8 +36,7 @@
 		Defaults to *"highp"* if supported by the device. See the note in "Things to Avoid"
 		[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices here].<br />
 
-		[page:Boolean alpha] - whether the canvas contains an alpha (transparency) buffer or not.
-	  Default is *false*.<br />
+		[page:Boolean alpha] - controls the default clear alpha value. When set to *true*, the value is *0*. Otherwise it's *1*. Default is *false*.<br />
 
 		[page:Boolean premultipliedAlpha] - whether the renderer will assume that colors have
 		[link:https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#Premultiplied_alpha premultiplied alpha].

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -30,7 +30,7 @@
 		[page:String precision] - 着色器精度. 可以是 *"highp"*, *"mediump"* 或者 *"lowp"*.
 		如果设备支持，默认为*"highp"* . 点击[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices here] 查看"应该避免的事"<br />
 
-		[page:Boolean alpha] - canvas是否包含alpha (透明度)。默认为 *false*<br />
+		[page:Boolean alpha] - controls the default clear alpha value. When set to *true*, the value is *0*. Otherwise it's *1*. Default is *false*.<br />
 
 		[page:Boolean premultipliedAlpha] - renderer是否假设颜色有
 		[link:https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#Premultiplied_alpha premultiplied alpha].


### PR DESCRIPTION
Fixed #24051.

**Description**

Clarifies the `alpha` parameter of `WebGLRenderer`.
