### PR TITLE
SelectionHelper: Remove unused parameter from constructor.

### DIFF
--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -4,7 +4,7 @@ import {
 
 class SelectionHelper {
 
-	constructor( selectionBox, renderer, cssClassName ) {
+	constructor( renderer, cssClassName ) {
 
 		this.element = document.createElement( 'div' );
 		this.element.classList.add( cssClassName );

--- a/examples/misc_boxselection.html
+++ b/examples/misc_boxselection.html
@@ -149,7 +149,7 @@
 			}
 
 			const selectionBox = new SelectionBox( camera, scene );
-			const helper = new SelectionHelper( selectionBox, renderer, 'selectBox' );
+			const helper = new SelectionHelper( renderer, 'selectBox' );
 
 			document.addEventListener( 'pointerdown', function ( event ) {
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/selectionhelper-has-an-unused-parameter/38127

**Description**

Parameter `selectionBox` is never used.