### PR TITLE
WebXRManager: Fix caching of baseReferenceFrame and teleport example.

### DIFF
--- a/examples/webxr_vr_teleport.html
+++ b/examples/webxr_vr_teleport.html
@@ -36,7 +36,7 @@
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;
 
-			let room, marker, floor;
+			let room, marker, floor, baseReferenceSpace;
 
 			let INTERSECTION;
 			const tempMatrix = new THREE.Matrix4();
@@ -84,6 +84,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.outputEncoding = THREE.sRGBEncoding;
+				renderer.xr.addEventListener( 'sessionstart', () => { baseReferenceSpace = renderer.xr.getReferenceSpace(); } )
 				renderer.xr.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -105,7 +106,6 @@
 
 					if ( INTERSECTION ) {
 
-						const baseReferenceSpace = renderer.xr.getReferenceSpace();
 						const offsetPosition = { x: - INTERSECTION.x, y: - INTERSECTION.y, z: - INTERSECTION.z, w: 1 };
 						const offsetRotation = new THREE.Quaternion();
 						const transform = new XRRigidTransform( offsetPosition, offsetRotation );

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -131,6 +131,15 @@ class WebXRManager extends EventDispatcher {
 
 		function onSessionEnd() {
 
+			session.removeEventListener( 'select', onSessionEvent );
+			session.removeEventListener( 'selectstart', onSessionEvent );
+			session.removeEventListener( 'selectend', onSessionEvent );
+			session.removeEventListener( 'squeeze', onSessionEvent );
+			session.removeEventListener( 'squeezestart', onSessionEvent );
+			session.removeEventListener( 'squeezeend', onSessionEvent );
+			session.removeEventListener( 'end', onSessionEnd );
+			session.removeEventListener( 'inputsourceschange', onInputSourcesChange );
+
 			inputSourcesMap.forEach( function ( controller, inputSource ) {
 
 				if ( controller !== undefined ) {
@@ -321,6 +330,7 @@ class WebXRManager extends EventDispatcher {
 				// Set foveation to maximum.
 				this.setFoveation( 1.0 );
 
+				customReferenceSpace = null;
 				referenceSpace = await session.requestReferenceSpace( referenceSpaceType );
 
 				animation.setContext( session );


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/24033

**Description**

The teleporter example was broken in a few ways.

* the example wasn't creating a transform from the original baseReferenceFrame acquired from the WebXR manager, leading to really strange offsets after the initial teleport.  The first teleport would look correct, but then you'd be modifying a modified space.
* the baseReferenceFrame wasn't nulled out on sub-sequent entering of vr sessions, only allowing you to enter into the example with VR once
* the example needs to watch for changes in the session to re-grab baseReferenceFrame again

Video of it working:

https://user-images.githubusercontent.com/294042/168413544-1210d3cf-7c82-4fdf-9191-d95c42300265.mp4


