### PR TITLE
HemisphereLight: Use super in copy().

### DIFF
--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -19,7 +19,7 @@ class HemisphereLight extends Light {
 
 	copy( source ) {
 
-		Light.prototype.copy.call( this, source );
+		super.copy( source );
 
 		this.groundColor.copy( source.groundColor );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24047#issuecomment-1124407732

**Description**

`HemisphereLight.copy()` used an outdated approach for calling `copy()` of its upper class.
