### PR TITLE
Color: Do not use prototype for r/g/b properties.

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -56,6 +56,10 @@ class Color {
 
 	constructor( r, g, b ) {
 
+		this.r = 1;
+		this.g = 1;
+		this.b = 1;
+
 		if ( g === undefined && b === undefined ) {
 
 			// r is THREE.Color, hex or string
@@ -607,8 +611,5 @@ class Color {
 Color.NAMES = _colorKeywords;
 
 Color.prototype.isColor = true;
-Color.prototype.r = 1;
-Color.prototype.g = 1;
-Color.prototype.b = 1;
 
 export { Color, SRGBToLinear };


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24047#issuecomment-1124407732

**Description**

Just defining `r`, `g` and `b` in the constructor with default values makes the code more readable and more consistent compared the other math classes.