### PR TITLE
`NormalMapNode`: Fix `dpdx` and `dpdy` called from non-uniform control flow

### DIFF
--- a/examples/jsm/nodes/display/NormalMapNode.js
+++ b/examples/jsm/nodes/display/NormalMapNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import ModelNode from '../accessors/ModelNode.js';
-import { ShaderNode, positionView, normalView, uv, vec3, cond, add, sub, mul, dFdx, dFdy, cross, max, dot, normalize, inversesqrt, equal, faceDirection } from '../shadernode/ShaderNodeBaseElements.js';
+import { ShaderNode, positionView, normalView, uv, vec3, add, sub, mul, dFdx, dFdy, cross, max, dot, normalize, inversesqrt, faceDirection } from '../shadernode/ShaderNodeBaseElements.js';
 
 import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from 'three';
 
@@ -25,7 +25,7 @@ const perturbNormal2ArbNode = new ShaderNode( ( inputs ) => {
 	const B = add( mul( q1perp, st0.y ), mul( q0perp, st1.y ) );
 
 	const det = max( dot( T, T ), dot( B, B ) );
-	const scale = cond( equal( det, 0 ), 0, mul( faceDirection, inversesqrt( det ) ) );
+	const scale = mul( faceDirection, inversesqrt( det ) );
 
 	return normalize( add( mul( T, mul( mapN.x, scale ) ), mul( B, mul( mapN.y, scale ) ), mul( N, mapN.z ) ) );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24059#issuecomment-1126672468

**Description**

I believe that this conditional was inserted to optimize the shader, although conditionals are always expensive for GPU.

Code without conditionals is understood as `uniform control flow` and with conditional `non-uniform control flow`.
Ref: https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.50.pdf - `page 23`

This fix `WebGPU` `warning: 'dpdy' must only be called from uniform control flow` and follow the approach closer of http://www.thetenthplanet.de/archives/1180

I wounder if this is not responsible for bugs in `WebGL` using `perturbNormal2Arb` too!?...

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
