### PR TITLE
Manual: translate material table into chinese

### DIFF
--- a/manual/list.json
+++ b/manual/list.json
@@ -356,7 +356,7 @@
 			"VR - Point To Select": "zh/webxr-point-to-select"
 		},
 		"参考": {
-			"Material Table": "zh/material-table"
+			"材质特性表": "zh/material-table"
 		}
 	}
 }

--- a/manual/resources/threejs-material-table.css
+++ b/manual/resources/threejs-material-table.css
@@ -12,14 +12,15 @@
 }
 #material-table thead>td>a {
     text-orientation: upright;
-    writing-mode: vertical-lr;
+    /* writing-mode: vertical-lr; */
     text-decoration: none;
     display: block;
-    letter-spacing: -2px;
+    /* letter-spacing: -2px; */
 }
 #material-table table {
     border-collapse: collapse;
     background: #cde;
+    width: 100%;
 }
 #material-table td:nth-child(1) {
     text-align: right;

--- a/manual/resources/threejs-material-table.css
+++ b/manual/resources/threejs-material-table.css
@@ -12,15 +12,14 @@
 }
 #material-table thead>td>a {
     text-orientation: upright;
-    /* writing-mode: vertical-lr; */
+    writing-mode: vertical-lr;
     text-decoration: none;
     display: block;
-    /* letter-spacing: -2px; */
+    letter-spacing: -2px;
 }
 #material-table table {
     border-collapse: collapse;
     background: #cde;
-    width: 100%;
 }
 #material-table td:nth-child(1) {
     text-align: right;

--- a/manual/zh/material-table.html
+++ b/manual/zh/material-table.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="zh"><head>
     <meta charset="utf-8">
-    <title>Material Feature Table</title>
+    <title>材质特性表</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@threejs">
@@ -27,13 +27,16 @@
   <body>
     <div class="container">
       <div class="lesson-title">
-        <h1>Material Feature Table</h1>
+        <h1>材质特性表</h1>
       </div>
       <div class="lesson">
         <div class="lesson-main">
-          <p>抱歉，还没有中文翻译哦。 <a href="https://github.com/mrdoob/three.js">欢迎加入翻译</a>! 😄</p>
-<p><a href="/manual/en/material-table.html">英文原文链接</a>.</p>
-
+          <p>在THREE.js中最常见的材质就是网格材质了，这里有一个表格，分别显示了哪些材质支持哪些特性。</p>
+          <div>
+            <div id="material-table" class="threejs_center"></div>
+            <script type="module" src="../resources/threejs-material-table.js"></script>
+            <link rel="stylesheet" href="../resources/threejs-material-table.css">
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Translate "material table" into chinese.

That's a very little change, but I also update the table css style because the vertical title text make the table crammed. I am not sure why using "writing-mode: vertical-lr" so I just remove it.

