### PR TITLE
ObjectLoader: Check type of `Source.data` for loading images.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -168,7 +168,7 @@ class ObjectLoader extends Loader {
 
 			for ( const uuid in images ) {
 
-				if ( images[ uuid ] instanceof HTMLImageElement ) {
+				if ( images[ uuid ].data instanceof HTMLImageElement ) {
 
 					hasImages = true;
 					break;


### PR DESCRIPTION
Fixed #24066.

**Description**

Since https://github.com/mrdoob/three.js/pull/22846
values of images map are instances of Source.
Should check the type of the `data` member instead.

