### PR TITLE
3DMLoader: Remove usage of THREE namespace.

### DIFF
--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -21,6 +21,7 @@ import {
 	CanvasTexture,
 	LinearFilter,
 	ClampToEdgeWrapping,
+	RepeatWrapping,
 	TextureLoader
 } from 'three';
 
@@ -288,8 +289,8 @@ class Rhino3dmLoader extends Loader {
 
 				}
 
-				map.wrapS = texture.wrapU === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
-				map.wrapT = texture.wrapV === 0 ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+				map.wrapS = texture.wrapU === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+				map.wrapT = texture.wrapV === 0 ? RepeatWrapping : ClampToEdgeWrapping;
 				map.repeat.set( texture.repeat[ 0 ], texture.repeat[ 1 ] );
 
 			}


### PR DESCRIPTION
Fixed #24073.

**Description**

Remove usage of the `THREE` namespace from `3DMLoader`.
