### PR TITLE
Docs: Supports to inline code

### DIFF
--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -25,8 +25,8 @@
 
 		<h3>[name]( [param:AnimationMixer mixer], [param:AnimationClip clip], [param:Object3D localRoot] )</h3>
 		<p>
-			[page:AnimationMixer mixer] - the *AnimationMixer* that is controlled by this action.<br />
-			[page:AnimationClip clip] - the *AnimationClip* that holds the animation data for this action.<br />
+			[page:AnimationMixer mixer] - the `AnimationMixer` that is controlled by this action.<br />
+			[page:AnimationClip clip] - the `AnimationClip` that holds the animation data for this action.<br />
 			[page:Object3D localRoot] - the root object on which this action is performed.<br /><br />
 
 			Note: Instead of calling this constructor directly you should instantiate an AnimationAction with
@@ -39,29 +39,29 @@
 
 		<h3>[property:Boolean clampWhenFinished]</h3>
 		<p>
-			If *clampWhenFinished* is set to true the animation will automatically be [page:.paused paused]
+			If `clampWhenFinished` is set to true the animation will automatically be [page:.paused paused]
 			on its last frame.<br /><br />
 
-			If *clampWhenFinished* is set to false, [page:.enabled enabled] will automatically be switched
+			If `clampWhenFinished` is set to false, [page:.enabled enabled] will automatically be switched
 			to false when the last loop of the action has finished, so that this action has no further
 			impact.<br /><br />
 
 			Default is false.<br /><br />
 
-			Note: *clampWhenFinished* has no impact if the action is interrupted (it has only an effect if
+			Note: `clampWhenFinished` has no impact if the action is interrupted (it has only an effect if
 			its last loop has really finished).
 		</p>
 
 		<h3>[property:Boolean enabled]</h3>
 		<p>
-			Setting *enabled* to *false* disables this action, so that it has no impact. Default is *true*.<br /><br />
+			Setting `enabled` to `false` disables this action, so that it has no impact. Default is `true`.<br /><br />
 
 			When the action is re-enabled, the animation continues from its current [page:.time time]
-			(setting *enabled* to *false* doesn't reset the action).<br /><br />
+			(setting `enabled` to `false` doesn't reset the action).<br /><br />
 
-			Note: Setting *enabled* to *true* doesn’t automatically restart the animation. Setting *enabled*
-			to *true* will only restart the animation immediately if the following condition is fulfilled:
-			[page:.paused paused] is *false*, this action has not been deactivated in the meantime (by
+			Note: Setting `enabled` to `true` doesn’t automatically restart the animation. Setting `enabled`
+			to `true` will only restart the animation immediately if the following condition is fulfilled:
+			[page:.paused paused] is `false`, this action has not been deactivated in the meantime (by
 			executing a [page:.stop stop] or [page:.reset reset] command), and neither [page:.weight weight]
 			nor [page:.timeScale timeScale] is 0.
 		</p>
@@ -73,22 +73,22 @@
 
 			Must be one of these constants:<br /><br />
 			[page:Animation THREE.LoopOnce] - playing the clip once,<br />
-			[page:Animation THREE.LoopRepeat] - playing the clip with the chosen number of *repetitions*,
+			[page:Animation THREE.LoopRepeat] - playing the clip with the chosen number of `repetitions`,
 			each time jumping from the end of the clip directly to its beginning,<br />
-			[page:Animation THREE.LoopPingPong] - playing the clip with the chosen number of *repetitions*,
+			[page:Animation THREE.LoopPingPong] - playing the clip with the chosen number of `repetitions`,
 			alternately playing forward and backward.
 		</p>
 
 		<h3>[property:Boolean paused]</h3>
 		<p>
-			Setting *paused* to *true* pauses the execution of the action by setting the effective time scale
-			to 0. Default is *false*.<br /><br />
+			Setting `paused` to `true` pauses the execution of the action by setting the effective time scale
+			to 0. Default is `false`.<br /><br />
 		</p>
 
 		<h3>[property:Number repetitions]</h3>
 		<p>
 			The number of repetitions of the performed [page:AnimationClip] over the course of this action.
-			Can be set via [page:.setLoop setLoop]. Default is *Infinity*.<br /><br />
+			Can be set via [page:.setLoop setLoop]. Default is `Infinity`.<br /><br />
 			Setting this number has no effect, if the [page:.loop loop mode] is set to
 			[page:Animation THREE.LoopOnce].
 		</p>
@@ -106,7 +106,7 @@
 		<p>
 			Scaling factor for the [page:.time time]. A value of 0 causes the animation to pause. Negative
 			values cause the animation to play backwards. Default is 1.<br /><br />
-			Properties/methods concerning *timeScale* (respectively *time*) are:
+			Properties/methods concerning `timeScale` (respectively `time`) are:
 			[page:.getEffectiveTimeScale getEffectiveTimeScale],
 			[page:.halt halt],
 			[page:.paused paused],
@@ -121,7 +121,7 @@
 		<p>
 			The degree of influence of this action (in the interval [0, 1]). Values between 0 (no impact)
 			and 1 (full impact) can be used to blend between several actions. Default is 1. <br /><br />
-			Properties/methods concerning *weight* are:
+			Properties/methods concerning `weight` are:
 			[page:.crossFadeFrom crossFadeFrom],
 			[page:.crossFadeTo crossFadeTo],
 			[page:.enabled enabled],
@@ -134,12 +134,12 @@
 
 		<h3>[property:Boolean zeroSlopeAtEnd]</h3>
 		<p>
-			Enables smooth interpolation without separate clips for start, loop and end. Default is *true*.
+			Enables smooth interpolation without separate clips for start, loop and end. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean zeroSlopeAtStart]</h3>
 		<p>
-			Enables smooth interpolation without separate clips for start, loop and end. Default is *true*.
+			Enables smooth interpolation without separate clips for start, loop and end. Default is `true`.
 		</p>
 
 
@@ -154,7 +154,7 @@
 			If warpBoolean is true, additional [page:.warp warping] (gradually changes of the time scales)
 			will be applied.<br /><br />
 
-			Note: Like with *fadeIn*/*fadeOut*, the fading starts/ends with a weight of 1.
+			Note: Like with `fadeIn`/`fadeOut`, the fading starts/ends with a weight of 1.
 
 		</p>
 
@@ -165,7 +165,7 @@
 			If warpBoolean is true, additional [page:.warp warping] (gradually changes of the time scales)
 			will be applied.<br /><br />
 
-			Note: Like with *fadeIn*/*fadeOut*, the fading starts/ends with a weight of 1.
+			Note: Like with `fadeIn`/`fadeOut`, the fading starts/ends with a weight of 1.
 		</p>
 
 		<h3>[method:this fadeIn]( [param:Number durationInSeconds] )</h3>
@@ -222,7 +222,7 @@
 			[page:.timeScale timeScale] is different from 0, and there is no scheduling for a delayed start
 			([page:.startAt startAt]).<br /><br />
 
-			Note: *isRunning* being true doesn’t necessarily mean that the animation can actually be seen.
+			Note: `isRunning` being true doesn’t necessarily mean that the animation can actually be seen.
 			This is only the case, if [page:.weight weight] is additionally set to a non-zero value.
 		</p>
 
@@ -253,8 +253,8 @@
 			[page:.time time] to 0, interrupts any scheduled fading and warping, and removes the internal
 			loop count and scheduling for delayed starting.<br /><br />
 
-			Note: .*reset* is always called by [page:.stop stop], but .*reset* doesn’t call .*stop* itself.
-			This means: If you want both, resetting and stopping, don’t call .*reset*; call .*stop* instead.
+			Note: .`reset` is always called by [page:.stop stop], but .`reset` doesn’t call .`stop` itself.
+			This means: If you want both, resetting and stopping, don’t call .`reset`; call .`stop` instead.
 		</p>
 
 		<h3>[method:this setDuration]( [param:Number durationInSeconds] )</h3>
@@ -271,7 +271,7 @@
 			to this value; otherwise the effective time scale (directly affecting the animation at
 			this moment) will be set to 0.<br /><br />
 
-			Note: .*paused* will not be switched to *true* automatically, if .*timeScale* is set to 0 by
+			Note: .`paused` will not be switched to `true` automatically, if .`timeScale` is set to 0 by
 			this method.
 		</p>
 
@@ -283,7 +283,7 @@
 			to this value; otherwise the effective weight (directly affecting the animation at this moment)
 			will be set to 0.<br /><br />
 
-			Note: .*enabled* will not be switched to *false* automatically, if .*weight* is set to 0 by
+			Note: .`enabled` will not be switched to `false` automatically, if .`weight` is set to 0 by
 			this method.
 		</p>
 
@@ -298,9 +298,9 @@
 			Defines the time for a delayed start (usually passed as [page:AnimationMixer.time] +
 			deltaTimeInSeconds). This method can be chained.<br /><br />
 
-			Note: The animation will only start at the given time, if .*startAt* is chained with
+			Note: The animation will only start at the given time, if .`startAt` is chained with
 			[page:.play play], or if the action has already been activated in the mixer (by a previous
-			call of .*play*, without stopping or resetting it in the meantime).
+			call of .`play`, without stopping or resetting it in the meantime).
 		</p>
 
 		<h3>[method:this stop]()</h3>
@@ -332,13 +332,13 @@
 			Synchronizing is done by setting this action’s [page:.time time] and [page:.timeScale timeScale] values
 			to the corresponding values of the other action (stopping any scheduled warping).<br /><br />
 
-			Note: Future changes of the other action's *time* and *timeScale* will not be detected.
+			Note: Future changes of the other action's `time` and `timeScale` will not be detected.
 		</p>
 
 		<h3>[method:this warp]( [param:Number startTimeScale], [param:Number endTimeScale], [param:Number durationInSeconds] )</h3>
 		<p>
 			Changes the playback speed, within the passed time interval, by modifying
-			[page:.timeScale timeScale] gradually from *startTimeScale* to *endTimeScale*. This method can
+			[page:.timeScale timeScale] gradually from `startTimeScale` to `endTimeScale`. This method can
 			be chained.
 		</p>
 

--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -63,7 +63,7 @@
 			to `true` will only restart the animation immediately if the following condition is fulfilled:
 			[page:.paused paused] is `false`, this action has not been deactivated in the meantime (by
 			executing a [page:.stop stop] or [page:.reset reset] command), and neither [page:.weight weight]
-			nor [page:.timeScale timeScale] is 0.
+			nor [page:.timeScale timeScale] is `0`.
 		</p>
 
 		<h3>[property:Number loop]</h3>
@@ -82,7 +82,7 @@
 		<h3>[property:Boolean paused]</h3>
 		<p>
 			Setting `paused` to `true` pauses the execution of the action by setting the effective time scale
-			to 0. Default is `false`.<br /><br />
+			to `0`. Default is `false`.<br /><br />
 		</p>
 
 		<h3>[property:Number repetitions]</h3>
@@ -95,17 +95,17 @@
 
 		<h3>[property:Number time]</h3>
 		<p>
-			The local time of this action (in seconds, starting with 0).<br /><br />
+			The local time of this action (in seconds, starting with `0`).<br /><br />
 
-			The value gets clamped or wrapped to 0...clip.duration (according to the loop state). It can be
+			The value gets clamped or wrapped to `0...clip.duration` (according to the loop state). It can be
 			scaled relatively to the global mixer time by changing [page:.timeScale timeScale] (using
 			[page:.setEffectiveTimeScale setEffectiveTimeScale] or [page:.setDuration setDuration]).<br />
 		</p>
 
 		<h3>[property:Number timeScale]</h3>
 		<p>
-			Scaling factor for the [page:.time time]. A value of 0 causes the animation to pause. Negative
-			values cause the animation to play backwards. Default is 1.<br /><br />
+			Scaling factor for the [page:.time time]. A value of `0` causes the animation to pause. Negative
+			values cause the animation to play backwards. Default is `1`.<br /><br />
 			Properties/methods concerning `timeScale` (respectively `time`) are:
 			[page:.getEffectiveTimeScale getEffectiveTimeScale],
 			[page:.halt halt],
@@ -119,8 +119,8 @@
 
 		<h3>[property:Number weight]</h3>
 		<p>
-			The degree of influence of this action (in the interval [0, 1]). Values between 0 (no impact)
-			and 1 (full impact) can be used to blend between several actions. Default is 1. <br /><br />
+			The degree of influence of this action (in the interval `[0, 1]`). Values between `0` (no impact)
+			and 1 (full impact) can be used to blend between several actions. Default is `1`. <br /><br />
 			Properties/methods concerning `weight` are:
 			[page:.crossFadeFrom crossFadeFrom],
 			[page:.crossFadeTo crossFadeTo],
@@ -170,13 +170,13 @@
 
 		<h3>[method:this fadeIn]( [param:Number durationInSeconds] )</h3>
 		<p>
-			Increases the [page:.weight weight] of this action gradually from 0 to 1, within the passed time
+			Increases the [page:.weight weight] of this action gradually from `0` to `1`, within the passed time
 			interval. This method can be chained.
 		</p>
 
 		<h3>[method:this fadeOut]( [param:Number durationInSeconds] )</h3>
 		<p>
-			Decreases the [page:.weight weight] of this action gradually from 1 to 0, within the passed time
+			Decreases the [page:.weight weight] of this action gradually from `1` to `0`, within the passed time
 			interval. This method can be chained.
 		</p>
 
@@ -209,7 +209,7 @@
 
 		<h3>[method:this halt]( [param:Number durationInSeconds] )</h3>
 		<p>
-			Decelerates this animation's speed to 0 by decreasing [page:.timeScale timeScale] gradually
+			Decelerates this animation's speed to `0` by decreasing [page:.timeScale timeScale] gradually
 			(starting from its current value), within the passed time interval. This method can be chained.
 		</p>
 
@@ -219,7 +219,7 @@
 
 			In addition to being activated in the mixer (see [page:.isScheduled isScheduled]) the following conditions must be fulfilled:
 			[page:.paused paused] is equal to false, [page:.enabled enabled] is equal to true,
-			[page:.timeScale timeScale] is different from 0, and there is no scheduling for a delayed start
+			[page:.timeScale timeScale] is different from `0`, and there is no scheduling for a delayed start
 			([page:.startAt startAt]).<br /><br />
 
 			Note: `isRunning` being true doesn’t necessarily mean that the animation can actually be seen.
@@ -250,7 +250,7 @@
 			Resets the action. This method can be chained.<br /><br />
 
 			This method sets [page:.paused paused] to false, [page:.enabled enabled] to true,
-			[page:.time time] to 0, interrupts any scheduled fading and warping, and removes the internal
+			[page:.time time] to `0`, interrupts any scheduled fading and warping, and removes the internal
 			loop count and scheduling for delayed starting.<br /><br />
 
 			Note: .`reset` is always called by [page:.stop stop], but .`reset` doesn’t call .`stop` itself.
@@ -269,9 +269,9 @@
 
 			If [page:.paused paused] is false, the effective time scale (an internal property) will also be set
 			to this value; otherwise the effective time scale (directly affecting the animation at
-			this moment) will be set to 0.<br /><br />
+			this moment) will be set to `0`.<br /><br />
 
-			Note: .`paused` will not be switched to `true` automatically, if .`timeScale` is set to 0 by
+			Note: .`paused` will not be switched to `true` automatically, if .`timeScale` is set to `0` by
 			this method.
 		</p>
 
@@ -281,9 +281,9 @@
 
 			If [page:.enabled enabled] is true, the effective weight (an internal property) will also be set
 			to this value; otherwise the effective weight (directly affecting the animation at this moment)
-			will be set to 0.<br /><br />
+			will be set to `0`.<br /><br />
 
-			Note: .`enabled` will not be switched to `false` automatically, if .`weight` is set to 0 by
+			Note: .`enabled` will not be switched to `false` automatically, if .`weight` is set to `0` by
 			this method.
 		</p>
 

--- a/docs/api/en/animation/AnimationClip.html
+++ b/docs/api/en/animation/AnimationClip.html
@@ -24,7 +24,7 @@
 		<p>
 			[page:String name] - a name for this clip.<br />
 			[page:Number duration] - the duration of this clip (in seconds). If a negative value is passed,
-			the duration will be calculated from the passed *tracks* array.<br />
+			the duration will be calculated from the passed `tracks` array.<br />
 			[page:Array tracks] - an array of [page:KeyframeTrack KeyframeTracks].<br /><br />
 
 			Note: Instead of instantiating an AnimationClip directly with the constructor, you can use one
@@ -113,7 +113,7 @@
 			Returns a new AnimationClip from the passed morph targets array of a geometry, taking a name and the number of frames per second.<br /><br />
 
 			Note: The fps parameter is required, but the animation speed can be overridden in an
-			*AnimationAction* via [page:AnimationAction.setDuration animationAction.setDuration].
+			`AnimationAction` via [page:AnimationAction.setDuration animationAction.setDuration].
 		</p>
 
 		<h3>[method:AnimationClip findByName]( [param:Object objectOrClipArray], [param:String name] )</h3>

--- a/docs/api/en/animation/AnimationMixer.html
+++ b/docs/api/en/animation/AnimationMixer.html
@@ -33,14 +33,14 @@
 
 		<h3>[property:Number time]</h3>
 		<p>
-			The global mixer time (in seconds; starting with 0 on the mixer's creation).
+			The global mixer time (in seconds; starting with `0` on the mixer's creation).
 		</p>
 
 		<h3>[property:Number timeScale]</h3>
 		<p>
 			A scaling factor for the global [page:.time mixer time].<br /><br />
 
-			Note: Setting the mixer's timeScale to 0 and later back to 1 is a possibility to pause/unpause
+			Note: Setting the mixer's timeScale to `0` and later back to `1` is a possibility to pause/unpause
 			all actions that are controlled by this mixer.
 		</p>
 

--- a/docs/api/en/animation/AnimationObjectGroup.html
+++ b/docs/api/en/animation/AnimationObjectGroup.html
@@ -51,14 +51,14 @@
 
 		<h3>[property:Object stats]</h3>
 		<p>
-			An object that contains some informations of this *AnimationObjectGroup* (total number, number
+			An object that contains some informations of this `AnimationObjectGroup` (total number, number
 			in use, number of bindings per object)
 		</p>
 
 		<h3>[property:String uuid]</h3>
 		<p>
 			The [link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID] of this
-			*AnimationObjectGroup*. It gets automatically assigned and shouldn't be edited.
+			`AnimationObjectGroup`. It gets automatically assigned and shouldn't be edited.
 		</p>
 
 
@@ -67,17 +67,17 @@
 
 		<h3>[method:undefined add]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
-			Adds an arbitrary number of objects to this *AnimationObjectGroup*.
+			Adds an arbitrary number of objects to this `AnimationObjectGroup`.
 		</p>
 
 		<h3>[method:undefined remove]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
-			Removes an arbitrary number of objects from this *AnimationObjectGroup*.
+			Removes an arbitrary number of objects from this `AnimationObjectGroup`.
 		</p>
 
 		<h3>[method:undefined uncache]( [param:Object obj1], [param:Object obj2], [param:Object obj3], ... )</h3>
 		<p>
-			Deallocates all memory resources for the passed objects of this *AnimationObjectGroup*.
+			Deallocates all memory resources for the passed objects of this `AnimationObjectGroup`.
 		</p>
 
 

--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -39,7 +39,7 @@
 
 		<h3>[method:Boolean isTypedArray]( object )</h3>
 		<p>
-		Returns *true* if the object is a typed array.
+		Returns `true` if the object is a typed array.
 		</p>
 
 		<h3>[method:AnimationClip makeClipAdditive]( [param:AnimationClip targetClip], [param:Number referenceFrame], [param:AnimationClip referenceClip], [param:Number fps] )</h3>

--- a/docs/api/en/animation/KeyframeTrack.html
+++ b/docs/api/en/animation/KeyframeTrack.html
@@ -24,12 +24,12 @@
 		<p>
 			In contrast to the animation hierarchy of the
 			[link:https://github.com/mrdoob/three.js/wiki/JSON-Model-format-3 JSON model format] a
-			*KeyframeTrack* doesn't store its single keyframes as objects in a "keys" array (holding the
+			`KeyframeTrack` doesn't store its single keyframes as objects in a "keys" array (holding the
 			times and the values for each frame together in one place).
 		</p>
 
 		<p>
-			Instead of this there are always two arrays in a *KeyframeTrack*: the [page:.times times] array
+			Instead of this there are always two arrays in a `KeyframeTrack`: the [page:.times times] array
 			stores the time values for all keyframes of this track in sequential order, and the
 			[page:.values values] array contains the corresponding changing values of the animated property.
 		</p>
@@ -43,7 +43,7 @@
 
 		<p>
 			Corresponding to the different possible types of animated values there are several subclasses of
-			*KeyframeTrack*, inheriting the most properties and methods:
+			`KeyframeTrack`, inheriting the most properties and methods:
 		</p>
 
 		<ul>
@@ -77,7 +77,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )</h3>
 		<p>
-			[page:String name] - the identifier for the *KeyframeTrack*.<br />
+			[page:String name] - the identifier for the `KeyframeTrack`.<br />
 			[page:Array times] - an array of keyframe times, converted internally to a
 			[link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array Float32Array].<br />
 			[page:Array values] - an array with the values related to the times array, converted internally to a
@@ -232,8 +232,8 @@
 
 		<h3>[method:this trim]( [param:Number startTimeInSeconds], [param:Number endTimeInSeconds] )</h3>
 		<p>
-			Removes keyframes before *startTime* and after *endTime*,
-			without changing any values within the range [*startTime*, *endTime*].
+			Removes keyframes before `startTime` and after `endTime`,
+			without changing any values within the range [`startTime`, `endTime`].
 		</p>
 
 		<h3>[method:Boolean validate]()</h3>
@@ -243,7 +243,7 @@
 
 		<p>
 			This method logs errors to the console, if a track is empty, if the [page:.valueSize value size] is not valid, if an item
-			in the [page:.times times] or [page:.values values] array is not a valid number or if the items in the *times* array are out of order.
+			in the [page:.times times] or [page:.values values] array is not a valid number or if the items in the `times` array are out of order.
 		</p>
 
 		<h2>Static Methods</h2>

--- a/docs/api/en/animation/PropertyMixer.html
+++ b/docs/api/en/animation/PropertyMixer.html
@@ -44,12 +44,12 @@
 
 		<h3>[property:Number cumulativeWeight]</h3>
 		<p>
-			Default is *0*.
+			Default is `0`.
 		</p>
 
 		<h3>[property:Number cumulativeWeightAdditive]</h3>
 		<p>
-			Default is *0*.
+			Default is `0`.
 		</p>
 
 		<h3>[property:Number valueSize]</h3>
@@ -59,12 +59,12 @@
 
 		<h3>[property:Number referenceCount]</h3>
 		<p>
-			Default is *0*.
+			Default is `0`.
 		</p>
 
 		<h3>[property:Number useCount]</h3>
 		<p>
-			Default is *0*.
+			Default is `0`.
 		</p>
 
 
@@ -75,14 +75,14 @@
 		<p>
 			Accumulate data in [page:PropertyMixer.buffer buffer][accuIndex] 'incoming' region into 'accu[i]'.<br />
 
-			If weight is *0* this does nothing.
+			If weight is `0` this does nothing.
 		</p>
 
 		<h3>[method:undefined accumulateAdditive]( [param:Number weight] )</h3>
 		<p>
 			Accumulate data in the 'incoming' region into 'add'.<br />
 
-			If weight is *0* this does nothing.
+			If weight is `0` this does nothing.
 		</p>
 
 

--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -42,7 +42,7 @@
 
 		<h3>[property:Array ValueBufferType]</h3>
 		<p>
-			A normal Array (no Float32Array in this case, unlike *ValueBufferType* of [page:KeyframeTrack]).
+			A normal Array (no Float32Array in this case, unlike `ValueBufferType` of [page:KeyframeTrack]).
 		</p>
 
 		<h3>[property:String ValueTypeName]</h3>

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -45,7 +45,7 @@
 
 		<h3>[property:Array ValueBufferType]</h3>
 		<p>
-			A normal Array (no Float32Array in this case, unlike *ValueBufferType* of [page:KeyframeTrack]).
+			A normal Array (no Float32Array in this case, unlike `ValueBufferType` of [page:KeyframeTrack]).
 		</p>
 
 		<h3>[property:String ValueTypeName]</h3>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -56,13 +56,13 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean autoplay]</h3>
-		<p>Whether to start playback automatically. Default is *false*.</p>
+		<p>Whether to start playback automatically. Default is `false`.</p>
 
 		<h3>[property:AudioContext context]</h3>
 		<p>The [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext AudioContext] of the [page:AudioListener listener] given in the constructor.</p>
 
 		<h3>[property:Number detune]</h3>
-		<p>Modify pitch, measured in cents. +/- 100 is a semitone. +/- 1200 is an octave. Default is *0*.</p>
+		<p>Modify pitch, measured in cents. +/- 100 is a semitone. +/- 1200 is an octave. Default is `0`.</p>
 
 		<h3>[property:Array filters]</h3>
 		<p>Represents an array of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioNode AudioNodes]. Can be used to apply a variety of low-order filters to create more complex sound effects.
@@ -74,7 +74,7 @@
 
 		<h3>[property:Boolean hasPlaybackControl]</h3>
 		<p>Whether playback can be controlled using the [page:Audio.play play](),
-			[page:Audio.pause pause]() etc. methods. Default is *true*.</p>
+			[page:Audio.pause pause]() etc. methods. Default is `true`.</p>
 
 		<h3>[property:Boolean isPlaying]</h3>
 		<p>Whether the audio is currently playing.</p>
@@ -83,13 +83,13 @@
 		<p>A reference to the listener object of this audio.</p>
 
 		<h3>[property:Number playbackRate]</h3>
-		<p>Speed of playback. Default is *1*.</p>
+		<p>Speed of playback. Default is `1`.</p>
 
 		<h3>[property:Number offset]</h3>
-		<p>An offset to the time within the audio buffer that playback should begin. Same as the *offset* parameter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *0*.</p>
+		<p>An offset to the time within the audio buffer that playback should begin. Same as the `offset` parameter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is `0`.</p>
 
 		<h3>[property:Number duration]</h3>
-		<p>Overrides the duration of the audio. Same as the *duration* parameter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is *undefined* to play the whole buffer.</p>
+		<p>Overrides the duration of the audio. Same as the `duration` parameter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is `undefined` to play the whole buffer.</p>
 
 		<h3>[property:String source]</h3>
 		<p>An [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] created
@@ -191,18 +191,18 @@
 
 		<h3>[method:this setLoop]( [param:Boolean value] )</h3>
 		<p>
-		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loop source.loop] to *value*
+		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loop source.loop] to `value`
 		(whether playback should loop).
 		</p>
 
 		<h3>[method:this setLoopStart]( [param:Float value] )</h3>
 		<p>
-		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopStart source.loopStart] to *value*.
+		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopStart source.loopStart] to `value`.
 		</p>
 
 		<h3>[method:this setLoopEnd]( [param:Float value] )</h3>
 		<p>
-		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopEnd source.loopEnd] to *value*.
+		Set [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopEnd source.loopEnd] to `value`.
 		</p>
 
 		<h3>[method:this setMediaElementSource]( mediaElement )</h3>
@@ -226,7 +226,7 @@
 
 		<h3>[method:this setPlaybackRate]( [param:Float value] )</h3>
 		<p>
-		If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, set the [page:Audio.playbackRate playbackRate] to *value*.
+		If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, set the [page:Audio.playbackRate playbackRate] to `value`.
 		</p>
 
 		<h3>[method:this setVolume]( [param:Float value] )</h3>

--- a/docs/api/en/audio/AudioContext.html
+++ b/docs/api/en/audio/AudioContext.html
@@ -24,13 +24,13 @@
 
 		<h3>[method:AudioContext getContext]()</h3>
 		<p>
-		Return the value of the variable *context* in the outer scope, if defined,
+		Return the value of the variable `context` in the outer scope, if defined,
 		otherwise set it to a new [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext AudioContext].
 		</p>
 
 		<h3>[method:AudioContext setContext]( [param:AudioContext value] )</h3>
 		<p>
-		 Set the variable *context* in the outer scope to *value*.
+		 Set the variable `context` in the outer scope to `value`.
 		</p>
 
 

--- a/docs/api/en/audio/AudioListener.html
+++ b/docs/api/en/audio/AudioListener.html
@@ -64,10 +64,10 @@
 		using [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createGain AudioContext.createGain]().</p>
 
 		<h3>[property:AudioNode filter]</h3>
-		<p>Default is *null*.</p>
+		<p>Default is `null`.</p>
 
 		<h3>[property:Number timeDelta]</h3>
-		<p>Time delta value for audio entities. Use in context of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/linearRampToValueAtTime AudioParam.linearRampToValueAtTimeDefault](). Default is *0*.</p>
+		<p>Time delta value for audio entities. Use in context of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/linearRampToValueAtTime AudioParam.linearRampToValueAtTimeDefault](). Default is .</p>
 
 		<h2>Methods</h2>
 
@@ -79,7 +79,7 @@
 
 		<h3>[method:this removeFilter]()</h3>
 		<p>
-		Set the [page:AudioListener.filter filter] property to *null*.
+		Set the [page:AudioListener.filter filter] property to `null`.
 		</p>
 
 		<h3>[method:AudioNode getFilter]()</h3>
@@ -89,7 +89,7 @@
 
 		<h3>[method:this setFilter]( [param:AudioNode value] )</h3>
 		<p>
-		Set the [page:AudioListener.filter filter] property to *value*.
+		Set the [page:AudioListener.filter filter] property to `value`.
 		</p>
 
 		<h3>[method:Float getMasterVolume]()</h3>

--- a/docs/api/en/cameras/ArrayCamera.html
+++ b/docs/api/en/cameras/ArrayCamera.html
@@ -13,7 +13,7 @@
 
 		<p class="desc">
 			[name] can be used in order to efficiently render a scene with a predefined set of cameras. This is an important performance aspect for rendering VR scenes.<br />
-			An instance of [name] always has an array of sub cameras. It's mandatory to define for each sub camera the *viewport* property which determines the part of the viewport that is rendered with this camera.
+			An instance of [name] always has an array of sub cameras. It's mandatory to define for each sub camera the `viewport` property which determines the part of the viewport that is rendered with this camera.
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -86,7 +86,7 @@
 		<p>
 			Camera frustum near plane. Default is `0.1`.<br /><br />
 
-			The valid range is between 0 and the current value of the [page:.far far] plane.
+			The valid range is between `0` and the current value of the [page:.far far] plane.
 			Note that, unlike for the [page:PerspectiveCamera], `0` is a valid value for an
 			OrthographicCamera's near plane.
 		</p>

--- a/docs/api/en/cameras/OrthographicCamera.html
+++ b/docs/api/en/cameras/OrthographicCamera.html
@@ -69,7 +69,7 @@
 
 		<h3>[property:Float far]</h3>
 		<p>
-		Camera frustum far plane. Default is *2000*.<br /><br />
+		Camera frustum far plane. Default is `2000`.<br /><br />
 
 		Must be greater than the current value of [page:.near near] plane.
 		</p>
@@ -84,10 +84,10 @@
 
 		<h3>[property:Float near]</h3>
 		<p>
-			Camera frustum near plane. Default is *0.1*.<br /><br />
+			Camera frustum near plane. Default is `0.1`.<br /><br />
 
 			The valid range is between 0 and the current value of the [page:.far far] plane.
-			Note that, unlike for the [page:PerspectiveCamera], *0* is a valid value for an
+			Note that, unlike for the [page:PerspectiveCamera], `0` is a valid value for an
 			OrthographicCamera's near plane.
 		</p>
 
@@ -98,10 +98,10 @@
 		<p>Camera frustum top plane.</p>
 
 		<h3>[property:Object view]</h3>
-		<p>Set by [page:OrthographicCamera.setViewOffset setViewOffset]. Default is *null*.</p>
+		<p>Set by [page:OrthographicCamera.setViewOffset setViewOffset]. Default is `null`.</p>
 
 		<h3>[property:number zoom]</h3>
-		<p>Gets or sets the zoom factor of the camera. Default is *1*.</p>
+		<p>Gets or sets the zoom factor of the camera. Default is `1`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:Camera] class for common methods.</p>

--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -56,11 +56,11 @@
 		</p>
 
 		<h3>[property:Float aspect]</h3>
-		<p>Camera frustum aspect ratio, usually the canvas width / canvas height. Default is *1* (square canvas).</p>
+		<p>Camera frustum aspect ratio, usually the canvas width / canvas height. Default is `1` (square canvas).</p>
 
 		<h3>[property:Float far]</h3>
 		<p>
-			Camera frustum far plane. Default is *2000*.<br /><br />
+			Camera frustum far plane. Default is `2000`.<br /><br />
 
 			Must be greater than the current value of [page:.near near] plane.
 		</p>
@@ -69,16 +69,16 @@
 		<p>Film size used for the larger axis. Default is 35 (millimeters). This parameter does not influence the projection matrix unless .filmOffset is set to a nonzero value.</p>
 
 		<h3>[property:Float filmOffset]</h3>
-		<p>Horizontal off-center offset in the same unit as .filmGauge. Default is *0*.</p>
+		<p>Horizontal off-center offset in the same unit as `.filmGauge`. Default is `0`.</p>
 
 		<h3>[property:Float focus]</h3>
 		<p>Object distance used for stereoscopy and depth-of-field effects.
 			This parameter does not influence the projection matrix unless a [page:StereoCamera] is being used.
-			Default is *10*.
+			Default is `10`.
 		</p>
 
 		<h3>[property:Float fov]</h3>
-		<p>Camera frustum vertical field of view, from bottom to top of view, in degrees. Default is *50*.</p>
+		<p>Camera frustum vertical field of view, from bottom to top of view, in degrees. Default is `50`.</p>
 
 		<h3>[property:Boolean isPerspectiveCamera]</h3>
 		<p>
@@ -88,10 +88,10 @@
 
 		<h3>[property:Float near]</h3>
 		<p>
-			Camera frustum near plane. Default is *0.1*.<br /><br />
+			Camera frustum near plane. Default is `0.1`.<br /><br />
 
 			The valid range is greater than 0 and less than the current value of the [page:.far far] plane.
-			Note that, unlike for the [page:OrthographicCamera], *0* is <em>not</em> a valid value
+			Note that, unlike for the [page:OrthographicCamera], `0` is <em>not</em> a valid value
 			for a PerspectiveCamera's near plane.
 		</p>
 
@@ -103,7 +103,7 @@
 		</p>
 
 		<h3>[property:number zoom]</h3>
-		<p>Gets or sets the zoom factor of the camera. Default is *1*.</p>
+		<p>Gets or sets the zoom factor of the camera. Default is `1`.</p>
 
 
 		<h2>Methods</h2>

--- a/docs/api/en/cameras/StereoCamera.html
+++ b/docs/api/en/cameras/StereoCamera.html
@@ -30,10 +30,10 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Float aspect]</h3>
-		<p>Default is *1*.</p>
+		<p>Default is `1`.</p>
 
 		<h3>[property:Float eyeSep]</h3>
-		<p>Default is *0.064*.</p>
+		<p>Default is `0.064`.</p>
 
 		<h3>[property:PerspectiveCamera cameraL]</h3>
 		<p>Left camera. This is added to [page:Layers layer 1] - objects to be rendered

--- a/docs/api/en/constants/Materials.html
+++ b/docs/api/en/constants/Materials.html
@@ -119,10 +119,10 @@
 		[page:Materials ZeroStencilOp] will set the stencil value to 0.<br />
 		[page:Materials KeepStencilOp] will not change the current stencil value.<br />
 		[page:Materials ReplaceStencilOp] will replace the stencil value with the specified stencil reference value.<br />
-		[page:Materials IncrementStencilOp] will increment the current stencil value by 1.<br />
-		[page:Materials DecrementStencilOp] will decrement the current stencil value by 1.<br />
-		[page:Materials IncrementWrapStencilOp] will increment the current stencil value by 1. If the value increments past 255 it will be set to 0.<br />
-		[page:Materials DecrementWrapStencilOp] will increment the current stencil value by 1. If the value decrements below 0 it will be set to 255.<br />
+		[page:Materials IncrementStencilOp] will increment the current stencil value by `1`.<br />
+		[page:Materials DecrementStencilOp] will decrement the current stencil value by `1`.<br />
+		[page:Materials IncrementWrapStencilOp] will increment the current stencil value by `1`. If the value increments past `255` it will be set to `0`.<br />
+		[page:Materials DecrementWrapStencilOp] will increment the current stencil value by `1`. If the value decrements below `0` it will be set to `255`.<br />
 		[page:Materials InvertStencilOp] will perform a bitwise inversion of the current stencil value.<br />
 		</p>
 

--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -152,7 +152,7 @@
 		</code>
 		<p>
 		For use with a texture's [page:Texture.format format]	property, these define
-		how elements of a 2d texture, or *texels*, are read by shaders.<br /><br />
+		how elements of a 2d texture, or `texels`, are read by shaders.<br /><br />
 
 		[page:constant AlphaFormat] discards the red, green and blue components and reads just the alpha component.<br /><br />
 
@@ -186,7 +186,7 @@
 
 		[page:constant LuminanceAlphaFormat] reads each element as a luminance/alpha double.
 		The same process occurs as for the [page:constant LuminanceFormat], except that the
-		alpha channel may have values other than *1.0*.<br /><br />
+		alpha channel may have values other than `1.0`.<br /><br />
 
 		[page:constant DepthFormat] reads each element as a single depth value, converts it to floating point, and clamps to the range [0,1].
 		This is the default for [page:DepthTexture DepthTexture].<br /><br />
@@ -345,7 +345,7 @@
 		texture when using a WebGL 2 rendering context.<br /><br />
 
 		For use with a texture's [page:Texture.internalFormat internalFormat]	property,
-		these define how elements of a texture, or *texels*, are stored on the GPU.<br /><br />
+		these define how elements of a texture, or `texels`, are stored on the GPU.<br /><br />
 
 		[page:constant R8] stores the red component on 8 bits.<br /><br />
 
@@ -539,7 +539,7 @@
 		For use with a Texture's [page:Texture.encoding encoding]	property.<br /><br />
 
 		If the encoding type is changed after the texture has already been used by a material,
-		you will need to set [page:Material.needsUpdate Material.needsUpdate] to *true* to make the material recompile.<br /><br />
+		you will need to set [page:Material.needsUpdate Material.needsUpdate] to `true` to make the material recompile.<br /><br />
 
 		[page:constant LinearEncoding] is the default.
 		Values other than this are only valid for a material's map, envMap and emissiveMap.

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -37,7 +37,7 @@
 
 		[page:Boolean normalized] -- (optional) Applies to integer data only. Indicates how the underlying data
 		in the buffer maps to the values in the GLSL code. For instance, if [page:TypedArray array] is an instance
-		of UInt16Array, and [page:Boolean normalized] is true, the values 0 - +65535 in the array
+		of UInt16Array, and [page:Boolean normalized] is true, the values `0 - +65535` in the array
 		 data will be mapped to 0.0f - +1.0f in the GLSL attribute. An Int16Array (signed) would map
 		 from -32768 - +32767 to -1.0f - +1.0f. If [page:Boolean normalized] is false, the values
 		 will be converted to floats unmodified, i.e. 32767 becomes 32767.0f.
@@ -92,7 +92,7 @@
 
 		<h3>[property:Object updateRange]</h3>
 		<p>Object containing:<br />
-			[page:Integer offset]: Default is . Position at which to start update.<br />
+			[page:Integer offset]: Default is `0`. Position at which to start update.<br />
 			[page:Integer count]: Default is `-1`, which means don't use update ranges. <br /><br />
 
 			This can be used to only update some components of stored vectors (for example, just the component

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -92,8 +92,8 @@
 
 		<h3>[property:Object updateRange]</h3>
 		<p>Object containing:<br />
-			[page:Integer offset]: Default is *0*. Position at which to start update.<br />
-			[page:Integer count]: Default is *-1*, which means don't use update ranges. <br /><br />
+			[page:Integer offset]: Default is . Position at which to start update.<br />
+			[page:Integer count]: Default is `-1`, which means don't use update ranges. <br /><br />
 
 			This can be used to only update some components of stored vectors (for example, just the component
 			related to color).
@@ -101,7 +101,7 @@
 
 		<h3>[property:Usage usage]</h3>
 		<p>
-			Defines the intended usage pattern of the data store for optimization purposes. Corresponds to the *usage* parameter of
+			Defines the intended usage pattern of the data store for optimization purposes. Corresponds to the `usage` parameter of
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData WebGLRenderingContext.bufferData]().
 			Default is [page:BufferAttributeUsage StaticDrawUsage]. See usage [page:BufferAttributeUsage constants] for all possible values. <br /><br />
 			

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -69,13 +69,13 @@
 		<h3>[property:Box3 boundingBox]</h3>
 		<p>
 			Bounding box for the bufferGeometry, which can be calculated with
-			[page:.computeBoundingBox](). Default is *null*.
+			[page:.computeBoundingBox](). Default is `null`.
 		</p>
 
 		<h3>[property:Sphere boundingSphere]</h3>
 		<p>
 			Bounding sphere for the bufferGeometry, which can be calculated with
-			[page:.computeBoundingSphere](). Default is *null*.
+			[page:.computeBoundingSphere](). Default is `null`.
 		</p>
 
 		<h3>[property:Object drawRange]</h3>
@@ -128,7 +128,7 @@
 			If this attribute is not set, the [page:WebGLRenderer renderer] assumes that each three contiguous
 			positions represent a single triangle.
 
-			Default is *null*.
+			Default is `null`.
 		</p>
 
 		<h3>[property:Boolean isBufferGeometry]</h3>
@@ -145,7 +145,7 @@
 		<p>
 			Used to control the morph target behavior; when set to true, the morph target data is treated as relative offsets, rather than as absolute positions/normals.
 
-			Default is *false*.
+			Default is `false`.
 		</p>
 
 		<h3>[property:String name]</h3>
@@ -204,13 +204,13 @@
 		<h3>[method:undefined computeBoundingBox]()</h3>
 		<p>
 		Computes bounding box of the geometry, updating [page:.boundingBox] attribute.<br />
-		Bounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
+		Bounding boxes aren't computed by default. They need to be explicitly computed, otherwise they are `null`.
 		</p>
 
 		<h3>[method:undefined computeBoundingSphere]()</h3>
 		<p>
 		Computes bounding sphere of the geometry, updating [page:.boundingSphere] attribute.<br />
-		Bounding spheres aren't computed by default. They need to be explicitly computed, otherwise they are *null*.
+		Bounding spheres aren't computed by default. They need to be explicitly computed, otherwise they are `null`.
 		</p>
 
 		<h3>[method:undefined computeTangents]()</h3>
@@ -236,7 +236,7 @@
 		<p>Return the [page:.index] buffer.</p>
 
 		<h3>[method:Boolean hasAttribute]( [param:String name] )</h3>
-		<p>Returns *true* if the attribute with the specified name exists.</p>
+		<p>Returns `true` if the attribute with the specified name exists.</p>
 
 		<h3>[method:this lookAt] ( [param:Vector3 vector] )</h3>
 		<p>

--- a/docs/api/en/core/Clock.html
+++ b/docs/api/en/core/Clock.html
@@ -18,42 +18,42 @@
 
 		<h3>[name]( [param:Boolean autoStart] )</h3>
 		<p>
-		autoStart — (optional) whether to automatically start the clock when [page:.getDelta]() is called for the first time. Default is *true*.
+		autoStart — (optional) whether to automatically start the clock when [page:.getDelta]() is called for the first time. Default is `true`.
 		</p>
 
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean autoStart]</h3>
 		<p>
-		If set, starts the clock automatically when [page:.getDelta]() is called for the first time. Default is *true*.
+		If set, starts the clock automatically when [page:.getDelta]() is called for the first time. Default is `true`.
 		</p>
 
 		<h3>[property:Float startTime]</h3>
 		<p>
-		Holds the time at which the clock's [page:Clock.start start] method was last called. Default is *0*.
+		Holds the time at which the clock's [page:Clock.start start] method was last called. Default is `0`.
  		</p>
 
 		<h3>[property:Float oldTime]</h3>
 		<p>
 		Holds the time at which the clock's [page:Clock.start start], [page:.getElapsedTime]() or [page:.getDelta]()
-		methods were last called. Default is *0*.
+		methods were last called. Default is `0`.
  		</p>
 
 		<h3>[property:Float elapsedTime]</h3>
 		<p>
-		Keeps track of the total time that the clock has been running. Default is *0*.
+		Keeps track of the total time that the clock has been running. Default is `0`.
  		</p>
 
 		<h3>[property:Boolean running]</h3>
 		<p>
-		Whether the clock is running or not. Default is *false*.
+		Whether the clock is running or not. Default is `false`.
  		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:undefined start]()</h3>
 		<p>
-		Starts clock. Also sets the [page:.startTime] and [page:.oldTime] to the current time, sets [page:.elapsedTime] to *0* and [page:.running] to *true*.
+		Starts clock. Also sets the [page:.startTime] and [page:.oldTime] to the current time, sets [page:.elapsedTime] to `0` and [page:.running] to `true`.
 		</p>
 
 		<h3>[method:undefined stop]()</h3>
@@ -64,13 +64,13 @@
 		<h3>[method:Float getElapsedTime]()</h3>
 		<p>
 		Get the seconds passed since the clock started and sets [page:.oldTime] to the current time.<br />
-		If [page:.autoStart] is *true* and the clock is not running, also starts the clock.
+		If [page:.autoStart] is `true` and the clock is not running, also starts the clock.
 		</p>
 
 		<h3>[method:Float getDelta]()</h3>
 		<p>
 		Get the seconds passed since the time [page:.oldTime] was set and sets [page:.oldTime] to the current time.<br />
-		If [page:.autoStart] is *true* and the clock is not running, also starts the clock.
+		If [page:.autoStart] is `true` and the clock is not running, also starts the clock.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/core/GLBufferAttribute.html
+++ b/docs/api/en/core/GLBufferAttribute.html
@@ -12,7 +12,7 @@
 		<p class="desc">
 			This buffer attribute class does not construct a VBO. Instead, it uses
 			whatever VBO is passed in constructor and can later be altered via the
-			*buffer* property.<br /><br />
+			`buffer` property.<br /><br />
 			It is required to pass additional params alongside the VBO. Those are:
 			the GL context, the GL data type, the number of components per vertex,
 			the number of bytes per component, and the number of vertices.<br /><br />
@@ -23,15 +23,15 @@
 		<h2>Constructor</h2>
 		<h3>[name]( [param:WebGLBuffer buffer], [param:GLenum type], [param:Integer itemSize], [param:Integer elementSize], [param:Integer count] )</h3>
 		<p>
-		*buffer* — Must be a <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer" target="_blank">WebGLBuffer</a>.
+		`buffer` — Must be a <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer" target="_blank">WebGLBuffer</a>.
 		<br />
-		*type* — One of <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants#Data_types" target="_blank">WebGL Data Types</a>.
+		`type` — One of <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants#Data_types" target="_blank">WebGL Data Types</a>.
 		<br />
-		*itemSize* — The number of values of the array that should be associated with
+		`itemSize` — The number of values of the array that should be associated with
 		a particular vertex. For instance, if this
 		attribute is storing a 3-component vector (such as a position, normal, or color), then itemSize should be 3.
 		<br />
-		*elementSize* — 1, 2 or 4. The corresponding size (in bytes) for the given "type" param.
+		`elementSize` — 1, 2 or 4. The corresponding size (in bytes) for the given "type" param.
 		<ul>
 			<li>gl.FLOAT: 4</li>
 			<li>gl.UNSIGNED_SHORT: 2</li>
@@ -41,7 +41,7 @@
 			<li>gl.BYTE: 1</li>
 			<li>gl.UNSIGNED_BYTE: 1</li>
 		</ul>
-		*count* — The expected number of vertices in VBO.
+		`count` — The expected number of vertices in VBO.
 		</p>
 
 		<h2>Properties</h2>
@@ -63,7 +63,7 @@
 
 		<h3>[property:Integer elementSize]</h3>
 		<p>
-			Stores the corresponding size in bytes for the current *type* property value.
+			Stores the corresponding size in bytes for the current `type` property value.
 		</p>
 		<p>
 			See above (constructor) for a list of known type sizes.
@@ -75,28 +75,28 @@
 			describing the underlying VBO contents.
 		</p>
 		<p>
-			Set this property together with *elementSize*. The recommended way is
-			using the *setType* method.
+			Set this property together with `elementSize`. The recommended way is
+			using the `setType` method.
 		</p>
 
 		<h3>[property:Boolean isGLBufferAttribute]</h3>
 		<p>
-			Read-only. Always *true*.
+			Read-only. Always `true`.
 		</p>
 
 		<h2>Methods</h2>
 
 		<h3>[method:this setBuffer]( buffer ) </h3>
-		<p>Sets the *buffer* property.</p>
+		<p>Sets the `buffer` property.</p>
 
 		<h3>[method:this setType]( type, elementSize ) </h3>
-		<p>Sets the both *type* and *elementSize* properties.</p>
+		<p>Sets the both `type` and `elementSize` properties.</p>
 
 		<h3>[method:this setItemSize]( itemSize ) </h3>
-		<p>Sets the *itemSize* property.</p>
+		<p>Sets the `itemSize` property.</p>
 
 		<h3>[method:this setCount]( count ) </h3>
-		<p>Sets the *count* property.</p>
+		<p>Sets the `count` property.</p>
 
 		<h3>[property:Integer version]</h3>
 		<p>
@@ -105,7 +105,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Default is *false*. Setting this to true increments [page:GLBufferAttribute.version version].
+		Default is `false`. Setting this to true increments [page:GLBufferAttribute.version version].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/core/InstancedBufferAttribute.html
+++ b/docs/api/en/core/InstancedBufferAttribute.html
@@ -25,7 +25,7 @@
 
 		<h3>[property:Number meshPerAttribute]</h3>
 		<p>
-			Defines how often a value of this buffer attribute should be repeated. A value of one means that each value of the instanced attribute is used for a single instance. A value of two means that each value is used for two consecutive instances (and so on). Default is *1*.
+			Defines how often a value of this buffer attribute should be repeated. A value of one means that each value of the instanced attribute is used for a single instance. A value of two means that each value is used for two consecutive instances (and so on). Default is `1`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/core/InstancedBufferGeometry.html
+++ b/docs/api/en/core/InstancedBufferGeometry.html
@@ -25,7 +25,7 @@
 
 		<h3>[property:Number instanceCount]</h3>
 		<p>
-			Default is *Infinity*.
+			Default is `Infinity`.
 		</p>
 
 		<h3>[property:Boolean isInstancedBufferGeometry]</h3>

--- a/docs/api/en/core/InstancedInterleavedBuffer.html
+++ b/docs/api/en/core/InstancedInterleavedBuffer.html
@@ -27,7 +27,7 @@
 
 		<h3>[property:Number meshPerAttribute]</h3>
 		<p>
-			Default is *1*.
+			Default is `1`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/core/InterleavedBuffer.html
+++ b/docs/api/en/core/InterleavedBuffer.html
@@ -46,8 +46,8 @@
 		<h3>[property:Object updateRange]</h3>
 		<p>
 		Object containing offset and count.<br />
-		- [page:Number offset]: Default is *0*.<br />
-		- [page:Number count]: Default is *-1*.<br />
+		- [page:Number offset]: Default is `0`.<br />
+		- [page:Number count]: Default is `-1`.<br />
 		</p>
 
 		<h3>[property:String uuid]</h3>
@@ -62,12 +62,12 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Default is *false*. Setting this to true increments [page:InterleavedBuffer.version version].
+		Default is `false`. Setting this to true increments [page:InterleavedBuffer.version version].
 		</p>
 
 		<h3>[property:Usage usage]</h3>
 		<p>
-			Defines the intended usage pattern of the data store for optimization purposes. Corresponds to the *usage* parameter of
+			Defines the intended usage pattern of the data store for optimization purposes. Corresponds to the `usage` parameter of
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData WebGLRenderingContext.bufferData]().
 		</p>
 
@@ -79,12 +79,12 @@
 		</p>
 
 		<h3>[method:this copyAt]( [param:Integer index1], [param:InterleavedBuffer attribute], [param:Integer index2] ) </h3>
-		<p>Copies data from attribute[index2] to [page:InterleavedBuffer.array array][index1].</p>
+		<p>Copies data from `attribute[index2]` to [page:InterleavedBuffer.array array][index1].</p>
 
 		<h3>[method:this set]( [param:TypedArray value], [param:Integer offset] ) </h3>
 		<p>
 			value - The source (typed) array.<br/>
-			offset - The offset into the target array at which to begin writing values from the source array. Default is *0*.<br/><br />
+			offset - The offset into the target array at which to begin writing values from the source array. Default is .<br/><br />
 
 			Stores multiple values in the buffer, reading input values from a specified array.
 		</p>

--- a/docs/api/en/core/InterleavedBufferAttribute.html
+++ b/docs/api/en/core/InterleavedBufferAttribute.html
@@ -56,12 +56,12 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-			Default is *false*. Setting this to *true* will send the entire interleaved buffer (not just the specific attribute data) to the GPU again.
+			Default is `false`. Setting this to `true` will send the entire interleaved buffer (not just the specific attribute data) to the GPU again.
 		</p>
 
 		<h3>[property:Boolean normalized]</h3>
 		<p>
-			Default is *false*.
+			Default is `false`.
 		</p>
 
 		<h3>[property:Integer offset]</h3>

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A [page:Layers] object assigns an [page:Object3D] to 1 or more of 32 layers numbered 0 to 31
+			A [page:Layers] object assigns an [page:Object3D] to 1 or more of 32 layers numbered `0` to `31`
 			- internally the layers are stored as a [link:https://en.wikipedia.org/wiki/Mask_(computing) bit mask], and by default all
 			Object3Ds are a member of layer 0.<br /><br />
 

--- a/docs/api/en/core/Layers.html
+++ b/docs/api/en/core/Layers.html
@@ -48,28 +48,28 @@
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
-			Remove membership of this *layer*.
+			Remove membership of this `layer`.
 		</p>
 
 		<h3>[method:undefined enable]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
-			Add membership of this *layer*.
+			Add membership of this `layer`.
 		</p>
 
 		<h3>[method:undefined set]( [param:Integer layer] )</h3>
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
-			Set membership to *layer*, and remove membership all other layers.
+			Set membership to `layer`, and remove membership all other layers.
 		</p>
 
 		<h3>[method:Boolean test]( [param:Layers layers] )</h3>
 		<p>
 			layers - a Layers object<br /><br />
 
-			Returns true if this and the passed *layers* object have at least one layer in common.
+			Returns true if this and the passed `layers` object have at least one layer in common.
 		</p>
 
 		<h3>[method:Boolean isEnabled]( [param:Integer layer] )</h3>
@@ -83,7 +83,7 @@
 		<p>
 			layer - an integer from 0 to 31.<br /><br />
 
-			Toggle membership of *layer*.
+			Toggle membership of `layer`.
 		</p>
 
 		<h3>[method:undefined enableAll]()</h3>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -33,7 +33,7 @@
 		<p>Array with object's animation clips.</p>
 
 		<h3>[property:Boolean castShadow]</h3>
-		<p>Whether the object gets rendered into shadow map. Default is *false*.</p>
+		<p>Whether the object gets rendered into shadow map. Default is `false`.</p>
 
 		<h3>[property:Array children]</h3>
 		<p>Array with object's children. See [page:Group] for info on manually grouping objects.</p>
@@ -41,12 +41,12 @@
 		<h3>[property:Material customDepthMaterial]</h3>
 		<p>
 		Custom depth material to be used when rendering to the depth map. Can only be used in context of meshes.
-		When shadow-casting with a [page:DirectionalLight] or [page:SpotLight], if you are modifying vertex positions in the vertex shader you must specify a customDepthMaterial for proper shadows. Default is *undefined*.
+		When shadow-casting with a [page:DirectionalLight] or [page:SpotLight], if you are modifying vertex positions in the vertex shader you must specify a customDepthMaterial for proper shadows. Default is `undefined`.
 		</p>
 
 		<h3>[property:Material customDistanceMaterial]</h3>
 		<p>
-		Same as [page:.customDepthMaterial customDepthMaterial], but used with [page:PointLight]. Default is *undefined*.
+		Same as [page:.customDepthMaterial customDepthMaterial], but used with [page:PointLight]. Default is `undefined`.
 		</p>
 
 		<h3>[property:Boolean frustumCulled]</h3>
@@ -87,7 +87,7 @@
 		<h3>[property:Boolean matrixWorldNeedsUpdate]</h3>
 		<p>
 		When this is set, it calculates the matrixWorld in that frame and resets this property
-		 to false. Default is *false*.
+		 to false. Default is `false`.
 		</p>
 
 		<h3>[property:Matrix4 modelViewMatrix]</h3>
@@ -112,7 +112,7 @@
 		material, group.
 		</p>
 		<p>
-		Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+		Please notice that this callback is only executed for `renderable` 3D objects. Meaning 3D objects which define their visual
 		appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
 		Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
 		</p>
@@ -124,7 +124,7 @@
 		material, group.
 		</p>
 		<p>
-		Please notice that this callback is only executed for *renderable* 3D objects. Meaning 3D objects which define their visual
+		Please notice that this callback is only executed for `renderable` 3D objects. Meaning 3D objects which define their visual
 		appearance with geometries and materials like instances of [page:Mesh], [page:Line], [page:Points] or [page:Sprite].
 		Instances of [page:Object3D], [page:Group] or [page:Bone] are not renderable and thus this callback is not executed for such objects.
 		</p>
@@ -134,20 +134,20 @@
 		one parent.</p>
 
 		<h3>[property:Vector3 position]</h3>
-		<p>A [page:Vector3] representing the object's local position. Default is (0, 0, 0).</p>
+		<p>A [page:Vector3] representing the object's local position. Default is `(0, 0, 0)`.</p>
 
 		<h3>[property:Quaternion quaternion]</h3>
 		<p>Object's local rotation as a [page:Quaternion Quaternion].</p>
 
 		<h3>[property:Boolean receiveShadow]</h3>
-		<p>Whether the material receives shadows. Default is *false*.</p>
+		<p>Whether the material receives shadows. Default is `false`.</p>
 
 		<h3>[property:Number renderOrder]</h3>
 		<p>
 		This value allows the default rendering order of [link:https://en.wikipedia.org/wiki/Scene_graph scene graph]
 		objects to be overridden although opaque and transparent objects remain sorted independently. When this property
 		is set for an instance of [page:Group Group], all descendants objects will be sorted and rendered together.
-		Sorting is from lowest to highest renderOrder. Default value is *0*.
+		Sorting is from lowest to highest renderOrder. Default value is .
 		</p>
 
 		<h3>[property:Euler rotation]</h3>
@@ -179,7 +179,7 @@
 		</p>
 
 		<h3>[property:Boolean visible]</h3>
-		<p>Object gets rendered if *true*. Default is *true*.</p>
+		<p>Object gets rendered if `true`. Default is `true`.</p>
 
 
 
@@ -189,7 +189,7 @@
 			Static properties and methods are defined per class rather than per instance of that class.
 			This means that changing [page:Object3D.DefaultUp] or [page:Object3D.DefaultMatrixAutoUpdate]
 			will change the values of [page:.up up] and [page:.matrixAutoUpdate matrixAutoUpdate] for
-			<em>every</em>	instance of Object3D (or derived classes)	created after the change has
+			`every`	instance of Object3D (or derived classes)	created after the change has
 			been made (already created Object3Ds will not be affected).
 		</p>
 
@@ -213,7 +213,7 @@
 
 		<h3>[method:this add]( [param:Object3D object], ... )</h3>
 		<p>
-		Adds *object* as child of this object. An arbitrary number of objects may be added. Any current parent on an
+		Adds `object` as child of this object. An arbitrary number of objects may be added. Any current parent on an
 		object passed in here will be removed, since an object can have at most one parent.<br /><br />
 
 		See [page:Group] for info on manually grouping objects.
@@ -226,7 +226,7 @@
 		<p>Applies the rotation represented by the quaternion to the object.</p>
 
 		<h3>[method:this attach]( [param:Object3D object] )</h3>
-		<p>Adds *object* as a child of this, while maintaining the object's world transform.<br/><br/>
+		<p>Adds `object` as a child of this, while maintaining the object's world transform.<br/><br/>
 		Note: This method does not support scene graphs having non-uniformly-scaled nodes(s).
 		</p>
 
@@ -327,7 +327,7 @@
 
 		<h3>[method:this remove]( [param:Object3D object], ... )</h3>
 		<p>
-		Removes *object* as child of this object. An arbitrary number of objects may be removed.
+		Removes `object` as child of this object. An arbitrary number of objects may be removed.
 		</p>
 
 		<h3>[method:this removeFromParent]()</h3>
@@ -427,13 +427,13 @@
 		</p>
 
 		<h3>[method:this translateX]( [param:Float distance] )</h3>
-		<p>Translates object along x axis in object space by *distance* units.</p>
+		<p>Translates object along x axis in object space by `distance` units.</p>
 
 		<h3>[method:this translateY]( [param:Float distance] )</h3>
-		<p>Translates object along y axis in object space by *distance* units.</p>
+		<p>Translates object along y axis in object space by `distance` units.</p>
 
 		<h3>[method:this translateZ]( [param:Float distance] )</h3>
-		<p>Translates object along z axis in object space by *distance* units.</p>
+		<p>Translates object along z axis in object space by `distance` units.</p>
 
 		<h3>[method:undefined traverse]( [param:Function callback] )</h3>
 		<p>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -163,7 +163,7 @@
 		<h3>[property:Vector3 up]</h3>
 		<p>
 		This is used by the [page:.lookAt lookAt] method, for example, to determine the orientation of the result.<br />
-		Default is [page:Object3D.DefaultUp] - that is, ( 0, 1, 0 ).
+		Default is [page:Object3D.DefaultUp] - that is, `( 0, 1, 0 )`.
 		</p>
 
 		<h3>[property:Object userData]</h3>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -147,7 +147,7 @@
 		This value allows the default rendering order of [link:https://en.wikipedia.org/wiki/Scene_graph scene graph]
 		objects to be overridden although opaque and transparent objects remain sorted independently. When this property
 		is set for an instance of [page:Group Group], all descendants objects will be sorted and rendered together.
-		Sorting is from lowest to highest renderOrder. Default value is .
+		Sorting is from lowest to highest renderOrder. Default value is `0`.
 		</p>
 
 		<h3>[property:Euler rotation]</h3>

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -107,7 +107,7 @@
 		<h3>[property:Layers layers]</h3>
 		<p>
 		Used by [name] to selectively ignore 3D objects when performing intersection tests. The following code example ensures that
-		only 3D objects on layer *1* will be honored by the instance of [name].
+		only 3D objects on layer `1` will be honored by the instance of [name].
 
 		<code>
 		raycaster.layers.set( 1 );
@@ -145,7 +145,7 @@
 		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
 		</p>
 		<p>
-		Updates the ray with a new origin and direction. Please note that this method only copies the values from the arguments.
+		Updates the ray with a new origin and direction. Please Note that this method only copies the values from the arguments.
 		</p>
 
 		<h3>[method:undefined setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>
@@ -180,10 +180,10 @@
 			[page:Integer instanceId] – The index number of the instance where the ray intersects the InstancedMesh
 		</p>
 		<p>
-		*Raycaster* delegates to the [page:Object3D.raycast raycast] method of the passed object, when evaluating whether the ray intersects the object or not. This allows [page:Mesh meshes] to respond differently to ray casting than [page:Line lines] and [page:Points pointclouds].
+		`Raycaster` delegates to the [page:Object3D.raycast raycast] method of the passed object, when evaluating whether the ray intersects the object or not. This allows [page:Mesh meshes] to respond differently to ray casting than [page:Line lines] and [page:Points pointclouds].
 		</p>
 		<p>
-		*Note* that for meshes, faces must be pointed towards the origin of the [page:.ray ray] in order to be detected; intersections of the ray passing through the back of a face will not be detected. To raycast against both faces of an object, you'll want to set the [page:Mesh.material material]'s [page:Material.side side] property to *THREE.DoubleSide*.
+		*Note* that for meshes, faces must be pointed towards the origin of the [page:.ray ray] in order to be detected; intersections of the ray passing through the back of a face will not be detected. To raycast against both faces of an object, you'll want to set the [page:Mesh.material material]'s [page:Material.side side] property to `THREE.DoubleSide`.
 		</p>
 
 		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive], [param:Array optionalTarget] )</h3>

--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -145,7 +145,7 @@
 		[page:Vector3 direction] — The normalized direction vector that gives direction to the ray.
 		</p>
 		<p>
-		Updates the ray with a new origin and direction. Please Note that this method only copies the values from the arguments.
+		Updates the ray with a new origin and direction. Please note that this method only copies the values from the arguments.
 		</p>
 
 		<h3>[method:undefined setFromCamera]( [param:Vector2 coords], [param:Camera camera] )</h3>

--- a/docs/api/en/core/Uniform.html
+++ b/docs/api/en/core/Uniform.html
@@ -26,14 +26,14 @@
 		<h2>Uniform types</h2>
 
 		<p>
-		Each uniform must have a *value* property. The type of the value must correspond to the
+		Each uniform must have a `value` property. The type of the value must correspond to the
 		type of the uniform variable in the GLSL code as specified for the primitive GLSL types
 		in the table below. Uniform structures and arrays are also supported. GLSL arrays of primitive
 		type must either be specified as an array of the corresponding THREE objects or as a flat
 		array containing the data of all the objects. In other words; GLSL primitives in arrays
 		must not be represented by arrays. This rule does not apply transitively.
-		An array of *vec2* arrays, each with a length of five vectors, must be an array of arrays,
-		of either five [page:Vector2] objects or ten *number*s.
+		An array of `vec2` arrays, each with a length of five vectors, must be an array of arrays,
+		of either five [page:Vector2] objects or ten `number`s.
 		</p>
 		<table>
 			<caption><a id="uniform-types">Uniform types</a></caption>
@@ -188,7 +188,7 @@
 		<h2>Structured Uniforms</h2>
 
 		<p>
-			Sometimes you want to organize uniforms as *structs* in your shader code. The following style must be used so *three.js* is able
+			Sometimes you want to organize uniforms as `structs` in your shader code. The following style must be used so `three.js` is able
 			to process structured uniform data.
 		</p>
 		<code>
@@ -214,7 +214,7 @@
 		<h2>Structured Uniforms with Arrays</h2>
 
 		<p>
-			It's also possible to manage *structs* in arrays. The syntax for this use case looks like so:
+			It's also possible to manage `structs` in arrays. The syntax for this use case looks like so:
 		</p>
 		<code>
 		const entry1 = {

--- a/docs/api/en/extras/PMREMGenerator.html
+++ b/docs/api/en/extras/PMREMGenerator.html
@@ -60,9 +60,9 @@
 		<h3>[method:WebGLRenderTarget fromScene]( [param:Scene scene], [param:Number sigma], [param:Number near], [param:Number far] )</h3>
 		<p>
 			[page:Scene scene] - The given scene.<br>
-			[page:Number sigma] - (optional) Specifies a blur radius in radians to be applied to the scene before PMREM generation. Default is *0*.<br>
-			[page:Number near] - (optional) The near plane value. Default is *0.1*.<br>
-			[page:Number far] - (optional) The far plane value. Default is *100*.<br /><br />
+			[page:Number sigma] - (optional) Specifies a blur radius in radians to be applied to the scene before PMREM generation. Default is `0`.<br>
+			[page:Number near] - (optional) The near plane value. Default is `0.1`.<br>
+			[page:Number far] - (optional) The far plane value. Default is `100`.<br /><br />
 
 			Generates a PMREM from a supplied Scene, which can be faster than using an image if networking bandwidth is low.
 			Optional near and far planes ensure the scene is rendered in its entirety (the cubeCamera is placed at the origin).

--- a/docs/api/en/extras/core/Curve.html
+++ b/docs/api/en/extras/core/Curve.html
@@ -50,14 +50,14 @@
 
 		<h3>[method:Array getPoints]( [param:Integer divisions] )</h3>
 		<p>
-			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
+			divisions -- number of pieces to divide the curve into. Default is `5`.<br /><br />
 
 			Returns a set of divisions + 1 points using getPoint( t ).
 		</p>
 
 		<h3>[method:Array getSpacedPoints]( [param:Integer divisions] )</h3>
 		<p>
-			divisions -- number of pieces to divide the curve into. Default is *5*.<br /><br />
+			divisions -- number of pieces to divide the curve into. Default is `5`.<br /><br />
 
 			Returns a set of divisions + 1 equi-spaced points using getPointAt( u ).
 		</p>

--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -46,9 +46,9 @@
 
 		<h3>[method:Array getPoints]( [param:Integer divisions] )</h3>
 		<p>
-			divisions -- number of pieces to divide the curve into. Default is *12*.<br /><br />
+			divisions -- number of pieces to divide the curve into. Default is `12`.<br /><br />
 
-			Returns an array of points representing a sequence of curves. The *division* parameter defines
+			Returns an array of points representing a sequence of curves. The `division` parameter defines
 			the number of pieces each curve is divided into. However, for optimization and quality purposes,
 			the actual sampling resolution for each curve depends on its type. For example, for a [page:LineCurve],
 			the returned number of points is always just 2.
@@ -56,7 +56,7 @@
 
 		<h3>[method:Array getSpacedPoints]( [param:Integer divisions] )</h3>
 		<p>
-			divisions -- number of pieces to divide the curve into. Default is *40*.<br /><br />
+			divisions -- number of pieces to divide the curve into. Default is `40`.<br /><br />
 
 			Returns a set of divisions + 1 equi-spaced points using getPointAt( u ).
 		</p>

--- a/docs/api/en/extras/core/Path.html
+++ b/docs/api/en/extras/core/Path.html
@@ -65,7 +65,7 @@
 			radius -- The radius of the arc.<br />
 			startAngle -- The start angle in radians.<br />
 			endAngle -- The end angle in radians.<br />
-			clockwise -- Sweep the arc clockwise. Defaults to *false*.<br /><br />
+			clockwise -- Sweep the arc clockwise. Defaults to `false`.<br /><br />
 
 			Adds an absolutely positioned [page:EllipseCurve EllipseCurve] to the path.
 		</p>
@@ -89,7 +89,7 @@
 		radius -- The radius of the arc.<br />
 		startAngle -- The start angle in radians.<br />
 		endAngle -- The end angle in radians.<br />
-		clockwise -- Sweep the arc clockwise. Defaults to *false*.<br /><br />
+		clockwise -- Sweep the arc clockwise. Defaults to `false`.<br /><br />
 
 		Adds an [page:EllipseCurve EllipseCurve] to the path, positioned relative to [page:.currentPoint].
 		</p>
@@ -105,8 +105,8 @@
 			yRadius -- The radius of the ellipse in the y axis.<br />
 			startAngle -- The start angle in radians.<br />
 			endAngle -- The end angle in radians.<br />
-			clockwise -- Sweep the ellipse clockwise. Defaults to *false*.<br />
-			rotation -- The rotation angle of the ellipse in radians, counterclockwise from the positive X axis. Optional, defaults to *0*.<br /><br />
+			clockwise -- Sweep the ellipse clockwise. Defaults to `false`.<br />
+			rotation -- The rotation angle of the ellipse in radians, counterclockwise from the positive X axis. Optional, defaults to `0`.<br /><br />
 
 			Adds an [page:EllipseCurve EllipseCurve] to the path, positioned relative to [page:.currentPoint].
 		</p>

--- a/docs/api/en/extras/curves/CatmullRomCurve3.html
+++ b/docs/api/en/extras/curves/CatmullRomCurve3.html
@@ -46,9 +46,9 @@
 		<h3>[name]( [param:Array points], [param:Boolean closed], [param:String curveType], [param:Float tension] )</h3>
 		<p>
 			points – An array of [page:Vector3] points<br/>
-			closed – Whether the curve is closed. Default is *false*.<br/>
-			curveType – Type of the curve. Default is *centripetal*.<br/>
-			tension – Tension of the curve. Default is *0.5*.
+			closed – Whether the curve is closed. Default is `false`.<br/>
+			curveType – Type of the curve. Default is `centripetal`.<br/>
+			tension – Tension of the curve. Default is `0.5`.
 		</p>
 
 
@@ -62,10 +62,10 @@
 		<p>The curve will loop back onto itself when this is true.</p>
 
 		<h3>[property:String curveType]</h3>
-		<p>Possible values are *centripetal*, *chordal* and *catmullrom*.</p>
+		<p>Possible values are `centripetal`, `chordal` and `catmullrom`.</p>
 
 		<h3>[property:Float tension]</h3>
-		<p>When [page:.curveType] is *catmullrom*, defines catmullrom's tension.</p>
+		<p>When [page:.curveType] is `catmullrom`, defines catmullrom's tension.</p>
 
 
 		<h2>Methods</h2>

--- a/docs/api/en/extras/curves/EllipseCurve.html
+++ b/docs/api/en/extras/curves/EllipseCurve.html
@@ -41,14 +41,14 @@
 
 		<h3>[name]( [param:Float aX], [param:Float aY], [param:Float xRadius], [param:Float yRadius], [param:Radians aStartAngle], [param:Radians aEndAngle], [param:Boolean aClockwise], [param:Radians aRotation] )</h3>
 		<p>
-			[page:Float aX] – The X center of the ellipse. Default is *0*.<br/>
-			[page:Float aY] – The Y center of the ellipse. Default is *0*.<br/>
-			[page:Float xRadius] – The radius of the ellipse in the x direction. Default is *1*.<br/>
-			[page:Float yRadius] – The radius of the ellipse in the y direction. Default is *1*.<br/>
-			[page:Radians aStartAngle] – The start angle of the curve in radians starting from the positive X axis.  Default is *0*.<br/>
-			[page:Radians aEndAngle] – The end angle of the curve in radians starting from the positive X axis. Default is *2 x Math.PI*.<br/>
-			[page:Boolean aClockwise] – Whether the ellipse is drawn clockwise. Default is *false*.<br/>
-			[page:Radians aRotation]  – The rotation angle of the ellipse in radians, counterclockwise from the positive X axis (optional). Default is *0*.<br/><br/>
+			[page:Float aX] – The X center of the ellipse. Default is `0`.<br/>
+			[page:Float aY] – The Y center of the ellipse. Default is `0`.<br/>
+			[page:Float xRadius] – The radius of the ellipse in the x direction. Default is `1`.<br/>
+			[page:Float yRadius] – The radius of the ellipse in the y direction. Default is `1`.<br/>
+			[page:Radians aStartAngle] – The start angle of the curve in radians starting from the positive X axis.  Default is `0`.<br/>
+			[page:Radians aEndAngle] – The end angle of the curve in radians starting from the positive X axis. Default is `2 x Math.PI`.<br/>
+			[page:Boolean aClockwise] – Whether the ellipse is drawn clockwise. Default is `false`.<br/>
+			[page:Radians aRotation]  – The rotation angle of the ellipse in radians, counterclockwise from the positive X axis (optional). Default is `0`.<br/><br/>
 		</p>
 
 		<h2>Properties</h2>
@@ -76,7 +76,7 @@
 		<p>Whether the ellipse is drawn clockwise.</p>
 
 		<h3>[property:Float aRotation]</h3>
-		<p>The rotation angle of the ellipse in radians, counterclockwise from the positive X axis (optional). Default is *0*.</p>
+		<p>The rotation angle of the ellipse in radians, counterclockwise from the positive X axis (optional). Default is `0`.</p>
 
 
 		<h2>Methods</h2>

--- a/docs/api/en/geometries/SphereGeometry.html
+++ b/docs/api/en/geometries/SphereGeometry.html
@@ -54,7 +54,7 @@
 		</p>
 
 		<p>
-		The geometry is created by sweeping and calculating vertexes around the Y axis (horizontal sweep) and the Z axis (vertical sweep). Thus, incomplete spheres (akin to <em>'sphere slices'</em>) can be created through the use of different values of phiStart, phiLength, thetaStart and thetaLength, in order to define the points in which we start (or end) calculating those vertices.
+		The geometry is created by sweeping and calculating vertexes around the Y axis (horizontal sweep) and the Z axis (vertical sweep). Thus, incomplete spheres (akin to `'sphere slices'`) can be created through the use of different values of phiStart, phiLength, thetaStart and thetaLength, in order to define the points in which we start (or end) calculating those vertices.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/en/geometries/TubeGeometry.html
+++ b/docs/api/en/geometries/TubeGeometry.html
@@ -69,10 +69,10 @@
 		<h3>[name]([param:Curve path], [param:Integer tubularSegments], [param:Float radius], [param:Integer radialSegments], [param:Boolean closed])</h3>
 		<p>
 		path — [page:Curve] - A 3D path that inherits from the [page:Curve] base class. Default is a quadratic bezier curve.<br />
-		tubularSegments — [page:Integer] - The number of segments that make up the tube. Default is *64*.<br />
-		radius — [page:Float] - The radius of the tube. Default is *1*.<br />
-		radialSegments — [page:Integer] - The number of segments that make up the cross-section. Default is *8*.<br />
-		closed — [page:Boolean] Is the tube open or closed. Default is *false*.<br />
+		tubularSegments — [page:Integer] - The number of segments that make up the tube. Default is `64`.<br />
+		radius — [page:Float] - The radius of the tube. Default is `1`.<br />
+		radialSegments — [page:Integer] - The number of segments that make up the cross-section. Default is `8`.<br />
+		closed — [page:Boolean] Is the tube open or closed. Default is `false`.<br />
 		</p>
 
 

--- a/docs/api/en/helpers/ArrowHelper.html
+++ b/docs/api/en/helpers/ArrowHelper.html
@@ -41,7 +41,7 @@
 		<p>
 		[page:Vector3 dir] -- direction from origin. Must be a unit vector. <br />
 		[page:Vector3 origin] -- Point at which the arrow starts.<br />
-		[page:Number length] -- length of the arrow. Default is *1*.<br />
+		[page:Number length] -- length of the arrow. Default is `1`.<br />
 		[page:Number hex] -- hexadecimal value to define color. Default is 0xffff00.<br />
 		[page:Number headLength] -- The length of the head of the arrow. Default is 0.2 * length.<br />
 		[page:Number headWidth] -- The width of the head of the arrow. Default is 0.2 * headLength.<br />

--- a/docs/api/en/helpers/AxesHelper.html
+++ b/docs/api/en/helpers/AxesHelper.html
@@ -35,7 +35,7 @@ scene.add( axesHelper );
 
 		<h3>[name]( [param:Number size] )</h3>
 		<p>
-		[page:Number size] -- (optional) size of the lines representing the axes. Default is *1*.
+		[page:Number size] -- (optional) size of the lines representing the axes. Default is `1`.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -52,7 +52,7 @@ scene.add( helper );
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			camera's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 

--- a/docs/api/en/helpers/DirectionalLightHelper.html
+++ b/docs/api/en/helpers/DirectionalLightHelper.html
@@ -32,7 +32,7 @@
 		<p>
 			[page:DirectionalLight light]-- The light to be visualized. <br /><br />
 
-			[page:Number size] -- (optional) dimensions of the plane. Default is *1*.<br /><br />
+			[page:Number size] -- (optional) dimensions of the plane. Default is `1`.<br /><br />
 
 			[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light.
 		</p>
@@ -53,13 +53,13 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			light's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 
 		<h3>[property:hex color]</h3>
 		<p>
-			The color parameter passed in the constructor. Default is *undefined*. If this is changed,
+			The color parameter passed in the constructor. Default is `undefined`. If this is changed,
 			the helper's color will update the next time [page:.update update] is called.
 		</p>
 

--- a/docs/api/en/helpers/HemisphereLightHelper.html
+++ b/docs/api/en/helpers/HemisphereLightHelper.html
@@ -47,13 +47,13 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			hemisphereLight's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 
 		<h3>[property:hex color]</h3>
 		<p>
-			 The color parameter passed in the constructor. Default is *undefined*. If this is changed, the helper's color will update
+			 The color parameter passed in the constructor. Default is `undefined`. If this is changed, the helper's color will update
 			the next time [page:.update update] is called.
 		</p>
 

--- a/docs/api/en/helpers/PointLightHelper.html
+++ b/docs/api/en/helpers/PointLightHelper.html
@@ -40,7 +40,7 @@
 		<p>
 		[page:PointLight light] -- The light to be visualized. <br /><br />
 
-		[page:Float sphereSize] -- (optional) The size of the sphere helper. Default is *1*.<br /><br />
+		[page:Float sphereSize] -- (optional) The size of the sphere helper. Default is `1`.<br /><br />
 
 		[page:Hex color] -- (optional) if this is not the set the helper will take the color of the light.
 		</p>
@@ -56,13 +56,13 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			pointLight's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 
 		<h3>[property:hex color]</h3>
 		<p>
-			 The color parameter passed in the constructor. Default is *undefined*. If this is changed, the helper's color will update
+			 The color parameter passed in the constructor. Default is `undefined`. If this is changed, the helper's color will update
 			the next time [page:.update update] is called.
 		</p>
 

--- a/docs/api/en/helpers/SpotLightHelper.html
+++ b/docs/api/en/helpers/SpotLightHelper.html
@@ -52,13 +52,13 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			spotLight's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 
 		<h3>[property:hex color]</h3>
 		<p>
-			 The color parameter passed in the constructor. Default is *undefined*. If this is changed, the helper's color will update
+			 The color parameter passed in the constructor. Default is `undefined`. If this is changed, the helper's color will update
 			the next time [page:.update update] is called.
 		</p>
 

--- a/docs/api/en/lights/DirectionalLight.html
+++ b/docs/api/en/lights/DirectionalLight.html
@@ -69,9 +69,9 @@
 
 		<h3>[property:Boolean castShadow]</h3>
 		<p>
-			If set to *true* light will cast dynamic shadows. *Warning*: This is expensive and
+			If set to `true` light will cast dynamic shadows. *Warning*: This is expensive and
 			requires tweaking to get shadows looking right. See the [page:DirectionalLightShadow] for details.
-			The default is *false*.
+			The default is `false`.
 		</p>
 
 		<h3>[property:Boolean isDirectionalLight]</h3>
@@ -92,7 +92,7 @@
 		<h3>[property:Object3D target]</h3>
 		<p>
 			The DirectionalLight points from its [page:.position position] to target.position. The default
-			position of the target is *(0, 0, 0)*.<br />
+			position of the target is `(0, 0, 0)`.<br />
 
 			*Note*: For the target's position to be changed to anything other than the default,
 			it must be added to the [page:Scene scene] using

--- a/docs/api/en/lights/Light.html
+++ b/docs/api/en/lights/Light.html
@@ -42,7 +42,7 @@
 		<p>
 			The light's intensity, or strength.<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, the units of intensity depend on the type of light.<br />
-			Default - *1.0*.
+			Default - `1.0`.
 		</p>
 
 		<h3>[property:Boolean isLight]</h3>

--- a/docs/api/en/lights/PointLight.html
+++ b/docs/api/en/lights/PointLight.html
@@ -57,29 +57,29 @@ scene.add( light );
 		<p>
 			The amount the light dims along the distance of the light<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, decay = 2 leads to physically realistic light falloff.<br/>
-			Default is *1*.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Float distance]</h3>
 		<p>
-			<em>Default mode</em> — When distance is zero, light does not attenuate. When distance is
+			`Default mode` — When distance is zero, light does not attenuate. When distance is
 			non-zero, light will attenuate linearly from maximum intensity at the light's position down to
 			zero at this distance from the light.
 		</p>
 		<p>
-			<em>[page:WebGLRenderer.physicallyCorrectLights Physically correct] mode</em> — When distance
+			`[page:WebGLRenderer.physicallyCorrectLights Physically correct] mode` — When distance
 			is zero, light will attenuate according to inverse-square law to infinite distance. When
 			distance is non-zero, light will attenuate according to inverse-square law until near the
 			distance cutoff, where it will then attenuate quickly and smoothly to 0. Inherently, cutoffs
 			are not physically correct.
 		</p>
 		<p>
-			Default is *0.0*.
+			Default is `0.0`.
 		</p>
 
 		<h3>[property:Float intensity]</h3>
 		<p>
-			The light's intensity. Default is *1*. <br />
+			The light's intensity. Default is `1`.<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, intensity is the luminous
 			intensity of the light measured in candela (cd).<br /><br />
 

--- a/docs/api/en/lights/RectAreaLight.html
+++ b/docs/api/en/lights/RectAreaLight.html
@@ -19,7 +19,7 @@
 			<ul>
 				<li>There is no shadow support.</li>
 				<li>Only [page:MeshStandardMaterial MeshStandardMaterial] and [page:MeshPhysicalMaterial MeshPhysicalMaterial] are supported.</li>
-				<li>You have to include [link:https://threejs.org/examples/jsm/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] into your scene and call *init()*.</li>
+				<li>You have to include [link:https://threejs.org/examples/jsm/lights/RectAreaLightUniformsLib.js RectAreaLightUniformsLib] into your scene and call `init()`.</li>
 			</ul>
 		</p>
 
@@ -69,7 +69,7 @@ rectLight.add( rectLightHelper );
 
 		<h3>[property:Float intensity]</h3>
 		<p>
-			The light's intensity. Default is *1*. <br />
+			The light's intensity. Default is `1`.<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, intensity is the luminance
 			(brightness) of the light measured in nits (cd/m^2).<br /><br />
 

--- a/docs/api/en/lights/SpotLight.html
+++ b/docs/api/en/lights/SpotLight.html
@@ -68,44 +68,44 @@
 		<h3>[property:Float angle]</h3>
 		<p>
 			Maximum extent of the spotlight, in radians, from its direction. Should be no more than
-			*Math.PI/2*. The default is *Math.PI/3*.
+			`Math.PI/2`. The default is `Math.PI/3`.
 		</p>
 
 
 		<h3>[property:Boolean castShadow]</h3>
 		<p>
-			If set to *true* light will cast dynamic shadows. *Warning*: This is expensive and
+			If set to `true` light will cast dynamic shadows. *Warning*: This is expensive and
 			requires tweaking to get shadows looking right. See the [page:SpotLightShadow] for details.
-			The default is *false*.
+			The default is `false`.
 		</p>
 
 		<h3>[property:Float decay]</h3>
 		<p>
 			The amount the light dims along the distance of the light.<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, decay = 2 leads to
-			physically realistic light falloff. The default is *1*.
+			physically realistic light falloff. The default is `1`.
 		</p>
 
 		<h3>[property:Float distance]</h3>
 		<p>
-			<em>Default mode</em> — When distance is zero, light does not attenuate. When distance is
+			`Default mode` — When distance is zero, light does not attenuate. When distance is
 			non-zero, light will attenuate linearly from maximum intensity at the light's position down to
 			zero at this distance from the light.
 		</p>
 		<p>
-			<em>[page:WebGLRenderer.physicallyCorrectLights Physically correct] mode</em> — When distance
+			`[page:WebGLRenderer.physicallyCorrectLights Physically correct] mode` — When distance
 			is zero, light will attenuate according to inverse-square law to infinite distance. When
 			distance is non-zero, light will attenuate according to inverse-square law until near the
-			distance cutoff, where it will then attenuate quickly and smoothly to 0. Inherently, cutoffs
+			distance cutoff, where it will then attenuate quickly and smoothly to `0`. Inherently, cutoffs
 			are not physically correct.
 		</p>
 		<p>
-			Default is *0.0*.
+			Default is `0.0`.
 		</p>
 
 		<h3>[property:Float intensity]</h3>
 		<p>
-			The light's intensity. Default is *1*. <br />
+			The light's intensity. Default is `1`.<br />
 			In [page:WebGLRenderer.physicallyCorrectLights physically correct] mode, intensity is the luminous
 			intensity of the light measured in candela (cd).<br /><br />
 
@@ -121,7 +121,7 @@
 		<h3>[property:Float penumbra]</h3>
 		<p>
 			Percent of the spotlight cone that is attenuated due to penumbra. Takes values between
-			zero and 1. The default is *0.0*.
+			zero and 1. The default is `0.0`.
 		</p>
 
 		<h3>[property:Vector3 position]</h3>

--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -29,8 +29,8 @@
 
 		<h3>[property:Boolean autoUpdate]</h3>
 		<p>
-			Enables automatic updates of the light's shadow. Default is *true*.
-			If you do not require dynamic lighting / shadows, you may set this to *false*.
+			Enables automatic updates of the light's shadow. Default is `true`.
+			If you do not require dynamic lighting / shadows, you may set this to `false`.
 		</p>
 
 		<h3>[property:Camera camera]</h3>
@@ -80,8 +80,8 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-			When set to *true*, shadow maps will be updated in the next *render* call. Default is *false*.
-			If you have set [page:.autoUpdate] to *false*, you will need to set this property to *true* and then make a render call to update the light's shadow.
+			When set to `true`, shadow maps will be updated in the next `render` call. Default is `false`.
+			If you have set [page:.autoUpdate] to `false`, you will need to set this property to `true` and then make a render call to update the light's shadow.
 		</p>
 
 		<h3>[property:Float normalBias]</h3>

--- a/docs/api/en/lights/shadows/SpotLightShadow.html
+++ b/docs/api/en/lights/shadows/SpotLightShadow.html
@@ -67,18 +67,18 @@
 			The light's view of the world. This is used to generate a depth map of the scene; objects behind
 			other objects from the light's perspective will be in shadow.<br /><br />
 
-			The default is a [page:PerspectiveCamera] with [page:PerspectiveCamera.near near] clipping plane at 0.5.
+			The default is a [page:PerspectiveCamera] with [page:PerspectiveCamera.near near] clipping plane at `0.5`.
 			The [page:PerspectiveCamera.fov fov] will track the [page:SpotLight.angle angle] property of the owning
 			[page:SpotLight SpotLight] via the [page:SpotLightShadow.update update] method. Similarly, the
 			[page:PerspectiveCamera.aspect aspect] property will track the aspect of the
 			[page:LightShadow.mapSize mapSize]. If the [page:SpotLight.distance distance] property of the light is
-			set, the [page:PerspectiveCamera.far far] clipping plane will track that, otherwise it defaults to 500.
+			set, the [page:PerspectiveCamera.far far] clipping plane will track that, otherwise it defaults to `500`.
 
 		</p>
 
 		<h3>[property:Number focus]</h3>
 		<p>
-			Used to focus the shadow camera. The camera's field of view is set as a percentage of the spotlight's field-of-view. Range is [0, 1]. Default is 1.0.<br/>
+			Used to focus the shadow camera. The camera's field of view is set as a percentage of the spotlight's field-of-view. Range is `[0, 1]`. Default is `1.0`.<br/>
 		</p>
 
 		<h3>[property:Boolean isSpotLightShadow]</h3>

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -82,8 +82,8 @@
 
 		<h3>[method:BufferGeometry parse]( [param:Object json] )</h3>
 		<p>
-		[page:Object json] — The <em>JSON</em> structure to parse.<br /><br />
-		Parse a <em>JSON</em> structure and return a [page:BufferGeometry].
+		[page:Object json] — The `JSON` structure to parse.<br /><br />
+		Parse a `JSON` structure and return a [page:BufferGeometry].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/loaders/Cache.html
+++ b/docs/api/en/loaders/Cache.html
@@ -32,7 +32,7 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Boolean enabled]</h3>
-		<p>Whether caching is enabled. Default is *false*.</p>
+		<p>Whether caching is enabled. Default is `false`.</p>
 
 		<h3>[property:Object files]</h3>
 		<p>An [page:Object object] that holds cached files.</p>
@@ -53,7 +53,7 @@
 		<p>
 		[page:String key] — A string key <br /><br />
 
-		Get the value of [page:String key]. If the key does not exist *undefined* is returned.
+		Get the value of [page:String key]. If the key does not exist `undefined` is returned.
 		</p>
 
 		<h3>[method:undefined remove]( [param:String key] )</h3>

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -44,7 +44,7 @@
 		</code>
 
 		<p>
-			<em>Note:</em> The cache must be enabled using
+			*Note:* The cache must be enabled using
 			<code>THREE.Cache.enabled = true;</code>
 			This is a global property and only needs to be set once to be used by all loaders that use FileLoader internally.
 			[page:Cache Cache] is a cache module that holds the response from each request made through this loader, so each file is requested once.
@@ -65,11 +65,11 @@
 		<h3>[property:String mimeType]</h3>
 		<p>
 			The expected [link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types mimeType].
-			See [page:.setMimeType]. Default is *undefined*.
+			See [page:.setMimeType]. Default is `undefined`.
 		</p>
 
 		<h3>[property:String responseType]</h3>
-		<p>The expected response type. See [page:.setResponseType]. Default is *undefined*.</p>
+		<p>The expected response type. See [page:.setResponseType]. Default is `undefined`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>
@@ -88,7 +88,7 @@
 		<h3>[method:this setMimeType]( [param:String mimeType] )</h3>
 		<p>
 			Set the expected [link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types mimeType]
-			of the file being loaded. Note that in many cases this will be determined automatically, so by default it is *undefined*.
+			of the file being loaded. Note that in many cases this will be determined automatically, so by default it is `undefined`.
 		</p>
 
 		<h3>[method:this setResponseType]( [param:String responseType] )</h3>

--- a/docs/api/en/loaders/ImageBitmapLoader.html
+++ b/docs/api/en/loaders/ImageBitmapLoader.html
@@ -78,7 +78,7 @@
 		</p>
 
 		<h3>[property:String options]</h3>
-		<p>An optional object that sets options for the internally used [link:https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap createImageBitmap] factory method. Default is *undefined*.</p>
+		<p>An optional object that sets options for the internally used [link:https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap createImageBitmap] factory method. Default is `undefined`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:Loader] class for common methods.</p>

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -29,13 +29,13 @@
 		<h3>[property:String crossOrigin]</h3>
 		<p>
 		The crossOrigin string to implement CORS for loading the url from a different domain that allows CORS.
-		Default is *anonymous*.
+		Default is `anonymous`.
 		</p>
 
 		<h3>[property:Boolean withCredentials]</h3>
 		<p>
 			Whether the XMLHttpRequest uses credentials. See [page:.setWithCredentials].
-			Default is *false*.
+			Default is `false`.
 		</p>
 
 		<h3>[property:LoadingManager manager]</h3>

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -77,7 +77,7 @@
 		<p>
 		[page:Object json] — The json object containing the parameters of the Material.<br /><br />
 
-		Parse a <em>JSON</em> structure and create a new [page:Material] of the type [page:String json.type] with parameters defined in the json object.
+		Parse a `JSON` structure and create a new [page:Material] of the type [page:String json.type] with parameters defined in the json object.
 		</p>
 
 		<h3>[method:this setTextures]( [param:Object textures] )</h3>

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -90,7 +90,7 @@
 		[page:Object json] — required. The JSON source to parse.<br /><br />
 		[page:Function onLoad] — Will be called when parsed completes. The argument will be the parsed [page:Object3D object].<br /><br />
 
-		Parse a <em>JSON</em> structure and return a three.js object.
+		Parse a `JSON` structure and return a three.js object.
 		This is used internally by [page:.load]() but can also be used directly to parse a previously loaded JSON structure.
 		</p>
 

--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -52,7 +52,7 @@
 		Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+		string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -62,11 +62,11 @@
 		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Float linewidth]</h3>
 		<p>
-			Controls line thickness. Default is *1*.<br /><br />
+			Controls line thickness. Default is `1`.<br /><br />
 
 			Due to limitations of the [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
 			with the [page:WebGLRenderer WebGL] renderer on most platforms linewidth will

--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -45,10 +45,10 @@
 		<p>See the base [page:LineBasicMaterial] class for common properties.</p>
 
 		<h3>[property:number dashSize]</h3>
-		<p>The size of the dash. This is both the gap with the stroke. Default is *3*.</p>
+		<p>The size of the dash. This is both the gap with the stroke. Default is `3`.</p>
 
 		<h3>[property:number gapSize]</h3>
-		<p>The size of the gap. Default is *1*.</p>
+		<p>The size of the gap. Default is `1`.</p>
 
 		<h3>[property:Boolean isLineDashedMaterial]</h3>
 		<p>
@@ -57,7 +57,7 @@
 
 
 		<h3>[property:number scale]</h3>
-		<p>The scale of the dashed part of a line. Default is *1*.</p>
+		<p>The scale of the dashed part of a line. Default is `1`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:LineBasicMaterial] class for common methods.</p>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -33,13 +33,13 @@
 		<p>
 		Sets the alpha value to be used when running an alpha test.
 		The material will not be rendered if the opacity is lower than this value.
-		Default is *0*.
+		Default is `0`.
 		</p>
 
 		<h3>[property:Float alphaToCoverage]</h3>
 		<p>
-		Enables alpha to coverage. Can only be used with MSAA-enabled contexts (meaning when the renderer was created with *antialias* parameter set to *true*).
-		Default is *false*.
+		Enables alpha to coverage. Can only be used with MSAA-enabled contexts (meaning when the renderer was created with `antialias` parameter set to `true`).
+		Default is `false`.
 		</p>
 
 		<h3>[property:Integer blendDst]</h3>
@@ -50,7 +50,7 @@
 		</p>
 
 		<h3>[property:Integer blendDstAlpha]</h3>
-		<p>The transparency of the [page:.blendDst]. Uses [page:.blendDst] value if null. Default is *null*.</p>
+		<p>The transparency of the [page:.blendDst]. Uses [page:.blendDst] value if null. Default is `null`.</p>
 
 		<h3>[property:Integer blendEquation]</h3>
 		<p>
@@ -60,7 +60,7 @@
 		</p>
 
 		<h3>[property:Integer blendEquationAlpha]</h3>
-		<p>The transparency of the [page:.blendEquation]. Uses [page:.blendEquation] value if null. Default is *null*.</p>
+		<p>The transparency of the [page:.blendEquation]. Uses [page:.blendEquation] value if null. Default is `null`.</p>
 
 		<h3>[property:Blending blending]</h3>
 		<p>
@@ -77,12 +77,12 @@
 		</p>
 
 		<h3>[property:Integer blendSrcAlpha]</h3>
-		<p>The transparency of the [page:.blendSrc]. Uses [page:.blendSrc] value if null. Default is *null*.</p>
+		<p>The transparency of the [page:.blendSrc]. Uses [page:.blendSrc] value if null. Default is `null`.</p>
 
 		<h3>[property:Boolean clipIntersection]</h3>
 		<p>
 		Changes the behavior of clipping planes so that only their intersection is clipped, rather than their union.
-		Default is *false*.
+		Default is `false`.
 		</p>
 
 		<h3>[property:Array clippingPlanes]</h3>
@@ -90,25 +90,25 @@
 		User-defined clipping planes specified as THREE.Plane objects in world space.
 		These planes apply to the objects this material is attached to.
 		Points in space whose signed distance to the plane is negative are clipped (not rendered).
-		This requires [page:WebGLRenderer.localClippingEnabled] to be *true*.
+		This requires [page:WebGLRenderer.localClippingEnabled] to be `true`.
 		See the [example:webgl_clipping_intersection WebGL / clipping /intersection] example.
-		Default is *null*.
+		Default is `null`.
 		</p>
 
 		<h3>[property:Boolean clipShadows]</h3>
 		<p>
-		Defines whether to clip shadows according to the clipping planes specified on this material. Default is *false*.
+		Defines whether to clip shadows according to the clipping planes specified on this material. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean colorWrite]</h3>
 		<p>
 		Whether to render the material's color.
-		This can be used in conjunction with a mesh's [page:Integer renderOrder] property to create invisible objects that occlude other objects. Default is *true*.
+		This can be used in conjunction with a mesh's [page:Integer renderOrder] property to create invisible objects that occlude other objects. Default is `true`.
 		</p>
 
 		<h3>[property:Object defines]</h3>
 		<p>
-		Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. The pairs are defined in both vertex and fragment shaders.  Default is *undefined*.
+		Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. The pairs are defined in both vertex and fragment shaders.  Default is `undefined`.
 		</p>
 
 		<h3>[property:Integer depthFunc]</h3>
@@ -118,12 +118,12 @@
 
 		<h3>[property:Boolean depthTest]</h3>
 		<p>
-		Whether to have depth test enabled when rendering this material. Default is *true*.
+		Whether to have depth test enabled when rendering this material. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean depthWrite]</h3>
 		<p>
-		Whether rendering this material has any effect on the depth buffer. Default is *true*.<br /><br />
+		Whether rendering this material has any effect on the depth buffer. Default is `true`.<br /><br />
 
 		When drawing 2D overlays it can be useful to disable the depth writing in order to layer several things together without creating z-index artifacts.
 		</p>
@@ -135,12 +135,12 @@
 
 		<h3>[property:Boolean stencilWrite]</h3>
 		<p>
-		Whether stencil operations are performed against the stencil buffer. In order to perform writes or comparisons against the stencil buffer this value must be *true*. Default is *false*.
+		Whether stencil operations are performed against the stencil buffer. In order to perform writes or comparisons against the stencil buffer this value must be `true`. Default is `false`.
 		</p>
 
 		<h3>[property:Integer stencilWriteMask]</h3>
 		<p>
-		The bit mask to use when writing to the stencil buffer. Default is *0xFF*.
+		The bit mask to use when writing to the stencil buffer. Default is `0xFF`.
 		</p>
 
 		<h3>[property:Integer stencilFunc]</h3>
@@ -150,12 +150,12 @@
 
 		<h3>[property:Integer stencilRef]</h3>
 		<p>
-		The value to use when performing stencil comparisons or stencil operations. Default is *0*.
+		The value to use when performing stencil comparisons or stencil operations. Default is `0`.
 		</p>
 
 		<h3>[property:Integer stencilFuncMask]</h3>
 		<p>
-		The bit mask to use when comparing against the stencil buffer. Default is *0xFF*.
+		The bit mask to use when comparing against the stencil buffer. Default is `0xFF`.
 		</p>
 
 		<h3>[property:Integer stencilFail]</h3>
@@ -186,48 +186,48 @@
 
 		<h3>[property:Float opacity]</h3>
 		<p>
-		Float in the range of *0.0* - *1.0* indicating how transparent the material is.
-		A value of *0.0* indicates fully transparent, *1.0* is fully opaque.<br />
-		If the material's [page:Boolean transparent] property is not set to *true*, the material will remain
+		Float in the range of `0.0` - `1.0` indicating how transparent the material is.
+		A value of `0.0` indicates fully transparent, `1.0` is fully opaque.<br />
+		If the material's [page:Boolean transparent] property is not set to `true`, the material will remain
 		fully opaque and this value will only affect its color. <br />
-		Default is *1.0*.
+		Default is `1.0`.
 		</p>
 
 		<h3>[property:Boolean polygonOffset]</h3>
 		<p>
-		Whether to use polygon offset. Default is *false*. This corresponds to the *GL_POLYGON_OFFSET_FILL* WebGL feature.
+		Whether to use polygon offset. Default is `false`. This corresponds to the `GL_POLYGON_OFFSET_FILL` WebGL feature.
 		</p>
 
 		<h3>[property:Integer polygonOffsetFactor]</h3>
-		<p>Sets the polygon offset factor. Default is *0*.</p>
+		<p>Sets the polygon offset factor. Default is `0`.</p>
 
 		<h3>[property:Integer polygonOffsetUnits]</h3>
-		<p>Sets the polygon offset units. Default is *0*.</p>
+		<p>Sets the polygon offset units. Default is `0`.</p>
 
 		<h3>[property:String precision]</h3>
 		<p>
-		Override the renderer's default precision for this material. Can be "*highp*", "*mediump*" or "*lowp*".
-		Default is *null*.
+		Override the renderer's default precision for this material. Can be "`highp`", "`mediump`" or "`lowp`".
+		Default is `null`.
 		</p>
 
 		<h3>[property:Boolean premultipliedAlpha]</h3>
 		<p>
 		Whether to premultiply the alpha (transparency) value.
 		See [Example:webgl_materials_physical_transmission WebGL / Materials / Physical / Transmission] for an example of the difference.
-		Default is *false*.
+		Default is `false`.
 		</p>
 
 		<h3>[property:Boolean dithering]</h3>
 		<p>
 		Whether to apply dithering to the color to remove the appearance of banding.
-		Default is *false*.
+		Default is `false`.
 		</p>
 
 		<h3>[property:Integer shadowSide]</h3>
 		<p>
 		Defines which side of faces cast shadows.
-		When set, can be [page:Materials THREE.FrontSide], [page:Materials THREE.BackSide], or [page:Materials THREE.DoubleSide]. Default is *null*. <br />
-		If *null*, the side casting shadows is determined as follows: <br />
+		When set, can be [page:Materials THREE.FrontSide], [page:Materials THREE.BackSide], or [page:Materials THREE.DoubleSide]. Default is `null`. <br />
+		If `null`, the side casting shadows is determined as follows: <br />
 
 		<table>
 			<thead>
@@ -265,7 +265,7 @@
 
 		<h3>[property:Boolean toneMapped]</h3>
 		<p>
-		Defines whether this material is tone mapped according to the renderer's [page:WebGLRenderer.toneMapping toneMapping] setting. Default is *true*.
+		Defines whether this material is tone mapped according to the renderer's [page:WebGLRenderer.toneMapping toneMapping] setting. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean transparent]</h3>
@@ -275,7 +275,7 @@
 		non-transparent objects. <br />
 		When set to true, the extent to which the material is transparent is
 		controlled by setting its [page:Float opacity] property. <br />
-		Default is *false*.
+		Default is `false`.
 		</p>
 
 		<h3>[property:String type]</h3>
@@ -292,17 +292,17 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
+		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
 		</p>
 
 		<h3>[property:Boolean vertexColors]</h3>
 		<p>
-		Defines whether vertex coloring is used. Default is *false*.
+		Defines whether vertex coloring is used. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean visible]</h3>
 		<p>
-		Defines whether this material is visible. Default is *true*.
+		Defines whether this material is visible. Default is `true`.
 		</p>
 
 		<h3>[property:Object userData]</h3>
@@ -369,7 +369,7 @@
 		<h3>[method:undefined setValues]( [param:Object values] )</h3>
 		<p>
 		values -- a container with parameters.<br />
-		Sets the properties based on the *values*.
+		Sets the properties based on the `values`.
 		</p>
 
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -108,7 +108,7 @@
 
 		<h3>[property:Object defines]</h3>
 		<p>
-		Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. { MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }. The pairs are defined in both vertex and fragment shaders.  Default is `undefined`.
+		Custom defines to be injected into the shader. These are passed in form of an object literal, with key/value pairs. `{ MY_CUSTOM_DEFINE: '' , PI2: Math.PI * 2 }`. The pairs are defined in both vertex and fragment shaders.  Default is `undefined`.
 		</p>
 
 		<h3>[property:Integer depthFunc]</h3>
@@ -206,7 +206,7 @@
 
 		<h3>[property:String precision]</h3>
 		<p>
-		Override the renderer's default precision for this material. Can be "`highp`", "`mediump`" or "`lowp`".
+		Override the renderer's default precision for this material. Can be `"highp"`, `"mediump"` or `"lowp"`.
 		Default is `null`.
 		</p>
 

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -44,7 +44,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -84,7 +84,7 @@
 		<p>The environment map. Default is null.</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
@@ -105,14 +105,14 @@
 		<p>
 			The index of refraction (IOR) of air (approximately 1) divided by the index of refraction of the material.
 			It is used with environment mapping modes [page:Textures THREE.CubeRefractionMapping] and [page:Textures THREE.EquirectangularRefractionMapping].
-			The refraction ratio should not exceed 1. Default is *0.98*.
+			The refraction ratio should not exceed 1. Default is `0.98`.
 		</p>
 
 		<h3>[property:Texture specularMap]</h3>
 		<p>Specular map used by the material. Default is null.</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>Render geometry as wireframe. Default is `false` (i.e. render as flat polygons).</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshDepthMaterial.html
+++ b/docs/api/en/materials/MeshDepthMaterial.html
@@ -79,7 +79,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Whether the material is affected by fog. Default is `false`.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null.</p>

--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -90,7 +90,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Whether the material is affected by fog. Default is `false`.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null.</p>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -55,7 +55,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -111,7 +111,7 @@
 		<p>The environment map. Default is null.</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
@@ -129,14 +129,14 @@
 		<p>
 			The index of refraction (IOR) of air (approximately 1) divided by the index of refraction of the material.
 			It is used with environment mapping modes [page:Textures THREE.CubeRefractionMapping] and [page:Textures THREE.EquirectangularRefractionMapping].
-			The refraction ratio should not exceed 1. Default is *0.98*.
+			The refraction ratio should not exceed 1. Default is `0.98`.
 		</p>
 
 		<h3>[property:Texture specularMap]</h3>
 		<p>Specular map used by the material. Default is null.</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>Render geometry as wireframe. Default is `false` (i.e. render as flat polygons).</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshMatcapMaterial.html
+++ b/docs/api/en/materials/MeshMatcapMaterial.html
@@ -43,7 +43,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -101,7 +101,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>The color map. Default is null. The texture map color is modulated by the diffuse [page:.color].</p>

--- a/docs/api/en/materials/MeshNormalMaterial.html
+++ b/docs/api/en/materials/MeshNormalMaterial.html
@@ -81,7 +81,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *false*.</p>
+		<p>Whether the material is affected by fog. Default is `false`.</p>
 
 		<h3>[property:Texture normalMap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -54,7 +54,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -148,7 +148,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
@@ -191,15 +191,15 @@
 		<p>
 			The index of refraction (IOR) of air (approximately 1) divided by the index of refraction of the material.
 			It is used with environment mapping modes [page:Textures THREE.CubeRefractionMapping] and [page:Textures THREE.EquirectangularRefractionMapping].
-			The refraction ratio should not exceed 1. Default is *0.98*.
+			The refraction ratio should not exceed 1. Default is `0.98`.
 		</p>
 
 		<h3>[property:Float shininess]</h3>
-		<p>How shiny the [page:.specular] highlight is; a higher value gives a sharper highlight. Default is *30*.</p>
+		<p>How shiny the [page:.specular] highlight is; a higher value gives a sharper highlight. Default is `30`.</p>
 
 		<h3>[property:Color specular]</h3>
 		<p>
-			Specular color of the material. Default is a [page:Color] set to *0x111111* (very dark grey).<br /><br />
+			Specular color of the material. Default is a [page:Color] set to `0x111111` (very dark grey).<br /><br />
 
 			This defines how shiny the material is and the color of its shine.
 		</p>
@@ -211,7 +211,7 @@
 		</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>Render geometry as wireframe. Default is `false` (i.e. render as flat polygons).</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -72,7 +72,7 @@
 		Any property of the material (including any property inherited from [page:Material] and [page:MeshStandardMaterial]) can be passed in here.<br /><br />
 
 		The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-		string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+		string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 
@@ -81,39 +81,39 @@
 
 		<h3>[property:Color attenuationColor]</h3>
 		<p>
-		The color that white light turns into due to absorption when reaching the attenuation distance. Default is *white* (0xffffff).
+		The color that white light turns into due to absorption when reaching the attenuation distance. Default is `white` (0xffffff).
 		</p>
 
 		<h3>[property:Float attenuationDistance]</h3>
 		<p>
-		Density of the medium given as the average distance that light travels in the medium before interacting with a particle. The value is given in world space. Default is *0*.
+		Density of the medium given as the average distance that light travels in the medium before interacting with a particle. The value is given in world space. Default is `0`.
 		</p>
 
 		<h3>[property:Float clearcoat]</h3>
 		<p>
-		Represents the intensity of the clear coat layer, from *0.0* to *1.0*. Use clear coat related properties to enable multilayer
-		materials that have a thin translucent layer over the base layer. Default is *0.0*.
+		Represents the intensity of the clear coat layer, from `0.0` to `1.0`. Use clear coat related properties to enable multilayer
+		materials that have a thin translucent layer over the base layer. Default is `0.0`.
 		</p>
 
 		<h3>[property:Texture clearcoatMap]</h3>
 		<p>
 		The red channel of this texture is multiplied against [page:.clearcoat], for per-pixel control
-		over a coating's intensity. Default is *null*.
+		over a coating's intensity. Default is `null`.
 		</p>
 
 		<h3>[property:Texture clearcoatNormalMap]</h3>
-		<p>Can be used to enable independent normals for the clear coat layer. Default is *null*.</p>
+		<p>Can be used to enable independent normals for the clear coat layer. Default is `null`.</p>
 
 		<h3>[property:Vector2 clearcoatNormalScale]</h3>
-		<p>How much [page:.clearcoatNormalMap] affects the clear coat layer, from *(0,0)* to *(1,1)*. Default is *(1,1)*.</p>
+		<p>How much [page:.clearcoatNormalMap] affects the clear coat layer, from `(0,0)` to `(1,1)`. Default is `(1,1)`.</p>
 
 		<h3>[property:Float clearcoatRoughness]</h3>
-		<p>Roughness of the clear coat layer, from *0.0* to *1.0*. Default is *0.0*.</p>
+		<p>Roughness of the clear coat layer, from `0.0` to `1.0`. Default is `0.0`.</p>
 
 		<h3>[property:Texture clearcoatRoughnessMap]</h3>
 		<p>
 		The green channel of this texture is multiplied against [page:.clearcoatRoughness], for per-pixel control
-		over a coating's roughness. Default is *null*.
+		over a coating's roughness. Default is `null`.
 		</p>
 
 		<h3>[property:Object defines]</h3>
@@ -132,89 +132,89 @@
 
 		<h3>[property:Float ior]</h3>
 		<p>
-			Index-of-refraction for non-metallic materials, from *1.0* to *2.333*. Default is *1.5*.<br />
+			Index-of-refraction for non-metallic materials, from `1.0` to `2.333`. Default is `1.5`.<br />
 		</p>
 
 		<h3>[property:Float reflectivity]</h3>
 		<p>
-			Degree of reflectivity, from *0.0* to *1.0*. Default is *0.5*, which corresponds to an index-of-refraction of 1.5.<br />
+			Degree of reflectivity, from `0.0` to `1.0`. Default is `0.5`, which corresponds to an index-of-refraction of 1.5.<br />
 
-			This models the reflectivity of non-metallic materials. It has no effect when [page:MeshStandardMaterial.metalness metalness] is *1.0*
+			This models the reflectivity of non-metallic materials. It has no effect when [page:MeshStandardMaterial.metalness metalness] is `1.0`
 		</p>
 
 		<h3>[property:Float sheen]</h3>
 		<p>
-			The intensity of the sheen layer, from *0.0* to *1.0*. Default is *0.0*.
+			The intensity of the sheen layer, from `0.0` to `1.0`. Default is `0.0`.
 		</p>
 
 		<h3>[property:Float sheenRoughness]</h3>
 		<p>
-			Roughness of the sheen layer, from *0.0* to *1.0*. Default is *1.0*.
+			Roughness of the sheen layer, from `0.0` to `1.0`. Default is `1.0`.
 		</p>
 
 		<h3>[property:Texture sheenRoughnessMap]</h3>
 		<p>
 			The alpha channel of this texture is multiplied against [page:.sheenRoughness], for per-pixel control
-			over sheen roughness. Default is *null*.
+			over sheen roughness. Default is `null`.
 		</p>
 
 		<h3>[property:Color sheenColor]</h3>
 		<p>
-			The sheen tint. Default is *0xffffff*, white.
+			The sheen tint. Default is `0xffffff`, white.
 		</p>
 
 		<h3>[property:Texture sheenColorMap]</h3>
 		<p>
 			The RGB channels of this texture are multiplied against [page:.sheenColor], for per-pixel control
-			over sheen tint. Default is *null*.
+			over sheen tint. Default is `null`.
 		</p>
 
 		<h3>[property:Float specularIntensity]</h3>
 		<p>
-			A float that scales the amount of specular reflection for non-metals only. When set to zero, the model is effectively Lambertian. From *0.0* to *1.0*. Default is *0.0*.
+			A float that scales the amount of specular reflection for non-metals only. When set to zero, the model is effectively Lambertian. From `0.0` to `1.0`. Default is `0.0`.
 		</p>
 
 		<h3>[property:Texture specularIntensityMap]</h3>
 		<p>
-			The alpha channel of this texture is multiplied against [page:.specularIntensity], for per-pixel control over specular intensity. Default is *null*.
+			The alpha channel of this texture is multiplied against [page:.specularIntensity], for per-pixel control over specular intensity. Default is `null`.
 		</p>
 
 		<h3>[property:Color specularColor]</h3>
 		<p>
 			A [page:Color] that tints the specular reflection at normal incidence for non-metals only.
-			Default is *0xffffff*, white.
+			Default is `0xffffff`, white.
 		</p>
 
 		<h3>[property:Texture specularColorMap]</h3>
 		<p>
-			The RGB channels of this texture are multiplied against [page:.specularColor], for per-pixel control over specular color. Default is *null*.
+			The RGB channels of this texture are multiplied against [page:.specularColor], for per-pixel control over specular color. Default is `null`.
 		</p>
 
 		<h3>[property:Float thickness]</h3>
 		<p>
-		The thickness of the volume beneath the surface. The value is given in the coordinate space of the mesh. If the value is 0 the material is thin-walled. Otherwise the material is a volume boundary. Default is *0*.
+		The thickness of the volume beneath the surface. The value is given in the coordinate space of the mesh. If the value is 0 the material is thin-walled. Otherwise the material is a volume boundary. Default is `0`.
 		</p>
 
 		<h3>[property:Texture thicknessMap]</h3>
 		<p>
-		A texture that defines the thickness, stored in the G channel. This will be multiplied by [page:.thickness]. Default is *null*.
+		A texture that defines the thickness, stored in the G channel. This will be multiplied by [page:.thickness]. Default is `null`.
 		</p>
 
 		<h3>[property:Float transmission]</h3>
 		<p>
-		Degree of transmission (or optical transparency), from *0.0* to *1.0*. Default is *0.0*.<br />
+		Degree of transmission (or optical transparency), from `0.0` to `1.0`. Default is `0.0`.<br />
 
 		Thin, transparent or semitransparent, plastic or glass materials remain largely reflective even if they are fully transmissive.
 
 		The transmission property can be used to model these materials.<br />
 
-		When transmission is non-zero, [page:Material.opacity opacity] should be set to *1*.
+		When transmission is non-zero, [page:Material.opacity opacity] should be set to `0`.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>
 		<p>
 			The red channel of this texture is multiplied against [page:.transmission], for per-pixel control
-			over optical transparency. Default is *null*.
+			over optical transparency. Default is `null`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -79,7 +79,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -178,7 +178,7 @@
 		</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Boolean isMeshStandardMaterial]</h3>
 		<p>
@@ -235,7 +235,7 @@
 		<p>The green channel of this texture is used to alter the roughness of the material.</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>Render geometry as wireframe. Default is `false` (i.e. render as flat polygons).</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -44,7 +44,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -121,11 +121,11 @@
 		<p>Intensity of the emissive light. Modulates the emissive color. Default is 1.</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture gradientMap]</h3>
 		<p>Gradient map for toon shading. It's required to set [page:Texture.minFilter] and [page:Texture.magFilter] to
-			[page:Textures THREE.NearestFilter] when using this type of texture. Default is *null*.</p>
+			[page:Textures THREE.NearestFilter] when using this type of texture. Default is `null`.</p>
 
 		<h3>[property:Texture lightMap]</h3>
 		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
@@ -158,7 +158,7 @@
 		</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>Render geometry as wireframe. Default is `false` (i.e. render as flat polygons).</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>

--- a/docs/api/en/materials/PointsMaterial.html
+++ b/docs/api/en/materials/PointsMaterial.html
@@ -61,7 +61,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 		</p>
 
 		<h2>Properties</h2>
@@ -82,7 +82,7 @@
 		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>Sets the color of the points using data from a [page:Texture].</p>

--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -19,11 +19,11 @@
 			<li>implement an effect not included with any of the built-in [page:Material materials]</li>
 			<li>combine many objects into a single [page:BufferGeometry] in order to improve performance</li>
 		</ul>
-		There are the following notes to bear in mind when using a *ShaderMaterial*:
+		There are the following notes to bear in mind when using a `ShaderMaterial`:
 
 		<ul>
 			<li>
-				A *ShaderMaterial* will only be rendered properly by [page:WebGLRenderer],
+				A `ShaderMaterial` will only be rendered properly by [page:WebGLRenderer],
 				since the GLSL code in the [link:https://en.wikipedia.org/wiki/Shader#Vertex_shaders vertexShader]
 				and [link:https://en.wikipedia.org/wiki/Shader#Pixel_shaders fragmentShader] properties must
 				be compiled and run on the GPU using WebGL.
@@ -43,7 +43,7 @@
 				[page:RawShaderMaterial] instead of this class.
 			</li>
 			<li>
-				You can use the directive #pragma unroll_loop_start and #pragma unroll_loop_end in order to unroll a *for* loop in GLSL by the shader preprocessor.
+				You can use the directive #pragma unroll_loop_start and #pragma unroll_loop_end in order to unroll a `for` loop in GLSL by the shader preprocessor.
 				The directive has to be placed right above the loop. The loop formatting has to correspond to a defined standard.
 				<ul>
 					<li>
@@ -53,7 +53,7 @@
 						The loop variable has to be *i*.
 					</li>
 					<li>
-						The value *UNROLLED_LOOP_INDEX* will be replaced with the explicitly value of *i* for the given iteration and can be used in preprocessor statements.
+						The value `UNROLLED_LOOP_INDEX` will be replaced with the explicitly value of *i* for the given iteration and can be used in preprocessor statements.
 					</li>
 				</ul>
 				<code>
@@ -120,8 +120,8 @@
 			<p>You can specify two different types of shaders for each material:</p>
 			<ul>
 				<li>
-					The vertex shader runs first; it receives *attributes*, calculates / manipulates
-					the position of each individual vertex, and passes additional data (*varying*s) to the fragment shader.
+					The vertex shader runs first; it receives `attributes`, calculates / manipulates
+					the position of each individual vertex, and passes additional data (`varying`s) to the fragment shader.
 				</li>
 				<li>
 					The fragment ( or pixel ) shader runs second; it sets the color of each individual "fragment"
@@ -131,22 +131,22 @@
 			<p>There are three types of variables in shaders: uniforms, attributes, and varyings:</p>
 			<ul>
 				<li>
-					*Uniforms* are variables that have the same value for all vertices - lighting, fog,
+					`Uniforms` are variables that have the same value for all vertices - lighting, fog,
 					and shadow maps are examples of data that would be stored in uniforms.
 					Uniforms can be accessed by both the vertex shader and the fragment shader.
 				</li>
 				<li>
-					*Attributes* are variables associated with each vertex---for instance, the vertex position,
+					`Attributes` are variables associated with each vertex---for instance, the vertex position,
 					face normal, and vertex color are all examples of data that would be stored in attributes.
-					Attributes can <em>only</em> be accessed within the vertex shader.
+					Attributes can `only` be accessed within the vertex shader.
 				</li>
 				<li>
-					*Varyings* are variables that are passed from the vertex shader to the fragment shader.
+					`Varyings` are variables that are passed from the vertex shader to the fragment shader.
 					For each fragment, the value of each varying will be smoothly interpolated from the values of adjacent vertices.
 				</li>
 			</ul>
 			<p>
-				Note that <em>within</em> the shader itself, uniforms and attributes act like constants;
+				Note that `within` the shader itself, uniforms and attributes act like constants;
 				you can only modify their values by passing different values to the buffers from your JavaScript code.
 			</p>
 		</div>
@@ -157,7 +157,7 @@
 	<div>
 			<p>
 			The [page:WebGLRenderer] provides many attributes and uniforms to shaders by default;
-			definitions of these variables are prepended to your *fragmentShader* and *vertexShader*
+			definitions of these variables are prepended to your `fragmentShader` and `vertexShader`
 			code by the [page:WebGLProgram] when the shader is compiled; you don't need to declare them yourself.
 			See [page:WebGLProgram] for details of these variables.
 			</p>
@@ -179,14 +179,14 @@
 		<div>
 			<p>
 				Both custom attributes and uniforms must be declared in your GLSL shader code
-				(within *vertexShader* and/or *fragmentShader*). Custom uniforms must be defined in <em>both</em>
-				the *uniforms* property of your *ShaderMaterial*, whereas any custom attributes must be
-				defined via [page:BufferAttribute] instances. Note that *varying*s only need to
+				(within `vertexShader` and/or `fragmentShader`). Custom uniforms must be defined in `both`
+				the `uniforms` property of your `ShaderMaterial`, whereas any custom attributes must be
+				defined via [page:BufferAttribute] instances. Note that `varying`s only need to
 				be declared within the shader code (not within the material).
 			</p>
 			<p>
 				To declare a custom attribute, please reference the [page:BufferGeometry] page for an overview,
-				and the [page:BufferAttribute] page for a detailed look at the *BufferAttribute* API.
+				and the [page:BufferAttribute] page for a detailed look at the `BufferAttribute` API.
 			</p>
 			<p>
 				When creating your attributes, each typed array that you create to hold your
@@ -235,13 +235,13 @@
 			</table>
 
 			<p>
-				Note that attribute buffers are <em>not</em> refreshed automatically when their values change. To update custom attributes,
-				set the *needsUpdate* flag to true on the [page:BufferAttribute] of the geometry (see [page:BufferGeometry]
+				Note that attribute buffers are `not` refreshed automatically when their values change. To update custom attributes,
+				set the `needsUpdate` flag to true on the [page:BufferAttribute] of the geometry (see [page:BufferGeometry]
 				for further details).
 			</p>
 
 			<p>
-			To declare a custom [page:Uniform], use the *uniforms* property:
+			To declare a custom [page:Uniform], use the `uniforms` property:
 			<code>
 			uniforms: {
 				time: { value: 1.0 },
@@ -293,7 +293,7 @@ this.defaultAttributeValues = {
 
 		<h3>[property:Object defines]</h3>
 		<p>
-		Defines custom constants using *#define* directives within the GLSL code for both the
+		Defines custom constants using `#define` directives within the GLSL code for both the
 		vertex shader and the fragment shader; each key/value pair yields another directive:
 		<code>
 		defines: {
@@ -333,14 +333,14 @@ this.extensions = {
 		<h3>[property:String fragmentShader]</h3>
 		<p>
 		Fragment shader GLSL code.  This is the actual code for the shader. In the example above,
-		the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed
+		the `vertexShader` and `fragmentShader` code is extracted from the DOM; it could be passed
 		as a string directly or loaded via AJAX instead.
 		</p>
 
 		<h3>[property:String glslVersion]</h3>
 		<p>
 		Defines the GLSL version of custom shader code. Only relevant for WebGL 2 in order to define whether to specify
-		GLSL 3.0 or not. Valid values are *THREE.GLSL1* or *THREE.GLSL3*. Default is *null*.
+		GLSL 3.0 or not. Valid values are `THREE.GLSL1` or `THREE.GLSL3`. Default is `null`.
 		</p>
 
 		<h3>[property:String index0AttributeName]</h3>
@@ -384,25 +384,25 @@ this.extensions = {
 		<code>
 		{ value: 1.0 }
 		</code>
-		where *value* is the value of the uniform. Names must match the name of the uniform,
+		where `value` is the value of the uniform. Names must match the name of the uniform,
 		as defined in the GLSL code. Note that uniforms are refreshed on every frame,
 		so updating the value of the uniform will immediately update the value available to the GLSL code.
 		</p>
 
 		<h3>[property:Boolean uniformsNeedUpdate]</h3>
 		<p>
-		Can be used to force a uniform update while changing uniforms in [page:Object3D.onBeforeRender](). Default is *false*.
+		Can be used to force a uniform update while changing uniforms in [page:Object3D.onBeforeRender](). Default is `false`.
 		</p>
 
 		<h3>[property:Boolean vertexColors]</h3>
 		<p>
-		Defines whether vertex coloring is used. Default is *false*.
+		Defines whether vertex coloring is used. Default is `false`.
 		</p>
 
 		<h3>[property:String vertexShader]</h3>
 		<p>
 		Vertex shader GLSL code.  This is the actual code for the shader. In the example above,
-		the *vertexShader* and *fragmentShader* code is extracted from the DOM; it could be passed
+		the `vertexShader` and `fragmentShader` code is extracted from the DOM; it could be passed
 		as a string directly or loaded via AJAX instead.
 		</p>
 
@@ -427,9 +427,9 @@ this.extensions = {
 		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
 		<p>
 		Generates a shallow copy of this material. Note that the vertexShader and fragmentShader
-		are copied <em>by reference</em>, as are the definitions of the *attributes*; this means
+		are copied `by reference`, as are the definitions of the `attributes`; this means
 		that clones of the material will share the same compiled [page:WebGLProgram]. However, the
-		*uniforms* are copied <em>by value</em>, which allows you to have different sets of uniforms
+		`uniforms` are copied `by value`, which allows you to have different sets of uniforms
 		for different copies of the material.
 		</p>
 

--- a/docs/api/en/materials/ShadowMaterial.html
+++ b/docs/api/en/materials/ShadowMaterial.html
@@ -52,10 +52,10 @@
 		<p>[page:Color] of the material, by default set to black (0x000000).</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Boolean transparent]</h3>
-		<p>Defines whether this material is transparent. Default is *true*.</p>
+		<p>Defines whether this material is transparent. Default is `true`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:Material] classes for common methods.</p>

--- a/docs/api/en/materials/SpriteMaterial.html
+++ b/docs/api/en/materials/SpriteMaterial.html
@@ -39,7 +39,7 @@
 			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
 
 			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			string and is `0xffffff` (white) by default. [page:Color.set]( color ) is called internally.
 
 			SpriteMaterials are not clipped by using [page:Material.clippingPlanes].
 		</p>
@@ -63,7 +63,7 @@
 		<p>[page:Color] of the material, by default set to white (0xffffff). The [page:.map] is multiplied by the color.</p>
 
 		<h3>[property:Boolean fog]</h3>
-		<p>Whether the material is affected by fog. Default is *true*.</p>
+		<p>Whether the material is affected by fog. Default is `true`.</p>
 
 		<h3>[property:Boolean isSpriteMaterial]</h3>
 		<p>
@@ -77,10 +77,10 @@
 		<p>The rotation of the sprite in radians. Default is 0.</p>
 
 		<h3>[property:Boolean sizeAttenuation]</h3>
-		<p>Whether the size of the sprite is attenuated by the camera depth. (Perspective camera only.) Default is *true*.</p>
+		<p>Whether the size of the sprite is attenuated by the camera depth. (Perspective camera only.) Default is `true`.</p>
 
 		<h3>[property:Boolean transparent]</h3>
-		<p>Defines whether this material is transparent. Default is *true*.</p>
+		<p>Defines whether this material is transparent. Default is `true`.</p>
 
 		<h2>Methods</h2>
 		<p>See the base [page:Material] class for common methods.</p>

--- a/docs/api/en/math/Box3.html
+++ b/docs/api/en/math/Box3.html
@@ -159,7 +159,7 @@
 		Expands this box equilaterally by [page:Vector3 vector]. The width of this box will be
 		expanded by the x component of [page:Vector3 vector] in both directions. The height of
 		this box will be expanded by the y component of [page:Vector3 vector] in both directions.
-		The depth of this box will be expanded by the z component of *vector* in both directions.
+		The depth of this box will be expanded by the z component of `vector` in both directions.
 		</p>
 
 		<h3>[method:Sphere getBoundingSphere]( [param:Sphere target] )</h3>
@@ -251,7 +251,7 @@
 		<p>
 		array -- An array of position data that the resulting box will envelop.<br /><br />
 
-		Sets the upper and lower bounds of this box to include all of the data in *array*.
+		Sets the upper and lower bounds of this box to include all of the data in `array`.
 		</p>
 
 		<h3>[method:this setFromBufferAttribute]( [param:BufferAttribute attribute] )</h3>

--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -185,23 +185,23 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>[method:String getStyle]( [param:string colorSpace] = SRGBColorSpace )</h3>
-		<p>Returns the value of this color as a CSS style string. Example: 'rgb(255,0,0)'.</p>
+		<p>Returns the value of this color as a CSS style string. Example: `rgb(255,0,0)`.</p>
 
 		<h3>[method:this lerp]( [param:Color color], [param:Float alpha] ) </h3>
 		<p>
 		[page:Color color] - color to converge on.<br />
-		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor in the closed interval `[0, 1]`.<br /><br />
 
 		Linearly interpolates this color's RGB values toward the RGB values of the passed argument.
-		The alpha argument can be thought of as the ratio between the two colors, where 0.0 is
-		this color and 1.0 is the first argument.
+		The alpha argument can be thought of as the ratio between the two colors, where `0.0` is
+		this color and `1.0` is the first argument.
 		</p>
 
 		<h3>[method:this lerpColors]( [param:Color color1], [param:Color color2], [param:Float alpha] )</h3>
 		<p>
 		[page:Color color1] - the starting [page:Color].<br />
 		[page:Color color2] - [page:Color] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Sets this color to be the color linearly interpolated between [page:Color color1] and
 		[page:Color color2] where alpha is the percent distance along the line connecting the two colors
@@ -211,7 +211,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		<h3>[method:this lerpHSL]( [param:Color color], [param:Float alpha] ) </h3>
 		<p>
 		[page:Color color] - color to converge on.<br />
-		[page:Float alpha] - interpolation factor in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor in the closed interval `[0, 1]`.<br /><br />
 
 		Linearly interpolates this color's HSL values toward the HSL values of the passed argument.
 		It differs from the classic [page:.lerp] by not interpolating straight from one color to the other,

--- a/docs/api/en/math/Cylindrical.html
+++ b/docs/api/en/math/Cylindrical.html
@@ -19,10 +19,10 @@
 		<h3>[name]( [param:Float radius], [param:Float theta], [param:Float y] )</h3>
 		<p>
 		[page:Float radius] - distance from the origin to a point in the x-z plane.
-		Default is *1.0*.<br />
+		Default is `1.0`.<br />
 		[page:Float theta] - counterclockwise angle in the x-z plane measured in radians
-		from the positive z-axis. Default is *0*.<br />
-		[page:Float y] - height above the x-z plane. Default is *0*.
+		from the positive z-axis. Default is `0`.<br />
+		[page:Float y] - height above the x-z plane. Default is `0`.
 		</p>
 
 

--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -91,10 +91,10 @@
 		<p>
 		[page:Array array] of length 3 or 4. The optional 4th argument corresponds to the [page:.order order].<br /><br />
 
-		Assigns this euler's [page:.x x] angle to array[0]. <br />
-		Assigns this euler's [page:.y y] angle to array[1]. <br />
-		Assigns this euler's [page:.z z] angle to array[2]. <br />
-		Optionally assigns this euler's [page:.order order] to array[3].
+		Assigns this euler's [page:.x x] angle to `array[0]`. <br />
+		Assigns this euler's [page:.y y] angle to `array[1]`. <br />
+		Assigns this euler's [page:.z z] angle to `array[2]`. <br />
+		Optionally assigns this euler's [page:.order order] to `array[3]`.
 		</p>
 
 		<h3>[method:this reorder]( [param:String newOrder] )</h3>

--- a/docs/api/en/math/Euler.html
+++ b/docs/api/en/math/Euler.html
@@ -33,9 +33,9 @@
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>
 		<p>
-		[page:Float x] - (optional) the angle of the x axis in radians. Default is *0*.<br />
-		[page:Float y] - (optional) the angle of the y axis in radians. Default is *0*.<br />
-		[page:Float z] - (optional) the angle of the z axis in radians. Default is *0*.<br />
+		[page:Float x] - (optional) the angle of the x axis in radians. Default is `0`.<br />
+		[page:Float y] - (optional) the angle of the y axis in radians. Default is `0`.<br />
+		[page:Float z] - (optional) the angle of the z axis in radians. Default is `0`.<br />
 		[page:String order] - (optional) a string representing the order that the rotations are applied,
 		defaults to 'XYZ' (must be upper case).<br /><br />
 
@@ -55,8 +55,8 @@
 			rotated around its X axis, then its Y axis and finally its Z axis. Other possibilities are:
 			'YZX', 'ZXY', 'XZY', 'YXZ' and 'ZYX'. These must be in upper case.<br /><br />
 
-			Three.js uses <em>intrinsic</em> Tait-Bryan angles. This means that rotations are performed with respect
-			to the <em>local</em> coordinate system. That is, for order 'XYZ', the rotation is first around the local-X
+			Three.js uses `intrinsic` Tait-Bryan angles. This means that rotations are performed with respect
+			to the `local` coordinate system. That is, for order 'XYZ', the rotation is first around the local-X
 			axis (which is the same as the world-X axis), then around local-Y (which may now be different from the
 			world Y-axis), then local-Z (which may be different from the world Z-axis).<br /><br />
 		</p>
@@ -102,7 +102,7 @@
 		Resets the euler angle with a new order by creating a quaternion from this euler angle
 		and then setting this euler angle with the quaternion and the new order. <br /><br />
 
-		<em>WARNING</em>: this discards revolution information.
+		<em>*Warning*: this discards revolution information.</em>
 		</p>
 
 		<h3>[method:this set]( [param:Float x], [param:Float y], [param:Float z], [param:String order] )</h3>

--- a/docs/api/en/math/Interpolant.html
+++ b/docs/api/en/math/Interpolant.html
@@ -18,7 +18,7 @@
 
 		This class provides the interval seek in a Template Method, deferring the actual interpolation to derived classes.<br /><br />
 
-		Time complexity is *O(1)* for linear access crossing at most two points and *O(log N)* for random access,
+		Time complexity is `O(1)` for linear access crossing at most two points and `O(log N)` for random access,
 		where *N* is the number of positions.<br /><br />
 
 		References:	[link:http://www.oodesign.com/template-method-pattern.html http://www.oodesign.com/template-method-pattern.html]

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -17,8 +17,8 @@
 
 		<h3>[name]( [param:Vector3 start], [param:Vector3 end] )</h3>
 		<p>
-		[page:Vector3 start] - Start of the line segment. Default is (0, 0, 0).<br />
-		[page:Vector3 end] - End of the line segment. Default is (0, 0, 0).<br /><br />
+		[page:Vector3 start] - Start of the line segment. Default is `(0, 0, 0)`.<br />
+		[page:Vector3 end] - End of the line segment. Default is `(0, 0, 0)`.<br /><br />
 
 		Creates a new [name].
 		</p>

--- a/docs/api/en/math/Line3.html
+++ b/docs/api/en/math/Line3.html
@@ -66,7 +66,7 @@
 		<h3>[method:Float closestPointToPointParameter]( [param:Vector3 point], [param:Boolean clampToLine] )</h3>
 		<p>
 		[page:Vector3 point] - the point for which to return a point parameter. <br />
-		[page:Boolean clampToLine] - Whether to clamp the result to the range [0, 1].<br /><br />
+		[page:Boolean clampToLine] - Whether to clamp the result to the range `[0, 1]`.<br /><br />
 
 		Returns a point parameter based on the closest point as projected on the line segment.
 		If [page:Boolean clampToLine] is true, then the returned value will be between 0 and 1.

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -48,14 +48,14 @@
 		[page:Float y] - End point.<br />
 		[page:Float value] - A value between start and end.<br><br />
 
-		Returns the percentage in the closed interval [0, 1] of the given value between the start and end point.
+		Returns the percentage in the closed interval `[0, 1]` of the given value between the start and end point.
 		</p>
 
 		<h3>[method:Float lerp]( [param:Float x], [param:Float y], [param:Float t] )</h3>
 		<p>
 		[page:Float x] - Start point. <br />
 		[page:Float y] - End point. <br />
-		[page:Float t] - interpolation factor in the closed interval [0, 1].<br><br />
+		[page:Float t] - interpolation factor in the closed interval `[0, 1]`.<br><br />
 
 		Returns a value [link:https://en.wikipedia.org/wiki/Linear_interpolation linearly interpolated]
 		from two known points based on the given interval - [page:Float t] = 0 will return [page:Float x]
@@ -110,7 +110,7 @@
 		<p>Random integer in the interval [[page:Float low], [page:Float high]].</p>
 
 		<h3>[method:Float seededRandom]( [param:Integer seed] )</h3>
-		<p>Deterministic pseudo-random float in the interval [0, 1]. The integer [page:Integer seed] is optional.</p>
+		<p>Deterministic pseudo-random float in the interval `[0, 1]`. The integer [page:Integer seed] is optional.</p>
 
 		<h3>[method:Float smoothstep]( [param:Float x], [param:Float min], [param:Float max] )</h3>
 		<p>

--- a/docs/api/en/math/MathUtils.html
+++ b/docs/api/en/math/MathUtils.html
@@ -40,7 +40,7 @@
 		</p>
 
 		<h3>[method:Boolean isPowerOfTwo]( [param:Number n] )</h3>
-		<p>Return *true* if [page:Number n] is a power of 2.</p>
+		<p>Return `true` if [page:Number n] is a power of 2.</p>
 
 		<h3>[method:Float inverseLerp]( [param:Float x], [param:Float y], [param:Float value] )</h3>
 		<p>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -19,7 +19,7 @@
 
 			This allows a [page:Vector3] representing a point in 3D space to undergo transformations
 			such as translation, rotation, shear, scale, reflection, orthogonal or perspective projection
-			and so on, by being multiplied by the matrix. This is known as	<em>applying</em>
+			and so on, by being multiplied by the matrix. This is known as	`applying`
 			the matrix to the vector.<br /><br />
 
 			Every [page:Object3D] has three associated Matrix4s:

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -21,7 +21,7 @@
 		<h3>[name]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<p>
 		[page:Vector3 normal] - (optional) a unit length [page:Vector3] defining the normal of the plane. Default is *(1, 0, 0)*.<br />
-		[page:Float constant] - (optional) the signed distance from the origin to the plane. Default is *0*.
+		[page:Float constant] - (optional) the signed distance from the origin to the plane. Default is `0`.
 		</p>
 
 
@@ -132,7 +132,7 @@
 		<h3>[method:this set]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<p>
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal of the plane.<br />
-			[page:Float constant] - the signed distance from the origin to the plane. Default is *0*.<br /><br />
+			[page:Float constant] - the signed distance from the origin to the plane. Default is `0`.<br /><br />
 
 			Sets this plane's [page:.normal normal] and [page:.constant constant] properties by copying the values from the given normal.
 		</p>

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -164,7 +164,7 @@
 		<h3>[method:this slerp]( [param:Quaternion qb], [param:Float t] )</h3>
 		<p>
 			[page:Quaternion qb] - The other quaternion rotation<br />
-			[page:Float t] - interpolation factor in the closed interval [0, 1].<br /><br />
+			[page:Float t] - interpolation factor in the closed interval `[0, 1]`.<br /><br />
 
 			Handles the spherical linear interpolation between quaternions. [page:Float t] represents the
 			amount of rotation between this quaternion (where [page:Float t] is 0) and [page:Quaternion qb] (where

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -132,7 +132,7 @@
 		<p>
 			[link:https://en.wikipedia.org/wiki/Normalized_vector Normalizes] this quaternion - that is,
 		calculated the quaternion that performs the same rotation as this one, but has [page:.length length]
-		equal to *1*.
+		equal to `1`.
 		</p>
 
 		<h3>[method:this multiply]( [param:Quaternion q] )</h3>
@@ -169,7 +169,7 @@
 			Handles the spherical linear interpolation between quaternions. [page:Float t] represents the
 			amount of rotation between this quaternion (where [page:Float t] is 0) and [page:Quaternion qb] (where
 			[page:Float t] is 1). This quaternion is set to the result. Also see the static version of the
-			*slerp* below.
+			`slerp` below.
 
 			<code>
 			// rotate a mesh towards a target quaternion
@@ -187,7 +187,7 @@
 		<p>
 		Sets this quaternion from rotation specified by [page:Vector3 axis] and [page:Float angle].<br />
 		Adapted from the method [link:http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm here].<br />
-		*Axis* is assumed to be normalized, *angle* is in radians.
+		`Axis` is assumed to be normalized, `angle` is in radians.
 		</p>
 
 		<h3>[method:this setFromEuler]( [param:Euler euler] )</h3>
@@ -233,9 +233,9 @@
 		[page:Array dst] - The output array.<br />
 		[page:Integer dstOffset] - An offset into the output array.<br />
 		[page:Array src0] - The source array of the starting quaternion.<br />
-		[page:Integer srcOffset0] - An offset into the array *src0*.<br />
+		[page:Integer srcOffset0] - An offset into the array `src0`.<br />
 		[page:Array src1] - The source array of the target quaternion.<br />
-		[page:Integer srcOffset1] - An offset into the array *src1*.<br />
+		[page:Integer srcOffset1] - An offset into the array `src1`.<br />
 		[page:Float t] - Normalized interpolation factor (between 0 and 1).<br /><br />
 
 		This SLERP implementation assumes the quaternion data are managed in flat arrays.
@@ -246,9 +246,9 @@
 		[page:Array dst] - The output array.<br />
 		[page:Integer dstOffset] - An offset into the output array.<br />
 		[page:Array src0] - The source array of the starting quaternion.<br />
-		[page:Integer srcOffset0] - An offset into the array *src0*.<br />
+		[page:Integer srcOffset0] - An offset into the array `src0`.<br />
 		[page:Array src1] - The source array of the target quaternion.<br />
-		[page:Integer srcOffset1] - An offset into the array *src1*.<br /><br />
+		[page:Integer srcOffset1] - An offset into the array `src1`.<br /><br />
 
 		This multiplication implementation assumes the quaternion data are managed in flat arrays.
 		</p>

--- a/docs/api/en/math/Ray.html
+++ b/docs/api/en/math/Ray.html
@@ -32,7 +32,7 @@
 		<h2>Properties</h2>
 
 		<h3>[property:Vector3 origin]</h3>
-		<p>The origin of the [page:Ray]. Default is a [page:Vector3] at (0, 0, 0).</p>
+		<p>The origin of the [page:Ray]. Default is a [page:Vector3] at `(0, 0, 0)`.</p>
 
 		<h3>[property:Vector3 direction]</h3>
 		<p>
@@ -102,7 +102,7 @@
 		<p>
 		[page:Plane plane] - the [page:Plane] to get the distance to.<br /><br />
 
-		Get the distance from [page:.origin origin] to the [page:Plane], or *null* if the [page:Ray] doesn't intersect the [page:Plane].
+		Get the distance from [page:.origin origin] to the [page:Plane], or `null` if the [page:Ray] doesn't intersect the [page:Plane].
 		</p>
 
 		<h3>[method:Float distanceToPoint]( [param:Vector3 point] )</h3>
@@ -127,7 +127,7 @@
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Box3], returning the intersection point or
-		*null* if there is no intersection.
+		`null` if there is no intersection.
 		</p>
 
 		<h3>[method:Vector3 intersectPlane]( [param:Plane plane], [param:Vector3 target] )</h3>
@@ -136,7 +136,7 @@
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Plane], returning the intersection point or
-		*null* if there is no intersection.
+		`null` if there is no intersection.
 		</p>
 
 		<h3>[method:Vector3 intersectSphere]( [param:Sphere sphere], [param:Vector3 target] )</h3>
@@ -145,7 +145,7 @@
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 		Intersect this [page:Ray] with a [page:Sphere], returning the intersection point or
-		*null* if there is no intersection.
+		`null` if there is no intersection.
 		</p>
 
 		<h3>[method:Vector3 intersectTriangle]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c], [param:Boolean backfaceCulling], [param:Vector3 target] )</h3>
@@ -154,7 +154,7 @@
 		[page:Boolean backfaceCulling] - whether to use backface culling.<br />
 		[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
-		Intersect this [page:Ray] with a triangle, returning the intersection point or *null*
+		Intersect this [page:Ray] with a triangle, returning the intersection point or `null`
 		if there is no intersection.
 		</p>
 

--- a/docs/api/en/math/Sphere.html
+++ b/docs/api/en/math/Sphere.html
@@ -14,7 +14,7 @@
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Vector3 center], [param:Float radius] )</h3>
 		<p>
-		[page:Vector3 center] - center of the sphere. Default is a [page:Vector3] at (0, 0, 0). <br />
+		[page:Vector3 center] - center of the sphere. Default is a [page:Vector3] at `(0, 0, 0)`. <br />
 		[page:Float radius] - radius of the sphere. Default is -1.<br /><br />
 
 		Creates a new [name].
@@ -26,7 +26,7 @@
 
 
 		<h3>[property:Vector3 center]</h3>
-		<p>A [page:Vector3] defining the center of the sphere. Default is (0, 0, 0).</p>
+		<p>A [page:Vector3] defining the center of the sphere. Default is `(0, 0, 0)`.</p>
 
 		<h3>[property:Float radius]</h3>
 		<p>The radius of the sphere. Default is -1.</p>

--- a/docs/api/en/math/Spherical.html
+++ b/docs/api/en/math/Spherical.html
@@ -18,9 +18,9 @@
 		<h3>[name]( [param:Float radius], [param:Float phi], [param:Float theta] )</h3>
 		<p>
 		[page:Float radius] - the radius, or the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-		(straight-line distance) from the point to the origin. Default is *1.0*.<br />
-		[page:Float phi] - polar angle in radians from the y (up) axis. Default is *0*.<br />
-		[page:Float theta] - equator angle in radians around the y (up) axis. Default is *0*.<br /><br />
+		(straight-line distance) from the point to the origin. Default is `1.0`.<br />
+		[page:Float phi] - polar angle in radians from the y (up) axis. Default is `0`.<br />
+		[page:Float theta] - equator angle in radians around the y (up) axis. Default is `0`.<br /><br />
 
 		The poles (phi) are at the positive and negative y axis. The equator (theta) starts at positive z.
 		</p>

--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -20,9 +20,9 @@
 
 		<h3>[name]( [param:Vector3 a], [param:Vector3 b], [param:Vector3 c] )</h3>
 		<p>
-		[page:Vector3 a] - the first corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />
-		[page:Vector3 b] - the second corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br />
-		[page:Vector3 c] - the final corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).<br /><br />
+		[page:Vector3 a] - the first corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.<br />
+		[page:Vector3 b] - the second corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.<br />
+		[page:Vector3 c] - the final corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.<br /><br />
 
 		Creates a new [name].
 		</p>
@@ -32,17 +32,17 @@
 
 		<h3>[property:Vector3 a]</h3>
 		<p>
-			The first corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).
+			The first corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.
 		</p>
 
 		<h3>[property:Vector3 b]</h3>
 		<p>
-			The second corner of the triangle. Default is a [page:Vector3] at (0, 0, 0).
+			The second corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.
 		</p>
 
 		<h3>[property:Vector3 c]</h3>
 		<p>
-		the final corner of the triangle. Default is a [page:Vector3] at (0, 0, 0)
+			The final corner of the triangle. Default is a [page:Vector3] at `(0, 0, 0)`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -23,8 +23,8 @@
 			<li>
 				A direction and length across a plane. In three.js the length will always be the
 				[link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-				(straight-line distance) from (0, 0) to (x, y) and the direction is also
-				measured from (0, 0) towards (x, y).
+				(straight-line distance) from `(0, 0)` to `(x, y)` and the direction is also
+				measured from `(0, 0)` towards `(x, y)`.
 			</li>
 			<li>
 				Any arbitrary ordered pair of numbers.
@@ -37,7 +37,7 @@
 		</p>
 
 		<p>
-			Iterating through a [name] instance will yield its components (x, y) in the corresponding order.
+			Iterating through a [name] instance will yield its components `(x, y)` in the corresponding order.
 		</p>
 
 		<h2>Code Example</h2>
@@ -194,7 +194,7 @@
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
 
-		Sets this vector's [page:.x x] value to be array[ offset ] and [page:.y y] value to be array[ offset + 1 ].
+		Sets this vector's [page:.x x] value to be `array[ offset ]` and [page:.y y] value to be `array[ offset + 1 ]`.
 		</p>
 
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
@@ -232,7 +232,7 @@
 		<h3>[method:this lerp]( [param:Vector2 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector2 v] - [page:Vector2] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Linearly interpolates between this vector and [page:Vector2 v], where alpha is the
 		percent distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector2 v].
@@ -242,7 +242,7 @@
 		<p>
 		[page:Vector2 v1] - the starting [page:Vector2].<br />
 		[page:Vector2 v2] - [page:Vector2] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Sets this vector to be the vector linearly interpolated between [page:Vector2 v1] and
 		[page:Vector2 v2] where alpha is the percent distance along the line connecting the two vectors

--- a/docs/api/en/math/Vector2.html
+++ b/docs/api/en/math/Vector2.html
@@ -56,8 +56,8 @@
 
 		<h3>[name]( [param:Float x], [param:Float y] )</h3>
 		<p>
-		[page:Float x] - the x value of this vector. Default is *0*.<br />
-		[page:Float y] -  the y value of this vector. Default is *0*.<br /><br />
+		[page:Float x] - the x value of this vector. Default is `0`.<br />
+		[page:Float y] -  the y value of this vector. Default is `0`.<br /><br />
 
 		Creates a new [name].
 		</p>
@@ -184,7 +184,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector2 v] )</h3>
-		<p>Returns *true* if the components of this vector and [page:Vector2 v] are strictly equal; *false* otherwise.</p>
+		<p>Returns `true` if the components of this vector and [page:Vector2 v] are strictly equal; `false` otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -22,8 +22,8 @@
 			<li>
 				A direction and length in 3D space. In three.js the length will always be the
 				[link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-				(straight-line distance) from (0, 0, 0) to (x, y, z) and the direction is also
-				measured from (0, 0, 0) towards (x, y, z).
+				(straight-line distance) from `(0, 0, 0)` to `(x, y, z)` and the direction is also
+				measured from `(0, 0, 0)` towards `(x, y, z)`.
 			</li>
 			<li>
 				Any arbitrary ordered triplet of numbers.
@@ -56,9 +56,9 @@
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z] )</h3>
 		<p>
-		[page:Float x] - the x value of this vector. Default is *0*.<br />
-		[page:Float y] -  the y value of this vector. Default is *0*.<br />
-		[page:Float z] - the z value of this vector. Default is *0*.<br /><br />
+		[page:Float x] - the x value of this vector. Default is `0`.<br />
+		[page:Float y] -  the y value of this vector. Default is `0`.<br />
+		[page:Float z] - the z value of this vector. Default is `0`.<br /><br />
 
 		Creates a new [name].
 		</p>
@@ -210,7 +210,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector3 v] )</h3>
-		<p>Returns *true* if the components of this vector and [page:Vector3 v] are strictly equal; *false* otherwise.</p>
+		<p>Returns `true` if the components of this vector and [page:Vector3 v] are strictly equal; `false` otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -36,7 +36,7 @@
 		</p>
 
 		<p>
-		Iterating through a [name] instance will yield its components (x, y, z) in the corresponding order.
+		Iterating through a [name] instance will yield its components `(x, y, z)` in the corresponding order.
 		</p>
 
 
@@ -220,8 +220,8 @@
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - ( optional) offset into the array. Default is 0.<br /><br />
 
-		Sets this vector's [page:.x x] value to be array[ offset + 0 ], [page:.y y] value to be array[ offset + 1 ]
-		and [page:.z z] value to be array[ offset + 2 ].
+		Sets this vector's [page:.x x] value to be `array[ offset + 0 ]`, [page:.y y] value to be `array[ offset + 1 ]`
+		and [page:.z z] value to be `array[ offset + 2 ]`.
 		</p>
 
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
@@ -260,7 +260,7 @@
 		<h3>[method:this lerp]( [param:Vector3 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector3 v] - [page:Vector3] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Linearly interpolate between this vector and [page:Vector3 v], where alpha is the
 		percent distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector3 v].
@@ -270,7 +270,7 @@
 		<p>
 		[page:Vector3 v1] - the starting [page:Vector3].<br />
 		[page:Vector3 v2] - [page:Vector3] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Sets this vector to be the vector linearly interpolated between [page:Vector3 v1] and
 		[page:Vector3 v2] where alpha is the percent distance along the line connecting the two vectors

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -22,8 +22,8 @@
 			<li>
 				A direction and length in 4D space. In three.js the length will always be the
 				[link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean distance]
-				(straight-line distance) from (0, 0, 0, 0) to (x, y, z, w) and the direction is also
-				measured from (0, 0, 0, 0) towards (x, y, z, w).
+				(straight-line distance) from `(0, 0, 0, 0)` to `(x, y, z, w)` and the direction is also
+				measured from `(0, 0, 0, 0)` towards `(x, y, z, w)`.
 			</li>
 			<li>
 				Any arbitrary ordered quadruplet of numbers.
@@ -31,11 +31,11 @@
 		</ul>
 
 		<p>
-		There are other things a 4D vector can be used to represent, however these are the most common uses in three.js.
+		There are other things a 4D vector can be used to represent, however these are the most common uses in *three.js*.
 		</p>
 
 		<p>
-		Iterating through a [name] instance will yield its components (x, y, z, w) in the corresponding order.
+		Iterating through a [name] instance will yield its components `(x, y, z, w)` in the corresponding order.
 		</p>
 
 		<h2>Code Example</h2>
@@ -169,8 +169,8 @@
 		[page:Array array] - the source array.<br />
 		[page:Integer offset] - (optional) offset into the array. Default is 0.<br /><br />
 
-		Sets this vector's [page:.x x] value to be array[ offset + 0 ], [page:.y y] value to be array[ offset + 1 ]
-		[page:.z z] value to be array[ offset + 2 ] and [page:.w w ] value to be array[ offset + 3 ].
+		Sets this vector's [page:.x x] value to be `array[ offset + 0 ]`, [page:.y y] value to be `array[ offset + 1 ]`
+		[page:.z z] value to be `array[ offset + 2 ]` and [page:.w w ] value to be `array[ offset + 3 ]`.
 		</p>
 
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
@@ -193,7 +193,7 @@
 
 		<h3>[method:Float length]()</h3>
 		<p>Computes the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) from (0, 0, 0, 0) to (x, y, z, w).</p>
+		(straight-line length) from `(0, 0, 0, 0)` to `(x, y, z, w)`.</p>
 
 		<h3>[method:Float manhattanLength]()</h3>
 		<p>
@@ -203,24 +203,24 @@
 		<h3>[method:Float lengthSq]()</h3>
 		<p>
 		Computes the square of the [link:https://en.wikipedia.org/wiki/Euclidean_distance Euclidean length]
-		(straight-line length) from (0, 0, 0, 0) to (x, y, z, w). If you are 	comparing the lengths of
+		(straight-line length) from `(0, 0, 0, 0)` to `(x, y, z, w)`. If you are comparing the lengths of
 		vectors, you should compare the length squared instead as it is slightly more efficient to calculate.
 		</p>
 
 		<h3>[method:this lerp]( [param:Vector4 v], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector4 v] - [page:Vector4] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Linearly interpolates between this vector and [page:Vector4 v], where alpha is the
-		percent distance along the line - alpha = 0 will be this vector, and alpha = 1 will be [page:Vector4 v].
+		percent distance along the line - `alpha = 0` will be this vector, and `alpha = 1` will be [page:Vector4 v].
 		</p>
 
 		<h3>[method:this lerpVectors]( [param:Vector4 v1], [param:Vector4 v2], [param:Float alpha] )</h3>
 		<p>
 		[page:Vector4 v1] - the starting [page:Vector4].<br />
 		[page:Vector4 v2] - [page:Vector4] to interpolate towards.<br />
-		[page:Float alpha] - interpolation factor, typically in the closed interval [0, 1].<br /><br />
+		[page:Float alpha] - interpolation factor, typically in the closed interval `[0, 1]`.<br /><br />
 
 		Sets this vector to be the vector linearly interpolated between [page:Vector4 v1] and
 		[page:Vector4 v2] where alpha is the percent distance along the line connecting the two vectors

--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -54,10 +54,10 @@
 
 		<h3>[name]( [param:Float x], [param:Float y], [param:Float z], [param:Float w] )</h3>
 		<p>
-		[page:Float x] - the x value of this vector. Default is *0*.<br />
-		[page:Float y] -  the y value of this vector. Default is *0*.<br />
-		[page:Float z] - the z value of this vector. Default is *0*.<br />
-		[page:Float w] - the w value of this vector. Default is *1*.<br /><br />
+		[page:Float x] - the x value of this vector. Default is `0`.<br />
+		[page:Float y] -  the y value of this vector. Default is `0`.<br />
+		[page:Float z] - the z value of this vector. Default is `0`.<br />
+		[page:Float w] - the w value of this vector. Default is `1`.<br /><br />
 
 		Creates a new [name].
 		</p>
@@ -159,7 +159,7 @@
 		</p>
 
 		<h3>[method:Boolean equals]( [param:Vector4 v] )</h3>
-		<p>Returns *true* if the components of this vector and [page:Vector4 v] are strictly equal; *false* otherwise.</p>
+		<p>Returns `true` if the components of this vector and [page:Vector4 v] are strictly equal; `false` otherwise.</p>
 
 		<h3>[method:this floor]()</h3>
 		<p>The components of this vector are rounded down to the nearest integer value.</p>

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -40,7 +40,7 @@
 
 		<h3>[property:Integer count]</h3>
 		<p>
-			The number of instances. The *count* value passed into the constructor represents the maximum number of
+			The number of instances. The `count` value passed into the constructor represents the maximum number of
 			instances of this mesh. You can change the number of instances at runtime to an integer value
 			in the range [0, count].
 		</p>
@@ -50,7 +50,7 @@
 
 		<h3>[property:InstancedBufferAttribute instanceColor]</h3>
 		<p>
-			Represents the colors of all instances. *null* by default.
+			Represents the colors of all instances. `null` by default.
 			You have to set its [page:BufferAttribute.needsUpdate needsUpdate] flag to true if you modify instanced data via [page:.setColorAt]().
 		</p>
 

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 			A mesh that has a [page:Skeleton] with [page:Bone bones] that can then be used to animate the vertices of the geometry.<br /><br />
 
-			[name] can only be used with WebGL 2. With WebGL 1 *OES_texture_float* and vertex textures support is required.
+			[name] can only be used with WebGL 2. With WebGL 1 `OES_texture_float` and vertex textures support is required.
 		</p>
 
 		<iframe id="scene" src="scenes/bones-browser.html"></iframe>

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -36,13 +36,13 @@
 		[page:Constant wrapT] - default is [page:Textures ClampToEdgeWrapping]. <br />
 		[page:Constant magFilter] - default is [page:Textures .LinearFilter]. <br />
 		[page:Constant minFilter] - default is [page:Textures LinearFilter]. <br />
-		[page:Boolean generateMipmaps] - default is *false*.<br />
+		[page:Boolean generateMipmaps] - default is `false`.<br />
 		[page:Constant format] - default is [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
-		[page:Number anisotropy] - default is *1*. See [page:Texture.anisotropy]<br />
+		[page:Number anisotropy] - default is `1`. See [page:Texture.anisotropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
-		[page:Boolean depthBuffer] - default is *true*.<br />
-		[page:Boolean stencilBuffer] - default is *false*.<br /><br />
+		[page:Boolean depthBuffer] - default is `true`.<br />
+		[page:Boolean stencilBuffer] - default is `false`.<br /><br />
 
 		Creates a new [name]
 		</p>
@@ -68,7 +68,7 @@
 		<h3>[method:undefined clear]( [param:WebGLRenderer renderer], [param:Boolean color], [param:Boolean depth], [param:Boolean stencil] )</h3>
 		<p>
 			Call this to clear the renderTarget's color, depth, and/or stencil buffers.
-			The color buffer is set to the renderer's current clear color. Arguments default to *true*.
+			The color buffer is set to the renderer's current clear color. Arguments default to `true`.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -35,13 +35,13 @@
 		[page:Constant wrapT] - default is [page:Textures ClampToEdgeWrapping]. <br />
 		[page:Constant magFilter] - default is [page:Textures LinearFilter]. <br />
 		[page:Constant minFilter] - default is [page:Textures LinearFilter]. <br />
-		[page:Boolean generateMipmaps] - default is *false*.<br />
+		[page:Boolean generateMipmaps] - default is `false`.<br />
 		[page:Constant format] - default is [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
-		[page:Number anisotropy] - default is *1*. See [page:Texture.anisotropy]<br />
+		[page:Number anisotropy] - default is `1`. See [page:Texture.anisotropy]<br />
 		[page:Constant encoding] - default is [page:Textures LinearEncoding]. <br />
-		[page:Boolean depthBuffer] - default is *true*. <br />
-		[page:Boolean stencilBuffer] - default is *false*.<br />
+		[page:Boolean depthBuffer] - default is `true`. <br />
+		[page:Boolean stencilBuffer] - default is `false`.<br />
 		[page:Number samples] - default is 0.<br /><br />
 
 		Creates a new [name]
@@ -101,7 +101,7 @@
 
 		<h3>[property:Number samples]</h3>
 		<p>
-		Defines the count of MSAA samples. Can only be used with WebGL 2. Default is *0*.
+		Defines the count of MSAA samples. Can only be used with WebGL 2. Default is `0`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -237,7 +237,7 @@
 			If you do not require dynamic lighting / shadows, you may set this to `false` when the renderer is instantiated.<br />
 		- [page:Boolean needsUpdate]:
 			When set to `true`, shadow maps in the scene will be updated in the next `render` call. Default is `false`.<br />
-			If you have disabled automatic updates to shadow maps (*shadowMap.autoUpdate = false*), you will need to set this to `true` and then make a render call to update the shadows in your scene.<br />
+			If you have disabled automatic updates to shadow maps (`shadowMap.autoUpdate = false`), you will need to set this to `true` and then make a render call to update the shadows in your scene.<br />
 		- [page:Integer type]:
 			Defines shadow map type (unfiltered, percentage close filtering, percentage close filtering with bilinear filtering in shader).
 			Options are:

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -32,41 +32,41 @@
 	  [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext RenderingContext].
 		Default is null.<br />
 
-		[page:String precision] - Shader precision. Can be *"highp"*, *"mediump"* or *"lowp"*.
-		Defaults to *"highp"* if supported by the device. See the note in "Things to Avoid"
+		[page:String precision] - Shader precision. Can be `"highp"`, `"mediump"` or `"lowp"`.
+		Defaults to `"highp"` if supported by the device. See the note in "Things to Avoid"
 		[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices here].<br />
 
-		[page:Boolean alpha] - controls the default clear alpha value. When set to *true*, the value is *0*. Otherwise it's *1*. Default is *false*.<br />
+		[page:Boolean alpha] - controls the default clear alpha value. When set to `true`, the value is `0`. Otherwise it's `1`. Default is `false`.<br />
 
 		[page:Boolean premultipliedAlpha] - whether the renderer will assume that colors have
 		[link:https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#Premultiplied_alpha premultiplied alpha].
-		Default is *true*.<br />
+		Default is `true`.<br />
 
-		[page:Boolean antialias] - whether to perform antialiasing. Default is *false*.<br />
+		[page:Boolean antialias] - whether to perform antialiasing. Default is `false`.<br />
 
 		[page:Boolean stencil] - whether the drawing buffer has a
 		[link:https://en.wikipedia.org/wiki/Stencil_buffer stencil buffer] of at least 8 bits.
-		Default is *true*.<br />
+		Default is `true`.<br />
 
 		[page:Boolean preserveDrawingBuffer] - whether to preserve the buffers until manually cleared
-		or overwritten. Default is *false*.<br />
+		or overwritten. Default is `false`.<br />
 
 		[page:String powerPreference] - Provides a hint to the user agent indicating what configuration
-		of GPU is suitable for this WebGL context. Can be *"high-performance"*, *"low-power"* or *"default"*. Default is *"default"*.
+		of GPU is suitable for this WebGL context. Can be `"high-performance"`, `"low-power"` or `"default"`. Default is `"default"`.
 		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2 WebGL spec] for details.<br />
 
-		[page:Boolean failIfMajorPerformanceCaveat] - whether the renderer creation will fail upon low performance is detected. Default is *false*.
+		[page:Boolean failIfMajorPerformanceCaveat] - whether the renderer creation will fail upon low performance is detected. Default is `false`.
 		See [link:https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2 WebGL spec] for details.<br />
 
 		[page:Boolean depth] - whether the drawing buffer has a
 		[link:https://en.wikipedia.org/wiki/Z-buffering depth buffer] of at least 16 bits.
-		Default is *true*.<br />
+		Default is `true`.<br />
 
 		[page:Boolean logarithmicDepthBuffer] -  whether to use a logarithmic depth buffer. It may
 		be necessary to use this if dealing with huge differences in scale in a single scene. Note that this setting
 		uses gl_FragDepth if available which disables the [link:https://www.khronos.org/opengl/wiki/Early_Fragment_Test Early Fragment Test]
 		optimization and can cause a decrease in performance.
-		Default is *false*. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
+		Default is `false`. See the [example:webgl_camera_logarithmicdepthbuffer camera / logarithmicdepthbuffer] example.
 		</p>
 
 		<h2>Properties</h2>
@@ -78,21 +78,21 @@
 		<h3>[property:Boolean autoClearColor]</h3>
 		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the color buffer.
-			Default is *true*.
+			Default is `true`.
 		</p>
 
 
 		<h3>[property:Boolean autoClearDepth]</h3>
 		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the depth buffer.
-			Default is *true*.
+			Default is `true`.
 		</p>
 
 
 		<h3>[property:Boolean autoClearStencil]</h3>
 		<p>
 			If [page:.autoClear autoClear] is true, defines whether the renderer should clear the stencil buffer.
-			Default is *true*.
+			Default is `true`.
 		</p>
 
 		<h3>[property:Object debug]</h3>
@@ -102,7 +102,7 @@
 			for errors during compilation and linkage process. It may be useful to disable this check in production for performance gain.
 			It is strongly recommended to keep these checks enabled during development.
 			If the shader does not compile and link - it will not work and associated material will not render.
-			Default is *true*.
+			Default is `true`.
 		</p>
 
 		<h3>[property:Object capabilities]</h3>
@@ -110,31 +110,31 @@
 		An object containing details about the capabilities of the current [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext RenderingContext].<br />
 
 		- [page:Boolean floatFragmentTextures]: whether the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float OES_texture_float] extension.<br />
-		- [page:Boolean floatVertexTextures]: *true* if [page:Boolean floatFragmentTextures] and [page:Boolean vertexTextures] are both true.<br />
+		- [page:Boolean floatVertexTextures]: `true` if [page:Boolean floatFragmentTextures] and [page:Boolean vertexTextures] are both true.<br />
 		- [page:Method getMaxAnisotropy](): Returns the maximum available anisotropy.<br />
 		- [page:Method getMaxPrecision](): Returns the maximum available precision for vertex and fragment shaders. <br />
-		- [page:Boolean isWebGL2]: *true* if the context in use is a WebGL2RenderingContext object.<br />
-		- [page:Boolean logarithmicDepthBuffer]: *true* if the [page:parameter logarithmicDepthBuffer] was set to true in the constructor and
+		- [page:Boolean isWebGL2]: `true` if the context in use is a WebGL2RenderingContext object.<br />
+		- [page:Boolean logarithmicDepthBuffer]: `true` if the [page:parameter logarithmicDepthBuffer] was set to true in the constructor and
 		the context supports the [link:https://developer.mozilla.org/en-US/docs/Web/API/EXT_frag_depth EXT_frag_depth] extension.<br />
-		- [page:Integer maxAttributes]: The value of *gl.MAX_VERTEX_ATTRIBS*.<br />
-		- [page:Integer maxCubemapSize]: The value of *gl.MAX_CUBE_MAP_TEXTURE_SIZE*.
+		- [page:Integer maxAttributes]: The value of `gl.MAX_VERTEX_ATTRIBS`.<br />
+		- [page:Integer maxCubemapSize]: The value of `gl.MAX_CUBE_MAP_TEXTURE_SIZE`.
 		Maximum height * width of cube map textures that a shader can use.<br />
-		- [page:Integer maxFragmentUniforms]: The value of *gl.MAX_FRAGMENT_UNIFORM_VECTORS*.
+		- [page:Integer maxFragmentUniforms]: The value of `gl.MAX_FRAGMENT_UNIFORM_VECTORS`.
 		  The number of uniforms that can be used by a fragment shader.<br />
-		- [page:Integer maxSamples]: The value of *gl.MAX_SAMPLES*.
+		- [page:Integer maxSamples]: The value of `gl.MAX_SAMPLES`.
 		Maximum number of samples in context of Multisample anti-aliasing (MSAA).<br />
-		- [page:Integer maxTextureSize]: The value of *gl.MAX_TEXTURE_SIZE*.
+		- [page:Integer maxTextureSize]: The value of `gl.MAX_TEXTURE_SIZE`.
 		Maximum height * width of a texture that a shader use.<br />
-		- [page:Integer maxTextures]: The value of *gl.MAX_TEXTURE_IMAGE_UNITS*.
+		- [page:Integer maxTextures]: The value of `gl.MAX_TEXTURE_IMAGE_UNITS`.
 		  The maximum number of textures that can be used by a shader.<br />
-		- [page:Integer maxVaryings]: The value of *gl.MAX_VARYING_VECTORS*.
+		- [page:Integer maxVaryings]: The value of `gl.MAX_VARYING_VECTORS`.
 		  The number of varying vectors that can used by shaders.<br />
-		- [page:Integer maxVertexTextures]: The value of *gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS*.
+		- [page:Integer maxVertexTextures]: The value of `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS`.
 		   The number of textures that can be used in a vertex shader.<br />
-		- [page:Integer maxVertexUniforms]: The value of *gl.MAX_VERTEX_UNIFORM_VECTORS*.
+		- [page:Integer maxVertexUniforms]: The value of `gl.MAX_VERTEX_UNIFORM_VECTORS`.
 		   The maximum number of uniforms that can be used in a vertex shader.<br />
 		- [page:String precision]: The shader precision currently being used by the renderer.<br />
-		- [page:Boolean vertexTextures]: *true* if [property:Integer maxVertexTextures] is greater than 0 (i.e. vertex textures can be used).<br />
+		- [page:Boolean vertexTextures]: `true` if [property:Integer maxVertexTextures] is greater than 0 (i.e. vertex textures can be used).<br />
 		</p>
 
 		<h3>[property:Array clippingPlanes]</h3>
@@ -161,11 +161,11 @@
 		This method can check for the following extensions:<br />
 
 		<ul>
-			<li>*WEBGL_depth_texture*</li>
-			<li>*EXT_texture_filter_anisotropic*</li>
-			<li>*WEBGL_compressed_texture_s3tc*</li>
-			<li>*WEBGL_compressed_texture_pvrtc*</li>
-			<li>*WEBGL_compressed_texture_etc1*</li>
+			<li>`WEBGL_depth_texture`</li>
+			<li>`EXT_texture_filter_anisotropic`</li>
+			<li>`WEBGL_compressed_texture_s3tc`</li>
+			<li>`WEBGL_compressed_texture_pvrtc`</li>
+			<li>`WEBGL_compressed_texture_etc1`</li>
 		</ul>
 		</p>
 
@@ -198,22 +198,22 @@
 		</ul>
 		</p>
 		<p>By default these data are reset at each render call but when having multiple render passes per frame (e.g. when using post processing) it can be preferred to reset with a custom pattern.
-			First, set *autoReset* to *false*.
+			First, set `autoReset` to `false`.
 		<code>
 		renderer.info.autoReset = false;
 		</code>
-		Call *reset()* whenever you have finished to render a single frame.
+		Call `reset()` whenever you have finished to render a single frame.
 		<code>
 		renderer.info.reset();
 		</code>
 		</p>
 
 		<h3>[property:Boolean localClippingEnabled]</h3>
-		<p>Defines whether the renderer respects object-level clipping planes. Default is *false*.</p>
+		<p>Defines whether the renderer respects object-level clipping planes. Default is `false`.</p>
 
 		<h3>[property:Boolean physicallyCorrectLights]</h3>
 		<p>
-		Whether to use physically correct lighting mode. Default is *false*.
+		Whether to use physically correct lighting mode. Default is `false`.
 		See the [example:webgl_lights_physical lights / physical] example.
 		</p>
 
@@ -231,13 +231,13 @@
 		<p>
 		This contains the reference to the shadow map, if used.<br />
 		- [page:Boolean enabled]:
-			If set, use shadow maps in the scene. Default is *false*.<br />
+			If set, use shadow maps in the scene. Default is `false`.<br />
 		- [page:Boolean autoUpdate]:
-			Enables automatic updates to the shadows in the scene. Default is *true*.<br />
-			If you do not require dynamic lighting / shadows, you may set this to *false* when the renderer is instantiated.<br />
+			Enables automatic updates to the shadows in the scene. Default is `true`.<br />
+			If you do not require dynamic lighting / shadows, you may set this to `false` when the renderer is instantiated.<br />
 		- [page:Boolean needsUpdate]:
-			When set to *true*, shadow maps in the scene will be updated in the next *render* call. Default is *false*.<br />
-			If you have disabled automatic updates to shadow maps (*shadowMap.autoUpdate = false*), you will need to set this to *true* and then make a render call to update the shadows in your scene.<br />
+			When set to `true`, shadow maps in the scene will be updated in the next `render` call. Default is `false`.<br />
+			If you have disabled automatic updates to shadow maps (*shadowMap.autoUpdate = false*), you will need to set this to `true` and then make a render call to update the shadows in your scene.<br />
 		- [page:Integer type]:
 			Defines shadow map type (unfiltered, percentage close filtering, percentage close filtering with bilinear filtering in shader).
 			Options are:
@@ -252,7 +252,7 @@
 
 		<h3>[property:Boolean sortObjects]</h3>
 		<p>
-		Defines whether the renderer should sort objects. Default is *true*.<br /><br />
+		Defines whether the renderer should sort objects. Default is `true`.<br /><br />
 
 		Note: Sorting is used to attempt to properly render objects that have some degree of transparency.
 		By definition, sorting objects may not work in all cases.  Depending on the needs of application,
@@ -272,7 +272,7 @@
 
 		<h3>[property:Number toneMappingExposure]</h3>
 		<p>
-		Exposure level of tone mapping. Default is *1*.
+		Exposure level of tone mapping. Default is `1`.
 		</p>
 
 		<h3>[property:WebXRManager xr]</h3>
@@ -286,7 +286,7 @@
 		<p>
 		Tells the renderer to clear its color, depth or stencil drawing buffer(s).
 			This method initializes the color buffer to the current clear color value.<br />
-		Arguments default to *true*.
+		Arguments default to `true`.
 		</p>
 
 		<h3>[method:undefined clearColor]( )</h3>
@@ -344,7 +344,7 @@
 		<p>Returns the current active mipmap level.</p>
 
 		<h3>[method:RenderTarget getRenderTarget]()</h3>
-		<p>Returns the current [page:RenderTarget RenderTarget] if there are; returns *null* otherwise.</p>
+		<p>Returns the current [page:RenderTarget RenderTarget] if there are; returns `null` otherwise.</p>
 
 		<h3>[method:Vector4 getCurrentViewport]( [param:Vector4 target] )</h3>
 		<p>
@@ -371,7 +371,7 @@
 		</p>
 
 		<h3>[method:Boolean getScissorTest]()</h3>
-		<p>Returns *true* if scissor test is enabled; returns *false* otherwise.</p>
+		<p>Returns `true` if scissor test is enabled; returns `false` otherwise.</p>
 
 		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
 		<p>
@@ -419,7 +419,7 @@
 		<p>A built in function that can be used instead of [link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]. For WebXR projects this function must be used.</p>
 
 		<h3>[method:undefined setClearAlpha]( [param:Float alpha] )</h3>
-		<p>Sets the clear alpha. Valid input is a float between *0.0* and *1.0*.</p>
+		<p>Sets the clear alpha. Valid input is a float between `0.0` and `1.0`.</p>
 
 		<h3>[method:undefined setClearColor]( [param:Color color], [param:Float alpha] )</h3>
 		<p>Sets the clear color and opacity.</p>
@@ -429,7 +429,7 @@
 
 		<h3>[method:undefined setRenderTarget]( [param:WebGLRenderTarget renderTarget], [param:Integer activeCubeFace], [param:Integer activeMipmapLevel] )</h3>
 		<p>
-		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated. When *null* is given, the canvas is set as the active render target instead.<br />
+		renderTarget -- The [page:WebGLRenderTarget renderTarget] that needs to be activated. When `null` is given, the canvas is set as the active render target instead.<br />
 		activeCubeFace -- Specifies the active cube side (PX 0, NX 1, PY 2, NY 3, PZ 4, NZ 5) of [page:WebGLCubeRenderTarget]. When passing a [page:WebGLArrayRenderTarget] or [page:WebGL3DRenderTarget] this indicates the z layer to render in to (optional).<br />
 		activeMipmapLevel -- Specifies the active mipmap level (optional).<br /><br />
 		This method sets the active rendertarget.

--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -21,18 +21,18 @@
 
 		<h3>[property:Boolean cameraAutoUpdate]</h3>
 		<p>
-		Whether the manager's XR camera should be automatically updated or not. Default is *true*.
+		Whether the manager's XR camera should be automatically updated or not. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean enabled]</h3>
 		<p>
-		This flag notifies the renderer to be ready for XR rendering. Default is *false*. Set it to *true* if you are going
+		This flag notifies the renderer to be ready for XR rendering. Default is `false`. Set it to `true` if you are going
 		to use XR in your app.
 		</p>
 
 		<h3>[property:Boolean isPresenting]</h3>
 		<p>
-		Whether XR presentation is active or not. Default is *false*. This flag is read-only and automatically set by [name].
+		Whether XR presentation is active or not. Default is `false`. This flag is read-only and automatically set by [name].
 		</p>
 
 		<h2>Methods</h2>
@@ -43,7 +43,7 @@
 		For each view it holds a separate camera object in its [page:ArrayCamera.cameras cameras] property.
 		</p>
 		<p>
-		The camera's *fov* is currently not used and does not reflect the fov of the XR camera. If you need the fov on app level,
+		The camera's `fov` is currently not used and does not reflect the fov of the XR camera. If you need the fov on app level,
 		you have to compute in manually from the XR camera's projection matrices.
 		</p>
 
@@ -59,7 +59,7 @@
 		<p>
 		[page:Integer index] — The index of the controller. <br /><br />
 
-		Returns a [page:Group] representing the so called *grip* space of the XR controller.
+		Returns a [page:Group] representing the so called `grip` space of the XR controller.
 		Use this space if the user is going to hold other 3D objects like a lightsaber.
 		</p>
 
@@ -78,7 +78,7 @@
 		<p>
 		[page:Integer index] — The index of the controller. <br /><br />
 
-		Returns a [page:Group] representing the so called *hand* or *joint* space of the XR controller.
+		Returns a [page:Group] representing the so called `hand` or `joint` space of the XR controller.
 		Use this space for visualizing the user's hands when no physical controllers are used.
 		</p>
 
@@ -89,14 +89,14 @@
 
 		<h3>[method:XRSession getSession]()</h3>
 		<p>
-		Returns the *XRSession* object which allows a more fine-grained management of active WebXR sessions on application level.
+		Returns the `XRSession` object which allows a more fine-grained management of active WebXR sessions on application level.
 		</p>
 
 		<h3>[method:undefined setFoveation]( [param:Float foveation] )</h3>
 		<p>
 		[page:Float foveation] — The foveation to set.<br /><br />
 
-		Specifies the amount of foveation used by the XR compositor for the layer. Must be a value between *0* and *1*.
+		Specifies the amount of foveation used by the XR compositor for the layer. Must be a value between `0` and `1`.
 		</p>
 
 		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
@@ -104,7 +104,7 @@
 		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
 
 		Specifies the scaling factor to use when determining the size of the framebuffer when rendering to a XR device.
-		The value is relative to the default XR device display resolution. Default is *1*. A value of *0.5* would specify
+		The value is relative to the default XR device display resolution. Default is `1`. A value of `0.5` would specify
 		a framebuffer with 50% of the display's native resolution.
 		</p>
 
@@ -124,13 +124,13 @@
 		[page:String referenceSpaceType] — The reference space type to set.<br /><br />
 
 		Can be used to configure a spatial relationship with the user's physical environment. Depending on how the user moves in 3D space, setting an
-		appropriate reference space can improve tracking. Default is *local-floor*.
+		appropriate reference space can improve tracking. Default is `local-floor`.
 		Please check out the [link:https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType MDN] for possible values and their use cases.
 		</p>
 
 		<h3>[method:undefined updateCamera]( [param:PerspectiveCamera camera] )</h3>
 		<p>
-		Updates the state of the XR camera. Use this method on app level if you set [page:.cameraAutoUpdate] to *false*.
+		Updates the state of the XR camera. Use this method on app level if you set [page:.cameraAutoUpdate] to `false`.
 		The method requires the non-XR camera of the scene as a parameter. The passed in camera's transformation is automatically
 		adjusted to the position of the XR camera when calling this method.
 		</p>

--- a/docs/api/en/textures/CanvasTexture.html
+++ b/docs/api/en/textures/CanvasTexture.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 		Creates a texture from a canvas element.<br /><br />
 
-		This is almost the same as the base [page:Texture Texture] class, except that it sets [page:Texture.needsUpdate needsUpdate] to *true* immediately.
+		This is almost the same as the base [page:Texture Texture] class, except that it sets [page:Texture.needsUpdate needsUpdate] to `true` immediately.
 		</p>
 
 

--- a/docs/api/en/textures/CubeTexture.html
+++ b/docs/api/en/textures/CubeTexture.html
@@ -48,7 +48,7 @@
 
 		<h3>[property:Boolean flipY]</h3>
 		<p>
-		If set to *true*, the texture is flipped along the vertical axis when uploaded to the GPU. Default is *false*.
+		If set to `true`, the texture is flipped along the vertical axis when uploaded to the GPU. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean isCubeTexture]</h3>

--- a/docs/api/en/textures/DataTexture.html
+++ b/docs/api/en/textures/DataTexture.html
@@ -72,7 +72,7 @@
 
 		<h3>[property:Boolean flipY]</h3>
 		<p>
-		If set to *true*, the texture is flipped along the vertical axis when uploaded to the GPU. Default is *false*.
+		If set to `true`, the texture is flipped along the vertical axis when uploaded to the GPU. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean generateMipmaps]</h3>

--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -92,7 +92,7 @@
 
 		<h3>[page:Texture.flipY flipY]</h3>
 		<p>
-		Depth textures do not need to be flipped so this is *false* by default.
+		Depth textures do not need to be flipped so this is `false` by default.
 		</p>
 
 		<h3>[page:Texture.generateMipmaps .generateMipmaps]</h3>

--- a/docs/api/en/textures/Source.html
+++ b/docs/api/en/textures/Source.html
@@ -17,7 +17,7 @@
 
 		<h3>[name]( [param:Any data] )</h3>
 		<p>
-			[page:Any data] -- The data definition of a texture. Default is *null*.
+			[page:Any data] -- The data definition of a texture. Default is `null`.
 		</p>
 
 		<h2>Properties</h2>
@@ -29,7 +29,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Set this to *true* to trigger a data upload to the GPU next time the source is used.
+		Set this to `true` to trigger a data upload to the GPU next time the source is used.
 		</p>
 
 		<h3>[property:String uuid]</h3>
@@ -40,7 +40,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
+		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -149,10 +149,10 @@
 		<h3>[property:Vector2 offset]</h3>
 		<p>
 		How much a single repetition of the texture is offset from the beginning, in each direction U and V.
-		Typical range is *0.0* to *1.0*.
+		Typical range is `0.0` to `1.0`.
 		</p>
 		<p>
-			The below texture types share the *first* uv channel in the engine. The offset (and repeat) setting is evaluated according to
+			The below texture types share the `first` uv channel in the engine. The offset (and repeat) setting is evaluated according to
 			the following priorities and then shared by those textures:
 			<ol>
 				<li>color map</li>
@@ -170,7 +170,7 @@
 			</ol>
 		</p>
 		<p>
-			The below texture types share the *second* uv channel in the engine. The offset (and repeat) setting is evaluated according to
+			The below texture types share the `second` uv channel in the engine. The offset (and repeat) setting is evaluated according to
 			the following priorities and then shared by those textures:
 			<ol>
 				<li>ao map</li>
@@ -188,7 +188,7 @@
 
 		<h3>[property:number rotation]</h3>
 		<p>
-		How much the texture is rotated around the center point, in radians. Positive values are counter-clockwise. Default is *0*.
+		How much the texture is rotated around the center point, in radians. Positive values are counter-clockwise. Default is `0`.
 		</p>
 
 		<h3>[property:Vector2 center]</h3>
@@ -219,7 +219,7 @@
 
 		<h3>[property:Boolean premultiplyAlpha]</h3>
 		<p>
-		If set to *true*, the alpha channel, if present, is multiplied into the color channels when the texture is uploaded to the GPU. Default is *false*.<br /><br />
+		If set to `true`, the alpha channel, if present, is multiplied into the color channels when the texture is uploaded to the GPU. Default is `false`.<br /><br />
 
 		Note that this property has no effect for [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap ImageBitmap].
 		You need to configure on bitmap creation instead. See [page:ImageBitmapLoader].
@@ -227,7 +227,7 @@
 
 		<h3>[property:Boolean flipY]</h3>
 		<p>
-		If set to *true*, the texture is flipped along the vertical axis when uploaded to the GPU. Default is *true*.<br /><br />
+		If set to `true`, the texture is flipped along the vertical axis when uploaded to the GPU. Default is `true`.<br /><br />
 
 		Note that this property has no effect for [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap ImageBitmap].
 		You need to configure on bitmap creation instead. See [page:ImageBitmapLoader].
@@ -253,7 +253,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
+		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
 		</p>
 
 		<h3>[property:Function onUpdate]</h3>
@@ -264,7 +264,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Set this to *true* to trigger an update next time the texture is used. Particularly important for setting the wrap mode.
+		Set this to `true` to trigger an update next time the texture is used. Particularly important for setting the wrap mode.
 		</p>
 
 		<h3>[property:Object userData]</h3>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -14,7 +14,7 @@
 		<p class="desc">
 		Creates a texture for use with a video texture.<br /><br />
 
-		This is almost the same as the base [page:Texture Texture] class, except that it continuously sets [page:Texture.needsUpdate needsUpdate] to *true* so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
+		This is almost the same as the base [page:Texture Texture] class, except that it continuously sets [page:Texture.needsUpdate needsUpdate] to `true` so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
 		</p>
 
 		<h2>Code Example</h2>
@@ -90,7 +90,7 @@
 
 		<h3>[method:undefined update]()</h3>
 		<p>
-		This is called automatically and sets [property:Boolean needsUpdate] to *true* every time
+		This is called automatically and sets [property:Boolean needsUpdate] to `true` every time
 		a new frame is available.
 		</p>
 

--- a/docs/examples/en/animations/CCDIKSolver.html
+++ b/docs/examples/en/animations/CCDIKSolver.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<p class="desc"> A solver for IK with <a href="https://sites.google.com/site/auraliusproject/ccd-algorithm"><em>CCD Algorithm</em></a>. <br /><br />
+		<p class="desc"> A solver for IK with <a href="https://sites.google.com/site/auraliusproject/ccd-algorithm">`CCD Algorithm`</a>. <br /><br />
 		[name] solves Inverse Kinematics Problem with CCD Algorithm.
 		[name] is designed to work with [page:SkinnedMesh] but also can be used with [page:MMDLoader] or [page:GLTFLoader] skeleton.
 		</p>

--- a/docs/examples/en/animations/MMDAnimationHelper.html
+++ b/docs/examples/en/animations/MMDAnimationHelper.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<p class="desc"> A animation helper for <a href="https://sites.google.com/view/evpvp/"><em>MMD</em></a> resources. <br /><br />
+		<p class="desc"> A animation helper for <a href="https://sites.google.com/view/evpvp/">`MMD`</a> resources. <br /><br />
 		[name] handles animation of MMD assets loaded by [page:MMDLoader] with MMD special features as IK, Grant, and Physics.
 		It uses [page:CCDIKSolver] and [page:MMDPhysics] inside.
 		</p>

--- a/docs/examples/en/animations/MMDPhysics.html
+++ b/docs/examples/en/animations/MMDPhysics.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<p class="desc"> A Physics handler for <a href="https://sites.google.com/view/evpvp/"><em>MMD</em></a> resources. <br /><br />
+		<p class="desc"> A Physics handler for <a href="https://sites.google.com/view/evpvp/">`MMD`</a> resources. <br /><br />
 		[name] calculates Physics for model loaded by [page:MMDLoader] with <a href="https://github.com/kripken/ammo.js/">ammo.js</a> (Bullet-based JavaScript Physics engine).
 		</p>
 

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -123,7 +123,7 @@
 
 		<h3>[property:Boolean enabled]</h3>
 		<p>
-			When set to *false*, the controls will not respond to user input. Default is *true*.
+			When set to `false`, the controls will not respond to user input. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean enableAnimations]</h3>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -94,7 +94,7 @@
 		<h3>[property:Boolean transformGroup]</h3>
 		<p>
 			This option only works if the [page:DragControls.objects] array contains a single draggable group object.
-			If set to *true*, [name] does not transform individual objects but the entire group. Default is *false*.
+			If set to `true`, [name] does not transform individual objects but the entire group. Default is `false`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/controls/FirstPersonControls.html
+++ b/docs/examples/en/controls/FirstPersonControls.html
@@ -37,17 +37,17 @@
 
 		<h3>[property:Boolean activeLook]</h3>
 		<p>
-			Whether or not it's possible to look around. Default is *true*.
+			Whether or not it's possible to look around. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean autoForward]</h3>
 		<p>
-			Whether or not the camera is automatically moved forward. Default is *false*.
+			Whether or not the camera is automatically moved forward. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean constrainVertical]</h3>
 		<p>
-			Whether or not looking around is vertically constrained by [[page:.verticalMin], [page:.verticalMax]]. Default is *false*.
+			Whether or not looking around is vertically constrained by [[page:.verticalMin], [page:.verticalMax]]. Default is `false`.
 		</p>
 
 		<h3>[property:HTMLDOMElement domElement]</h3>
@@ -58,7 +58,7 @@
 
 		<h3>[property:Boolean enabled]</h3>
 		<p>
-			Whether or not the controls are enabled. Default is *true*.
+			Whether or not the controls are enabled. Default is `true`.
 		</p>
 
 		<h3>[property:Number heightCoef]</h3>
@@ -78,18 +78,18 @@
 
 		<h3>[property:Boolean heightSpeed]</h3>
 		<p>
-			Whether or not the camera's height influences the forward movement speed. Default is *false*.
+			Whether or not the camera's height influences the forward movement speed. Default is `false`.
 			Use the properties [page:.heightCoef], [page:.heightMin] and [page:.heightMax] for configuration.
 		</p>
 
 		<h3>[property:Boolean lookVertical]</h3>
 		<p>
-			Whether or not it's possible to vertically look around. Default is *true*.
+			Whether or not it's possible to vertically look around. Default is `true`.
 		</p>
 
 		<h3>[property:Number lookSpeed]</h3>
 		<p>
-			The look around speed. Default is *0.005*.
+			The look around speed. Default is `0.005`.
 		</p>
 
 		<h3>[property:Boolean mouseDragOn]</h3>
@@ -109,7 +109,7 @@
 
 		<h3>[property:Number verticalMax]</h3>
 		<p>
-			How far you can vertically look around, upper limit. Range is 0 to Math.PI radians. Default is *Math.PI*.
+			How far you can vertically look around, upper limit. Range is 0 to Math.PI radians. Default is `Math.PI`.
 		</p>
 
 		<h3>[property:Number verticalMin]</h3>

--- a/docs/examples/en/controls/FlyControls.html
+++ b/docs/examples/en/controls/FlyControls.html
@@ -45,7 +45,7 @@
 
 		<h3>[property:Boolean autoForward]</h3>
 		<p>
-			If set to *true*, the camera automatically moves forward (and does not stop) when initially translated. Default is *false*.
+			If set to `true`, the camera automatically moves forward (and does not stop) when initially translated. Default is `false`.
 		</p>
 
 		<h3>[property:HTMLDOMElement domElement]</h3>
@@ -56,7 +56,7 @@
 
 		<h3>[property:Boolean dragToLook]</h3>
 		<p>
-			If set to *true*, you can only look around by performing a drag interaction. Default is *false*.
+			If set to `true`, you can only look around by performing a drag interaction. Default is `false`.
 		</p>
 
 		<h3>[property:Number movementSpeed]</h3>
@@ -71,7 +71,7 @@
 
 		<h3>[property:Number rollSpeed]</h3>
 		<p>
-			The rotation speed. Default is *0.005*.
+			The rotation speed. Default is `0.005`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -106,7 +106,7 @@
 
 		<h3>[property:Boolean enabled]</h3>
 		<p>
-			When set to *false*, the controls will not respond to user input. Default is *true*.
+			When set to `false`, the controls will not respond to user input. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean enableDamping]</h3>
@@ -289,7 +289,7 @@ controls.touches = {
 
 		<h3>[method:undefined listenToKeyEvents] ( [param:HTMLDOMElement domElement] )</h3>
 		<p>
-			Adds key event listeners to the given DOM element. *window* is a recommended argument for using this method.
+			Adds key event listeners to the given DOM element. `window` is a recommended argument for using this method.
 		</p>
 
 		<h3>[method:undefined reset] ()</h3>

--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -64,7 +64,7 @@
 
 		<h3>[property:Number dynamicDampingFactor]</h3>
 		<p>
-			Defines the intensity of damping. Only considered if [page:.staticMoving staticMoving] is set to *false*. Default is *0.2*.
+			Defines the intensity of damping. Only considered if [page:.staticMoving staticMoving] is set to `false`. Default is `0.2`.
 		</p>
 
 		<h3>[property:Boolean enabled]</h3>
@@ -85,7 +85,7 @@
 
 		<h3>[property:Number maxDistance]</h3>
 		<p>
-			How far you can zoom out. Default is *Infinity*.
+			How far you can zoom out. Default is `Infinity`.
 		</p>
 
 		<h3>[property:Number minDistance]</h3>
@@ -98,25 +98,25 @@
 		<p>
 			This object contains references to the mouse actions used by the controls.
 			<ul>
-				<li>.LEFT is assigned with *THREE.MOUSE.ROTATE*</li>
-				<li>.MIDDLE is assigned with *THREE.MOUSE.ZOOM*</li>
-				<li>.RIGHT is assigned with *THREE.MOUSE.PAN*</li>
+				<li>.LEFT is assigned with `THREE.MOUSE.ROTATE`</li>
+				<li>.MIDDLE is assigned with `THREE.MOUSE.ZOOM`</li>
+				<li>.RIGHT is assigned with `THREE.MOUSE.PAN`</li>
 			</ul>
 		</p>
 
 		<h3>[property:Boolean noPan]</h3>
 		<p>
-			Whether or not panning is disabled. Default is *false*.
+			Whether or not panning is disabled. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean noRotate]</h3>
 		<p>
-			Whether or not rotation is disabled. Default is *false*.
+			Whether or not rotation is disabled. Default is `false`.
 		</p>
 
 		<h3>[property:Boolean noZoom]</h3>
 		<p>
-			Whether or not zooming is disabled. Default is *false*.
+			Whether or not zooming is disabled. Default is `false`.
 		</p>
 
 		<h3>[property:Camera object]</h3>
@@ -126,12 +126,12 @@
 
 		<h3>[property:Number panSpeed]</h3>
 		<p>
-			The pan speed. Default is *0.3*.
+			The pan speed. Default is `0.3`.
 		</p>
 
 		<h3>[property:Number rotateSpeed]</h3>
 		<p>
-			The rotation speed. Default is *1.0*.
+			The rotation speed. Default is `1.0`.
 		</p>
 
 		<h3>[property:Object screen]</h3>
@@ -147,12 +147,12 @@
 
 		<h3>[property:Boolean staticMoving]</h3>
 		<p>
-			Whether or not damping is disabled. Default is *false*.
+			Whether or not damping is disabled. Default is `false`.
 		</p>
 
 		<h3>[property:Number zoomSpeed]</h3>
 		<p>
-			The zoom speed. Default is *1.2*.
+			The zoom speed. Default is `1.2`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -92,7 +92,7 @@
 
 		<h3>[property:String mode]</h3>
 		<p>
-			The current transformation mode. Possible values are "translate", "rotate" and "scale". Default is *translate*.
+			The current transformation mode. Possible values are "translate", "rotate" and "scale". Default is `translate`.
 		</p>
 
 		<h3>[property:Object3D object]</h3>
@@ -103,22 +103,22 @@
 		<h3>[property:Number rotationSnap]</h3>
 		<p>
 			By default, 3D objects are continuously rotated. If you set this property to a numeric value (radians), you can define in which
-			steps the 3D object should be rotated. Default is *null*.
+			steps the 3D object should be rotated. Default is `null`.
 		</p>
 
 		<h3>[property:Boolean showX]</h3>
 		<p>
-			Whether or not the x-axis helper should be visible. Default is *true*.
+			Whether or not the x-axis helper should be visible. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean showY]</h3>
 		<p>
-			Whether or not the y-axis helper should be visible. Default is *true*.
+			Whether or not the y-axis helper should be visible. Default is `true`.
 		</p>
 
 		<h3>[property:Boolean showZ]</h3>
 		<p>
-			Whether or not the z-axis helper should be visible. Default is *true*.
+			Whether or not the z-axis helper should be visible. Default is `true`.
 		</p>
 
 		<h3>[property:Number size]</h3>
@@ -128,13 +128,13 @@
 
 		<h3>[property:String space]</h3>
 		<p>
-			Defines in which coordinate space transformations should be performed. Possible values are "world" and "local". Default is *world*.
+			Defines in which coordinate space transformations should be performed. Possible values are "world" and "local". Default is `world`.
 		</p>
 
 		<h3>[property:Number translationSnap]</h3>
 		<p>
 			By default, 3D objects are continuously translated. If you set this property to a numeric value (world units), you can define in which
-			steps the 3D object should be translated. Default is *null*.
+			steps the 3D object should be translated. Default is `null`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/exporters/ColladaExporter.html
+++ b/docs/examples/en/exporters/ColladaExporter.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		An exporter for *Collada*.
+		An exporter for `Collada`.
 		<br /><br />
 		<a href="https://www.khronos.org/collada/" target="_blank">Collada</a> is a
 		file format for robust representation of scenes, materials, animations, and other 3D content in an xml format.

--- a/docs/examples/en/exporters/EXRExporter.html
+++ b/docs/examples/en/exporters/EXRExporter.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		An exporter for *EXR*.
+		An exporter for `EXR`.
 		<br /><br />
 		<a href="https://www.openexr.com/" target="_blank">EXR</a> ( Extended Dynamic Range) is an
 		<a href="https://github.com/AcademySoftwareFoundation/openexr" target="_blank">open format specification</a>

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		An exporter for *glTF* 2.0.
+		An exporter for `glTF` 2.0.
 		<br /><br />
 		<a href="https://www.khronos.org/gltf" target="_blank">glTF</a> (GL Transmission Format) is an
 		<a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0" target="_blank">open format specification</a>
@@ -122,7 +122,7 @@
 			<li>maxTextureSize - int. Restricts the image maximum size (both width and height) to the given value. Default is Infinity.</li>
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
 			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
-			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's <em>userData.gltfExtensions</em> property. Default is false.</li>
+			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's `userData.gltfExtensions` property. Default is false.</li>
 		</ul>
 		</p>
 		<p>

--- a/docs/examples/en/exporters/PLYExporter.html
+++ b/docs/examples/en/exporters/PLYExporter.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		An exporter for *PLY*.
+		An exporter for `PLY`.
 		<br /><br />
 		<a href="https://en.wikipedia.org/wiki/PLY_(file_format)" target="_blank">PLY</a> (Polygon or Stanford Triangle Format) is a
 		file format for efficient delivery and loading of simple, static 3D content in a dense format.

--- a/docs/examples/en/helpers/RectAreaLightHelper.html
+++ b/docs/examples/en/helpers/RectAreaLightHelper.html
@@ -42,7 +42,7 @@
 
 		<h3>[property:hex color]</h3>
 		<p>
-						 The color parameter passed in the constructor. Default is *undefined*. If this is changed, the helper's color will update
+						 The color parameter passed in the constructor. Default is `undefined`. If this is changed, the helper's color will update
 						the next time [page:.update update] is called.
 		</p>
 

--- a/docs/examples/en/helpers/VertexNormalsHelper.html
+++ b/docs/examples/en/helpers/VertexNormalsHelper.html
@@ -52,7 +52,7 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			object's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 

--- a/docs/examples/en/helpers/VertexTangentsHelper.html
+++ b/docs/examples/en/helpers/VertexTangentsHelper.html
@@ -53,7 +53,7 @@
 
 		<h3>[property:Object matrixAutoUpdate]</h3>
 		<p>
-			See [page:Object3D.matrixAutoUpdate]. Set to *false* here as the helper is using the
+			See [page:Object3D.matrixAutoUpdate]. Set to `false` here as the helper is using the
 			object's [page:Object3D.matrixWorld matrixWorld].
 		</p>
 

--- a/docs/examples/en/lights/LightProbeGenerator.html
+++ b/docs/examples/en/lights/LightProbeGenerator.html
@@ -33,7 +33,7 @@
 			Creates a light probe from the given (radiance) environment map. The method expects that the environment map is represented as a cube render target.
 		</p>
 		<p>
-			The [page:Texture.format format] of the cube render target must be set to *RGBA*.
+			The [page:Texture.format format] of the cube render target must be set to `RGBA`.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -163,23 +163,23 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.3dm</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.3dm` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Begin loading from url and call the <em>onLoad</em> function with the resulting Object3d.
+		Begin loading from url and call the `onLoad` function with the resulting Object3d.
 		</p>
 
 		<h3>[method:undefined parse]( [param:ArrayBuffer buffer], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:ArrayBuffer buffer] — An ArrayBuffer representing the Rhino <em>File3dm</em> document.<br />
+		[page:ArrayBuffer buffer] — An ArrayBuffer representing the Rhino `File3dm` document.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Parse a File3dm ArrayBuffer and call the <em>onLoad</em> function with the resulting Object3d.
+		Parse a File3dm ArrayBuffer and call the `onLoad` function with the resulting Object3d.
 		See <a href="https://github.com/mcneel/rhino-developer-samples/tree/7/rhino3dm/js/SampleParse3dmObjects">this example</a> for further reference.
 		</p>
 

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -18,8 +18,8 @@
 		</p>
 
 		<p>
-			Standalone Draco files have a <em>.drc</em> extension, and contain vertex positions,
-			normals, colors, and other attributes. Draco files <em>do not</em> contain materials,
+			Standalone Draco files have a `.drc` extension, and contain vertex positions,
+			normals, colors, and other attributes. Draco files *do not* contain materials,
 			textures, animation, or node hierarchies – to use these features, embed Draco geometry
 			inside of a glTF file. A normal glTF file can be converted to a Draco-compressed glTF file
 			using [link:https://github.com/AnalyticalGraphicsInc/gltf-pipeline glTF-Pipeline]. When
@@ -106,13 +106,13 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.drc</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.drc` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Begin loading from url and call the <em>onLoad</em> function with the decompressed geometry.
+		Begin loading from url and call the `onLoad` function with the decompressed geometry.
 		</p>
 
 		<h3>[method:this setDecoderPath]( [param:String value] )</h3>
@@ -122,7 +122,7 @@
 
 		<h3>[method:this setDecoderConfig]( [param:Object config] )</h3>
 		<p>
-			[page:String config.type] - (Optional) <em>"js"</em> or <em>"wasm"</em>.<br />
+			[page:String config.type] - (Optional) `"js"` or `"wasm"`.<br />
 		</p>
 		<p>
 		Provides configuration for the decoder libraries. Configuration cannot be changed

--- a/docs/examples/en/loaders/FontLoader.html
+++ b/docs/examples/en/loaders/FontLoader.html
@@ -79,8 +79,8 @@
 
 		<h3>[method:Font parse]( [param:Object json] )</h3>
 		<p>
-		[page:Object json] — The <em>JSON</em> structure to parse.<br /><br />
-		Parse a <em>JSON</em> structure and return a font.
+		[page:Object json] — The `JSON` structure to parse.<br /><br />
+		Parse a `JSON` structure and return a font.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc"> A loader for <em>glTF 2.0</em> resources. <br /><br />
+		<p class="desc"> A loader for `glTF 2.0` resources. <br /><br />
 		[link:https://www.khronos.org/gltf glTF] (GL Transmission Format) is an
 		[link:https://github.com/KhronosGroup/glTF/tree/master/specification/2.0 open format specification]
 		for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
@@ -196,7 +196,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.gltf</em> or <em>.glb</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.gltf` or `.glb` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
@@ -220,13 +220,13 @@
 
 		<h3>[method:undefined parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>
 		<p>
-		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or <em>JSON</em> string.<br />
+		[page:ArrayBuffer data] — glTF asset to parse, as an ArrayBuffer or `JSON` string.<br />
 		[page:String path] — The base path from which to find subsequent glTF resources such as textures and .bin data files.<br />
 		[page:Function onLoad] — A function to be called when parse completes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during parsing. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Parse a glTF-based ArrayBuffer or <em>JSON</em> String and fire [page:Function onLoad] callback when complete. The argument to [page:Function onLoad] will be an [page:Object] that contains loaded parts: .[page:Group scene], .[page:Array scenes], .[page:Array cameras], .[page:Array animations], and .[page:Object asset].
+		Parse a glTF-based ArrayBuffer or `JSON` String and fire [page:Function onLoad] callback when complete. The argument to [page:Function onLoad] will be an [page:Object] that contains loaded parts: .[page:Group scene], .[page:Array scenes], .[page:Array cameras], .[page:Array animations], and .[page:Object asset].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -82,13 +82,13 @@
 
 		<h3>[method:CompressedTexture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.basis</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.basis` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>
-		Load from url and call the <em>onLoad</em> function with the transcoded [page:CompressedTexture].
+		Load from url and call the `onLoad` function with the transcoded [page:CompressedTexture].
 		</p>
 
 		<h3>[method:this detectSupport]( [param:WebGLRenderer renderer] )</h3>

--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc"> A loader for <em>LDraw</em> resources. <br /><br />
+		<p class="desc"> A loader for `LDraw` resources. <br /><br />
 		[link:https://ldraw.org LDraw] (LEGO Draw) is an
 		[link:https://ldraw.org/article/218.html open format specification] for describing LEGO
 		and other construction set 3D models.</p>

--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc"> A loader for <a href="https://sites.google.com/view/evpvp/"><em>MMD</em></a> resources. <br /><br />
+		<p class="desc"> A loader for <a href="https://sites.google.com/view/evpvp/">`MMD`</a> resources. <br /><br />
 		[name] creates Three.js Objects from MMD resources as PMD, PMX, VMD, and VPD files.
 		See [page:MMDAnimationHelper] for MMD animation handling as IK, Grant, and Physics.<br /><br />
 
@@ -73,7 +73,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.pmd</em> or <em>.pmx</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.pmd` or `.pmx` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
@@ -84,7 +84,7 @@
 
 		<h3>[method:undefined loadAnimation]( [param:String url], [param:Object3D object], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string or an array of string containing the path/URL of the <em>.vmd</em> file(s).If two or more files are specified, they'll be merged.<br />
+		[page:String url] — A string or an array of string containing the path/URL of the `.vmd` file(s).If two or more files are specified, they'll be merged.<br />
 		[page:Object3D object] — [page:SkinnedMesh] or [page:Camera]. Clip and its tracks will be fitting to this object.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
@@ -96,8 +96,8 @@
 
 		<h3>[method:undefined loadWithAnimation]( [param:String modelUrl], [param:String vmdUrl], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String modelUrl] — A string containing the path/URL of the <em>.pmd</em> or <em>.pmx</em> file.<br />
-		[page:String vmdUrl] — A string or an array of string containing the path/URL of the <em>.vmd</em> file(s).<br />
+		[page:String modelUrl] — A string containing the path/URL of the `.pmd` or `.pmx` file.<br />
+		[page:String vmdUrl] — A string or an array of string containing the path/URL of the `.vmd` file(s).<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />

--- a/docs/examples/en/loaders/MTLLoader.html
+++ b/docs/examples/en/loaders/MTLLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading an <em>.mtl</em> resource, used internally by [page:OBJLoader].<br />
+		<p class="desc">A loader for loading an `.mtl` resource, used internally by [page:OBJLoader].<br />
 		The Material Template Library format (MTL) or .MTL File Format is a companion file format to .OBJ that describes surface shading
 		(material) properties of objects within one or more .OBJ files.
 		</p>
@@ -34,7 +34,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-			[page:String url] — A string containing the path/URL of the <em>.mtl</em> file.<br />
+			[page:String url] — A string containing the path/URL of the `.mtl` file.<br />
 			[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
 			[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 			[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
@@ -61,11 +61,11 @@
 
 		<h3>[method:MTLLoaderMaterialCreator parse]( [param:String text, param:String path] )</h3>
 		<p>
-			[page:String text] — The textual <em>mtl</em> structure to parse.
+			[page:String text] — The textual `mtl` structure to parse.
 			[page:String path] — The path to the MTL file.
 		</p>
 		<p>
-			Parse a <em>mtl</em> text structure and return a [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
+			Parse a `mtl` text structure and return a [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] instance.<br />
 		</p>
 
 

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.obj</em> resource.<br />
+		<p class="desc">A loader for loading a `.obj` resource.<br />
 		The <a href="https://en.wikipedia.org/wiki/Wavefront_.obj_file">OBJ file format</a> is a simple data-format
 		that represents 3D geometry in a human readable format as the position of each vertex, the UV position of
 		each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list of
@@ -72,7 +72,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.obj</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.obj` file.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:Object3D] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
@@ -83,12 +83,12 @@
 
 		<h3>[method:Object3D parse]( [param:String text] )</h3>
 		<p>
-		[page:String text] — The textual <em>obj</em> structure to parse.
+		[page:String text] — The textual `obj` structure to parse.
 		</p>
 		<p>
 		Returns an [page:Object3D]. It contains the parsed meshes as [page:Mesh] and lines as [page:LineSegments].<br />
 		All geometry is created as [page:BufferGeometry]. Default materials are created as [page:MeshPhongMaterial].<br />
-		If an <em>obj</em> object or group uses multiple materials while declaring faces, geometry groups and an array of materials are used.
+		If an `obj` object or group uses multiple materials while declaring faces, geometry groups and an array of materials are used.
 		</p>
 
 		<h3>[method:this setMaterials]( [param:MTLLoader.MaterialCreator materials] )</h3>

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.pcd</em> resource. <br />
+		<p class="desc">A loader for loading a `.pcd` resource. <br />
 		Point Cloud Data is a file format for <a href="https://en.wikipedia.org/wiki/Point_Cloud_Library">Point Cloud Library</a>. <br />
 		Loader support ascii and (compressed) binary.
 		</p>
@@ -76,7 +76,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.pcd</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.pcd` file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:Object3D] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
@@ -93,7 +93,7 @@
 		[page:String url] — The file name or file url.
 		</p>
 		<p>
-		Parse an <em>pcd</em> binary structure and return an [page:Object3D].<br />
+		Parse an `pcd` binary structure and return an [page:Object3D].<br />
 		The object is converted to [page:Points] with a [page:BufferGeometry] and a [page:PointsMaterial].
 		</p>
 

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.pdb</em> resource.<br>
+		<p class="desc">A loader for loading a `.pdb` resource.<br>
 		The <a href="http://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format)">Protein Data Bank</a> file format is a textual file describing the three-dimensional structures of molecules.
 		</p>
 
@@ -73,7 +73,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.pdb</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.pdb` file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives the object having the following properties. [page:BufferGeometry geometryAtoms], [page:BufferGeometry geometryBonds] and the [page:Object JSON] structure.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />
@@ -84,10 +84,10 @@
 
 		<h3>[method:Object parse]( [param:String text] )</h3>
 		<p>
-		[page:String text] — The textual <em>pdb</em> structure to parse.
+		[page:String text] — The textual `pdb` structure to parse.
 		</p>
 		<p>
-		Parse a <em>pdb</em> text and return a <em>JSON</em> structure.<br />
+		Parse a `pdb` text and return a `JSON` structure.<br />
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/loaders/PRWMLoader.html
+++ b/docs/examples/en/loaders/PRWMLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.prwm</em> resource.<br />
+		<p class="desc">A loader for loading a `.prwm` resource.<br />
 		Packed Raw WebGL Model is an open-source binary file format for nD geometries specifically designed for
 		JavaScript and WebGL with a strong focus on fast parsing (from 1ms to 0.1ms in Chrome 59
 		on a MBP Late 2013). The parsing of PRWM file is especially fast when the endianness of the file is
@@ -74,7 +74,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.prwm</em> file. Any <em>*</em> character in the URL will be automatically replaced by <em>le</em> or <em>be</em> depending on the platform endianness.<br />
+		[page:String url] — A string containing the path/URL of the `.prwm` file. Any `*` character in the URL will be automatically replaced by `le` or `be` depending on the platform endianness.<br />
 		[page:Function onLoad] — (optional) A function to be called after the loading is successfully completed. The function receives the loaded [page:BufferGeometry] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The function receives a XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
@@ -85,10 +85,10 @@
 
 		<h3>[method:BufferGeometry parse]( [param:ArrayBuffer arrayBuffer] )</h3>
 		<p>
-		[page:ArrayBuffer arrayBuffer] — ArrayBuffer containing the <em>prwm</em> data.
+		[page:ArrayBuffer arrayBuffer] — ArrayBuffer containing the `prwm` data.
 		</p>
 		<p>
-		Parse a <em>prwm</em> file passed as an ArrayBuffer and directly return an instance of [page:BufferGeometry].
+		Parse a `prwm` file passed as an ArrayBuffer and directly return an instance of [page:BufferGeometry].
 		</p>
 
 		<h3>PRWMLoader.isBigEndianPlatform( )</h3>

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.svg</em> resource.<br >
+		<p class="desc">A loader for loading a `.svg` resource.<br >
 		<a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">Scalable Vector Graphics</a> is an XML-based vector image format for two-dimensional graphics with support for interactivity and animation.
 		</p>
 
@@ -95,7 +95,7 @@
 
 		<h3>[method:undefined load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.svg</em> file.<br />
+		[page:String url] — A string containing the path/URL of the `.svg` file.<br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives an array of [page:ShapePath] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains [page:Integer total] and [page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">A loader for loading a <em>.tga</em> resource. <br />
+		<p class="desc">A loader for loading a `.tga` resource. <br />
 		<a href="https://en.wikipedia.org/wiki/Truevision_TGA">TGA</a> is a raster graphics, image file format.
 		</p>
 
@@ -74,7 +74,7 @@
 
 		<h3>[method:DataTexture load]( [param:String url], [param:Function onLoad], [param:Function onProgress], [param:Function onError] )</h3>
 		<p>
-		[page:String url] — A string containing the path/URL of the <em>.tga</em> file. <br />
+		[page:String url] — A string containing the path/URL of the `.tga` file. <br />
 		[page:Function onLoad] — (optional) A function to be called after loading is successfully completed. The function receives loaded [page:DataTexture] as an argument.<br />
 		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, which contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives the error as an argument.<br />

--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -25,8 +25,8 @@
 
 		<h3>[name]( [param:String colormap], [param:Number count] )</h3>
 		<p>
-		colormap - Sets a colormap from predefined colormaps. Available colormaps are: *rainbow*, *cooltowarm*, *blackbody*, *grayscale*. Default is *rainbow*.<br />
-		count - Sets the number of colors used to represent the data array. Default is *32*.
+		colormap - Sets a colormap from predefined colormaps. Available colormaps are: `rainbow`, `cooltowarm`, `blackbody`, `grayscale`. Default is `rainbow`.<br />
+		count - Sets the number of colors used to represent the data array. Default is `32`.
 		</p>
 
 		<h2>Properties</h2>
@@ -38,7 +38,7 @@
 
 		<h3>[property:Array map]</h3>
 		<p>
-		The currently selected color map. Default is the *rainbow* color map.
+		The currently selected color map. Default is the `rainbow` color map.
 		</p>
 
 		<h3>[property:Number minV]</h3>
@@ -53,7 +53,7 @@
 
 		<h3>[property:Number n]</h3>
 		<p>
-		The number of colors of the current selected color map. Default is *32*.
+		The number of colors of the current selected color map. Default is `32`.
 		</p>
 
 		<h2>Methods</h2>
@@ -91,7 +91,7 @@
 		<h3>[method:this setColorMap]( [param:String colormap], [param:Number count] )</h3>
 		<p>
 		colormap — The name of the color map.<br />
-		count — The number of colors. Default is *32*.
+		count — The number of colors. Default is `32`.
 		</p>
 		<p>
 		Configure the lookup table for the given color map and number of colors.

--- a/docs/examples/en/math/OBB.html
+++ b/docs/examples/en/math/OBB.html
@@ -131,7 +131,7 @@
 		<h3>[method:Boolean intersectsOBB]( [param:OBB obb], [param:Number epsilon] )</h3>
 		<p>
 			[page:OBB obb] — The OBB to test.<br />
-			[page:Number epsilon] — An optional numeric value to counteract arithmetic errors. Default is *Number.EPSILON*.
+			[page:Number epsilon] — An optional numeric value to counteract arithmetic errors. Default is `Number.EPSILON`.
 		</p>
 		<p>
 			Whether the given [name] intersects this [name] or not.
@@ -152,7 +152,7 @@
 		</p>
 		<p>
 			Performs a Ray/OBB intersection test and stores the intersection point to the given 3D vector.
-			If no intersection is detected, *null* is returned.
+			If no intersection is detected, `null` is returned.
 		</p>
 
 		<h3>[method:this set]( [param:Vector3 center], [param:Vector3 halfSize], [param:Matrix3 rotation] )</h3>

--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -124,7 +124,7 @@
 		<p>
 			[page:Vector3 point] - A point in 3D space.<br /><br />
 
-			Returns *true* if the given point is inside this convex hull.
+			Returns `true` if the given point is inside this convex hull.
 		</p>
 
 		<h3>[method:this deleteFaceVertices]( [param:Face face], [param:Face absorbingFace]	)</h3>
@@ -145,14 +145,14 @@
 			[page:Ray ray] - The given ray.<br />
 			[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
 
-			Performs a ray intersection test with this convext hull. If no intersection is found, *null* is returned.
+			Performs a ray intersection test with this convext hull. If no intersection is found, `null` is returned.
 		</p>
 
 		<h3>[method:Boolean intersectsRay]( [param:Ray ray] )</h3>
 		<p>
 			[page:Ray ray] - The given ray.<br /><br />
 
-			Returns *true* if the given ray intersects with this convex hull.
+			Returns `true` if the given ray intersects with this convex hull.
 		</p>
 
 		<h3>[method:this makeEmpty]()</h3>

--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -12,7 +12,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			Creates a simulated lens flare that tracks a light. [name] can only be used when setting the *alpha* context parameter of [page:WebGLRenderer] to *true*.
+			Creates a simulated lens flare that tracks a light. [name] can only be used when setting the `alpha` context parameter of [page:WebGLRenderer] to `true`.
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/renderers/CSS2DRenderer.html
+++ b/docs/examples/en/renderers/CSS2DRenderer.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">[name] is a simplified version of [page:CSS3DRenderer]. The only transformation that is supported is translation.<br /><br />
-			The renderer is very useful if you want to combine HTML based labels with 3D objects. Here too, the respective DOM elements are wrapped into an instance of *CSS2DObject* and added to the scene graph.<br />
+			The renderer is very useful if you want to combine HTML based labels with 3D objects. Here too, the respective DOM elements are wrapped into an instance of `CSS2DObject` and added to the scene graph.<br />
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/renderers/CSS3DRenderer.html
+++ b/docs/examples/en/renderers/CSS3DRenderer.html
@@ -19,7 +19,7 @@
 				<li>It's not possible to use the material system of *three.js*.</li>
 				<li>It's also not possible to use geometries.</li>
 			</ul>
-			So [name] is just focused on ordinary DOM elements. These elements are wrapped into special objects (*CSS3DObject* or *CSS3DSprite*) and then added to the scene graph.
+			So `[name]` is just focused on ordinary DOM elements. These elements are wrapped into special objects (`CSS3DObject` or `CSS3DSprite`) and then added to the scene graph.
 		</p>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -48,7 +48,7 @@
 
 		<h3>[property:Number overdraw]</h3>
 		<p>
-		Number of fractional pixels to enlarge polygons in order to prevent anti-aliasing gaps. Range is [0..1]. Default is *0.5*.
+		Number of fractional pixels to enlarge polygons in order to prevent anti-aliasing gaps. Range is [0..1]. Default is `0.5`.
 		</p>
 
 		<h2>Methods</h2>
@@ -80,7 +80,7 @@
 
 		<h3>[method:undefined setQuality]()</h3>
 		<p>
-			Sets the render quality. Possible values are *low* and *high* (default).
+			Sets the render quality. Possible values are `low` and `high` (default).
 		</p>
 
 		<h3>[method:undefined setSize]( [param:Number width], [param:Number height] )</h3>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -77,7 +77,7 @@
 		drawMode -- The draw mode of the given geometry.<br /><br />
 
 		Returns a new indexed [page:BufferGeometry BufferGeometry] based on the [page:DrawModes THREE.TrianglesDrawMode] draw mode. This mode
-		corresponds to the *gl.TRIANGLES* WebGL primitive.
+		corresponds to the `gl.TRIANGLES` WebGL primitive.
 
 		</p>
 

--- a/docs/manual/en/introduction/Animation-system.html
+++ b/docs/manual/en/introduction/Animation-system.html
@@ -39,7 +39,7 @@
 			should be an array named "animations", containing the [page:AnimationClip AnimationClips]
 			for this model (see a list of possible loaders below).<br /><br />
 
-			Each *AnimationClip* usually holds the data for a certain activity of the object. If the
+			Each `AnimationClip` usually holds the data for a certain activity of the object. If the
 			mesh is a character, for example, there may be one AnimationClip for a walkcycle, a second
 			for a jump, a third for sidestepping and so on.
 
@@ -49,7 +49,7 @@
 
 		<p class="desc">
 
-			Inside of such an *AnimationClip* the data for each animated property are stored in a
+			Inside of such an `AnimationClip` the data for each animated property are stored in a
 			separate [page:KeyframeTrack]. Assuming a character object has a [page:Skeleton skeleton],
 			one keyframe track could store the data for the position changes of the lower arm bone
 			over time, a different track the data for the rotation changes of the same bone, a third
@@ -78,9 +78,9 @@
 
 		<p class="desc">
 
-			The *AnimationMixer* itself has only very few (general) properties and methods, because it
+			The `AnimationMixer` itself has only very few (general) properties and methods, because it
 			can be controlled by the [page:AnimationAction AnimationActions]. By configuring an
-			*AnimationAction* you can determine when a certain *AnimationClip* shall be played, paused
+			`AnimationAction` you can determine when a certain `AnimationClip` shall be played, paused
 			or stopped on one of the mixers, if and how often the clip has to be repeated, whether it
 			shall be performed with a fade or a time scaling, and some additional things, such crossfading
 			or synchronizing.

--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -51,21 +51,21 @@
 
 		<p>Let's take a moment to explain what's going on here. We have now set up the scene, our camera and the renderer.</p>
 
-		<p>There are a few different cameras in three.js. For now, let's use a <strong>PerspectiveCamera</strong>.</p>
+		<p>There are a few different cameras in three.js. For now, let's use a `PerspectiveCamera`.</p>
 
-		<p>The first attribute is the <strong>field of view</strong>. FOV is the extent of the scene that is seen on the display at any given moment. The value is in degrees.</p>
+		<p>The first attribute is the `field of view`. FOV is the extent of the scene that is seen on the display at any given moment. The value is in degrees.</p>
 
-		<p>The second one is the <strong>aspect ratio</strong>. You almost always want to use the width of the element divided by the height, or you'll get the same result as when you play old movies on a widescreen TV - the image looks squished.</p>
+		<p>The second one is the `aspect ratio`. You almost always want to use the width of the element divided by the height, or you'll get the same result as when you play old movies on a widescreen TV - the image looks squished.</p>
 
-		<p>The next two attributes are the <strong>near</strong> and <strong>far</strong> clipping plane. What that means, is that objects further away from the camera than the value of <strong>far</strong> or closer than <strong>near</strong> won't be rendered. You don't have to worry about this now, but you may want to use other values in your apps to get better performance.</p>
+		<p>The next two attributes are the `near` and `far` clipping plane. What that means, is that objects further away from the camera than the value of `far` or closer than `near` won't be rendered. You don't have to worry about this now, but you may want to use other values in your apps to get better performance.</p>
 
 		<p>Next up is the renderer. This is where the magic happens. In addition to the WebGLRenderer we use here, three.js comes with a few others, often used as fallbacks for users with older browsers or for those who don't have WebGL support for some reason.</p>
 
-		<p>In addition to creating the renderer instance, we also need to set the size at which we want it to render our app. It's a good idea to use the width and height of the area we want to fill with our app - in this case, the width and height of the browser window. For performance intensive apps, you can also give <strong>setSize</strong> smaller values, like <strong>window.innerWidth/2</strong> and <strong>window.innerHeight/2</strong>, which will make the app render at quarter size.</p>
+		<p>In addition to creating the renderer instance, we also need to set the size at which we want it to render our app. It's a good idea to use the width and height of the area we want to fill with our app - in this case, the width and height of the browser window. For performance intensive apps, you can also give `setSize` smaller values, like `window.innerWidth/2` and `window.innerHeight/2`, which will make the app render at quarter size.</p>
 
-		<p>If you wish to keep the size of your app but render it at a lower resolution, you can do so by calling <strong>setSize</strong> with false as <strong>updateStyle</strong> (the third argument). For example, <strong>setSize(window.innerWidth/2, window.innerHeight/2, false)</strong> will render your app at half resolution, given that your &lt;canvas&gt; has 100% width and height.</p>
+		<p>If you wish to keep the size of your app but render it at a lower resolution, you can do so by calling `setSize` with false as `updateStyle` (the third argument). For example, `setSize(window.innerWidth/2, window.innerHeight/2, false)` will render your app at half resolution, given that your &lt;canvas&gt; has 100% width and height.</p>
 
-		<p>Last but not least, we add the <strong>renderer</strong> element to our HTML document. This is a &lt;canvas&gt; element the renderer uses to display the scene to us.</p>
+		<p>Last but not least, we add the `renderer` element to our HTML document. This is a &lt;canvas&gt; element the renderer uses to display the scene to us.</p>
 
 		<p><em>"That's all good, but where's that cube you promised?"</em> Let's add it now.</p>
 
@@ -78,17 +78,17 @@
 		camera.position.z = 5;
 		</code>
 
-		<p>To create a cube, we need a <strong>BoxGeometry</strong>. This is an object that contains all the points (<strong>vertices</strong>) and fill (<strong>faces</strong>) of the cube. We'll explore this more in the future.</p>
+		<p>To create a cube, we need a `BoxGeometry`. This is an object that contains all the points (`vertices`) and fill (`faces`) of the cube. We'll explore this more in the future.</p>
 
-		<p>In addition to the geometry, we need a material to color it. Three.js comes with several materials, but we'll stick to the <strong>MeshBasicMaterial</strong> for now. All materials take an object of properties which will be applied to them. To keep things very simple, we only supply a color attribute of <strong>0x00ff00</strong>, which is green. This works the same way that colors work in CSS or Photoshop (<strong>hex colors</strong>).</p>
+		<p>In addition to the geometry, we need a material to color it. Three.js comes with several materials, but we'll stick to the `MeshBasicMaterial` for now. All materials take an object of properties which will be applied to them. To keep things very simple, we only supply a color attribute of `0x00ff00`, which is green. This works the same way that colors work in CSS or Photoshop (`hex colors`).</p>
 
-		<p>The third thing we need is a <strong>Mesh</strong>. A mesh is an object that takes a geometry, and applies a material to it, which we then can insert to our scene, and move freely around.</p>
+		<p>The third thing we need is a `Mesh`. A mesh is an object that takes a geometry, and applies a material to it, which we then can insert to our scene, and move freely around.</p>
 
-		<p>By default, when we call <strong>scene.add()</strong>, the thing we add will be added to the coordinates <strong>(0,0,0)</strong>. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
+		<p>By default, when we call `scene.add()`, the thing we add will be added to the coordinates `(0,0,0)`. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
 		<h2>Rendering the scene</h2>
 
-		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a <strong>render or animate loop</strong>.</p>
+		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a `render or animate loop`.</p>
 
 		<code>
 		function animate() {
@@ -98,20 +98,20 @@
 		animate();
 		</code>
 
-		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but <strong>requestAnimationFrame</strong> has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
+		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but `requestAnimationFrame` has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
 		<h2>Animating the cube</h2>
 
 		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
-		<p>Add the following right above the <strong>renderer.render</strong> call in your <strong>animate</strong> function:</p>
+		<p>Add the following right above the `renderer.render` call in your `animate` function:</p>
 
 		<code>
 		cube.rotation.x += 0.01;
 		cube.rotation.y += 0.01;
 		</code>
 
-		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with an <strong>animate</strong> function that's hundreds of lines.</p>
+		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with an `animate` function that's hundreds of lines.</p>
 
 		<h2>The result</h2>
 		<p>Congratulations! You have now completed your first three.js application. It's simple, but you have to start somewhere.</p>

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -38,7 +38,7 @@ document.body.appendChild( VRButton.createButton( renderer ) );
 	</code>
 
 	<p>
-		Next, you have to tell your instance of *WebGLRenderer* to enable XR rendering.
+		Next, you have to tell your instance of `WebGLRenderer` to enable XR rendering.
 	</p>
 
 	<code>

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -45,8 +45,8 @@
 	</p>
 
 	<p>
-		If you use an *ImageBitmap* as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
-		An automated call of *ImageBitmap.close()* in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
+		If you use an `ImageBitmap` as the texture's data source, you have to call [link:https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap/close ImageBitmap.close]() at the application level to dispose of all CPU-side resources.
+		An automated call of `ImageBitmap.close()` in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
 	</p>
 
 	<h2>Render Targets</h2>
@@ -60,8 +60,8 @@
 	<h2>Miscellaneous</h2>
 
 	<p>
-		There are other classes from the examples directory like controls or post processing passes which provide *dispose()* methods in order to remove internal event listeners
-		or render targets. In general, it's recommended to check the API or documentation of a class and watch for *dispose()*. If present, you should use it when cleaning things up.
+		There are other classes from the examples directory like controls or post processing passes which provide `dispose()` methods in order to remove internal event listeners
+		or render targets. In general, it's recommended to check the API or documentation of a class and watch for `dispose()`. If present, you should use it when cleaning things up.
 	</p>
 
 	<h2>FAQ</h2>
@@ -72,7 +72,7 @@
 		This question was asked many times by the community so it's important to clarify this matter. Fact is that *three.js* does not know the lifetime or scope
 		of user-created entities like geometries or materials. This is the responsibility of the application. For example even if a material is currently not used for rendering,
 		it might be necessary for the next frame. So if the application decides that a certain object can be deleted, it has to	notify the engine via calling the respective
-		*dispose()* method.
+		`dispose()` method.
 	</p>
 
 	<h3>Does removing a mesh from the scene also dispose its geometry and material?</h3>
@@ -89,14 +89,14 @@
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 
-	<h3>What happens when you call *dispose()* on a texture but the image is not loaded yet?</h3>
+	<h3>What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
 
 	<p>
 		Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
 		nothing happens. No resources were allocated so there is also no need for clean up.
 	</p>
 
-	<h3>What happens when I call *dispose()* and then use the respective object at a later point?</h3>
+	<h3>What happens when I call `dispose()` and then use the respective object at a later point?</h3>
 
 	<p>
 		The deleted internal resources will be created again by the engine. So no runtime error will occur but you might notice a negative performance impact for the current frame,
@@ -106,7 +106,7 @@
 	<h3>How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
 
 	<p>
-		In general, there is no definite recommendation for this. It highly depends on the specific use case when calling *dispose()* is appropriate. It's important to highlight that
+		In general, there is no definite recommendation for this. It highly depends on the specific use case when calling `dispose()` is appropriate. It's important to highlight that
 		it's not always necessary to dispose objects all the time. A good example for this is a game which consists of multiple levels. A good place for object disposal is when
 		switching the level. The app could traverse through the old scene and dispose all obsolete materials, geometries and textures. As mentioned in the previous section, it does not
 		produce a runtime error if you dispose an object that is actually still in use. The worst thing that can happen is performance drop for a single frame.

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -58,8 +58,8 @@
 
 		<p>
 			Our composer is now ready so it's possible to configure the chain of post-processing passes. These passes are responsible for creating
-			the final visual output of the application. They are processed in order of their addition/insertion. In our example, the instance of *RenderPass*
-			is executed first and then the instance of *GlitchPass*. The last enabled pass in the chain is automatically rendered to the screen. The setup
+			the final visual output of the application. They are processed in order of their addition/insertion. In our example, the instance of `RenderPass`
+			is executed first and then the instance of `GlitchPass`. The last enabled pass in the chain is automatically rendered to the screen. The setup
 			of the passes looks like so:
 		</p>
 
@@ -72,8 +72,8 @@
 		</code>
 
 		<p>
-			*RenderPass* is normally placed at the beginning of the chain in order to provide the rendered scene as an input for the next post-processing step. In our case,
-			*GlitchPass* is going to use these image data to apply a wild glitch effect. Check out this [link:https://threejs.org/examples/webgl_postprocessing_glitch live example]
+			`RenderPass` is normally placed at the beginning of the chain in order to provide the rendered scene as an input for the next post-processing step. In our case,
+			`GlitchPass` is going to use these image data to apply a wild glitch effect. Check out this [link:https://threejs.org/examples/webgl_postprocessing_glitch live example]
 			to see it in action.
 		</p>
 
@@ -88,7 +88,7 @@
 
 		<p>
 			Sometimes you want to write a custom post-processing shader and include it into the chain of post-processing passes. For this scenario,
-			you can utilize *ShaderPass*. After importing the file and your custom shader, you can use the following code to setup the pass.
+			you can utilize `ShaderPass`. After importing the file and your custom shader, you can use the following code to setup the pass.
 		</p>
 
 		<code>
@@ -103,7 +103,7 @@
 
 		<p>
 			The repository provides a file called [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/shaders/CopyShader.js CopyShader] which is a
-			good starting code for your own custom shader. *CopyShader* just copies the image contents of the [page:EffectComposer]'s read buffer
+			good starting code for your own custom shader. `CopyShader` just copies the image contents of the [page:EffectComposer]'s read buffer
 			to its write buffer without applying any effects.
 		</p>
 

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -64,7 +64,7 @@
 
 		<p>
 			The three.js library can be used without any build system, either by uploading files to your own web server or by using an existing CDN. Because the library relies on ES modules, any script that references it must use <em>type="module"</em> as shown below.
-			It is also require to define an Import Map which resolves the bare module specifier *three*.
+			It is also require to define an Import Map which resolves the bare module specifier `three`.
 		</p>
 
 		<code>

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -144,7 +144,7 @@
 		</li>
 		<li>
 			Look for failed texture requests in the network tab, like
-			`C:\\Path\To\Model\texture.jpg`. Use paths relative to your
+			`"C:\\Path\To\Model\texture.jpg"`. Use paths relative to your
 			model instead, such as `images/texture.jpg` — this may require
 			editing the model file in a text editor.
 		</li>

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -122,7 +122,7 @@
 	<ol>
 		<li>
 			Check the JavaScript console for errors, and make sure you've used an
-			<em>onError</em> callback when calling <em>.load()</em> to log the result.
+			`onError` callback when calling `.load()` to log the result.
 		</li>
 		<li>
 			View the model in another application. For glTF, drag-and-drop viewers
@@ -144,8 +144,8 @@
 		</li>
 		<li>
 			Look for failed texture requests in the network tab, like
-			<em>C:\\Path\To\Model\texture.jpg</em>. Use paths relative to your
-			model instead, such as <em>images/texture.jpg</em> — this may require
+			`C:\\Path\To\Model\texture.jpg`. Use paths relative to your
+			model instead, such as `images/texture.jpg` — this may require
 			editing the model file in a text editor.
 		</li>
 	</ol>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -10,23 +10,23 @@
 		<h1>[name]</h1>
 
 		<p>
-		Three.js uses *matrices* to encode 3D transformations---translations (position), rotations, and scaling. Every instance of [page:Object3D] has a [page:Object3D.matrix matrix] which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
+		Three.js uses `matrices` to encode 3D transformations---translations (position), rotations, and scaling. Every instance of [page:Object3D] has a [page:Object3D.matrix matrix] which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
 		</p>
 
-		<h2>Convenience properties and *matrixAutoUpdate*</h2>
+		<h2>Convenience properties and `matrixAutoUpdate`</h2>
 
 		<p>
 			There are two ways to update an object's transformation:
 		</p>
 		<ol>
 			<li>
-				Modify the object's *position*, *quaternion*, and *scale* properties, and let three.js recompute
+				Modify the object's `position`, `quaternion`, and `scale` properties, and let three.js recompute
 				the object's matrix from these properties:
 				<code>
 object.position.copy( start_position );
 object.quaternion.copy( quaternion );
 				</code>
-				By default, the *matrixAutoUpdate* property is set true, and the matrix will be automatically recalculated.
+				By default, the `matrixAutoUpdate` property is set true, and the matrix will be automatically recalculated.
 				If the object is static, or you wish to manually control when recalculation occurs, better performance can be obtained by setting the property false:
 				<code>
 object.matrixAutoUpdate = false;
@@ -43,7 +43,7 @@ object.matrix.setRotationFromQuaternion( quaternion );
 object.matrix.setPosition( start_position );
 object.matrixAutoUpdate = false;
 				</code>
-				Note that *matrixAutoUpdate* <em>must</em> be set to *false* in this case, and you should make sure <em>not</em> to call *updateMatrix*. Calling *updateMatrix* will clobber the manual changes made to the matrix, recalculating the matrix from *position*, *scale*, and so on.
+				Note that `matrixAutoUpdate` <em>must</em> be set to `false` in this case, and you should make sure <em>not</em> to call `updateMatrix`. Calling `updateMatrix` will clobber the manual changes made to the matrix, recalculating the matrix from `position`, `scale`, and so on.
 			</li>
 		</ol>
 
@@ -60,7 +60,7 @@ object.matrixAutoUpdate = false;
 		Three.js provides two ways of representing 3D rotations: [page:Euler Euler angles] and [page:Quaternion Quaternions], as well as methods for converting between the two. Euler angles are subject to a problem called "gimbal lock," where certain configurations can lose a degree of freedom (preventing the object from being rotated about one axis). For this reason, object rotations are <em>always</em> stored in the object's [page:Object3D.quaternion quaternion].
 		</p>
 		<p>
-		Previous versions of the library included a *useQuaternion* property which, when set to false, would cause the object's [page:Object3D.matrix matrix] to be calculated from an Euler angle. This practice is deprecated---instead, you should use the [page:Object3D.setRotationFromEuler setRotationFromEuler] method, which will update the quaternion.
+		Previous versions of the library included a `useQuaternion` property which, when set to false, would cause the object's [page:Object3D.matrix matrix] to be calculated from an Euler angle. This practice is deprecated---instead, you should use the [page:Object3D.setRotationFromEuler setRotationFromEuler] method, which will update the quaternion.
 		</p>
 
 	</body>

--- a/docs/page.js
+++ b/docs/page.js
@@ -72,6 +72,7 @@ function onDocumentLoad() {
 	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+)\]/gi, '<a href="$1" target="_blank">$1</a>' ); // [link:url]
 	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+) ([\w\:\/\.\-\_\'\s]+)\]/gi, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
 	text = text.replace( /\*([\w\d\"\-\(][\w\d\ \/\+\-\(\)\=\,\."]*[\w\d\"\)]|\w)\*/gi, '<strong>$1</strong>' ); // *text*
+	text = text.replace( /\`(.*?)\`/gi, '<code class="inline">$1</code>' ); // `code`
 
 	text = text.replace( /\[example:([\w\_]+)\]/gi, '[example:$1 $1]' ); // [example:name] to [example:name title]
 	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, '<a href="../examples/#$1" target="_blank">$2</a>' ); // [example:name title]


### PR DESCRIPTION
**Description**

Add supports to inline code using syntax similar to `github`
```
Some `inline code`
```

![image](https://user-images.githubusercontent.com/502810/168958885-b16c4904-245e-4dfa-a7a2-e524f870ff9c.png)

![image](https://user-images.githubusercontent.com/502810/168959314-9dbdb4c2-66dd-4d2f-b307-661ecc3e2101.png)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
