### PR TITLE
GLTFExporter: Fallback for missing material.opacity

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -1135,7 +1135,7 @@
 			} // pbrMetallicRoughness.baseColorFactor
 
 
-			const color = material.color.toArray().concat( [ material.opacity ] );
+			const color = material.color.toArray().concat( [ material.opacity || 0 ] );
 
 			if ( ! equalArray( color, [ 1, 1, 1, 1 ] ) ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1267,7 +1267,7 @@ class GLTFWriter {
 		}
 
 		// pbrMetallicRoughness.baseColorFactor
-		const color = material.color.toArray().concat( [ material.opacity ] );
+		const color = material.color.toArray().concat( [ material.opacity || 0 ] );
 
 		if ( ! equalArray( color, [ 1, 1, 1, 1 ] ) ) {
 


### PR DESCRIPTION
**Description**

when i use gltfExporter to export a binarity scene, and then import to blender2.8, it will get a error with  baseColorFactor data  format, i dont konw which violate the gltf's standard, but i found the solution:

before to export gltf, do below will fix this error, if not be approved, just give a solution, thx
```
    scene.traverseVisible(node => {
            if (node.material && !node.material.opacity) node.material.opacity = 0;
          });
```

the error which blender's terminal shonw:
```
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 781 in statement base_color_factor = from_union([lambda x: from_list(from_float, x), from_none], obj.get("baseColorFactor"))
10:34:20 | ERROR: An error occurred on line 71 in statement return [f(y) for y in x]
10:34:20 | ERROR: An error occurred on line 71 in statement return [f(y) for y in x]
10:34:20 | ERROR: An error occurred on line 75 in statement assert isinstance(x, (float, int)) and not isinstance(x, bool)
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 38 in statement assert x is None
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 781 in statement base_color_factor = from_union([lambda x: from_list(from_float, x), from_none], obj.get("baseColorFactor"))
10:34:20 | ERROR: An error occurred on line 56 in statement assert False
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 38 in statement assert x is None
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 1174 in statement materials = from_union([lambda x: from_list(Material.from_dict, x), from_none], obj.get("materials"))
10:34:20 | ERROR: An error occurred on line 71 in statement return [f(y) for y in x]
10:34:20 | ERROR: An error occurred on line 71 in statement return [f(y) for y in x]
10:34:20 | ERROR: An error occurred on line 840 in statement obj.get("pbrMetallicRoughness"))
10:34:20 | ERROR: An error occurred on line 56 in statement assert False
10:34:20 | ERROR: An error occurred on line 46 in statement return f(x)
10:34:20 | ERROR: An error occurred on line 38 in statement assert x is None
Error: Traceback (most recent call last):
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\__init__.py", line 850, in execute
    return self.import_gltf2(context)
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\__init__.py", line 869, in import_gltf2
    return self.unit_import(self.filepath, import_settings)
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\__init__.py", line 877, in unit_import
    success, txt = self.gltf_importer.read()
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\io\imp\gltf2_io_gltf.py", line 173, in read
    success, txt = self.load_glb()
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\io\imp\gltf2_io_gltf.py", line 125, in load_glb
    self.data = gltf_from_dict(json_)
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\io\com\gltf2_io.py", line 1218, in gltf_from_dict
    return Gltf.from_dict(s)
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\io\com\gltf2_io.py", line 1174, in from_dict
    materials = from_union([lambda x: from_list(Material.from_dict, x), from_none], obj.get("materials"))
  File "\AppData\Local\Programs\Python\Python37\2.82\scripts\addons\io_scene_gltf2\io\com\gltf2_io.py", line 56, in from_union
    assert False
AssertionError

location: \AppData\Local\Programs\Python\Python37\2.82\scripts\modules\bpy\ops.py:201
```