### PR TITLE
NodeMaterial: add .customProgramCacheKey()

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -31,6 +31,12 @@ class NodeMaterial extends ShaderMaterial {
 
 	}
 
+	customProgramCacheKey() {
+
+		return this.uuid + '-' + this.version;
+
+	}
+
 	generateMain( builder ) {
 
 		const object = builder.object;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24078

**Description**

Add `NodeMaterial.customProgramCacheKey()` but ignore program cache for now.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
