### PR TITLE
Docs: Update "How to run things locally"

### DIFF
--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -21,21 +21,20 @@
 			 	security restrictions, loading from a file system will fail with a security exception.
 		 	</p>
 
-			<p>There are two ways to solve this:</p>
-
-			<ol>
-				<li>
-					Change security for local files in a browser. This allows you to access your page as: <code>file:///yourFile.html</code>
-				</li>
-				<li>
-					Run files from a local web server. This allows you to access your page as: <code>http://localhost/yourFile.html</code>
-				</li>
-			</ol>
+			<p>
+				To solve this, run files from a local web server. This allows you to access your page as:
+			</p>
+			
+			<p>
+				<code>http://localhost/yourFile.html</code>
+			</p>
 
 			<p>
-				If you use option 1, be aware that you may open yourself to some vulnerabilities if using
-				the same browser for a regular web surfing. You may want to create a separate browser
-				profile / shortcut used just for local development to be safe. Let's go over each option in turn.
+				While it is also possible to change browser security settings for local files, be aware that you
+				may open yourself to some vulnerabilities if using the same browser for a regular web surfing. 
+				You may want to create a separate browser profile / shortcut used just for local development to 
+				be safe. We recommend using a local server instead of changing security settings, and will go over
+				how to install and use a local server below.
 			</p>
 		</div>
 

--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -30,11 +30,10 @@
 			</p>
 
 			<p>
-				While it is also possible to change browser security settings for local files, be aware that you
-				may open yourself to some vulnerabilities if using the same browser for a regular web surfing. 
-				You may want to create a separate browser profile / shortcut used just for local development to 
-				be safe. We recommend using a local server instead of changing security settings, and will go over
-				how to install and use a local server below.
+				While it is also possible to change browser security settings instead of running a local server,
+				we do not recommend that approach. Doing so may open your device up to vulnerabilities, if the
+				same browser is used for regular web surfing. Use of a local server is standard practice in 
+				web development, and we explain how to install and use a local server below.
 			</p>
 		</div>
 


### PR DESCRIPTION
Current wording offers two options (change browser settings, or use local server) and suggests we'll explain both, but then only explains the second. As discussed in #15334 we should not encourage users to change their browser's security settings. This PR simplifies the wording to present a local server as the default option.

Preview:

- https://raw.githack.com/mrdoob/three.js/donmccurdy-local-server-not-settings/docs/index.html#manual/en/introduction/How-to-run-things-locally