### PR TITLE
Nodes: Rename diffuseColor to baseColor

### DIFF
--- a/examples/jsm/nodes/functions/BSDF/BRDF_Lambert.js
+++ b/examples/jsm/nodes/functions/BSDF/BRDF_Lambert.js
@@ -1,8 +1,8 @@
 import { ShaderNode, mul } from '../../shadernode/ShaderNodeBaseElements.js';
 
-const BRDF_Lambert = new ShaderNode( ( inputs ) => {
+const BRDF_Lambert = new ShaderNode( ( { baseColor } ) => {
 
-	return mul( 1 / Math.PI, inputs.diffuseColor ); // punctual light
+	return mul( 1 / Math.PI, baseColor.rgb ); // punctual light
 
 } ); // validated
 

--- a/examples/jsm/nodes/functions/PhysicalLightingModel.js
+++ b/examples/jsm/nodes/functions/PhysicalLightingModel.js
@@ -5,7 +5,7 @@ import {
 	ShaderNode,
 	vec3, mul, saturate, add, sub, dot, div, transformedNormalView,
 	pow, exp2, dotNV,
-	diffuseColor, specularColor, roughness, temp
+	baseColor, specularColor, roughness, temp
 } from '../shadernode/ShaderNodeElements.js';
 
 // Fdez-Agüera's "Multiple-Scattering Microfacet Model for Real-Time Image Based Lighting"
@@ -40,7 +40,7 @@ const RE_IndirectSpecular_Physical = new ShaderNode( ( inputs ) => {
 
 	computeMultiscattering( singleScattering, multiScattering );
 
-	const diffuse = mul( diffuseColor, sub( 1.0, add( singleScattering, multiScattering ) ) );
+	const diffuse = mul( baseColor, sub( 1.0, add( singleScattering, multiScattering ) ) );
 
 	reflectedLight.indirectSpecular.add( mul( radiance, singleScattering ) );
 	reflectedLight.indirectSpecular.add( mul( multiScattering, cosineWeightedIrradiance ) );
@@ -53,7 +53,7 @@ const RE_IndirectDiffuse_Physical = new ShaderNode( ( inputs ) => {
 
 	const { irradiance, reflectedLight } = inputs;
 
-	reflectedLight.indirectDiffuse.add( mul( irradiance, BRDF_Lambert.call( { diffuseColor } ) ) );
+	reflectedLight.indirectDiffuse.add( mul( irradiance, BRDF_Lambert.call( { baseColor } ) ) );
 
 } );
 
@@ -64,7 +64,7 @@ const RE_Direct_Physical = new ShaderNode( ( inputs ) => {
 	const dotNL = saturate( dot( transformedNormalView, lightDirection ) );
 	const irradiance = mul( dotNL, lightColor );
 
-	reflectedLight.directDiffuse.add( mul( irradiance, BRDF_Lambert.call( { diffuseColor: diffuseColor.rgb } ) ) );
+	reflectedLight.directDiffuse.add( mul( irradiance, BRDF_Lambert.call( { baseColor } ) ) );
 
 	reflectedLight.directSpecular.add( mul( irradiance, BRDF_GGX.call( { lightDirection, f0: specularColor, f90: 1, roughness } ) ) );
 

--- a/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
@@ -50,10 +50,12 @@ export default class MeshStandardNodeMaterial extends NodeMaterial {
 
 	build( builder ) {
 
-		let { colorNode, diffuseColorNode } = this.generateMain( builder );
+		this.generateVertex( builder );
+
+		let { colorNode, baseColorNode } = this.generateBaseColor( builder );
 		const envNode = this.envNode || builder.scene.environmentNode;
 
-		diffuseColorNode = this.generateStandardMaterial( builder, { colorNode, diffuseColorNode } );
+		baseColorNode = this.generateStandardMaterial( builder, { colorNode, baseColorNode } );
 
 		if ( this.lightsNode ) builder.lightsNode = this.lightsNode;
 
@@ -77,13 +79,13 @@ export default class MeshStandardNodeMaterial extends NodeMaterial {
 
 		}
 
-		const outgoingLightNode = this.generateLight( builder, { diffuseColorNode, lightingModelNode: PhysicalLightingModel } );
+		const outgoingLightNode = this.generateLight( builder, { baseColorNode, lightingModelNode: PhysicalLightingModel } );
 
-		this.generateOutput( builder, { diffuseColorNode, outgoingLightNode } );
+		this.generateOutput( builder, { baseColorNode, outgoingLightNode } );
 
 	}
 
-	generateStandardMaterial( builder, { colorNode, diffuseColorNode } ) {
+	generateStandardMaterial( builder, { colorNode, baseColorNode } ) {
 
 		const { material } = builder;
 
@@ -92,7 +94,7 @@ export default class MeshStandardNodeMaterial extends NodeMaterial {
 		let metalnessNode = this.metalnessNode ? float( this.metalnessNode ) : materialMetalness;
 
 		metalnessNode = builder.addFlow( 'fragment', label( metalnessNode, 'Metalness' ) );
-		builder.addFlow( 'fragment', assign( diffuseColorNode, vec4( mul( diffuseColorNode.rgb, invert( metalnessNode ) ), diffuseColorNode.a ) ) );
+		builder.addFlow( 'fragment', assign( baseColorNode, vec4( mul( baseColorNode.rgb, invert( metalnessNode ) ), baseColorNode.a ) ) );
 
 		// ROUGHNESS
 
@@ -113,17 +115,17 @@ export default class MeshStandardNodeMaterial extends NodeMaterial {
 
 		builder.addFlow( 'fragment', label( normalNode, 'TransformedNormalView' ) );
 
-		return diffuseColorNode;
+		return baseColorNode;
 
 	}
 
-	generateLight( builder, { diffuseColorNode, lightingModelNode, lightsNode = builder.lightsNode } ) {
+	generateLight( builder, { baseColorNode, lightingModelNode, lightsNode = builder.lightsNode } ) {
 
 		const renderer = builder.renderer;
 
 		// OUTGOING LIGHT
 
-		let outgoingLightNode = super.generateLight( builder, { diffuseColorNode, lightingModelNode, lightsNode } );
+		let outgoingLightNode = super.generateLight( builder, { baseColorNode, lightingModelNode, lightsNode } );
 
 		// EMISSIVE
 

--- a/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
@@ -140,7 +140,7 @@ export const materialOpacity = nodeImmutable( MaterialNode, MaterialNode.OPACITY
 export const materialRoughness = nodeImmutable( MaterialNode, MaterialNode.ROUGHNESS );
 export const materialMetalness = nodeImmutable( MaterialNode, MaterialNode.METALNESS );
 
-export const diffuseColor = nodeImmutable( PropertyNode, 'DiffuseColor', 'vec4' );
+export const baseColor = nodeImmutable( PropertyNode, 'BaseColor', 'vec4' );
 export const roughness = nodeImmutable( PropertyNode, 'Roughness', 'float' );
 export const metalness = nodeImmutable( PropertyNode, 'Metalness', 'float' );
 export const alphaTest = nodeImmutable( PropertyNode, 'AlphaTest', 'float' );


### PR DESCRIPTION
**Description**

I think that `baseColor` follow better the nomenclature of PBR on modern (metallic) workflow.

- [x] `ShaderNode`: Rename `diffuseColor` to `baseColor`.
- [x] `NodeMaterial`: Split `.generateMain()` to `.generateBaseColor()` and `.generateVertex()`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
