### PR TITLE
Orbitcontrols: Time-based damping using geometric series' closed-form formula

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -5,7 +5,8 @@ import {
 	Spherical,
 	TOUCH,
 	Vector2,
-	Vector3
+	Vector3,
+	Clock,
 } from 'three';
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
@@ -182,10 +183,13 @@ class OrbitControls extends EventDispatcher {
 
 				}
 
+				const deltaTime = clock.getDelta() / ( 1 / 60 );
+				const dampingFactorByTime = 1 - Math.pow( 1 - scope.dampingFactor, deltaTime );
+
 				if ( scope.enableDamping ) {
 
-					spherical.theta += sphericalDelta.theta * scope.dampingFactor;
-					spherical.phi += sphericalDelta.phi * scope.dampingFactor;
+					spherical.theta += sphericalDelta.theta * dampingFactorByTime;
+					spherical.phi += sphericalDelta.phi * dampingFactorByTime;
 
 				} else {
 
@@ -234,7 +238,7 @@ class OrbitControls extends EventDispatcher {
 
 				if ( scope.enableDamping === true ) {
 
-					scope.target.addScaledVector( panOffset, scope.dampingFactor );
+					scope.target.addScaledVector( panOffset, dampingFactorByTime );
 
 				} else {
 
@@ -314,6 +318,16 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
+		this.isAccelerating = function () {
+
+			return sphericalDelta.phi < - EPS || EPS < sphericalDelta.phi ||
+				sphericalDelta.theta < - EPS || EPS < sphericalDelta.theta ||
+				panOffset.x < - EPS || EPS < panOffset.x ||
+				panOffset.y < - EPS || EPS < panOffset.y ||
+				panOffset.z < - EPS || EPS < panOffset.z;
+
+		};
+
 		//
 		// internals
 		//
@@ -334,6 +348,8 @@ class OrbitControls extends EventDispatcher {
 		let state = STATE.NONE;
 
 		const EPS = 0.000001;
+
+		const clock = new Clock();
 
 		// current position in spherical coordinates
 		const spherical = new Spherical();
@@ -952,6 +968,7 @@ class OrbitControls extends EventDispatcher {
 
 			if ( state !== STATE.NONE ) {
 
+				clock.start();
 				scope.dispatchEvent( _startEvent );
 
 			}
@@ -1092,6 +1109,7 @@ class OrbitControls extends EventDispatcher {
 
 			if ( state !== STATE.NONE ) {
 
+				clock.start();
 				scope.dispatchEvent( _startEvent );
 
 			}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -257,10 +257,11 @@ class OrbitControls extends EventDispatcher {
 
 				if ( scope.enableDamping === true ) {
 
-					sphericalDelta.theta *= ( 1 - scope.dampingFactor );
-					sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+					const amp = Math.pow( 1 - scope.dampingFactor, deltaTime );
+					sphericalDelta.theta *= amp;
+					sphericalDelta.phi *= amp;
 
-					panOffset.multiplyScalar( 1 - scope.dampingFactor );
+					panOffset.multiplyScalar( amp );
 
 				} else {
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -20,6 +20,8 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - orbit controls
+			<br/>
+			Accelerating - <span id="accelerating">false</span>
 		</div>
 
 		<!-- Import maps polyfill -->
@@ -129,6 +131,8 @@
 				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
 
 				render();
+
+				document.getElementById( 'accelerating' ).innerText = controls.isAccelerating() ? 'true' : 'false';
 
 			}
 


### PR DESCRIPTION
**Description**

The current Orbitcontrols uses geometric series to calculate damping. The problem of serial approach is that the acceleration is defined by the frame number. It results in somewhat unnatural and lengthened drag when the application has low FPS.

This PR takes continuous approach using geometric series' [closed-form formula](https://en.wikipedia.org/wiki/Geometric_series#Closed-form_formula). With this update the same amount of energy will be damped in exactly 1 second (no matter how many frames would take) whereas it took 60 frames (no matter how much time would take) before.

I added `isAccelerating()` to expose acceleration because when you have damping turned on and you want to call render only when the camera is moving, acceleration becomes the criterion but currently there's no way to know it.