### PR TITLE
Editor: Add PCDLoader.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -509,6 +509,28 @@ function Loader( editor ) {
 
 			}
 
+			case 'pcd':
+
+			{
+
+				reader.addEventListener( 'load', async function ( event ) {
+
+					const contents = event.target.result;
+
+					const { PCDLoader } = await import( '../../examples/jsm/loaders/PCDLoader.js' );
+
+					const points = new PCDLoader().parse( contents );
+					points.name = filename;
+
+					editor.execute( new AddObjectCommand( editor, points ) );
+
+				}, false );
+				reader.readAsArrayBuffer( file );
+
+				break;
+
+			}
+
 			case 'ply':
 
 			{

--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -47,19 +47,23 @@ function ViewportInfo( editor ) {
 
 				objects ++;
 
-				if ( object.isMesh ) {
+				if ( object.isMesh || object.isPoints ) {
 
 					const geometry = object.geometry;
 
 					vertices += geometry.attributes.position.count;
 
-					if ( geometry.index !== null ) {
+					if ( object.isMesh ) {
 
-						triangles += geometry.index.count / 3;
+						if ( geometry.index !== null ) {
 
-					} else {
+							triangles += geometry.index.count / 3;
 
-						triangles += geometry.attributes.position.count / 3;
+						} else {
+
+							triangles += geometry.attributes.position.count / 3;
+
+						}
 
 					}
 

--- a/editor/sw.js
+++ b/editor/sw.js
@@ -45,6 +45,7 @@ const assets = [
 	'../examples/jsm/loaders/MD2Loader.js',
 	'../examples/jsm/loaders/OBJLoader.js',
 	'../examples/jsm/loaders/MTLLoader.js',
+	'../examples/jsm/loaders/PCDLoader.js',
 	'../examples/jsm/loaders/PLYLoader.js',
 	'../examples/jsm/loaders/RGBELoader.js',
 	'../examples/jsm/loaders/STLLoader.js',

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -31,7 +31,7 @@ class PCDLoader extends Loader {
 
 			try {
 
-				onLoad( scope.parse( data, url ) );
+				onLoad( scope.parse( data ) );
 
 			} catch ( e ) {
 
@@ -53,7 +53,7 @@ class PCDLoader extends Loader {
 
 	}
 
-	parse( data, url ) {
+	parse( data ) {
 
 		// from https://gitlab.com/taketwo/three-pcd-loader/blob/master/decompress-lzf.js
 
@@ -398,13 +398,7 @@ class PCDLoader extends Loader {
 
 		// build point cloud
 
-		const mesh = new Points( geometry, material );
-		let name = url.split( '' ).reverse().join( '' );
-		name = /([^\/]*)/.exec( name );
-		name = name[ 1 ].split( '' ).reverse().join( '' );
-		mesh.name = name;
-
-		return mesh;
+		return new Points( geometry, material );
 
 	}
 

--- a/examples/webgl_loader_pcd.html
+++ b/examples/webgl_loader_pcd.html
@@ -63,6 +63,7 @@
 
 					points.geometry.center();
 					points.geometry.rotateX( Math.PI );
+					points.name = 'Zaghetto.pcd';
 					scene.add( points );
 
 					render();


### PR DESCRIPTION
Related issue: -

**Description**

The editor can now load PCD assets which makes it easier to debug PCD files.  The PR also ensures the number of vertices is now correctly displayed for point clouds in the info section.

To make this change work, it was necessary to remove the file name extraction from `PCDLoader.parse()` which requires an URL. Since this kind of logic is unusual for a loader, it's better to remove it in any event.
