### PR TITLE
GLTFLoader: add arbitrary property animation through KHR_animation_pointer support

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -74,6 +74,7 @@ class GLTFLoader extends Loader {
 		this.dracoLoader = null;
 		this.ktx2Loader = null;
 		this.meshoptDecoder = null;
+		this.animationPointerResolver = null;
 
 		this.pluginCallbacks = [];
 
@@ -164,6 +165,12 @@ class GLTFLoader extends Loader {
 		this.register( function ( parser ) {
 
 			return new GLTFMeshGpuInstancing( parser );
+
+		} );
+		
+		this.register( function ( parser ) {
+
+			return new GLTFAnimationPointerExtension( parser );
 
 		} );
 
@@ -271,6 +278,13 @@ class GLTFLoader extends Loader {
 
 	}
 
+	setAnimationPointerResolver( animationPointerResolver ) {
+
+		this.animationPointerResolver = animationPointerResolver;
+		return this;
+
+	}
+
 	register( callback ) {
 
 		if ( this.pluginCallbacks.indexOf( callback ) === - 1 ) {
@@ -351,7 +365,8 @@ class GLTFLoader extends Loader {
 			requestHeader: this.requestHeader,
 			manager: this.manager,
 			ktx2Loader: this.ktx2Loader,
-			meshoptDecoder: this.meshoptDecoder
+			meshoptDecoder: this.meshoptDecoder,
+			animationPointerResolver: this.animationPointerResolver,
 
 		} );
 
@@ -486,6 +501,7 @@ const EXTENSIONS = {
 	KHR_TEXTURE_TRANSFORM: 'KHR_texture_transform',
 	KHR_MESH_QUANTIZATION: 'KHR_mesh_quantization',
 	KHR_MATERIALS_EMISSIVE_STRENGTH: 'KHR_materials_emissive_strength',
+	KHR_ANIMATION_POINTER: 'KHR_animation_pointer',
 	EXT_TEXTURE_WEBP: 'EXT_texture_webp',
 	EXT_TEXTURE_AVIF: 'EXT_texture_avif',
 	EXT_MESHOPT_COMPRESSION: 'EXT_meshopt_compression',
@@ -801,6 +817,554 @@ class GLTFMaterialsClearcoatExtension {
 		}
 
 		return Promise.all( pending );
+
+	}
+
+}
+
+/**
+ * Animation Pointer Extension
+ *
+ * Draft Specification: https://github.com/ux3d/glTF/tree/extensions/KHR_animation_pointer/extensions/2.0/Khronos/KHR_animation_pointer
+ */
+
+class GLTFAnimationPointerExtension {
+
+	ANIMATION_TARGET_TYPE = {
+		node: 'node',
+		material: 'material',
+		camera: 'camera',
+		light: 'light',
+	};
+
+	constructor( parser ) {
+
+		this.parser = parser;
+		this.name = EXTENSIONS.KHR_ANIMATION_POINTER;
+
+	}
+
+	_animationPointerDebug = false;
+	_havePatchedPropertyBindings = false;
+	_patchPropertyBindingFindNode() {
+
+		if ( this._havePatchedPropertyBindings ) return;
+		this._havePatchedPropertyBindings = true;
+
+		// HACK monkey patching findNode to ensure we can map to other types required by KHR_animation_pointer.
+		const find = PropertyBinding.findNode;
+
+		// "node" is the Animator component in our case
+		// "path" is the animated property path, just with translated material names.
+		PropertyBinding.findNode = ( node, path ) => {
+
+			if ( path.startsWith( '.materials.' ) ) {
+
+				if ( this._animationPointerDebug ) console.log( 'FIND', path );
+
+				const remainingPath = path.substring( '.materials.'.length ).substring( path.indexOf( '.' ) );
+				const nextIndex = remainingPath.indexOf( '.' );
+				const uuid = nextIndex < 0 ? remainingPath : remainingPath.substring( 0, nextIndex );
+				let res = null;
+				node.traverse( x => {
+
+					if ( res !== null || x.type !== 'Mesh' ) return;
+					if ( x[ 'material' ]?.uuid === uuid || x[ 'material' ]?.name === uuid ) {
+
+						res = x[ 'material' ];
+						if ( this._animationPointerDebug ) console.log( res, remainingPath );
+						if ( res !== null ) {
+
+							if ( remainingPath.endsWith( '.map' ) )
+								res = res[ 'map' ];
+							else if ( remainingPath.endsWith( '.emissiveMap' ) )
+								res = res[ 'emissiveMap' ];
+
+							// TODO other texture slots only make sense if three.js actually supports them
+							// (currently only .map can have repeat/offset)
+
+						}
+
+					}
+
+				} );
+
+				return res;
+
+			} else if ( path.startsWith( '.nodes.' ) || path.startsWith( '.lights.' ) || path.startsWith( '.cameras.' ) ) {
+
+				const sections = path.split( '.' );
+				let currentTarget = undefined;
+				for ( let i = 1; i < sections.length; i ++ ) {
+
+					const val = sections[ i ];
+					const isUUID = val.length == 36;
+					if ( isUUID ) {
+
+						// access by UUID
+						currentTarget = node.getObjectByProperty( 'uuid', val );
+
+					} else if ( currentTarget && currentTarget[ val ] ) {
+
+						// access by index
+						const index = Number.parseInt( val );
+						let key = val;
+						if ( index >= 0 ) key = index;
+						currentTarget = currentTarget[ key ];
+						if ( this._animationPointerDebug )
+							console.log( currentTarget );
+
+					} else {
+
+						// access by node name
+						const foundNode = node.getObjectByName( val );
+						if ( foundNode )
+							currentTarget = foundNode;
+					}
+
+				}
+
+				if ( ! currentTarget ) {
+
+					const originalFindResult = find( node, sections[ 2 ] );
+
+					if ( ! originalFindResult )
+						console.warn( EXTENSIONS.KHR_ANIMATION_POINTER + ': Property binding not found', path, node, node.name, sections );
+
+					return originalFindResult;
+
+				}
+
+				if ( this._animationPointerDebug )
+					console.log( 'NODE', path, currentTarget );
+
+				return currentTarget;
+
+			}
+
+			return find( node, path );
+
+		};
+
+	}
+
+	loadAnimationTargetFromChannel( animationChannel ) {
+
+		if ( ! this._havePatchedPropertyBindings )
+			this._patchPropertyBindingFindNode();
+
+		const target = animationChannel.target;
+		const useExtension = target.extensions && target.extensions[ EXTENSIONS.KHR_ANIMATION_POINTER ] && target.path && target.path === 'pointer';
+		if ( ! useExtension ) return null;
+
+		let targetProperty = undefined;
+
+		// check if this is a extension animation
+		let type = this.ANIMATION_TARGET_TYPE.node;
+		let targetId = undefined;
+
+		if ( useExtension ) {
+
+			const ext = target.extensions[ EXTENSIONS.KHR_ANIMATION_POINTER ];
+			let path = ext.pointer;
+			if ( this._animationPointerDebug )
+				console.log( 'Original path: ' + path, target );
+
+			if ( ! path ) {
+
+				console.warn( 'Invalid path', ext, target );
+				return;
+
+			}
+
+			if ( path.startsWith( '/materials/' ) )
+				type = this.ANIMATION_TARGET_TYPE.material;
+			else if ( path.startsWith( '/extensions/KHR_lights_punctual/lights/' ) )
+				type = this.ANIMATION_TARGET_TYPE.light;
+			else if ( path.startsWith( '/cameras/' ) )
+				type = this.ANIMATION_TARGET_TYPE.camera;
+
+			targetId = this._tryResolveTargetId( path, type );
+			if ( targetId === null || isNaN( targetId ) ) {
+
+				console.warn( 'Failed resolving animation node id: ' + targetId, path );
+				return;
+
+			} else {
+
+				if ( this._animationPointerDebug ) console.log( 'Resolved node ID for ' + type, targetId );
+
+			}
+
+			// TODO could be parsed better
+			switch ( type ) {
+
+				case this.ANIMATION_TARGET_TYPE.material:
+					const pathIndex = ( '/materials/' + targetId.toString() + '/' ).length;
+					const pathStart = path.substring( 0, pathIndex );
+					targetProperty = path.substring( pathIndex );
+
+					switch ( targetProperty ) {
+
+						// Core Spec PBR Properties
+						case 'pbrMetallicRoughness/baseColorFactor':
+							targetProperty = 'color';
+							break;
+						case 'pbrMetallicRoughness/roughnessFactor':
+							targetProperty = 'roughness';
+							break;
+						case 'pbrMetallicRoughness/metallicFactor':
+							targetProperty = 'metalness';
+							break;
+						case 'emissiveFactor':
+							targetProperty = 'emissive';
+							break;
+						case 'alphaCutoff':
+							targetProperty = 'alphaTest';
+							break;
+						case 'occlusionTexture/strength':
+							targetProperty = 'aoMapIntensity';
+							break;
+						case 'normalTexture/scale':
+							targetProperty = 'normalScale';
+							break;
+
+						// Core Spec + KHR_texture_transform
+						case 'pbrMetallicRoughness/baseColorTexture/extensions/KHR_texture_transform/scale':
+							targetProperty = 'map/repeat';
+							break;
+						case 'pbrMetallicRoughness/baseColorTexture/extensions/KHR_texture_transform/offset':
+							targetProperty = 'map/offset';
+							break;
+
+						// UV transforms for anything but map doesn't seem to currently be supported in three.js
+						case 'emissiveTexture/extensions/KHR_texture_transform/scale':
+							targetProperty = 'emissiveMap/repeat';
+							break;
+						case 'emissiveTexture/extensions/KHR_texture_transform/offset':
+							targetProperty = 'emissiveMap/offset';
+							break;
+
+						// KHR_materials_emissive_strength
+						case 'extensions/KHR_materials_emissive_strength/emissiveStrength':
+							targetProperty = 'emissiveIntensity';
+							break;
+
+						// KHR_materials_transmission
+						case 'extensions/KHR_materials_transmission/transmissionFactor':
+							targetProperty = 'transmission';
+							break;
+
+						// KHR_materials_ior
+						case 'extensions/KHR_materials_ior/ior':
+							targetProperty = 'ior';
+							break;
+
+						// KHR_materials_volume
+						case 'extensions/KHR_materials_volume/thicknessFactor':
+							targetProperty = 'thickness';
+							break;
+						case 'extensions/KHR_materials_volume/attenuationColor':
+							targetProperty = 'attenuationColor';
+							break;
+						case 'extensions/KHR_materials_volume/attenuationDistance':
+							targetProperty = 'attenuationDistance';
+							break;
+
+						// KHR_materials_iridescence
+						case 'extensions/KHR_materials_iridescence/iridescenceFactor':
+							targetProperty = 'iridescence';
+							break;
+						case 'extensions/KHR_materials_iridescence/iridescenceIor':
+							targetProperty = 'iridescenceIOR';
+							break;
+						case 'extensions/KHR_materials_iridescence/iridescenceThicknessMinimum':
+							targetProperty = 'iridescenceThicknessRange[0]';
+							break;
+						case 'extensions/KHR_materials_iridescence/iridescenceThicknessMaximum':
+							targetProperty = 'iridescenceThicknessRange[1]';
+							break;
+
+						// KHR_materials_clearcoat
+						case 'extensions/KHR_materials_clearcoat/clearcoatFactor':
+							targetProperty = 'clearcoat';
+							break;
+						case 'extensions/KHR_materials_clearcoat/clearcoatRoughnessFactor':
+							targetProperty = 'clearcoatRoughness';
+							break;
+
+						// KHR_materials_sheen
+						case 'extensions/KHR_materials_sheen/sheenColorFactor':
+							targetProperty = 'sheenColor';
+							break;
+						case 'extensions/KHR_materials_sheen/sheenRoughnessFactor':
+							targetProperty = 'sheenRoughness';
+							break;
+
+						// KHR_materials_specular
+						case 'extensions/KHR_materials_specular/specularFactor':
+							targetProperty = 'specularIntensity';
+							break;
+						case 'extensions/KHR_materials_specular/specularColorFactor':
+							targetProperty = 'specularColor';
+							break;
+
+					}
+
+					path = pathStart + targetProperty;
+					if ( this._animationPointerDebug ) console.log( 'PROPERTY PATH', pathStart, targetProperty, path );
+					break;
+
+				case this.ANIMATION_TARGET_TYPE.node:
+					const pathIndexNode = ( '/nodes/' + targetId.toString() + '/' ).length;
+					const pathStartNode = path.substring( 0, pathIndexNode );
+					targetProperty = path.substring( pathIndexNode );
+
+					switch ( targetProperty ) {
+
+						case 'translation':
+							targetProperty = 'position';
+							break;
+						case 'rotation':
+							targetProperty = 'quaternion';
+							break;
+						case 'scale':
+							targetProperty = 'scale';
+							break;
+						case 'weights':
+							targetProperty = 'morphTargetInfluences';
+							break;
+
+					}
+
+					path = pathStartNode + targetProperty;
+					break;
+
+				case this.ANIMATION_TARGET_TYPE.light:
+					const pathIndexLight = ( '/extensions/KHR_lights_punctual/lights/' + targetId.toString() + '/' ).length;
+					targetProperty = path.substring( pathIndexLight );
+
+					switch ( targetProperty ) {
+
+						case 'color':
+							break;
+						case 'intensity':
+							break;
+						case 'spot/innerConeAngle':
+							// TODO would need to set .penumbra, but requires calculations on every animation change (?)
+							targetProperty = 'penumbra';
+							break;
+						case 'spot/outerConeAngle':
+							targetProperty = 'angle';
+							break;
+						case 'range':
+							targetProperty = 'distance';
+							break;
+
+					}
+
+					path = '/lights/' + targetId.toString() + '/' + targetProperty;
+					break;
+
+				case this.ANIMATION_TARGET_TYPE.camera:
+					const pathIndexCamera = ( '/cameras/' + targetId.toString() + '/' ).length;
+					const pathStartCamera = path.substring( 0, pathIndexCamera );
+					targetProperty = path.substring( pathIndexCamera );
+
+					switch ( targetProperty ) {
+
+						case 'perspective/yfov':
+							targetProperty = 'fov';
+							break;
+						case 'perspective/znear':
+						case 'orthographic/znear':
+							targetProperty = 'near';
+							break;
+						case 'perspective/zfar':
+						case 'orthographic/zfar':
+							targetProperty = 'far';
+							break;
+						case 'perspective/aspect':
+							targetProperty = 'aspect';
+							break;
+						// these two write to the same target property since three.js orthographic camera only supports 'zoom'.
+						// TODO should there be a warning for either of them? E.g. a warning for "xmag" so that "yfov" + "ymag" work by default?
+						case 'orthographic/xmag':
+							targetProperty = 'zoom';
+							break;
+						case 'orthographic/ymag':
+							targetProperty = 'zoom';
+							break;
+
+					}
+
+					path = pathStartCamera + targetProperty;
+					break;
+
+			}
+
+			const pointerResolver = this.parser.options.animationPointerResolver;
+			if ( pointerResolver && pointerResolver.resolvePath ) {
+
+				path = pointerResolver.resolvePath( path );
+
+			}
+
+			target.extensions[ EXTENSIONS.KHR_ANIMATION_POINTER ].pointer = path;
+
+		}
+
+		if ( targetId === null || isNaN( targetId ) ) {
+
+			console.warn( 'Failed resolving animation node id: ' + targetId, target );
+			return;
+
+		}
+
+		let depPromise;
+
+		if ( type === this.ANIMATION_TARGET_TYPE.node )
+			depPromise = this.parser.getDependency( 'node', targetId );
+		else if ( type === this.ANIMATION_TARGET_TYPE.material )
+			depPromise = this.parser.getDependency( 'material', targetId );
+		else if ( type === this.ANIMATION_TARGET_TYPE.light )
+			depPromise = this.parser.getDependency( 'light', targetId );
+		else if ( type === this.ANIMATION_TARGET_TYPE.camera )
+			depPromise = this.parser.getDependency( 'camera', targetId );
+		else
+			console.error( 'Unhandled type', type );
+
+		return depPromise;
+
+	}
+
+	createAnimationTracks( node, inputAccessor, outputAccessor, sampler, target ) {
+
+		const useExtension = target.extensions && target.extensions[ EXTENSIONS.KHR_ANIMATION_POINTER ] && target.path && target.path === 'pointer';
+		if ( ! useExtension ) return null;
+
+		let animationPointerPropertyPath = target.extensions[ EXTENSIONS.KHR_ANIMATION_POINTER ].pointer;
+		if ( ! animationPointerPropertyPath ) return null;
+
+		const tracks = [];
+
+		animationPointerPropertyPath = animationPointerPropertyPath.replaceAll( '/', '.' );
+		// replace node/material/camera/light ID by UUID
+		const parts = animationPointerPropertyPath.split( '.' );
+		parts[ 2 ] = node.name ?? node.uuid;
+		animationPointerPropertyPath = parts.join( '.' );
+		if ( this._animationPointerDebug )
+			console.log( node, inputAccessor, outputAccessor, target, animationPointerPropertyPath );
+
+		let TypedKeyframeTrack;
+
+		switch ( outputAccessor.itemSize ) {
+
+			case 1:
+				TypedKeyframeTrack = NumberKeyframeTrack;
+				break;
+			case 2:
+			case 3:
+				TypedKeyframeTrack = VectorKeyframeTrack;
+				break;
+			case 4:
+
+				if ( animationPointerPropertyPath.endsWith( '.quaternion' ) )
+					TypedKeyframeTrack = QuaternionKeyframeTrack;
+				else
+					TypedKeyframeTrack = ColorKeyframeTrack;
+
+				break;
+
+		}
+
+		const interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : InterpolateLinear;
+
+		let outputArray = this.parser.getArrayFromAccessor( outputAccessor );
+
+		// convert fov values from radians to degrees
+		if ( animationPointerPropertyPath.endsWith( '.fov' ) ) {
+			
+			outputArray = outputArray.map( value => value / Math.PI * 180 );
+
+		}
+
+		const track = new TypedKeyframeTrack(
+			animationPointerPropertyPath,
+			inputAccessor.array,
+			outputArray,
+			interpolation
+		);
+
+		// Override interpolation with custom factory method.
+		if ( interpolation === 'CUBICSPLINE' ) {
+
+			this.parser.createCubicSplineTrackInterpolant( track );
+
+		}
+
+		tracks.push( track );
+
+		// glTF has opacity animation as last component of baseColorFactor,
+		// so we need to split that up here and create a separate opacity track if that is animated.
+		if ( animationPointerPropertyPath && outputAccessor.itemSize === 4 &&
+			animationPointerPropertyPath.startsWith( '.materials.' ) && animationPointerPropertyPath.endsWith( '.color' ) ) {
+
+			const opacityArray = new Float32Array( outputArray.length / 4 );
+
+			for ( let j = 0, jl = outputArray.length / 4; j < jl; j += 1 ) {
+
+				opacityArray[ j ] = outputArray[ j * 4 + 3 ];
+
+			}
+
+			const opacityTrack = new TypedKeyframeTrack(
+				animationPointerPropertyPath.replace( '.color', '.opacity' ),
+				inputAccessor.array,
+				opacityArray,
+				interpolation
+			);
+
+			// Override interpolation with custom factory method.
+			if ( interpolation === 'CUBICSPLINE' ) {
+
+				createCubicSplineTrackInterpolant( track );
+
+			}
+
+			tracks.push( opacityTrack );
+
+		}
+
+		return tracks;
+
+	}
+
+
+	_tryResolveTargetId( path, type ) {
+
+		let name = '';
+		if ( type === 'node' ) {
+
+			name = path.substring( '/nodes/'.length );
+
+		} else if ( type === 'material' ) {
+
+			name = path.substring( '/materials/'.length );
+
+		} else if ( type === 'light' ) {
+
+			name = path.substring( '/extensions/KHR_lights_punctual/lights/'.length );
+
+		} else if ( type === 'camera' ) {
+
+			name = path.substring( '/cameras/'.length );
+
+		}
+
+		name = name.substring( 0, name.indexOf( '/' ) );
+		const index = Number.parseInt( name );
+		return index;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2399,48 +2399,6 @@ function getNormalizedComponentScale( constructor ) {
 
 }
 
-function getArrayFromAccessor( accessor ) {
-
-	let outputArray = accessor.array;
-
-	if ( accessor.normalized ) {
-
-		const scale = getNormalizedComponentScale( outputArray.constructor );
-		const scaled = new Float32Array( outputArray.length );
-
-		for ( let j = 0, jl = outputArray.length; j < jl; j ++ ) {
-
-			scaled[ j ] = outputArray[ j ] * scale;
-
-		}
-
-		outputArray = scaled;
-
-	}
-
-	return outputArray;
-
-}
-
-function createCubicSplineTrackInterpolant( track ) {
-
-	track.createInterpolant = function InterpolantFactoryMethodGLTFCubicSpline( result ) {
-
-		// A CUBICSPLINE keyframe in glTF has three output values for each input value,
-		// representing inTangent, splineVertex, and outTangent. As a result, track.getValueSize()
-		// must be divided by three to get the interpolant's sampleSize argument.
-
-		const interpolantType = ( this instanceof QuaternionKeyframeTrack ) ? GLTFCubicSplineQuaternionInterpolant : GLTFCubicSplineInterpolant;
-
-		return new interpolantType( this.times, this.values, this.getValueSize() / 3, result );
-
-	};
-
-	// Mark as CUBICSPLINE. `track.getInterpolation()` doesn't support custom interpolants.
-	track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline = true;
-
-}
-
 function getImageURIMimeType( uri ) {
 
 	if ( uri.search( /\.jpe?g($|\?)/i ) > 0 || uri.search( /^data\:image\/jpeg/ ) === 0 ) return 'image/jpeg';
@@ -4384,7 +4342,7 @@ class GLTFParser {
 
 		const interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : InterpolateLinear;
 
-		const outputArray = getArrayFromAccessor( outputAccessor );
+		const outputArray = this.getArrayFromAccessor( outputAccessor );
 
 		for ( let j = 0, jl = targetNames.length; j < jl; j ++ ) {
 
@@ -4398,7 +4356,7 @@ class GLTFParser {
 			// Override interpolation with custom factory method.
 			if ( interpolation === 'CUBICSPLINE' ) {
 
-				createCubicSplineTrackInterpolant( track );
+				this.createCubicSplineTrackInterpolant( track );
 
 			}
 
@@ -4407,6 +4365,48 @@ class GLTFParser {
 		}
 
 		return tracks;
+
+	}
+
+	getArrayFromAccessor( accessor ) {
+
+		let outputArray = accessor.array;
+
+		if ( accessor.normalized ) {
+
+			const scale = getNormalizedComponentScale( outputArray.constructor );
+			const scaled = new Float32Array( outputArray.length );
+
+			for ( let j = 0, jl = outputArray.length; j < jl; j ++ ) {
+
+				scaled[ j ] = outputArray[ j ] * scale;
+
+			}
+
+			outputArray = scaled;
+
+		}
+
+		return outputArray;
+
+	}
+
+	createCubicSplineTrackInterpolant( track ) {
+
+		track.createInterpolant = function InterpolantFactoryMethodGLTFCubicSpline( result ) {
+
+			// A CUBICSPLINE keyframe in glTF has three output values for each input value,
+			// representing inTangent, splineVertex, and outTangent. As a result, track.getValueSize()
+			// must be divided by three to get the interpolant's sampleSize argument.
+
+			const interpolantType = ( this instanceof QuaternionKeyframeTrack ) ? GLTFCubicSplineQuaternionInterpolant : GLTFCubicSplineInterpolant;
+
+			return new interpolantType( this.times, this.values, this.getValueSize() / 3, result );
+
+		};
+
+		// Mark as CUBICSPLINE. `track.getInterpolation()` doesn't support custom interpolants.
+		track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline = true;
 
 	}
 


### PR DESCRIPTION
**The following PRs are rolled into this one and ideally are merged first:**
- #24252 
- #24193
- #24603 

**Description**

This PR adds support for[ KHR_animation_pointer](https://github.com/ux3d/glTF/tree/extensions/KHR_animation_pointer/extensions/2.0/Khronos/KHR_animation_pointer). We wanted to put this out early for discussion. There's a good amount of refactoring to be done (especially figuring out how to do property binding in a clean/extensible way, and how to deal with animated cameras/lights/materials that three might duplicate in certain cases).

**three.js fork with built drag-and-drop viewer can be found here:**
https://needle.tools/three.js/examples/?q=loader_mu#webgl_loader_multiple

**Some sample models are here:**
https://github.com/KhronosGroup/glTF-Sample-Models/pull/353

To quickly test, just download some of the GLB files from the sample-models fork and drop them into the three-js fork above :)

**Known Limitations**
- If lights or cameras are used on multiple nodes, three.js duplicates those. This currently isn't supported here. When animating lights/cameras is wanted, each node should have a unique light/camera.
- Three.js only allows texture transforms on map and aoMap, not on other properties. This means they can be animated but don't have an effect. Custom shaders can still use those properties, so I think it's valuable to still import their animations (this is incomplete right now).
- Materials might be duplicated depending on what features a particular mesh has (with/without vertex colors, normals, tangents). Tracks would need to be duplicated in this case as well to point to those new materials.

**Next steps**
Before doing the remaining implementation (which mostly consists of mapping glTF JSON Pointer strings to three.js property names), I think a couple of points are worth discussing:
- currently `PropertyBinding.findNode` is monkey patched to support materials and node uuids. It may be that custom extensions need to have callbacks into this (e.g. KHR_animation_pointer wants to resolve materials). I'm unsure if `findNode` itself should be extended to support more cases or a callback mechanism be introduced (I'd prefer the callback).
- ~~lights currently don't work, getDependency doesn't have 'lights' right now (another candidate for a callback for `findNode`).~~
- naming-wise it's a bit weird that `pendingNodes` may now contain other things than nodes (e.g. materials). Should we rename this to `pendingDependencies`?
- given that at some point three.js may also want to export with KHR_animation_pointer, I'm unsure of where all the path and property remapping should happen. I guess for now import is good to tackle first to find all edge cases and then later talk about export.
- some properties in three.js work differently - e.g. Light.penumbra is calculated from inner and outer spot angle. Not sure what the right approach would be during animation. Precalculating this as array seems rather complicated (inner and outer spot could have separate keyframe times etc.).
- Light.angle also needs to be converted from rad to deg, which can probably be done when creating the Track array.

cc @donmccurdy @elalish @mrdoob and probably others :) I'm really looking forward to having support for this, opens up many possibilities.

Babylon and Gestaltor seem to have also started implementations.
- https://github.com/BabylonJS/Babylon.js/issues/12544

This contribution is funded by [Needle](https://needle.tools) and [prefrontal cortex](https://prefrontalcortex.de)