### PR TITLE
ShapePath: Fix unlinked holes when path has hole on first AND last

### DIFF
--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -206,6 +206,14 @@ class ShapePath {
 		// only Holes? -> probably all Shapes with wrong orientation
 		if ( ! newShapes[ 0 ] )	return	toShapesNoHoles( subPaths );
 
+		if ( newShapeHoles.length > newShapes.length ) {
+
+			const restShapeHoles = newShapeHoles.pop();
+
+			Array.prototype.push.apply( newShapeHoles[ newShapeHoles.length - 1 ], restShapeHoles );
+
+		}
+
 
 		if ( newShapes.length > 1 ) {
 


### PR DESCRIPTION
Related issue: none

**Description**

When holes on first AND last in the path, `ShapePath.toShapes()` incorrectly ignores the holes.
For example, the letter `激` in typeface.json has 5 holes, 1 shape, and 2 holes. The last 2 holes are incorrectly ignored.

## Expected behavior
![image](https://user-images.githubusercontent.com/14163516/169914673-420054ac-7527-4434-a27b-bfefaacaa1ac.png)

## Actual behavior
![image](https://user-images.githubusercontent.com/14163516/169914762-51213e53-5e0f-4339-946a-cdc6d2293a44.png)

## typeface.json
```json
{
  "glyphs": {
    "激": {
      "ha": 1389,
      "x_min": 5,
      "x_max": 1389,
      "o": "m 802 545 l 751 545 l 751 530 l 817 536 l 802 545 m 1104 519 l 1116 696 l 1072 696 l 1051 629 l 1088 637 l 1104 519 m 449 545 l 358 545 l 351 536 l 449 530 l 449 545 m 595 746 l 595 727 l 628 727 l 628 746 l 595 746 m 595 872 l 628 872 l 628 891 l 595 891 l 595 872 m 286 410 l 8 521 l 153 818 l 350 635 l 350 897 l 267 774 l 5 903 l 175 1185 l 350 1005 l 350 1078 l 434 1078 l 439 1184 l 773 1175 l 754 1078 l 852 1078 l 852 935 l 898 1183 l 1222 1154 l 1179 1019 l 1388 1024 l 1388 693 l 1355 696 l 1314 220 l 1389 199 l 1359 -175 l 1107 -49 l 864 -175 l 850 -62 l 844 -186 l 589 -179 l 581 -95 l 570 -182 l 328 -75 l 311 -180 l 5 -77 l 172 346 l 392 294 l 373 184 l 412 319 l 323 313 l 323 487 l 286 410 m 873 313 l 646 319 l 640 300 l 865 300 l 863 198 l 939 228 l 884 484 l 873 492 l 873 313 m 623 60 l 629 99 l 612 99 l 605 62 l 623 60 z "
    }
  },
  "familyName": "GN-KMBFont-UB-NewstyleKanaB",
  "ascender": 1194,
  "descender": -475,
  "underlinePosition": -130,
  "underlineThickness": 65,
  "boundingBox": {
    "yMin": -450,
    "xMin": -142,
    "yMax": 1298,
    "xMax": 1679
  },
  "resolution": 1000,
  "original_font_information": {
    "format": 0,
    "copyright": "Nagoriyuki/Getsuren",
    "fontFamily": "GN-KMBFont-UB-NewstyleKanaB",
    "fontSubfamily": "Ultra",
    "uniqueID": "GN-KMBFont-UB-NewstyleKanaB",
    "fullName": "GN-KMBFont-UB-NewstyleKanaB",
    "version": "Version 0.99b",
    "postScriptName": "GN-KMBFont-UB-NewstyleKanaB",
    "trademark": "GN-KMBFont-UB-NewstyleKanaB"
  },
  "cssFontWeight": "normal",
  "cssFontStyle": "normal"
}
```