### PR TITLE
PCDLoader: Avoid stringifying entire file; fix parse function inconsistencies

### DIFF
--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -209,18 +209,33 @@
 
 			const position = [];
 			const normal = [];
-			const color = []; // ascii
+			const color = [];
+
+			// ascii
 
 			if ( PCDheader.data === 'ascii' ) {
 
 				const offset = PCDheader.offset;
-				const pcdData = textData.slice( PCDheader.headerLen );
-				const lines = pcdData.split( '\n' );
+				const pointData = data.slice( PCDheader.headerLen );
+				const uint8Data = new Uint8Array( pointData );
+				let previous_idx = 0;
+				let lineStr = '';
+				for ( let i = 0, l = uint8Data.length; i < l; i ++ ) {
 
-				for ( let i = 0, l = lines.length; i < l; i ++ ) {
+					if ( uint8Data[ i ] === '\n'.charCodeAt( 0 ) ) {
 
-					if ( lines[ i ] === '' ) continue;
-					const line = lines[ i ].split( ' ' );
+						lineStr = LoaderUtils.decodeText( uint8Data.slice( previous_idx, i ) );
+						previous_idx = i;
+
+					} else {
+
+						continue;
+
+					}
+
+					if ( lineStr === '' ) continue;
+
+					const line = lineStr.split( ' ' );
 
 					if ( offset.x !== undefined ) {
 

--- a/examples/js/loaders/PCDLoader.js
+++ b/examples/js/loaders/PCDLoader.js
@@ -43,7 +43,12 @@
 
 		}
 
-		parse( data, url ) {
+		/**
+		 * Parse Point Cloud Data (PCD) from an ArrayBuffer
+		 * @param data {ArrayBuffer}
+		 * @returns {*}
+		 */
+		parse( data ) {
 
 			// from https://gitlab.com/taketwo/three-pcd-loader/blob/master/decompress-lzf.js
 			function decompressLZF( inData, outLength ) {
@@ -104,6 +109,11 @@
 
 			}
 
+			/**
+			 * Parse the ASCII header of a PCD File.
+			 * @param data {string}
+			 * @returns {{}}
+			 */
 			function parseHeader( data ) {
 
 				const PCDheader = {};
@@ -188,7 +198,12 @@
 
 			}
 
-			const textData = THREE.LoaderUtils.decodeText( new Uint8Array( data ) ); // parse header (always ascii format)
+			// Grab at most 8000 bytes of the PCD file to ensure we aren't trying to create a string that's too
+			// big for the javascript heap. 8000 is an arbitrary number that seems like it should be bigger than
+			// any PCD header.
+
+			const slice = data.slice( 0, Math.min( 8000, data.byteLength ) );
+			const textData = THREE.LoaderUtils.decodeText( new Uint8Array( slice ) ); // parse header (always ascii format)
 
 			const PCDheader = parseHeader( textData ); // parse data
 
@@ -352,12 +367,7 @@
 			} // build point cloud
 
 
-			const mesh = new THREE.Points( geometry, material );
-			let name = url.split( '' ).reverse().join( '' );
-			name = /([^\/]*)/.exec( name );
-			name = name[ 1 ].split( '' ).reverse().join( '' );
-			mesh.name = name;
-			return mesh;
+			return new THREE.Points( geometry, material );
 
 		}
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -53,6 +53,11 @@ class PCDLoader extends Loader {
 
 	}
 
+	/**
+	 * Parse Point Cloud Data (PCD) from an ArrayBuffer
+	 * @param data {ArrayBuffer}
+	 * @returns {*}
+	 */
 	parse( data ) {
 
 		// from https://gitlab.com/taketwo/three-pcd-loader/blob/master/decompress-lzf.js
@@ -110,6 +115,11 @@ class PCDLoader extends Loader {
 
 		}
 
+		/**
+		 * Parse the ASCII header of a PCD File.
+		 * @param data {string}
+		 * @returns {{}}
+		 */
 		function parseHeader( data ) {
 
 			const PCDheader = {};
@@ -218,7 +228,12 @@ class PCDLoader extends Loader {
 
 		}
 
-		const textData = LoaderUtils.decodeText( new Uint8Array( data ) );
+		// Grab at most 8000 bytes of the PCD file to ensure we aren't trying to create a string that's too
+		// big for the javascript heap. 8000 is an arbitrary number that seems like it should be bigger than
+		// any PCD header.
+
+		const slice = data.slice( 0, Math.min( 8000, data.byteLength ) );
+		const textData = LoaderUtils.decodeText( new Uint8Array( slice ) );
 
 		// parse header (always ascii format)
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -250,14 +250,26 @@ class PCDLoader extends Loader {
 		if ( PCDheader.data === 'ascii' ) {
 
 			const offset = PCDheader.offset;
-			const pcdData = textData.slice( PCDheader.headerLen );
-			const lines = pcdData.split( '\n' );
+			const pointData = data.slice( PCDheader.headerLen );
+			const uint8Data = new Uint8Array( pointData );
+			let previous_idx = 0;
+			let lineStr = '';
+			for ( let i = 0, l = uint8Data.length; i < l; i ++ ) {
 
-			for ( let i = 0, l = lines.length; i < l; i ++ ) {
+				if ( uint8Data[ i ] === '\n'.charCodeAt( 0 ) ) {
 
-				if ( lines[ i ] === '' ) continue;
+					lineStr = LoaderUtils.decodeText( uint8Data.slice( previous_idx, i ) );
+					previous_idx = i;
 
-				const line = lines[ i ].split( ' ' );
+				} else {
+
+					continue;
+
+				}
+
+				if ( lineStr === '' ) continue;
+
+				const line = lineStr.split( ' ' );
 
 				if ( offset.x !== undefined ) {
 


### PR DESCRIPTION
Hello!

Two things in this PR:

* When I try to load a very large PCD (> 600Mb) in Chrome, the parsing fails. I believe this is because `PCDLoader` attempts to load the entire `ArrayBuffer` into a string. Instead, I just load the first 8000 bytes into a string to parse the header. The 8000 is arbitrary, but I think is much more than the max length a PCD header could be.
* I noticed that #24106 updated `PCDLoader.parse()` in the `.mjs` to not take a `url` parameter but the `.js` example still used this parameter. I removed the parameter from the `.js` version to make the behavior match the `.mjs` version.

