### PR TITLE
Object3D: Honor `recursive` parameter of `copy()` in subclasses.

### DIFF
--- a/examples/jsm/misc/MorphAnimMesh.js
+++ b/examples/jsm/misc/MorphAnimMesh.js
@@ -60,9 +60,9 @@ class MorphAnimMesh extends Mesh {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.mixer = new AnimationMixer( this );
 

--- a/examples/jsm/objects/LightningStorm.js
+++ b/examples/jsm/objects/LightningStorm.js
@@ -207,9 +207,9 @@ class LightningStorm extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.stormParams.size = source.stormParams.size;
 		this.stormParams.minHeight = source.stormParams.minHeight;

--- a/src/helpers/BoxHelper.js
+++ b/src/helpers/BoxHelper.js
@@ -91,9 +91,9 @@ class BoxHelper extends LineSegments {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.object = source.object;
 

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -19,9 +19,9 @@ class HemisphereLight extends Light {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.groundColor.copy( source.groundColor );
 

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -22,9 +22,9 @@ class Light extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.color.copy( source.color );
 		this.intensity = source.intensity;

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -39,9 +39,9 @@ class PointLight extends Light {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.distance = source.distance;
 		this.decay = source.decay;

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -47,9 +47,9 @@ class SpotLight extends Light {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.distance = source.distance;
 		this.angle = source.angle;

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -26,9 +26,9 @@ class InstancedMesh extends Mesh {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.instanceMatrix.copy( source.instanceMatrix );
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -30,9 +30,9 @@ class Line extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.material = source.material;
 		this.geometry = source.geometry;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -49,9 +49,9 @@ class Mesh extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		if ( source.morphTargetInfluences !== undefined ) {
 

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -28,9 +28,9 @@ class Points extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.material = source.material;
 		this.geometry = source.geometry;

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -27,9 +27,9 @@ class SkinnedMesh extends Mesh {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		this.bindMode = source.bindMode;
 		this.bindMatrix.copy( source.bindMatrix );

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -137,9 +137,9 @@ class Sprite extends Object3D {
 
 	}
 
-	copy( source ) {
+	copy( source, recursive ) {
 
-		super.copy( source );
+		super.copy( source, recursive );
 
 		if ( source.center !== undefined ) this.center.copy( source.center );
 


### PR DESCRIPTION
**Description**

I've had a situation where I would need to clone a Spotlight or PointLight which had children, but without wanting those children. It did not seem possible as the `copy` method did not pass the `recursive` argument to the inherited `Object3D.copy` method.

So I've added the `recursive` argument to the `copy` method of a few classes.

Unless there is a reason of not allowing to pass the recursive argument is intentional, which I may have missed?
