### PR TITLE
WebGLProgram: Fix error logging

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -52,7 +52,7 @@ function getShaderErrors( gl, shader, type ) {
 		// --enable-privileged-webgl-extension
 		// console.log( '**' + type + '**', gl.getExtension( 'WEBGL_debug_shaders' ).getTranslatedShaderSource( shader ) );
 
-		const errorLine = parseInt( errorMatches[ 0 ] );
+		const errorLine = parseInt( errorMatches[ 1 ] );
 		return type.toUpperCase() + '\n\n' + errors + '\n\n' + handleSource( gl.getShaderSource( shader ), errorLine );
 
 	} else {


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/24127

**Description**

The result of executing `RegExp.prototype.exec()` contains the matched string as the first element and the capture groups as the next ones.

The mistake was introduced in https://github.com/mrdoob/three.js/pull/23843.