### PR TITLE
WebGLProgram: show error line indicator

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -15,7 +15,7 @@ function handleSource( string, errorLine ) {
 
 	for ( let i = from; i < to; i ++ ) {
 
-		const line = i + 1
+		const line = i + 1;
 		lines2.push( `${line === errorLine ? '>' : ' '} ${line}: ${lines[ i ]}` );
 
 	}

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -15,7 +15,8 @@ function handleSource( string, errorLine ) {
 
 	for ( let i = from; i < to; i ++ ) {
 
-		lines2.push( ( i + 1 ) + ': ' + lines[ i ] );
+		const line = i + 1
+		lines2.push( `${line === errorLine ? '>' : ' '} ${line}: ${lines[ i ]}` );
 
 	}
 


### PR DESCRIPTION
Related issue: #24130

**Description**

With the errors fix, I noticed the shader error logging could be improved.
To let the user understand quickly which line is erroring.

| Before this PR | After this PR |
|----------------|--------------|
| <img width="577" alt="Screenshot 2022-05-25 at 17 59 27" src="https://user-images.githubusercontent.com/7217420/170307830-9ab359b2-aac1-481a-a233-54982fcc6741.png"> | <img width="539" alt="Screenshot 2022-05-25 at 18 10 11" src="https://user-images.githubusercontent.com/7217420/170308304-0db3a09d-12e1-4050-ad99-68ee5453b7f9.png"> |
