### PR TITLE
WebGPU: Fix wrong auto dimension on MacOS while generate MipMaps

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { GPUIndexFormat, GPUFilterMode, GPUPrimitiveTopology, GPULoadOp, GPUStoreOp } from './constants.js';
+import { GPUTextureViewDimension, GPUIndexFormat, GPUFilterMode, GPUPrimitiveTopology, GPULoadOp, GPUStoreOp } from './constants.js';
 
 // ported from https://github.com/toji/web-texture-tool/blob/master/src/webgpu-mipmap-generator.js
 
@@ -132,6 +132,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		let srcView = textureGPU.createView( {
 			baseMipLevel: 0,
 			mipLevelCount: 1,
+			dimension: GPUTextureViewDimension.TwoD,
 			baseArrayLayer
 		} );
 
@@ -140,6 +141,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 			const dstView = textureGPU.createView( {
 				baseMipLevel: i,
 				mipLevelCount: 1,
+				dimension: GPUTextureViewDimension.TwoD,
 				baseArrayLayer
 			} );
 


### PR DESCRIPTION
**Description**

Fix wrong auto dimension on `MacOS` while generate `MipMaps`

EDIT: They assume a wrong self dimension for this context. The bug seems to be on `Windows` which assumes the `2d` `dimension` even this being a `cube` automatically if this is not sent in the object.

To reproduce this bug on `Windows` just put for `srcView`:
`dimension: GPUTextureViewDimension.Cube`

Maybe this parameter should be made explicit in the future?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
