### PR TITLE
WebGLMultipleRenderTargets: Example fix iOS with MSAA

### DIFF
--- a/examples/webgl2_multiple_rendertargets.html
+++ b/examples/webgl2_multiple_rendertargets.html
@@ -164,7 +164,6 @@
 
 					renderTarget.texture[ i ].minFilter = THREE.NearestFilter;
 					renderTarget.texture[ i ].magFilter = THREE.NearestFilter;
-					renderTarget.texture[ i ].type = THREE.FloatType;
 
 				}
 
@@ -245,6 +244,13 @@
 			function render() {
 
 				renderTarget.samples = parameters.samples;
+
+				// safari prior 15.5 needs the renderer to be cleared()
+				// if ( parameters.samples > 0 ) {
+
+					// renderer.clear();
+
+				// }
 
 				scene.traverse( function ( child ) {
 

--- a/examples/webgl2_multiple_rendertargets.html
+++ b/examples/webgl2_multiple_rendertargets.html
@@ -245,13 +245,6 @@
 
 				renderTarget.samples = parameters.samples;
 
-				// safari prior 15.5 needs the renderer to be cleared()
-				// if ( parameters.samples > 0 ) {
-
-					// renderer.clear();
-
-				// }
-
 				scene.traverse( function ( child ) {
 
 					if ( child.material !== undefined ) {


### PR DESCRIPTION
There is another issue only on iOS, some texture types will break in certain cases. I don't have an explanation of the why, I think it's just a bug.

Also, there was an issue with Safari which was fixed in the latest version (15.5) where it was required to clear the canvas before rendering the scene. I only added comments since this issue has been patched, should we add it anyway?