### PR TITLE
Fix pointer duplication issue in WebXR Hand Examples

### DIFF
--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -46,13 +46,16 @@ class OculusHandPointerModel extends THREE.Object3D {
 		hand.addEventListener( 'connected', ( event ) => {
 
 			const xrInputSource = event.data;
+
 			if ( xrInputSource.hand ) {
 
 				this.visible = true;
 				this.xrInputSource = xrInputSource;
 
-				if (this.pointerObject === null) {
+				if ( this.pointerObject === null ) {
+
 					this.createPointer();
+
 				}
 
 			}

--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -51,7 +51,9 @@ class OculusHandPointerModel extends THREE.Object3D {
 				this.visible = true;
 				this.xrInputSource = xrInputSource;
 
-				this.createPointer();
+				if (this.pointerObject === null) {
+					this.createPointer();
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: #24055

**Description**

The WebXR hand examples were made with the assumption that the hands `connected` event would only fire once, which is the current behavior in Oculus Quest, but not in Hololens (which send connected / disconnected events as hands enter and leave the view). This changes the pointer creation logic in the hands examples so that it'd only create the pointer on the `connected` event if no pointer has already been created.

Note that I do not own a Hololens device so I have not personally tested this to make sure that the behavior is correct on Hololens. An alternative to this would be to destroy the pointers on `disconnected` events, and recreate it on `connected`.