### PR TITLE
fix: don't crash when `material` is `undefined` during  `ray.intersectObject`

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -270,13 +270,13 @@ function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point 
 
 	let intersect;
 
-	if ( material.side === BackSide ) {
+	if ( material && ( material.side === BackSide ) ) {
 
 		intersect = ray.intersectTriangle( pC, pB, pA, true, point );
 
 	} else {
 
-		intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
+		intersect = ray.intersectTriangle( pA, pB, pC, material ? material.side !== DoubleSide : false, point );
 
 	}
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/36955

**Description**

Sometimes `groupMaterial` can be `undefined` when `group.materialIndex` is `-1`. Rather than fail with a runtime error, simply perform the intersection assuming no backface culling (i.e. `DoubleSide`).

The thought here is that the most important thing is the geometry. A missing material should not be an issue as far as casting a ray is concerned, but more of a hint (use the sidedness when the material exists).

- [ ] add test if approved to move forward