### PR TITLE
WebGLShadowMap: Make test for clipping planes more robust. 

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -247,7 +247,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		}
 
-		if ( ( _renderer.localClippingEnabled && material.clipShadows === true && material.clippingPlanes.length !== 0 ) ||
+		if ( ( _renderer.localClippingEnabled && material.clipShadows === true && Array.isArray( material.clippingPlanes ) && material.clippingPlanes.length !== 0 ) ||
 			( material.displacementMap && material.displacementScale !== 0 ) ||
 			( material.alphaMap && material.alphaTest > 0 ) ) {
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Without this, a `null` `clippingPlanes` array (the default value) causes a runtime error when `clipShadows` is `true`.

https://github.com/mrdoob/three.js/blob/0c26bb4bb8220126447c8373154ac045588441de/src/materials/Material.js#L49


- [ ] add test if approved to move forward