### PR TITLE
feature: load events for `Texture`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three",
-  "version": "0.139.1",
+  "version": "0.141.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three",
-      "version": "0.139.1",
+      "version": "0.141.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.9",

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -29,7 +29,25 @@ class TextureLoader extends Loader {
 
 			}
 
-		}, onProgress, onError );
+			texture.dispatchEvent( { type: 'load' } );
+
+		}, function () {
+
+			// TODO unimplemented in ImageLoader, so this is never called.
+
+			// texture.dispatchEvent( { type: 'progress', percent: ___ } )
+
+		}, function ( event ) {
+
+			if ( onError !== undefined ) {
+
+				onError( event );
+
+			}
+
+			texture.dispatchEvent( { type: 'error', errorEvent: event } );
+
+		} );
 
 		return texture;
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/38533


- [ ] add test if approved to move forward

**Description**

Some APIs (f.e. libs) that receive textures employ hacks (no other choice) to detect when textures are loaded. Here is an example of code from @marcofugaro's [`three-projected-material`](https://github.com/marcofugaro/three-projected-material/blob/29099152d9775a5007fa5296d7f79540967fa519/src/three-utils.js#L29-L41):

```js
// run the callback when the image will be loaded
export function addLoadListener(texture, callback) {
  // return if it's already loaded
  if (texture.image && texture.image.videoWidth !== 0 && texture.image.videoHeight !== 0) {
    return
  }

  const interval = setInterval(() => {
    if (texture.image && texture.image.videoWidth !== 0 && texture.image.videoHeight !== 0) {
      clearInterval(interval)
      return callback(texture)
    }
  }, 16)
}
```

The benefits of `Texture`s emitting events are

1. library authors do not have to remember to always include a `needsUpdate` setter in their classes and to tell end users to remember to call it after texture load
2. end users don't have to remember set `needsUpdate = true`

Win win.

### Real-world bug

When using `three-projected-material` (taking into account the above `addLoadListener` function), without an infinite render loop but calling `requestAnimationFrame` only when needed, this happens:

```js
const mat = new ProjectedMaterial()

const texture = new TextureLoader.load('foo.jpg', () => {
  requestAnimationFrame(render) // draw when texture is loaded
})

mat.texture = texture
render() // render once initially, the texture will be missing in the render

// Note that ProjectedMaterial needs to set `this.uniforms.isTextureLoaded = true` once `addLoadListener` detects the texture to be loaded using `setInterval`

// ... later ...

// animation frame from the texture load fires, but this.uniforms.isTextureLoaded is still false so texture does not show up.

// ... later ...

// addLoadListener's setInterval loop finally detects the texture is loaded *after* the animation frame, and sets `this.uniforms.isTextureLoaded = true`, but there is no way for us to know that we need to re-render the scene.
```

And so what happens is we are stuck without the texture showing up (unless we use an infinite render loop, and not all apps do that if they need to save CPU and aren't constantly animating things).

The `this.uniforms.isTextureLoaded` line I mentioned in the comments is [here](https://github.com/marcofugaro/three-projected-material/blob/29099152d9775a5007fa5296d7f79540967fa519/src/ProjectedMaterial.js#L35-L39).