### PR TITLE
Allow Object3D.add to handle empty array with noop

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -299,6 +299,12 @@ class Object3D extends EventDispatcher {
 
 	add( object ) {
 
+		if ( arguments.length === 0 ) {
+
+			return this;
+
+		}
+
 		if ( arguments.length > 1 ) {
 
 			for ( let i = 0; i < arguments.length; i ++ ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -297,51 +297,38 @@ class Object3D extends EventDispatcher {
 
 	}
 
-	add( object ) {
+	add( ...objects ) {
 
-		if ( arguments.length === 0 ) {
+		objects.forEach( object => {
 
-			return this;
+			if ( object === this ) {
 
-		}
+				console.error( 'THREE.Object3D.add: object can\'t be added as a child of itself.', object );
 
-		if ( arguments.length > 1 ) {
+			} else {
 
-			for ( let i = 0; i < arguments.length; i ++ ) {
+				if ( object && object.isObject3D ) {
 
-				this.add( arguments[ i ] );
+					if ( object.parent !== null ) {
 
-			}
+						object.parent.remove( object );
 
-			return this;
+					}
 
-		}
+					object.parent = this;
+					this.children.push( object );
 
-		if ( object === this ) {
+					object.dispatchEvent( _addedEvent );
 
-			console.error( 'THREE.Object3D.add: object can\'t be added as a child of itself.', object );
-			return this;
+				} else {
 
-		}
+					console.error( 'THREE.Object3D.add: object not an instance of THREE.Object3D.', object );
 
-		if ( object && object.isObject3D ) {
-
-			if ( object.parent !== null ) {
-
-				object.parent.remove( object );
+				}
 
 			}
 
-			object.parent = this;
-			this.children.push( object );
-
-			object.dispatchEvent( _addedEvent );
-
-		} else {
-
-			console.error( 'THREE.Object3D.add: object not an instance of THREE.Object3D.', object );
-
-		}
+		} );
 
 		return this;
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -1147,8 +1147,8 @@ export default QUnit.module( 'Core', () => {
 		QUnit.test( 'add empty array', ( assert ) => {
 
 			var obj = new Object3D();
-			obj.add(...[]);
-		
+			obj.add();
+
 			assert.numEqual( obj.children.length, 0, 'no children added' );
 		
 		} );

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -1144,6 +1144,15 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'add empty array', ( assert ) => {
+
+			var obj = new Object3D();
+			obj.add(...[]);
+		
+			assert.numEqual( obj.children.length, 0, 'no children added' );
+		
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
Related issue: #24147

**Description**

Passing a spread empty array to `Object3D.add` throws with error: `THREE.Object3D.add: object not an instance of THREE.Object3D. undefined`. This should result in a noop - not an error. 

```js
const objsToAdd: THREE.Object3D[] = []
const obj = new Object3D()
obj.add(...objsToAdd) // should be noop not error
```
