### PR TITLE
Helpers: Add missing `type` definitions.

### DIFF
--- a/src/helpers/DirectionalLightHelper.js
+++ b/src/helpers/DirectionalLightHelper.js
@@ -22,6 +22,8 @@ class DirectionalLightHelper extends Object3D {
 
 		this.color = color;
 
+		this.type = 'DirectionalLightHelper';
+
 		if ( size === undefined ) size = 1;
 
 		let geometry = new BufferGeometry();

--- a/src/helpers/HemisphereLightHelper.js
+++ b/src/helpers/HemisphereLightHelper.js
@@ -23,6 +23,8 @@ class HemisphereLightHelper extends Object3D {
 
 		this.color = color;
 
+		this.type = 'HemisphereLightHelper';
+
 		const geometry = new OctahedronGeometry( size );
 		geometry.rotateY( Math.PI * 0.5 );
 

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -20,6 +20,8 @@ class SpotLightHelper extends Object3D {
 
 		this.color = color;
 
+		this.type = 'SpotLightLightHelper';
+
 		const geometry = new BufferGeometry();
 
 		const positions = [

--- a/src/helpers/SpotLightHelper.js
+++ b/src/helpers/SpotLightHelper.js
@@ -20,7 +20,7 @@ class SpotLightHelper extends Object3D {
 
 		this.color = color;
 
-		this.type = 'SpotLightLightHelper';
+		this.type = 'SpotLightHelper';
 
 		const geometry = new BufferGeometry();
 


### PR DESCRIPTION
**Description**

Directional Light Helper, Spot Light Helper and Hemisphere Light Helper didn't have types,

So they inherited their parent's type "Object3D",

which isn't consistent with all the other helpers like Point Light Helper which has a type of "PointLightHelper".

This PR gives them their own types.
