### PR TITLE
SimplifyModifier: Add check if face are not undefined.

### DIFF
--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -342,7 +342,7 @@ function collapse( vertices, faces, u, v ) { // u and v are pointers to vertices
 	// delete triangles on edge uv:
 	for ( let i = u.faces.length - 1; i >= 0; i -- ) {
 
-		if ( u.faces[ i ].hasVertex( v ) ) {
+		if ( u.faces[ i ] && u.faces[ i ].hasVertex( v ) ) {
 
 			removeFace( u.faces[ i ], faces );
 


### PR DESCRIPTION
add check if face are not undefined

check with u.faces[i]

**Description**

add condition for undefined for loop

Now I’m making code for web 3d world viewer. I want to make lod system for my world and for that, I have to use simplify modifier for this.

Anyway, when I use simplify modifier to simplify gltf model it shows error with this

```
SimplifyModifier.js:293 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'hasVertex')
    at collapse (SimplifyModifier.js:293:1)
    at SimplifyModifier.modify (SimplifyModifier.js:99:1)
```
I spend lot of time to search about it, but I can’t find the hint

So I console log it to find out what happen to simplify modifier and I think this might be reason.


I console log this loop

```
  for (let i = u.faces.length - 1; i >= 0; i--) {
    console.log(u, i);
    if (u.faces[i].hasVertex(v)) {
      removeFace(u.faces[i], faces);
    }
  }
```
I found that when removeFace function run, it sometimes remove two faces at one loop. As you can see in picture above, first length of u.faces.length = 8, and value i = 7, at second loop u.faces.length = 6, and value i = 6 this cause error.

Is it okay with just add `if (!u.faces[i]) continue; `in for loop?
it seems running but I think it work not propery.






*This contribution is funded by [forum](https://discourse.threejs.org/t/webgl-modifier-simplifier-error/38100/10)*
