### PR TITLE
SplitNode: Fix unecessary swizzle

### DIFF
--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -1,6 +1,8 @@
 import Node from '../core/Node.js';
 import { vector } from '../core/NodeBuilder.js';
 
+const vectorComponents = 'xyzw';
+
 class SplitNode extends Node {
 
 	constructor( node, components = 'x' ) {
@@ -32,10 +34,12 @@ class SplitNode extends Node {
 
 	}
 
-	generate( builder ) {
+	generate( builder, output ) {
 
 		const node = this.node;
 		const nodeTypeLength = builder.getTypeLength( node.getNodeType( builder ) );
+
+		let snippet = null;
 
 		if ( nodeTypeLength > 1 ) {
 
@@ -45,7 +49,7 @@ class SplitNode extends Node {
 
 			if ( componentsLength >= nodeTypeLength ) {
 
-				// need expand the input node
+				// needed expand the input node
 
 				type = builder.getTypeFromLength( this.getVectorLength() );
 
@@ -53,15 +57,27 @@ class SplitNode extends Node {
 
 			const nodeSnippet = node.build( builder, type );
 
-			return `${nodeSnippet}.${this.components}`;
+			if ( this.components.length === nodeTypeLength && this.components === vectorComponents.substr( 0, this.components.length ) ) {
+
+				// unecessary swizzle
+
+				snippet = builder.format( nodeSnippet, type, output );
+
+			} else {
+
+				snippet = builder.format( `${nodeSnippet}.${this.components}`, this.getNodeType( builder ), output );
+
+			}
 
 		} else {
 
-			// ignore components if node is a float
+			// ignore .components if .node returns float/integer
 
-			return node.build( builder );
+			snippet = node.build( builder, output );
 
 		}
+
+		return snippet;
 
 	}
 

--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -57,7 +57,7 @@ class SplitNode extends Node {
 
 			const nodeSnippet = node.build( builder, type );
 
-			if ( this.components.length === nodeTypeLength && this.components === vectorComponents.substr( 0, this.components.length ) ) {
+			if ( this.components.length === nodeTypeLength && this.components === vectorComponents.slice( 0, this.components.length ) ) {
 
 				// unecessary swizzle
 


### PR DESCRIPTION
**Description**

The idea is to force the optimization in case the user sets this unnecessarily.

`After`: 
.. `nodeVary3.xyz.xyz` ..
```js
// FLOW -> TransformedNormalView
nodeVar7 = cross( dpdy( nodeVary3.xyz.xyz ), normalize( nodeVary4 ) );
nodeVar8 = dpdx( nodeVary1.xy );
nodeVar9 = cross( normalize( nodeVary4 ), dpdx( nodeVary3.xyz.xyz ) );
nodeVar10 = dpdy( nodeVary1.xy );
...
```

`Before`:
.. `nodeVary3.xyz` ..
```js
// FLOW -> TransformedNormalView
nodeVar7 = cross( dpdy( nodeVary3.xyz ), normalize( nodeVary4 ) );
nodeVar8 = dpdx( nodeVary1 );
nodeVar9 = cross( normalize( nodeVary4 ), dpdx( nodeVary3.xyz ) );
nodeVar10 = dpdy( nodeVary1 );
...
```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://example.com)*
