### PR TITLE
Vector*: Add toJSON() methods.

### DIFF
--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -434,6 +434,12 @@ class Vector2 {
 
 	}
 
+	toJSON() {
+
+		return { x: this.x, y: this.y };
+
+	}
+
 	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -696,6 +696,12 @@ class Vector3 {
 
 	}
 
+	toJSON() {
+
+		return { x: this.x, y: this.y, z: this.z };
+
+	}
+
 	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -622,6 +622,12 @@ class Vector4 {
 
 	}
 
+	toJSON() {
+
+		return { x: this.x, y: this.y, z: this.z, w: this.w };
+
+	}
+
 	fromBufferAttribute( attribute, index, offset ) {
 
 		if ( offset !== undefined ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24167#issuecomment-1144416382

**Description**

Adds a `toJSON()` method to all vector classes so the `is*` properties are not honored when the default JS serialization is used.
