### PR TITLE
Improve ShadowMesh.js and Prevent Shadow Overlap

### DIFF
--- a/examples/jsm/objects/ShadowMesh.js
+++ b/examples/jsm/objects/ShadowMesh.js
@@ -1,7 +1,9 @@
 import {
 	Matrix4,
 	Mesh,
-	MeshBasicMaterial
+	MeshBasicMaterial,
+	EqualStencilFunc,
+	IncrementStencilOp
 } from 'three';
 
 /**
@@ -19,7 +21,11 @@ class ShadowMesh extends Mesh {
 			color: 0x000000,
 			transparent: true,
 			opacity: 0.6,
-			depthWrite: false
+			depthWrite: false,
+			stencilWrite: true,
+            		stencilFunc: EqualStencilFunc,
+            		stencilRef: 0,
+            		stencilZPass: IncrementStencilOp
 
 		} );
 


### PR DESCRIPTION
A simple use of the stencil buffer can prevent ugly artifacts caused by the planar projected shadow of the geometry overlapping with itself.

No Stencil Buffer:
<img width="346" alt="Screen Shot 2022-06-02 at 1 06 14 PM" src="https://user-images.githubusercontent.com/43304488/171685249-bfcb3e51-fadd-4ee8-89a9-a4cd95951f98.png">

Stencil Buffer:

<img width="528" alt="Screen Shot 2022-06-02 at 1 06 36 PM" src="https://user-images.githubusercontent.com/43304488/171685306-31d91d77-ed83-48d5-ada9-467a07290557.png">

This change makes shadowmeshes a viable technique to use for games in which shadowing is simple and only desired for a few dynamic objects, at virtually no cost to the ease of use of the class.