### PR TITLE
Revert change to GLTFLoader introduced in #24181

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3197,7 +3197,9 @@ class GLTFParser {
 			if ( ! pointsMaterial ) {
 
 				pointsMaterial = new PointsMaterial();
-				pointsMaterial.copy( material );
+				Material.prototype.copy.call( pointsMaterial, material );
+				pointsMaterial.color.copy( material.color );
+				pointsMaterial.map = material.map;
 				pointsMaterial.sizeAttenuation = false; // glTF spec says points should be 1px
 
 				this.cache.add( cacheKey, pointsMaterial );
@@ -3215,7 +3217,8 @@ class GLTFParser {
 			if ( ! lineMaterial ) {
 
 				lineMaterial = new LineBasicMaterial();
-				lineMaterial.copy( material );
+				Material.prototype.copy.call( lineMaterial, material );
+				lineMaterial.color.copy( material.color );
 
 				this.cache.add( cacheKey, lineMaterial );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24181#discussion_r889018955

**Description**

Revert the change to GLTFLoader introduced in https://github.com/mrdoob/three.js/pull/24181.