### PR TITLE
Update Fiddle link to match other translations

### DIFF
--- a/docs/manual/ja/introduction/How-to-update-things.html
+++ b/docs/manual/ja/introduction/How-to-update-things.html
@@ -115,7 +115,7 @@ line.geometry.computeBoundingSphere();
 			</code>
 
         <p>
-            [link:http://jsfiddle.net/w67tzfhx/ Here is a fiddle] showing an animated line which you can adapt to your use case. ここ([link:http://jsfiddle.net/w67tzfhx/ link])では、あなたのユースケースに合わせることができるアニメーションを表示しています。
+            [link:https://jsfiddle.net/xvnctbL0/2/ Here is a fiddle] showing an animated line which you can adapt to your use case. ここ([link:https://jsfiddle.net/xvnctbL0/2/ link])では、あなたのユースケースに合わせることができるアニメーションを表示しています。
         </p>
 
         <h3>Examples</h3>


### PR DESCRIPTION
This pull request updates a link in the Japanese docs `docs/manual/ja/introduction/How-to-update-things.html` to be consistent with the other translations.

More importantly, the linked [Fiddle](https://jsfiddle.net/xvnctbL0/2/) in all translations contains the old addAttributes at `line 46` (causing an error) and should be updated to setAttributes for the example code to function.
I can open a separate issue for this fix request if necessary.

**To Reproduce**

1. Go to [https://jsfiddle.net/xvnctbL0/2/](url) 
2. See error on line 46 `geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );`

**Fix**
The code on `line 46` of the Fiddle can be updated to: 
```js
geometry.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
```
