### PR TITLE
Remove `.is` checks in UniformUtils

### DIFF
--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -14,10 +14,7 @@ export function cloneUniforms( src ) {
 
 			const property = src[ u ][ p ];
 
-			if ( property && ( property.isColor ||
-				property.isMatrix3 || property.isMatrix4 ||
-				property.isVector2 || property.isVector3 || property.isVector4 ||
-				property.isTexture || property.isQuaternion ) ) {
+			if ( property && property.clone !== undefined ) {
 
 				dst[ u ][ p ] = property.clone();
 

--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -18,7 +18,7 @@ export function cloneUniforms( src ) {
 
 				dst[ u ][ p ] = property.clone();
 
-			} else if ( Array.isArray( property ) ) {
+			} else if ( property && property.slice !== undefined ) {
 
 				dst[ u ][ p ] = property.slice();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24199#issuecomment-1148978716

**Description**

Remove `.is` checks in the UniformUtils, instead use "check by method" (duck typing).