### PR TITLE
Pure annotations house cleaning

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -10,18 +10,18 @@ const _wordCharOrDot = '[^' + _RESERVED_CHARS_RE.replace( '\\.', '' ) + ']';
 
 // Parent directories, delimited by '/' or ':'. Currently unused, but must
 // be matched to parse the rest of the track name.
-const _directoryRe = /((?:WC+[\/:])*)/.source.replace( 'WC', _wordChar );
+const _directoryRe = /*@__PURE__*/ /((?:WC+[\/:])*)/.source.replace( 'WC', _wordChar );
 
 // Target node. May contain word characters (a-zA-Z0-9_) and '.' or '-'.
-const _nodeRe = /(WCOD+)?/.source.replace( 'WCOD', _wordCharOrDot );
+const _nodeRe = /*@__PURE__*/ /(WCOD+)?/.source.replace( 'WCOD', _wordCharOrDot );
 
 // Object on target node, and accessor. May not contain reserved
 // characters. Accessor may contain any character except closing bracket.
-const _objectRe = /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', _wordChar );
+const _objectRe = /*@__PURE__*/ /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', _wordChar );
 
 // Property and accessor. May not contain reserved characters. Accessor may
 // contain any non-bracket characters.
-const _propertyRe = /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', _wordChar );
+const _propertyRe = /*@__PURE__*/ /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', _wordChar );
 
 const _trackRe = new RegExp( ''
 	+ '^'

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -921,7 +921,7 @@ class Object3D extends EventDispatcher {
 
 }
 
-Object3D.DefaultUp = new Vector3( 0, 1, 0 );
+Object3D.DefaultUp = /*@__PURE__*/ new Vector3( 0, 1, 0 );
 Object3D.DefaultMatrixAutoUpdate = true;
 
 export { Object3D };

--- a/src/extras/core/Path.js
+++ b/src/extras/core/Path.js
@@ -11,6 +11,7 @@ class Path extends CurvePath {
 	constructor( points ) {
 
 		super();
+
 		this.type = 'Path';
 
 		this.currentPoint = new Vector2();

--- a/src/extras/curves/CatmullRomCurve3.js
+++ b/src/extras/curves/CatmullRomCurve3.js
@@ -78,8 +78,8 @@ function CubicPoly() {
 
 //
 
-const tmp = new Vector3();
-const px = new CubicPoly(), py = new CubicPoly(), pz = new CubicPoly();
+const tmp = /*@__PURE__*/ new Vector3();
+const px = /*@__PURE__*/ new CubicPoly(), /*@__PURE__*/ py = new CubicPoly(), /*@__PURE__*/ pz = new CubicPoly();
 
 class CatmullRomCurve3 extends Curve {
 

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -4,10 +4,10 @@ import * as MathUtils from '../math/MathUtils.js';
 import { Triangle } from '../math/Triangle.js';
 import { Vector3 } from '../math/Vector3.js';
 
-const _v0 = new Vector3();
-const _v1 = new Vector3();
-const _normal = new Vector3();
-const _triangle = new Triangle();
+const _v0 = /*@__PURE__*/ new Vector3();
+const _v1 = /*@__PURE__*/ new Vector3();
+const _normal = /*@__PURE__*/ new Vector3();
+const _triangle = /*@__PURE__*/ new Triangle();
 
 class EdgesGeometry extends BufferGeometry {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1,4 +1,5 @@
 import { Vector3 } from './Vector3.js';
+
 class Matrix4 {
 
 	constructor() {

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -1,5 +1,6 @@
 import * as MathUtils from './MathUtils.js';
 import { Quaternion } from './Quaternion.js';
+
 class Vector3 {
 
 	constructor( x = 0, y = 0, z = 0 ) {

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -46,10 +46,10 @@ import { Texture } from '../../textures/Texture.js';
 import { DataArrayTexture } from '../../textures/DataArrayTexture.js';
 import { Data3DTexture } from '../../textures/Data3DTexture.js';
 
-const emptyTexture = new Texture();
-const emptyArrayTexture = new DataArrayTexture();
-const empty3dTexture = new Data3DTexture();
-const emptyCubeTexture = new CubeTexture();
+const emptyTexture = /*@__PURE__*/ new Texture();
+const emptyArrayTexture = /*@__PURE__*/ new DataArrayTexture();
+const empty3dTexture = /*@__PURE__*/ new Data3DTexture();
+const emptyCubeTexture = /*@__PURE__*/ new CubeTexture();
 
 // --- Utilities ---
 


### PR DESCRIPTION
Related issue: mrdoob/three.js#24199

Troubleshooting the remaining side-effects, I removed all the `/*@__PURE__*/` annotations and then manually re-added them all to compare the differences.

Note that pure annotations only have an effect when placed in front of call expressions, as [noted](https://twitter.com/lukastaegert/status/1523700165772677123) by Lukas. 😉