### PR TITLE
WebGLNodeBuilder: Fix native `renderer.toneMapping` usage

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -64,7 +64,8 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 	_parseObject() {
 
-		const material = this.material;
+		const { material, renderer } = this;
+
 		let type = material.type;
 
 		// shader lib
@@ -85,7 +86,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 		}
 
-		if ( material.isMeshStandardNodeMaterial !== true ) {
+		if ( renderer.toneMappingNode?.isNode === true ) {
 
 			this.replaceCode( 'fragment', getIncludeSnippet( 'tonemapping_fragment' ), '' );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24204

**Description**

Fix native `renderer.toneMapping` if `renderer.toneMappingNode` is not being used.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Googie via Igalia](https://igalia.com)*
