### PR TITLE
USDZExporter: Log warning when material.side === THREE.DoubleSide

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -407,6 +407,13 @@ function buildMaterial( material, textures ) {
 
 	}
 
+
+	if ( material.side === THREE.DoubleSide ) {
+
+		console.warn( 'THREE.USDZExporter: USDZ does not support double sided materials', material );
+
+	}
+
 	if ( material.map !== null ) {
 
 		inputs.push( `${ pad }color3f inputs:diffuseColor.connect = </Materials/Material_${ material.id }/Texture_${ material.map.id }_diffuse.outputs:rgb>` );


### PR DESCRIPTION
Related issue: https://github.com/google/model-viewer/issues/3516