### PR TITLE
Tree-shaking: DataUtils

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -148,7 +148,7 @@ export { Path } from './extras/core/Path.js';
 export { ShapePath } from './extras/core/ShapePath.js';
 export { CurvePath } from './extras/core/CurvePath.js';
 export { Curve } from './extras/core/Curve.js';
-export { DataUtils } from './extras/DataUtils.js';
+export * as DataUtils from './extras/DataUtils.js';
 export { ImageUtils } from './extras/ImageUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
 export { PMREMGenerator } from './extras/PMREMGenerator.js';

--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -8,14 +8,16 @@ class DataUtils {
 
 	static toHalfFloat( val ) {
 
+		if ( ! this._floatView ) this._generateTables();
+
 		if ( Math.abs( val ) > 65504 ) console.warn( 'THREE.DataUtils.toHalfFloat(): Value out of range.' );
 
 		val = clamp( val, - 65504, 65504 );
 
-		_floatView[ 0 ] = val;
-		const f = _uint32View[ 0 ];
+		this._floatView[ 0 ] = val;
+		const f = this._uint32View[ 0 ];
 		const e = ( f >> 23 ) & 0x1ff;
-		return _baseTable[ e ] + ( ( f & 0x007fffff ) >> _shiftTable[ e ] );
+		return this._baseTable[ e ] + ( ( f & 0x007fffff ) >> this._shiftTable[ e ] );
 
 	}
 
@@ -23,129 +25,137 @@ class DataUtils {
 
 	static fromHalfFloat( val ) {
 
+		if ( ! this._floatView ) this._generateTables();
+
 		const m = val >> 10;
-		_uint32View[ 0 ] = _mantissaTable[ _offsetTable[ m ] + ( val & 0x3ff ) ] + _exponentTable[ m ];
-		return _floatView[ 0 ];
+		this._uint32View[ 0 ] = this._mantissaTable[ this._offsetTable[ m ] + ( val & 0x3ff ) ] + this._exponentTable[ m ];
+		return this._floatView[ 0 ];
 
 	}
 
-}
+	static _generateTables() {
 
-// float32 to float16 helpers
+		// float32 to float16 helpers
 
-const _buffer = new ArrayBuffer( 4 );
-const _floatView = new Float32Array( _buffer );
-const _uint32View = new Uint32Array( _buffer );
+		const _buffer = new ArrayBuffer( 4 );
 
-const _baseTable = new Uint32Array( 512 );
-const _shiftTable = new Uint32Array( 512 );
+		this._floatView = new Float32Array( _buffer );
+		this._uint32View = new Uint32Array( _buffer );
 
-for ( let i = 0; i < 256; ++ i ) {
+		this._baseTable = new Uint32Array( 512 );
+		this._shiftTable = new Uint32Array( 512 );
 
-	const e = i - 127;
+		for ( let i = 0; i < 256; ++ i ) {
 
-	// very small number (0, -0)
+			const e = i - 127;
 
-	if ( e < - 27 ) {
+			// very small number (0, -0)
 
-		_baseTable[ i ] = 0x0000;
-		_baseTable[ i | 0x100 ] = 0x8000;
-		_shiftTable[ i ] = 24;
-		_shiftTable[ i | 0x100 ] = 24;
+			if ( e < - 27 ) {
 
-		// small number (denorm)
+				this._baseTable[ i ] = 0x0000;
+				this._baseTable[ i | 0x100 ] = 0x8000;
+				this._shiftTable[ i ] = 24;
+				this._shiftTable[ i | 0x100 ] = 24;
 
-	} else if ( e < - 14 ) {
+				// small number (denorm)
 
-		_baseTable[ i ] = 0x0400 >> ( - e - 14 );
-		_baseTable[ i | 0x100 ] = ( 0x0400 >> ( - e - 14 ) ) | 0x8000;
-		_shiftTable[ i ] = - e - 1;
-		_shiftTable[ i | 0x100 ] = - e - 1;
+			} else if ( e < - 14 ) {
 
-		// normal number
+				this._baseTable[ i ] = 0x0400 >> ( - e - 14 );
+				this._baseTable[ i | 0x100 ] = ( 0x0400 >> ( - e - 14 ) ) | 0x8000;
+				this._shiftTable[ i ] = - e - 1;
+				this._shiftTable[ i | 0x100 ] = - e - 1;
 
-	} else if ( e <= 15 ) {
+				// normal number
 
-		_baseTable[ i ] = ( e + 15 ) << 10;
-		_baseTable[ i | 0x100 ] = ( ( e + 15 ) << 10 ) | 0x8000;
-		_shiftTable[ i ] = 13;
-		_shiftTable[ i | 0x100 ] = 13;
+			} else if ( e <= 15 ) {
 
-		// large number (Infinity, -Infinity)
+				this._baseTable[ i ] = ( e + 15 ) << 10;
+				this._baseTable[ i | 0x100 ] = ( ( e + 15 ) << 10 ) | 0x8000;
+				this._shiftTable[ i ] = 13;
+				this._shiftTable[ i | 0x100 ] = 13;
 
-	} else if ( e < 128 ) {
+				// large number (Infinity, -Infinity)
 
-		_baseTable[ i ] = 0x7c00;
-		_baseTable[ i | 0x100 ] = 0xfc00;
-		_shiftTable[ i ] = 24;
-		_shiftTable[ i | 0x100 ] = 24;
+			} else if ( e < 128 ) {
 
-		// stay (NaN, Infinity, -Infinity)
+				this._baseTable[ i ] = 0x7c00;
+				this._baseTable[ i | 0x100 ] = 0xfc00;
+				this._shiftTable[ i ] = 24;
+				this._shiftTable[ i | 0x100 ] = 24;
 
-	} else {
+				// stay (NaN, Infinity, -Infinity)
 
-		_baseTable[ i ] = 0x7c00;
-		_baseTable[ i | 0x100 ] = 0xfc00;
-		_shiftTable[ i ] = 13;
-		_shiftTable[ i | 0x100 ] = 13;
+			} else {
 
-	}
+				this._baseTable[ i ] = 0x7c00;
+				this._baseTable[ i | 0x100 ] = 0xfc00;
+				this._shiftTable[ i ] = 13;
+				this._shiftTable[ i | 0x100 ] = 13;
 
-}
+			}
 
-// float16 to float32 helpers
+		}
 
-const _mantissaTable = new Uint32Array( 2048 );
-const _exponentTable = new Uint32Array( 64 );
-const _offsetTable = new Uint32Array( 64 );
+		// float16 to float32 helpers
 
-for ( let i = 1; i < 1024; ++ i ) {
+		this._mantissaTable = new Uint32Array( 2048 );
+		this._exponentTable = new Uint32Array( 64 );
+		this._offsetTable = new Uint32Array( 64 );
 
-	let m = i << 13; // zero pad mantissa bits
-	let e = 0; // zero exponent
+		for ( let i = 1; i < 1024; ++ i ) {
 
-	// normalized
-	while ( ( m & 0x00800000 ) === 0 ) {
+			let m = i << 13; // zero pad mantissa bits
+			let e = 0; // zero exponent
 
-		m <<= 1;
-		e -= 0x00800000; // decrement exponent
+			// normalized
+			while ( ( m & 0x00800000 ) === 0 ) {
 
-	}
+				m <<= 1;
+				e -= 0x00800000; // decrement exponent
 
-	m &= ~ 0x00800000; // clear leading 1 bit
-	e += 0x38800000; // adjust bias
+			}
 
-	_mantissaTable[ i ] = m | e;
+			m &= ~ 0x00800000; // clear leading 1 bit
+			e += 0x38800000; // adjust bias
 
-}
+			this._mantissaTable[ i ] = m | e;
 
-for ( let i = 1024; i < 2048; ++ i ) {
+		}
 
-	_mantissaTable[ i ] = 0x38000000 + ( ( i - 1024 ) << 13 );
+		for ( let i = 1024; i < 2048; ++ i ) {
 
-}
+			this._mantissaTable[ i ] = 0x38000000 + ( ( i - 1024 ) << 13 );
 
-for ( let i = 1; i < 31; ++ i ) {
+		}
 
-	_exponentTable[ i ] = i << 23;
+		for ( let i = 1; i < 31; ++ i ) {
 
-}
+			this._exponentTable[ i ] = i << 23;
 
-_exponentTable[ 31 ] = 0x47800000;
-_exponentTable[ 32 ] = 0x80000000;
-for ( let i = 33; i < 63; ++ i ) {
+		}
 
-	_exponentTable[ i ] = 0x80000000 + ( ( i - 32 ) << 23 );
+		this._exponentTable[ 31 ] = 0x47800000;
+		this._exponentTable[ 32 ] = 0x80000000;
 
-}
+		for ( let i = 33; i < 63; ++ i ) {
 
-_exponentTable[ 63 ] = 0xc7800000;
+			this._exponentTable[ i ] = 0x80000000 + ( ( i - 32 ) << 23 );
 
-for ( let i = 1; i < 64; ++ i ) {
+		}
 
-	if ( i !== 32 ) {
+		this._exponentTable[ 63 ] = 0xc7800000;
 
-		_offsetTable[ i ] = 1024;
+		for ( let i = 1; i < 64; ++ i ) {
+
+			if ( i !== 32 ) {
+
+				this._offsetTable[ i ] = 1024;
+
+			}
+
+		}
 
 	}
 

--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -2,163 +2,177 @@ import { clamp } from '../math/MathUtils.js';
 
 // Fast Half Float Conversions, http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
 
-class DataUtils {
+const {
+	floatView: _floatView,
+	uint32View: _uint32View,
+	baseTable: _baseTable,
+	shiftTable: _shiftTable,
+	mantissaTable: _mantissaTable,
+	exponentTable: _exponentTable,
+	offsetTable: _offsetTable
+} = /*@__PURE__*/ _generateTables();
 
-	// float32 to float16
+function _generateTables() {
 
-	static toHalfFloat( val ) {
+	// float32 to float16 helpers
 
-		if ( ! this._floatView ) this._generateTables();
+	const buffer = new ArrayBuffer( 4 );
+	const floatView = new Float32Array( buffer );
+	const uint32View = new Uint32Array( buffer );
 
-		if ( Math.abs( val ) > 65504 ) console.warn( 'THREE.DataUtils.toHalfFloat(): Value out of range.' );
+	const baseTable = new Uint32Array( 512 );
+	const shiftTable = new Uint32Array( 512 );
 
-		val = clamp( val, - 65504, 65504 );
+	for ( let i = 0; i < 256; ++ i ) {
 
-		this._floatView[ 0 ] = val;
-		const f = this._uint32View[ 0 ];
-		const e = ( f >> 23 ) & 0x1ff;
-		return this._baseTable[ e ] + ( ( f & 0x007fffff ) >> this._shiftTable[ e ] );
+		const e = i - 127;
 
-	}
+		// very small number (0, -0)
 
-	// float16 to float32
+		if ( e < - 27 ) {
 
-	static fromHalfFloat( val ) {
+			baseTable[ i ] = 0x0000;
+			baseTable[ i | 0x100 ] = 0x8000;
+			shiftTable[ i ] = 24;
+			shiftTable[ i | 0x100 ] = 24;
 
-		if ( ! this._floatView ) this._generateTables();
+			// small number (denorm)
 
-		const m = val >> 10;
-		this._uint32View[ 0 ] = this._mantissaTable[ this._offsetTable[ m ] + ( val & 0x3ff ) ] + this._exponentTable[ m ];
-		return this._floatView[ 0 ];
+		} else if ( e < - 14 ) {
 
-	}
+			baseTable[ i ] = 0x0400 >> ( - e - 14 );
+			baseTable[ i | 0x100 ] = ( 0x0400 >> ( - e - 14 ) ) | 0x8000;
+			shiftTable[ i ] = - e - 1;
+			shiftTable[ i | 0x100 ] = - e - 1;
 
-	static _generateTables() {
+			// normal number
 
-		// float32 to float16 helpers
+		} else if ( e <= 15 ) {
 
-		const _buffer = new ArrayBuffer( 4 );
+			baseTable[ i ] = ( e + 15 ) << 10;
+			baseTable[ i | 0x100 ] = ( ( e + 15 ) << 10 ) | 0x8000;
+			shiftTable[ i ] = 13;
+			shiftTable[ i | 0x100 ] = 13;
 
-		this._floatView = new Float32Array( _buffer );
-		this._uint32View = new Uint32Array( _buffer );
+			// large number (Infinity, -Infinity)
 
-		this._baseTable = new Uint32Array( 512 );
-		this._shiftTable = new Uint32Array( 512 );
+		} else if ( e < 128 ) {
 
-		for ( let i = 0; i < 256; ++ i ) {
+			baseTable[ i ] = 0x7c00;
+			baseTable[ i | 0x100 ] = 0xfc00;
+			shiftTable[ i ] = 24;
+			shiftTable[ i | 0x100 ] = 24;
 
-			const e = i - 127;
+			// stay (NaN, Infinity, -Infinity)
 
-			// very small number (0, -0)
+		} else {
 
-			if ( e < - 27 ) {
-
-				this._baseTable[ i ] = 0x0000;
-				this._baseTable[ i | 0x100 ] = 0x8000;
-				this._shiftTable[ i ] = 24;
-				this._shiftTable[ i | 0x100 ] = 24;
-
-				// small number (denorm)
-
-			} else if ( e < - 14 ) {
-
-				this._baseTable[ i ] = 0x0400 >> ( - e - 14 );
-				this._baseTable[ i | 0x100 ] = ( 0x0400 >> ( - e - 14 ) ) | 0x8000;
-				this._shiftTable[ i ] = - e - 1;
-				this._shiftTable[ i | 0x100 ] = - e - 1;
-
-				// normal number
-
-			} else if ( e <= 15 ) {
-
-				this._baseTable[ i ] = ( e + 15 ) << 10;
-				this._baseTable[ i | 0x100 ] = ( ( e + 15 ) << 10 ) | 0x8000;
-				this._shiftTable[ i ] = 13;
-				this._shiftTable[ i | 0x100 ] = 13;
-
-				// large number (Infinity, -Infinity)
-
-			} else if ( e < 128 ) {
-
-				this._baseTable[ i ] = 0x7c00;
-				this._baseTable[ i | 0x100 ] = 0xfc00;
-				this._shiftTable[ i ] = 24;
-				this._shiftTable[ i | 0x100 ] = 24;
-
-				// stay (NaN, Infinity, -Infinity)
-
-			} else {
-
-				this._baseTable[ i ] = 0x7c00;
-				this._baseTable[ i | 0x100 ] = 0xfc00;
-				this._shiftTable[ i ] = 13;
-				this._shiftTable[ i | 0x100 ] = 13;
-
-			}
-
-		}
-
-		// float16 to float32 helpers
-
-		this._mantissaTable = new Uint32Array( 2048 );
-		this._exponentTable = new Uint32Array( 64 );
-		this._offsetTable = new Uint32Array( 64 );
-
-		for ( let i = 1; i < 1024; ++ i ) {
-
-			let m = i << 13; // zero pad mantissa bits
-			let e = 0; // zero exponent
-
-			// normalized
-			while ( ( m & 0x00800000 ) === 0 ) {
-
-				m <<= 1;
-				e -= 0x00800000; // decrement exponent
-
-			}
-
-			m &= ~ 0x00800000; // clear leading 1 bit
-			e += 0x38800000; // adjust bias
-
-			this._mantissaTable[ i ] = m | e;
-
-		}
-
-		for ( let i = 1024; i < 2048; ++ i ) {
-
-			this._mantissaTable[ i ] = 0x38000000 + ( ( i - 1024 ) << 13 );
-
-		}
-
-		for ( let i = 1; i < 31; ++ i ) {
-
-			this._exponentTable[ i ] = i << 23;
-
-		}
-
-		this._exponentTable[ 31 ] = 0x47800000;
-		this._exponentTable[ 32 ] = 0x80000000;
-
-		for ( let i = 33; i < 63; ++ i ) {
-
-			this._exponentTable[ i ] = 0x80000000 + ( ( i - 32 ) << 23 );
-
-		}
-
-		this._exponentTable[ 63 ] = 0xc7800000;
-
-		for ( let i = 1; i < 64; ++ i ) {
-
-			if ( i !== 32 ) {
-
-				this._offsetTable[ i ] = 1024;
-
-			}
+			baseTable[ i ] = 0x7c00;
+			baseTable[ i | 0x100 ] = 0xfc00;
+			shiftTable[ i ] = 13;
+			shiftTable[ i | 0x100 ] = 13;
 
 		}
 
 	}
+
+	// float16 to float32 helpers
+
+	const mantissaTable = new Uint32Array( 2048 );
+	const exponentTable = new Uint32Array( 64 );
+	const offsetTable = new Uint32Array( 64 );
+
+	for ( let i = 1; i < 1024; ++ i ) {
+
+		let m = i << 13; // zero pad mantissa bits
+		let e = 0; // zero exponent
+
+		// normalized
+		while ( ( m & 0x00800000 ) === 0 ) {
+
+			m <<= 1;
+			e -= 0x00800000; // decrement exponent
+
+		}
+
+		m &= ~ 0x00800000; // clear leading 1 bit
+		e += 0x38800000; // adjust bias
+
+		mantissaTable[ i ] = m | e;
+
+	}
+
+	for ( let i = 1024; i < 2048; ++ i ) {
+
+		mantissaTable[ i ] = 0x38000000 + ( ( i - 1024 ) << 13 );
+
+	}
+
+	for ( let i = 1; i < 31; ++ i ) {
+
+		exponentTable[ i ] = i << 23;
+
+	}
+
+	exponentTable[ 31 ] = 0x47800000;
+	exponentTable[ 32 ] = 0x80000000;
+
+	for ( let i = 33; i < 63; ++ i ) {
+
+		exponentTable[ i ] = 0x80000000 + ( ( i - 32 ) << 23 );
+
+	}
+
+	exponentTable[ 63 ] = 0xc7800000;
+
+	for ( let i = 1; i < 64; ++ i ) {
+
+		if ( i !== 32 ) {
+
+			offsetTable[ i ] = 1024;
+
+		}
+
+	}
+
+	return {
+		floatView: floatView,
+		uint32View: uint32View,
+		baseTable: baseTable,
+		shiftTable: shiftTable,
+		mantissaTable: mantissaTable,
+		exponentTable: exponentTable,
+		offsetTable: offsetTable,
+	};
 
 }
 
-export { DataUtils };
+// float32 to float16
+
+function toHalfFloat( val ) {
+
+	if ( Math.abs( val ) > 65504 ) console.warn( 'THREE.DataUtils.toHalfFloat(): Value out of range.' );
+
+	val = clamp( val, - 65504, 65504 );
+
+	_floatView[ 0 ] = val;
+	const f = _uint32View[ 0 ];
+	const e = ( f >> 23 ) & 0x1ff;
+	return _baseTable[ e ] + ( ( f & 0x007fffff ) >> _shiftTable[ e ] );
+
+}
+
+// float16 to float32
+
+function fromHalfFloat( val ) {
+
+	const m = val >> 10;
+	_uint32View[ 0 ] = _mantissaTable[ _offsetTable[ m ] + ( val & 0x3ff ) ] + _exponentTable[ m ];
+	return _floatView[ 0 ];
+
+}
+
+export {
+	toHalfFloat,
+	fromHalfFloat,
+};

--- a/test/unit/src/extras/DataUtils.tests.js
+++ b/test/unit/src/extras/DataUtils.tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 
-import { DataUtils } from '../../../../src/extras/DataUtils.js';
+import * as DataUtils from '../../../../src/extras/DataUtils.js';
 
 export default QUnit.module( 'Extras', () => {
 


### PR DESCRIPTION
Related issue: #24199

Troubleshooting the remaining side-effects, converted `DataUtils` to a ~singleton~ plain functions pattern to allow for tree-shaking, linted and tested with the `rectarealight` example.