### PR TITLE
Core: make Vector and Matrix .is* property non-enumerable

### DIFF
--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -2,7 +2,7 @@ class Matrix3 {
 
 	constructor() {
 
-		this.isMatrix3 = true;
+		Matrix3.prototype.isMatrix3 = true;
 
 		this.elements = [
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -4,7 +4,7 @@ class Matrix4 {
 
 	constructor() {
 
-		this.isMatrix4 = true;
+		Matrix4.prototype.isMatrix4 = true;
 
 		this.elements = [
 

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -2,7 +2,7 @@ class Vector2 {
 
 	constructor( x = 0, y = 0 ) {
 
-		this.isVector2 = true;
+		Vector2.prototype.isVector2 = true;
 
 		this.x = x;
 		this.y = y;

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -5,7 +5,7 @@ class Vector3 {
 
 	constructor( x = 0, y = 0, z = 0 ) {
 
-		this.isVector3 = true;
+		Vector3.prototype.isVector3 = true;
 
 		this.x = x;
 		this.y = y;

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -2,7 +2,7 @@ class Vector4 {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
 
-		this.isVector4 = true;
+		Vector4.prototype.isVector4 = true;
 
 		this.x = x;
 		this.y = y;

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -301,9 +301,11 @@ export default QUnit.module( 'Core', () => {
 			obj.translateOnAxis( new Vector3( 0, 1, 0 ), 1.23 );
 			obj.translateOnAxis( new Vector3( 0, 0, 1 ), - 4.56 );
 
-			assert.numEqual( obj.position.x, 1, 'x is equal' );
-			assert.numEqual( obj.position.y, 1.23, 'y is equal' );
-			assert.numEqual( obj.position.z, - 4.56, 'z is equal' );
+			assert.propEqual( obj.position, {
+				x: 1,
+				y: 1.23,
+				z: - 4.56,
+			} );
 
 		} );
 


### PR DESCRIPTION
Related issue: Fixes #24167 as proposed by https://github.com/mrdoob/three.js/issues/24167#issuecomment-1148980263

**Description**

Since we decided not to support `.toJSON()` for Vector and Matrix classes (#24172), let's support the JSON.stringify() serialization.

Setting the prototype in the constructor allows for tree-shaking and makes the `.isVector3` property non-enumerable, so it doesn't show up in the JSON.stringify().

This does not make a breaking change as opposed to the `instanceof` method 😬