### PR TITLE
Tree-shaking: ShaderLib and UniformsLib

### DIFF
--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -6,9 +6,9 @@ import { UniformsLib } from './UniformsLib.js';
 import { Color } from '../../math/Color.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 
-class ShaderLib {
+const ShaderLib = {
 
-	static basic = {
+	basic: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -22,9 +22,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshbasic_vert,
 		fragmentShader: ShaderChunk.meshbasic_frag
 
-	};
+	},
 
-	static lambert = {
+	lambert: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -43,9 +43,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshlambert_vert,
 		fragmentShader: ShaderChunk.meshlambert_frag
 
-	};
+	},
 
-	static phong = {
+	phong: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -69,9 +69,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshphong_vert,
 		fragmentShader: ShaderChunk.meshphong_frag
 
-	};
+	},
 
-	static standard = {
+	standard: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -97,51 +97,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshphysical_vert,
 		fragmentShader: ShaderChunk.meshphysical_frag
 
-	};
+	},
 
-	static physical = {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
-			this.standard.uniforms,
-			{
-				clearcoat: { value: 0 },
-				clearcoatMap: { value: null },
-				clearcoatRoughness: { value: 0 },
-				clearcoatRoughnessMap: { value: null },
-				clearcoatNormalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) },
-				clearcoatNormalMap: { value: null },
-				iridescence: { value: 0 },
-				iridescenceMap: { value: null },
-				iridescenceIOR: { value: 1.3 },
-				iridescenceThicknessMinimum: { value: 100 },
-				iridescenceThicknessMaximum: { value: 400 },
-				iridescenceThicknessMap: { value: null },
-				sheen: { value: 0 },
-				sheenColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
-				sheenColorMap: { value: null },
-				sheenRoughness: { value: 1 },
-				sheenRoughnessMap: { value: null },
-				transmission: { value: 0 },
-				transmissionMap: { value: null },
-				transmissionSamplerSize: { value: /*@__PURE__*/ new Vector2() },
-				transmissionSamplerMap: { value: null },
-				thickness: { value: 0 },
-				thicknessMap: { value: null },
-				attenuationDistance: { value: 0 },
-				attenuationColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
-				specularIntensity: { value: 1 },
-				specularIntensityMap: { value: null },
-				specularColor: { value: /*@__PURE__*/ new Color( 1, 1, 1 ) },
-				specularColorMap: { value: null },
-			}
-		] ),
-
-		vertexShader: ShaderChunk.meshphysical_vert,
-		fragmentShader: ShaderChunk.meshphysical_frag
-
-	};
-
-	static toon = {
+	toon: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -162,9 +120,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshtoon_vert,
 		fragmentShader: ShaderChunk.meshtoon_frag
 
-	};
+	},
 
-	static matcap = {
+	matcap: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -180,9 +138,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshmatcap_vert,
 		fragmentShader: ShaderChunk.meshmatcap_frag
 
-	};
+	},
 
-	static points = {
+	points: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.points,
@@ -192,9 +150,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.points_vert,
 		fragmentShader: ShaderChunk.points_frag
 
-	};
+	},
 
-	static dashed = {
+	dashed: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -209,9 +167,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.linedashed_vert,
 		fragmentShader: ShaderChunk.linedashed_frag
 
-	};
+	},
 
-	static depth = {
+	depth: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -221,9 +179,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.depth_vert,
 		fragmentShader: ShaderChunk.depth_frag
 
-	};
+	},
 
-	static normal = {
+	normal: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -238,9 +196,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.meshnormal_vert,
 		fragmentShader: ShaderChunk.meshnormal_frag
 
-	};
+	},
 
-	static sprite = {
+	sprite: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.sprite,
@@ -250,9 +208,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.sprite_vert,
 		fragmentShader: ShaderChunk.sprite_frag
 
-	};
+	},
 
-	static background = {
+	background: {
 
 		uniforms: {
 			uvTransform: { value: /*@__PURE__*/ new Matrix3() },
@@ -262,9 +220,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.background_vert,
 		fragmentShader: ShaderChunk.background_frag
 
-	};
+	},
 
-	static cube = {
+	cube: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.envmap,
@@ -276,9 +234,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.cube_vert,
 		fragmentShader: ShaderChunk.cube_frag
 
-	};
+	},
 
-	static equirect = {
+	equirect: {
 
 		uniforms: {
 			tEquirect: { value: null },
@@ -287,9 +245,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.equirect_vert,
 		fragmentShader: ShaderChunk.equirect_frag
 
-	};
+	},
 
-	static distanceRGBA = {
+	distanceRGBA: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
@@ -304,9 +262,9 @@ class ShaderLib {
 		vertexShader: ShaderChunk.distanceRGBA_vert,
 		fragmentShader: ShaderChunk.distanceRGBA_frag
 
-	};
+	},
 
-	static shadow = {
+	shadow: {
 
 		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.lights,
@@ -320,8 +278,51 @@ class ShaderLib {
 		vertexShader: ShaderChunk.shadow_vert,
 		fragmentShader: ShaderChunk.shadow_frag
 
-	};
+	}
 
-}
+};
+
+ShaderLib.physical = {
+
+	uniforms: /*@__PURE__*/ mergeUniforms( [
+		ShaderLib.standard.uniforms,
+		{
+			clearcoat: { value: 0 },
+			clearcoatMap: { value: null },
+			clearcoatRoughness: { value: 0 },
+			clearcoatRoughnessMap: { value: null },
+			clearcoatNormalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) },
+			clearcoatNormalMap: { value: null },
+			iridescence: { value: 0 },
+			iridescenceMap: { value: null },
+			iridescenceIOR: { value: 1.3 },
+			iridescenceThicknessMinimum: { value: 100 },
+			iridescenceThicknessMaximum: { value: 400 },
+			iridescenceThicknessMap: { value: null },
+			sheen: { value: 0 },
+			sheenColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
+			sheenColorMap: { value: null },
+			sheenRoughness: { value: 1 },
+			sheenRoughnessMap: { value: null },
+			transmission: { value: 0 },
+			transmissionMap: { value: null },
+			transmissionSamplerSize: { value: /*@__PURE__*/ new Vector2() },
+			transmissionSamplerMap: { value: null },
+			thickness: { value: 0 },
+			thicknessMap: { value: null },
+			attenuationDistance: { value: 0 },
+			attenuationColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
+			specularIntensity: { value: 1 },
+			specularIntensityMap: { value: null },
+			specularColor: { value: /*@__PURE__*/ new Color( 1, 1, 1 ) },
+			specularColorMap: { value: null },
+		}
+	] ),
+
+	vertexShader: ShaderChunk.meshphysical_vert,
+	fragmentShader: ShaderChunk.meshphysical_frag
+
+};
+
 
 export { ShaderLib };

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -10,7 +10,7 @@ class ShaderLib {
 
 	static basic = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
@@ -26,7 +26,7 @@ class ShaderLib {
 
 	static lambert = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
@@ -36,7 +36,7 @@ class ShaderLib {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) }
+				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) }
 			}
 		] ),
 
@@ -47,7 +47,7 @@ class ShaderLib {
 
 	static phong = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
@@ -60,8 +60,8 @@ class ShaderLib {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) },
-				specular: { value: new Color( 0x111111 ) },
+				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) },
+				specular: { value: /*@__PURE__*/ new Color( 0x111111 ) },
 				shininess: { value: 30 }
 			}
 		] ),
@@ -73,7 +73,7 @@ class ShaderLib {
 
 	static standard = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.envmap,
 			UniformsLib.aomap,
@@ -87,7 +87,7 @@ class ShaderLib {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) },
+				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) },
 				roughness: { value: 1.0 },
 				metalness: { value: 0.0 },
 				envMapIntensity: { value: 1 } // temporary
@@ -101,14 +101,14 @@ class ShaderLib {
 
 	static physical = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			this.standard.uniforms,
 			{
 				clearcoat: { value: 0 },
 				clearcoatMap: { value: null },
 				clearcoatRoughness: { value: 0 },
 				clearcoatRoughnessMap: { value: null },
-				clearcoatNormalScale: { value: new Vector2( 1, 1 ) },
+				clearcoatNormalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) },
 				clearcoatNormalMap: { value: null },
 				iridescence: { value: 0 },
 				iridescenceMap: { value: null },
@@ -117,21 +117,21 @@ class ShaderLib {
 				iridescenceThicknessMaximum: { value: 400 },
 				iridescenceThicknessMap: { value: null },
 				sheen: { value: 0 },
-				sheenColor: { value: new Color( 0x000000 ) },
+				sheenColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
 				sheenColorMap: { value: null },
 				sheenRoughness: { value: 1 },
 				sheenRoughnessMap: { value: null },
 				transmission: { value: 0 },
 				transmissionMap: { value: null },
-				transmissionSamplerSize: { value: new Vector2() },
+				transmissionSamplerSize: { value: /*@__PURE__*/ new Vector2() },
 				transmissionSamplerMap: { value: null },
 				thickness: { value: 0 },
 				thicknessMap: { value: null },
 				attenuationDistance: { value: 0 },
-				attenuationColor: { value: new Color( 0x000000 ) },
+				attenuationColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
 				specularIntensity: { value: 1 },
 				specularIntensityMap: { value: null },
-				specularColor: { value: new Color( 1, 1, 1 ) },
+				specularColor: { value: /*@__PURE__*/ new Color( 1, 1, 1 ) },
 				specularColorMap: { value: null },
 			}
 		] ),
@@ -143,7 +143,7 @@ class ShaderLib {
 
 	static toon = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
@@ -155,7 +155,7 @@ class ShaderLib {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: new Color( 0x000000 ) }
+				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) }
 			}
 		] ),
 
@@ -166,7 +166,7 @@ class ShaderLib {
 
 	static matcap = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.bumpmap,
 			UniformsLib.normalmap,
@@ -184,7 +184,7 @@ class ShaderLib {
 
 	static points = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.points,
 			UniformsLib.fog
 		] ),
@@ -196,7 +196,7 @@ class ShaderLib {
 
 	static dashed = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.fog,
 			{
@@ -213,7 +213,7 @@ class ShaderLib {
 
 	static depth = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.displacementmap
 		] ),
@@ -225,7 +225,7 @@ class ShaderLib {
 
 	static normal = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.bumpmap,
 			UniformsLib.normalmap,
@@ -242,7 +242,7 @@ class ShaderLib {
 
 	static sprite = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.sprite,
 			UniformsLib.fog
 		] ),
@@ -255,7 +255,7 @@ class ShaderLib {
 	static background = {
 
 		uniforms: {
-			uvTransform: { value: new Matrix3() },
+			uvTransform: { value: /*@__PURE__*/ new Matrix3() },
 			t2D: { value: null },
 		},
 
@@ -266,7 +266,7 @@ class ShaderLib {
 
 	static cube = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.envmap,
 			{
 				opacity: { value: 1.0 }
@@ -291,11 +291,11 @@ class ShaderLib {
 
 	static distanceRGBA = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.common,
 			UniformsLib.displacementmap,
 			{
-				referencePosition: { value: new Vector3() },
+				referencePosition: { value: /*@__PURE__*/ new Vector3() },
 				nearDistance: { value: 1 },
 				farDistance: { value: 1000 }
 			}
@@ -308,11 +308,11 @@ class ShaderLib {
 
 	static shadow = {
 
-		uniforms: mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms( [
 			UniformsLib.lights,
 			UniformsLib.fog,
 			{
-				color: { value: new Color( 0x00000 ) },
+				color: { value: /*@__PURE__*/ new Color( 0x00000 ) },
 				opacity: { value: 1.0 }
 			},
 		] ),

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -6,9 +6,9 @@ import { UniformsLib } from './UniformsLib.js';
 import { Color } from '../../math/Color.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 
-const ShaderLib = {
+class ShaderLib {
 
-	basic: {
+	static basic = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -22,9 +22,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshbasic_vert,
 		fragmentShader: ShaderChunk.meshbasic_frag
 
-	},
+	};
 
-	lambert: {
+	static lambert = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -43,9 +43,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshlambert_vert,
 		fragmentShader: ShaderChunk.meshlambert_frag
 
-	},
+	};
 
-	phong: {
+	static phong = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -69,9 +69,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshphong_vert,
 		fragmentShader: ShaderChunk.meshphong_frag
 
-	},
+	};
 
-	standard: {
+	static standard = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -97,9 +97,51 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshphysical_vert,
 		fragmentShader: ShaderChunk.meshphysical_frag
 
-	},
+	};
 
-	toon: {
+	static physical = {
+
+		uniforms: mergeUniforms( [
+			this.standard.uniforms,
+			{
+				clearcoat: { value: 0 },
+				clearcoatMap: { value: null },
+				clearcoatRoughness: { value: 0 },
+				clearcoatRoughnessMap: { value: null },
+				clearcoatNormalScale: { value: new Vector2( 1, 1 ) },
+				clearcoatNormalMap: { value: null },
+				iridescence: { value: 0 },
+				iridescenceMap: { value: null },
+				iridescenceIOR: { value: 1.3 },
+				iridescenceThicknessMinimum: { value: 100 },
+				iridescenceThicknessMaximum: { value: 400 },
+				iridescenceThicknessMap: { value: null },
+				sheen: { value: 0 },
+				sheenColor: { value: new Color( 0x000000 ) },
+				sheenColorMap: { value: null },
+				sheenRoughness: { value: 1 },
+				sheenRoughnessMap: { value: null },
+				transmission: { value: 0 },
+				transmissionMap: { value: null },
+				transmissionSamplerSize: { value: new Vector2() },
+				transmissionSamplerMap: { value: null },
+				thickness: { value: 0 },
+				thicknessMap: { value: null },
+				attenuationDistance: { value: 0 },
+				attenuationColor: { value: new Color( 0x000000 ) },
+				specularIntensity: { value: 1 },
+				specularIntensityMap: { value: null },
+				specularColor: { value: new Color( 1, 1, 1 ) },
+				specularColorMap: { value: null },
+			}
+		] ),
+
+		vertexShader: ShaderChunk.meshphysical_vert,
+		fragmentShader: ShaderChunk.meshphysical_frag
+
+	};
+
+	static toon = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -120,9 +162,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshtoon_vert,
 		fragmentShader: ShaderChunk.meshtoon_frag
 
-	},
+	};
 
-	matcap: {
+	static matcap = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -138,9 +180,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshmatcap_vert,
 		fragmentShader: ShaderChunk.meshmatcap_frag
 
-	},
+	};
 
-	points: {
+	static points = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.points,
@@ -150,9 +192,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.points_vert,
 		fragmentShader: ShaderChunk.points_frag
 
-	},
+	};
 
-	dashed: {
+	static dashed = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -167,9 +209,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.linedashed_vert,
 		fragmentShader: ShaderChunk.linedashed_frag
 
-	},
+	};
 
-	depth: {
+	static depth = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -179,9 +221,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.depth_vert,
 		fragmentShader: ShaderChunk.depth_frag
 
-	},
+	};
 
-	normal: {
+	static normal = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -196,9 +238,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.meshnormal_vert,
 		fragmentShader: ShaderChunk.meshnormal_frag
 
-	},
+	};
 
-	sprite: {
+	static sprite = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.sprite,
@@ -208,9 +250,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.sprite_vert,
 		fragmentShader: ShaderChunk.sprite_frag
 
-	},
+	};
 
-	background: {
+	static background = {
 
 		uniforms: {
 			uvTransform: { value: new Matrix3() },
@@ -220,12 +262,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.background_vert,
 		fragmentShader: ShaderChunk.background_frag
 
-	},
-	/* -------------------------------------------------------------------------
-	//	Cube map shader
-	 ------------------------------------------------------------------------- */
+	};
 
-	cube: {
+	static cube = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.envmap,
@@ -237,9 +276,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.cube_vert,
 		fragmentShader: ShaderChunk.cube_frag
 
-	},
+	};
 
-	equirect: {
+	static equirect = {
 
 		uniforms: {
 			tEquirect: { value: null },
@@ -248,9 +287,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.equirect_vert,
 		fragmentShader: ShaderChunk.equirect_frag
 
-	},
+	};
 
-	distanceRGBA: {
+	static distanceRGBA = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
@@ -265,9 +304,9 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.distanceRGBA_vert,
 		fragmentShader: ShaderChunk.distanceRGBA_frag
 
-	},
+	};
 
-	shadow: {
+	static shadow = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.lights,
@@ -281,51 +320,8 @@ const ShaderLib = {
 		vertexShader: ShaderChunk.shadow_vert,
 		fragmentShader: ShaderChunk.shadow_frag
 
-	}
+	};
 
-};
-
-ShaderLib.physical = {
-
-	uniforms: mergeUniforms( [
-		ShaderLib.standard.uniforms,
-		{
-			clearcoat: { value: 0 },
-			clearcoatMap: { value: null },
-			clearcoatRoughness: { value: 0 },
-			clearcoatRoughnessMap: { value: null },
-			clearcoatNormalScale: { value: new Vector2( 1, 1 ) },
-			clearcoatNormalMap: { value: null },
-			iridescence: { value: 0 },
-			iridescenceMap: { value: null },
-			iridescenceIOR: { value: 1.3 },
-			iridescenceThicknessMinimum: { value: 100 },
-			iridescenceThicknessMaximum: { value: 400 },
-			iridescenceThicknessMap: { value: null },
-			sheen: { value: 0 },
-			sheenColor: { value: new Color( 0x000000 ) },
-			sheenColorMap: { value: null },
-			sheenRoughness: { value: 1 },
-			sheenRoughnessMap: { value: null },
-			transmission: { value: 0 },
-			transmissionMap: { value: null },
-			transmissionSamplerSize: { value: new Vector2() },
-			transmissionSamplerMap: { value: null },
-			thickness: { value: 0 },
-			thicknessMap: { value: null },
-			attenuationDistance: { value: 0 },
-			attenuationColor: { value: new Color( 0x000000 ) },
-			specularIntensity: { value: 1 },
-			specularIntensityMap: { value: null },
-			specularColor: { value: new Color( 1, 1, 1 ) },
-			specularColorMap: { value: null },
-		}
-	] ),
-
-	vertexShader: ShaderChunk.meshphysical_vert,
-	fragmentShader: ShaderChunk.meshphysical_frag
-
-};
-
+}
 
 export { ShaderLib };

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -6,9 +6,9 @@ import { Matrix3 } from '../../math/Matrix3.js';
  * Uniforms library for shared webgl shaders
  */
 
-const UniformsLib = {
+class UniformsLib {
 
-	common: {
+	static common = {
 
 		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -20,15 +20,15 @@ const UniformsLib = {
 		alphaMap: { value: null },
 		alphaTest: { value: 0 }
 
-	},
+	};
 
-	specularmap: {
+	static specularmap = {
 
 		specularMap: { value: null },
 
-	},
+	};
 
-	envmap: {
+	static envmap = {
 
 		envMap: { value: null },
 		flipEnvMap: { value: - 1 },
@@ -36,78 +36,78 @@ const UniformsLib = {
 		ior: { value: 1.5 }, // physical
 		refractionRatio: { value: 0.98 } // basic, lambert, phong
 
-	},
+	};
 
-	aomap: {
+	static aomap = {
 
 		aoMap: { value: null },
 		aoMapIntensity: { value: 1 }
 
-	},
+	};
 
-	lightmap: {
+	static lightmap = {
 
 		lightMap: { value: null },
 		lightMapIntensity: { value: 1 }
 
-	},
+	};
 
-	emissivemap: {
+	static emissivemap = {
 
 		emissiveMap: { value: null }
 
-	},
+	};
 
-	bumpmap: {
+	static bumpmap = {
 
 		bumpMap: { value: null },
 		bumpScale: { value: 1 }
 
-	},
+	};
 
-	normalmap: {
+	static normalmap = {
 
 		normalMap: { value: null },
 		normalScale: { value: new Vector2( 1, 1 ) }
 
-	},
+	};
 
-	displacementmap: {
+	static displacementmap = {
 
 		displacementMap: { value: null },
 		displacementScale: { value: 1 },
 		displacementBias: { value: 0 }
 
-	},
+	};
 
-	roughnessmap: {
+	static roughnessmap = {
 
 		roughnessMap: { value: null }
 
-	},
+	};
 
-	metalnessmap: {
+	static metalnessmap = {
 
 		metalnessMap: { value: null }
 
-	},
+	};
 
-	gradientmap: {
+	static gradientmap = {
 
 		gradientMap: { value: null }
 
-	},
+	};
 
-	fog: {
+	static fog = {
 
 		fogDensity: { value: 0.00025 },
 		fogNear: { value: 1 },
 		fogFar: { value: 2000 },
 		fogColor: { value: new Color( 0xffffff ) }
 
-	},
+	};
 
-	lights: {
+	static lights = {
 
 		ambientLightColor: { value: [] },
 
@@ -184,9 +184,9 @@ const UniformsLib = {
 		ltc_1: { value: null },
 		ltc_2: { value: null }
 
-	},
+	};
 
-	points: {
+	static points = {
 
 		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -197,9 +197,9 @@ const UniformsLib = {
 		alphaTest: { value: 0 },
 		uvTransform: { value: new Matrix3() }
 
-	},
+	};
 
-	sprite: {
+	static sprite = {
 
 		diffuse: { value: new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -210,8 +210,8 @@ const UniformsLib = {
 		alphaTest: { value: 0 },
 		uvTransform: { value: new Matrix3() }
 
-	}
+	};
 
-};
+}
 
 export { UniformsLib };

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -6,9 +6,9 @@ import { Matrix3 } from '../../math/Matrix3.js';
  * Uniforms library for shared webgl shaders
  */
 
-class UniformsLib {
+const UniformsLib = {
 
-	static common = {
+	common: {
 
 		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -20,15 +20,15 @@ class UniformsLib {
 		alphaMap: { value: null },
 		alphaTest: { value: 0 }
 
-	};
+	},
 
-	static specularmap = {
+	specularmap: {
 
 		specularMap: { value: null },
 
-	};
+	},
 
-	static envmap = {
+	envmap: {
 
 		envMap: { value: null },
 		flipEnvMap: { value: - 1 },
@@ -36,78 +36,78 @@ class UniformsLib {
 		ior: { value: 1.5 }, // physical
 		refractionRatio: { value: 0.98 } // basic, lambert, phong
 
-	};
+	},
 
-	static aomap = {
+	aomap: {
 
 		aoMap: { value: null },
 		aoMapIntensity: { value: 1 }
 
-	};
+	},
 
-	static lightmap = {
+	lightmap: {
 
 		lightMap: { value: null },
 		lightMapIntensity: { value: 1 }
 
-	};
+	},
 
-	static emissivemap = {
+	emissivemap: {
 
 		emissiveMap: { value: null }
 
-	};
+	},
 
-	static bumpmap = {
+	bumpmap: {
 
 		bumpMap: { value: null },
 		bumpScale: { value: 1 }
 
-	};
+	},
 
-	static normalmap = {
+	normalmap: {
 
 		normalMap: { value: null },
 		normalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) }
 
-	};
+	},
 
-	static displacementmap = {
+	displacementmap: {
 
 		displacementMap: { value: null },
 		displacementScale: { value: 1 },
 		displacementBias: { value: 0 }
 
-	};
+	},
 
-	static roughnessmap = {
+	roughnessmap: {
 
 		roughnessMap: { value: null }
 
-	};
+	},
 
-	static metalnessmap = {
+	metalnessmap: {
 
 		metalnessMap: { value: null }
 
-	};
+	},
 
-	static gradientmap = {
+	gradientmap: {
 
 		gradientMap: { value: null }
 
-	};
+	},
 
-	static fog = {
+	fog: {
 
 		fogDensity: { value: 0.00025 },
 		fogNear: { value: 1 },
 		fogFar: { value: 2000 },
 		fogColor: { value: /*@__PURE__*/ new Color( 0xffffff ) }
 
-	};
+	},
 
-	static lights = {
+	lights: {
 
 		ambientLightColor: { value: [] },
 
@@ -184,9 +184,9 @@ class UniformsLib {
 		ltc_1: { value: null },
 		ltc_2: { value: null }
 
-	};
+	},
 
-	static points = {
+	points: {
 
 		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -197,9 +197,9 @@ class UniformsLib {
 		alphaTest: { value: 0 },
 		uvTransform: { value: /*@__PURE__*/ new Matrix3() }
 
-	};
+	},
 
-	static sprite = {
+	sprite: {
 
 		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
@@ -210,8 +210,8 @@ class UniformsLib {
 		alphaTest: { value: 0 },
 		uvTransform: { value: /*@__PURE__*/ new Matrix3() }
 
-	};
+	}
 
-}
+};
 
 export { UniformsLib };

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -10,12 +10,12 @@ class UniformsLib {
 
 	static common = {
 
-		diffuse: { value: new Color( 0xffffff ) },
+		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
 
 		map: { value: null },
-		uvTransform: { value: new Matrix3() },
-		uv2Transform: { value: new Matrix3() },
+		uvTransform: { value: /*@__PURE__*/ new Matrix3() },
+		uv2Transform: { value: /*@__PURE__*/ new Matrix3() },
 
 		alphaMap: { value: null },
 		alphaTest: { value: 0 }
@@ -68,7 +68,7 @@ class UniformsLib {
 	static normalmap = {
 
 		normalMap: { value: null },
-		normalScale: { value: new Vector2( 1, 1 ) }
+		normalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) }
 
 	};
 
@@ -103,7 +103,7 @@ class UniformsLib {
 		fogDensity: { value: 0.00025 },
 		fogNear: { value: 1 },
 		fogFar: { value: 2000 },
-		fogColor: { value: new Color( 0xffffff ) }
+		fogColor: { value: /*@__PURE__*/ new Color( 0xffffff ) }
 
 	};
 
@@ -188,27 +188,27 @@ class UniformsLib {
 
 	static points = {
 
-		diffuse: { value: new Color( 0xffffff ) },
+		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
 		size: { value: 1.0 },
 		scale: { value: 1.0 },
 		map: { value: null },
 		alphaMap: { value: null },
 		alphaTest: { value: 0 },
-		uvTransform: { value: new Matrix3() }
+		uvTransform: { value: /*@__PURE__*/ new Matrix3() }
 
 	};
 
 	static sprite = {
 
-		diffuse: { value: new Color( 0xffffff ) },
+		diffuse: { value: /*@__PURE__*/ new Color( 0xffffff ) },
 		opacity: { value: 1.0 },
-		center: { value: new Vector2( 0.5, 0.5 ) },
+		center: { value: /*@__PURE__*/ new Vector2( 0.5, 0.5 ) },
 		rotation: { value: 0.0 },
 		map: { value: null },
 		alphaMap: { value: null },
 		alphaTest: { value: 0 },
-		uvTransform: { value: new Matrix3() }
+		uvTransform: { value: /*@__PURE__*/ new Matrix3() }
 
 	};
 


### PR DESCRIPTION
Related issue: #24199

Troubleshooting the remaining side-effects, ~converted both `ShaderLib` and `UniformsLib` to static class fields for discussion~ added pure annotations.