### PR TITLE
Disable sRGBA format for WebXR

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -11,7 +11,6 @@ import {
 	DepthFormat,
 	DepthStencilFormat,
 	RGBAFormat,
-	sRGBEncoding,
 	UnsignedByteType,
 	UnsignedIntType,
 	UnsignedInt248Type,
@@ -297,7 +296,7 @@ class WebXRManager extends EventDispatcher {
 					}
 
 					const projectionlayerInit = {
-						colorFormat: ( renderer.outputEncoding === sRGBEncoding ) ? gl.SRGB8_ALPHA8 : gl.RGBA8,
+						colorFormat: gl.RGBA8,
 						depthFormat: glDepthFormat,
 						scaleFactor: framebufferScaleFactor
 					};


### PR DESCRIPTION
The WebXR manager is creating an sRGB swapchain when using layers.
This is different from 2D or the regular WebXR workflows.

There were bugs in the Quest browser where it didn't handle sRGB gamma correction properly. However, we fixed that bug and now we see that three.js has the wrong colors when the experience is using sRGB. 
With latest browser, you will see that gamma is applied twice, likely once by three and once when rgb colors are rendered into the srgb swapchain.

*This contribution is funded by [Meta](https://oculus.com)*
