### PR TITLE
Docs: Fix type hint for currentPoint property of Path class

### DIFF
--- a/docs/api/en/extras/core/Path.html
+++ b/docs/api/en/extras/core/Path.html
@@ -52,7 +52,7 @@
 		<h2>Properties</h2>
 		<p>See the base [page:CurvePath] class for common properties.</p>
 
-		<h3>[property:Array currentPoint]</h3>
+		<h3>[property:Vector2 currentPoint]</h3>
 		<p>The current offset of the path. Any new [page:Curve] added will start here.</p>
 
 

--- a/docs/api/ko/extras/core/Path.html
+++ b/docs/api/ko/extras/core/Path.html
@@ -51,7 +51,7 @@
 		<h2>프로퍼티</h2>
 		<p>일반 프로퍼티는 기본 [page:CurvePath] 클래스를 참고하세요.</p>
 
-		<h3>[property:Array currentPoint]</h3>
+		<h3>[property:Vector2 currentPoint]</h3>
 		<p>path의 현재 오프셋입니다. 새 [page:Curve]들은 여기서부터 시작될 것입니다.</p>
 
 

--- a/docs/api/zh/extras/core/Path.html
+++ b/docs/api/zh/extras/core/Path.html
@@ -51,7 +51,7 @@
 		<h2>属性</h2>
 		<p>共有属性请参见其基类[page:CurvePath]。</p>
 
-		<h3>[property:Array currentPoint]</h3>
+		<h3>[property:Vector2 currentPoint]</h3>
 		<p>路径当前的偏移量，任何新被加入的[page:Curve]将会从这里开始。</p>
 
 


### PR DESCRIPTION
Related issue: none

**Description**

The type of currentPoint in Path class should be Vector2.
