### PR TITLE
Tree-shaking: Move registration event and multiple instances check

### DIFF
--- a/src/Three.js
+++ b/src/Three.js
@@ -1,5 +1,3 @@
-import { REVISION } from './constants.js';
-
 export { WebGLArrayRenderTarget } from './renderers/WebGLArrayRenderTarget.js';
 export { WebGL3DRenderTarget } from './renderers/WebGL3DRenderTarget.js';
 export { WebGLMultipleRenderTargets } from './renderers/WebGLMultipleRenderTargets.js';
@@ -155,25 +153,3 @@ export { PMREMGenerator } from './extras/PMREMGenerator.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 export * from './constants.js';
 export * from './Three.Legacy.js';
-
-if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
-
-	__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
-		revision: REVISION,
-	} } ) );
-
-}
-
-if ( typeof window !== 'undefined' ) {
-
-	if ( window.__THREE__ ) {
-
-		console.warn( 'WARNING: Multiple instances of Three.js being imported.' );
-
-	} else {
-
-		window.__THREE__ = REVISION;
-
-	}
-
-}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -56,6 +56,28 @@ function createCanvasElement() {
 
 function WebGLRenderer( parameters = {} ) {
 
+	if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+		__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
+			revision: REVISION,
+		} } ) );
+
+	}
+
+	if ( typeof window !== 'undefined' ) {
+
+		if ( window.__THREE__ ) {
+
+			console.warn( 'WARNING: Multiple instances of Three.js being imported.' );
+
+		} else {
+
+			window.__THREE__ = REVISION;
+
+		}
+
+	}
+
 	this.isWebGLRenderer = true;
 
 	const _canvas = parameters.canvas !== undefined ? parameters.canvas : createCanvasElement(),

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -56,28 +56,6 @@ function createCanvasElement() {
 
 function WebGLRenderer( parameters = {} ) {
 
-	if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
-
-		__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
-			revision: REVISION,
-		} } ) );
-
-	}
-
-	if ( typeof window !== 'undefined' ) {
-
-		if ( window.__THREE__ ) {
-
-			console.warn( 'WARNING: Multiple instances of Three.js being imported.' );
-
-		} else {
-
-			window.__THREE__ = REVISION;
-
-		}
-
-	}
-
 	this.isWebGLRenderer = true;
 
 	const _canvas = parameters.canvas !== undefined ? parameters.canvas : createCanvasElement(),

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -4,7 +4,7 @@ import babelrc from './.babelrc.json';
 
 export function glconstants() {
 
-	var constants = {
+	const constants = {
 		POINTS: 0, ZERO: 0, NONE: 0,
 		LINES: 1, ONE: 1,
 		LINE_LOOP: 2,
@@ -283,6 +283,29 @@ ${ code }`;
 
 }
 
+const outro = /* js */ `if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+	__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
+		revision: REVISION,
+	} } ) );
+
+}
+
+if ( typeof window !== 'undefined' ) {
+
+	if ( window.__THREE__ ) {
+
+		console.warn( 'WARNING: Multiple instances of Three.js being imported.' );
+
+	} else {
+
+		window.__THREE__ = REVISION;
+
+	}
+
+}
+`;
+
 let builds = [
 	{
 		input: 'src/Three.js',
@@ -295,7 +318,8 @@ let builds = [
 		output: [
 			{
 				format: 'esm',
-				file: 'build/three.module.js'
+				file: 'build/three.module.js',
+				outro: outro
 			}
 		]
 	},
@@ -318,12 +342,14 @@ let builds = [
 				format: 'umd',
 				name: 'THREE',
 				file: 'build/three.js',
+				outro: outro,
 				indent: '\t'
 			},
 			{
 				format: 'cjs',
 				name: 'THREE',
 				file: 'build/three.cjs',
+				outro: outro,
 				indent: '\t'
 			}
 		]
@@ -347,7 +373,8 @@ let builds = [
 			{
 				format: 'umd',
 				name: 'THREE',
-				file: 'build/three.min.js'
+				file: 'build/three.min.js',
+				outro: outro
 			}
 		]
 	}


### PR DESCRIPTION
Related issue: #24199

Troubleshooting the remaining side-effects, moved the registration event and multiple instances check from `src/Three.js` to ~`WebGLRenderer` when it's instantiated, for discussion~ the builds.