### PR TITLE
[opt]: add fast method for invert transform matrix

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -251,7 +251,15 @@ class Object3D extends EventDispatcher {
 
 	worldToLocal( vector ) {
 
-		return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invertTransform() );
+		if ( this.matrixAutoUpdate ) {
+
+			return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invertTransform() );
+
+		} else {
+
+			return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invert() );
+
+		}
 
 	}
 
@@ -411,7 +419,15 @@ class Object3D extends EventDispatcher {
 
 		this.updateWorldMatrix( true, false );
 
-		_m1.copy( this.matrixWorld ).invertTransform();
+		if ( this.matrixAutoUpdate ) {
+
+			_m1.copy( this.matrixWorld ).invertTransform();
+
+		} else {
+
+			_m1.copy( this.matrixWorld ).invert();
+
+		}
 
 		if ( object.parent !== null ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -251,7 +251,7 @@ class Object3D extends EventDispatcher {
 
 	worldToLocal( vector ) {
 
-		return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invert() );
+		return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invertTransform() );
 
 	}
 
@@ -411,7 +411,7 @@ class Object3D extends EventDispatcher {
 
 		this.updateWorldMatrix( true, false );
 
-		_m1.copy( this.matrixWorld ).invert();
+		_m1.copy( this.matrixWorld ).invertTransform();
 
 		if ( object.parent !== null ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -545,6 +545,50 @@ class Matrix4 {
 
 	}
 
+	// base on https://lxjk.github.io/2017/09/03/Fast-4x4-Matrix-Inverse-with-SSE-SIMD-Explained.html
+	invertTransform() {
+
+		// invert rotation
+		const te = this.elements;
+		let tmp;
+		tmp = te[ 1 ]; te[ 1 ] = te[ 4 ]; te[ 4 ] = tmp;
+		tmp = te[ 2 ]; te[ 2 ] = te[ 8 ]; te[ 8 ] = tmp;
+		tmp = te[ 6 ]; te[ 6 ] = te[ 9 ]; te[ 9 ] = tmp;
+
+		// invert scale
+		const squareSizeX = te[ 0 ] * te[ 0 ] + te[ 4 ] * te[ 4 ] + te[ 8 ] * te[ 8 ];
+		const squareSizeY = te[ 1 ] * te[ 1 ] + te[ 5 ] * te[ 5 ] + te[ 9 ] * te[ 9 ];
+		const squareSizeZ = te[ 2 ] * te[ 2 ] + te[ 6 ] * te[ 6 ] + te[ 10 ] * te[ 10 ];
+
+		const rSquareSizeX = squareSizeX == 0 ? 1 : 1 / squareSizeX;
+		const rSquareSizeY = squareSizeY == 0 ? 1 : 1 / squareSizeY;
+		const rSquareSizeZ = squareSizeZ == 0 ? 1 : 1 / squareSizeZ;
+
+		te[ 0 ] *= rSquareSizeX;
+		te[ 1 ] *= rSquareSizeY;
+		te[ 2 ] *= rSquareSizeZ;
+
+		te[ 4 ] *= rSquareSizeX;
+		te[ 5 ] *= rSquareSizeY;
+		te[ 6 ] *= rSquareSizeZ;
+
+		te[ 8 ] *= rSquareSizeX;
+		te[ 9 ] *= rSquareSizeY;
+		te[ 10 ] *= rSquareSizeZ;
+
+		// invert translate
+		const Tx = te[ 12 ];
+		const Ty = te[ 13 ];
+		const Tz = te[ 14 ];
+
+		te[ 12 ] = - ( te[ 0 ] * Tx + te[ 4 ] * Ty + te[ 8 ] * Tz );
+		te[ 13 ] = - ( te[ 1 ] * Tx + te[ 5 ] * Ty + te[ 9 ] * Tz );
+		te[ 14 ] = - ( te[ 2 ] * Tx + te[ 6 ] * Ty + te[ 10 ] * Tz );
+
+		return this;
+
+	}
+
 	scale( v ) {
 
 		const te = this.elements;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -548,11 +548,11 @@ class Matrix4 {
 	// base on https://lxjk.github.io/2017/09/03/Fast-4x4-Matrix-Inverse-with-SSE-SIMD-Explained.html
 	invertTransform() {
 
-		let te = this.elements, tmp,
+		const te = this.elements, n14 = te[ 12 ], n24 = te[ 13 ], n34 = te[ 14 ];
+		let tmp,
 			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ],
 			n12 = te[ 4 ], n22 = te[ 5 ], n32 = te[ 6 ],
-			n13 = te[ 8 ], n23 = te[ 9 ], n33 = te[ 10 ],
-			n14 = te[ 12 ], n24 = te[ 13 ], n34 = te[ 14 ];
+			n13 = te[ 8 ], n23 = te[ 9 ], n33 = te[ 10 ];
 
 		// invert rotation
 		tmp = n21; n21 = n12; n12 = tmp;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -548,42 +548,50 @@ class Matrix4 {
 	// base on https://lxjk.github.io/2017/09/03/Fast-4x4-Matrix-Inverse-with-SSE-SIMD-Explained.html
 	invertTransform() {
 
+		let te = this.elements, tmp,
+			n11 = te[ 0 ], n21 = te[ 1 ], n31 = te[ 2 ],
+			n12 = te[ 4 ], n22 = te[ 5 ], n32 = te[ 6 ],
+			n13 = te[ 8 ], n23 = te[ 9 ], n33 = te[ 10 ],
+			n14 = te[ 12 ], n24 = te[ 13 ], n34 = te[ 14 ];
+
 		// invert rotation
-		const te = this.elements;
-		let tmp;
-		tmp = te[ 1 ]; te[ 1 ] = te[ 4 ]; te[ 4 ] = tmp;
-		tmp = te[ 2 ]; te[ 2 ] = te[ 8 ]; te[ 8 ] = tmp;
-		tmp = te[ 6 ]; te[ 6 ] = te[ 9 ]; te[ 9 ] = tmp;
+		tmp = n21; n21 = n12; n12 = tmp;
+		tmp = n31; n31 = n13; n13 = tmp;
+		tmp = n32; n32 = n23; n23 = tmp;
 
 		// invert scale
-		const squareSizeX = te[ 0 ] * te[ 0 ] + te[ 4 ] * te[ 4 ] + te[ 8 ] * te[ 8 ];
-		const squareSizeY = te[ 1 ] * te[ 1 ] + te[ 5 ] * te[ 5 ] + te[ 9 ] * te[ 9 ];
-		const squareSizeZ = te[ 2 ] * te[ 2 ] + te[ 6 ] * te[ 6 ] + te[ 10 ] * te[ 10 ];
+		const squareSizeX = n11 * n11 + n12 * n12 + n13 * n13;
+		const squareSizeY = n21 * n21 + n22 * n22 + n23 * n23;
+		const squareSizeZ = n31 * n31 + n32 * n32 + n33 * n33;
 
 		const rSquareSizeX = squareSizeX == 0 ? 1 : 1 / squareSizeX;
 		const rSquareSizeY = squareSizeY == 0 ? 1 : 1 / squareSizeY;
 		const rSquareSizeZ = squareSizeZ == 0 ? 1 : 1 / squareSizeZ;
 
-		te[ 0 ] *= rSquareSizeX;
-		te[ 1 ] *= rSquareSizeY;
-		te[ 2 ] *= rSquareSizeZ;
+		n11 *= rSquareSizeX;
+		n21 *= rSquareSizeY;
+		n31 *= rSquareSizeZ;
+		n12 *= rSquareSizeX;
+		n22 *= rSquareSizeY;
+		n32 *= rSquareSizeZ;
+		n13 *= rSquareSizeX;
+		n23 *= rSquareSizeY;
+		n33 *= rSquareSizeZ;
 
-		te[ 4 ] *= rSquareSizeX;
-		te[ 5 ] *= rSquareSizeY;
-		te[ 6 ] *= rSquareSizeZ;
-
-		te[ 8 ] *= rSquareSizeX;
-		te[ 9 ] *= rSquareSizeY;
-		te[ 10 ] *= rSquareSizeZ;
+		te[ 0 ] = n11;
+		te[ 1 ] = n21;
+		te[ 2 ] = n31;
+		te[ 4 ] = n12;
+		te[ 5 ] = n22;
+		te[ 6 ] = n32;
+		te[ 8 ] = n13;
+		te[ 9 ] = n23;
+		te[ 10 ] = n33;
 
 		// invert translate
-		const Tx = te[ 12 ];
-		const Ty = te[ 13 ];
-		const Tz = te[ 14 ];
-
-		te[ 12 ] = - ( te[ 0 ] * Tx + te[ 4 ] * Ty + te[ 8 ] * Tz );
-		te[ 13 ] = - ( te[ 1 ] * Tx + te[ 5 ] * Ty + te[ 9 ] * Tz );
-		te[ 14 ] = - ( te[ 2 ] * Tx + te[ 6 ] * Ty + te[ 10 ] * Tz );
+		te[ 12 ] = - ( n11 * n14 + n12 * n24 + n13 * n34 );
+		te[ 13 ] = - ( n21 * n14 + n22 * n24 + n23 * n34 );
+		te[ 14 ] = - ( n31 * n14 + n32 * n24 + n33 * n34 );
 
 		return this;
 

--- a/test/benchmark/benchmarks.html
+++ b/test/benchmark/benchmarks.html
@@ -15,6 +15,7 @@
     <script src="core/Vector3Storage.js"></script>
     <script src="core/Vector3Length.js"></script>
     <script src="core/Float32Array.js"></script>
+    <script src="core/Matrix4Invert.js"></script>
     <script src="core/UpdateMatrixWorld.js"></script>
     <script src="core/TriangleClosestPoint.js"></script>
   </head>

--- a/test/benchmark/core/Matrix4Invert.js
+++ b/test/benchmark/core/Matrix4Invert.js
@@ -1,0 +1,53 @@
+( function () {
+
+	THREE = Bench.THREE;
+
+  const mat4 = new THREE.Matrix4( 4 );
+  mat4.makeRotationX( Math.PI / 2 );
+  mat4.setPosition( 1, 2, 3 );
+  mat4.scale( new THREE.Vector3( 1, 2, 3 ) );
+
+	var suite = Bench.newSuite( 'Matrix 4 Invert' );
+
+  const t0 = performance.now();
+
+  for ( var i = 0; i < 1000000; i ++ ) {
+
+    mat4.invert();
+    
+  }
+
+  const t1 = performance.now();
+
+  for ( var i = 0; i < 1000000; i ++ ) {
+
+    mat4.invertTransform();
+
+  }
+
+  const t2 = performance.now();
+
+  console.log( 'invert 1000000 cost:', ( t1 - t0 ).toFixed( 2 ) );
+  console.log( 'invertTransform 1000000 cost:', ( t2 - t1 ).toFixed( 2 ) );
+
+	suite.add( 'Invert', function () {
+
+		for ( var i = 0; i < 1000000; i ++ ) {
+
+      mat4.invert();
+			
+		}
+
+	} );
+
+	suite.add( 'InvertTransform', function () {
+
+		for ( var i = 0; i < 1000000; i ++ ) {
+
+      mat4.invertTransform();
+
+		}
+
+	} );
+
+} )();

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -532,6 +532,54 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'invertTransform', ( assert ) => {
+
+			var zero = new Matrix4().set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+			var identity = new Matrix4();
+
+			var a = new Matrix4();
+			var b = new Matrix4().set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+
+			a.copy( b ).invertTransform();
+			assert.ok( matrixEquals4( a, zero ), 'Passed!' );
+
+
+			var testMatrices = [
+				new Matrix4().makeRotationX( 0.3 ),
+				new Matrix4().makeRotationX( - 0.3 ),
+				new Matrix4().makeRotationY( 0.3 ),
+				new Matrix4().makeRotationY( - 0.3 ),
+				new Matrix4().makeRotationZ( 0.3 ),
+				new Matrix4().makeRotationZ( - 0.3 ),
+				new Matrix4().makeScale( 1, 2, 3 ),
+				new Matrix4().makeScale( 1 / 8, 1 / 2, 1 / 3 ),
+				new Matrix4().makeTranslation( 1, 2, 3 )
+			];
+
+			for ( var i = 0, il = testMatrices.length; i < il; i ++ ) {
+
+				var m = testMatrices[ i ];
+
+				var mInverse = new Matrix4().copy( m ).invertTransform();
+				var mSelfInverse = m.clone();
+				mSelfInverse.copy( mSelfInverse ).invertTransform();
+
+				// self-inverse should the same as inverse
+				assert.ok( matrixEquals4( mSelfInverse, mInverse ), 'Passed!' );
+
+				// the determinant of the inverse should be the reciprocal
+				assert.ok( Math.abs( m.determinant() * mInverse.determinant() - 1 ) < 0.0001, 'Passed!' );
+
+				var mProduct = new Matrix4().multiplyMatrices( m, mInverse );
+
+				// the determinant of the identity matrix is 1
+				assert.ok( Math.abs( mProduct.determinant() - 1 ) < 0.0001, 'Passed!' );
+				assert.ok( matrixEquals4( mProduct, identity ), 'Passed!' );
+
+			}
+
+		} );
+
 		QUnit.test( 'scale', ( assert ) => {
 
 			var a = new Matrix4().set( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 );


### PR DESCRIPTION
**Description**

method is form https://lxjk.github.io/2017/09/03/Fast-4x4-Matrix-Inverse-with-SSE-SIMD-Explained.html

invert a transform matrix can be divided into 3 step:

0. invert rotation
1. invert scale
2. invert translate

this is 2x faster then general matrix invert.

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/12824616/173246567-341873f3-00f6-4c21-912f-90d7e9651283.png">

another benchmark

https://deepkolos.github.io/simd-wasm-matrix/example/index.html

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/12824616/173246651-8652ec6a-8677-4eee-b6af-92351aa3dafb.png">

in the example **webgl_performance_static**, with CPU slowdown x6

update matrix world by invert

![W8P9Wjutje](https://user-images.githubusercontent.com/12824616/173246771-a385a728-f432-4217-b0c6-b35d0f868962.jpg)

update matrix world by invertTransform

![Cq2V91JX7U](https://user-images.githubusercontent.com/12824616/173246781-b31ed7a7-e29c-420e-a415-d14e8da53d84.jpg)
