### PR TITLE
make CameraHelper more customizable | choose colors | leave out sections if desired

### DIFF
--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -18,7 +18,15 @@ const _camera = /*@__PURE__*/ new Camera();
 
 class CameraHelper extends LineSegments {
 
-	constructor( camera ) {
+	constructor( camera, {
+        colorNearFrustum = new Color( 0xffaa00 ),
+        colorFarFrustum = new Color( 0xffaa00 ),
+        colorSideFrustum = new Color( 0xffaa00 ),
+        colorCone = new Color( 0xff0000 ),
+        colorUp = new Color( 0x00aaff ),
+        colorTarget = new Color( 0xffffff ),
+        colorCross = new Color( 0x333333 ),
+    } = {} ) {
 
 		const geometry = new BufferGeometry();
 		const material = new LineBasicMaterial( { color: 0xffffff, vertexColors: true, toneMapped: false } );
@@ -28,60 +36,66 @@ class CameraHelper extends LineSegments {
 
 		const pointMap = {};
 
-		// colors
-
-		const colorFrustum = new Color( 0xffaa00 );
-		const colorCone = new Color( 0xff0000 );
-		const colorUp = new Color( 0x00aaff );
-		const colorTarget = new Color( 0xffffff );
-		const colorCross = new Color( 0x333333 );
-
 		// near
 
-		addLine( 'n1', 'n2', colorFrustum );
-		addLine( 'n2', 'n4', colorFrustum );
-		addLine( 'n4', 'n3', colorFrustum );
-		addLine( 'n3', 'n1', colorFrustum );
+		if (colorNearFrustum) {
+            addLine( 'n1', 'n2', colorNearFrustum );
+		    addLine( 'n2', 'n4', colorNearFrustum );
+		    addLine( 'n4', 'n3', colorNearFrustum );
+		    addLine( 'n3', 'n1', colorNearFrustum );
+        }
 
 		// far
 
-		addLine( 'f1', 'f2', colorFrustum );
-		addLine( 'f2', 'f4', colorFrustum );
-		addLine( 'f4', 'f3', colorFrustum );
-		addLine( 'f3', 'f1', colorFrustum );
+        if (colorFarFrustum) {
+		addLine( 'f1', 'f2', colorFarFrustum );
+		addLine( 'f2', 'f4', colorFarFrustum );
+		addLine( 'f4', 'f3', colorFarFrustum );
+		addLine( 'f3', 'f1', colorFarFrustum );
+        }
 
 		// sides
 
-		addLine( 'n1', 'f1', colorFrustum );
-		addLine( 'n2', 'f2', colorFrustum );
-		addLine( 'n3', 'f3', colorFrustum );
-		addLine( 'n4', 'f4', colorFrustum );
+        if (colorSideFrustum) {
+		addLine( 'n1', 'f1', colorSideFrustum );
+		addLine( 'n2', 'f2', colorSideFrustum );
+		addLine( 'n3', 'f3', colorSideFrustum );
+		addLine( 'n4', 'f4', colorSideFrustum );
+        }
 
 		// cone
 
+        if (colorCone) {
 		addLine( 'p', 'n1', colorCone );
 		addLine( 'p', 'n2', colorCone );
 		addLine( 'p', 'n3', colorCone );
 		addLine( 'p', 'n4', colorCone );
+        }
 
 		// up
 
+        if (colorUp) {
 		addLine( 'u1', 'u2', colorUp );
 		addLine( 'u2', 'u3', colorUp );
 		addLine( 'u3', 'u1', colorUp );
+        }
 
 		// target
 
-		addLine( 'c', 't', colorTarget );
-		addLine( 'p', 'c', colorCross );
+		if (colorTarget) {
+        addLine( 'c', 't', colorTarget );
+		addLine( 'p', 'c', colorTarget );
+        }
 
 		// cross
 
+        if (colorCross) {
 		addLine( 'cn1', 'cn2', colorCross );
 		addLine( 'cn3', 'cn4', colorCross );
 
 		addLine( 'cf1', 'cf2', colorCross );
 		addLine( 'cf3', 'cf4', colorCross );
+        }
 
 		function addLine( a, b, color ) {
 
@@ -109,6 +123,16 @@ class CameraHelper extends LineSegments {
 		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
 		super( geometry, material );
+
+        this.colorOptions = {
+            colorNearFrustum,
+            colorFarFrustum,
+            colorSideFrustum,
+            colorCone,
+            colorUp,
+            colorTarget,
+            colorCross,
+        }
 
 		this.type = 'CameraHelper';
 
@@ -138,31 +162,38 @@ class CameraHelper extends LineSegments {
 
 		// center / target
 
+        if (this.colorOptions.colorTarget) {
 		setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
 		setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
+        }
 
 		// near
 
+        if (this.colorOptions.colorNearFrustum) {
 		setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
 		setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
 		setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
 		setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
+        }
 
 		// far
 
+        if (this.colorOptions.colorFarFrustum) {
 		setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
 		setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
 		setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
 		setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
+        }
 
 		// up
-
+        if (this.colorOptions.colorUp) {
 		setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
 		setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
 		setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
+        }
 
 		// cross
-
+        if (this.colorOptions.colorCross) {
 		setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
 		setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
 		setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
@@ -172,6 +203,7 @@ class CameraHelper extends LineSegments {
 		setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
 		setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
 		setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
+        }
 
 		geometry.getAttribute( 'position' ).needsUpdate = true;
 

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -48,53 +48,53 @@ class CameraHelper extends LineSegments {
 		// far
 
         if (colorFarFrustum) {
-		addLine( 'f1', 'f2', colorFarFrustum );
-		addLine( 'f2', 'f4', colorFarFrustum );
-		addLine( 'f4', 'f3', colorFarFrustum );
-		addLine( 'f3', 'f1', colorFarFrustum );
+			addLine( 'f1', 'f2', colorFarFrustum );
+			addLine( 'f2', 'f4', colorFarFrustum );
+			addLine( 'f4', 'f3', colorFarFrustum );
+			addLine( 'f3', 'f1', colorFarFrustum );
         }
 
 		// sides
 
         if (colorSideFrustum) {
-		addLine( 'n1', 'f1', colorSideFrustum );
-		addLine( 'n2', 'f2', colorSideFrustum );
-		addLine( 'n3', 'f3', colorSideFrustum );
-		addLine( 'n4', 'f4', colorSideFrustum );
+			addLine( 'n1', 'f1', colorSideFrustum );
+			addLine( 'n2', 'f2', colorSideFrustum );
+			addLine( 'n3', 'f3', colorSideFrustum );
+			addLine( 'n4', 'f4', colorSideFrustum );
         }
 
 		// cone
 
         if (colorCone) {
-		addLine( 'p', 'n1', colorCone );
-		addLine( 'p', 'n2', colorCone );
-		addLine( 'p', 'n3', colorCone );
-		addLine( 'p', 'n4', colorCone );
+			addLine( 'p', 'n1', colorCone );
+			addLine( 'p', 'n2', colorCone );
+			addLine( 'p', 'n3', colorCone );
+			addLine( 'p', 'n4', colorCone );
         }
 
 		// up
 
         if (colorUp) {
-		addLine( 'u1', 'u2', colorUp );
-		addLine( 'u2', 'u3', colorUp );
-		addLine( 'u3', 'u1', colorUp );
+			addLine( 'u1', 'u2', colorUp );
+			addLine( 'u2', 'u3', colorUp );
+			addLine( 'u3', 'u1', colorUp );
         }
 
 		// target
 
 		if (colorTarget) {
-        addLine( 'c', 't', colorTarget );
-		addLine( 'p', 'c', colorTarget );
+        	addLine( 'c', 't', colorTarget );
+			addLine( 'p', 'c', colorTarget );
         }
 
 		// cross
 
         if (colorCross) {
-		addLine( 'cn1', 'cn2', colorCross );
-		addLine( 'cn3', 'cn4', colorCross );
+			addLine( 'cn1', 'cn2', colorCross );
+			addLine( 'cn3', 'cn4', colorCross );
 
-		addLine( 'cf1', 'cf2', colorCross );
-		addLine( 'cf3', 'cf4', colorCross );
+			addLine( 'cf1', 'cf2', colorCross );
+			addLine( 'cf3', 'cf4', colorCross );
         }
 
 		function addLine( a, b, color ) {
@@ -163,46 +163,46 @@ class CameraHelper extends LineSegments {
 		// center / target
 
         if (this.colorOptions.colorTarget) {
-		setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
-		setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
+			setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
+			setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
         }
 
 		// near
 
         if (this.colorOptions.colorNearFrustum) {
-		setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
-		setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
-		setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
-		setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
+			setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
+			setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
+			setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
+			setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
         }
 
 		// far
 
         if (this.colorOptions.colorFarFrustum) {
-		setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
-		setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
-		setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
-		setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
+			setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
+			setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
+			setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
+			setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
         }
 
 		// up
         if (this.colorOptions.colorUp) {
-		setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
-		setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
-		setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
+			setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
+			setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
+			setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
         }
 
 		// cross
         if (this.colorOptions.colorCross) {
-		setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
-		setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
-		setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
-		setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
+			setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
+			setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
+			setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
+			setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
 
-		setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
-		setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
-		setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
-		setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
+			setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
+			setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
+			setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
+			setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
         }
 
 		geometry.getAttribute( 'position' ).needsUpdate = true;


### PR DESCRIPTION
**Description**

Camera helper has too much going on,

If all that's needed is the info about the location and face direction of the camera,

the extra lines for the entire frustum of rendering is unneeded and gets in the way.

Same may be true vice-versa.

This PR makes the camera helper more customizable with extra arguments for the colors of the different parts of the helper.

Passing null instead of a color prevents that part of the helper from being rendered.

